### PR TITLE
matrix power error solved

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,15 +2100,13 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if(n.is_Integer == False):
+            if n.is_Integer == False:
                 for i in range(N):
                     for j in range(N-i):
                         bn = binomial(n, i)
                         if isinstance(bn, binomial):
                             bn = bn._eval_expand_func()
-                        jc[j, i+j] = l**(n-i)*bn
-
-                 
+                        jc[j, i+j] = l**(n-i)*bn    
             elif l == 0 and (n < N - 1) != False:
                 raise ValueError("Matrix det == 0; not invertible")
             elif l == 0 and N > 1 and n % 1 != 0:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,7 +2100,7 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if n.is_Integer == False:
+            if str(n).isdigit() == False:
                 for i in range(N):
                     for j in range(N-i):
                         bn = binomial(n, i)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,7 +2100,16 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if l == 0 and (n < N - 1) != False:
+            if(n.is_Integer == False):
+                for i in range(N):
+                    for j in range(N-i):
+                        bn = binomial(n, i)
+                        if isinstance(bn, binomial):
+                            bn = bn._eval_expand_func()
+                        jc[j, i+j] = l**(n-i)*bn
+
+                 
+            elif l == 0 and (n < N - 1) != False:
                 raise ValueError("Matrix det == 0; not invertible")
             elif l == 0 and N > 1 and n % 1 != 0:
                 raise ValueError("Non-integer power cannot be evaluated")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
"Fixes  #15593"

#### Brief description of what is fixed or changed
Modified `matrix.py` such that if matrix power contains `variable` then it would do without raising exceptions.
for example
` rot_z_generator = Matrix([
    [0, 1, 0],
    [-1, 0, 0],
    [0, 0, 0]
])

k = symbols("k")
rot_z_generator**k`



#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  -  make function  if(n.is_Integer == False).
<!-- END RELEASE NOTES -->
