### PR TITLE
Fix of Matrix expressions sometimes gives Add and Mul instead of MatA…

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -245,6 +245,12 @@ class Mul(Expr, AssocOp):
 
                 else:
                     # NCMul can have commutative parts as well
+                    if isinstance(o, MatrixExpr):
+                        if isinstance(coeff, MatrixExpr):
+                            coeff *= o
+                        else:
+                            coeff = o.__mul__(coeff)
+                        continue
                     for q in o.args:
                         if q.is_commutative:
                             seq.append(q)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,13 +2,13 @@ from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, zoo, Integer,
-        sign, im, nan, Dummy, factorial, comp, refine
+        sign, im, nan, Dummy, factorial, comp, refine, MatrixSymbol
 )
 from sympy.core.compatibility import long, range
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import verify_numerically
-
+from sympy.matrices.expressions import MatMul
 
 a, c, x, y, z = symbols('a,c,x,y,z')
 b = Symbol("b", positive=True)
@@ -1751,6 +1751,15 @@ def test_issue_6077():
     assert 2**x/2**(2.0*x) == 2**(-1.0*x)
     assert 2**x*2**(2.0*x) == 2**(3.0*x)
     assert 2**(1.5*x)*2**(2.5*x) == 2**(4.0*x)
+
+
+def test_issue_15665():
+    n = Symbol('n')
+    A = MatrixSymbol("A", n, n)
+    B = MatrixSymbol("B", n, n)
+
+    assert isinstance(Mul(A, B), MatMul)
+    assert isinstance(Mul(-1, Mul(A, B)), MatMul)
 
 
 def test_mul_flatten_oo():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,15 +2,14 @@ from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, zoo, Integer,
-        sign, im, nan, Dummy, factorial, comp, refine, MatrixSymbol
+        sign, im, nan, Dummy, factorial, comp, refine
 )
 from sympy.core.compatibility import long, range
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import verify_numerically
-from sympy.matrices.expressions import MatMul
 
-a, c, x, y, z, n = symbols('a,c,x,y,z,n')
+a, c, x, y, z = symbols('a,c,x,y,z')
 b = Symbol("b", positive=True)
 
 
@@ -1985,11 +1984,3 @@ def test_Add_is_zero():
 
 def test_issue_14392():
     assert (sin(zoo)**2).as_real_imag() == (nan, nan)
-
-
-def test_issue_15665():
-    A = MatrixSymbol("A", n, n)
-    B = MatrixSymbol("B", n, n)
-
-    assert isinstance(Mul(A, B), MatMul)
-    assert isinstance(Mul(-1, Mul(A, B)), MatMul)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -10,7 +10,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import verify_numerically
 from sympy.matrices.expressions import MatMul
 
-a, c, x, y, z = symbols('a,c,x,y,z')
+a, c, x, y, z, n = symbols('a,c,x,y,z,n')
 b = Symbol("b", positive=True)
 
 
@@ -1753,15 +1753,6 @@ def test_issue_6077():
     assert 2**(1.5*x)*2**(2.5*x) == 2**(4.0*x)
 
 
-def test_issue_15665():
-    n = Symbol('n')
-    A = MatrixSymbol("A", n, n)
-    B = MatrixSymbol("B", n, n)
-
-    assert isinstance(Mul(A, B), MatMul)
-    assert isinstance(Mul(-1, Mul(A, B)), MatMul)
-
-
 def test_mul_flatten_oo():
     p = symbols('p', positive=True)
     n, m = symbols('n,m', negative=True)
@@ -1994,3 +1985,11 @@ def test_Add_is_zero():
 
 def test_issue_14392():
     assert (sin(zoo)**2).as_real_imag() == (nan, nan)
+
+
+def test_issue_15665():
+    A = MatrixSymbol("A", n, n)
+    B = MatrixSymbol("B", n, n)
+
+    assert isinstance(Mul(A, B), MatMul)
+    assert isinstance(Mul(-1, Mul(A, B)), MatMul)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,8 +1,9 @@
 from sympy import (abc, Add, cos, Derivative, diff, exp, Float, Function,
     I, Integer, log, Mul, oo, Poly, Rational, S, sin, sqrt, Symbol, symbols,
-    Wild, pi, meijerg
+    Wild, pi, meijerg, MatrixSymbol
 )
 from sympy.utilities.pytest import XFAIL
+from sympy.matrices.expressions import MatMul
 
 
 def test_symbol():
@@ -617,3 +618,11 @@ def test_gh_issue_2711():
     assert f.find(a + b) == \
         {meijerg(((), ()), ((S.Zero,), ()), x), x, S.Zero}
     assert f.find(a**2) == {meijerg(((), ()), ((S.Zero,), ()), x), x}
+
+def test_issue_15665():
+    n=Symbol('n')
+    A = MatrixSymbol("A", n, n)
+    B = MatrixSymbol("B", n, n)
+
+    assert isinstance(Mul(A, B), MatMul)
+    assert isinstance(Mul(-1, Mul(A, B)), MatMul)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,9 +1,8 @@
 from sympy import (abc, Add, cos, Derivative, diff, exp, Float, Function,
     I, Integer, log, Mul, oo, Poly, Rational, S, sin, sqrt, Symbol, symbols,
-    Wild, pi, meijerg, MatrixSymbol
+    Wild, pi, meijerg
 )
 from sympy.utilities.pytest import XFAIL
-from sympy.matrices.expressions import MatMul
 
 
 def test_symbol():
@@ -618,11 +617,3 @@ def test_gh_issue_2711():
     assert f.find(a + b) == \
         {meijerg(((), ()), ((S.Zero,), ()), x), x, S.Zero}
     assert f.find(a**2) == {meijerg(((), ()), ((S.Zero,), ()), x), x}
-
-def test_issue_15665():
-    n=Symbol('n')
-    A = MatrixSymbol("A", n, n)
-    B = MatrixSymbol("B", n, n)
-
-    assert isinstance(Mul(A, B), MatMul)
-    assert isinstance(Mul(-1, Mul(A, B)), MatMul)

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -139,3 +139,7 @@ def test_issue_12950():
 def test_construction_with_Mul():
     assert Mul(C, D) == MatMul(C, D)
     assert Mul(D, C) == MatMul(D, C)
+
+def test_issue_15665():
+    assert isinstance(Mul(C, D), MatMul)
+    assert isinstance(Mul(-1, Mul(C, D)), MatMul)


### PR DESCRIPTION
…dd and MatMul

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15665 


#### Brief description of what is fixed or changed
Modified Mul.flatten such that it returns the correct return type in case of matrices i.e

>>> A = MatrixSymbol("A", n, n)
>>> B = MatrixSymbol("B", n, n)
>>> type(Mul(A, B))
<class 'sympy.matrices.expressions.matmul.MatMul'>
>>> type(Mul(-1, Mul(A, B)))
<class 'sympy.matrices.expressions.matmul.MatMul'>

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
       * fixed a bug in the flatten function


<!-- END RELEASE NOTES -->
