### PR TITLE
Set CSS to DejaVu Sans Mono

### DIFF
--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -290,10 +290,12 @@ p.admonition-title:after {
 }
 
 pre {
+    font-family: DejaVu Sans Mono, DejaVu Sans, monospace;
+    font-size: 80%;
     padding: 5px;
     background-color: {{ theme_codebgcolor }};
     color: {{ theme_codetextcolor }};
-    line-height: 120%;
+    line-height: 100%;
     border: 1px solid #ac9;
     border-left: none;
     border-right: none;

--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -290,7 +290,7 @@ p.admonition-title:after {
 }
 
 pre {
-    font-family: DejaVu Sans Mono, DejaVu Sans, monospace;
+    font-family: DejaVu Sans Mono, monospace;
     font-size: 80%;
     padding: 5px;
     background-color: {{ theme_codebgcolor }};

--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -291,11 +291,11 @@ p.admonition-title:after {
 
 pre {
     font-family: DejaVu Sans Mono, monospace;
-    font-size: 80%;
+    font-size: 100%;
     padding: 5px;
     background-color: {{ theme_codebgcolor }};
     color: {{ theme_codetextcolor }};
-    line-height: 100%;
+    line-height: 120%;
     border: 1px solid #ac9;
     border-left: none;
     border-right: none;


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15700 

#### Brief description of what is fixed or changed
The font was set to DejaVu Sans Mono in CSS.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
     * Set the monospace font to DejaVu Sans Mono (if it is installed) in the docs
<!-- END RELEASE NOTES -->
