### PR TITLE
Improved printing of multiple derivatives in MathML

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -11,6 +11,7 @@ from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
 
+from itertools import groupby
 
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
@@ -427,6 +428,25 @@ class MathMLContentPrinter(MathMLPrinterBase):
         x_1 = self.dom.createElement('bvar')
         for sym in e.variables:
             x_1.appendChild(self._print(sym))
+
+        x.appendChild(x_1)
+        x.appendChild(self._print(e.expr))
+        return x
+
+    def _print_Derivative2(self,e):
+        x = self.dom.createElement('apply')
+        x.appendChild(self.dom.createElement(self.mathml_tag(e)))
+        x_1 = self.dom.createElement('bvar')
+        rle_syms = ((s,len(list(repeats))) for s,repeats in groupby(e.symbols))
+
+
+        for sym,times in rle_syms:
+            x_1.appendChild(self._print(sym))
+            if times > 1:
+                degree = self.dom.createElement('degree')
+                degree.appendChild(self._print(sympify(times)))
+                x_1.appendChild(degree)
+
 
         x.appendChild(x_1)
         x.appendChild(self._print(e.expr))

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -11,7 +11,6 @@ from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
 
-from itertools import groupby
 
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
@@ -426,8 +425,7 @@ class MathMLContentPrinter(MathMLPrinterBase):
         x.appendChild(self.dom.createElement(diff_symbol))
         x_1 = self.dom.createElement('bvar')
 
-        rle_syms = ((s,len(list(repeats))) for s, repeats in groupby(e.variables))
-        for sym, times in rle_syms:
+        for sym, times in reversed(e.variable_count):
             x_1.appendChild(self._print(sym))
             if times > 1:
                 degree = self.dom.createElement('degree')

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -424,29 +424,15 @@ class MathMLContentPrinter(MathMLPrinterBase):
         if requires_partial(e):
             diff_symbol = 'partialdiff'
         x.appendChild(self.dom.createElement(diff_symbol))
-
         x_1 = self.dom.createElement('bvar')
-        for sym in e.variables:
-            x_1.appendChild(self._print(sym))
 
-        x.appendChild(x_1)
-        x.appendChild(self._print(e.expr))
-        return x
-
-    def _print_Derivative2(self,e):
-        x = self.dom.createElement('apply')
-        x.appendChild(self.dom.createElement(self.mathml_tag(e)))
-        x_1 = self.dom.createElement('bvar')
-        rle_syms = ((s,len(list(repeats))) for s,repeats in groupby(e.symbols))
-
-
-        for sym,times in rle_syms:
+        rle_syms = ((s,len(list(repeats))) for s, repeats in groupby(e.variables))
+        for sym, times in rle_syms:
             x_1.appendChild(self._print(sym))
             if times > 1:
                 degree = self.dom.createElement('degree')
                 degree.appendChild(self._print(sympify(times)))
                 x_1.appendChild(degree)
-
 
         x.appendChild(x_1)
         x.appendChild(self._print(e.expr))
@@ -859,7 +845,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_Derivative(self, e):
-        mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mo')
         if requires_partial(e):
             x.appendChild(self.dom.createTextNode('&#x2202;'))
@@ -870,15 +855,12 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             y = self.dom.createElement('mo')
             y.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
 
-        brac = self.dom.createElement('mfenced')
-        brac.appendChild(self._print(e.expr))
         mrow = self.dom.createElement('mrow')
-        mrow.appendChild(x)
-        mrow.appendChild(brac)
+        frac = self.dom.createElement('mfrac')
+        frac.appendChild(x)
 
+        m = self.dom.createElement('mrow')
         for sym in e.variables:
-            frac = self.dom.createElement('mfrac')
-            m = self.dom.createElement('mrow')
             x = self.dom.createElement('mo')
             if requires_partial(e):
                 x.appendChild(self.dom.createTextNode('&#x2202;'))
@@ -887,11 +869,12 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             y = self._print(sym)
             m.appendChild(x)
             m.appendChild(y)
-            frac.appendChild(mrow)
-            frac.appendChild(m)
-            mrow = frac
+        frac.appendChild(m)
+        mrow.appendChild(frac)
 
-        return frac
+        mrow.appendChild(self._print(e.expr))
+
+        return mrow
 
     def _print_Function(self, e):
         mrow = self.dom.createElement('mrow')

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,7 +1,7 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, S, \
-    MatrixSymbol
+    MatrixSymbol, Function, Derivative
 from sympy.stats.rv import RandomSymbol
 from sympy.printing.mathml import mathml, MathMLContentPrinter, MathMLPresentationPrinter, \
     MathMLPrinter
@@ -508,22 +508,28 @@ def test_presentation_mathml_functions():
         ].childNodes[0].nodeValue == 'x'
 
     mml_2 = mpp._print(diff(sin(x), x, evaluate=False))
-    assert mml_2.nodeName == 'mfrac'
+    assert mml_2.nodeName == 'mrow'
     assert mml_2.childNodes[0].childNodes[0
-        ].childNodes[0].nodeValue == '&dd;'
-    assert mml_2.childNodes[0].childNodes[1
+        ].childNodes[0].childNodes[0].nodeValue == '&dd;'
+    assert mml_2.childNodes[1].childNodes[1
         ].nodeName == 'mfenced'
-    assert mml_2.childNodes[1].childNodes[
-        0].childNodes[0].nodeValue == '&dd;'
+    assert mml_2.childNodes[0].childNodes[1
+        ].childNodes[0].childNodes[0].nodeValue == '&dd;'
 
     mml_3 = mpp._print(diff(cos(x*y), x, evaluate=False))
-    assert mml_3.nodeName == 'mfrac'
+    assert mml_3.childNodes[0].nodeName == 'mfrac'
     assert mml_3.childNodes[0].childNodes[0
-        ].childNodes[0].nodeValue == '&#x2202;'
-    assert mml_2.childNodes[0].childNodes[1
-        ].nodeName == 'mfenced'
-    assert mml_3.childNodes[1].childNodes[
-        0].childNodes[0].nodeValue == '&#x2202;'
+        ].childNodes[0].childNodes[0].nodeValue == '&#x2202;'
+    assert mml_3.childNodes[1].childNodes[0
+        ].childNodes[0].nodeValue == 'cos'
+
+
+def test_print_derivative():
+    f = Function('f')
+    z = Symbol('z')
+    d = Derivative(f(x, y, z), x, z, x, z, z, y)
+    assert mathml(d) == r'<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
+    assert mathml(d, printer='presentation') == r'<mrow><mfrac><mrow><msup><mo>&#x2202;</mo><mn>6</mn></msup></mrow><mrow><mo>&#x2202;</mo><mi>y</mi><msup><mo>&#x2202;</mo><mn>2</mn></msup><mi>z</mi><mo>&#x2202;</mo><mi>x</mi><mo>&#x2202;</mo><mi>z</mi><mo>&#x2202;</mo><mi>x</mi></mrow></mfrac><mrow><mi>f</mi><mfenced><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow></mrow>'
 
 
 def test_presentation_mathml_limits():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15988 
Closes #15975 

#### Brief description of what is fixed or changed
Proper adaptation of #15975 (and #3926). Not much of the original code left, but I kept the history correct.

I also fixed #15988 so now
`d=Derivative(f(x, y, z), x, z, x, z, z, y)`
looks like
![image](https://user-images.githubusercontent.com/8114497/52899358-88933300-31e9-11e9-904c-25cf32bd9393.png)
rather than
![image](https://user-images.githubusercontent.com/8114497/52842849-a3d64380-3100-11e9-845f-8abacba54635.png)
as before in the MathML presentation printer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Corrected and improved MathML presentation printing of multiple derivatives.
<!-- END RELEASE NOTES -->
