### PR TITLE
Use a 2-stage split for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 stages:
+- quality
 - baseline
 - test
 env:
@@ -20,6 +21,13 @@ python:
 
 matrix:
   include:
+    - stage: quality
+      python: 3.7
+      dist: xenial
+      sudo: true
+      script: bin/test quality
+      env:
+
     - stage: baseline
       python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,8 @@ matrix:
           packages:
             - pypy
 
+  fast_finish: true
+
   allow_failures:
     # PyPy randomly fails because of some PyPy bugs (Fatal RPython error: AssertionError)
     - python: "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 sudo: false
+stages:
+- baseline
+- test
 env:
   matrix:
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
@@ -17,7 +20,8 @@ python:
 
 matrix:
   include:
-    - python: 3.7
+    - stage: baseline
+      python: 3.7
       dist: xenial
       sudo: true
       env:
@@ -33,7 +37,8 @@ matrix:
       env:
         - SPLIT="2/2" TEST_SYMPY="true"
 
-    - python: 2.7
+    - stage: test
+      python: 2.7
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ stages:
 - test
 env:
   matrix:
-  - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
   - SPLIT="1/2" TEST_SYMPY="true"
   - SPLIT="2/2" TEST_SYMPY="true"
+  - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
   global:
     - secure: "YIEZal9EBTL+fg2YmoZoS8Bvt3eAVUOZjb38CtqpzR2CCSXWoUk35KG23m2NknlY1iKfYJyt7XWBszT/VKOQEbWQq7PIakV4vIByrWacgBxy1x3WC+rZoW7TX+JJiL+y942qIYbMoNMMB8xFpE5RDLSjSecMpFhJJXoafVTvju8="
 dist: trusty


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Not sure I've done this right but I'm hoping this will split the Travis tests into two stages. The idea is that the second stage only executes if the first succeeds. See
[https://docs.travis-ci.com/user/build-stages/](https://docs.travis-ci.com/user/build-stages/)

I think I've set this up to run doctests and code quality and splits 1-4 of the non-slow tests in the first stage only on Python 3.7. If that succeeds then the second stage tests the other Python versions, the slow tests, the optional dependency tests and the allow failure tests.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
