### PR TITLE
Fixed call to `spoly` with too few arguments

### DIFF
--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -733,7 +733,7 @@ def is_groebner(G, ring):
     """
     for i in range(len(G)):
         for j in range(i + 1, len(G)):
-            s = spoly(G[i], G[j])
+            s = spoly(G[i], G[j], ring)
             s = s.rem(G)
             if s:
                 return False

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -5,7 +5,7 @@ from sympy.polys.groebnertools import (
     lbp, lbp_key, critical_pair,
     cp_key, is_rewritable_or_comparable,
     Sign, Polyn, Num, s_poly, f5_reduce,
-    groebner_lcm, groebner_gcd,
+    groebner_lcm, groebner_gcd, is_groebner
 )
 
 from sympy.polys.fglmtools import _representing_matrices
@@ -14,7 +14,7 @@ from sympy.polys.orderings import lex, grlex
 from sympy.polys.rings import ring, xring
 from sympy.polys.domains import ZZ, QQ
 
-from sympy.utilities.pytest import slow
+from sympy.utilities.pytest import slow, XFAIL
 from sympy.polys import polyconfig as config
 from sympy.core.compatibility import range
 
@@ -516,3 +516,14 @@ def test_groebner_gcd():
 
     assert groebner_gcd(x**2 - y**2, x - y) == x - y
     assert groebner_gcd(2*x**2 - 2*y**2, 2*x - 2*y) == x - y
+
+def test_is_groebner():
+    R, x,y = ring("x,y", QQ, grlex)
+    valid_groebner = [x**2, x*y, -QQ(1,2)*x + y**2]
+    assert is_groebner(valid_groebner, R)
+
+@XFAIL
+def test_is_groebner_xfail():
+    R, x,y = ring("x,y", QQ, grlex)
+    invalid_groebner = [x**3, x*y, -QQ(1,2)*x + y**2]
+    assert is_groebner(invalid_groebner, R)

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -14,7 +14,7 @@ from sympy.polys.orderings import lex, grlex
 from sympy.polys.rings import ring, xring
 from sympy.polys.domains import ZZ, QQ
 
-from sympy.utilities.pytest import slow, XFAIL
+from sympy.utilities.pytest import slow
 from sympy.polys import polyconfig as config
 from sympy.core.compatibility import range
 

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -520,10 +520,6 @@ def test_groebner_gcd():
 def test_is_groebner():
     R, x,y = ring("x,y", QQ, grlex)
     valid_groebner = [x**2, x*y, -QQ(1,2)*x + y**2]
-    assert is_groebner(valid_groebner, R)
-
-@XFAIL
-def test_is_groebner_xfail():
-    R, x,y = ring("x,y", QQ, grlex)
     invalid_groebner = [x**3, x*y, -QQ(1,2)*x + y**2]
-    assert is_groebner(invalid_groebner, R)
+    assert is_groebner(valid_groebner, R) is True
+    assert is_groebner(invalid_groebner, R) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The call to `spoly` in line 736 of `/sympy/polys/groebnertools.py` is made with two arguments instead of three.
I've corrected the call from `s = spoly(G[i], G[j])` to `s = spoly(G[i], G[j], ring)`

I work for Semmle and I noticed the bug with our LGTM code analyzer
https://lgtm.com/projects/g/sympy/sympy/snapshot/dist-1950035-1542114507979/files/sympy/polys/groebnertools.py?sort=name&dir=ASC&mode=heatmap#xb556b1828d679496:1

#### Other comments
I've run the tests in sympy/sympy/polys/tests/ and they pass

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * fixed a bug with a call to `spoly` in `groebnertools.py`
<!-- END RELEASE NOTES -->
