### PR TITLE
continuum_mechanics: fix apply_support() for plural fixed supports

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -340,7 +340,7 @@ class Beam(object):
             reaction_moment = Symbol('M_'+str(loc))
             self.apply_load(reaction_load, loc, -1)
             self.apply_load(reaction_moment, loc, -2)
-            self.bc_deflection = [(loc, 0)]
+            self.bc_deflection.append((loc, 0))
             self.bc_slope.append((loc, 0))
 
     def apply_load(self, value, start, order, end=None):
@@ -1744,7 +1744,7 @@ class Beam3D(Beam):
             reaction_load = Symbol('R_'+str(loc))
             reaction_moment = Symbol('M_'+str(loc))
             self._reaction_loads[reaction_load] = [reaction_load, reaction_moment]
-            self.bc_deflection = [(loc, [0, 0, 0])]
+            self.bc_deflection.append((loc, [0, 0, 0]))
             self.bc_slope.append((loc, [0, 0, 0]))
 
     def solve_for_reaction_loads(self, *reaction):

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -417,6 +417,16 @@ def test_apply_support():
     assert b.deflection() == (4000*x/3 - 4*SingularityFunction(x, 0, 3)/3 + SingularityFunction(x, 10, 3)
             + 60*SingularityFunction(x, 30, 2) + SingularityFunction(x, 30, 3)/3 - 12000)/(E*I)
 
+    P = Symbol('P', positive=True)
+    L = Symbol('L', positive=True)
+    b = Beam(L, E, I)
+    b.apply_support(0, type='fixed')
+    b.apply_support(L, type='fixed')
+    b.apply_load(-P, L/2, -1)
+    R_0, R_L, M_0, M_L = symbols('R_0, R_L, M_0, M_L')
+    b.solve_for_reaction_loads(R_0, R_L, M_0, M_L)
+    assert b.reaction_loads == {R_0: P/2, R_L: P/2, M_0: -L*P/8, M_L: L*P/8}
+
 
 def max_shear_force(self):
     E = Symbol('E')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15663

#### Brief description of what is fixed or changed
* Fixed typo in `beam.py`
* Added a test case in `test_beam.py`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
    * Fixed wrong result for plural fixed supports.
<!-- END RELEASE NOTES -->
