### PR TITLE
added the fold_frac_powers and fold_short_frac flag to mathml printer

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -554,7 +554,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             numer, denom = fraction(expr)
             if denom is not S.One:
                 frac = self.dom.createElement('mfrac')
-                if self._settings["fold_short_frac"]:
+                print(expr)
+                if self._settings["fold_short_frac"] and len(str(expr)) < 7:
                     frac.setAttribute('bevelled', 'true')
                 xnum = self._print(numer)
                 xden = self._print(denom)
@@ -865,29 +866,29 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_Pow(self, e):
         # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if e.exp.is_negative:
-            if self._settings['fold_short_frac'] and len(str(e.base)) < 3:
-                frac = self.dom.createElement('mfrac')
-                frac.setAttribute('bevelled', 'true')
-                frac.appendChild(self._print(1))
-                mrow = self.dom.createElement('mrow')
-                x = self.dom.createElement('mfenced')
-                x.appendChild(self._print(e.base))
-                mrow.appendChild(x)
-                x = self.dom.createElement('msup')
-                x.appendChild(mrow)
-                x.appendChild(self._print(-e.exp))
-                frac.appendChild(x)
-                return frac
-            if len(str(e.base)) > 1:
-                mrow = self.dom.createElement('mrow')
-                x = self.dom.createElement('mfenced')
-                x.appendChild(self._print(e.base))
-                mrow.appendChild(x)
-                x = self.dom.createElement('msup')
-                x.appendChild(mrow)
-                x.appendChild(self._print(e.exp))
-                return x
+        if e.exp.is_negative and self._settings['fold_short_frac'] and len(str(e.base)) < 7:
+            frac = self.dom.createElement('mfrac')
+            frac.setAttribute('bevelled', 'true')
+            frac.appendChild(self._print(1))
+            mrow = self.dom.createElement('mrow')
+            x = self.dom.createElement('mfenced')
+            x.appendChild(self._print(e.base))
+            mrow.appendChild(x)
+            x = self.dom.createElement('msup')
+            x.appendChild(mrow)
+            x.appendChild(self._print(-e.exp))
+            frac.appendChild(x)
+            return frac
+
+        if e.exp.is_negative or len(str(e.base)) > 1:
+            mrow = self.dom.createElement('mrow')
+            x = self.dom.createElement('mfenced')
+            x.appendChild(self._print(e.base))
+            mrow.appendChild(x)
+            x = self.dom.createElement('msup')
+            x.appendChild(mrow)
+            x.appendChild(self._print(e.exp))
+            return x
 
         if e.exp.is_Rational and e.exp.p == 1 and self._settings['root_notation']:
             if e.exp.q == 2:

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -4,7 +4,7 @@ A MathML printer.
 
 from __future__ import print_function, division
 
-from sympy import sympify, S, Mul, symbol
+from sympy import sympify, S, Mul
 from sympy.core.function import _coeff_isneg
 from sympy.core.compatibility import range, string_types
 from sympy.printing.conventions import split_super_sub, requires_partial

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -4,7 +4,7 @@ A MathML printer.
 
 from __future__ import print_function, division
 
-from sympy import sympify, S, Mul
+from sympy import sympify, S, Mul, symbol
 from sympy.core.function import _coeff_isneg
 from sympy.core.compatibility import range, string_types
 from sympy.printing.conventions import split_super_sub, requires_partial
@@ -871,16 +871,15 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 frac.setAttribute('bevelled', 'true')
                 frac.appendChild(self._print(1))
                 mrow = self.dom.createElement('mrow')
-                if e.exp.p == -1 and e.exp.q == 1:
-                    mrow.appendChild(self._print(e.base))
-                    frac.appendChild(mrow)
-                    return frac
-                if type(e.base) == symbol.Symbol:
+                if e.base.is_symbol:
                     x = self.dom.createElement('mfenced')
                     x.appendChild(self._print(e.base))
                     mrow.appendChild(x)
                 else:
                     mrow.appendChild(self._print(e.base))
+                if e.exp.p == -1 and e.exp.q == 1:
+                    frac.appendChild(mrow)
+                    return frac
                 x = self.dom.createElement('msup')
                 x.appendChild(mrow)
                 x.appendChild(self._print(-e.exp))

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -554,7 +554,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             numer, denom = fraction(expr)
             if denom is not S.One:
                 frac = self.dom.createElement('mfrac')
-                print(expr)
                 if self._settings["fold_short_frac"] and len(str(expr)) < 7:
                     frac.setAttribute('bevelled', 'true')
                 xnum = self._print(numer)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -865,19 +865,27 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_Pow(self, e):
         # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if e.exp.is_negative and self._settings['fold_short_frac'] and len(str(e.base)) < 7:
-            frac = self.dom.createElement('mfrac')
-            frac.setAttribute('bevelled', 'true')
-            frac.appendChild(self._print(1))
-            mrow = self.dom.createElement('mrow')
-            x = self.dom.createElement('mfenced')
-            x.appendChild(self._print(e.base))
-            mrow.appendChild(x)
-            x = self.dom.createElement('msup')
-            x.appendChild(mrow)
-            x.appendChild(self._print(-e.exp))
-            frac.appendChild(x)
-            return frac
+        if self._settings['fold_short_frac'] and len(str(e.base)) < 7:
+            if e.exp.is_negative:
+                frac = self.dom.createElement('mfrac')
+                frac.setAttribute('bevelled', 'true')
+                frac.appendChild(self._print(1))
+                mrow = self.dom.createElement('mrow')
+                if e.exp.p == -1 and e.exp.q == 1:
+                    mrow.appendChild(self._print(e.base))
+                    frac.appendChild(mrow)
+                    return frac
+                if type(e.base) == symbol.Symbol:
+                    x = self.dom.createElement('mfenced')
+                    x.appendChild(self._print(e.base))
+                    mrow.appendChild(x)
+                else:
+                    mrow.appendChild(self._print(e.base))
+                x = self.dom.createElement('msup')
+                x.appendChild(mrow)
+                x.appendChild(self._print(-e.exp))
+                frac.appendChild(x)
+                return frac
 
         if e.exp.is_negative or len(str(e.base)) > 1:
             mrow = self.dom.createElement('mrow')

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -554,6 +554,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             numer, denom = fraction(expr)
             if denom is not S.One:
                 frac = self.dom.createElement('mfrac')
+                if self._settings["fold_short_frac"]:
+                    frac.setAttribute('bevelled', 'true')
                 xnum = self._print(numer)
                 xden = self._print(denom)
                 frac.appendChild(xnum)
@@ -636,6 +638,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             x.appendChild(self.dom.createTextNode(str(e.p)))
             return x
         x = self.dom.createElement('mfrac')
+        if self._settings["fold_frac_powers"]:
+            x.setAttribute('bevelled', 'true')
         num = self.dom.createElement('mn')
         num.appendChild(self.dom.createTextNode(str(e.p)))
         x.appendChild(num)
@@ -861,15 +865,29 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_Pow(self, e):
         # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if e.exp.is_negative or len(str(e.base)) > 1:
-            mrow = self.dom.createElement('mrow')
-            x = self.dom.createElement('mfenced')
-            x.appendChild(self._print(e.base))
-            mrow.appendChild(x)
-            x = self.dom.createElement('msup')
-            x.appendChild(mrow)
-            x.appendChild(self._print(e.exp))
-            return x
+        if e.exp.is_negative:
+            if self._settings['fold_short_frac'] and len(str(e.base)) < 3:
+                frac = self.dom.createElement('mfrac')
+                frac.setAttribute('bevelled', 'true')
+                frac.appendChild(self._print(1))
+                mrow = self.dom.createElement('mrow')
+                x = self.dom.createElement('mfenced')
+                x.appendChild(self._print(e.base))
+                mrow.appendChild(x)
+                x = self.dom.createElement('msup')
+                x.appendChild(mrow)
+                x.appendChild(self._print(-e.exp))
+                frac.appendChild(x)
+                return frac
+            if len(str(e.base)) > 1:
+                mrow = self.dom.createElement('mrow')
+                x = self.dom.createElement('mfenced')
+                x.appendChild(self._print(e.base))
+                mrow.appendChild(x)
+                x = self.dom.createElement('msup')
+                x.appendChild(mrow)
+                x.appendChild(self._print(e.exp))
+                return x
 
         if e.exp.is_Rational and e.exp.p == 1 and self._settings['root_notation']:
             if e.exp.q == 2:

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -982,6 +982,20 @@ def test_root_notation_print():
     assert mathml(x**(S(1)/3), printer='content', root_notation=False) == '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
 
 
+def test_fold_frac_powers_print():
+    expr = x ** Rational(5, 2)
+    assert mathml(expr, printer='presentation') == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=True) == '<msup><mi>x</mi><mfrac bevelled="true"><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=False) == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+
+
+def test_fold_short_frac_print():
+    expr = 1 / y ** 2
+    assert mathml(expr, printer='presentation') == '<msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>-2</mn></msup>'
+    assert mathml(expr, printer='presentation', fold_short_frac=True) == '<mfrac bevelled="true"><mn>1</mn><msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>2</mn></msup></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=False) == '<msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>-2</mn></msup>'
+
+
 def test_print_factorials():
     assert mpp.doprint(factorial(x)) == '<mrow><mi>x</mi><mo>!</mo></mrow>'
     assert mpp.doprint(factorial(x + 1)) == '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!</mo></mrow>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

- Added the Fold_frac_powers and fold_short_frac flags to the mathml presentation printer

#### Other comments


#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing 

    - Added the Fold_frac_powers and fold_short_frac flags to the mathml presentation printer
<!-- END RELEASE NOTES -->
