### PR TITLE
[WIP] Simplify the sets obtained from trigonometric solveset

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -904,7 +904,7 @@ def solve_decomposition(f, symbol, domain):
                2
     >>> f3 = sin(x + 2)
     >>> pprint(sd(f3, x, S.Reals), use_unicode=False)
-    {2*n*pi - 2 | n in Integers} U {2*n*pi - 2 + pi | n in Integers}
+    {n*pi - 2 | n in Integers}
 
     """
     from sympy.solvers.decompogen import decompogen
@@ -1733,11 +1733,11 @@ def solveset(f, symbol=None, domain=S.Complexes):
     but there may be some slight difference:
 
     >>> pprint(solveset(sin(x)/x,x), use_unicode=False)
-    ({2*n*pi | n in Integers} \ {0}) U ({2*n*pi + pi | n in Integers} \ {0})
+    {n*pi | n in Integers} \ {0}
 
     >>> p = Symbol('p', positive=True)
     >>> pprint(solveset(sin(p)/p, p), use_unicode=False)
-    {2*n*pi | n in Integers} U {2*n*pi + pi | n in Integers}
+    {n*pi | n in Integers}
 
     * Inequalities can be solved over the real domain only. Use of a complex
       domain leads to a NotImplementedError.

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -753,19 +753,16 @@ def test_solveset_complex_tan():
 def test_solve_trig():
     from sympy.abc import n
     assert solveset_real(sin(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
+        imageset(Lambda(n, pi*n), S.Integers)
 
     assert solveset_real(sin(x) - 1, x) == \
         imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
 
     assert solveset_real(cos(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n + pi/2), S.Integers),
-              imageset(Lambda(n, 2*pi*n + 3*pi/2), S.Integers))
+        imageset(Lambda(n, pi*n + pi/2), S.Integers)
 
     assert solveset_real(sin(x) + cos(x), x) == \
-        Union(imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers),
-              imageset(Lambda(n, 2*n*pi + 7*pi/4), S.Integers))
+        imageset(Lambda(n, n*pi + 3*pi/4), S.Integers)
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
 
@@ -1173,15 +1170,14 @@ def test_solve_decomposition():
     f6 = 1/log(x)
     f7 = 1/x
 
-    s1 = ImageSet(Lambda(n, 2*n*pi), S.Integers)
-    s2 = ImageSet(Lambda(n, 2*n*pi + pi), S.Integers)
+    s1 = ImageSet(Lambda(n, n*pi), S.Integers)
     s3 = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
     s4 = ImageSet(Lambda(n, 2*n*pi - 1), S.Integers)
     s5 = ImageSet(Lambda(n, 2*n*pi - 1 + pi), S.Integers)
 
     assert solve_decomposition(f1, x, S.Reals) == FiniteSet(0, log(2), log(3))
     assert solve_decomposition(f2, x, S.Reals) == s3
-    assert solve_decomposition(f3, x, S.Reals) == Union(s1, s2, s3)
+    assert solve_decomposition(f3, x, S.Reals) == Union(s1, s3)
     assert solve_decomposition(f4, x, S.Reals) == Union(s4, s5)
     assert solve_decomposition(f5, x, S.Reals) == FiniteSet(-2)
     assert solve_decomposition(f6, x, S.Reals) == S.EmptySet

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1171,14 +1171,13 @@ def test_solve_decomposition():
     f7 = 1/x
 
     s1 = ImageSet(Lambda(n, n*pi), S.Integers)
-    s3 = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
-    s4 = ImageSet(Lambda(n, 2*n*pi - 1), S.Integers)
-    s5 = ImageSet(Lambda(n, 2*n*pi - 1 + pi), S.Integers)
+    s2 = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
+    s3 = ImageSet(Lambda(n, n*pi - 1), S.Integers)
 
     assert solve_decomposition(f1, x, S.Reals) == FiniteSet(0, log(2), log(3))
     assert solve_decomposition(f2, x, S.Reals) == s3
-    assert solve_decomposition(f3, x, S.Reals) == Union(s1, s3)
-    assert solve_decomposition(f4, x, S.Reals) == Union(s4, s5)
+    assert solve_decomposition(f3, x, S.Reals) == Union(s1, s2)
+    assert solve_decomposition(f4, x, S.Reals) == Union(s3)
     assert solve_decomposition(f5, x, S.Reals) == FiniteSet(-2)
     assert solve_decomposition(f6, x, S.Reals) == S.EmptySet
     assert solve_decomposition(f7, x, S.Reals) == S.EmptySet

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1175,9 +1175,9 @@ def test_solve_decomposition():
     s3 = ImageSet(Lambda(n, n*pi - 1), S.Integers)
 
     assert solve_decomposition(f1, x, S.Reals) == FiniteSet(0, log(2), log(3))
-    assert solve_decomposition(f2, x, S.Reals) == s3
+    assert solve_decomposition(f2, x, S.Reals) == s2
     assert solve_decomposition(f3, x, S.Reals) == Union(s1, s2)
-    assert solve_decomposition(f4, x, S.Reals) == Union(s3)
+    assert solve_decomposition(f4, x, S.Reals) == s3
     assert solve_decomposition(f5, x, S.Reals) == FiniteSet(-2)
     assert solve_decomposition(f6, x, S.Reals) == S.EmptySet
     assert solve_decomposition(f7, x, S.Reals) == S.EmptySet

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -33,7 +33,7 @@ from sympy.matrices import Matrix, GramSchmidt, eye
 from sympy.matrices.expressions.blockmatrix import BlockMatrix, block_collapse
 from sympy.matrices.expressions import MatrixSymbol, ZeroMatrix
 from sympy.physics.quantum import Commutator
-from sympy.assumptions import assuming
+from sympy.assumptions import assuming, ImageSet
 from sympy.polys.rings import vring
 from sympy.polys.fields import vfield
 from sympy.polys.solvers import solve_lin_sys
@@ -929,13 +929,11 @@ def test_M12():
     ]
 
 
-@XFAIL
 def test_M13():
     n = Dummy('n')
-    assert solveset_real(sin(x) - cos(x), x) == ImageSet(Lambda(n, n*pi - 7*pi/4), S.Integers)
+    assert solveset_real(sin(x) - cos(x), x) == ImageSet(Lambda(n, n*pi + pi/4), S.Integers)
 
 
-@XFAIL
 def test_M14():
     n = Dummy('n')
     assert solveset_real(tan(x) - 1, x) == ImageSet(Lambda(n, n*pi + pi/4), S.Integers)
@@ -948,10 +946,9 @@ def test_M15():
                                            ImageSet(Lambda(n, 2*n*pi + 5*pi/6), S.Integers))
 
 
-@XFAIL
 def test_M16():
     n = Dummy('n')
-    assert solveset(sin(x) - tan(x), x) == ImageSet(Lambda(n, n*pi), Integers())
+    assert solveset(sin(x) - tan(x), x) == ImageSet(Lambda(n, n*pi), S.Integers)
 
 
 @XFAIL

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -33,7 +33,7 @@ from sympy.matrices import Matrix, GramSchmidt, eye
 from sympy.matrices.expressions.blockmatrix import BlockMatrix, block_collapse
 from sympy.matrices.expressions import MatrixSymbol, ZeroMatrix
 from sympy.physics.quantum import Commutator
-from sympy.assumptions import assuming, ImageSet
+from sympy.assumptions import assuming
 from sympy.polys.rings import vring
 from sympy.polys.fields import vfield
 from sympy.polys.solvers import solve_lin_sys
@@ -45,6 +45,7 @@ from sympy.integrals.transforms import laplace_transform,\
     mellin_transform
 from sympy.functions.special.error_functions import erf
 from sympy.functions.special.delta_functions import Heaviside
+from sympy.sets import ImageSet
 from sympy.solvers.recurr import rsolve
 from sympy.solvers.solveset import solveset, solveset_real, linsolve
 from sympy.solvers.ode import dsolve


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Relates to #16031 

I just found out about #11188 and #12011. They seem more general, which may be a reason that they are not yet merged. There are several more issues and PRs that relates to this to some extent.

#### Brief description of what is fixed or changed
Some simple heuristics for simplifying (primarily) the `Union` of `ImageSet`s that comes from the trigonometric solveset solvers.

More code comments and tests are needed, but I want to get some initial input if it is a worthwhile path to go or not? Also, I'm not really happy with the structure of the code. Finally, it is worthwhile to check all the existing tests etc.

#### Other comments
One fundamental reason why I decided to just solve it locally is that it is not obvious to me how Dummy variables with identical name but different indices shall be handled. By knowing that the ImageSets come from the same solution, I can also be certain that Dummy-variables with the same name actually are the same. I think.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   * The solutions from solveset of trigonometric expressions is simpler.
<!-- END RELEASE NOTES -->
