### PR TITLE
Tweak solve_least_squares

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4130,6 +4130,14 @@ class MatrixBase(MatrixDeprecated,
     def solve_least_squares(self, rhs, method='CH'):
         """Return the least-square fit to the data.
 
+        Parameters
+        ==========
+
+        rhs : Matrix
+            Vectors representing the right hand side of the linear equation.
+
+        method : string or boolean
+
         By default the cholesky_solve routine is used (method='CH'); other
         methods of matrix inversion can be used. To find out which are
         available, see the docstring of the .inv() method.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4134,7 +4134,7 @@ class MatrixBase(MatrixDeprecated,
         ==========
 
         rhs : Matrix
-            Vectors representing the right hand side of the linear equation.
+            Vector representing the right hand side of the linear equation.
 
         method : string or boolean, optional
             If set to ``'CH'``, ``cholesky_solve`` routine will be used.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4199,7 +4199,7 @@ class MatrixBase(MatrixDeprecated,
             return self.pinv_solve(rhs)
         else:
             t = self.H
-            return (t * self).solve(t * rhs)
+            return (t * self).solve(t * rhs, method=method)
 
     def solve(self, rhs, method='GJ'):
         """Return the unique soln making self*soln = rhs.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4141,8 +4141,6 @@ class MatrixBase(MatrixDeprecated,
 
             If set to ``'QR'``, ``QRsolve`` routine will be used.
 
-            If set to ``'LDL'``, ``LDLsolve`` routine will be used.
-
             If set to ``'PINV'``, ``pinv_solve`` routine will be used.
 
             Other linear solving methods may be used, which can be inherited

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4183,8 +4183,9 @@ class MatrixBase(MatrixDeprecated,
         """
         if method == 'CH':
             return self.cholesky_solve(rhs)
-        t = self.H
-        return (t * self).inv(method=method) * t * rhs
+        else:
+            t = self.H
+            return (t * self).solve(t * rhs)
 
     def solve(self, rhs, method='GJ'):
         """Return the unique soln making self*soln = rhs.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4149,6 +4149,12 @@ class MatrixBase(MatrixDeprecated,
             from ``.solve()``, after applying a naive approach of using dot
             product of conjugate transposed ``self`` in both sides.
 
+        Returns
+        =======
+
+        solutions : Matrix
+            Vector representing the solution.
+
         Examples
         ========
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4136,7 +4136,7 @@ class MatrixBase(MatrixDeprecated,
         rhs : Matrix
             Vectors representing the right hand side of the linear equation.
 
-        method : string or boolean
+        method : string or boolean, optional
             If set to ``'CH'``, ``cholesky_solve`` routine will be used.
 
             If set to ``'QR'``, ``QRsolve`` routine will be used.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4183,6 +4183,12 @@ class MatrixBase(MatrixDeprecated,
         """
         if method == 'CH':
             return self.cholesky_solve(rhs)
+        elif method == 'QR':
+            return self.QRsolve(rhs)
+        elif method == 'LDL':
+            return self.LDLsolve(rhs)
+        elif method == 'PINV':
+            return self.pinv_solve(rhs)
         else:
             t = self.H
             return (t * self).solve(t * rhs)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4143,9 +4143,9 @@ class MatrixBase(MatrixDeprecated,
 
             If set to ``'PINV'``, ``pinv_solve`` routine will be used.
 
-            Other linear solving methods may be used, which can be inherited
-            from ``.solve()``, after applying a naive approach of using dot
-            product of conjugate transposed ``self`` in both sides.
+            Otherwise, a naive approach solution involving the conjugate of
+            self will be returned. The passed method will be passed on to the
+            ``solve`` routine.
 
         Returns
         =======

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4143,9 +4143,9 @@ class MatrixBase(MatrixDeprecated,
 
             If set to ``'PINV'``, ``pinv_solve`` routine will be used.
 
-            Otherwise, a naive approach solution involving the conjugate of
-            self will be returned. The passed method will be passed on to the
-            ``solve`` routine.
+            Otherwise, the conjugate of self will be used to create a system
+            of equations that is passed to ``solve`` along with the hint
+            defined by ``method``.
 
         Returns
         =======

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4137,10 +4137,17 @@ class MatrixBase(MatrixDeprecated,
             Vectors representing the right hand side of the linear equation.
 
         method : string or boolean
+            If set to ``'CH'``, ``cholesky_solve`` routine will be used.
 
-        By default the cholesky_solve routine is used (method='CH'); other
-        methods of matrix inversion can be used. To find out which are
-        available, see the docstring of the .inv() method.
+            If set to ``'QR'``, ``QRsolve`` routine will be used.
+
+            If set to ``'LDL'``, ``LDLsolve`` routine will be used.
+
+            If set to ``'PINV'``, ``pinv_solve`` routine will be used.
+
+            Other linear solving methods may be used, which can be inherited
+            from ``.solve()``, after applying a naive approach of using dot
+            product of conjugate transposed ``self`` in both sides.
 
         Examples
         ========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
#15178

#### Brief description of what is fixed or changed

As well as `solve`, I think `solve_least_squares` can make use of more efficient routines than computing inverses, and I simply replaced the default routine with solve, to make use of any linear solver implemented in and also by the fact that it already contains the naive inverse computation method.

I also added every least squares methods available in sympy.

I think the there is no test case specifically for this function though, but the specific tests for each individual solvers.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Added options for `solve_least_squares` to select more methods. 

<!-- END RELEASE NOTES -->
