### PR TITLE
Stats:Improved parameter handling by Benini distribution

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -232,6 +232,17 @@ def Arcsin(name, a=0, b=1):
 class BeniniDistribution(SingleContinuousDistribution):
     _argnames = ('alpha', 'beta', 'sigma')
 
+    def __new__(name, *args):
+        alpha = args[BeniniDistribution._argnames.index('alpha')]
+        beta = args[BeniniDistribution._argnames.index('beta')]
+        sigma = args[BeniniDistribution._argnames.index('sigma')]
+
+        if not alpha.is_positive or not beta.is_positive:
+            raise ValueError("Shape parameters must be positive.")
+        if not sigma.is_positive:
+            raise ValueError("Scale paramter must be positive.")
+        return super(BeniniDistribution, name).__new__(name, *args)
+
     @property
     def set(self):
         return Interval(self.sigma, oo)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -232,6 +232,17 @@ def Arcsin(name, a=0, b=1):
 class BeniniDistribution(SingleContinuousDistribution):
     _argnames = ('alpha', 'beta', 'sigma')
 
+    def __new__(name, *args):
+        alpha = args[BeniniDistribution._argnames.index('alpha')]
+        beta = args[BeniniDistribution._argnames.index('beta')]
+        sigma = args[BeniniDistribution._argnames.index('sigma')]
+        if not alpha.is_positive or not beta.is_positive:
+            raise ValueError("The shape parameters must be positive.")
+        if not sigma.is_positive:
+            raise ValueError("The scale parameter must be positive.")
+        return super(BeniniDistribution, name).__new__(name, *args)
+
+
     @property
     def set(self):
         return Interval(self.sigma, oo)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -233,13 +233,11 @@ class BeniniDistribution(SingleContinuousDistribution):
     _argnames = ('alpha', 'beta', 'sigma')
 
     def __new__(name, *args):
-        alpha = args[BeniniDistribution._argnames.index('alpha')]
-        beta = args[BeniniDistribution._argnames.index('beta')]
-        sigma = args[BeniniDistribution._argnames.index('sigma')]
+        alpha, beta, sigma = args
 
-        if not alpha.is_positive or not beta.is_positive:
+        if not alpha > 0 or not beta > 0:
             raise ValueError("Shape parameters must be positive.")
-        if not sigma.is_positive:
+        if not sigma > 0:
             raise ValueError("Scale paramter must be positive.")
         return super(BeniniDistribution, name).__new__(name, *args)
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -232,17 +232,6 @@ def Arcsin(name, a=0, b=1):
 class BeniniDistribution(SingleContinuousDistribution):
     _argnames = ('alpha', 'beta', 'sigma')
 
-    def __new__(name, *args):
-        alpha = args[BeniniDistribution._argnames.index('alpha')]
-        beta = args[BeniniDistribution._argnames.index('beta')]
-        sigma = args[BeniniDistribution._argnames.index('sigma')]
-        if not alpha.is_positive or not beta.is_positive:
-            raise ValueError("The shape parameters must be positive.")
-        if not sigma.is_positive:
-            raise ValueError("The scale parameter must be positive.")
-        return super(BeniniDistribution, name).__new__(name, *args)
-
-
     @property
     def set(self):
         return Interval(self.sigma, oo)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -232,14 +232,11 @@ def Arcsin(name, a=0, b=1):
 class BeniniDistribution(SingleContinuousDistribution):
     _argnames = ('alpha', 'beta', 'sigma')
 
-    def __new__(name, *args):
-        alpha, beta, sigma = args
-
-        if not alpha > 0 or not beta > 0:
-            raise ValueError("Shape parameters must be positive.")
-        if not sigma > 0:
-            raise ValueError("Scale paramter must be positive.")
-        return super(BeniniDistribution, name).__new__(name, *args)
+    @staticmethod
+    def check(alpha, beta, sigma):
+        _value_check(alpha > 0, "Shape parameter Alpha must be positive.")
+        _value_check(beta > 0, "Shape parameter Beta must be positive.")
+        _value_check(sigma >0, "Scale parameter Sigma must be positive.")
 
     @property
     def set(self):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -236,7 +236,7 @@ class BeniniDistribution(SingleContinuousDistribution):
     def check(alpha, beta, sigma):
         _value_check(alpha > 0, "Shape parameter Alpha must be positive.")
         _value_check(beta > 0, "Shape parameter Beta must be positive.")
-        _value_check(sigma >0, "Scale parameter Sigma must be positive.")
+        _value_check(sigma > 0, "Scale parameter Sigma must be positive.")
 
     @property
     def set(self):

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -188,12 +188,26 @@ def test_arcsin():
 
 def test_benini():
     alpha = Symbol("alpha", positive=True)
-    b = Symbol("beta", positive=True)
+    beta = Symbol("beta", positive=True)
     sigma = Symbol("sigma", positive=True)
 
-    X = Benini('x', alpha, b, sigma)
-    assert density(X)(x) == ((alpha/x + 2*b*log(x/sigma)/x)
-                          *exp(-alpha*log(x/sigma) - b*log(x/sigma)**2))
+    X = Benini('x', alpha, beta, sigma)
+    assert density(X)(x) == ((alpha/x + 2*beta*log(x/sigma)/x)
+                          *exp(-alpha*log(x/sigma) - beta*log(x/sigma)**2))
+
+    alpha = Symbol("alpha", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+
+    alpha = Symbol("alpha", positive=True)
+    beta = Symbol("beta", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+
+    beta = Symbol("beta", positive=True)
+    sigma = Symbol("sigma", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
 
 def test_beta():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -188,26 +188,12 @@ def test_arcsin():
 
 def test_benini():
     alpha = Symbol("alpha", positive=True)
-    beta = Symbol("beta", positive=True)
+    b = Symbol("beta", positive=True)
     sigma = Symbol("sigma", positive=True)
 
-    X = Benini('x', alpha, beta, sigma)
-    assert density(X)(x) == ((alpha/x + 2*beta*log(x/sigma)/x)
-                          *exp(-alpha*log(x/sigma) - beta*log(x/sigma)**2))
-
-    alpha = Symbol("alpha", positive=False)
-
-    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
-
-    alpha = Symbol("alpha", positive=True)
-    beta = Symbol("beta", positive=False)
-
-    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
-
-    beta = Symbol("beta", positive=True)
-    sigma = Symbol("sigma", positive=False)
-
-    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+    X = Benini('x', alpha, b, sigma)
+    assert density(X)(x) == ((alpha/x + 2*b*log(x/sigma)/x)
+                          *exp(-alpha*log(x/sigma) - b*log(x/sigma)**2))
 
 
 def test_beta():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -196,20 +196,16 @@ def test_benini():
                           *exp(-alpha*log(x/sigma) - beta*log(x/sigma)**2))
 
     alpha = Symbol("alpha", positive=False)
-
     raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
     beta = Symbol("beta", positive=False)
-
     raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
     alpha = Symbol("alpha", positive=True)
-
     raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
     beta = Symbol("beta", positive=True)
     sigma = Symbol("sigma", positive=False)
-
     raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -188,12 +188,29 @@ def test_arcsin():
 
 def test_benini():
     alpha = Symbol("alpha", positive=True)
-    b = Symbol("beta", positive=True)
+    beta = Symbol("beta", positive=True)
     sigma = Symbol("sigma", positive=True)
 
-    X = Benini('x', alpha, b, sigma)
-    assert density(X)(x) == ((alpha/x + 2*b*log(x/sigma)/x)
-                          *exp(-alpha*log(x/sigma) - b*log(x/sigma)**2))
+    X = Benini('x', alpha, beta, sigma)
+    assert density(X)(x) == ((alpha/x + 2*beta*log(x/sigma)/x)
+                          *exp(-alpha*log(x/sigma) - beta*log(x/sigma)**2))
+
+    alpha = Symbol("alpha", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+
+    beta = Symbol("beta", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+
+    alpha = Symbol("alpha", positive=True)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
+
+    beta = Symbol("beta", positive=True)
+    sigma = Symbol("sigma", positive=False)
+
+    raises(ValueError, lambda: Benini('x', alpha, beta, sigma))
 
 
 def test_beta():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16107 

#### Brief description of what is fixed or changed
Benini allows only positive shape and scale parameters. After this fix, non-positive parameters will result in an error.
Also, test cases for checking that valid parameter values are being given added.

#### Other comments
Total 8 possibilities for signs of alpha, beta and sigma. The tests include 5 out of them.
1) all positive
2) alpha negative
3) beta negative
4) alpha and beta negative
5) sigma negative
The error generated looks like `Shape parameters must be positive.` Should it explicitly say `alpha is negative`. I have not written this because the end user may change the names of parameters and get confused.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Benini distribution now takes positive parameter values
<!-- END RELEASE NOTES -->
