### PR TITLE
Skip the test in _compilation if compiler is not installed

### DIFF
--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -48,6 +48,10 @@ def test_compile_link_import_strings():
     if not cython:
         skip("cython not installed.")
 
+    from sympy.utilities._compilation import has_c
+    if not has_c():
+        skip("No C compiler found.")
+
     compile_kw = dict(std='c99', include_dirs=[numpy.get_include()])
     info = None
     try:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #15713 

#### Brief description of what is fixed or changed

I think that this test may fail on some systems because it depends on the external C compilers.
The test should be skipped for systems without `gcc`, `icc`, or `clang`.

```
sympy.utilities._compilation.util.CompilerNotFoundError: No binary located for candidates: ['gcc', 'icc', 'clang']
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
