### PR TITLE
lambdify: Correct the logic of namespace generation in _import

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -16,19 +16,8 @@ from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, string_types, range, builtins, integer_types, PY3)
 from sympy.utilities.decorator import doctest_depends_on
 
-# These are the namespaces the lambda functions will use.
-MATH = {}
-MPMATH = {}
-NUMPY = {}
-SCIPY = {}
-TENSORFLOW = {}
-SYMPY = {}
-NUMEXPR = {}
-
 # Default namespaces, letting us define translations that can't be defined
 # by simple variable maps, like I => 1j
-# These are separate from the names above because the above names are modified
-# throughout this file, whereas these should remain unmodified.
 MATH_DEFAULT = {}
 MPMATH_DEFAULT = {}
 NUMPY_DEFAULT = {"I": 1j}
@@ -36,6 +25,19 @@ SCIPY_DEFAULT = {"I": 1j}
 TENSORFLOW_DEFAULT = {}
 SYMPY_DEFAULT = {}
 NUMEXPR_DEFAULT = {}
+
+# These are the namespaces the lambda functions will use.
+# These are separate from the names above because they are modified
+# throughout this file, whereas the defaults should remain unmodified.
+
+MATH = MATH_DEFAULT.copy()
+MPMATH = MPMATH_DEFAULT.copy()
+NUMPY = NUMPY_DEFAULT.copy()
+SCIPY = SCIPY_DEFAULT.copy()
+TENSORFLOW = TENSORFLOW_DEFAULT.copy()
+SYMPY = SYMPY_DEFAULT.copy()
+NUMEXPR = NUMEXPR_DEFAULT.copy()
+
 
 # Mappings between sympy and other modules function names.
 MATH_TRANSLATIONS = {
@@ -104,7 +106,7 @@ MODULES = {
 }
 
 
-def _import(module, reload="False"):
+def _import(module, reload=False):
     """
     Creates a global translation dictionary for module.
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

In lambdify.py, the signature `_import(module, reload="False")` has a typo: the parameter `reload` is used as a bool and "False" is a truthy string. With this parameter value, `if reload:` executes every time. 

https://github.com/sympy/sympy/blob/15f56f3b0006d2ed2c29bde3c43e91618012c849/sympy/utilities/lambdify.py#L125-L127

Correcting the typo brings up another issue: `namespace != namespace_default` is used above as an indication that "The namespace was already generated". But this isn't so because, for example, the initial values of `NUMPY` and `NUMPY_DEFAULT` are different (contrary to the purpose of having a default namespace).  To avoid such discrepancies, `NUMPY` should be created as a copy of `NUMPY_DEFAULT`, and similarly for other namespaces.
 
#### Other comments

I can't think of tests to add, because the function works already: it just reloads the namespace every time contrary to the intent, and has a confusing default parameter.  

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
