### PR TITLE
[To be closed] Added _print_derivative2 methods from #3926

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -660,6 +660,27 @@ class LatexPrinter(Printer):
 
         return r"%s %s" % (tex, self.parenthesize(expr.expr, PRECEDENCE["Mul"], strict=True))
 
+    def _print_Derivative2(self,expr):
+        tex = ""
+        def to_tex(sym_and_times):
+            times= len(list(sym_and_times[1]))
+            if times == 1:
+                return r"\partial %s" % self._print(sym_and_times[0])
+            else:
+                return r"\partial^{%s} %s" % (times, self._print(sym_and_times[0]))
+
+        tex = ''.join(itertools.imap(to_tex, itertools.groupby(expr.symbols)))
+        dim = len(expr.symbols)
+        if dim > 1:
+            tex = r"\frac{\partial^{%s}}{%s} " % (dim, tex)
+        else:
+            tex = r"\frac{\partial}{%s}" % (tex)
+
+        if isinstance(expr.expr, AssocOp):
+            return r"%s\left(%s\right)" % (tex, self._print(expr.expr))
+        else:
+            return r"%s %s" % (tex, self._print(expr.expr))
+
     def _print_Subs(self, subs):
         expr, old, new = subs.args
         latex_expr = self._print(expr)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -11,6 +11,7 @@ from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
 
+from itertools import groupby
 
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
@@ -422,6 +423,23 @@ class MathMLContentPrinter(MathMLPrinterBase):
         x_1 = self.dom.createElement('bvar')
         for sym in e.variables:
             x_1.appendChild(self._print(sym))
+
+        x.appendChild(x_1)
+        x.appendChild(self._print(e.expr))
+        return x
+
+    def _print_Derivative2(self,e):
+        x = self.dom.createElement('apply')
+        x.appendChild(self.dom.createElement(self.mathml_tag(e)))
+        x_1 = self.dom.createElement('bvar')
+        rle_syms = ((s,len(list(repeats))) for s,repeats in groupby(e.symbols))
+
+        for sym,times in rle_syms:
+            x_1.appendChild(self._print(sym))
+            if times > 1:
+                degree = self.dom.createElement('degree')
+                degree.appendChild(self._print(sympify(times)))
+                x_1.appendChild(degree)
 
         x.appendChild(x_1)
         x.appendChild(self._print(e.expr))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -356,6 +356,32 @@ class PrettyPrinter(Printer):
 
         return pform
 
+    def _print_Derivative2(self, deriv):
+        syms = ((s,len(list(repeats))) for s,repeats in itertools.groupby(reversed(deriv.symbols)))
+        x = None
+        for sym,times in syms:
+            S = self._print(sym)
+            dS= prettyForm(*S.left('d'))
+            if times > 1:
+                dS = dS ** prettyForm(str(times))
+            if x is None:
+                x = dS
+            else:
+                x = prettyForm(*x.right(' '))
+                x = prettyForm(*x.right(dS))
+
+        f = prettyForm(binding=prettyForm.FUNC, *self._print(deriv.expr).parens())
+
+        pform = prettyForm('d')
+        dim = len(deriv.symbols)
+        if dim > 1:
+            pform = pform ** prettyForm(str(dim))
+
+        pform = prettyForm(*pform.below(stringPict.LINE, x))
+        pform.baseline = pform.baseline + 1
+        pform = prettyForm(*stringPict.next(pform, f))
+        return pform
+
     def _print_Cycle(self, dc):
         from sympy.combinatorics.permutations import Permutation, Cycle
         # for Empty Cycle


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #3926 

#### Brief description of what is fixed or changed
As the attached diff in #3926 was pretty large due to line endings, I extracted the interesting parts, the methods `_print_derivative2` for LaTex, pretty and MathML printers.

#### Other comments
Not sure what to do with it. It looked quite promising in the original PR. Maybe one should have a switch to select between these two methods of printing?

I have not checked the code more than modifying it to work with current Python and sympy version, at least from a "no-static-warnings-in-Spyder"-perspective.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
