### PR TITLE
Fix for Piecewise function

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -187,8 +187,9 @@ class lambdify(object):
                                                  use_python_cmath=True)
         self.failure = False
 
-    def __call__(self, args):
-        args = complex(args)
+    def __call__(self, args, kwargs = {}):
+        if kwargs.get('complex_wrap_evalf', None) is not None:
+            args = complex(args)
         try:
             #The result can be sympy.Float. Hence wrap it with complex type.
             result = complex(self.lambda_func(args))
@@ -239,6 +240,9 @@ class lambdify(object):
 
 
 def experimental_lambdify(*args, **kwargs):
+    if kwargs.get('use_python_math', None) is True:
+        if kwargs.get('complex_wrap_evalf', None):
+            kwargs['complex_wrap_evalf']=False
     l = Lambdifier(*args, **kwargs)
     return l
 

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -188,7 +188,7 @@ class lambdify(object):
         self.failure = False
 
     def __call__(self, args, kwargs = {}):
-        if kwargs.get('complex_wrap_evalf', None) is not None:
+        if not self.lambda_func.use_python_math:
             args = complex(args)
         try:
             #The result can be sympy.Float. Hence wrap it with complex type.
@@ -240,9 +240,6 @@ class lambdify(object):
 
 
 def experimental_lambdify(*args, **kwargs):
-    if kwargs.get('use_python_math', None) is True:
-        if kwargs.get('complex_wrap_evalf', None):
-            kwargs['complex_wrap_evalf']=False
     l = Lambdifier(*args, **kwargs)
     return l
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15702 

#### Brief description of what is fixed or changed
Earlier it was giving error for below case
```
f1 = sin(x)
f2 = Abs(x)
f3 = x**2
f = Piecewise((f1, x < -pi),(f2, x < 1.0), (f3, True)) 
plot(f)
TypeError: '<' not supported between instances of 'complex' and 'float'
```
Now it gives the correct plot

```
f1 = sin(x)
f2 = Abs(x)
f3 = x**2
f = Piecewise((f1, x < -pi),(f2, x < 1.0), (f3, True)) 
plot(f)
```
![plot_sympy](https://user-images.githubusercontent.com/39242494/51202017-abe56c80-1923-11e9-8aa7-50e8c1357752.png)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
       * Now if backend ```use_python_math``` is ```True``` then ```complex_wrap_evalf``` will be ```False```.
<!-- END RELEASE NOTES -->
