### PR TITLE
solve constant integration  for rubi_integral

### DIFF
--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -306,7 +306,8 @@ def rubi_integrate(expr, var, showsteps=False):
     Returns Integral object if unable to integrate.
     '''
     expr = S(expr)
-    if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)) or expr.as_independent(var)[1] == 0 or 1:
+    if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)) or expr.as_independent(var)[1] == (0 or 1):
+        print("true")
         return S(expr)*var
     expr = expr.replace(sym_exp, exp)
     rules_applied[:] = []

--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -3,7 +3,7 @@ matchpy = import_module("matchpy")
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.core import Integer, Float
 import inspect, re
-from sympy import powsimp
+from sympy import powsimp, S
 
 if matchpy:
     from matchpy import (Operation, CommutativeOperation, AssociativeOperation,
@@ -305,12 +305,13 @@ def rubi_integrate(expr, var, showsteps=False):
 
     Returns Integral object if unable to integrate.
     '''
+    expr = S(expr)
+    if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)) or expr.as_independent(var)[1] == 0 or 1:
+        return S(expr)*var
     expr = expr.replace(sym_exp, exp)
     rules_applied[:] = []
     expr = process_trig(expr)
     expr = rubi_powsimp(expr)
-    if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)):
-        return S(expr)*var
     if isinstance(expr, Add):
         results = 0
         for ex in expr.args:

--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -307,7 +307,6 @@ def rubi_integrate(expr, var, showsteps=False):
     '''
     expr = S(expr)
     if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)) or expr.as_independent(var)[1] == (0 or 1):
-        print("true")
         return S(expr)*var
     expr = expr.replace(sym_exp, exp)
     rules_applied[:] = []


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15554 and #15543 

#### Brief description of what is fixed or changed
Unable to integrate constant variable or independent variable

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - rubi_integrate function changed
<!-- END RELEASE NOTES -->
