### PR TITLE
Cleanup matrix aliases, sympify table, and use absolute imports

### DIFF
--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -241,7 +241,7 @@ def interpolating_spline(d, x, X, Y):
     """
     from sympy import symbols, Number, Dummy, Rational
     from sympy.solvers.solveset import linsolve
-    from sympy.matrices.dense import Matrix
+    from sympy.matrices.dense import MutableDenseMatrix as Matrix
 
     # Input sanitization
     d = sympify(d)

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -3,26 +3,23 @@
 Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
-from .common import ShapeError, NonSquareMatrixError
-from .dense import (
-    GramSchmidt, casoratian, diag, eye, hessian, jordan_cell,
-    list2numpy, matrix2numpy, matrix_multiply_elementwise, ones,
-    randMatrix, rot_axis1, rot_axis2, rot_axis3, symarray, wronskian,
-    zeros)
-from .dense import MutableDenseMatrix
+from .common import NonSquareMatrixError, ShapeError
+from .dense import (GramSchmidt, MutableDenseMatrix, casoratian, diag, eye,
+                    hessian, jordan_cell, list2numpy, matrix2numpy,
+                    matrix_multiply_elementwise, ones, randMatrix, rot_axis1,
+                    rot_axis2, rot_axis3, symarray, wronskian, zeros)
+from .expressions import (Adjoint, BlockDiagMatrix, BlockMatrix, Determinant,
+                          DiagonalMatrix, DiagonalOf, DotProduct,
+                          FunctionMatrix, HadamardProduct, Identity, Inverse,
+                          KroneckerProduct, MatAdd, MatMul, MatPow, MatrixExpr,
+                          MatrixSlice, MatrixSymbol, Trace, Transpose,
+                          ZeroMatrix, block_collapse, blockcut, det,
+                          hadamard_product, kronecker_product, matrix_symbols,
+                          trace)
+from .immutable import ImmutableDenseMatrix, ImmutableSparseMatrix
 from .matrices import DeferredVector, MatrixBase
+from .sparse import MutableSparseMatrix
 
 Matrix = MutableMatrix = MutableDenseMatrix
-
-from .sparse import MutableSparseMatrix
-from .immutable import ImmutableDenseMatrix, ImmutableSparseMatrix
-
 ImmutableMatrix = ImmutableDenseMatrix
 SparseMatrix = MutableSparseMatrix
-
-from .expressions import (
-    MatrixSlice, BlockDiagMatrix, BlockMatrix, FunctionMatrix, Identity,
-    Inverse, MatAdd, MatMul, MatPow, MatrixExpr, MatrixSymbol, Trace,
-    Transpose, ZeroMatrix, blockcut, block_collapse, matrix_symbols, Adjoint,
-    hadamard_product, HadamardProduct, Determinant, det, DiagonalMatrix,
-    DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -366,7 +366,7 @@ class DenseMatrix(MatrixBase):
         [1, 2],
         [3, 5]])
         """
-        return Matrix(self)
+        return MutableDenseMatrix(self)
 
     def equals(self, other, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,
@@ -424,7 +424,7 @@ def _force_mutable(x):
         a = x.__array__()
         if len(a.shape) == 0:
             return sympify(a)
-        return Matrix(x)
+        return MutableDenseMatrix(x)
     return x
 
 
@@ -611,7 +611,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         """
         if not is_sequence(value):
             raise TypeError("`value` must be an ordered iterable, not %s." % type(value))
-        return self.copyin_matrix(key, Matrix(value))
+        return self.copyin_matrix(key, MutableDenseMatrix(value))
 
     def copyin_matrix(self, key, value):
         """Copy in values from a matrix into the given bounds.
@@ -798,8 +798,6 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
 
     # Utility functions
 
-MutableMatrix = Matrix = MutableDenseMatrix
-
 ###########
 # Numpy Utility Functions:
 # list2numpy, matrix2numpy, symmarray, rot_axis[123]
@@ -877,7 +875,7 @@ def rot_axis3(theta):
     lil = ((ct, st, 0),
            (-st, ct, 0),
            (0, 0, 1))
-    return Matrix(lil)
+    return MutableDenseMatrix(lil)
 
 
 def rot_axis2(theta):
@@ -920,7 +918,7 @@ def rot_axis2(theta):
     lil = ((ct, 0, -st),
            (0, 1, 0),
            (st, 0, ct))
-    return Matrix(lil)
+    return MutableDenseMatrix(lil)
 
 
 def rot_axis1(theta):
@@ -963,7 +961,7 @@ def rot_axis1(theta):
     lil = ((1, 0, 0),
            (0, ct, st),
            (0, -st, ct))
-    return Matrix(lil)
+    return MutableDenseMatrix(lil)
 
 
 @doctest_depends_on(modules=('numpy',))
@@ -1073,8 +1071,6 @@ def casoratian(seqs, n, zero=True):
        True
 
     """
-    from .dense import Matrix
-
     seqs = list(map(sympify, seqs))
 
     if not zero:
@@ -1084,7 +1080,7 @@ def casoratian(seqs, n, zero=True):
 
     k = len(seqs)
 
-    return Matrix(k, k, f).det()
+    return MutableDenseMatrix(k, k, f).det()
 
 
 def eye(*args, **kwargs):
@@ -1097,9 +1093,7 @@ def eye(*args, **kwargs):
     zeros
     ones
     """
-    from .dense import Matrix
-
-    return Matrix.eye(*args, **kwargs)
+    return MutableDenseMatrix.eye(*args, **kwargs)
 
 
 def diag(*values, **kwargs):
@@ -1188,18 +1182,15 @@ def diag(*values, **kwargs):
 
     eye
     """
-
-    from .dense import Matrix
-
     # diag assumes any lists passed in are to be interpreted
     # as arguments to Matrix, so apply Matrix to any list arguments
     def normalize(m):
         if is_sequence(m) and not isinstance(m, MatrixBase):
-            return Matrix(m)
+            return MutableDenseMatrix(m)
         return m
     values = (normalize(m) for m in values)
 
-    return Matrix.diag(*values, **kwargs)
+    return MutableDenseMatrix.diag(*values, **kwargs)
 
 
 def GramSchmidt(vlist, orthonormal=False):
@@ -1317,9 +1308,7 @@ def jordan_cell(eigenval, n):
     [0, 0, x, 1],
     [0, 0, 0, x]])
     """
-    from .dense import Matrix
-
-    return Matrix.jordan_block(size=n, eigenvalue=eigenval)
+    return MutableDenseMatrix.jordan_block(size=n, eigenvalue=eigenval)
 
 
 def matrix_multiply_elementwise(A, B):
@@ -1356,9 +1345,8 @@ def ones(*args, **kwargs):
 
     if 'c' in kwargs:
         kwargs['cols'] = kwargs.pop('c')
-    from .dense import Matrix
 
-    return Matrix.ones(*args, **kwargs)
+    return MutableDenseMatrix.ones(*args, **kwargs)
 
 
 def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
@@ -1415,7 +1403,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     prng = prng or random.Random(seed)
 
     if not symmetric:
-        m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
+        m = MutableDenseMatrix._new(r, c, lambda i, j: prng.randint(min, max))
         if percent == 100:
             return m
         z = int(r*c*(100 - percent) // 100)
@@ -1460,14 +1448,12 @@ def wronskian(functions, var, method='bareiss'):
     sympy.matrices.mutable.Matrix.jacobian
     hessian
     """
-    from .dense import Matrix
-
     for index in range(0, len(functions)):
         functions[index] = sympify(functions[index])
     n = len(functions)
     if n == 0:
         return 1
-    W = Matrix(n, n, lambda i, j: functions[i].diff(var, j))
+    W = MutableDenseMatrix(n, n, lambda i, j: functions[i].diff(var, j))
     return W.det(method)
 
 
@@ -1482,10 +1468,7 @@ def zeros(*args, **kwargs):
     eye
     diag
     """
-
     if 'c' in kwargs:
         kwargs['cols'] = kwargs.pop('c')
 
-    from .dense import Matrix
-
-    return Matrix.zeros(*args, **kwargs)
+    return MutableDenseMatrix.zeros(*args, **kwargs)

--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -1,5 +1,5 @@
 from sympy.matrices.expressions import MatrixExpr
-from sympy import MatrixBase
+from sympy.matrices.matrices import MatrixBase
 
 
 class ElementwiseApplyFunction(MatrixExpr):

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -16,7 +16,7 @@ from sympy.matrices.expressions.trace import Trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
-from sympy.matrices import Matrix, ShapeError
+from sympy.matrices.common import ShapeError
 from sympy.functions.elementary.complexes import re, im
 
 class BlockMatrix(MatrixExpr):
@@ -101,6 +101,7 @@ class BlockMatrix(MatrixExpr):
         return self + other
 
     def _eval_transpose(self):
+        from sympy.matrices.dense import MutableDenseMatrix as Matrix
         # Flip all the individual matrices
         matrices = [transpose(matrix) for matrix in self.blocks]
         # Make a copy
@@ -127,6 +128,8 @@ class BlockMatrix(MatrixExpr):
         return Determinant(self)
 
     def as_real_imag(self):
+        from sympy.matrices.dense import MutableDenseMatrix as Matrix
+
         real_matrices = [re(matrix) for matrix in self.blocks]
         real_matrices = Matrix(self.blockshape[0], self.blockshape[1], real_matrices)
 
@@ -381,6 +384,7 @@ def bc_inverse(expr):
     return blockinverse_2x2(Inverse(reblock_2x2(expr.arg)))
 
 def blockinverse_1x1(expr):
+    from sympy.matrices.dense import MutableDenseMatrix as Matrix
     if isinstance(expr.arg, BlockMatrix) and expr.arg.blockshape == (1, 1):
         mat = Matrix([[expr.arg.blocks[0].inverse()]])
         return BlockMatrix(mat)
@@ -404,7 +408,7 @@ def deblock(B):
     wrap = lambda x: x if isinstance(x, BlockMatrix) else BlockMatrix([[x]])
     bb = B.blocks.applyfunc(wrap)  # everything is a block
 
-    from sympy import Matrix
+    from sympy.matrices.dense import MutableDenseMatrix as Matrix
     try:
         MM = Matrix(0, sum(bb[0, i].blocks.shape[1] for i in range(bb.shape[1])), [])
         for row in range(0, bb.shape[0]):

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division
 
 from .matexpr import MatrixExpr
 from sympy import Basic, sympify
-from sympy.matrices import Matrix
 from sympy.functions.elementary.complexes import re, im
 
 class FunctionMatrix(MatrixExpr):
@@ -49,4 +48,5 @@ class FunctionMatrix(MatrixExpr):
         return Trace(self).rewrite(Sum).doit()
 
     def as_real_imag(self):
-        return (re(Matrix(self)), im(Matrix(self)))
+        from sympy.matrices.dense import MutableDenseMatrix
+        return (re(MutableDenseMatrix(self)), im(MutableDenseMatrix(self)))

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -48,5 +48,5 @@ class FunctionMatrix(MatrixExpr):
         return Trace(self).rewrite(Sum).doit()
 
     def as_real_imag(self):
-        from sympy.matrices.dense import MutableDenseMatrix
-        return (re(MutableDenseMatrix(self)), im(MutableDenseMatrix(self)))
+        from sympy.matrices.dense import MutableDenseMatrix as Matrix
+        return (re(Matrix(self)), im(Matrix(self)))

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -5,7 +5,6 @@ from operator import add
 
 from sympy.core import Add, Basic, sympify
 from sympy.functions import adjoint
-from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, flatten, sort, condition,
     exhaust, do_one, glom)
@@ -118,6 +117,7 @@ def merge_explicit(matadd):
     A + [    ]
         [3  5]
     """
+    from sympy.matrices.matrices import MatrixBase
     groups = sift(matadd.args, lambda arg: isinstance(arg, MatrixBase))
     if len(groups[True]) > 1:
         return MatAdd(*(groups[False] + [reduce(add, groups[True])]))

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -591,7 +591,7 @@ class MatrixElement(Expr):
 
     def __new__(cls, name, n, m):
         n, m = map(sympify, (n, m))
-        from sympy import MatrixBase
+        from sympy.matrices.matrices import MatrixBase
         if isinstance(name, (MatrixBase,)):
             if n.is_Integer and m.is_Integer:
                 return name[n, m]
@@ -615,7 +615,7 @@ class MatrixElement(Expr):
         from sympy import Sum, symbols, Dummy
 
         if not isinstance(v, MatrixElement):
-            from sympy import MatrixBase
+            from sympy.matrices.matrices import MatrixBase
             if isinstance(self.parent, MatrixBase):
                 return self.parent.diff(v)[self.i, self.j]
             return S.Zero

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -10,7 +10,6 @@ from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
 from sympy.matrices.expressions.matexpr import (MatrixExpr, ShapeError,
         Identity, ZeroMatrix, GenericIdentity)
 from sympy.matrices.expressions.matpow import MatPow
-from sympy.matrices.matrices import MatrixBase
 
 
 class MatMul(MatrixExpr, Mul):
@@ -56,7 +55,8 @@ class MatMul(MatrixExpr, Mul):
         return (matrices[0].rows, matrices[-1].cols)
 
     def _entry(self, i, j, expand=True):
-        from sympy import Dummy, Sum, Mul, ImmutableMatrix, Integer
+        from sympy import Dummy, Sum, Mul, Integer
+        from sympy.matrices.immutable import ImmutableDenseMatrix
 
         coeff, matrices = self.as_coeff_matrices()
 
@@ -73,7 +73,7 @@ class MatMul(MatrixExpr, Mul):
             ind_ranges[i] = arg.shape[1] - 1
         matrices = [arg[indices[i], indices[i+1]] for i, arg in enumerate(matrices)]
         expr_in_sum = Mul.fromiter(matrices)
-        if any(v.has(ImmutableMatrix) for v in matrices):
+        if any(v.has(ImmutableDenseMatrix) for v in matrices):
             expand = True
         result = coeff*Sum(
                 expr_in_sum,
@@ -221,6 +221,7 @@ def merge_explicit(matmul):
     [    ]*A*[    ]
     [1  1]   [3  4]
     """
+    from sympy.matrices.matrices import MatrixBase
     if not any(isinstance(arg, MatrixBase) for arg in matmul.args):
         return matmul
     newargs = []

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -4,7 +4,6 @@ from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
 from .transpose import Transpose
 from sympy.core.sympify import _sympify
 from sympy.core.compatibility import range
-from sympy.matrices import MatrixBase
 from sympy.core import S, Basic
 
 
@@ -51,6 +50,7 @@ class MatPow(MatrixExpr):
         return A._entry(i, j)
 
     def doit(self, **kwargs):
+        from sympy.matrices.matrices import MatrixBase
         from sympy.matrices.expressions import Inverse
         deep = kwargs.get('deep', True)
         if deep:

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -8,6 +8,10 @@ from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
 
+def sympify_matrix(arg):
+    return arg.as_immutable()
+sympify_converter[MatrixBase] = sympify_matrix
+
 class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     """Create an immutable version of a matrix.
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -5,6 +5,7 @@ from sympy.core.cache import cacheit
 from sympy.core.sympify import converter as sympify_converter
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
+from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -5,13 +5,8 @@ from sympy.core.cache import cacheit
 from sympy.core.sympify import converter as sympify_converter
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
-from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
-
-def sympify_matrix(arg):
-    return arg.as_immutable()
-sympify_converter[MatrixBase] = sympify_matrix
 
 class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     """Create an immutable version of a matrix.
@@ -125,9 +120,6 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
 # the object is non-zero
 # See https://github.com/sympy/sympy/issues/7213
 ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero
-
-# make sure ImmutableDenseMatrix is aliased as ImmutableMatrix
-ImmutableMatrix = ImmutableDenseMatrix
 
 
 class ImmutableSparseMatrix(SparseMatrix, Basic):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1903,15 +1903,14 @@ class MatrixDeprecated(MatrixCommon):
     def _legacy_array_dot(self, b):
         """Compatibility function for deprecated behavior of ``matrix.dot(vector)``
         """
-        from .dense import MutableDenseMatrix
-
+        from .dense import MutableDenseMatrix as Matrix
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
                 if len(b) != self.cols and len(b) != self.rows:
                     raise ShapeError(
                         "Dimensions incorrect for dot product: %s, %s" % (
                             self.shape, len(b)))
-                return self.dot(MutableDenseMatrix(b))
+                return self.dot(Matrix(b))
             else:
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
@@ -2389,7 +2388,7 @@ class MatrixBase(MatrixDeprecated,
         [0, 0, 4, 0],
         [2, 2, 4, 2]])
         """
-        from .dense import MutableDenseMatrix
+        from .dense import MutableDenseMatrix as Matrix
 
         is_slice = isinstance(key, slice)
         i, j = key = self.key2ij(key)
@@ -2405,7 +2404,7 @@ class MatrixBase(MatrixDeprecated,
         else:
             if (not is_mat and
                     not isinstance(value, Basic) and is_sequence(value)):
-                value = MutableDenseMatrix(value)
+                value = Matrix(value)
                 is_mat = True
             if is_mat:
                 if is_slice:
@@ -3094,8 +3093,7 @@ class MatrixBase(MatrixDeprecated,
         if not self.is_square:
             raise NonSquareMatrixError("A Matrix must be square to invert.")
 
-        big = Matrix.hstack(
-            self.as_mutable(), Matrix.eye(self.rows))
+        big = Matrix.hstack(self.as_mutable(), Matrix.eye(self.rows))
         red = big.rref(iszerofunc=iszerofunc, simplify=True)[0]
         if any(iszerofunc(red[j, j]) for j in range(red.rows)):
             raise ValueError("Matrix det == 0; not invertible.")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2722,7 +2722,7 @@ class MatrixBase(MatrixDeprecated,
         multiply
         multiply_elementwise
         """
-        from .dense import MutableDenseMatrix
+        from .dense import MutableDenseMatrix as Matrix
 
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
@@ -2730,7 +2730,7 @@ class MatrixBase(MatrixDeprecated,
                     raise ShapeError(
                         "Dimensions incorrect for dot product: %s, %s" % (
                             self.shape, len(b)))
-                return self.dot(MutableDenseMatrix(b))
+                return self.dot(Matrix(b))
             else:
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
@@ -3090,12 +3090,12 @@ class MatrixBase(MatrixDeprecated,
         inverse_LU
         inverse_ADJ
         """
-        from .dense import MutableDenseMatrix
+        from .dense import MutableDenseMatrix as Matrix
         if not self.is_square:
             raise NonSquareMatrixError("A Matrix must be square to invert.")
 
-        big = MutableDenseMatrix.hstack(
-            self.as_mutable(), MutableDenseMatrix.eye(self.rows))
+        big = Matrix.hstack(
+            self.as_mutable(), Matrix.eye(self.rows))
         red = big.rref(iszerofunc=iszerofunc, simplify=True)[0]
         if any(iszerofunc(red[j, j]) for j in range(red.rows)):
             raise ValueError("Matrix det == 0; not invertible.")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1903,7 +1903,7 @@ class MatrixDeprecated(MatrixCommon):
     def _legacy_array_dot(self, b):
         """Compatibility function for deprecated behavior of ``matrix.dot(vector)``
         """
-        from .dense import Matrix
+        from .dense import MutableDenseMatrix
 
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
@@ -1911,7 +1911,7 @@ class MatrixDeprecated(MatrixCommon):
                     raise ShapeError(
                         "Dimensions incorrect for dot product: %s, %s" % (
                             self.shape, len(b)))
-                return self.dot(Matrix(b))
+                return self.dot(MutableDenseMatrix(b))
             else:
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
@@ -2389,7 +2389,7 @@ class MatrixBase(MatrixDeprecated,
         [0, 0, 4, 0],
         [2, 2, 4, 2]])
         """
-        from .dense import Matrix
+        from .dense import MutableDenseMatrix
 
         is_slice = isinstance(key, slice)
         i, j = key = self.key2ij(key)
@@ -2405,7 +2405,7 @@ class MatrixBase(MatrixDeprecated,
         else:
             if (not is_mat and
                     not isinstance(value, Basic) and is_sequence(value)):
-                value = Matrix(value)
+                value = MutableDenseMatrix(value)
                 is_mat = True
             if is_mat:
                 if is_slice:
@@ -2418,6 +2418,9 @@ class MatrixBase(MatrixDeprecated,
             else:
                 return i, j, self._sympify(value)
             return
+
+    def _sympy_(self):
+        return self.as_immutable()
 
     def add(self, b):
         """Return self + b """
@@ -2722,7 +2725,7 @@ class MatrixBase(MatrixDeprecated,
         multiply
         multiply_elementwise
         """
-        from .dense import Matrix
+        from .dense import MutableDenseMatrix
 
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
@@ -2730,7 +2733,7 @@ class MatrixBase(MatrixDeprecated,
                     raise ShapeError(
                         "Dimensions incorrect for dot product: %s, %s" % (
                             self.shape, len(b)))
-                return self.dot(Matrix(b))
+                return self.dot(MutableDenseMatrix(b))
             else:
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
@@ -3090,11 +3093,12 @@ class MatrixBase(MatrixDeprecated,
         inverse_LU
         inverse_ADJ
         """
-        from .dense import Matrix
+        from .dense import MutableDenseMatrix
         if not self.is_square:
             raise NonSquareMatrixError("A Matrix must be square to invert.")
 
-        big = Matrix.hstack(self.as_mutable(), Matrix.eye(self.rows))
+        big = MutableDenseMatrix.hstack(
+            self.as_mutable(), MutableDenseMatrix.eye(self.rows))
         red = big.rref(iszerofunc=iszerofunc, simplify=True)[0]
         if any(iszerofunc(red[j, j]) for j in range(red.rows)):
             raise ValueError("Matrix det == 0; not invertible.")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2419,9 +2419,6 @@ class MatrixBase(MatrixDeprecated,
                 return i, j, self._sympify(value)
             return
 
-    def _sympy_(self):
-        return self.as_immutable()
-
     def add(self, b):
         """Return self + b """
         return self + b

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -12,7 +12,6 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import uniq
 
 from .common import a2idx
-from .dense import Matrix
 from .matrices import MatrixBase, ShapeError
 
 
@@ -79,7 +78,8 @@ class SparseMatrix(MatrixBase):
                             self._smat[(i, j)] = value
         else:
             # handle full matrix forms with _handle_creation_inputs
-            r, c, _list = Matrix._handle_creation_inputs(*args)
+            from .dense import MutableDenseMatrix
+            r, c, _list = MutableDenseMatrix._handle_creation_inputs(*args)
             self.rows = r
             self.cols = c
             for i in range(self.rows):
@@ -1063,9 +1063,11 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
             self._smat[k, j] = v
 
     def copyin_list(self, key, value):
+        from .dense import MutableDenseMatrix
+
         if not is_sequence(value):
             raise TypeError("`value` must be of type list or tuple.")
-        self.copyin_matrix(key, Matrix(value))
+        self.copyin_matrix(key, MutableDenseMatrix(value))
 
     def copyin_matrix(self, key, value):
         # include this here because it's not part of BaseMatrix

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -78,8 +78,8 @@ class SparseMatrix(MatrixBase):
                             self._smat[(i, j)] = value
         else:
             # handle full matrix forms with _handle_creation_inputs
-            from .dense import MutableDenseMatrix
-            r, c, _list = MutableDenseMatrix._handle_creation_inputs(*args)
+            from .dense import MutableDenseMatrix as Matrix
+            r, c, _list = Matrix._handle_creation_inputs(*args)
             self.rows = r
             self.cols = c
             for i in range(self.rows):
@@ -1063,11 +1063,11 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
             self._smat[k, j] = v
 
     def copyin_list(self, key, value):
-        from .dense import MutableDenseMatrix
+        from .dense import MutableDenseMatrix as Matrix
 
         if not is_sequence(value):
             raise TypeError("`value` must be of type list or tuple.")
-        self.copyin_matrix(key, MutableDenseMatrix(value))
+        self.copyin_matrix(key, Matrix(value))
 
     def copyin_matrix(self, key, value):
         # include this here because it's not part of BaseMatrix

--- a/sympy/polys/tests/test_polymatrix.py
+++ b/sympy/polys/tests/test_polymatrix.py
@@ -1,4 +1,4 @@
-from sympy.matrices.dense import Matrix
+from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.polys.polymatrix import PolyMatrix
 from sympy.polys import Poly
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#6509 

#### Brief description of what is fixed or changed

There have been a lot of modules using `Matrix` as `MutableDenseMatrix`, but I think they should be changed to the exact class `MutableDenseMatrix` before any attempt to change SymPy's matrix to the immutable version.

Also, I have moved some `MatrixBase` or `Matrix` imports locally in matrix expression modules, to solve some issues potentially caused by cyclic imports between matrix expressions and explicit version.

I have cleaned the matrix aliasing under `dense.py` and `immutable.py`, and moved to the __init__.py, to minimize the side effects and to make module management easier.

Also, instead of modifying global sympify converter dictionary like before, I think that adding `_sympy_` method under the `MatrixBase` module should be more straightforward.

I have also sorted the imports in `__init__.py`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `Matrix` and `MutableMatrix` will raise `ImportError` when imported from `sympy.matrices.dense`. Use `sympy.matrices` instead
  - `ImmutableMatrix` will raise `ImportError` when imported from `sympy.matrices.immutable`. Use `sympy.matrices` instead

<!-- END RELEASE NOTES -->
