### PR TITLE
test_case_for_simplify_and_transpose.py_changed

### DIFF
--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -3,6 +3,8 @@ from sympy.matrices.expressions import MatrixSymbol, Adjoint, trace, Transpose
 from sympy.matrices import eye, Matrix
 from sympy import symbols, S
 from sympy import refine, Q
+from sympy import (Identity, Matrix, MatrixSymbol, simplify, trace)
+
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
 A = MatrixSymbol('A', n, m)
@@ -47,13 +49,12 @@ def test_transpose1x1():
 
 
 def test_as_explicit():
-    import sympy as s
     n = 3
-    v = s.MatrixSymbol('v',3,1)
-    A = s.MatrixSymbol('A',3,3)
+    v = MatrixSymbol('v',3,1)
+    A = MatrixSymbol('A',3,3)
     quadratic = v.T*A*v
-    x = s.Matrix([i+1 for i in range(n)])
-    X = s.Identity(n)
+    x = Matrix([i+1 for i in range(n)])
+    X = Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
-    assert subbed.as_explicit()
-    assert s.simplify((s.trace(quadratic.as_explicit())).xreplace({v:x,A:X}))
+    assert subbed.as_explicit() == Matrix([[14]])
+    

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -52,7 +52,7 @@ def test_as_explicit():
     v = s.MatrixSymbol('v',3,1)
     A = s.MatrixSymbol('A',3,3)
     quadratic = v.T*A*v
-    x = s.Matrix([i+1 for i in xrange(n)])
+    x = s.Matrix([i+1 for i in range(n)])
     X = s.Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
     assert subbed.as_explicit()

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -57,4 +57,3 @@ def test_as_explicit():
     X = Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
     assert subbed.as_explicit() == Matrix([[14]])
-    

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -44,3 +44,15 @@ def test_transpose1x1():
     m = MatrixSymbol('m', 1, 1)
     assert m == refine(m.T)
     assert m == refine(m.T.T)
+
+def test_as_explicit():
+    import sympy as s
+    n = 3
+    v = s.MatrixSymbol('v',3,1)
+    A = s.MatrixSymbol('A',3,3)
+    quadratic = v.T*A*v
+    x = s.Matrix([i+1 for i in xrange(n)])
+    X = s.Identity(n)
+    subbed = quadratic.xreplace({v:x,A:X})
+    assert subbed.as_explicit()
+    assert s.simplify((s.trace(quadratic.as_explicit())).xreplace({v:x,A:X}))

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -45,6 +45,7 @@ def test_transpose1x1():
     assert m == refine(m.T)
     assert m == refine(m.T.T)
 
+
 def test_as_explicit():
     import sympy as s
     n = 3

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -50,8 +50,8 @@ class Transpose(MatrixExpr):
     def shape(self):
         return self.arg.shape[::-1]
 
-    def _entry(self, i, j, expand=False):
-        return self.arg._entry(j, i, expand=expand)
+    def _entry(self, i, j):
+        return self.arg._entry(j, i)
 
     def _eval_adjoint(self):
         return conjugate(self.arg)

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -50,7 +50,7 @@ class Transpose(MatrixExpr):
     def shape(self):
         return self.arg.shape[::-1]
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, expand=False):
         return self.arg._entry(j, i)
 
     def _eval_adjoint(self):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -3,10 +3,10 @@ from sympy import (
     collect,cos, cosh, cot, coth, count_ops, csch, Derivative, diff, E,
     Eq, erf, exp, exp_polar, expand, expand_multinomial, factor,
     factorial, Float, fraction, Function, gamma, GoldenRatio, hyper,
-    hypersimp, I, Integral, integrate, log, logcombine, Lt, Matrix,
+    hypersimp, I, Identity, Integral, integrate, log, logcombine, Lt, Matrix,
     MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise, posify, rad,
     Rational, root, S, separatevars, signsimp, simplify, sign, sin,
-    sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan, tanh,
+    sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan, tanh, trace,
     zoo)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import nthroot, inversecombine
@@ -32,15 +32,14 @@ def test_factorial_simplify():
 
 
 def test_simplify_scalar_for_quadratic_Matrix_computations():
-    import sympy as s
     n = 3
-    v = s.MatrixSymbol('v',3,1)
-    A = s.MatrixSymbol('A',3,3)
+    v = MatrixSymbol('v',3,1)
+    A = MatrixSymbol('A',3,3)
     quadratic = v.T*A*v
-    x = s.Matrix([i+1 for i in range(n)])
-    X = s.Identity(n)
+    x = Matrix([i+1 for i in range(n)])
+    X = Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
-    assert simplify(s.trace(subbed))
+    assert simplify(trace(subbed))==14
 
 
 def test_simplify_expr():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -37,7 +37,7 @@ def test_simplify_scalar_for_quadratic_Matrix_computations():
     v = s.MatrixSymbol('v',3,1)
     A = s.MatrixSymbol('A',3,3)
     quadratic = v.T*A*v
-    x = s.Matrix([i+1 for i in xrange(n)])
+    x = s.Matrix([i+1 for i in range(n)])
     X = s.Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
     assert simplify(s.trace(subbed))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -30,7 +30,9 @@ def test_factorial_simplify():
     assert simplify(factorial(x)/x) == factorial(x - 1)
     assert simplify(factorial(factorial(x))) == factorial(factorial(x))
 
+
 def test_simplify_scalar_for_quadratic_Matrix_computations():
+    import sympy as s
     n = 3
     v = s.MatrixSymbol('v',3,1)
     A = s.MatrixSymbol('A',3,3)
@@ -39,6 +41,7 @@ def test_simplify_scalar_for_quadratic_Matrix_computations():
     X = s.Identity(n)
     subbed = quadratic.xreplace({v:x,A:X})
     assert simplify(s.trace(subbed))
+
 
 def test_simplify_expr():
     x, y, z, k, n, m, w, s, A = symbols('x,y,z,k,n,m,w,s,A')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -30,6 +30,15 @@ def test_factorial_simplify():
     assert simplify(factorial(x)/x) == factorial(x - 1)
     assert simplify(factorial(factorial(x))) == factorial(factorial(x))
 
+def test_simplify_scalar_for_quadratic_Matrix_computations():
+    n = 3
+    v = s.MatrixSymbol('v',3,1)
+    A = s.MatrixSymbol('A',3,3)
+    quadratic = v.T*A*v
+    x = s.Matrix([i+1 for i in xrange(n)])
+    X = s.Identity(n)
+    subbed = quadratic.xreplace({v:x,A:X})
+    assert simplify(s.trace(subbed))
 
 def test_simplify_expr():
     x, y, z, k, n, m, w, s, A = symbols('x,y,z,k,n,m,w,s,A')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -33,13 +33,13 @@ def test_factorial_simplify():
 
 def test_simplify_scalar_for_quadratic_Matrix_computations():
     n = 3
-    v = MatrixSymbol('v',3,1)
-    A = MatrixSymbol('A',3,3)
+    v = MatrixSymbol('v', 3, 1)
+    A = MatrixSymbol('A', 3, 3)
     quadratic = v.T*A*v
-    x = Matrix([i+1 for i in range(n)])
+    x = Matrix([i + 1 for i in range(n)])
     X = Identity(n)
-    subbed = quadratic.xreplace({v:x,A:X})
-    assert simplify(trace(subbed))==14
+    subbed = quadratic.xreplace({v:x, A:X})
+    assert simplify(trace(subbed)) == 14
 
 
 def test_simplify_expr():


### PR DESCRIPTION
<!-- Test case for simplification of quadratic operation using simplify() on matrix added and transpose.py changed-->

#### References to other Issues or PRs
Fixes #9817


#### Brief description of what is fixed or changed
Test for simplify() added when quadratic operations are applied on matrices to return a scalar value.
Also transpose.py changed so that as_explicit() run normally without any error.

#### Other comments
* Tested and working normally.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * fixed a bug with transpose.py (removed expand keyword in _entry call).
<!-- END RELEASE NOTES -->
