### PR TITLE
Cleanup imports in matrices module

### DIFF
--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -4,23 +4,21 @@ Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
 from .common import ShapeError, NonSquareMatrixError
-
-from .matrices import DeferredVector, MatrixBase
-
 from .dense import (
-    GramSchmidt, Matrix, casoratian, diag, eye, hessian, jordan_cell,
+    GramSchmidt, casoratian, diag, eye, hessian, jordan_cell,
     list2numpy, matrix2numpy, matrix_multiply_elementwise, ones,
     randMatrix, rot_axis1, rot_axis2, rot_axis3, symarray, wronskian,
     zeros)
+from .dense import MutableDenseMatrix
+from .matrices import DeferredVector, MatrixBase
 
-MutableDenseMatrix = MutableMatrix = Matrix
+Matrix = MutableMatrix = MutableDenseMatrix
 
 from .sparse import MutableSparseMatrix
+from .immutable import ImmutableDenseMatrix, ImmutableSparseMatrix
 
+ImmutableMatrix = ImmutableDenseMatrix
 SparseMatrix = MutableSparseMatrix
-
-from .immutable import (
-    ImmutableMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix)
 
 from .expressions import (
     MatrixSlice, BlockDiagMatrix, BlockMatrix, FunctionMatrix, Identity,

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -3,8 +3,9 @@
 Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
-from .matrices import (DeferredVector, ShapeError, NonSquareMatrixError,
-                       MatrixBase)
+from .common import ShapeError, NonSquareMatrixError
+
+from .matrices import DeferredVector, MatrixBase
 
 from .dense import (
     GramSchmidt, Matrix, casoratian, diag, eye, hessian, jordan_cell,
@@ -18,10 +19,12 @@ from .sparse import MutableSparseMatrix
 
 SparseMatrix = MutableSparseMatrix
 
-from .immutable import ImmutableMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
+from .immutable import (
+    ImmutableMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix)
 
-from .expressions import (MatrixSlice, BlockDiagMatrix, BlockMatrix,
-                          FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,
-                          MatrixSymbol, Trace, Transpose, ZeroMatrix, blockcut, block_collapse,
-                          matrix_symbols, Adjoint, hadamard_product, HadamardProduct,
-                          Determinant, det, DiagonalMatrix, DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct)
+from .expressions import (
+    MatrixSlice, BlockDiagMatrix, BlockMatrix, FunctionMatrix, Identity,
+    Inverse, MatAdd, MatMul, MatPow, MatrixExpr, MatrixSymbol, Trace,
+    Transpose, ZeroMatrix, blockcut, block_collapse, matrix_symbols, Adjoint,
+    hadamard_product, HadamardProduct, Determinant, det, DiagonalMatrix,
+    DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -4,27 +4,25 @@ when creating more advanced matrices (e.g., matrices over rings,
 etc.).
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
-from sympy.core.add import Add
-from sympy.core.basic import Basic, Atom
+from collections import defaultdict
+from types import FunctionType
+
+from sympy.assumptions.refine import refine
+from sympy.core.basic import Atom
+from sympy.core.compatibility import (
+    Iterable, as_int, is_sequence, range, reduce)
+from sympy.core.decorators import call_highest_priority
 from sympy.core.expr import Expr
-from sympy.core.symbol import Symbol
 from sympy.core.function import count_ops
 from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import is_sequence, default_sort_key, range, \
-    NotIterable, Iterable
-
-from sympy.simplify import simplify as _simplify, signsimp, nsimplify
-from sympy.utilities.iterables import flatten
 from sympy.functions import Abs
-from sympy.core.compatibility import reduce, as_int, string_types
-from sympy.assumptions.refine import refine
-from sympy.core.decorators import call_highest_priority
+from sympy.simplify import simplify as _simplify
+from sympy.utilities.iterables import flatten
 
-from types import FunctionType
-from collections import defaultdict
 
 class MatrixError(Exception):
     pass

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,25 +1,23 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import random
-from sympy import Derivative
 
 from sympy.core import SympifyError
 from sympy.core.basic import Basic
+from sympy.core.compatibility import is_sequence, range, reduce
 from sympy.core.expr import Expr
-from sympy.core.compatibility import is_sequence, as_int, range, reduce
 from sympy.core.function import count_ops, expand_mul
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.functions.elementary.complexes import Abs
-from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.simplify import simplify as _simplify
-from sympy.utilities.misc import filldedent
-from sympy.utilities.decorator import doctest_depends_on
-
-from sympy.matrices.matrices import MatrixBase, ShapeError
+from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.matrices.common import a2idx, classof
+from sympy.matrices.matrices import MatrixBase, ShapeError
+from sympy.simplify import simplify as _simplify
+from sympy.utilities.decorator import doctest_depends_on
+from sympy.utilities.misc import filldedent
+
 
 def _iszero(x):
     """Returns True if x is zero."""

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -5,14 +5,14 @@ The dense matrix is stored as a list of lists.
 
 """
 
-from sympy.matrices.densetools import col, eye, augment
-from sympy.matrices.densetools import rowadd, rowmul, conjugate_transpose
-from sympy.core.symbol import symbols
+import copy
+
 from sympy.core.compatibility import range
 from sympy.core.power import isqrt
+from sympy.core.symbol import symbols
+from sympy.matrices.densetools import (
+    augment, col, conjugate_transpose, eye, rowadd, rowmul)
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-
-import copy
 
 SymPyDeprecationWarning(
     feature="densesolve",

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,12 +1,11 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
-from sympy.core import Basic, Integer, Tuple, Dict, S, sympify
+from sympy.core import Basic, Dict, Integer, S, Tuple, sympify
 from sympy.core.sympify import converter as sympify_converter
-
-from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.dense import DenseMatrix
-from sympy.matrices.sparse import SparseMatrix, MutableSparseMatrix
 from sympy.matrices.expressions import MatrixExpr
+from sympy.matrices.matrices import MatrixBase
+from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
 
 def sympify_matrix(arg):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,36 +1,33 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
+
+from types import FunctionType
 
 from mpmath.libmp.libmpf import prec_to_dps
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic
+from sympy.core.compatibility import (
+    Callable, NotIterable, as_int, default_sort_key, is_sequence, range,
+    reduce, string_types)
+from sympy.core.decorators import deprecated
 from sympy.core.expr import Expr
 from sympy.core.function import expand_mul
+from sympy.core.numbers import Float, Integer, mod_inverse
 from sympy.core.power import Pow
-from sympy.core.symbol import (Symbol, Dummy, symbols,
-    _uniquely_named_symbol)
-from sympy.core.numbers import Integer, mod_inverse, Float
 from sympy.core.singleton import S
+from sympy.core.symbol import Dummy, Symbol, _uniquely_named_symbol, symbols
 from sympy.core.sympify import sympify
-from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.functions import exp, factorial
-from sympy.polys import PurePoly, roots, cancel
+from sympy.functions.elementary.miscellaneous import Max, Min, sqrt
+from sympy.polys import PurePoly, cancel, roots
 from sympy.printing import sstr
-from sympy.simplify import simplify as _simplify, nsimplify
-from sympy.core.compatibility import reduce, as_int, string_types, Callable
-
-from sympy.utilities.iterables import flatten, numbered_symbols
-from sympy.core.compatibility import (is_sequence, default_sort_key, range,
-    NotIterable)
-
+from sympy.simplify import nsimplify
+from sympy.simplify import simplify as _simplify
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import flatten, numbered_symbols
 
-from types import FunctionType
-
-from .common import (a2idx, MatrixError, ShapeError,
-        NonSquareMatrixError, MatrixCommon)
-
-from sympy.core.decorators import deprecated
+from .common import (
+    MatrixCommon, MatrixError, NonSquareMatrixError, ShapeError, a2idx)
 
 
 def _iszero(x):

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -1,10 +1,9 @@
-from __future__ import print_function, division
-from sympy.matrices import diag
+'''Functions returning normal forms of matrices'''
+from __future__ import division, print_function
 
-'''
-Functions returning normal forms of matrices
+from sympy.matrices.dense import diag
 
-'''
+
 def smith_normal_form(m, domain = None):
     '''
     Return the Smith Normal Form of a matrix `m` over the ring `domain`.

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1,20 +1,19 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import copy
 from collections import defaultdict
 
+from sympy.core.compatibility import Callable, as_int, is_sequence, range
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
-from sympy.core.compatibility import is_sequence, as_int, range, Callable
-from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S
 from sympy.functions import Abs
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import uniq
 
-from .matrices import MatrixBase, ShapeError
-from .dense import Matrix
 from .common import a2idx
+from .dense import Matrix
+from .matrices import MatrixBase, ShapeError
 
 
 class SparseMatrix(MatrixBase):

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,7 +1,8 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
-from sympy import SparseMatrix
+
+from .sparse import SparseMatrix
 
 
 def _doktocsr(dok):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

- [x] Cleanup unused imports in every files
- [x] Sort imports in every files (except for `__init__.py`)
- [x] 79 characters for import lines

And also,
- Moved the module docstring to the topmost position in `normalforms.py`
- Changed aliasing from `MutableDenseMatrix = MutableMatrix = Matrix` to `Matrix = MutableMatrix = MutableDenseMatrix` in `__init__.py`
- Added alias `ImmutableMatrix = ImmutableDenseMatrix` in `__init__.py`

I personally think that matrix class renaming should be better be done in init.py other than places such as `dense.py`. so that it can be modified more easily later.
However, I think there can be some more thing to modify, because some modules are still importing `Matrix` from `dense.py`.

And also, sorting imports in `__init__.py` is not possible because the import errors given by matrix expression modules when changing the ordering. I think there may have been some cyclic imports.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
