### PR TITLE
Fix Matrix Equality and MatrixExpr

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -549,6 +549,15 @@ class MatrixExpr(Expr):
         from .applyfunc import ElementwiseApplyFunction
         return ElementwiseApplyFunction(func, self)
 
+    def _eval_Eq(self, other):
+        if not isinstance(other, MatrixExpr):
+            return False
+        if self.shape != other.shape:
+            return False
+        if (self - other).is_ZeroMatrix:
+            return True
+        return Eq(self, other, evaluate=False)
+
 
 def _matrix_derivative(expr, x):
     from sympy import Derivative

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -10,6 +10,7 @@ from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         SparseMatrix, Transpose, Adjoint)
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.utilities.pytest import raises
+from sympy import Eq
 
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
@@ -362,8 +363,7 @@ def test_issue_2750():
     assert (x.T*x).as_explicit()**-1 == Matrix([[x[0, 0]**(-2)]])
 
 
-def test_matrix_equality():
-    from sympy import Eq
+def test_issue_7842():
     A = MatrixSymbol('A', 3, 1)
     B = MatrixSymbol('B', 2, 1)
     assert Eq(A, B) == False

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -360,3 +360,14 @@ def test_issue_2749():
 def test_issue_2750():
     x = MatrixSymbol('x', 1, 1)
     assert (x.T*x).as_explicit()**-1 == Matrix([[x[0, 0]**(-2)]])
+
+
+def test_matrix_equality():
+    from sympy import Eq
+    A = MatrixSymbol('A', 3, 1)
+    B = MatrixSymbol('B', 2, 1)
+    assert Eq(A, B) == False
+    assert Eq(A[1,0], B[1, 0]).func is Eq
+    A = ZeroMatrix(2, 3)
+    B = ZeroMatrix(2, 3)
+    assert Eq(A, B) == True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #7842 
Fixes #16042
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Test case for equality in matrices.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  matrices
   *  _eval_Eq added for MatExpr
<!-- END RELEASE NOTES -->
