### PR TITLE
Remove inconsistency in no. of arguments passed.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -397,7 +397,6 @@ Gagandeep Singh <singh.23@iitj.ac.in> MathLover <36567889+czgdp1807@users.norepl
 Gagandeep Singh <singh.23@iitj.ac.in> czgdp1807 <singh.23@iitj.ac.in>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <36567889+czgdp1807@users.noreply.github.com>
 Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <czgdp1807@gmail.com>
-Gagandeep Singh <singh.23@iitj.ac.in> Gagandeep Singh <singh.23@iitj.ac.in>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
 Yatna Verma <yatnavermaa@gmail.com> yatna <yatnavermaa@gmail.com>
 Jared Lumpe <mjlumpe@gmail.com> Michael Jared Lumpe <mjlumpe@gmail.com>

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -189,7 +189,7 @@ def dup_gf_sqf_part(f, K):
     return dup_convert(g, K.dom, K)
 
 
-def dmp_gf_sqf_part(f, K):
+def dmp_gf_sqf_part(f, u, K):
     """Compute square-free part of ``f`` in ``GF(p)[X]``. """
     raise NotImplementedError('multivariate polynomials over finite fields')
 
@@ -244,7 +244,7 @@ def dmp_sqf_part(f, u, K):
         return dup_sqf_part(f, K)
 
     if K.is_FiniteField:
-        return dmp_gf_sqf_part(f, K)
+        return dmp_gf_sqf_part(f, u, K)
 
     if dmp_zero_p(f, u):
         return f

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -244,7 +244,7 @@ def dmp_sqf_part(f, u, K):
         return dup_sqf_part(f, K)
 
     if K.is_FiniteField:
-        return dmp_gf_sqf_part(f, u, K)
+        return dmp_gf_sqf_part(f, K)
 
     if dmp_zero_p(f, u):
         return f


### PR DESCRIPTION
dmp_gf_sqf_part takes at most 2 arguments but in dmp_sqf_part, 3 args are being passed

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
closes #7612 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
