### PR TITLE
Add orthogonal polynomials to SciPy printer

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -681,8 +681,17 @@ _known_functions_scipy_special = {
     'gamma': 'gamma',
     'loggamma': 'gammaln',
     'digamma': 'psi',
-    'RisingFactorial': 'poch'
+    'RisingFactorial': 'poch',
+    'jacobi': 'eval_jacobi',
+    'gegenbauer': 'eval_gegenbauer',
+    'chebyshevt': 'eval_chebyt',
+    'chebyshevu': 'eval_chebyu',
+    'legendre': 'eval_legendre',
+    'hermite': 'eval_hermite',
+    'laguerre': 'eval_laguerre',
+    'assoc_laguerre': 'eval_genlaguerre',
 }
+
 _known_constants_scipy_constants = {
     'GoldenRatio': 'golden_ratio',
     'Pi': 'pi',
@@ -711,6 +720,13 @@ class SciPyPrinter(NumPyPrinter):
 
     _print_ImmutableSparseMatrix = _print_SparseMatrix
 
+    # SciPy's lpmv has a different order of arguments from assoc_legendre
+    def _print_assoc_legendre(self, expr):
+        return "{0}({2}, {1}, {3})".format(
+            self._module_format('scipy.special.lpmv'),
+            self._print(expr.args[0]),
+            self._print(expr.args[1]),
+            self._print(expr.args[2]))
 
 for k in SciPyPrinter._kf:
     setattr(SciPyPrinter, '_print_%s' % k, _print_known_func)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15654

#### Brief description of what is fixed or changed

SciPy implementation of orthogonal polynomials is generally consistent with SymPy, except for different names and in some cases, different order of arguments. SciPy printer is made aware of this correspondence. Tests for all these functions are added. 

#### Other comments

Oddly enough, SciPy's Hermite polynomials are implemented for real arguments only.  

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added support for orthogonal polynomials to SciPy code printer  
<!-- END RELEASE NOTES -->
