### PR TITLE
Expand QR Decomposition capabilities

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4055,12 +4055,12 @@ class MatrixBase(MatrixDeprecated,
 
         n = mat.rows
         m = mat.cols
-        rank = 0
+        ranked = list()
 
         Q, R = mat.zeros(n, Min(n, m)), mat.zeros(Min(n, m),m)
         for j in range(m):  # for each column vector
             tmp = mat[:, j]  # take original v
-            for i in range(Min(j, n, rank)):
+            for i in range(Min(j, n)):
                 # subtract the project of mat on new vector
                 R[i, j] = Q[:, i].dot(mat[:, j])
                 tmp -= Q[:, i] * R[i, j]
@@ -4069,11 +4069,14 @@ class MatrixBase(MatrixDeprecated,
             if j < n:
                 R[j, j] = tmp.norm()
                 if not R[j, j].is_zero:
-                    rank += 1
+                    ranked.append(j)
                     Q[:, j] = tmp / R[j, j]
 
-        if rank != 0:
-            return cls(Q[:, :rank]), cls(R[:rank, :])
+        if len(ranked) != 0:
+            return (
+            cls(Q.extract(range(Q.rows), ranked)),
+            cls(R.extract(ranked, range(R.cols)))
+            )
         else:
             # Trivial case handling for zero-rank matrix
             # Force Q as matrix containing standard basis vectors

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4053,9 +4053,6 @@ class MatrixBase(MatrixDeprecated,
         cls = self.__class__
         mat = self.as_mutable()
 
-        if not mat.rows >= mat.cols:
-            raise MatrixError(
-                "The number of rows must be greater than columns")
         n = mat.rows
         m = mat.cols
         rank = n

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4065,20 +4065,21 @@ class MatrixBase(MatrixDeprecated,
                 rank -= 1
         if not rank == mat.cols:
             raise MatrixError("The rank of the matrix must match the columns")
-        Q, R = mat.zeros(n, m), mat.zeros(m)
+        Q, R = mat.zeros(n, Min(n, m)), mat.zeros(Min(n, m),m)
         for j in range(m):  # for each column vector
             tmp = mat[:, j]  # take original v
-            for i in range(j):
+            for i in range(Min(j, n)):
                 # subtract the project of mat on new vector
                 R[i, j] = Q[:, i].dot(mat[:, j])
                 tmp -= Q[:, i] * R[i, j]
                 tmp.expand()
             # normalize it
-            R[j, j] = tmp.norm()
-            Q[:, j] = tmp / R[j, j]
-            if Q[:, j].norm() != 1:
-                raise NotImplementedError(
-                    "Could not normalize the vector %d." % j)
+            if j < n:
+                R[j, j] = tmp.norm()
+                Q[:, j] = tmp / R[j, j]
+                if Q[:, j].norm() != 1:
+                    raise NotImplementedError(
+                        "Could not normalize the vector %d." % j)
 
         return cls(Q), cls(R)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4070,7 +4070,8 @@ class MatrixBase(MatrixDeprecated,
             tmp = mat[:, j]  # take original v
             for i in range(j):
                 # subtract the project of mat on new vector
-                tmp -= Q[:, i] * mat[:, j].dot(Q[:, i])
+                R[i, j] = Q[:, i].dot(mat[:, j])
+                tmp -= Q[:, i] * R[i, j]
                 tmp.expand()
             # normalize it
             R[j, j] = tmp.norm()
@@ -4078,8 +4079,7 @@ class MatrixBase(MatrixDeprecated,
             if Q[:, j].norm() != 1:
                 raise NotImplementedError(
                     "Could not normalize the vector %d." % j)
-            for i in range(j):
-                R[i, j] = Q[:, i].dot(mat[:, j])
+
         return cls(Q), cls(R)
 
     def QRsolve(self, b):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4055,13 +4055,6 @@ class MatrixBase(MatrixDeprecated,
 
         n = mat.rows
         m = mat.cols
-        rank = n
-        row_reduced = mat.rref()[0]
-        for i in range(row_reduced.rows):
-            if row_reduced.row(i).norm() == 0:
-                rank -= 1
-        if not rank == mat.cols:
-            raise MatrixError("The rank of the matrix must match the columns")
         Q, R = mat.zeros(n, Min(n, m)), mat.zeros(Min(n, m),m)
         for j in range(m):  # for each column vector
             tmp = mat[:, j]  # take original v

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4063,7 +4063,7 @@ class MatrixBase(MatrixDeprecated,
         if n < m:
             nOrig = n
             n = m
-            mat.col_join(mat.zeros(n - nOrig, m))
+            mat = mat.col_join(mat.zeros(n - nOrig, m))
         else:
             nOrig = n
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4057,9 +4057,8 @@ class MatrixBase(MatrixDeprecated,
         m = mat.cols
         ranked = list()
 
-        # If matrix is fat, pad additional zeros to make it square.
-        # Variable nOrig is used to collect the original dimensions, so that
-        # it can be used to truncate unncecssary zeros from the Q
+        # Pad with additional rows to make wide matrices square
+        # nOrig keeps track of original size so zeros can be trimmed from Q
         if n < m:
             nOrig = n
             n = m

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -903,6 +903,12 @@ def test_QR_trivial():
     assert R.is_upper
     assert A == Q*R
 
+    A = Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0], [1, 2, 3]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
 
 def test_nullspace():
     # first test reduced row-ech form

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -814,16 +814,73 @@ def test_QR_non_square():
     assert R.is_upper
     assert A == Q*R
 
+    A = Matrix(2, 1, [1, 2])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
     # Short and fat matrices
     A = Matrix([[1, 2, 3], [4, 5, 6]])
     Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.rows)
+    assert Q.T * Q == eye(Q.cols)
     assert R.is_upper
     assert A == Q*R
 
     A = Matrix([[1, 2, 3, 4], [1, 4, 9, 16], [1, 8, 27, 64]])
     Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.rows)
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix(1, 2, [1, 2])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+def test_QR_trivial():
+    # Rank deficient matrices
+    A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    # Zero rank matrices
+    A = Matrix([[0, 0, 0]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0], [0, 0, 0]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0], [0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
     assert R.is_upper
     assert A == Q*R
 
@@ -1892,9 +1949,6 @@ def test_errors():
     raises(NonSquareMatrixError, lambda: Matrix([1, 2]).trace())
     raises(TypeError, lambda: Matrix([1]).applyfunc(1))
     raises(ShapeError, lambda: Matrix([1]).LUsolve(Matrix([[1, 2], [3, 4]])))
-    raises(MatrixError, lambda: Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]
-           ]).QRdecomposition())
-    raises(MatrixError, lambda: Matrix(1, 2, [1, 2]).QRdecomposition())
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minor(4, 5))
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minor_submatrix(4, 5))
     raises(TypeError, lambda: Matrix([1, 2, 3]).cross(1))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -884,6 +884,25 @@ def test_QR_trivial():
     assert R.is_upper
     assert A == Q*R
 
+    # Rank deficient matrices with zero norm from beginning columns
+    A = Matrix([[0, 0, 0], [1, 2, 3]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0], [2, 4, 6, 8]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
 
 def test_nullspace():
     # first test reduced row-ech form

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -821,7 +821,7 @@ def test_QR_non_square():
     print R.is_upper
     print A == Q*R
 
-    A = Matrix([[1,2,3,4],[1,4,9,16],[1,8,27,64]])
+    A = Matrix([[1, 2, 3, 4], [1, 4, 9, 16], [1, 8, 27, 64]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.rows)
     print R.is_upper

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -801,7 +801,7 @@ def test_QR():
 
 
 def test_QR_non_square():
-    # Tall and thin matrices
+    # Narrow (cols < rows) matrices
     A = Matrix([[9, 0, 26], [12, 0, -7], [0, 4, 4], [0, -3, -3]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.cols)
@@ -820,7 +820,7 @@ def test_QR_non_square():
     assert R.is_upper
     assert A == Q*R
 
-    # Short and fat matrices
+    # Wide (cols > rows) matrices
     A = Matrix([[1, 2, 3], [4, 5, 6]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.cols)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -801,6 +801,7 @@ def test_QR():
 
 
 def test_QR_non_square():
+    # Tall and thin matrices
     A = Matrix([[9, 0, 26], [12, 0, -7], [0, 4, 4], [0, -3, -3]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.cols)
@@ -812,6 +813,19 @@ def test_QR_non_square():
     assert Q.T * Q == eye(Q.cols)
     assert R.is_upper
     assert A == Q*R
+
+    # Short and fat matrices
+    A = Matrix([[1, 2, 3], [4, 5, 6]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.rows)
+    print R.is_upper
+    print A == Q*R
+
+    A = Matrix([[1,2,3,4],[1,4,9,16],[1,8,27,64]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.rows)
+    print R.is_upper
+    print A == Q*R
 
 
 def test_nullspace():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -818,14 +818,14 @@ def test_QR_non_square():
     A = Matrix([[1, 2, 3], [4, 5, 6]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.rows)
-    print R.is_upper
-    print A == Q*R
+    assert R.is_upper
+    assert A == Q*R
 
     A = Matrix([[1, 2, 3, 4], [1, 4, 9, 16], [1, 8, 27, 64]])
     Q, R = A.QRdecomposition()
     assert Q.T * Q == eye(Q.rows)
-    print R.is_upper
-    print A == Q*R
+    assert R.is_upper
+    assert A == Q*R
 
 
 def test_nullspace():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

The `QRdecomposition` has not implemented

- Decomposition on fat matrices
- Decomposition on rank-deficient matrices
- Decomposition on zero-rank matrices

In this patch, it would be able to handle cases sympy previously could not handle, as

- Fat matrices will be decomposed into square Q, and R with same dimensions as original.
- Previously, the computation was aborted when `norm` evaluated into 0, but now, it will move on to the next column.
- Zero-rank matrices will return Q forced with standard basis vectors, with R containing only zeros

Also, some other improvements are done as

- Deleted `rref` subroutine, and implemented rank check in the middle of computation

This implementation will be able to extend the capability of Classical Gram-Schmidt procedure.
Though I'm not exactly sure about the mathematical properties involved.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Modified `QRdecomposition` to handle rank-deficient matrices and matrices with more columns than rows.

<!-- END RELEASE NOTES -->
