### PR TITLE
functions: Add a rewrite from exp to Pow

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -467,6 +467,12 @@ class exp(ExpBase):
                 if not isinstance(cosine, cos) and not isinstance (sine, sin):
                     return cosine + S.ImaginaryUnit*sine
 
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
+        if arg.is_Mul:
+            logs = [a for a in arg.args if isinstance(a, log) and len(a.args) == 1]
+            if logs:
+                return Pow(logs[0].args[0], arg.coeff(logs[0]))
+
 
 class log(Function):
     r"""

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -2,7 +2,7 @@ from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
-    AccumBounds, MatrixSymbol)
+    AccumBounds, MatrixSymbol, Pow)
 from sympy.abc import x, y, z
 
 
@@ -117,6 +117,9 @@ def test_exp_rewrite():
     assert exp(x).rewrite(tanh) == (1 + tanh(x/2))/(1 - tanh(x/2))
     assert exp(pi*I/4).rewrite(sqrt) == sqrt(2)/2 + sqrt(2)*I/2
     assert exp(pi*I/3).rewrite(sqrt) == S(1)/2 + sqrt(3)*I/2
+    assert exp(x*log(y)).rewrite(Pow) == y**x
+    assert exp(log(x)*log(y)).rewrite(Pow) == x**log(y)
+    assert exp(log(log(x))*y).rewrite(Pow) == log(x)**y
 
     n = Symbol('n', integer=True)
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -118,7 +118,7 @@ def test_exp_rewrite():
     assert exp(pi*I/4).rewrite(sqrt) == sqrt(2)/2 + sqrt(2)*I/2
     assert exp(pi*I/3).rewrite(sqrt) == S(1)/2 + sqrt(3)*I/2
     assert exp(x*log(y)).rewrite(Pow) == y**x
-    assert exp(log(x)*log(y)).rewrite(Pow) == x**log(y)
+    assert exp(log(x)*log(y)).rewrite(Pow) in [x**log(y), y**log(x)]
     assert exp(log(log(x))*y).rewrite(Pow) == log(x)**y
 
     n = Symbol('n', integer=True)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15659 

#### Brief description of what is fixed or changed

The added functionality `exp.rewrite(Pow)` is the inverse of the existing `Pow.rewrite(exp)`. For example, `exp(x*log(y))` is rewritten as `y**x`. If several logarithms are present, the first in the list of args is used. If no logarithms are present, the expression is unchanged. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
   * Exponential function with a logarithmic factor in its argument can be rewritten as a power.
<!-- END RELEASE NOTES -->
