### PR TITLE
Added MathML presentation printing for domains and fixed bug

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -929,7 +929,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_AssocOp(self, e):
         mrow = self.dom.createElement('mrow')
         mi = self.dom.createElement('mi')
-        mi.append(self.dom.createTextNode(self.mathml_tag(e)))
+        mi.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
         mrow.appendChild(mi)
         for arg in e.args:
             mrow.appendChild(self._print(arg))
@@ -948,6 +948,50 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         dom_element = self.dom.createElement(self.mathml_tag(p))
         dom_element.appendChild(self.dom.createTextNode(str(p)))
         return dom_element
+
+
+    def _print_Integers(self, e):
+        x = self.dom.createElement('mi')
+        x.setAttribute('mathvariant', 'normal')
+        x.appendChild(self.dom.createTextNode('&#x2124;'))
+        return x
+
+
+    def _print_Complexes(self, e):
+        x = self.dom.createElement('mi')
+        x.setAttribute('mathvariant', 'normal')
+        x.appendChild(self.dom.createTextNode('&#x2102;'))
+        return x
+
+
+    def _print_Reals(self, e):
+        x = self.dom.createElement('mi')
+        x.setAttribute('mathvariant', 'normal')
+        x.appendChild(self.dom.createTextNode('&#x211D;'))
+        return x
+
+
+    def _print_Naturals(self, e):
+        x = self.dom.createElement('mi')
+        x.setAttribute('mathvariant', 'normal')
+        x.appendChild(self.dom.createTextNode('&#x2115;'))
+        return x
+
+
+    def _print_Naturals0(self, e):
+        sub = self.dom.createElement('msub')
+        x = self.dom.createElement('mi')
+        x.setAttribute('mathvariant', 'normal')
+        x.appendChild(self.dom.createTextNode('&#x2115;'))
+        sub.appendChild(x)
+        sub.appendChild(self._print(S.Zero))
+        return sub
+
+
+    def _print_EmptySet(self, e):
+        x = self.dom.createElement('mo')
+        x.appendChild(self.dom.createTextNode('&#x2205;'))
+        return x
 
 
 def mathml(expr, printer='content', **settings):

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -925,6 +925,25 @@ def test_toprettyxml_hooking():
     assert prettyxml_old2 == doc2.toprettyxml()
 
 
+def test_print_domains():
+    from sympy import Complexes, Integers, Naturals, Naturals0, Reals
+
+    assert mpp.doprint(Complexes) == '<mi mathvariant="normal">&#x2102;</mi>'
+    assert mpp.doprint(Integers) == '<mi mathvariant="normal">&#x2124;</mi>'
+    assert mpp.doprint(Naturals) == '<mi mathvariant="normal">&#x2115;</mi>'
+    assert mpp.doprint(Naturals0) == '<msub><mi mathvariant="normal">&#x2115;</mi><mn>0</mn></msub>'
+    assert mpp.doprint(Reals) == '<mi mathvariant="normal">&#x211D;</mi>'
+
+
+def test_print_AssocOp():
+    from sympy.core.operations import AssocOp
+    class TestAssocOp(AssocOp):
+        identity = 0
+
+    expr = TestAssocOp(1, 2)
+    mpp.doprint(expr) == '<mrow><mi>testassocop</mi><mn>2</mn><mn>1</mn></mrow>'
+
+
 def test_print_basic():
     expr = Basic(1, 2)
     assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Solves a few of the things in #16036 

#### Brief description of what is fixed or changed
Introduces MathML presentation printing for Complexes, EmptySet, Integers, Naturals, Naturals0, and Reals.

Fixed a bug in MathML presentation of AssocOp, manifested through And and Or (at least):
```
In [130]: mathml(And(Eq(x,y), (x >= y)), printer='presentation')
Traceback (most recent call last):

  File "<ipython-input-130-09857f4d79b8>", line 1, in <module>
    mathml(And(Eq(x,y), (x >= y)), printer='presentation')

  File "C:\Users\Oscar\sympy\sympy\printing\mathml.py", line 958, in mathml
    return MathMLPresentationPrinter(settings).doprint(expr)

  File "C:\Users\Oscar\sympy\sympy\printing\mathml.py", line 61, in doprint
    mathML = Printer._print(self, expr)

  File "C:\Users\Oscar\sympy\sympy\printing\printer.py", line 287, in _print
    return getattr(self, printmethod)(expr, **kwargs)

  File "C:\Users\Oscar\sympy\sympy\printing\mathml.py", line 932, in _print_AssocOp
    mi.append(self.dom.createTextNode(self.mathml_tag(e)))

AttributeError: 'Element' object has no attribute 'append'
```
Now there is no error, although the output is strictly not what it can be:
```
In [129]: mathml(And(Eq(x,y), (x >= y)), printer='presentation')
Out[129]: '<mrow><mi>and</mi><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mrow><mi>x</mi><mo>&#x2265;</mo><mi>y</mi></mrow></mrow>'
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Added support for printing domains in the MathML presentation printer
<!-- END RELEASE NOTES -->
