### PR TITLE
Remove the automatic reordering of the "notes" and "examples" sections in Sphinx

### DIFF
--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -108,10 +108,10 @@ class NumpyDocString(Mapping):
             'Attributes': [],
             'Methods': [],
             'See Also': [],
-            'Notes': [],
+            # 'Notes': [],
             'Warnings': [],
             'References': '',
-            'Examples': '',
+            # 'Examples': '',
             'index': {}
         }
         self._other_keys = []

--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -238,12 +238,10 @@ class SphinxDocString(NumpyDocString):
         for param_list in ('Other Parameters', 'Raises', 'Warns'):
             out += self._str_param_list(param_list)
         out += self._str_warnings()
-        out += self._str_see_also(func_role)
-        out += self._str_section('Notes')
-        out += self._str_references()
-        out += self._str_examples()
         for s in self._other_keys:
             out += self._str_section(s)
+        out += self._str_see_also(func_role)
+        out += self._str_references()
         out += self._str_member_list('Attributes')
         out = self._str_indent(out, indent)
         return '\n'.join(out)


### PR DESCRIPTION
There is no special formatting applied to these sections (we do not use the
plot feature of numpydoc), so there is no reason to treat them as special
headers. It's annoying to have these sections in a specific place in the
docstring and for Sphinx to move them around. For example, if you put "notes"
at the end, without this patch, it would move it to the top.

It still does reorder other sections, such as see also and references, but
these have special formatting applied to them, so it's less of an issue.
Potentially moving to napoleon would fix this (I haven't 100% confirmed). See
issue #15375.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
