### PR TITLE
Add missing docs for gauss_lobatto

### DIFF
--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -127,6 +127,8 @@ any order and any precision:
 
 .. autofunction:: sympy.integrals.quadrature.gauss_jacobi
 
+.. autofunction:: sympy.integrals.quadrature.gauss_lobatto
+
 Integration over Polytopes
 ==========================
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
#11728

#### Brief description of what is fixed or changed

From the latest [docs](https://docs.sympy.org/dev/modules/integrals/integrals.html#numeric-integrals), I found gauss_lobatto link broken because the doc has not been added.



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
