### PR TITLE
Supress PendingDeprecationWarning for np.matrix

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# np.matrix is deprecated but still used in sympy.physics.quantum:
+#    https://github.com/sympy/sympy/issues/15563
+# This prevents ~800 warnings showing up running the tests under pytest.
+filterwarnings =
+    ignore:.*the matrix subclass is not the recommended way.*:PendingDeprecationWarning


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

See #15563 

#### Brief description of what is fixed or changed

Adds `pytest.ini` config file for pytest. Adds a warning filter to ignore `PendingDeprecationWarning` for `np.matrix` when running the tests under pytest with numpy installed.

Upstream numpy has added `PendingDeprecationWarning` for `np.matrix`. Without this patch 800 warnings are shown when running the full test suite under pytest because of the different places where `np.matrix` is used.

#### Other comments

Here I'm suggesting to suppress this warning because it's already been seen and #15563 has already been opened. In general though these `PendingDeprecationWarnings` should probably be made visible by sympy's `bin/test` test runner as is done by unittest and pytest. It is recommended that test runners enable these warnings in [pep 565](https://github.com/oscarbenjamin/sympy/pull/new/npmatrix_warnings). The purpose of `PendingDeprecationWarning` is precisely that it should be ignored by default but made visible under test runners - it's supposed to be an early warning for downstream projects that have good testing.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
