### PR TITLE
Improve logarithmic substitution in manualintegrate

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,6 +1,6 @@
 from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
-    tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfi,
+    tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfc, erfi,
     EulerGamma, Expr, factor, Function, gamma, gammasimp, I, Idx, im, IndexedBase,
     Integral, integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
@@ -1440,3 +1440,15 @@ def test_issue_15457():
 def test_issue_15431():
     assert integrate(x*exp(x)*log(x), x) == \
         (x*exp(x) - exp(x))*log(x) - exp(x) + Ei(x)
+
+
+def test_issue_15640_log_substitutions():
+    f = x/log(x)
+    F = Ei(2*log(x))
+    assert integrate(f, x) == F and F.diff(x) == f
+    f = x**3/log(x)**2
+    F = -x**4/log(x) + 4*Ei(4*log(x))
+    assert integrate(f, x) == F and F.diff(x) == f
+    f = sqrt(log(x))/x**2
+    F = -sqrt(pi)*erfc(sqrt(log(x)))/2 - sqrt(log(x))/x
+    assert integrate(f, x) == F and F.diff(x) == f

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -7,7 +7,7 @@ from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Ei, Ci, Si, Chi, Shi, fresnels, fresnelc, polylog, erf, erfi,
                    sinh, cosh, elliptic_f, elliptic_e)
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
-    _parts_rule, integral_steps, contains_dont_know)
+    _parts_rule, integral_steps, contains_dont_know, manual_subs)
 
 x, y, z, u, n, a, b, c = symbols('x y z u n a b c')
 f = Function('f')
@@ -459,3 +459,18 @@ def test_issue_8520():
     assert manualintegrate(x**2/(x**6 + 25), x) == atan(x**3/5)/15
     f = x/(9*x**4 + 4)**2
     assert manualintegrate(f, x).diff(x).factor() == f
+
+
+def test_manual_subs():
+    x, y = symbols('x y')
+    expr = log(x) + exp(x)
+    # if log(x) is y, then exp(y) is x
+    assert manual_subs(expr, log(x), y) == y + exp(exp(y))
+    # if exp(x) is y, then log(y) need not be x
+    assert manual_subs(expr, exp(x), y) == log(x) + y
+
+
+def test_issue_15471():
+    f = log(x)*cos(log(x))/x**(S(3)/4)
+    F = -128*x**(1/4)*sin(log(x))/289 + 240*x**(1/4)*cos(log(x))/289 + (16*x**(1/4)*sin(log(x))/17 + 4*x**(1/4)*cos(log(x))/17)*log(x)
+    assert manualintegrate(f, x) == F and F.diff(x).equals(f)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3115,6 +3115,13 @@ def test_nth_algebraic_redundant_solutions():
     solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 2, x)
     assert solns_final == [Eq(f(x), C1*exp(C2*x))]
 
+    # This one needs a substitution f' = g.
+    eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
+    assert sol == dsolve(eqn, f(x))
+
+
 #
 # These tests can be combined with the above test if they get fixed
 # so that dsolve actually works in all these cases.
@@ -3164,14 +3171,6 @@ def test_nth_algebraic_prep2():
     assert sol == dsolve(eqn, f(x), prep=True, hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
-
-# This one needs a substitution f' = g. Should be doable...
-@XFAIL
-def test_2nd_order_substitution():
-    eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
-    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
-    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
-    assert sol == dsolve(eqn, f(x))
 
 # This needs a combination of solutions from nth_algebraic and some other
 # method from dsolve


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15640. Makes progress toward #15471.

#### Brief description of what is fixed or changed

When the substitution `subs(log(x), u)` is made, SymPy does not replace `x` with `exp(u)`, nor does it replace`x**a` with `exp(a*u)`. (The latter would be correct even for complex numbers, since `log(x) = u` implies `exp(a*log(x)) = exp(a*u)`, and `exp(a*log(x))` is how `x**a` is defined.) This is problematic for manual integration which needs to completely replace the variable of integration by a new one.

To solve this, a helper function `manual_subs` is added to manualintegrate. Similarly to the existing `manual_diff`, it is a wrapper that optimizes the outcome of substitution for the purpose of manualintegrate. As a result, a bunch of new integrals get evaluated with `integrate`. 

#### Other comments

The integral mentioned in #15471 is now evaluated with `manualintegrate` but `integrate` still gets stuck in heurisch before ever getting to manual.

It would be easy to make `subs` perform such substitutions in general, but then the current heurisch algorithm breaks down. It needs to replace `log(x)` by a new variable without changing x everywhere, opposite to what manualintegrate needs. Using `xreplace` instead of `subs` in heurisch breaks it as well, because the algorithm needs some amount of math-awareness in substitution (example: if `sqrt(x) = u`, then `x` is `u**2`).

Also, if generic `subs` applied the new substitution logic to logarithms, it should do the same for other functions with left inverses, like atan or asin. But such substitutions would be a waste of time in integration: indeed, when I implemented them, they substantially slowed down `manualintegrate(atan(x)*log(x), x)` because of many added possibilities for (useless) substitutions.

Also, one of XFAIL tests added in #15255 passes now that #15619 got merged. It's moved with other passing tests per a comment in the file.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Improved the logic of substitutions involving logarithms
<!-- END RELEASE NOTES -->
