### PR TITLE
numbers:Fixed Integer and StdFactKB memory leak

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1898,65 +1898,6 @@ class Rational(Number):
         return self, S.Zero
 
 
-# int -> Integer
-_intcache = {}
-
-
-# TODO move this tracing facility to sympy/core/trace.py  ?
-def _intcache_printinfo():
-    ints = sorted(_intcache.keys())
-    nhit = _intcache_hits
-    nmiss = _intcache_misses
-
-    if nhit == 0 and nmiss == 0:
-        print()
-        print('Integer cache statistic was not collected')
-        return
-
-    miss_ratio = float(nmiss) / (nhit + nmiss)
-
-    print()
-    print('Integer cache statistic')
-    print('-----------------------')
-    print()
-    print('#items: %i' % len(ints))
-    print()
-    print(' #hit   #miss               #total')
-    print()
-    print('%5i   %5i (%7.5f %%)   %5i' % (
-        nhit, nmiss, miss_ratio*100, nhit + nmiss)
-    )
-    print()
-    print(ints)
-
-_intcache_hits = 0
-_intcache_misses = 0
-
-
-def int_trace(f):
-    import os
-    if os.getenv('SYMPY_TRACE_INT', 'no').lower() != 'yes':
-        return f
-
-    def Integer_tracer(cls, i):
-        global _intcache_hits, _intcache_misses
-
-        try:
-            _intcache_hits += 1
-            return _intcache[i]
-        except KeyError:
-            _intcache_hits -= 1
-            _intcache_misses += 1
-
-            return f(cls, i)
-
-    # also we want to hook our _intcache_printinfo into sys.atexit
-    import atexit
-    atexit.register(_intcache_printinfo)
-
-    return Integer_tracer
-
-
 class Integer(Rational):
     """Represents integer numbers of any size.
 
@@ -1999,7 +1940,7 @@ class Integer(Rational):
         return mpmath.make_mpf(self._as_mpf_val(prec))
 
     # TODO caching with decorator, but not to degrade performance
-    @int_trace
+    @cacheit
     def __new__(cls, i):
         if isinstance(i, string_types):
             i = i.replace(' ', '')
@@ -2014,16 +1955,25 @@ class Integer(Rational):
         except TypeError:
             raise TypeError(
                 "Argument of Integer should be of numeric type, got %s." % i)
-        try:
-            return _intcache[ival]
-        except KeyError:
-            # We only work with well-behaved integer types. This converts, for
-            # example, numpy.int32 instances.
-            obj = Expr.__new__(cls)
-            obj.p = ival
 
-            _intcache[ival] = obj
-            return obj
+        # We only work with well-behaved integer types. This converts, for
+        # example, numpy.int32 instances.
+
+        if ival == 1:
+            return S.One
+
+        if ival == -1:
+            return S.NegativeOne
+
+        if ival == 0:
+            return S.Zero
+
+        obj = Expr.__new__(cls)
+        obj.p = ival
+
+        return obj
+
+
 
     def __getnewargs__(self):
         return (self.p,)
@@ -3923,10 +3873,6 @@ def sympify_complex(a):
     return real + S.ImaginaryUnit*imag
 
 converter[complex] = sympify_complex
-
-_intcache[0] = S.Zero
-_intcache[1] = S.One
-_intcache[-1] = S.NegativeOne
 
 from .power import Pow, integer_nthroot
 from .mul import Mul

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -8,7 +8,7 @@ from sympy import (Rational, Symbol, Float, I, sqrt, cbrt, oo, nan, pi, E,
 from sympy.core.compatibility import long
 from sympy.core.power import integer_nthroot, isqrt, integer_log
 from sympy.core.logic import fuzzy_not
-from sympy.core.numbers import (igcd, ilcm, igcdex, seterr, _intcache,
+from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
     igcd2, igcd_lehmer, mpf_norm, comp, mod_inverse)
 from sympy.core.mod import Mod
 from sympy.polys.domains.groundtypes import PythonRational
@@ -27,28 +27,6 @@ t = Symbol('t', real=False)
 def same_and_same_prec(a, b):
     # stricter matching for Floats
     return a == b and a._prec == b._prec
-
-
-def test_integers_cache():
-    python_int = 2**65 + 3175259
-
-    while python_int in _intcache or hash(python_int) in _intcache:
-        python_int += 1
-
-    sympy_int = Integer(python_int)
-
-    assert python_int in _intcache
-    assert hash(python_int) not in _intcache
-
-    sympy_int_int = Integer(sympy_int)
-
-    assert python_int in _intcache
-    assert hash(python_int) not in _intcache
-
-    sympy_hash_int = Integer(hash(python_int))
-
-    assert python_int in _intcache
-    assert hash(python_int) in _intcache
 
 
 def test_seterr():


### PR DESCRIPTION
Fixed the Integer and StDFactKB memory leak by changing the cache
infrastructure from _intcache which is adhoc and unbound to a proper
cache infrastructure cacheit.
The following code was used to test the success of the issue

>>import os
>>os.environ['SYMPY_USE_CACHE'] = 'no'
>>from sympy.parsing.sympy_parser import parse.expr
>>import gc
>>import objgraph

>>for i in range(100000):
	parse.expr('log({})'.format(i), local_dict=dict(),
evaluate=False)

>>gc.collect()

>>print(objgraph.show_most_common_types(limit=10))

running the above command with the _intcache infrastructure gave the
following results

dict               204812
StdFactKB          200490
Integer            199996
function           15255
tuple              4835
weakref            1820
list               1624
cell               1435
property           1232
wrapper_descriptor 1058
None

After replacing the _intcache with a proper infrastructure, running the
program gave this result

function           15253
tuple              4835
dict               4815
weakref            1820
list               1624
cell               1435
property           1232
wrapper_descriptor 1058
getset_descriptor  866
method_descriptor  857
None

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
