### PR TITLE
Comparison of None with oo/-oo and finite numbers

### DIFF
--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1920,7 +1920,7 @@ def test_NegativeInfinity():
 
 def test_issue_6133():
     raises(TypeError, lambda: (-oo < None))
-    raises(TypeError, lambda: (-2 < None))
+    raises(TypeError, lambda: (S(-2) < None))
     raises(TypeError, lambda: (oo < None))
     raises(TypeError, lambda: (oo > None))
-    raises(TypeError, lambda: (2 < None))
+    raises(TypeError, lambda: (S(2) < None))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1917,3 +1917,10 @@ def test_NegativeInfinity():
     assert((-oo).ceiling() == -oo)
     assert((-oo)**11 == -oo)
     assert((-oo)**12 == oo)
+
+def test_issue_6133():
+    raises(TypeError, lambda: (-oo < None))
+    raises(TypeError, lambda: (-2 < None))
+    raises(TypeError, lambda: (oo < None))
+    raises(TypeError, lambda: (oo > None))
+    raises(TypeError, lambda: (2 < None))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #6133
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Tests were added for comparison of ` None ` with ` oo/-oo ` and finite numbers. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
