### PR TITLE
Fix of powsimp to simplify further

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -216,6 +216,14 @@ def multiplicity(p, n):
                 if p.q == 1:
                     if n.p == 1:
                         return -multiplicity(p.p, n.q)
+                    elif isinstance(n.p, int):
+                        numerator=n.p
+                        denominator=n.q
+                        s=S.One
+                        while numerator%p.p==0:
+                            s*=p.p
+                            numerator/=p.p
+                        return multiplicity(p.p,s/denominator)
                     return S.Zero
                 elif p.p == 1:
                     return multiplicity(p.q, n.q)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -216,14 +216,6 @@ def multiplicity(p, n):
                 if p.q == 1:
                     if n.p == 1:
                         return -multiplicity(p.p, n.q)
-                    elif isinstance(n.p, int):
-                        numerator=n.p
-                        denominator=n.q
-                        s=S.One
-                        while numerator%p.p==0:
-                            s*=p.p
-                            numerator/=p.p
-                        return multiplicity(p.p,s/denominator)
                     return S.Zero
                 elif p.p == 1:
                     return multiplicity(p.q, n.q)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -166,8 +166,13 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if (b and b.is_Rational and not all(ei.is_Number for ei in e) and \
                     coeff is not S.One and
                     b not in (S.One, S.NegativeOne)):
-
-                m = multiplicity(abs(b), abs(coeff))
+                numerator=coeff.p
+                denominator=coeff.q
+                s=S.One
+                while numerator%b==0:
+                    s*=b
+                    numerator/=b
+                m = multiplicity(abs(b), abs(s/denominator))
                 if m:
                     e.append(m)
                     coeff /= b**m

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -13,7 +13,6 @@ from sympy.polys import lcm, gcd
 from sympy.ntheory.factor_ import multiplicity
 
 
-
 def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
     """
     reduces expression by combining powers with similar bases and exponents.
@@ -101,6 +100,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
     """
     from sympy.matrices.expressions.matexpr import MatrixSymbol
 
+
     def recurse(arg, **kwargs):
         _deep = kwargs.get('deep', deep)
         _combine = kwargs.get('combine', combine)
@@ -166,7 +166,13 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if (b and b.is_Rational and not all(ei.is_Number for ei in e) and \
                     coeff is not S.One and
                     b not in (S.One, S.NegativeOne)):
-                m = multiplicity(abs(b), abs(coeff))
+                numerator=coeff.p
+                denominator=coeff.q
+                s=S.One
+                while numerator%b==0:
+                    s*=b
+                    numerator/=b
+                m = multiplicity(abs(b), abs(s/denominator))
                 if m:
                     e.append(m)
                     coeff /= b**m

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -166,13 +166,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if (b and b.is_Rational and not all(ei.is_Number for ei in e) and \
                     coeff is not S.One and
                     b not in (S.One, S.NegativeOne)):
-                numerator=coeff.p
-                denominator=coeff.q
-                s=S.One
-                while numerator%b==0:
-                    s*=b
-                    numerator/=b
-                m = multiplicity(abs(b), abs(s/denominator))
+
+                m = multiplicity(abs(b), abs(coeff))
                 if m:
                     e.append(m)
                     coeff /= b**m


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15559 


#### Brief description of what is fixed or changed
Earlier it give
```
>>> powsimp(3**x/3)
3**(x - 1)
>>> powsimp(2*3**x/3) 
2*3**x/3
```
Now it gives
```
>>> powsimp(3**x/3)
3**(x - 1)
>>> powsimp(2*3**x/3) 
2*3**(x-1)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
          * fixed powsimp for above trivial case
<!-- END RELEASE NOTES -->
