### PR TITLE
Matrices: Improve speed for inverse_LU

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4007,14 +4007,9 @@ class MatrixBase(MatrixDeprecated,
             is_zero = iszerofunc(lu[i, j])
             if is_zero:
                 raise ValueError(msg_rank_error)
-
-            # It tries simplify again for the check, but it may not
-            # attempt to store the result back to the matrix since it
-            # sometimes makes the backward substitution bloated.
-            if is_zero == None:
-                if iszerofunc(_simplify(lu[i, j])):
+            elif is_zero == None:
+                if lu[i, j].equals(0):
                     raise ValueError(msg_rank_error)
-
 
         return lu, row_swaps
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4,9 +4,9 @@ from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
     S, Symbol, cos, exp, expand_mul, oo, pi, signsimp, simplify, sin, sqrt, symbols,
     sympify, trigsimp, tan, sstr, diff, Function)
-from sympy.matrices.matrices import (ShapeError, MatrixError,
-    NonSquareMatrixError, DeferredVector, _find_reasonable_pivot_naive,
-    _simplify)
+from sympy.matrices.matrices import (
+    ShapeError, MatrixError, NonInvertibleMatrixError, NonSquareMatrixError,
+    DeferredVector, _find_reasonable_pivot_naive, _simplify)
 from sympy.matrices import (
     GramSchmidt, ImmutableMatrix, ImmutableSparseMatrix, Matrix,
     SparseMatrix, casoratian, diag, eye, hessian,
@@ -2833,9 +2833,9 @@ def test_invertible_check():
     # matrix will be returned even though m is not invertible
     assert m.rref()[0] != eye(3)
     assert m.rref(simplify=signsimp)[0] != eye(3)
-    raises(ValueError, lambda: m.inv(method="ADJ"))
-    raises(ValueError, lambda: m.inv(method="GE"))
-    raises(ValueError, lambda: m.inv(method="LU"))
+    raises(NonInvertibleMatrixError, lambda: m.inv(method="ADJ"))
+    raises(NonInvertibleMatrixError, lambda: m.inv(method="GE"))
+    raises(NonInvertibleMatrixError, lambda: m.inv(method="LU"))
 
 
 def test_issue_3959():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -340,9 +340,8 @@ def test_linear_systemLU():
 
     M = Matrix([[1, 2, 0, 1], [1, 3, 2*n, 1], [4, -1, n**2, 1]])
 
-    assert solve_linear_system_LU(M, [x, y, z]) == {z: -3/(n**2 + 18*n),
-                                                  x: 1 - 12*n/(n**2 + 18*n),
-                                                  y: 6*n/(n**2 + 18*n)}
+    assert solve_linear_system_LU(M, [x, y, z]) == {
+        x: 1 - 12/(n + 18), y: 6/(n + 18), z: -3/(n*(n + 18))}
 
 # Note: multiple solutions exist for some of these equations, so the tests
 # should be expected to break if the implementation of the solver changes

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -340,8 +340,8 @@ def test_linear_systemLU():
 
     M = Matrix([[1, 2, 0, 1], [1, 3, 2*n, 1], [4, -1, n**2, 1]])
 
-    assert solve_linear_system_LU(M, [x, y, z]) == {
-        x: 1 - 12/(n + 18), y: 6/(n + 18), z: -3/(n*(n + 18))}
+    assert solve_linear_system_LU(M, [x, y, z]) == \
+        {x: 1 - 12/(n + 18), y: 6/(n + 18), z: -3/(n*(n + 18))}
 
 # Note: multiple solutions exist for some of these equations, so the tests
 # should be expected to break if the implementation of the solver changes


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`inverse_lu` uses inefficient check
https://github.com/sympy/sympy/blob/b68caad822d3ad0ae1fa09c78c9ed2db927e73cb/sympy/matrices/matrices.py#L3094-L3096
that uses computing the RREF only to test out the rank.

However, it is a well known mathematical property that LU decomposition can also reveal the rank in the mid-computation.
And currently, #16077 have been merged, so that the LU solver can properly use `rankcheck` to effectively detect singular matrices.

I have profiled
```
from sympy import *
import cProfile

m = Matrix(15, 15, lambda i, j: 1 / (i+j+1))
cProfile.run("m.inverse_LU()")
```

And the performance have increased from
`433417 function calls (422507 primitive calls) in 0.650 seconds`
to
`289821 function calls (283214 primitive calls) in 0.148 seconds`

And I have also concluded that the performance degradation of computing RREF was so huge that it had exceeded the actual LU computation itself.
`1    0.000    0.000    0.503    0.503 matrices.py:886(rref)`

#### Other comments

However, if the LUsolve gets extended with a parametric solver capability, I think it should be revisited again for possible issues.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed performance slowdown in `inverse_LU`
<!-- END RELEASE NOTES -->
