### PR TITLE
Fixed simplification of an evaluated tan(3*pi/8)

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1611,3 +1611,6 @@ def test_issue_14543():
     assert sec(pi/2 + x) == -csc(x)
     assert sec(3*pi/2 + x) == csc(x)
     assert sec(3*pi/2 - x) == -csc(x)
+
+def test_issue_15959():
+    assert tan(3*pi/8) == 1 + sqrt(2)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1006,7 +1006,7 @@ class tan(TrigonometricFunction):
                             and not isinstance(sresult, cos):
                         if sresult == 0:
                             return S.ComplexInfinity
-                        return (1 - cresult)/sresult
+                        return 1/sresult - cresult/sresult
                 table2 = {
                     12: (3, 4),
                     20: (4, 5),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15959 

#### Brief description of what is fixed or changed
Earlier
```
tan(3*pi/8)
sqrt(2)(sqrt(2)/2+1)
```
Now it gives more simplified answer
```
tan(3*pi/8)
sqrt(2)+1
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * fixed simplification of an evaluated tangent
<!-- END RELEASE NOTES -->
