### PR TITLE
Fixing is_zero for complex numbers while Add

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -554,7 +554,7 @@ class Add(Expr, AssocOp):
                 return
         if z == len(self.args):
             return True
-        if len(nz) == len(self.args):
+        if not len(nz) == len(self.args):
             return None
         b = self.func(*nz)
         if b.is_zero:


### PR DESCRIPTION
References to other Issues or PRs
#15873 

Other comments:

<!-- BEGIN RELEASE NOTES -->

- core
  - Fix `is_zero` becoming `False` on some expressions with `Add`.

<!-- END RELEASE NOTES -->
