### PR TITLE
Fixed vector derivatives printing 

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -127,7 +127,6 @@ class VectorLatexPrinter(LatexPrinter):
             return r"\left(%s\right)" % self.doprint(der_expr)
 
         # check if expr is a dynamicsymbol
-        from sympy.core.function import AppliedUndef
         t = dynamicsymbols._t
         expr = der_expr.expr
         red = expr.atoms(AppliedUndef)
@@ -148,6 +147,10 @@ class VectorLatexPrinter(LatexPrinter):
             base = r"\ddot{%s}" % base
         elif dots == 3:
             base = r"\dddot{%s}" % base
+        elif dots == 4:
+            base = r"\ddddot{%s}" % base
+        else: # Fallback to standard printing
+            return LatexPrinter().doprint(der_expr)
         if len(base_split) is not 1:
             base += '_' + base_split[1]
         return base
@@ -161,9 +164,7 @@ class VectorPrettyPrinter(PrettyPrinter):
         # XXX use U('PARTIAL DIFFERENTIAL') here ?
         t = dynamicsymbols._t
         dot_i = 0
-        can_break = True
         syms = list(reversed(deriv.variables))
-        x = None
 
         while len(syms) > 0:
             if syms[-1] == t:
@@ -177,11 +178,17 @@ class VectorPrettyPrinter(PrettyPrinter):
                 return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
         else:
             pform = self._print_Function(deriv.expr)
+
         # the following condition would happen with some sort of non-standard
         # dynamic symbol I guess, so we'll just print the SymPy way
         if len(pform.picture) > 1:
             return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
 
+        # There are only special symbols up to fourth-order derivatives
+        if dot_i >= 5:
+            return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
+
+        # Deal with special symbols
         dots = {0 : u"",
                 1 : u"\N{COMBINING DOT ABOVE}",
                 2 : u"\N{COMBINING DIAERESIS}",

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -220,3 +220,34 @@ def test_issue_13354():
     expected = """(a + b) a_x + (b + c) a_y + (a + c) a_z"""
 
     assert ascii_vpretty(z) == expected
+
+def test_vector_derivative_printing():
+    # First order tested above
+
+    # Second order
+    v = omega.diff().diff() * N.x
+
+    assert v._latex() == r'\ddot{\omega}\mathbf{\hat{n}_x}'
+    assert unicode_vpretty(v) == 'ω̈ n_x'
+    assert ascii_vpretty(v) == 'omëga n_x'
+
+    # Third order
+    v = omega.diff().diff().diff() * N.x
+
+    assert v._latex() == r'\dddot{\omega}\mathbf{\hat{n}_x}'
+    assert unicode_vpretty(v) == 'ω⃛ n_x'
+    assert ascii_vpretty(v) == 'ome⃛ga n_x'
+
+    # Fourth order
+    v = omega.diff().diff().diff().diff() * N.x
+
+    assert v._latex() == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
+    assert unicode_vpretty(v) == 'ω⃜ n_x'
+    assert ascii_vpretty(v) == 'ome⃜ga n_x'
+
+    # Fifth order
+    v = omega.diff().diff().diff().diff().diff() * N.x
+
+    assert v._latex() == r'\frac{d^{5}}{d t^{5}} \omega{\left (t \right )}\mathbf{\hat{n}_x}'
+    assert unicode_vpretty(v) == '  5\n d\n───(ω) n_x\n  5\ndt'
+    assert ascii_vpretty(v) == '  5\n d\n---(omega) n_x\n  5\ndt'

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -228,26 +228,26 @@ def test_vector_derivative_printing():
     v = omega.diff().diff() * N.x
 
     assert v._latex() == r'\ddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω̈ n_x'
-    assert ascii_vpretty(v) == 'omëga n_x'
+    assert unicode_vpretty(v) == u('ω̈ n_x')
+    assert ascii_vpretty(v) == u('omëga n_x')
 
     # Third order
     v = omega.diff().diff().diff() * N.x
 
     assert v._latex() == r'\dddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃛ n_x'
-    assert ascii_vpretty(v) == 'ome⃛ga n_x'
+    assert unicode_vpretty(v) == u('ω⃛ n_x')
+    assert ascii_vpretty(v) == u('ome⃛ga n_x')
 
     # Fourth order
     v = omega.diff().diff().diff().diff() * N.x
 
     assert v._latex() == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃜ n_x'
-    assert ascii_vpretty(v) == 'ome⃜ga n_x'
+    assert unicode_vpretty(v) == u('ω⃜ n_x')
+    assert ascii_vpretty(v) == u('ome⃜ga n_x')
 
     # Fifth order
     v = omega.diff().diff().diff().diff().diff() * N.x
 
-    assert v._latex() == r'\frac{d^{5}}{d t^{5}} \omega{\left (t \right )}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == '  5\n d\n───(ω) n_x\n  5\ndt'
+    assert v._latex() == r'\frac{d^{5}}{d t^{5}} \omega{\left(t \right)}\mathbf{\hat{n}_x}'
+    assert unicode_vpretty(v) == u('  5\n d\n───(ω) n_x\n  5\ndt')
     assert ascii_vpretty(v) == '  5\n d\n---(omega) n_x\n  5\ndt'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #10173

#### Brief description of what is fixed or changed
Fixed the fourth-order printing issue.

This has been attempted in #10283 and #15022 but no unit tests were added. It wasn't clear which one of these I should base it on, but as seen, the current PR deals with higher order derivatives as well. And fixes some unused/redundant imports.

#### Other comments
I choose to keep two separate `if`-clauses to make the comments stand alone, while the newly added `if dot_i >= 5:` could easily have been added with the previous `if`.

The result looks different in different renders, see https://github.com/sympy/sympy/issues/14425#issuecomment-457834386 Hence, it may look a bit "ugly" in certain circumstances.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
   * printing of arbitrary order vector derivatives is fixed
<!-- END RELEASE NOTES -->
