### PR TITLE
polys: Use bottom_up in factor with deep=True

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6318,6 +6318,19 @@ def factor(f, *gens, **args):
     """
     f = sympify(f)
     if args.pop('deep', False):
+        from sympy.simplify.simplify import bottom_up
+        def _try_factor(expr):
+            """
+            Factor, but avoid changing the expression when unable to.
+            """
+            fac = factor(expr)
+            if fac.is_Mul or fac.is_Pow:
+                return fac
+            return expr
+
+        f = bottom_up(f, _try_factor)
+        # clean up any subexpressions that may have been expanded
+        # while factoring out a larger expression
         partials = {}
         muladd = f.atoms(Mul, Add)
         for p in muladd:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2462,6 +2462,7 @@ def test_factor():
 
     # deep option
     assert factor(sin(x**2 + x) + x, deep=True) == sin(x*(x + 1)) + x
+    assert factor(sin(x**2 + x)*x, deep=True) == sin(x*(x + 1))*x
 
     assert factor(sqrt(x**2)) == sqrt(x**2)
 
@@ -3283,3 +3284,10 @@ def test_issue_14364():
     assert gcd([S(6)*(1 + sqrt(7))/5, S(2)*(1 + sqrt(7))/7, S(4)*(1 + sqrt(7))/13]) == S(2)/455 * (1 + sqrt(7))
     assert lcm((S(7)/sqrt(15)/2, S(5)/sqrt(15)/6, S(5)/sqrt(15)/8)) == S(35)/(2*sqrt(15))
     assert lcm([S(5)*(2 + 2**(S(5)/7))/6, S(7)*(2 + 2**(S(5)/7))/2, S(13)*(2 + 2**(S(5)/7))/4]) == S(455)/2 * (2 + 2**(S(5)/7))
+
+
+def test_issue_15669():
+    x = Symbol("x", positive=True)
+    expr = (16*x**3/(-x**2 + sqrt(8*x**2 + (x**2 - 2)**2) + 2)**2 -
+        2*2**(S(4)/5)*x*(-x**2 + sqrt(8*x**2 + (x**2 - 2)**2) + 2)**(S(3)/5) + 10*x)
+    assert factor(expr, deep=True) == x*(x**2 + 2)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15669

#### Brief description of what is fixed or changed

Currently, the option `deep=True` of `factor` is implemented by factoring subexpressions simultaneously. But factoring some subexpression may result in simplification that enables factoring elsewhere. Using `bottom_up` allows for such cascading factorization.

On the other hand, `factor` by necessity involves expansion and so it's possible that on the way up the algorithm will re-expand some smaller terms. So, the previous algorithm is retained for cleanup after `bottom_up`.
 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys 
  * The flag `deep=True` of `factor` results in a more thorough factorization than previously.
<!-- END RELEASE NOTES -->
