### PR TITLE
Cleanup tensor product from quantum physics module

### DIFF
--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -255,7 +255,48 @@ def extract_commutative(kron):
 
 
 def matrix_kronecker_product(*matrices):
+    """Compute the kronecker product of a sequence of sympy Matrices.
 
+    This is the standard Kronecker product of matrices [1].
+
+    Parameters
+    ==========
+
+    matrices : tuple of MatrixBase instances
+        The matrices to take the kronecker product of.
+
+    Returns
+    =======
+
+    matrix : MatrixBase
+        The kronecker product matrix.
+
+    Examples
+    ========
+
+    >>> from sympy import I, Matrix, symbols
+    >>> from sympy.physics.quantum.matrixutils import _sympy_tensor_product
+
+    >>> m1 = Matrix([[1,2],[3,4]])
+    >>> m2 = Matrix([[1,0],[0,1]])
+    >>> _sympy_tensor_product(m1, m2)
+    Matrix([
+    [1, 0, 2, 0],
+    [0, 1, 0, 2],
+    [3, 0, 4, 0],
+    [0, 3, 0, 4]])
+    >>> _sympy_tensor_product(m2, m1)
+    Matrix([
+    [1, 2, 0, 0],
+    [3, 4, 0, 0],
+    [0, 0, 1, 2],
+    [0, 0, 3, 4]])
+
+    References
+    ==========
+
+    [1] https://en.wikipedia.org/wiki/Kronecker_product
+    """
     # Make sure we have a sequence of Matrices
     if not all(isinstance(m, MatrixBase) for m in matrices):
         raise TypeError(

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -276,7 +276,7 @@ def matrix_kronecker_product(*matrices):
 
     >>> from sympy import Matrix
     >>> from sympy.matrices.expressions.kronecker import (
-    matrix_kronecker_product)
+    ... matrix_kronecker_product)
 
     >>> m1 = Matrix([[1,2],[3,4]])
     >>> m2 = Matrix([[1,0],[0,1]])

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -255,7 +255,7 @@ def extract_commutative(kron):
 
 
 def matrix_kronecker_product(*matrices):
-    """Compute the kronecker product of a sequence of sympy Matrices.
+    """Compute the Kronecker product of a sequence of SymPy Matrices.
 
     This is the standard Kronecker product of matrices [1].
 
@@ -263,13 +263,13 @@ def matrix_kronecker_product(*matrices):
     ==========
 
     matrices : tuple of MatrixBase instances
-        The matrices to take the kronecker product of.
+        The matrices to take the Kronecker product of.
 
     Returns
     =======
 
     matrix : MatrixBase
-        The kronecker product matrix.
+        The Kronecker product matrix.
 
     Examples
     ========

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -275,17 +275,17 @@ def matrix_kronecker_product(*matrices):
     ========
 
     >>> from sympy import I, Matrix, symbols
-    >>> from sympy.physics.quantum.matrixutils import _sympy_tensor_product
+    >>> from sympy.matrices.expressions import matrix_kronecker_product
 
     >>> m1 = Matrix([[1,2],[3,4]])
     >>> m2 = Matrix([[1,0],[0,1]])
-    >>> _sympy_tensor_product(m1, m2)
+    >>> matrix_kronecker_product(m1, m2)
     Matrix([
     [1, 0, 2, 0],
     [0, 1, 0, 2],
     [3, 0, 4, 0],
     [0, 3, 0, 4]])
-    >>> _sympy_tensor_product(m2, m1)
+    >>> matrix_kronecker_product(m2, m1)
     Matrix([
     [1, 2, 0, 0],
     [3, 4, 0, 0],

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -274,8 +274,9 @@ def matrix_kronecker_product(*matrices):
     Examples
     ========
 
-    >>> from sympy import I, Matrix, symbols
-    >>> from sympy.matrices.expressions import matrix_kronecker_product
+    >>> from sympy import Matrix
+    >>> from sympy.matrices.expressions.kronecker import (
+    matrix_kronecker_product)
 
     >>> m1 = Matrix([[1,2],[3,4]])
     >>> m2 = Matrix([[1,0],[0,1]])

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -147,46 +147,6 @@ def matrix_dagger(e):
 # TODO: Move this into sympy.matricies.
 def _sympy_tensor_product(*matrices):
     """Compute the kronecker product of a sequence of sympy Matrices.
-
-    This is the standard Kronecker product of matrices [1].
-
-    Parameters
-    ==========
-
-    matrices : tuple of MatrixBase instances
-        The matrices to take the kronecker product of.
-
-    Returns
-    =======
-
-    matrix : MatrixBase
-        The kronecker product matrix.
-
-    Examples
-    ========
-
-    >>> from sympy import I, Matrix, symbols
-    >>> from sympy.physics.quantum.matrixutils import _sympy_tensor_product
-
-    >>> m1 = Matrix([[1,2],[3,4]])
-    >>> m2 = Matrix([[1,0],[0,1]])
-    >>> _sympy_tensor_product(m1, m2)
-    Matrix([
-    [1, 0, 2, 0],
-    [0, 1, 0, 2],
-    [3, 0, 4, 0],
-    [0, 3, 0, 4]])
-    >>> _sympy_tensor_product(m2, m1)
-    Matrix([
-    [1, 2, 0, 0],
-    [3, 4, 0, 0],
-    [0, 0, 1, 2],
-    [0, 0, 3, 4]])
-
-    References
-    ==========
-
-    [1] https://en.wikipedia.org/wiki/Kronecker_product
     """
     from sympy.matrices.expressions.kronecker import matrix_kronecker_product
 

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -188,35 +188,9 @@ def _sympy_tensor_product(*matrices):
 
     [1] https://en.wikipedia.org/wiki/Kronecker_product
     """
-    # Make sure we have a sequence of Matrices
-    if not all(isinstance(m, MatrixBase) for m in matrices):
-        raise TypeError(
-            'Sequence of Matrices expected, got: %s' % repr(matrices)
-        )
+    from sympy.matrices.expressions.kronecker import matrix_kronecker_product
 
-    # Pull out the first element in the product.
-    matrix_expansion = matrices[-1]
-    # Do the tensor product working from right to left.
-    for mat in reversed(matrices[:-1]):
-        rows = mat.rows
-        cols = mat.cols
-        # Go through each row appending tensor product to.
-        # running matrix_expansion.
-        for i in range(rows):
-            start = matrix_expansion*mat[i*cols]
-            # Go through each column joining each item
-            for j in range(cols - 1):
-                start = start.row_join(
-                    matrix_expansion*mat[i*cols + j + 1]
-                )
-            # If this is the first element, make it the start of the
-            # new row.
-            if i == 0:
-                next = start
-            else:
-                next = next.col_join(start)
-        matrix_expansion = next
-    return matrix_expansion
+    return matrix_kronecker_product(*matrices)
 
 
 def _numpy_tensor_product(*product):

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -146,7 +146,7 @@ def matrix_dagger(e):
 
 # TODO: Move this into sympy.matricies.
 def _sympy_tensor_product(*matrices):
-    """Compute the tensor product of a sequence of sympy Matrices.
+    """Compute the kronecker product of a sequence of sympy Matrices.
 
     This is the standard Kronecker product of matrices [1].
 
@@ -154,13 +154,13 @@ def _sympy_tensor_product(*matrices):
     ==========
 
     matrices : tuple of MatrixBase instances
-        The matrices to take the tensor product of.
+        The matrices to take the kronecker product of.
 
     Returns
     =======
 
     matrix : MatrixBase
-        The tensor product matrix.
+        The kronecker product matrix.
 
     Examples
     ========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
#14264

#### Brief description of what is fixed or changed

[_sympy_tensor_product](https://github.com/sympy/sympy/blob/ebc6d7271d1fe59f8a234fb921f416d270dd7333/sympy/physics/quantum/matrixutils.py#L147-L219) in quantum physics module and [matrix_kronecker_product](https://github.com/sympy/sympy/blob/ebc6d7271d1fe59f8a234fb921f416d270dd7333/sympy/matrices/expressions/kronecker.py#L257-L292) in matrix expressions module are using almost identical code.

But I think the latter was updated for #10735, so one from the physics should be deleted.

I have also moved the docstrings.

#### Other comments

MatrixBase still does not have any method for kronecker product. Should it be moved there instead?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
