### PR TITLE
Fixed imports, comments, and some bugs in printing

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -20,7 +20,7 @@ from sympy.core import S
 from sympy.core.compatibility import string_types, range
 from sympy.core.decorators import deprecated
 from sympy.codegen.ast import (
-    Assignment, Pointer, Type, Variable, Declaration,
+    Assignment, Pointer, Variable, Declaration,
     real, complex_, integer, bool_, float32, float64, float80,
     complex64, complex128, intc, value_const, pointer_const,
     int8, int16, int32, int64, uint8, uint16, uint32, uint64, untyped

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -4,7 +4,6 @@ from functools import wraps
 
 from sympy.core import Add, Mul, Pow, S, sympify, Float
 from sympy.core.basic import Basic
-from sympy.core.containers import Tuple
 from sympy.core.compatibility import default_sort_key, string_types
 from sympy.core.function import Lambda
 from sympy.core.mul import _keep_coeff

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -14,17 +14,20 @@ _name_with_digits_p = re.compile(r'^([a-zA-Z]+)([0-9]+)$')
 def split_super_sub(text):
     """Split a symbol name into a name, superscripts and subscripts
 
-       The first part of the symbol name is considered to be its actual
-       'name', followed by super- and subscripts. Each superscript is
-       preceded with a "^" character or by "__". Each subscript is preceded
-       by a "_" character.  The three return values are the actual name, a
-       list with superscripts and a list with subscripts.
+    The first part of the symbol name is considered to be its actual
+    'name', followed by super- and subscripts. Each superscript is
+    preceded with a "^" character or by "__". Each subscript is preceded
+    by a "_" character.  The three return values are the actual name, a
+    list with superscripts and a list with subscripts.
 
-       >>> from sympy.printing.conventions import split_super_sub
-       >>> split_super_sub('a_x^1')
-       ('a', ['1'], ['x'])
-       >>> split_super_sub('var_sub1__sup_sub2')
-       ('var', ['sup'], ['sub1', 'sub2'])
+    Examples
+    ========
+
+    >>> from sympy.printing.conventions import split_super_sub
+    >>> split_super_sub('a_x^1')
+    ('a', ['1'], ['x'])
+    >>> split_super_sub('var_sub1__sup_sub2')
+    ('var', ['sup'], ['sub1', 'sub2'])
 
     """
     if len(text) == 0:

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -33,6 +33,9 @@ def purestr(x):
 def styleof(expr, styles=default_styles):
     """ Merge style dictionaries in order
 
+    Examples
+    ========
+
     >>> from sympy import Symbol, Basic, Expr
     >>> from sympy.printing.dot import styleof
     >>> styles = [(Basic, {'color': 'blue', 'shape': 'ellipse'}),
@@ -54,6 +57,9 @@ def styleof(expr, styles=default_styles):
 def attrprint(d, delimiter=', '):
     """ Print a dictionary of attributes
 
+    Examples
+    ========
+
     >>> from sympy.printing.dot import attrprint
     >>> print(attrprint({'color': 'blue', 'shape': 'ellipse'}))
     "color"="blue", "shape"="ellipse"
@@ -62,6 +68,9 @@ def attrprint(d, delimiter=', '):
 
 def dotnode(expr, styles=default_styles, labelfunc=str, pos=(), repeat=True):
     """ String defining a node
+
+    Examples
+    ========
 
     >>> from sympy.printing.dot import dotnode
     >>> from sympy.abc import x
@@ -85,6 +94,9 @@ def dotedges(expr, atom=lambda x: not isinstance(x, Basic), pos=(), repeat=True)
     """ List of strings for all expr->expr.arg pairs
 
     See the docstring of dotprint for explanations of the options.
+
+    Examples
+    ========
 
     >>> from sympy.printing.dot import dotedges
     >>> from sympy.abc import x

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -23,11 +23,6 @@ from collections import defaultdict
 from itertools import chain
 import string
 
-from sympy.core import S, Add, N, Float, Symbol
-from sympy.core.compatibility import string_types, range
-from sympy.core.function import Function
-from sympy.core.relational import Eq
-from sympy.sets import Range
 from sympy.codegen.ast import (
     Assignment, Attribute, Declaration, Pointer, Type, value_const,
     float32, float64, float80, complex64, complex128, int8, int16, int32,
@@ -37,9 +32,14 @@ from sympy.codegen.fnodes import (
     allocatable, isign, dsign, cmplx, merge, literal_dp, elemental, pure,
     intent_in, intent_out, intent_inout
 )
-from sympy.printing.printer import printer_context
-from sympy.printing.codeprinter import CodePrinter, requires
+from sympy.core import S, Add, N, Float, Symbol
+from sympy.core.compatibility import string_types, range
+from sympy.core.function import Function
+from sympy.core.relational import Eq
+from sympy.sets import Range
+from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
+from sympy.printing.printer import printer_context
 
 
 known_functions = {
@@ -712,7 +712,7 @@ class FCodePrinter(CodePrinter):
             "{function_head}\n"
             "end function\n"
             "end interface"
-        ).format(function_head=self._head(entity, fp, *args))
+        ).format(function_head=self._head(entity, fp))
 
     def _print_FunctionDefinition(self, fd):
         if elemental in fd.attrs:

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -24,7 +24,7 @@ from itertools import chain
 import string
 
 from sympy.codegen.ast import (
-    Assignment, Attribute, Declaration, Pointer, Type, value_const,
+    Assignment, Declaration, Pointer, value_const,
     float32, float64, float80, complex64, complex128, int8, int16, int32,
     int64, intc, real, integer,  bool_, complex_
 )

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -1,10 +1,9 @@
-from sympy import Basic, Function, Symbol
-from sympy.printing.codeprinter import CodePrinter
-from sympy.core.function import _coeff_isneg
-from sympy.printing.precedence import precedence
-from sympy.core.compatibility import string_types, range
-from sympy.core import S
 from sympy.codegen.ast import Assignment
+from sympy.core import S
+from sympy.core.compatibility import string_types, range
+from sympy.core.function import _coeff_isneg, Lambda
+from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.precedence import precedence
 from functools import reduce
 
 known_functions = {
@@ -199,7 +198,7 @@ class GLSLPrinter(CodePrinter):
                 func = cond_func
             else:
                 for cond, func in cond_func:
-                    if cond(args):
+                    if cond(func_args):
                         break
             if func is not None:
                 try:

--- a/sympy/printing/gtk.py
+++ b/sympy/printing/gtk.py
@@ -8,7 +8,8 @@ import os
 def print_gtk(x, start_viewer=True):
     """Print to Gtkmathview, a gtk widget capable of rendering MathML.
 
-    Needs libgtkmathview-bin"""
+    Needs libgtkmathview-bin
+    """
     from sympy.utilities.mathml import c2p
 
     tmp = tempfile.mktemp()  # create a temp file to store the result

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -9,11 +9,11 @@ Math object where possible.
 
 from __future__ import print_function, division
 
-from sympy.core import S
 from sympy.codegen.ast import Assignment
+from sympy.core import S
+from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
-from sympy.core.compatibility import string_types, range
 
 
 # dictionary mapping sympy function to (argument_conditions, Javascript_function).

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -1,14 +1,9 @@
 from __future__ import print_function, division
-from distutils.version import LooseVersion as V
-
-from .str import StrPrinter
 from .pycode import (
     PythonCodePrinter,
     MpmathPrinter,  # MpmathPrinter is imported for backward compatibility
     NumPyPrinter  # NumPyPrinter is imported for backward compatibility
 )
-from sympy.core.basic import Basic
-from sympy.external import import_module
 from sympy.utilities import default_sort_key
 
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -7,13 +7,12 @@ from __future__ import print_function, division
 import itertools
 
 from sympy.core import S, Add, Symbol, Mod
-from sympy.core.sympify import SympifyError
 from sympy.core.alphabets import greeks
-from sympy.core.operations import AssocOp
 from sympy.core.containers import Tuple
+from sympy.core.function import _coeff_isneg, AppliedUndef, Derivative
+from sympy.core.operations import AssocOp
+from sympy.core.sympify import SympifyError
 from sympy.logic.boolalg import true
-from sympy.core.function import (_coeff_isneg,
-    UndefinedFunction, AppliedUndef, Derivative)
 
 ## sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
@@ -239,7 +238,7 @@ class LatexPrinter(Printer):
         specifies that this expr is the last to appear in a Mul.
         ``first=True`` specifies that this expr is the first to appear in a Mul.
         """
-        from sympy import Integral, Piecewise, Product, Sum
+        from sympy import Integral, Product, Sum
 
         if expr.is_Mul:
             if not first and _coeff_isneg(expr):
@@ -815,7 +814,6 @@ class LatexPrinter(Printer):
         else:
             symbols = self._print(tuple(symbols))
 
-        args = (symbols, self._print(expr))
         tex = r"\left( %s \mapsto %s \right)" % (symbols, self._print(expr))
 
         return tex
@@ -1481,7 +1479,7 @@ class LatexPrinter(Printer):
             return r"%s^\dagger" % self._print(mat)
 
     def _print_MatMul(self, expr):
-        from sympy import Add, MatAdd, HadamardProduct, MatMul, Mul
+        from sympy import MatMul, Mul
 
         parens = lambda x: self.parenthesize(x, precedence_traditional(expr), False)
 

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -368,6 +368,7 @@ def llvm_callable(args, expr, callback_type=None):
 
     Parameters
     ==========
+
     args : List of Symbol
         Arguments to the generated function.  Usually the free symbols in
         the expression.  Currently each one is assumed to convert to
@@ -383,10 +384,12 @@ def llvm_callable(args, expr, callback_type=None):
 
     Returns
     =======
+
     Compiled function that can evaluate the expression.
 
     Examples
     ========
+
     >>> import sympy.printing.llvmjitcode as jit
     >>> from sympy.abc import a
     >>> e = a*a + a + 1

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -4,8 +4,8 @@ Mathematica code printer
 
 from __future__ import print_function, division
 from sympy.printing.codeprinter import CodePrinter
-from sympy.printing.str import StrPrinter
 from sympy.printing.precedence import precedence
+from sympy.printing.str import StrPrinter
 
 # Used in MCodePrinter._print_Function(self)
 known_functions = {

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -6,11 +6,10 @@ from __future__ import print_function, division
 
 from sympy import sympify, S, Mul
 from sympy.core.function import _coeff_isneg
-from sympy.core.alphabets import greeks
 from sympy.core.compatibility import range
-from .printer import Printer
-from .pretty.pretty_symbology import greek_unicode
 from .conventions import split_super_sub, requires_partial
+from .pretty.pretty_symbology import greek_unicode
+from .printer import Printer
 
 
 class MathMLPrinterBase(Printer):
@@ -340,7 +339,6 @@ class MathMLContentPrinter(MathMLPrinterBase):
                 return mi
 
         # translate name, supers and subs to unicode characters
-        greek_letters = set(greeks) # make a copy
         def translate(s):
             if s in greek_unicode:
                 return greek_unicode.get(s)
@@ -748,7 +746,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 return mi
 
         # translate name, supers and subs to unicode characters
-        greek_letters = set(greeks) # make a copy
         def translate(s):
             if s in greek_unicode:
                 return greek_unicode.get(s)
@@ -868,7 +865,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mi.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
         mrow.appendChild(mi)
         for arg in e:
-            x.appendChild(self._print(arg))
+            mrow.appendChild(self._print(arg))
         return mrow
 
     def _print_AssocOp(self, e):

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -424,7 +424,7 @@ class MathMLContentPrinter(MathMLPrinterBase):
 
     def _print_Basic(self, e):
         x = self.dom.createElement(self.mathml_tag(e))
-        for arg in e:
+        for arg in e.args:
             x.appendChild(self._print(arg))
         return x
 
@@ -864,7 +864,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mi = self.dom.createElement('mi')
         mi.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
         mrow.appendChild(mi)
-        for arg in e:
+        for arg in e.args:
             mrow.appendChild(self._print(arg))
         return mrow
 

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -864,8 +864,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mi = self.dom.createElement('mi')
         mi.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
         mrow.appendChild(mi)
+        brac = self.dom.createElement('mfenced')
         for arg in e.args:
-            mrow.appendChild(self._print(arg))
+            brac.appendChild(self._print(arg))
+        mrow.appendChild(brac)
         return mrow
 
     def _print_AssocOp(self, e):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -11,10 +11,10 @@ complete source code files.
 """
 
 from __future__ import print_function, division
+from sympy.codegen.ast import Assignment
 from sympy.core import Mul, Pow, S, Rational
 from sympy.core.compatibility import string_types, range
 from sympy.core.mul import _keep_coeff
-from sympy.codegen.ast import Assignment
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -3,31 +3,26 @@ from __future__ import print_function, division
 import itertools
 
 from sympy.core import S
+from sympy.core.compatibility import range
 from sympy.core.containers import Tuple
 from sympy.core.function import _coeff_isneg
-from sympy.core.mod import Mod
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
 from sympy.core.relational import Equality
 from sympy.core.symbol import Symbol
-from sympy.printing.precedence import PRECEDENCE, precedence, precedence_traditional
-from sympy.utilities import group
-from sympy.utilities.iterables import has_variety
 from sympy.core.sympify import SympifyError
-from sympy.core.compatibility import range
-from sympy.core.add import Add
-
+from sympy.printing.conventions import requires_partial
+from sympy.printing.precedence import PRECEDENCE, precedence, precedence_traditional
 from sympy.printing.printer import Printer
 from sympy.printing.str import sstr
-from sympy.printing.conventions import requires_partial
+from sympy.utilities import default_sort_key
+from sympy.utilities.iterables import has_variety
 
 from .stringpict import prettyForm, stringPict
 from .pretty_symbology import xstr, hobj, vobj, xobj, xsym, pretty_symbol, \
     pretty_atom, pretty_use_unicode, pretty_try_use_unicode, greek_unicode, U, \
     annotated
-
-from sympy.utilities import default_sort_key
 
 # rename for usage from outside
 pprint_use_unicode = pretty_use_unicode
@@ -1026,8 +1021,6 @@ class PrettyPrinter(Printer):
         top = stringPict(" "*center.width())
         bot = stringPict(" "*center.width())
 
-        no_top = True
-        no_bot = True
         last_valence = None
         prev_map = None
 
@@ -1045,12 +1038,10 @@ class PrettyPrinter(Printer):
             else:
                 prev_map = False
             if index.is_up:
-                no_top = False
                 top = stringPict(*top.right(indpic))
                 center = stringPict(*center.right(" "*indpic.width()))
                 bot = stringPict(*bot.right(" "*indpic.width()))
             else:
-                no_bot = False
                 bot = stringPict(*bot.right(indpic))
                 center = stringPict(*center.right(" "*indpic.width()))
                 top = stringPict(*top.right(" "*indpic.width()))

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,7 +15,7 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode
-from sympy.core.compatibility import string_types, range
+from sympy.core.compatibility import string_types, range, unicode
 
 
 class stringPict(object):

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 
-import os
-from os.path import join
-import tempfile
-import shutil
 import io
 from io import BytesIO
+import os
+from os.path import join
+import shutil
+import tempfile
 
 try:
     from subprocess import STDOUT, CalledProcessError, check_output
@@ -13,12 +13,10 @@ except ImportError:
     pass
 
 from sympy.core.compatibility import unicode, u_decode
-
+from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
 from .latex import latex
-
-from sympy.utilities.decorator import doctest_depends_on
 
 __doctest_requires__ = {('preview',): ['pyglet']}
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -6,11 +6,10 @@ This module contains python code printers for plain python as well as NumPy & Sc
 
 
 from collections import defaultdict
-from functools import wraps
 from itertools import chain
-from sympy.core import sympify, S
-from .precedence import precedence
+from sympy.core import S
 from .codeprinter import CodePrinter
+from .precedence import precedence
 
 _kw_py2and3 = {
     'and', 'as', 'assert', 'break', 'class', 'continue', 'def', 'del', 'elif',
@@ -106,9 +105,6 @@ class AbstractPythonCodePrinter(CodePrinter):
         self.known_constants = dict(self._kc, **(settings or {}).get(
             'user_constants', {}))
 
-    def _get_statement(self, codestring):
-        return codestring
-
     def _declare_number_const(self, name, value):
         return "%s = %s" % (name, value)
 
@@ -126,7 +122,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         return lines
 
     def _get_statement(self, codestring):
-        return "%s" % codestring
+        return "{}".format(codestring)
 
     def _get_comment(self, text):
         return "  # {0}".format(text)
@@ -488,11 +484,10 @@ class NumPyPrinter(PythonCodePrinter):
     _kc = {k: 'numpy.'+v for k, v in _known_constants_math.items()}
 
 
-    def _print_seq(self, seq):
+    def _print_seq(self, seq, delimiter= ', '):
         "General sequence printer: converts to tuple"
         # Print tuples here instead of lists because numba supports
         #     tuples in nopython mode.
-        delimite.get('delimiter', ', ')
         return '({},)'.format(delimiter.join(self._print(item) for item in seq))
 
     def _print_MatMul(self, expr):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -484,10 +484,11 @@ class NumPyPrinter(PythonCodePrinter):
     _kc = {k: 'numpy.'+v for k, v in _known_constants_math.items()}
 
 
-    def _print_seq(self, seq, delimiter= ', '):
+    def _print_seq(self, seq):
         "General sequence printer: converts to tuple"
         # Print tuples here instead of lists because numba supports
         #     tuples in nopython mode.
+        delimiter=', '
         return '({},)'.format(delimiter.join(self._print(item) for item in seq))
 
     def _print_MatMul(self, expr):

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -10,9 +10,8 @@ using the functions defined in math.h where possible.
 
 from __future__ import print_function, division
 
-from sympy.core import S
-from sympy.core.compatibility import string_types, range
 from sympy.codegen.ast import Assignment
+from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from sympy.sets.fancysets import Range
@@ -179,13 +178,13 @@ class RCodePrinter(CodePrinter):
         return '-Inf'
 
     def _print_Assignment(self, expr):
-        from sympy.functions.elementary.piecewise import Piecewise
         from sympy.matrices.expressions.matexpr import MatrixSymbol
         from sympy.tensor.indexed import IndexedBase
         lhs = expr.lhs
         rhs = expr.rhs
         # We special case assignments that take multiple lines
         #if isinstance(expr.rhs, Piecewise):
+        #    from sympy.functions.elementary.piecewise import Piecewise
         #    # Here we modify Piecewise so each expression is now
         #    # an Assignment, and then continue on the print.
         #    expressions = []

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -9,8 +9,7 @@ from __future__ import print_function, division
 
 from sympy.core.function import AppliedUndef
 from .printer import Printer
-import mpmath.libmp as mlib
-from mpmath.libmp import repr_dps
+from mpmath.libmp import repr_dps, to_str as mlib_to_str
 from sympy.core.compatibility import range
 
 
@@ -153,7 +152,7 @@ class ReprPrinter(Printer):
         return 'Fraction(%s, %s)' % (self._print(expr.numerator), self._print(expr.denominator))
 
     def _print_Float(self, expr):
-        r = mlib.to_str(expr._mpf_, repr_dps(expr._prec))
+        r = mlib_to_str(expr._mpf_, repr_dps(expr._prec))
         return "%s('%s', precision=%i)" % (expr.__class__.__name__, r, expr._prec)
 
     def _print_Sum2(self, expr):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -9,8 +9,7 @@ from sympy.core.mul import _keep_coeff
 from .printer import Printer
 from sympy.printing.precedence import precedence, PRECEDENCE
 
-import mpmath.libmp as mlib
-from mpmath.libmp import prec_to_dps
+from mpmath.libmp import prec_to_dps, to_str as mlib_to_str
 
 from sympy.utilities import default_sort_key
 
@@ -625,7 +624,7 @@ class StrPrinter(Printer):
             strip = True
         elif self._settings["full_prec"] == "auto":
             strip = self._print_level > 1
-        rv = mlib.to_str(expr._mpf_, dps, strip_zeros=strip)
+        rv = mlib_to_str(expr._mpf_, dps, strip_zeros=strip)
         if rv.startswith('-.0'):
             rv = '-0.' + rv[3:]
         elif rv.startswith('.0'):

--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
-from sympy.core.containers import Tuple
 from sympy.core.compatibility import range
+from sympy.core.containers import Tuple
 
 from types import FunctionType
 

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,12 +1,10 @@
 from distutils.version import LooseVersion as V
-import collections
 
+from sympy import Mul
 from sympy.core.compatibility import Iterable
-from sympy.printing.printer import Printer
+from sympy.external import import_module
 from sympy.printing.precedence import PRECEDENCE
 from sympy.printing.pycode import AbstractPythonCodePrinter
-from sympy import Mul
-from sympy.external import import_module
 import sympy
 
 

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -5,15 +5,17 @@ from sympy import (sin, cos, atan2, log, exp, gamma, conjugate, sqrt,
                    sign, Mod)
 
 from sympy.codegen import For, Assignment, aug_assign
-from sympy.codegen.ast import Declaration, Type, Variable, float32, float64, value_const, real, bool_, While
+from sympy.codegen.ast import Declaration, Variable, float32, float64, \
+        value_const, real, bool_, While, FunctionPrototype, FunctionDefinition, \
+        integer, Return
+from sympy.core.compatibility import range
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or, Not, Equivalent, Xor
+from sympy.matrices import Matrix, MatrixSymbol
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import range
-from sympy.matrices import Matrix, MatrixSymbol
 
 
 def test_printmethod():
@@ -780,3 +782,26 @@ def test_While():
         '   x = x - 1\n'
         'end do'
     )
+
+
+def test_FunctionPrototype_print():
+    x = symbols('x')
+    n = symbols('n', integer=True)
+    vx = Variable(x, type=real)
+    vn = Variable(n, type=integer)
+    fp1 = FunctionPrototype(real, 'power', [vx, vn])
+    # Should be changed to proper test once multi-line generation is working
+    # see https://github.com/sympy/sympy/issues/15824
+    raises(NotImplementedError, lambda: fcode(fp1))
+
+
+def test_FunctionDefinition_print():
+    x = symbols('x')
+    n = symbols('n', integer=True)
+    vx = Variable(x, type=real)
+    vn = Variable(n, type=integer)
+    body = [Assignment(x, x**n), Return(x)]
+    fd1 = FunctionDefinition(real, 'power', [vx, vn], body)
+    # Should be changed to proper test once multi-line generation is working
+    # see https://github.com/sympy/sympy/issues/15824
+    raises(NotImplementedError, lambda: fcode(fd1))

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,6 +1,6 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
-    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix
+    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic
 from sympy.printing.mathml import mathml, MathMLContentPrinter, MathMLPresentationPrinter, \
     MathMLPrinter
 
@@ -933,3 +933,8 @@ def test_toprettyxml_hooking():
 
     assert prettyxml_old1 == doc1.toprettyxml()
     assert prettyxml_old2 == doc2.toprettyxml()
+
+def test_print_basic():
+    expr = Basic(1, 2)
+    assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mn>1</mn><mn>2</mn></mrow>'
+    assert mp.doprint(expr) == '<basic><cn>1</cn><cn>2</cn></basic>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -936,5 +936,5 @@ def test_toprettyxml_hooking():
 
 def test_print_basic():
     expr = Basic(1, 2)
-    assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mn>1</mn><mn>2</mn></mrow>'
+    assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
     assert mp.doprint(expr) == '<basic><cn>1</cn><cn>2</cn></basic>'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -2,12 +2,11 @@
 from __future__ import absolute_import
 
 from sympy.codegen import Assignment
+from sympy.codegen.ast import none
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
 from sympy.core.numbers import pi
-from sympy.codegen.ast import none
-from sympy.external import import_module
-from sympy.logic import And, Or
 from sympy.functions import acos, Piecewise, sign
+from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol
 from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
@@ -92,3 +91,16 @@ def test_issue_14283():
 
     assert prntr.doprint(zoo) == "float('nan')"
     assert prntr.doprint(-oo) == "float('-inf')"
+
+
+def test_sequences():
+    prntr = PythonCodePrinter()
+
+    assert prntr.doprint(zoo) == "float('nan')"
+    assert prntr.doprint(-oo) == "float('-inf')"
+
+
+def test_NumPyPrinter_print_seq():
+    n = NumPyPrinter()
+
+    assert n._print_seq(range(2)) == '(0, 1,)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -92,14 +92,6 @@ def test_issue_14283():
     assert prntr.doprint(zoo) == "float('nan')"
     assert prntr.doprint(-oo) == "float('-inf')"
 
-
-def test_sequences():
-    prntr = PythonCodePrinter()
-
-    assert prntr.doprint(zoo) == "float('nan')"
-    assert prntr.doprint(-oo) == "float('-inf')"
-
-
 def test_NumPyPrinter_print_seq():
     n = NumPyPrinter()
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range, is_sequence
 from sympy.external import import_module
 from sympy.printing.printer import Printer
-from sympy.core.compatibility import range, is_sequence
 import sympy
 from functools import partial
 
@@ -292,7 +292,9 @@ class TheanoPrinter(Printer):
 
         See Also
         ========
+
         theano.tensor.Tensor
+
         """
         if dtypes is None:
             dtypes = {}

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -59,7 +59,11 @@ def tree(node):
 
     It uses print_node() together with pprint_nodes() on node.args recursively.
 
-    See also: print_tree()
+    See Also
+    ========
+
+    print_tree
+
     """
     subtrees = []
     for arg in node.args:
@@ -112,6 +116,10 @@ def print_tree(node):
       transcendental: False
       zero: False
 
-    See also: tree()
+    See Also
+    ========
+
+    tree
+
     """
     print(tree(node))


### PR DESCRIPTION
 <!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Clean up of imports and documentation. Some syntax error-type of bugs were also fixed(?). At least no syntax errors anymore...

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * MathML printer now has a working fallback for Basic
   * Fortran printer for FunctionPrototype does not give a syntax error anymore (although an exception as multiline prining is not yet supported)
   * Fixed PyCode printer for sequences
<!-- END RELEASE NOTES -->
