### PR TITLE
Fix hang in casoratian determinant leading to hang in rsolve

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1084,7 +1084,7 @@ def casoratian(seqs, n, zero=True):
 
     k = len(seqs)
 
-    return Matrix(k, k, f).det()
+    return Matrix(k, k, f).det(method="berkowitz")
 
 
 def eye(*args, **kwargs):

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1084,7 +1084,7 @@ def casoratian(seqs, n, zero=True):
 
     k = len(seqs)
 
-    return Matrix(k, k, f).det(method="berkowitz")
+    return Matrix(k, k, f).det()
 
 
 def eye(*args, **kwargs):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -211,7 +211,7 @@ class MatrixDeterminant(MatrixCommon):
             def entry(i, j):
                 ret = (pivot_val*tmp_mat[i, j + 1] - mat[pivot_pos, j + 1]*tmp_mat[i, 0]) / cumm
                 if not ret.is_Atom:
-                    cancel(ret)
+                    return cancel(ret)
                 return ret
 
             return sign*bareiss(self._new(mat.rows - 1, mat.cols - 1, entry), pivot_val)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -202,3 +202,8 @@ def test_issue_6844():
     f = y(n + 2) - y(n + 1) + y(n)/4
     assert rsolve(f, y(n)) == 2**(-n)*(C0 + C1*n)
     assert rsolve(f, y(n), {y(0): 0, y(1): 1}) == 2*2**(-n)*n
+
+
+def test_issue_15751():
+    f = y(n) + 21*y(n + 1) - 273*y(n + 2) - 1092*y(n + 3) + 1820*y(n + 4) + 1092*y(n + 5) - 273*y(n + 6) - 21*y(n + 7) + y(n + 8)
+    assert rsolve(f, y(n)) is not None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15751.

#### Brief description of what is fixed or changed

Fix unused return value of 'cancel' in bareiss leading to a hang (probably infinite loop) with certain determinants. Fixes a hang in rsolve due to hanging casoratian calculation.

#### Other comments

Recurrence equations like 0 = y(n) + 21*y(n + 1) - 273*y(n + 2) - 1092*y(n + 3) + 1820*y(n + 4) + 1092*y(n + 5) - 273*y(n + 6) - 21*y(n + 7) + y(n + 8) no longer hang rsolve

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* matrices
    * Fix unused return value of 'cancel' in bareiss leading to a hang with certain determinants.

<!-- END RELEASE NOTES -->
