### PR TITLE
sympy.utilities.misc: ordinal(113) is not '113rd'

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -428,23 +428,15 @@ def ordinal(num):
     """
     # modified from https://codereview.stackexchange.com/questions/41298/producing-ordinal-numbers
     n = as_int(num)
-    if n < 0:
-        return '-%s' % ordinal(-n)
-    if n == 0 or 4 <= n <= 20:
+    k = abs(n) % 100
+    if 11 <= k <= 13:
         suffix = 'th'
-    elif n == 1 or (n % 10) == 1:
+    elif k % 10 == 1:
         suffix = 'st'
-    elif n == 2 or (n % 10) == 2:
+    elif k % 10 == 2:
         suffix = 'nd'
-    elif n == 3 or (n % 10) == 3:
+    elif k % 10 == 3:
         suffix = 'rd'
-    elif n < 101:
-        suffix = 'th'
     else:
-        suffix = ordinal(n % 100)
-        if len(suffix) == 3:
-            # e.g. 103 -> 3rd
-            # so add other 0 back
-            suffix = '0' + suffix
-        n = str(n)[:-2]
+        suffix = 'th'
     return str(n) + suffix

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import unichr
+from sympy.core.compatibility import range, unichr
 from sympy.utilities.misc import translate, replace, ordinal
 
 def test_translate():
@@ -35,3 +35,4 @@ def test_ordinal():
     assert ordinal(103) == '103rd'
     assert ordinal(104) == '104th'
     assert ordinal(200) == '200th'
+    assert all(ordinal(i) == str(i) + 'th' for i in range(-220, -203))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
A small bugfix in the new-ish ordinal function correcting its behavior on numbers 111, 112, 113, 211, 212, 213, and the like.

#### Other comments
No release notes entry because this bug was not in the previous release.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
