### PR TITLE
Add matplotlib installation tutorial doc/readme.rst

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -12,6 +12,14 @@ and do::
 
     make html
 
+If you get **mpmath** error, install python-mpmath package::
+
+    apt-get install python-mpmath
+
+If you get **matplotlib** error, install python-matplotlib package::
+
+    apt-get install python-matplotlib
+
 and to view it, do::
 
     firefox _build/html/index.html
@@ -30,6 +38,10 @@ After that, run::
 If you get **mpmath** error, install python3-mpmath package::
 
     dnf install python3-mpmath
+
+If you get **matplotlib** error, install python3-matplotlib package::
+
+    dnf install python3-matplotlib
 
 And view it at::
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think building sphinx doc would need `matplotlib` after #15310.
And the tutorial may have to be updated about that.

Also, I think that `mpmath` package is not trivial to fedora.

#### Other comments

I have also found that the `make` package had to be installed manually. 
And `apt-get` or `dnf` should be updated to fetch the packages like python, graphviz, or it gives error.
At least it happens with minimal copy of Linux installed on my windows subsystem.

So as I think they are not always getting shipped with every Linux distributions, should they be documented?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
