### PR TITLE
Printing of Fancy Sets

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -82,6 +82,18 @@ class ReprPrinter(Printer):
     def _print_Integer(self, expr):
         return 'Integer(%i)' % expr.p
 
+    def _print_Integers(self, expr):
+        return 'S.Integers'
+
+    def _print_Naturals(self, expr):
+        return 'S.Naturals'
+
+    def _print_Naturals0(self, expr):
+        return 'S.Naturals0'
+
+    def _print_Reals(self, expr):
+        return 'S.Reals'
+
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -83,16 +83,16 @@ class ReprPrinter(Printer):
         return 'Integer(%i)' % expr.p
 
     def _print_Integers(self, expr):
-        return 'S.Integers'
+        return 'Integers'
 
     def _print_Naturals(self, expr):
-        return 'S.Naturals'
+        return 'Naturals'
 
     def _print_Naturals0(self, expr):
-        return 'S.Naturals0'
+        return 'Naturals0'
 
     def _print_Reals(self, expr):
-        return 'S.Reals'
+        return 'Reals'
 
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -570,16 +570,16 @@ class StrPrinter(Printer):
         return str(expr.p)
 
     def _print_Integers(self, expr):
-        return 'S.Integers'
+        return 'Integers'
 
     def _print_Naturals(self, expr):
-        return 'S.Naturals'
+        return 'Naturals'
 
     def _print_Naturals0(self, expr):
-        return 'S.Naturals0'
+        return 'Naturals0'
 
     def _print_Reals(self, expr):
-        return 'S.Reals'
+        return 'Reals'
 
     def _print_int(self, expr):
         return str(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -570,16 +570,16 @@ class StrPrinter(Printer):
         return str(expr.p)
 
     def _print_Integers(self, expr):
-        return 'Integers'
+        return 'S.Integers'
 
     def _print_Naturals(self, expr):
-        return 'Naturals'
+        return 'S.Naturals'
 
     def _print_Naturals0(self, expr):
-        return 'Naturals0'
+        return 'S.Naturals0'
 
     def _print_Reals(self, expr):
-        return 'Reals'
+        return 'S.Reals'
 
     def _print_int(self, expr):
         return str(expr)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -243,15 +243,34 @@ def test_DMP():
     assert srepr(ZZ.old_poly_ring(x)([1, 2])) == \
         "DMP([1, 2], ZZ, ring=GlobalPolynomialRing(ZZ, Symbol('x')))"
 
+
 def test_FiniteExtension():
     assert srepr(FiniteExtension(Poly(x**2 + 1, x))) == \
         "FiniteExtension(Poly(x**2 + 1, x, domain='ZZ'))"
+
 
 def test_ExtensionElement():
     A = FiniteExtension(Poly(x**2 + 1, x))
     assert srepr(A.generator) == \
         "ExtElem(DMP([1, 0], ZZ, ring=GlobalPolynomialRing(ZZ, Symbol('x'))), FiniteExtension(Poly(x**2 + 1, x, domain='ZZ')))"
 
+
 def test_BooleanAtom():
     assert srepr(true) == "true"
     assert srepr(false) == "false"
+
+
+def test_Integers():
+    sT(S.Integers, "Integers")
+
+
+def test_Naturals():
+    sT(S.Naturals, "Naturals")
+
+
+def test_Naturals0():
+    sT(S.Naturals0, "Naturals0")
+
+
+def test_Reals():
+    sT(S.Reals, "Reals")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #10672: Set printing issues

#### Brief description of what is fixed or changed
Changed the way sets `S.Integers`, `S.Reals`, `S.Naturals` and `S.Naturals0` are printed using all of `print()`, `str()`, and `srepr()`.

#### Other comments
Now printing would result in S.Integers instead of Integers or Integers(), which is now the correct name of the set.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Changed printing using str() and repr() of S.Integers, S.Reals, S.Naturals and S.Naturals0 to the names of the sets themselves
<!-- END RELEASE NOTES -->
