### PR TITLE
Added negated property to Relational and BooleanAtom

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -141,10 +141,20 @@ class Relational(Boolean, Expr, EvalfMixin):
         x < 1
         >>> _.negated
         x >= 1
+
+        Notes
+        =====
+
+        This works more or less identical to ``~``/``Not``. The difference is
+        that ``negated`` returns the relationship even if `evaluate=False`.
+        Hence, this is useful in code when checking for e.g. negated relations
+        to exisiting ones as it will not be affected by the `evaluate` flag.
+
         """
         ops = {Eq: Ne, Ge: Lt, Gt: Le, Le: Gt, Lt: Ge, Ne: Eq}
-        a, b = self.args
-        return ops.get(self.func, self.func)(a, b, evaluate=False)
+        # If there ever will be new Relational subclasses, the following line will work until it is properly sorted out
+        # return ops.get(self.func, lambda a, b, evaluate=False: ~(self.func(a, b, evaluate=evaluate)))(*self.args, evaluate=False)
+        return ops.get(self.func)(*self.args, evaluate=False)
 
     def _eval_evalf(self, prec):
         return self.func(*[s._evalf(prec) for s in self.args])

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -122,7 +122,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         """
         ops = {Gt: Lt, Ge: Le, Lt: Gt, Le: Ge}
         a, b = self.args
-        return ops.get(self.func, self.func)(b, a, evaluate=False)
+        return Relational.__new__(ops.get(self.func, self.func), b, a)
 
     @property
     def negated(self):
@@ -154,7 +154,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         ops = {Eq: Ne, Ge: Lt, Gt: Le, Le: Gt, Lt: Ge, Ne: Eq}
         # If there ever will be new Relational subclasses, the following line will work until it is properly sorted out
         # return ops.get(self.func, lambda a, b, evaluate=False: ~(self.func(a, b, evaluate=evaluate)))(*self.args, evaluate=False)
-        return ops.get(self.func)(*self.args, evaluate=False)
+        return Relational.__new__(ops.get(self.func), *self.args)
 
     def _eval_evalf(self, prec):
         return self.func(*[s._evalf(prec) for s in self.args])

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -124,6 +124,28 @@ class Relational(Boolean, Expr, EvalfMixin):
         a, b = self.args
         return ops.get(self.func, self.func)(b, a, evaluate=False)
 
+    @property
+    def negated(self):
+        """Return the negated relationship.
+
+        Examples
+        ========
+
+        >>> from sympy import Eq
+        >>> from sympy.abc import x
+        >>> Eq(x, 1)
+        Eq(x, 1)
+        >>> _.negated
+        Ne(x, 1)
+        >>> x < 1
+        x < 1
+        >>> _.negated
+        x >= 1
+        """
+        ops = {Eq: Ne, Ge: Lt, Gt: Le, Le: Gt, Lt: Ge, Ne: Eq}
+        a, b = self.args
+        return ops.get(self.func, self.func)(a, b, evaluate=False)
+
     def _eval_evalf(self, prec):
         return self.func(*[s._evalf(prec) for s in self.args])
 
@@ -500,7 +522,7 @@ class Unequality(Relational):
         if evaluate:
             is_equal = Equality(lhs, rhs)
             if isinstance(is_equal, BooleanAtom):
-                return ~is_equal
+                return is_equal.negated
 
         return Relational.__new__(cls, lhs, rhs, **options)
 
@@ -524,7 +546,7 @@ class Unequality(Relational):
         if isinstance(eq, Equality):
             # send back Ne with the new args
             return self.func(*eq.args)
-        return ~eq  # result of Ne is ~Eq
+        return eq.negated  # result of Ne is the negated Eq
 
 Ne = Unequality
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function, Eq,
-    log, cos, sin, Add)
+    log, cos, sin, Add, floor, ceiling)
 from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
@@ -658,17 +658,20 @@ def test_canonical():
 
 
 @XFAIL
-def test_issue_8444():
+def test_issue_8444_nonworkingtests():
     x = symbols('x', real=True)
     assert (x <= oo) == (x >= -oo) == True
 
     x = symbols('x')
     assert x >= floor(x)
     assert (x < floor(x)) == False
-    assert Gt(x, floor(x)) == Gt(x, floor(x), evaluate=False)
-    assert Ge(x, floor(x)) == Ge(x, floor(x), evaluate=False)
     assert x <= ceiling(x)
     assert (x > ceiling(x)) == False
+
+def test_issue_8444_workingtests():
+    x = symbols('x')
+    assert Gt(x, floor(x)) == Gt(x, floor(x), evaluate=False)
+    assert Ge(x, floor(x)) == Ge(x, floor(x), evaluate=False)
     assert Lt(x, ceiling(x)) == Lt(x, ceiling(x), evaluate=False)
     assert Le(x, ceiling(x)) == Le(x, ceiling(x), evaluate=False)
     i = symbols('i', integer=True)
@@ -803,6 +806,21 @@ def test_Equality_rewrite_as_Add():
     assert eq.rewrite(Add, evaluate=None).args == (x, x, y, -y)
     assert eq.rewrite(Add, evaluate=False).args == (x, y, x, -y)
 
+
 def test_issue_15847():
     a = Ne(x*(x+y), x**2 + x*y)
     assert simplify(a) == False
+
+
+def test_negated_property():
+    eq = Eq(x, y)
+    assert eq.negated == Ne(x, y)
+
+    eq = Ne(x, y)
+    assert eq.negated == Eq(x, y)
+
+    eq = Ge(x + y, y - x)
+    assert eq.negated == Lt(x + y, y - x)
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(x, y).negated.negated == f(x, y)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -267,12 +267,12 @@ class Piecewise(Function):
                 nonredundant = []
                 for c in cond.args:
                     if (isinstance(c, Relational) and
-                            (~c).canonical in current_cond):
+                            c.negated.canonical in current_cond):
                         continue
                     nonredundant.append(c)
                 cond = cond.func(*nonredundant)
             elif isinstance(cond, Relational):
-                if (~cond).canonical in current_cond:
+                if cond.negated.canonical in current_cond:
                     cond = S.true
 
             current_cond.add(cond)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -320,6 +320,10 @@ class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
     def __hash__(self):
         return hash(True)
 
+    @property
+    def negated(self):
+        return S.false
+
     def as_set(self):
         """
         Rewrite logic operators and relationals in terms of real sets.
@@ -382,6 +386,10 @@ class BooleanFalse(with_metaclass(Singleton, BooleanAtom)):
 
     def __hash__(self):
         return hash(False)
+
+    @property
+    def negated(self):
+        return S.true
 
     def as_set(self):
         """
@@ -542,7 +550,7 @@ class And(LatticeOp, BooleanFunction):
                 c = x.canonical
                 if c in rel:
                     continue
-                nc = (~c).canonical
+                nc = c.negated.canonical
                 if any(r == nc for r in rel):
                     return [S.false]
                 rel.append(c)
@@ -652,7 +660,7 @@ class Or(LatticeOp, BooleanFunction):
                 c = x.canonical
                 if c in rel:
                     continue
-                nc = (~c).canonical
+                nc = c.negated.canonical
                 if any(r == nc for r in rel):
                     return [S.true]
                 rel.append(c)
@@ -842,7 +850,7 @@ class Xor(BooleanFunction):
                 argset.remove(arg)
             else:
                 argset.add(arg)
-        rel = [(r, r.canonical, (~r).canonical) for r in argset if r.is_Relational]
+        rel = [(r, r.canonical, r.negated.canonical) for r in argset if r.is_Relational]
         odd = False  # is number of complimentary pairs odd? start 0 -> False
         remove = []
         for i, (r, c, nc) in enumerate(rel):
@@ -1050,7 +1058,7 @@ class Implies(BooleanFunction):
         elif A.is_Relational and B.is_Relational:
             if A.canonical == B.canonical:
                 return S.true
-            if (~A).canonical == B.canonical:
+            if A.negated.canonical == B.canonical:
                 return B
         else:
             return Basic.__new__(cls, *args)
@@ -1093,7 +1101,7 @@ class Equivalent(BooleanFunction):
         rel = []
         for r in argset:
             if isinstance(r, Relational):
-                rel.append((r, r.canonical, (~r).canonical))
+                rel.append((r, r.canonical, r.negated.canonical))
         remove = []
         for i, (r, c, nc) in enumerate(rel):
             for j in range(i + 1, len(rel)):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -737,6 +737,11 @@ def test_canonical_atoms():
     assert false.canonical == false
 
 
+def test_negated_atoms():
+    assert true.negated == false
+    assert false.negated == true
+
+
 def test_issue_8777():
     assert And(x > 2, x < oo).as_set() == Interval(2, oo, left_open=True)
     assert And(x >= 1, x < oo).as_set() == Interval(1, oo)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15869 

#### Brief description of what is fixed or changed
I have added a property `negated` to `Relational`s that returns the opposite Relational, so `Eq(x, y).negated` gives `Ne(x, y)`. This has only minor benefits over ~, one is that it ignores evaluate = False, so code that relies on negating a relation, primarily in `logic`, see #15869. The purpose of this code is to compare temporary expressions, so not to actually evaluate the expressions, so from that perspective it should be OK, just as the property `canonical` returns a slightly different expression, independent of evaluate. Hence, it should be used with a bit of care.

I also added the property to `BooleanAtom` which makes sense because the result of a `Relational` is a `BooleanAtom`, but doesn't make sense as no other objects in `logic` has that property. From a coding perspective it is only used in a few places (at the moment, only checked quite few cases, could be more).

#### Other comments
Not sure if there should be a release note. I guess it can be convenient for the user to know about it sometimes.

~~I also believe that it is slightly faster than using Not as there should be more processing steps involved with Not. Not a major factor, but no drawback either.~~ Timeit tests show that this is < 10% slower. Not obvious why.

Finally, I split the tests for #8444 as not all of them fails at the moment. Better to have those working is an executed test. Slightly unrelated, but better put it in here as I happened to see it now.

Oh, yeah, I was thinking quite long before deciding on `negated`. One may imagine `inverted` or `complemented` as well. And probably a few more options. I know how to change it...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Relationals now have a property negated, which returns the opposite to the relation, similar to ~.
<!-- END RELEASE NOTES -->
