### PR TITLE
Add Python 3.7 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 matrix:
   include:
@@ -32,7 +33,7 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
-    - python: 3.6
+    - python: 3.7
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
@@ -47,7 +48,7 @@ matrix:
             - gfortran
             - python-scipy
 
-    - python: 3.6
+    - python: 3.7
       env:
         - TEST_SPHINX="true"
         - FASTCACHE="false"
@@ -78,15 +79,15 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
-    - python: 3.6
+    - python: 3.7
       env:
         - TEST_SLOW="true"
         - SPLIT="1/3"
-    - python: 3.6
+    - python: 3.7
       env:
         - TEST_SLOW="true"
         - SPLIT="2/3"
-    - python: 3.6
+    - python: 3.7
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       sudo: true
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
         - TEST_SAGE="true"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,10 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
-    - python: 3.7
-      dist: xenial
-      sudo: true
+    - python: 3.6
+      # This is actually 3.7 (once all the dependencies support it). We use
+      # python: 3.6 here because 3.7 requires the slower xenial/sudo: true container,
+      # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
       # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
         - TEST_SAGE="true"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7"
       addons:
         apt:
           packages:
@@ -263,7 +263,7 @@ before_install:
         conda config --prepend channels conda-forge --prepend channels symengine/label/dev;
 
         conda info -a;
-        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION ${TEST_OPT_DEPENDENCY};
+        conda create -q -n test-environment ${TEST_OPT_DEPENDENCY};
         source activate test-environment;
         export CPATH=$CONDA_PREFIX/include;
         export LIBRARY_PATH=$CONDA_PREFIX/lib;

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,8 @@ matrix:
         - TEST_SLOW="true"
         - SPLIT="2/3"
     - python: 3.7
+      dist: xenial
+      sudo: true
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,35 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
 
 matrix:
   include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="1/4" TEST_SYMPY="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="2/4" TEST_SYMPY="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="3/4" TEST_SYMPY="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="4/4" TEST_SYMPY="true"
+
     - python: 2.7
       env:
         - TEST_ASCII="true"
@@ -34,6 +59,8 @@ matrix:
             - liblapack-dev
             - gfortran
     - python: 3.7
+      dist: xenial
+      sudo: true
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle"
@@ -49,6 +76,8 @@ matrix:
             - python-scipy
 
     - python: 3.7
+      dist: xenial
+      sudo: true
       env:
         - TEST_SPHINX="true"
         - FASTCACHE="false"
@@ -80,10 +109,14 @@ matrix:
         - TEST_SLOW="true"
         - SPLIT="3/3"
     - python: 3.7
+      dist: xenial
+      sudo: true
       env:
         - TEST_SLOW="true"
         - SPLIT="1/3"
     - python: 3.7
+      dist: xenial
+      sudo: true
       env:
         - TEST_SLOW="true"
         - SPLIT="2/3"

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -47,8 +47,10 @@ mkdir empty
 cd empty
 
 if [[ "${TEST_ASCII}" == "true" ]]; then
-    export OLD_LC_ALL=$LC_ALL
-    export LC_ALL=C
+    # Force Python to act like pre-3.7 where LC_ALL=C causes
+    # UnicodeEncodeErrors. Once the lowest Python version we support is 3.7,
+    # we can consider dropping this test entirely. See PEP 538.
+    export PYTHONIOENCODING=ascii:strict
     cat <<EOF | python
 print('Testing ASCII')
 try:
@@ -61,7 +63,6 @@ import sympy
 if not (sympy.test('print') and sympy.doctest()):
     raise Exception('Tests failed')
 EOF
-    export LC_ALL=$OLD_LC_ALL
 fi
 
 if [[ "${TEST_DOCTESTS}" == "true" ]]; then


### PR DESCRIPTION
This also moves all the 3.6-only builds like optional dependency, docs, and
slow tests from 3.6 to 3.7.

Note: I'm not 100% sure this will work. I think all the conda packages from the optional dependency build should be available for 3.7, but I'm not positive, especially for Sage. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
