### PR TITLE
Fix nth_algebraic to respect constants from the ODE

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -374,6 +374,17 @@ def get_numbered_constants(eq, num=1, start=1, prefix='C'):
     in eq already.
     """
 
+    ncs = iter_numbered_constants(eq, start, prefix)
+    Cs = [next(ncs) for i in range(num)]
+    return (Cs[0] if num == 1 else tuple(Cs))
+
+
+def iter_numbered_constants(eq, start=1, prefix='C'):
+    """
+    Returns an iterator of constants that do not occur
+    in eq already.
+    """
+
     if isinstance(eq, Expr):
         eq = [eq]
     elif not iterable(eq):
@@ -383,9 +394,7 @@ def get_numbered_constants(eq, num=1, start=1, prefix='C'):
     func_set = set().union(*[i.atoms(Function) for i in eq])
     if func_set:
         atom_set |= {Symbol(str(f.func)) for f in func_set}
-    ncs = numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
-    Cs = [next(ncs) for i in range(num)]
-    return (Cs[0] if num == 1 else tuple(Cs))
+    return numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
 
 
 def dsolve(eq, func=None, hint="default", simplify=True,
@@ -3998,7 +4007,7 @@ def _nth_algebraic_match(eq, func):
     """
 
     # Each integration should generate a different constant
-    constants = iter(numbered_symbols(prefix='C', cls=Symbol, start=1))
+    constants = iter_numbered_constants(eq)
     constant = lambda: next(constants, None)
 
     # Like Derivative but "invertible"

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3152,6 +3152,16 @@ def test_nth_algebraic():
     assert set(solns) == set(dsolve(eqn, f(x)))
 
 
+def test_nth_algebraic_issue15999():
+    # FIXME: When issue 4838 is resolved this test should be changed...
+    eqn = f(x).diff(x) - C1
+    sol1 = Eq(f(x), C1*x + C2) # Correct solution
+    sol2 = Eq(f(x), C2*x + C1) # Incorrect: issue 4838
+    assert checkodesol(eqn, sol1, order=1, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x), hint='nth_algebraic') == sol2
+    assert dsolve(eqn, f(x)) == sol2
+
+
 def test_nth_algebraic_redundant_solutions():
     # This one has a redundant solution that should be removed
     eqn = f(x)*f(x).diff(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #15999 

#### Brief description of what is fixed or changed

In ode.py adds a new function `iter_numbered_constants` that is analogous to `get_numbered_constants` but returns a generator allowing for an arbitrary number of constants to be used. Uses this new function in the nth_algebraic solver.

The effect is that whereas with master we have
```julia
In [1]: C1 = Symbol('C1')                                                                                                                                     

In [2]: dsolve(f(x).diff(x)-C1)                                                                                                                               
Out[2]: f(x) = C₁⋅(x + 1)
```
this PR gives
```julia
In [1]: C1 = Symbol('C1')                                                                                                                                     

In [2]: dsolve(f(x).diff(x)-C1)                                                                                                                               
Out[2]: f(x) = C₁ + C₂⋅x
```
which is using a new integration constant `C2`. Note that this is still incorrect - the constants C1 and C2 got switched around by odesimp due to #4838. This PR fixes one problem in getting that to work though.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * fix nth_algebraic solver so it doesn't clobber integration constants from the source ODE.
<!-- END RELEASE NOTES -->
