### PR TITLE
corrected truth value of Unequality(Ne) for simplify

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -524,7 +524,8 @@ class Unequality(Relational):
             ratio, measure, rational, inverse)
         if isinstance(eq, Equality):
             eq = self.func(*eq.args)
-        return eq
+            return eq
+        return ~eq
 
 Ne = Unequality
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -520,12 +520,13 @@ class Unequality(Relational):
         return set()
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
+        # simplify as an equality
         eq = Equality(*self.args)._eval_simplify(
             ratio, measure, rational, inverse)
         if isinstance(eq, Equality):
-            eq = self.func(*eq.args)
-            return eq
-        return ~eq
+            # send back Ne with the new args
+            return self.func(*eq.args)
+        return ~eq  # result of Ne is ~Eq
 
 Ne = Unequality
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -802,3 +802,7 @@ def test_Equality_rewrite_as_Add():
     assert eq.rewrite(Add) == 2*x
     assert eq.rewrite(Add, evaluate=None).args == (x, x, y, -y)
     assert eq.rewrite(Add, evaluate=False).args == (x, y, x, -y)
+
+def test_issue_15847():
+    a = Ne(x*(x+y), x**2 + x*y)
+    assert simplify(a) == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15847 

#### Brief description of what is fixed or changed
simplify of Ne is giving True after simplification of a = Ne(x*(x+y), x**2 + x*y)(look above issue)
so I just change change little bit simplify function in relation so that it should give False.

#### Other comment
I have done edits based on above issue .
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
   - change simplify function for Ne.
<!-- END RELEASE NOTES -->
