### PR TITLE
solve exp and difference of logs  with irrational coefficients

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -231,6 +231,7 @@ class exp(ExpBase):
         from sympy.calculus import AccumBounds
         from sympy.sets.setexpr import SetExpr
         from sympy.matrices.matrices import MatrixBase
+        from sympy import logcombine
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -277,9 +278,9 @@ class exp(ExpBase):
 
             coeffs, log_term = [coeff], None
             for term in Mul.make_args(terms):
-                if isinstance(term, log):
+                if isinstance(logcombine(term), log):
                     if log_term is None:
-                        log_term = term.args[0]
+                        log_term = logcombine(term).args[0]
                     else:
                         return None
                 elif term.is_comparable:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -278,9 +278,10 @@ class exp(ExpBase):
 
             coeffs, log_term = [coeff], None
             for term in Mul.make_args(terms):
-                if isinstance(logcombine(term), log):
+                term_ = logcombine(term)
+                if isinstance(term_, log):
                     if log_term is None:
-                        log_term = logcombine(term).args[0]
+                        log_term = term_.args[0]
                     else:
                         return None
                 elif term.is_comparable:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15949

#### Brief description of what is fixed or changed
```
In [1]: x,y=symbols('x y',positive=True)                                                                                                                                                                     

In [2]: exp(sqrt(2)*(log(x)-log(y)))                                                                                                                                                                         
Out[2]: 
 √2⋅(log(x) - log(y))
ℯ    
```
As expression is not combining by itself.
So I use logcombine to combine when x,y is positive .
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - use logcombine to combine "logs  with irrational coefficients" 
<!-- END RELEASE NOTES -->
