### PR TITLE
Add reducible solver to dsolve

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -288,7 +288,6 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
     "nth_algebraic",
-    "order_reducible",
     "separable",
     "1st_exact",
     "1st_linear",
@@ -309,6 +308,7 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters",
     "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters",
     "Liouville",
+    "order_reducible",
     "2nd_power_series_ordinary",
     "2nd_power_series_regular",
     "nth_algebraic_Integral",

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -287,7 +287,7 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: ``best``, and ``all_Integral`` meta-hints should not be included in this
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
-   "nth_algebraic",
+    "nth_algebraic",
     "separable",
     "1st_exact",
     "1st_linear",

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4024,8 +4024,9 @@ def _order_reducible_match(eq, func):
     vc= [d.variable_count[0] for d in eq.atoms(Derivative)
          if d.expr == func and len(d.variable_count) == 1]
     ords = [c for v, c in vc if v == x]
-    if ords:
+    if len(ords) > 1:
         smallest = min(ords)
+        # as long as no order is < 1 this should be true
         if smallest < 2:
             smallest = None
     else:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4016,7 +4016,7 @@ def _order_reducible_match(eq, func):
     r"""
     Matches any differential equation that can be rewritten with a smaller
     order. Only derivatives of ``func`` alone, wrt a single variable,
-    are considered.
+    are considered, and only in them should ``func`` appear.
     """
     # ODE only handles functions of 1 variable so this affirms that state
     assert len(func.args) == 1
@@ -4024,15 +4024,17 @@ def _order_reducible_match(eq, func):
     vc= [d.variable_count[0] for d in eq.atoms(Derivative)
          if d.expr == func and len(d.variable_count) == 1]
     ords = [c for v, c in vc if v == x]
-    if len(ords) > 1:
-        smallest = min(ords)
-        # as long as no order is < 1 this should be true
-        if smallest < 2:
-            smallest = None
-    else:
-        smallest = None
-    if smallest:
-        return {'n': smallest}
+    if len(ords) < 2:
+        return
+    smallest = min(ords)
+    # as long as no order is < 1 this should be true
+    if smallest < 2:
+        return
+    # make sure func does not appear outside of derivatives
+    D = Dummy()
+    if eq.subs(func.diff(x, smallest)).has(func):
+        return
+    return {'n': smallest}
 
 def ode_order_reducible(eq, func, order, match):
     r"""

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -288,6 +288,7 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
     "nth_algebraic",
+    "order_reducible",
     "separable",
     "1st_exact",
     "1st_linear",
@@ -323,7 +324,6 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters_Integral",
     "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters_Integral",
     "Liouville_Integral",
-    "order_reducible",
        )
 
 lie_heuristics = (
@@ -4027,12 +4027,9 @@ def _order_reducible_match(eq, func):
     if len(ords) < 2:
         return
     smallest = min(ords)
-    # as long as no order is < 1 this should be true
-    if smallest < 2:
-        return
     # make sure func does not appear outside of derivatives
     D = Dummy()
-    if eq.subs(func.diff(x, smallest)).has(func):
+    if eq.subs(func.diff(x, smallest), D).has(func):
         return
     return {'n': smallest}
 
@@ -4049,13 +4046,13 @@ def ode_order_reducible(eq, func, order, match):
     # get a unique function name for g
     names = [f.name for f in eq.atoms(AppliedUndef)]
     while True:
-        g = Dummy().name
-        if g not in names:
+        name = Dummy().name
+        if name not in names:
             g = Function(name)
             break
     w = f(x).diff(x, n)
     geq = eq.subs(w, g(x))
-    gsol = dsolve(eq, g(x))
+    gsol = dsolve(geq, g(x))
     fsol = dsolve(gsol.subs(g(x), w), f(x))  # or do integration n times
 
     return fsol

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -287,6 +287,7 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: ``best``, and ``all_Integral`` meta-hints should not be included in this
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
+    "order_reducible_substitution",
     "nth_algebraic",
     "separable",
     "1st_exact",
@@ -323,7 +324,7 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters_Integral",
     "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters_Integral",
     "Liouville_Integral",
-    )
+      )
 
 lie_heuristics = (
     "abaco1_simple",
@@ -1356,6 +1357,14 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
 
     if order > 0:
+        # Any ODE that can be solved with a substitution and
+        # repeated integration e.g.:
+        # `d^2/dx^2(y) + x*d/dx(y) = constant
+        #f'(x) must be finite for this to work
+        r = _order_reducible_substitution_match(reduced_eq, func)
+        if r:
+            matching_hints['order_reducible_substitution'] = r
+
         # Any ODE that can be solved with a combination of algebra and
         # integrals e.g.:
         # d^3/dx^3(x y) = F(x)
@@ -4002,6 +4011,53 @@ def _frobenius(n, m, p0, q0, p, q, x0, x, c, check=None):
             frobdict[numsyms[i]] = -num/(indicial.subs(d, m+i))
 
     return frobdict
+
+def _order_reducible_substitution_match(eq, func):
+    r"""
+    Matches any differential equation that `order_reducible_substitution` can solve.
+    For this to work equation should have a minimum order of derivative to be 1, i.e.,
+    `f(x)` should not be present.
+    """
+    fx = func
+    assert len(func.args) == 1  # ODE only handles functions of 1 variable
+    x = func.args[0]
+    D = Dummy()
+    for d in ordered(eq.atoms(Derivative)):
+        try:
+            (v, c), = d.variable_count  # ValueError if not a singleton
+            if v != x:
+                raise ValueError  # not a derivative of interest
+        except ValueError:
+            continue
+        # d was the lowest-ordered derivative of interest
+        Deq = eq.subs(d, D)
+        if Deq.has(fx):
+            return  # it didn't clear all occurrences of f(x)
+        # there is no fx right now; see if there is a derivative of D
+        if not Deq.subs(Derivative(D, x), fx).has(fx):
+            return  # there was no derivative left
+        return {'var': c}
+
+# Use repeated substitution until we do not have a function independent of derivative
+def ode_order_reducible_substitution(eq, func, order, match):
+    r"""
+    Substitutes lowest order derivate in equation to function with order
+    of derivative as 0.Eg `f^(n)(x) = g(x)`, where n is the least order derivate.
+    match[var] or n here is how many times the function if solved is to be integrated
+    to  get f(x) since `g(x) = f^(match[var])(x)`.
+    """
+    x = func.args[0]
+    f = func.func
+    while True:
+        g = Function(Dummy().name)
+        if not eq.has(g(x)):
+            break
+    w = f(x).diff(x, match['var'])
+    eq = eq.subs(w, g(x))
+    eq = dsolve(eq, g(x))
+    eq = dsolve(eq.subs(g(x), w), f(x))
+
+    return eq
 
 def _nth_algebraic_match(eq, func):
     r"""

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4044,7 +4044,7 @@ def ode_order_reducible(eq, func, order, match):
     f = func.func
     n = match['n']
     # get a unique function name for g
-    names = [f.name for f in eq.atoms(AppliedUndef)]
+    names = [a.name for a in eq.atoms(AppliedUndef)]
     while True:
         name = Dummy().name
         if name not in names:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -287,8 +287,7 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: ``best``, and ``all_Integral`` meta-hints should not be included in this
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
-    "order_reducible_substitution",
-    "nth_algebraic",
+   "nth_algebraic",
     "separable",
     "1st_exact",
     "1st_linear",
@@ -324,7 +323,8 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters_Integral",
     "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters_Integral",
     "Liouville_Integral",
-      )
+    "order_reducible",
+       )
 
 lie_heuristics = (
     "abaco1_simple",
@@ -1361,9 +1361,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         # repeated integration e.g.:
         # `d^2/dx^2(y) + x*d/dx(y) = constant
         #f'(x) must be finite for this to work
-        r = _order_reducible_substitution_match(reduced_eq, func)
+        r = _order_reducible_match(reduced_eq, func)
         if r:
-            matching_hints['order_reducible_substitution'] = r
+            matching_hints['order_reducible'] = r
 
         # Any ODE that can be solved with a combination of algebra and
         # integrals e.g.:
@@ -4012,52 +4012,50 @@ def _frobenius(n, m, p0, q0, p, q, x0, x, c, check=None):
 
     return frobdict
 
-def _order_reducible_substitution_match(eq, func):
+def _order_reducible_match(eq, func):
     r"""
-    Matches any differential equation that `order_reducible_substitution` can solve.
-    For this to work equation should have a minimum order of derivative to be 1, i.e.,
-    `f(x)` should not be present.
+    Matches any differential equation that can be rewritten with a smaller
+    order. Only derivatives of ``func`` alone, wrt a single variable,
+    are considered.
     """
-    fx = func
-    assert len(func.args) == 1  # ODE only handles functions of 1 variable
+    # ODE only handles functions of 1 variable so this affirms that state
+    assert len(func.args) == 1
     x = func.args[0]
-    D = Dummy()
-    for d in ordered(eq.atoms(Derivative)):
-        try:
-            (v, c), = d.variable_count  # ValueError if not a singleton
-            if v != x:
-                raise ValueError  # not a derivative of interest
-        except ValueError:
-            continue
-        # d was the lowest-ordered derivative of interest
-        Deq = eq.subs(d, D)
-        if Deq.has(fx):
-            return  # it didn't clear all occurrences of f(x)
-        # there is no fx right now; see if there is a derivative of D
-        if not Deq.subs(Derivative(D, x), fx).has(fx):
-            return  # there was no derivative left
-        return {'var': c}
+    vc= [d.variable_count[0] for d in eq.atoms(Derivative)
+         if d.expr == func and len(d.variable_count) == 1]
+    ords = [c for v, c in vc if v == x]
+    if ords:
+        smallest = min(ords)
+        if smallest < 2:
+            smallest = None
+    else:
+        smallest = None
+    if smallest:
+        return {'n': smallest}
 
-# Use repeated substitution until we do not have a function independent of derivative
-def ode_order_reducible_substitution(eq, func, order, match):
+def ode_order_reducible(eq, func, order, match):
     r"""
     Substitutes lowest order derivate in equation to function with order
-    of derivative as 0.Eg `f^(n)(x) = g(x)`, where n is the least order derivate.
-    match[var] or n here is how many times the function if solved is to be integrated
-    to  get f(x) since `g(x) = f^(match[var])(x)`.
+    of derivative as `f^(n)(x) = g(x)`, where `n` (`match['n']`)
+    is the least-order derivative. The solution for `f(x)` is the n-times
+    integrated value of `g(x)`.
     """
     x = func.args[0]
     f = func.func
+    n = match['n']
+    # get a unique function name for g
+    names = [f.name for f in eq.atoms(AppliedUndef)]
     while True:
-        g = Function(Dummy().name)
-        if not eq.has(g(x)):
+        g = Dummy().name
+        if g not in names:
+            g = Function(name)
             break
-    w = f(x).diff(x, match['var'])
-    eq = eq.subs(w, g(x))
-    eq = dsolve(eq, g(x))
-    eq = dsolve(eq.subs(g(x), w), f(x))
+    w = f(x).diff(x, n)
+    geq = eq.subs(w, g(x))
+    gsol = dsolve(eq, g(x))
+    fsol = dsolve(gsol.subs(g(x), w), f(x))  # or do integration n times
 
-    return eq
+    return fsol
 
 def _nth_algebraic_match(eq, func):
     r"""

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -712,7 +712,7 @@ def test_dsolve_options():
 
 def test_classify_ode():
     assert classify_ode(f(x).diff(x, 2), f(x)) == \
-        ('order_reducible_substitution',
+        (
         'nth_algebraic',
         'nth_linear_constant_coeff_homogeneous',
         'nth_linear_euler_eq_homogeneous',
@@ -720,6 +720,7 @@ def test_classify_ode():
         '2nd_power_series_ordinary',
         'nth_algebraic_Integral',
         'Liouville_Integral',
+        'order_reducible',
         )
     assert classify_ode(f(x), f(x)) == ()
     assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == (
@@ -3064,25 +3065,27 @@ def test_sysode_linear_neq_order1():
     assert dsolve(eq, simplify=False) == sols_eq
 
 
-def test_order_reducible_substitution():
+def test_order_reducible():
     eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
     sol = Eq(f(x),
              C1 - sqrt(-1/C1)*log(-C1*sqrt(-1/C1) + x) + sqrt(-1/C1)*log(C1*sqrt(-1/C1) + x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
-    assert sol == dsolve(eqn, f(x), hint='order_reducible_substitution')
+    assert sol == dsolve(eqn, f(x), hint='order_reducible')
     assert sol == dsolve(eqn, f(x))
 
     w, y= symbols('w y')
     f = Function('f')
-    F = lambda eq: _order_reducible_substitution_match(eq, f(x))
+    F = lambda eq: _order_reducible_match(eq, f(x))
     fx = f(x)
     D = Derivative
     assert F(D(y*fx, x, y) + D(fx, x)) is None
     assert F(D(y*f(y), y, y) + D(f(y), y)) is None
     assert F(fx*D(fx, x) + D(fx, x, 2)) is None
-    assert F(D(x*f(y), y, 2) + D(w*y*fx, x, 3)) == dict(var=3)
-    assert F(D(f(w), w, 2) + D(f(w), w, 3) + D(fx, x, 4)) == dict(var=4)
+    assert F(D(x*f(y), y, 2) + D(w*y*fx, x, 3)) is None  # no simplification by design
+    assert F(D(f(w), w, 2) + D(f(w), w, 3) + D(fx, x, 4)) is None
+    assert F(D(fx, x, 2) + D(fx, x, 3)) == dict(n=2)
 
+    
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
     sol = Eq(f(x), C1 + g(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -712,7 +712,8 @@ def test_dsolve_options():
 
 def test_classify_ode():
     assert classify_ode(f(x).diff(x, 2), f(x)) == \
-        ('nth_algebraic',
+        ('order_reducible_substitution',
+        'nth_algebraic',
         'nth_linear_constant_coeff_homogeneous',
         'nth_linear_euler_eq_homogeneous',
         'Liouville',
@@ -3062,6 +3063,25 @@ def test_sysode_linear_neq_order1():
 
     assert dsolve(eq, simplify=False) == sols_eq
 
+
+def test_order_reducible_substitution():
+    eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
+    sol = Eq(f(x),
+             C1 - sqrt(-1/C1)*log(-C1*sqrt(-1/C1) + x) + sqrt(-1/C1)*log(C1*sqrt(-1/C1) + x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
+    assert sol == dsolve(eqn, f(x), hint='order_reducible_substitution')
+    assert sol == dsolve(eqn, f(x))
+
+    w, y= symbols('w y')
+    f = Function('f')
+    F = lambda eq: _order_reducible_substitution_match(eq, f(x))
+    fx = f(x)
+    D = Derivative
+    assert F(D(y*fx, x, y) + D(fx, x)) is None
+    assert F(D(y*f(y), y, y) + D(f(y), y)) is None
+    assert F(fx*D(fx, x) + D(fx, x, 2)) is None
+    assert F(D(x*f(y), y, 2) + D(w*y*fx, x, 3)) == dict(var=3)
+    assert F(D(f(w), w, 2) + D(f(w), w, 3) + D(fx, x, 4)) == dict(var=4)
 
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3085,7 +3085,7 @@ def test_order_reducible():
     assert F(D(f(w), w, 2) + D(f(w), w, 3) + D(fx, x, 4)) is None
     assert F(D(fx, x, 2) + D(fx, x, 3)) == dict(n=2)
 
-    
+
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
     sol = Eq(f(x), C1 + g(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3075,33 +3075,26 @@ def test_order_reducible():
     assert sol == dsolve(eqn, f(x))
 
     F = lambda eq: _order_reducible_match(eq, f(x))
-    fx = f(x)
     D = Derivative
-    assert F(D(y*fx, x, y) + D(fx, x)) is None
+    assert F(D(y*f(x), x, y) + D(f(x), x)) is None
     assert F(D(y*f(y), y, y) + D(f(y), y)) is None
-    assert F(fx*D(fx, x) + D(fx, x, 2)) is None
-    assert F(D(x*f(y), y, 2) + D(u*y*fx, x, 3)) is None  # no simplification by design
-    assert F(D(f(y), y, 2) + D(f(y), y, 3) + D(fx, x, 4)) is None
-    assert F(D(fx, x, 2) + D(fx, x, 3)) == dict(n=2)
+    assert F(f(x)*D(f(x), x) + D(f(x), x, 2)) is None
+    assert F(D(x*f(y), y, 2) + D(u*y*f(x), x, 3)) is None  # no simplification by design
+    assert F(D(f(y), y, 2) + D(f(y), y, 3) + D(f(x), x, 4)) is None
+    assert F(D(f(x), x, 2) + D(f(x), x, 3)) == dict(n=2)
 
-# FIXME before merging. When the test_order_reducible tests are passing they should be
-# combined into a single function.
-
-def test_order_reducible_2():
     eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
     sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x))
     assert sol == dsolve(eqn, f(x), hint='order_reducible')
 
-def test_order_reducible_3():
     eqn = Eq(sqrt(2) * f(x).diff(x,x,x) + f(x).diff(x), 0)
     sol = Eq(f(x), C1 + C2*sin(2**(S(3)/4)*x/2) + C3*cos(2**(S(3)/4)*x/2))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x))
     assert sol == dsolve(eqn, f(x), hint='order_reducible')
 
-def test_order_reducible_4():
     eqn = f(x).diff(x, 2) + 2*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-2*x))
     sols = constant_renumber(sol, 'C', 1, 2)
@@ -3109,7 +3102,6 @@ def test_order_reducible_4():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_5():
     eqn = f(x).diff(x, 3) + f(x).diff(x, 2) - 6*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-3*x) + C3*exp(2*x))
     sols = constant_renumber(sol, 'C', 1, 2)
@@ -3117,7 +3109,6 @@ def test_order_reducible_5():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_6():
     eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
         4*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(x) + C3*exp(-2*x) + C4*exp(2*x))
@@ -3126,7 +3117,6 @@ def test_order_reducible_6():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_7():
     eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
     sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
     sols = constant_renumber(sol, 'C', 1, 4)
@@ -3134,7 +3124,6 @@ def test_order_reducible_7():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_8():
     eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
     sols = constant_renumber(sol, 'C', 1, 4)
@@ -3142,7 +3131,6 @@ def test_order_reducible_8():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_9():
     eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
     sols = constant_renumber(sol, 'C', 1, 4)
@@ -3150,7 +3138,6 @@ def test_order_reducible_9():
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
-def test_order_reducible_10():
     eqn = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x)
     # These are equivalent:
     sol1 = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
@@ -3161,6 +3148,7 @@ def test_order_reducible_10():
     assert checkodesol(eqn, sol2, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol1, sol1s)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol2, sol2s)
+
 
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3073,16 +3073,14 @@ def test_order_reducible():
     assert sol == dsolve(eqn, f(x), hint='order_reducible')
     assert sol == dsolve(eqn, f(x))
 
-    w, y= symbols('w y')
-    f = Function('f')
     F = lambda eq: _order_reducible_match(eq, f(x))
     fx = f(x)
     D = Derivative
     assert F(D(y*fx, x, y) + D(fx, x)) is None
     assert F(D(y*f(y), y, y) + D(f(y), y)) is None
     assert F(fx*D(fx, x) + D(fx, x, 2)) is None
-    assert F(D(x*f(y), y, 2) + D(w*y*fx, x, 3)) is None  # no simplification by design
-    assert F(D(f(w), w, 2) + D(f(w), w, 3) + D(fx, x, 4)) is None
+    assert F(D(x*f(y), y, 2) + D(u*y*fx, x, 3)) is None  # no simplification by design
+    assert F(D(f(y), y, 2) + D(f(y), y, 3) + D(fx, x, 4)) is None
     assert F(D(fx, x, 2) + D(fx, x, 3)) == dict(n=2)
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -720,7 +720,6 @@ def test_classify_ode():
         '2nd_power_series_ordinary',
         'nth_algebraic_Integral',
         'Liouville_Integral',
-        'order_reducible',
         )
     assert classify_ode(f(x), f(x)) == ()
     assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == (
@@ -3066,6 +3065,8 @@ def test_sysode_linear_neq_order1():
 
 
 def test_order_reducible():
+    from sympy.solvers.ode import _order_reducible_match
+
     eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
     sol = Eq(f(x),
              C1 - sqrt(-1/C1)*log(-C1*sqrt(-1/C1) + x) + sqrt(-1/C1)*log(C1*sqrt(-1/C1) + x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3070,7 +3070,7 @@ def test_order_reducible():
     eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
     sol = Eq(f(x),
              C1 - sqrt(-1/C1)*log(-C1*sqrt(-1/C1) + x) + sqrt(-1/C1)*log(C1*sqrt(-1/C1) + x))
-    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x), hint='order_reducible')
     assert sol == dsolve(eqn, f(x))
 
@@ -3084,6 +3084,79 @@ def test_order_reducible():
     assert F(D(f(y), y, 2) + D(f(y), y, 3) + D(fx, x, 4)) is None
     assert F(D(fx, x, 2) + D(fx, x, 3)) == dict(n=2)
 
+# FIXME before merging. When the test_order_reducible tests are passing they should be
+# combined into a single function.
+
+def test_order_reducible_2():
+    eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert sol == dsolve(eqn, f(x))
+    assert sol == dsolve(eqn, f(x), hint='order_reducible')
+
+def test_order_reducible_3():
+    eqn = Eq(sqrt(2) * f(x).diff(x,x,x) + f(x).diff(x), 0)
+    sol = Eq(f(x), C1 + C2*sin(2**(S(3)/4)*x/2) + C3*cos(2**(S(3)/4)*x/2))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert sol == dsolve(eqn, f(x))
+    assert sol == dsolve(eqn, f(x), hint='order_reducible')
+
+def test_order_reducible_4():
+    eqn = f(x).diff(x, 2) + 2*f(x).diff(x)
+    sol = Eq(f(x), C1 + C2*exp(-2*x))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_5():
+    eqn = f(x).diff(x, 3) + f(x).diff(x, 2) - 6*f(x).diff(x)
+    sol = Eq(f(x), C1 + C2*exp(-3*x) + C3*exp(2*x))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_6():
+    eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
+        4*f(x).diff(x)
+    sol = Eq(f(x), C1 + C2*exp(x) + C3*exp(-2*x) + C4*exp(2*x))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_7():
+    eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
+    sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_8():
+    eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
+    sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_9():
+    eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
+    sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
+    sols = constant_renumber(sol, 'C', 1, 3)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+
+def test_order_reducible_10():
+    eqn = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x)
+    sol = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3069,7 +3069,7 @@ def test_order_reducible():
 
     eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
     sol = Eq(f(x),
-             C1 - sqrt(-1/C1)*log(-C1*sqrt(-1/C1) + x) + sqrt(-1/C1)*log(C1*sqrt(-1/C1) + x))
+             C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x), hint='order_reducible')
     assert sol == dsolve(eqn, f(x))
@@ -3121,7 +3121,7 @@ def test_order_reducible_6():
     eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
         4*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(x) + C3*exp(-2*x) + C4*exp(2*x))
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(sol, 'C', 1, 4)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3129,7 +3129,7 @@ def test_order_reducible_6():
 def test_order_reducible_7():
     eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
     sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(sol, 'C', 1, 4)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3137,7 +3137,7 @@ def test_order_reducible_7():
 def test_order_reducible_8():
     eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(sol, 'C', 1, 4)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3145,18 +3145,22 @@ def test_order_reducible_8():
 def test_order_reducible_9():
     eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(sol, 'C', 1, 4)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
 def test_order_reducible_10():
     eqn = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x)
-    sol = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
-    sols = constant_renumber(sol, 'C', 1, 2)
-    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
-    assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    # These are equivalent:
+    sol1 = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
+    sol2 = Eq(f(x), C1 + C2*(x*sin(x) + cos(x)) + C3*(-x*cos(x) + sin(x)) + C4*sin(x) + C5*cos(x))
+    sol1s = constant_renumber(sol1, 'C', 1, 5)
+    sol2s = constant_renumber(sol2, 'C', 1, 5)
+    assert checkodesol(eqn, sol1, order=2, solve_for_func=False) == (True, 0)
+    assert checkodesol(eqn, sol2, order=2, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x)) in (sol1, sol1s)
+    assert dsolve(eqn, f(x), hint='order_reducible') in (sol2, sol2s)
 
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #15881 
Continues #15964 

#### Brief description of what is fixed or changed


#### Other comments

This continues #15964. I've squashed the commits from there into a single commit here and amended the author.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * New reducible hint in dsolve to solve ODEs that only depend on derivatives of the dependent variable by substitution.
<!-- END RELEASE NOTES -->
