### PR TITLE
[WIP] Fixing is_zero for complex numbers in Add

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -534,36 +534,14 @@ class Add(Expr, AssocOp):
             # issue 10528: there is no way to know if a nc symbol
             # is zero or not
             return
-        nz = []
-        z = 0
-        im_or_z = False
-        im = False
-        for a in self.args:
-            if a.is_real:
-                if a.is_zero:
-                    z += 1
-                elif a.is_zero is False:
-                    nz.append(a)
-                else:
-                    return
-            elif a.is_imaginary:
-                im = True
-            elif (S.ImaginaryUnit*a).is_real:
-                im_or_z = True
-            else:
-                return
-        if z == len(self.args):
-            return True
-        if len(nz) == len(self.args):
-            return None
-        b = self.func(*nz)
-        if b.is_zero:
-            if not im_or_z and not im:
-                return True
-            if im and not im_or_z:
-                return False
-        if b.is_zero is False:
-            return False
+
+        from sympy.functions.elementary.complexes import re, im
+        real_list = [re(arg) for arg in self.args]
+        imag_list = [im(arg) for arg in self.args]
+
+        return (
+            self.func(*real_list).is_zero and
+            self.func(*imag_list).is_zero)
 
     def _eval_is_odd(self):
         l = [f for f in self.args if not (f.is_even is True)]

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -534,14 +534,36 @@ class Add(Expr, AssocOp):
             # issue 10528: there is no way to know if a nc symbol
             # is zero or not
             return
-
-        from sympy.functions.elementary.complexes import re, im
-        real_list = [re(arg) for arg in self.args]
-        imag_list = [im(arg) for arg in self.args]
-
-        return (
-            self.func(*real_list).is_zero and
-            self.func(*imag_list).is_zero)
+        nz = []
+        z = 0
+        im_or_z = False
+        im = False
+        for a in self.args:
+            if a.is_real:
+                if a.is_zero:
+                    z += 1
+                elif a.is_zero is False:
+                    nz.append(a)
+                else:
+                    return
+            elif a.is_imaginary:
+                im = True
+            elif (S.ImaginaryUnit*a).is_real:
+                im_or_z = True
+            else:
+                return
+        if z == len(self.args):
+            return True
+        if len(nz) == 0 or len(nz) == len(self.args):
+            return None
+        b = self.func(*nz)
+        if b.is_zero:
+            if not im_or_z and not im:
+                return True
+            if im and not im_or_z:
+                return False
+        if b.is_zero is False:
+            return False
 
     def _eval_is_odd(self):
         l = [f for f in self.args if not (f.is_even is True)]

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1986,6 +1986,9 @@ def test_Add_is_zero():
     x, y = symbols('x y', zero=True)
     assert (x + y).is_zero
 
+    # Issue 15873
+    e = -2*I + (1 + I)**2
+    assert e.is_zero == True
 
 def test_issue_14392():
     assert (sin(zoo)**2).as_real_imag() == (nan, nan)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1988,10 +1988,12 @@ def test_Add_is_zero():
 
     # Issue 15873
     e = -2*I + (1 + I)**2
-    assert e.is_zero == True
+    assert e.is_zero is None
+
 
 def test_issue_14392():
     assert (sin(zoo)**2).as_real_imag() == (nan, nan)
+
 
 def test_divmod():
     assert divmod(x, y) == (x//y, x % y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #15873

closes #15880
#### Brief description of what is fixed or changed

The example `-2*I + (1 + I)**2` gets past the breakpoint
```
            if im and not im_or_z:
                return False
```
giving the wrong determination.

From my understanding, the original logic seems identical to separating the expression into real and imaginary parts and testing it against zero, ~~so I may experiment here with more simple logic.~~

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- core
  - Fix `is_zero` becoming `False` on some expressions with `Add`.

<!-- END RELEASE NOTES -->
