### PR TITLE
Fixed Min/Max when no args are given

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -340,7 +340,10 @@ def real_root(arg, n=None, evaluate=None):
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
         if not args:
-            raise ValueError("The Max/Min functions must have arguments.")
+            if cls == Min:
+                return S.Infinity
+            if cls == Max:
+                return S.NegativeInfinity
 
         args = (sympify(arg) for arg in args)
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -340,7 +340,7 @@ def real_root(arg, n=None, evaluate=None):
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
         if not args:
-            cls._eval_no_args()
+            return cls._eval_no_args()
 
         args = (sympify(arg) for arg in args)
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -339,11 +339,6 @@ def real_root(arg, n=None, evaluate=None):
 
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
-        if not args:
-            if cls == Min:
-                return S.Infinity
-            if cls == Max:
-                return S.NegativeInfinity
 
         args = (sympify(arg) for arg in args)
 
@@ -733,6 +728,11 @@ class Max(MinMaxBase, Application):
     zero = S.Infinity
     identity = S.NegativeInfinity
 
+    def __new__(cls, *args, **assumptions):
+        if not args:
+            return S.NegativeInfinity
+        return super(Max, cls).__new__(cls, *args, **assumptions)
+
     def fdiff( self, argindex ):
         from sympy import Heaviside
         n = len(self.args)
@@ -797,6 +797,11 @@ class Min(MinMaxBase, Application):
     """
     zero = S.NegativeInfinity
     identity = S.Infinity
+
+    def __new__(cls, *args, **assumptions):
+        if not args:
+            return S.Infinity
+        return super(Min, cls).__new__(cls, *args, **assumptions)
 
     def fdiff( self, argindex ):
         from sympy import Heaviside

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -340,7 +340,7 @@ def real_root(arg, n=None, evaluate=None):
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
         if not args:
-            cls._eval_no_args()
+            cls._eval_no_args(cls)
 
         args = (sympify(arg) for arg in args)
 
@@ -730,7 +730,7 @@ class Max(MinMaxBase, Application):
     zero = S.Infinity
     identity = S.NegativeInfinity
 
-    def _eval_no_args():
+    def _eval_no_args(self):
         return S.NegativeInfinity
 
     def fdiff( self, argindex ):
@@ -798,7 +798,7 @@ class Min(MinMaxBase, Application):
     zero = S.NegativeInfinity
     identity = S.Infinity
 
-    def _eval_no_args():
+    def _eval_no_args(self):
         return S.Infinity
 
     def fdiff( self, argindex ):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -339,8 +339,6 @@ def real_root(arg, n=None, evaluate=None):
 
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
-        if not args:
-            return cls._eval_no_args()
 
         args = (sympify(arg) for arg in args)
 
@@ -730,10 +728,6 @@ class Max(MinMaxBase, Application):
     zero = S.Infinity
     identity = S.NegativeInfinity
 
-    @classmethod
-    def _eval_no_args(cls):
-        return S.NegativeInfinity
-
     def fdiff( self, argindex ):
         from sympy import Heaviside
         n = len(self.args)
@@ -798,10 +792,6 @@ class Min(MinMaxBase, Application):
     """
     zero = S.NegativeInfinity
     identity = S.Infinity
-
-    @classmethod
-    def _eval_no_args(cls):
-        return S.Infinity
 
     def fdiff( self, argindex ):
         from sympy import Heaviside

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -339,6 +339,8 @@ def real_root(arg, n=None, evaluate=None):
 
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
+        if not args:
+            cls._eval_no_args()
 
         args = (sympify(arg) for arg in args)
 
@@ -728,10 +730,8 @@ class Max(MinMaxBase, Application):
     zero = S.Infinity
     identity = S.NegativeInfinity
 
-    def __new__(cls, *args, **assumptions):
-        if not args:
-            return S.NegativeInfinity
-        return super(Max, cls).__new__(cls, *args, **assumptions)
+    def _eval_no_args():
+        return S.NegativeInfinity
 
     def fdiff( self, argindex ):
         from sympy import Heaviside
@@ -798,10 +798,8 @@ class Min(MinMaxBase, Application):
     zero = S.NegativeInfinity
     identity = S.Infinity
 
-    def __new__(cls, *args, **assumptions):
-        if not args:
-            return S.Infinity
-        return super(Min, cls).__new__(cls, *args, **assumptions)
+    def _eval_no_args():
+        return S.Infinity
 
     def fdiff( self, argindex ):
         from sympy import Heaviside

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -340,7 +340,7 @@ def real_root(arg, n=None, evaluate=None):
 class MinMaxBase(Expr, LatticeOp):
     def __new__(cls, *args, **assumptions):
         if not args:
-            cls._eval_no_args(cls)
+            cls._eval_no_args()
 
         args = (sympify(arg) for arg in args)
 
@@ -730,7 +730,8 @@ class Max(MinMaxBase, Application):
     zero = S.Infinity
     identity = S.NegativeInfinity
 
-    def _eval_no_args(self):
+    @classmethod
+    def _eval_no_args(cls):
         return S.NegativeInfinity
 
     def fdiff( self, argindex ):
@@ -798,7 +799,8 @@ class Min(MinMaxBase, Application):
     zero = S.NegativeInfinity
     identity = S.Infinity
 
-    def _eval_no_args(self):
+    @classmethod
+    def _eval_no_args(cls):
         return S.Infinity
 
     def fdiff( self, argindex ):

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -87,6 +87,7 @@ def test_Min():
 
     # lists
     assert Min() == S.Infinity
+    assert Min(x) == x
     assert Min(x, y) == Min(y, x)
     assert Min(x, y, z) == Min(z, y, x)
     assert Min(x, Min(y, z)) == Min(z, y, x)
@@ -158,6 +159,7 @@ def test_Max():
     # lists
 
     assert Max() == S.NegativeInfinity
+    assert Max(x) == x
     assert Max(x, y) == Max(y, x)
     assert Max(x, y, z) == Max(z, y, x)
     assert Max(x, Max(y, z)) == Max(z, y, x)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -86,7 +86,7 @@ def test_Min():
     assert Min(p, p_).func is Min
 
     # lists
-    raises(ValueError, lambda: Min())
+    assert Min() == S.Infinity
     assert Min(x, y) == Min(y, x)
     assert Min(x, y, z) == Min(z, y, x)
     assert Min(x, Min(y, z)) == Min(z, y, x)
@@ -157,7 +157,7 @@ def test_Max():
 
     # lists
 
-    raises(ValueError, lambda: Max())
+    assert Max() == S.NegativeInfinity
     assert Max(x, y) == Max(y, x)
     assert Max(x, y, z) == Max(z, y, x)
     assert Max(x, Max(y, z)) == Max(z, y, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15808 

#### Brief description of what is fixed or changed
Earlier Value error was raised when no args are given
```
Min()
ValueError: The Max/Min functions must have arguments.
Max()
ValueError: The Max/Min functions must have arguments.
```
Now it gives `S.Infinity` and `S.NegativeInfinity` respectively.
```
Min()
oo

Max()
-oo
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Min / Max return Infinity / NegativeInfinity when no args are given.
<!-- END RELEASE NOTES -->
