### PR TITLE
This change helps in handling unicode text better

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -941,7 +941,7 @@ class Basic(with_metaclass(ManagedProperties)):
 
         sequence = list(sequence)
         for i, s in enumerate(sequence):
-            if type(s[0]) is str:
+            if isinstance(s[0], string_types):
                 # when old is a string we prefer Symbol
                 s = Symbol(s[0]), s[1]
             try:

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -7,7 +7,7 @@ import sys
 from sympy.core.basic import (Basic, Atom, preorder_traversal, as_Basic,
     _atomic)
 from sympy.core.singleton import S
-from sympy.core.symbol import symbols
+from sympy.core.symbol import symbols, Symbol
 from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
@@ -116,6 +116,8 @@ def test_subs():
     # will convert the first to a symbol but will raise an error if foo
     # cannot be sympified; sympification is strict if foo is not string
     raises(ValueError, lambda: b21.subs(b1='bad arg'))
+
+    assert Symbol(u"text").subs({u"text": b1}) == b1
 
 
 def test_atoms():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16087 

#### Brief description of what is fixed or changed
In python 2.7, earlier `print(sympy.Symbol(u"s").subs({u"s": 1}))` gave the output as `s` but should give `1`. Now fixed. This was because type of s[0] being generated was unicode

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improvised Unicode text handling by subs
<!-- END RELEASE NOTES -->
