### PR TITLE
printing unevaluated Integrals

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1058,7 +1058,7 @@ class Expr(Basic, EvalfMixin):
                     if factor.is_number:
                         try:
                             coeff *= complex(factor)
-                        except (TypeError,ValueError):
+                        except (TypeError, ValueError):
                             pass
                         else:
                             continue

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1058,7 +1058,7 @@ class Expr(Basic, EvalfMixin):
                     if factor.is_number:
                         try:
                             coeff *= complex(factor)
-                        except TypeError:
+                        except (TypeError,ValueError):
                             pass
                         else:
                             continue

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -15,6 +15,7 @@ from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, raises, slow, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically
 from sympy.integrals.integrals import Integral
+from sympy import factorial
 
 x, y, a, t, x_1, x_2, z, s = symbols('x y a t x_1 x_2 z s')
 n = Symbol('n', integer=True)
@@ -1465,3 +1466,10 @@ def test_issue_15640_log_substitutions():
     f = sqrt(log(x))/x**2
     F = -sqrt(pi)*erfc(sqrt(log(x)))/2 - sqrt(log(x))/x
     assert integrate(f, x) == F and F.diff(x) == f
+
+
+def test_issue_15716():
+    x = Symbol('x')
+    e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
+    definite = integrate(e, [x, -oo, oo])
+    assert Integral(e, (x, -oo, oo)).doit() == definite

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -15,7 +15,6 @@ from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, raises, slow, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically
 from sympy.integrals.integrals import Integral
-from sympy import factorial
 
 x, y, a, t, x_1, x_2, z, s = symbols('x y a t x_1 x_2 z s')
 n = Symbol('n', integer=True)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1476,9 +1476,3 @@ def test_issue_4311():
         (x**4/4 - 9*x**2/2, x <= -3),
         (-x**4/4 + 9*x**2/2 - S(81)/2, x <= 3),
         (x**4/4 - 9*x**2/2, True))
-
-def test_issue_15716():
-    x = Symbol('x')
-    e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
-    definite = integrate(e, [x, -oo, oo])
-    assert Integral(e, (x, -oo, oo)).doit() == definite

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1476,3 +1476,9 @@ def test_issue_4311():
         (x**4/4 - 9*x**2/2, x <= -3),
         (-x**4/4 + 9*x**2/2 - S(81)/2, x <= 3),
         (x**4/4 - 9*x**2/2, True))
+
+def test_issue_15716():
+    x = Symbol('x')
+    e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
+    definite = integrate(e, [x, -oo, oo])
+    assert Integral(e, (x, -oo, oo)).doit() == definite

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -814,5 +814,5 @@ def test_Subs_printing():
 def test_issue_15716():
     x = Symbol('x')
     e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
-    definite = integrate(e, [x, -oo, oo])
-    assert str(Integral(e, (x, -oo, oo)).doit()) == str(definite)
+    assert str(Integral(e, (x, -oo, oo)).doit()) == \
+    '-(Integral(-3*3**x/factorial(x), (x, -oo, oo)) + Integral(3**x*log(3**x/factorial(x))/factorial(x), (x, -oo, oo)))*exp(-3)'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -814,5 +814,5 @@ def test_Subs_printing():
 def test_issue_15716():
     x = Symbol('x')
     e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
-    assert str(Integral(e, (x, -oo, oo)).doit()) == \
-    '-(Integral(-3*3**x/factorial(x), (x, -oo, oo)) + Integral(3**x*log(3**x/factorial(x))/factorial(x), (x, -oo, oo)))*exp(-3)'
+    assert str(Integral(e, (x, -oo, oo)).doit()) ==  '-(Integral(-3*3**x/factorial(x), (x, -oo, oo))' \
+    ' + Integral(3**x*log(3**x/factorial(x))/factorial(x), (x, -oo, oo)))*exp(-3)'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -16,6 +16,7 @@ from sympy.core.compatibility import range
 from sympy.printing import sstr, sstrrepr, StrPrinter
 from sympy.core.trace import Tr
 from sympy import MatrixSymbol
+from sympy import factorial, log, integrate
 
 x, y, z, w, t = symbols('x,y,z,w,t')
 d = Dummy('d')
@@ -809,3 +810,9 @@ def test_MatrixSymbol_printing():
 def test_Subs_printing():
     assert str(Subs(x, (x,), (1,))) == 'Subs(x, x, 1)'
     assert str(Subs(x + y, (x, y), (1, 2))) == 'Subs(x + y, (x, y), (1, 2))'
+
+def test_issue_15716():
+    x = Symbol('x')
+    e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
+    definite = integrate(e, [x, -oo, oo])
+    assert str(Integral(e, (x, -oo, oo)).doit()) == str(definite)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g.  See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15716


#### Brief description of what is fixed or changed
```
>>> from sympy import *
>>> x = Symbol('x')
>>> e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
>>> i = integrate(e, [x, -oo, oo])
>>> i
During this definite integral an exception is raised which is "ValueError" so i just add "ValueError" .
```

  

#### Other comments

 


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - catch ValueError from unevaluated integrals
<!-- END RELEASE NOTES -->

