### PR TITLE
NotImplementedError if nonlinsolve can't solve equations in real domain

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3054,7 +3054,7 @@ def nonlinsolve(system, *symbols):
 
         # positive dimensional system
         res = _handle_positive_dimensional(polys, symbols, denominators)
-        if isinstance(res, EmptySet) and [not p.domain.is_Exact for p in polys]:
+        if isinstance(res, EmptySet) and any(not p.domain.is_Exact for p in polys):
             raise NotImplementedError("Equation not in exact domain. Try converting to rational")
         else:
             return res

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2803,6 +2803,7 @@ def _handle_positive_dimensional(polys, symbols, denominators):
         new_system, symbols, result, [],
         denominators)
     return result
+
 # end of def _handle_positive_dimensional()
 
 
@@ -3007,6 +3008,7 @@ def nonlinsolve(system, *symbols):
 
     """
     from sympy.polys.polytools import is_zero_dimensional
+    from sympy.polys import RR
 
     if not system:
         return S.EmptySet
@@ -3051,7 +3053,11 @@ def nonlinsolve(system, *symbols):
                 return result
 
         # positive dimensional system
-        return _handle_positive_dimensional(polys, symbols, denominators)
+        res = _handle_positive_dimensional(polys, symbols, denominators)
+        if isinstance(res, EmptySet) and [True for p in polys if p.domain == RR]:
+            raise NotImplementedError("Equation not in exact domain. Try converting to rational")
+        else:
+            return res
 
     else:
         # If all the equations are not polynomial.

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3054,7 +3054,7 @@ def nonlinsolve(system, *symbols):
 
         # positive dimensional system
         res = _handle_positive_dimensional(polys, symbols, denominators)
-        if isinstance(res, EmptySet) and [True for p in polys if p.domain == RR]:
+        if isinstance(res, EmptySet) and [not p.domain.is_Exact for p in polys]:
             raise NotImplementedError("Equation not in exact domain. Try converting to rational")
         else:
             return res

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1224,6 +1224,7 @@ def test_nonlinsolve_abs():
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))
+    raises(NotImplementedError, lambda: nonlinsolve([(x+y)**2 - 9, x**2 - y**2 -3/4], (x, y)))
 
 
 def test_trig_system():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15888 

#### Brief description of what is fixed or changed
If the equations are in real domain, then nonlinsolve() returns EmptySet() for most of the cases, because solveset applies `Gröbner bases` which do not work on Real domain. So instead of an EmptySet() now it will return a `NotImplementedError` with proper detail.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
    - Raise NonImplementedError when solveset fails with polynomials over inexact domain.
<!-- END RELEASE NOTES -->
