### PR TITLE
continuum_mechanics: Fixed beams having identical second moment now returns correct deflection and slope values.

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -997,7 +997,7 @@ class Beam(object):
             return self._hinge_beam_slope
         if not self._boundary_conditions['slope']:
             return diff(self.deflection(), x)
-        if self._composite_type == "fixed":
+        if isinstance(I, Piecewise) and self._composite_type == "fixed":
             args = I.args
             slope = 0
             conditions = []
@@ -1064,7 +1064,7 @@ class Beam(object):
         if self._composite_type == "hinge":
             return self._hinge_beam_deflection
         if not self._boundary_conditions['deflection'] and not self._boundary_conditions['slope']:
-            if self._composite_type == "fixed":
+            if isinstance(I, Piecewise) and self._composite_type == "fixed":
                 args = I.args
                 conditions = []
                 prev_slope = 0
@@ -1093,7 +1093,7 @@ class Beam(object):
             constant = symbols(base_char + '4')
             return integrate(self.slope(), x) + constant
         elif not self._boundary_conditions['slope'] and self._boundary_conditions['deflection']:
-            if self._composite_type == "fixed":
+            if isinstance(I, Piecewise) and self._composite_type == "fixed":
                 args = I.args
                 conditions = []
                 prev_slope = 0
@@ -1126,7 +1126,7 @@ class Beam(object):
             deflection_curve = deflection_curve.subs({C3: constants[0][0], C4: constants[0][1]})
             return S(1)/(E*I)*deflection_curve
 
-        if self._composite_type == "fixed":
+        if isinstance(I, Piecewise) and self._composite_type == "fixed":
             args = I.args
             conditions = []
             prev_slope = 0

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -324,6 +324,25 @@ def test_composite_beam():
     assert b.deflection().subs(x, 2*l) == 7*P*l**3/(24*E*I)
     assert b.deflection().subs(x, 3*l) == 5*P*l**3/(16*E*I)
 
+    # When beams having same second moment are joined.
+    b1 = Beam(2, 500, 10)
+    b2 = Beam(2, 500, 10)
+    b = b1.join(b2, "fixed")
+    b.apply_load(M1, 0, -2)
+    b.apply_load(R1, 0, -1)
+    b.apply_load(R2, 1, -1)
+    b.apply_load(R3, 4, -1)
+    b.apply_load(10, 3, -1)
+    b.bc_slope = [(0, 0)]
+    b.bc_deflection = [(0, 0), (1, 0), (4, 0)]
+    b.solve_for_reaction_loads(M1, R1, R2, R3)
+    assert b.slope() == -2*SingularityFunction(x, 0, 1)/5625 + SingularityFunction(x, 0, 2)/1875\
+                - 133*SingularityFunction(x, 1, 2)/135000 + SingularityFunction(x, 3, 2)/1000\
+                - 37*SingularityFunction(x, 4, 2)/67500
+    assert b.deflection() == -SingularityFunction(x, 0, 2)/5625 + SingularityFunction(x, 0, 3)/5625\
+                    - 133*SingularityFunction(x, 1, 3)/405000 + SingularityFunction(x, 3, 3)/3000\
+                    - 37*SingularityFunction(x, 4, 3)/202500
+
 
 def test_point_cflexure():
     E = Symbol('E')


### PR DESCRIPTION
#### Brief description of what is fixed or changed
The issue was mentioned [here](https://groups.google.com/d/msg/sympy/RikS3ZyUldI/haed-mp1AQAJ) in the mailing list. 
Previously, if we used `join` method on two beams having same value of `I`, it made slope and deflection values equal to 0. eg:
```
>>> b1 = Beam(2, 500, 10)
>>> b2 = Beam(2, 500, 10)
>>> b = b1.join(b2, "fixed")
>>> b.apply_load(M1, 0, -2)
>>> b.apply_load(R1, 0, -1)
>>> b.apply_load(R2, 1, -1)
>>> b.apply_load(R3, 4, -1)
>>> b.apply_load(10, 3, -1)
>>> b.bc_slope = [(0, 0)]
>>> b.bc_deflection = [(0, 0), (1, 0), (4, 0)]
>>> b.solve_for_reaction_loads(M1, R1, R2, R3)
```
```
>>> b.slope()
0
>>> b.deflection()
0
```
So a check was included to see if the value of `I` is changing along the length of the beam. If it doesn't, just treat it like a single beam.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
