### PR TITLE
Bugfix for sympy.Integrate returning NaN as a result

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -144,6 +144,8 @@ def find_substitutions(integrand, symbol, u_var):
     results = []
 
     def test_subterm(u, u_diff):
+        if u_diff == 0:
+            return False
         substituted = integrand / u_diff
         if symbol not in substituted.free_symbols:
             # replaced everything already

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -459,3 +459,17 @@ def test_issue_8520():
     assert manualintegrate(x**2/(x**6 + 25), x) == atan(x**3/5)/15
     f = x/(9*x**4 + 4)**2
     assert manualintegrate(f, x).diff(x).factor() == f
+
+    
+def test_issue15494():
+    from sympy.abc import t, s
+
+    Z0 = Function('Z0')
+    Z1 = Function('Z1')
+
+    k01, k10= symbols('k01 k10', real=True, positive=True)
+
+    integrand = (exp(s/2)-2*exp(1.6*s)+exp(s))*exp(s)
+    solution  = integrate(integrand, s)
+
+    assert solution == 0.666666666666667*exp(1.5*s) + 0.5*exp(2.0*s) - 0.769230769230769*exp(2.6*s)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -488,3 +488,4 @@ def test_issue15494():
     solution  = integrate(integrand, s)
 
     assert solution == 0.666666666666667*exp(1.5*s) + 0.5*exp(2.0*s) - 0.769230769230769*exp(2.6*s)
+    

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -488,4 +488,3 @@ def test_issue15494():
     solution  = integrate(integrand, s)
 
     assert solution == 0.666666666666667*exp(1.5*s) + 0.5*exp(2.0*s) - 0.769230769230769*exp(2.6*s)
-    

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -477,14 +477,7 @@ def test_issue_15471():
 
 
 def test_issue15494():
-    from sympy.abc import t, s
-
-    Z0 = Function('Z0')
-    Z1 = Function('Z1')
-
-    k01, k10= symbols('k01 k10', real=True, positive=True)
-
-    integrand = (exp(s/2)-2*exp(1.6*s)+exp(s))*exp(s)
+    t, s = symbols('t s', real=True, positive=True)
+    integrand = (exp(s/2) - 2*exp(1.6*s) + exp(s))*exp(s)
     solution  = integrate(integrand, s)
-
     assert solution == 0.666666666666667*exp(1.5*s) + 0.5*exp(2.0*s) - 0.769230769230769*exp(2.6*s)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15494 

#### Brief description of what is fixed or changed
Prevent the code from accepting an integration rule that will return NaN as the result. Basically at one point, the script divides the integrand by the derivative of a subterm. If this subterm is a constant, the division returns the complex infinity, which in term forces sympy.integrate to return NaN as the result of the integral, even though it can calculate it if this false rule is not added to its set. The easiest way to do this (as proposed by @jksuom ) is to directly return false if the derivative of the subterm is found to be zero, thus preventing the script from creating the rule.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Prevent sympy.integrate from returning NaN as the result of an integral instead of its real answer.
<!-- END RELEASE NOTES -->
