### PR TITLE
Add reduction_of_order solver to dsolve

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -231,6 +231,7 @@ of those tests will surely fail.
 
 """
 
+
 from __future__ import print_function, division
 
 from collections import defaultdict

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -682,28 +682,30 @@ def dsolve(eq, func=None, hint="default", simplify=True,
 
 
 def reduction_of_order(eq):
+    
     r'''
+    
     Patch here  <------------
     I would like to make it a wrapper.I have learned about decorators but haven't used them
-    so I would do it if you say. 
-    Function created to try to solve equations refered to issue
-       dsolve doesn't know order-reducing substitutions #15881
-       #Steps:
+    so I would do it if you say.Function created to try to solve equations refered to issue
+    dsolve doesn't know order-reducing substitutions #15881
+    #Steps:
        1: Try to use dsolve.
        2: This is a recursive call till we are not left with a linear equation:
        If NotImplemented error is raised try substituting whole expression with g(x)
-       (I think Dummy should be used but I do not understand the working of it very well 
+       (I think Dummy should be used but I do not understand the working of it very well
        so I'm letting it be a substitution function for the time being.)
        3: Still unable to solve ?Then again raise the NotImplementedError.
        #A thing I read which I would like to ask is that the given equation is a Liouville equation
         and it's method is already implemented then why is sympy unable to solve it.
        Example :
-       >>from sympy.abc import x
-       >>from sympy import Function
-       >>f = Function("f")(x)
-       >>eq = f(x).diff(x, 2) + x * f(x).diff(x)**2
+       >>>from sympy.abc import x
+       >>>from sympy import Function
+       >>>f = Function("f")(x)
+       >>>eq = f(x).diff(x, 2) + x * f(x).diff(x)**2
        >>print(eq)
        Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
+       
     '''    
     try: 
         

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -231,7 +231,6 @@ of those tests will surely fail.
 
 """
 
-
 from __future__ import print_function, division
 
 from collections import defaultdict
@@ -710,8 +709,6 @@ Function created to try to solve equations refered to issue
    Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
    
 '''
-
-
 def reduction_of_order(eq):
     
     try: 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -680,37 +680,31 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             hint = hints['hint']
             return _helper_simplify(eq, hint, hints, simplify, ics=ics)
 
-'''
-Patch here  <------------
-I would like to make it a wrapper.I have learned about decorators but haven't used them
-so I would do it if you say. 
 
-Function created to try to solve equations refered to issue
-   dsolve doesn't know order-reducing substitutions #15881
-   #Steps:
-   1: Try to use dsolve.
-
-   2: This is a recursive call till we are not left with a linear equation:
-   If NotImplemented error is raised try substituting whole expression with g(x)
-   (I think Dummy should be used but I do not understand the working of it very well 
-   so I'm letting it be a substitution function for the time being.)
-   
-   3: Still unable to solve ?Then again raise the NotImplementedError.
-   
-   #A thing I read which I would like to ask is that the given equation is a Liouville equation
-    and it's method is already implemented then why is sympy unable to solve it?
-   
-   Example :
-   from sympy.abc import x
-   from sympy import Function
-   f = Function("f")(x)
-   eq = f(x).diff(x, 2) + x * f(x).diff(x)**2
-   print(eq)
-   Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
-   
-'''
 def reduction_of_order(eq):
-    
+    r'''
+    Patch here  <------------
+    I would like to make it a wrapper.I have learned about decorators but haven't used them
+    so I would do it if you say. 
+    Function created to try to solve equations refered to issue
+       dsolve doesn't know order-reducing substitutions #15881
+       #Steps:
+       1: Try to use dsolve.
+       2: This is a recursive call till we are not left with a linear equation:
+       If NotImplemented error is raised try substituting whole expression with g(x)
+       (I think Dummy should be used but I do not understand the working of it very well 
+       so I'm letting it be a substitution function for the time being.)
+       3: Still unable to solve ?Then again raise the NotImplementedError.
+       #A thing I read which I would like to ask is that the given equation is a Liouville equation
+        and it's method is already implemented then why is sympy unable to solve it.
+       Example :
+       >>from sympy.abc import x
+       >>from sympy import Function
+       >>f = Function("f")(x)
+       >>eq = f(x).diff(x, 2) + x * f(x).diff(x)**2
+       >>print(eq)
+       Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
+    '''    
     try: 
         
         return dsolve(eq)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
Added a function named "reduction_of_order"

was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #15881" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Added a function named "reduction_of_order" which tries solving equations consisting of derivatives only
using dsolve recursively with function substitution.  

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * ode
   * added a new function to solve the particular type of differential equations
* functions
    * reduction_of_order
<!-- END RELEASE NOTES -->
