### PR TITLE
Polynomials containing NaN should be illegal

### DIFF
--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -196,7 +196,12 @@ def _parallel_dict_from_expr_if_gens(exprs, opt):
             coeff, monom = [], [0]*k
 
             for factor in Mul.make_args(term):
-                if not _not_a_coeff(factor) and factor.is_Number:
+                not_a_coeff = _not_a_coeff(factor)
+                if not_a_coeff:
+                    raise PolynomialError(
+                        "{} is not a valid coefficient.".format(factor))
+
+                if not not_a_coeff and factor.is_Number:
                     coeff.append(factor)
                 else:
                     try:
@@ -255,7 +260,12 @@ def _parallel_dict_from_expr_no_gens(exprs, opt):
             coeff, elements = [], {}
 
             for factor in Mul.make_args(term):
-                if not _not_a_coeff(factor) and (factor.is_Number or _is_coeff(factor)):
+                not_a_coeff = _not_a_coeff(factor)
+                if not_a_coeff:
+                    raise PolynomialError(
+                        "{} is not a valid coefficient.".format(factor))
+
+                if not not_a_coeff and (factor.is_Number or _is_coeff(factor)):
                     coeff.append(factor)
                 else:
                     if opt.series is False:

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -138,4 +138,3 @@ def test_issue_11538():
         assert construct_domain(x + n)[0] == ZZ[x, n]
     assert construct_domain(GoldenRatio)[0] == EX
     assert construct_domain(x + GoldenRatio)[0] == EX
-

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -138,3 +138,4 @@ def test_issue_11538():
         assert construct_domain(x + n)[0] == ZZ[x, n]
     assert construct_domain(GoldenRatio)[0] == EX
     assert construct_domain(x + GoldenRatio)[0] == EX
+

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -145,6 +145,8 @@ def test_Poly_from_list():
 
     raises(MultivariatePolynomialError, lambda: Poly.from_list([[]], gens=(x, y)))
 
+    raises(PolynomialError, lambda: Poly.from_list([S.NaN, S.NaN], gens=(x)))
+
 
 def test_Poly_from_poly():
     f = Poly(x + 7, x, domain=ZZ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I have discovered some unexpected behaviors for polynomials containing NaN as coefficients

<img src="https://user-images.githubusercontent.com/34944973/53463106-5905e580-3a89-11e9-813c-48d1516df516.png" width="384px">

It gives incorrect roots like above.

It is silently giving incorrect results, and would cause problems for places using polynomial module, where `nan` value can be expected to be thrown out in the middle of computation.

I don't know if only `roots` is having problem with `nan`, and if some other methods are having problems with `nan`, it would be better be handled as exception while creation.

#### Other comments

Also, I think the `simplify` makes generators `nan` like in below

<img src="https://user-images.githubusercontent.com/34944973/53463253-c154c700-3a89-11e9-8b66-4ce3994725ad.png" width="384px">

should it also be an issue?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - Fixed wrong results caused by polynomials containing `nan`.
  - Polynomials will raise `PolynomialError` if it contains `nan` in any coefficients or exponents
<!-- END RELEASE NOTES -->
