### PR TITLE
Logic: Add `canonical` property to `Not`

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -418,10 +418,6 @@ class BooleanFunction(Application, Boolean):
             rational=rational, inverse=inverse) for a in self.args])
         return simplify_logic(rv)
 
-    @property
-    def canonical(self):
-        return self.func(getattr(self.args[0], 'canonical', self.args[0]))
-
     def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         return self._eval_simplify(ratio, measure, rational, inverse)
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -418,6 +418,10 @@ class BooleanFunction(Application, Boolean):
             rational=rational, inverse=inverse) for a in self.args])
         return simplify_logic(rv)
 
+    @property
+    def canonical(self):
+        return self.func(getattr(self.args[0], 'canonical', self.args[0]))
+
     def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         return self._eval_simplify(ratio, measure, rational, inverse)
 
@@ -735,10 +739,6 @@ class Not(BooleanFunction):
             return StrictGreaterThan(*arg.args)
         if isinstance(arg, GreaterThan):
             return StrictLessThan(*arg.args)
-
-    @property
-    def canonical(self):
-        return self.func(getattr(self.args[0], 'canonical', self.args[0]))
 
     def _eval_as_set(self):
         """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -738,7 +738,7 @@ class Not(BooleanFunction):
 
     @property
     def canonical(self):
-        return self
+        return self.func(getattr(self.args[0], 'canonical', self.args[0]))
 
     def _eval_as_set(self):
         """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -546,7 +546,10 @@ class And(LatticeOp, BooleanFunction):
                 c = x.canonical
                 if c in rel:
                     continue
-                nc = (~c).canonical
+                nc = ~c
+                if not isinstance(nc, Relational):
+                    continue
+                nc = nc.canonical
                 if any(r == nc for r in rel):
                     return [S.false]
                 rel.append(c)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -736,6 +736,10 @@ class Not(BooleanFunction):
         if isinstance(arg, GreaterThan):
             return StrictLessThan(*arg.args)
 
+    @property
+    def canonical(self):
+        return self
+
     def _eval_as_set(self):
         """
         Rewrite logic operators and relationals in terms of real sets.

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -114,7 +114,6 @@ def test_Not():
     assert Not(0) is true
     assert Not(1) is false
     assert Not(2) is false
-    assert Not(A).canonical == Not(A)
 
 
 def test_Nand():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -114,6 +114,9 @@ def test_Not():
     assert Not(0) is true
     assert Not(1) is false
     assert Not(2) is false
+    assert Not(A).canonical == Not(A)
+    e = A > 1
+    assert Not(e).canonical == Not(e)
 
 
 def test_Nand():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -115,8 +115,6 @@ def test_Not():
     assert Not(1) is false
     assert Not(2) is false
     assert Not(A).canonical == Not(A)
-    e = A > 1
-    assert Not(e).canonical == Not(e)
 
 
 def test_Nand():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The `_new_args_filter` for `And` and `Or` calls `(~c).canonical` explicitly,
which cause `AttributeError`s because that property is not implemented.

To trigger the error, try the following snippet:
```
from sympy import *
a, b, c, d = symbols('a b c d')
expr = (a > b) & (b > c)

with evaluate(False):
    print(expr.xreplace({b: d}))
```

#### Other comments
I'm not 100% that this is the preferred way to fix this, but it highlights the issue and contains one very simple solution. If there is a better way to prevent the given example from triggering an `AttributeError`, please let me know.

<!-- BEGIN RELEASE NOTES -->
* logic
  * Added canonical property to Not
<!-- END RELEASE NOTES -->