### PR TITLE
raise value error for Eq(RootOf(), Symbol)

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -970,12 +970,8 @@ class ComplexRootOf(RootOf):
         # is_real value of the CRootOf instance.
         if type(self) == type(other):
             return sympify(self == other)
-        if other.is_number and other.has(AppliedUndef) or not other.is_number:
-            # it's a number that can't be evaluated or it's not a number in its current form
-            # though simplification might identify it as such (but that is the user's choice)
+        if not other.is_number:
             return None
-        if not (other.is_number and not other.has(AppliedUndef)):
-            return S.false
         if not other.is_finite:
             return S.false
         z = self.expr.subs(self.expr.free_symbols.pop(), other).is_zero

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
-    symbols, sympify, Rational, Dummy, Symbol)
+    symbols, sympify, Rational, Dummy)
 from sympy.core.cache import cacheit
 from sympy.core.function import AppliedUndef
 from sympy.functions.elementary.miscellaneous import root as _root

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -970,8 +970,10 @@ class ComplexRootOf(RootOf):
         # is_real value of the CRootOf instance.
         if type(self) == type(other):
             return sympify(self == other)
-        if other.has(Symbol):
-            return
+        if other.is_number and other.has(AppliedUndef) or not other.is_number:
+            # it's a number that can't be evaluated or it's not a number in its current form
+            # though simplification might identify it as such (but that is the user's choice)
+            return None
         if not (other.is_number and not other.has(AppliedUndef)):
             return S.false
         if not other.is_finite:

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
-    symbols, sympify, Rational, Dummy)
+    symbols, sympify, Rational, Dummy, Symbol)
 from sympy.core.cache import cacheit
 from sympy.core.function import AppliedUndef
 from sympy.functions.elementary.miscellaneous import root as _root
@@ -970,7 +970,7 @@ class ComplexRootOf(RootOf):
         # is_real value of the CRootOf instance.
         if type(self) == type(other):
             return sympify(self == other)
-        if other.is_Symbol:
+        if other.has(Symbol):
             return
         if not (other.is_number and not other.has(AppliedUndef)):
             return S.false

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -970,6 +970,8 @@ class ComplexRootOf(RootOf):
         # is_real value of the CRootOf instance.
         if type(self) == type(other):
             return sympify(self == other)
+        if other.is_Symbol:
+            return
         if not (other.is_number and not other.has(AppliedUndef)):
             return S.false
         if not other.is_finite:

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -12,7 +12,7 @@ from sympy.polys.polyerrors import (
 
 from sympy import (
     S, sqrt, I, Rational, Float, Lambda, log, exp, tan, Function, Eq,
-    solve, legendre_poly, Symbol, Integral
+    solve, legendre_poly, Integral
 )
 
 from sympy.utilities.pytest import raises
@@ -566,8 +566,8 @@ def test_eval_approx_relative():
         '-0.10', '0.05 - 3.2*I', '0.05 + 3.2*I']
     assert all(abs(((a[i] - t[i])/t[i]).n()) < 1e-2 for i in range(len(a)))
 
+
 def test_issue_15920():
-    x = Symbol("x")
-    r = rootof(x**5-x+1,0)
+    r = rootof(x**5 - x + 1, 0)
     p = Integral(x, (x, 1, y))
     assert Eq(r, p).lhs is r and Eq(r, p).rhs is p

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -12,7 +12,7 @@ from sympy.polys.polyerrors import (
 
 from sympy import (
     S, sqrt, I, Rational, Float, Lambda, log, exp, tan, Function, Eq,
-    solve, legendre_poly
+    solve, legendre_poly, Symbol, Integral
 )
 
 from sympy.utilities.pytest import raises
@@ -142,8 +142,7 @@ def test_CRootOf___eval_Eq__():
     assert Eq(r, 0) is S.false
     assert Eq(r, S.Infinity) is S.false
     assert Eq(r, I) is S.false
-    assert Eq(r, f(0)) is S.false
-    assert Eq(r, f(0)) is S.false
+    assert Eq(r, f(0)).lhs is r and Eq(r, f(0)).rhs is f(0)
     sol = solve(eq)
     for s in sol:
         if s.is_real:
@@ -566,3 +565,9 @@ def test_eval_approx_relative():
     assert [str(i) for i in a] == [
         '-0.10', '0.05 - 3.2*I', '0.05 + 3.2*I']
     assert all(abs(((a[i] - t[i])/t[i]).n()) < 1e-2 for i in range(len(a)))
+
+def test_issue_15920():
+    x = Symbol("x")
+    r = rootof(x**5-x+1,0)
+    p = Integral(x, (x, 1, y))
+    assert Eq(r, p).lhs is r and Eq(r, p).rhs is p

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -138,7 +138,7 @@ def test_CRootOf___eval_Eq__():
     r1 = rootof(eq, 1)
     assert Eq(r, r1) is S.false
     assert Eq(r, r) is S.true
-    assert Eq(r, x) is S.false
+    assert Eq(r, x).lhs is r and Eq(r, x).rhs is x
     assert Eq(r, 0) is S.false
     assert Eq(r, S.Infinity) is S.false
     assert Eq(r, I) is S.false


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #15920

#### Other comments
```
In [20]: x = Symbol('x')                                                                                                          

In [21]: y = Symbol('y')                                                                                                          

In [22]: r = RootOf(x**5 - x + 1, 0)                                                                                              

In [23]: Eq(r, y)                                                                                                                 
Out[23]: False
```
As y is symbol so we do not know the exact answer of Eq(r, y) so we can't say it's answer will be false .
SO I am returning same equation as it is.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - returning  same equation for Eq(root, Symbol) instead of False.
<!-- END RELEASE NOTES -->
