### PR TITLE
Changed behaviour of __eq__() for Polygon

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1060,9 +1060,9 @@ class Polygon(GeometrySet):
         oargs = o.args
         n = len(args)
         o0 = oargs[0]
-        for i0 in xrange(n):
+        for i0 in range(n):
             if args[i0] == o0:
-                if all(args[(i0 + i) % n] == oargs[i] for i in xrange(1, n)):
+                if all(args[(i0 + i) % n] == oargs[i] for i in range(1, n)):
                     return True
         return False
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1034,22 +1034,34 @@ class Polygon(GeometrySet):
             ).format(2. * scale_factor, path, fill_color)
 
     def __eq__(self, o):
+        """
+        Two polygons are equal only if
+            they have same set of vertices.
+        and order of vertices passed to constructor is same.
+
+        Examples
+        ========
+
+        >> from sympy import Point, Triangle
+        >> a = Triangle(Point(0, 0), Point(4, 0), Point(4, 3))
+        >> b = Triangle(Point(0, 0), Point(4, 3), Point(4, 0))
+        >> a==b
+        False
+        >>
+        >> c = Triangle(Point(0, 0), Point(4, 0), Point(4, 3))
+        >> a==c
+        True
+        """
+
         if not isinstance(o, Polygon) or len(self.args) != len(o.args):
             return False
 
-        # See if self can ever be traversed (cw or ccw) from any of its
-        # vertices to match all points of o
         args = self.args
         oargs = o.args
-        n = len(args)
-        o0 = oargs[0]
-        for i0 in range(n):
-            if args[i0] == o0:
-                if all(args[(i0 + i) % n] == oargs[i] for i in range(1, n)):
-                    return True
-                if all(args[(i0 - i) % n] == oargs[i] for i in range(1, n)):
-                    return True
-        return False
+        if args == oargs:
+            return True
+        else:
+            return False
 
     def __hash__(self):
         return super(Polygon, self).__hash__()

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1037,7 +1037,7 @@ class Polygon(GeometrySet):
         """
         Two polygons are equal only if
             they have same set of vertices.
-        and order of vertices passed to constructor is same.
+        and cyclic order of vertices passed to constructor is same.
 
         Examples
         ========
@@ -1058,10 +1058,13 @@ class Polygon(GeometrySet):
 
         args = self.args
         oargs = o.args
-        if args == oargs:
-            return True
-        else:
-            return False
+        n = len(args)
+        o0 = oargs[0]
+        for i0 in xrange(n):
+            if args[i0] == o0:
+                if all(args[(i0 + i) % n] == oargs[i] for i in xrange(1, n)):
+                    return True
+        return False
 
     def __hash__(self):
         return super(Polygon, self).__hash__()

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -59,6 +59,9 @@ def test_polygon():
         Point(0, 0), Point(3, -1),
         Point(6, 0), Point(4, 5),
         Point(2, 3), Point(0, 3))
+    p8 = Polygon(
+        Point(-9, 6.6), Point(-4, -3),
+        Point(-8.4, -8.7), Point(-11, 1))
 
     r = Ray(Point(-9,6.6), Point(-9,5.5))
     #
@@ -66,6 +69,7 @@ def test_polygon():
     #
     assert p1 == p7
     assert p1 != p2
+    assert p6 == p8
     assert len(p1.args) == 6
     assert len(p1.sides) == 6
     assert p1.perimeter == 5 + 2*sqrt(10) + sqrt(29) + sqrt(8)

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -55,11 +55,17 @@ def test_polygon():
     p6 = Polygon(
         Point(-11, 1), Point(-9, 6.6),
         Point(-4, -3), Point(-8.4, -8.7))
+    p7 = Polygon(
+        Point(0, 0), Point(3, -1),
+        Point(6, 0), Point(4, 5),
+        Point(2, 3), Point(0, 3))
+
     r = Ray(Point(-9,6.6), Point(-9,5.5))
     #
     # General polygon
     #
-    assert p1 == p2
+    assert p1 == p7
+    assert p1 != p2
     assert len(p1.args) == 6
     assert len(p1.sides) == 6
     assert p1.perimeter == 5 + 2*sqrt(10) + sqrt(29) + sqrt(8)

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -233,7 +233,7 @@ def test_polygon():
     assert m[p1] == Segment(p1, Point(Rational(5, 2), Rational(5, 2)))
     assert t3.medians[p1] == Segment(p1, Point(x1/2, x1/2))
     assert intersection(m[p1], m[p2], m[p3]) == [t1.centroid]
-    assert t1.medial == Triangle(Point(2.5, 0), Point(0, 2.5), Point(2.5, 2.5))
+    assert t1.medial == Triangle(Point(2.5, 0), Point(2.5, 2.5), Point(0, 2.5))
 
     # Nine-point circle
     assert t1.nine_point_circle == Circle(Point(2.5, 0), Point(0, 2.5), Point(2.5, 2.5))


### PR DESCRIPTION
Changed behaviour of  `__eq__()` for Polygon
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #7998


#### Brief description of what is fixed or changed
Earlier order of vertices was irrelevant when checking equality 
of two polygons.
Now two polygons are considered equal only if they are made from
same set of vertices and cyclic order of vertices at time of initialization was 
same for both. 
Two polygons having area with same magnitude but opposite sign will be
considered unequal.
New behavior-
```
>>> a = Triangle( Point(0, 0), Point(1, 0), Point(1, 1) )
>>> b = Triangle( Point(1, 0), Point(1, 1), Point(0, 0) )
>>> c = Triangle( Point(0, 0), Point(1, 1), Point(1, 0) )
>>> a==b
True
>>> a==c
False
```
Hash of two equal polygons need not necessarily be same.

#### Other comments
I had to change some test cases to account for changed behavior.
I am not sure whether this behavior from == is expected now as it
may break some existing code.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
   * changed behavior of  `__eq__()` for Polygon
<!-- END RELEASE NOTES -->
