### PR TITLE
Random variables can be used as given_condition

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -594,7 +594,6 @@ def given(expr, condition=None, **kwargs):
     ------------------
              ____
          2*\/ pi
-
     """
 
     if not random_symbols(condition) or pspace_independent(expr, condition):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -726,8 +726,11 @@ def probability(condition, given_condition=None, numsamples=None,
     given_condition = sympify(given_condition)
 
     if isinstance(given_condition, RandomSymbol):
-        from sympy.stats.symbolic_probability import Probability
-        return Probability(condition, given_condition)
+        if any([dependent(rv, given_condition) for rv in random_symbols(condition)]):
+            from sympy.stats.symbolic_probability import Probability
+            return Probability(condition, given_condition)
+        else:
+            return probability(condition)
 
     if given_condition is not None and \
             not isinstance(given_condition, (Relational, Boolean)):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -726,18 +726,8 @@ def probability(condition, given_condition=None, numsamples=None,
     given_condition = sympify(given_condition)
 
     if isinstance(given_condition, RandomSymbol):
-        rand_var = given_condition
-        rvs_cond = random_symbols(condition)
-        if len(rvs_cond) > 1:
-            raise NotImplementedError("Multivariate inequalities not implemented yet.")
-        if independent(rvs_cond[0], rand_var):
-            return probability(condition, numsamples=None, evaluate=evaluate, **kwargs)
-        p_a = probability(condition, numsamples=None, evaluate=evaluate, **kwargs)
-        _t = Symbol('_t')
-        _x = Symbol('_x')
-        pdf = Lambda(_x, density(rand_var, condition)(_t)*p_a/density(rand_var)(_x))
-        return pdf
-
+        from sympy.stats.symbolic_probability import Probability
+        return Probability(condition, given_condition)
 
     if given_condition is not None and \
             not isinstance(given_condition, (Relational, Boolean)):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -586,14 +586,16 @@ def given(expr, condition=None, **kwargs):
     >>> X = Normal('X', 0, 1)
     >>> Y = Normal('Y', 0, 1)
     >>> pprint(density(X + Y, Y)(z), use_unicode=False)
-                    2
-           -(-Y + z)
-           -----------
-      ___       2
-    \/ 2 *e
-    ------------------
-             ____
-         2*\/ pi
+                           2       2
+                     -z      -z
+                     ----    ----
+    /      /z\    \   4       4       /z\
+    |- erfc|-| + 2|*e       e    *erfc|-|
+    \      \2/    /                   \2/
+    --------------------- + -------------
+               ____                ____
+           4*\/ pi             4*\/ pi
+
     """
 
     if not random_symbols(condition) or pspace_independent(expr, condition):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -613,6 +613,7 @@ def given(expr, condition=None, **kwargs):
 
         sums = 0
         for res in results:
+            res = RandomSymbol(res, rv.pspace)
             temp = expr.subs(rv, res)
             if temp == True:
                 return True
@@ -725,7 +726,7 @@ def probability(condition, given_condition=None, numsamples=None,
     given_condition = sympify(given_condition)
 
     if given_condition is not None and \
-            not isinstance(given_condition, (Relational, Boolean)):
+            not isinstance(given_condition, (Relational, Boolean, RandomSymbol)):
         raise ValueError("%s is not a relational or combination of relationals"
                 % (given_condition))
     if given_condition == False:

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -230,4 +230,5 @@ def test_issue_8129():
 
 def test_issue_12237():
     X = Normal('X', 0, 1)
-    assert P(X > 0, X) == 1/2
+    Z = P(X > 0, X)
+    assert Z == Probability(X > 0, X)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -235,4 +235,4 @@ def test_issue_12237():
     U = P(X > 0, X)
     V = P(Y < 0, X)
     assert U == Probability(X > 0, X)
-    assert V == 1/2
+    assert str(V) == '1/2'

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -232,7 +232,7 @@ def test_issue_8129():
 def test_issue_12237():
     X = Normal('X', 0, 1)
     Y = Normal('Y', 0, 1)
-    Z = P(X > 0, X)
-    assert Z == Probability(X > 0, X)
+    Y = P(X > 0, X)
     Z = P(Y < 0, X)
+    assert Y == Probability(X > 0, X)
     assert Z == 1/2

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -10,6 +10,7 @@ from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArg
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core.compatibility import range
 from sympy.abc import x
+from sympy.stats.symbolic_probability import Probability
 
 
 def test_where():

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -231,5 +231,8 @@ def test_issue_8129():
 
 def test_issue_12237():
     X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 1)
     Z = P(X > 0, X)
     assert Z == Probability(X > 0, X)
+    Z = P(Y < 0, X)
+    assert Z == 1/2

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -232,7 +232,7 @@ def test_issue_8129():
 def test_issue_12237():
     X = Normal('X', 0, 1)
     Y = Normal('Y', 0, 1)
-    Y = P(X > 0, X)
-    Z = P(Y < 0, X)
-    assert Y == Probability(X > 0, X)
-    assert Z == 1/2
+    U = P(X > 0, X)
+    V = P(Y < 0, X)
+    assert U == Probability(X > 0, X)
+    assert V == 1/2

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -227,3 +227,7 @@ def test_issue_8129():
     assert P(X >= X) == 1
     assert P(X > X) == 0
     assert P(X > X+1) == 0
+
+def test_issue_12237():
+    X = Normal('X', 0, 1)
+    assert P(X > 0, X) == 1/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #12237 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Probability can now work if random variables are
passed as given_condition. A regression test
has been added

#### Other comments
I came to know about this issue from [here](https://gitter.im/sympy/sympy).
Since no PR referenced the above issue, I have made an attempt to fix the same.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Random variable can be used as given_condition
<!-- END RELEASE NOTES -->
