### PR TITLE
Added entropy, mgf, and cf in MultivariateNormalDistribution

### DIFF
--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,5 +1,5 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt,
-    IndexedBase)
+    IndexedBase, log, E, I)
 from sympy.stats.rv import _value_check, random_symbols
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
@@ -103,6 +103,20 @@ class MultivariateNormalDistribution(JointDistribution):
         return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
             -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
                 (_mu - sym)))[0])
+
+    def entropy(self):
+        sigma = self.sigma
+        return log(2*pi*E*det(sigma))/2
+
+    def mgf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        t = ImmutableMatrix(args)
+        return exp(mu.transpose()*t + t.transpose()*(sigma*t)/2)
+
+    def cf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        t = ImmutableMatrix(args)
+        return exp(I*(mu.transpose()*t) - t.transpose()*(sigma*t)/2)
 
 #-------------------------------------------------------------------------------
 # Multivariate Laplace distribution ---------------------------------------------------------


### PR DESCRIPTION
#### References to other Issues or PRs
https://en.wikipedia.org/wiki/Multivariate_normal_distribution

#### Brief description of what is fixed or changed
The methods, entropy, mgf and cf have been added to
sympy.stats.joint_rv_types.MultivariateNormalDistribution.
Entropy is calculated by entropy, Moment Generating Function
by mgf and Characteristic Function by cf.

#### Other comments
I don't know whether [MGF](https://en.wikipedia.org/wiki/Moment-generating_function), [CF](https://en.wikipedia.org/wiki/Characteristic_function_(probability_theory)) and [Entropy](https://en.wikipedia.org/wiki/Information_entropy) have already been implemented or not for  MultivariateNormalDistribution. Since, I didn't find them in the class, I thought of implementing
them. Just an effort. :-)
In addition, I am doubtful that where to write tests for the methods I have added. I was unable to find tests for pdf, marginal_distribution, etc.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
   * entropy, mgf and cf have been added in  MultivariateNormalDistribution.
<!-- END RELEASE NOTES -->
