### PR TITLE
[WIP] Permutations: Use perm_cyclic flag in pprint/latex to print cyclic notation. print_cyclic is depreciated

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -998,28 +998,20 @@ class Permutation(Basic):
         return self._array_form[:]
 
     def __repr__(self):
+        """
+        Default Representation Array Form
+        """
         from sympy.combinatorics.permutations import Permutation, Cycle
-        if Permutation.print_cyclic:
-            if not self.size:
-                return 'Permutation()'
-            # before taking Cycle notation, see if the last element is
-            # a singleton and move it to the head of the string
-            s = Cycle(self)(self.size - 1).__repr__()[len('Cycle'):]
-            last = s.rfind('(')
-            if not last == 0 and ',' not in s[last:]:
-                s = s[last:] + s[:last]
-            return 'Permutation%s' %s
-        else:
-            s = self.support()
-            if not s:
-                if self.size < 5:
-                    return 'Permutation(%s)' % str(self.array_form)
-                return 'Permutation([], size=%s)' % self.size
-            trim = str(self.array_form[:s[-1] + 1]) + ', size=%s' % self.size
-            use = full = str(self.array_form)
-            if len(trim) < len(full):
-                use = trim
-            return 'Permutation(%s)' % use
+        s = self.support()
+        if not s:
+            if self.size < 5:
+                return 'Permutation(%s)' % str(self.array_form)
+            return 'Permutation([], size=%s)' % self.size
+        trim = str(self.array_form[:s[-1] + 1]) + ', size=%s' % self.size
+        use = full = str(self.array_form)
+        if len(trim) < len(full):
+            use = trim
+        return 'Permutation(%s)' % use
 
     def list(self, size=None):
         """Return the permutation as an explicit list, possibly
@@ -2819,7 +2811,6 @@ class Permutation(Basic):
     # global flag to control how permutations are printed
     # when True, Permutation([0, 2, 1, 3]) -> Cycle(1, 2)
     # when False, Permutation([0, 2, 1, 3]) -> Permutation([0, 2, 1])
-    print_cyclic = True
 
 
 def _merge(arr, temp, left, mid, right):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -135,6 +135,7 @@ class LatexPrinter(Printer):
         "mat_delim": "[",
         "symbol_names": {},
         "ln_notation": False,
+        "perm_cyclic": True,
     }
 
     def __init__(self, settings=None):
@@ -340,7 +341,12 @@ class LatexPrinter(Printer):
         term_tex = term_tex.replace(']', r"\right)")
         return term_tex
 
-    _print_Permutation = _print_Cycle
+    def _print_Permutation(self, expr):
+        if self._settings.get("perm_cyclic",True):
+            return self._print_Cycle(expr)
+        else:
+            pass
+
 
     def _print_Float(self, expr):
         # Based off of that in StrPrinter
@@ -2270,7 +2276,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     fold_short_frac=None, inv_trig_style="abbreviated",
     itex=False, ln_notation=False, long_frac_ratio=None,
     mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
-    order=None, symbol_names=None):
+    order=None, symbol_names=None, perm_cyclic=True):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2447,6 +2453,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         'mul_symbol' : mul_symbol,
         'order' : order,
         'symbol_names' : symbol_names,
+        'perm_cyclic' : perm_cyclic,
     }
 
     return LatexPrinter(settings).doprint(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -345,7 +345,16 @@ class LatexPrinter(Printer):
         if self._settings.get("perm_cyclic",True):
             return self._print_Cycle(expr)
         else:
-            pass
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+            use = full = self._print(expr.array_form)
+            if len(trim) < len(full):
+                use = trim
+            return 'Permutation(%s)' % use
 
 
     def _print_Float(self, expr):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -45,6 +45,7 @@ class PrettyPrinter(Printer):
         "wrap_line": True,
         "num_columns": None,
         "use_unicode_sqrt_char": True,
+        "perm_cyclic": True
     }
 
     def __init__(self, settings=None):
@@ -372,6 +373,12 @@ class PrettyPrinter(Printer):
             l = self._print(str(tuple(i)).replace(',', ''))
             cyc = prettyForm(*cyc.right(l))
         return cyc
+
+    def _print_Permutation(self,expr):
+        if self._settings.get("perm_cyclic",True):
+            return self._print_Cycle(expr)
+        else:
+            pass
 
     def _print_PDF(self, pdf):
         lim = self._print(pdf.pdf.args[0])
@@ -2450,7 +2457,8 @@ def pretty(expr, **settings):
 
 
 def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
-                 full_prec="auto", order=None, use_unicode_sqrt_char=True):
+                 full_prec="auto", order=None, use_unicode_sqrt_char=True,
+                 perm_cyclic=True):
     """Prints expr in pretty form.
 
     pprint is just a shortcut for this function.
@@ -2484,7 +2492,8 @@ def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
     """
     print(pretty(expr, wrap_line=wrap_line, num_columns=num_columns,
                  use_unicode=use_unicode, full_prec=full_prec, order=order,
-                 use_unicode_sqrt_char=use_unicode_sqrt_char))
+                 use_unicode_sqrt_char=use_unicode_sqrt_char,
+                 perm_cyclic=perm_cyclic))
 
 pprint = pretty_print
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -378,7 +378,13 @@ class PrettyPrinter(Printer):
         if self._settings.get("perm_cyclic",True):
             return self._print_Cycle(expr)
         else:
-            pass
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            use = self._print(expr.array_form)
+            return prettyForm('Permutation(%s)' % use)
 
     def _print_PDF(self, pdf):
         lim = self._print(pdf.pdf.args[0])

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -22,6 +22,7 @@ class StrPrinter(Printer):
         "full_prec": "auto",
         "sympy_integers": False,
         "abbrev": False,
+        "perm_cyclic": False,
     }
 
     _relationals = dict()
@@ -365,16 +366,28 @@ class StrPrinter(Printer):
 
     def _print_Permutation(self, expr):
         from sympy.combinatorics.permutations import Permutation, Cycle
-        s = expr.support()
-        if not s:
-            if expr.size < 5:
-                return 'Permutation(%s)' % self._print(expr.array_form)
-            return 'Permutation([], size=%s)' % self._print(expr.size)
-        trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
-        use = full = self._print(expr.array_form)
-        if len(trim) < len(full):
-            use = trim
-        return 'Permutation(%s)' % use
+        if self._settings.get("perm_cyclic",True):
+            if not expr.size:
+                return '()'
+            # before taking Cycle notation, see if the last element is
+            # a singleton and move it to the head of the string
+            s = Cycle(expr)(expr.size - 1).__repr__()[len('Cycle'):]
+            last = s.rfind('(')
+            if not last == 0 and ',' not in s[last:]:
+                s = s[last:] + s[:last]
+            s = s.replace(',', '')
+            return s
+        else:
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+            use = full = self._print(expr.array_form)
+            if len(trim) < len(full):
+                use = trim
+            return 'Permutation(%s)' % use
 
     def _print_Subs(self, obj):
         expr, old, new = obj.args

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -365,28 +365,16 @@ class StrPrinter(Printer):
 
     def _print_Permutation(self, expr):
         from sympy.combinatorics.permutations import Permutation, Cycle
-        if Permutation.print_cyclic:
-            if not expr.size:
-                return '()'
-            # before taking Cycle notation, see if the last element is
-            # a singleton and move it to the head of the string
-            s = Cycle(expr)(expr.size - 1).__repr__()[len('Cycle'):]
-            last = s.rfind('(')
-            if not last == 0 and ',' not in s[last:]:
-                s = s[last:] + s[:last]
-            s = s.replace(',', '')
-            return s
-        else:
-            s = expr.support()
-            if not s:
-                if expr.size < 5:
-                    return 'Permutation(%s)' % self._print(expr.array_form)
-                return 'Permutation([], size=%s)' % self._print(expr.size)
-            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
-            use = full = self._print(expr.array_form)
-            if len(trim) < len(full):
-                use = trim
-            return 'Permutation(%s)' % use
+        s = expr.support()
+        if not s:
+            if expr.size < 5:
+                return 'Permutation(%s)' % self._print(expr.array_form)
+            return 'Permutation([], size=%s)' % self._print(expr.size)
+        trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+        use = full = self._print(expr.array_form)
+        if len(trim) < len(full):
+            use = trim
+        return 'Permutation(%s)' % use
 
     def _print_Subs(self, obj):
         expr, old, new = obj.args


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
`print_cyclic` is depreciated.
`str` printer prints only the array form of Permutation.
To print cyclic form, use `pprint` or `print_latex` with the flag `perm_cyclic=True`. or alternatively use `init_printing(perm_cyclic=True)` in an interactive session.
Default behavior for `pprint` etc. is to print cyclic form.

#### References to other Issues or PRs
Fixes #15201 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Other Comments

I have not updated the doctests to reflect these changes. Naturally, they are going to fail.
It would be better to get a review of these changes and decide on the intended behavior before all the tests are changed.

`print_cyclic` is used all over the place. What is the best way to change all those? Should that be a seperate pull request?

There will also be a need to change documentation. 

@asmeurer 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
    * `Permutations.print_cyclic` is depreciated.
    * To print cyclic form of permutations, use the new flag `perm_cyclic` with pprint or latex
    * `print Permutation(1,2,3)` only prints array form

<!-- END RELEASE NOTES -->
