### PR TITLE
geometry/util: fixed idiff() for Function support

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1164,10 +1164,9 @@ class Derivative(Expr):
     def __new__(cls, expr, *variables, **kwargs):
 
         from sympy.matrices.common import MatrixCommon
-        from sympy import Integer, Eq
+        from sympy import Integer
         from sympy.tensor.array import Array, NDimArray, derive_by_array
         from sympy.utilities.misc import filldedent
-        from sympy.core import Equality
 
         expr = sympify(expr)
         try:
@@ -1326,10 +1325,6 @@ class Derivative(Expr):
         # we return here if evaluate is False or if there is no
         # _eval_derivative method
         if not evaluate or not hasattr(expr, '_eval_derivative'):
-            # return the derivative of Equality
-            if isinstance(expr, Equality):
-                return Eq(expr.lhs.diff(), expr.rhs.diff())
-
             # return an unevaluated Derivative
             if evaluate and variable_count == [(expr, 1)] and expr.is_scalar:
                 # special hack providing evaluation for classes

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1164,9 +1164,10 @@ class Derivative(Expr):
     def __new__(cls, expr, *variables, **kwargs):
 
         from sympy.matrices.common import MatrixCommon
-        from sympy import Integer
+        from sympy import Integer, Eq
         from sympy.tensor.array import Array, NDimArray, derive_by_array
         from sympy.utilities.misc import filldedent
+        from sympy.core import Equality
 
         expr = sympify(expr)
         try:
@@ -1325,6 +1326,10 @@ class Derivative(Expr):
         # we return here if evaluate is False or if there is no
         # _eval_derivative method
         if not evaluate or not hasattr(expr, '_eval_derivative'):
+            # return the derivative of Equality
+            if isinstance(expr, Equality):
+                return Eq(expr.lhs.diff(), expr.rhs.diff())
+
             # return an unevaluated Derivative
             if evaluate and variable_count == [(expr, 1)] and expr.is_scalar:
                 # special hack providing evaluation for classes

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,5 +1,5 @@
-from sympy import Symbol, sqrt, Derivative, S
-from sympy.geometry import Point, Point2D, Line, Circle ,Polygon, Segment, convex_hull, intersection, centroid
+from sympy import Symbol, sqrt, Derivative, S, Function, exp, Eq
+from sympy.geometry import Point, Point2D, Line, Circle, Polygon, Segment, convex_hull, intersection, centroid
 from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points
 from sympy.solvers.solvers import solve
 from sympy.utilities.pytest import raises
@@ -9,6 +9,8 @@ def test_idiff():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
     t = Symbol('t', real=True)
+    f = Function('f')
+    g = Function('g')
     # the use of idiff in ellipse also provides coverage
     circ = x**2 + y**2 - 4
     ans = -3*x*(x**2 + y**2)/y**5
@@ -19,6 +21,11 @@ def test_idiff():
     assert ans.subs(y, solve(circ, y)[0]).equals(explicit)
     assert True in [sol.diff(x, 3).equals(explicit) for sol in solve(circ, y)]
     assert idiff(x + t + y, [y, t], x) == -Derivative(t, x) - 1
+    assert idiff(f(x) * exp(f(x)) - x * exp(x), f(x), x) == (x + 1) * exp(x - f(x))/(f(x) + 1)
+    assert idiff(f(x) - y * exp(x), [f(x), y], x) == (y + Derivative(y, x)) * exp(x)
+    assert idiff(f(x) - y * exp(x), [y, f(x)], x) == -y + exp(-x) * Derivative(f(x), x)
+    assert idiff(Eq(y * exp(y), x * exp(x)), y, x) == (x + 1) * exp(x - y)/(y + 1)
+    assert idiff(Eq(f(x), g(x)), [f(x), g(x)], x) == Derivative(g(x), x)
 
 
 def test_intersection():

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, sqrt, Derivative, S, Function, exp, Eq
+from sympy import Symbol, sqrt, Derivative, S, Function, exp
 from sympy.geometry import Point, Point2D, Line, Circle, Polygon, Segment, convex_hull, intersection, centroid
 from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points
 from sympy.solvers.solvers import solve
@@ -24,8 +24,7 @@ def test_idiff():
     assert idiff(f(x) * exp(f(x)) - x * exp(x), f(x), x) == (x + 1) * exp(x - f(x))/(f(x) + 1)
     assert idiff(f(x) - y * exp(x), [f(x), y], x) == (y + Derivative(y, x)) * exp(x)
     assert idiff(f(x) - y * exp(x), [y, f(x)], x) == -y + exp(-x) * Derivative(f(x), x)
-    assert idiff(Eq(y * exp(y), x * exp(x)), y, x) == (x + 1) * exp(x - y)/(y + 1)
-    assert idiff(Eq(f(x), g(x)), [f(x), g(x)], x) == Derivative(g(x), x)
+    assert idiff(f(x) - g(x), [f(x), g(x)], x) == Derivative(g(x), x)
 
 
 def test_intersection():

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -17,6 +17,7 @@ from sympy.core.compatibility import (
     is_sequence, range, string_types, ordered)
 from sympy.core.containers import OrderedSet
 from .point import Point, Point2D
+from  sympy.core import Equality, Add
 
 
 def find(x, equation):
@@ -570,6 +571,13 @@ def idiff(eq, y, x, n=1):
         y = y[0]
     elif isinstance(y, Symbol):
         dep = {y}
+    elif isinstance(y, Function):
+        pass
+    else:
+        raise ValueError("expecting x-dependent symbol(s) or function(s) but got: %s" % y)
+
+    if isinstance(eq, Equality):
+        eq = eq.rewrite(Add)
 
     f = dict([(s, Function(
         s.name)(x)) for s in eq.free_symbols if s != x and s in dep])

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -576,9 +576,6 @@ def idiff(eq, y, x, n=1):
     else:
         raise ValueError("expecting x-dependent symbol(s) or function(s) but got: %s" % y)
 
-    if isinstance(eq, Equality):
-        eq = eq.rewrite(Add)
-
     f = dict([(s, Function(
         s.name)(x)) for s in eq.free_symbols if s != x and s in dep])
 

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -17,7 +17,6 @@ from sympy.core.compatibility import (
     is_sequence, range, string_types, ordered)
 from sympy.core.containers import OrderedSet
 from .point import Point, Point2D
-from  sympy.core import Equality, Add
 
 
 def find(x, equation):

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -570,12 +570,15 @@ def idiff(eq, y, x, n=1):
         y = y[0]
     elif isinstance(y, Symbol):
         dep = {y}
-    else:
-        raise ValueError("expecting x-dependent symbol(s) but got: %s" % y)
 
     f = dict([(s, Function(
         s.name)(x)) for s in eq.free_symbols if s != x and s in dep])
-    dydx = Function(y.name)(x).diff(x)
+
+    if isinstance(y, Symbol):
+        dydx = Function(y.name)(x).diff(x)
+    else:
+        dydx = y.diff(x)
+
     eq = eq.subs(f)
     derivs = {}
     for i in range(n):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15584 

#### Brief description of what is fixed or changed
Now idiff(eq, y, x, n=1) supports:

- Eq as its first argument.
	Example:
		In [1]: from sympy import *
		In [2]: x, y = symbols('x y')
		In [3]: print(idiff(Eq(y*exp(y), x*exp(x)), y, x))
		Out [3]: (x + 1)*exp(x - y)/(y + 1)

- f(x) instead of y, where f is a Function.
	Example:
		In [1]: from sympy import *
		In [2]: x = symbols('x')
		In [3]: f = Function('f')
		In [4]: print(idiff(f(x)*exp(f(x)) - x*exp(x), f(x), x))
		Out [4]: (x + 1)*exp(x - f(x))/(f(x) + 1)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
    * in idiff added support for the case when y is a Function
<!-- END RELEASE NOTES -->
