### PR TITLE
Dsolve constantsimp

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2955,6 +2955,7 @@ def constant_renumber(expr, variables=None, newconstants=None):
         newstartnumber maintains its values throughout recursive calls.
 
         """
+        # FIXME: Use nonlocal here when support for Py2 is dropped:
         global newstartnumber
 
         if isinstance(expr, Equality):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2872,9 +2872,6 @@ def constantsimp(expr, constants):
 
 def constant_renumber(expr, variables=None, newconstants=None):
     r"""
-    FIXME: Need to redo this docstring. This now renumbers constants in expr
-    without using symbols from eq.
-
     Renumber arbitrary constants in ``expr`` to use the symbol names as given
     in ``newconstants``. In the process, this reorders expression terms in a
     standard way.
@@ -2925,12 +2922,13 @@ def constant_renumber(expr, variables=None, newconstants=None):
         renumbered = [constant_renumber(e, variables, newconstants) for e in expr]
         return type(expr)(renumbered)
 
-    # Symbols in solution bot not ODE are constants
+    # Symbols in solution but not ODE are constants
     if variables is not None:
-        constantsymbols = list(expr.free_symbols - set(variables))
+        variables = set(variables)
+        constantsymbols = list(expr.free_symbols - variables)
+    # Any Cn is a constant...
     else:
         variables = set()
-        # Any Cn is a constant...
         isconstant = lambda s: s.startswith('C') and s[1:].isdigit()
         constantsymbols = [sym for sym in expr.free_symbols if isconstant(sym.name)]
 

--- a/sympy/solvers/tests/test_constantsimp.py
+++ b/sympy/solvers/tests/test_constantsimp.py
@@ -5,8 +5,7 @@ should serve as a set of test cases.
 
 from sympy import (acos, cos, cosh, Eq, exp, Function, I, Integral, log, Pow,
                    S, sin, sinh, sqrt, Symbol, Add)
-from sympy.solvers.ode import constantsimp
-from sympy.solvers.ode import constant_renumber as _constant_renumber
+from sympy.solvers.ode import constantsimp, constant_renumber
 from sympy.utilities.pytest import XFAIL
 
 
@@ -21,149 +20,139 @@ C3 = Symbol('C3')
 f = Function('f')
 
 
-# FIXME: this is just temporary. The calls to constant_renumber below should
-# be updated.
-def constant_renumber(expr, C, i, j):
-    dummy_ode = x*y*z*_a
-    return _constant_renumber(dummy_ode, expr)
-
-
 def test_constant_mul():
     # We want C1 (Constant) below to absorb the y's, but not the x's
-    assert constant_renumber(constantsimp(y*C1, [C1]), 'C', 1, 1) == C1*y
-    assert constant_renumber(constantsimp(C1*y, [C1]), 'C', 1, 1) == C1*y
-    assert constant_renumber(constantsimp(x*C1, [C1]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*x, [C1]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(2*C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*2, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(y*C1*x, [C1, y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*y*C1, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*x*C1, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*x*y, [C1, y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*C1*y, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*y*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
-    assert constant_renumber(constantsimp(y*C1*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
-    assert constant_renumber(constantsimp(x*(y*C1), [C1]), 'C', 1, 1) == x*y*C1
-    assert constant_renumber(constantsimp(x*(C1*y), [C1]), 'C', 1, 1) == x*y*C1
-    assert constant_renumber(constantsimp(C1*(x*y), [C1, y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp((x*y)*C1, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((y*x)*C1, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*(y + 1)*C1, [C1, y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp((C1*x)*y, [C1, y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(y*(x*C1), [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((x*C1)*y, [C1, y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(
-        constantsimp(C1*x*y*x*y*2, [C1, y]), 'C', 1, 1) == C1*x**2
-    assert constant_renumber(constantsimp(C1*x*y*z, [C1, y, z]), 'C', 1, 1) == C1*x
-    assert constant_renumber(
-        constantsimp(C1*x*y**2*sin(z), [C1, y, z]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(C1*C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2*C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1*C1*C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(
-        constantsimp(C1*x*2**x, [C1]), 'C', 1, 1) == C1*x*2**x
+    assert constant_renumber(constantsimp(y*C1, [C1])) == C1*y
+    assert constant_renumber(constantsimp(C1*y, [C1])) == C1*y
+    assert constant_renumber(constantsimp(x*C1, [C1])) == x*C1
+    assert constant_renumber(constantsimp(C1*x, [C1])) == x*C1
+    assert constant_renumber(constantsimp(2*C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1*2, [C1])) == C1
+    assert constant_renumber(constantsimp(y*C1*x, [C1, y])) == C1*x
+    assert constant_renumber(constantsimp(x*y*C1, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp(y*x*C1, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp(C1*x*y, [C1, y])) == C1*x
+    assert constant_renumber(constantsimp(x*C1*y, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp(C1*y*(y + 1), [C1])) == C1*y*(y+1)
+    assert constant_renumber(constantsimp(y*C1*(y + 1), [C1])) == C1*y*(y+1)
+    assert constant_renumber(constantsimp(x*(y*C1), [C1])) == x*y*C1
+    assert constant_renumber(constantsimp(x*(C1*y), [C1])) == x*y*C1
+    assert constant_renumber(constantsimp(C1*(x*y), [C1, y])) == C1*x
+    assert constant_renumber(constantsimp((x*y)*C1, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp((y*x)*C1, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp(y*(y + 1)*C1, [C1, y])) == C1
+    assert constant_renumber(constantsimp((C1*x)*y, [C1, y])) == C1*x
+    assert constant_renumber(constantsimp(y*(x*C1), [C1, y])) == x*C1
+    assert constant_renumber(constantsimp((x*C1)*y, [C1, y])) == x*C1
+    assert constant_renumber(constantsimp(C1*x*y*x*y*2, [C1, y])) == C1*x**2
+    assert constant_renumber(constantsimp(C1*x*y*z, [C1, y, z])) == C1*x
+    assert constant_renumber(constantsimp(C1*x*y**2*sin(z), [C1, y, z])) == C1*x
+    assert constant_renumber(constantsimp(C1*C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1*C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C2*C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C1*C1*C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C1*x*2**x, [C1])) == C1*x*2**x
 
 def test_constant_add():
-    assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + 2, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(2 + C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + y, [C1, y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + x, [C1]), 'C', 1, 1) == C1 + x
-    assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2 + C1, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1 + C2 + C1, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1 + C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1 + 2, [C1])) == C1
+    assert constant_renumber(constantsimp(2 + C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1 + y, [C1, y])) == C1
+    assert constant_renumber(constantsimp(C1 + x, [C1])) == C1 + x
+    assert constant_renumber(constantsimp(C1 + C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1 + C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C2 + C1, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C1 + C2 + C1, [C1, C2])) == C1
 
 
 def test_constant_power_as_base():
-    assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(Pow(C1, C1), [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C1, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C2, [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1**y, [C1, y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**x, [C1]), 'C', 1, 1) == C1**x
-    assert constant_renumber(constantsimp(C1**2, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**C1, [C1])) == C1
+    assert constant_renumber(constantsimp(Pow(C1, C1), [C1])) == C1
+    assert constant_renumber(constantsimp(C1**C1, [C1])) == C1
+    assert constant_renumber(constantsimp(C1**C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C2**C1, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C2**C2, [C1, C2])) == C1
+    assert constant_renumber(constantsimp(C1**y, [C1, y])) == C1
+    assert constant_renumber(constantsimp(C1**x, [C1])) == C1**x
+    assert constant_renumber(constantsimp(C1**2, [C1])) == C1
     assert constant_renumber(
-        constantsimp(C1**(x*y), [C1]), 'C', 1, 1) == C1**(x*y)
+        constantsimp(C1**(x*y), [C1])) == C1**(x*y)
 
 
 def test_constant_power_as_exp():
-    assert constant_renumber(constantsimp(x**C1, [C1]), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(y**C1, [C1, y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x**y**C1, [C1, y]), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(x**C1, [C1])) == x**C1
+    assert constant_renumber(constantsimp(y**C1, [C1, y])) == C1
+    assert constant_renumber(constantsimp(x**y**C1, [C1, y])) == x**C1
     assert constant_renumber(
-        constantsimp((x**y)**C1, [C1]), 'C', 1, 1) == (x**y)**C1
+        constantsimp((x**y)**C1, [C1])) == (x**y)**C1
     assert constant_renumber(
-        constantsimp(x**(y**C1), [C1, y]), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(x**C1**y, [C1, y]), 'C', 1, 1) == x**C1
+        constantsimp(x**(y**C1), [C1, y])) == x**C1
+    assert constant_renumber(constantsimp(x**C1**y, [C1, y])) == x**C1
     assert constant_renumber(
-        constantsimp(x**(C1**y), [C1, y]), 'C', 1, 1) == x**C1
+        constantsimp(x**(C1**y), [C1, y])) == x**C1
     assert constant_renumber(
-        constantsimp((x**C1)**y, [C1]), 'C', 1, 1) == (x**C1)**y
-    assert constant_renumber(constantsimp(2**C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(S(2)**C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(exp(C1), [C1]), 'C', 1, 1) == C1
+        constantsimp((x**C1)**y, [C1])) == (x**C1)**y
+    assert constant_renumber(constantsimp(2**C1, [C1])) == C1
+    assert constant_renumber(constantsimp(S(2)**C1, [C1])) == C1
+    assert constant_renumber(constantsimp(exp(C1), [C1])) == C1
     assert constant_renumber(
-        constantsimp(exp(C1 + x), [C1]), 'C', 1, 1) == C1*exp(x)
-    assert constant_renumber(constantsimp(Pow(2, C1), [C1]), 'C', 1, 1) == C1
+        constantsimp(exp(C1 + x), [C1])) == C1*exp(x)
+    assert constant_renumber(constantsimp(Pow(2, C1), [C1])) == C1
 
 
 def test_constant_function():
-    assert constant_renumber(constantsimp(sin(C1), [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1), [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1, C1), [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1, C2), [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C1), [C1, C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C2), [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(sin(C1), [C1])) == C1
+    assert constant_renumber(constantsimp(f(C1), [C1])) == C1
+    assert constant_renumber(constantsimp(f(C1, C1), [C1])) == C1
+    assert constant_renumber(constantsimp(f(C1, C2), [C1, C2])) == C1
+    assert constant_renumber(constantsimp(f(C2, C1), [C1, C2])) == C1
+    assert constant_renumber(constantsimp(f(C2, C2), [C1, C2])) == C1
     assert constant_renumber(
-        constantsimp(f(C1, x), [C1]), 'C', 1, 2) == f(C1, x)
-    assert constant_renumber(constantsimp(f(C1, y), [C1, y]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(y, C1), [C1, y]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C1, y, C2), [C1, C2, y]), 'C', 1, 2) == C1
+        constantsimp(f(C1, x), [C1])) == f(C1, x)
+    assert constant_renumber(constantsimp(f(C1, y), [C1, y])) == C1
+    assert constant_renumber(constantsimp(f(y, C1), [C1, y])) == C1
+    assert constant_renumber(constantsimp(f(C1, y, C2), [C1, C2, y])) == C1
 
 
 def test_constant_function_multiple():
     # The rules to not renumber in this case would be too complicated, and
     # dsolve is not likely to ever encounter anything remotely like this.
     assert constant_renumber(
-        constantsimp(f(C1, C1, x), [C1]), 'C', 1, 1) == f(C1, C1, x)
+        constantsimp(f(C1, C1, x), [C1])) == f(C1, C1, x)
 
 
 def test_constant_multiple():
-    assert constant_renumber(constantsimp(C1*2 + 2, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x*2/C1, [C1]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(C1**2*2 + 2, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1*2 + 2, [C1])) == C1
+    assert constant_renumber(constantsimp(x*2/C1, [C1])) == C1*x
+    assert constant_renumber(constantsimp(C1**2*2 + 2, [C1])) == C1
     assert constant_renumber(
-        constantsimp(sin(2*C1) + x + sqrt(2), [C1]), 'C', 1, 1) == C1 + x
-    assert constant_renumber(constantsimp(2*C1 + C2, [C1, C2]), 'C', 1, 2) == C1
+        constantsimp(sin(2*C1) + x + sqrt(2), [C1])) == C1 + x
+    assert constant_renumber(constantsimp(2*C1 + C2, [C1, C2])) == C1
 
 def test_constant_repeated():
-    assert C1 + C1*x == constant_renumber( C1 + C1*x, 'C', 1, 3)
+    assert C1 + C1*x == constant_renumber( C1 + C1*x)
 
 def test_ode_solutions():
     # only a few examples here, the rest will be tested in the actual dsolve tests
-    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), [C1, C2, C3]), 'C', 1, 3) == \
-        constant_renumber((C1*exp(x) + C2*exp(2*x)), 'C', 1, 2)
+    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), [C1, C2, C3])) == \
+        constant_renumber((C1*exp(x) + C2*exp(2*x)))
     assert constant_renumber(
-        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), [C1, C2]),
-        'C', 1, 2) == constant_renumber(Eq(f(x), C1*sinh(x/3) + C2*cosh(x/3)), 'C', 1, 2)
-    assert constant_renumber(constantsimp(Eq(f(x), acos((-C1)/cos(x))), [C1]), 'C', 1, 1) == \
+        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), [C1, C2])
+        ) == constant_renumber(Eq(f(x), C1*sinh(x/3) + C2*cosh(x/3)))
+    assert constant_renumber(constantsimp(Eq(f(x), acos((-C1)/cos(x))), [C1])) == \
         Eq(f(x), acos(C1/cos(x)))
     assert constant_renumber(
-        constantsimp(Eq(log(f(x)/C1) + 2*exp(x/f(x)), 0), [C1]),
-        'C', 1, 1) == Eq(log(C1*f(x)) + 2*exp(x/f(x)), 0)
+        constantsimp(Eq(log(f(x)/C1) + 2*exp(x/f(x)), 0), [C1])
+        ) == Eq(log(C1*f(x)) + 2*exp(x/f(x)), 0)
     assert constant_renumber(constantsimp(Eq(log(x*sqrt(2)*sqrt(1/x)*sqrt(f(x))
-        /C1) + x**2/(2*f(x)**2), 0), [C1]), 'C', 1, 1) == \
+        /C1) + x**2/(2*f(x)**2), 0), [C1])) == \
         Eq(log(C1*sqrt(x)*sqrt(f(x))) + x**2/(2*f(x)**2), 0)
     assert constant_renumber(constantsimp(Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(x/C1) -
-        cos(f(x)/x)*exp(-f(x)/x)/2, 0), [C1]), 'C', 1, 1) == \
+        cos(f(x)/x)*exp(-f(x)/x)/2, 0), [C1])) == \
         Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(C1*x) - cos(f(x)/x)*
            exp(-f(x)/x)/2, 0)
     assert constant_renumber(constantsimp(Eq(-Integral(-1/(sqrt(1 - u2**2)*u2),
-        (u2, _a, x/f(x))) + log(f(x)/C1), 0), [C1]), 'C', 1, 1) == \
+        (u2, _a, x/f(x))) + log(f(x)/C1), 0), [C1])) == \
         Eq(-Integral(-1/(u2*sqrt(1 - u2**2)), (u2, _a, x/f(x))) +
         log(C1*f(x)), 0)
     assert [constantsimp(i, [C1]) for i in [Eq(f(x), sqrt(-C1*x + x**2)), Eq(f(x), -sqrt(-C1*x + x**2))]] == \

--- a/sympy/solvers/tests/test_constantsimp.py
+++ b/sympy/solvers/tests/test_constantsimp.py
@@ -4,18 +4,28 @@ should serve as a set of test cases.
 """
 
 from sympy import (acos, cos, cosh, Eq, exp, Function, I, Integral, log, Pow,
-                   S, sin, sinh, sqrt, Symbol)
-from sympy.solvers.ode import constant_renumber, constantsimp
+                   S, sin, sinh, sqrt, Symbol, Add)
+from sympy.solvers.ode import constantsimp
+from sympy.solvers.ode import constant_renumber as _constant_renumber
 from sympy.utilities.pytest import XFAIL
 
 
 x = Symbol('x')
 y = Symbol('y')
 z = Symbol('z')
+u2 = Symbol('u2')
+_a = Symbol('_a')
 C1 = Symbol('C1')
 C2 = Symbol('C2')
 C3 = Symbol('C3')
 f = Function('f')
+
+
+# FIXME: this is just temporary. The calls to constant_renumber below should
+# be updated.
+def constant_renumber(expr, C, i, j):
+    dummy_ode = x*y*z*_a
+    return _constant_renumber(dummy_ode, expr)
 
 
 def test_constant_mul():
@@ -152,8 +162,6 @@ def test_ode_solutions():
         cos(f(x)/x)*exp(-f(x)/x)/2, 0), [C1]), 'C', 1, 1) == \
         Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(C1*x) - cos(f(x)/x)*
            exp(-f(x)/x)/2, 0)
-    u2 = Symbol('u2')
-    _a = Symbol('_a')
     assert constant_renumber(constantsimp(Eq(-Integral(-1/(sqrt(1 - u2**2)*u2),
         (u2, _a, x/f(x))) + log(f(x)/C1), 0), [C1]), 'C', 1, 1) == \
         Eq(-Integral(-1/(u2*sqrt(1 - u2**2)), (u2, _a, x/f(x))) +

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3070,19 +3070,23 @@ def test_issue_11290():
 
 
 def test_issue_4838():
+    # Issue #15999
     eq = f(x).diff(x) - C1*f(x)
     sol = Eq(f(x), C2*exp(C1*x))
     assert dsolve(eq, f(x)) == sol
     assert checkodesol(eq, sol, order=1, solve_for_func=False) == (True, 0)
 
-
-# FIXME: fails due to issue #15999
-@XFAIL
-def test_issue_13691():
+    # Issue #13691
     eq = f(x).diff(x) - C1*g(x).diff(x)
-    ans = Eq(f(x), C2 + C1*g(x))
-    sol = dsolve(eq, f(x))
-    assert str(sol) == str(ans)
+    sol = Eq(f(x), C2 + C1*g(x))
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, f(x), order=1, solve_for_func=False) == (True, 0)
+
+    # Issue #4838
+    eq = f(x).diff(x) - 3*C1 - 3*x**2
+    sol = Eq(f(x), C2 + 3*C1*x + x**3)
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == (True, 0)
 
 
 def test_issue_14395():
@@ -3256,13 +3260,11 @@ def test_nth_algebraic():
 
 
 def test_nth_algebraic_issue15999():
-    # FIXME: When issue 4838 is resolved this test should be changed...
     eqn = f(x).diff(x) - C1
-    sol1 = Eq(f(x), C1*x + C2) # Correct solution
-    sol2 = Eq(f(x), C2*x + C1) # Incorrect: issue 4838
-    assert checkodesol(eqn, sol1, order=1, solve_for_func=False) == (True, 0)
-    assert dsolve(eqn, f(x), hint='nth_algebraic') == sol2
-    assert dsolve(eqn, f(x)) == sol2
+    sol = Eq(f(x), C1*x + C2) # Correct solution
+    assert checkodesol(eqn, sol, order=1, solve_for_func=False) == (True, 0)
+    assert dsolve(eqn, f(x), hint='nth_algebraic') == sol
+    assert dsolve(eqn, f(x)) == sol
 
 
 def test_nth_algebraic_redundant_solutions():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3069,6 +3069,13 @@ def test_issue_11290():
     assert checkodesol(eq, sol_1, order=1, solve_for_func=False)
 
 
+def test_issue_13691():
+    eq = f(x).diff(x) - C1*g(x).diff(x)
+    ans = Eq(f(x), C2 + C1*g(x))
+    sol = dsolve(eq, f(x))
+    assert str(sol) == str(ans)
+
+
 def test_issue_14395():
     eq = Derivative(f(x), x, x) + 9*f(x) - sec(x)
     sol = Eq(f(x), (C1 - x/3 + sin(2*x)/3)*sin(3*x) + (C2 + log(cos(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1664,36 +1664,36 @@ def test_nth_linear_constant_coeff_homogeneous():
                    + (C3*sin(sqrt(3)*x/2) + C4*cos(sqrt(3)*x/2))*sqrt(exp(x)))
     sol32 = Eq(f(x), C1*sin(x*sqrt(-sqrt(3) + 2)) + C2*sin(x*sqrt(sqrt(3) + 2))
                    + C3*cos(x*sqrt(-sqrt(3) + 2)) + C4*cos(x*sqrt(sqrt(3) + 2)))
-    sol1s = constant_renumber(eq1, sol1)
-    sol2s = constant_renumber(eq2, sol2)
-    sol3s = constant_renumber(eq3, sol3)
-    sol4s = constant_renumber(eq4, sol4)
-    sol5s = constant_renumber(eq5, sol5)
-    sol6s = constant_renumber(eq6, sol6)
-    sol7s = constant_renumber(eq7, sol7)
-    sol8s = constant_renumber(eq8, sol8)
-    sol9s = constant_renumber(eq9, sol9)
-    sol10s = constant_renumber(eq10, sol10)
-    sol11s = constant_renumber(eq11, sol11)
-    sol12s = constant_renumber(eq12, sol12)
-    sol13s = constant_renumber(eq13, sol13)
-    sol14s = constant_renumber(eq14, sol14)
-    sol15s = constant_renumber(eq15, sol15)
-    sol16s = constant_renumber(eq16, sol16)
-    sol17s = constant_renumber(eq17, sol17)
-    sol18s = constant_renumber(eq18, sol18)
-    sol19s = constant_renumber(eq19, sol19)
-    sol20s = constant_renumber(eq20, sol20)
-    sol21s = constant_renumber(eq21, sol21)
-    sol22s = constant_renumber(eq22, sol22)
-    sol23s = constant_renumber(eq23, sol23)
-    sol24s = constant_renumber(eq24, sol24)
-    sol25s = constant_renumber(eq25, sol25)
-    sol26s = constant_renumber(eq26, sol26)
-    sol27s = constant_renumber(eq27, sol27)
-    sol28s = constant_renumber(eq28, sol28)
-    sol29s = constant_renumber(eq29, sol29)
-    sol30s = constant_renumber(eq30, sol30)
+    sol1s = constant_renumber(sol1)
+    sol2s = constant_renumber(sol2)
+    sol3s = constant_renumber(sol3)
+    sol4s = constant_renumber(sol4)
+    sol5s = constant_renumber(sol5)
+    sol6s = constant_renumber(sol6)
+    sol7s = constant_renumber(sol7)
+    sol8s = constant_renumber(sol8)
+    sol9s = constant_renumber(sol9)
+    sol10s = constant_renumber(sol10)
+    sol11s = constant_renumber(sol11)
+    sol12s = constant_renumber(sol12)
+    sol13s = constant_renumber(sol13)
+    sol14s = constant_renumber(sol14)
+    sol15s = constant_renumber(sol15)
+    sol16s = constant_renumber(sol16)
+    sol17s = constant_renumber(sol17)
+    sol18s = constant_renumber(sol18)
+    sol19s = constant_renumber(sol19)
+    sol20s = constant_renumber(sol20)
+    sol21s = constant_renumber(sol21)
+    sol22s = constant_renumber(sol22)
+    sol23s = constant_renumber(sol23)
+    sol24s = constant_renumber(sol24)
+    sol25s = constant_renumber(sol25)
+    sol26s = constant_renumber(sol26)
+    sol27s = constant_renumber(sol27)
+    sol28s = constant_renumber(sol28)
+    sol29s = constant_renumber(sol29)
+    sol30s = constant_renumber(sol30)
     assert dsolve(eq1) in (sol1, sol1s)
     assert dsolve(eq2) in (sol2, sol2s)
     assert dsolve(eq3) in (sol3, sol3s)
@@ -2070,33 +2070,33 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
         C1 + (C2 + C3*x - x**2/8)*sin(x) + (C4 + C5*x + x**2/8)*cos(x) + x**2)
     sol27 = Eq(f(x), cos(3*x)/16 + C1*cos(x) + (C2 + x/4)*sin(x))
     sol28 = Eq(f(x), C1 + x)
-    sol1s = constant_renumber(eq1, sol1)
-    sol2s = constant_renumber(eq2, sol2)
-    sol3s = constant_renumber(eq3, sol3)
-    sol4s = constant_renumber(eq4, sol4)
-    sol5s = constant_renumber(eq5, sol5)
-    sol6s = constant_renumber(eq6, sol6)
-    sol7s = constant_renumber(eq7, sol7)
-    sol8s = constant_renumber(eq8, sol8)
-    sol9s = constant_renumber(eq9, sol9)
-    sol10s = constant_renumber(eq10, sol10)
-    sol11s = constant_renumber(eq11, sol11)
-    sol12s = constant_renumber(eq12, sol12)
-    sol13s = constant_renumber(eq13, sol13)
-    sol14s = constant_renumber(eq14, sol14)
-    sol15s = constant_renumber(eq15, sol15)
-    sol16s = constant_renumber(eq16, sol16)
-    sol17s = constant_renumber(eq17, sol17)
-    sol18s = constant_renumber(eq18, sol18)
-    sol19s = constant_renumber(eq19, sol19)
-    sol20s = constant_renumber(eq20, sol20)
-    sol21s = constant_renumber(eq21, sol21)
-    sol22s = constant_renumber(eq22, sol22)
-    sol23s = constant_renumber(eq23, sol23)
-    sol24s = constant_renumber(eq24, sol24)
-    sol25s = constant_renumber(eq25, sol25)
-    sol26s = constant_renumber(eq26, sol26)
-    sol27s = constant_renumber(eq27, sol27)
+    sol1s = constant_renumber(sol1)
+    sol2s = constant_renumber(sol2)
+    sol3s = constant_renumber(sol3)
+    sol4s = constant_renumber(sol4)
+    sol5s = constant_renumber(sol5)
+    sol6s = constant_renumber(sol6)
+    sol7s = constant_renumber(sol7)
+    sol8s = constant_renumber(sol8)
+    sol9s = constant_renumber(sol9)
+    sol10s = constant_renumber(sol10)
+    sol11s = constant_renumber(sol11)
+    sol12s = constant_renumber(sol12)
+    sol13s = constant_renumber(sol13)
+    sol14s = constant_renumber(sol14)
+    sol15s = constant_renumber(sol15)
+    sol16s = constant_renumber(sol16)
+    sol17s = constant_renumber(sol17)
+    sol18s = constant_renumber(sol18)
+    sol19s = constant_renumber(sol19)
+    sol20s = constant_renumber(sol20)
+    sol21s = constant_renumber(sol21)
+    sol22s = constant_renumber(sol22)
+    sol23s = constant_renumber(sol23)
+    sol24s = constant_renumber(sol24)
+    sol25s = constant_renumber(sol25)
+    sol26s = constant_renumber(sol26)
+    sol27s = constant_renumber(sol27)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
     assert dsolve(eq3, hint=hint) in (sol3, sol3s)
@@ -2210,18 +2210,18 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     sol11 = Eq(f(x), cos(x)*(C2 - Integral(1/cos(x), x)) + sin(x)*(C1 +
         Integral(1/sin(x), x)))
     sol12 = Eq(f(x), C1 + C2*x + x**3*(C3 + log(x)/6) + C4*x**2)
-    sol1s = constant_renumber(eq1, sol1)
-    sol2s = constant_renumber(eq2, sol2)
-    sol3s = constant_renumber(eq3, sol3)
-    sol4s = constant_renumber(eq4, sol4)
-    sol5s = constant_renumber(eq5, sol5)
-    sol6s = constant_renumber(eq6, sol6)
-    sol7s = constant_renumber(eq7, sol7)
-    sol8s = constant_renumber(eq8, sol8)
-    sol9s = constant_renumber(eq9, sol9)
-    sol10s = constant_renumber(eq10, sol10)
-    sol11s = constant_renumber(eq11, sol11)
-    sol12s = constant_renumber(eq12, sol12)
+    sol1s = constant_renumber(sol1)
+    sol2s = constant_renumber(sol2)
+    sol3s = constant_renumber(sol3)
+    sol4s = constant_renumber(sol4)
+    sol5s = constant_renumber(sol5)
+    sol6s = constant_renumber(sol6)
+    sol7s = constant_renumber(sol7)
+    sol8s = constant_renumber(sol8)
+    sol9s = constant_renumber(sol9)
+    sol10s = constant_renumber(sol10)
+    sol11s = constant_renumber(sol11)
+    sol12s = constant_renumber(sol12)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
     assert dsolve(eq3, hint=hint) in (sol3, sol3s)
@@ -2279,11 +2279,11 @@ def test_Liouville_ODE():
     sol4 = set([Eq(f(x), sqrt(C1 + C2*exp(x))*exp(-x/2)),
                 Eq(f(x), -sqrt(C1 + C2*exp(x))*exp(-x/2))])
     sol5 = Eq(f(x), log(C1 + C2/x))
-    sol1s = constant_renumber(eq1, sol1)
-    sol2s = constant_renumber(eq2, sol2)
-    sol3s = constant_renumber(eq3, sol3)
-    sol4s = constant_renumber(eq4, sol4)
-    sol5s = constant_renumber(eq5, sol5)
+    sol1s = constant_renumber(sol1)
+    sol2s = constant_renumber(sol2)
+    sol3s = constant_renumber(sol3)
+    sol4s = constant_renumber(sol4)
+    sol5s = constant_renumber(sol5)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq1a, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
@@ -2311,7 +2311,7 @@ def test_unexpanded_Liouville_ODE():
     eq1 = diff(f(x), x)/x + diff(f(x), x, x)/2 - diff(f(x), x)**2/2
     eq2 = eq1*exp(-f(x))/exp(f(x))
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
-    sol2s = constant_renumber(eq2, sol2)
+    sol2s = constant_renumber(sol2)
     assert dsolve(eq2) in (sol2, sol2s)
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
 
@@ -2351,12 +2351,12 @@ def test_constant_renumber_order_issue_5308():
 
     eq = f(x).diff(x) - y - x
 
-    assert constant_renumber(eq, C1*x + C2*y) == \
-        constant_renumber(eq, C1*y + C2*x) == \
+    assert constant_renumber(C1*x + C2*y) == \
+        constant_renumber(C1*y + C2*x) == \
         C1*x + C2*y
     e = C1*(C2 + x)*(C3 + y)
     for a, b, c in variations([C1, C2, C3], 3):
-        assert constant_renumber(eq, a*(b + x)*(c + y)) == e
+        assert constant_renumber(a*(b + x)*(c + y)) == e
 
 
 def test_issue_5770():
@@ -2392,21 +2392,21 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
     eq = Eq(-3*diff(f(x), x)*x + 2*x**2*diff(f(x), x, x), 0)
     sol = C1 + C2*x**Rational(5, 2)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(3*f(x) - 5*diff(f(x), x)*x + 2*x**2*diff(f(x), x, x), 0)
     sol = C1*sqrt(x) + C2*x**3
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(4*f(x) + 5*diff(f(x), x)*x + x**2*diff(f(x), x, x), 0)
     sol = (C1 + C2*log(x))/x**2
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2414,14 +2414,14 @@ def test_nth_order_linear_euler_eq_homogeneous():
     eq = Eq(6*f(x) - 6*diff(f(x), x)*x + 1*x**2*diff(f(x), x, x) + x**3*diff(f(x), x, x, x), 0)
     sol = dsolve(eq, f(x), hint=our_hint)
     sol = C1/x**2 + C2*x + C3*x**3
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(-125*f(x) + 61*diff(f(x), x)*x - 12*x**2*diff(f(x), x, x) + x**3*diff(f(x), x, x, x), 0)
     sol = x**5*(C1 + C2*log(x) + C3*log(x)**2)
-    sols = [sol, constant_renumber(eq, sol)]
+    sols = [sol, constant_renumber(sol)]
     sols += [sols[-1].expand()]
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in sols
@@ -2429,14 +2429,14 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
     eq = t**2*diff(y(t), t, 2) + t*diff(y(t), t) - 9*y(t)
     sol = C1*t**3 + C2*t**-3
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, y(t), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = sin(x)*x**2*f(x).diff(x, 2) + sin(x)*x*f(x).diff(x) + sin(x)*f(x)
     sol = C1*sin(log(x)) + C2*cos(log(x))
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2455,35 +2455,35 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_undetermined_coefficients():
 
     eq = Eq(x**2*diff(f(x), x, x) + x*diff(f(x), x), 1)
     sol =  C1 + C2*log(x) + log(x)**2/2
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
     sol = x*(C1 + C2*x + Rational(1, 2)*x**2)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - x*diff(f(x), x) - 3*f(x), log(x)/x)
     sol =  C1/x + C2*x**3 - Rational(1, 16)*log(x)/x - Rational(1, 8)*log(x)**2/x
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) + 3*x*diff(f(x), x) - 8*f(x), log(x)**3 - log(x))
     sol = C1/x**4 + C2*x**2 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**3*diff(f(x), x, x, x) - 3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), log(x))
     sol = C1*x + C2*x**2 + C3*x**3 - Rational(1, 6)*log(x) - Rational(11, 36)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2502,28 +2502,28 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_variation_of_parameters():
 
     eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4)
     sol = C1*x + C2*x**2 + x**4/6
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), x**3*exp(x))
     sol = C1/x**2 + C2*x + x*exp(x)/3 - 4*exp(x)/3 + 8*exp(x)/(3*x) - 8*exp(x)/(3*x**2)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4*exp(x))
     sol = C1*x + C2*x**2 + x**2*exp(x) - 2*x*exp(x)
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - log(x)
     sol = C1*x + C2*x**2 + log(x)/2 + S(3)/4
-    sols = constant_renumber(eq, sol)
+    sols = constant_renumber(sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -3159,14 +3159,14 @@ def test_order_reducible():
 
     eqn = f(x).diff(x, 2) + 2*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-2*x))
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 3) + f(x).diff(x, 2) - 6*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-3*x) + C3*exp(2*x))
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3174,28 +3174,28 @@ def test_order_reducible():
     eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
         4*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(x) + C3*exp(-2*x) + C4*exp(2*x))
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
     sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
-    sols = constant_renumber(eqn, sol)
+    sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3204,8 +3204,8 @@ def test_order_reducible():
     # These are equivalent:
     sol1 = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
     sol2 = Eq(f(x), C1 + C2*(x*sin(x) + cos(x)) + C3*(-x*cos(x) + sin(x)) + C4*sin(x) + C5*cos(x))
-    sol1s = constant_renumber(eqn, sol1)
-    sol2s = constant_renumber(eqn, sol2)
+    sol1s = constant_renumber(sol1)
+    sol2s = constant_renumber(sol2)
     assert checkodesol(eqn, sol1, order=2, solve_for_func=False) == (True, 0)
     assert checkodesol(eqn, sol2, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol1, sol1s)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1664,36 +1664,36 @@ def test_nth_linear_constant_coeff_homogeneous():
                    + (C3*sin(sqrt(3)*x/2) + C4*cos(sqrt(3)*x/2))*sqrt(exp(x)))
     sol32 = Eq(f(x), C1*sin(x*sqrt(-sqrt(3) + 2)) + C2*sin(x*sqrt(sqrt(3) + 2))
                    + C3*cos(x*sqrt(-sqrt(3) + 2)) + C4*cos(x*sqrt(sqrt(3) + 2)))
-    sol1s = constant_renumber(sol1, 'C', 1, 2)
-    sol2s = constant_renumber(sol2, 'C', 1, 2)
-    sol3s = constant_renumber(sol3, 'C', 1, 2)
-    sol4s = constant_renumber(sol4, 'C', 1, 3)
-    sol5s = constant_renumber(sol5, 'C', 1, 2)
-    sol6s = constant_renumber(sol6, 'C', 1, 2)
-    sol7s = constant_renumber(sol7, 'C', 1, 3)
-    sol8s = constant_renumber(sol8, 'C', 1, 4)
-    sol9s = constant_renumber(sol9, 'C', 1, 4)
-    sol10s = constant_renumber(sol10, 'C', 1, 4)
-    sol11s = constant_renumber(sol11, 'C', 1, 2)
-    sol12s = constant_renumber(sol12, 'C', 1, 2)
-    sol13s = constant_renumber(sol13, 'C', 1, 4)
-    sol14s = constant_renumber(sol14, 'C', 1, 2)
-    sol15s = constant_renumber(sol15, 'C', 1, 3)
-    sol16s = constant_renumber(sol16, 'C', 1, 3)
-    sol17s = constant_renumber(sol17, 'C', 1, 2)
-    sol18s = constant_renumber(sol18, 'C', 1, 4)
-    sol19s = constant_renumber(sol19, 'C', 1, 4)
-    sol20s = constant_renumber(sol20, 'C', 1, 4)
-    sol21s = constant_renumber(sol21, 'C', 1, 4)
-    sol22s = constant_renumber(sol22, 'C', 1, 4)
-    sol23s = constant_renumber(sol23, 'C', 1, 2)
-    sol24s = constant_renumber(sol24, 'C', 1, 2)
-    sol25s = constant_renumber(sol25, 'C', 1, 4)
-    sol26s = constant_renumber(sol26, 'C', 1, 2)
-    sol27s = constant_renumber(sol27, 'C', 1, 4)
-    sol28s = constant_renumber(sol28, 'C', 1, 3)
-    sol29s = constant_renumber(sol29, 'C', 1, 4)
-    sol30s = constant_renumber(sol30, 'C', 1, 5)
+    sol1s = constant_renumber(eq1, sol1)
+    sol2s = constant_renumber(eq2, sol2)
+    sol3s = constant_renumber(eq3, sol3)
+    sol4s = constant_renumber(eq4, sol4)
+    sol5s = constant_renumber(eq5, sol5)
+    sol6s = constant_renumber(eq6, sol6)
+    sol7s = constant_renumber(eq7, sol7)
+    sol8s = constant_renumber(eq8, sol8)
+    sol9s = constant_renumber(eq9, sol9)
+    sol10s = constant_renumber(eq10, sol10)
+    sol11s = constant_renumber(eq11, sol11)
+    sol12s = constant_renumber(eq12, sol12)
+    sol13s = constant_renumber(eq13, sol13)
+    sol14s = constant_renumber(eq14, sol14)
+    sol15s = constant_renumber(eq15, sol15)
+    sol16s = constant_renumber(eq16, sol16)
+    sol17s = constant_renumber(eq17, sol17)
+    sol18s = constant_renumber(eq18, sol18)
+    sol19s = constant_renumber(eq19, sol19)
+    sol20s = constant_renumber(eq20, sol20)
+    sol21s = constant_renumber(eq21, sol21)
+    sol22s = constant_renumber(eq22, sol22)
+    sol23s = constant_renumber(eq23, sol23)
+    sol24s = constant_renumber(eq24, sol24)
+    sol25s = constant_renumber(eq25, sol25)
+    sol26s = constant_renumber(eq26, sol26)
+    sol27s = constant_renumber(eq27, sol27)
+    sol28s = constant_renumber(eq28, sol28)
+    sol29s = constant_renumber(eq29, sol29)
+    sol30s = constant_renumber(eq30, sol30)
     assert dsolve(eq1) in (sol1, sol1s)
     assert dsolve(eq2) in (sol2, sol2s)
     assert dsolve(eq3) in (sol3, sol3s)
@@ -2070,33 +2070,33 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
         C1 + (C2 + C3*x - x**2/8)*sin(x) + (C4 + C5*x + x**2/8)*cos(x) + x**2)
     sol27 = Eq(f(x), cos(3*x)/16 + C1*cos(x) + (C2 + x/4)*sin(x))
     sol28 = Eq(f(x), C1 + x)
-    sol1s = constant_renumber(sol1, 'C', 1, 3)
-    sol2s = constant_renumber(sol2, 'C', 1, 3)
-    sol3s = constant_renumber(sol3, 'C', 1, 2)
-    sol4s = constant_renumber(sol4, 'C', 1, 2)
-    sol5s = constant_renumber(sol5, 'C', 1, 2)
-    sol6s = constant_renumber(sol6, 'C', 1, 2)
-    sol7s = constant_renumber(sol7, 'C', 1, 2)
-    sol8s = constant_renumber(sol8, 'C', 1, 2)
-    sol9s = constant_renumber(sol9, 'C', 1, 2)
-    sol10s = constant_renumber(sol10, 'C', 1, 2)
-    sol11s = constant_renumber(sol11, 'C', 1, 2)
-    sol12s = constant_renumber(sol12, 'C', 1, 2)
-    sol13s = constant_renumber(sol13, 'C', 1, 4)
-    sol14s = constant_renumber(sol14, 'C', 1, 2)
-    sol15s = constant_renumber(sol15, 'C', 1, 2)
-    sol16s = constant_renumber(sol16, 'C', 1, 2)
-    sol17s = constant_renumber(sol17, 'C', 1, 2)
-    sol18s = constant_renumber(sol18, 'C', 1, 3)
-    sol19s = constant_renumber(sol19, 'C', 1, 2)
-    sol20s = constant_renumber(sol20, 'C', 1, 2)
-    sol21s = constant_renumber(sol21, 'C', 1, 2)
-    sol22s = constant_renumber(sol22, 'C', 1, 2)
-    sol23s = constant_renumber(sol23, 'C', 1, 3)
-    sol24s = constant_renumber(sol24, 'C', 1, 2)
-    sol25s = constant_renumber(sol25, 'C', 1, 3)
-    sol26s = constant_renumber(sol26, 'C', 1, 5)
-    sol27s = constant_renumber(sol27, 'C', 1, 2)
+    sol1s = constant_renumber(eq1, sol1)
+    sol2s = constant_renumber(eq2, sol2)
+    sol3s = constant_renumber(eq3, sol3)
+    sol4s = constant_renumber(eq4, sol4)
+    sol5s = constant_renumber(eq5, sol5)
+    sol6s = constant_renumber(eq6, sol6)
+    sol7s = constant_renumber(eq7, sol7)
+    sol8s = constant_renumber(eq8, sol8)
+    sol9s = constant_renumber(eq9, sol9)
+    sol10s = constant_renumber(eq10, sol10)
+    sol11s = constant_renumber(eq11, sol11)
+    sol12s = constant_renumber(eq12, sol12)
+    sol13s = constant_renumber(eq13, sol13)
+    sol14s = constant_renumber(eq14, sol14)
+    sol15s = constant_renumber(eq15, sol15)
+    sol16s = constant_renumber(eq16, sol16)
+    sol17s = constant_renumber(eq17, sol17)
+    sol18s = constant_renumber(eq18, sol18)
+    sol19s = constant_renumber(eq19, sol19)
+    sol20s = constant_renumber(eq20, sol20)
+    sol21s = constant_renumber(eq21, sol21)
+    sol22s = constant_renumber(eq22, sol22)
+    sol23s = constant_renumber(eq23, sol23)
+    sol24s = constant_renumber(eq24, sol24)
+    sol25s = constant_renumber(eq25, sol25)
+    sol26s = constant_renumber(eq26, sol26)
+    sol27s = constant_renumber(eq27, sol27)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
     assert dsolve(eq3, hint=hint) in (sol3, sol3s)
@@ -2210,18 +2210,18 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     sol11 = Eq(f(x), cos(x)*(C2 - Integral(1/cos(x), x)) + sin(x)*(C1 +
         Integral(1/sin(x), x)))
     sol12 = Eq(f(x), C1 + C2*x + x**3*(C3 + log(x)/6) + C4*x**2)
-    sol1s = constant_renumber(sol1, 'C', 1, 3)
-    sol2s = constant_renumber(sol2, 'C', 1, 3)
-    sol3s = constant_renumber(sol3, 'C', 1, 2)
-    sol4s = constant_renumber(sol4, 'C', 1, 2)
-    sol5s = constant_renumber(sol5, 'C', 1, 2)
-    sol6s = constant_renumber(sol6, 'C', 1, 2)
-    sol7s = constant_renumber(sol7, 'C', 1, 2)
-    sol8s = constant_renumber(sol8, 'C', 1, 2)
-    sol9s = constant_renumber(sol9, 'C', 1, 3)
-    sol10s = constant_renumber(sol10, 'C', 1, 2)
-    sol11s = constant_renumber(sol11, 'C', 1, 2)
-    sol12s = constant_renumber(sol12, 'C', 1, 4)
+    sol1s = constant_renumber(eq1, sol1)
+    sol2s = constant_renumber(eq2, sol2)
+    sol3s = constant_renumber(eq3, sol3)
+    sol4s = constant_renumber(eq4, sol4)
+    sol5s = constant_renumber(eq5, sol5)
+    sol6s = constant_renumber(eq6, sol6)
+    sol7s = constant_renumber(eq7, sol7)
+    sol8s = constant_renumber(eq8, sol8)
+    sol9s = constant_renumber(eq9, sol9)
+    sol10s = constant_renumber(eq10, sol10)
+    sol11s = constant_renumber(eq11, sol11)
+    sol12s = constant_renumber(eq12, sol12)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
     assert dsolve(eq3, hint=hint) in (sol3, sol3s)
@@ -2279,11 +2279,11 @@ def test_Liouville_ODE():
     sol4 = set([Eq(f(x), sqrt(C1 + C2*exp(x))*exp(-x/2)),
                 Eq(f(x), -sqrt(C1 + C2*exp(x))*exp(-x/2))])
     sol5 = Eq(f(x), log(C1 + C2/x))
-    sol1s = constant_renumber(sol1, 'C', 1, 2)
-    sol2s = constant_renumber(sol2, 'C', 1, 2)
-    sol3s = constant_renumber(sol3, 'C', 1, 2)
-    sol4s = constant_renumber(sol4, 'C', 1, 2)
-    sol5s = constant_renumber(sol5, 'C', 1, 2)
+    sol1s = constant_renumber(eq1, sol1)
+    sol2s = constant_renumber(eq2, sol2)
+    sol3s = constant_renumber(eq3, sol3)
+    sol4s = constant_renumber(eq4, sol4)
+    sol5s = constant_renumber(eq5, sol5)
     assert dsolve(eq1, hint=hint) in (sol1, sol1s)
     assert dsolve(eq1a, hint=hint) in (sol1, sol1s)
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
@@ -2311,7 +2311,7 @@ def test_unexpanded_Liouville_ODE():
     eq1 = diff(f(x), x)/x + diff(f(x), x, x)/2 - diff(f(x), x)**2/2
     eq2 = eq1*exp(-f(x))/exp(f(x))
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
-    sol2s = constant_renumber(sol2, 'C', 1, 2)
+    sol2s = constant_renumber(eq2, sol2)
     assert dsolve(eq2) in (sol2, sol2s)
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
 
@@ -2349,12 +2349,14 @@ def test_issue_4825():
 def test_constant_renumber_order_issue_5308():
     from sympy.utilities.iterables import variations
 
-    assert constant_renumber(C1*x + C2*y, "C", 1, 2) == \
-        constant_renumber(C1*y + C2*x, "C", 1, 2) == \
+    eq = f(x).diff(x) - y - x
+
+    assert constant_renumber(eq, C1*x + C2*y) == \
+        constant_renumber(eq, C1*y + C2*x) == \
         C1*x + C2*y
     e = C1*(C2 + x)*(C3 + y)
     for a, b, c in variations([C1, C2, C3], 3):
-        assert constant_renumber(a*(b + x)*(c + y), "C", 1, 3) == e
+        assert constant_renumber(eq, a*(b + x)*(c + y)) == e
 
 
 def test_issue_5770():
@@ -2390,21 +2392,21 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
     eq = Eq(-3*diff(f(x), x)*x + 2*x**2*diff(f(x), x, x), 0)
     sol = C1 + C2*x**Rational(5, 2)
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(3*f(x) - 5*diff(f(x), x)*x + 2*x**2*diff(f(x), x, x), 0)
     sol = C1*sqrt(x) + C2*x**3
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(4*f(x) + 5*diff(f(x), x)*x + x**2*diff(f(x), x, x), 0)
     sol = (C1 + C2*log(x))/x**2
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2412,14 +2414,14 @@ def test_nth_order_linear_euler_eq_homogeneous():
     eq = Eq(6*f(x) - 6*diff(f(x), x)*x + 1*x**2*diff(f(x), x, x) + x**3*diff(f(x), x, x, x), 0)
     sol = dsolve(eq, f(x), hint=our_hint)
     sol = C1/x**2 + C2*x + C3*x**3
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(-125*f(x) + 61*diff(f(x), x)*x - 12*x**2*diff(f(x), x, x) + x**3*diff(f(x), x, x, x), 0)
     sol = x**5*(C1 + C2*log(x) + C3*log(x)**2)
-    sols = [sol, constant_renumber(sol, 'C', 1, 4)]
+    sols = [sol, constant_renumber(eq, sol)]
     sols += [sols[-1].expand()]
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in sols
@@ -2427,14 +2429,14 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
     eq = t**2*diff(y(t), t, 2) + t*diff(y(t), t) - 9*y(t)
     sol = C1*t**3 + C2*t**-3
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, y(t), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = sin(x)*x**2*f(x).diff(x, 2) + sin(x)*x*f(x).diff(x) + sin(x)*f(x)
     sol = C1*sin(log(x)) + C2*cos(log(x))
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2453,35 +2455,35 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_undetermined_coefficients():
 
     eq = Eq(x**2*diff(f(x), x, x) + x*diff(f(x), x), 1)
     sol =  C1 + C2*log(x) + log(x)**2/2
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
     sol = x*(C1 + C2*x + Rational(1, 2)*x**2)
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - x*diff(f(x), x) - 3*f(x), log(x)/x)
     sol =  C1/x + C2*x**3 - Rational(1, 16)*log(x)/x - Rational(1, 8)*log(x)**2/x
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) + 3*x*diff(f(x), x) - 8*f(x), log(x)**3 - log(x))
     sol = C1/x**4 + C2*x**2 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**3*diff(f(x), x, x, x) - 3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), log(x))
     sol = C1*x + C2*x**2 + C3*x**3 - Rational(1, 6)*log(x) - Rational(11, 36)
-    sols = constant_renumber(sol, 'C', 1, 3)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -2500,28 +2502,28 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_variation_of_parameters():
 
     eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4)
     sol = C1*x + C2*x**2 + x**4/6
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), x**3*exp(x))
     sol = C1/x**2 + C2*x + x*exp(x)/3 - 4*exp(x)/3 + 8*exp(x)/(3*x) - 8*exp(x)/(3*x**2)
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4*exp(x))
     sol = C1*x + C2*x**2 + x**2*exp(x) - 2*x*exp(x)
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - log(x)
     sol = C1*x + C2*x**2 + log(x)/2 + S(3)/4
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eq, sol)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
@@ -3157,14 +3159,14 @@ def test_order_reducible():
 
     eqn = f(x).diff(x, 2) + 2*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-2*x))
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 3) + f(x).diff(x, 2) - 6*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-3*x) + C3*exp(2*x))
-    sols = constant_renumber(sol, 'C', 1, 2)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3172,28 +3174,28 @@ def test_order_reducible():
     eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
         4*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(x) + C3*exp(-2*x) + C4*exp(2*x))
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
     sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = constant_renumber(eqn, sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
     assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
@@ -3202,8 +3204,8 @@ def test_order_reducible():
     # These are equivalent:
     sol1 = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
     sol2 = Eq(f(x), C1 + C2*(x*sin(x) + cos(x)) + C3*(-x*cos(x) + sin(x)) + C4*sin(x) + C5*cos(x))
-    sol1s = constant_renumber(sol1, 'C', 1, 5)
-    sol2s = constant_renumber(sol2, 'C', 1, 5)
+    sol1s = constant_renumber(eqn, sol1)
+    sol2s = constant_renumber(eqn, sol2)
     assert checkodesol(eqn, sol1, order=2, solve_for_func=False) == (True, 0)
     assert checkodesol(eqn, sol2, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol1, sol1s)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3069,6 +3069,15 @@ def test_issue_11290():
     assert checkodesol(eq, sol_1, order=1, solve_for_func=False)
 
 
+def test_issue_4838():
+    eq = f(x).diff(x) - C1*f(x)
+    sol = Eq(f(x), C2*exp(C1*x))
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == (True, 0)
+
+
+# FIXME: fails due to issue #15999
+@XFAIL
 def test_issue_13691():
     eq = f(x).diff(x) - C1*g(x).diff(x)
     ans = Eq(f(x), C2 + C1*g(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #4838 
Fixes #13691 
Resurrects #13752 
- [x] needs #16008

See also #4435

#### Brief description of what is fixed or changed

Fix odesimp and constant_renumber so that integration constants in the original ODE are not renumbered. On master we have:
```julia
In [1]: C1 = Symbol('C1')                                                                                                                                     

In [2]: dsolve(f(x).diff(x)-C1*f(x))                                                                                                                          
Out[2]: 
           C₂⋅x
f(x) = C₁⋅ℯ 
```
This PR gives
```julia
In [2]: C1 = Symbol('C1')                                                                                                                                     

In [3]: dsolve(f(x).diff(x)-C1*f(x))                                                                                                                          
Out[3]: 
           C₁⋅x
f(x) = C₂⋅ℯ  
```

#### Other comments

I'm not happy with this patch yet. It feels a bit kludgey and I think it can be done in a cleaner way. I started from #13752 and ended up here by the time I had it working (not much from the original diff remains). It took a little while to get it to work though so I'm just putting it here for now to see how it copes on Travis.

This doesn't yet work with any ODE solved by the nth_algebraic solver due to #15999. If #16008 gets merged I'll rebase that in here and clean this up.

Also possibly there are more open issues that this could close.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * dsolve, constantsimp and odesimp no longer renumber inregration constants found in the original ODE.
<!-- END RELEASE NOTES -->

### TODO
- [x] delete exclude code
- [x] rename nonconstants to variables
- [ ] update docstrings
- [x] add tests