### PR TITLE
rankcheck in LUDecomposition does not correctly handle last row

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3583,6 +3583,15 @@ class MatrixBase(MatrixDeprecated,
                 # elimination is complete.
                 return lu, row_swaps
 
+        if rankcheck:
+            if iszerofunc(
+            lu[Min(lu.rows, lu.cols) - 1, Min(lu.rows, lu.cols) - 1]):
+                raise ValueError("Rank of matrix is strictly less than"
+                                 " number of rows or columns."
+                                 " Pass keyword argument"
+                                 " rankcheck=False to compute"
+                                 " the LU decomposition of this matrix.")
+
         return lu, row_swaps
 
     def LUdecompositionFF(self):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -622,6 +622,13 @@ def test_LUdecomp():
     P, L, Dee, U = M.LUdecompositionFF()
     assert P*M == L*Dee.inv()*U
 
+    # issue 15794
+    M = Matrix(
+        [[1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]]
+    )
+    raises(ValueError, lambda : M.LUdecomposition_Simple(rankcheck=True))
 
 def test_LUsolve():
     A = Matrix([[2, 3, 5],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

```
from sympy import *

A = Matrix(
    [[1, 2, 3],
    [4, 5, 6],
    [7, 8, 9]]
)
(lu, perm)=A.LUdecomposition_Simple(rankcheck=True)
A.rank()
```
This is an example of rank deficient matrix, but rankcheck does not raise ValueError.
I think the computation is bounded strictly before last row, so that it is unaware of any zeros in the last row.
I have added a zero test for last diagonal entry after computation.

#### Other comments

I think there is another breakpoint at
https://github.com/sympy/sympy/blob/28d913d3cead6c5646307ffa6540b21d65059dfd/sympy/matrices/matrices.py#L3523-L3529
But I don't know which cases of matrices would invoke the code.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - `rankcheck` in `LUdecomposition_Simple` correctly raises `ValueError` when the last row is found rank deficient.

<!-- END RELEASE NOTES -->
