### PR TITLE
Added configuration option for imaginary_unit in the LaTeX and pretty printers

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3812,7 +3812,7 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
     __slots__ = []
 
     def _latex(self, printer):
-        return r"i"
+        return printer._settings['imaginary_unit']
 
     @staticmethod
     def __abs__():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3812,7 +3812,7 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
     __slots__ = []
 
     def _latex(self, printer):
-        return printer._settings['imaginary_unit']
+        return printer._settings['imaginary_unit_latex']
 
     @staticmethod
     def __abs__():

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -135,6 +135,7 @@ class LatexPrinter(Printer):
         "order": None,
         "symbol_names": {},
         "root_notation": True,
+        "imaginary_unit": "i",
     }
 
     def __init__(self, settings=None):
@@ -2269,7 +2270,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     fold_short_frac=None, inv_trig_style="abbreviated",
     itex=False, ln_notation=False, long_frac_ratio=None,
     mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
-    order=None, symbol_names=None, root_notation=True):
+    order=None, symbol_names=None, root_notation=True, imaginary_unit="i"):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2325,6 +2326,9 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     root_notation : boolean, optional
         If set to ``False``, exponents of the form 1/n are printed in fractonal form.
         Default is ``True``, to print exponent in root form.
+    imaginary_unit : string, optional
+        String to use for the imaginary unit. Default is "i". Common alternatives
+        are "j" and "\\textrm{i}".
 
     Notes
     =====
@@ -2450,6 +2454,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         'order' : order,
         'symbol_names' : symbol_names,
         'root_notation' : root_notation,
+        'imaginary_unit' : imaginary_unit,
     }
 
     return LatexPrinter(settings).doprint(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -178,8 +178,21 @@ class LatexPrinter(Printer):
 
         self._delim_dict = {'(': ')', '[': ']'}
 
-        if not isinstance(self._settings['imaginary_unit'], string_types):
-            raise TypeError("'imaginary_unit' must be a string, not {}".format(self._settings['imaginary_unit']))
+        imaginary_unit_table = {
+            None: r"i",
+            "i": r"i",
+            "ri": r"\mathrm{i}",
+            "ti": r"\text{i}",
+            "j": r"j",
+            "rj": r"\mathrm{j}",
+            "tj": r"\text{j}",
+        }
+        try:
+            self._settings['imaginary_unit_latex'] = \
+                imaginary_unit_table[self._settings['imaginary_unit']]
+        except KeyError:
+            self._settings['imaginary_unit_latex'] = \
+                self._settings['imaginary_unit']
 
     def parenthesize(self, item, level, strict=False):
         prec_val = precedence_traditional(item)
@@ -2330,8 +2343,9 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         If set to ``False``, exponents of the form 1/n are printed in fractonal form.
         Default is ``True``, to print exponent in root form.
     imaginary_unit : string, optional
-        String to use for the imaginary unit. Default is "i". Common alternatives
-        are "j" and "\\textrm{i}".
+        String to use for the imaginary unit. Defined options are "i" (default)
+        and "j". Adding "b" or "t" in front gives ``\mathrm`` or ``\text``, so
+        "bi" leads to ``\mathrm{i}`` which gives `\mathrm{i}`.
 
     Notes
     =====

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -177,7 +177,7 @@ class LatexPrinter(Printer):
                     self._settings['mul_symbol']
 
         self._delim_dict = {'(': ')', '[': ']'}
-        
+
         if not isinstance(self._settings['imaginary_unit'], string_types):
             raise TypeError("'imaginary_unit' must be a string, not {}".format(self._settings['imaginary_unit']))
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -23,7 +23,7 @@ from sympy.printing.precedence import precedence, PRECEDENCE
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
 
-from sympy.core.compatibility import default_sort_key, range
+from sympy.core.compatibility import default_sort_key, range, string_types
 from sympy.utilities.iterables import has_variety
 
 import re
@@ -177,6 +177,9 @@ class LatexPrinter(Printer):
                     self._settings['mul_symbol']
 
         self._delim_dict = {'(': ')', '[': ']'}
+        
+        if not isinstance(self._settings['imaginary_unit'], string_types):
+            raise TypeError("'imaginary_unit' must be a string, not {}".format(self._settings['imaginary_unit']))
 
     def parenthesize(self, item, level, strict=False):
         prec_val = precedence_traditional(item)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 import itertools
 
 from sympy.core import S
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, string_types
 from sympy.core.containers import Tuple
 from sympy.core.function import _coeff_isneg
 from sympy.core.mul import Mul
@@ -41,10 +41,16 @@ class PrettyPrinter(Printer):
         "num_columns": None,
         "use_unicode_sqrt_char": True,
         "root_notation": True,
+        "imaginary_unit": "i",
     }
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)
+
+        if not isinstance(self._settings['imaginary_unit'], string_types):
+            raise TypeError("'imaginary_unit' must a string, not {}".format(self._settings['imaginary_unit']))
+        elif self._settings['imaginary_unit'] not in ["i", "j"]:
+            raise ValueError("'imaginary_unit' must be either 'i' or 'j', not '{}'".format(self._settings['imaginary_unit']))
         self.emptyPrinter = lambda x: prettyForm(xstr(x))
 
     @property
@@ -136,7 +142,7 @@ class PrettyPrinter(Printer):
     def _print_Atom(self, e):
         try:
             # print atoms like Exp1 or Pi
-            return prettyForm(pretty_atom(e.__class__.__name__))
+            return prettyForm(pretty_atom(e.__class__.__name__, printer=self))
         except KeyError:
             return self.emptyPrinter(e)
 
@@ -2458,7 +2464,8 @@ def pretty(expr, **settings):
 
 
 def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
-                 full_prec="auto", order=None, use_unicode_sqrt_char=True, root_notation = True):
+                 full_prec="auto", order=None, use_unicode_sqrt_char=True,
+                 root_notation = True, imaginary_unit="i"):
     """Prints expr in pretty form.
 
     pprint is just a shortcut for this function.
@@ -2493,10 +2500,14 @@ def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
         Set to 'False' for printing exponents of the form 1/n in fractional form;
         By default exponent is printed in root form.
 
+    imaginary_unit : string, optional (default="i")
+        Letter to use for imaginary unit when use_unicode is True.
+        Can be "i" (default) or "j".
     """
     print(pretty(expr, wrap_line=wrap_line, num_columns=num_columns,
                  use_unicode=use_unicode, full_prec=full_prec, order=order,
-                 use_unicode_sqrt_char=use_unicode_sqrt_char, root_notation=root_notation))
+                 use_unicode_sqrt_char=use_unicode_sqrt_char,
+                 root_notation=root_notation, imaginary_unit=imaginary_unit))
 
 pprint = pretty_print
 

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -487,10 +487,13 @@ atoms_table = {
 }
 
 
-def pretty_atom(atom_name, default=None):
+def pretty_atom(atom_name, default=None, printer=None):
     """return pretty representation of an atom"""
     if _use_unicode:
-        return atoms_table[atom_name]
+        if printer is not None and atom_name == 'ImaginaryUnit' and printer._settings['imaginary_unit'] == 'j':
+            return U('DOUBLE-STRUCK ITALIC SMALL J')
+        else:
+            return atoms_table[atom_name]
     else:
         if default is not None:
             return default

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6503,12 +6503,14 @@ def test_issue_15560():
     result = 'a*(a x a)'
     assert e == result
 
+
 def test_issue_15583():
 
     N = mechanics.ReferenceFrame('N')
     result = '(n_x, n_y, n_z)'
     e = pretty((N.x, N.y, N.z))
     assert e == result
+
 
 def test_put_accent_in_middle_of_string():
     assert put_accent_in_middle_of_string('a', u'\N{COMBINING TILDE}') == u'ã'
@@ -6517,3 +6519,13 @@ def test_put_accent_in_middle_of_string():
     assert put_accent_in_middle_of_string('aaaa', u'\N{COMBINING TILDE}') == u'aaãa'
     assert put_accent_in_middle_of_string('aaaaa', u'\N{COMBINING TILDE}') == u'aaãaa'
     assert put_accent_in_middle_of_string('abcdefg', u'\N{COMBINING FOUR DOTS ABOVE}') == u'abcd⃜efg'
+
+def test_imaginary_unit():
+    from sympy import pretty # As it is redefined above
+    assert pretty(1 + I, use_unicode=False) == '1 + I'
+    assert pretty(1 + I, use_unicode=True) == u'1 + ⅈ'
+    assert pretty(1 + I, use_unicode=False, imaginary_unit='j') == '1 + I'
+    assert pretty(1 + I, use_unicode=True, imaginary_unit='j') == u'1 + ⅉ'
+
+    raises(TypeError, lambda: pretty(I, imaginary_unit=I))
+    raises(ValueError, lambda: pretty(I, imaginary_unit="kkk"))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,7 +17,7 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-     UnevaluatedExpr, Quaternion)
+     UnevaluatedExpr, Quaternion, I)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -1913,3 +1913,13 @@ def test_print_basic():
     assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
     assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'
     assert latex(unimplemented_expr_sup_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'
+
+def test_imaginary_unit():
+    assert latex(1 + I) == '1 + i'
+    assert latex(1 + I, imaginary_unit='j') == '1 + j'
+    assert latex(1 + I, imaginary_unit='foo') == '1 + foo'
+    assert latex(1 + I, imaginary_unit='foo') == '1 + foo'
+    assert latex(I, imaginary_unit=r"\text{i}") == '\\text{i}'
+
+    raises(TypeError, lambda: latex(I, imaginary_unit=I))
+    raises(TypeError, lambda: latex(I, imaginary_unit=latex))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1918,7 +1918,6 @@ def test_imaginary_unit():
     assert latex(1 + I) == '1 + i'
     assert latex(1 + I, imaginary_unit='j') == '1 + j'
     assert latex(1 + I, imaginary_unit='foo') == '1 + foo'
-    assert latex(1 + I, imaginary_unit='foo') == '1 + foo'
     assert latex(I, imaginary_unit=r"\text{i}") == '\\text{i}'
 
     raises(TypeError, lambda: latex(I, imaginary_unit=I))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1918,7 +1918,4 @@ def test_imaginary_unit():
     assert latex(1 + I) == '1 + i'
     assert latex(1 + I, imaginary_unit='j') == '1 + j'
     assert latex(1 + I, imaginary_unit='foo') == '1 + foo'
-    assert latex(I, imaginary_unit=r"\text{i}") == '\\text{i}'
-
-    raises(TypeError, lambda: latex(I, imaginary_unit=I))
-    raises(TypeError, lambda: latex(I, imaginary_unit=latex))
+    assert latex(I, imaginary_unit=r"ti") == '\\text{i}'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -944,3 +944,5 @@ def test_print_basic():
 def test_root_notation_print():
     assert mathml(x**(S(1)/3), printer='presentation') == '<mroot><mi>x</mi><mn>3</mn></mroot>'
     assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) == '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
+    assert mathml(x**(S(1)/3), printer='content') == '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
+    assert mathml(x**(S(1)/3), printer='content', root_notation=False) == '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
It is possible to change the LaTeX used for the imaginary unit. Earlier it was always `i`, now it can be anything the user wants. Most likely, people will use `j` (this is what I will use most of the time) or `\mathrm{i}`. Set by `imaginary_unit` as an optional argument.

#### Other comments
Should one add a check that it is actually a string (`ininstance in string_types`)? Is it possible to break something serious by sending in e.g. a lambda there?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Representation of the imaginary unit, `I` in sympy, can be redefined in the LaTeX-printer through the optional argument `imaginary_unit`. Default is `"i"`.
<!-- END RELEASE NOTES -->
