### PR TITLE
Calculation of critical angle and Fresnel coefficients

### DIFF
--- a/sympy/physics/optics/__init__.py
+++ b/sympy/physics/optics/__init__.py
@@ -30,6 +30,7 @@ __all__.extend(medium.__all__)
 
 
 from . import utils
-from .utils import (refraction_angle, fresnel_coefficients, deviation, brewster_angle, critical_angle, lens_makers_formula,
+from .utils import (refraction_angle, fresnel_coefficients,
+        deviation, brewster_angle, critical_angle, lens_makers_formula,
     mirror_formula, lens_formula, hyperfocal_distance, transverse_magnification)
 __all__.extend(utils.__all__)

--- a/sympy/physics/optics/__init__.py
+++ b/sympy/physics/optics/__init__.py
@@ -30,6 +30,6 @@ __all__.extend(medium.__all__)
 
 
 from . import utils
-from .utils import (refraction_angle, deviation, brewster_angle, lens_makers_formula,
+from .utils import (refraction_angle, fresnel_coefficients, deviation, brewster_angle, critical_angle, lens_makers_formula,
     mirror_formula, lens_formula, hyperfocal_distance, transverse_magnification)
 __all__.extend(utils.__all__)

--- a/sympy/physics/optics/medium.py
+++ b/sympy/physics/optics/medium.py
@@ -180,7 +180,7 @@ class Medium(Symbol):
 
     def __str__(self):
         from sympy.printing import sstr
-        return type(self).__name__ + ': ' + sstr([self._permittivity, 
+        return type(self).__name__ + ': ' + sstr([self._permittivity,
                 self._permeability, self._n])
 
     def __lt__(self, other):

--- a/sympy/physics/optics/medium.py
+++ b/sympy/physics/optics/medium.py
@@ -125,7 +125,7 @@ class Medium(Symbol):
         True
 
         """
-        if self._permittivity != None and self._permeability != None:
+        if self._permittivity is not None and self._permeability is not None:
             return 1/sqrt(self._permittivity*self._permeability)
         else:
             return c/self._n

--- a/sympy/physics/optics/medium.py
+++ b/sympy/physics/optics/medium.py
@@ -120,9 +120,15 @@ class Medium(Symbol):
         >>> m = Medium('m')
         >>> m.speed
         299792458*meter/second
+        >>> m2 = Medium('m2', n=1)
+        >>> m.speed == m2.speed
+        True
 
         """
-        return 1/sqrt(self._permittivity*self._permeability)
+        if self._permittivity != None and self._permeability != None:
+            return 1/sqrt(self._permittivity*self._permeability)
+        else:
+            return c/self._n
 
     @property
     def refractive_index(self):
@@ -174,7 +180,8 @@ class Medium(Symbol):
 
     def __str__(self):
         from sympy.printing import sstr
-        return type(self).__name__ + sstr(self.args)
+        return type(self).__name__ + ': ' + sstr([self._permittivity, 
+                self._permeability, self._n])
 
     def __lt__(self, other):
         """

--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -1,6 +1,6 @@
 from sympy.physics.optics.utils import (refraction_angle, fresnel_coefficients,
-        deviation, brewster_angle, critical_angle, lens_makers_formula, 
-        mirror_formula, lens_formula, hyperfocal_distance, 
+        deviation, brewster_angle, critical_angle, lens_makers_formula,
+        mirror_formula, lens_formula, hyperfocal_distance,
         transverse_magnification)
 from sympy.physics.optics.medium import Medium
 from sympy.physics.units import e0
@@ -64,16 +64,17 @@ def test_refraction_angle():
 
 
 def test_fresnel_coefficients():
-    assert fresnel_coefficients(0.5, 1, 1.33) == \
-        [0.111628141072695, -0.171375696718781, 0.8358100632385485, 0.828624303281219]
-    assert fresnel_coefficients(0.5, 1.33, 1) == \
-            [-0.0772642294415684, 0.204821852417292, 1.22723857484271, 1.20482185241729]
+    assert list(round(i, 5) for i in fresnel_coefficients(0.5, 1, 1.33)) == \
+        [0.11163, -0.17138, 0.83581, 0.82862]
+    assert list(round(i, 5) for i in fresnel_coefficients(0.5, 1.33, 1)) == \
+            [-0.07726, 0.20482, 1.22724, 1.20482]
     m1 = Medium('m1')
     m2 = Medium('m2', n=2)
-    assert fresnel_coefficients(0.3, m1, m2) == \
-        [0.317843553417859, -0.348645229818821, 0.658921776708929, 0.651354770181179]
-    assert fresnel_coefficients(0.6, m2, m1) == \
-        [-0.235625382192159 - 0.971843958291041*I, 0.816477005968898 - 0.577377951366403*I]
+    assert list(round(i, 5) for i in fresnel_coefficients(0.3, m1, m2)) == \
+        [0.31784, -0.34865, 0.65892, 0.65135]
+    assert list(list(round(j, 5) for j in i.as_real_imag()) for i in \
+            fresnel_coefficients(0.6, m2, m1)) == \
+        [[-0.23563, -0.97184], [0.81648, -0.57738]]
 
 
 def test_deviation():
@@ -96,12 +97,15 @@ def test_brewster_angle():
     m1 = Medium('m1', n=1)
     m2 = Medium('m2', n=1.33)
     assert round(brewster_angle(m1, m2), 2) == 0.93
+    m1 = Medium('m1', permittivity=e0, n=1)
+    m2 = Medium('m2', permittivity=e0, n=1.33)
+    assert round(brewster_angle(m1, m2), 2) == 0.93
 
 
 def test_critical_angle():
     m1 = Medium('m1', n=1)
     m2 = Medium('m2', n=1.33)
-    assert round(critical_angle(m1, m2), 2) == 0.85
+    assert round(critical_angle(m2, m1), 2) == 0.85
 
 
 def test_lens_makers_formula():

--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -1,6 +1,7 @@
-from sympy.physics.optics.utils import (refraction_angle, deviation,
-    brewster_angle, lens_makers_formula, mirror_formula, lens_formula,
-    hyperfocal_distance, transverse_magnification)
+from sympy.physics.optics.utils import (refraction_angle, fresnel_coefficients,
+        deviation, brewster_angle, critical_angle, lens_makers_formula, 
+        mirror_formula, lens_formula, hyperfocal_distance, 
+        transverse_magnification)
 from sympy.physics.optics.medium import Medium
 from sympy.physics.units import e0
 
@@ -62,10 +63,21 @@ def test_refraction_angle():
         Ray3D(Point3D(0, 0, 0), direction_ratio=[1, 1, -1])
 
 
+def test_fresnel_coefficients():
+    assert fresnel_coefficients(0.5, 1, 1.33) == \
+        [0.111628141072695, -0.171375696718781, 0.8358100632385485, 0.828624303281219]
+    assert fresnel_coefficients(0.5, 1.33, 1) == \
+            [-0.0772642294415684, 0.204821852417292, 1.22723857484271, 1.20482185241729]
+    m1 = Medium('m1')
+    m2 = Medium('m2', n=2)
+    assert fresnel_coefficients(0.3, m1, m2) == \
+        [0.317843553417859, -0.348645229818821, 0.658921776708929, 0.651354770181179]
+    assert fresnel_coefficients(0.6, m2, m1) == \
+        [-0.235625382192159 - 0.971843958291041*I, 0.816477005968898 - 0.577377951366403*I]
+
+
 def test_deviation():
     n1, n2 = symbols('n1, n2')
-    m1 = Medium('m1')
-    m2 = Medium('m2')
     r1 = Ray3D(Point3D(-1, -1, 1), Point3D(0, 0, 0))
     n = Matrix([0, 0, 1])
     i = Matrix([-1, -1, -1])
@@ -81,9 +93,15 @@ def test_deviation():
 
 
 def test_brewster_angle():
-    m1 = Medium('m1', permittivity=e0, n=1)
-    m2 = Medium('m2', permittivity=e0, n=1.33)
+    m1 = Medium('m1', n=1)
+    m2 = Medium('m2', n=1.33)
     assert round(brewster_angle(m1, m2), 2) == 0.93
+
+
+def test_critical_angle():
+    m1 = Medium('m1', n=1)
+    m2 = Medium('m2', n=1.33)
+    assert round(critical_angle(m1, m2), 2) == 0.85
 
 
 def test_lens_makers_formula():

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -241,25 +241,26 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
 
     if angle_of_total_internal_reflection_onset == None or\
     angle_of_total_internal_reflection_onset > angle_of_incidence:
-        R_s = -sin(angle_of_incidence-angle_of_refraction)\
-                /sin(angle_of_incidence+angle_of_refraction)
-        R_p = tan(angle_of_incidence-angle_of_refraction)\
-                /tan(angle_of_incidence+angle_of_refraction)
+        R_s = -sin(angle_of_incidence - angle_of_refraction)\
+                /sin(angle_of_incidence + angle_of_refraction)
+        R_p = tan(angle_of_incidence - angle_of_refraction)\
+                /tan(angle_of_incidence + angle_of_refraction)
         T_s = 2*sin(angle_of_refraction)*cos(angle_of_incidence)\
-                /sin(angle_of_incidence+angle_of_refraction)
+                /sin(angle_of_incidence + angle_of_refraction)
         T_p = 2*sin(angle_of_refraction)*cos(angle_of_incidence)\
-                /(sin(angle_of_incidence+angle_of_refraction)*cos(angle_of_incidence-angle_of_refraction))
+                /(sin(angle_of_incidence + angle_of_refraction)\
+                *cos(angle_of_incidence - angle_of_refraction))
         return [R_p, R_s, T_p, T_s]
     else:
         n = n2/n1
         R_s = cancel((cos(angle_of_incidence)-\
-                I*sqrt(sin(angle_of_incidence)**2-n**2))\
+                I*sqrt(sin(angle_of_incidence)**2 - n**2))\
                 /(cos(angle_of_incidence)+\
-                I*sqrt(sin(angle_of_incidence)**2-n**2)))
+                I*sqrt(sin(angle_of_incidence)**2 - n**2)))
         R_p = cancel((n**2*cos(angle_of_incidence)-\
-                I*sqrt(sin(angle_of_incidence)**2-n**2))\
+                I*sqrt(sin(angle_of_incidence)**2 - n**2))\
                 /(n**2*cos(angle_of_incidence)+\
-                I*sqrt(sin(angle_of_incidence)**2-n**2)))
+                I*sqrt(sin(angle_of_incidence)**2 - n**2)))
         return [R_p, R_s]
 
 

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -27,7 +27,8 @@ __all__ = ['refraction_angle',
            'transverse_magnification'
            ]
 
-from sympy import Symbol, sympify, sqrt, Matrix, acos, oo, Limit, atan2, asin, cos, sin, tan, I, simplify
+from sympy import Symbol, sympify, sqrt, Matrix, acos, oo, Limit, atan2, asin,\
+cos, sin, tan, I, cancel
 from sympy.core.compatibility import is_sequence
 from sympy.geometry.line import Ray3D, Point3D
 from sympy.geometry.util import intersection
@@ -251,11 +252,11 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
         return [R_p, R_s, T_p, T_s]
     else:
         n = n2/n1
-        R_s = simplify((cos(angle_of_incidence)-\
+        R_s = cancel((cos(angle_of_incidence)-\
                 I*sqrt(sin(angle_of_incidence)**2-n**2))\
                 /(cos(angle_of_incidence)+\
                 I*sqrt(sin(angle_of_incidence)**2-n**2)))
-        R_p = simplify((n**2*cos(angle_of_incidence)-\
+        R_p = cancel((n**2*cos(angle_of_incidence)-\
                 I*sqrt(sin(angle_of_incidence)**2-n**2))\
                 /(n**2*cos(angle_of_incidence)+\
                 I*sqrt(sin(angle_of_incidence)**2-n**2)))

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -181,19 +181,29 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
     transmission coefficients. Those are obtained for both polarisations
     when the electric field vector is in the plane of incidence (labelled 'p')
     and when the electric field vector is perpendicular to the plane of
-    incidence (labelled 's'). There four real coefficients unless the incident
-    ray reflects in total internal in which case there are two complex ones.
-    Angle of incidence is the angle between the incident ray and the surface
-    normal. ``medium1`` and ``medium2`` can be ``Medium`` or any sympifiable object.
+    incidence (labelled 's'). There are four real coefficients unless the
+    incident ray reflects in total internal in which case there are two complex
+    ones. Angle of incidence is the angle between the incident ray and the
+    surface normal. ``medium1`` and ``medium2`` can be ``Medium`` or any
+    sympifiable object.
 
     Parameters
     ==========
 
     angle_of_incidence : sympifiable
+
     medium1 : Medium or sympifiable
         Medium 1 or its refractive index
+
     medium2 : Medium or sympifiable
         Medium 2 or its refractive index
+
+    Returns a list with four real Fresnel coefficients:
+    [reflection p (TM), reflection s (TE),
+    transmission p (TM), transmission s (TE)]
+    If the ray is undergoes total internal reflection then returns a
+    list of two complex Fresnel coefficients:
+    [reflection p (TM), reflection s (TE)]
 
     Examples
     ========
@@ -205,6 +215,11 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
     >>> fresnel_coefficients(0.6, 2, 1)
     [-0.235625382192159 - 0.971843958291041*I,
              0.816477005968898 - 0.577377951366403*I]
+
+    References
+    ==========
+
+    https://en.wikipedia.org/wiki/Fresnel_equations
     """
 
     if isinstance(medium1, Medium):
@@ -223,16 +238,27 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
     except ValueError:
         angle_of_total_internal_reflection_onset = None
 
-    if angle_of_total_internal_reflection_onset == None or angle_of_total_internal_reflection_onset > angle_of_incidence:
-        R_s = -sin(angle_of_incidence-angle_of_refraction)/sin(angle_of_incidence+angle_of_refraction)
-        R_p = tan(angle_of_incidence-angle_of_refraction)/tan(angle_of_incidence+angle_of_refraction)
-        T_s = 2*sin(angle_of_refraction)*cos(angle_of_incidence)/sin(angle_of_incidence+angle_of_refraction)
-        T_p = 2*sin(angle_of_refraction)*cos(angle_of_incidence)/(sin(angle_of_incidence+angle_of_refraction)*cos(angle_of_incidence-angle_of_refraction))
+    if angle_of_total_internal_reflection_onset == None or\
+    angle_of_total_internal_reflection_onset > angle_of_incidence:
+        R_s = -sin(angle_of_incidence-angle_of_refraction)\
+                /sin(angle_of_incidence+angle_of_refraction)
+        R_p = tan(angle_of_incidence-angle_of_refraction)\
+                /tan(angle_of_incidence+angle_of_refraction)
+        T_s = 2*sin(angle_of_refraction)*cos(angle_of_incidence)\
+                /sin(angle_of_incidence+angle_of_refraction)
+        T_p = 2*sin(angle_of_refraction)*cos(angle_of_incidence)\
+                /(sin(angle_of_incidence+angle_of_refraction)*cos(angle_of_incidence-angle_of_refraction))
         return [R_p, R_s, T_p, T_s]
     else:
         n = n2/n1
-        R_s = simplify((cos(angle_of_incidence)-I*sqrt(sin(angle_of_incidence)**2-n**2))/(cos(angle_of_incidence)+I*sqrt(sin(angle_of_incidence)**2-n**2)))
-        R_p = simplify((n**2*cos(angle_of_incidence)-I*sqrt(sin(angle_of_incidence)**2-n**2))/(n**2*cos(angle_of_incidence)+I*sqrt(sin(angle_of_incidence)**2-n**2)))
+        R_s = simplify((cos(angle_of_incidence)-\
+                I*sqrt(sin(angle_of_incidence)**2-n**2))\
+                /(cos(angle_of_incidence)+\
+                I*sqrt(sin(angle_of_incidence)**2-n**2)))
+        R_p = simplify((n**2*cos(angle_of_incidence)-\
+                I*sqrt(sin(angle_of_incidence)**2-n**2))\
+                /(n**2*cos(angle_of_incidence)+\
+                I*sqrt(sin(angle_of_incidence)**2-n**2)))
         return [R_p, R_s]
 
 

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -176,24 +176,23 @@ def refraction_angle(incident, medium1, medium2, normal=None, plane=None):
 
 
 def fresnel_coefficients(angle_of_incidence, medium1, medium2):
-    # TODO documentation + examples/doctests + tests 
     """
-    This function uses Fresnel equations to calculate reflection and 
+    This function uses Fresnel equations to calculate reflection and
     transmission coefficients. Those are obtained for both polarisations
     when the electric field vector is in the plane of incidence (labelled 'p')
-    and when the electric field vector is perpendicular to the plane of 
+    and when the electric field vector is perpendicular to the plane of
     incidence (labelled 's'). There four real coefficients unless the incident
     ray reflects in total internal in which case there are two complex ones.
-    Angle of incidence is the angle between the incident ray and the surface 
-    normal. `medium1` and `medium2` can be `Medium` or any sympifiable object.
+    Angle of incidence is the angle between the incident ray and the surface
+    normal. ``medium1`` and ``medium2`` can be ``Medium`` or any sympifiable object.
 
     Parameters
     ==========
 
-    angle_of_inciddence : sympifiable
-    medium1 : sympy.physics.optics.medium.Medium or sympifiable
+    angle_of_incidence : sympifiable
+    medium1 : Medium or sympifiable
         Medium 1 or its refractive index
-    medium2 : sympy.physics.optics.medium.Medium or sympifiable
+    medium2 : Medium or sympifiable
         Medium 2 or its refractive index
 
     Examples
@@ -201,7 +200,7 @@ def fresnel_coefficients(angle_of_incidence, medium1, medium2):
 
     >>> from sympy.physics.optics import fresnel_coefficients
     >>> fresnel_coefficients(0.3, 1, 2)
-    [0.317843553417859, -0.348645229818821, 
+    [0.317843553417859, -0.348645229818821,
             0.658921776708929, 0.651354770181179]
     >>> fresnel_coefficients(0.6, 2, 1)
     [-0.235625382192159 - 0.971843958291041*I,
@@ -387,7 +386,7 @@ def critical_angle(medium1, medium2):
         n2 = sympify(medium2)
 
     if n2 > n1:
-        raise ValueError('Total internal reflection impossible for n1 > n2')
+        raise ValueError('Total internal reflection impossible for n1 < n2')
     else:
         return asin(n2/n1)
 

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -2,8 +2,10 @@
 **Contains**
 
 * refraction_angle
+* fresnel_coefficients
 * deviation
 * brewster_angle
+* critical_angle
 * lens_makers_formula
 * mirror_formula
 * lens_formula
@@ -15,7 +17,9 @@ from __future__ import division
 
 __all__ = ['refraction_angle',
            'deviation',
+           'fresnel_coefficients',
            'brewster_angle',
+           'critical_angle',
            'lens_makers_formula',
            'mirror_formula',
            'lens_formula',
@@ -23,9 +27,9 @@ __all__ = ['refraction_angle',
            'transverse_magnification'
            ]
 
-from sympy import Symbol, sympify, sqrt, Matrix, acos, oo, Limit, atan2
+from sympy import Symbol, sympify, sqrt, Matrix, acos, oo, Limit, atan2, asin, cos, sin, tan, I, simplify
 from sympy.core.compatibility import is_sequence
-from sympy.geometry.line import Ray3D
+from sympy.geometry.line import Ray3D, Point3D
 from sympy.geometry.util import intersection
 from sympy.geometry.plane import Plane
 from .medium import Medium
@@ -171,6 +175,68 @@ def refraction_angle(incident, medium1, medium2, normal=None, plane=None):
         return Ray3D(intersection_pt, direction_ratio=drs)
 
 
+def fresnel_coefficients(angle_of_incidence, medium1, medium2):
+    # TODO documentation + examples/doctests + tests 
+    """
+    This function uses Fresnel equations to calculate reflection and 
+    transmission coefficients. Those are obtained for both polarisations
+    when the electric field vector is in the plane of incidence (labelled 'p')
+    and when the electric field vector is perpendicular to the plane of 
+    incidence (labelled 's'). There four real coefficients unless the incident
+    ray reflects in total internal in which case there are two complex ones.
+    Angle of incidence is the angle between the incident ray and the surface 
+    normal. `medium1` and `medium2` can be `Medium` or any sympifiable object.
+
+    Parameters
+    ==========
+
+    angle_of_inciddence : sympifiable
+    medium1 : sympy.physics.optics.medium.Medium or sympifiable
+        Medium 1 or its refractive index
+    medium2 : sympy.physics.optics.medium.Medium or sympifiable
+        Medium 2 or its refractive index
+
+    Examples
+    ========
+
+    >>> from sympy.physics.optics import fresnel_coefficients
+    >>> fresnel_coefficients(0.3, 1, 2)
+    [0.317843553417859, -0.348645229818821, 
+            0.658921776708929, 0.651354770181179]
+    >>> fresnel_coefficients(0.6, 2, 1)
+    [-0.235625382192159 - 0.971843958291041*I,
+             0.816477005968898 - 0.577377951366403*I]
+    """
+
+    if isinstance(medium1, Medium):
+        n1 = medium1.refractive_index
+    else:
+        n1 = sympify(medium1)
+
+    if isinstance(medium2, Medium):
+        n2 = medium2.refractive_index
+    else:
+        n2 = sympify(medium2)
+
+    angle_of_refraction = asin(n1*sin(angle_of_incidence)/n2)
+    try:
+        angle_of_total_internal_reflection_onset = critical_angle(n1, n2)
+    except ValueError:
+        angle_of_total_internal_reflection_onset = None
+
+    if angle_of_total_internal_reflection_onset == None or angle_of_total_internal_reflection_onset > angle_of_incidence:
+        R_s = -sin(angle_of_incidence-angle_of_refraction)/sin(angle_of_incidence+angle_of_refraction)
+        R_p = tan(angle_of_incidence-angle_of_refraction)/tan(angle_of_incidence+angle_of_refraction)
+        T_s = 2*sin(angle_of_refraction)*cos(angle_of_incidence)/sin(angle_of_incidence+angle_of_refraction)
+        T_p = 2*sin(angle_of_refraction)*cos(angle_of_incidence)/(sin(angle_of_incidence+angle_of_refraction)*cos(angle_of_incidence-angle_of_refraction))
+        return [R_p, R_s, T_p, T_s]
+    else:
+        n = n2/n1
+        R_s = simplify((cos(angle_of_incidence)-I*sqrt(sin(angle_of_incidence)**2-n**2))/(cos(angle_of_incidence)+I*sqrt(sin(angle_of_incidence)**2-n**2)))
+        R_p = simplify((n**2*cos(angle_of_incidence)-I*sqrt(sin(angle_of_incidence)**2-n**2))/(n**2*cos(angle_of_incidence)+I*sqrt(sin(angle_of_incidence)**2-n**2)))
+        return [R_p, R_s]
+
+
 def deviation(incident, medium1, medium2, normal=None, plane=None):
     """
     This function calculates the angle of deviation of a ray
@@ -286,6 +352,45 @@ def brewster_angle(medium1, medium2):
         n2 = sympify(medium2)
 
     return atan2(n2, n1)
+
+def critical_angle(medium1, medium2):
+    """
+    This function calculates the critical angle of incidence (marking the onset
+    of total internal) to Medium 2 from Medium 1 in radians.
+
+    Parameters
+    ==========
+
+    medium 1 : Medium or sympifiable
+        Refractive index of Medium 1
+    medium 2 : Medium or sympifiable
+        Refractive index of Medium 1
+
+    Examples
+    ========
+
+    >>> from sympy.physics.optics import critical_angle
+    >>> critical_angle(1.33, 1)
+    0.850908514477849
+
+    """
+    n1, n2 = None, None
+
+    if isinstance(medium1, Medium):
+        n1 = medium1.refractive_index
+    else:
+        n1 = sympify(medium1)
+
+    if isinstance(medium2, Medium):
+        n2 = medium2.refractive_index
+    else:
+        n2 = sympify(medium2)
+
+    if n2 > n1:
+        raise ValueError('Total internal reflection impossible for n1 > n2')
+    else:
+        return asin(n2/n1)
+
 
 
 def lens_makers_formula(n_lens, n_surr, r1, r2):


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* physics.optics
   * Added two new functions to `physics.optics.utils`:
   1) `critical_angle() `calculates the onset of total internal reflection, "TIR" when possible (n2 < n1)
   2) `fresnel_coefficients()` calculates real reflection and transmission coefficients when out of TIR and complex ones when the ray is TIR'ed
<!-- END RELEASE NOTES -->
   * Small fix: calculating speed of light in medium is possible given only the refractive index.
   * Associated tests
   * The motivation for the above being that SymPy is well-suited to become a basic 'optics calculator' which would be a go-to tool for small tasks especially given that it can be used via SymPy Live.