### PR TITLE
integrals: Add 'heurisch' flag to integrate()

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1205,6 +1205,19 @@ def test_risch_option():
     assert integrate(erf(x), x, risch=True) == Integral(erf(x), x)
     # TODO: How to test risch=False?
 
+
+def test_heurisch_option():
+    raises(ValueError, lambda: integrate(1/x, x, risch=True, heurisch=True))
+    # an integral that heurisch can handle
+    assert integrate(exp(x**2), x, heurisch=True) == sqrt(pi)*erfi(x)/2
+    # an integral that heurisch currently cannot handle
+    assert integrate(exp(x)/x, x, heurisch=True) == Integral(exp(x)/x, x)
+    # an integral where heurisch currently hangs, issue 15471
+    assert integrate(log(x)*cos(log(x))/x**(S(3)/4), x, heurisch=False) == (
+        -128*x**(S(1)/4)*sin(log(x))/289 + 240*x**(S(1)/4)*cos(log(x))/289 +
+        (16*x**(S(1)/4)*sin(log(x))/17 + 4*x**(S(1)/4)*cos(log(x))/17)*log(x))
+
+
 def test_issue_6828():
     f = 1/(1.08*x**2 - 4.3)
     g = integrate(f, x).diff(x)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The function `integrate` has boolean flags risch, meijerg, and manual which can be used to disable a particular method (False), or to use only that method (True). This PR adds such a flag for the other  general integration method, "heurisch" (parallel / heuristic Risch algorithm). This method is known to sometimes take extremely long time (practically hanging the computation), so it may be desirable to disable it in some contexts. For example, the integral in #15471 can be computed by setting `heurisch=False`. Also, these flags make it easier to debug `integrate`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
   * Added a flag `heurisch` to `integrate`. It can be used to disable the parallel/heuristic Risch algorithm, or to use this algorithm exclusively.    
<!-- END RELEASE NOTES -->
