### PR TITLE
LaTeX printing: Re-establish 'plain' as default ...

### DIFF
--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -176,7 +176,7 @@ spherical Bessel function `j_\nu(z)`.
 Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\LaTeX`.
 
   >>> latex(Integral(cos(x)**2, (x, 0, pi)))
-  \int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx
+  \int\limits_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx
 
 Why SymPy?
 ==========

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -424,9 +424,8 @@ class Basic(with_metaclass(ManagedProperties)):
         SymPy objects, like lists and dictionaries of expressions.
         """
         from sympy.printing.latex import latex
-        s = latex(self, mode='equation*')
-        s = s.strip('$')
-        return "$$%s$$" % s
+        s = latex(self, mode='plain')
+        return "$\\displaystyle %s$" % s
 
     _repr_latex_orig = _repr_latex_
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -148,6 +148,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         """
         if _can_print_latex(o):
             s = latex(o, mode=latex_mode, **settings)
+            if latex_mode == 'plain':
+                s = '$\\displaystyle %s$' % s
             try:
                 return _preview_wrapper(s)
             except RuntimeError as e:
@@ -171,8 +173,9 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         """
         if _can_print_latex(o):
             s = latex(o, mode=latex_mode, **settings)
-            s = s.strip('$')
-            return '$$%s$$' % s
+            if latex_mode == 'plain':
+                return '$\\displaystyle %s$' % s
+            return s
 
     def _result_display(self, arg):
         """IPython's pretty-printer display hook, for use in IPython 0.10
@@ -269,7 +272,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
                   no_global=False, ip=None, euler=False, forecolor='Black',
                   backcolor='Transparent', fontsize='10pt',
-                  latex_mode='equation*', print_builtin=True,
+                  latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
                   latex_printer=None, **settings):
     r"""
@@ -325,7 +328,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     fontsize: string, optional, default='10pt'
         A font size to pass to the LaTeX documentclass function in the
         preamble.
-    latex_mode: string, optional, default='equation*'
+    latex_mode: string, optional, default='plain'
         The mode used in the LaTeX printer. Can be one of:
         {'inline'|'plain'|'equation'|'equation*'}.
     print_builtin: boolean, optional, default=True

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -88,7 +88,7 @@ def test_print_builtin_option():
                     u'{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}',
                     "{n_i: 3, pi: 3.14}",
                     u'{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}')
-    assert latex == r'$$\begin{equation*}\left \{ n_{i} : 3, \quad \pi : 3.14\right \}\end{equation*}$$'
+    assert latex == r'$\displaystyle \left \{ n_{i} : 3, \quad \pi : 3.14\right \}$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("init_printing(use_latex=True, print_builtin=False)")
@@ -135,7 +135,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c']['text/latex'] == '$$\\begin{equation*}\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )\\end{equation*}$$'
+        assert app.user_ns['c']['text/latex'] == '$\\displaystyle \\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$'
     else:
         assert app.user_ns['a'][0]['text/plain'] ==  '(True, False)'
         assert 'text/latex' not in app.user_ns['a'][0]
@@ -147,7 +147,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c'][0]['text/latex'] == '$$\\begin{equation*}\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )\\end{equation*}$$'
+        assert app.user_ns['c'][0]['text/latex'] == '$\\displaystyle \\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$'
 
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2052,9 +2052,8 @@ class MatrixBase(MatrixDeprecated,
         SymPy objects, like lists and dictionaries of expressions.
         """
         from sympy.printing.latex import latex
-        s = latex(self, mode='equation*')
-        s = s.strip('$')
-        return "$$%s$$" % s
+        s = latex(self, mode='plain')
+        return "$\\displaystyle %s$" % s
 
     _repr_latex_orig = _repr_latex_
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -387,9 +387,8 @@ class Dyadic(object):
         SymPy objects, like lists and dictionaries of expressions.
         """
         from sympy.printing.latex import latex
-        s = latex(self, mode='equation*')
-        s = s.strip('$')
-        return "$$%s$$" % s
+        s = latex(self, mode='plain')
+        return "$\\displaystyle %s$" % s
 
     _repr_latex_orig = _repr_latex_
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -463,9 +463,8 @@ class Vector(object):
         SymPy objects, like lists and dictionaries of expressions.
         """
         from sympy.printing.latex import latex
-        s = latex(self, mode='equation*')
-        s = s.strip('$')
-        return "$$%s$$" % s
+        s = latex(self, mode='plain')
+        return "$\\displaystyle %s$" % s
 
     _repr_latex_orig = _repr_latex_
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -669,7 +669,7 @@ class LatexPrinter(Printer):
                 tex += r"\int"
 
                 if len(lim) > 1:
-                    if self._settings['mode'] in ['equation', 'equation*'] \
+                    if self._settings['mode'] != 'inline' \
                             and not self._settings['itex']:
                         tex += r"\limits"
 

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -180,7 +180,9 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     if isinstance(expr, str):
         latex_string = expr
     else:
-        latex_string = latex(expr, mode='inline', **latex_settings)
+        latex_string = ('$\\displaystyle ' +
+                        latex(expr, mode='plain', **latex_settings) +
+                        '$')
 
     try:
         workdir = tempfile.mkdtemp()

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -564,7 +564,7 @@ def test_latex_derivatives():
 
     # use ordinary d when one of the variables has been integrated out
     assert latex(diff(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == \
-        r"\frac{d}{d y} \int_{0}^{\infty} e^{- x y}\, dx"
+        r"\frac{d}{d y} \int\limits_{0}^{\infty} e^{- x y}\, dx"
 
     # Derivative wrapped in power:
     assert latex(diff(x, x, evaluate=False)**2) == \
@@ -584,15 +584,15 @@ def test_latex_subs():
 
 def test_latex_integrals():
     assert latex(Integral(log(x), x)) == r"\int \log{\left (x \right )}\, dx"
-    assert latex(Integral(x**2, (x, 0, 1))) == r"\int_{0}^{1} x^{2}\, dx"
-    assert latex(Integral(x**2, (x, 10, 20))) == r"\int_{10}^{20} x^{2}\, dx"
+    assert latex(Integral(x**2, (x, 0, 1))) == r"\int\limits_{0}^{1} x^{2}\, dx"
+    assert latex(Integral(x**2, (x, 10, 20))) == r"\int\limits_{10}^{20} x^{2}\, dx"
     assert latex(Integral(
-        y*x**2, (x, 0, 1), y)) == r"\int\int_{0}^{1} x^{2} y\, dx\, dy"
+        y*x**2, (x, 0, 1), y)) == r"\int\int\limits_{0}^{1} x^{2} y\, dx\, dy"
     assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*') \
         == r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
     assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*', itex=True) \
         == r"$$\int\int_{0}^{1} x^{2} y\, dx\, dy$$"
-    assert latex(Integral(x, (x, 0))) == r"\int^{0} x\, dx"
+    assert latex(Integral(x, (x, 0))) == r"\int\limits^{0} x\, dx"
     assert latex(Integral(x*y, x, y)) == r"\iint x y\, dx\, dy"
     assert latex(Integral(x*y*z, x, y, z)) == r"\iiint x y z\, dx\, dy\, dz"
     assert latex(Integral(x*y*z*t, x, y, z, t)) == \
@@ -600,7 +600,7 @@ def test_latex_integrals():
     assert latex(Integral(x, x, x, x, x, x, x)) == \
         r"\int\int\int\int\int\int x\, dx\, dx\, dx\, dx\, dx\, dx"
     assert latex(Integral(x, x, y, (z, 0, 1))) == \
-        r"\int_{0}^{1}\int\int x\, dx\, dy\, dz"
+        r"\int\limits_{0}^{1}\int\int x\, dx\, dy\, dz"
 
     # fix issue #10806
     assert latex(Integral(z, z)**2) == r"\left(\int z\, dz\right)^{2}"

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -307,9 +307,8 @@ class NDimArray(object):
         SymPy objects, like lists and dictionaries of expressions.
         """
         from sympy.printing.latex import latex
-        s = latex(self, mode='equation*')
-        s = s.strip('$')
-        return "$$%s$$" % s
+        s = latex(self, mode='plain')
+        return "$\\displaystyle %s$" % s
 
     _repr_latex_orig = _repr_latex_
 


### PR DESCRIPTION
... but make a few sneaky changes to make it still work.

#### References to other Issues or PRs

Unlike before, this also works when processed by LaTeX, and therefore fixes #15623.

It also closes #15329 because those changes are included.

#### Brief description of what is fixed or changed

The default `latex_mode` is now once again `'plain'`, as it was before  #15367.

For a short time the default was `'equation*'`, which isn't even plain LaTeX (it requires the `amsmath` package).
Also, `equation*` (and `equation` as well as several other environments) are typeset in the center of the page by LaTeX, which doesn't make too much sense in a REPL-like context.

To make `'plain'` great again, I changed two little things:

* The integral gets its limits below and above, with `\limits`, for all modes except `'inline'`
* When `'plain'` stuff is actually printed, it gets embedded in `$\displaystyle ...$`, which makes it left-aligned and not squished into a shallow line, see #15329, which this PR supersedes.

#### Work in Progress

I haven't changed the tests yet, I wanted to wait for some general feedback first.

I'm not sure if `use_latex='matplotlib'` works correctly. When I tried it, the result looked quite ugly, but it somehow resembled the right result. Is it supposed to look ugly?

#### Other comments

![image](https://user-images.githubusercontent.com/705404/49960358-40694300-ff10-11e8-973e-90305bd8e0bd.png)

The default should look like before, but the underlying LaTeX code is framed quite differently.

The `'equation*'` variant looks the same, but that's just because the Jupyter notebook forces it to the left. Without that, it would be center-aligned (but that's a different discussion for a later time).

The `'inline'` variant now looks actually like an inline equation (unlike before). This is of course ugly and I guess nobody ever wants to use it. But it works anyway.

It also works with `use_latex='png'`:

![image](https://user-images.githubusercontent.com/705404/49961301-a8b92400-ff12-11e8-87b7-2a3bd7d80c2f.png)

And, which is the reason I'm doing all this, it also works in `nbsphinx` using LaTeX/PDF output  (the screenshot is from the upcoming release, current `master` branch):

![image](https://user-images.githubusercontent.com/705404/49961792-ccc93500-ff13-11e8-9d12-2f12bc789bb6.png)

Note that here the `'equation*'` variant is centered, because it is actually processed by LaTeX.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* interactive
  * By default, LaTeX output in the Jupyter notebook is framed with `$\displaystyle ...$`. This prevents it from being centered in PDF output from nbconvert (see https://github.com/jupyter/notebook/issues/4060). 
<!-- END RELEASE NOTES -->
