### PR TITLE
Use cdnjs.cloudflare.com for Mathjax in docs

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -32,8 +32,10 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode',
 # To stop docstrings inheritance.
 autodoc_inherit_docstrings = False
 
-# MathJax file, which is free to use.  See https://www.mathjax.org/docs/2.0/start.html
-mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full'
+# MathJax file, which is free to use.  See https://www.mathjax.org/#gettingstarted
+# As explained in the link using latest.js will get the latest version even
+# though it says 2.7.5.
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML-full'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14859 
Revives #14379

#### Brief description of what is fixed or changed

Updates the link for Mathjax used in the Sphinx docs since the old Mathjax CDN was retied 2 years ago. The docs were already being redirected to cdnjs.cloudflare.com but that redirect will not last forever. This uses cdnjs.cloudflare.com directly.

I have build the docs locally to test this. I can see the new URL in view source and I've checked a few pages to see that the equations still render correctly.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* other
    * Use the cdnjs.cloudflare.com CDN for Mathjax in the online documentation
<!-- END RELEASE NOTES -->
