### PR TITLE
Revert the decorators from test_autowrap

### DIFF
--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -85,7 +85,6 @@ def test_cython_wrapper_inoutarg():
     assert source == expected
 
 
-@cleanup_tmp_files
 def test_cython_wrapper_compile_flags():
     from sympy import Equality
     x, y, z = symbols('x,y,z')
@@ -185,6 +184,8 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
         setup_text = f.read()
     assert setup_text == expected
 
+    TmpFileManager.cleanup()
+
 def test_autowrap_dummy():
     x, y, z = symbols('x y z')
 
@@ -226,8 +227,6 @@ def test_autowrap_args():
     assert f.args == "y, x, z"
     assert f.returns == "z"
 
-
-@cleanup_tmp_files
 def test_autowrap_store_files():
     x, y = symbols('x y')
     tmp = tempfile.mkdtemp()
@@ -237,6 +236,7 @@ def test_autowrap_store_files():
     assert f() == str(x + y)
     assert os.access(tmp, os.F_OK)
 
+    TmpFileManager.cleanup()
 
 def test_autowrap_store_files_issue_gh12939():
     x, y = symbols('x y')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#15354

#### Brief description of what is fixed or changed

I think the decorators do not work as expected, as it makes the test unrecognized from bin/test.
I have just reverted to `cleanup()` method, for workaround.
Though wrapping the whole test code inside `try` ~~ `finally` statement would be the best solution, but I don't think that it would be a good idea to add an additional tabbing for about 100 lines.

I'm still figuring out the cause, but at least this should be notified as an issue.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
