### PR TITLE
Add support for matrices in mathematica_code

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -94,6 +94,14 @@ class MCodePrinter(CodePrinter):
     _print_tuple = _print_list
     _print_Tuple = _print_list
 
+    def _print_Matrix(self, expr):
+        return self._print_list(
+        [self._print_list(expr.row(i)) for i in range(expr.rows)]
+        )
+    _print_ImmutableMatrix = _print_Matrix
+    _print_ImmutableDenseMatrix = _print_Matrix
+    _print_MutableDenseMatrix = _print_Matrix
+
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_mfunc = self.known_functions[expr.func.__name__]

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -102,6 +102,22 @@ class MCodePrinter(CodePrinter):
     _print_ImmutableDenseMatrix = _print_Matrix
     _print_MutableDenseMatrix = _print_Matrix
 
+    def _print_SparseMatrix(self, expr):
+        def print_rule(pos, val):
+            return '{} -> {}'.format(
+            self.doprint((pos[0]+1, pos[1]+1)), self.doprint(val))
+        def print_data():
+            return self._print_list(
+            [print_rule(key, value) for key, value in expr._smat.items()]
+            )
+        def print_dims():
+            return self._print_list(
+            [self.doprint(expr.rows), self.doprint(expr.cols)]
+            )
+        return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
+    _print_MutableSparseMatrix = _print_SparseMatrix
+    _print_ImmutableSparseMatrix = _print_SparseMatrix
+
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_mfunc = self.known_functions[expr.func.__name__]

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -103,12 +103,15 @@ class MCodePrinter(CodePrinter):
     _print_MutableDenseMatrix = _print_Matrix
 
     def _print_SparseMatrix(self, expr):
+        from sympy.core.compatibility import default_sort_key
+
         def print_rule(pos, val):
             return '{} -> {}'.format(
             self.doprint((pos[0]+1, pos[1]+1)), self.doprint(val))
         def print_data():
             return self._print_list(
-            [print_rule(key, value) for key, value in expr._smat.items()]
+            [print_rule(key, value)
+            for key, value in sorted(expr._smat.items(), key=default_sort_key)]
             )
         def print_dims():
             return self._print_list(

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -67,6 +67,42 @@ def test_containers():
     assert mcode(Tuple(*[1, 2, 3])) == "{1, 2, 3}"
 
 
+def test_matrices():
+    from sympy.matrices import MutableDenseMatrix, MutableSparseMatrix
+    A = MutableDenseMatrix(
+        [[1, -1, 0, 0],
+        [0, 1, -1, 0],
+        [0, 0, 1, -1],
+        [0, 0, 0, 1]]
+    )
+    B = MutableSparseMatrix(
+        [[1, -1, 0, 0],
+        [0, 1, -1, 0],
+        [0, 0, 1, -1],
+        [0, 0, 0, 1]]
+    )
+
+    assert mcode(A) == """\
+{{1, -1, 0, 0}, \
+{0, 1, -1, 0}, \
+{0, 0, 1, -1}, \
+{0, 0, 0, 1}}\
+"""
+    assert mcode(B) == """\
+SparseArray[\
+{{1, 1} -> 1, {1, 2} -> -1, {2, 2} -> 1, {2, 3} -> -1, \
+{3, 3} -> 1, {3, 4} -> -1, {4, 4} -> 1}, {4, 4}]\
+"""
+
+    # Trivial cases of matrices
+    assert mcode(MutableDenseMatrix(0, 0, [])) == '{}'
+    assert mcode(MutableSparseMatrix(0, 0, [])) == 'SparseArray[{}, {0, 0}]'
+    assert mcode(MutableDenseMatrix(0, 3, [])) == '{}'
+    assert mcode(MutableSparseMatrix(0, 3, [])) == 'SparseArray[{}, {0, 3}]'
+    assert mcode(MutableDenseMatrix(3, 0, [])) == '{{}, {}, {}}'
+    assert mcode(MutableSparseMatrix(3, 0, [])) == 'SparseArray[{}, {3, 0}]'
+
+
 def test_Integral():
     assert mcode(Integral(sin(sin(x)), x)) == "Hold[Integrate[Sin[Sin[x]], x]]"
     assert mcode(Integral(exp(-x**2 - y**2),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#15618

#### Brief description of what is fixed or changed

Previously, printing dense matrices in mathematica had thrown
```TypeError: unhashable type: 'MutableDenseMatrix'```
and printing sparse matrices was bugged by the reason #15791.

I have added proper matrix printing functions for mathematica.

Mathematica's dense arrays are represented as nested lists,
and sparse arrays are constructed by rules in `SparseArray[]` function.

#### Other comments

References for Mathematica Dense Matrices -
https://reference.wolfram.com/language/howto/CreateAMatrix.html
References for Mathematica Sparse Matrices -
https://reference.wolfram.com/language/ref/SparseArray.html

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- printing
  - `mathematica_code` can print dense and sparse matrices

<!-- END RELEASE NOTES -->
