### PR TITLE
Trivial case handling for normalized

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3697,8 +3697,30 @@ class MatrixBase(MatrixDeprecated,
         """
         return self * b
 
-    def normalized(self):
+    def normalized(self, iszerofunc=_iszero):
         """Return the normalized version of ``self``.
+
+        Parameters
+        ==========
+
+        iszerofunc : Function, optional
+            A function to determine whether self is a zero vector.
+            The default ``_iszero`` tests to see if each element is
+            exactly zero.
+
+        Returns
+        =======
+
+        Matrix
+            Normalized vector form of self.
+            It has the same length as a unit vector. However, a zero vector
+            will be returned for a vector with norm 0.
+
+        Raises
+        ======
+
+        ShapeError
+            If the matrix is not in a vector form.
 
         See Also
         ========
@@ -3708,7 +3730,10 @@ class MatrixBase(MatrixDeprecated,
         if self.rows != 1 and self.cols != 1:
             raise ShapeError("A Matrix must be a vector to normalize.")
         norm = self.norm()
-        out = self.applyfunc(lambda i: i / norm)
+        if iszerofunc(norm):
+            out = self.zeros(self.rows, self.cols)
+        else:
+            out = self.applyfunc(lambda i: i / norm)
         return out
 
     def norm(self, ord=None):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2348,6 +2348,15 @@ def test_normalized():
     assert Matrix([3, 4]).normalized() == \
         Matrix([Rational(3, 5), Rational(4, 5)])
 
+    # Zero vector trivial cases
+    assert Matrix([0, 0, 0]).normalized() == Matrix([0, 0, 0])
+
+    # Machine precision error truncation trivial cases
+    m = Matrix([0,0,1.e-100])
+    assert m.normalized(
+    iszerofunc=lambda x: x.evalf(n=10, chop=True).is_zero
+    ) == Matrix([0, 0, 0])
+
 
 def test_print_nonzero():
     assert capture(lambda: eye(3).print_nonzero()) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Zero vectors should be trivially normalized to zero, 
But when executing
```
from sympy import *

Matrix([0,0,0]).normalized()
```
It gives NaN because it simply performs the division on zero.
I have fixed this, and also reformatted the documentation with the new parameter added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Fixed wrong results on performing `.normalized` on zero vectors

<!-- END RELEASE NOTES -->
