### PR TITLE
Support Fourier Parameters for Fast Fourier Transform

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -258,8 +258,21 @@ class AskUnitaryHandler(CommonHandler):
     def DFTMatrix(expr, assumptions):
         n = expr.args[0]
         a, b = expr.args[1], expr.args[2]
-        if a.is_zero and b.is_integer and n.gcd(b) == 1:
+        if ask(Q.zero(a), assumptions) and ask(Q.integer(b), assumptions) \
+            and b.gcd(n) == 1:
             return True
+
+        if ask(Q.zero(a)) == False:
+            return False
+
+        if ask(Q.integer(b)) == False:
+            return False
+
+        if ask(Q.integer(b)) and b.gcd(n) != 1:
+            return False
+
+        return None
+
 
     Factorization = staticmethod(partial(_Factorization, Q.unitary))
 

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -255,8 +255,11 @@ class AskUnitaryHandler(CommonHandler):
             return ask(Q.unitary(expr.parent), assumptions)
 
     @staticmethod
-    def DFT(expr, assumptions):
-        return True
+    def DFTMatrix(expr, assumptions):
+        n = expr.args[0]
+        a, b = expr.args[1]
+        if a.is_zero and b.is_integer and n.gcd(b) == 1:
+            return True
 
     Factorization = staticmethod(partial(_Factorization, Q.unitary))
 
@@ -625,4 +628,6 @@ class AskComplexElementsHandler(CommonHandler):
     MatrixSlice = staticmethod(partial(MS_elements, Q.complex_elements))
     BlockMatrix = staticmethod(partial(BM_elements, Q.complex_elements))
 
-    DFT = staticmethod(CommonHandler.AlwaysTrue)
+    @staticmethod
+    def DFTMatrix(expr, assumptions):
+        return test_closed_group(expr, assumptions, Q.complex_elements)

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -257,7 +257,7 @@ class AskUnitaryHandler(CommonHandler):
     @staticmethod
     def DFTMatrix(expr, assumptions):
         n = expr.args[0]
-        a, b = expr.args[1]
+        a, b = expr.args[1], expr.args[2]
         if a.is_zero and b.is_integer and n.gcd(b) == 1:
             return True
 

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -214,8 +214,9 @@ def test_matrix_element_sets():
     assert ask(Q.complex(X[1, 2]), Q.complex_elements(X))
     assert ask(Q.integer_elements(Identity(3)))
     assert ask(Q.integer_elements(ZeroMatrix(3, 3)))
-    from sympy.matrices.expressions.fourier import DFT
-    assert ask(Q.complex_elements(DFT(3)))
+
+    from sympy.matrices.expressions.fourier import DFTMatrix
+    assert ask(Q.complex_elements(DFTMatrix(3)))
 
 
 def test_matrix_element_sets_slices_blocks():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2910,15 +2910,10 @@ def test_sympy__matrices__expressions__funcmatrix__FunctionMatrix():
     i, j = symbols('i,j')
     assert _test_args(FunctionMatrix(3, 3, Lambda((i, j), i - j) ))
 
-def test_sympy__matrices__expressions__fourier__DFT():
-    from sympy.matrices.expressions.fourier import DFT
+def test_sympy__matrices__expressions__fourier__DFTMatrix():
+    from sympy.matrices.expressions.fourier import DFTMatrix
     from sympy import S
-    assert _test_args(DFT(S(2)))
-
-def test_sympy__matrices__expressions__fourier__IDFT():
-    from sympy.matrices.expressions.fourier import IDFT
-    from sympy import S
-    assert _test_args(IDFT(S(2)))
+    assert _test_args(DFTMatrix(S(2)))
 
 from sympy.matrices.expressions import MatrixSymbol
 X = MatrixSymbol('X', 10, 10)

--- a/sympy/discrete/tests/test_convolutions.py
+++ b/sympy/discrete/tests/test_convolutions.py
@@ -172,7 +172,10 @@ def test_convolution_fft():
                         [10037624576503, 1005370659728895, 9997492572392]
 
     raises(TypeError, lambda: convolution_fft(x, y))
-    raises(ValueError, lambda: convolution_fft([x, y], [y, x]))
+    assert convolution_fft([x, y], [y, x]) = \
+        [-x**2/4 + x*y/2 - y**2/4 + (x + y)**2/4,
+         3*x**2/4 - x*y/2 + 3*y**2/4 + (x + y)**2/4,
+         -x**2/4 + x*y/2 - y**2/4 + (x + y)**2/4]
 
 
 def test_convolution_ntt():

--- a/sympy/discrete/tests/test_convolutions.py
+++ b/sympy/discrete/tests/test_convolutions.py
@@ -172,7 +172,7 @@ def test_convolution_fft():
                         [10037624576503, 1005370659728895, 9997492572392]
 
     raises(TypeError, lambda: convolution_fft(x, y))
-    assert convolution_fft([x, y], [y, x]) = \
+    assert convolution_fft([x, y], [y, x]) == \
         [-x**2/4 + x*y/2 - y**2/4 + (x + y)**2/4,
          3*x**2/4 - x*y/2 + 3*y**2/4 + (x + y)**2/4,
          -x**2/4 + x*y/2 - y**2/4 + (x + y)**2/4]

--- a/sympy/discrete/tests/test_transforms.py
+++ b/sympy/discrete/tests/test_transforms.py
@@ -27,7 +27,11 @@ def test_fft_ifft():
 
     x = Symbol('x', real=True)
     raises(TypeError, lambda: fft(x))
-    raises(ValueError, lambda: ifft([x, 2*x, 3*x**2, 4*x**3]))
+    assert ifft([x, 2*x, 3*x**2, 4*x**3]) == \
+        [x**3 + 3*x**2/4 + 3*x/4,
+         I*x**3 - 3*x**2/4 + x/4 - I*x/2,
+         -x**3 + 3*x**2/4 - x/4,
+         -I*x**3 - 3*x**2/4 + x/4 + I*x/2]
 
 
 def test_ntt_intt():

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -71,14 +71,10 @@ def _fourier_transform(seq, dps, inverse=False, fourier_params=(1, 1)):
 
 
 def fft(seq, dps=None, fourier_params=(1, 1)):
-    r"""
-    Performs the Discrete Fourier Transform (**DFT**) in the complex domain.
+    r"""Performs the Fast Fourier Transform (**FFT**).
 
     The sequence is automatically padded to the right with zeros, as the
     *radix-2 FFT* requires the number of sample points to be a power of 2.
-
-    This method should be used with default arguments only for short sequences
-    as the complexity of expressions increases with the size of the sequence.
 
     Parameters
     ==========
@@ -92,19 +88,25 @@ def fft(seq, dps=None, fourier_params=(1, 1)):
     fourier_params : (Expr, Expr)
         Specifies the formula used for discrete Fourier transformation.
 
-        (1, 1) is the SymPy's defaults.
+        Different libraries or CAS may use different conventions which
+        should be taken some precaution into.
+        The conventional settings are :
 
-        (1, -1) is equivalent to the NumPy and MATLAB's default settings for
-        the ``fft`` and ``ifft``.
+        SymPy : (1, 1)
 
-        (0, 1) is equivalent to the Mathematica's default settings for
-        ``Fourier`` and ``InverseFourier``.
+        NumPy, MATLAB : (1, -1)
 
-        (0, -1) is equivalent to the Maple's default settings for
-        ``FourierTransform`` and ``InverseFourierTransform``
+        Mathematica : (0, 1)
 
-        For further information about the options and formulas, see ``Notes``
-        section.
+        Maple : (0, -1)
+
+        You may also pass the symbols to get the full symbolic result
+        for the FFT.
+        However, we also do not block you from passing the numbers which
+        may be invalid to be consider a fourier transform, or out of
+        convention.
+
+        Explicit formula is described in the notes section below.
 
     Notes
     =====

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -29,17 +29,12 @@ def _fourier_transform(seq, dps, inverse=False, fourier_params=(1, 1)):
                         "for Fourier Transform")
 
     a = [sympify(arg) for arg in seq]
-    if any(x.has(Symbol) for x in a):
-        raise ValueError("Expected non-symbolic coefficients")
 
     n = len(a)
     if n < 2:
         return a
 
     (alpha, beta) = sympify(fourier_params)
-    beta = as_int(beta)
-    if beta not in [-1, 1]:
-        raise NotImplementedError("The second fourier_params must be 1 or -1")
 
     b = n.bit_length() - 1
     if n&(n - 1): # not a power of 2

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -38,7 +38,7 @@ def _fourier_transform(seq, dps, inverse=False, fourier_params=(1, 1)):
 
     (alpha, beta) = sympify(fourier_params)
     beta = as_int(beta)
-    if beta != S.One and beta != S.NegativeOne:
+    if beta not in [-1, 1]:
         raise NotImplementedError("The second fourier_params must be 1 or -1")
 
     b = n.bit_length() - 1

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -89,8 +89,8 @@ def fft(seq, dps=None, fourier_params=(1, 1)):
     dps : Integer
         Specifies the number of decimal digits for precision.
 
-    fourier_params : (Number, Number)
-        Specifies the formula used for Fourier transformation.
+    fourier_params : (Expr, Expr)
+        Specifies the formula used for discrete Fourier transformation.
 
         (1, 1) is the SymPy's defaults.
 
@@ -105,12 +105,6 @@ def fft(seq, dps=None, fourier_params=(1, 1)):
 
         For further information about the options and formulas, see ``Notes``
         section.
-
-    Raises
-    ======
-
-    NotImplementedError :
-        If given ``fourier_params`` are not supported.
 
     Notes
     =====
@@ -141,6 +135,27 @@ def fft(seq, dps=None, fourier_params=(1, 1)):
     where `\omega_{N} = e^{2 \pi i \beta/N}`
 
     while `(\alpha,\beta)` are ``fourier_params``.
+
+    However, there may be certain restrictions which can be placed onto
+    `\alpha` and `\beta`, if you want to make your FFT scheme valid for
+    most of the context it is being used.
+    `\alpha` can work fine with any real numbers because it may only
+    scale the output result.
+    However, specifying `\beta` into zero or any number which is not
+    relatively prime to the length of the list may make the fourier
+    matrix singular, which may result in no theoritical way of inversing
+    the transform by another transform.
+    Specifying `\beta` into non-integer may result not make the fourier
+    matrix singular, but still it may not be possible to compute the
+    inverse from doing another forward transformation with negative
+    beta, and you may have to directly evaluate the inverse matrix to
+    get the original result back.
+    These behaviors may easily be observed by experimenting with our
+    library, and the conventional reason that most of the textbooks or
+    numerical libraries are setting `\beta` into `1` or `-1` is that
+    it is the most practical way of specifying the relatively-prime
+    integer without having to worry about cases where the length of the
+    the list to transform may vary.
 
     Examples
     ========

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -146,10 +146,9 @@ def fft(seq, dps=None, fourier_params=(1, 1)):
     matrix singular, which may result in no theoritical way of inversing
     the transform by another transform.
     Specifying `\beta` into non-integer may result not make the fourier
-    matrix singular, but still it may not be possible to compute the
-    inverse from doing another forward transformation with negative
-    beta, and you may have to directly evaluate the inverse matrix to
-    get the original result back.
+    matrix singular in the loose definition, but cooley-tukey scheme
+    may break and the algorithm may not yield the same result as the
+    corresponding DFT matrix with the same parameter.
     These behaviors may easily be observed by experimenting with our
     library, and the conventional reason that most of the textbooks or
     numerical libraries are setting `\beta` into `1` or `-1` is that

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -1,25 +1,60 @@
 from __future__ import print_function, division
 
-from sympy.matrices.expressions import MatrixExpr
+from sympy.core.sympify import _sympify
+from sympy.core.decorators import deprecated
+
+from .matexpr import MatrixExpr
+from .inverse import Inverse
+
 from sympy import S, I, sqrt, exp
 
-class DFT(MatrixExpr):
-    """ Discrete Fourier Transform """
+class DFTMatrix(MatrixExpr):
+    """Discrete Fourier transformation matrix"""
     n = property(lambda self: self.args[0])
     shape = property(lambda self: (self.n, self.n))
 
-    def _entry(self, i, j, **kwargs):
-        w = exp(-2*S.Pi*I/self.n)
-        return w**(i*j) / sqrt(self.n)
+    def __new__(cls, n, fourier_params=(0, -1)):
+        n = _sympify(n)
+        if n.is_number and not (n.is_integer and n.is_positive):
+            raise ValueError(
+                'Matrix size {} should be specified as a positive integer.')
+
+        (a, b) = _sympify(fourier_params)
+
+        return MatrixExpr().__new__(cls, n, a, b)
+
+    def _entry(self, i, j):
+        n = self.rows
+        a, b = self.args[1], self.args[2]
+        w = exp(2*S.Pi*I*b / n)
+
+        return w**(i*j) / sqrt(n**(1-a))
 
     def _eval_inverse(self):
-        return IDFT(self.n)
+        n = self.rows
+        a, b = self.args[1], self.args[2]
 
-class IDFT(DFT):
-    """ Inverse Discrete Fourier Transform """
-    def _entry(self, i, j, **kwargs):
-        w = exp(-2*S.Pi*I/self.n)
-        return w**(-i*j) / sqrt(self.n)
+        if b.is_number and b.is_integer:
+            if b.gcd(n) != 1:
+                raise ValueError(
+                    'The DFT Matrix with the specification is not invertible')
+            if not b.is_integer:
+                return Inverse(self)
 
-    def _eval_inverse(self):
-        return DFT(self.n)
+            return DFTMatrix(n, fourier_params=(-a, -b))
+
+@deprecated(
+    issue=99999,
+    useinstead="DFTMatrix",
+    deprecated_since_version="1.5")
+def DFT(n):
+    """Discrete Fourier transformation matrix."""
+    return DFTMatrix(n)
+
+
+@deprecated(
+    issue=99999,
+    useinstead="DFTMatrix.inverse",
+    deprecated_since_version="1.5")
+def IDFT(n):
+    return DFTMatrix(n).inverse()

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -14,13 +14,13 @@ class DFTMatrix(MatrixExpr):
     n = property(lambda self: self.args[0])
     shape = property(lambda self: (self.n, self.n))
 
-    def __new__(cls, n, a=0, b=-1)):
+    def __new__(cls, n, a=0, b=-1):
         n = _sympify(n)
         if n.is_number and not (n.is_integer and n.is_positive):
             raise ValueError(
                 'Matrix size {} should be specified as a positive integer.')
 
-        (a, b) = _sympify([a, b])
+        (a, b) = _sympify(a), _sympify(b)
 
         return MatrixExpr().__new__(cls, n, a, b)
 

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -14,26 +14,26 @@ class DFTMatrix(MatrixExpr):
     n = property(lambda self: self.args[0])
     shape = property(lambda self: (self.n, self.n))
 
-    def __new__(cls, n, fourier_params=(0, -1)):
+    def __new__(cls, n, a=0, b=-1)):
         n = _sympify(n)
         if n.is_number and not (n.is_integer and n.is_positive):
             raise ValueError(
                 'Matrix size {} should be specified as a positive integer.')
 
-        (a, b) = _sympify(fourier_params)
+        (a, b) = _sympify([a, b])
 
-        return MatrixExpr().__new__(cls, n, Tuple(a, b))
+        return MatrixExpr().__new__(cls, n, a, b)
 
     def _entry(self, i, j):
         n = self.rows
-        a, b = self.args[1][:]
+        a, b = self.args[1], self.args[2]
         w = exp(2*S.Pi*I*b / n)
 
         return w**(i*j) / sqrt(n**(1-a))
 
     def _eval_inverse(self):
         n = self.rows
-        a, b = self.args[1][:]
+        a, b = self.args[1], self.args[2]
 
         if b.is_number and b.is_integer:
             if b.gcd(n) != 1:
@@ -42,7 +42,7 @@ class DFTMatrix(MatrixExpr):
             if not b.is_integer:
                 return Inverse(self)
 
-            return DFTMatrix(n, fourier_params=(-a, -b))
+            return DFTMatrix(n, a=-a, b=-b)
 
 @deprecated(
     issue=99999,

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.sympify import _sympify
 from sympy.core.decorators import deprecated
+from sympy.core.containers import Tuple
 
 from .matexpr import MatrixExpr
 from .inverse import Inverse
@@ -21,18 +22,18 @@ class DFTMatrix(MatrixExpr):
 
         (a, b) = _sympify(fourier_params)
 
-        return MatrixExpr().__new__(cls, n, a, b)
+        return MatrixExpr().__new__(cls, n, Tuple(a, b))
 
     def _entry(self, i, j):
         n = self.rows
-        a, b = self.args[1], self.args[2]
+        a, b = self.args[1][:]
         w = exp(2*S.Pi*I*b / n)
 
         return w**(i*j) / sqrt(n**(1-a))
 
     def _eval_inverse(self):
         n = self.rows
-        a, b = self.args[1], self.args[2]
+        a, b = self.args[1][:]
 
         if b.is_number and b.is_integer:
             if b.gcd(n) != 1:

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -2,9 +2,13 @@ from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity
 from sympy.abc import n, i, j
+from sympy.utilities.pytest import warns_deprecated_sympy
+
+
 def test_dft():
-    assert DFT(4).shape == (4, 4)
-    assert ask(Q.unitary(DFT(4)))
-    assert Abs(simplify(det(Matrix(DFT(4))))) == 1
-    assert DFT(n)*IDFT(n) == Identity(n)
-    assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)
+    with warns_deprecated_sympy():
+        assert DFT(4).shape == (4, 4)
+        assert ask(Q.unitary(DFT(4)))
+        assert Abs(simplify(det(Matrix(DFT(4))))) == 1
+        assert DFT(n)*IDFT(n) == Identity(n)
+        assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -21,9 +21,9 @@ def test_dft_matrix():
     assert ask(Q.unitary(DFTMatrix(4, a=1, b=0))) == False
 
     assert ask(Q.unitary(DFTMatrix(n, a=1, b=0))) == False
-    assert ask(Q.unitary(DFTMatrix(4, a=a, b=0))) == None
+    assert ask(Q.unitary(DFTMatrix(4, a=a, b=0))) == False
     assert ask(Q.unitary(DFTMatrix(4, a=0, b=b))) == None
-    assert ask(Q.unitary(DFTMatrix(n, a=a, b=0))) == None
+    assert ask(Q.unitary(DFTMatrix(n, a=a, b=0))) == False
     assert ask(Q.unitary(DFTMatrix(n, a=1, b=b))) == False
     assert ask(Q.unitary(DFTMatrix(n, a=a, b=b))) == None
 

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,14 +1,31 @@
-from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
-from sympy.matrices.expressions.fourier import DFT, IDFT
+from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt, symbols
+from sympy.matrices.expressions.fourier import DFT, IDFT, DFTMatrix
 from sympy.matrices import det, Matrix, Identity
 from sympy.abc import n, i, j
 from sympy.utilities.pytest import warns_deprecated_sympy
 
 
-def test_dft():
+def test_deprecated_dft():
     with warns_deprecated_sympy():
         assert DFT(4).shape == (4, 4)
         assert ask(Q.unitary(DFT(4)))
         assert Abs(simplify(det(Matrix(DFT(4))))) == 1
         assert DFT(n)*IDFT(n) == Identity(n)
         assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)
+
+def test_dft_matrix():
+    n, a, b = symbols('n a b')
+    assert ask(Q.unitary(DFTMatrix(4, a=0, b=0))) == False
+    assert ask(Q.unitary(DFTMatrix(4, a=0, b=1)))
+    assert ask(Q.unitary(DFTMatrix(4, a=0, b=2))) == False
+    assert ask(Q.unitary(DFTMatrix(4, a=1, b=0))) == False
+
+    assert ask(Q.unitary(DFTMatrix(n, a=1, b=0))) == False
+    assert ask(Q.unitary(DFTMatrix(4, a=a, b=0))) == None
+    assert ask(Q.unitary(DFTMatrix(4, a=0, b=b))) == None
+    assert ask(Q.unitary(DFTMatrix(n, a=a, b=0))) == None
+    assert ask(Q.unitary(DFTMatrix(n, a=1, b=b))) == False
+    assert ask(Q.unitary(DFTMatrix(n, a=a, b=b))) == None
+
+    n = symbols('n', integer=True)
+    assert ask(Q.unitary(DFTMatrix(n, a=0, b=1))) == True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#14725

#### Brief description of what is fixed or changed

I think the formula in the references of FFT doc is not matching the actual code
https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
http://mathworld.wolfram.com/FastFourierTransform.html

It should be `-2*pi/n`, but I think the actual implementation had used `2*pi/n`.

https://github.com/sympy/sympy/blob/28d913d3cead6c5646307ffa6540b21d65059dfd/sympy/discrete/transforms.py#L50-L55

And it is giving a different result than NumPy.

<img src="https://user-images.githubusercontent.com/34944973/51424482-cfedca00-1c11-11e9-8bbc-369257956b24.png" width="300">

~~If the design should not be changed, then fourier formula should be added in the documentation, so that the users would not confuse.~~

I have added a option to customize formula for Fourier transform, so that it can be used to give consistent output as the formula used SymPy's `fourier_transform`, or some other libraries or common notations.

I have also added the exact formula in the docs.

~~I think this should be considered before merging #15787~~

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- discrete
  - Added `fourier_parameters` option for `fft`
<!-- END RELEASE NOTES -->
