### PR TITLE
Derivative of matrix expression is now implicit

### DIFF
--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -71,10 +71,12 @@ class Inverse(MatPow):
         arg = self.args[0]
         lines = arg._eval_derivative_matrix_lines(x)
         for line in lines:
-            line.first *= -self.T
-            line.second *= self
-            line.first_T *= self
-            line.second_T *= -self.T
+            if line.transposed:
+                line.first *= self
+                line.second *= -self.T
+            else:
+                line.first *= -self.T
+                line.second *= self
         return lines
 
 

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -67,6 +67,16 @@ class Inverse(MatPow):
         else:
             return self.arg.inverse()
 
+    def _eval_derivative_matrix_lines(self, x):
+        arg = self.args[0]
+        lines = arg._eval_derivative_matrix_lines(x)
+        for line in lines:
+            line.first *= -self.T
+            line.second *= self
+            line.first_T *= self
+            line.second_T *= -self.T
+        return lines
+
 
 from sympy.assumptions.ask import ask, Q
 from sympy.assumptions.refine import handlers_dict

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -67,6 +67,10 @@ class MatAdd(MatrixExpr, Add):
             args = self.args
         return canonicalize(MatAdd(*args))
 
+    def _eval_derivative_matrix_lines(self, x):
+        add_lines = [arg._eval_derivative_matrix_lines(x) for arg in self.args]
+        return [j for i in add_lines for j in i]
+
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -901,8 +901,7 @@ def matrix_derivative(expr, x):
 
     shape = first.shape + second.shape
     rank = sum([i != 1 for i in shape])
-    if rank > 2:
-        return Derivative(expr, x)
+    return Derivative(expr, x)
 
 
 from .matmul import MatMul

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -197,20 +197,7 @@ class MatrixExpr(Expr):
         return Adjoint(self)
 
     def _eval_derivative(self, x):
-        from sympy import Derivative
-        lines = self._eval_derivative_matrix_lines(x)
-
-        first = lines[0].first
-        second = lines[0].second
-
-        one_final = (first.shape[1] == 1) and (second.shape[1] == 1)
-
-        if lines[0].trace or one_final:
-            return reduce(lambda x,y: x+y, [lr.first * lr.second.T + lr.first_T * lr.second_T.T for lr in lines])
-
-        shape = first.shape + second.shape
-        rank = sum([i != 1 for i in shape])
-        return Derivative(self, x)
+        return _matrix_derivative(self, x)
 
     def _eval_derivative_n_times(self, x, n):
         return Basic._eval_derivative_n_times(self, x, n)
@@ -557,6 +544,23 @@ class MatrixExpr(Expr):
             return remove_matelement(retexpr, *ind0)
         else:
             return remove_matelement(retexpr, first_index, last_index)
+
+
+def _matrix_derivative(expr, x):
+    from sympy import Derivative
+    lines = expr._eval_derivative_matrix_lines(x)
+
+    first = lines[0].first
+    second = lines[0].second
+
+    one_final = (first.shape[1] == 1) and (second.shape[1] == 1)
+
+    if lines[0].trace or one_final:
+        return reduce(lambda x,y: x+y, [lr.first * lr.second.T + lr.first_T * lr.second_T.T for lr in lines])
+
+    shape = first.shape + second.shape
+    rank = sum([i != 1 for i in shape])
+    return Derivative(expr, x)
 
 
 class MatrixElement(Expr):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -135,6 +135,29 @@ class MatMul(MatrixExpr, Mul):
 
         return coeff_c, coeff_nc + matrices
 
+    def _eval_derivative_matrix_lines(self, x):
+        from .transpose import Transpose
+        with_x_ind = [i for i, arg in enumerate(self.args) if arg.has(x)]
+        lines = []
+        for ind in with_x_ind:
+            left_args = self.args[:ind]
+            right_args = self.args[ind+1:]
+
+            right_mat = MatMul.fromiter(right_args)
+            right_rev = MatMul.fromiter([Transpose(i).doit() for i in reversed(right_args)])
+            left_mat = MatMul.fromiter(left_args)
+            left_rev = MatMul.fromiter([Transpose(i).doit() for i in reversed(left_args)])
+
+            d = self.args[ind]._eval_derivative_matrix_lines(x)
+            for i in d:
+                i.first *= left_rev
+                i.second *= right_mat
+                i.first_T *= right_mat
+                i.second_T *= left_rev
+                lines.append(i)
+
+        return lines
+
 
 def validate(*matrices):
     """ Checks for valid shapes for args of MatMul """

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -150,10 +150,12 @@ class MatMul(MatrixExpr, Mul):
 
             d = self.args[ind]._eval_derivative_matrix_lines(x)
             for i in d:
-                i.first *= left_rev
-                i.second *= right_mat
-                i.first_T *= right_mat
-                i.second_T *= left_rev
+                if i.transposed:
+                    i.first *= right_mat
+                    i.second *= left_rev
+                else:
+                    i.first *= left_rev
+                    i.second *= right_mat
                 lines.append(i)
 
         return lines

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -87,3 +87,18 @@ class MatPow(MatrixExpr):
     def _eval_transpose(self):
         base, exp = self.args
         return MatPow(base.T, exp)
+
+    def _eval_derivative_matrix_lines(self, x):
+        from .matmul import MatMul
+        exp = self.exp
+        if (exp > 0) == True:
+            newexpr = MatMul.fromiter([self.base for i in range(exp)])
+        elif (exp == -1) == True:
+            return Inverse(self.base)._eval_derivative_matrix_lines(x)
+        elif (exp < 0) == True:
+            newexpr = MatMul.fromiter([Inverse(self.base) for i in range(-exp)])
+        elif (exp == 0) == True:
+            return self.doit()._eval_derivative_matrix_lines(x)
+        else:
+            raise NotImplementedError("cannot evaluate %s derived by %s" % (self, x))
+        return newexpr._eval_derivative_matrix_lines(x)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -223,7 +223,7 @@ def test_matrix_derivatives_of_traces():
 
     # Cookbook example 125:
     expr = Trace(Inverse(X.T*C*X)*A)
-    # Warning: result in the cookbook appears to be wrong:
+    # Warning: result in the cookbook is equivalent if B and C are symmetric:
     assert expr.diff(X) == - X.inv().T*A.T*X.inv()*C.inv().T*X.inv().T - X.inv().T*A*X.inv()*C.inv()*X.inv().T
 
     # Cookbook example 126:
@@ -232,7 +232,7 @@ def test_matrix_derivatives_of_traces():
 
     # Cookbook example 127:
     expr = Trace((A + X.T*C*X).inv()*(X.T*B*X))
-    # Warning: result in the cookbook appears to be wrong:
+    # Warning: result in the cookbook is equivalent if B and C are symmetric:
     assert expr.diff(X) == B*X*Inverse(A + X.T*C*X) - C*X*Inverse(A + X.T*C*X)*X.T*B*X*Inverse(A + X.T*C*X) - C.T*X*Inverse(A.T + (C*X).T*X)*X.T*B.T*X*Inverse(A.T + (C*X).T*X) + B.T*X*Inverse(A.T + (C*X).T*X)
 
 

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -36,6 +36,26 @@ def test_matrix_derivative_trivial_cases():
     assert X.diff(A) == 0
 
 
+def test_matrix_derivative_with_inverse():
+
+    # Cookbook example 61:
+    expr = a.T*Inverse(X)*b
+    assert expr.diff(X) == -Inverse(X).T*a*b.T*Inverse(X).T
+
+    # Cookbook example 62:
+    expr = Determinant(Inverse(X))
+    # Not implemented yet:
+    # assert expr.diff(X) == -Determinant(X.inv())*(X.inv()).T
+
+    # Cookbook example 63:
+    expr = Trace(A*Inverse(X)*B)
+    assert expr.diff(X) == -(X**(-1)*B*A*X**(-1)).T
+
+    # Cookbook example 64:
+    expr = Trace(Inverse(X + A))
+    assert expr.diff(X) == -(Inverse(X + A)).T**2
+
+
 def test_matrix_derivative_vectors_and_scalars():
 
     # Cookbook example 69:
@@ -51,6 +71,12 @@ def test_matrix_derivative_vectors_and_scalars():
     # Cookbook example 71:
     expr = a.T*X.T*b
     assert expr.diff(X) == b*a.T
+
+    # Cookbook example 72:
+    expr = a.T*X*a
+    assert expr.diff(X) == a*a.T
+    expr = a.T*X.T*a
+    assert expr.diff(X) == a*a.T
 
     # Cookbook example 77:
     expr = b.T*X.T*X*c
@@ -71,21 +97,6 @@ def test_matrix_derivative_vectors_and_scalars():
     # Cookbook example 83:
     expr = (X*b + c).T*D*(X*b + c)
     assert expr.diff(X) == D*(X*b + c)*b.T + D.T*(X*b + c)*b.T
-
-
-def test_matrix_derivative_with_inverse():
-
-    # Cookbook example 61:
-    expr = a.T*Inverse(X)*b
-    assert expr.diff(X) == -Inverse(X).T*a*b.T*Inverse(X).T
-
-    # Cookbook example 63:
-    expr = Trace(A*Inverse(X)*B)
-    assert expr.diff(X) == -(X**(-1)*B*A*X**(-1)).T
-
-    # Cookbook example 64:
-    expr = Trace(Inverse(X + A))
-    assert expr.diff(X) == -(Inverse(X + A)).T**2
 
 
 def test_matrix_derivatives_of_traces():
@@ -189,3 +200,43 @@ def test_matrix_derivatives_of_traces():
     # expr = Trace(TensorProduct(X, X))
     # expr = Trace(X)*Trace(X)
     # expr.diff(X) == 2*Trace(X)*Identity(k)
+
+    # Higher Order
+
+    # Cookbook example 121:
+    expr = Trace(X**k)
+    #assert expr.diff(X) == k*(X**(k-1)).T
+
+    # Cookbook example 122:
+    expr = Trace(A*X**k)
+    #assert expr.diff(X) == # Needs indices
+
+    # Cookbook example 123:
+    expr = Trace(B.T*X.T*C*X*X.T*C*X*B)
+    assert expr.diff(X) == C*X*X.T*C*X*B*B.T + C.T*X*B*B.T*X.T*C.T*X + C*X*B*B.T*X.T*C*X + C.T*X*X.T*C.T*X*B*B.T
+
+    # Other
+
+    # Cookbook example 124:
+    expr = Trace(A*X**(-1)*B)
+    assert expr.diff(X) == -Inverse(X).T*A.T*B.T*Inverse(X).T
+
+    # Cookbook example 125:
+    expr = Trace(Inverse(X.T*C*X)*A)
+    part1 = -(C*X*(X.T*C*X).inv())
+    part2 = (X.T*C*X).inv()
+    assert expr.diff(X) == part1*A*part2 + part1*A.T*part2
+
+    # Cookbook example 126:
+    expr = Trace((X.T*C*X).inv()*(X.T*B*X))
+    assert expr.diff(X) == -2*C*X*(X.T*C*X).inv()*X.T*B*X*(X.T*C*X).inv() + 2*B*X*(X.T*C*X).inv()
+
+    # Cookbook example 127:
+    expr = Trace((A + X.T*C*X).inv()*(X.T*B*X))
+    #assert expr.diff(X) == -2*C*X*(A + X.T*C*X).inv()*X.T*B*X*(A + X.T*C*X).inv() + 2*B*X*(A + X.T*C*X).inv()
+
+
+def test_derivatives_of_complicated_matrix_expr():
+    expr = a.T*(A*X*(X.T*B + X*A) + B.T*X.T*(a*b.T*(X*D*X.T + X*(X.T*B + A*X)*D*B - X.T*C.T*A)*B + B*(X*D.T + B*A*X*A.T - 3*X*D))*B + 42*X*B*X.T*A.T*(X + X.T))*b
+    result = (B*(B*A*X*A.T - 3*X*D + X*D.T) + a*b.T*(X*(A*X + X.T*B)*D*B + X*D*X.T - X.T*C.T*A)*B)*B*b*a.T*B.T + B**2*b*a.T*B.T*X.T*a*b.T*X*D + 42*A*X*B.T*X.T*a*b.T + B*D*B**3*b*a.T*B.T*X.T*a*b.T*X + B*b*a.T*A*X + 42*a*b.T*(X + X.T)*A*X*B.T + b*a.T*X*B*a*b.T*B.T**2*X*D.T + b*a.T*X*B*a*b.T*B.T**3*D.T*(B.T*X + X.T*A.T) + 42*b*a.T*X*B*X.T*A.T + 42*A.T*(X + X.T)*b*a.T*X*B + A.T*B.T**2*X*B*a*b.T*B.T*A + A.T*a*b.T*(A.T*X.T + B.T*X) + A.T*X.T*b*a.T*X*B*a*b.T*B.T**3*D.T + B.T*X*B*a*b.T*B.T*D - 3*B.T*X*B*a*b.T*B.T*D.T - C.T*A*B**2*b*a.T*B.T*X.T*a*b.T + X.T*A.T*a*b.T*A.T
+    assert expr.diff(X) == result

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -223,9 +223,8 @@ def test_matrix_derivatives_of_traces():
 
     # Cookbook example 125:
     expr = Trace(Inverse(X.T*C*X)*A)
-    part1 = -(C*X*(X.T*C*X).inv())
-    part2 = (X.T*C*X).inv()
-    assert expr.diff(X) == part1*A*part2 + part1*A.T*part2
+    # Warning: result in the cookbook appears to be wrong:
+    assert expr.diff(X) == - X.inv().T*A.T*X.inv()*C.inv().T*X.inv().T - X.inv().T*A*X.inv()*C.inv()*X.inv().T
 
     # Cookbook example 126:
     expr = Trace((X.T*C*X).inv()*(X.T*B*X))
@@ -233,7 +232,8 @@ def test_matrix_derivatives_of_traces():
 
     # Cookbook example 127:
     expr = Trace((A + X.T*C*X).inv()*(X.T*B*X))
-    #assert expr.diff(X) == -2*C*X*(A + X.T*C*X).inv()*X.T*B*X*(A + X.T*C*X).inv() + 2*B*X*(A + X.T*C*X).inv()
+    # Warning: result in the cookbook appears to be wrong:
+    assert expr.diff(X) == B*X*Inverse(A + X.T*C*X) - C*X*Inverse(A + X.T*C*X)*X.T*B*X*Inverse(A + X.T*C*X) - C.T*X*Inverse(A.T + (C*X).T*X)*X.T*B.T*X*Inverse(A.T + (C*X).T*X) + B.T*X*Inverse(A.T + (C*X).T*X)
 
 
 def test_derivatives_of_complicated_matrix_expr():

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -35,8 +35,14 @@ class Trace(Expr):
         return self
 
     def _eval_derivative(self, v):
-        from sympy.matrices.expressions.matexpr import MatrixExpr
-        return MatrixExpr._eval_derivative(self, v)
+        from sympy.matrices.expressions.matexpr import _matrix_derivative
+        return _matrix_derivative(self, v)
+
+    def _eval_derivative_matrix_lines(self, x):
+        r = self.args[0]._eval_derivative_matrix_lines(x)
+        for lr in r:
+            lr.trace = True
+        return r
 
     @property
     def arg(self):
@@ -60,12 +66,6 @@ class Trace(Expr):
         from sympy import Sum, Dummy
         i = Dummy('i')
         return Sum(self.arg[i, i], (i, 0, self.arg.rows-1)).doit()
-
-    def _eval_derivative_matrix_lines(self, x):
-        r = self.args[0]._eval_derivative_matrix_lines(x)
-        for lr in r:
-            lr.trace = True
-        return r
 
 
 def trace(expr):

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -35,19 +35,8 @@ class Trace(Expr):
         return self
 
     def _eval_derivative(self, v):
-        from sympy import Dummy, MatrixExpr, Sum
-        if not isinstance(v, MatrixExpr):
-            return None
-
-        t1 = Dummy("t_1")
-        m = Dummy("m")
-        n = Dummy("n")
-        # TODO: use self.rewrite(Sum) instead:
-        return MatrixExpr.from_index_summation(
-                Sum(self.args[0][t1, t1].diff(v[m, n]), (t1, 0, self.args[0].shape[0]-1)),
-                m,
-                dimensions=(v.args[1:])
-            )
+        from sympy.matrices.expressions.matexpr import matrix_derivative
+        return matrix_derivative(self, v)
 
     @property
     def arg(self):

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -35,8 +35,8 @@ class Trace(Expr):
         return self
 
     def _eval_derivative(self, v):
-        from sympy.matrices.expressions.matexpr import matrix_derivative
-        return matrix_derivative(self, v)
+        from sympy.matrices.expressions.matexpr import MatrixExpr
+        return MatrixExpr._eval_derivative(self, v)
 
     @property
     def arg(self):
@@ -60,6 +60,12 @@ class Trace(Expr):
         from sympy import Sum, Dummy
         i = Dummy('i')
         return Sum(self.arg[i, i], (i, 0, self.arg.rows-1)).doit()
+
+    def _eval_derivative_matrix_lines(self, x):
+        r = self.args[0]._eval_derivative_matrix_lines(x)
+        for lr in r:
+            lr.trace = True
+        return r
 
 
 def trace(expr):

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -70,6 +70,11 @@ class Transpose(MatrixExpr):
         from sympy.matrices.expressions.determinant import det
         return det(self.arg)
 
+    def _eval_derivative_matrix_lines(self, x):
+        lines = self.args[0]._eval_derivative_matrix_lines(x)
+        return [i.transpose() for i in lines]
+
+
 def transpose(expr):
     """Matrix transpose"""
     return Transpose(expr).doit(deep=False)


### PR DESCRIPTION
Got rid of all parsers of indexed expressions for the calculation of the matrix derivative.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Derivatives of matrix expressions do not rely on indexed expressions anymore. The algorithm now calculates the result implicitly.
<!-- END RELEASE NOTES -->
