### PR TITLE
Minor speed improvement for eigenvals

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1225,6 +1225,10 @@ class MatrixEigen(MatrixSubspaces):
         if not mat:
             return {}
 
+        if rational:
+            mat = mat.applyfunc(
+                lambda x: nsimplify(x, rational=True) if x.has(Float) else x)
+
         if mat.is_upper or mat.is_lower:
             if not self.is_square:
                 raise NonSquareMatrixError()
@@ -1240,10 +1244,6 @@ class MatrixEigen(MatrixSubspaces):
                         eigs[diagonal_entry] = 0
                     eigs[diagonal_entry] += 1
         else:
-            if rational:
-                if any(v.has(Float) for v in mat):
-                    mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
-
             flags.pop('simplify', None)  # pop unsupported flag
             if isinstance(simplify, FunctionType):
                 eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1219,13 +1219,11 @@ class MatrixEigen(MatrixSubspaces):
         """
         simplify = flags.get('simplify', False) # Collect simplify flag before popped up, to reuse later in the routine.
         multiple = flags.get('multiple', False) # Collect multiple flag to decide whether return as a dict or list.
+        rational = flags.pop('rational', True)
 
         mat = self
         if not mat:
             return {}
-        if flags.pop('rational', True):
-            if mat.has(Float):
-                mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
 
         if mat.is_upper or mat.is_lower:
             if not self.is_square:
@@ -1242,6 +1240,10 @@ class MatrixEigen(MatrixSubspaces):
                         eigs[diagonal_entry] = 0
                     eigs[diagonal_entry] += 1
         else:
+            if rational:
+                if any(v.has(Float) for v in mat):
+                    mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
+
             flags.pop('simplify', None)  # pop unsupported flag
             if isinstance(simplify, FunctionType):
                 eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -238,7 +238,7 @@ def entropy(density):
     >>> from sympy import S, log
     >>> up = JzKet(S(1)/2,S(1)/2)
     >>> down = JzKet(S(1)/2,-S(1)/2)
-    >>> d = Density((up,0.5),(down,0.5))
+    >>> d = Density((up,S(1)/2),(down,S(1)/2))
     >>> entropy(d)
     log(2)/2
 

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -159,7 +159,7 @@ def test_get_prob():
 def test_entropy():
     up = JzKet(S(1)/2, S(1)/2)
     down = JzKet(S(1)/2, -S(1)/2)
-    d = Density((up, 0.5), (down, 0.5))
+    d = Density((up, S(1)/2), (down, S(1)/2))
 
     # test for density object
     ent = entropy(d)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I think that executing rationalization
https://github.com/sympy/sympy/blob/53b5006a1a56c71fadc954e3ca530879b31db415/sympy/matrices/matrices.py#L1226-L1228
can have significant slowdown for large matrices.
But I don't think that it is necessary for computing eigenvalues of lower or upper triangular matrices, because it is well known property that eigenvalues are simply diagonals.

I have moved the code to execute only before passed to `charpoly` (if there are problems)
And I have confirmed it gives boost for some extreme cases like triangularized hilbert matrices

```
import cProfile
from sympy import *

def entry(i, j):
    if i >= j:
        return 1 / (i + j + 1)
    else:
        return 0

m = Matrix(100, 100, entry)
m = m.evalf()
cProfile.run("m.eigenvals()")
```
from `7360125 function calls (7299486 primitive calls) in 5.948 seconds`
to `97238 function calls (97216 primitive calls) in 0.036 seconds`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
