### PR TITLE
Consider more substitutions inside integer powers

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -30,6 +30,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
+from sympy.ntheory.factor_ import divisors
 
 ZERO = sympy.S.Zero
 
@@ -180,10 +181,18 @@ def find_substitutions(integrand, symbol, u_var):
                 r.extend(possible_subterms(u))
             return r
         elif isinstance(term, sympy.Pow):
+            r = []
             if term.args[1].is_constant(symbol):
-                return [term.args[0]]
+                r.append(term.args[0])
             elif term.args[0].is_constant(symbol):
-                return [term.args[1]]
+                r.append(term.args[1])
+            if term.args[1].is_Integer:
+                r.extend([term.args[0]**d for d in divisors(term.args[1])
+                    if 1 < d < abs(term.args[1])])
+                if term.args[0].is_Add:
+                    r.extend([t for t in possible_subterms(term.args[0])
+                        if t.is_Pow])
+            return r
         elif isinstance(term, sympy.Add):
             r = []
             for arg in term.args:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -401,3 +401,10 @@ def test_issue_9858():
         x*exp(7*x)/7 + x*exp(6*x)/6 + x*exp(5*x)/5 + x*exp(4*x)/4 +
         x*exp(3*x)/3 + x*exp(2*x)/2 + x*exp(x) - exp(7*x)/49 -exp(6*x)/36 -
         exp(5*x)/25 - exp(4*x)/16 - exp(3*x)/9 - exp(2*x)/4 - exp(x))
+
+
+def test_issue_8520():
+    assert manualintegrate(x/(x**4 + 1), x) == atan(x**2)/2
+    assert manualintegrate(x**2/(x**6 + 25), x) == atan(x**3/5)/15
+    f = x/(9*x**4 + 4)**2
+    assert manualintegrate(f, x).diff(x).factor() == f


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #8520

#### Brief description of what is fixed or changed

Currently `manualintegrate(x/(1 + x**4), x)` fails to find the substitution `u = x**2`. The reason is twofold: first, in `Pow(1 + x**4, -1)` only the subterm `1 + x**4` is considered for substitution (and not its summands); second, even if `x**4` was considered, `x**2` would not be. Both are corrected now. For the latter: if `x**n` is a candidate for substitution, so is `x**d` when `d` divides `n`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * expanded the options for power substitution `u = x**k` in manual integration  
<!-- END RELEASE NOTES -->
