### PR TITLE
periodicity of e**(I*x)

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
-                   cot, sec, csc, Abs, symbols)
+                   cot, sec, csc, Abs, symbols, I, re)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex)
 from sympy.core import Add, Mul, Pow
@@ -93,6 +93,7 @@ def test_not_empty_in():
 def test_periodicity():
     x = Symbol('x')
     y = Symbol('y')
+    z = Symbol('z', real=True)
 
     assert periodicity(sin(2*x), x) == pi
     assert periodicity((-2)*tan(4*x), x) == pi/4
@@ -117,11 +118,22 @@ def test_periodicity():
     assert periodicity(tan((3*x-2)%4), x) == S(4)/3
     assert periodicity((sqrt(2)*(x+1)+x) % 3, x) == 3 / (sqrt(2)+1)
     assert periodicity((x**2+1) % x, x) == None
-
+    assert periodicity(sin(re(x)), x) == 2*pi
     assert periodicity(sin(x)**2 + cos(x)**2, x) == S.Zero
     assert periodicity(tan(x), y) == S.Zero
+    assert periodicity(sin(x) + I*cos(x), x) == 2*pi
+    assert periodicity(x - sin(2*y), y) == pi
 
     assert periodicity(exp(x), x) is None
+    assert periodicity(exp(I*x), x) == 2*pi
+    assert periodicity(exp(I*z), z) == 2*pi
+    assert periodicity(exp(z), z) is None
+    assert periodicity(exp(log(sin(z) + I*cos(2*z)), evaluate=False), z) == 2*pi
+    assert periodicity(exp(log(sin(2*z) + I*cos(z)), evaluate=False), z) == 2*pi
+    assert periodicity(exp(sin(z)), z) == 2*pi
+    assert periodicity(exp(2*I*z), z) == pi
+    assert periodicity(exp(z + I*sin(z)), z) is None
+    assert periodicity(exp(cos(z/2) + sin(z)), z) == 4*pi
     assert periodicity(log(x), x) is None
     assert periodicity(exp(x)**sin(x), x) is None
     assert periodicity(sin(x)**y, y) is None

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1,4 +1,4 @@
-from sympy import Order, S, log, limit, lcm_list, pi, Abs
+from sympy import Order, S, log, limit, lcm_list, pi, Abs, im, re, Symbol, Dummy
 from sympy.core.basic import Basic
 from sympy.core import Add, Mul, Pow
 from sympy.logic.boolalg import And
@@ -412,12 +412,17 @@ def periodicity(f, symbol, check=False):
     from sympy.core.function import diff
     from sympy.core.mod import Mod
     from sympy.core.relational import Relational
+    from sympy.functions.elementary.exponential import exp
     from sympy.functions.elementary.complexes import Abs
     from sympy.functions.elementary.trigonometric import (
         TrigonometricFunction, sin, cos, csc, sec)
     from sympy.simplify.simplify import simplify
     from sympy.solvers.decompogen import decompogen
     from sympy.polys.polytools import degree, lcm_list
+
+    temp = Dummy('x', real=True)
+    f = f.subs(symbol, temp)
+    symbol = temp
 
     def _check(orig_f, period):
         '''Return the checked period or raise an error.'''
@@ -473,6 +478,13 @@ def periodicity(f, symbol, check=False):
                     raise NotImplementedError(err)
             # else let new orig_f and period be
             # checked below
+
+    if isinstance(f, exp):
+        if im(f) != 0:
+            period_real = periodicity(re(f), symbol)
+            period_imag = periodicity(im(f), symbol)
+            if period_real is not None and period_imag is not None:
+                period = lcim([period_real, period_imag])
 
     if f.is_Pow:
         base, expo = f.args


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`periodicity()` can now calculate period of  expressions of form  `exp(I*x)` when x is `real`.
`None` is returned for complex `x`.

```
>>> from sympy import *
>>> from sympy.calculus.util import periodicity
>>> x = Symbol('x', real=True)
>>> y = Symbol('y')
>>> periodicity(exp(I*x))
2*pi 
>>> periodicity(exp(y))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * fix periodicity of exponential of form exp(I*x)
<!-- END RELEASE NOTES -->
