### PR TITLE
printing: Attempt at speeding up ccode(Min(*long_list))

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -696,7 +696,18 @@ class C99CodePrinter(_C9XCodePrinter, C89CodePrinter):
         if nest:
             args = self._print(expr.args[0])
             if len(expr.args) > 1:
-                args += ', %s' % self._print(expr.func(*expr.args[1:]))
+                parenPile = ''
+                for currArg in expr.args[1:-1]:
+                    parenPile += ')'
+                    args += ', {ns}{name}{suffix}({next}'.format(
+                        ns=self._ns,
+                        name=known,
+                        suffix=suffix,
+                        next = self._print(currArg)
+                    )
+                args += ', %s%s' % (
+                    self._print(expr.func(*expr.args[-1:])),
+                    parenPile)
         else:
             args = ', '.join(map(lambda arg: self._print(arg), expr.args))
         return '{ns}{name}{suffix}({args})'.format(

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -417,20 +417,28 @@ class C89CodePrinter(CodePrinter):
     def _print_Max(self, expr):
         if "Max" in self.known_functions:
             return self._print_Function(expr)
-        from sympy import Max
-        if len(expr.args) == 1:
-            return self._print(expr.args[0])
-        return "((%(a)s > %(b)s) ? %(a)s : %(b)s)" % {
-            'a': expr.args[0], 'b': self._print(Max(*expr.args[1:]))}
+        def inner_print_max(args): # The more natural abstraction of creating
+            if len(args) == 1:     # and printing smaller Max objects is slow
+                return self._print(args[0]) # when there are many arguments.
+            half = len(args) // 2
+            return "((%(a)s > %(b)s) ? %(a)s : %(b)s)" % {
+                'a': inner_print_max(args[:half]),
+                'b': inner_print_max(args[half:])
+            }
+        return inner_print_max(expr.args)
 
     def _print_Min(self, expr):
         if "Min" in self.known_functions:
             return self._print_Function(expr)
-        from sympy import Min
-        if len(expr.args) == 1:
-            return self._print(expr.args[0])
-        return "((%(a)s < %(b)s) ? %(a)s : %(b)s)" % {
-            'a': expr.args[0], 'b': self._print(Min(*expr.args[1:]))}
+        def inner_print_min(args): # The more natural abstraction of creating
+            if len(args) == 1:     # and printing smaller Min objects is slow
+                return self._print(args[0]) # when there are many arguments.
+            half = len(args) // 2
+            return "((%(a)s < %(b)s) ? %(a)s : %(b)s)" % {
+                'a': inner_print_min(args[:half]),
+                'b': inner_print_min(args[half:])
+            }
+        return inner_print_min(expr.args)
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
@@ -696,18 +704,19 @@ class C99CodePrinter(_C9XCodePrinter, C89CodePrinter):
         if nest:
             args = self._print(expr.args[0])
             if len(expr.args) > 1:
-                parenPile = ''
-                for currArg in expr.args[1:-1]:
-                    parenPile += ')'
+                paren_pile = ''
+                for curr_arg in expr.args[1:-1]:
+                    paren_pile += ')'
                     args += ', {ns}{name}{suffix}({next}'.format(
                         ns=self._ns,
                         name=known,
                         suffix=suffix,
-                        next = self._print(currArg)
+                        next = self._print(curr_arg)
                     )
                 args += ', %s%s' % (
-                    self._print(expr.func(*expr.args[-1:])),
-                    parenPile)
+                    self._print(expr.func(expr.args[-1])),
+                    paren_pile
+                )
         else:
             args = ', '.join(map(lambda arg: self._print(arg), expr.args))
         return '{ns}{name}{suffix}({args})'.format(

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -72,6 +72,14 @@ def test_ccode_Max():
     assert ccode(Max(x,x*x),user_functions={"Max":"my_max", "Pow":"my_pow"}) == 'my_max(x, my_pow(x, 2))'
 
 
+def test_ccode_Min_performance():
+    #Shouldn't take more than a few seconds
+    big_min = Min(*symbols('a[0:50]'))
+    for curr_standard in ('c89', 'c99', 'c11'):
+        output = ccode(big_min, standard=curr_standard)
+        assert output.count('(') == output.count(')')
+
+
 def test_ccode_constants_mathh():
     assert ccode(exp(1)) == "M_E"
     assert ccode(pi) == "M_PI"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15424.


#### Brief description of what is fixed or changed
_print_math_func in sympy.printing.ccode.C99CodePrinter no longer recursively prints sub-objects when run with `nest=True`, making the printing of Min objects with many arguments much faster.

#### Other comments
Only the printing of the Min objects is made faster: Constructing a Min object from a long argument list remains slow.

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * printing C code for Min and Max objects with many arguments is much faster
<!-- END RELEASE NOTES -->
