### PR TITLE
Fix of Evalf doesn't work for expressions involving Symbols

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -551,6 +551,19 @@ class Function(Application, Expr):
             if any(bad(a) for a in args):
                 raise ValueError  # one or more args failed to compute with significance
         except ValueError:
+            from sympy.functions.elementary.exponential import exp
+            if isinstance(self, exp):
+                try:
+                    args = []
+                    for a in self.args:
+                        newa = a._eval_evalf(prec)
+                        if newa is None:
+                            args.append(a)
+                        else:
+                            args.append(newa)
+                    return self.func(*args)
+                except:
+                    pass
             return
 
         with mpmath.workprec(prec):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -551,19 +551,17 @@ class Function(Application, Expr):
             if any(bad(a) for a in args):
                 raise ValueError  # one or more args failed to compute with significance
         except ValueError:
-            from sympy.functions.elementary.exponential import exp
-            if isinstance(self, exp):
-                try:
-                    args = []
-                    for a in self.args:
-                        newa = a._eval_evalf(prec)
-                        if newa is None:
-                            args.append(a)
-                        else:
-                            args.append(newa)
-                    return self.func(*args)
-                except:
-                    pass
+            try:
+                args = []
+                for a in self.args:
+                    newa = a._eval_evalf(prec)
+                    if newa is None:
+                        args.append(a)
+                    else:
+                        args.append(newa)
+                return self.func(*args)
+            except:
+                pass
             return
 
         with mpmath.workprec(prec):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15919 

#### Brief description of what is fixed or changed
Earlier 
```
r = RootOf(x**5 - x + 1, 0)
exp(r*x).evalf()
exp(x*CRootOf(x**5 - x + 1, 0))
```
Now
```
r = RootOf(x**5 - x + 1, 0)
exp(r*x).evalf()
exp(-1.16730397826142*x)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * fixed a bug in _eval_evalf function in function.py
<!-- END RELEASE NOTES -->
