### PR TITLE
Fixed summation in summation(x**y*y, (y, -oo, oo)).doit() to prevent infinite loop

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1163,7 +1163,7 @@ def eval_sum_hyper(f, i_a_b):
                 return None
             (res1, cond1), (res2, cond2) = res1, res2
             cond = And(cond1, cond2)
-            if cond != True:
+            if cond == False:
                 return None
             return Piecewise((res1 - res2, cond), (old_sum, True))
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1175,7 +1175,7 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond == False or cond._eval_as_set() == S.EmptySet:
+        if cond == False or cond.as_set() == S.EmptySet:
             return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1175,8 +1175,13 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond != True:
+        if cond == False:
             return None
+        if cond._eval_as_set() == S.EmptySet:
+            if f.subs(i, 0) == 0:
+                return eval_sum_hyper(f, (i, a, S(-1))) + eval_sum_hyper(f, (i, S(1), b))
+            else:
+                return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 
     # Now b == oo, a != -oo

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1163,7 +1163,7 @@ def eval_sum_hyper(f, i_a_b):
                 return None
             (res1, cond1), (res2, cond2) = res1, res2
             cond = And(cond1, cond2)
-            if cond == False:
+            if cond != True:
                 return None
             return Piecewise((res1 - res2, cond), (old_sum, True))
 
@@ -1175,7 +1175,7 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond == False:
+        if cond != True:
             return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1175,13 +1175,8 @@ def eval_sum_hyper(f, i_a_b):
         res1, cond1 = res1
         res2, cond2 = res2
         cond = And(cond1, cond2)
-        if cond == False:
+        if cond == False or cond._eval_as_set() == S.EmptySet:
             return None
-        if cond._eval_as_set() == S.EmptySet:
-            if f.subs(i, 0) == 0:
-                return eval_sum_hyper(f, (i, a, S(-1))) + eval_sum_hyper(f, (i, S(1), b))
-            else:
-                return None
         return Piecewise((res1 + res2, cond), (old_sum, True))
 
     # Now b == oo, a != -oo

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1078,3 +1078,6 @@ def test_Sum_dummy_eq():
     assert Sum(x, (x, a, c)).dummy_eq(Sum(y, (y, a, c)))
     assert Sum(x, (x, a, d)).dummy_eq(Sum(y, (y, a, c)), c)
     assert not Sum(x, (x, a, d)).dummy_eq(Sum(y, (y, a, c)))
+
+def test_issue_15852():
+    assert summation(x**y*y, (y, -oo, oo)).doit() == Sum(x**y*y, (y, -oo, oo))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15852 

#### Brief description of what is fixed or changed
Earlier 
```
from sympy import symbols, summation, oo
y = symbols('y', integer=True)
x = symbols('x')
summation(x**y*y, (y, -oo, oo)).doit()
```
stucked in infinite loop due to condition in `eval_sum_hyper`

Now 
```
from sympy import symbols, summation, oo
y = symbols('y', integer=True)
x = symbols('x')
summation(x**y*y, (y, -oo, oo)).doit()
Sum(x**y*y, (y, -oo, oo))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * fixed a bug in `eval_sum_hyper` 
<!-- END RELEASE NOTES -->
