### PR TITLE
Replace deprecated np.asscalar

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -67,7 +67,7 @@ def _convert_numpy_types(a, **sympify_args):
             prec = np.finfo(a).nmant + 1
             # E.g. double precision means prec=53 but nmant=52
             # Leading bit of mantissa is always 1, so is not stored
-            a = str(list(np.reshape(a.item(),
+            a = str(list(np.reshape(np.asarray(a),
                                     (1, np.size(a)))[0]))[1:-1]
             return Float(a, precision=prec)
         except NotImplementedError:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -58,16 +58,16 @@ def _convert_numpy_types(a, **sympify_args):
     import numpy as np
     if not isinstance(a, np.floating):
         if np.iscomplex(a):
-            return converter[complex](np.asscalar(a))
+            return converter[complex](a.item())
         else:
-            return sympify(np.asscalar(a), **sympify_args)
+            return sympify(a.item(), **sympify_args)
     else:
         try:
             from sympy.core.numbers import Float
             prec = np.finfo(a).nmant + 1
             # E.g. double precision means prec=53 but nmant=52
             # Leading bit of mantissa is always 1, so is not stored
-            a = str(list(np.reshape(np.asarray(a),
+            a = str(list(np.reshape(a.item(),
                                     (1, np.size(a)))[0]))[1:-1]
             return Float(a, precision=prec)
         except NotImplementedError:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes  #16062
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Replace deprecated ` np.asscalar ` with ` a.item() `.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  core
   *  replace np.asscalar in sympify
<!-- END RELEASE NOTES -->
