### PR TITLE
Fix for finite fourier series

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -95,7 +95,6 @@ def test_sympy__assumptions__sathandlers__UnevaluatedOnFree():
     from sympy import Q
     assert _test_args(UnevaluatedOnFree(Q.positive))
     assert _test_args(UnevaluatedOnFree(Q.positive(x)))
-    assert _test_args(UnevaluatedOnFree(Q.positive(x*y)))
 
 def test_sympy__assumptions__sathandlers__AllArgs():
     from sympy.assumptions.sathandlers import AllArgs
@@ -3760,6 +3759,10 @@ def test_sympy__series__series_class__SeriesBase():
 def test_sympy__series__fourier__FourierSeries():
     from sympy.series.fourier import fourier_series
     assert _test_args(fourier_series(x, (x, -pi, pi)))
+
+def test_sympy__series__fourier__FiniteFourierSeries():
+    from sympy.series.fourier import fourier_series
+    assert _test_args(fourier_series(sin(pi*x), (x, -1, 1)))
 
 
 def test_sympy__series__formal__FormalPowerSeries():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -95,6 +95,7 @@ def test_sympy__assumptions__sathandlers__UnevaluatedOnFree():
     from sympy import Q
     assert _test_args(UnevaluatedOnFree(Q.positive))
     assert _test_args(UnevaluatedOnFree(Q.positive(x)))
+    assert _test_args(UnevaluatedOnFree(Q.positive(x * y)))
 
 def test_sympy__assumptions__sathandlers__AllArgs():
     from sympy.assumptions.sathandlers import AllArgs

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -97,7 +97,7 @@ def finite_check(f, x):
 
     def check_sincos(expr, x):
         if type(expr) == sin or type(expr) == cos:
-            a = Wild('a', properties=[lambda k: x not in k.free_symbols, ])
+            a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
             b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
 
             sincos_args = expr.args[0]

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -440,7 +440,7 @@ class FourierSeries(SeriesBase):
         return self.__add__(-other)
 
 
-class FiniteFourierSeries:
+class FiniteFourierSeries(object):
 
     def __init__(self, series):
         self.series = series

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -92,14 +92,12 @@ def _process_limits(func, limits):
 
 
 def finite_check(f, x, L):
+
     def check_fx(exprs, x):
         return x not in exprs.free_symbols
 
-    def check_sincos(expr, x, L):
+    def check_sincos(expr, x, L, a, b):
         if type(expr) == sin or type(expr) == cos:
-            a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
-            b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
-
             sincos_args = expr.args[0]
 
             if sincos_args.match(a*(pi/L)*x + b) is not None:
@@ -112,13 +110,15 @@ def finite_check(f, x, L):
     add_coeff = expr.as_coeff_add()
     res_expr += add_coeff[0]
 
+    a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
+    b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
+
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
         for t in mul_coeffs:
-            if not (check_fx(t, x) or check_sincos(t, x, L)):
+            if not (check_fx(t, x) or check_sincos(t, x, L,a ,b)):
                 return False, f
         res_expr += TR10(s)
-    a = Wild('a', properties=[lambda k:k.is_Integer, lambda k:k != 0, ])
     return True, res_expr.collect([sin(a*(pi/L)*x), cos(a*(pi/L)*x)])
 
 

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -91,18 +91,18 @@ def _process_limits(func, limits):
     return sympify((x, start, stop))
 
 
-def finite_check(f, x):
+def finite_check(f, x, L):
     def check_fx(exprs, x):
         return x not in exprs.free_symbols
 
-    def check_sincos(expr, x):
+    def check_sincos(expr, x, L):
         if type(expr) == sin or type(expr) == cos:
             a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
             b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
 
             sincos_args = expr.args[0]
 
-            if sincos_args.match(a * x + b) is not None:
+            if sincos_args.match(a*(pi/L)*x + b) is not None:
                 return True
             else:
                 return False
@@ -115,11 +115,11 @@ def finite_check(f, x):
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
         for t in mul_coeffs:
-            if not (check_fx(t, x) or check_sincos(t, x)):
+            if not (check_fx(t, x) or check_sincos(t, x, L)):
                 return False, f
         res_expr += TR10(s)
     a = Wild('a', properties=[lambda k:k.is_Integer, lambda k:k != 0, ])
-    return True, res_expr.collect([sin(a*x), cos(a*x)])
+    return True, res_expr.collect([sin(a*(pi/L)*x), cos(a*(pi/L)*x)])
 
 
 class FourierSeries(SeriesBase):
@@ -502,7 +502,8 @@ def fourier_series(f, limits=None):
     if x not in f.free_symbols:
         return f
 
-    is_finite, res_f = finite_check(f, x)
+    L = abs(limits[2] - limits[1])/2
+    is_finite, res_f = finite_check(f, x, L)
 
     if is_finite:
         return res_f

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -440,6 +440,15 @@ class FourierSeries(SeriesBase):
         return self.__add__(-other)
 
 
+class FiniteFourierSeries:
+
+    def __init__(self, series):
+        self.series = series
+
+    def truncate(self, n=3):
+        return self.series
+
+
 def fourier_series(f, limits=None):
     """Computes Fourier sine/cosine series expansion.
 
@@ -506,7 +515,7 @@ def fourier_series(f, limits=None):
     is_finite, res_f = finite_check(f, x, L)
 
     if is_finite:
-        return res_f
+        return FiniteFourierSeries(res_f)
 
     n = Dummy('n')
     neg_f = f.subs(x, -x)

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -115,7 +115,7 @@ def finite_check(f, x):
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
         for t in mul_coeffs:
-            if not(check_fx(t, x) or check_sincos(t, x)):
+            if not (check_fx(t, x) or check_sincos(t, x)):
                 return False, f
         res_expr += TR10(s)
     a = Wild('a', properties=[lambda k:k.is_Integer, lambda k:k != 0, ])

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -96,7 +96,7 @@ def finite_check(f, x, L):
     def check_fx(exprs, x):
         return x not in exprs.free_symbols
 
-    def check_sincos(expr, x, L, a, b):
+    def check_sincos(expr, x, L):
         if type(expr) == sin or type(expr) == cos:
             sincos_args = expr.args[0]
 
@@ -116,7 +116,7 @@ def finite_check(f, x, L):
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
         for t in mul_coeffs:
-            if not (check_fx(t, x) or check_sincos(t, x, L,a ,b)):
+            if not (check_fx(t, x) or check_sincos(t, x, L)):
                 return False, f
         res_expr += TR10(s)
     return True, res_expr.collect([sin(a*(pi/L)*x), cos(a*(pi/L)*x)])

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy import pi, oo, Wild
+from sympy import pi, oo, Wild, Basic
 from sympy.core.expr import Expr
 from sympy.core.add import Add
 from sympy.core.compatibility import is_sequence
@@ -440,13 +440,13 @@ class FourierSeries(SeriesBase):
         return self.__add__(-other)
 
 
-class FiniteFourierSeries(object):
-
-    def __init__(self, series):
-        self.series = series
+class FiniteFourierSeries(Basic):
+    def __new__(cls, *args):
+        obj = Basic.__new__(cls, *args)
+        return obj
 
     def truncate(self, n=3):
-        return self.series
+        return Add(*self._args)
 
 
 def fourier_series(f, limits=None):

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -143,3 +143,6 @@ def test_FourierSeries_finite():
     assert fourier_series(sin(4*x+3) + cos(3*x+4)) ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
            + cos(4)*cos(3*x) + sin(3)*cos(4*x)
     assert fourier_series(sin(x)+cos(x)*tan(x)) == 2*sin(x)
+    assert fourier_series(cos(pi*x), (x, -1, 1)) == cos(pi*x)
+    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x,-1,1)) ==  -log(pi*y)*sin(4*pi*x) \
+           - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -134,15 +134,15 @@ def test_FourierSeries__add__sub():
 
 def test_FourierSeries_finite():
 
-    assert fourier_series(sin(x)) == sin(x)
-    # assert type(fourier_series(sin(x)*log(x))) == FourierSeries
-    # assert type(fourier_series(sin(x**2+6))) == FourierSeries
-    assert fourier_series(sin(x)*log(y)*exp(z),(x,pi,-pi)) == sin(x)*log(y)*exp(z)
-    assert fourier_series(sin(x)**6) == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
+    assert fourier_series(sin(x)).truncate() == sin(x)
+    # assert type(fourier_series(sin(x)*log(x))).truncate() == FourierSeries
+    # assert type(fourier_series(sin(x**2+6))).truncate() == FourierSeries
+    assert fourier_series(sin(x)*log(y)*exp(z),(x,pi,-pi)).truncate() == sin(x)*log(y)*exp(z)
+    assert fourier_series(sin(x)**6).truncate() == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
            + Rational(5, 16)
-    assert fourier_series(sin(4*x+3) + cos(3*x+4)) ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
+    assert fourier_series(sin(4*x+3) + cos(3*x+4)).truncate() ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
            + cos(4)*cos(3*x) + sin(3)*cos(4*x)
-    assert fourier_series(sin(x)+cos(x)*tan(x)) == 2*sin(x)
-    assert fourier_series(cos(pi*x), (x, -1, 1)) == cos(pi*x)
-    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x,-1,1)) ==  -log(pi*y)*sin(4*pi*x) \
+    assert fourier_series(sin(x)+cos(x)*tan(x)).truncate() == 2*sin(x)
+    assert fourier_series(cos(pi*x), (x, -1, 1)).truncate() == cos(pi*x)
+    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x, -1, 1)).truncate() == -log(pi*y)*sin(4*pi*x)\
            - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, pi, Piecewise, sin, cos, sinc, Rational,
-                   oo, fourier_series, Add)
+                   oo, fourier_series, Add, log, exp, tan)
 from sympy.series.fourier import FourierSeries
 from sympy.utilities.pytest import raises
 from sympy.core.cache import lru_cache
@@ -130,3 +130,16 @@ def test_FourierSeries__add__sub():
     assert isinstance(fo + 1, Add)
 
     raises(ValueError, lambda: fo + fourier_series(x, (x, 0, 2)))
+
+
+def test_FourierSeries_finite():
+
+    assert fourier_series(sin(x)) == sin(x)
+    # assert type(fourier_series(sin(x)*log(x))) == FourierSeries
+    # assert type(fourier_series(sin(x**2+6))) == FourierSeries
+    assert fourier_series(sin(x)*log(y)*exp(z),(x,pi,-pi)) == sin(x)*log(y)*exp(z)
+    assert fourier_series(sin(x)**6) == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
+           + Rational(5, 16)
+    assert fourier_series(sin(4*x+3) + cos(3*x+4)) ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
+           + cos(4)*cos(3*x) + sin(3)*cos(4*x)
+    assert fourier_series(sin(x)+cos(x)*tan(x)) == 2*sin(x)


### PR DESCRIPTION
Fix for Finite Fourier Series

#### References to other Issues or PRs
Fixes #15701 

#### Brief description of what is fixed or changed
The expression is checked for being finite. Currently, the Fourier Series form of expression is returned if the expression is finite. Otherwise, a FourierSeries object is returned.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * added a check for finite fourier series in `fourier_series`
<!-- END RELEASE NOTES -->
