### PR TITLE
Complex and constant Theano code generation (revived #9187)

### DIFF
--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -269,3 +269,15 @@ def test_Relationals():
     assert theq(theano_code(x < y), xt < yt)
     assert theq(theano_code(x >= y), xt >= yt)
     assert theq(theano_code(x <= y), xt <= yt)
+    
+def test_complexfunctions():
+    xt, yt = theano_code(x, dtypes={x:'complex128'}), theano_code(y, dtypes={y: 'complex128'})
+    from sympy import conjugate
+    from theano.tensor import as_tensor_variable as atv
+    from theano.tensor import complex as cplx
+    assert theq(theano_code(y*conjugate(x)), yt*(xt.conj()))
+    assert theq(theano_code((1+2j)*x), xt*(atv(1.0)+atv(2.0)*cplx(0,1)))
+
+def test_constantfunctions():
+    tf = theano_function([],[1+1j])
+    assert(tf()==1+1j)

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -598,7 +598,7 @@ def test_Relationals():
     assert theq(theano_code_(x >= y), xt >= yt)
     assert theq(theano_code_(x <= y), xt <= yt)
 
-    
+
 def test_complexfunctions():
     xt, yt = theano_code(x, dtypes={x:'complex128'}), theano_code(y, dtypes={y: 'complex128'})
     from sympy import conjugate

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -51,7 +51,9 @@ if theano:
             sympy.GreaterThan: tt.ge,
             sympy.Max: tt.maximum,  # Sympy accept >2 inputs, Theano only 2
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
-
+            sympy.conjugate: tt.conj,
+            sympy.numbers.ImaginaryUnit: lambda:tt.complex(0,1),
+            
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
             sympy.HadamardProduct: tt.Elemwise(ts.mul),

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -225,5 +225,9 @@ def theano_function(inputs, outputs, dtypes={}, cache=None, **kwargs):
                    broadcastables=broadcastables)
     tinputs  = list(map(code, inputs))
     toutputs = list(map(code, outputs))
+
+    #fix constant expressions as variables
+    toutputs = [output if isinstance(output, theano.Variable) else tt.as_tensor_variable(output) for output in toutputs]
+
     toutputs = toutputs[0] if len(toutputs) == 1 else toutputs
     return theano.function(tinputs, toutputs, **theano_kwargs)

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -55,7 +55,6 @@ if theano:
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
             sympy.conjugate: tt.conj,
             sympy.numbers.ImaginaryUnit: lambda:tt.complex(0,1),
-            
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
             sympy.HadamardProduct: tt.Elemwise(ts.mul),
@@ -498,7 +497,9 @@ def theano_function(inputs, outputs, scalar=False, **kwargs):
     tinputs = list(map(code, inputs))
     toutputs = list(map(code, outputs))
 
-<<<<<<< HEAD
+    #fix constant expressions as variables
+    toutputs = [output if isinstance(output, theano.Variable) else tt.as_tensor_variable(output) for output in toutputs]
+
     if len(toutputs) == 1:
         toutputs = toutputs[0]
 
@@ -526,10 +527,3 @@ def theano_function(inputs, outputs, scalar=False, **kwargs):
     wrapper.__doc__ = func.__doc__
     wrapper.theano_function = func
     return wrapper
-=======
-    #fix constant expressions as variables
-    toutputs = [output if isinstance(output, theano.Variable) else tt.as_tensor_variable(output) for output in toutputs]
-
-    toutputs = toutputs[0] if len(toutputs) == 1 else toutputs
-    return theano.function(tinputs, toutputs, **theano_kwargs)
->>>>>>> 3e8854204a2a090a36c03dfb3491e18cb2a11865

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -228,8 +228,15 @@ default_datatypes = {
 }
 
 
-def get_default_datatype(expr, complex_allowed=False):
+COMPLEX_ALLOWED = False
+def get_default_datatype(expr, complex_allowed=None):
     """Derives an appropriate datatype based on the expression."""
+    if complex_allowed is None:
+        complex_allowed = COMPLEX_ALLOWED
+    if complex_allowed:
+        final_dtype = "complex"
+    else:
+        final_dtype = "float"
     if expr.is_integer:
         return default_datatypes["int"]
     elif expr.is_real:
@@ -241,10 +248,10 @@ def get_default_datatype(expr, complex_allowed=False):
             if dt is "int" and not element.is_integer:
                 dt = "float"
             if dt is "float" and not element.is_real:
-                return default_datatypes["complex"]
+                return default_datatypes[final_dtype]
         return default_datatypes[dt]
     else:
-        return default_datatypes["complex"]
+        return default_datatypes[final_dtype]
 
 
 class Variable(object):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -95,7 +95,7 @@ from sympy.printing.octave import OctaveCodePrinter
 from sympy.printing.rust import RustCodePrinter
 from sympy.tensor import Idx, Indexed, IndexedBase
 from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
-                            MatrixExpr, MatrixSlice, MutableMatrix)
+                            MatrixExpr, MatrixSlice)
 
 
 __all__ = [
@@ -249,11 +249,11 @@ class DataType(object):
 default_datatypes = {
     "int": DataType("int", "INTEGER*4", "int", "", "", "i32"),
     "float": DataType("double", "REAL*8", "float", "", "", "f64"),
-    "complex": DataType("double", "COMPLEX*16", "complex", "") #FIXME:
-       # complex is only 
-       # supported in fortran and python. So to not break c-code generation, we 
-       # stick with double (but actually should raise an exeption for explicitly
-       # complex variables (x.is_complex==True)) 
+    "complex": DataType("double", "COMPLEX*16", "complex", "", "", "float") #FIXME:
+       # complex is only supported in fortran, python, julia, and octave.
+       # So to not break c or rust code generation, we stick with double or
+       # float, respecitvely (but actually should raise an exeption for
+       # explicitly complex variables (x.is_complex==True))
 }
 
 
@@ -507,7 +507,7 @@ class Result(Variable, ResultBase):
 
         if name is None:
             name = 'result_%d' % abs(hash(expr))
-            
+
         if datatype is None:
             #try to infer data type from the expression
             datatype = get_default_datatype(expr)

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1401,6 +1401,8 @@ def test_fcode_matrixsymbol_slice_autoname():
     assert source == expected
     
 def test_fcode_complex():
+    import sympy.utilities.codegen
+    sympy.utilities.codegen.COMPLEX_ALLOWED = True
     x = Symbol('x', real=True)
     y = Symbol('y',real=True)
     result = codegen(('test',x+y), 'f95', 'test', header=False, empty=False)
@@ -1426,3 +1428,4 @@ def test_fcode_complex():
         "end function\n"
         )
     assert source==expected
+    sympy.utilities.codegen.COMPLEX_ALLOWED = False

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1,6 +1,6 @@
 from sympy.core import symbols, Eq, pi, Catalan, Lambda, Dummy
 from sympy.core.compatibility import StringIO
-from sympy import erf, Integral
+from sympy import erf, Integral, Symbol
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol
 from sympy.utilities.codegen import (codegen, make_routine, CCodeGen,
@@ -1399,3 +1399,30 @@ def test_fcode_matrixsymbol_slice_autoname():
     out = b[1]
     expected = expected % {'hash': out}
     assert source == expected
+    
+def test_fcode_complex():
+    x = Symbol('x', real=True)
+    y = Symbol('y',real=True)
+    result = codegen(('test',x+y), 'f95', 'test', header=False, empty=False)
+    source = (result[0][1])
+    expected = (
+        "REAL*8 function test(x, y)\n"
+        "implicit none\n"
+        "REAL*8, intent(in) :: x\n"
+        "REAL*8, intent(in) :: y\n"
+        "test = x + y\n"
+        "end function\n")
+    assert source == expected
+    x = Symbol('x')
+    y = Symbol('y',real=True)
+    result = codegen(('test',x+y), 'f95', 'test', header=False, empty=False)
+    source = (result[0][1])
+    expected = (
+        "COMPLEX*16 function test(x, y)\n"
+        "implicit none\n"
+        "COMPLEX*16, intent(in) :: x\n"
+        "REAL*8, intent(in) :: y\n"
+        "test = x + y\n"
+        "end function\n"
+        )
+    assert source==expected

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1526,7 +1526,7 @@ def test_c_with_printer():
     result = codegen(("test", expr), "C","file", header=False, empty=False, printer = CustomPrinter())
     assert result == expected
 
-    
+
 def test_fcode_complex():
     import sympy.utilities.codegen
     sympy.utilities.codegen.COMPLEX_ALLOWED = True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
CLoses #9187

#### Brief description of what is fixed or changed
I decided to revive #9187 as it seemed useful and easy.

Complex variables are explicitly supported for Theano.
Constant functions do no longer generate a crash.
Explicit support for complex variables in codegen. I updated the comment as it seemed like rust does not support complex variables (although I just found https://autumnai.github.io/cuticula/num/complex/struct.Complex.html but do not know the status of that (hadn't even heard of rust before...))

#### Other comments
It seems like `sympy.utilities.codegen.COMPLEX_ALLOWED` is used to control the code generation's use of complex variables. Probably better to pass it through `codegen` but there may be a reason it is not done (have not analyzed the code that much).

As the FIXME says, one should probably add en exception for the case of explicitly complex variables and code generation in c or rust(?).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Theano printing now supports complex variables, conjugates and constant functions

* codegen
   * Fortran code generation now supports complex variables by default (COMPLEX*16)
<!-- END RELEASE NOTES -->
