### PR TITLE
Use SciPy implementation of Bessel functions of real order

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -673,10 +673,10 @@ for k in NumPyPrinter._kc:
 _known_functions_scipy_special = {
     'erf': 'erf',
     'erfc': 'erfc',
-    'besselj': 'jn',
-    'bessely': 'yn',
+    'besselj': 'jv',
+    'bessely': 'yv',
     'besseli': 'iv',
-    'besselk': 'kn',
+    'besselk': 'kv',
     'factorial': 'factorial',
     'gamma': 'gamma',
     'loggamma': 'gammaln',

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -983,24 +983,41 @@ def test_scipy_fns():
         scipy.special.psi]
     numpy.random.seed(0)
     for (sympy_fn, scipy_fn) in zip(single_arg_sympy_fns, single_arg_scipy_fns):
-        test_values = 20 * numpy.random.rand(20)
-        f = lambdify(x, sympy_fn(x), modules = "scipy")
-        assert numpy.all(abs(f(test_values) - scipy_fn(test_values)) < 1e-15)
+        f = lambdify(x, sympy_fn(x), modules="scipy")
+        for i in range(20):
+            tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
+            # SciPy thinks that factorial(z) is 0 when re(z) < 0.
+            # SymPy does not think so.
+            if sympy_fn == factorial and numpy.real(tv) < 0:
+                tv = tv + 2*numpy.abs(numpy.real(tv))
+            # SciPy supports gammaln for real arguments only,
+            # and there is also a branch cut along the negative real axis
+            if sympy_fn == loggamma:
+                tv = numpy.abs(tv)
+            # SymPy's digamma evaluates as polygamma(0, z)
+            # which SciPy supports for real arguments only
+            if sympy_fn == digamma:
+                tv = numpy.real(tv)
+            sympy_result = sympy_fn(tv).evalf()
+            assert abs(f(tv) - sympy_result) < 1e-13*(1 + abs(sympy_result))
+            assert abs(f(tv) - scipy_fn(tv)) < 1e-13*(1 + abs(sympy_result))
 
     double_arg_sympy_fns = [RisingFactorial, besselj, bessely, besseli,
         besselk]
-    double_arg_scipy_fns = [scipy.special.poch, scipy.special.jn,
-        scipy.special.yn, scipy.special.iv, scipy.special.kn]
-
-    #suppress scipy warnings
-    import warnings
-    warnings.filterwarnings('ignore', '.*floating point number truncated*')
-
+    double_arg_scipy_fns = [scipy.special.poch, scipy.special.jv,
+        scipy.special.yv, scipy.special.iv, scipy.special.kv]
     for (sympy_fn, scipy_fn) in zip(double_arg_sympy_fns, double_arg_scipy_fns):
+        f = lambdify((x, y), sympy_fn(x, y), modules="scipy")
         for i in range(20):
-            test_values = 20 * numpy.random.rand(2)
-            f = lambdify((x,y), sympy_fn(x,y), modules = "scipy")
-            assert abs(f(*test_values) - scipy_fn(*test_values)) < 1e-15
+            # SciPy supports only real orders of Bessel functions
+            tv1 = numpy.random.uniform(-10, 10)
+            tv2 = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
+            # SciPy supports poch for real arguments only
+            if sympy_fn == RisingFactorial:
+                tv2 = numpy.real(tv2)
+            sympy_result = sympy_fn(tv1, tv2).evalf()
+            assert abs(f(tv1, tv2) - sympy_result) < 1e-13*(1 + abs(sympy_result))
+            assert abs(f(tv1, tv2) - scipy_fn(tv1, tv2)) < 1e-13*(1 + abs(sympy_result))
 
 
 def test_lambdify_inspect():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15612. Closes #14050  (which was fixed by #14992) by including tests for complex-argument erf. 

#### Brief description of what is fixed or changed

Replaced integer-order Bessel functions like `scipy.special.yn` by real-order versions like `scipy.special.yv`. Corrected the test of SciPy functions in lambdify so that the output of lambdify is tested against SymPy/mpmath evaluation of the same functions. Included tests for complex arguments where supported by SciPy.

#### Other comments

These comments were included in `test_lambdify.py` but may be worth mentioning here as well. 

1. SciPy thinks that factorial(z) is 0 when re(z) < 0. SymPy/mpmath does not think so.
2. SciPy supports gammaln for real arguments only. This function also has a branch cut along the negative real axis, which SciPy and mpmath treat differently. 
3. SymPy's digamma evaluates as `polygamma(0, z)` which SciPy supports for real arguments only. SciPy does support `scipy.special.psi`, i.e., digamma, for complex arguments. But this does not get used since there is no `digamma` class in SymPy.  
4. SciPy does not support complex orders of Bessel functions; mpmath does.
5. SciPy supports RisingFactorial (scipy.special.poch) for real arguments only

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * correctly matches Bessel functions to SciPy analogues in SciPy code printer 
<!-- END RELEASE NOTES -->
