### PR TITLE
Add \left and \right to floor, ceil, angle and Dirac ket LaTeX printing

### DIFF
--- a/doc/src/modules/combinatorics/fp_groups.rst
+++ b/doc/src/modules/combinatorics/fp_groups.rst
@@ -42,7 +42,7 @@ returned.
 
 Example of construction of a finitely-presented group.
 The symmetric group of degree 4 may be represented as a two generator group
-with presentation `\langle a, b \mid a^2, b^3, (ab)^4 \rangle`. Giving the relations as a
+with presentation `\left\langle a, b \mid a^2, b^3, (ab)^4 \right\rangle`. Giving the relations as a
 list of relators, group in SymPy would be specified as:
 
 >>> F, a, b = free_group("a, b")
@@ -51,7 +51,7 @@ list of relators, group in SymPy would be specified as:
 <fp group on the generators (a, b)>
 
 Currently groups with relators having presentation like
-`\langle r, s, t \mid r^2, s^2, t^2, rst = str = trs \rangle` will have to be specified as:
+`\left\langle r, s, t \mid r^2, s^2, t^2, rst = str = trs \right\rangle` will have to be specified as:
 
 >>> F, r, s, t = free_group("r, s, t")
 >>> G = FpGroup(F, [r**2, s**2, t**2, r*s*t*r**-1*t**-1*s**-1, s*t*r*s**-1*r**-1*t**-1])
@@ -209,12 +209,12 @@ whose index does not exceed some (modest) integer bound.
 Low Index Subgroups
 ```````````````````
 
-``low_index_subgroups(G, N)``: Given a finitely presented group `G = \langle X \mid R \rangle`
+``low_index_subgroups(G, N)``: Given a finitely presented group `G = \left\langle X \mid R \right\rangle`
 (can be a free group), and ``N`` a positive integer, determine the conjugacy classes of
 subgroups of ``G`` whose indices is less than or equal to ``N``.
 
-For example to find all subgroups of `G = \langle a, b \mid a^2 = b^3 = (ab)^4 = 1 \rangle`
-having index <= 4, can be found as follows:
+For example to find all subgroups of `G = \left\langle a, b \mid a^2 = b^3 = (ab)^4 = 1 \right\rangle`
+having index `\le` 4, can be found as follows:
 
 >>> from sympy.combinatorics.fp_groups import low_index_subgroups
 >>> F, a, b = free_group("a, b")

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -582,13 +582,13 @@ class AccumulationBounds(AtomicExpr):
 
     Let `a` and `b` be reals such that a <= b.
 
-    `\langle a, b\rangle = \{x \in \mathbb{R} \mid a \le x \le b\}`
+    `\left\langle a, b\right\rangle = \{x \in \mathbb{R} \mid a \le x \le b\}`
 
-    `\langle -\infty, b\rangle = \{x \in \mathbb{R} \mid x \le b\} \cup \{-\infty, \infty\}`
+    `\left\langle -\infty, b\right\rangle = \{x \in \mathbb{R} \mid x \le b\} \cup \{-\infty, \infty\}`
 
-    `\langle a, \infty \rangle = \{x \in \mathbb{R} \mid a \le x\} \cup \{-\infty, \infty\}`
+    `\left\langle a, \infty \right\rangle = \{x \in \mathbb{R} \mid a \le x\} \cup \{-\infty, \infty\}`
 
-    `\langle -\infty, \infty \rangle = \mathbb{R} \cup \{-\infty, \infty\}`
+    `\left\langle -\infty, \infty \right\rangle = \mathbb{R} \cup \{-\infty, \infty\}`
 
     `oo` and `-oo` are added to the second and third definition respectively,
     since if either `-oo` or `oo` is an argument, then the other one should
@@ -686,7 +686,7 @@ class AccumulationBounds(AtomicExpr):
 
     Some elementary functions can also take AccumulationBounds as input.
     A function `f` evaluated for some real AccumulationBounds `<a, b>`
-    is defined as `f(\langle a, b\rangle) = \{ f(x) \mid a \le x \le b \}`
+    is defined as `f(\left\langle a, b\right\rangle) = \{ f(x) \mid a \le x \le b \}`
 
     >>> sin(AccumBounds(pi/6, pi/3))
     AccumBounds(1/2, sqrt(3)/2)

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -282,7 +282,7 @@ class FreeGroup(DefaultPrinting):
         can refer to the smallest cardinality of a generating set
         for G, that is
 
-        \operatorname{rank}(G)=\min\{ |X|: X\subseteq G, \langle X\rangle =G\}.
+        \operatorname{rank}(G)=\min\{ |X|: X\subseteq G, \left\langle X\right\rangle =G\}.
 
         """
         return self._rank

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -254,7 +254,7 @@ class frac(Function):
     For real numbers it is defined [1]_ as
 
     .. math::
-        x - \lfloor{x}\rfloor
+        x - \left\lfloor{x}\right\rfloor
 
     Examples
     ========

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -156,7 +156,7 @@ class CG(Wigner3j):
     coefficients are defined as [1]_:
 
     .. math ::
-        C^{j_1,m_1}_{j_2,m_2,j_3,m_3} = \langle j_1,m_1;j_2,m_2 | j_3,m_3\rangle
+        C^{j_1,m_1}_{j_2,m_2,j_3,m_3} = \left\langle j_1,m_1;j_2,m_2 | j_3,m_3\right\rangle
 
     Parameters
     ==========

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -311,14 +311,14 @@ def render_label(label, inits={}):
 
     >>> from sympy.physics.quantum.circuitplot import render_label
     >>> render_label('q0')
-    '$|q0\\\\rangle$'
+    '$\\\\left|q0\\\\right\\\\rangle$'
     >>> render_label('q0', {'q0':'0'})
-    '$|q0\\\\rangle=|0\\\\rangle$'
+    '$\\\\left|q0\\\\right\\\\rangle=\\\\left|0\\\\right\\\\rangle$'
     """
     init = inits.get(label)
     if init:
-        return r'$|%s\rangle=|%s\rangle$' % (label, init)
-    return r'$|%s\rangle$' % label
+        return r'$\left|%s\right\rangle=\left|%s\right\rangle$' % (label, init)
+    return r'$\left|%s\right\rangle$' % label
 
 def labeller(n, symbol='q'):
     """Autogenerate labels for wires of quantum circuits.

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1633,8 +1633,8 @@ class JzKetCoupled(CoupledSpinState, Ket):
     The other required parameter in ``jn``, which is a tuple defining the `j_n`
     angular momentum quantum numbers of the product spaces. So for example, if
     a state represented the coupling of the product basis state
-    `|j_1,m_1\rangle\times|j_2,m_2\rangle`, the ``jn`` for this state would be
-    ``(j1,j2)``.
+    `\left|j_1,m_1\right\rangle\times\left|j_2,m_2\right\rangle`, the ``jn``
+    for this state would be ``(j1,j2)``.
 
     The final option is ``jcoupling``, which is used to define how the spaces
     specified by ``jn`` are coupled, which includes both the order these spaces

--- a/sympy/physics/quantum/tests/test_circuitplot.py
+++ b/sympy/physics/quantum/tests/test_circuitplot.py
@@ -7,8 +7,8 @@ from sympy.utilities.pytest import skip
 mpl = import_module('matplotlib')
 
 def test_render_label():
-    assert render_label('q0') == r'$|q0\rangle$'
-    assert render_label('q0', {'q0': '0'}) == r'$|q0\rangle=|0\rangle$'
+    assert render_label('q0') == r'$\left|q0\right\rangle$'
+    assert render_label('q0', {'q0': '0'}) == r'$\left|q0\right\rangle=\left|0\right\rangle$'
 
 def test_Mz():
     assert str(Mz(0)) == 'Mz(0)'

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -218,7 +218,7 @@ def wigner_3j(j_1, j_2, j_3, m_1, m_2, m_3):
 def clebsch_gordan(j_1, j_2, j_3, m_1, m_2, m_3):
     r"""
     Calculates the Clebsch-Gordan coefficient
-    `\langle j_1 m_1 \; j_2 m_2 | j_3 m_3 \rangle`.
+    `\left\langle j_1 m_1 \; j_2 m_2 | j_3 m_3 \right\rangle`.
 
     The reference for this function is [Edmonds74]_.
 
@@ -248,7 +248,7 @@ def clebsch_gordan(j_1, j_2, j_3, m_1, m_2, m_3):
 
     .. math::
 
-        \langle j_1 m_1 \; j_2 m_2 | j_3 m_3 \rangle
+        \left\langle j_1 m_1 \; j_2 m_2 | j_3 m_3 \right\rangle
         =(-1)^{j_1-j_2+m_3} \sqrt{2j_3+1}
         \operatorname{Wigner3j}(j_1,j_2,j_3,m_1,m_2,-m_3)
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -30,7 +30,7 @@ from sympy.utilities.iterables import has_variety
 import re
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax
-# Complete list at http://www.mathjax.org/docs/1.1/tex.html#supported-latex-commands
+# Complete list at https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
 # This variable only contains those functions which sympy uses.
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
                     'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec', 'csc',

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -832,7 +832,7 @@ class LatexPrinter(Printer):
     _print_Min = _print_Max = _hprint_variadic_function
 
     def _print_floor(self, expr, exp=None):
-        tex = r"\lfloor{%s}\rfloor" % self._print(expr.args[0])
+        tex = r"\left\lfloor{%s}\right\rfloor" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
@@ -840,7 +840,7 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_ceiling(self, expr, exp=None):
-        tex = r"\lceil{%s}\rceil" % self._print(expr.args[0])
+        tex = r"\left\lceil{%s}\right\rceil" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1700,7 +1700,7 @@ class LatexPrinter(Printer):
     def _print_SingularityFunction(self, expr):
         shift = self._print(expr.args[0] - expr.args[1])
         power = self._print(expr.args[2])
-        tex = r"{\langle %s \rangle}^{%s}" % (shift, power)
+        tex = r"{\left\langle %s \right\rangle}^{%s}" % (shift, power)
         return tex
 
     def _print_Heaviside(self, expr, exp=None):
@@ -1811,7 +1811,7 @@ class LatexPrinter(Printer):
                    (left, self._print(i.start), self._print(i.end), right)
 
     def _print_AccumulationBounds(self, i):
-        return r"\langle %s, %s\rangle" % \
+        return r"\left\langle %s, %s\right\rangle" % \
                 (self._print(i.min), self._print(i.max))
 
     def _print_Union(self, u):
@@ -2134,11 +2134,11 @@ class LatexPrinter(Printer):
             '{' + self._print(x) + '}' for x in m)
 
     def _print_SubModule(self, m):
-        return r"\left< %s \right>" % ",".join(
+        return r"\left\langle %s \right\rangle" % ",".join(
             '{' + self._print(x) + '}' for x in m.gens)
 
     def _print_ModuleImplementedIdeal(self, m):
-        return r"\left< %s \right>" % ",".join(
+        return r"\left\langle %s \right\rangle" % ",".join(
             '{' + self._print(x) + '}' for [x] in m._module.gens)
 
     def _print_Quaternion(self, expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -322,8 +322,8 @@ def test_latex_functions():
     assert latex(FallingFactorial(3, k)) == r"{\left(3\right)}_{k}"
     assert latex(RisingFactorial(3, k)) == r"{3}^{\left(k\right)}"
 
-    assert latex(floor(x)) == r"\lfloor{x}\rfloor"
-    assert latex(ceiling(x)) == r"\lceil{x}\rceil"
+    assert latex(floor(x)) == r"\left\lfloor{x}\right\rfloor"
+    assert latex(ceiling(x)) == r"\left\lceil{x}\right\rceil"
     assert latex(Min(x, 2, x**3)) == r"\min\left(2, x, x^{3}\right)"
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -155,12 +155,12 @@ def test_latex_builtins():
 
 
 def test_latex_SingularityFunction():
-    assert latex(SingularityFunction(x, 4, 5)) == r"{\langle x - 4 \rangle}^{5}"
-    assert latex(SingularityFunction(x, -3, 4)) == r"{\langle x + 3 \rangle}^{4}"
-    assert latex(SingularityFunction(x, 0, 4)) == r"{\langle x \rangle}^{4}"
-    assert latex(SingularityFunction(x, a, n)) == r"{\langle - a + x \rangle}^{n}"
-    assert latex(SingularityFunction(x, 4, -2)) == r"{\langle x - 4 \rangle}^{-2}"
-    assert latex(SingularityFunction(x, 4, -1)) == r"{\langle x - 4 \rangle}^{-1}"
+    assert latex(SingularityFunction(x, 4, 5)) == r"{\left\langle x - 4 \right\rangle}^{5}"
+    assert latex(SingularityFunction(x, -3, 4)) == r"{\left\langle x + 3 \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, 0, 4)) == r"{\left\langle x \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, a, n)) == r"{\left\langle - a + x \right\rangle}^{n}"
+    assert latex(SingularityFunction(x, 4, -2)) == r"{\left\langle x - 4 \right\rangle}^{-2}"
+    assert latex(SingularityFunction(x, 4, -1)) == r"{\left\langle x - 4 \right\rangle}^{-1}"
 
 def test_latex_cycle():
     assert latex(Cycle(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
@@ -716,9 +716,9 @@ def test_latex_intervals():
 
 def test_latex_AccumuBounds():
     a = Symbol('a', real=True)
-    assert latex(AccumBounds(0, 1)) == r"\langle 0, 1\rangle"
-    assert latex(AccumBounds(0, a)) == r"\langle 0, a\rangle"
-    assert latex(AccumBounds(a + 1, a + 2)) == r"\langle a + 1, a + 2\rangle"
+    assert latex(AccumBounds(0, 1)) == r"\left\langle 0, 1\right\rangle"
+    assert latex(AccumBounds(0, a)) == r"\left\langle 0, a\right\rangle"
+    assert latex(AccumBounds(a + 1, a + 2)) == r"\left\langle a + 1, a + 2\right\rangle"
 
 
 def test_latex_emptyset():
@@ -1365,15 +1365,15 @@ def test_Modules():
 
     assert latex(F) == r"{\mathbb{Q}\left[x, y\right]}^{2}"
     assert latex(M) == \
-        r"\left< {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right>"
+        r"\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle"
 
     I = R.ideal(x**2, y)
-    assert latex(I) == r"\left< {x^{2}},{y} \right>"
+    assert latex(I) == r"\left\langle {x^{2}},{y} \right\rangle"
 
     Q = F / M
-    assert latex(Q) == r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left< {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right>}"
+    assert latex(Q) == r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}"
     assert latex(Q.submodule([1, x**3/2], [2, y])) == \
-        r"\left< {{\left[ {1},{\frac{x^{3}}{2}} \right]} + {\left< {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right>}},{{\left[ {2},{y} \right]} + {\left< {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right>}} \right>"
+        r"\left\langle {{\left[ {1},{\frac{x^{3}}{2}} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}},{{\left[ {2},{y} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}} \right\rangle"
 
     h = homomorphism(QQ.old_poly_ring(x).free_module(2), QQ.old_poly_ring(x).free_module(2), [0, 0])
 
@@ -1385,8 +1385,8 @@ def test_QuotientRing():
     R = QQ.old_poly_ring(x)/[x**2 + 1]
 
     assert latex(
-        R) == r"\frac{\mathbb{Q}\left[x\right]}{\left< {x^{2} + 1} \right>}"
-    assert latex(R.one) == r"{1} + {\left< {x^{2} + 1} \right>}"
+        R) == r"\frac{\mathbb{Q}\left[x\right]}{\left\langle {x^{2} + 1} \right\rangle}"
+    assert latex(R.one) == r"{1} + {\left\langle {x^{2} + 1} \right\rangle}"
 
 
 def test_Tr():

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2861,7 +2861,7 @@ def UniformSum(name, n):
     The density of the Irwin-Hall distribution is given by
 
     .. math ::
-        f(x) := \frac{1}{(n-1)!}\sum_{k=0}^{\lfloor x\rfloor}(-1)^k
+        f(x) := \frac{1}{(n-1)!}\sum_{k=0}^{\left\lfloor x\right\rfloor}(-1)^k
                 \binom{n}{k}(x-k)^{n-1}
 
     Parameters

--- a/sympy/utilities/mathml/data/mmltex.xsl
+++ b/sympy/utilities/mathml/data/mmltex.xsl
@@ -940,12 +940,12 @@ priority="2">
 
 <!-- 4.4.9.1 mean -->
 <xsl:template match="m:apply[*[1][self::m:mean]]">
-	<xsl:text>\langle </xsl:text>
+	<xsl:text>\left\langle </xsl:text>
 	<xsl:for-each select="*[position()&gt;1]">
 		<xsl:apply-templates select="."/>
 		<xsl:if test="position() !=last()"><xsl:text>, </xsl:text></xsl:if>
 	</xsl:for-each>
-	<xsl:text>\rangle </xsl:text>
+	<xsl:text>\right\rangle </xsl:text>
 </xsl:template>
 
 <!-- 4.4.9.2 sdef -->
@@ -960,11 +960,11 @@ priority="2">
 
 <!-- 4.4.9.5 moment -->
 <xsl:template match="m:apply[*[1][self::m:moment]]">
-	<xsl:text>\langle </xsl:text>
+	<xsl:text>\left\langle </xsl:text>
 	<xsl:apply-templates select="*[last()]"/>
 	<xsl:text>^{</xsl:text>
 	<xsl:apply-templates select="m:degree/node()"/>
-	<xsl:text>}\rangle</xsl:text>
+	<xsl:text>}\right\rangle</xsl:text>
 	<xsl:if test="m:momentabout">
 		<xsl:text>_{</xsl:text>
 		<xsl:apply-templates select="m:momentabout/node()"/>

--- a/sympy/utilities/mathml/data/mmltex.xsl
+++ b/sympy/utilities/mathml/data/mmltex.xsl
@@ -456,16 +456,16 @@ Modified Fabian Seoane 2007 for sympy
 
 <!-- 4.4.3.25 floor -->
 <xsl:template match="m:apply[*[1][self::m:floor]]">
-	<xsl:text>\lfloor </xsl:text>
+	<xsl:text>\left\lfloor </xsl:text>
 	<xsl:apply-templates select="*[2]"/>
-	<xsl:text>\rfloor </xsl:text>
+	<xsl:text>\right\rfloor </xsl:text>
 </xsl:template>
 
 <!-- 4.4.3.25 ceiling -->
 <xsl:template match="m:apply[*[1][self::m:ceiling]]">
-	<xsl:text>\lceil </xsl:text>
+	<xsl:text>\left\lceil </xsl:text>
 	<xsl:apply-templates select="*[2]"/>
-	<xsl:text>\rceil </xsl:text>
+	<xsl:text>\right\rceil </xsl:text>
 </xsl:template>
 
 <!-- 4.4.4.1 eq -->


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Now, `\left` and `right` is always added to the printing of `floor`, `ceiling`, when `langle` and `rangle` is used, and for the Dirac ket `|a>`.

Before:
![image](https://user-images.githubusercontent.com/8114497/51106841-498a5000-17ed-11e9-89d8-1c7b0bcd82d9.png)

Now:
![image](https://user-images.githubusercontent.com/8114497/51106848-4f803100-17ed-11e9-9aea-f71de090e7e3.png)

I also updated the link the the MathJax documentation,

#### Other comments
It can be argued if it should also be changed in the documentation. I did it, although not strictly required.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * When printing to LaTeX, `ceiling`, `floor`, <> and Dirac ket |a>now always add `\left` and `\right`
<!-- END RELEASE NOTES -->
