### PR TITLE
solving integral returning "nan"

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -28,6 +28,7 @@ from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
 from sympy.simplify.fu import sincos_to_sum
+import sympy
 
 
 class Integral(AddWithLimits):
@@ -826,7 +827,7 @@ class Integral(AddWithLimits):
         from sympy.integrals.heurisch import heurisch as heurisch_, heurisch_wrapper
         from sympy.integrals.rationaltools import ratint
         from sympy.integrals.risch import risch_integrate
-
+        f= sympy.simplify(f)
         if risch:
             try:
                 return risch_integrate(f, x, conds=conds)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1021,6 +1021,8 @@ class Integral(AddWithLimits):
             if h is None and manual is not False:
                 try:
                     result = manualintegrate(g, x)
+                    if result == S.NaN:
+                        result=None
                     if result is not None and not isinstance(result, Integral):
                         if result.has(Integral) and not manual:
                             # Try to have other algorithms do the integrals

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -827,7 +827,7 @@ class Integral(AddWithLimits):
         from sympy.integrals.heurisch import heurisch as heurisch_, heurisch_wrapper
         from sympy.integrals.rationaltools import ratint
         from sympy.integrals.risch import risch_integrate
-        f= sympy.simplify(f)
+        f = sympy.simplify(f, rational = True)
         if risch:
             try:
                 return risch_integrate(f, x, conds=conds)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1022,7 +1022,7 @@ class Integral(AddWithLimits):
                 try:
                     result = manualintegrate(g, x)
                     if result == S.NaN:
-                        result=None
+                        result = None
                     if result is not None and not isinstance(result, Integral):
                         if result.has(Integral) and not manual:
                             # Try to have other algorithms do the integrals

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -28,7 +28,6 @@ from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
 from sympy.simplify.fu import sincos_to_sum
-import sympy
 
 
 class Integral(AddWithLimits):
@@ -827,7 +826,7 @@ class Integral(AddWithLimits):
         from sympy.integrals.heurisch import heurisch as heurisch_, heurisch_wrapper
         from sympy.integrals.rationaltools import ratint
         from sympy.integrals.risch import risch_integrate
-        f = sympy.simplify(f, rational = True)
+
         if risch:
             try:
                 return risch_integrate(f, x, conds=conds)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1021,8 +1021,6 @@ class Integral(AddWithLimits):
             if h is None and manual is not False:
                 try:
                     result = manualintegrate(g, x)
-                    if result == S.NaN:
-                        result = None
                     if result is not None and not isinstance(result, Integral):
                         if result.has(Integral) and not manual:
                             # Try to have other algorithms do the integrals

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -176,6 +176,8 @@ def find_substitutions(integrand, symbol, u_var):
     results = []
 
     def test_subterm(u, u_diff):
+        if u_diff == 0:
+            return False
         substituted = integrand / u_diff
         if symbol not in substituted.free_symbols:
             # replaced everything already

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,6 +32,7 @@ from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
 from sympy.ntheory.factor_ import divisors
+from sympy import cancel,exp
 
 ZERO = sympy.S.Zero
 
@@ -1575,6 +1576,9 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
+    if len(f.args) > 1 :
+        if all(i.has(exp) for i in f.args):
+            f = cancel(f)
     result = _manualintegrate(integral_steps(f, var))
     # Clear the cache of u-parts
     _parts_u_cache.clear()

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1578,9 +1578,8 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
-    if len(f.args) > 1 :
-        if all(i.has(exp) for i in f.args):
-            f = cancel(f)
+    if all(i.has(exp) for i in f.args):
+        f = cancel(f)
     result = _manualintegrate(integral_steps(f, var))
     # Clear the cache of u-parts
     _parts_u_cache.clear()

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,6 +32,7 @@ from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
 from sympy.ntheory.factor_ import divisors
+from sympy import exp
 
 ZERO = sympy.S.Zero
 
@@ -1575,6 +1576,9 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
+    if len(f.args) > 1 :
+        if all(i.has(exp) for i in f.args):
+            f = f.expand()
     result = _manualintegrate(integral_steps(f, var))
     # Clear the cache of u-parts
     _parts_u_cache.clear()

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,7 +32,6 @@ from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
 from sympy.ntheory.factor_ import divisors
-from sympy import exp
 
 ZERO = sympy.S.Zero
 
@@ -1576,9 +1575,6 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
-    if len(f.args) > 1 :
-        if all(i.has(exp) for i in f.args):
-            f = f.expand()
     result = _manualintegrate(integral_steps(f, var))
     # Clear the cache of u-parts
     _parts_u_cache.clear()

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -32,7 +32,7 @@ from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
 from sympy.polys.polytools import degree
 from sympy.ntheory.factor_ import divisors
-from sympy import cancel,exp
+from sympy import cancel, exp
 
 ZERO = sympy.S.Zero
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1478,6 +1478,6 @@ def test_issue_4311():
 
 def test_issue_15494():
     x = symbols('x')
-    integrand = (-2*exp(1.5*x)+exp(x))*exp(x)
+    integrand = (sy.exp(x/2)-2*sy.exp(1.6*x)+sy.exp(x))*sy.exp(x)
     sol = integrate(integrand, x)
-    assert sol == exp(2*x)/2 - 0.8*exp(2.5*x)
+    assert str(sol) == str(0.666666666666667*exp(Rational(3,2)*x) + 0.5*exp(2*x) -  0.769230769230769*exp(2.6*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1475,3 +1475,9 @@ def test_issue_4311():
         (x**4/4 - 9*x**2/2, x <= -3),
         (-x**4/4 + 9*x**2/2 - S(81)/2, x <= 3),
         (x**4/4 - 9*x**2/2, True))
+
+def test_issue_15494():
+    x = symbols('x')
+    integrand = (-2*exp(1.5*x)+exp(x))*exp(x)
+    sol = integrate(integrand, x)
+    assert sol == exp(2*x)/2 - 0.8*exp(2.5*x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1480,4 +1480,4 @@ def test_issue_15494():
     x = symbols('x', real=True, positive=True)
     integrand = (exp(x/2)-2*exp(1.6*x)+exp(x))*exp(x)
     sol = integrate(integrand, x)
-    assert str(sol) == str(0.666666666666667*exp(Rational(3,2)*x) + 0.5*exp(2*x) -  0.769230769230769*exp(2.6*x))
+    assert str(sol) == str(Rational(2, 3)*exp(Rational(3,2)*x) + Rational(1, 2)*exp(2*x) -  0.769230769230769*exp(2.6*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1477,7 +1477,7 @@ def test_issue_4311():
         (x**4/4 - 9*x**2/2, True))
 
 def test_issue_15494():
-    x = symbols('x')
+    x = symbols('x', real=True, positive=True)
     integrand = (exp(x/2)-2*exp(1.6*x)+exp(x))*exp(x)
     sol = integrate(integrand, x)
     assert str(sol) == str(0.666666666666667*exp(Rational(3,2)*x) + 0.5*exp(2*x) -  0.769230769230769*exp(2.6*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1478,6 +1478,6 @@ def test_issue_4311():
 
 def test_issue_15494():
     x = symbols('x')
-    integrand = (sy.exp(x/2)-2*sy.exp(1.6*x)+sy.exp(x))*sy.exp(x)
+    integrand = (exp(x/2)-2*exp(1.6*x)+exp(x))*exp(x)
     sol = integrate(integrand, x)
     assert str(sol) == str(0.666666666666667*exp(Rational(3,2)*x) + 0.5*exp(2*x) -  0.769230769230769*exp(2.6*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1480,4 +1480,5 @@ def test_issue_15494():
     x = symbols('x', real=True, positive=True)
     integrand = (exp(x/2)-2*exp(1.6*x)+exp(x))*exp(x)
     sol = integrate(integrand, x)
-    assert str(sol) == str(Rational(2, 3)*exp(Rational(3,2)*x) + Rational(1, 2)*exp(2*x) -  0.769230769230769*exp(2.6*x))
+    expected = Rational(2, 3)*exp(Rational(3,2)*x) + Rational(1, 2)*exp(2*x) -  0.769230769230769*exp(2.6*x)
+    assert abs(sol - expected) < 1e-15 * exp(2.6*x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1479,6 +1479,6 @@ def test_issue_4311():
 def test_issue_15494():
     x = symbols('x', real=True, positive=True)
     integrand = (exp(x/2)-2*exp(1.6*x)+exp(x))*exp(x)
-    sol = integrate(integrand, x)
+    sol = integrate(integrand, x, manual=True)
     expected = Rational(2, 3)*exp(Rational(3,2)*x) + Rational(1, 2)*exp(2*x) -  0.769230769230769*exp(2.6*x)
     assert abs(sol - expected) < 1e-15 * exp(2.6*x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15494.


#### Brief description of what is fixed or changed
integral is returning nan,so i made changes to evaluate it. 

#### Other comments

integral of multiplication of "sympy.exp" is very easy but it is taking more time than usual so i just expand expression so that it can easily solved by manualmultiplication method. 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - fixed issue related to the wrong result and hanging of integral
<!-- END RELEASE NOTES -->
