### PR TITLE
Implement manual integration with special functions

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -352,34 +352,35 @@ def special_function_rule(integral):
     e = sympy.Wild('e', exclude=[symbol], properties=[
         lambda x: not (x.is_nonnegative and x.is_integer)])
     wilds = (a, b, c, d, e)
-    # patterns consist of a SymPy class, wildcard match, and an optional
-    # condition coded as a lambda (when Wild properties are not enough)
-    patterns = {
-        (sympy.Mul, sympy.exp(a*symbol + b)/symbol): EiRule,
-        (sympy.Mul, sympy.cos(a*symbol + b)/symbol): CiRule,
-        (sympy.Mul, sympy.cosh(a*symbol + b)/symbol): ChiRule,
-        (sympy.Mul, sympy.sin(a*symbol + b)/symbol): SiRule,
-        (sympy.Mul, sympy.sinh(a*symbol + b)/symbol): ShiRule,
-        (sympy.Pow, 1/sympy.log(a*symbol + b)): LiRule,
-        (sympy.exp, sympy.exp(a*symbol**2 + b*symbol + c)): ErfRule,
-        (sympy.sin, sympy.sin(a*symbol**2 + b*symbol + c)): FresnelSRule,
-        (sympy.cos, sympy.cos(a*symbol**2 + b*symbol + c)): FresnelCRule,
-        (sympy.Mul, symbol**e*sympy.exp(a*symbol)): UpperGammaRule,
-        (sympy.Mul, sympy.polylog(b, a*symbol)/symbol): PolylogRule,
+    # patterns consist of a SymPy class, a wildcard expr, an optional
+    # condition coded as a lambda (when Wild properties are not enough),
+    # followed by an applicable rule
+    patterns = (
+        (sympy.Mul, sympy.exp(a*symbol + b)/symbol, None, EiRule),
+        (sympy.Mul, sympy.cos(a*symbol + b)/symbol, None, CiRule),
+        (sympy.Mul, sympy.cosh(a*symbol + b)/symbol, None, ChiRule),
+        (sympy.Mul, sympy.sin(a*symbol + b)/symbol, None, SiRule),
+        (sympy.Mul, sympy.sinh(a*symbol + b)/symbol, None, ShiRule),
+        (sympy.Pow, 1/sympy.log(a*symbol + b), None, LiRule),
+        (sympy.exp, sympy.exp(a*symbol**2 + b*symbol + c), None, ErfRule),
+        (sympy.sin, sympy.sin(a*symbol**2 + b*symbol + c), None, FresnelSRule),
+        (sympy.cos, sympy.cos(a*symbol**2 + b*symbol + c), None, FresnelCRule),
+        (sympy.Mul, symbol**e*sympy.exp(a*symbol), None, UpperGammaRule),
+        (sympy.Mul, sympy.polylog(b, a*symbol)/symbol, None, PolylogRule),
         (sympy.Pow, 1/sympy.sqrt(a - d*sympy.sin(symbol)**2),
-            lambda a, d: a != d): EllipticFRule,
+            lambda a, d: a != d, EllipticFRule),
         (sympy.Pow, sympy.sqrt(a - d*sympy.sin(symbol)**2),
-            lambda a, d: a != d): EllipticERule,
-    }
+            lambda a, d: a != d, EllipticERule),
+    )
     for p in patterns:
         if isinstance(integrand, p[0]):
             match = integrand.match(p[1])
             if match:
                 wild_vals = tuple(match.get(w) for w in wilds
                                   if match.get(w) is not None)
-                if len(p) < 3 or p[2](*wild_vals):
+                if p[2] is None or p[2](*wild_vals):
                     args = wild_vals + (integrand, symbol)
-                    return patterns[p](*args)
+                    return p[3](*args)
 
 
 def inverse_trig_rule(integral):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -75,6 +75,19 @@ LegendreRule = Rule("LegendreRule", "n")
 HermiteRule = Rule("HermiteRule", "n")
 LaguerreRule = Rule("LaguerreRule", "n")
 AssocLaguerreRule = Rule("AssocLaguerreRule", "n a")
+CiRule = Rule("CiRule", "a b")
+ChiRule = Rule("ChiRule", "a b")
+EiRule = Rule("EiRule", "a b")
+SiRule = Rule("SiRule", "a b")
+ShiRule = Rule("ShiRule", "a b")
+ErfRule = Rule("ErfRule", "a b c")
+FresnelCRule = Rule("FresnelCRule", "a b c")
+FresnelSRule = Rule("FresnelSRule", "a b c")
+LiRule = Rule("LiRule", "a b")
+PolylogRule = Rule("PolylogRule", "a b")
+UpperGammaRule = Rule("UpperGammaRule", "a e")
+EllipticFRule = Rule("EllipticFRule", "a d")
+EllipticERule = Rule("EllipticERule", "a d")
 
 IntegralInfo = namedtuple('IntegralInfo', 'integrand symbol')
 
@@ -330,6 +343,45 @@ def orthogonal_poly_rule(integral):
                     return orthogonal_poly_classes[klass](*args)
 
 
+def special_function_rule(integral):
+    integrand, symbol = integral
+    a = sympy.Wild('a', exclude=[symbol], properties=[lambda x: not x.is_zero])
+    b = sympy.Wild('b', exclude=[symbol])
+    c = sympy.Wild('c', exclude=[symbol])
+    d = sympy.Wild('d', exclude=[symbol], properties=[lambda x: not x.is_zero])
+    e = sympy.Wild('e', exclude=[symbol], properties=[
+        lambda x: not (x.is_nonnegative and x.is_integer)])
+    wilds = (a, b, c, d, e)
+    # patterns consist of a SymPy class, wildcard match, and an optional
+    # condition coded as a lambda (when Wild properties are not enough)
+    patterns = {
+        (sympy.Mul, sympy.exp(a*symbol + b)/symbol): EiRule,
+        (sympy.Mul, sympy.cos(a*symbol + b)/symbol): CiRule,
+        (sympy.Mul, sympy.cosh(a*symbol + b)/symbol): ChiRule,
+        (sympy.Mul, sympy.sin(a*symbol + b)/symbol): SiRule,
+        (sympy.Mul, sympy.sinh(a*symbol + b)/symbol): ShiRule,
+        (sympy.Pow, 1/sympy.log(a*symbol + b)): LiRule,
+        (sympy.exp, sympy.exp(a*symbol**2 + b*symbol + c)): ErfRule,
+        (sympy.sin, sympy.sin(a*symbol**2 + b*symbol + c)): FresnelSRule,
+        (sympy.cos, sympy.cos(a*symbol**2 + b*symbol + c)): FresnelCRule,
+        (sympy.Mul, symbol**e*sympy.exp(a*symbol)): UpperGammaRule,
+        (sympy.Mul, sympy.polylog(b, a*symbol)/symbol): PolylogRule,
+        (sympy.Pow, 1/sympy.sqrt(a - d*sympy.sin(symbol)**2),
+            lambda a, d: a != d): EllipticFRule,
+        (sympy.Pow, sympy.sqrt(a - d*sympy.sin(symbol)**2),
+            lambda a, d: a != d): EllipticERule,
+    }
+    for p in patterns:
+        if isinstance(integrand, p[0]):
+            match = integrand.match(p[1])
+            if match:
+                wild_vals = tuple(match.get(w) for w in wilds
+                                  if match.get(w) is not None)
+                if len(p) < 3 or p[2](*wild_vals):
+                    args = wild_vals + (integrand, symbol)
+                    return patterns[p](*args)
+
+
 def inverse_trig_rule(integral):
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
@@ -420,7 +472,9 @@ def _parts_rule(integrand, symbol):
     # log, inverse trig, algebraic, trigonometric, exponential
     def pull_out_algebraic(integrand):
         integrand = integrand.cancel().together()
-        algebraic = [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)]
+        # iterating over Piecewise args would not work here
+        algebraic = ([] if isinstance(integrand, sympy.Piecewise)
+            else [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)])
         if algebraic:
             u = sympy.Mul(*algebraic)
             dv = (integrand / u).cancel()
@@ -474,19 +528,32 @@ def _parts_rule(integrand, symbol):
             # Can integrate a polynomial times OrthogonalPolynomial
             if rule == pull_out_algebraic and isinstance(dv, OrthogonalPolynomial):
                     v_step = integral_steps(dv, symbol)
-                    if isinstance(v_step, DontKnowRule):
+                    if contains_dont_know(v_step):
                         return
                     else:
                         du = u.diff(symbol)
                         v = _manualintegrate(v_step)
                         return u, dv, v, du, v_step
 
-            for rule in liate_rules[index + 1:]:
-                r = rule(integrand)
-                # make sure dv is amenable to integration
-                if r and r[0].subs(dummy, 1).equals(dv):
-                    du = u.diff(symbol)
-                    v_step = integral_steps(sympy.simplify(dv), symbol)
+            # make sure dv is amenable to integration
+            accept = False
+            if index < 2:  # log and inverse trig are usually worth trying
+                accept = True
+            elif (rule == pull_out_algebraic and dv.args and
+                all(isinstance(a, (sympy.sin, sympy.cos, sympy.exp))
+                for a in dv.args)):
+                    accept = True
+            else:
+                for rule in liate_rules[index + 1:]:
+                    r = rule(integrand)
+                    if r and r[0].subs(dummy, 1).equals(dv):
+                        accept = True
+                        break
+
+            if accept:
+                du = u.diff(symbol)
+                v_step = integral_steps(sympy.simplify(dv), symbol)
+                if not contains_dont_know(v_step):
                     v = _manualintegrate(v_step)
                     return u, dv, v, du, v_step
 
@@ -512,11 +579,12 @@ def parts_rule(integral):
                 return
             _parts_u_cache[cachekey] += 1
 
-        while True:
-            if (integrand / (v * du)).cancel() == 1:
+        # Try cyclic integration by parts a few times
+        for _ in range(4):
+            coefficient = ((v * du) / integrand).cancel()
+            if coefficient == 1:
                 break
-            if symbol not in (integrand / (v * du)).cancel().free_symbols:
-                coefficient = ((v * du) / integrand).cancel()
+            if symbol not in coefficient.free_symbols:
                 rule = CyclicPartsRule(
                     [PartsRule(u, dv, v_step, None, None, None)
                      for (u, dv, v, du, v_step) in steps],
@@ -528,11 +596,15 @@ def parts_rule(integral):
                                              constant * integrand, symbol)
                 return rule
 
-            result = _parts_rule(v * du, symbol)
+            # _parts_rule is sensitive to constants, factor it out
+            next_constant, next_integrand = (v * du).as_coeff_Mul()
+            result = _parts_rule(next_integrand, symbol)
 
             if result:
                 u, dv, v, du, v_step = result
-                steps.append(result)
+                u *= next_constant
+                du *= next_constant
+                steps.append((u, dv, v, du, v_step))
             else:
                 break
 
@@ -1114,6 +1186,7 @@ def integral_steps(integrand, symbol, **options):
         return _integral_is_subclass
 
     result = do_one(
+        null_safe(special_function_rule),
         null_safe(switch(key, {
             sympy.Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule), \
                               null_safe(quadratic_denom_rule)),
@@ -1181,6 +1254,9 @@ def eval_add(substeps, integrand, symbol):
 @evaluates(URule)
 def eval_u(u_var, u_func, constant, substep, integrand, symbol):
     result = _manualintegrate(substep)
+    if u_func.is_Pow and u_func.exp == -1:
+        # avoid needless -log(1/x) from substitution
+        result = result.subs(sympy.log(u_var), -sympy.log(u_func.base))
     return result.subs(u_var, u_func)
 
 @evaluates(PartsRule)
@@ -1349,6 +1425,66 @@ def eval_laguerre(n, integrand, symbol):
 @evaluates(AssocLaguerreRule)
 def eval_assoclaguerre(n, a, integrand, symbol):
     return -sympy.assoc_laguerre(n + 1, a - 1, symbol)
+
+@evaluates(CiRule)
+def eval_ci(a, b, integrand, symbol):
+    return sympy.cos(b)*sympy.Ci(a*symbol) - sympy.sin(b)*sympy.Si(a*symbol)
+
+@evaluates(ChiRule)
+def eval_chi(a, b, integrand, symbol):
+    return sympy.cosh(b)*sympy.Chi(a*symbol) + sympy.sinh(b)*sympy.Shi(a*symbol)
+
+@evaluates(EiRule)
+def eval_ei(a, b, integrand, symbol):
+    return sympy.exp(b)*sympy.Ei(a*symbol)
+
+@evaluates(SiRule)
+def eval_si(a, b, integrand, symbol):
+    return sympy.sin(b)*sympy.Ci(a*symbol) + sympy.cos(b)*sympy.Si(a*symbol)
+
+@evaluates(ShiRule)
+def eval_shi(a, b, integrand, symbol):
+    return sympy.sinh(b)*sympy.Chi(a*symbol) + sympy.cosh(b)*sympy.Shi(a*symbol)
+
+@evaluates(ErfRule)
+def eval_erf(a, b, c, integrand, symbol):
+    return Piecewise(
+        (sympy.sqrt(sympy.pi/(-a))/2 * sympy.exp(c - b**2/(4*a)) *
+            sympy.erf((-2*a*symbol - b)/(2*sympy.sqrt(-a))), a < 0),
+        (sympy.sqrt(sympy.pi/a)/2 * sympy.exp(c - b**2/(4*a)) *
+            sympy.erfi((2*a*symbol + b)/(2*sympy.sqrt(a))), True))
+
+@evaluates(FresnelCRule)
+def eval_fresnelc(a, b, c, integrand, symbol):
+    return sympy.sqrt(sympy.pi/(2*a)) * (
+        sympy.cos(b**2/(4*a) - c)*sympy.fresnelc((2*a*symbol + b)/sympy.sqrt(2*a*sympy.pi)) +
+        sympy.sin(b**2/(4*a) - c)*sympy.fresnels((2*a*symbol + b)/sympy.sqrt(2*a*sympy.pi)))
+
+@evaluates(FresnelSRule)
+def eval_fresnels(a, b, c, integrand, symbol):
+    return sympy.sqrt(sympy.pi/(2*a)) * (
+        sympy.cos(b**2/(4*a) - c)*sympy.fresnels((2*a*symbol + b)/sympy.sqrt(2*a*sympy.pi)) -
+        sympy.sin(b**2/(4*a) - c)*sympy.fresnelc((2*a*symbol + b)/sympy.sqrt(2*a*sympy.pi)))
+
+@evaluates(LiRule)
+def eval_li(a, b, integrand, symbol):
+    return sympy.li(a*symbol + b)/a
+
+@evaluates(PolylogRule)
+def eval_polylog(a, b, integrand, symbol):
+    return sympy.polylog(b + 1, a*symbol)
+
+@evaluates(UpperGammaRule)
+def eval_uppergamma(a, e, integrand, symbol):
+    return symbol**e * (-a*symbol)**(-e) * sympy.uppergamma(e + 1, -a*symbol)/a
+
+@evaluates(EllipticFRule)
+def eval_elliptic_f(a, d, integrand, symbol):
+    return sympy.elliptic_f(symbol, d/a)/sympy.sqrt(a)
+
+@evaluates(EllipticERule)
+def eval_elliptic_e(a, d, integrand, symbol):
+    return sympy.elliptic_e(symbol, d/a)*sympy.sqrt(a)
 
 @evaluates(DontKnowRule)
 def eval_dontknowrule(integrand, symbol):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1188,7 +1188,7 @@ def test_powers():
 def test_manual_option():
     raises(ValueError, lambda: integrate(1/x, x, manual=True, meijerg=True))
     # an example of a function that manual integration cannot handle
-    assert integrate(exp(x**2), x, manual=True) == Integral(exp(x**2), x)
+    assert integrate(log(1+x)/x, (x, 0, 1), manual=True).has(Integral)
 
 
 def test_meijerg_option():
@@ -1329,10 +1329,10 @@ def test_singularities():
 
 def test_issue_12645():
     x, y = symbols('x y', real=True)
-    assert (integrate(sin(x*x + y*y),
+    assert (integrate(sin(x*x*x + y*y),
                       (x, -sqrt(pi - y*y), sqrt(pi - y*y)),
                       (y, -sqrt(pi), sqrt(pi)))
-                == Integral(sin(x**2 + y**2),
+                == Integral(sin(x**3 + y**2),
                             (x, -sqrt(-y**2 + pi), sqrt(-y**2 + pi)),
                             (y, -sqrt(pi), sqrt(pi))))
 
@@ -1435,3 +1435,8 @@ def test_issue_15457():
     assert indefinite.subs(x, 3) - indefinite.subs(x, 1) == -2 + 2*E
     assert definite.subs({a: -3, b: -1}) == -exp(3) + exp(5)
     assert indefinite.subs(x, -1) - indefinite.subs(x, -3) == -exp(3) + exp(5)
+
+
+def test_issue_15431():
+    assert integrate(x*exp(x)*log(x), x) == \
+        (x*exp(x) - exp(x))*log(x) - exp(x) + Ei(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -364,8 +364,7 @@ def test_issue_2850():
 
 def test_issue_9462():
     assert manualintegrate(sin(2*x)*exp(x), x) == exp(x)*sin(2*x)/5 - 2*exp(x)*cos(2*x)/5
-    assert not contains_dont_know(integral_steps(sin(2*x)*exp(x), x)
-)
+    assert not contains_dont_know(integral_steps(sin(2*x)*exp(x), x))
     assert manualintegrate((x - 3) / (x**2 - 2*x + 2)**2, x) == \
                            Integral(x/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x) \
                            - 3*Integral(1/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2486,8 +2486,7 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_variation_of_parameters():
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
-    from sympy.integrals.risch import NonElementaryIntegral
-    sol = Eq(f(x), C1 + C2*log(x) + (x - 1)*exp(x)*log(x) - NonElementaryIntegral(x*exp(x)*log(x), x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint) == sol
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #9462. Fixes #15431. Fixes #15451

#### Brief description of what is fixed or changed

Several non-elementary antiderivatives are now recognized by `manualintegrate`. Additionally, cyclic integration by parts is corrected: previously it could integrate `exp(x)*sin(x)` but not `exp(x)*sin(2*x)` because additional constant factors were not handled.
The heuristics for integration by parts are slightly expanded in terms of the choices of `dv` term, now that more kinds of `dv` can be handled. For example, `x*exp(x)*sin(2*x)` uses `dv = exp(x)*sin(2*x)` which was previously not allowed.

These changes also expand the capability of `integrate`, which was previously unable to integrate, for example, `sin(x**2 + 1)` or `sqrt(4 - sin(x)**2)`

### Other comments

The rule `special_function_rule` is added first to the list in `integral_steps` because it is a quick exit, and because applying elementary calculus rules to such integrals is veritable waste of time.

This PR implements "easy parts" of https://github.com/sympy/sympy/issues/15429#issuecomment-433559265 and of https://github.com/sympy/sympy/issues/15471#issuecomment-438860606
Completely fixing #15471 will also require a change of `.subs(log(x), u)` logic, so that it transforms `log(x)*cos(log(x))/x**(S(3)/4)` into `u*cos(u)*exp(3*u/4)`. This is left for future work.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added standard non-elementary antiderivatives to manualintegrate.
<!-- END RELEASE NOTES -->
