### PR TITLE
More canonical canonical

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -211,7 +211,7 @@ definite integrals.  Here is a sampling of some of the power of ``integrate``.
     ⌡
     0
     >>> integ.doit()
-    ⎧ Γ(y + 1)    for -re(y) < 1
+    ⎧ Γ(y + 1)    for re(y) > -1
     ⎪
     ⎪∞
     ⎪⌠

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -203,10 +203,10 @@ class Relational(Boolean, Expr, EvalfMixin):
         """
         args = self.args
         r = self
-        if len(r.rhs.free_symbols) == 0:
-            if len(r.lhs.free_symbols) == 0 and r.lhs > r.rhs:
+        if r.rhs.is_number:
+            if r.lhs.is_number and r.lhs > r.rhs:
                 r = r.reversed
-        elif len(r.lhs.free_symbols) == 0:
+        elif r.lhs.is_number:
             r = r.reversed
         elif tuple(ordered(args)) != args:
                 r = r.reversed
@@ -214,12 +214,12 @@ class Relational(Boolean, Expr, EvalfMixin):
         # Check if first value has negative sign
         if r.lhs.could_extract_minus_sign():
             r = r.reversedsign
-        elif len(r.rhs.free_symbols) != 0 and r.rhs.could_extract_minus_sign():
+        elif not r.rhs.is_number and r.rhs.could_extract_minus_sign():
             # Right hand side have a minus, but not lhs.
             # How does the expression with reversed signs behave?
             # This is so that expressions of the type Eq(x, -y) and Eq(-x, y) have the same canonical representation
             rs = r.reversed.reversedsign
-            orderedlhs =ordered([r.lhs, rs.lhs])
+            orderedlhs = ordered([r.lhs, rs.lhs])
             if next(orderedlhs) == rs.lhs:
                 r = rs
         return r

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -218,7 +218,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         if not isinstance(r.lhs, BooleanAtom) and r.lhs.could_extract_minus_sign():
             r = r.reversedsign
         elif not isinstance(r.rhs, BooleanAtom) and not r.rhs.is_number and r.rhs.could_extract_minus_sign():
-            # Right hand side have a minus, but not lhs.
+            # Right hand side has a minus, but not lhs.
             # How does the expression with reversed signs behave?
             # This is so that expressions of the type Eq(x, -y) and Eq(-x, y) have the same canonical representation
             expr1, _ = ordered([r.lhs, -r.rhs])

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -206,11 +206,9 @@ class Relational(Boolean, Expr, EvalfMixin):
         """
         args = self.args
         r = self
-#        if not r.rhs.free_symbols:
         if r.rhs.is_number:
             if r.rhs.is_Number and r.lhs.is_Number and r.lhs > r.rhs:
                 r = r.reversed
- #       elif not r.lhs.free_symbols:
         elif r.lhs.is_number:
             r = r.reversed
         elif tuple(ordered(args)) != args:
@@ -219,7 +217,6 @@ class Relational(Boolean, Expr, EvalfMixin):
         # Check if first value has negative sign
         if not isinstance(r.lhs, BooleanAtom) and r.lhs.could_extract_minus_sign():
             r = r.reversedsign
-#        elif (not isinstance(r.rhs, BooleanAtom)) and r.rhs.free_symbols and r.rhs.could_extract_minus_sign():
         elif not isinstance(r.rhs, BooleanAtom) and not r.rhs.is_number and r.rhs.could_extract_minus_sign():
             # Right hand side have a minus, but not lhs.
             # How does the expression with reversed signs behave?

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -214,13 +214,13 @@ class Relational(Boolean, Expr, EvalfMixin):
         elif r.lhs.is_number:
             r = r.reversed
         elif tuple(ordered(args)) != args:
-                r = r.reversed
+            r = r.reversed
 
         # Check if first value has negative sign
-        if (not isinstance(r.lhs, BooleanAtom)) and r.lhs.could_extract_minus_sign():
+        if not isinstance(r.lhs, BooleanAtom) and r.lhs.could_extract_minus_sign():
             r = r.reversedsign
 #        elif (not isinstance(r.rhs, BooleanAtom)) and r.rhs.free_symbols and r.rhs.could_extract_minus_sign():
-        elif (not isinstance(r.rhs, BooleanAtom)) and r.rhs.is_number and r.rhs.could_extract_minus_sign():
+        elif not isinstance(r.rhs, BooleanAtom) and not r.rhs.is_number and r.rhs.could_extract_minus_sign():
             # Right hand side have a minus, but not lhs.
             # How does the expression with reversed signs behave?
             # This is so that expressions of the type Eq(x, -y) and Eq(-x, y) have the same canonical representation

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -203,8 +203,6 @@ class Relational(Boolean, Expr, EvalfMixin):
         """
         args = self.args
         r = self
-        rhsnumber = (len(r.rhs.free_symbols) == 0)
-        lhsnumber = (len(r.lhs.free_symbols) == 0)
         if len(r.rhs.free_symbols) == 0:
             if len(r.lhs.free_symbols) == 0 and r.lhs > r.rhs:
                 r = r.reversed

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -204,7 +204,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         args = self.args
         r = self
         if r.rhs.is_number:
-            if r.lhs.is_number and r.lhs > r.rhs:
+            if r.rhs.is_Number and r.lhs.is_Number and r.lhs > r.rhs:
                 r = r.reversed
         elif r.lhs.is_number:
             r = r.reversed

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -120,7 +120,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         >>> _.reversed
         1 > x
         """
-        ops = {Gt: Lt, Ge: Le, Lt: Gt, Le: Ge}
+        ops = {Eq: Eq, Gt: Lt, Ge: Le, Lt: Gt, Le: Ge, Ne: Ne}
         a, b = self.args
         return Relational.__new__(ops.get(self.func, self.func), b, a)
 
@@ -144,7 +144,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         """
         a, b = self.args
         if not (isinstance(a, BooleanAtom) or isinstance(b, BooleanAtom)):
-            ops = {Gt: Lt, Ge: Le, Lt: Gt, Le: Ge}
+            ops = {Eq: Eq, Gt: Lt, Ge: Le, Lt: Gt, Le: Ge, Ne: Ne}
             return Relational.__new__(ops.get(self.func, self.func), -a, -b)
         else:
             return self
@@ -221,8 +221,8 @@ class Relational(Boolean, Expr, EvalfMixin):
             # Right hand side have a minus, but not lhs.
             # How does the expression with reversed signs behave?
             # This is so that expressions of the type Eq(x, -y) and Eq(-x, y) have the same canonical representation
-            orderedlhs = ordered([r.lhs, -r.rhs])
-            if next(orderedlhs) != r.lhs:
+            expr1, _ = ordered([r.lhs, -r.rhs])
+            if expr1 != r.lhs:
                 r = r.reversed.reversedsign
         return r
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -852,5 +852,7 @@ def test_improved_canonical():
     test_different_forms(generate_forms(x >= -y))
     test_different_forms(generate_forms(Eq(x, -y)))
     test_different_forms(generate_forms(Ne(x, -y)))
+    test_different_forms(generate_forms(pi < x))
+    test_different_forms(generate_forms(pi - 5*y < -x + 2*y**2 -7))
 
     assert (pi >= x).canonical == (x <= pi)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -853,6 +853,6 @@ def test_improved_canonical():
     test_different_forms(generate_forms(Eq(x, -y)))
     test_different_forms(generate_forms(Ne(x, -y)))
     test_different_forms(generate_forms(pi < x))
-    test_different_forms(generate_forms(pi - 5*y < -x + 2*y**2 -7))
+    test_different_forms(generate_forms(pi - 5*y < -x + 2*y**2 - 7))
 
     assert (pi >= x).canonical == (x <= pi)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,13 +1,15 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
-    Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function, Eq,
+    Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
     log, cos, sin, Add, floor, ceiling)
 from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
-                                   Gt, Ge, Ne, _canonical)
+                                   Gt, Ge, Ne)
 from sympy.sets.sets import Interval, FiniteSet
+
+from itertools import combinations
 
 x, y, z, t = symbols('x,y,z,t')
 
@@ -824,3 +826,31 @@ def test_negated_property():
 
     for f in (Eq, Ne, Ge, Gt, Le, Lt):
         assert f(x, y).negated.negated == f(x, y)
+
+
+def test_reversedsign_property():
+    eq = Eq(x, y)
+    assert eq.reversedsign == Eq(-x, -y)
+
+    eq = Ne(x, y)
+    assert eq.reversedsign == Ne(-x, -y)
+
+    eq = Ge(x + y, y - x)
+    assert eq.reversedsign == Le(-x - y, x - y)
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(x, y).reversedsign.reversedsign == f(x, y)
+
+
+def test_improved_canonical():
+    def test_different_forms(listofforms):
+        for form1, form2 in combinations(listofforms, 2):
+            assert form1.canonical == form2.canonical
+    def generate_forms(expr):
+        return [expr, expr.reversed, expr.reversedsign, expr.reversed.reversedsign]
+    test_different_forms(generate_forms(x > -y))
+    test_different_forms(generate_forms(x >= -y))
+    test_different_forms(generate_forms(Eq(x, -y)))
+    test_different_forms(generate_forms(Ne(x, -y)))
+
+    assert (pi >= x).canonical == (x <= pi)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -841,6 +841,27 @@ def test_reversedsign_property():
     for f in (Eq, Ne, Ge, Gt, Le, Lt):
         assert f(x, y).reversedsign.reversedsign == f(x, y)
 
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(-x, y).reversedsign.reversedsign == f(-x, y)
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(x, -y).reversedsign.reversedsign == f(x, -y)
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(-x, -y).reversedsign.reversedsign == f(-x, -y)
+
+def test_reversed_reversedsign_property():
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(x, y).reversed.reversedsign == f(x, y).reversedsign.reversed
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(-x, y).reversed.reversedsign == f(-x, y).reversedsign.reversed
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(x, -y).reversed.reversedsign == f(x, -y).reversedsign.reversed
+
+    for f in (Eq, Ne, Ge, Gt, Le, Lt):
+        assert f(-x, -y).reversed.reversedsign == f(-x, -y).reversedsign.reversed
 
 def test_improved_canonical():
     def test_different_forms(listofforms):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1448,7 +1448,7 @@ def integrate(*args, **kwargs):
     in interactive sessions and should be avoided in library code.
 
     >>> integrate(x**a*exp(-x), (x, 0, oo)) # same as conds='piecewise'
-    Piecewise((gamma(a + 1), -re(a) < 1),
+    Piecewise((gamma(a + 1), re(a) > -1),
         (Integral(x**a*exp(-x), (x, 0, oo)), True))
 
     >>> integrate(x**a*exp(-x), (x, 0, oo), conds='none')

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -630,7 +630,7 @@ def test_messy():
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
-        (0, And(S(0) < re(a/2) + S(1)/2, S(0) < re(a/2) + 1))
+        (0, And(re(a/2) + S(1)/2 > S(0), re(a/2) + 1) > S(0))
 
     # NOTE s < 0 can be done, but argument reduction is not good enough yet
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -630,7 +630,7 @@ def test_messy():
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
-        (0, And(re(a/2) + S(1)/2 > S(0), re(a/2) + 1) > S(0))
+        (0, And(re(a/2) + S(1)/2 > S(0), re(a/2) + 1 > S(0)))
 
     # NOTE s < 0 can be done, but argument reduction is not good enough yet
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -99,10 +99,10 @@ def test_mellin_transform():
         (1/(nu + s), (-re(nu), oo), True)
 
     assert MT((1 - x)**(beta - 1)*Heaviside(1 - x), x, s) == \
-        (gamma(beta)*gamma(s)/gamma(beta + s), (0, oo), -re(beta) < 0)
+        (gamma(beta)*gamma(s)/gamma(beta + s), (0, oo), re(beta) > 0)
     assert MT((x - 1)**(beta - 1)*Heaviside(x - 1), x, s) == \
         (gamma(beta)*gamma(1 - beta - s)/gamma(1 - s),
-            (-oo, -re(beta) + 1), -re(beta) < 0)
+            (-oo, -re(beta) + 1), re(beta) > 0)
 
     assert MT((1 + x)**(-rho), x, s) == \
         (gamma(s)*gamma(rho - s)/gamma(rho), (0, re(rho)), True)
@@ -116,7 +116,7 @@ def test_mellin_transform():
         (0, re(rho)), And(re(rho) - 1 < 0, re(rho) < 1))
     mt = MT((1 - x)**(beta - 1)*Heaviside(1 - x)
             + a*(x - 1)**(beta - 1)*Heaviside(x - 1), x, s)
-    assert mt[1], mt[2] == ((0, -re(beta) + 1), -re(beta) < 0)
+    assert mt[1], mt[2] == ((0, -re(beta) + 1), re(beta) > 0)
 
     assert MT((x**a - b**a)/(x - b), x, s)[0] == \
         pi*b**(a + s - 1)*sin(pi*a)/(sin(pi*s)*sin(pi*(a + s)))

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -480,7 +480,7 @@ def test_laplace_transform():
 
     assert LT(exp(t), t, s)[:2] == (1/(s - 1), 1)
     assert LT(exp(2*t), t, s)[:2] == (1/(s - 2), 2)
-    assert LT(exp(a*t), t, s)[:2] == (1/(s - a), a)
+    assert LT(exp(a*t), t, s)[:2] == (1/(s - a), 0)
 
     assert LT(log(t/a), t, s) == ((log(a*s) + EulerGamma)/s/-1, 0, True)
 
@@ -808,14 +808,14 @@ def test_issue_7173():
     ans = laplace_transform(sinh(a*x)*cosh(a*x), x, s)
     r, e = cse(ans)
     assert r == [
-        (x0, pi/2),
-        (x1, arg(a)),
-        (x2, Abs(x1)),
-        (x3, Abs(x1 + pi))]
+        (x0, arg(a)),
+        (x1, Abs(x0)),
+        (x2, pi/2),
+        (x3, Abs(x0 + pi))]
     assert e == [
         a/(-4*a**2 + s**2),
         0,
-        ((x0 >= x2) | (x2 < x0)) & ((x0 >= x3) | (x3 < x0))]
+        ((x1 <= x2) | (x1 < x2)) & ((x3 <= x2) | (x3 < x2))]
 
 
 def test_issue_8514():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -480,7 +480,7 @@ def test_laplace_transform():
 
     assert LT(exp(t), t, s)[:2] == (1/(s - 1), 1)
     assert LT(exp(2*t), t, s)[:2] == (1/(s - 2), 2)
-    assert LT(exp(a*t), t, s)[:2] == (1/(s - a), 0)
+    assert LT(exp(a*t), t, s)[:2] == (1/(s - a), a)
 
     assert LT(log(t/a), t, s) == ((log(a*s) + EulerGamma)/s/-1, 0, True)
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -299,7 +299,7 @@ def test_expint():
     # TODO LT of Si, Shi, Chi is a mess ...
     assert laplace_transform(Ci(x), x, s) == (-log(1 + s**2)/2/s, 0, True)
     assert laplace_transform(expint(a, x), x, s) == \
-        (lerchphi(s*exp_polar(I*pi), 1, a), 0, S(0) < re(a))
+        (lerchphi(s*exp_polar(I*pi), 1, a), 0, re(a) > S(0))
     assert laplace_transform(expint(1, x), x, s) == (log(s + 1)/s, 0, True)
     assert laplace_transform(expint(2, x), x, s) == \
         ((s - log(s + 1))/s**2, 0, True)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.core.compatibility import reduce, range, iterable
 from sympy.core.function import Function
+from sympy.core.relational import _canonical
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy
 from sympy.integrals import integrate, Integral
@@ -1064,7 +1065,7 @@ def _laplace_transform(f, t, s_, simplify=True):
     if simplify:
         F = _simplifyconds(F, s, a)
         aux = _simplifyconds(aux, s, a)
-    return _simplify(F.subs(s, s_), simplify), sbs(a), sbs(aux)
+    return _simplify(F.subs(s, s_), simplify), sbs(a), _canonical(sbs(aux))
 
 
 class LaplaceTransform(IntegralTransform):
@@ -1124,7 +1125,7 @@ def laplace_transform(f, t, s, **hints):
     >>> from sympy.integrals import laplace_transform
     >>> from sympy.abc import t, s, a
     >>> laplace_transform(t**a, t, s)
-    (s**(-a)*gamma(a + 1)/s, 0, -re(a) < 1)
+    (s**(-a)*gamma(a + 1)/s, 0, re(a) > -1)
 
     See Also
     ========

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -988,7 +988,6 @@ def _laplace_transform(f, t, s_, simplify=True):
         a = -oo
         aux = S.true
         conds = conjuncts(to_cnf(conds))
-        u = Dummy('u', real=True)
         p, q, w1, w2, w3, w4, w5 = symbols(
             'p q w1 w2 w3 w4 w5', cls=Wild, exclude=[s])
         patterns = (
@@ -1011,14 +1010,14 @@ def _laplace_transform(f, t, s_, simplify=True):
                 if m:
                     if m[q].is_positive and m[w2]/m[p] == pi/2:
                         d = re(s + m[w3]) > 0
-                m = d.match(cos(w1*abs(arg(s*w5))*w2)*abs(s**w3)**w4 - p > 0)
+                m = d.match(p - cos(w1*abs(arg(s*w5))*w2)*abs(s**w3)**w4 < 0)
                 if not m:
                     m = d.match(
-                        cos(abs(arg_(s**w1*w5, q))*w2)*abs(s**w3)**w4 - p > 0)
+                        cos(p - abs(arg_(s**w1*w5, q))*w2)*abs(s**w3)**w4 < 0)
                 if not m:
                     m = d.match(
-                        cos(abs(arg_(polar_lift(s)**w1*w5, q))*w2
-                            )*abs(s**w3)**w4 - p > 0)
+                        p - cos(abs(arg_(polar_lift(s)**w1*w5, q))*w2
+                            )*abs(s**w3)**w4 < 0)
                 if m and all(m[wild].is_positive for wild in [w1, w2, w3, w4, w5]):
                     d = re(s) > m[p]
                 d_ = d.replace(

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.core.compatibility import reduce, range, iterable
 from sympy.core.function import Function
-from sympy.core.relational import _canonical
+from sympy.core.relational import _canonical, Ge, Gt
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy
 from sympy.integrals import integrate, Integral
@@ -1003,13 +1003,15 @@ def _laplace_transform(f, t, s_, simplify=True):
             for d in disjuncts(c):
                 if d.is_Relational and s in d.rhs.free_symbols:
                     d = d.reversed
+                if d.is_Relational and isinstance(d, (Ge, Gt)):
+                    d = d.reversedsign
                 for pat in patterns:
                     m = d.match(pat)
                     if m:
                         break
                 if m:
                     if m[q].is_positive and m[w2]/m[p] == pi/2:
-                        d = re(s + m[w3]) > 0
+                        d = -re(s + m[w3]) < 0
                 m = d.match(p - cos(w1*abs(arg(s*w5))*w2)*abs(s**w3)**w4 < 0)
                 if not m:
                     m = d.match(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15899

#### Brief description of what is fixed or changed
The canonical property now gives the same result for more different input combinations. This can simplify the code in some other places as well, e.g. some recent PRs on simplifying Piecewise and Relationals.

The rationale is now:
 1. Expressions without free symbols on the right-hand side.
 2. Expressions with free symbols based on `ordered`
 3. Expression on left-hand side should not start with `-`, in that case change signs

There is a loophole from just doing these three checks which is that the ordering may change based on the sign. For example `y < -x` will stay like that unless it is explicitly checked if `x < -y` is a "better" expression (based on the ordering of the left-hand sides). This complicates the code a bit compared to before, but also leads to the same expression for more possible inputs.


As part of this, the property `reversedsign` was introduced for `Relational`. This simply returns the same Relations but with the sign changed, so `x >= y` becomes `-x <= -y` (`reversed` gives `y <= x`).

#### Other comments
As far as I can tell, there are four possible forms of a Relational, given that it is not simplified etc. For `x > y` there are also `y < x`, `-x < -y` and `-y > -x`. All these should give the same canonical, even with x and y replaces with more complicated expressions.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
     * The `Relational` property `canonical` now gives the same result in more cases which is helpful in some other methods.
<!-- END RELEASE NOTES -->
