### PR TITLE
as_int more strict about input

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -13,7 +13,7 @@ class AskPrimeHandler(CommonHandler):
     """
     Handler for key 'prime'
     Test that an expression represents a prime number. When the
-    expression is a number the result, when True, is subject to
+    expression is an exact number, the result (when True) is subject to
     the limitations of isprime() which is used to return the result.
     """
 
@@ -24,19 +24,20 @@ class AskPrimeHandler(CommonHandler):
     @staticmethod
     def _number(expr, assumptions):
         # helper method
+        exact = not expr.atoms(Float)
         try:
             i = int(expr.round())
-            if not (expr - i).equals(0):
+            if (expr - i).equals(0) is False:
                 raise TypeError
         except TypeError:
             return False
-        return isprime(expr)
+        if exact:
+            return isprime(i)
+        # when not exact, we won't give a True or False
+        # since the number represents an approximate value
 
     @staticmethod
     def Basic(expr, assumptions):
-        # Just use int(expr) once
-        # https://github.com/sympy/sympy/issues/4561
-        # is solved
         if expr.is_number:
             return AskPrimeHandler._number(expr, assumptions)
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -354,37 +354,66 @@ except ImportError:
     maketrans = str.maketrans
 
 
-def as_int(n):
+def as_int(n, strict=True):
     """
     Convert the argument to a builtin integer.
 
-    The return value is guaranteed to be equal to the input. ValueError is
-    raised if the input has a non-integral value.
+    The return value is guaranteed to be equal to the input. ValueError
+    is raised if the input has a non-integral value. When ``strict`` is
+    False, non-integer input that compares equal to the integer value
+    will not raise an error.
+
 
     Examples
     ========
 
     >>> from sympy.core.compatibility import as_int
-    >>> from sympy import sqrt
-    >>> 3.0
-    3.0
-    >>> as_int(3.0) # convert to int and test for equality
+    >>> from sympy import sqrt, S
+
+    The function is primarily concerned with sanitizing input for
+    functions that need to work with builtin integers, so anything that
+    is unambiguously an integer should be returned as an int:
+
+    >>> as_int(S(3))
     3
-    >>> int(sqrt(10))
-    3
-    >>> as_int(sqrt(10))
+
+    Floats, being of limited precision, are not assumed to be exact and
+    will raise an error unless the ``strict`` flag is False. This
+    precision issue becomes apparent for large floating point numbers:
+
+    >>> big = 1e23
+    >>> type(big) is float
+    True
+    >>> big == int(big)
+    True
+    >>> as_int(big)
     Traceback (most recent call last):
     ...
     ValueError: ... is not an integer
+    >>> as_int(big, strict=False)
+    99999999999999991611392
 
+    Input that might be a complex representation of an integer value is
+    also rejected by default:
+
+    >>> one = sqrt(3 + 2*sqrt(2)) - sqrt(2)
+    >>> int(one) == 1
+    True
+    >>> as_int(one)
+    Traceback (most recent call last):
+    ...
+    ValueError: ... is not an integer
     """
+    from sympy.core.numbers import Integer
     try:
+        if strict and not isinstance(n, SYMPY_INTS + (Integer,)):
+            raise TypeError
         result = int(n)
         if result != n:
             raise TypeError
+        return result
     except TypeError:
         raise ValueError('%s is not an integer' % (n,))
-    return result
 
 
 def default_sort_key(item, order=None):

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -367,12 +367,14 @@ def get_integer_part(expr, no, options, return_ints=False):
             if s:
                 doit = True
                 from sympy.core.compatibility import as_int
+                # use strict=False with as_int because we take
+                # 2.0 == 2
                 for v in s.values():
                     try:
-                        as_int(v)
+                        as_int(v, strict=False)
                     except ValueError:
                         try:
-                            [as_int(i) for i in v.as_real_imag()]
+                            [as_int(i, strict=False) for i in v.as_real_imag()]
                             continue
                         except (ValueError, AttributeError):
                             doit = False

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -671,7 +671,7 @@ class Pow(Expr):
                     # Allow fractional powers for commutative objects
                     pow = coeff1/coeff2
                     try:
-                        pow = as_int(pow)
+                        pow = as_int(pow, strict=False)
                         combines = True
                     except ValueError:
                         combines = isinstance(Pow._eval_power(

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -18,6 +18,13 @@ def test_as_int():
     raises(ValueError, lambda : as_int(S.Infinity))
     raises(ValueError, lambda : as_int(S.NegativeInfinity))
     raises(ValueError, lambda : as_int(S.ComplexInfinity))
+    # for the following, limited precision makes int(arg) == arg
+    # but the int value is not necessarily what a user might have
+    # expected; Q.prime is more nuanced in its response for
+    # expressions which might be complex representations of an
+    # integer. This is not -- by design -- as_ints role.
+    raises(ValueError, lambda : as_int(1e23))
+    raises(ValueError, lambda : as_int(S('1.'+'0'*20+'1')))
 
 
 def test_iterable():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1738,9 +1738,9 @@ def test_issue_10020():
 def test_invert_numbers():
     assert S(2).invert(5) == 3
     assert S(2).invert(S(5)/2) == S.Half
-    assert S(2).invert(5.) == 3
+    assert S(2).invert(5.) == 0.5
     assert S(2).invert(S(5)) == 3
-    assert S(2.).invert(5) == 3
+    assert S(2.).invert(5) == 0.5
     assert S(sqrt(2)).invert(5) == 1/sqrt(2)
     assert S(sqrt(2)).invert(sqrt(3)) == 1/sqrt(2)
 

--- a/sympy/discrete/tests/test_transforms.py
+++ b/sympy/discrete/tests/test_transforms.py
@@ -56,8 +56,7 @@ def test_ntt_intt():
     raises(ValueError, lambda: ntt([1.2, 2.1, 3.5], p))
     raises(ValueError, lambda: ntt([3, 5, 6], q))
     raises(ValueError, lambda: ntt([4, 5, 7], r))
-
-    assert ntt([1.0, 2.0, 3.0], p) == ntt([1, 2, 3], p)
+    raises(ValueError, lambda: ntt([1.0, 2.0, 3.0], p))
 
 
 def test_fwht_ifwht():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1612,7 +1612,7 @@ def test_creation_args():
     raises(TypeError, lambda: zeros(1, 2, 3, 4))
     assert zeros(long(3)) == zeros(3)
     assert zeros(Integer(3)) == zeros(3)
-    assert zeros(3.) == zeros(3)
+    raises(ValueError, lambda: zeros(3.))
     assert eye(long(3)) == eye(3)
     assert eye(Integer(3)) == eye(3)
     assert eye(3.) == eye(3)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1615,7 +1615,7 @@ def test_creation_args():
     raises(ValueError, lambda: zeros(3.))
     assert eye(long(3)) == eye(3)
     assert eye(Integer(3)) == eye(3)
-    assert eye(3.) == eye(3)
+    raises(ValueError, lambda: eye(3.))
     assert ones(long(3), Integer(4)) == ones(3, 4)
     raises(TypeError, lambda: Matrix(5))
     raises(TypeError, lambda: Matrix(1, 2))

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -495,10 +495,30 @@ def isprime(n):
     Notes
     =====
 
-    This routine is not meant to deal with expressions which may
-    represent a prime number. Floats -- even those that are
-    equal to an integer value -- return False because they
-    represent numbers of limited precision.
+    This routine is intended only for integer input, not numerical
+    expressions which may represent numbers. Floats are also
+    rejected as input because they represent numbers of limited
+    precision. While it is tempting to permit 7.0 to represent an
+    integer there are errors that may "pass silently" if this is
+    allowed:
+
+    >>> from sympy import Float, S
+    >>> int(1e3) == 1e3 == 10**3
+    True
+    >>> int(1e23) == 1e23
+    True
+    >>> int(1e23) == 10**23
+    False
+
+    >>> near_int = 1 + S(1)/10**19
+    >>> near_int == int(near_int)
+    False
+    >>> n = Float(near_int, 10)  # truncated by precision
+    >>> n == int(n)
+    True
+    >>> n = Float(near_int, 20)
+    >>> n = int(n)
+    False
 
     See Also
     ========

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -6,7 +6,6 @@ Primality testing
 from __future__ import print_function, division
 
 from sympy.core.compatibility import range, as_int
-from sympy.core.numbers import Float
 
 from mpmath.libmp import bitcount as _bitlength
 
@@ -488,8 +487,18 @@ def isprime(n):
     >>> from sympy.ntheory import isprime
     >>> isprime(13)
     True
+    >>> isprime(13.0)  # limited precision
+    False
     >>> isprime(15)
     False
+
+    Notes
+    =====
+
+    This routine is not meant to deal with expressions which may
+    represent a prime number. Floats -- even those that are
+    equal to an integer value -- return False because they
+    represent numbers of limited precision.
 
     See Also
     ========
@@ -505,9 +514,10 @@ def isprime(n):
       http://mpqs.free.fr/LucasPseudoprimes.pdf
     - https://en.wikipedia.org/wiki/Baillie-PSW_primality_test
     """
-    if isinstance(n, (Float, float)):
+    try:
+        n = as_int(n)
+    except ValueError:
         return False
-    n = int(n)
 
     # Step 1, do quick composite testing via trial division.  The individual
     # modulo tests benchmark faster than one or two primorial igcds for me.

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -517,7 +517,7 @@ def isprime(n):
     >>> n == int(n)
     True
     >>> n = Float(near_int, 20)
-    >>> n = int(n)
+    >>> n == int(n)
     False
 
     See Also

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -132,6 +132,7 @@ def test_isprime():
     sieve.extend(3000)
     assert isprime(2819)
     assert not isprime(2931)
+    assert not isprime(2.0)
 
 
 def test_is_square():


### PR DESCRIPTION
A strict=True flag can be set to False if one wants to
get the integer value of a float that tests equal to its
integer value. But this is not recommended since floats
have limited precision:
```python
int(1.000000000000000000001) == 1
int(1e23) != 10**23
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #9097 as an alternative
closes #16045 
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * AskPrimeHandler will return None if the input is equal to an Integer but contains Float values that make it imprecise
* core
  * compatibility - as_int now rejects (by default) non-literal integer input. This means many number theory functions now raise TypeError on integral float inputs like `7.0`.
<!-- END RELEASE NOTES -->
