### PR TITLE
Fix behaviors for printing sparse matrix code

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -519,6 +519,8 @@ class CodePrinter(StrPrinter):
     _print_RootSum = _print_not_supported
     _print_Sample = _print_not_supported
     _print_SparseMatrix = _print_not_supported
+    _print_MutableSparseMatrix = _print_not_supported
+    _print_ImmutableSparseMatrix = _print_not_supported
     _print_Uniform = _print_not_supported
     _print_Unit = _print_not_supported
     _print_Wild = _print_not_supported

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -35,3 +35,9 @@ def test_print_Symbol():
     p = setup_test_printer(reserved_word_suffix='_He_Man')
     p.reserved_words.update(['if'])
     assert p._print(y) == 'if_He_Man'
+
+def test_issue_15791():
+    assert (CodePrinter._print_MutableSparseMatrix.__name__ ==
+    CodePrinter._print_not_supported.__name__)
+    assert (CodePrinter._print_ImmutableSparseMatrix.__name__ ==
+    CodePrinter._print_not_supported.__name__)

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,4 +1,5 @@
 from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.str import StrPrinter
 from sympy.core import symbols
 from sympy.core.symbol import Dummy
 from sympy.utilities.pytest import raises
@@ -41,3 +42,7 @@ def test_issue_15791():
     CodePrinter._print_not_supported.__name__)
     assert (CodePrinter._print_ImmutableSparseMatrix.__name__ ==
     CodePrinter._print_not_supported.__name__)
+    assert (CodePrinter._print_MutableSparseMatrix.__name__ !=
+    StrPrinter._print_MatrixBase.__name__)
+    assert (CodePrinter._print_ImmutableSparseMatrix.__name__ !=
+    StrPrinter._print_MatrixBase.__name__)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think some code printers are not properly printing 'Not supported on' on sparse matrices
```
>>>from sympy import *

>>>A = MutableSparseMatrix([[1, 2], [3, 4]])
>>>print_ccode(A)
Matrix([
[1, 2],
[3, 4]])
```

I've added _print_not_supported for each sparse matrices,
so it will properly output
```
>>>print_ccode(A)
// Not supported in C:
// ImmutableSparseMatrix
Matrix([
[1, 2],
[3, 4]])
```

It will also apply to fortran or javascript or other languages.
But I also think that it should not be ImmutableSparseMatrix, as I have posted an issue #15790.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Code printers will properly behave for sparse matrices, if not supported
<!-- END RELEASE NOTES -->
