### PR TITLE
Add tensorflow to doctest dependency in lambdify test

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -172,7 +172,7 @@ def _import(module, reload=False):
 # linecache.
 _lambdify_generated_counter = 1
 
-@doctest_depends_on(modules=('numpy',), python_version=(3,))
+@doctest_depends_on(modules=('numpy', 'tensorflow', ), python_version=(3,))
 def lambdify(args, expr, modules=None, printer=None, use_imps=True,
              dummify=False):
     """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

While running `bin/doctest`, I'm encountering failures with only-numpy environments

```
================================================= test process starts ==================================================
executable:         /home/sylee957/anaconda3/envs/sympy_dev_36_numpy/bin/python  (3.6.8-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python
numpy:              1.15.4
hash randomization: on (PYTHONHASHSEED=762624080)

sympy/plotting/experimental_lambdify.py[2] ..                                                                       [OK]
sympy/utilities/lambdify.py[4] ...F                                                                               [FAIL]

________________________________________________________________________________________________________________________
__________________________________________ sympy.utilities.lambdify.lambdify ___________________________________________
File "/mnt/c/users/sylee/documents/github/sympy/sympy/utilities/lambdify.py", line 584, in sympy.utilities.lambdify.lambdify
Failed example:
    import tensorflow as tf
Exception raised:
    Traceback (most recent call last):
      File "/home/sylee957/anaconda3/envs/sympy_dev_36_numpy/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest sympy.utilities.lambdify.lambdify[76]>", line 1, in <module>
        import tensorflow as tf
    ModuleNotFoundError: No module named 'tensorflow'
**********************************************************************
```

Because one of the doctest silently depends on the tensorflow.
This issue is not visible on travis, because travis tests the dependencies all at once, or none for all.

Now it should properly skip the test
```
================================================= test process starts ==================================================
executable:         /home/sylee957/anaconda3/envs/sympy_dev_36_numpy/bin/python  (3.6.8-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python
numpy:              1.15.4
hash randomization: on (PYTHONHASHSEED=4096827460)

sympy/plotting/experimental_lambdify.py[2] ..                                                                       [OK]
sympy/utilities/lambdify.py[4] ...s                                                                                 [OK]

================================= tests finished: 5 passed, 1 skipped, in 0.04 seconds =================================
```

Also, I have found that this line had been added in #15768 https://github.com/sympy/sympy/blob/d44e6038bec476750bcbaf0fcffff4a108097e3e/sympy/utilities/lambdify.py#L18
But it does not seem like working as it advertises.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
