### PR TITLE
Integration of Polygon gives no len() error solved

### DIFF
--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -62,16 +62,16 @@ def polytope_integrate(poly, expr=None, **kwargs):
     clockwise = kwargs.get('clockwise', False)
     max_degree = kwargs.get('max_degree', None)
 
-    if clockwise is True:
-        if isinstance(poly, Polygon):
+    isPoly = isinstance(poly, Polygon)
+    if isPoly:
+        poly = poly.vertices
+        if clockwise:
             poly = point_sort(poly)
-            if not isinstance(poly, Polygon):
-                poly = Polygon(*poly)
-        else:
+    elif clockwise:
             raise TypeError("clockwise=True works for only 2-Polytope"
                             "V-representation input")
 
-    if isinstance(poly, Polygon):
+    if isPoly:
         # For Vertex Representation(2D case)
         hp_params = hyperplane_parameters(poly)
         facets = poly.sides

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -64,7 +64,7 @@ def polytope_integrate(poly, expr=None, **kwargs):
 
     if clockwise:
         if isinstance(poly, Polygon):
-            poly = Polygon(point_sort(poly.vertices), evaluate=False)
+            poly = Polygon(*point_sort(poly.vertices), evaluate=False)
         else:
             raise TypeError("clockwise=True works for only 2-Polytope"
                             "V-representation input")

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -1009,7 +1009,12 @@ def point_sort(poly, normal=None, clockwise=True):
     >>> point_sort([Point(0, 0), Point(1, 0), Point(1, 1)])
     [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
     """
-    n = len(poly.vertices)
+    if(isinstance(poly, Polygon)):
+        n = len(poly.vertices)
+    else:
+        n = len(poly)
+        poly = Polygon(*poly)
+
     if n < 2:
         return poly
 
@@ -1017,11 +1022,11 @@ def point_sort(poly, normal=None, clockwise=True):
     dim = len(poly.vertices[0])
     if dim == 2:
         center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                       sum(map(lambda vertex: vertex.y, poly.vertices)) / n)
+                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n)
     else:
         center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                       sum(map(lambda vertex: vertex.y, poly.vertices)) / n,
-                       sum(map(lambda vertex: vertex.z, poly.vertices)) / n)
+                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n,
+                        sum(map(lambda vertex: vertex.z, poly.vertices)) / n)
 
     def compare(a, b):
         if a.x - center.x >= S.Zero and b.x - center.x < S.Zero:

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -1009,19 +1009,19 @@ def point_sort(poly, normal=None, clockwise=True):
     >>> point_sort([Point(0, 0), Point(1, 0), Point(1, 1)])
     [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
     """
-    n = len(poly)
+    n = len(poly.vertices)
     if n < 2:
         return poly
 
     order = S(1) if clockwise else S(-1)
-    dim = len(poly[0])
+    dim = len(poly.vertices[0])
     if dim == 2:
-        center = Point(sum(map(lambda vertex: vertex.x, poly)) / n,
-                       sum(map(lambda vertex: vertex.y, poly)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
+                       sum(map(lambda vertex: vertex.y, poly.vertices)) / n)
     else:
-        center = Point(sum(map(lambda vertex: vertex.x, poly)) / n,
-                       sum(map(lambda vertex: vertex.y, poly)) / n,
-                       sum(map(lambda vertex: vertex.z, poly)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
+                       sum(map(lambda vertex: vertex.y, poly.vertices)) / n,
+                       sum(map(lambda vertex: vertex.z, poly.vertices)) / n)
 
     def compare(a, b):
         if a.x - center.x >= S.Zero and b.x - center.x < S.Zero:
@@ -1055,8 +1055,9 @@ def point_sort(poly, normal=None, clockwise=True):
             return order
 
     if dim == 2:
-        return sorted(poly, key=cmp_to_key(compare))
-    return sorted(poly, key=cmp_to_key(compare3d))
+        return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare)))
+
+    return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare3d)))
 
 
 def norm(point):

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -65,6 +65,8 @@ def polytope_integrate(poly, expr=None, **kwargs):
     if clockwise is True:
         if isinstance(poly, Polygon):
             poly = point_sort(poly)
+            if not isinstance(poly, Polygon):
+                poly = Polygon(*poly)
         else:
             raise TypeError("clockwise=True works for only 2-Polytope"
                             "V-representation input")
@@ -1009,26 +1011,20 @@ def point_sort(poly, normal=None, clockwise=True):
     >>> point_sort([Point(0, 0), Point(1, 0), Point(1, 1)])
     [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
     """
-    flag = 0
-    if(isinstance(poly, Polygon)):
-        n = len(poly.vertices)
-    else:
-        flag = 1
-        n = len(poly)
-        poly = Polygon(*poly)
-
+    pts = poly.vertices if isinstance(poly, Polygon) else poly
+    n = len(pts)
     if n < 2:
-        return poly
+        return list(pts)
 
     order = S(1) if clockwise else S(-1)
-    dim = len(poly.vertices[0])
+    dim = len(pts[0])
     if dim == 2:
-        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, pts)) / n,
+                        sum(map(lambda vertex: vertex.y, pts)) / n)
     else:
-        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.z, poly.vertices)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, pts)) / n,
+                        sum(map(lambda vertex: vertex.y, pts)) / n,
+                        sum(map(lambda vertex: vertex.z, pts)) / n)
 
     def compare(a, b):
         if a.x - center.x >= S.Zero and b.x - center.x < S.Zero:
@@ -1061,15 +1057,7 @@ def point_sort(poly, normal=None, clockwise=True):
         elif dot_product > S.Zero:
             return order
 
-    if dim == 2:
-        if flag == 0:
-            return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare)))
-        else:
-            return sorted(poly.vertices, key=cmp_to_key(compare))
-    if flag == 0:
-        return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare3d)))
-    else:
-        return sorted(poly.vertices, key=cmp_to_key(compare3d))
+    return sorted(pts, key=cmp_to_key(compare if dim==2 else compare3d))
 
 
 def norm(point):

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -1009,9 +1009,11 @@ def point_sort(poly, normal=None, clockwise=True):
     >>> point_sort([Point(0, 0), Point(1, 0), Point(1, 1)])
     [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
     """
+    flag = 0
     if(isinstance(poly, Polygon)):
         n = len(poly.vertices)
     else:
+        flag = 1
         n = len(poly)
         poly = Polygon(*poly)
 
@@ -1060,9 +1062,14 @@ def point_sort(poly, normal=None, clockwise=True):
             return order
 
     if dim == 2:
-        return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare)))
-
-    return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare3d)))
+        if flag == 0:
+            return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare)))
+        else:
+            return sorted(poly.vertices, key=cmp_to_key(compare))
+    if flag == 0:
+        return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare3d)))
+    else:
+        return sorted(poly.vertices, key=cmp_to_key(compare3d))
 
 
 def norm(point):

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -62,16 +62,14 @@ def polytope_integrate(poly, expr=None, **kwargs):
     clockwise = kwargs.get('clockwise', False)
     max_degree = kwargs.get('max_degree', None)
 
-    isPoly = isinstance(poly, Polygon)
-    if isPoly:
-        poly = poly.vertices
-        if clockwise:
-            poly = point_sort(poly)
-    elif clockwise:
+    if clockwise:
+        if isinstance(poly, Polygon):
+            poly = Polygon(point_sort(poly.vertices), evaluate=False)
+        else:
             raise TypeError("clockwise=True works for only 2-Polytope"
                             "V-representation input")
 
-    if isPoly:
+    if isinstance(poly, Polygon):
         # For Vertex Representation(2D case)
         hp_params = hyperplane_parameters(poly)
         facets = poly.sides

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -1009,26 +1009,20 @@ def point_sort(poly, normal=None, clockwise=True):
     >>> point_sort([Point(0, 0), Point(1, 0), Point(1, 1)])
     [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
     """
-    flag = 0
-    if(isinstance(poly, Polygon)):
-        n = len(poly.vertices)
-    else:
-        flag = 1
-        n = len(poly)
-        poly = Polygon(*poly)
-
+    pts = poly.vertices if isinstance(poly, Polygon) else poly
+    n = len(pts)
     if n < 2:
-        return poly
+        return list(pts)
 
     order = S(1) if clockwise else S(-1)
-    dim = len(poly.vertices[0])
+    dim = len(pts[0])
     if dim == 2:
-        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, pts)) / n,
+                        sum(map(lambda vertex: vertex.y, pts)) / n)
     else:
-        center = Point(sum(map(lambda vertex: vertex.x, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.y, poly.vertices)) / n,
-                        sum(map(lambda vertex: vertex.z, poly.vertices)) / n)
+        center = Point(sum(map(lambda vertex: vertex.x, pts)) / n,
+                        sum(map(lambda vertex: vertex.y, pts)) / n,
+                        sum(map(lambda vertex: vertex.z, pts)) / n)
 
     def compare(a, b):
         if a.x - center.x >= S.Zero and b.x - center.x < S.Zero:
@@ -1061,15 +1055,7 @@ def point_sort(poly, normal=None, clockwise=True):
         elif dot_product > S.Zero:
             return order
 
-    if dim == 2:
-        if flag == 0:
-            return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare)))
-        else:
-            return sorted(poly.vertices, key=cmp_to_key(compare))
-    if flag == 0:
-        return Polygon(*sorted(poly.vertices, key=cmp_to_key(compare3d)))
-    else:
-        return sorted(poly.vertices, key=cmp_to_key(compare3d))
+    return sorted(pts, key=cmp_to_key(compare if dim==2 else compare3d))
 
 
 def norm(point):

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -3,11 +3,11 @@ from sympy import sqrt, Abs
 from sympy.core import S
 
 from sympy.integrals.intpoly import (decompose, best_origin,
-                                     polytope_integrate)
+                                     polytope_integrate, point_sort)
 
 from sympy.geometry.line import Segment2D
 from sympy.geometry.polygon import Polygon
-from sympy.geometry.point import Point
+from sympy.geometry.point import Point, Point2D
 from sympy.abc import x, y, z
 
 
@@ -489,6 +489,14 @@ def test_polytope_integrate():
         {1: 125, x: 625 / S(2), x * z: 3125 / S(4), y: 625 / S(2),
          y * z: 3125 / S(4), z ** 2: 3125 / S(3), y ** 2: 3125 / S(3),
          z: 625 / S(2), x * y: 3125 / S(4), x ** 2: 3125 / S(3)}
+
+def test_point_sort():
+    assert point_sort([Point(0, 0), Point(1, 0), Point(1, 1)]) == \
+        [Point2D(1, 1), Point2D(1, 0), Point2D(0, 0)]
+
+    fig6 = Polygon((0, 0), (1, 0), (1, 1))
+    assert polytope_integrate(fig6, x*y) == S(-1)/8
+    assert polytope_integrate(fig6, x*y, clockwise = True) == S(1)/8
 
 
 def test_polytopes_intersecting_sides():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #15843 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Integrating a function over a polygon(in intergrals/intpoly.py) it gives no method len() error. Also some more changes are made as object of Polygon() was passes as poly but was used as a list at some positions which gave error. Those are also resolved.
#### Brief description of what is fixed or changed
Earlier the output was.
![screenshot from 2019-01-26 03-12-14](https://user-images.githubusercontent.com/40005050/51774631-08613c80-2119-11e9-9b9d-2473146020bc.png)

After changing output is
![screenshot from 2019-01-26 03-13-38](https://user-images.githubusercontent.com/40005050/51774659-19aa4900-2119-11e9-9a41-8995b24d22e3.png)
 


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- integrals

   - Added functionality to pass both Polygon type object and a list to point_sort in intpoly.py

<!-- END RELEASE NOTES -->
