### PR TITLE
(Don't merge) Travis stages fail on pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 sudo: false
+stages:
+- baseline
+- test
 env:
   matrix:
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
@@ -17,7 +20,8 @@ python:
 
 matrix:
   include:
-    - python: 3.7
+    - stage: baseline
+      python: 3.7
       dist: xenial
       sudo: true
       env:
@@ -33,7 +37,8 @@ matrix:
       env:
         - SPLIT="2/2" TEST_SYMPY="true"
 
-    - python: 2.7
+    - stage: test
+      python: 2.7
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -15,6 +15,10 @@ See the webpage for more information and documentation:
 from __future__ import absolute_import, print_function
 del absolute_import, print_function
 
+import platform
+if platform.python_implementation() == 'PyPy':
+    raise ValueError('Failing on PyPy deliberately!')
+
 try:
     import mpmath
 except ImportError:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Test of #16023. The pypy tests should fail with this PR. I want to see if the PR is still mergeable to test the allow failures function of Travis is still working.


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
