### PR TITLE
Adjust the logic of Abs->Piecewise rewrite in integrate

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -458,7 +458,7 @@ class Integral(AddWithLimits):
 
             if function.has(Abs, sign) and (
                 (len(xab) < 3 and all(x.is_real for x in xab)) or
-                (len(xab) == 3 and all(x.is_real and not(x.is_infinite) for
+                (len(xab) == 3 and all(x.is_real and not x.is_infinite for
                  x in xab[1:]))):
                     # some improper integrals are better off with Abs
                     xr = Dummy("xr", real=True)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -458,7 +458,7 @@ class Integral(AddWithLimits):
 
             if function.has(Abs, sign) and (
                 (len(xab) < 3 and all(x.is_real for x in xab)) or
-                (len(xab) == 3 and all(x.is_real and x.is_finite for
+                (len(xab) == 3 and all(x.is_real and not(x.is_infinite) for
                  x in xab[1:]))):
                     # some improper integrals are better off with Abs
                     xr = Dummy("xr", real=True)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1425,3 +1425,13 @@ def test_issue_15292():
 
 def test_issue_4514():
     assert integrate(sin(2*x)/sin(x), x) == 2*sin(x)
+
+
+def test_issue_15457():
+    x, a, b = symbols('x a b', real=True)
+    definite = integrate(exp(Abs(x-2)), (x, a, b))
+    indefinite = integrate(exp(Abs(x-2)), x)
+    assert definite.subs({a: 1, b: 3}) == -2 + 2*E
+    assert indefinite.subs(x, 3) - indefinite.subs(x, 1) == -2 + 2*E
+    assert definite.subs({a: -3, b: -1}) == -exp(3) + exp(5)
+    assert indefinite.subs(x, -1) - indefinite.subs(x, -3) == -exp(3) + exp(5)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15457 

#### Brief description of what is fixed or changed

According to a comment in integrals.py, "some improper integrals are better off with Abs", that is, with Meijer G method rather than Piecewise logic. This motivated the condition `all(x.is_real and x.is_finite for x in xab[1:])` for automatic Abs->Piecewise rewrite. But this condition leaves Abs in when `x.is_finite` is None, which offers no advantage because the integral is not actually known to be improper. Instead it should be `all(x.is_real and not(x.is_infinite) for x in xab[1:])`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * adjusted the logic of Abs->Piecewise rewrite for definite integrals
<!-- END RELEASE NOTES -->
