### PR TITLE
 Consistent lack of space after \left and \right in LaTeX 

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -291,7 +291,7 @@ which case the defaults ``x0=0`` and ``n=6`` will be used.
     1 + x + ── + O⎝x ⎠
             2
 
-The `O\left (x^4\right )` term at the end represents the Landau order term at
+The `O\left(x^4\right)` term at the end represents the Landau order term at
 `x=0` (not to be confused with big O notation used in computer science, which
 generally represents the Landau order term at `x=\infty`).  It means that all
 x terms with power greater than or equal to `x^4` are omitted.  Order terms

--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -173,10 +173,10 @@ spherical Bessel function `j_\nu(z)`.
   ────────────────────
            √π
 
-Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\LaTeX`.
+Print `\int_{0}^{\pi} \cos^{2}{\left(x \right)}\, dx` using `\LaTeX`.
 
   >>> latex(Integral(cos(x)**2, (x, 0, pi)))
-  \int\limits_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx
+  \int\limits_{0}^{\pi} \cos^{2}{\left(x \right)}\, dx
 
 Why SymPy?
 ==========

--- a/doc/src/tutorial/simplification.rst
+++ b/doc/src/tutorial/simplification.rst
@@ -315,7 +315,7 @@ under other conditions as well).  A common consequence of the failure of
 identity 2 is that `\sqrt{x}\sqrt{y} \neq \sqrt{xy}`.
 
 Identity 3 is not always true.  For example, if `x = -1`, `a = 2`, and `b =
-\frac{1}{2}`, then `(x^a)^b = {\left ((-1)^2\right )}^{1/2} = \sqrt{1} = 1`
+\frac{1}{2}`, then `(x^a)^b = {\left((-1)^2\right)}^{1/2} = \sqrt{1} = 1`
 and `x^{ab} = (-1)^{2\cdot1/2} = (-1)^1 = -1`.  However, identity 3 is true
 when `b` is an integer (again, it may also hold in other cases as well).  Two
 common consequences of the failure of identity 3 are that `\sqrt{x^2}\neq x`
@@ -330,7 +330,7 @@ To summarize
 +-----------------------+------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------+
 |2. `x^ay^a = (xy)^a`   |`x, y \geq 0` and `a \in \mathbb{R}`|`(-1)^{1/2}(-1)^{1/2} \neq (-1\cdot-1)^{1/2}`       |`\sqrt{x}\sqrt{y} \neq \sqrt{xy}` in general                                 |
 +-----------------------+------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------+
-|3. `(x^a)^b = x^{ab}`  |`b \in \mathbb{Z}`                  |`{\left((-1)^2\right )}^{1/2} \neq (-1)^{2\cdot1/2}`|`\sqrt{x^2}\neq x` and `\sqrt{\frac{1}{x}}\neq\frac{1}{\sqrt{x}}` in general |
+|3. `(x^a)^b = x^{ab}`  |`b \in \mathbb{Z}`                  |`{\left((-1)^2\right)}^{1/2} \neq (-1)^{2\cdot1/2}` |`\sqrt{x^2}\neq x` and `\sqrt{\frac{1}{x}}\neq\frac{1}{\sqrt{x}}` in general |
 +-----------------------+------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------+
 
 
@@ -499,16 +499,16 @@ is real.
 
 As before, ``z`` and ``t`` will be Symbols with no additional assumptions.
 
-Note that the identity `\log{\left (\frac{x}{y}\right )} = \log(x) - \log(y)`
-is a special case of identities 1 and 2 by `\log{\left (\frac{x}{y}\right )}
-=` `\log{\left (x\cdot\frac{1}{y}\right )} =` `\log(x) + \log{\left(
-y^{-1}\right )} =` `\log(x) - \log(y)`, and thus it also holds if `x` and `y`
+Note that the identity `\log{\left(\frac{x}{y}\right)} = \log(x) - \log(y)`
+is a special case of identities 1 and 2 by `\log{\left(\frac{x}{y}\right)}
+=` `\log{\left(x\cdot\frac{1}{y}\right)} =` `\log(x) + \log{\left(
+y^{-1}\right)} =` `\log(x) - \log(y)`, and thus it also holds if `x` and `y`
 are positive, but may not hold in general.
 
-We also see that `\log{\left( e^x \right)} = x` comes from `\log{\left ( e^x
+We also see that `\log{\left( e^x \right)} = x` comes from `\log{\left( e^x
 \right)} = x\log(e) = x`, and thus holds when `x` is real (and it can be
 verified that it does not hold in general for arbitrary complex `x`, for
-example, `\log{\left (e^{x + 2\pi i}\right)} = \log{\left (e^x\right )} = x
+example, `\log{\left(e^{x + 2\pi i}\right)} = \log{\left(e^x\right)} = x
 \neq x + 2\pi i`).
 
 expand_log

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -88,7 +88,7 @@ def test_print_builtin_option():
                     u'{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}',
                     "{n_i: 3, pi: 3.14}",
                     u'{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}')
-    assert latex == r'$\displaystyle \left \{ n_{i} : 3, \quad \pi : 3.14\right \}$'
+    assert latex == r'$\displaystyle \left\{ n_{i} : 3, \quad \pi : 3.14\right\}$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("init_printing(use_latex=True, print_builtin=False)")
@@ -135,7 +135,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c']['text/latex'] == '$\\displaystyle \\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$'
+        assert app.user_ns['c']['text/latex'] == '$\\displaystyle \\left( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right)$'
     else:
         assert app.user_ns['a'][0]['text/plain'] ==  '(True, False)'
         assert 'text/latex' not in app.user_ns['a'][0]
@@ -147,7 +147,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c'][0]['text/latex'] == '$\\displaystyle \\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$'
+        assert app.user_ns['c'][0]['text/latex'] == '$\\displaystyle \\left( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right)$'
 
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -547,7 +547,7 @@ DifferentialOperator⎜──(f(x)),f(x)⎟\n\
     assert pretty(d) == ascii_str
     assert upretty(d) == ucode_str
     assert latex(d) == \
-        r'DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)'
+        r'DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)'
     sT(d, "DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))")
     assert str(b) == 'Operator(B,t,1/2)'
     assert pretty(b) == 'Operator(B,t,1/2)'
@@ -822,7 +822,7 @@ u("""\
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left(x \right)},f{\left(x \right)}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
     sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -195,7 +195,7 @@ def test_vlatex(): # vlatex is broken #12078
     g = Function('g')
     h = Function('h')
 
-    expected = r'J \left(\frac{d}{d x} g{\left (x \right )} - \frac{d}{d x} h{\left (x \right )}\right)'
+    expected = r'J \left(\frac{d}{d x} g{\left(x \right)} - \frac{d}{d x} h{\left(x \right)}\right)'
 
     expr = J*f(x).diff(x).subs(f(x), g(x)-h(x))
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -777,7 +777,7 @@ class LatexPrinter(Printer):
                 else:
                     name += r"%s"
             else:
-                name += r"{\left (%s \right )}"
+                name += r"{\left(%s \right)}"
 
             if inv_trig_power_case and exp is not None:
                 name += r"^{%s}" % exp
@@ -849,9 +849,9 @@ class LatexPrinter(Printer):
 
     def _print_log(self, expr, exp=None):
         if not self._settings["ln_notation"]:
-            tex = r"\log{\left (%s \right )}" % self._print(expr.args[0])
+            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
         else:
-            tex = r"\ln{\left (%s \right )}" % self._print(expr.args[0])
+            tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
@@ -932,7 +932,7 @@ class LatexPrinter(Printer):
 
     def _print_polar_lift(self, expr, exp=None):
         func = r"\operatorname{polar\_lift}"
-        arg = r"{\left (%s \right )}" % self._print(expr.args[0])
+        arg = r"{\left(%s \right)}" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}%s" % (func, exp, arg)
@@ -1470,7 +1470,7 @@ class LatexPrinter(Printer):
 
     def _print_Trace(self, expr):
         mat = expr.arg
-        return r"\mathrm{tr}\left (%s \right )" % self._print(mat)
+        return r"\mathrm{tr}\left(%s \right)" % self._print(mat)
 
     def _print_Adjoint(self, expr):
         mat = expr.arg
@@ -1656,7 +1656,7 @@ class LatexPrinter(Printer):
         return self._print(expr.args[0])
 
     def _print_tuple(self, expr):
-        return r"\left ( %s\right )" % \
+        return r"\left( %s\right)" % \
             r", \quad ".join([ self._print(i) for i in expr ])
 
     def _print_TensorProduct(self, expr):
@@ -1671,7 +1671,7 @@ class LatexPrinter(Printer):
         return self._print_tuple(expr)
 
     def _print_list(self, expr):
-        return r"\left [ %s\right ]" % \
+        return r"\left[ %s\right]" % \
             r", \quad ".join([ self._print(i) for i in expr ])
 
     def _print_dict(self, d):
@@ -1682,7 +1682,7 @@ class LatexPrinter(Printer):
             val = d[key]
             items.append("%s : %s" % (self._print(key), self._print(val)))
 
-        return r"\left \{ %s\right \}" % r", \quad ".join(items)
+        return r"\left\{ %s\right\}" % r", \quad ".join(items)
 
     def _print_Dict(self, expr):
         return self._print_dict(expr)
@@ -1965,7 +1965,7 @@ class LatexPrinter(Printer):
 
         args = ", ".join([expr] + gens + [domain])
         if cls in accepted_latex_functions:
-            tex = r"\%s {\left (%s \right )}" % (cls, args)
+            tex = r"\%s {\left(%s \right)}" % (cls, args)
         else:
             tex = r"\operatorname{%s}{\left( %s \right)}" % (cls, args)
 
@@ -2376,7 +2376,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     >>> print(latex((2*tau)**Rational(7,2), fold_frac_powers=True))
     8 \sqrt{2} \tau^{7/2}
     >>> print(latex((2*tau)**sin(Rational(7,2))))
-    \left(2 \tau\right)^{\sin{\left (\frac{7}{2} \right )}}
+    \left(2 \tau\right)^{\sin{\left(\frac{7}{2} \right)}}
     >>> print(latex((2*tau)**sin(Rational(7,2)), fold_func_brackets=True))
     \left(2 \tau\right)^{\sin {\frac{7}{2}}}
     >>> print(latex(3*x**2/y))
@@ -2391,16 +2391,16 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     Multiplication options:
 
     >>> print(latex((2*tau)**sin(Rational(7,2)), mul_symbol="times"))
-    \left(2 \times \tau\right)^{\sin{\left (\frac{7}{2} \right )}}
+    \left(2 \times \tau\right)^{\sin{\left(\frac{7}{2} \right)}}
 
     Trig options:
 
     >>> print(latex(asin(Rational(7,2))))
-    \operatorname{asin}{\left (\frac{7}{2} \right )}
+    \operatorname{asin}{\left(\frac{7}{2} \right)}
     >>> print(latex(asin(Rational(7,2)), inv_trig_style="full"))
-    \arcsin{\left (\frac{7}{2} \right )}
+    \arcsin{\left(\frac{7}{2} \right)}
     >>> print(latex(asin(Rational(7,2)), inv_trig_style="power"))
-    \sin^{-1}{\left (\frac{7}{2} \right )}
+    \sin^{-1}{\left(\frac{7}{2} \right)}
 
     Matrix options:
 
@@ -2419,15 +2419,15 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     Logarithms:
 
     >>> print(latex(log(10)))
-    \log{\left (10 \right )}
+    \log{\left(10 \right)}
     >>> print(latex(log(10), ln_notation=True))
-    \ln{\left (10 \right )}
+    \ln{\left(10 \right)}
 
     ``latex()`` also supports the builtin container types list, tuple, and
     dictionary.
 
     >>> print(latex([2/x, y], mode='inline'))
-    $\left [ 2 / x, \quad y\right ]$
+    $\left[ 2 / x, \quad y\right]$
 
     """
     if symbol_names is None:

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -123,7 +123,7 @@ in a shorter form.
 
 The output of the code above is::
 
-    \\frac{\\partial^{2}}{\\partial x\\partial y}  f{\\left (x,y \\right )}
+    \\frac{\\partial^{2}}{\\partial x\\partial y}  f{\\left(x,y \\right)}
     f_{xy}
 
 Example of Custom Printing Method

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -111,12 +111,12 @@ def test_latex_basic():
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
     assert latex(1.5e20*x, mul_symbol='times') == r"1.5 \times 10^{20} \times x"
 
-    assert latex(1/sin(x)) == r"\frac{1}{\sin{\left (x \right )}}"
-    assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left (x \right )}}"
+    assert latex(1/sin(x)) == r"\frac{1}{\sin{\left(x \right)}}"
+    assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**Rational(3, 2)) == \
-        r"\sin^{\frac{3}{2}}{\left (x \right )}"
+        r"\sin^{\frac{3}{2}}{\left(x \right)}"
     assert latex(sin(x)**Rational(3, 2), fold_frac_powers=True) == \
-        r"\sin^{3/2}{\left (x \right )}"
+        r"\sin^{3/2}{\left(x \right)}"
 
     assert latex(~x) == r"\neg x"
     assert latex(x & y) == r"x \wedge y"
@@ -143,7 +143,7 @@ def test_latex_basic():
         r"x_i \Rightarrow y_i"
 
     p = Symbol('p', positive=True)
-    assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left (p \right )}"
+    assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left(p \right)}"
 
 
 def test_latex_builtins():
@@ -252,61 +252,61 @@ def test_latex_functions():
     assert latex(exp(1) + exp(2)) == "e + e^{2}"
 
     f = Function('f')
-    assert latex(f(x)) == r'f{\left (x \right )}'
+    assert latex(f(x)) == r'f{\left(x \right)}'
     assert latex(f) == r'f'
 
     g = Function('g')
-    assert latex(g(x, y)) == r'g{\left (x,y \right )}'
+    assert latex(g(x, y)) == r'g{\left(x,y \right)}'
     assert latex(g) == r'g'
 
     h = Function('h')
-    assert latex(h(x, y, z)) == r'h{\left (x,y,z \right )}'
+    assert latex(h(x, y, z)) == r'h{\left(x,y,z \right)}'
     assert latex(h) == r'h'
 
     Li = Function('Li')
     assert latex(Li) == r'\operatorname{Li}'
-    assert latex(Li(x)) == r'\operatorname{Li}{\left (x \right )}'
+    assert latex(Li(x)) == r'\operatorname{Li}{\left(x \right)}'
 
     mybeta = Function('beta')
     # not to be confused with the beta function
-    assert latex(mybeta(x, y, z)) == r"\beta{\left (x,y,z \right )}"
+    assert latex(mybeta(x, y, z)) == r"\beta{\left(x,y,z \right)}"
     assert latex(beta(x, y)) == r'\operatorname{B}\left(x, y\right)'
-    assert latex(mybeta(x)) == r"\beta{\left (x \right )}"
+    assert latex(mybeta(x)) == r"\beta{\left(x \right)}"
     assert latex(mybeta) == r"\beta"
 
     g = Function('gamma')
     # not to be confused with the gamma function
-    assert latex(g(x, y, z)) == r"\gamma{\left (x,y,z \right )}"
-    assert latex(g(x)) == r"\gamma{\left (x \right )}"
+    assert latex(g(x, y, z)) == r"\gamma{\left(x,y,z \right)}"
+    assert latex(g(x)) == r"\gamma{\left(x \right)}"
     assert latex(g) == r"\gamma"
 
     a1 = Function('a_1')
 
     assert latex(a1) == r"\operatorname{a_{1}}"
-    assert latex(a1(x)) == r"\operatorname{a_{1}}{\left (x \right )}"
+    assert latex(a1(x)) == r"\operatorname{a_{1}}{\left(x \right)}"
 
     # issue 5868
     omega1 = Function('omega1')
     assert latex(omega1) == r"\omega_{1}"
-    assert latex(omega1(x)) == r"\omega_{1}{\left (x \right )}"
+    assert latex(omega1(x)) == r"\omega_{1}{\left(x \right)}"
 
-    assert latex(sin(x)) == r"\sin{\left (x \right )}"
+    assert latex(sin(x)) == r"\sin{\left(x \right)}"
     assert latex(sin(x), fold_func_brackets=True) == r"\sin {x}"
     assert latex(sin(2*x**2), fold_func_brackets=True) == \
         r"\sin {2 x^{2}}"
     assert latex(sin(x**2), fold_func_brackets=True) == \
         r"\sin {x^{2}}"
 
-    assert latex(asin(x)**2) == r"\operatorname{asin}^{2}{\left (x \right )}"
+    assert latex(asin(x)**2) == r"\operatorname{asin}^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="full") == \
-        r"\arcsin^{2}{\left (x \right )}"
+        r"\arcsin^{2}{\left(x \right)}"
     assert latex(asin(x)**2, inv_trig_style="power") == \
-        r"\sin^{-1}{\left (x \right )}^{2}"
+        r"\sin^{-1}{\left(x \right)}^{2}"
     assert latex(asin(x**2), inv_trig_style="power",
                  fold_func_brackets=True) == \
         r"\sin^{-1} {x^{2}}"
     assert latex(acsc(x), inv_trig_style="full") == \
-        r"\operatorname{arccsc}{\left (x \right )}"
+        r"\operatorname{arccsc}{\left(x \right)}"
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"
@@ -341,18 +341,18 @@ def test_latex_functions():
     assert latex(Order(x, (x, 0))) == r"O\left(x\right)"
     assert latex(Order(x, (x, oo))) == r"O\left(x; x\rightarrow \infty\right)"
     assert latex(Order(x - y, (x, y))) == r"O\left(x - y; x\rightarrow y\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left ( x, \quad y\right )\rightarrow \left ( 0, \quad 0\right )\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left ( x, \quad y\right )\rightarrow \left ( 0, \quad 0\right )\right)"
-    assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left ( x, \quad y\right )\rightarrow \left ( \infty, \quad \infty\right )\right)"
+    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \quad y\right)\rightarrow \left( 0, \quad 0\right)\right)"
+    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \quad y\right)\rightarrow \left( 0, \quad 0\right)\right)"
+    assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left( x, \quad y\right)\rightarrow \left( \infty, \quad \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
 
-    assert latex(cot(x)) == r'\cot{\left (x \right )}'
-    assert latex(coth(x)) == r'\coth{\left (x \right )}'
+    assert latex(cot(x)) == r'\cot{\left(x \right)}'
+    assert latex(coth(x)) == r'\coth{\left(x \right)}'
     assert latex(re(x)) == r'\Re{\left(x\right)}'
     assert latex(im(x)) == r'\Im{x}'
     assert latex(root(x, y)) == r'x^{\frac{1}{y}}'
-    assert latex(arg(x)) == r'\arg{\left (x \right )}'
+    assert latex(arg(x)) == r'\arg{\left(x \right)}'
     assert latex(zeta(x)) == r'\zeta\left(x\right)'
 
     assert latex(zeta(x)) == r"\zeta\left(x\right)"
@@ -381,12 +381,12 @@ def test_latex_functions():
     assert latex(elliptic_pi(x, y)) == r"\Pi\left(x\middle| y\right)"
     assert latex(elliptic_pi(x, y)**2) == r"\Pi^{2}\left(x\middle| y\right)"
 
-    assert latex(Ei(x)) == r'\operatorname{Ei}{\left (x \right )}'
-    assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left (x \right )}'
+    assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
+    assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'
     assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}^{2}\left(y\right)'
-    assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left (x \right )}'
-    assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left (x \right )}'
-    assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left (x \right )}'
+    assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left(x \right)}'
+    assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left(x \right)}'
+    assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left(x \right)}'
     assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
     assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
     assert latex(
@@ -423,9 +423,9 @@ def test_latex_functions():
 
     # Test latex printing of function names with "_"
     assert latex(
-        polar_lift(0)) == r"\operatorname{polar\_lift}{\left (0 \right )}"
+        polar_lift(0)) == r"\operatorname{polar\_lift}{\left(0 \right)}"
     assert latex(polar_lift(
-        0)**3) == r"\operatorname{polar\_lift}^{3}{\left (0 \right )}"
+        0)**3) == r"\operatorname{polar\_lift}^{3}{\left(0 \right)}"
 
     assert latex(totient(n)) == r'\phi\left(n\right)'
     assert latex(totient(n) ** 2) == r'\left(\phi\left(n\right)\right)^{2}'
@@ -457,7 +457,7 @@ def test_latex_functions():
 
     # some unknown function name should get rendered with \operatorname
     fjlkd = Function('fjlkd')
-    assert latex(fjlkd(x)) == r'\operatorname{fjlkd}{\left (x \right )}'
+    assert latex(fjlkd(x)) == r'\operatorname{fjlkd}{\left(x \right)}'
     # even when it is referred to without an argument
     assert latex(fjlkd) == r'\operatorname{fjlkd}'
 
@@ -467,7 +467,7 @@ def test_function_subclass_different_name():
     class mygamma(gamma):
         pass
     assert latex(mygamma) == r"\operatorname{mygamma}"
-    assert latex(mygamma(x)) == r"\operatorname{mygamma}{\left (x \right )}"
+    assert latex(mygamma(x)) == r"\operatorname{mygamma}{\left(x \right)}"
 
 
 def test_hyper_printing():
@@ -538,21 +538,21 @@ def test_latex_derivatives():
     assert latex(diff(x**3, x, evaluate=False)) == \
         r"\frac{d}{d x} x^{3}"
     assert latex(diff(sin(x) + x**2, x, evaluate=False)) == \
-        r"\frac{d}{d x} \left(x^{2} + \sin{\left (x \right )}\right)"
+        r"\frac{d}{d x} \left(x^{2} + \sin{\left(x \right)}\right)"
     assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False)) == \
-        r"\frac{d^{2}}{d x^{2}} \left(x^{2} + \sin{\left (x \right )}\right)"
+        r"\frac{d^{2}}{d x^{2}} \left(x^{2} + \sin{\left(x \right)}\right)"
     assert latex(diff(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False), evaluate=False)) == \
-        r"\frac{d^{3}}{d x^{3}} \left(x^{2} + \sin{\left (x \right )}\right)"
+        r"\frac{d^{3}}{d x^{3}} \left(x^{2} + \sin{\left(x \right)}\right)"
 
     # \partial for partial derivatives
     assert latex(diff(sin(x * y), x, evaluate=False)) == \
-        r"\frac{\partial}{\partial x} \sin{\left (x y \right )}"
+        r"\frac{\partial}{\partial x} \sin{\left(x y \right)}"
     assert latex(diff(sin(x * y) + x**2, x, evaluate=False)) == \
-        r"\frac{\partial}{\partial x} \left(x^{2} + \sin{\left (x y \right )}\right)"
+        r"\frac{\partial}{\partial x} \left(x^{2} + \sin{\left(x y \right)}\right)"
     assert latex(diff(diff(sin(x*y) + x**2, x, evaluate=False), x, evaluate=False)) == \
-        r"\frac{\partial^{2}}{\partial x^{2}} \left(x^{2} + \sin{\left (x y \right )}\right)"
+        r"\frac{\partial^{2}}{\partial x^{2}} \left(x^{2} + \sin{\left(x y \right)}\right)"
     assert latex(diff(diff(diff(sin(x*y) + x**2, x, evaluate=False), x, evaluate=False), x, evaluate=False)) == \
-        r"\frac{\partial^{3}}{\partial x^{3}} \left(x^{2} + \sin{\left (x y \right )}\right)"
+        r"\frac{\partial^{3}}{\partial x^{3}} \left(x^{2} + \sin{\left(x y \right)}\right)"
 
     # mixed partial derivatives
     f = Function("f")
@@ -571,10 +571,10 @@ def test_latex_derivatives():
         r"\left(\frac{d}{d x} x\right)^{2}"
 
     assert latex(diff(f(x), x)**2) == \
-        r"\left(\frac{d}{d x} f{\left (x \right )}\right)^{2}"
+        r"\left(\frac{d}{d x} f{\left(x \right)}\right)^{2}"
 
     assert latex(diff(f(x), (x, n))) == \
-        r"\frac{d^{n}}{d x^{n}} f{\left (x \right )}"
+        r"\frac{d^{n}}{d x^{n}} f{\left(x \right)}"
 
 
 def test_latex_subs():
@@ -583,7 +583,7 @@ def test_latex_subs():
 
 
 def test_latex_integrals():
-    assert latex(Integral(log(x), x)) == r"\int \log{\left (x \right )}\, dx"
+    assert latex(Integral(log(x), x)) == r"\int \log{\left(x \right)}\, dx"
     assert latex(Integral(x**2, (x, 0, 1))) == r"\int\limits_{0}^{1} x^{2}\, dx"
     assert latex(Integral(x**2, (x, 10, 20))) == r"\int\limits_{10}^{20} x^{2}\, dx"
     assert latex(Integral(
@@ -695,7 +695,7 @@ def test_latex_sequences():
 
 
 def test_latex_FourierSeries():
-    latex_str = r'2 \sin{\left (x \right )} - \sin{\left (2 x \right )} + \frac{2 \sin{\left (3 x \right )}}{3} + \ldots'
+    latex_str = r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
 
 
@@ -794,7 +794,7 @@ def test_latex_ComplexRegion():
     assert latex(ComplexRegion(Interval(3, 5)*Interval(4, 6))) == \
         r"\left\{x + y i\; |\; x, y \in \left[3, 5\right] \times \left[4, 6\right] \right\}"
     assert latex(ComplexRegion(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == \
-        r"\left\{r \left(i \sin{\left (\theta \right )} + \cos{\left (\theta \right )}\right)\; |\; r, \theta \in \left[0, 1\right] \times \left[0, 2 \pi\right) \right\}"
+        r"\left\{r \left(i \sin{\left(\theta \right)} + \cos{\left(\theta \right)}\right)\; |\; r, \theta \in \left[0, 1\right] \times \left[0, 2 \pi\right) \right\}"
 
 
 def test_latex_Contains():
@@ -831,23 +831,23 @@ def test_latex_limits():
 
     # issue 8175
     f = Function('f')
-    assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left (x \right )}"
-    assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left (x \right )}"
+    assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left(x \right)}"
 
     # issue #10806
-    assert latex(Limit(f(x), x, 0)**2) == r"\left(\lim_{x \to 0^+} f{\left (x \right )}\right)^{2}"
+    assert latex(Limit(f(x), x, 0)**2) == r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
     # bi-directional limit
-    assert latex(Limit(f(x), x, 0, dir='+-')) == r"\lim_{x \to 0} f{\left (x \right )}"
+    assert latex(Limit(f(x), x, 0, dir='+-')) == r"\lim_{x \to 0} f{\left(x \right)}"
 
 
 def test_latex_log():
-    assert latex(log(x)) == r"\log{\left (x \right )}"
-    assert latex(ln(x)) == r"\log{\left (x \right )}"
-    assert latex(log(x), ln_notation=True) == r"\ln{\left (x \right )}"
-    assert latex(log(x)+log(y)) == r"\log{\left (x \right )} + \log{\left (y \right )}"
-    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left (x \right )} + \ln{\left (y \right )}"
-    assert latex(pow(log(x),x)) == r"\log{\left (x \right )}^{x}"
-    assert latex(pow(log(x),x), ln_notation=True) == r"\ln{\left (x \right )}^{x}"
+    assert latex(log(x)) == r"\log{\left(x \right)}"
+    assert latex(ln(x)) == r"\log{\left(x \right)}"
+    assert latex(log(x), ln_notation=True) == r"\ln{\left(x \right)}"
+    assert latex(log(x)+log(y)) == r"\log{\left(x \right)} + \log{\left(y \right)}"
+    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left(x \right)} + \ln{\left(y \right)}"
+    assert latex(pow(log(x),x)) == r"\log{\left(x \right)}^{x}"
+    assert latex(pow(log(x),x), ln_notation=True) == r"\ln{\left(x \right)}^{x}"
 
 
 def test_issue_3568():
@@ -866,19 +866,19 @@ def test_latex():
         "\\begin{equation*}8 \\sqrt{2} \\mu^{\\frac{7}{2}}\\end{equation*}"
     assert latex((2*mu)**Rational(7, 2), mode='equation', itex=True) == \
         "$$8 \\sqrt{2} \\mu^{\\frac{7}{2}}$$"
-    assert latex([2/x, y]) == r"\left [ \frac{2}{x}, \quad y\right ]"
+    assert latex([2/x, y]) == r"\left[ \frac{2}{x}, \quad y\right]"
 
 
 def test_latex_dict():
     d = {Rational(1): 1, x**2: 2, x: 3, x**3: 4}
-    assert latex(d) == r'\left \{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right \}'
+    assert latex(d) == r'\left\{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right\}'
     D = Dict(d)
-    assert latex(D) == r'\left \{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right \}'
+    assert latex(D) == r'\left\{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right\}'
 
 
 def test_latex_list():
     l = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
-    assert latex(l) == r'\left [ \omega_{1}, \quad a, \quad \alpha\right ]'
+    assert latex(l) == r'\left[ \omega_{1}, \quad a, \quad \alpha\right]'
 
 
 def test_latex_rational():
@@ -982,12 +982,12 @@ def test_latex_matrix_with_functions():
     M = Matrix([[sin(theta1(t)), cos(theta1(t))],
                 [cos(theta1(t).diff(t)), sin(theta1(t).diff(t))]])
 
-    expected = (r'\left[\begin{matrix}\sin{\left '
-                r'(\theta_{1}{\left (t \right )} \right )} & '
-                r'\cos{\left (\theta_{1}{\left (t \right )} \right '
-                r')}\\\cos{\left (\frac{d}{d t} \theta_{1}{\left (t '
-                r'\right )} \right )} & \sin{\left (\frac{d}{d t} '
-                r'\theta_{1}{\left (t \right )} \right '
+    expected = (r'\left[\begin{matrix}\sin{\left('
+                r'\theta_{1}{\left(t \right)} \right)} & '
+                r'\cos{\left(\theta_{1}{\left(t \right)} \right)'
+                r'}\\\cos{\left(\frac{d}{d t} \theta_{1}{\left(t '
+                r'\right)} \right)} & \sin{\left(\frac{d}{d t} '
+                r'\theta_{1}{\left(t \right)} \right'
                 r')}\end{matrix}\right]')
 
     assert latex(M) == expected
@@ -1043,8 +1043,8 @@ def test_latex_mul_symbol():
 
 def test_latex_issue_4381():
     y = 4*4**log(2)
-    assert latex(y) == r'4 \cdot 4^{\log{\left (2 \right )}}'
-    assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left (2 \right )}}}'
+    assert latex(y) == r'4 \cdot 4^{\log{\left(2 \right)}}'
+    assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left(2 \right)}}}'
 
 
 def test_latex_issue_4576():
@@ -1103,7 +1103,7 @@ def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
         r"\left( x \mapsto x + 1 \right)"
     assert latex(Lambda((x, y), x + 1)) == \
-        r"\left( \left ( x, \quad y\right ) \mapsto x + 1 \right)"
+        r"\left( \left( x, \quad y\right) \mapsto x + 1 \right)"
 
 
 def test_latex_PolyElement():
@@ -1173,7 +1173,7 @@ def test_latex_ComplexRootOf():
 
 def test_latex_RootSum():
     assert latex(RootSum(x**5 + x + 3, sin)) == \
-        r"\operatorname{RootSum} {\left(x^{5} + x + 3, \left( x \mapsto \sin{\left (x \right )} \right)\right)}"
+        r"\operatorname{RootSum} {\left(x^{5} + x + 3, \left( x \mapsto \sin{\left(x \right)} \right)\right)}"
 
 
 def test_settings():
@@ -1275,20 +1275,20 @@ def test_integral_transforms():
     a = Symbol("a")
     b = Symbol("b")
 
-    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
+    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
+    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
+    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
+    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
+    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
 
 def test_PolynomialRingBase():
@@ -1323,22 +1323,22 @@ def test_categories():
     assert latex(d) == r"\emptyset"
 
     d = Diagram({f1: "unique", f2: S.EmptySet})
-    assert latex(d) == r"\left \{ f_{2}\circ f_{1}:A_{1}" \
+    assert latex(d) == r"\left\{ f_{2}\circ f_{1}:A_{1}" \
         r"\rightarrow A_{3} : \emptyset, \quad id:A_{1}\rightarrow " \
         r"A_{1} : \emptyset, \quad id:A_{2}\rightarrow A_{2} : " \
         r"\emptyset, \quad id:A_{3}\rightarrow A_{3} : \emptyset, " \
         r"\quad f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}, " \
-        r"\quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}"
+        r"\quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right\}"
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
-    assert latex(d) == r"\left \{ f_{2}\circ f_{1}:A_{1}" \
+    assert latex(d) == r"\left\{ f_{2}\circ f_{1}:A_{1}" \
         r"\rightarrow A_{3} : \emptyset, \quad id:A_{1}\rightarrow " \
         r"A_{1} : \emptyset, \quad id:A_{2}\rightarrow A_{2} : " \
         r"\emptyset, \quad id:A_{3}\rightarrow A_{3} : \emptyset, " \
         r"\quad f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}," \
-        r" \quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}" \
-        r"\Longrightarrow \left \{ f_{2}\circ f_{1}:A_{1}" \
-        r"\rightarrow A_{3} : \left\{unique\right\}\right \}"
+        r" \quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right\}" \
+        r"\Longrightarrow \left\{ f_{2}\circ f_{1}:A_{1}" \
+        r"\rightarrow A_{3} : \left\{unique\right\}\right\}"
 
     # A linear diagram.
     A = Object("A")
@@ -1461,21 +1461,21 @@ def test_latex_greek_functions():
     # \Alpha, \Beta, \Eta, etc.
     s = Function('Alpha')
     assert latex(s) == r'A'
-    assert latex(s(x)) == r'A{\left (x \right )}'
+    assert latex(s(x)) == r'A{\left(x \right)}'
     s = Function('Beta')
     assert latex(s) == r'B'
     s = Function('Eta')
     assert latex(s) == r'H'
-    assert latex(s(x)) == r'H{\left (x \right )}'
+    assert latex(s(x)) == r'H{\left(x \right)}'
 
     # bug because sympy.core.numbers.Pi is special
     p = Function('Pi')
-    # assert latex(p(x)) == r'\Pi{\left (x \right )}'
+    # assert latex(p(x)) == r'\Pi{\left(x \right)}'
     assert latex(p) == r'\Pi'
 
     # bug because not all greeks are included
     c = Function('chi')
-    assert latex(c(x)) == r'\chi{\left (x \right )}'
+    assert latex(c(x)) == r'\chi{\left(x \right)}'
     assert latex(c) == r'\chi'
 
 
@@ -1631,7 +1631,7 @@ def test_builtin_no_args():
 
 def test_issue_6853():
     p = Function('Pi')
-    assert latex(p(x)) == r"\Pi{\left (x \right )}"
+    assert latex(p(x)) == r"\Pi{\left(x \right)}"
 
 
 def test_Mul():
@@ -1698,7 +1698,7 @@ def test_issue_10489():
     latexSymbolWithBrace = 'C_{x_{0}}'
     s = Symbol(latexSymbolWithBrace)
     assert latex(s) == latexSymbolWithBrace
-    assert latex(cos(s)) == r'\cos{\left (C_{x_{0}} \right )}'
+    assert latex(cos(s)) == r'\cos{\left(C_{x_{0}} \right)}'
 
 
 def test_issue_12886():
@@ -1886,8 +1886,8 @@ def test_trace():
     # Issue 15303
     from sympy import trace
     A = MatrixSymbol("A", 2, 2)
-    assert latex(trace(A)) == r"\mathrm{tr}\left (A \right )"
-    assert latex(trace(A**2)) == r"\mathrm{tr}\left (A^{2} \right )"
+    assert latex(trace(A)) == r"\mathrm{tr}\left(A \right)"
+    assert latex(trace(A**2)) == r"\mathrm{tr}\left(A^{2} \right)"
 
 
 def test_print_basic():

--- a/sympy/printing/tests/test_tableform.py
+++ b/sympy/printing/tests/test_tableform.py
@@ -109,7 +109,7 @@ def test_TableForm_latex():
         '\\hline\n'
         '1 &   & $x^{3}$ \\\\\n'
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )
     s = latex(TableForm([[0, x**3], ["c", S(1)/4], [sqrt(x), sin(x**2)]],
@@ -120,7 +120,7 @@ def test_TableForm_latex():
         '\\hline\n'
         '1 &   & $x^{3}$ \\\\\n'
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )
     s = latex(TableForm([[0, x**3], ["c", S(1)/4], [sqrt(x), sin(x**2)]],
@@ -131,7 +131,7 @@ def test_TableForm_latex():
         '\\hline\n'
         '1 &   & $x^{3}$ \\\\\n'
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )
     s = latex(TableForm([["a", x**3], ["c", S(1)/4], [sqrt(x), sin(x**2)]],
@@ -142,7 +142,7 @@ def test_TableForm_latex():
         '\\hline\n'
         '1 & $a$ & $x^{3}$ \\\\\n'
         '2 & $c$ & $\\frac{1}{4}$ \\\\\n'
-        '3 & $\\sqrt{x}$ & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '3 & $\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )
     s = latex(TableForm([["a", x**3], ["c", S(1)/4], [sqrt(x), sin(x**2)]],
@@ -153,7 +153,7 @@ def test_TableForm_latex():
         '\\hline\n'
         '1 & (a) & $x^{3}$ \\\\\n'
         '2 & (c) & $\\frac{1}{4}$ \\\\\n'
-        '3 & (sqrt(x)) & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '3 & (sqrt(x)) & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )
 
@@ -177,6 +177,6 @@ def test_TableForm_latex():
         '\\begin{tabular}{l l}\n'
         '$a$ & $x^{3}$ \\\\\n'
         '$c$ & $\\frac{1}{4}$ \\\\\n'
-        '$\\sqrt{x}$ & $\\sin{\\left (x^{2} \\right )}$ \\\\\n'
+        '$\\sqrt{x}$ & $\\sin{\\left(x^{2} \\right)}$ \\\\\n'
         '\\end{tabular}'
     )

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4469,7 +4469,7 @@ def ode_nth_linear_euler_eq_nonhomogeneous_variation_of_parameters(eq, func, ord
     where `W(x)` is the Wronskian of the fundamental system (the system of `n`
     linearly independent solutions to the homogeneous equation), and `W_i(x)`
     is the Wronskian of the fundamental system with the `i`\th column replaced
-    with `[0, 0, \cdots, 0, \frac{x^{- n}}{a_n} g{\left (x \right )}]`.
+    with `[0, 0, \cdots, 0, \frac{x^{- n}}{a_n} g{\left(x \right)}]`.
 
     This method is general enough to solve any `n`\th order inhomogeneous
     linear differential equation, but sometimes SymPy cannot simplify the

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -151,7 +151,7 @@ def test_latex_printing():
     assert latex(v[6]) == ('(\\mathbf{{x}_{N}} + a^{2})\\mathbf{\\hat{i}_' +
                           '{N}} + \\mathbf{\\hat{k}_{N}}')
     assert latex(v[8]) == ('\\mathbf{\\hat{j}_{N}} + (\\mathbf{{x}_' +
-                           '{C}}^{2} - \\int f{\\left (b \\right )}\\,' +
+                           '{C}}^{2} - \\int f{\\left(b \\right)}\\,' +
                            ' db)\\mathbf{\\hat{k}_{N}}')
     assert latex(s) == '3 \\mathbf{{y}_{C}} \\mathbf{{x}_{N}}^{2}'
     assert latex(d[0]) == '(\\mathbf{\\hat{0}}|\\mathbf{\\hat{0}})'
@@ -161,8 +161,8 @@ def test_latex_printing():
                            'hat{k}_{N}}) + (\\mathbf{\\hat{i}_{N}}{|' +
                            '}\\mathbf{\\hat{k}_{N}})')
     assert latex(d[11]) == ('(a^{2} + b)(\\mathbf{\\hat{i}_{N}}{|}\\' +
-                            'mathbf{\\hat{k}_{N}}) + (\\int f{\\left (' +
-                            'b \\right )}\\, db)(\\mathbf{\\hat{k}_{N}' +
+                            'mathbf{\\hat{k}_{N}}) + (\\int f{\\left(' +
+                            'b \\right)}\\, db)(\\mathbf{\\hat{k}_{N}' +
                             '}{|}\\mathbf{\\hat{k}_{N}})')
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Sometimes there was a space after \left and \right before the next symbol (typically bracket). For consistency reasons this is all removed now.

#### Other comments


#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * LaTeX printing now consistently does not use a space after `\left` and `\right`

<!-- END RELEASE NOTES -->
