### PR TITLE
Remove get_monomials_set of MacaulayResultant

### DIFF
--- a/sympy/polys/multivariate_resultants.py
+++ b/sympy/polys/multivariate_resultants.py
@@ -19,7 +19,6 @@ from sympy.functions.combinatorial.factorials import binomial
 
 from itertools import combinations_with_replacement
 
-from operator import itemgetter
 
 class DixonResultant():
     """
@@ -268,16 +267,6 @@ class MacaulayResultant():
 
         return sorted(monomials, reverse=True,
                       key=monomial_key('lex', self.variables))
-
-    def get_monomials_set(self):
-        r"""
-        Returns
-        -------
-        self.monomial_set: set
-            The set T. Set of all possible monomials of degree degree_m
-        """
-        monomial_set = self.get_monomials_of_certain_degree(self.degree_m)
-        self.monomial_set = monomial_set
 
     def get_row_coefficients(self):
         """

--- a/sympy/polys/tests/test_multivariate_resultants.py
+++ b/sympy/polys/tests/test_multivariate_resultants.py
@@ -117,7 +117,6 @@ def test_macaulay_example_one():
     assert mac.degrees == [2, 2, 1]
     assert mac.degree_m == 3
 
-    mac.get_monomials_set()
     assert mac.monomial_set == [x ** 3, x ** 2 * y, x ** 2 * z,
                                 x * y ** 2,
                                 x * y * z, x * z ** 2, y ** 3,
@@ -148,9 +147,6 @@ def test_macaulay_example_two():
 
     assert mac.degrees == [1, 2, 3]
     assert mac.degree_m == 4
-
-    mac.get_monomials_set()
-
     assert mac.monomials_size == 15
     assert len(mac.get_row_coefficients()) == mac.n
 


### PR DESCRIPTION
monomial_set is available as an attribute.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Remove get_monomials_set of MacaulayResultant
<!-- END RELEASE NOTES -->
