### PR TITLE
Improve the handling of oscillating sequences in limit_seq

### DIFF
--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -1,8 +1,9 @@
 from sympy import (symbols, Symbol, oo, Sum, harmonic, Add, S, binomial,
-    factorial, log, fibonacci)
+    factorial, log, fibonacci, sin, cos, pi, I, sqrt)
 from sympy.series.limitseq import limit_seq
 from sympy.series.limitseq import difference_delta as dd
 from sympy.utilities.pytest import raises, XFAIL
+from sympy.calculus.util import AccumulationBounds
 
 n, m, k = symbols('n m k', integer=True)
 
@@ -87,7 +88,20 @@ def test_alternating_sign():
     assert limit_seq((-1)**n/n**2, n) == 0
     assert limit_seq((-2)**(n+1)/(n + 3**n), n) == 0
     assert limit_seq((2*n + (-1)**n)/(n + 1), n) == 2
-    assert limit_seq((-3)**n/(n + 3**n), n) is None
+    assert limit_seq(sin(pi*n), n) == 0
+    assert limit_seq(cos(2*pi*n), n) == 1
+    assert limit_seq((S(-1)/5)**n, n) == 0
+    assert limit_seq((-1/5)**n, n) == 0
+    assert limit_seq((I/3)**n, n) == 0
+    assert limit_seq(sqrt(n)*(I/2)**n, n) == 0
+    assert limit_seq(n**7*(I/3)**n, n) == 0
+
+
+def test_accum_bounds():
+    assert limit_seq((-1)**n, n) == AccumulationBounds(-1, 1)
+    assert limit_seq(cos(pi*n), n) == AccumulationBounds(-1, 1)
+    assert limit_seq(sin(pi*n/2)**2, n) == AccumulationBounds(0, 1)
+    assert limit_seq(2*(-3)**n/(n + 3**n), n) == AccumulationBounds(-2, 2)
 
 
 def test_limitseq_sum():

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -95,6 +95,7 @@ def test_alternating_sign():
     assert limit_seq((I/3)**n, n) == 0
     assert limit_seq(sqrt(n)*(I/2)**n, n) == 0
     assert limit_seq(n**7*(I/3)**n, n) == 0
+    assert limit_seq(n/(n + 1) + (I/2)**n, n) == 1
 
 
 def test_accum_bounds():
@@ -102,6 +103,7 @@ def test_accum_bounds():
     assert limit_seq(cos(pi*n), n) == AccumulationBounds(-1, 1)
     assert limit_seq(sin(pi*n/2)**2, n) == AccumulationBounds(0, 1)
     assert limit_seq(2*(-3)**n/(n + 3**n), n) == AccumulationBounds(-2, 2)
+    assert limit_seq(3*n/(n + 1) + 2*(-1)**n, n) == AccumulationBounds(1, 5)
 
 
 def test_limitseq_sum():


### PR DESCRIPTION
#### References to other Issues or PRs

Closes #14198 by including those commits from a now-deleted repository. Addresses some (not all) of the issues with oscillatory sequences in #14192 

#### Brief description of what is fixed or changed

Oscillatory sequences are handled by using odd and even dummy indices (this is more efficient than replacing n by `2*n` or `2*n+1` as was previously done). Also, the presence of sin or cos in the formula now also qualifies a sequence as oscillatory, in addition to powers with a negative base.

When the limits along even and odd indices exist but are different, AccumBounds is returned instead of None.

For some sequences, the absolute value can be handled by limit_seq while the original sequence cannot (for example, (I/2)**n). If the limit of absolute value is 0, the limit of the original sequence is also
0.

For example, `limit_seq((-S.Half)**n)` returned nothing previously, now it returns 0.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* series
   * Improved the computation of limits of oscillating sequences 
<!-- END RELEASE NOTES -->
