### PR TITLE
Tell pytest to only collect tests under sympy dir

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,9 @@
 [pytest]
+
+# Only run tests under the sympy/ directory. Otherwise pytest will attempt to
+# collect tests from e.g. the bin/ directory as well.
+testpaths = sympy
+
 # np.matrix is deprecated but still used in sympy.physics.quantum:
 #    https://github.com/sympy/sympy/issues/15563
 # This prevents ~800 warnings showing up running the tests under pytest.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Add `testpaths = sympy` to `pytest.ini`. This means that when running `$ pytest` from the root sympy dir (without specifying any paths) only tests from under the `sympy/` directory are collected.

#### Other comments

The release note below refers to many PRs. This is just thw final one to make the tests work under pytest (apart from #15587 which is still waiting).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * Make Sympy's tests runnable under pytest.
<!-- END RELEASE NOTES -->
