### PR TITLE
Use assert ... is True in XFAIL tests

### DIFF
--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -38,7 +38,7 @@ def test_singular():
 
 @XFAIL
 def test_invertible_fullrank():
-    assert ask(Q.invertible(X), Q.fullrank(X))
+    assert ask(Q.invertible(X), Q.fullrank(X)) is True
 
 
 def test_symmetric():
@@ -151,10 +151,10 @@ def test_non_trivial_implies():
     X = MatrixSymbol('X', 3, 3)
     Y = MatrixSymbol('Y', 3, 3)
     assert ask(Q.lower_triangular(X+Y), Q.lower_triangular(X) &
-               Q.lower_triangular(Y))
-    assert ask(Q.triangular(X), Q.lower_triangular(X))
+               Q.lower_triangular(Y)) is True
+    assert ask(Q.triangular(X), Q.lower_triangular(X)) is True
     assert ask(Q.triangular(X+Y), Q.lower_triangular(X) &
-               Q.lower_triangular(Y))
+               Q.lower_triangular(Y)) is True
 
 def test_MatrixSlice():
     X = MatrixSymbol('X', 4, 4)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -733,9 +733,8 @@ def test_J16():
     raise NotImplementedError("diff(zeta(x), x) @ x=0 == -log(2*pi)/2")
 
 
-@XFAIL
 def test_J17():
-    assert deltaintegrate(f((x + 2)/5)*DiracDelta((x - 2)/3) - g(x)*diff(DiracDelta(x - 1), x), (x, 0, 3))
+    assert integrate(f((x + 2)/5)*DiracDelta((x - 2)/3) - g(x)*diff(DiracDelta(x - 1), x), (x, 0, 3)) == 3*f(S(4)/5) + Subs(Derivative(g(x), x), x, 1)
 
 
 @XFAIL
@@ -1158,8 +1157,8 @@ def test_N1():
 @XFAIL
 def test_N2():
     x = symbols('x', real=True)
-    assert ask(Q.is_true(x**4 - x + 1 > 0))
-    assert ask(Q.is_true(x**4 - x + 1 > 1)) == False
+    assert ask(Q.is_true(x**4 - x + 1 > 0)) is True
+    assert ask(Q.is_true(x**4 - x + 1 > 1)) is False
 
 
 @XFAIL
@@ -1170,25 +1169,25 @@ def test_N3():
 @XFAIL
 def test_N4():
     x, y = symbols('x y', real=True)
-    assert ask(Q.is_true(2*x**2 > 2*y**2), Q.is_true((x > y) & (y > 0)))
+    assert ask(Q.is_true(2*x**2 > 2*y**2), Q.is_true((x > y) & (y > 0))) is True
 
 
 @XFAIL
 def test_N5():
     x, y, k = symbols('x y k', real=True)
-    assert ask(Q.is_true(k*x**2 > k*y**2), Q.is_true((x > y) & (y > 0) & (k > 0)))
+    assert ask(Q.is_true(k*x**2 > k*y**2), Q.is_true((x > y) & (y > 0) & (k > 0))) is True
 
 
 @XFAIL
 def test_N6():
     x, y, k, n = symbols('x y k n', real=True)
-    assert ask(Q.is_true(k*x**n > k*y**n), Q.is_true((x > y) & (y > 0) & (k > 0) & (n > 0)))
+    assert ask(Q.is_true(k*x**n > k*y**n), Q.is_true((x > y) & (y > 0) & (k > 0) & (n > 0))) is True
 
 
 @XFAIL
 def test_N7():
     x, y = symbols('x y', real=True)
-    assert ask(Q.is_true(y > 0), Q.is_true((x > 1) & (y >= x - 1)))
+    assert ask(Q.is_true(y > 0), Q.is_true((x > 1) & (y >= x - 1))) is True
 
 
 @XFAIL


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Changes failing asserts in xfail tests to use `assert ... is True` rather than just `assert ...`. Otherwise the result is `assert None` which triggers a warning under pytest

#### Other comments

I raised this as an issue with `pytest`: [https://github.com/pytest-dev/pytest/issues/4639](https://github.com/pytest-dev/pytest/issues/4639).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
