### PR TITLE
sympy.plot issue with logarithmic axis solved

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1075,12 +1075,8 @@ class MatplotlibBackend(BaseBackend):
         if parent.title:
             self.ax.set_title(parent.title)
         if parent.xlabel:
-            if parent.xscale is 'log':
-                parent.xlabel='log(%s)' % parent.xlabel
             self.ax.set_xlabel(parent.xlabel, position=(1, 0))
         if parent.ylabel:
-            if parent.xscale is 'log':
-                parent.ylabel='f(%s)' % parent.xlabel
             self.ax.set_ylabel(parent.ylabel, position=(0, 1))
 
     def show(self):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -533,7 +533,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
 
             if self.xscale is 'log':
                 self.start=np.log(self.start)
-
+                self.end=np.log(self.end)
 
             f_start = f(self.start)
             f_end = f(self.end)
@@ -544,13 +544,19 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
     def get_points(self):
         np = import_module('numpy')
         if self.only_integers is True:
-            list_x = np.linspace(int(self.start), int(self.end),
+            if self.xscale is 'log':
+                list_x = np.logspace(int(self.start), int(self.end),
+                        num=int(self.end) - int(self.start) + 1)
+            else:
+                list_x = np.linspace(int(self.start), int(self.end),
                     num=int(self.end) - int(self.start) + 1)
         else:
-            list_x = np.linspace(self.start, self.end, num=self.nb_of_points)
+            if self.xscale is 'log':
+                list_x = np.logspace(self.start, self.end, num=self.nb_of_points)
+            else:
+                list_x = np.linspace(self.start, self.end, num=self.nb_of_points)
         f = vectorized_lambdify([self.var], self.expr)
         list_y = f(list_x)
-        print(list_x)
         return (list_x, list_y)
 
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -454,6 +454,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         self.depth = kwargs.get('depth', 12)
         self.line_color = kwargs.get('line_color', None)
         self.xscale=kwargs.get('xscale','linear')
+        self.flag=0
 
 
 
@@ -497,8 +498,13 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 ynew = f(xnew)
                 new_point = np.array([xnew, ynew])
 
+                if self.flag==1:
+                    return
                 #Maximum depth
                 if depth > self.depth:
+                    if p[1] is None or q[1] is None:
+                        self.flag=1
+                        return
                     list_segments.append([p, q])
 
                 #Sample irrespective of whether the line is flat till the
@@ -512,7 +518,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 #sample those points further.
                 elif p[1] is None and q[1] is None:
                     if self.xscale is 'log':
-                        xarray = np.logspace(p[0], q[0], 10)
+                        xarray = np.logspace(p[0],q[0], 10)
                     else:
                         xarray = np.linspace(p[0], q[0], 10)
                     yarray = list(map(f, xarray))
@@ -532,8 +538,8 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                     list_segments.append([p, q])
 
             if self.xscale is 'log':
-                self.start=np.log(self.start)
-                self.end=np.log(self.end)
+                self.start=np.log10(self.start)
+                self.end=np.log10(self.end)
 
             f_start = f(self.start)
             f_end = f(self.end)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
"Fixes #15556 "


#### Brief description of what is fixed or changed
Modified plot.py such that now plot is sampling in a logarithmic space instead of linear space ,if xscale is given to be 'log'

For example:

from sympy import cos, log, plot
from sympy.abc import x
plot(sin(log(x), (x, .001,10), xscale='log'

![sympy_issue](https://user-images.githubusercontent.com/39242494/49691286-e01b7f80-fb64-11e8-90ca-853efe9bbc73.png)


#### Other comments
Now xlabel and ylabel also show with respect to log if xscale='log is to be given
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
       * fixed a issue of logarithmic plot
<!-- END RELEASE NOTES -->
