### PR TITLE
Resolved simple merge conflict in #1053

### DIFF
--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -93,7 +93,7 @@ def qapply(e, **options):
         result = 0
         for arg in e.args:
             result += qapply(arg, **options)
-        return result
+        return result.expand()
 
     # For a Density operator call qapply on its state
     elif isinstance(e, Density):

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -111,7 +111,13 @@ def qapply(e, **options):
 
     # We have a Mul where there might be actual operators to apply to kets.
     elif isinstance(e, Mul):
-        result = qapply_Mul(e, **options)
+        c_part, nc_part = e.args_cnc()
+        c_mul = Mul(*c_part)
+        nc_mul = Mul(*nc_part)
+        if isinstance(nc_mul, Mul):
+            result = c_mul*qapply_Mul(nc_mul, **options)
+        else:
+            result = c_mul*qapply(nc_mul, **options)
         if result == e and dagger:
             return Dagger(qapply_Mul(Dagger(e), **options))
         else:

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -88,4 +88,4 @@ def test_grover():
     nqubits = 4
     basis_states = superposition_basis(nqubits)
     expected = (-13*basis_states)/64 + 264*IntQubit(2, nqubits)/256
-    assert apply_grover(return_one_on_two, 4).simplify() == qapply(expected)
+    assert apply_grover(return_one_on_two, 4).simplify() == qapply(expected).simplify()

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -48,7 +48,7 @@ def test_OracleGate():
 def test_WGate():
     nqubits = 2
     basis_states = superposition_basis(nqubits)
-    assert qapply(WGate(nqubits)*basis_states) == basis_states
+    assert qapply(WGate(nqubits)*basis_states).simplify().expand() == basis_states
 
     expected = ((2/sqrt(pow(2, nqubits)))*basis_states) - IntQubit(1, nqubits)
     assert qapply(WGate(nqubits)*IntQubit(1, nqubits)) == expected
@@ -59,7 +59,7 @@ def test_grover_iteration_1():
     basis_states = superposition_basis(numqubits)
     v = OracleGate(numqubits, return_one_on_one)
     expected = IntQubit(1, numqubits)
-    assert qapply(grover_iteration(basis_states, v)) == expected
+    assert qapply(grover_iteration(basis_states, v)).simplify() == expected
 
 
 def test_grover_iteration_2():
@@ -78,14 +78,14 @@ def test_grover_iteration_2():
     # Probability of Qubit('0010') was 251/256 (3) vs 781/1024 (4)
     # Ask about measurement
     expected = (-13*basis_states)/64 + 264*IntQubit(2, numqubits)/256
-    assert qapply(expected) == iterated
+    assert qapply(expected).simplify() == iterated.simplify()
 
 
 def test_grover():
     nqubits = 2
-    assert apply_grover(return_one_on_one, nqubits) == IntQubit(1, nqubits)
+    assert apply_grover(return_one_on_one, nqubits).simplify() == IntQubit(1, nqubits)
 
     nqubits = 4
     basis_states = superposition_basis(nqubits)
     expected = (-13*basis_states)/64 + 264*IntQubit(2, nqubits)/256
-    assert apply_grover(return_one_on_two, 4) == qapply(expected)
+    assert apply_grover(return_one_on_two, 4).simplify() == qapply(expected)

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -48,7 +48,7 @@ def test_OracleGate():
 def test_WGate():
     nqubits = 2
     basis_states = superposition_basis(nqubits)
-    assert qapply(WGate(nqubits)*basis_states).simplify().expand() == basis_states
+    assert qapply(WGate(nqubits)*basis_states) == basis_states
 
     expected = ((2/sqrt(pow(2, nqubits)))*basis_states) - IntQubit(1, nqubits)
     assert qapply(WGate(nqubits)*IntQubit(1, nqubits)) == expected
@@ -59,7 +59,7 @@ def test_grover_iteration_1():
     basis_states = superposition_basis(numqubits)
     v = OracleGate(numqubits, return_one_on_one)
     expected = IntQubit(1, numqubits)
-    assert qapply(grover_iteration(basis_states, v)).simplify() == expected
+    assert qapply(grover_iteration(basis_states, v)) == expected
 
 
 def test_grover_iteration_2():
@@ -78,14 +78,14 @@ def test_grover_iteration_2():
     # Probability of Qubit('0010') was 251/256 (3) vs 781/1024 (4)
     # Ask about measurement
     expected = (-13*basis_states)/64 + 264*IntQubit(2, numqubits)/256
-    assert qapply(expected).simplify() == iterated.simplify()
+    assert qapply(expected) == iterated
 
 
 def test_grover():
     nqubits = 2
-    assert apply_grover(return_one_on_one, nqubits).simplify() == IntQubit(1, nqubits)
+    assert apply_grover(return_one_on_one, nqubits) == IntQubit(1, nqubits)
 
     nqubits = 4
     basis_states = superposition_basis(nqubits)
     expected = (-13*basis_states)/64 + 264*IntQubit(2, nqubits)/256
-    assert apply_grover(return_one_on_two, 4).simplify() == qapply(expected).simplify()
+    assert apply_grover(return_one_on_two, 4) == qapply(expected)

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -1,4 +1,4 @@
-from sympy import I, Integer, sqrt, symbols
+from sympy import I, Integer, sqrt, symbols, S, Mul
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
@@ -8,6 +8,7 @@ from sympy.physics.quantum.gate import H
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
+from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.state import Ket
 from sympy.physics.quantum.density import Density
 from sympy.physics.quantum.qubit import Qubit
@@ -117,3 +118,10 @@ def test_issue_6073():
 def test_density():
     d = Density([Jz*mo, 0.5], [Jz*po, 0.5])
     assert qapply(d) == Density([-hbar*mo, 0.5], [hbar*po, 0.5])
+
+
+def test_issue3044():
+    expr1 = TensorProduct(Jz*JzKet(S(2),S(-1))/sqrt(2), Jz*JzKet(S(1)/2,S(1)/2))
+    result = Mul(S(-1), S(1)/4, (2**(S(1)/2)), hbar**2)
+    result *= TensorProduct(JzKet(2,-1), JzKet(S(1)/2,S(1)/2))
+    assert qapply(expr1) == result


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #6143

#### Brief description of what is fixed or changed
Just merged and fixed simple conflict in tests from #1053 
Fixed the format of results to pass a few other tests.

#### Other comments
I had to add `.simplify()` (and one time `expand()`) to the output to get some other tests to pass. Probably this is better done inside the code though. Just doing it when returning a result from the part that has changed does not simplify it completely though and it seems unnecessary to simplify every returned value, although that will probably give the "correct" result. 

Typically I get expressions like 
![image](https://user-images.githubusercontent.com/8114497/51904896-21d7e200-23c0-11e9-8c31-3e76e73ab266.png)
which should be simplified to 
![image](https://user-images.githubusercontent.com/8114497/51904918-2d2b0d80-23c0-11e9-9196-aab71407ac9e.png)

Another way would be to improve the comparison of expressions.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
    * `qapply` now works for `c_part*TensorProduct`
<!-- END RELEASE NOTES -->
