### PR TITLE
Fix for wrong result from discrete logarithm

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1201,6 +1201,7 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
                         return e
                 except ValueError:
                     pass
+                break
     raise ValueError("Pollard's Rho failed to find logarithm")
 
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1133,7 +1133,6 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
 
     if order is None:
         order = n_order(b, n)
-
     prng = Random()
     if rseed is not None:
         prng.seed(rseed)
@@ -1196,8 +1195,17 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
 
             if xa == xb:
                 r = (ba - bb) % order
-                if r != 0:
-                    return mod_inverse(r, order) * (ab - aa) % order
+                if not isprime(order):
+                    if mod_inverse(r, order):
+                        if r != 0:
+                            e = mod_inverse(r, order) * (ab - aa) % order
+                            if (pow(b, e, n) - a) % n == 0:
+                                return mod_inverse(r, order) * (ab - aa) % order
+                else:
+                    if r != 0:
+                        e = mod_inverse(r, order) * (ab - aa) % order
+                        if (pow(b, e, n) - a) % n == 0:
+                            return mod_inverse(r, order) * (ab - aa) % order
                 break
 
     raise ValueError("Pollard's Rho failed to find logarithm")

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1195,19 +1195,12 @@ def _discrete_log_pollard_rho(n, a, b, order=None, retries=10, rseed=None):
 
             if xa == xb:
                 r = (ba - bb) % order
-                if not isprime(order):
-                    if mod_inverse(r, order):
-                        if r != 0:
-                            e = mod_inverse(r, order) * (ab - aa) % order
-                            if (pow(b, e, n) - a) % n == 0:
-                                return mod_inverse(r, order) * (ab - aa) % order
-                else:
-                    if r != 0:
-                        e = mod_inverse(r, order) * (ab - aa) % order
-                        if (pow(b, e, n) - a) % n == 0:
-                            return mod_inverse(r, order) * (ab - aa) % order
-                break
-
+                try:
+                    e = mod_inverse(r, order) * (ab - aa) % order
+                    if (pow(b, e, n) - a) % n == 0:
+                        return e
+                except ValueError:
+                    pass
     raise ValueError("Pollard's Rho failed to find logarithm")
 
 

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -233,6 +233,9 @@ def test_residue():
     assert _discrete_log_pollard_rho(6138719, 2**19, 2, rseed=0) == 19
     assert _discrete_log_pollard_rho(36721943, 2**40, 2, rseed=0) == 40
     assert _discrete_log_pollard_rho(24567899, 3**333, 3, rseed=0) == 333
+    raises(ValueError, lambda: _discrete_log_pollard_rho(11, 7, 31, rseed=0))
+    raises(ValueError, lambda: _discrete_log_pollard_rho(227, 3**7, 5, rseed=0))
+
     assert _discrete_log_pohlig_hellman(98376431, 11**9, 11) == 9
     assert _discrete_log_pohlig_hellman(78723213, 11**31, 11) == 31
     assert _discrete_log_pohlig_hellman(32942478, 11**98, 11) == 98


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #15977
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Previously the `_discrete_log_pollard_rho` method for discrete logarithm was producing results even if the base of the log `b` is not a generator of the multiplicative group modulo `order(n)`. Now after guessing the behavior of the given parameters, it will produce `Pollard's Rho failed to find logarithm` for non-generation of multiplicative group.    
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  ntheory
   *  fix _discrete_log_pollard_rho method for wrong results
<!-- END RELEASE NOTES -->
