### PR TITLE
Corrected 1V/1A to give 1 ohm

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -53,7 +53,7 @@ meter.set_scale_factor(One)
 # gram; used to define its prefixed units
 g = gram = grams = Quantity("gram", abbrev="g")
 gram.set_dimension(mass)
-gram.set_scale_factor(One)
+gram.set_scale_factor(kilo/1000)
 
 # NOTE: the `kilogram` has scale factor 1000. In SI, kg is a base unit, but
 # nonetheless we are trying to be compatible with the `kilo` prefix. In a
@@ -65,7 +65,7 @@ gram.set_scale_factor(One)
 # (that is, support all kinds of unit systems).
 kg = kilogram = kilograms = Quantity("kilogram", abbrev="kg")
 kilogram.set_dimension(mass)
-kilogram.set_scale_factor(kilo*gram)
+kilogram.set_scale_factor(One)
 
 s = second = seconds = Quantity("second", abbrev="s")
 second.set_dimension(time)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -3,7 +3,7 @@
 from sympy import (Abs, Add, Basic, Function, Number, Rational, S, Symbol,
     diff, exp, integrate, log, sin, sqrt, symbols)
 from sympy.physics.units import (amount_of_substance, convert_to, find_unit,
-    volume)
+    volume, voltage, current, ohm)
 from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
     day, energy, foot, grams, hour, inch, kg, km, m, meter, mile, millimeter,
     minute, pressure, quart, s, second, speed_of_light, temperature, bit,
@@ -42,6 +42,12 @@ def test_convert_to():
     # Wrong dimension to convert:
     assert q.convert_to(s) == q
     assert speed_of_light.convert_to(m) == speed_of_light
+
+    vs = Quantity('vs')
+    vs.set_dimension(voltage)
+    vs_i = Quantity('vs_i')
+    vs_i.set_dimension(current)
+    assert convert_to(vs/vs_i, ohm) == ohm
 
 
 def test_Quantity_definition():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #15647

#### Brief description of what is fixed or changed
In SI units Kilogram is the base unit so should have a scale factor 1, which corrects 1V/1A to 1 ohm.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.units
    * corrected scale factor for SI unit Kilogram to 1.
<!-- END RELEASE NOTES -->
