### PR TITLE
Added a test for integration of a function with abs

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1465,3 +1465,13 @@ def test_issue_15640_log_substitutions():
     f = sqrt(log(x))/x**2
     F = -sqrt(pi)*erfc(sqrt(log(x)))/2 - sqrt(log(x))/x
     assert integrate(f, x) == F and F.diff(x) == f
+
+
+def test_issue_4311():
+    x = symbols('x')
+    assert integrate(x*abs(9-x**2), x) == Integral(x*abs(9-x**2), x)
+    x = symbols('x', real=True)
+    assert integrate(x*abs(9-x**2), x) == Piecewise(
+        (x**4/4 - 9*x**2/2, x <= -3),
+        (-x**4/4 + 9*x**2/2 - S(81)/2, x <= 3),
+        (x**4/4 - 9*x**2/2, True))


### PR DESCRIPTION
#### References to other Issues or PRs

Closes #4311 by adding a test for it 

#### Brief description of what is fixed or changed

At this time, `integrate(x*abs(9-x**2), x)` works as expected, returning a Piecewise if x is real, and remaining unevaluated if x is not (since there is no antiderivative in the complex plane for a function with abs). A test is added to close the issue. 
 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
