### PR TITLE
Fixed LaTeX-printing of ConditionSet with FiniteSet

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1879,7 +1879,7 @@ class LatexPrinter(Printer):
             vars_print,
             vars_print,
             self._print(s.base_set),
-            self._print(s.condition.as_expr()))
+            self._print(s.condition))
 
     def _print_ComplexRegion(self, s):
         vars_print = ', '.join([self._print(var) for var in s.variables])

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1883,6 +1883,13 @@ def test_latex_printer_tensor():
     assert latex(expr) == 'K{}^{i=3,j}{}_{kl}'
 
 
+def test_issue_15353():
+    from sympy import nonlinsolve, sin, cos, symbols
+    a, x = symbols('a x')
+    sol = nonlinsolve([(sin(a*x)),cos(a*x)],[x,a])
+    assert latex(sol) == r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in \mathbb{C} \wedge \left\{\sin{\left(a x \right)}, \cos{\left(a x \right)}\right\} \right\}'
+
+
 def test_trace():
     # Issue 15303
     from sympy import trace


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15353 

#### Brief description of what is fixed or changed
LaTeX printing of ConditionSet with a FiniteSet used to throw an exception. Now it prints.

`ConditionSet((x, a), {sin(a*x), cos(a*x)}, Complexes(Reals x Reals, False))`

prints as

![image](https://user-images.githubusercontent.com/8114497/52733424-fad5fe80-2fc2-11e9-87ce-ea9acf67314b.png)

No idea if it is correct, but it matches exactly what the issue reporter thought would be a good result and since I only did a minor change, I think it can be correct also for other cases.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * LaTeX-printing of `ConditionSet`with `FiniteSet` now works.
<!-- END RELEASE NOTES -->
