### PR TITLE
Revert "Fixing matrix expressions and poly-tools"

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1243,7 +1243,7 @@ def _mask_nc(eq, name=None):
     Multiple nc-symbols:
 
     >>> _mask_nc(A**2 - B**2, 'd')
-    (A**2 - B**2, {}, [A, B])
+    (A**2 - B**2, None, [A, B])
 
     An nc-object with nc-symbols but no others outside of it:
 
@@ -1309,9 +1309,8 @@ def _mask_nc(eq, name=None):
         if any(a == r[0] for r in rep):
             pot.skip()
         elif not a.is_commutative:
-            if a.is_symbol:
+            if a.is_Symbol:
                 nc_syms.add(a)
-                pot.skip()
             elif not (a.is_Add or a.is_Mul or a.is_Pow):
                 nc_obj.add(a)
                 pot.skip()
@@ -1334,7 +1333,7 @@ def _mask_nc(eq, name=None):
 
     nc_syms = list(nc_syms)
     nc_syms.sort(key=default_sort_key)
-    return expr, {v: k for k, v in rep}, nc_syms
+    return expr, {v: k for k, v in rep} or None, nc_syms
 
 
 def factor_nc(expr):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -274,10 +274,7 @@ class Mul(Expr, AssocOp):
                 continue
 
             elif isinstance(o, MatrixExpr):
-                if isinstance(coeff, MatrixExpr):
-                    coeff *= o
-                else:
-                    coeff = o.__mul__(coeff)
+                coeff = o.__mul__(coeff)
                 continue
 
             elif o is S.ComplexInfinity:

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -13,8 +13,7 @@ from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError, ZeroMatri
 from sympy.utilities import default_sort_key, sift
 from sympy.core.operations import AssocOp
 
-
-class MatAdd(MatrixExpr, Add):
+class MatAdd(MatrixExpr, AssocOp):
     """A Sum of Matrix Expressions
 
     MatAdd inherits from and operates like SymPy Add
@@ -33,12 +32,10 @@ class MatAdd(MatrixExpr, Add):
 
     def __new__(cls, *args, **kwargs):
         args = list(map(sympify, args))
-        check = kwargs.get('check', False)
+        check = kwargs.get('check', True)
 
         obj = Basic.__new__(cls, *args)
         if check:
-            if all(not isinstance(i, MatrixExpr) for i in args):
-                return Add.fromiter(args)
             validate(*args)
         return obj
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -68,7 +68,7 @@ class MatrixExpr(Expr):
 
     is_commutative = False
     is_number = False
-    is_symbol = False
+    is_symbol = True
 
     def __new__(cls, *args, **kwargs):
         args = map(sympify, args)
@@ -84,22 +84,22 @@ class MatrixExpr(Expr):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__radd__')
     def __add__(self, other):
-        return MatAdd(self, other, check=True).doit()
+        return MatAdd(self, other).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__add__')
     def __radd__(self, other):
-        return MatAdd(other, self, check=True).doit()
+        return MatAdd(other, self).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
-        return MatAdd(self, -other, check=True).doit()
+        return MatAdd(self, -other).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
-        return MatAdd(other, -self, check=True).doit()
+        return MatAdd(other, -self).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rmul__')
@@ -198,9 +198,6 @@ class MatrixExpr(Expr):
 
     def _eval_derivative(self, x):
         return _matrix_derivative(self, x)
-
-    def _eval_derivative_n_times(self, x, n):
-        return Basic._eval_derivative_n_times(self, x, n)
 
     def _entry(self, i, j, **kwargs):
         raise NotImplementedError(
@@ -642,7 +639,6 @@ class MatrixSymbol(MatrixExpr):
     I + 2*A*B
     """
     is_commutative = False
-    is_symbol = True
     _diff_wrt = True
 
     def __new__(cls, name, n, m):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -13,7 +13,7 @@ from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.matrices import MatrixBase
 
 
-class MatMul(MatrixExpr, Mul):
+class MatMul(MatrixExpr):
     """
     A product of matrix expressions
 

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -1,5 +1,5 @@
 from sympy import KroneckerDelta, diff, Piecewise, And
-from sympy import Sum, Dummy, factor, expand
+from sympy import Sum, Dummy
 
 from sympy.core import S, symbols, Add, Mul
 from sympy.core.compatibility import long
@@ -338,12 +338,3 @@ def test_MatrixElement_with_values():
 def test_inv():
     B = MatrixSymbol('B', 3, 3)
     assert B.inv() == B**-1
-
-def test_factor_expand():
-    A = MatrixSymbol("A", n, n)
-    B = MatrixSymbol("B", n, n)
-    expr1 = (A + B)*(C + D)
-    expr2 = A*C + B*C + A*D + B*D
-    assert expr1 != expr2
-    assert expand(expr1) == expr2
-    assert factor(expr2) == expr1

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -1,4 +1,4 @@
-from sympy.core import I, symbols, Basic, Mul
+from sympy.core import I, symbols, Basic
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
@@ -135,7 +135,3 @@ def test_matmul_args_cnc():
 def test_issue_12950():
     M = Matrix([[Symbol("x")]]) * MatrixSymbol("A", 1, 1)
     assert MatrixSymbol("A", 1, 1).as_explicit()[0]*Symbol('x') == M.as_explicit()[0]
-
-def test_construction_with_Mul():
-    assert Mul(C, D) == MatMul(C, D)
-    assert Mul(D, C) == MatMul(D, C)


### PR DESCRIPTION
Reverts sympy/sympy#15373

See https://github.com/sympy/sympy/pull/15373#issuecomment-448379918 and https://github.com/sympy/sympy/issues/15665.

Unless we can find a better way to make Mul.flatten return subclasses, I would revert this. 

Fixes https://github.com/sympy/sympy/issues/15665

#### Release Notes

<!-- BEGIN RELEASE NOTES --> 
NO ENTRY

**(NOTE: We need to manually remove the changelog entry from  https://github.com/sympy/sympy/pull/15373 from the [release notes](https://github.com/sympy/sympy/wiki/Release-Notes-for-1.4) once this is merged)**

Also, whoever merges, please delete the branch after doing so (GitHub creates a new branch on the main repo for PR reverts)