### PR TITLE
Added reference to missing packages in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ You can generate everything at the above site in your local copy of SymPy by::
     $ cd doc
     $ make html
 
+To fulfill the package requirement, ensure that all the dependencies for building
+documentation enlisted in `doc/README.rst` are satisfied.
+
 Then the docs will be in `_build/html`. If you don't want to read that, here
 is a short usage:
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -16,6 +16,10 @@ and to view it, do::
 
     firefox _build/html/index.html
 
+If you get **mpmath** error, install python3-mpmath package::
+
+    apt-get install python3-mpmath
+
 Fedora
 ------
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -6,9 +6,12 @@ Debian/Ubuntu
 
 To make the html documentation, install the prerequisites::
 
-    apt-get install python-sphinx texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x graphviz
+    sudo apt-get install texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x graphviz
+    pip install mpmath sphinx docutils matplotlib
 
-and do::
+The Python dependencies can be installed either with **pip** (as shown here) or with **apt-get** (install python-<package>).
+
+Now type in the command::
 
     make html
 
@@ -16,9 +19,6 @@ and to view it, do::
 
     firefox _build/html/index.html
 
-If you get **mpmath** error, install python3-mpmath package::
-
-    apt-get install python3-mpmath
 
 Fedora
 ------


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #15621 - But does not change the apt-get install to pip because I am not sure that is a good idea.

#### Brief description of what is fixed or changed
Made minor updates to the `README.rst` and `docs/README.rst` helping new users install dependencies when building docs

#### Other comments
* To `README.rst`
  - In the build docs section, added reference to docs/README.rst if package requirements are not satisfied.
* To `docs/README.rst`
  - Reduplicated the segment on installing python-mpmath if build fails in the Ubuntu/Debian segment.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
