### PR TITLE
solved sqrt(1+sin(x))

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1021,6 +1021,10 @@ class Integral(AddWithLimits):
             if h is None and manual is not False:
                 try:
                     result = manualintegrate(g, x)
+
+                    if result is not None and isinstance(result, Integral) and result != Integral(g, x):
+                        return result.doit()
+
                     if result is not None and not isinstance(result, Integral):
                         if result.has(Integral) and not manual:
                             # Try to have other algorithms do the integrals

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -697,8 +697,6 @@ def trig_rule(integral):
         arg = integrand.args[0]
         rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
                      (sympy.csc(arg) + sympy.cot(arg)))
-    elif integrand == sympy.sqrt(1+sympy.sin(symbol)):
-        rewritten = (sympy.sin(symbol/2) + sympy.cos(symbol/2))
     else:
         match = integrand.match(sympy.sqrt(1 + sympy.sin(a*symbol)))
         if not match:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -696,6 +696,8 @@ def trig_rule(integral):
         arg = integrand.args[0]
         rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
                      (sympy.csc(arg) + sympy.cot(arg)))
+    elif integrand == sympy.sqrt(1+sympy.sin(symbol)):
+        rewritten = (sympy.sin(symbol/2) + sympy.cos(symbol/2))
     else:
         return
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -701,7 +701,7 @@ def trig_rule(integral):
         match = integrand.match(sympy.sqrt(1 + sympy.sin(a*symbol)))
         if not match:
             return
-        rewritten = (sympy.sin((match[a]*symbol)/2) + sympy.cos((match[a]*symbol)/2))
+        rewritten = abs(sympy.cos(match[a]*symbol)) / sympy.sqrt(1-sympy.sin(match[a]*symbol))
 
     return RewriteRule(
         rewritten,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -666,6 +666,7 @@ def parts_rule(integral):
 
 def trig_rule(integral):
     integrand, symbol = integral
+    a = sympy.Wild('a', exclude=[symbol])
     if isinstance(integrand, sympy.sin) or isinstance(integrand, sympy.cos):
         arg = integrand.args[0]
 
@@ -699,7 +700,10 @@ def trig_rule(integral):
     elif integrand == sympy.sqrt(1+sympy.sin(symbol)):
         rewritten = (sympy.sin(symbol/2) + sympy.cos(symbol/2))
     else:
-        return
+        match = integrand.match(sympy.sqrt(1 + sympy.sin(a*symbol)))
+        if not match:
+            return
+        rewritten = (sympy.sin((match[a]*symbol)/2) + sympy.cos((match[a]*symbol)/2))
 
     return RewriteRule(
         rewritten,

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1475,3 +1475,10 @@ def test_issue_4311():
         (x**4/4 - 9*x**2/2, x <= -3),
         (-x**4/4 + 9*x**2/2 - S(81)/2, x <= 3),
         (x**4/4 - 9*x**2/2, True))
+def test_issue_15730():
+    x = Symbol('x', real=True)
+    f = integrate(sqrt(1+sin(x)), x)
+    F = Piecewise((2*sqrt(-sin(x) + 1), x <= 0), (-2*sqrt(-sin(x) + 1) + 4, x <= pi/2),\
+    (2*sqrt(-sin(x) + 1) + 4, x <= 3*pi/2), (-2*sqrt(-sin(x) + 1) + 4 + 4*sqrt(2), x <= 2*pi),\
+    (2*sqrt(-sin(x) + 1) + 4*sqrt(2), True))
+    assert f == F

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -474,8 +474,3 @@ def test_issue_15471():
     f = log(x)*cos(log(x))/x**(S(3)/4)
     F = -128*x**(1/4)*sin(log(x))/289 + 240*x**(1/4)*cos(log(x))/289 + (16*x**(1/4)*sin(log(x))/17 + 4*x**(1/4)*cos(log(x))/17)*log(x)
     assert manualintegrate(f, x) == F and F.diff(x).equals(f)
-
-def test_issue_15773():
-    f = sqrt(5+5*sin(5*x))
-    F = sqrt(5)*(2*sin(5*x/2)/5-2*cos(5*x/2)/5)
-    assert manualintegrate(f, x) == F

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -474,3 +474,8 @@ def test_issue_15471():
     f = log(x)*cos(log(x))/x**(S(3)/4)
     F = -128*x**(1/4)*sin(log(x))/289 + 240*x**(1/4)*cos(log(x))/289 + (16*x**(1/4)*sin(log(x))/17 + 4*x**(1/4)*cos(log(x))/17)*log(x)
     assert manualintegrate(f, x) == F and F.diff(x).equals(f)
+
+def test_issue_15773():
+    f = sqrt(5+5*sin(5*x))
+    F = sqrt(5)*(2*sin(5*x/2)/5-2*cos(5*x/2)/5)
+    assert manualintegrate(f, x) == F


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15730.


#### Brief description of what is fixed or changed
unable to integrate integrate(sqrt(1+sin(x)),x) ,so i add a case of this function in manual integrate .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - added (sqrt(1+sin(x)),x)  case
<!-- END RELEASE NOTES -->
