### PR TITLE
Hash function of Polygon class changed

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -11,7 +11,7 @@ from sympy.logic import And
 from sympy.matrices import Matrix
 from sympy.simplify import simplify
 from sympy.utilities import default_sort_key
-from sympy.utilities.iterables import has_dups, has_variety, uniq
+from sympy.utilities.iterables import has_dups, has_variety, uniq, rotate_left, least_rotation
 from sympy.utilities.misc import func_name
 
 from .entity import GeometryEntity, GeometrySet
@@ -145,6 +145,9 @@ class Polygon(GeometrySet):
                 i += 1
 
         vertices = list(nodup)
+
+
+
 
         if len(vertices) > 3:
             return GeometryEntity.__new__(cls, *vertices, **kwargs)
@@ -1053,6 +1056,26 @@ class Polygon(GeometrySet):
 
     def __hash__(self):
         return super(Polygon, self).__hash__()
+
+    def _hashable_content(self):
+        def ref_list(point_list):
+            '''
+            Converts list of Point objects to their corresponding
+            order in sorting.
+            '''
+            kee = {}
+            for i, p in enumerate(ordered(set(point_list))):
+                kee[p] = i
+            return [kee[p] for p in point_list]
+
+        # find minimal rotation of both normal and reverse list
+        # of points and use smaller of the two to compute hash.
+        S1 = ref_list( self.args)
+        r_nor = rotate_left( S1, least_rotation( S1))
+        S2 = ref_list( list( reversed(self.args) ))
+        r_rev = rotate_left( S2, least_rotation( S2))
+        r = r_nor if r_nor < r_rev else r_rev
+        return tuple(r)
 
     def __contains__(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1038,41 +1038,24 @@ class Polygon(GeometrySet):
 
     def _hashable_content(self):
 
+        D = {}
         def ref_list(point_list):
             kee = {}
             for i, p in enumerate(ordered(set(point_list))):
                 kee[p] = i
+                D[i] = p
             return [kee[p] for p in point_list]
 
-        S1 = ref_list( self.args)
-        r_nor = rotate_left( S1, least_rotation( S1))
-        S2 = ref_list( list( reversed(self.args) ))
-        r_rev = rotate_left( S2, least_rotation( S2))
+        S1 = ref_list(self.args)
+        r_nor = rotate_left(S1, least_rotation(S1))
+        S2 = ref_list(list(reversed(self.args)))
+        r_rev = rotate_left(S2, least_rotation(S2))
         if r_nor < r_rev:
-            res = r_nor
-        else :
-            res = r_rev
-        return tuple(res)
-
-    def _hashable_content(self):
-        def ref_list(point_list):
-            '''
-            Converts list of Point objects to their corresponding
-            order in sorting.
-            '''
-            kee = {}
-            for i, p in enumerate(ordered(set(point_list))):
-                kee[p] = i
-            return [kee[p] for p in point_list]
-
-        # find minimal rotation of both normal and reverse list
-        # of points and use smaller of the two to compute hash.
-        S1 = ref_list( self.args)
-        r_nor = rotate_left( S1, least_rotation( S1))
-        S2 = ref_list( list( reversed(self.args) ))
-        r_rev = rotate_left( S2, least_rotation( S2))
-        r = r_nor if r_nor < r_rev else r_rev
-        return tuple(r)
+            r = r_nor
+        else:
+            r = r_rev
+        canonical_args = [ D[order] for order in r ]
+        return tuple(canonical_args)
 
     def __contains__(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -146,9 +146,6 @@ class Polygon(GeometrySet):
 
         vertices = list(nodup)
 
-
-
-
         if len(vertices) > 3:
             return GeometryEntity.__new__(cls, *vertices, **kwargs)
         elif len(vertices) == 3:

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -1,6 +1,6 @@
 from sympy import Abs, Rational, Float, S, Symbol, symbols, cos, pi, sqrt, oo
 from sympy.functions.elementary.trigonometric import tan
-from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Point2D, Polygon, Ray, RegularPolygon, Segment, Triangle,
+from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Point2D, Polygon, Ray, RegularPolygon, Segment, Triangle, are_similar,
                             convex_hull, intersection, Line)
 from sympy.utilities.pytest import raises, slow, warns
 from sympy.utilities.randtest import verify_numerically
@@ -212,9 +212,9 @@ def test_polygon():
     assert t1.is_equilateral() is False
     assert t2.is_equilateral()
     assert t3.is_equilateral() is False
-    assert t1.is_similar(t2) is False
-    assert t1.is_similar(t3)
-    assert t2.is_similar(t3) is False
+    assert are_similar(t1, t2) is False
+    assert are_similar(t1, t3)
+    assert are_similar(t2, t3) is False
     assert t1.is_similar(Point(0, 0)) is False
 
     # Bisectors

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -1,6 +1,6 @@
 from sympy import Abs, Rational, Float, S, Symbol, symbols, cos, pi, sqrt, oo
 from sympy.functions.elementary.trigonometric import tan
-from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Point2D, Polygon, Ray, RegularPolygon, Segment, Triangle, are_similar,
+from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Point2D, Polygon, Ray, RegularPolygon, Segment, Triangle,
                             convex_hull, intersection, Line)
 from sympy.utilities.pytest import raises, slow, warns
 from sympy.utilities.randtest import verify_numerically
@@ -17,6 +17,10 @@ def feq(a, b):
 def test_polygon():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
+    q = Symbol('q', real=True)
+    u = Symbol('u', real=True)
+    v = Symbol('v', real=True)
+    w = Symbol('w', real=True)
     x1 = Symbol('x1', real=True)
     half = Rational(1, 2)
     a, b, c = Point(0, 0), Point(2, 0), Point(3, 3)
@@ -55,6 +59,16 @@ def test_polygon():
     p6 = Polygon(
         Point(-11, 1), Point(-9, 6.6),
         Point(-4, -3), Point(-8.4, -8.7))
+    p7 = Polygon(
+        Point(x, y), Point(q, u),
+        Point(v, w))
+    p8 = Polygon(
+        Point(x, y), Point(v, w),
+        Point(q, u))
+    p9 = Polygon(
+        Point(0, 0), Point(4, 4),
+        Point(3, 0), Point(5, 2))
+
     r = Ray(Point(-9,6.6), Point(-9,5.5))
     #
     # General polygon
@@ -88,6 +102,9 @@ def test_polygon():
         Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(
                 Polygon(Point(0, 0), Point(0, 1), Point(1, 1)))
     assert hash(p5) == hash(Polygon(Point(0, 0), Point(4, 4), Point(0, 4)))
+    assert hash(p1) == hash(p2)
+    assert hash(p7) == hash(p8)
+    assert hash(p3) != hash(p9)
     assert p5 == Polygon(Point(4, 4), Point(0, 4), Point(0, 0))
     assert Polygon(Point(4, 4), Point(0, 4), Point(0, 0)) in p5
     assert p5 != Point(0, 4)
@@ -195,9 +212,9 @@ def test_polygon():
     assert t1.is_equilateral() is False
     assert t2.is_equilateral()
     assert t3.is_equilateral() is False
-    assert are_similar(t1, t2) is False
-    assert are_similar(t1, t3)
-    assert are_similar(t2, t3) is False
+    assert t1.is_similar(t2) is False
+    assert t1.is_similar(t3)
+    assert t2.is_similar(t3) is False
     assert t1.is_similar(Point(0, 0)) is False
 
     # Bisectors

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -17,6 +17,10 @@ def feq(a, b):
 def test_polygon():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)
+    q = Symbol('q', real=True)
+    u = Symbol('u', real=True)
+    v = Symbol('v', real=True)
+    w = Symbol('w', real=True)
     x1 = Symbol('x1', real=True)
     half = Rational(1, 2)
     a, b, c = Point(0, 0), Point(2, 0), Point(3, 3)
@@ -55,6 +59,16 @@ def test_polygon():
     p6 = Polygon(
         Point(-11, 1), Point(-9, 6.6),
         Point(-4, -3), Point(-8.4, -8.7))
+    p7 = Polygon(
+        Point(x, y), Point(q, u),
+        Point(v, w))
+    p8 = Polygon(
+        Point(x, y), Point(v, w),
+        Point(q, u))
+    p9 = Polygon(
+        Point(0, 0), Point(4, 4),
+        Point(3, 0), Point(5, 2))
+
     r = Ray(Point(-9,6.6), Point(-9,5.5))
     #
     # General polygon
@@ -88,6 +102,9 @@ def test_polygon():
         Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(
                 Polygon(Point(0, 0), Point(0, 1), Point(1, 1)))
     assert hash(p5) == hash(Polygon(Point(0, 0), Point(4, 4), Point(0, 4)))
+    assert hash(p1) == hash(p2)
+    assert hash(p7) == hash(p8)
+    assert hash(p3) != hash(p9)
     assert p5 == Polygon(Point(4, 4), Point(0, 4), Point(0, 0))
     assert Polygon(Point(4, 4), Point(0, 4), Point(0, 0)) in p5
     assert p5 != Point(0, 4)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -975,7 +975,7 @@ def least_rotation(x):
     3
     >>> rotate_left(a, _)
     [1, 2, 3, 1, 5]
-    
+
     .. seealso:: https://en.wikipedia.org/wiki/Lexicographically_minimal_string_rotation
     '''
     S = x + x      # Concatenate string to it self to avoid modular arithmetic

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -961,6 +961,42 @@ def rotate_right(x, y):
     return x[y:] + x[:y]
 
 
+def least_rotation(x):
+    '''
+    Returns the number of steps of left rotation required to
+    obtain lexicographically minimal string/list/tuple, etc.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import least_rotation, rotate_left
+    >>> a = [3, 1, 5, 1, 2]
+    >>> least_rotation(a)
+    3
+    >>> rotate_left(a, _)
+    [1, 2, 3, 1, 5]
+    
+    .. seealso:: https://en.wikipedia.org/wiki/Lexicographically_minimal_string_rotation
+    '''
+    S = x + x      # Concatenate string to it self to avoid modular arithmetic
+    f = [-1] * len(S)     # Failure function
+    k = 0       # Least rotation of string found so far
+    for j in range(1,len(S)):
+        sj = S[j]
+        i = f[j-k-1]
+        while i != -1 and sj != S[k+i+1]:
+            if sj < S[k+i+1]:
+                k = j-i-1
+            i = f[i]
+        if sj != S[k+i+1]:
+            if sj < S[k]:
+                k = j
+            f[j-k] = -1
+        else:
+            f[j-k] = i+1
+    return k
+
+
 def multiset_combinations(m, n, g=None):
     """
     Return the unique combinations of size ``n`` from multiset ``m``.

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -961,6 +961,42 @@ def rotate_right(x, y):
     return x[y:] + x[:y]
 
 
+def least_rotation(x):
+    '''
+    Returns the number of steps of left rotation required to
+    obtain lexicographically minimal string/list/tuple, etc.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import least_rotation, rotate_left
+    >>> a = [3, 1, 5, 1, 2]
+    >>> least_rotation(a)
+    3
+    >>> rotate_left(a, _)
+    [1, 2, 3, 1, 5]
+
+    .. seealso:: https://en.wikipedia.org/wiki/Lexicographically_minimal_string_rotation
+    '''
+    S = x + x      # Concatenate string to it self to avoid modular arithmetic
+    f = [-1] * len(S)     # Failure function
+    k = 0       # Least rotation of string found so far
+    for j in range(1,len(S)):
+        sj = S[j]
+        i = f[j-k-1]
+        while i != -1 and sj != S[k+i+1]:
+            if sj < S[k+i+1]:
+                k = j-i-1
+            i = f[i]
+        if sj != S[k+i+1]:
+            if sj < S[k]:
+                k = j
+            f[j-k] = -1
+        else:
+            f[j-k] = i+1
+    return k
+
+
 def multiset_combinations(m, n, g=None):
     """
     Return the unique combinations of size ``n`` from multiset ``m``.


### PR DESCRIPTION
Hash of Polygons which compare equal is made same. 
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #7998

#### Brief description of what is fixed or changed
Two Polygons are equal if they have set of vertices (AS defined in geometry module). 
Before this PR, hash of two equal Polygons  having different order of vertices was different.
This has been fixed now.

Earlier -
```
   >>> a = Polygon( Point(0, 0), Point(1, 0), Point(1,1)
   >>> b = Polygon( Point(0, 0), Point(1, 1), Point(1, 0)
   >>>  a == b
   >>>  True
   >>>  hash(a) == hash(b)
   False
```
Now-
```
   >>> a = Polygon( Point(0, 0), Point(1, 0), Point(1,1)
   >>> b = Polygon( Point(0, 0), Point(1, 1), Point(1, 0)
   >>> a == b
   True
   >>> hash(a) == hash(b)
   True
```
#### Other comments
See [#15747](https://github.com/sympy/sympy/pull/15747)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
   * hash function of Polygon modified
<!-- END RELEASE NOTES -->
