### PR TITLE
LaTeX printing: Use "standalone" document class for preview()

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -42,7 +42,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     except ImportError:
         pass
 
-    preamble = "\\documentclass[%s]{standalone}\n" \
+    preamble = "\\documentclass[varwidth,%s]{standalone}\n" \
                "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
     if euler:
         addpackages = '\\usepackage{euler}'

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -42,8 +42,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     except ImportError:
         pass
 
-    preamble = "\\documentclass[%s]{article}\n" \
-               "\\pagestyle{empty}\n" \
+    preamble = "\\documentclass[%s]{standalone}\n" \
                "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
     if euler:
         addpackages = '\\usepackage{euler}'

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -166,7 +166,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         package_includes = "\n" + "\n".join(["\\usepackage{%s}" % p
                                              for p in actual_packages])
 
-        preamble = r"""\documentclass[12pt]{standalone}
+        preamble = r"""\documentclass[varwidth,12pt]{standalone}
 %s
 
 \begin{document}

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -166,8 +166,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         package_includes = "\n" + "\n".join(["\\usepackage{%s}" % p
                                              for p in actual_packages])
 
-        preamble = r"""\documentclass[12pt]{article}
-\pagestyle{empty}
+        preamble = r"""\documentclass[12pt]{standalone}
 %s
 
 \begin{document}


### PR DESCRIPTION
#### References to other Issues or PRs

Fix for bug discovered in #15625.

#### Brief description of what is fixed or changed

If `preview()` is used with a very long expression in inline mode (using `$...$`), the intermediate DVI file grows larger than one page and the following conversion to PNG only shows the last page.

The same problem appears when using `init_printing(use_latex='png')`  because it uses the same machinery.

This PR switches to the `standalone` document class, which doesn't create multiple pages.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * use `\documentclass{standalone}` by default when using LaTeX to render expressions
<!-- END RELEASE NOTES -->
