### PR TITLE
evalf cant solve Piecewise with imaginary

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1463,6 +1463,11 @@ class EvalfMixin(object):
 
     def _evalf(self, prec):
         """Helper for evalf. Does the same thing but takes binary precision"""
+        from sympy import I
+        base, exp = self.as_base_exp()
+        if exp.has(I) and not self.free_symbols:
+            from sympy.core.evalf import EvalfMixin
+            return EvalfMixin.evalf(self)
         r = self._eval_evalf(prec)
         if r is None:
             r = self


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #15897 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Using the `evalf()` function does not fully eval Piecewise(mainly with imaginary values).
Example.

```
>>> (I**I).evalf()
0.207879576350762

```
But using with piecewise gave,

```
>>> Piecewise((I**I, x > 0), (1, True)).evalf()
Piecewise((I**I, x > 0), (1.0, True))
```

After fixing the issue, the output is,

```
>>> Piecewise((I**I, x > 0), (1, True)).evalf()
Piecewise((0.207879576350762, x > 0), (1.0, True))

>>>Piecewise(((I+I)**I, x > 0), (1, True)).evalf()
Piecewise((0.159909056928068 + 0.132826999424621*I, x > 0), (1.0, True))
```

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
