### PR TITLE
Corrected three and four dots above accents and put accents in middle of strings

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -7,6 +7,7 @@ from sympy.interactive.printing import init_printing
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter, translate
 from sympy.printing.pretty.pretty import PrettyPrinter
+from sympy.printing.pretty.pretty_symbology import put_accent_in_middle_of_string
 from sympy.printing.str import StrPrinter
 
 __all__ = ['vprint', 'vsstrrepr', 'vsprint', 'vpprint', 'vlatex',
@@ -196,15 +197,9 @@ class VectorPrettyPrinter(PrettyPrinter):
                 4 : u"\N{COMBINING FOUR DOTS ABOVE}"}
 
         d = pform.__dict__
-        pic = d['picture'][0]
-        uni = d['unicode']
-        lp = len(pic) // 2 + 1
-        lu = len(uni) // 2 + 1
-        pic_split = [pic[:lp], pic[lp:]]
-        uni_split = [uni[:lu], uni[lu:]]
 
-        d['picture'] = [pic_split[0] + dots[dot_i] + pic_split[1]]
-        d['unicode'] =  uni_split[0] + dots[dot_i] + uni_split[1]
+        d['picture'] = [put_accent_in_middle_of_string(d['picture'][0], dots[dot_i])]
+        d['unicode'] =  put_accent_in_middle_of_string(d['unicode'], dots[dot_i])
 
         return pform
 

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -195,19 +195,19 @@ for s in '+-=()':
 # TODO: Make brackets adjust to height of contents
 modifier_dict = {
     # Accents
-    'mathring': lambda s: s+u'\N{COMBINING RING ABOVE}',
-    'ddddot': lambda s: s+u'\N{COMBINING DIAERESIS}\N{COMBINING DIAERESIS}',
-    'dddot': lambda s: s+u'\N{COMBINING DIAERESIS}\N{COMBINING DOT ABOVE}',
-    'ddot': lambda s: s+u'\N{COMBINING DIAERESIS}',
-    'dot': lambda s: s+u'\N{COMBINING DOT ABOVE}',
-    'check': lambda s: s+u'\N{COMBINING CARON}',
-    'breve': lambda s: s+u'\N{COMBINING BREVE}',
-    'acute': lambda s: s+u'\N{COMBINING ACUTE ACCENT}',
-    'grave': lambda s: s+u'\N{COMBINING GRAVE ACCENT}',
-    'tilde': lambda s: s+u'\N{COMBINING TILDE}',
-    'hat': lambda s: s+u'\N{COMBINING CIRCUMFLEX ACCENT}',
-    'bar': lambda s: s+u'\N{COMBINING OVERLINE}',
-    'vec': lambda s: s+u'\N{COMBINING RIGHT ARROW ABOVE}',
+    'mathring': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING RING ABOVE}'),
+    'ddddot': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING FOUR DOTS ABOVE}'),
+    'dddot': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING THREE DOTS ABOVE}'),
+    'ddot': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING DIAERESIS}'),
+    'dot': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING DOT ABOVE}'),
+    'check': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING CARON}'),
+    'breve': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING BREVE}'),
+    'acute': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING ACUTE ACCENT}'),
+    'grave': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING GRAVE ACCENT}'),
+    'tilde': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING TILDE}'),
+    'hat': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING CIRCUMFLEX ACCENT}'),
+    'bar': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING OVERLINE}'),
+    'vec': lambda s: put_accent_in_middle_of_string(s, u'\N{COMBINING RIGHT ARROW ABOVE}'),
     'prime': lambda s: s+u'\N{PRIME}',
     'prm': lambda s: s+u'\N{PRIME}',
     # # Faces -- these are here for some compatibility with latex printing
@@ -580,3 +580,38 @@ def annotated(letter):
         return ucode_pics[letter]
     else:
         return ascii_pics[letter]
+
+def put_accent_in_middle_of_string(string, accent):
+    """
+    Returns a string with accent inserted on the middle character. Useful to
+    put combining accents on symbol names, including multi-character names.
+
+    Parameters
+    ==========
+
+    string : string
+        The string to place the accent in.
+    accent : string
+        The combining accent to insert
+
+    Examples
+    ========
+
+    >>> from sympy.printing.pretty.pretty_symbology import put_accent_in_middle_of_string
+    >>> put_accent_in_middle_of_string('abcde', u'\N{COMBINING TILDE}')
+    'abc̃de'
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Combining_character
+    .. [2] https://en.wikipedia.org/wiki/Combining_Diacritical_Marks
+
+    """
+
+    # Accent is placed on the previous character, although it may not always look
+    # like that depending on console
+    midpoint = len(string) // 2 + 1
+    firstpart = string[:midpoint]
+    secondpart = string[midpoint:]
+    return firstpart + accent + secondpart

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -598,7 +598,7 @@ def put_accent_in_middle_of_string(string, accent):
     ========
 
     >>> from sympy.printing.pretty.pretty_symbology import put_accent_in_middle_of_string
-    >>> put_accent_in_middle_of_string('abcde', u'\N{COMBINING TILDE}')
+    >>> put_accent_in_middle_of_string('abcde', u'\N{COMBINING TILDE}') #doctest +SKIP
     'abc̃de'
 
     References

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -594,13 +594,6 @@ def put_accent_in_middle_of_string(string, accent):
     accent : string
         The combining accent to insert
 
-    Examples
-    ========
-
-    >>> from sympy.printing.pretty.pretty_symbology import put_accent_in_middle_of_string
-    >>> put_accent_in_middle_of_string('abcde', u'\N{COMBINING TILDE}') #doctest +SKIP
-    'abc̃de'
-
     References
     ==========
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -24,6 +24,7 @@ from sympy.matrices import Adjoint, Inverse, MatrixSymbol, Transpose, KroneckerP
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
+from sympy.printing.pretty.pretty_symbology import put_accent_in_middle_of_string
 
 from sympy.physics.units import joule, degree, radian
 from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
@@ -319,8 +320,8 @@ def test_missing_in_2X_issue_9047():
 def test_upretty_modifiers():
     # Accents
     assert upretty( Symbol('Fmathring') ) == u'F̊'
-    assert upretty( Symbol('Fddddot') ) == u'F̈̈'
-    assert upretty( Symbol('Fdddot') ) == u'F̈̇'
+    assert upretty( Symbol('Fddddot') ) == u'F⃜'
+    assert upretty( Symbol('Fdddot') ) == u'F⃛'
     assert upretty( Symbol('Fddot') ) == u'F̈'
     assert upretty( Symbol('Fdot') ) == u'Ḟ'
     assert upretty( Symbol('Fcheck') ) == u'F̌'
@@ -6508,3 +6509,11 @@ def test_issue_15583():
     result = '(n_x, n_y, n_z)'
     e = pretty((N.x, N.y, N.z))
     assert e == result
+
+def test_put_accent_in_middle_of_string():
+    assert put_accent_in_middle_of_string('a', u'\N{COMBINING TILDE}') == u'ã'
+    assert put_accent_in_middle_of_string('aa', u'\N{COMBINING TILDE}') == u'aã'
+    assert put_accent_in_middle_of_string('aaa', u'\N{COMBINING TILDE}') == u'aãa'
+    assert put_accent_in_middle_of_string('aaaa', u'\N{COMBINING TILDE}') == u'aaãa'
+    assert put_accent_in_middle_of_string('aaaaa', u'\N{COMBINING TILDE}') == u'aaãaa'
+    assert put_accent_in_middle_of_string('abcdefg', u'\N{COMBINING FOUR DOTS ABOVE}') == u'abcd⃜efg'


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
For the pretty printer:

The combining accents for three and four dots above were incorrect earlier, see https://github.com/sympy/sympy/issues/15884#issuecomment-459255822

Also, now in case of multi-character symbol names, the combining accent is put on the middle character instead of the last.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Corrected Unicode symbols for three and four dots above in pretty printer (dddot and ddddot modifiers)
    * Modifier is now put on the middle character in case of multi-character symbol names
<!-- END RELEASE NOTES -->
