### PR TITLE
changing scale_factor of kg to One

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -50,22 +50,13 @@ m = meter = meters = Quantity("meter", abbrev="m")
 meter.set_dimension(length)
 meter.set_scale_factor(One)
 
-# gram; used to define its prefixed units
-g = gram = grams = Quantity("gram", abbrev="g")
-gram.set_dimension(mass)
-gram.set_scale_factor(One)
-
-# NOTE: the `kilogram` has scale factor 1000. In SI, kg is a base unit, but
-# nonetheless we are trying to be compatible with the `kilo` prefix. In a
-# similar manner, people using CGS or gaussian units could argue that the
-# `centimeter` rather than `meter` is the fundamental unit for length, but the
-# scale factor of `centimeter` will be kept as 1/100 to be compatible with the
-# `centi` prefix.  The current state of the code assumes SI unit dimensions, in
+# NOTE: the `kilogram` has scale factor of 1 in SI.
+# The current state of the code assumes SI unit dimensions, in
 # the future this module will be modified in order to be unit system-neutral
 # (that is, support all kinds of unit systems).
 kg = kilogram = kilograms = Quantity("kilogram", abbrev="kg")
 kilogram.set_dimension(mass)
-kilogram.set_scale_factor(kilo*gram)
+kilogram.set_scale_factor(One)
 
 s = second = seconds = Quantity("second", abbrev="s")
 second.set_dimension(time)
@@ -87,6 +78,9 @@ cd = candela = candelas = Quantity("candela", abbrev="cd")
 candela.set_dimension(luminous_intensity)
 candela.set_scale_factor(One)
 
+g = gram = grams = Quantity("gram", abbrev="g")
+gram.set_dimension(mass)
+gram.set_scale_factor(kilogram/kilo)
 
 mg = milligram = milligrams = Quantity("milligram", abbrev="mg")
 milligram.set_dimension(mass)

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -53,7 +53,7 @@ def test_print_unit_base():
 
     mksa = UnitSystem((m, kg, s, A), (Js,))
     with warns_deprecated_sympy():
-        assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
+        assert mksa.print_unit_base(Js) == m**2*kg*s**-1
 
 
 def test_extend():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes  #15647".

#### Brief description of what is fixed or changed
ohm.scale_factor=1000


This value of 1000 conflicts with the definition, this should be 1 .
and the reason of this is "scale_factor"  of "kg" is not one.
so i changed "definitions" file to make it 1.
and also test file. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- physics.units
  - corrected scale factor Kilogram to 1 as per SI unit.


  <!-- END RELEASE NOTES -->
