### PR TITLE
More numerically stable nullity-chain construction for jordan_block

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1549,18 +1549,15 @@ class MatrixEigen(MatrixSubspaces):
             i = 1
             while True:
                 nullity = cols - eig_mat(val, i).rank()
+
+                # Raise exceptions during runtime if encountered
+                # wrong results
                 if nullity > algebraic_multiplicity:
-                    # Nullity must not exceed algebraic multiplicity.
-                    # But if it happens with bad zero testing, The
-                    # computation must be aborted
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "
                         "result while computing Jordan block: "
                         "{}".format(self))
                 if nullity <= ret[-1]:
-                    # Nullity must always increase until the
-                    # algebraic multiplicity is met. But wrong
-                    # result may have to be caught in Runtime.
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "
                         "result while computing Jordan block: "

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1628,6 +1628,9 @@ class MatrixEigen(MatrixSubspaces):
                 (eig, size) for size, num in size_nums for _ in range(num))
 
         jordan_form_size = sum(size for eig, size in block_structure)
+
+        # XXX Added runtime check. Must improve rank computation
+        # for matrices with complex numbers or symbols.
         if jordan_form_size != self.rows:
             raise MatrixError(
                 "SymPy had encountered an inconsistent result while "

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1550,14 +1550,9 @@ class MatrixEigen(MatrixSubspaces):
             while True:
                 nullity = cols - eig_mat(val, i).rank()
 
-                # Raise exceptions during runtime if encountered
-                # wrong results
-                if nullity > algebraic_multiplicity:
-                    raise MatrixError(
-                        "SymPy had encountered an inconsistent "
-                        "result while computing Jordan block: "
-                        "{}".format(self))
-                if nullity <= ret[-1]:
+                # XXX Added runtime check. Must improve rank computation
+                # for matrices with complex numbers or symbols.
+                if nullity > algebraic_multiplicity or nullity <= ret[-1]:
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "
                         "result while computing Jordan block: "

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1554,6 +1554,8 @@ class MatrixEigen(MatrixSubspaces):
                 nullity = cols - eig_mat(val, i).rank()
                 i += 1
 
+                # XXX Added runtime check. Must improve rank computation
+                # for matrices with complex numbers or symbols.
                 if nullity < ret[-1] or nullity > algebraic_multiplicity:
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1554,8 +1554,9 @@ class MatrixEigen(MatrixSubspaces):
                 nullity = cols - eig_mat(val, i).rank()
                 i += 1
 
-                # XXX Added runtime check. Must improve rank computation
-                # for matrices with complex numbers or symbols.
+                # Due to issues like #7146 and #15872, SymPy sometimes
+                # gives the wrong rank. In this case, raise an error
+                # instead of returning an incorrect matrix
                 if nullity < ret[-1] or nullity > algebraic_multiplicity:
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "
@@ -1629,8 +1630,6 @@ class MatrixEigen(MatrixSubspaces):
 
         jordan_form_size = sum(size for eig, size in block_structure)
 
-        # XXX Added runtime check. Must improve rank computation
-        # for matrices with complex numbers or symbols.
         if jordan_form_size != self.rows:
             raise MatrixError(
                 "SymPy had encountered an inconsistent result while "

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1546,26 +1546,32 @@ class MatrixEigen(MatrixSubspaces):
             cols = self.cols
             ret = [0]
 
-            nullity_prev = 0
             i = 1
             while True:
-                nullity_next = cols - eig_mat(val, i).rank()
-
-                monotonic_check = nullity_next == nullity_prev
-                multiplicity_check = nullity_prev == algebraic_multiplicity
-
-                if monotonic_check is True and multiplicity_check is True:
-                    break
-                elif monotonic_check is False and multiplicity_check is False:
-                    ret.append(nullity_next)
-                    nullity_prev = nullity_next
-                    i += 1
-                    continue
-                else:
+                nullity = cols - eig_mat(val, i).rank()
+                if nullity > algebraic_multiplicity:
+                    # Nullity must not exceed algebraic multiplicity.
+                    # But if it happens with bad zero testing, The
+                    # computation must be aborted
                     raise MatrixError(
-                        "SymPy had encountered an inconsistent result while "
-                        "computing Jordan block."
-                        )
+                        "SymPy had encountered an inconsistent "
+                        "result while computing Jordan block: "
+                        "{}".format(self))
+                if nullity <= ret[-1]:
+                    # Nullity must always increase until the
+                    # algebraic multiplicity is met. But wrong
+                    # result may have to be caught in Runtime.
+                    raise MatrixError(
+                        "SymPy had encountered an inconsistent "
+                        "result while computing Jordan block: "
+                        "{}".format(self))
+
+                # Normal behavior
+                ret.append(nullity)
+                if nullity == algebraic_multiplicity:
+                    break
+                else:
+                    i += 1
 
             return ret
 
@@ -1636,7 +1642,7 @@ class MatrixEigen(MatrixSubspaces):
         if jordan_form_size != self.rows:
             raise MatrixError(
                 "SymPy had encountered an inconsistent result while "
-                "computing Jordan block.")
+                "computing Jordan block. : {}".format(self))
 
         blocks = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structure)
         jordan_mat = mat.diag(*blocks)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1545,25 +1545,20 @@ class MatrixEigen(MatrixSubspaces):
             # so use the rank-nullity theorem
             cols = self.cols
             ret = [0]
-
-            i = 1
-            while True:
+            nullity = cols - eig_mat(val, 1).rank()
+            i = 2
+            while nullity != ret[-1]:
+                ret.append(nullity)
+                if nullity == algebraic_multiplicity:
+                    break
                 nullity = cols - eig_mat(val, i).rank()
+                i += 1
 
-                # XXX Added runtime check. Must improve rank computation
-                # for matrices with complex numbers or symbols.
-                if nullity > algebraic_multiplicity or nullity <= ret[-1]:
+                if nullity < ret[-1] or nullity > algebraic_multiplicity:
                     raise MatrixError(
                         "SymPy had encountered an inconsistent "
                         "result while computing Jordan block: "
                         "{}".format(self))
-
-                # Normal behavior
-                ret.append(nullity)
-                if nullity == algebraic_multiplicity:
-                    break
-                else:
-                    i += 1
 
             return ret
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1563,7 +1563,7 @@ class MatrixEigen(MatrixSubspaces):
                     continue
                 else:
                     raise MatrixError(
-                        "SymPy had encountered an inconsistent result while"
+                        "SymPy had encountered an inconsistent result while "
                         "computing Jordan block."
                         )
 
@@ -1635,7 +1635,7 @@ class MatrixEigen(MatrixSubspaces):
         jordan_form_size = sum(size for eig, size in block_structure)
         if jordan_form_size != self.rows:
             raise MatrixError(
-                "SymPy had encountered an inconsistent result while"
+                "SymPy had encountered an inconsistent result while "
                 "computing Jordan block.")
 
         blocks = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structure)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1538,19 +1538,22 @@ class MatrixEigen(MatrixSubspaces):
             return mat_cache[(val, pow)]
 
         # helper functions
-        def nullity_chain(val):
+        def nullity_chain(val, algebraic_multiplicity):
             """Calculate the sequence  [0, nullity(E), nullity(E**2), ...]
             until it is constant where ``E = self - val*I``"""
             # mat.rank() is faster than computing the null space,
             # so use the rank-nullity theorem
             cols = self.cols
             ret = [0]
-            nullity = cols - eig_mat(val, 1).rank()
-            i = 2
-            while nullity != ret[-1]:
-                ret.append(nullity)
+
+            i = 1
+            while True:
                 nullity = cols - eig_mat(val, i).rank()
-                i += 1
+                ret.append(nullity)
+                if nullity == algebraic_multiplicity:
+                    break
+                else:
+                    i += 1
             return ret
 
         def blocks_from_nullity_chain(d):
@@ -1602,7 +1605,8 @@ class MatrixEigen(MatrixSubspaces):
 
         block_structure = []
         for eig in sorted(eigs.keys(), key=default_sort_key):
-            chain = nullity_chain(eig)
+            algebraic_multiplicity = eigs[eig]
+            chain = nullity_chain(eig, algebraic_multiplicity)
             block_sizes = blocks_from_nullity_chain(chain)
             # if block_sizes == [a, b, c, ...], then the number of
             # Jordan blocks of size 1 is a, of size 2 is b, etc.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1845,15 +1845,22 @@ def test_issue_10220():
                         [0, 0, 0, 1]])
 
 def test_jordan_form_issue_15858():
-    # q is too complicated for inverting if not simplified
-    A = ImmutableMatrix(
-        [[1, 1, 1, 0], [-2, -1, 0, -1],
-        [0, 0, -1, -1], [0, 0, 2, 1]]
-        )
+    A = Matrix([
+        [1, 1, 1, 0],
+        [-2, -1, 0, -1],
+        [0, 0, -1, -1],
+        [0, 0, 2, 1]])
     (P, J) = A.jordan_form()
-    P = P.simplify()
-    PJP = (P * J * P.inv()).simplify()
-    assert PJP == A
+    assert simplify(P) == Matrix([
+        [-I, -I/2, I, I/2],
+        [-1 + I, 0, -1 - I, 0],
+        [0, I*(-1 + I)/2, 0, I*(1 + I)/2],
+        [0, 1, 0, 1]])
+    assert J == Matrix([
+        [-I, 1, 0, 0],
+        [0, -I, 0, 0],
+        [0, 0, I, 1],
+        [0, 0, 0, I]])
 
 def test_Matrix_berkowitz_charpoly():
     UA, K_i, K_w = symbols('UA K_i K_w')

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1844,6 +1844,16 @@ def test_issue_10220():
                         [0, 0, 1, 0],
                         [0, 0, 0, 1]])
 
+def test_jordan_form_issue_15858():
+    # q is too complicated for inverting if not simplified
+    A = ImmutableMatrix(
+        [[1, 1, 1, 0], [-2, -1, 0, -1],
+        [0, 0, -1, -1], [0, 0, 2, 1]]
+        )
+    (P, J) = A.jordan_form()
+    P = P.simplify()
+    PJP = (P * J * P.inv()).simplify()
+    assert PJP == A
 
 def test_Matrix_berkowitz_charpoly():
     UA, K_i, K_w = symbols('UA K_i K_w')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#15858

#### Brief description of what is fixed or changed

I think the issue #15858 may have originated from the `rref` issues, as I think that the nullity check had gone wrong like

```
>>>from sympy import *
>>>A = ImmutableMatrix([[1, 1, 1, 0], [-2, -1, 0, -1], [0, 0, -1, -1], [0, 0, 2, 1]])
eMat = A - Matrix.eye(4) * I
```
```
>>>(eMat * eMat * eMat).simplify().nullspace()
[Matrix([
 [-(-16 - 16*I)*(-4 - 4*I)*(4 - 4*I)/1024],
 [                                      1],
 [                                      0],
 [                                      0]]), Matrix([
 [-(-4 - 4*I)*(4 - 4*I)*(32 + (-2 + 6*I)*(4 + 4*I))/1024],
 [                                                     0],
 [                                          -(4 - 4*I)/8],
 [                                                     1]])]
```
```
>>>(eMat * eMat * eMat).nullspace()
[Matrix([
 [-(-4 - 4*I)*(-2 + (1 - I)**2 - 2*I*(-1 - I))/32],
 [                                              1],
 [                                              0],
 [                                              0]])]
```

And it may had caused the nullity chain to form like `[0, 1, 2, 1, 2]`, where it had gone down from 2 to 1, while for the right answer, it should only go up or stand still.

Though this won't fix the issue fundamentally, I would propose a different approach of checking to compare the nullity (geometric multiplicity) with algebraic multiplicity directly, so that it will stop computing once the algebraic multiplicity gets matched with geometric multiplicity, and in this way, the cases like previous one may not happen.

I think the reason that it had gone more unstable, was because of the change
[from](https://github.com/sympy/sympy/blame/1a5593f0fe46668bd4d0dc89440f342ed6fc4a16/sympy/matrices/matrices.py#L3852-L3853)

```
                while a_new > a[
                    -1]:  # as long as the nullspaces increase compute further powers
```
to

https://github.com/sympy/sympy/blob/97aeed33d99fabd4975c8e4fa6b322b4f87072b5/sympy/matrices/matrices.py#L3420

where it seems like it had changed from greater-than comparison to not-equal comparison.

While both may be theoretically correct, I think prior one may be more underdetermiation than the latter one, Though I would support the direct comparison with algebraic multiplicity if the reason should be.

#### Other comments

I also find that even if the computation succeeds, basis matrix is too complicated
![image](https://user-images.githubusercontent.com/34944973/51816573-7b7dd500-230a-11e9-8f29-b338787bb5ff.png)
And I think it may take too long to compute inverses, or even fail.

Test seems like taking more than 10 seconds even with `simplify()`

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed possible cases where `jordan_form` can compute wrong result.
<!-- END RELEASE NOTES -->
