### PR TITLE
Cleanup temporary files from test_plot_implicit

### DIFF
--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -62,8 +62,6 @@ def plot_implicit_tests(name):
         plot_and_save(Eq(y, re(cos(x) + I*sin(x))), name=name, dir=temp_dir)
 
     plot_and_save(x**2 - 1, title='An implicit plot', dir=temp_dir)
-    
-    TmpFileManager.cleanup()
 
 def test_line_color():
     x, y = symbols('x, y')
@@ -75,7 +73,10 @@ def test_line_color():
 def test_matplotlib():
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
     if matplotlib:
-        plot_implicit_tests('test')
-        test_line_color()
+        try:
+            plot_implicit_tests('test')
+            test_line_color()
+        finally:
+            TmpFileManager.cleanup()
     else:
         skip("Matplotlib not the default backend")

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -2,61 +2,68 @@ import warnings
 from sympy import (plot_implicit, cos, Symbol, symbols, Eq, sin, re, And, Or, exp, I,
                    tan, pi)
 from sympy.plotting.plot import unset_show
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, mkdtemp
 from sympy.utilities.pytest import skip, warns
 from sympy.external import import_module
+from sympy.utilities.tmpfiles import TmpFileManager, cleanup_tmp_files
 
 #Set plots not to show
 unset_show()
 
-def tmp_file(name=''):
-    return NamedTemporaryFile(suffix='.png').name
+def tmp_file(dir=None, name=''):
+    return NamedTemporaryFile(
+    prefix=name, suffix='.png', dir=dir, delete=False).name
 
 def plot_and_save(expr, *args, **kwargs):
     name = kwargs.pop('name', '')
+    dir = kwargs.pop('dir', None)
     p = plot_implicit(expr, *args, **kwargs)
-    p.save(tmp_file(name))
+    p.save(tmp_file(dir=dir, name=name))
     # Close the plot to avoid a warning from matplotlib
     p._backend.close()
 
 def plot_implicit_tests(name):
+    temp_dir = mkdtemp()
+    TmpFileManager.tmp_folder(temp_dir)
     x = Symbol('x')
     y = Symbol('y')
     z = Symbol('z')
     #implicit plot tests
-    plot_and_save(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), name=name)
+    plot_and_save(Eq(y, cos(x)), (x, -5, 5), (y, -2, 2), name=name, dir=temp_dir)
     plot_and_save(Eq(y**2, x**3 - x), (x, -5, 5),
-            (y, -4, 4), name=name)
+            (y, -4, 4), name=name, dir=temp_dir)
     plot_and_save(y > 1 / x, (x, -5, 5),
-            (y, -2, 2), name=name)
+            (y, -2, 2), name=name, dir=temp_dir)
     plot_and_save(y < 1 / tan(x), (x, -5, 5),
-            (y, -2, 2), name=name)
+            (y, -2, 2), name=name, dir=temp_dir)
     plot_and_save(y >= 2 * sin(x) * cos(x), (x, -5, 5),
-            (y, -2, 2), name=name)
+            (y, -2, 2), name=name, dir=temp_dir)
     plot_and_save(y <= x**2, (x, -3, 3),
-            (y, -1, 5), name=name)
+            (y, -1, 5), name=name, dir=temp_dir)
 
     #Test all input args for plot_implicit
-    plot_and_save(Eq(y**2, x**3 - x))
-    plot_and_save(Eq(y**2, x**3 - x), adaptive=False)
-    plot_and_save(Eq(y**2, x**3 - x), adaptive=False, points=500)
-    plot_and_save(y > x, (x, -5, 5))
-    plot_and_save(And(y > exp(x), y > x + 2))
-    plot_and_save(Or(y > x, y > -x))
-    plot_and_save(x**2 - 1, (x, -5, 5))
-    plot_and_save(x**2 - 1)
-    plot_and_save(y > x, depth=-5)
-    plot_and_save(y > x, depth=5)
-    plot_and_save(y > cos(x), adaptive=False)
-    plot_and_save(y < cos(x), adaptive=False)
-    plot_and_save(And(y > cos(x), Or(y > x, Eq(y, x))))
-    plot_and_save(y - cos(pi / x))
+    plot_and_save(Eq(y**2, x**3 - x), dir=temp_dir)
+    plot_and_save(Eq(y**2, x**3 - x), adaptive=False, dir=temp_dir)
+    plot_and_save(Eq(y**2, x**3 - x), adaptive=False, points=500, dir=temp_dir)
+    plot_and_save(y > x, (x, -5, 5), dir=temp_dir)
+    plot_and_save(And(y > exp(x), y > x + 2), dir=temp_dir)
+    plot_and_save(Or(y > x, y > -x), dir=temp_dir)
+    plot_and_save(x**2 - 1, (x, -5, 5), dir=temp_dir)
+    plot_and_save(x**2 - 1, dir=temp_dir)
+    plot_and_save(y > x, depth=-5, dir=temp_dir)
+    plot_and_save(y > x, depth=5, dir=temp_dir)
+    plot_and_save(y > cos(x), adaptive=False, dir=temp_dir)
+    plot_and_save(y < cos(x), adaptive=False, dir=temp_dir)
+    plot_and_save(And(y > cos(x), Or(y > x, Eq(y, x))), dir=temp_dir)
+    plot_and_save(y - cos(pi / x), dir=temp_dir)
 
     #Test plots which cannot be rendered using the adaptive algorithm
     with warns(UserWarning, match="Adaptive meshing could not be applied"):
-        plot_and_save(Eq(y, re(cos(x) + I*sin(x))), name=name)
+        plot_and_save(Eq(y, re(cos(x) + I*sin(x))), name=name, dir=temp_dir)
 
-    plot_and_save(x**2 - 1, title='An implicit plot')
+    plot_and_save(x**2 - 1, title='An implicit plot', dir=temp_dir)
+    
+    TmpFileManager.cleanup()
 
 def test_line_color():
     x, y = symbols('x, y')

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -12,7 +12,7 @@ unset_show()
 
 def tmp_file(dir=None, name=''):
     return NamedTemporaryFile(
-    prefix=name, suffix='.png', dir=dir, delete=False).name
+    suffix='.png', dir=dir, delete=False).name
 
 def plot_and_save(expr, *args, **kwargs):
     name = kwargs.pop('name', '')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I think this test generates some plotting figures under OS specific temp directory, which are not being cleaned up.

Though the documentation about `NamedTemporaryFile` says that it gets cleaned up after closed, however, I don't think it is working as intended.
I think sympy plotting module itself would have scrambled up how the temporary files are handled.

So I have changed like this
```
    return NamedTemporaryFile(
    suffix='.png', dir=dir, delete=False).name
```
so that `delete=False` may make it state more clear about manual deletion,
~~and also have used `name` feature, because I think the original code has some trivial problem that the argument `name` is not being used.~~

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
