### PR TITLE
Addition: Reason for not importing stats with `from sympy import *`

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -74,6 +74,7 @@ from .tensor import *
 from .parsing import *
 from .calculus import *
 from .algebras import *
+from .stats import *
 # Adds about .04-.05 seconds of import time
 # from combinatorics import *
 # This module is slow to import:

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -74,7 +74,8 @@ from .tensor import *
 from .parsing import *
 from .calculus import *
 from .algebras import *
-from .stats import *
+# This module causes conflicts with other modules:
+# from .stats import *
 # Adds about .04-.05 seconds of import time
 # from combinatorics import *
 # This module is slow to import:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
N/A

#### Brief description of what is fixed or changed
stats was not imported with `from sympy import *` earlier.
This commit fixes the above issue.

#### Other comments
I don't know the reason for not including `from .stats import *` in `__init__.py`. However,
when I used `from sympy import *`, it didn't import the `stats` module and hence this compelled
me to write a new line `from sympy.stats import  * `. I made this PR just for the ease of the user who
may face an error while working with stats module.
If I am wrong somewhere, then please correct me. If this change can cause performance issues then an explanation will be helpful. :-)
Note - After some discussion in the below comments with @ethankward, the change has been commented out and reason for doing the same has been mentioned.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * reason for not importing stats with `from sympy import *` has been included
<!-- END RELEASE NOTES -->
