### PR TITLE
change returnd nan value to None for summation

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -192,6 +192,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 f = -f
 
             newf = eval_sum(f, (i, a, b))
+            if newf is S.NaN:
+                newf = None
             if newf is None:
                 if f == self.function:
                     zeta_function = self.eval_zeta_function(f, (i, a, b))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #15838
#### Brief description of what is fixed or changed
This Equation is returning nan because it is unable to solve this summation for the general term so returning nan. So I just change nan to S.NaN  so that now it is returning the expression.

#### Other comments
For general term summation it is not working but for the range of value(like (2,10), it is working because it calculates manually.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - change nan to S.NaN 
<!-- END RELEASE NOTES -->
