### PR TITLE
Add assumptions on indexed symbols

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -390,13 +390,10 @@ class IndexedBase(Expr, NotIterable):
     Assumptions can be specified with keyword arguments the same way as for Symbol:
 
     >>> A_real = IndexedBase('A', real=True)
+    >>> A_real.is_real
+    True
     >>> A != A_real
     True
-    >>> A.assumptions0
-    {'commutative': True}
-    >>> sorted(A_real.assumptions0.items())
-    [('commutative', True), ('complex', True), ('hermitian', True), ('imaginary', False), ('real', True)]
-
     """
     is_commutative = True
     is_symbol = True

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -159,13 +159,15 @@ class Indexed(Expr):
                 return base[args]
 
 
-        # Apply assumptions, with same logic as for Symbol.__new__.
-        obj = Expr.__new__(cls, base, *args, **kw_args)
+        # Apply assumptions, see sympy.core.symbol.Symbol
         assumptions = dict() if assumptions is None else assumptions
+        tmp_asm_copy = assumptions.copy()
+
         is_commutative = fuzzy_bool(assumptions.get('commutative', True))
         assumptions['commutative'] = is_commutative
+        obj = Expr.__new__(cls, base, *args, **kw_args)
         obj._assumptions = StdFactKB(assumptions)
-
+        obj._assumptions._generator = tmp_asm_copy  # Issue #8873
         return obj
 
     @property

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -388,7 +388,15 @@ class IndexedBase(Expr, NotIterable):
     >>> B[i, j].shape
     (o, p)
 
+    Assumptions can be specified with keyword arguments the same way as for Symbol:
 
+    >>> A_real = IndexedBase('A', real=True)
+    >>> A != A_real
+    True
+    >>> A.assumptions0
+    {'commutative': True}
+    >>> sorted(A_real.assumptions0.items())
+    [('commutative', True), ('complex', True), ('hermitian', True), ('imaginary', False), ('real', True)]
 
     """
     is_commutative = True

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -143,7 +143,7 @@ class Indexed(Expr):
     is_symbol = True
     is_Atom = True
 
-   
+
     def __new__(cls, base, *args, **kw_args):
         from sympy.utilities.misc import filldedent
         from sympy.tensor.array.ndim_array import NDimArray

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -183,7 +183,7 @@ class Indexed(Expr):
         return obj
 
     def _hashable_content(self):
-        return super()._hashable_content() + tuple(sorted(self.assumptions0.items()))
+        return super(Indexed, self)._hashable_content() + tuple(sorted(self.assumptions0.items()))
 
     @property
     def name(self):
@@ -450,7 +450,7 @@ class IndexedBase(Expr, NotIterable):
         return self._name
 
     def _hashable_content(self):
-        return super()._hashable_content() + tuple(sorted(self.assumptions0.items()))
+        return super(IndexedBase, self)._hashable_content() + tuple(sorted(self.assumptions0.items()))
 
     @property
     def assumptions0(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -107,7 +107,7 @@ See the appropriate docstrings for a detailed explanation of the output.
 from __future__ import print_function, division
 
 from sympy.assumptions import Q
-from sympy.core.assumptions import StdFactKB
+from sympy.core.assumptions import StdFactKB, _assume_defined
 from sympy.core import Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import (is_sequence, string_types, NotIterable,
                                       Iterable)
@@ -144,7 +144,7 @@ class Indexed(Expr):
     def _filter_assumptions(kw_args):
         """Split the given dict into two parts: assumptions and not assumptions.
            Keys are taken as assumptions if they correspond to a handler on ``Q``."""
-        assumptions = {k: v for k, v in kw_args.items() if hasattr(Q, k)}
+        assumptions = {k: v for k, v in kw_args.items() if k in _assume_defined}
         Symbol._sanitize(assumptions)
         # return assumptions, not assumptions
         return assumptions, {k: v for k, v in kw_args.items() if k not in assumptions}

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -106,7 +106,6 @@ See the appropriate docstrings for a detailed explanation of the output.
 
 from __future__ import print_function, division
 
-from sympy.assumptions import Q
 from sympy.core.assumptions import StdFactKB, _assume_defined
 from sympy.core import Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import (is_sequence, string_types, NotIterable,

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -212,6 +212,10 @@ class Indexed(Expr):
             return S.Zero
 
     @property
+    def assumptions0(self):
+        return {k: v for k, v in self._assumptions.items() if v is not None}
+
+    @property
     def base(self):
         """Returns the ``IndexedBase`` of the ``Indexed`` object.
 
@@ -438,6 +442,10 @@ class IndexedBase(Expr, NotIterable):
     @property
     def name(self):
         return self._name
+
+    @property
+    def assumptions0(self):
+        return {k: v for k, v in self._assumptions.items() if v is not None}
 
     def __getitem__(self, indices, **kw_args):
         # Propagate assumptions onto new Indexed object.

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -436,6 +436,7 @@ class IndexedBase(Expr, NotIterable):
         obj._strides = strides
         obj._name = str(label)
         assumptions, _ = Indexed._filter_assumptions(kw_args)
+        obj._init_assumptions = assumptions
         Indexed._set_assumptions(obj, assumptions)
         return obj
 
@@ -449,7 +450,7 @@ class IndexedBase(Expr, NotIterable):
 
     def __getitem__(self, indices, **kw_args):
         # Propagate assumptions onto new Indexed object.
-        kw_args.update(self._assumptions)
+        kw_args.update(self._init_assumptions)
         if is_sequence(indices):
             # Special case needed because M[*my_tuple] is a syntax error.
             if self.shape and len(self.shape) != len(indices):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -166,7 +166,7 @@ class Indexed(Expr):
         if not args:
             raise IndexException("Indexed needs at least one index.")
         if isinstance(base, (string_types, Symbol)):
-            base = IndexedBase(base)
+            base = IndexedBase(base, **kw_args)
         elif not hasattr(base, '__getitem__') and not isinstance(base, IndexedBase):
             raise TypeError(filldedent("""
                 Indexed expects string, Symbol, or IndexedBase as base."""))

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -182,6 +182,9 @@ class Indexed(Expr):
         Indexed._set_assumptions(obj, assumptions)
         return obj
 
+    def _hashable_content(self):
+        return super()._hashable_content() + tuple(sorted(self.assumptions0.items()))
+
     @property
     def name(self):
         return str(self)
@@ -400,6 +403,8 @@ class IndexedBase(Expr, NotIterable):
     >>> B[i, j].shape
     (o, p)
 
+
+
     """
     is_commutative = True
     is_symbol = True
@@ -443,6 +448,9 @@ class IndexedBase(Expr, NotIterable):
     @property
     def name(self):
         return self._name
+
+    def _hashable_content(self):
+        return super()._hashable_content() + tuple(sorted(self.assumptions0.items()))
 
     @property
     def assumptions0(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -163,7 +163,11 @@ class Indexed(Expr):
                 return base[args]
 
         obj = Expr.__new__(cls, base, *args, **kw_args)
-        IndexedBase._set_assumptions(obj, base.assumptions0)
+
+        try:
+            IndexedBase._set_assumptions(obj, base.assumptions0)
+        except AttributeError:
+            IndexedBase._set_assumptions(obj, {})
         return obj
 
     def _hashable_content(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -467,7 +467,6 @@ class IndexedBase(Expr, NotIterable):
         return {k: v for k, v in self._assumptions.items() if v is not None}
 
     def __getitem__(self, indices, **kw_args):
-        # Propagate assumptions onto new Indexed object.
         if is_sequence(indices):
             # Special case needed because M[*my_tuple] is a syntax error.
             if self.shape and len(self.shape) != len(indices):

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -168,8 +168,8 @@ def test_Idx_subs():
 def test_IndexedBase_sugar():
     i, j = symbols('i j', integer=True)
     a = symbols('a')
-    A1 = Indexed(a, i, j, real=True)
-    A2 = IndexedBase(a, real=True)
+    A1 = Indexed(a, i, j)
+    A2 = IndexedBase(a)
     assert A1 == A2[i, j]
     assert A1 == A2[(i, j)]
     assert A1 == A2[[i, j]]
@@ -207,8 +207,7 @@ def test_IndexedBase_assumptions():
     i = Symbol('i', integer=True)
     a = Symbol('a')
     A = IndexedBase(a, positive=True)
-    b = Indexed(a, i, positive=True)
-    for c in (A, b, A[i]):
+    for c in (A, A[i]):
         assert c.is_real
         assert c.is_complex
         assert not c.is_imaginary
@@ -219,8 +218,7 @@ def test_IndexedBase_assumptions():
 
     assert A != IndexedBase(a)
     assert A == IndexedBase(a, positive=True, real=True)
-    assert b != Indexed(a, i, integer=True)
-    assert b == Indexed(a, i, positive=True, real=True)
+    assert A[i] != Indexed(a, i)
 
 
 def test_Indexed_constructor():

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -4,7 +4,7 @@ from sympy.tensor.indexed import IndexException
 from sympy.utilities.pytest import raises, XFAIL
 
 # import test:
-from sympy import IndexedBase, Idx, Indexed, S, sin, cos, Sum, Piecewise, And, Order, LessThan, StrictGreaterThan, \
+from sympy import IndexedBase, Idx, Indexed, S, sin, cos, exp, log, Sum, Piecewise, And, Order, LessThan, StrictGreaterThan, \
     GreaterThan, StrictLessThan, Range, Array, Subs, Function, KroneckerDelta, Derivative
 
 
@@ -201,6 +201,21 @@ def test_IndexedBase_shape():
     assert F.shape == Tuple(m)
     assert F[i].subs(i, j) == F[j]
     raises(IndexException, lambda: F[i, j])
+
+
+def test_IndexedBase_assumptions():
+    i = Symbol('i', integer=True)
+    a = Symbol('a')
+    A = IndexedBase(a, real=True, positive=True)
+    b = Indexed(a, i, real=True, positive=True)
+    for c in (A, b, A[i]):
+        assert c.is_real
+        assert c.is_complex
+        assert not c.is_imaginary
+        assert c.is_nonnegative
+        assert c.is_nonzero
+        assert c.is_commutative
+        assert log(exp(c)) == c
 
 
 def test_Indexed_constructor():

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -168,8 +168,8 @@ def test_Idx_subs():
 def test_IndexedBase_sugar():
     i, j = symbols('i j', integer=True)
     a = symbols('a')
-    A1 = Indexed(a, i, j)
-    A2 = IndexedBase(a)
+    A1 = Indexed(a, i, j, real=True)
+    A2 = IndexedBase(a, real=True)
     assert A1 == A2[i, j]
     assert A1 == A2[(i, j)]
     assert A1 == A2[[i, j]]

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -206,8 +206,8 @@ def test_IndexedBase_shape():
 def test_IndexedBase_assumptions():
     i = Symbol('i', integer=True)
     a = Symbol('a')
-    A = IndexedBase(a, real=True, positive=True)
-    b = Indexed(a, i, real=True, positive=True)
+    A = IndexedBase(a, positive=True)
+    b = Indexed(a, i, positive=True)
     for c in (A, b, A[i]):
         assert c.is_real
         assert c.is_complex
@@ -216,6 +216,11 @@ def test_IndexedBase_assumptions():
         assert c.is_nonzero
         assert c.is_commutative
         assert log(exp(c)) == c
+
+    assert A != IndexedBase(a)
+    assert A == IndexedBase(a, positive=True, real=True)
+    assert b != Indexed(a, i, integer=True)
+    assert b == Indexed(a, i, positive=True, real=True)
 
 
 def test_Indexed_constructor():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Constructor of ``IndexedBase`` now accepts assumptions the same way that ``Symbol`` accepts them. 

Fixes #13992.

#### Other comments

The following assertions all succeed after this change:

``` python
from sympy import Symbol, log, exp, ask, Q, IndexedBase, Indexed

i = Symbol("i", integer=True)
X = IndexedBase("X", real=True)

assert ask(Q.real(X))
assert ask(Q.real(X[i]))
assert log(exp(X)) == X
assert log(exp(X[i])) == X[i]
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * added support for assumptions on IndexedBase
<!-- END RELEASE NOTES -->
