### PR TITLE
Using Simplify in Integral will pull out the constant term

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -6,7 +6,7 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence, range
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
-from sympy.core.function import diff
+from sympy.core.function import diff, count_ops
 from sympy.core.mul import Mul
 from sympy.core.numbers import oo, pi
 from sympy.core.relational import Eq, Ne
@@ -27,6 +27,7 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
+from sympy.simplify import simplify
 from sympy.simplify.fu import sincos_to_sum
 
 
@@ -1099,6 +1100,15 @@ class Integral(AddWithLimits):
             if leading_term != 0:
                 break
         return integrate(leading_term, *self.args[1:])
+
+    def _eval_simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+        from sympy.simplify.simplify import extract_constants_from_sum_integral
+
+        expr = extract_constants_from_sum_integral(self)
+        if isinstance(expr, Integral):
+            return expr.func(*[simplify(x, ratio=ratio, measure=measure, rational=rational, inverse=inverse)
+                         for x in expr.args])
+        return expr.simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
 
     def as_sum(self, n=None, method="midpoint", evaluate=True):
         """

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -594,8 +594,11 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         # automatically passed to gammasimp
         expr = combsimp(expr)
 
-    if expr.has(Sum, Integral):
-        expr = extract_constants_from_sum_integral(expr)
+    if expr.has(Sum):
+        expr = sum_simplify(expr)
+
+    if isinstance(expr, Integral):
+        expr = expr._eval_simplify()
 
     if expr.has(Product):
         expr = product_simplify(expr)
@@ -649,6 +652,7 @@ def sum_simplify(s):
     from sympy.concrete.summations import Sum
     from sympy.core.function import expand
 
+    s = extract_constants_from_sum_integral(s)
     terms = Add.make_args(expand(s))
     s_t = [] # Sum Terms
     o_t = [] # Other Terms

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -596,15 +596,17 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
 
     if expr.has(Sum):
         expr = sum_simplify(expr)
-
-    if expr.has(Integral):
-        l=0
-        expr_ = expr.args[0]
-        args = Add.make_args(expr_)
-        for arg in args:
-            coeff, g = arg.as_independent(expr.args[1][0])
-            l = Add(coeff*Integral(g, expr.args[1]),l)
-        return l
+    try:
+        if expr.has(Integral):
+            l=0
+            expr_ = expr.args[0]
+            args = Add.make_args(expr_)
+            for arg in args:
+                coeff, g = arg.as_independent(expr.args[1][0])
+                l = Add(coeff*Integral(g, expr.args[1]),l)
+            return l
+    except TypeError:
+        pass
 
     if expr.has(Product):
         expr = product_simplify(expr)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -526,7 +526,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
 
     from sympy.simplify.hyperexpand import hyperexpand
     from sympy.functions.special.bessel import BesselBase
-    from sympy import Sum, Product
+    from sympy import Sum, Product, Integral
 
     if not isinstance(expr, Basic) or not expr.args:  # XXX: temporary hack
         return expr
@@ -536,7 +536,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         if not expr.args:  # simplified to atomic
             return expr
 
-    if not isinstance(expr, (Add, Mul, Pow, ExpBase)):
+    if not isinstance(expr, (Add, Mul, Pow, ExpBase, Integral)):
         return expr.func(*[simplify(x, ratio=ratio, measure=measure, rational=rational, inverse=inverse)
                          for x in expr.args])
 
@@ -596,6 +596,15 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
 
     if expr.has(Sum):
         expr = sum_simplify(expr)
+
+    if expr.has(Integral):
+        l=0
+        expr_ = expr.args[0]
+        args = Add.make_args(expr_)
+        for arg in args:
+            coeff, g = arg.as_independent(expr.args[1][0])
+            l = Add(coeff*Integral(g, expr.args[1]),l)
+        return l
 
     if expr.has(Product):
         expr = product_simplify(expr)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -783,5 +783,5 @@ def test_nc_simplify():
     assert nc_simplify(2*x**2) == 2*x**2
 
 def test_issue_15965():
-    x, y, z = symbols('x y z')
-    assert simplify(Integral(x*y-z,x)) == y*Integral(x, x) - z*Integral(1, x)
+    x, y, z, n = symbols('x y z n')
+    assert simplify(Integral(x*y,x)+Sum(z*x**y, (x, 1, n))) == y*Integral(x, x) + z*Sum(x**y, (x,1, n))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -784,4 +784,4 @@ def test_nc_simplify():
 
 def test_issue_15965():
     x, y, z = symbols('x y z')
-    assert simplify(Integral(x*y-z,x)) == y*Integral(x, x) - x*Integral(1, x)
+    assert simplify(Integral(x*y-z,x)) == y*Integral(x, x) - z*Integral(1, x)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -781,3 +781,7 @@ def test_nc_simplify():
     assert nc_simplify(expr) == (1-c)**-1
     # commutative expressions should be returned without an error
     assert nc_simplify(2*x**2) == 2*x**2
+
+def test_issue_15965():
+    x, y, z = symbols('x y z')
+    assert simplify(Integral(x*y-z,x)) == y*Integral(x, x) - x*Integral(1, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes##15965

#### Brief description of what is fixed or changed
Using simplify in `Sum `pulls out the constant term(independent term) outside the summation but this property is not present in `Integral` 
Example-
```
>>> Sum(x*y, (x, 1, n)).simplify()
    n    
   __    
   \ `   
y*  )   x
   /_,   
  x = 1  
>>> Integral(x*y, (x, 1, n)).simplify()
  n       
  /       
 |        
 |  x*y dx
 |        
/         
1
```
Now it is working -
```
In [4]: (Integral(x*y-z,x)).simplify()                                              
Out[4]: 
  ⌠          ⌠     
y⋅⎮ x dx - z⋅⎮ 1 dx
  ⌡          ⌡     

In [5]:  Integral(x*y, (x, 1, n)).simplify()                                        
Out[5]: 
  n     
  ⌠     
y⋅⎮ x dx
  ⌡     
  1   

```
#### Other comments
previous issue about this -#7971
and they talked about `doit`  by using simplify .
I don't have any idea about adding `doit`method in simplify.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more `inIntegeralformation`
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
  -  simplify now pulls independent factors out of integrals
<!-- END RELEASE NOTES -->
