### PR TITLE
minpoly-compose: preserve exponent of -1

### DIFF
--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -751,3 +751,11 @@ def test_minpoly_domain():
         domain=QQ.algebraic_field(sqrt(2))) == 2*x**2 - 3
 
     raises(NotAlgebraic, lambda: minimal_polynomial(y, x, domain=QQ))
+
+
+def test_issue_14831():
+    a = -2*sqrt(2)*sqrt(12*sqrt(2) + 17)
+    assert minimal_polynomial(a, x) == x**2 + 16*x - 8
+    e = (-3*sqrt(12*sqrt(2) + 17) + 12*sqrt(2) +
+         17 - 2*sqrt(2)*sqrt(12*sqrt(2) + 17))
+    assert minimal_polynomial(e, x) == x


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Closes #5934
Fixes #14831

#### Brief description of what is fixed or changed

`_minpoly_compose` computes the minimal polynomial of a product
by first combining all factors `b**e` where `b` and `e` are
rational. Each exponent `e` is written as `n/d` where `d` is the
least common multiple of all exponents. Then the product of the
powers `b**n` is computed and finally its `d`th root is taken.
This may give a result with wrong sign if `b == -1` and `n` is
even. That is what happens with one term of the expression in
issue 14831:

    >>> minimal_polynomial(-2*sqrt(2)*sqrt(12*sqrt(2) + 17), x)
    x**2 - 16*x - 8

This is the minimal polynomial of `2*sqrt(2)*sqrt(12*sqrt(2) + 17)`.
The correct result is `x**2 + 16*x - 8`.

This patch deals with powers of -1 separately taking care of
preserving the sign.

#### Other comments
I first encountered this bug in #5934 but there is no test for it as the expression is
so complicated.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
    - preserve exponent of -1 in _minpoly_compose
<!-- END RELEASE NOTES -->
