### PR TITLE
Simplified sympy.stats.Probability

### DIFF
--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -50,7 +50,7 @@ class Probability(Expr):
         return probability(arg, condition, evaluate=False)
 
     def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
-        return self.rewrite(Integral)
+        return probability(arg, condition, evaluate=False)
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References
Discussion held [here](https://gitter.im/sympy/sympy) with @Upabjojr. 

#### Brief description of what is fixed or changed
The methods, _eval_rewrite_as_Integral and _eval_rewrite_as_Sum now use the
same return statement, i.e., return probability(arg, condition, evaluate=False).
It can reduce one cycle of calls and decouples the _eval_rewrite_as_Integral
and _eval_rewrite_as_Sum methods.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
  * code of sympy.stats.Probability has been simplified
<!-- END RELEASE NOTES -->
