### PR TITLE
Fix of matrix power failure error

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -13,6 +13,7 @@ from sympy.core.symbol import Symbol
 from sympy.core.function import count_ops
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
+from sympy.core.power import Pow
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
     NotIterable, Iterable
 
@@ -2065,8 +2066,8 @@ class MatrixArithmetic(MatrixRequired):
                     except (AttributeError, MatrixError):
                         pass
                 return a._eval_pow_by_recursion(num)
-            elif num.is_Number!=True and num.is_negative==None:
-                return ("{}**{}").format(a,num)
+            elif num.is_Number!=True and num.is_negative==None and a.det()==0:
+                return Pow.__new__(type(a),a,num)
             elif isinstance(num, (Expr, float)):
                 return a._matrix_pow_by_jordan_blocks(num)
             else:

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -13,7 +13,6 @@ from sympy.core.symbol import Symbol
 from sympy.core.function import count_ops
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
-from sympy.core.power import Pow
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
     NotIterable, Iterable
 
@@ -2066,8 +2065,9 @@ class MatrixArithmetic(MatrixRequired):
                     except (AttributeError, MatrixError):
                         pass
                 return a._eval_pow_by_recursion(num)
-            elif num.is_Number!=True and num.is_negative==None and a.det()==0:
-                return Pow.__new__(type(a),a,num)
+            elif num.is_Number != True and num.is_negative == None and a.det() == 0:
+                from sympy.matrices.expressions import MatPow
+                return MatPow(a, num)
             elif isinstance(num, (Expr, float)):
                 return a._matrix_pow_by_jordan_blocks(num)
             else:

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2065,6 +2065,8 @@ class MatrixArithmetic(MatrixRequired):
                     except (AttributeError, MatrixError):
                         pass
                 return a._eval_pow_by_recursion(num)
+            elif num.is_Number!=True and num.is_negative==None:
+                return ("{}**{}").format(a,num)
             elif isinstance(num, (Expr, float)):
                 return a._matrix_pow_by_jordan_blocks(num)
             else:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -244,6 +244,8 @@ def test_power():
     assert A**10.2 == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])
     A = Matrix([[0, 1, 0], [0, 0, 1], [0, 0, 1]])  # Nilpotent jordan block size 2
     assert A**10.0 == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])
+    n = Symbol('n', integer=True)
+    assert isinstance(A**n, MatPow)
     n = Symbol('n', integer=True, nonnegative=True)
     raises(ValueError, lambda: A**n)
     assert A**(n + 2) == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -21,6 +21,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.solvers import solve
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
+from sympy.matrices.expressions import MatPow
 
 from sympy.abc import a, b, c, d, x, y, z, t
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -254,6 +254,12 @@ def test_power():
     A = Matrix([[0, 0, 1], [3, 0, 1], [4, 3, 1]])
     assert A**5.0 == Matrix([[168,  72,  89], [291, 144, 161], [572, 267, 329]])
     assert A**5.0 == A**5
+    A = Matrix([[0, 1, 0],[-1, 0, 0],[0, 0, 0]])
+    n = Symbol("n")
+    An = A**n
+    assert An.subs(n, 2).doit() == A**2
+    raises(ValueError, lambda: An.subs(n, -2).doit())
+    assert An * An == A**(2*n)
 
 
 def test_creation():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -244,8 +244,6 @@ def test_power():
     assert A**10.2 == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])
     A = Matrix([[0, 1, 0], [0, 0, 1], [0, 0, 1]])  # Nilpotent jordan block size 2
     assert A**10.0 == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])
-    n = Symbol('n', integer=True)
-    raises(ValueError, lambda: A**n)
     n = Symbol('n', integer=True, nonnegative=True)
     raises(ValueError, lambda: A**n)
     assert A**(n + 2) == Matrix([[0, 0, 1], [0, 0, 1], [0, 0, 1]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15593 

#### Brief description of what is fixed or changed
Earlier it raises an excpetion if ``` k.is_negative==None ``` in below example
```
rot_z_generator = Matrix([
    [0, 1, 0],
    [-1, 0, 0],
    [0, 0, 0]
])
k = symbols("k")
rot_z_generator**k

ValueError: Matrix det == 0; not invertible
```
Now it gives error only when it knows that k is definately negative otherwise it returns the same expression
```
rot_z_generator = Matrix([
    [0, 1, 0],
    [-1, 0, 0],
    [0, 0, 0]
])
k = symbols("k")
rot_z_generator**k

Matrix([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])**k
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
        * degenerate explicit matrices no longer raise an exception when raised to a symbolic power
<!-- END RELEASE NOTES -->
