### PR TITLE
Duplicate routine of matrix_multiply_elementwise

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1339,11 +1339,7 @@ def matrix_multiply_elementwise(A, B):
 
     __mul__
     """
-    if A.shape != B.shape:
-        raise ShapeError()
-    shape = A.shape
-    return classof(A, B)._new(shape[0], shape[1],
-                              lambda i, j: A[i, j]*B[i, j])
+    return A.multiply_elementwise(B)
 
 
 def ones(*args, **kwargs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I think the exact same implementation exists in `MatrixArithmetic.multiply_elementwise`, and also in the `_eval_multiply_elementwise`.
Also, there can be advantage of calling in this way, if more faster multiplication from #12640 was implemented by using more direct access of _mat elements..

It may also be deprecated if agreed on.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
