### PR TITLE
heurisch : Fix AssertionError

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -57,7 +57,7 @@ def components(f, x):
     result = set()
 
     if x in f.free_symbols:
-        if f.is_Symbol:
+        if f.is_symbol and f.is_commutative:
             result.add(f)
         elif f.is_Function or f.is_Derivative:
             for g in f.args:
@@ -450,6 +450,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     rev_mapping = {v: k for k, v in mapping}                            #
     if mappings is None:                                                #
         # optimizing the number of permutations of mapping              #
+        assert mapping[-1][0] == x # if not, find it and correct this comment
         unnecessary_permutations = [mapping.pop(-1)]
         mappings = permutations(mapping)
     else:

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -450,7 +450,6 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     rev_mapping = {v: k for k, v in mapping}                            #
     if mappings is None:                                                #
         # optimizing the number of permutations of mapping              #
-        assert mapping[-1][0] == x  # if not, find it and correct this comment
         unnecessary_permutations = [mapping.pop(-1)]
         mappings = permutations(mapping)
     else:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -16,7 +16,7 @@ from sympy.utilities.pytest import XFAIL, raises, slow, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically
 from sympy.integrals.integrals import Integral
 
-x, y, a, t, x_1, x_2, z, s = symbols('x y a t x_1 x_2 z s')
+x, y, a, t, x_1, x_2, z, s, b= symbols('x y a t x_1 x_2 z s b')
 n = Symbol('n', integer=True)
 f = Function('f')
 
@@ -1465,6 +1465,11 @@ def test_issue_15640_log_substitutions():
     f = sqrt(log(x))/x**2
     F = -sqrt(pi)*erfc(sqrt(log(x)))/2 - sqrt(log(x))/x
     assert integrate(f, x) == F and F.diff(x) == f
+
+def test_issue_15509():
+    assert integrate(cos(a*x + b), (x, x_1, x_2)) == Piecewise(
+        (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)), \
+            (-x_1*cos(b) + x_2*cos(b), True))
 
 
 def test_issue_4311():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1467,7 +1467,10 @@ def test_issue_15640_log_substitutions():
     assert integrate(f, x) == F and F.diff(x) == f
 
 def test_issue_15509():
-    assert integrate(cos(a*x + b), (x, x_1, x_2)) == Piecewise(
+    from sympy.vector import CoordSys3D    
+    N = CoordSys3D('N')
+    x = N.x
+    assert integrate(cos(a*x + b), (x, x_1, x_2), heurisch = True) == Piecewise(
         (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)), \
             (-x_1*cos(b) + x_2*cos(b), True))
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1467,10 +1467,10 @@ def test_issue_15640_log_substitutions():
     assert integrate(f, x) == F and F.diff(x) == f
 
 def test_issue_15509():
-    from sympy.vector import CoordSys3D    
+    from sympy.vector import CoordSys3D
     N = CoordSys3D('N')
     x = N.x
-    assert integrate(cos(a*x + b), (x, x_1, x_2), heurisch = True) == Piecewise(
+    assert integrate(cos(a*x + b), (x, x_1, x_2), heurisch=True) == Piecewise(
         (-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)), \
             (-x_1*cos(b) + x_2*cos(b), True))
 

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -43,6 +43,7 @@ class BaseScalar(AtomicExpr):
         return obj
 
     is_commutative = True
+    is_symbol = True
 
     @property
     def free_symbols(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15509 

#### Brief description of what is fixed or changed
Changed `BaseScalar` to `Symbol`.
No assertion error is raised and correct piecewise function is returned for following case.

```
>>> from sympy import *
>>> from sympy.vector import CoordSys3D
>>> N = CoordSys3D('N')
>>> x = N.x
>>> a,b,x_1,x_2 = symbols('a,b,x_1,x_2')
>>> integrate(cos(a*x_1 + b),(x, x_1, x_2))
Piecewise((-sin(a*x_1 + b)/a + sin(a*x_2 + b)/a, (a > -oo) & (a < oo) & Ne(a, 0)),(-x_1*cos(b) + x_2*cos(b), True))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Fix AssertionError in heurisch.py
<!-- END RELEASE NOTES -->
