### PR TITLE
WIP - Pytest doctest fix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,14 +8,14 @@ import json
 import sys
 import warnings
 import pytest
-from sympy.utilities.runtests import setup_pprint
+from sympy.utilities.runtests import setup_pprint, _get_doctest_blacklist
 
 durations_path = os.path.join(os.path.dirname(__file__), '.ci', 'durations.json')
 blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.json')
 
 # Collecting tests from rubi_tests under pytest leads to errors even if the
 # tests will be skipped.
-collect_ignore = ["sympy/integrals/rubi/rubi_tests"]
+collect_ignore = ["sympy/integrals/rubi/rubi_tests"] + _get_doctest_blacklist()
 
 # Set up printing for doctests
 setup_pprint()

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,10 @@ collect_ignore = ["sympy/integrals/rubi/rubi_tests"] + _get_doctest_blacklist()
 
 # Set up printing for doctests
 setup_pprint()
+sys.__displayhook__ = sys.displayhook
+#from sympy import pprint_use_unicode
+#pprint_use_unicode(False)
+
 
 def _mk_group(group_dict):
     return list(chain(*[[k+'::'+v for v in files] for k, files in group_dict.items()]))

--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,7 @@ blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.jso
 
 # Collecting tests from rubi_tests under pytest leads to errors even if the
 # tests will be skipped.
-collect_ignore = ["sympy/integrals/rubi/rubi_tests"] + _get_doctest_blacklist()
+collect_ignore = ["sympy/integrals/rubi"] + _get_doctest_blacklist()
 
 # Set up printing for doctests
 setup_pprint()

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,8 @@ blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.jso
 # Collecting tests from rubi_tests under pytest leads to errors even if the
 # tests will be skipped.
 collect_ignore = ["sympy/integrals/rubi"] + _get_doctest_blacklist()
+if sys.version_info < (3,):
+    collect_ignore.append('doc/src/gotchas.rst')
 
 # Set up printing for doctests
 setup_pprint()

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ import json
 import sys
 import warnings
 import pytest
+from sympy.utilities.runtests import setup_pprint
 
 durations_path = os.path.join(os.path.dirname(__file__), '.ci', 'durations.json')
 blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.json')
@@ -15,6 +16,9 @@ blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.jso
 # Collecting tests from rubi_tests under pytest leads to errors even if the
 # tests will be skipped.
 collect_ignore = ["sympy/integrals/rubi/rubi_tests"]
+
+# Set up printing for doctests
+setup_pprint()
 
 def _mk_group(group_dict):
     return list(chain(*[[k+'::'+v for v in files] for k, files in group_dict.items()]))

--- a/doc/src/gotchas.rst
+++ b/doc/src/gotchas.rst
@@ -301,8 +301,6 @@ evaluate the two numbers before SymPy has a chance to get
 to them.  The solution is to :func:`sympify` one of the numbers, or use
 :mod:`Rational`.
 
-.. doctest-skip::
-
     >>> x**(1/2)  # evaluates to x**0 or x**0.5
     x**0.5
     >>> x**(S(1)/2)  # sympyify one of the ints
@@ -329,8 +327,6 @@ you don't have to worry about this problem:
     obtaining the Python result for the division rather than a SymPy
     Rational.
 
-.. doctest-skip::
-
     >>> x = Symbol('x')
     >>> print(solve(7*x -22, x))
     [22/7]
@@ -352,8 +348,6 @@ Also, if you do not use :command:`isympy`, you could use ``from
 __future__ import division`` to prevent the ``/`` sign from performing
 `integer division <https://en.wikipedia.org/wiki/Integer_division>`_.
 
-.. doctest-skip::
-
     >>> from __future__ import division
     >>> 1/2   # With division imported it evaluates to a python float
     0.5
@@ -362,8 +356,6 @@ __future__ import division`` to prevent the ``/`` sign from performing
 
     But be careful: you will now receive floats where you might have desired
     a Rational:
-
-.. doctest-skip::
 
     >>> x**(1/2)
     x**0.5

--- a/doc/src/gotchas.rst
+++ b/doc/src/gotchas.rst
@@ -301,6 +301,8 @@ evaluate the two numbers before SymPy has a chance to get
 to them.  The solution is to :func:`sympify` one of the numbers, or use
 :mod:`Rational`.
 
+.. doctest-skip::
+
     >>> x**(1/2)  # evaluates to x**0 or x**0.5
     x**0.5
     >>> x**(S(1)/2)  # sympyify one of the ints
@@ -327,6 +329,8 @@ you don't have to worry about this problem:
     obtaining the Python result for the division rather than a SymPy
     Rational.
 
+.. doctest-skip::
+
     >>> x = Symbol('x')
     >>> print(solve(7*x -22, x))
     [22/7]
@@ -348,6 +352,8 @@ Also, if you do not use :command:`isympy`, you could use ``from
 __future__ import division`` to prevent the ``/`` sign from performing
 `integer division <https://en.wikipedia.org/wiki/Integer_division>`_.
 
+.. doctest-skip::
+
     >>> from __future__ import division
     >>> 1/2   # With division imported it evaluates to a python float
     0.5
@@ -356,6 +362,8 @@ __future__ import division`` to prevent the ``/`` sign from performing
 
     But be careful: you will now receive floats where you might have desired
     a Rational:
+
+.. doctest-skip::
 
     >>> x**(1/2)
     x**0.5

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -110,7 +110,7 @@ strings can occur without custom indices, and also overwrites the latex string
 that would be used if there were custom indices. ::
 
   >>> from sympy.physics.vector import ReferenceFrame, vlatex
-  >>> N = ReferenceFrame('N', latexs=['n1','\mathbf{n}_2','cat'])
+  >>> N = ReferenceFrame('N', latexs=['n1','\\mathbf{n}_2','cat'])
   >>> vlatex(N.x)
   'n1'
   >>> vlatex(N.y)

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,10 @@ doctest_optionflags =
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL
     ELLIPSIS
+    FLOAT_CMP
+
+norecursedirs =
+    sympy/parsing/autolev/test-examples
+    sympy/integrals/rubi/rubi_tests
+
+doctestplus = enabled

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,4 +11,7 @@ filterwarnings =
     ignore:.*the matrix subclass is not the recommended way.*:PendingDeprecationWarning
 
 # Normalise output of doctests.
-doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
+    ELLIPSIS

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,6 @@ testpaths = sympy
 # This prevents ~800 warnings showing up running the tests under pytest.
 filterwarnings =
     ignore:.*the matrix subclass is not the recommended way.*:PendingDeprecationWarning
+
+# Normalise output of doctests.
+doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 
 # Only run tests under the sympy/ directory. Otherwise pytest will attempt to
 # collect tests from e.g. the bin/ directory as well.
-testpaths = sympy
+testpaths = sympy doc/src
 
 # np.matrix is deprecated but still used in sympy.physics.quantum:
 #    https://github.com/sympy/sympy/issues/15563

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ testpaths = sympy
 # This prevents ~800 warnings showing up running the tests under pytest.
 filterwarnings =
     ignore:.*the matrix subclass is not the recommended way.*:PendingDeprecationWarning
+    ignore:IPython.utils.signatures backport for Python 2 is deprecated.*:DeprecationWarning
 
 # Normalise output of doctests.
 doctest_optionflags =

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1541,7 +1541,7 @@ class XypicDiagramDrawer(object):
     should be done:
 
     >>> def formatter(astr):
-    ...   astr.label = "\exists !" + astr.label
+    ...   astr.label = r"\exists !" + astr.label
     ...   astr.arrow_style = "{-->}"
     >>> drawer.arrow_formatters["unique"] = formatter
     >>> print(drawer.draw(diagram, grid))

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -95,6 +95,9 @@ from sympy.printing import latex
 from sympy.utilities.decorator import doctest_depends_on
 
 
+__doctest_requires__ = {('preview_diagram',): 'pyglet'}
+
+
 class _GrowableGrid(object):
     """
     Holds a growable grid of objects.

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1534,6 +1534,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
+        >>> Permutation.print_cyclic = False
         >>> p = Permutation([[2,0], [3,1]])
         >>> ~p
         Permutation([2, 3, 0, 1])
@@ -2336,6 +2337,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
+        >>> Permutation.print_cyclic = False
         >>> p = Permutation([4, 8, 0, 7, 1, 5, 3, 6, 2])
         >>> p.inversion_vector()
         [4, 7, 0, 5, 0, 2, 1, 1]
@@ -2515,6 +2517,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
+        >>> Permutation.print_cyclic = False
         >>> p = Permutation.josephus(3, 6, 1)
         >>> p
         Permutation([2, 5, 3, 1, 4, 0])

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -49,7 +49,7 @@ def dummy_sgs(dummies, sym, n):
     ========
 
     >>> from sympy.combinatorics.tensor_can import dummy_sgs
-    >>> dummy_sgs(range(2, 8), 0, 8)
+    >>> dummy_sgs(list(range(2, 8)), 0, 8)
     [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9],
      [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9],
      [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -216,9 +216,9 @@ def with_metaclass(meta, *bases):
     may omit it.
 
     >>> MyClass.__mro__
-    (<class 'MyClass'>, <... 'object'>)
+    (<class '...MyClass'>, <... 'object'>)
     >>> type(MyClass)
-    <class 'Meta'>
+    <class '...Meta'>
 
     """
     # This requires a bit of explanation: the basic idea is to make a dummy

--- a/sympy/deprecated/class_registry.py
+++ b/sympy/deprecated/class_registry.py
@@ -1,4 +1,4 @@
-from sympy.core.decorators import deprecated
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.core import BasicMeta, Registry, all_classes
 
 
@@ -26,14 +26,17 @@ class ClassRegistry(Registry):
         if cls not in self.__class__.__dict__.itervalues():
             all_classes.remove(cls)
 
-    @deprecated(
-        feature='C, including its class ClassRegistry,',
-        last_supported_version='1.0',
-        useinstead='direct imports from the defining module',
-        issue=9371,
-        deprecated_since_version='1.0')
-
     def __getattr__(self, name):
+        # Warning on hasattr(C, '__wrapped__') leadds to warnings during test
+        # collection when running doctests under pytest.
+        if name != '__wrapped__':
+            SymPyDeprecationWarning(
+                feature='C, including its class ClassRegistry,',
+                last_supported_version='1.0',
+                useinstead='direct imports from the defining module',
+                issue=9371,
+                deprecated_since_version='1.0').warn(stacklevel=2)
+
         return any(cls.__name__ == name for cls in all_classes)
 
     @property

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -21,6 +21,9 @@ matplotlib = import_module('matplotlib', __import__kwargs={'fromlist':['pyplot']
 numpy = import_module('numpy', __import__kwargs={'fromlist':['linspace']})
 
 
+__doctest_requires__ = {('Beam.plot_loading_results',): ['matplotlib']}
+
+
 class Beam(object):
     """
     A Beam is a structural element that is capable of withstanding load

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -436,10 +436,12 @@ class PicklableWithSlots(object):
         ...         self.foo = foo
         ...         self.bar = bar
 
-    To make :mod:`pickle` happy in doctest we have to use this hack::
+    To make :mod:`pickle` happy in doctest we have to use these hacks::
 
         >>> from sympy.core.compatibility import builtins
         >>> builtins.Some = Some
+        >>> from sympy.polys import polyutils
+        >>> polyutils.Some = Some
 
     Next lets see if we can create an instance, pickle it and unpickle::
 

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -22,6 +22,9 @@ if llvmlite:
     llvm.initialize_native_asmprinter()
 
 
+__doctest_requires__ = {('llvm_callable'): ['llvmlite']}
+
+
 class LLVMJitPrinter(Printer):
     '''Convert expressions to LLVM IR'''
     def __init__(self, module, builder, fn, *args, **kwargs):

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -20,6 +20,8 @@ from .latex import latex
 
 from sympy.utilities.decorator import doctest_depends_on
 
+__doctest_requires__ = {('preview',): ['pyglet']}
+
 @doctest_depends_on(exe=('latex', 'dvipng'), modules=('pyglet',),
             disable_viewers=('evince', 'gimp', 'superior-dvi-viewer'))
 def preview(expr, output='png', viewer=None, euler=True, packages=(),

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -10,6 +10,7 @@ from functools import update_wrapper
 
 from sympy.core.decorators import wraps
 from sympy.core.compatibility import class_types, get_function_globals, get_function_name, iterable
+from sympy.utilities.runtests import DependencyError, SymPyDocTests, PyTestReporter
 
 def threaded_factory(func, use_add):
     """A factory for ``threaded`` decorators. """
@@ -131,21 +132,35 @@ def doctest_depends_on(exe=None, modules=None, disable_viewers=None):
     """Adds metadata about the dependencies which need to be met for doctesting
     the docstrings of the decorated objects."""
 
-    def depends_on_deco(fn):
-        dependencies = {}
-        if exe is not None:
-            dependencies['executables'] = exe
-        if modules is not None:
-            dependencies['modules'] = modules
-        if disable_viewers is not None:
-            dependencies['disable_viewers'] = disable_viewers
+    dependencies = {}
+    if exe is not None:
+        dependencies['executables'] = exe
+    if modules is not None:
+        dependencies['modules'] = modules
+    if disable_viewers is not None:
+        dependencies['disable_viewers'] = disable_viewers
 
+    def skiptests():
+        r = PyTestReporter()
+        t = SymPyDocTests(r, None)
+        try:
+            t._check_dependencies(**dependencies)
+        except DependencyError:
+            return True  # Skip doctests
+        else:
+            return False # Run doctests
+
+    def depends_on_deco(fn):
         fn._doctest_depends_on = dependencies
+        fn.__doctest_skip__ = skiptests
 
         if inspect.isclass(fn):
             fn._doctest_depdends_on = no_attrs_in_subclass(
                 fn, fn._doctest_depends_on)
+            fn.__doctest_skip__ = no_attrs_in_subclass(
+                fn, fn.__doctest_skip__)
         return fn
+
     return depends_on_deco
 
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -259,16 +259,21 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         the generated function relies on the input being a numpy array:
 
         >>> from sympy import Piecewise
+        >>> from sympy.utilities.pytest import ignore_warnings
         >>> f = lambdify(x, Piecewise((x, x <= 1), (1/x, x > 1)), "numpy")
-        >>> f(array([-1, 0, 1, 2]))
+
+        >>> with ignore_warnings(RuntimeWarning):
+        ...     f(array([-1, 0, 1, 2]))
         [-1.   0.   1.   0.5]
+
         >>> f(0)
         Traceback (most recent call last):
             ...
         ZeroDivisionError: division by zero
 
         In such cases, the input should be wrapped in a numpy array:
-        >>> float(f(array([0])))
+        >>> with ignore_warnings(RuntimeWarning):
+        ...     float(f(array([0])))
         0.0
 
         Or if numpy functionality is not required another module can be used:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -16,6 +16,8 @@ from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, string_types, range, builtins, integer_types, PY3)
 from sympy.utilities.decorator import doctest_depends_on
 
+__doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
+
 # Default namespaces, letting us define translations that can't be defined
 # by simple variable maps, like I => 1j
 MATH_DEFAULT = {}

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -219,8 +219,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> array2mat = [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy']
     >>> f = lambdify((x, y), Matrix([x, y]), modules=array2mat)
     >>> f(1, 2)
-    matrix([[1],
-            [2]])
+    [[1]
+     [2]]
 
     Usage
     =====

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -9,6 +9,9 @@ from sympy.utilities.decorator import doctest_depends_on
 import xml.dom.minidom
 
 
+__doctest_requires__ = {('apply_xsl', 'c2p'): ['lxml']}
+
+
 def add_mathml_headers(s):
     return """<math xmlns:mml="http://www.w3.org/1998/Math/MathML"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -83,7 +83,7 @@ if not USE_PYTEST:
                 code()
             except expectedException:
                 return
-            raise AssertionError("DID NOT RAISE")
+            raise Failed("DID NOT RAISE")
         elif isinstance(code, str):
             raise TypeError(
                 '\'raises(xxx, "code")\' has been phased out; '
@@ -104,7 +104,7 @@ if not USE_PYTEST:
 
         def __exit__(self, exc_type, exc_value, traceback):
             if exc_type is None:
-                raise AssertionError("DID NOT RAISE")
+                raise Failed("DID NOT RAISE")
             return issubclass(exc_type, self.expectedException)
 
     class XFail(Exception):

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -114,6 +114,9 @@ if not USE_PYTEST:
     class Skipped(Exception):
         pass
 
+    class Failed(Exception):
+        pass
+
     def XFAIL(func):
         def wrapper():
             try:
@@ -167,7 +170,7 @@ if not USE_PYTEST:
         ...     pass
         Traceback (most recent call last):
         ...
-        AssertionError: Failed: DID NOT WARN. No warnings of type UserWarning\
+        Failed: DID NOT WARN. No warnings of type UserWarning\
         was emitted. The list of emitted warnings is: [].
         '''
         match = kwargs.pop('match', '')
@@ -188,7 +191,7 @@ if not USE_PYTEST:
                    ' No warnings of type %s was emitted.'
                    ' The list of emitted warnings is: %s.'
                    ) % (warningcls, [w.message for w in warnrec])
-            raise AssertionError(msg)
+            raise Failed(msg)
 
 
 else:
@@ -226,7 +229,7 @@ def warns_deprecated_sympy():
     ...     pass
     Traceback (most recent call last):
     ...
-    AssertionError: Failed: DID NOT WARN. No warnings of type \
+    Failed: DID NOT WARN. No warnings of type \
     SymPyDeprecationWarning was emitted. The list of emitted warnings is: [].
     '''
     with warns(SymPyDeprecationWarning):

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -13,7 +13,9 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 try:
     import py
-    from py.test import skip, raises, warns, Failed
+    from _pytest.python_api import raises
+    from _pytest.recwarn import warns
+    from _pytest.outcomes import skip, Failed
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -13,7 +13,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 try:
     import py
-    from py.test import skip, raises, warns
+    from py.test import skip, raises, warns, Failed
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -46,7 +46,7 @@ if not USE_PYTEST:
         >>> raises(ZeroDivisionError, lambda: 1/2)
         Traceback (most recent call last):
         ...
-        AssertionError: DID NOT RAISE
+        Failed: DID NOT RAISE
 
         >>> with raises(ZeroDivisionError):
         ...     n = 1/0
@@ -54,7 +54,7 @@ if not USE_PYTEST:
         ...     n = 1/2
         Traceback (most recent call last):
         ...
-        AssertionError: DID NOT RAISE
+        Failed: DID NOT RAISE
 
         Note that you cannot test multiple statements via
         ``with raises``:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -643,24 +643,10 @@ def doctest(*paths, **kwargs):
             return val
 
 
-def _doctest(*paths, **kwargs):
-    """
-    Internal function that actually runs the doctests.
+def _get_doctest_blacklist():
+    '''Get the default blacklist for the doctests'''
+    blacklist = []
 
-    All keyword arguments from ``doctest()`` are passed to this function
-    except for ``subprocess``.
-
-    Returns 0 if tests passed and 1 if they failed.  See the docstrings of
-    ``doctest()`` and ``test()`` for more information.
-    """
-    from sympy import pprint_use_unicode
-
-    normal = kwargs.get("normal", False)
-    verbose = kwargs.get("verbose", False)
-    colors = kwargs.get("colors", True)
-    force_colors = kwargs.get("force_colors", False)
-    blacklist = kwargs.get("blacklist", [])
-    split  = kwargs.get('split', None)
     blacklist.extend([
         "doc/src/modules/plotting.rst",  # generates live plots
         "doc/src/modules/physics/mechanics/autolev_parser.rst",
@@ -733,6 +719,34 @@ def _doctest(*paths, **kwargs):
     ])
 
     blacklist = convert_to_native_paths(blacklist)
+    return blacklist
+
+
+def _doctest(*paths, **kwargs):
+    """
+    Internal function that actually runs the doctests.
+
+    All keyword arguments from ``doctest()`` are passed to this function
+    except for ``subprocess``.
+
+    Returns 0 if tests passed and 1 if they failed.  See the docstrings of
+    ``doctest()`` and ``test()`` for more information.
+    """
+    from sympy import pprint_use_unicode
+
+    normal = kwargs.get("normal", False)
+    verbose = kwargs.get("verbose", False)
+    colors = kwargs.get("colors", True)
+    force_colors = kwargs.get("force_colors", False)
+    blacklist = kwargs.get("blacklist", [])
+    split  = kwargs.get('split', None)
+
+    blacklist.extend(_get_doctest_blacklist())
+
+    # Use a non-windowed backend, so that the tests work on Travis
+    if import_module('matplotlib') is not None:
+        import matplotlib
+        matplotlib.use('Agg')
 
     # Disable warnings for external modules
     import sympy.external

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -705,6 +705,12 @@ def _get_doctest_blacklist():
             "doc/src/modules/numeric-computation.rst",
         ])
 
+    if import_module('antlr4') is None:
+        blacklist.extend([
+            "sympy/parsing/autolev/__init__.py",
+            "sympy/parsing/latex/_parse_latex_antlr.py",
+        ])
+
     # disabled because of doctest failures in asmeurer's bot
     blacklist.extend([
         "sympy/utilities/autowrap.py",

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -20,7 +20,7 @@ def test_lack_of_exception_triggers_AssertionError_callable():
     try:
         raises(Exception, lambda: 1 + 1)
         assert False
-    except AssertionError as e:
+    except Failed as e:
         assert "DID NOT RAISE" in str(e)
 
 
@@ -45,7 +45,7 @@ def test_lack_of_exception_triggers_AssertionError_with():
         with raises(Exception):
             1 + 1
         assert False
-    except AssertionError as e:
+    except Failed as e:
         assert "DID NOT RAISE" in str(e)
 
 

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -1,14 +1,9 @@
 import warnings
 
-from sympy.utilities.pytest import (raises, warns, ignore_warnings, USE_PYTEST,
-                                    warns_deprecated_sympy)
+from sympy.utilities.pytest import (raises, warns, ignore_warnings,
+                                    warns_deprecated_sympy, Failed)
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-
-if USE_PYTEST:
-    from _pytest.outcomes import Failed
-else:
-    Failed = AssertionError
 
 
 # Test callables
@@ -25,7 +20,7 @@ def test_lack_of_exception_triggers_AssertionError_callable():
     try:
         raises(Exception, lambda: 1 + 1)
         assert False
-    except Failed as e:
+    except AssertionError as e:
         assert "DID NOT RAISE" in str(e)
 
 
@@ -50,7 +45,7 @@ def test_lack_of_exception_triggers_AssertionError_with():
         with raises(Exception):
             1 + 1
         assert False
-    except Failed as e:
+    except AssertionError as e:
         assert "DID NOT RAISE" in str(e)
 
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

(Still working on this and will tidy up later. I'm just about to go away for a bit and wanted to put this up for feedback on the general idea.)

Makes it possible to run Sympy's doctests using pytest and the doctestplus plugin:
[https://github.com/astropy/pytest-doctestplus](https://github.com/astropy/pytest-doctestplus)

~~Well, *almost* makes it possible. Right now `pytest --doctest-modules` gives 20 collection errors and 450 test fails. With this patch I'm down to 0 collection errors and about 8 test fails (all due to missing dependencies).~~

EDIT: This patch now successfully runs all doctests with no fails.

In general to use pytest with this patch you would do:
```console
$ pip install pytest pytest-doctestplus
$ pytest --doctest-plus --doctest-rst
```
However in getting this to work I have submitted some PRs to doctestplus that have been accepted but aren't released so install doctestplus with:
```console
$ git clone https://github.com/astropy/pytest-doctestplus.git
$ pip install -e pytest-doctestplus
```

To get this to work a few doctests were slightly modified. Also The `_doctest` function in `runtests.py` was rearranged so that the list of blacklisted modules could be used also under pytest. Some pytest and doctestplus configuration options are added to `conftest.py`.

I've added a hack to `conftest.py` that changes `sys.__display_hook__`. The stdlib doctest module resets `display_hook` before each doctest example is executed meaning that Sympy's pretty printing is disabled:
[https://github.com/python/cpython/blob/v3.7.2/Lib/doctest.py#L1470](https://github.com/python/cpython/blob/v3.7.2/Lib/doctest.py#L1470)
I've replaced `sys.__display_hook__` instead (monkey-patching the monkey-patch prevention). There are probably better ways to do this but it works for now...

#### Other comments

The standard pytest doctest plugin is unsuitable for Sympy. In particular it doesn't support inexact float comparison or running tests in rst files. The Astropy project wrote a pytest plugin to improve on this and then released it as a separate project. The comments in the code indicated that some parts were actually extracted from Sympy's doctest runner. While working on this I have submitted a few PRs to doctestplus.

~~Currently there are around 8 fails due to running doctests with missing dependencies. I sent a PR to doctestplus to add a decorator that could be used like sympy's `@doctest_depends_on` but the main doctestplus author isn't so keen on that idea so I'm discussing what would be a better approach for conditional skipping of doctests here: [https://github.com/astropy/pytest-doctestplus/pull/41](https://github.com/astropy/pytest-doctestplus/pull/41)~~

EDIT: I've used the doctestplus directives to skip doctests due to missing Python libraries. What is still missing is that doctestplus doesn't have a way to skip doctests based on missing command-line programs as is done by Sympy's `doctest_depends_on` decorator. This could lead to fails if you have certain Python libraries but not the needed command line utilities to run some tests.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * Make doctests runnable under pytest with doctestplus
<!-- END RELEASE NOTES -->
