### PR TITLE
Request people to manually backreference pull requests in the issue

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,9 @@ was changed. Do not include the issue number in the title. -->
 #### References to other Issues or PRs
 <!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
 format, e.g. "Fixes #1234". See
-https://github.com/blog/1506-closing-issues-via-pull-requests .-->
+https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
+write a comment on that issue linking back to this pull request once it is
+open. -->
 
 
 #### Brief description of what is fixed or changed


### PR DESCRIPTION
That is, in the pull request template.

The problem is that even though GitHub does automatically add cross references
when the issue is referenced, it does so in a way that most new people tend to
miss. An actual comment is more likely to be noticed, and is better practice
anyway.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
