### PR TITLE
Removed special handling of `sqrt(I)`

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -295,8 +295,12 @@ class Mul(Expr, AssocOp):
                 continue
 
             elif o.is_commutative:
+                #      e
+                # o = b
                 b, e = o.as_base_exp()
 
+                #  y
+                # 3
                 if o.is_Pow:
                     if b.is_Number:
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -295,12 +295,8 @@ class Mul(Expr, AssocOp):
                 continue
 
             elif o.is_commutative:
-                #      e
-                # o = b
                 b, e = o.as_base_exp()
 
-                #  y
-                # 3
                 if o.is_Pow:
                     if b.is_Number:
 
@@ -323,10 +319,6 @@ class Mul(Expr, AssocOp):
                         elif b.is_positive or e.is_integer:
                             num_exp.append((b, e))
                             continue
-
-                    elif b is S.ImaginaryUnit and e.is_Rational:
-                        neg1e += e/2
-                        continue
 
                 c_powers.append((b, e))
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3864,7 +3864,6 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
                 if expt == 2:
                     return -S.One
                 return -S.ImaginaryUnit
-            return (S.NegativeOne)**(expt*S.Half)
         return
 
     def as_base_exp(self):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -266,7 +266,7 @@ def test_pow_im():
     assert Mul(*args, evaluate=False)**e == ans
     assert Mul(*args)**e == ans
     assert Mul(Pow(-1, Rational(3, 2), evaluate=False), I, I) == I
-    assert Mul(I*Pow(I, S.Half, evaluate=False)) == (-1)**Rational(3, 4)
+    assert Mul(I*Pow(I, S.Half, evaluate=False)) == sqrt(I)*I
 
 
 def test_real_mul():

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -8,7 +8,7 @@ def test_complex():
     b = Symbol("b", real=True)
     e = (a + I*b)*(a - I*b)
     assert e.expand() == a**2 + b**2
-    assert sqrt(I) == (-1)**Rational(1, 4)
+    assert sqrt(I) == sqrt(I)
 
 
 def test_conjugate():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #15653 - sqrt(I) is converted into -1**(-4)

#### Brief description of what is fixed or changed
Removed the code that tried to oversimplify any expression of the form ImaginaryUnit (i) to a Rational exponent. As in `sqrt(I) * 2` being simplified to `2 * (-1) ** (1/4)` 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * sqrt(I) is left unchanged instead of being rewritten to (-1)**(1/4)
<!-- END RELEASE NOTES -->
