### PR TITLE
Correct Matrix multiplication  method for numpy printer.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,14 +2100,7 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if str(n).isdigit() == False:
-                for i in range(N):
-                    for j in range(N-i):
-                        bn = binomial(n, i)
-                        if isinstance(bn, binomial):
-                            bn = bn._eval_expand_func()
-                        jc[j, i+j] = l**(n-i)*bn    
-            elif l == 0 and (n < N - 1) != False:
+            if l == 0 and (n < N - 1) != False:
                 raise ValueError("Matrix det == 0; not invertible")
             elif l == 0 and N > 1 and n % 1 != 0:
                 raise ValueError("Non-integer power cannot be evaluated")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,15 +2100,13 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if(n.is_Integer == False):
+            if n.is_Integer == False:
                 for i in range(N):
                     for j in range(N-i):
                         bn = binomial(n, i)
                         if isinstance(bn, binomial):
                             bn = bn._eval_expand_func()
-                        jc[j, i+j] = l**(n-i)*bn
-
-                 
+                        jc[j, i+j] = l**(n-i)*bn    
             elif l == 0 and (n < N - 1) != False:
                 raise ValueError("Matrix det == 0; not invertible")
             elif l == 0 and N > 1 and n % 1 != 0:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,7 +2100,7 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if n.is_Integer == False:
+            if str(n).isdigit() == False:
                 for i in range(N):
                     for j in range(N-i):
                         bn = binomial(n, i)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2100,7 +2100,16 @@ class MatrixBase(MatrixDeprecated,
         def jordan_cell_power(jc, n):
             N = jc.shape[0]
             l = jc[0, 0]
-            if l == 0 and (n < N - 1) != False:
+            if(n.is_Integer == False):
+                for i in range(N):
+                    for j in range(N-i):
+                        bn = binomial(n, i)
+                        if isinstance(bn, binomial):
+                            bn = bn._eval_expand_func()
+                        jc[j, i+j] = l**(n-i)*bn
+
+                 
+            elif l == 0 and (n < N - 1) != False:
                 raise ValueError("Matrix det == 0; not invertible")
             elif l == 0 and N > 1 and n % 1 != 0:
                 raise ValueError("Non-integer power cannot be evaluated")

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -497,7 +497,7 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"
-        return '({0})'.format(').dot('.join(self._print(i) for i in expr.args))
+        return '({0})'.format(expr)
 
     def _print_MatPow(self, expr):
         "Matrix power printer"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
"Fixes #15482".


#### Brief description of what is fixed or changed
In [1]: from sympy import *

In [2]: M = MatrixSymbol("M", 3, 3)
   ...: N = MatrixSymbol("N", 3, 3)

In [3]: expr = M*N

In [4]: f = lambdify((M, N), expr, "numpy")

In [5]: f(eye(3), eye(3))
/home/francesco/workspace/sympy/sympy/matrices/matrices.py:2639: SymPyDeprecationWarning: 

Dot product of non row/column vectors has been deprecated since SymPy
1.2. Use * to take matrix products instead. See
https://github.com/sympy/sympy/issues/13815 for more info.

  useinstead="* to take matrix products").warn()
Out[5]: [1, 0, 0, 0, 1, 0, 0, 0, 1]
 
As output is not coming as matrix.So i changed numpy print function.




#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - NumPy matrix multiply 
<!-- END RELEASE NOTES -->
