### PR TITLE
[WIP] Added new simplifications for Piecewise and fixed issue with previous version

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -351,14 +351,12 @@ class Piecewise(Function):
                         other = [ei.subs(*e.args) for ei in other]
                 cond = And(*(eqs + other))
                 args[i] = args[i].func(expr, cond)
-        # See if expressions valid for a single point happens to evaluate
+        # See if expressions valid for an Equal expression happens to evaluate
         # to the same function as in the next piecewise segment, see:
         # https://github.com/sympy/sympy/issues/8458
         prevexpr = None
         for i, (expr, cond) in reversed(list(enumerate(args))):
             if prevexpr is not None:
-                _prevexpr = prevexpr
-                _expr = expr
                 if isinstance(cond, And):
                     eqs, other = sift(cond.args,
                         lambda i: isinstance(i, Equality), binary=True)
@@ -366,7 +364,9 @@ class Piecewise(Function):
                     eqs, other = [cond], []
                 else:
                     eqs = other = []
-                if eqs:
+                _prevexpr = prevexpr
+                _expr = expr
+                if eqs and not other:
                     eqs = list(ordered(eqs))
                     for j, e in enumerate(eqs):
                         # these blessed lhs objects behave like Symbols
@@ -377,12 +377,95 @@ class Piecewise(Function):
                                 Symbol, UndefinedFunction)):
                             _prevexpr = _prevexpr.subs(*e.args)
                             _expr = _expr.subs(*e.args)
+                # Did it evaluate to the same?
                 if _prevexpr == _expr:
+                    # Set the expression for the Not equal section to the same
+                    # as the next. These will be merged when creating the new
+                    # Piecewise
                     args[i] = args[i].func(args[i+1][0], cond)
+            prevexpr = expr
+        # Handle segments of the type Or(Eq(x, y), Eq(x, z), And(Eq(x, 2), Eq(y, 3)))
+        # Check if any of the Or-terms can be moved to the next segment
+        # This may or may not be a good idea, so we check the consequences here
+        newargs = args.copy()
+        prevexpr = None
+        anythingchanged = False
+        for i, (expr, cond) in reversed(list(enumerate(newargs))):
+            if prevexpr is not None:
+                if isinstance(cond, Or):
+                    terms = [] # Terms that must stay in the same segment
+                    movedterms = [] # Terms that can may just as well be in the next segment
+                    for j, orterm in enumerate(cond.args):
+                        if isinstance(orterm, And):
+                            eqs, other = sift(orterm.args,
+                                lambda i: isinstance(i, Equality), binary=True)
+                        elif isinstance(orterm, Equality):
+                            eqs, other = [orterm], []
+                        else:
+                            eqs = other = []
+                        _prevexpr = prevexpr
+                        _expr = expr
+                        if eqs and not other:
+                            eqs = list(ordered(eqs))
+                            for k, e in enumerate(eqs):
+                                # these blessed lhs objects behave like Symbols
+                                # and the rhs are simple replacements for the "symbols"
+                                if isinstance(e.lhs, (Symbol, UndefinedFunction)) and \
+                                    isinstance(e.rhs,
+                                        (Rational, NumberSymbol,
+                                        Symbol, UndefinedFunction)):
+                                    _prevexpr = _prevexpr.subs(*e.args)
+                                    _expr = _expr.subs(*e.args)
+                        if _prevexpr == _expr:
+                            movedterms.append(orterm)
+                        else:
+                            terms.append(orterm)
+                    # Are the any terms that can be in the next segment?
+                    if movedterms:
+                        anythingchanged = True
+                        newcond = Or(*(terms))
+                        movecond = Or(*(movedterms))
+                        newargs[i] = newargs[i].func(expr, newcond)
+                        newargs[i+1] = newargs[i+1].func(prevexpr, Or(newargs[i+1].cond, movecond))
+            prevexpr = expr
+        if anythingchanged:
+            oldcost = sum([measure(cond) for expr, cond in args])
+            newcost = sum([measure(cond) for expr, cond in newargs])
+            if newcost < ratio*oldcost:
+                args = newargs
+
+        # See if not equal expressions happens to evaluate to the
+        # same function as in the next piecewise segment for the not equal condition
+        prevexpr = None
+        for i, (expr, cond) in reversed(list(enumerate(args))):
+            if prevexpr is not None:
+                _prevexpr = prevexpr
+                _expr = expr
+                if isinstance(cond, And):
+                    eqs, other = sift(cond.args,
+                        lambda i: isinstance(i, Unequality), binary=True)
+                elif isinstance(cond, Unequality):
+                    eqs, other = [cond], []
                 else:
-                    prevexpr = expr
-            else:
-                prevexpr = expr
+                    eqs = other = []
+                if eqs and not other:
+                    eqs = list(ordered(eqs))
+                    for j, e in enumerate(eqs):
+                        # these blessed lhs objects behave like Symbols
+                        # and the rhs are simple replacements for the "symbols"
+                        if isinstance(e.lhs, (Symbol, UndefinedFunction)) and \
+                            isinstance(e.rhs,
+                                (Rational, NumberSymbol,
+                                Symbol, UndefinedFunction)):
+                            _prevexpr = _prevexpr.subs(*e.args)
+                            _expr = _expr.subs(*e.args)
+                # Did it evaluate to the same?
+                if _prevexpr == _expr:
+                    # Set the expression for the Not equal section to the same
+                    # as the next. These will be merged when creating the new
+                    # Piecewise
+                    args[i] = args[i].func(args[i+1][0], cond)
+            prevexpr = expr
         return self.func(*args)
 
     def _eval_as_leading_term(self, x):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1154,14 +1154,23 @@ def test_piecewise_simplify2():
     assert Piecewise((1, Eq(x, 0)), (sin(x)/x, True)).simplify() == Piecewise((1, Eq(x, 0)), (sin(x)/x, True))
     assert Piecewise((1, Eq(x, 0)), (sin(x) + 1 + x, True)).simplify() == x + sin(x) + 1
 
-    assert Piecewise((x**2, Ne(x, y)), (x*y, True)).simplify() == x*y
+    assert Piecewise((x**2, Ne(x, y)), (x*y, True)).simplify() == x**2
 
-    assert Piecewise((x**2, Ne(x, 2)), (2*x, Ne(x, 4)), (x*y, True)).simplify() == 2*x
+    assert Piecewise((x**2, Ne(x, 2)), (2*x, Ne(x, 4)), (x*y, True)).simplify() == x**2
 
     assert Piecewise((y*x**2, Eq(x, 2)), (y*2*x, Ge(x, 4)), (x*y, True)).simplify() == Piecewise((2*x*y, Or(Eq(x, 2), Ge(x, 4))), (x*y, True))
 
     p = Piecewise((x**2, And(Ne(x, 2), Ne(x, y))), (2*x, Ne(x, 4)), (x*y, True))
     ps = p.simplify()
-    assert ps == Piecewise((2*x, (Ne(x, 2) | Ne(x, 4)) & (Ne(x, 4) | Ne(x, y))), (x*y, True))
+    assert ps == Piecewise((x**2, (Ne(x, 2) | Ne(x, 4)) & (Ne(x, 4) | Ne(x, y))), (x*y, True))
     # Currently, the segment expressions must be simplified twice
-    assert ps.simplify() == Piecewise((2*x, Ne(x, 4) | (Ne(x, 2) & Ne(x, y))), (x*y, True))
+    assert ps.simplify() == Piecewise((x**2, Ne(x, 4) | (Ne(x, 2) & Ne(x, y))), (x*y, True))
+
+    # From example in #15705
+    a=symbols('a', real=True)
+    expr = Piecewise((-a, -a > a), (a, a >= -a))
+    p = Piecewise((0, 0 < expr), (expr, expr <= 0))
+    pf = piecewise_fold(p)
+    assert pf.simplify() == 0
+    # It actually works when simplifying the joint Piecewise as well
+    assert p.simplify() == 0

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -3,7 +3,7 @@ from sympy import (
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
     cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
-    factor_terms, DiracDelta, Heaviside, Add, Mul, factorial)
+    factor_terms, DiracDelta, Heaviside, Add, Mul, factorial, Ge)
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -1143,3 +1143,25 @@ def test_issue_8458():
     # Test for problem highlighted during review
     p3 = Piecewise((x+1, Eq(x, -1)), (4*x + (y-2)**4, Eq(x, 0) & Eq(x+y, 2)), (sin(x), True))
     assert p3.simplify() == Piecewise((0, Eq(x, -1)), (sin(x), True))
+
+
+def test_piecewise_simplify2():
+    # Test for issue introduced in earlier PR
+    assert Piecewise((2, And(Eq(x, 2), Ge(y,0))), (x, True)).simplify() == Piecewise((2, And(Eq(x, 2), Ge(y,0))), (x, True))
+
+    assert Piecewise((2+y, And(Eq(x, 2), Eq(y, 0))), (x, True)).simplify() == x
+    assert Piecewise((2+y, Or(Eq(x, 4), And(Eq(x, 2), Eq(y, 0)))), (x, True)).simplify() == Piecewise((2 + y, Or(Eq(x, 4))), (x, True))
+    assert Piecewise((1, Eq(x, 0)), (sin(x)/x, True)).simplify() == Piecewise((1, Eq(x, 0)), (sin(x)/x, True))
+    assert Piecewise((1, Eq(x, 0)), (sin(x) + 1 + x, True)).simplify() == x + sin(x) + 1
+
+    assert Piecewise((x**2, Ne(x, y)), (x*y, True)).simplify() == x*y
+
+    assert Piecewise((x**2, Ne(x, 2)), (2*x, Ne(x, 4)), (x*y, True)).simplify() == 2*x
+
+    assert Piecewise((y*x**2, Eq(x, 2)), (y*2*x, Ge(x, 4)), (x*y, True)).simplify() == Piecewise((2*x*y, Or(Eq(x, 2), Ge(x, 4))), (x*y, True))
+
+    p = Piecewise((x**2, And(Ne(x, 2), Ne(x, y))), (2*x, Ne(x, 4)), (x*y, True))
+    ps = p.simplify()
+    assert ps == Piecewise((2*x, (Ne(x, 2) | Ne(x, 4)) & (Ne(x, 4) | Ne(x, y))), (x*y, True))
+    # Currently, the segment expressions must be simplified twice
+    assert ps.simplify() == Piecewise((2*x, Ne(x, 4) | (Ne(x, 2) & Ne(x, y))), (x*y, True))


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Now Piecewise of the type
```
⎧y + 2  for x = 2 ∧ y = 0
⎨                        
⎩  x        otherwise    

```
can be simplified (to `x`) as well as of the type
```
⎧ 2            
⎪x    for x ≠ 2
⎪              
⎨2⋅x  for x ≠ 4
⎪              
⎪x⋅y  otherwise
⎩    
```          
(gives ~~`2⋅x`~~ `x**2`).

Hence, for Or-type of Equality or Or of And of Equality `Or(Eq..., And(Eq.., Eq...)))` it is checked if any of the terms in the Or can be moved to the next segment. It also checks if the total measure of the segment expressions is reduced. Here, one may think of cases where one term can be move to several of the following segments and one tries to figure out what the best combination is, probably through some exhaustive search. One may also note that the fact that segments are removed are not explicitly encouraged. This will follow from the simplification of the segment expressions, moving an expression should not increase the complexity, if anything reduce it, and with a sensible ratio this should be OK. But if we try to position an Or-term it will require that one also takes this into account and that will require additional computational complexity. If there are many cases that does not simplify well here it should be possible to implement though.

For Neq expressions, it is simply checked if the next expression happens to evaluate to the same expression as the Neq expression, for the same value as the Neq expression is not allowed to take. In that case, the expression of the latter expression is used for the first and eventually merged.

I also realized that there were some cases in the previous PR #15898 that did not work correctly. Those should work now.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
