### PR TITLE
Add "nqubits" parameter to IntQubit

### DIFF
--- a/examples/advanced/grover_example.py
+++ b/examples/advanced/grover_example.py
@@ -12,12 +12,12 @@ from sympy.physics.quantum.grover import (OracleGate, superposition_basis,
 def demo_vgate_app(v):
     for i in range(2**v.nqubits):
         print('qapply(v*IntQubit(%i, %r))' % (i, v.nqubits))
-        pprint(qapply(v*IntQubit(i, v.nqubits)))
-        qapply(v*IntQubit(i, v.nqubits))
+        pprint(qapply(v*IntQubit(i, nqubits=v.nqubits)))
+        qapply(v*IntQubit(i, nqubits=v.nqubits))
 
 
 def black_box(qubits):
-    return True if qubits == IntQubit(1, qubits.nqubits) else False
+    return True if qubits == IntQubit(1, nqubits=qubits.nqubits) else False
 
 
 def main():

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -55,7 +55,7 @@ def superposition_basis(nqubits):
     """
 
     amp = 1/sqrt(2**nqubits)
-    return sum([amp*IntQubit(n, nqubits) for n in range(2**nqubits)])
+    return sum([amp*IntQubit(n, nqubits=nqubits) for n in range(2**nqubits)])
 
 
 class OracleGate(Gate):
@@ -176,7 +176,7 @@ class OracleGate(Gate):
         matrixOracle = eye(nbasis)
         # Flip the sign given the output of the oracle function
         for i in range(nbasis):
-            if self.search_function(IntQubit(i, self.nqubits)):
+            if self.search_function(IntQubit(i, nqubits=self.nqubits)):
                 matrixOracle[i, i] = NegativeOne()
         return matrixOracle
 

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -129,10 +129,10 @@ class QExpr(Expr):
         """
 
         # First compute args and call Expr.__new__ to create the instance
-        args = cls._eval_args(args)
+        args = cls._eval_args(args, **old_assumptions)
         if len(args) == 0:
-            args = cls._eval_args(tuple(cls.default_args()))
-        inst = Expr.__new__(cls, *args, **old_assumptions)
+            args = cls._eval_args(tuple(cls.default_args()), **old_assumptions)
+        inst = Expr.__new__(cls, *args)
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)
         return inst

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -100,7 +100,7 @@ class QExpr(Expr):
     def free_symbols(self):
         return {self}
 
-    def __new__(cls, *args, **old_assumptions):
+    def __new__(cls, *args, **kwargs):
         """Construct a new quantum object.
 
         Parameters
@@ -129,9 +129,9 @@ class QExpr(Expr):
         """
 
         # First compute args and call Expr.__new__ to create the instance
-        args = cls._eval_args(args, **old_assumptions)
+        args = cls._eval_args(args, **kwargs)
         if len(args) == 0:
-            args = cls._eval_args(tuple(cls.default_args()), **old_assumptions)
+            args = cls._eval_args(tuple(cls.default_args()), **kwargs)
         inst = Expr.__new__(cls, *args)
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -282,14 +282,13 @@ class IntQubitState(QubitState):
     """A base class for qubits that work with binary representations."""
 
     @classmethod
-    def _eval_args(cls, args, **extra_args):
+    def _eval_args(cls, args, nqubits=None):
         # The case of a QubitState instance
         if len(args) == 1 and isinstance(args[0], QubitState):
             return QubitState._eval_args(args)
         # otherwise, args should be integer
         elif not all((isinstance(a, (int, Integer)) for a in args)):
             raise ValueError('values must be integers, got (%s)' % (tuple(type(a) for a in args),))
-        nqubits = extra_args.get('nqubits')
         # use nqubits if specified
         if nqubits is not None:
             if not isinstance(nqubits, (int, Integer)):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -283,8 +283,11 @@ class IntQubitState(QubitState):
 
     @classmethod
     def _eval_args(cls, args, **extra_args):
-        # args should be integer
-        if not all((isinstance(a, (int, Integer)) for a in args)):
+        # The case of a QubitState instance
+        if len(args) == 1 and isinstance(args[0], QubitState):
+            return QubitState._eval_args(args)
+        # otherwise, args should be integer
+        elif not all((isinstance(a, (int, Integer)) for a in args)):
             raise ValueError('values must be integers, got (%s)' % (tuple(type(a) for a in args),))
         nqubits = extra_args.get('nqubits')
         # use nqubits if specified
@@ -295,9 +298,6 @@ class IntQubitState(QubitState):
                 raise ValueError(
                     'too many positional arguments (%s). should be (number, nqubits=n)' % (args,))
             return cls._eval_args_with_nqubits(args[0], nqubits)
-        # The case of a QubitState instance
-        if len(args) == 1 and isinstance(args[0], QubitState):
-            return QubitState._eval_args(args)
         # For a single argument, we construct the binary representation of
         # that integer with the minimal number of bits.
         if len(args) == 1 and args[0] > 1:
@@ -357,9 +357,17 @@ class IntQubit(IntQubitState, Qubit):
     values : int, tuple
         If a single argument, the integer we want to represent in the qubit
         values. This integer will be represented using the fewest possible
-        number of qubits. If a pair of integers, the first integer gives the
-        integer to represent in binary form and the second integer gives
-        the number of qubits to use.
+        number of qubits.
+        If a pair of integers and the second value is more than one, the first
+        integer gives the integer to represent in binary form and the second 
+        integer gives the number of qubits to use.
+        List of zeros and ones is also accepted to generate qubit by bit pattern.
+ 
+    nqubits : int
+        The integer that represents the number of qubits.
+        This number should be passed with keyword ``nqubits=N``.
+        You can use this in order to avoid ambiguity of Qubit-style tuple of bits.
+        Please see the example below for more details.
 
     Examples
     ========
@@ -388,6 +396,21 @@ class IntQubit(IntQubitState, Qubit):
 
         >>> Qubit(q)
         |101>
+
+    Please note that ``IntQubit`` also accept ``Qubit``-style list of bits.
+    So, the code below yields qubits 3, not a single bit ``1``.
+
+        >>> IntQubit(1, 1)
+        |3>
+
+    To avoid ambiguity, use ``nqubits`` parameter.
+    Use of this keyword is recommended especially when you provide the values by variables.
+
+        >>> IntQubit(1, nqubits=1)
+        |1>
+        >>> a = 1
+        >>> IntQubit(a, nqubits=1)
+        |1>
     """
     @classmethod
     def dual_class(self):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -362,7 +362,7 @@ class IntQubit(IntQubitState, Qubit):
         integer gives the integer to represent in binary form and the second
         integer gives the number of qubits to use.
         List of zeros and ones is also accepted to generate qubit by bit pattern.
- 
+
     nqubits : int
         The integer that represents the number of qubits.
         This number should be passed with keyword ``nqubits=N``.

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -283,9 +283,14 @@ class IntQubitState(QubitState):
 
     @classmethod
     def _eval_args(cls, args, **extra_args):
+        # args should be integer
+        if not all((isinstance(a, (int, Integer)) for a in args)):
+            raise ValueError('values must be integers, got (%s)' % (tuple(type(a) for a in args),))
         nqubits = extra_args.get('nqubits')
         # use nqubits if specified
         if nqubits is not None:
+            if not isinstance(nqubits, (int, Integer)):
+                raise ValueError('nqubits must be an integer, got (%s)' % type(nqubits))
             if len(args) != 1:
                 raise ValueError(
                     'too many positional arguments (%s). should be (number, nqubits=n)' % (args,))

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -283,7 +283,7 @@ class IntQubitState(QubitState):
 
     @classmethod
     def _eval_args(cls, args, **extra_args):
-        nbits = extra_args.get('nbits')
+        nqubits = extra_args.get('nqubits')
         # The case of a QubitState instance
         if len(args) == 1 and isinstance(args[0], QubitState):
             return QubitState._eval_args(args)
@@ -296,14 +296,14 @@ class IntQubitState(QubitState):
             return QubitState._eval_args(qubit_values)
         # For two numbers, the second number is the number of bits
         # on which it is expressed, so IntQubit(0,5) == |00000>.
-        elif nbits is not None or (len(args) == 2 and args[1] > 1):
-            if nbits is None:
-                nbits = args[1]
+        elif nqubits is not None or (len(args) == 2 and args[1] > 1):
+            if nqubits is None:
+                nqubits = args[1]
             need = bitcount(abs(args[0]))
-            if nbits < need:
+            if nqubits < need:
                 raise ValueError(
-                    'cannot represent %s with %s bits' % (args[0], nbits))
-            qubit_values = [(args[0] >> i) & 1 for i in reversed(range(nbits))]
+                    'cannot represent %s with %s bits' % (args[0], nqubits))
+            qubit_values = [(args[0] >> i) & 1 for i in reversed(range(nqubits))]
             return QubitState._eval_args(qubit_values)
         else:
             return QubitState._eval_args(args)

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -359,7 +359,7 @@ class IntQubit(IntQubitState, Qubit):
         values. This integer will be represented using the fewest possible
         number of qubits.
         If a pair of integers and the second value is more than one, the first
-        integer gives the integer to represent in binary form and the second 
+        integer gives the integer to represent in binary form and the second
         integer gives the number of qubits to use.
         List of zeros and ones is also accepted to generate qubit by bit pattern.
  
@@ -397,7 +397,7 @@ class IntQubit(IntQubitState, Qubit):
         >>> Qubit(q)
         |101>
 
-    Please note that ``IntQubit`` also accept ``Qubit``-style list of bits.
+    Please note that ``IntQubit`` also accepts a ``Qubit``-style list of bits.
     So, the code below yields qubits 3, not a single bit ``1``.
 
         >>> IntQubit(1, 1)

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -282,7 +282,8 @@ class IntQubitState(QubitState):
     """A base class for qubits that work with binary representations."""
 
     @classmethod
-    def _eval_args(cls, args):
+    def _eval_args(cls, args, **extra_args):
+        nbits = extra_args.get('nbits')
         # The case of a QubitState instance
         if len(args) == 1 and isinstance(args[0], QubitState):
             return QubitState._eval_args(args)
@@ -295,12 +296,14 @@ class IntQubitState(QubitState):
             return QubitState._eval_args(qubit_values)
         # For two numbers, the second number is the number of bits
         # on which it is expressed, so IntQubit(0,5) == |00000>.
-        elif len(args) == 2 and args[1] > 1:
+        elif nbits is not None or (len(args) == 2 and args[1] > 1):
+            if nbits is None:
+                nbits = args[1]
             need = bitcount(abs(args[0]))
-            if args[1] < need:
+            if nbits < need:
                 raise ValueError(
-                    'cannot represent %s with %s bits' % (args[0], args[1]))
-            qubit_values = [(args[0] >> i) & 1 for i in reversed(range(args[1]))]
+                    'cannot represent %s with %s bits' % (args[0], nbits))
+            qubit_values = [(args[0] >> i) & 1 for i in reversed(range(nbits))]
             return QubitState._eval_args(qubit_values)
         else:
             return QubitState._eval_args(args)

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -11,17 +11,17 @@ def return_one_on_two(qubits):
 
 
 def return_one_on_one(qubits):
-    return qubits == IntQubit(1, qubits.nqubits)
+    return qubits == IntQubit(1, nqubits=qubits.nqubits)
 
 
 def test_superposition_basis():
     nbits = 2
-    first_half_state = IntQubit(0, nbits)/2 + IntQubit(1, nbits)/2
+    first_half_state = IntQubit(0, nqubits=nbits)/2 + IntQubit(1, nqubits=nbits)/2
     second_half_state = IntQubit(2, nbits)/2 + IntQubit(3, nbits)/2
     assert first_half_state + second_half_state == superposition_basis(nbits)
 
     nbits = 3
-    firstq = (1/sqrt(8))*IntQubit(0, nbits) + (1/sqrt(8))*IntQubit(1, nbits)
+    firstq = (1/sqrt(8))*IntQubit(0, nqubits=nbits) + (1/sqrt(8))*IntQubit(1, nqubits=nbits)
     secondq = (1/sqrt(8))*IntQubit(2, nbits) + (1/sqrt(8))*IntQubit(3, nbits)
     thirdq = (1/sqrt(8))*IntQubit(4, nbits) + (1/sqrt(8))*IntQubit(5, nbits)
     fourthq = (1/sqrt(8))*IntQubit(6, nbits) + (1/sqrt(8))*IntQubit(7, nbits)
@@ -35,30 +35,30 @@ def test_OracleGate():
 
     nbits = 2
     v = OracleGate(2, return_one_on_two)
-    assert qapply(v*IntQubit(0, nbits)) == IntQubit(0, nbits)
-    assert qapply(v*IntQubit(1, nbits)) == IntQubit(1, nbits)
+    assert qapply(v*IntQubit(0, nbits)) == IntQubit(0, nqubits=nbits)
+    assert qapply(v*IntQubit(1, nbits)) == IntQubit(1, nqubits=nbits)
     assert qapply(v*IntQubit(2, nbits)) == -IntQubit(2, nbits)
     assert qapply(v*IntQubit(3, nbits)) == IntQubit(3, nbits)
 
-    # Due to a bug of IntQubit, this first assertion is buggy
-    # assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
-    #     Matrix([[-1/sqrt(2), 0], [0, 1/sqrt(2)]])
+    assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
+           Matrix([[-1, 0], [0, 1]])
     assert represent(v, nqubits=2) == Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
+
 
 def test_WGate():
     nqubits = 2
     basis_states = superposition_basis(nqubits)
     assert qapply(WGate(nqubits)*basis_states) == basis_states
 
-    expected = ((2/sqrt(pow(2, nqubits)))*basis_states) - IntQubit(1, nqubits)
-    assert qapply(WGate(nqubits)*IntQubit(1, nqubits)) == expected
+    expected = ((2/sqrt(pow(2, nqubits)))*basis_states) - IntQubit(1, nqubits=nqubits)
+    assert qapply(WGate(nqubits)*IntQubit(1, nqubits=nqubits)) == expected
 
 
 def test_grover_iteration_1():
     numqubits = 2
     basis_states = superposition_basis(numqubits)
     v = OracleGate(numqubits, return_one_on_one)
-    expected = IntQubit(1, numqubits)
+    expected = IntQubit(1, nqubits=numqubits)
     assert qapply(grover_iteration(basis_states, v)) == expected
 
 
@@ -83,7 +83,7 @@ def test_grover_iteration_2():
 
 def test_grover():
     nqubits = 2
-    assert apply_grover(return_one_on_one, nqubits) == IntQubit(1, nqubits)
+    assert apply_grover(return_one_on_one, nqubits) == IntQubit(1, nqubits=nqubits)
 
     nqubits = 4
     basis_states = superposition_basis(nqubits)

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -94,6 +94,7 @@ def test_IntQubit():
     raises(ValueError, lambda: IntQubit('5'))
     raises(ValueError, lambda: IntQubit(5, '5'))
     raises(ValueError, lambda: IntQubit(5, nqubits='5'))
+    raises(TypeError, lambda: IntQubit(5, bad_arg=True))
 
 def test_superposition_of_states():
     state = 1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10')

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -54,7 +54,7 @@ def test_QubitBra():
 
 def test_IntQubit():
     # issue 9136
-    iqb = IntQubit(0, nbits=1)
+    iqb = IntQubit(0, nqubits=1)
     assert qubit_to_matrix(Qubit('0')) == qubit_to_matrix(iqb)
 
     iqb = IntQubit(1, nbits=1)

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -88,6 +88,9 @@ def test_IntQubit():
     assert iqb._eval_innerproduct_IntQubitBra(iqb_bra) == Integer(0)
     raises(ValueError, lambda: IntQubit(4, 1))
 
+    raises(ValueError, lambda: IntQubit('5'))
+    raises(ValueError, lambda: IntQubit(5, '5'))
+    raises(ValueError, lambda: IntQubit(5, nqubits='5'))
 
 def test_superposition_of_states():
     state = 1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10')

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -57,6 +57,9 @@ def test_IntQubit():
     iqb = IntQubit(0, nqubits=1)
     assert qubit_to_matrix(Qubit('0')) == qubit_to_matrix(iqb)
 
+    qb = Qubit('1010')
+    assert qubit_to_matrix(IntQubit(qb)) == qubit_to_matrix(qb)
+
     iqb = IntQubit(1, nqubits=1)
     assert qubit_to_matrix(Qubit('1')) == qubit_to_matrix(iqb)
     assert qubit_to_matrix(IntQubit(1)) == qubit_to_matrix(iqb)

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -57,11 +57,13 @@ def test_IntQubit():
     iqb = IntQubit(0, nqubits=1)
     assert qubit_to_matrix(Qubit('0')) == qubit_to_matrix(iqb)
 
-    iqb = IntQubit(1, nbits=1)
+    iqb = IntQubit(1, nqubits=1)
     assert qubit_to_matrix(Qubit('1')) == qubit_to_matrix(iqb)
+    assert qubit_to_matrix(IntQubit(1)) == qubit_to_matrix(iqb)
 
-    iqb = IntQubit(7, nbits=4)
-    assert qubit_to_matrix(Qubit('111')) == qubit_to_matrix(iqb)
+    iqb = IntQubit(7, nqubits=4)
+    assert qubit_to_matrix(Qubit('0111')) == qubit_to_matrix(iqb)
+    assert qubit_to_matrix(IntQubit(7, 4)) == qubit_to_matrix(iqb)
 
     iqb = IntQubit(8)
     assert iqb.as_int() == 8
@@ -176,6 +178,9 @@ def test_measure_all():
     state2 = Qubit('11')/sqrt(5) + 2*Qubit('00')/sqrt(5)
     assert measure_all(state2) == \
         [(Qubit('00'), Rational(4, 5)), (Qubit('11'), Rational(1, 5))]
+
+    # from issue #12585
+    assert measure_all(qapply(Qubit('0'))) == [(Qubit('0'), 1)]
 
 
 def test_eval_trace():

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -53,6 +53,16 @@ def test_QubitBra():
 
 
 def test_IntQubit():
+    # issue 9136
+    iqb = IntQubit(0, nbits=1)
+    assert qubit_to_matrix(Qubit('0')) == qubit_to_matrix(iqb)
+
+    iqb = IntQubit(1, nbits=1)
+    assert qubit_to_matrix(Qubit('1')) == qubit_to_matrix(iqb)
+
+    iqb = IntQubit(7, nbits=4)
+    assert qubit_to_matrix(Qubit('111')) == qubit_to_matrix(iqb)
+
     iqb = IntQubit(8)
     assert iqb.as_int() == 8
     assert iqb.qubit_values == (1, 0, 0, 0)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #9136
Fixes #12585

#### Brief description of what is fixed or changed
This PR fixes the ambiguity of `IntQubit` constructor.

```
IntQubit(3).args == Qubit('11').args   # bit pattern '11' (3) of implicit width 2
IntQubit(5, 4).args == Qubit('0101').args # bit pattern '0101' (5) of width 4.
IntQubit(1, 0, 1, 1, 1).args == Qubit('10111').args  # bit pattern '10111' of width 5

# the code below can be '1' (the second parameter is the width)
#  or '11' (the second parameter is another bit ).
#  Current implementation interpret this as '11'
IntQubit(1,1) 
```

This PR adds optional keyword argument `nqubits` to provide a workaround for the last case.
The usage of positional arguments are backward compatible.

```
IntQubit(1,1).args == Qubit('11').args
IntQubit(1, nqubits=1).args == Qubit('1').args
```

#### Other comments
`IntQubit` is a subclass of Qubit and they share most of code.
`args` of `IntQubit` needs to be the same with `Qubit`.

one point I'm not fully confident with this PR:
Is it safe to add keyword argument here?
It seems some old code has keyword argument `assumptions`, so I'm wondering there will be the chance that `Basic` get the keyword args back in some future.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.quantum
   * IntQubit now has a keyword argument "nqubit" in its constructor to avoid ambiguity
<!-- END RELEASE NOTES -->
