### PR TITLE
[WIP] Improved simplification of Relational

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -325,7 +325,8 @@ class Relational(Boolean, Expr, EvalfMixin):
                         scale = gcd(c)
                         c = [ctmp/scale for ctmp in c]
                         if leading.is_negative and isinstance(r, _Inequality):
-                            # Dividing with a negative number, so change order of arguments
+                            # Multiplying with -1 to get positive leading
+                            # polynomial term so change order of arguments,
                             # canonical will put the symbol back on the rhs later
                             r = r.func(constant/scale, -Poly.from_list(c, x).as_expr())
                         else:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -296,7 +296,7 @@ class Relational(Boolean, Expr, EvalfMixin):
             r = r.canonical
             # If there is only one symbol in the expression,
             # try to write it on a simplified form
-            free = r.free_symbols
+            free = list(filter(lambda x: x.is_real, r.free_symbols))
             if len(free) == 1:
                 try:
                     from sympy.solvers.solveset import linear_coeffs
@@ -318,9 +318,7 @@ class Relational(Boolean, Expr, EvalfMixin):
                     try:
                         p = poly(dif, x)
                         c = p.all_coeffs()
-                        leading = c[0]
-                        constant = c[-1]
-                        c[-1] = 0
+                        constant = c.pop()
                         scale = gcd(c)
                         c = [ctmp/scale for ctmp in c]
                         r = r.func(Poly.from_list(c, x).as_expr(), -constant/scale)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -294,6 +294,23 @@ class Relational(Boolean, Expr, EvalfMixin):
             if v is not None:
                 r = r.func._eval_relation(v, S.Zero)
 
+            # If there is only one symbol in the expression,
+            # try to write it on a simplified form
+            free = r.free_symbols
+            if len(free) == 1:
+                try:
+                    from sympy.solvers.solveset import linear_coeffs
+                    x = free.pop()
+                    dif = r.lhs - r.rhs
+                    m, b = linear_coeffs(dif, x)
+                    if m.is_zero is False:
+                        r = r.func(x + b/m, 0)
+                    elif x.is_real:
+                        r = r.func(b, S.zero)
+                except ValueError:
+                    pass
+        
+
         # Did we get a simplified result?
         r = r.canonical
         measure = kwargs['measure']
@@ -517,29 +534,6 @@ class Equality(Relational):
         # no cancellation, not canonical
         return Add._from_args(args)
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        from sympy.solvers.solveset import linear_coeffs
-        # standard simplify
-        e = super(Equality, self)._eval_simplify(
-            ratio, measure, rational, inverse)
-        if not isinstance(e, Equality):
-            return e
-        free = self.free_symbols
-        if len(free) == 1:
-            try:
-                x = free.pop()
-                m, b = linear_coeffs(
-                    e.rewrite(Add, evaluate=False), x)
-                if m.is_zero is False:
-                    enew = e.func(x, -b/m)
-                else:
-                    enew = (S.Zero == -b)
-                if measure(enew) <= ratio*measure(e):
-                    e = enew
-            except ValueError:
-                pass
-        return e.canonical
-
     @property
     def binary_symbols(self):
         if S.true in self.args or S.false in self.args:
@@ -681,35 +675,6 @@ class _Inequality(Relational):
 
         # make a "non-evaluated" Expr for the inequality
         return Relational.__new__(cls, lhs, rhs, **options)
-
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        # standard simplify
-        e = super(_Inequality, self)._eval_simplify(
-            ratio, measure, rational, inverse)
-        if not isinstance(e, _Inequality):
-            return e
-
-        # If there is only one symbol in the expression,
-        # try to write it on a simplified form
-        free = e.free_symbols
-        if len(free) == 1:
-            try:
-                from sympy.solvers.solveset import linear_coeffs
-                x = free.pop()
-                dif = e.lhs - e.rhs
-                m, b = linear_coeffs(dif, x)
-                if m.is_zero is False:
-                    e = e.func(x, -b/m)
-                elif x.is_real: # We do not want to cancel symbols if it
-                                #eventually turns out that they are complex
-                    e = (S.zero == -b)
-            except ValueError:
-                pass
-    
-        if measure(e) < ratio*measure(self):
-            return e.canonical
-        else:
-            return self
 
 class _Greater(_Inequality):
     """Not intended for general use

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -318,7 +318,8 @@ class Relational(Boolean, Expr, EvalfMixin):
                     try:
                         p = poly(dif, x)
                         c = p.all_coeffs()
-                        constant = c.pop()
+                        constant = c[-1]
+                        c[-1] = 0
                         scale = gcd(c)
                         c = [ctmp/scale for ctmp in c]
                         r = r.func(Poly.from_list(c, x).as_expr(), -constant/scale)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -316,7 +316,7 @@ class Relational(Boolean, Expr, EvalfMixin):
                     # maybe not a linear function, try polynomial
                     from sympy.polys import Poly, poly, PolynomialError, gcd
                     try:
-                        p = poly(dif)
+                        p = poly(dif, x)
                         c = p.all_coeffs()
                         leading = c[0]
                         constant = c[-1]

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -296,7 +296,7 @@ class Relational(Boolean, Expr, EvalfMixin):
             r = r.canonical
             # If there is only one symbol in the expression,
             # try to write it on a simplified form
-            free = list(filter(lambda x: x.is_real, r.free_symbols))
+            free = list(filter(lambda x: x.is_real is not False, r.free_symbols))
             if len(free) == 1:
                 try:
                     from sympy.solvers.solveset import linear_coeffs

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -635,7 +635,8 @@ def test_simplify_relational():
     # reason for the 'if r.is_Relational' in Relational's
     # _eval_simplify routine
     assert simplify(-(2**(3*pi/2) + 6**pi)**(1/pi) +
-                    2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
+        2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
+
     # canonical at least
     assert Eq(y, x).simplify() == Eq(x, y)
     assert Eq(x - 1, 0).simplify() == Eq(x, 1)
@@ -652,6 +653,7 @@ def test_simplify_relational():
     assert Ne(2*x, 4).simplify() == Ne(x, 2)
     assert Ne(z*x, 0).simplify() == S.false
 
+    # No real-valued assumptions
     assert Ge(y, x).simplify() == Le(x, y)
     assert Ge(x - 1, 0).simplify() == Ge(x, 1)
     assert Ge(x - 1, x).simplify() == S.false
@@ -680,6 +682,35 @@ def test_simplify_relational():
     assert Lt(2*x, 4).simplify() == Lt(x, 2)
     assert Lt(z*x, 0).simplify() == S.false
 
+    # Real-valued assumptions
+    xr, yr = symbols('x y', real=True)
+    assert Ge(yr, xr).simplify() == Le(xr, yr)
+    assert Ge(xr - 1, 0).simplify() == Ge(xr, 1)
+    assert Ge(xr - 1, xr).simplify() == S.false
+    assert Ge(2*xr - 1, xr).simplify() == Le(xr, 1)
+    assert Ge(2*xr, 4).simplify() == Ge(xr, 2)
+    assert Ge(z*xr, 0).simplify() == S.true
+
+    assert Le(yr, xr).simplify() == Ge(xr, yr)
+    assert Le(xr - 1, 0).simplify() == Le(xr, 1)
+    assert Le(xr - 1, xr).simplify() == S.true
+    assert Le(2*xr - 1, xr).simplify() == Ge(xr, 1)
+    assert Le(2*xr, 4).simplify() == Le(xr, 2)
+    assert Le(z*xr, 0).simplify() == S.true
+
+    assert Gt(yr, xr).simplify() == Lt(xr, yr)
+    assert Gt(xr - 1, 0).simplify() == Gt(xr, 1)
+    assert Gt(xr - 1, xr).simplify() == S.false
+    assert Gt(2*xr - 1, xr).simplify() == Lt(xr, 1)
+    assert Gt(2*xr, 4).simplify() == Gt(xr, 2)
+    assert Gt(z*xr, 0).simplify() == S.false
+
+    assert Lt(yr, xr).simplify() == Gt(xr, yr)
+    assert Lt(xr - 1, 0).simplify() == Lt(xr, 1)
+    assert Lt(xr - 1, xr).simplify() == S.true
+    assert Lt(2*xr - 1, xr).simplify() == Gt(xr, 1)
+    assert Lt(2*xr, 4).simplify() == Lt(xr, 2)
+    assert Lt(z*xr, 0).simplify() == S.false
 
 def test_equals():
     w, x, y, z = symbols('w:z')

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -975,9 +975,9 @@ def test_trigsimp():
 
 
 def test_polynomial_relation_simplification():
-    assert Ge(3*x*(x + 1) + 4, 3*x).simplify() == Ge(x**2, -Rational(4,3))
-    assert Le(-(3*x*(x + 1) + 4), -3*x).simplify() == Ge(x**2, -Rational(4,3))
-    assert ((x**2+3)*(x**2-1)+3*x >= 2*x**2).simplify() == (x**4 + 3*x >= 3)
+    assert Ge(3*x*(x + 1) + 4, 3*x).simplify() in [Ge(x**2, -Rational(4,3)), Le(-x**2, Rational(4, 3))]
+    assert Le(-(3*x*(x + 1) + 4), -3*x).simplify() in [Ge(x**2, -Rational(4,3)), Le(-x**2, Rational(4, 3))]
+    assert ((x**2+3)*(x**2-1)+3*x >= 2*x**2).simplify() in [(x**4 + 3*x >= 3), (-x**4 - 3*x <= -3)]
 
 def test_multivariate_linear_function_simplification():
     assert Ge(x + y, x - y).simplify() == Ge(y, 0)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -986,3 +986,6 @@ def test_multivariate_linear_function_simplification():
     assert (2*x + y > 2*x + y - 3).simplify() == True
     assert (2*x + y < 2*x + y - 3).simplify() == False
     assert (2*x + y < 2*x + y + 3).simplify() == True
+
+def test_nonpolymonial_relations():
+    assert Eq(cos(x), 0).simplify == Eq(cos(x), 0)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -624,6 +624,8 @@ def test_issue_8449():
 
 def test_simplify_relational():
     assert simplify(x*(y + 1) - x*y - x + 1 < x) == (x > 1)
+    assert simplify(x*(y + 1) - x*y - x - 1 < x) == (x > -1)
+    assert simplify(x < x*(y + 1) - x*y - x + 1) == (x < 1)
     r = S(1) < x
     # canonical operations are not the same as simplification,
     # so if there is no simplification, canonicalization will
@@ -657,60 +659,47 @@ def test_simplify_relational():
     assert Ge(y, x).simplify() == Le(x, y)
     assert Ge(x - 1, 0).simplify() == Ge(x, 1)
     assert Ge(x - 1, x).simplify() == S.false
-    assert Ge(2*x - 1, x).simplify() == Le(x, 1)
+    assert Ge(2*x - 1, x).simplify() == Ge(x, 1)
     assert Ge(2*x, 4).simplify() == Ge(x, 2)
     assert Ge(z*x, 0).simplify() == S.true
+    assert Ge(x, -2).simplify() == Ge(x, -2)
+    assert Ge(-x, -2).simplify() == Le(x, 2)
+    assert Ge(x, 2).simplify() == Ge(x, 2)
+    assert Ge(-x, 2).simplify() == Le(x, -2)
 
     assert Le(y, x).simplify() == Ge(x, y)
     assert Le(x - 1, 0).simplify() == Le(x, 1)
     assert Le(x - 1, x).simplify() == S.true
-    assert Le(2*x - 1, x).simplify() == Ge(x, 1)
+    assert Le(2*x - 1, x).simplify() == Le(x, 1)
     assert Le(2*x, 4).simplify() == Le(x, 2)
     assert Le(z*x, 0).simplify() == S.true
+    assert Le(x, -2).simplify() == Le(x, -2)
+    assert Le(-x, -2).simplify() == Ge(x, 2)
+    assert Le(x, 2).simplify() == Le(x, 2)
+    assert Le(-x, 2).simplify() == Ge(x, -2)
 
     assert Gt(y, x).simplify() == Lt(x, y)
     assert Gt(x - 1, 0).simplify() == Gt(x, 1)
     assert Gt(x - 1, x).simplify() == S.false
-    assert Gt(2*x - 1, x).simplify() == Lt(x, 1)
+    assert Gt(2*x - 1, x).simplify() == Gt(x, 1)
     assert Gt(2*x, 4).simplify() == Gt(x, 2)
     assert Gt(z*x, 0).simplify() == S.false
+    assert Gt(x, -2).simplify() == Gt(x, -2)
+    assert Gt(-x, -2).simplify() == Lt(x, 2)
+    assert Gt(x, 2).simplify() == Gt(x, 2)
+    assert Gt(-x, 2).simplify() == Lt(x, -2)
 
     assert Lt(y, x).simplify() == Gt(x, y)
     assert Lt(x - 1, 0).simplify() == Lt(x, 1)
     assert Lt(x - 1, x).simplify() == S.true
-    assert Lt(2*x - 1, x).simplify() == Gt(x, 1)
+    assert Lt(2*x - 1, x).simplify() == Lt(x, 1)
     assert Lt(2*x, 4).simplify() == Lt(x, 2)
     assert Lt(z*x, 0).simplify() == S.false
+    assert Lt(x, -2).simplify() == Lt(x, -2)
+    assert Lt(-x, -2).simplify() == Gt(x, 2)
+    assert Lt(x, 2).simplify() == Lt(x, 2)
+    assert Lt(-x, 2).simplify() == Gt(x, -2)
 
-    # Real-valued assumptions
-    xr, yr = symbols('x y', real=True)
-    assert Ge(yr, xr).simplify() == Le(xr, yr)
-    assert Ge(xr - 1, 0).simplify() == Ge(xr, 1)
-    assert Ge(xr - 1, xr).simplify() == S.false
-    assert Ge(2*xr - 1, xr).simplify() == Le(xr, 1)
-    assert Ge(2*xr, 4).simplify() == Ge(xr, 2)
-    assert Ge(z*xr, 0).simplify() == S.true
-
-    assert Le(yr, xr).simplify() == Ge(xr, yr)
-    assert Le(xr - 1, 0).simplify() == Le(xr, 1)
-    assert Le(xr - 1, xr).simplify() == S.true
-    assert Le(2*xr - 1, xr).simplify() == Ge(xr, 1)
-    assert Le(2*xr, 4).simplify() == Le(xr, 2)
-    assert Le(z*xr, 0).simplify() == S.true
-
-    assert Gt(yr, xr).simplify() == Lt(xr, yr)
-    assert Gt(xr - 1, 0).simplify() == Gt(xr, 1)
-    assert Gt(xr - 1, xr).simplify() == S.false
-    assert Gt(2*xr - 1, xr).simplify() == Lt(xr, 1)
-    assert Gt(2*xr, 4).simplify() == Gt(xr, 2)
-    assert Gt(z*xr, 0).simplify() == S.false
-
-    assert Lt(yr, xr).simplify() == Gt(xr, yr)
-    assert Lt(xr - 1, 0).simplify() == Lt(xr, 1)
-    assert Lt(xr - 1, xr).simplify() == S.true
-    assert Lt(2*xr - 1, xr).simplify() == Gt(xr, 1)
-    assert Lt(2*xr, 4).simplify() == Lt(xr, 2)
-    assert Lt(z*xr, 0).simplify() == S.false
 
 def test_equals():
     w, x, y, z = symbols('w:z')
@@ -983,3 +972,9 @@ def test_trigsimp():
     assert changed.subs(x, pi/8) is S.true
     # or an evaluated one
     assert trigsimp(Eq(cos(x)**2 + sin(x)**2, 1)) is S.true
+
+
+def test_polynomial_relation_simplification():
+    assert Ge(3*x*(x + 1) + 4, 3*x).simplify() == Ge(x**2, -Rational(4,3))
+    assert Le(-(3*x*(x + 1) + 4), -3*x).simplify() == Ge(x**2, -Rational(4,3))
+    assert ((x**2+3)*(x**2-1)+3*x >= 2*x**2).simplify() == (x**4 + 3*x >= 3)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -978,3 +978,11 @@ def test_polynomial_relation_simplification():
     assert Ge(3*x*(x + 1) + 4, 3*x).simplify() == Ge(x**2, -Rational(4,3))
     assert Le(-(3*x*(x + 1) + 4), -3*x).simplify() == Ge(x**2, -Rational(4,3))
     assert ((x**2+3)*(x**2-1)+3*x >= 2*x**2).simplify() == (x**4 + 3*x >= 3)
+
+def test_multivariate_linear_function_simplification():
+    assert Ge(x + y, x - y).simplify() == Ge(y, 0)
+    assert Le(-x + y, -x - y).simplify() == Ge(y, 0)
+    assert Eq(2*x + y, 2*x + y - 3).simplify() == False
+    assert (2*x + y > 2*x + y - 3).simplify() == True
+    assert (2*x + y < 2*x + y - 3).simplify() == False
+    assert (2*x + y < 2*x + y + 3).simplify() == True

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -637,14 +637,48 @@ def test_simplify_relational():
     assert simplify(-(2**(3*pi/2) + 6**pi)**(1/pi) +
                     2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
     # canonical at least
-    for f in (Eq, Ne):
-        f(y, x).simplify() == f(x, y)
-        f(x - 1, 0).simplify() == f(x, 1)
-        f(x - 1, x).simplify() == S.false
-        f(2*x - 1, x).simplify() == f(x, 1)
-        f(2*x, 4).simplify() == f(x, 2)
-        z = cos(1)**2 + sin(1)**2 - 1  # z.is_zero is None
-        f(z*x, 0).simplify() == f(z*x, 0)
+    assert Eq(y, x).simplify() == Eq(x, y)
+    assert Eq(x - 1, 0).simplify() == Eq(x, 1)
+    assert Eq(x - 1, x).simplify() == S.false
+    assert Eq(2*x - 1, x).simplify() == Eq(x, 1)
+    assert Eq(2*x, 4).simplify() == Eq(x, 2)
+    z = cos(1)**2 + sin(1)**2 - 1  # z.is_zero is None
+    assert Eq(z*x, 0).simplify() == S.true
+
+    assert Ne(y, x).simplify() == Ne(x, y)
+    assert Ne(x - 1, 0).simplify() == Ne(x, 1)
+    assert Ne(x - 1, x).simplify() == S.true
+    assert Ne(2*x - 1, x).simplify() == Ne(x, 1)
+    assert Ne(2*x, 4).simplify() == Ne(x, 2)
+    assert Ne(z*x, 0).simplify() == S.false
+
+    assert Ge(y, x).simplify() == Le(x, y)
+    assert Ge(x - 1, 0).simplify() == Ge(x, 1)
+    assert Ge(x - 1, x).simplify() == S.false
+    assert Ge(2*x - 1, x).simplify() == Le(x, 1)
+    assert Ge(2*x, 4).simplify() == Ge(x, 2)
+    assert Ge(z*x, 0).simplify() == S.true
+
+    assert Le(y, x).simplify() == Ge(x, y)
+    assert Le(x - 1, 0).simplify() == Le(x, 1)
+    assert Le(x - 1, x).simplify() == S.true
+    assert Le(2*x - 1, x).simplify() == Ge(x, 1)
+    assert Le(2*x, 4).simplify() == Le(x, 2)
+    assert Le(z*x, 0).simplify() == S.true
+
+    assert Gt(y, x).simplify() == Lt(x, y)
+    assert Gt(x - 1, 0).simplify() == Gt(x, 1)
+    assert Gt(x - 1, x).simplify() == S.false
+    assert Gt(2*x - 1, x).simplify() == Lt(x, 1)
+    assert Gt(2*x, 4).simplify() == Gt(x, 2)
+    assert Gt(z*x, 0).simplify() == S.false
+
+    assert Lt(y, x).simplify() == Gt(x, y)
+    assert Lt(x - 1, 0).simplify() == Lt(x, 1)
+    assert Lt(x - 1, x).simplify() == S.true
+    assert Lt(2*x - 1, x).simplify() == Gt(x, 1)
+    assert Lt(2*x, 4).simplify() == Lt(x, 2)
+    assert Lt(z*x, 0).simplify() == S.false
 
 
 def test_equals():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -981,11 +981,13 @@ def test_polynomial_relation_simplification():
 
 def test_multivariate_linear_function_simplification():
     assert Ge(x + y, x - y).simplify() == Ge(y, 0)
-    assert Le(-x + y, -x - y).simplify() == Ge(y, 0)
+    assert Le(-x + y, -x - y).simplify() == Le(y, 0)
     assert Eq(2*x + y, 2*x + y - 3).simplify() == False
     assert (2*x + y > 2*x + y - 3).simplify() == True
     assert (2*x + y < 2*x + y - 3).simplify() == False
     assert (2*x + y < 2*x + y + 3).simplify() == True
+    a, b, c, d, e, f, g = symbols('a b c d e f g')
+    assert Lt(a + b + c + 2*d, 3*d - f + g). simplify() == Lt(a, -b - c + d - f + g)
 
 def test_nonpolymonial_relations():
     assert Eq(cos(x), 0).simplify() == Eq(cos(x), 0)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -988,4 +988,4 @@ def test_multivariate_linear_function_simplification():
     assert (2*x + y < 2*x + y + 3).simplify() == True
 
 def test_nonpolymonial_relations():
-    assert Eq(cos(x), 0).simplify == Eq(cos(x), 0)
+    assert Eq(cos(x), 0).simplify() == Eq(cos(x), 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to https://github.com/sympy/sympy/issues/15705#issuecomment-457023883  #15898  #15899   (and probably more)

#### Brief description of what is fixed or changed
Improved simplification of `Relational`s with <, <=, >, >= with linear uni-variate expressions.

Added simplification for relations with uni-variate polynomials.

#### Other comments
For example, `a > -a` is now simplified to `a > 0`, `(x**2+3)*(x**2-1)+3*x >= 2*x**2` is simplified to `x**4 + 3*x >= 3`

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Improved simplification of relations
<!-- END RELEASE NOTES -->
