### PR TITLE
Custom otional label in Pauli matrices

### DIFF
--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -64,7 +64,8 @@ def epsilon(i, j, k):
 
 
 class Pauli(Symbol):
-    """The class representing algebraic properties of Pauli matrices. 
+    """
+    The class representing algebraic properties of Pauli matrices.
 
     The symbol used to display the Pauli matrices can be changed with an
     optional parameter ``label="sigma"``. Pauli matrices with different 
@@ -80,6 +81,7 @@ class Pauli(Symbol):
 
     See Also
     ========
+
     evaluate_pauli_product
 
     Examples
@@ -100,9 +102,9 @@ class Pauli(Symbol):
     >>> from sympy.physics.paulialgebra import Pauli
     >>> Pauli(1, label="tau")
     tau1
-    >>> Pauli(1)*Pauli(2, "tau")
+    >>> Pauli(1)*Pauli(2, label="tau")
     sigma1*tau2
-    >>> Pauli(1, "tau")*Pauli(2,"tau")
+    >>> Pauli(1, label="tau")*Pauli(2, label="tau")
     I*tau3
 
     >>> from sympy import I
@@ -115,7 +117,6 @@ class Pauli(Symbol):
     I*sigma2*sigma3
     >>> evaluate_pauli_product(f)
     -sigma1
-
     """
 
     __slots__ = ["i", "label"]
@@ -137,7 +138,7 @@ class Pauli(Symbol):
             j = self.i
             k = other.i
             jlab = self.label
-            klab = self.label
+            klab = other.label
 
             if jlab == klab:
                 return delta(j, k) \

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -64,18 +64,22 @@ def epsilon(i, j, k):
 
 
 class Pauli(Symbol):
-    """The class representing algebraic properties of Pauli matrices
+    """The class representing algebraic properties of Pauli matrices. 
+
+    The symbol used to display the Pauli matrices can be changed with an
+    optional parameter ``label="sigma"``. Pauli matrices with different 
+    ``label`` attributes cannot multiply together.
 
     If the left multiplication of symbol or number with Pauli matrix is needed,
     please use parentheses  to separate Pauli and symbolic multiplication
-    (for example: 2*I*(Pauli(3)*Pauli(2)))
+    (for example: 2*I*(Pauli(3)*Pauli(2))).
 
     Another variant is to use evaluate_pauli_product function to evaluate
     the product of Pauli matrices and other symbols (with commutative
-    multiply rules)
+    multiply rules).
 
     See Also
-    =======
+    ========
     evaluate_pauli_product
 
     Examples
@@ -93,6 +97,14 @@ class Pauli(Symbol):
     >>> Pauli(1)*Pauli(2)*Pauli(3)
     I
 
+    >>> from sympy.physics.paulialgebra import Pauli
+    >>> Pauli(1, label="tau")
+    tau1
+    >>> Pauli(1)*Pauli(2, "tau")
+    sigma1*tau2
+    >>> Pauli(1, "tau")*Pauli(2,"tau")
+    I*tau3
+
     >>> from sympy import I
     >>> I*(Pauli(2)*Pauli(3))
     -sigma1
@@ -106,27 +118,32 @@ class Pauli(Symbol):
 
     """
 
-    __slots__ = ["i"]
+    __slots__ = ["i", "label"]
 
-    def __new__(cls, i):
+    def __new__(cls, i, label="sigma"):
         if not i in [1, 2, 3]:
             raise IndexError("Invalid Pauli index")
-        obj = Symbol.__new__(cls, "sigma%d" % i, commutative=False, hermitian=True)
+        obj = Symbol.__new__(cls, "%s%d" %(label,i), commutative=False, hermitian=True)
         obj.i = i
+        obj.label = label
         return obj
 
     def __getnewargs__(self):
-        return (self.i,)
+        return (self.i,self.label,)
 
     # FIXME don't work for -I*Pauli(2)*Pauli(3)
     def __mul__(self, other):
         if isinstance(other, Pauli):
             j = self.i
             k = other.i
-            return delta(j, k) \
-                + I*epsilon(j, k, 1)*Pauli(1) \
-                + I*epsilon(j, k, 2)*Pauli(2) \
-                + I*epsilon(j, k, 3)*Pauli(3)
+            jlab = self.label
+            klab = self.label
+
+            if jlab == klab:
+                return delta(j, k) \
+                    + I*epsilon(j, k, 1)*Pauli(1,jlab) \
+                    + I*epsilon(j, k, 2)*Pauli(2,jlab) \
+                    + I*epsilon(j, k, 3)*Pauli(3,jlab)
         return super(Pauli, self).__mul__(other)
 
     def _eval_power(b, e):

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -68,7 +68,7 @@ class Pauli(Symbol):
     The class representing algebraic properties of Pauli matrices.
 
     The symbol used to display the Pauli matrices can be changed with an
-    optional parameter ``label="sigma"``. Pauli matrices with different 
+    optional parameter ``label="sigma"``. Pauli matrices with different
     ``label`` attributes cannot multiply together.
 
     If the left multiplication of symbol or number with Pauli matrix is needed,


### PR DESCRIPTION
Added an optional attribute label="sigma" to the Pauli class in
the sympy.physics.paulialgebra module.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
When working with direct products of two different 2x2 spaces, it is common to 
name Pauli matrices that refer to each one of these two spaces differently. In
this change I implemented the option to change the symbol that is used to 
represent Pauli matrices and added an explanation and some basic examples 
into the docstring.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.paulialgebra
  * added the option to change the symbol representing the Pauli matrices

<!-- END RELEASE NOTES -->
