### PR TITLE
dsolve: Use rootof properties for better form of solution

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4983,38 +4983,31 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     conjugate_roots = [] # used to prevent double-use of conjugate roots
     for root, multiplicity in charroots.items():
         for i in range(multiplicity):
-            if isinstance(root, RootOf):
-                gensols.append(exp(root*x))
-                if multiplicity != 1:
-                    raise ValueError("Value should be 1")
-                # This ordering is important
-                collectterms = [(0, root, 0)] + collectterms
+            if chareq_is_complex:
+                gensols.append(x**i*exp(root*x))
+                collectterms = [(i, root, 0)] + collectterms
+                continue
+            reroot = re(root)
+            imroot = im(root)
+            if imroot.has(atan2) and reroot.has(atan2):
+                # Remove this condition when re and im stop returning
+                # circular atan2 usages.
+                gensols.append(x**i*exp(root*x))
+                collectterms = [(i, root, 0)] + collectterms
             else:
-                if chareq_is_complex:
-                    gensols.append(x**i*exp(root*x))
-                    collectterms = [(i, root, 0)] + collectterms
-                    continue
-                reroot = re(root)
-                imroot = im(root)
-                if imroot.has(atan2) and reroot.has(atan2):
-                    # Remove this condition when re and im stop returning
-                    # circular atan2 usages.
-                    gensols.append(x**i*exp(root*x))
-                    collectterms = [(i, root, 0)] + collectterms
-                else:
-                    if root in conjugate_roots:
-                        collectterms = [(i, reroot, imroot)] + collectterms
-                        continue
-                    if imroot == 0:
-                        gensols.append(x**i*exp(reroot*x))
-                        collectterms = [(i, reroot, 0)] + collectterms
-                        continue
-                    conjugate_roots.append(conjugate(root))
-                    gensols.append(x**i*exp(reroot*x) * sin(abs(imroot) * x))
-                    gensols.append(x**i*exp(reroot*x) * cos(    imroot  * x))
-
-                    # This ordering is important
+                if root in conjugate_roots:
                     collectterms = [(i, reroot, imroot)] + collectterms
+                    continue
+                if imroot == 0:
+                    gensols.append(x**i*exp(reroot*x))
+                    collectterms = [(i, reroot, 0)] + collectterms
+                    continue
+                conjugate_roots.append(conjugate(root))
+                gensols.append(x**i*exp(reroot*x) * sin(abs(imroot) * x))
+                gensols.append(x**i*exp(reroot*x) * cos(    imroot  * x))
+
+                # This ordering is important
+                collectterms = [(i, reroot, imroot)] + collectterms
     if returns == 'list':
         return gensols
     elif returns in ('sol' 'both'):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4900,11 +4900,11 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     >>> dsolve(f(x).diff(x, 5) + 10*f(x).diff(x) - 2*f(x), f(x),
     ... hint='nth_linear_constant_coeff_homogeneous')
     ... # doctest: +NORMALIZE_WHITESPACE
-    Eq(f(x), C1*exp(x*CRootOf(_x**5 + 10*_x - 2, 0)) +
-    C2*exp(x*CRootOf(_x**5 + 10*_x - 2, 1)) +
-    C3*exp(x*CRootOf(_x**5 + 10*_x - 2, 2)) +
-    C4*exp(x*CRootOf(_x**5 + 10*_x - 2, 3)) +
-    C5*exp(x*CRootOf(_x**5 + 10*_x - 2, 4)))
+    Eq(f(x), C5*exp(x*CRootOf(_x**5 + 10*_x - 2, 0))
+    + (C1*sin(x*im(CRootOf(_x**5 + 10*_x - 2, 1)))
+    + C2*cos(x*im(CRootOf(_x**5 + 10*_x - 2, 1))))*exp(x*re(CRootOf(_x**5 + 10*_x - 2, 1)))
+    + (C3*sin(x*im(CRootOf(_x**5 + 10*_x - 2, 3)))
+    + C4*cos(x*im(CRootOf(_x**5 + 10*_x - 2, 3))))*exp(x*re(CRootOf(_x**5 + 10*_x - 2, 3))))
 
     Note that because this method does not involve integration, there is no
     ``nth_linear_constant_coeff_homogeneous_Integral`` hint.

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4981,7 +4981,12 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     collectterms = []
     gensols = []
     conjugate_roots = [] # used to prevent double-use of conjugate roots
-    for root, multiplicity in charroots.items():
+    # Loop over roots in theorder provided by roots/rootof...
+    for root in chareqroots:
+        # but don't repoeat multiple roots.
+        if root not in charroots:
+            continue
+        multiplicity = charroots.pop(root)
         for i in range(multiplicity):
             if chareq_is_complex:
                 gensols.append(x**i*exp(root*x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1,7 +1,7 @@
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
     Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
-    Piecewise, symbols, Poly, sec, Ei)
+    Piecewise, symbols, Poly, sec, Ei, re, im)
 from sympy.solvers.ode import (_undetermined_coefficients_match,
     checkodesol, classify_ode, classify_sysode, constant_renumber,
     constantsimp, homogeneous_order, infinitesimals, checkinfsol,
@@ -1757,25 +1757,52 @@ def test_nth_linear_constant_coeff_homogeneous():
 
 
 def test_nth_linear_constant_coeff_homogeneous_rootof():
+    # One real root, two complex conjugate pairs
     eq = f(x).diff(x, 5) + 11*f(x).diff(x) - 2*f(x)
+    r1, r2, r3, r4, r5 = [rootof(x**5 + 11*x - 2, n) for n in range(5)]
     sol = Eq(f(x),
-        C1*exp(x*rootof(x**5 + 11*x - 2, 0)) +
-        C2*exp(x*rootof(x**5 + 11*x - 2, 1)) +
-        C3*exp(x*rootof(x**5 + 11*x - 2, 2)) +
-        C4*exp(x*rootof(x**5 + 11*x - 2, 3)) +
-        C5*exp(x*rootof(x**5 + 11*x - 2, 4)))
-    assert dsolve(eq) == sol
-
-    eq = f(x).diff(x, 6) - 6*f(x).diff(x, 5) + 5*f(x).diff(x, 4) + 10*f(x).diff(x) - 50 * f(x)
-    sol = Eq(f(x),
-          C1*exp(5*x)
-        + C2*exp(x*rootof(x**5 - x**4 + 10, 0))
-        + C3*exp(x*rootof(x**5 - x**4 + 10, 1))
-        + C4*exp(x*rootof(x**5 - x**4 + 10, 2))
-        + C5*exp(x*rootof(x**5 - x**4 + 10, 3))
-        + C6*exp(x*rootof(x**5 - x**4 + 10, 4))
+            C5*exp(r1*x)
+            + exp(re(r2)*x) * (C1*sin(im(r2)*x) + C2*cos(im(r2)*x))
+            + exp(re(r4)*x) * (C3*sin(im(r4)*x) + C4*cos(im(r4)*x))
             )
     assert dsolve(eq) == sol
+
+    # Three real roots, one complex conjugate pair
+    eq = f(x).diff(x,5) - 3*f(x).diff(x) + f(x)
+    r1, r2, r3, r4, r5 = [rootof(x**5 - 3*x + 1, n) for n in range(5)]
+    sol = Eq(f(x),
+            C3*exp(r1*x) + C4*exp(r2*x) + C5*exp(r3*x)
+            + exp(re(r4)*x) * (C1*sin(im(r4)*x) + C2*cos(im(r4)*x))
+            )
+    assert dsolve(eq) == sol
+
+    # Five distinct real roots
+    eq = f(x).diff(x,5) - 100*f(x).diff(x,3) + 1000*f(x).diff(x) + f(x)
+    r1, r2, r3, r4, r5 = [rootof(x**5 - 100*x**3 + 1000*x + 1, n) for n in range(5)]
+    sol = Eq(f(x), C1*exp(r1*x) + C2*exp(r2*x) + C3*exp(r3*x) + C4*exp(r4*x) + C5*exp(r5*x))
+    assert dsolve(eq) == sol
+
+    # Rational root and unsolvable quintic
+    eq = f(x).diff(x, 6) - 6*f(x).diff(x, 5) + 5*f(x).diff(x, 4) + 10*f(x).diff(x) - 50 * f(x)
+    r2, r3, r4, r5, r6 = [rootof(x**5 - x**4 + 10, n) for n in range(5)]
+    sol = Eq(f(x),
+          C5*exp(5*x)
+        + C6*exp(x*r2)
+        + exp(re(r3)*x) * (C1*sin(im(r3)*x) + C2*cos(im(r3)*x))
+        + exp(re(r5)*x) * (C3*sin(im(r5)*x) + C4*cos(im(r5)*x))
+            )
+    assert dsolve(eq) == sol
+
+    # Five double roots (this is (x**5 - x + 1)**2)
+    eq = f(x).diff(x, 10) - 2*f(x).diff(x, 6) + 2*f(x).diff(x, 5) + f(x).diff(x, 2) - 2*f(x).diff(x, 1) + f(x)
+    r1, r2, r3, r4, r5 = [rootof(x**5 - x + 1, n) for n in range(5)]
+    sol = Eq(f(x),
+              (C1 + C2 *x)*exp(r1*x)
+            + exp(re(r2)*x) * ((C3 + C4*x)*sin(im(r2)*x) + (C5 + C6 *x)*cos(im(r2)*x))
+            + exp(re(r4)*x) * ((C7 + C8*x)*sin(im(r4)*x) + (C9 + C10*x)*cos(im(r4)*x))
+            )
+    assert dsolve(eq) == sol
+
 
 def test_nth_linear_constant_coeff_homogeneous_irrational():
     our_hint='nth_linear_constant_coeff_homogeneous'


### PR DESCRIPTION
See #15594. Use the properties of rootof to determine the form of
solutions for constant coefficient homogeneous ODEs in dsolve.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15594

#### Brief description of what is fixed or changed

Remove code to special case `RootOf` in `nth_linear_const_coeff_homogeneous`. The changes to the main code look more significant because of a change to indentation level: I've really just removed a single `if` and unindented everything inside the `else`.

This allows the existing code to get the correct form for solutions involving `RootOf`s including handling multiple roots and complex conjugate pairs.

Example:
```julia
In [1]: dsolve(f(x).diff(x,5) - f(x).diff(x) + f(x))                                                                              
Out[1]: 
                    ⎛ 5           ⎞                                                                                      ⎛      
           x⋅CRootOf⎝x  - x + 1, 0⎠   ⎛      ⎛    ⎛       ⎛ 5           ⎞⎞⎞         ⎛    ⎛       ⎛ 5           ⎞⎞⎞⎞  x⋅re⎝CRootO
f(x) = C₅⋅ℯ                         + ⎝C₁⋅sin⎝x⋅im⎝CRootOf⎝x  - x + 1, 1⎠⎠⎠ + C₂⋅cos⎝x⋅im⎝CRootOf⎝x  - x + 1, 1⎠⎠⎠⎠⋅ℯ           

 ⎛ 5           ⎞⎞                                                                                      ⎛       ⎛ 5           ⎞⎞
f⎝x  - x + 1, 1⎠⎠   ⎛      ⎛    ⎛       ⎛ 5           ⎞⎞⎞         ⎛    ⎛       ⎛ 5           ⎞⎞⎞⎞  x⋅re⎝CRootOf⎝x  - x + 1, 3⎠⎠
                  + ⎝C₃⋅sin⎝x⋅im⎝CRootOf⎝x  - x + 1, 3⎠⎠⎠ + C₄⋅cos⎝x⋅im⎝CRootOf⎝x  - x + 1, 3⎠⎠⎠⎠⋅ℯ  
```

Before this patch this would be
```julia
In [1]: dsolve(f(x).diff(x,5) - f(x).diff(x) + f(x))                                                                              
Out[1]: 
                    ⎛ 5           ⎞                ⎛ 5           ⎞                ⎛ 5           ⎞                ⎛ 5           ⎞
           x⋅CRootOf⎝x  - x + 1, 0⎠       x⋅CRootOf⎝x  - x + 1, 1⎠       x⋅CRootOf⎝x  - x + 1, 2⎠       x⋅CRootOf⎝x  - x + 1, 3⎠
f(x) = C₁⋅ℯ                         + C₂⋅ℯ                         + C₃⋅ℯ                         + C₄⋅ℯ                        

                ⎛ 5           ⎞
       x⋅CRootOf⎝x  - x + 1, 4⎠
 + C₅⋅ℯ                        
```
which would involve complex numbers if those `RootOf`s were `evalf`ed.

This patch also handles `RootOf`s where there are multiple roots (which previously raise an exception):
```julia
In [2]: eq                                                                                                                        
Out[2]: 
                      2             5             6          10       
         d           d             d             d          d         
f(x) - 2⋅──(f(x)) + ───(f(x)) + 2⋅───(f(x)) - 2⋅───(f(x)) + ────(f(x))
         dx           2             5             6           10      
                    dx            dx            dx          dx        

In [3]: dsolve(eq)                                                                                                                
Out[3]: 
                             ⎛ 5           ⎞                                                                                    
                    x⋅CRootOf⎝x  - x + 1, 0⎠   ⎛               ⎛    ⎛       ⎛ 5           ⎞⎞⎞                  ⎛    ⎛       ⎛ 5 
f(x) = (C₁ + C₂⋅x)⋅ℯ                         + ⎝(C₃ + C₄⋅x)⋅sin⎝x⋅im⎝CRootOf⎝x  - x + 1, 1⎠⎠⎠ + (C₅ + C₆⋅x)⋅cos⎝x⋅im⎝CRootOf⎝x  

                    ⎛       ⎛ 5           ⎞⎞                                                                                    
          ⎞⎞⎞⎞  x⋅re⎝CRootOf⎝x  - x + 1, 1⎠⎠   ⎛               ⎛    ⎛       ⎛ 5           ⎞⎞⎞                   ⎛    ⎛       ⎛ 5
- x + 1, 1⎠⎠⎠⎠⋅ℯ                             + ⎝(C₇ + C₈⋅x)⋅sin⎝x⋅im⎝CRootOf⎝x  - x + 1, 3⎠⎠⎠ + (C₁₀⋅x + C₉)⋅cos⎝x⋅im⎝CRootOf⎝x 

                     ⎛       ⎛ 5           ⎞⎞
           ⎞⎞⎞⎞  x⋅re⎝CRootOf⎝x  - x + 1, 3⎠⎠
 - x + 1, 3⎠⎠⎠⎠⋅ℯ 
```

#### Other comments

This would be more useful if it was possible to `evalf` those returned solutions. Unfortunately `evalf` doesn't seem to work with transcendental functions and free symbols. Simple example:
```julia
In [4]: exp(sqrt(2)*x).evalf()                                                                                                    
Out[4]: 
 √2⋅x
ℯ    
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
     * Return the correct RootOf form of solution for constant coefficient ODEs with unsolvable characteristic polynomials.
<!-- END RELEASE NOTES -->
