### PR TITLE
Added Auxiliary Circle Feature For Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1008,7 +1008,7 @@ class Ellipse(GeometrySet):
     def auxiliary_circle(self):
         """Returns equation of auxiliary circle of the ellipse.
 
-        Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle 
+        Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle
         whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.
 
         Parameters

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1024,7 +1024,7 @@ class Ellipse(GeometrySet):
         Examples
         ========
 
-        >>> from sympy import *
+        >>> from sympy import Circle, Ellipse, Point2D
         >>> e = Symbol('e')
         >>> c = Symbol('c')
         >>> e1 = Ellipse(Point2D(3, 8), 7, 8)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1029,24 +1029,26 @@ class Ellipse(GeometrySet):
         >>> c = Symbol('c')
         >>> e1 = Ellipse(Point2D(3, 8), 7, 8)
         >>> e = e1.auxiliary_circle()
+        >>> e
+        Circle(Point2D(2,5),8)
         >>> e.equation()
         (x - 3)**2 + (y - 8)**2 - 64
         >>> c1 = Circle(Point2D(2, 5), 4)
         >>> c = c1.auxiliary_circle()
+        >>> pprint(c)
+               2          2     
+        (x - 2)  + (y - 5)  - 16
         >>> c
         (x - 2)**2 + (y - 5)**2 - 16
         """
-        if(self.hradius != 0 and self.vradius != 0):
-            if(self.hradius >= self.vradius):
-                x = _symbol(x, real=True)
-                y = _symbol(y, real=True)
-                return Circle(Point2D(self.center.x, self.center.y), self.hradius)
-            else:
-                x = _symbol(x, real=True)
-                y = _symbol(y, real=True)
-                return Circle(Point2D(self.center.x, self.center.y), self.vradius)
-        else:
-            raise NotImplementedError('Auxiliary Circle of arbitrary Ellipse is not supported.')
+        if(self.hradius >= self.vradius):
+            x = _symbol(x, real=True)
+            y = _symbol(y, real=True)
+            return Circle(Point2D(self.center.x, self.center.y), self.hradius)
+        elif(self.hradius < self.vradius):
+            x = _symbol(x, real=True)
+            y = _symbol(y, real=True)
+            return Circle(Point2D(self.center.x, self.center.y), self.vradius)
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1034,7 +1034,7 @@ class Ellipse(GeometrySet):
         Circle(Point2D(2, 5), 4)
 
         """
-        return Circle(Point2D(self.center.x, self.center.y), Max(self.hradius, self.vradius))
+        return Circle(Point2D(self.center), Max(self.hradius, self.vradius))
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1005,8 +1005,11 @@ class Ellipse(GeometrySet):
         """
         return self.major * (1 - self.eccentricity ** 2)
 
-    def auxiliary_circle(self, x='x', y='y'):
+    def auxiliary_circle(self):
         """Returns equation of auxiliary circle of the ellipse.
+
+        Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle 
+        whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.
 
         Parameters
         ==========
@@ -1040,12 +1043,8 @@ class Ellipse(GeometrySet):
 
         """
         if(self.hradius >= self.vradius):
-            x = _symbol(x, real=True)
-            y = _symbol(y, real=True)
             return Circle(Point2D(self.center.x, self.center.y), self.hradius)
         elif(self.hradius < self.vradius):
-            x = _symbol(x, real=True)
-            y = _symbol(y, real=True)
             return Circle(Point2D(self.center.x, self.center.y), self.vradius)
 
     def plot_interval(self, parameter='t'):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1024,7 +1024,7 @@ class Ellipse(GeometrySet):
         Examples
         ========
 
-        >>> from sympy import Circle, Ellipse, Point2D
+        >>> from sympy import Circle, Ellipse, Point2D, Symbol
         >>> e = Symbol('e')
         >>> c = Symbol('c')
         >>> e1 = Ellipse(Point2D(3, 8), 7, 8)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1006,33 +1006,18 @@ class Ellipse(GeometrySet):
         return self.major * (1 - self.eccentricity ** 2)
 
     def auxiliary_circle(self):
-        """Returns Circle object as auxiliary circle of the ellipse.
-
-        Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle
-        whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.
-
-        Returns
-        =======
-
-        equation : sympy expression
+        """Returns a Circle whose diameter is the major axis of the ellipse.
 
         Examples
         ========
 
-        >>> from sympy import Circle, Ellipse, Point2D, Symbol
-        >>> e = Symbol('e')
-        >>> c = Symbol('c')
-        >>> e1 = Ellipse(Point2D(3, 8), 7, 8)
-        >>> e = e1.auxiliary_circle()
-        >>> e
-        Circle(Point2D(3, 8), 8)
-        >>> e.equation()
-        (x - 3)**2 + (y - 8)**2 - 64
-        >>> c1 = Circle(Point2D(2, 5), 4)
-        >>> c = c1.auxiliary_circle()
-        >>> c
-        Circle(Point2D(2, 5), 4)
-
+        >>> from sympy import Circle, Ellipse, Point, symbols
+        >>> c = Point(1, 2)
+        >>> Ellipse(c, 8, 7).auxiliary_circle()
+        Circle(Point2D(1, 2), 8)
+        >>> a, b = symbols('a b')
+        >>> Ellipse(c, a, b).auxiliary_circle()
+        Circle(Point2D(1, 2), Max(a, b))
         """
         return Circle(self.center, Max(self.hradius, self.vradius))
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1024,27 +1024,27 @@ class Ellipse(GeometrySet):
         Examples
         ========
 
-        >>> from sympy import Point2D, Ellipse, Circle
-        >>> e1 = Ellipse(Point2D(3, 0), 7, 8)
-        >>> e1.auxiliary_circle()
-        y**2 + (x - 3)**2 - 64
-        >>> c1 = Circle(Point2D(2, 0), 4)
-        >>> c1.auxiliary_circle()
-        y**2 + (x - 2)**2 - 16
+        >>> from sympy import *
+        >>> e = Symbol('e')
+        >>> c = Symbol('c')
+        >>> e1 = Ellipse(Point2D(3, 8), 7, 8)
+        >>> e = e1.auxiliary_circle()
+        >>> e.equation()
+        (x - 3)**2 + (y - 8)**2 - 64
+        >>> c1 = Circle(Point2D(2, 5), 4)
+        >>> c = c1.auxiliary_circle()
+        >>> c
+        (x - 2)**2 + (y - 5)**2 - 16
         """
         if(self.hradius != 0 and self.vradius != 0):
             if(self.hradius >= self.vradius):
                 x = _symbol(x, real=True)
                 y = _symbol(y, real=True)
-                t1 = (x - self.center.x)**2
-                t2 = (y - self.center.y)**2
-                return t1 + t2 - (self.hradius**2)
+                return Circle(Point2D(self.center.x, self.center.y), self.hradius)
             else:
                 x = _symbol(x, real=True)
                 y = _symbol(y, real=True)
-                t1 = (x - self.center.x)**2
-                t2 = (y - self.center.y)**2
-                return t1 + t2 - (self.vradius**2)
+                return Circle(Point2D(self.center.x, self.center.y), self.vradius)
         else:
             raise NotImplementedError('Auxiliary Circle of arbitrary Ellipse is not supported.')
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1030,16 +1030,14 @@ class Ellipse(GeometrySet):
         >>> e1 = Ellipse(Point2D(3, 8), 7, 8)
         >>> e = e1.auxiliary_circle()
         >>> e
-        Circle(Point2D(2,5),8)
+        Circle(Point2D(3, 8), 8)
         >>> e.equation()
         (x - 3)**2 + (y - 8)**2 - 64
         >>> c1 = Circle(Point2D(2, 5), 4)
         >>> c = c1.auxiliary_circle()
-        >>> pprint(c)
-               2          2     
-        (x - 2)  + (y - 5)  - 16
         >>> c
-        (x - 2)**2 + (y - 5)**2 - 16
+        Circle(Point2D(2, 5), 4)
+
         """
         if(self.hradius >= self.vradius):
             x = _symbol(x, real=True)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -15,7 +15,7 @@ from sympy.core.numbers import Rational, oo
 from sympy.core.compatibility import ordered
 from sympy.core.symbol import Dummy, _uniquely_named_symbol, _symbol
 from sympy.simplify import simplify, trigsimp
-from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.miscellaneous import sqrt, Max
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.elliptic_integrals import elliptic_e
 from sympy.geometry.exceptions import GeometryError
@@ -1042,10 +1042,7 @@ class Ellipse(GeometrySet):
         Circle(Point2D(2, 5), 4)
 
         """
-        if(self.hradius >= self.vradius):
-            return Circle(Point2D(self.center.x, self.center.y), self.hradius)
-        elif(self.hradius < self.vradius):
-            return Circle(Point2D(self.center.x, self.center.y), self.vradius)
+        return Circle(Point2D(self.center.x, self.center.y), Max(self.hradius, self.vradius))
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1006,7 +1006,7 @@ class Ellipse(GeometrySet):
         return self.major * (1 - self.eccentricity ** 2)
 
     def auxiliary_circle(self):
-        """Returns equation of auxiliary circle of the ellipse.
+        """Returns Circle object as auxiliary circle of the ellipse.
 
         Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle
         whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.
@@ -1034,7 +1034,7 @@ class Ellipse(GeometrySet):
         Circle(Point2D(2, 5), 4)
 
         """
-        return Circle(Point2D(self.center), Max(self.hradius, self.vradius))
+        return Circle(self.center, Max(self.hradius, self.vradius))
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1011,14 +1011,6 @@ class Ellipse(GeometrySet):
         Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle
         whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.
 
-        Parameters
-        ==========
-
-        x : str, optional
-            Label for the x-axis. Default value is 'x'.
-        y : str, optional
-            Label for the y-axis. Default value is 'y'.
-
         Returns
         =======
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1005,6 +1005,49 @@ class Ellipse(GeometrySet):
         """
         return self.major * (1 - self.eccentricity ** 2)
 
+    def auxiliary_circle(self, x='x', y='y'):
+        """Returns equation of auxiliary circle of the ellipse.
+
+        Parameters
+        ==========
+
+        x : str, optional
+            Label for the x-axis. Default value is 'x'.
+        y : str, optional
+            Label for the y-axis. Default value is 'y'.
+
+        Returns
+        =======
+
+        equation : sympy expression
+
+        Examples
+        ========
+
+        >>> from sympy import Point2D, Ellipse, Circle
+        >>> e1 = Ellipse(Point2D(3, 0), 7, 8)
+        >>> e1.auxiliary_circle()
+        y**2 + (x - 3)**2 - 64
+        >>> c1 = Circle(Point2D(2, 0), 4)
+        >>> c1.auxiliary_circle()
+        y**2 + (x - 2)**2 - 16
+        """
+        if(self.hradius != 100 and self.vradius != 100):
+            if(self.hradius >= self.vradius):
+                x = _symbol(x, real=True)
+                y = _symbol(y, real=True)
+                t1 = (x - self.center.x)**2
+                t2 = (y - self.center.y)**2
+                return t1 + t2 - (self.hradius**2)
+            else:
+                x = _symbol(x, real=True)
+                y = _symbol(y, real=True)
+                t1 = (x - self.center.x)**2
+                t2 = (y - self.center.y)**2
+                return t1 + t2 - (self.vradius**2)
+        else:
+            raise NotImplementedError('Auxiliary Circle of arbitrary Ellipse is not supported.')
+
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1032,7 +1032,7 @@ class Ellipse(GeometrySet):
         >>> c1.auxiliary_circle()
         y**2 + (x - 2)**2 - 16
         """
-        if(self.hradius != 100 and self.vradius != 100):
+        if(self.hradius != 0 and self.vradius != 0):
             if(self.hradius >= self.vradius):
                 x = _symbol(x, real=True)
                 y = _symbol(y, real=True)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -463,3 +463,38 @@ def test_circumference():
     assert abs(Ellipse(None, hradius=5, vradius=3).circumference.evalf(16) - 25.52699886339813) < 1e-10
 def test_issue_15259():
     assert Circle((1, 2), 0) == Point(1, 2)
+
+def test_auxiliary_circle():
+    x, y = symbols('x, y')
+
+    p1 = Point(0, 0)
+    p2 = Point(3, 4)
+
+    e1 = Ellipse(p1, 1,1)
+    e2 = Ellipse(p2, 2,2)
+
+    c1 = Circle(p1, 4)
+    c2 = Circle(p2, 8)
+
+    e3 = Ellipse(p1, 5,2)
+    e4 = Ellipse(p2, 6,4)
+
+    e5 = Ellipse(p2, 4,7)
+    e6 = Ellipse(p1, 9,5)
+
+    # circle If self.hradius = self.vradius
+
+    assert e1.auxiliary_circle() == x**2 + y**2 - 1
+    assert e2.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 4
+    assert c1.auxiliary_circle() == x**2 + y**2 - 16
+    assert c2.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 64
+
+    # horizontal ellipse If self.hradius > self.vradius
+
+    assert e3.auxiliary_circle() == x**2 + y**2 - 25
+    assert e4.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 36
+
+    # vertical ellipse If self.hradius < self.vradius
+
+    assert e5.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 49
+    assert e6.auxiliary_circle() == x**2 + y**2 - 81

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -471,7 +471,9 @@ def test_issue_15259():
 
 
 def test_auxiliary_circle():
-    x, y, a, b, e = symbols('x y a b e')
+    x, y, a, b = symbols('x y a b')
     e = Ellipse((x, y), a, b)
+    # the general result
     assert e.auxiliary_circle() == Circle((x, y), Max(a, b))
+    # a special case where Ellipse is a Circle
     assert Circle((3, 4), 8).auxiliary_circle() == Circle((3, 4), 8)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -464,6 +464,7 @@ def test_circumference():
 def test_issue_15259():
     assert Circle((1, 2), 0) == Point(1, 2)
 
+
 def test_auxiliary_circle():
     x, y = symbols('x, y')
 
@@ -479,22 +480,22 @@ def test_auxiliary_circle():
     e3 = Ellipse(p1, 5,2)
     e4 = Ellipse(p2, 6,4)
 
-    e5 = Ellipse(p2, 4,7)
-    e6 = Ellipse(p1, 9,5)
+    e5 = Ellipse(p1, 4,7)
+    e6 = Ellipse(p2, 5,9)
 
     # circle If self.hradius = self.vradius
 
-    assert e1.auxiliary_circle() == x**2 + y**2 - 1
-    assert e2.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 4
-    assert c1.auxiliary_circle() == x**2 + y**2 - 16
-    assert c2.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 64
+    assert e1.auxiliary_circle() == Circle(Point2D(0, 0), 1)
+    assert e2.auxiliary_circle() == Circle(Point2D(3, 4), 2)
+    assert c1.auxiliary_circle() == Circle(Point2D(0, 0), 4)
+    assert c2.auxiliary_circle() == Circle(Point2D(3, 4), 8)
 
     # horizontal ellipse If self.hradius > self.vradius
 
-    assert e3.auxiliary_circle() == x**2 + y**2 - 25
-    assert e4.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 36
+    assert e3.auxiliary_circle() == Circle(Point2D(0, 0), 5)
+    assert e4.auxiliary_circle() == Circle(Point2D(3, 4), 6)
 
     # vertical ellipse If self.hradius < self.vradius
 
-    assert e5.auxiliary_circle() == (x - 3)**2 + (y - 4)**2 - 49
-    assert e6.auxiliary_circle() == x**2 + y**2 - 81
+    assert e5.auxiliary_circle() == Circle(Point2D(0, 0), 7)
+    assert e6.auxiliary_circle() == Circle(Point2D(3, 4), 9)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -5,6 +5,7 @@ from sympy.geometry import (Circle, Ellipse, GeometryError, Line, Point, Polygon
 from sympy.utilities.pytest import raises
 from sympy import integrate
 from sympy.functions.special.elliptic_integrals import elliptic_e
+from sympy.functions.elementary.miscellaneous import Max
 
 
 def test_ellipse_equation_using_slope():
@@ -499,3 +500,10 @@ def test_auxiliary_circle():
 
     assert e5.auxiliary_circle() == Circle(Point2D(0, 0), 7)
     assert e6.auxiliary_circle() == Circle(Point2D(3, 4), 9)
+
+
+    def test_auxiliary_circle():
+    x, y, a, b, e = symbols('x y a b e')
+    e = Ellipse((x, y), a, b)
+    assert e.auxiliary_circle() == Circle((x, y), Max(a, b))
+

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -436,6 +436,7 @@ def test_parameter_value():
     assert e.parameter_value((3, 0), t) == {t: 0}
     raises(ValueError, lambda: e.parameter_value((4, 0), t))
 
+
 def test_second_moment_of_area():
     x, y = symbols('x, y')
     e = Ellipse(Point(0, 0), 5, 4)
@@ -446,6 +447,7 @@ def test_second_moment_of_area():
     assert I_yy == e.second_moment_of_area()[1]
     assert I_xx == e.second_moment_of_area()[0]
     assert I_xy == e.second_moment_of_area()[2]
+
 
 def test_circumference():
     M = Symbol('M')
@@ -462,48 +464,14 @@ def test_circumference():
 
     # test numerically
     assert abs(Ellipse(None, hradius=5, vradius=3).circumference.evalf(16) - 25.52699886339813) < 1e-10
+
+
 def test_issue_15259():
     assert Circle((1, 2), 0) == Point(1, 2)
 
 
 def test_auxiliary_circle():
-    x, y = symbols('x, y')
-
-    p1 = Point(0, 0)
-    p2 = Point(3, 4)
-
-    e1 = Ellipse(p1, 1,1)
-    e2 = Ellipse(p2, 2,2)
-
-    c1 = Circle(p1, 4)
-    c2 = Circle(p2, 8)
-
-    e3 = Ellipse(p1, 5,2)
-    e4 = Ellipse(p2, 6,4)
-
-    e5 = Ellipse(p1, 4,7)
-    e6 = Ellipse(p2, 5,9)
-
-    # circle If self.hradius = self.vradius
-
-    assert e1.auxiliary_circle() == Circle(Point2D(0, 0), 1)
-    assert e2.auxiliary_circle() == Circle(Point2D(3, 4), 2)
-    assert c1.auxiliary_circle() == Circle(Point2D(0, 0), 4)
-    assert c2.auxiliary_circle() == Circle(Point2D(3, 4), 8)
-
-    # horizontal ellipse If self.hradius > self.vradius
-
-    assert e3.auxiliary_circle() == Circle(Point2D(0, 0), 5)
-    assert e4.auxiliary_circle() == Circle(Point2D(3, 4), 6)
-
-    # vertical ellipse If self.hradius < self.vradius
-
-    assert e5.auxiliary_circle() == Circle(Point2D(0, 0), 7)
-    assert e6.auxiliary_circle() == Circle(Point2D(3, 4), 9)
-
-
-    def test_auxiliary_circle():
     x, y, a, b, e = symbols('x y a b e')
     e = Ellipse((x, y), a, b)
     assert e.auxiliary_circle() == Circle((x, y), Max(a, b))
-
+    assert Circle((3, 4), 8).auxiliary_circle() == Circle((3, 4), 8)


### PR DESCRIPTION
Auxiliary Circle of an ellipse is the circumcircle of an ellipse i.e. the circle whose centre concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.

The centre of the auxiliary circle is always the same as the ellipse's centre, the circle itself touches both vertices. Hence, the distance between a vertex and the centre is the circle's radius. In an ellipse, the distance between a vertex and the centre is given by the semi-major axis.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Other comments

I hope guidance and feedback from fellow mentors.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Added Auxiliary Circle Feature For Ellipse

<!-- END RELEASE NOTES -->
