### PR TITLE
Added correct LaTeX printing for sequences with symbolic limits

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1790,6 +1790,13 @@ class LatexPrinter(Printer):
               + r"\right\}")
 
     def _print_SeqFormula(self, s):
+        if len(s.start.free_symbols) > 0 or len(s.stop.free_symbols) > 0:
+            return r"\left\{%s\right\}_{%s=%s}^{%s}" % (
+                self._print(s.formula),
+                self._print(s.variables[0]),
+                self._print(s.start),
+                self._print(s.stop)
+            )
         if s.start is S.NegativeInfinity:
             stop = s.stop
             printset = (r'\ldots', s.coeff(stop - 3), s.coeff(stop - 2),

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1962,6 +1962,9 @@ class PrettyPrinter(Printer):
         else:
             dots = '...'
 
+        if len(s.start.free_symbols) > 0 or len(s.stop.free_symbols) > 0:
+            raise NotImplementedError("Pretty printing of sequences with symbolic bound not implemented")
+
         if s.start is S.NegativeInfinity:
             stop = s.stop
             printset = (dots, s.coeff(stop - 3), s.coeff(stop - 2),

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3772,6 +3772,18 @@ def test_pretty_sequences():
     assert pretty(SeqMul(s5, s6)) == ascii_str
     assert upretty(SeqMul(s5, s6)) == ucode_str
 
+    # Sequences with symbolic limits, issue 12629
+    s7 = SeqFormula(a**2, (a, 0, x))
+    raises(NotImplementedError, lambda: pretty(s7))
+    raises(NotImplementedError, lambda: upretty(s7))
+
+    b = Symbol('b')
+    s8 = SeqFormula(b*a**2, (a, 0, 2))
+    ascii_str = u'[0, b, 4*b]'
+    ucode_str = u'[0, b, 4⋅b]'
+    assert pretty(s8) == ascii_str
+    assert upretty(s8) == ucode_str
+
 
 def test_pretty_FourierSeries():
     f = fourier_series(x, (x, -pi, pi))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -694,6 +694,15 @@ def test_latex_sequences():
     latex_str = r'\left[\ldots, 18, 4, 2, 0\right]'
     assert latex(SeqMul(s5, s6)) == latex_str
 
+    # Sequences with symbolic limits, issue 12629
+    s7 = SeqFormula(a**2, (a, 0, x))
+    latex_str = r'\left\{a^{2}\right\}_{a=0}^{x}'
+    assert latex(s7) == latex_str
+
+    b = Symbol('b')
+    s8 = SeqFormula(b*a**2, (a, 0, 2))
+    latex_str = r'\left[0, b, 4 b\right]'
+    assert latex(s8) == latex_str
 
 def test_latex_FourierSeries():
     latex_str = r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -672,7 +672,7 @@ class SeqFormula(SeqExpr):
             raise ValueError('Invalid limits given: %s' % str(limits))
 
         if start is S.NegativeInfinity and stop is S.Infinity:
-                raise ValueError("Both the start and end value"
+                raise ValueError("Both the start and end value "
                                  "cannot be unbounded")
         limits = sympify((x, start, stop))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes part of #12629

#### Brief description of what is fixed or changed
Sequences with symbolic bound caused errors earlier in both the LaTeX and Pretty printers.
Now, the LaTeX printer works:
![image](https://user-images.githubusercontent.com/8114497/52743884-57ddae80-2fdb-11e9-916d-9d75cac0c37e.png)

The pretty printer throws a NonImplementedError with a message which is at least slightly better.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * LaTeX printer can now print sequences with symbolic bounds
<!-- END RELEASE NOTES -->
