### PR TITLE
Delete print in matrix test

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2817,7 +2817,8 @@ def test_pinv_rank_deficient():
 
 @XFAIL
 def test_pinv_rank_deficient_when_diagonalization_fails():
-    print('Test the four properties of the pseudoinverse for matrices when diagonalization of A.H*A fails.')
+    # Test the four properties of the pseudoinverse for matrices when
+    # diagonalization of A.H*A fails.'
     As = [Matrix([
         [61, 89, 55, 20, 71, 0],
         [62, 96, 85, 85, 16, 0],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Brief description of what is fixed or changed

I think printing in test function got merged in #15475.

![image](https://user-images.githubusercontent.com/34944973/50716301-607dc380-10c4-11e9-8077-6b2fd33cf6be.png)

And I'm seeing it in my terminal screen while running `bin/test matrices`.

I have deleted the print, and made the strings as a comment.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
