### PR TITLE
solved Incorrect lambdify of constant times matrix symbol

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -7,7 +7,7 @@ This module contains python code printers for plain python as well as NumPy & Sc
 
 from collections import defaultdict
 from itertools import chain
-from sympy.core import S, Number, Symbol
+from sympy.core import S, Number, Symbol, Mul, Add
 from .precedence import precedence
 from .codeprinter import CodePrinter
 
@@ -493,8 +493,8 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"
-        if isinstance(S(expr.args[0]), (Number, Symbol)):
-            return '({0})'.format(').dot('.join([self._print(expr.args[1]), self._print(expr.args[0])]))
+        if isinstance(expr.args[0], (Symbol, Number, Mul, Add)):
+            return '({0})'.format(').dot('.join(self._print(i) for i in expr.args[1::-1]))
         return '({0})'.format(').dot('.join(self._print(i) for i in expr.args))
 
     def _print_MatPow(self, expr):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -493,8 +493,9 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_MatMul(self, expr):
         "Matrix multiplication printer"
-        if isinstance(expr.args[0], (Symbol, Number, Mul, Add)):
-            return '({0})'.format(').dot('.join(self._print(i) for i in expr.args[1::-1]))
+        if expr.as_coeff_matrices()[0] is not S(1):
+            expr_list = expr.as_coeff_matrices()[1]+[(expr.as_coeff_matrices()[0])]
+            return '({0})'.format(').dot('.join(self._print(i) for i in expr_list))
         return '({0})'.format(').dot('.join(self._print(i) for i in expr.args))
 
     def _print_MatPow(self, expr):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1130,13 +1130,14 @@ def test_issue_15827():
     if not numpy:
         skip("numpy not installed")
     A = MatrixSymbol("A", 3, 3)
-    B = MatrixSymbol("B", 3, 2)
-    C = MatrixSymbol("C", 2, 3)
+    B = MatrixSymbol("B", 2, 3)
+    C = MatrixSymbol("C", 3, 4)
+    D = MatrixSymbol("D", 4, 5)
     k=symbols("k")
     f = lambdify(A, (2*k)*A)
     g = lambdify(A, (2+k)*A)
     h = lambdify(A, 2*A)
-    i = lambdify((A, B), 2*A*B)
+    i = lambdify((B, C, D), 2*B*C*D)
     assert numpy.array_equal(f(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2*k, 4*k, 6*k], [2*k, 4*k, 6*k], [2*k, 4*k, 6*k]], dtype=object))
 
@@ -1147,5 +1148,6 @@ def test_issue_15827():
     assert numpy.array_equal(h(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2, 4, 6], [2, 4, 6], [2, 4, 6]]))
 
-    assert numpy.array_equal(i(numpy.array([[1, 2], [1, 2], [1, 2]]), numpy.array([[1, 2, 3], [1, 2, 3]])), \
-    numpy.array([[2, 4], [2, 4], [2, 4]]))
+    assert numpy.array_equal(i(numpy.array([[1, 2, 3], [1, 2, 3]]), numpy.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]), \
+    numpy.array([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])), numpy.array([[ 120, 240, 360, 480, 600], \
+    [ 120, 240, 360, 480, 600]]))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1130,6 +1130,16 @@ def test_issue_15827():
     if not numpy:
         skip("numpy not installed")
     A = MatrixSymbol("A", 3, 3)
-    f = lambdify(A, 2*A)
+    k=Symbol("k")
+    f = lambdify(A, (2*k)*A)
+    g = lambdify(A, (2+k)*A)
+    h = lambdify(A, 2*A)
     assert numpy.array_equal(f(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
+    numpy.array([[2*k, 4*k, 6*k], [2*k, 4*k, 6*k], [2*k, 4*k, 6*k]], dtype=object)
+
+    assert numpy.array_equal(g(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
+    numpy.array([[k + 2, 2*k + 4, 3*k + 6], [k + 2, 2*k + 4, 3*k + 6], \
+    [k + 2, 2*k + 4, 3*k + 6]], dtype=object)
+
+    assert numpy.array_equal(h(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2, 4, 6], [2, 4, 6], [2, 4, 6]]))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1130,10 +1130,13 @@ def test_issue_15827():
     if not numpy:
         skip("numpy not installed")
     A = MatrixSymbol("A", 3, 3)
+    B = MatrixSymbol("B", 3, 2)
+    C = MatrixSymbol("C", 2, 3)
     k=symbols("k")
     f = lambdify(A, (2*k)*A)
     g = lambdify(A, (2+k)*A)
     h = lambdify(A, 2*A)
+    i = lambdify((A, B), 2*A*B)
     assert numpy.array_equal(f(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2*k, 4*k, 6*k], [2*k, 4*k, 6*k], [2*k, 4*k, 6*k]], dtype=object))
 
@@ -1143,3 +1146,6 @@ def test_issue_15827():
 
     assert numpy.array_equal(h(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2, 4, 6], [2, 4, 6], [2, 4, 6]]))
+
+    assert numpy.array_equal(i(numpy.array([[1, 2], [1, 2], [1, 2]]), numpy.array([[1, 2, 3], [1, 2, 3]])), \
+    numpy.array([[2, 4], [2, 4], [2, 4]]))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1130,16 +1130,16 @@ def test_issue_15827():
     if not numpy:
         skip("numpy not installed")
     A = MatrixSymbol("A", 3, 3)
-    k=Symbol("k")
+    k=symbols("k")
     f = lambdify(A, (2*k)*A)
     g = lambdify(A, (2+k)*A)
     h = lambdify(A, 2*A)
     assert numpy.array_equal(f(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
-    numpy.array([[2*k, 4*k, 6*k], [2*k, 4*k, 6*k], [2*k, 4*k, 6*k]], dtype=object)
+    numpy.array([[2*k, 4*k, 6*k], [2*k, 4*k, 6*k], [2*k, 4*k, 6*k]], dtype=object))
 
     assert numpy.array_equal(g(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[k + 2, 2*k + 4, 3*k + 6], [k + 2, 2*k + 4, 3*k + 6], \
-    [k + 2, 2*k + 4, 3*k + 6]], dtype=object)
+    [k + 2, 2*k + 4, 3*k + 6]], dtype=object))
 
     assert numpy.array_equal(h(numpy.array([[1, 2, 3], [1, 2, 3], [1, 2, 3]])), \
     numpy.array([[2, 4, 6], [2, 4, 6], [2, 4, 6]]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15827 

#### Brief description of what is fixed or changed
(integer.dot(numpymatrix)) is not define but (numpymatrix).dot(intger) define so i just change the order of dot product.
Now in master-
```
A = MatrixSymbol("A", 3, 3)
 f = lambdify(A, 2*A) 
```
So it it taking as `(2).dot(A)` and raising error (number has no dot product).
So i change the order of scalar multiplication now it is working like
```
A = MatrixSymbol("A", 3, 3)
 f = lambdify(A, 2*A) 
```
`(A).dot(2).`
and it is scalar multiplication with matrix so no commutative property require.


#### Other comments
example 
```
A = MatrixSymbol("A", 3, 3)
k=Symbol("k",3,3)
 f = lambdify(A, (2+k)*A) or f = lambdify(A, (2*k)*A)
```
this type is also not working.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
-  printing
    - change numpy matmul function. This fixes things like `lambdify(A, 2*A)` where `A` is a `MatrixSymbol`.
<!-- END RELEASE NOTES -->
