### PR TITLE
Mutable matrices should not use caches for eigenvectors and properties

### DIFF
--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 from sympy.core import Basic, Dict, Integer, S, Tuple, sympify
+from sympy.core.cache import cacheit
 from sympy.core.sympify import converter as sympify_converter
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
@@ -112,6 +113,13 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     def shape(self):
         return tuple(int(i) for i in self.args[:2])
 
+    def is_diagonalizable(self, reals_only=False, **kwargs):
+        return super(DenseMatrix, self).is_diagonalizable(
+            reals_only=reals_only, **kwargs)
+    is_diagonalizable.__doc__ = DenseMatrix.is_diagonalizable.__doc__
+    is_diagonalizable = cacheit(is_diagonalizable)
+
+
 # This is included after the class definition as a workaround for issue 7213.
 # See https://github.com/sympy/sympy/issues/7213
 # the object is non-zero
@@ -169,3 +177,9 @@ class ImmutableSparseMatrix(SparseMatrix, Basic):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
 
     _eval_Eq = ImmutableDenseMatrix._eval_Eq
+
+    def is_diagonalizable(self, reals_only=False, **kwargs):
+        return super(SparseMatrix, self).is_diagonalizable(
+            reals_only=reals_only, **kwargs)
+    is_diagonalizable.__doc__ = SparseMatrix.is_diagonalizable.__doc__
+    is_diagonalizable = cacheit(is_diagonalizable)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1075,8 +1075,23 @@ class MatrixEigen(MatrixSubspaces):
     """Provides basic matrix eigenvalue/vector operations.
     Should not be instantiated directly."""
 
-    _cache_is_diagonalizable = None
-    _cache_eigenvects = None
+    @property
+    def _cache_is_diagonalizable(self):
+        SymPyDeprecationWarning(
+            feature='_cache_is_diagonalizable',
+            deprecated_since_version="1.4",
+            issue=15887
+            ).warn()
+        return None
+
+    @property
+    def _cache_eigenvects(self):
+        SymPyDeprecationWarning(
+            feature='_cache_eigenvects',
+            deprecated_since_version="1.4",
+            issue=15887
+            ).warn()
+        return None
 
     def diagonalize(self, reals_only=False, sort=False, normalize=False):
         """
@@ -1131,12 +1146,10 @@ class MatrixEigen(MatrixSubspaces):
         if not self.is_square:
             raise NonSquareMatrixError()
 
-        if not self.is_diagonalizable(reals_only=reals_only, clear_cache=False):
+        if not self.is_diagonalizable(reals_only=reals_only):
             raise MatrixError("Matrix is not diagonalizable")
 
-        eigenvecs = self._cache_eigenvects
-        if eigenvecs is None:
-            eigenvecs = self.eigenvects(simplify=True)
+        eigenvecs = self.eigenvects(simplify=True)
 
         if sort:
             eigenvecs = sorted(eigenvecs, key=default_sort_key)
@@ -1421,43 +1434,36 @@ class MatrixEigen(MatrixSubspaces):
         is_diagonal
         diagonalize
         """
-
-        clear_cache = kwargs.get('clear_cache', True)
+        if 'clear_cache' in kwargs:
+            SymPyDeprecationWarning(
+                feature='clear_cache',
+                deprecated_since_version=1.4,
+                issue=15887
+            ).warn()
         if 'clear_subproducts' in kwargs:
-            clear_cache = kwargs.get('clear_subproducts')
-
-        def cleanup():
-            """Clears any cached values if requested"""
-            if clear_cache:
-                self._cache_eigenvects = None
-                self._cache_is_diagonalizable = None
+            SymPyDeprecationWarning(
+                feature='clear_subproducts',
+                deprecated_since_version=1.4,
+                issue=15887
+            ).warn()
 
         if not self.is_square:
-            cleanup()
             return False
-
-        # use the cached value if we have it
-        if self._cache_is_diagonalizable is not None:
-            ret = self._cache_is_diagonalizable
-            cleanup()
-            return ret
 
         if all(e.is_real for e in self) and self.is_symmetric():
             # every real symmetric matrix is real diagonalizable
-            self._cache_is_diagonalizable = True
-            cleanup()
             return True
 
-        self._cache_eigenvects = self.eigenvects(simplify=True)
+        eigenvecs = self.eigenvects(simplify=True)
+
         ret = True
-        for val, mult, basis in self._cache_eigenvects:
+        for val, mult, basis in eigenvecs:
             # if we have a complex eigenvalue
             if reals_only and not val.is_real:
                 ret = False
             # if the geometric multiplicity doesn't equal the algebraic
             if mult != len(basis):
                 ret = False
-        cleanup()
         return ret
 
     def jordan_form(self, calc_transform=True, **kwargs):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1726,6 +1726,32 @@ def test_diagonalization():
     assert m.is_diagonalizable()
 
 
+def test_issue_15887():
+    # Mutable matrix should not use cache
+    a = MutableDenseMatrix([[0, 1], [1, 0]])
+    assert a.is_diagonalizable() is True
+    a[1, 0] = 0
+    assert a.is_diagonalizable() is False
+
+    a = MutableDenseMatrix([[0, 1], [1, 0]])
+    a.diagonalize()
+    a[1, 0] = 0
+    raises(MatrixError, lambda: a.diagonalize())
+
+    # Test deprecated cache and kwargs
+    with warns_deprecated_sympy():
+        a._cache_eigenvects
+
+    with warns_deprecated_sympy():
+        a._cache_is_diagonalizable
+
+    with warns_deprecated_sympy():
+        a.is_diagonalizable(clear_cache=True)
+
+    with warns_deprecated_sympy():
+        a.is_diagonalizable(clear_subproducts=True)
+
+
 @XFAIL
 def test_eigen_vects():
     m = Matrix(2, 2, [1, 0, 0, I])

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -72,7 +72,9 @@ def check(a, exclude=[], check_attr=True):
 
         def c(a, b, d):
             for i in d:
-                if not hasattr(a, i) or i in excluded_attrs:
+                if i in excluded_attrs:
+                    continue
+                if not hasattr(a, i):
                     continue
                 attr = getattr(a, i)
                 if not hasattr(attr, "__call__"):

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -83,8 +83,9 @@ def check(a, exclude=[], check_attr=True):
                 c(a, b, d1)
                 c(b, a, d2)
         else:
-            c(a, b, d1)
-            c(b, a, d2)
+            with ignore_warnings(SymPyDeprecationWarning):
+                c(a, b, d1)
+                c(b, a, d2)
 
 
 #================== core =========================

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -32,7 +32,11 @@ from sympy import symbols, S
 from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
-excluded_attrs = set(['_assumptions', '_mhash'])
+excluded_attrs = set(
+    ['_assumptions', '_mhash', 'message',
+    # XXX Remove these after deprecation is done for issue #15887
+    '_cache_eigenvects', '_cache_is_diagonalizable']
+    )
 
 
 def check(a, exclude=[], check_attr=True):
@@ -75,17 +79,9 @@ def check(a, exclude=[], check_attr=True):
                     assert hasattr(b, i), i
                     assert getattr(b, i) == attr, "%s != %s, protocol: %s" % (getattr(b, i), attr, protocol)
 
-        # XXX Can be removed if Py2 support is dropped.
-        # DeprecationWarnings on Python 2.6 from calling e.g. getattr(a, 'message')
-        # This check eliminates 800 warnings.
-        if sys.version_info < (3,):
-            with ignore_warnings(DeprecationWarning):
-                c(a, b, d1)
-                c(b, a, d2)
-        else:
-            with ignore_warnings(SymPyDeprecationWarning):
-                c(a, b, d1)
-                c(b, a, d2)
+        c(a, b, d1)
+        c(b, a, d2)
+
 
 
 #================== core =========================


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I find that the original code is not careful about mutability of matrices.
https://github.com/sympy/sympy/blob/ce11e8bcb3a5353980f5c41a22fe517b8f5d8f13/sympy/matrices/matrices.py#L1426-L1462

For example, the second matrix is not diagonalizable, but with `clear_cache` set as `False`, it will constantly give wrong answer based on the stored value.

<img src="https://user-images.githubusercontent.com/34944973/51988944-4bd8f380-24e9-11e9-8209-d22adec1f527.png" width="500px">

A more critical case would be the `diagonalize()` function, because it forces `clear_cache=False`
Like below, you can see the wrong result is given by cached variables.

<img src="https://user-images.githubusercontent.com/34944973/51989255-01a44200-24ea-11e9-902d-9d0f77724810.png" width="350px">

Though it may be possible to make mutable matrices to use cache, but I think bookkeeping would be more complicated. So I have disabled cache for mutable matrices.

#### Other comments

I personally don't think that cacheing eigenvectors was originally good idea.
Eigenvectors can possibly be as large as the matrix itself.
And also I don't think that the cache is used by `eigenvects` function itself, or other functions that can make use of the result, like `eigenvals`, `jordan_form`, or ~~singular_values~~.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Fixed `diagonalize` and `is_diagonalizable` giving wrong results for mutable matrices.

<!-- END RELEASE NOTES -->
