### PR TITLE
Make keywords in jordan_block explicit, and improve docs

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -916,7 +916,7 @@ class MatrixSpecial(MatrixRequired):
         eigenval = kwargs.get('eigenval', None)
         if eigenvalue is None and eigenval is None:
             raise ValueError("Must supply an eigenvalue")
-        elif eigenvalue is not None and eigenval is not None:
+        elif eigenvalue != eigenval and None not in (eigenval, eigenvalue):
             raise ValueError(
                 "Inconsistent values are given: 'eigenval'={}, "
                 "'eigenvalue'={}".format(eigenval, eigenvalue))

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -783,7 +783,7 @@ class MatrixSpecial(MatrixRequired):
         return klass._eval_eye(rows, cols)
 
     @classmethod
-    def jordan_block(kls, size=None, eigenvalue=None, band='upper', **kwargs):
+    def jordan_block(kls, size=None, eigenvalue=None, **kwargs):
         """Returns a Jordan block
 
         Parameters
@@ -909,6 +909,7 @@ class MatrixSpecial(MatrixRequired):
             ).warn()
 
         klass = kwargs.pop('cls', kls)
+        band = kwargs.pop('band', 'upper')
         rows = kwargs.pop('rows', None)
         cols = kwargs.pop('cols', None)
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -790,7 +790,7 @@ class MatrixSpecial(MatrixRequired):
         Parameters
         ==========
 
-        size: Integer, optional
+        size : Integer, optional
             Specifies the shape of the Jordan block matrix.
 
         eigenvalue : Number or Symbol

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -913,13 +913,16 @@ class MatrixSpecial(MatrixRequired):
         rows = kwargs.pop('rows', None)
         cols = kwargs.pop('cols', None)
 
-        if eigenvalue is None:
-            # allow for a shortened form of `eigenvalue`
-            eigenval = kwargs.get('eigenval', None)
+        eigenval = kwargs.get('eigenval', None)
+        if eigenvalue is None and eigenval is None:
+            raise ValueError("Must supply an eigenvalue")
+        elif eigenvalue is not None and eigenval is not None:
+            raise ValueError(
+                "Inconsistent values are given: 'eigenval'={}, "
+                "'eigenvalue'={}".format(eigenval, eigenvalue))
+        else:
             if eigenval is not None:
                 eigenvalue = eigenval
-            else:
-                raise ValueError("Must supply an eigenvalue")
 
         if (size, rows, cols) == (None, None, None):
             raise ValueError("Must supply a matrix size")

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -21,6 +21,7 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions import Abs
 from sympy.simplify import simplify as _simplify
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
 
 
@@ -782,29 +783,59 @@ class MatrixSpecial(MatrixRequired):
         return klass._eval_eye(rows, cols)
 
     @classmethod
-    def jordan_block(kls, *args, **kwargs):
-        """Returns a Jordan block with the specified size
-        and eigenvalue.  You may call `jordan_block` with
-        two args (size, eigenvalue) or with keyword arguments.
+    def jordan_block(kls, size=None, eigenvalue=None, band='upper',
+        cls=None, **kwargs):
+        """Returns a Jordan block
 
-        kwargs
+        Parameters
+        ==========
+
+        size: Integer, optional
+            Specifies the shape of the Jordan block matrix.
+
+        eigenvalue : Number or Symbol
+            Specifies the value for the main diagonal of the matrix.
+
+            .. note::
+                The keyword ``eigenval`` is also specified as an alias
+                of this keyword, but it is not recommended to use.
+
+                We may deprecate the alias in later release.
+
+        band : 'upper' or 'lower', optional
+            Specifies the position of the off-diagonal to put `1` s on.
+
+        cls : Matrix, optional
+            Specifies the matrix class of the output form.
+
+            If it is not specified, the class type where the method is
+            being executed on will be returned.
+
+        rows, cols : Integer, optional
+            Specifies the shape of the Jordan block matrix. See Notes
+            section for the details of how these key works.
+
+            .. note::
+                This feature will be deprecated in the future.
+
+
+        Returns
+        =======
+
+        Matrix
+            A Jordan block matrix.
+
+        Raises
         ======
 
-        size : rows and columns of the matrix
-
-        rows : rows of the matrix (if None, rows=size)
-
-        cols : cols of the matrix (if None, cols=size)
-
-        eigenvalue : value on the diagonal of the matrix
-
-        band : position of off-diagonal 1s.  May be 'upper' or
-               'lower'. (Default: 'upper')
-
-        cls : class of the returned matrix
+        ValueError
+            If insufficient arguments are given for matrix size
+            specification, or no eigenvalue is given.
 
         Examples
         ========
+
+        Creating a default Jordan block:
 
         >>> from sympy import Matrix
         >>> from sympy.abc import x
@@ -814,37 +845,81 @@ class MatrixSpecial(MatrixRequired):
         [0, x, 1, 0],
         [0, 0, x, 1],
         [0, 0, 0, x]])
+
+        Creating an alternative Jordan block matrix where `1` is on
+        lower off-diagonal:
+
         >>> Matrix.jordan_block(4, x, band='lower')
         Matrix([
         [x, 0, 0, 0],
         [1, x, 0, 0],
         [0, 1, x, 0],
         [0, 0, 1, x]])
+
+        Creating a Jordan block with keyword arguments
+
         >>> Matrix.jordan_block(size=4, eigenvalue=x)
         Matrix([
         [x, 1, 0, 0],
         [0, x, 1, 0],
         [0, 0, x, 1],
         [0, 0, 0, x]])
-        """
 
-        klass = kwargs.get('cls', kls)
-        size, eigenvalue = None, None
-        if len(args) == 2:
-            size, eigenvalue = args
-        elif len(args) == 1:
-            size = args[0]
-        elif len(args) != 0:
-            raise ValueError("'jordan_block' accepts 0, 1, or 2 arguments, not {}".format(len(args)))
-        rows, cols = kwargs.get('rows', None), kwargs.get('cols', None)
-        size = kwargs.get('size', size)
-        band = kwargs.get('band', 'upper')
-        # allow for a shortened form of `eigenvalue`
-        eigenvalue = kwargs.get('eigenval', eigenvalue)
-        eigenvalue = kwargs.get('eigenvalue', eigenvalue)
+        Notes
+        =====
+
+        .. note::
+            This feature will be deprecated in the future.
+
+        The keyword arguments ``size``, ``rows``, ``cols`` relates to
+        the Jordan block size specifications.
+
+        If you want to create a square Jordan block, specify either
+        one of the three arguments.
+
+        If you want to create a rectangular Jordan block, specify
+        ``rows`` and ``cols`` individually.
+
+        +--------------------------------+---------------------+
+        |        Arguments Given         |     Matrix Shape    |
+        +----------+----------+----------+----------+----------+
+        |   size   |   rows   |   cols   |   rows   |   cols   |
+        +==========+==========+==========+==========+==========+
+        |   size   |         Any         |   size   |   size   |
+        +----------+----------+----------+----------+----------+
+        |          |        None         |     ValueError      |
+        |          +----------+----------+----------+----------+
+        |   None   |   rows   |   None   |   rows   |   rows   |
+        |          +----------+----------+----------+----------+
+        |          |   None   |   cols   |   cols   |   cols   |
+        +          +----------+----------+----------+----------+
+        |          |   rows   |   cols   |   rows   |   cols   |
+        +----------+----------+----------+----------+----------+
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Jordan_matrix
+        """
+        if 'rows' in kwargs or 'cols' in kwargs:
+            SymPyDeprecationWarning(
+                feature="Keyword arguments 'rows' or 'cols'",
+                issue=16102,
+                useinstead="a more generic banded matrix constructor",
+                deprecated_since_version="1.4"
+            ).warn()
+
+        klass = kls if cls is None else cls
+        rows = kwargs.pop('rows', None)
+        cols = kwargs.pop('cols', None)
 
         if eigenvalue is None:
-            raise ValueError("Must supply an eigenvalue")
+            # allow for a shortened form of `eigenvalue`
+            eigenval = kwargs.get('eigenval', None)
+            if eigenval is not None:
+                eigenvalue = eigenval
+            else:
+                raise ValueError("Must supply an eigenvalue")
 
         if (size, rows, cols) == (None, None, None):
             raise ValueError("Must supply a matrix size")

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -783,8 +783,7 @@ class MatrixSpecial(MatrixRequired):
         return klass._eval_eye(rows, cols)
 
     @classmethod
-    def jordan_block(kls, size=None, eigenvalue=None, band='upper',
-        cls=None, **kwargs):
+    def jordan_block(kls, size=None, eigenvalue=None, band='upper', **kwargs):
         """Returns a Jordan block
 
         Parameters
@@ -909,7 +908,7 @@ class MatrixSpecial(MatrixRequired):
                 deprecated_since_version="1.4"
             ).warn()
 
-        klass = kls if cls is None else cls
+        klass = kwargs.pop('cls', kls)
         rows = kwargs.pop('rows', None)
         cols = kwargs.pop('cols', None)
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1162,6 +1162,8 @@ def test_jordan_block():
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(2))
     # non-integral size
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(3.5, 2))
+    # size not specified
+    raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(eigenvalue=2))
 
     # Deprecated feature
     raises(SymPyDeprecationWarning,
@@ -1183,6 +1185,10 @@ def test_jordan_block():
                 [0, 2, 1],
                 [0, 0, 2],
                 [0, 0, 0]])
+
+    # Using alias keyword
+    assert SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) == \
+        SpecialOnlyMatrix.jordan_block(size=3, eigenval=2)
 
 
 # SubspaceOnlyMatrix tests

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -16,8 +16,10 @@ from sympy.matrices import (
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
 from sympy.core.compatibility import long, iterable, range
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, capture
-from sympy.utilities.pytest import raises, XFAIL, slow, skip
+from sympy.utilities.pytest import (raises, XFAIL, slow, skip,
+    warns_deprecated_sympy)
 from sympy.solvers import solve
 from sympy.assumptions import Q
 
@@ -1148,8 +1150,6 @@ def test_diag():
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \
             == SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) \
             == SpecialOnlyMatrix.jordan_block(3, 2, band='upper') == Matrix([
                     [2, 1, 0],
                     [0, 2, 1],
@@ -1162,6 +1162,27 @@ def test_jordan_block():
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(2))
     # non-integral size
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(3.5, 2))
+
+    # Deprecated feature
+    raises(SymPyDeprecationWarning,
+    lambda: SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2))
+
+    raises(SymPyDeprecationWarning,
+    lambda: SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2))
+
+    with warns_deprecated_sympy():
+        assert SpecialOnlyMatrix.jordan_block(3, 2) == \
+            SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) == \
+            SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2)
+
+    with warns_deprecated_sympy():
+        assert SpecialOnlyMatrix.jordan_block(
+            rows=4, cols=3, eigenvalue=2) == \
+            Matrix([
+                [2, 1, 0],
+                [0, 2, 1],
+                [0, 0, 2],
+                [0, 0, 0]])
 
 
 # SubspaceOnlyMatrix tests

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1164,6 +1164,10 @@ def test_jordan_block():
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(3.5, 2))
     # size not specified
     raises(ValueError, lambda: SpecialOnlyMatrix.jordan_block(eigenvalue=2))
+    # inconsistent eigenvalue
+    raises(ValueError,
+    lambda: SpecialOnlyMatrix.jordan_block(
+        eigenvalue=2, eigenval=4))
 
     # Deprecated feature
     raises(SymPyDeprecationWarning,

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1150,10 +1150,14 @@ def test_diag():
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \
             == SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) \
-            == SpecialOnlyMatrix.jordan_block(3, 2, band='upper') == Matrix([
-                    [2, 1, 0],
-                    [0, 2, 1],
-                    [0, 0, 2]])
+            == SpecialOnlyMatrix.jordan_block(3, 2, band='upper') \
+            == SpecialOnlyMatrix.jordan_block(
+                size=3, eigenval=2, eigenvalue=2) \
+            == Matrix([
+                [2, 1, 0],
+                [0, 2, 1],
+                [0, 0, 2]])
+
     assert SpecialOnlyMatrix.jordan_block(3, 2, band='lower') == Matrix([
                     [2, 0, 0],
                     [1, 2, 0],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#14030 #15370


#### Brief description of what is fixed or changed

I think it is possible to use explicit keywords for `jordan_block`, without much backward incompatible changes.

And also, I have made improvements to the docs, such as properly making it as a numpydoc format,
and creating a table for `rows`, `cols`, `size`.

However, I find keywords `eigenval` and `eigenvalue` are duplicate, and though I have used `eigenvalue` in here, it can also be changed to `eigenval`, or even deprecating one of them.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Changed keywords for `jordan_block` explicit. Note that these will become keyword-only in the future when SymPy drops Python 2 support. 
  - Improved the documentation of `jordan_block`
  - Raise `ValueError` when keyword arguments `'eigenval'` and `'eigenvalue'` have inconsistent value.
<!-- END RELEASE NOTES -->
