### PR TITLE
Mathematica code printer should not use StrPrinter.doprint

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -41,6 +41,7 @@ class MCodePrinter(CodePrinter):
     strings of the Wolfram's Mathematica code
     """
     printmethod = "_mcode"
+    language = "Wolfram Language"
 
     _default_settings = {
         'order': None,
@@ -64,7 +65,8 @@ class MCodePrinter(CodePrinter):
                 userfuncs[k] = [(lambda *x: True, v)]
                 self.known_functions.update(userfuncs)
 
-    doprint = StrPrinter.doprint
+    def _format_code(self, lines):
+        return lines
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)
@@ -80,46 +82,83 @@ class MCodePrinter(CodePrinter):
             res += '**'.join(self.parenthesize(a, PREC) for a in nc)
         return res
 
-    def _print_Pi(self, expr):
-        return 'Pi'
 
+    # Primitive numbers
+    def _print_Zero(self, expr):
+        return '0'
+
+    def _print_One(self, expr):
+        return '1'
+
+    def _print_NegativeOne(self, expr):
+        return '-1'
+
+    def _print_half(self, expr):
+        return '1/2'
+
+    def _print_ImaginaryUnit(self, expr):
+        return 'I'
+
+
+    # Infinity and invalid numbers
     def _print_Infinity(self, expr):
         return 'Infinity'
 
     def _print_NegativeInfinity(self, expr):
         return '-Infinity'
 
+    def _print_ComplexInfinity(self, expr):
+        return 'ComplexInfinity'
+
+    def _print_NaN(self, expr):
+        return 'Indeterminate'
+
+
+    # Mathematical constants
+    def _print_Exp1(self, expr):
+        return 'E'
+
+    def _print_Pi(self, expr):
+        return 'Pi'
+
+    def _print_GoldenRatio(self, expr):
+        return 'GoldenRatio'
+
+    def _print_TribonacciConstant(self, expr):
+        return self.doprint(expr._eval_expand_func())
+
+    def _print_EulerGamma(self, expr):
+        return 'EulerGamma'
+
+    def _print_Catalan(self, expr):
+        return 'Catalan'
+
+
     def _print_list(self, expr):
         return '{' + ', '.join(self.doprint(a) for a in expr) + '}'
     _print_tuple = _print_list
     _print_Tuple = _print_list
 
-    def _print_Matrix(self, expr):
-        return self._print_list(
-        [self._print_list(expr.row(i)) for i in range(expr.rows)]
-        )
-    _print_ImmutableMatrix = _print_Matrix
-    _print_ImmutableDenseMatrix = _print_Matrix
-    _print_MutableDenseMatrix = _print_Matrix
+    def _print_ImmutableDenseMatrix(self, expr):
+        return self.doprint(expr.tolist())
 
-    def _print_SparseMatrix(self, expr):
+    def _print_ImmutableSparseMatrix(self, expr):
         from sympy.core.compatibility import default_sort_key
 
         def print_rule(pos, val):
             return '{} -> {}'.format(
             self.doprint((pos[0]+1, pos[1]+1)), self.doprint(val))
+
         def print_data():
-            return self._print_list(
-            [print_rule(key, value)
-            for key, value in sorted(expr._smat.items(), key=default_sort_key)]
-            )
+            items = sorted(expr._smat.items(), key=default_sort_key)
+            return '{' + \
+                ', '.join(print_rule(k, v) for k, v in items) + \
+                '}'
+
         def print_dims():
-            return self._print_list(
-            [self.doprint(expr.rows), self.doprint(expr.cols)]
-            )
+            return self.doprint(expr.shape)
+
         return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
-    _print_MutableSparseMatrix = _print_SparseMatrix
-    _print_ImmutableSparseMatrix = _print_SparseMatrix
 
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
@@ -145,6 +184,10 @@ class MCodePrinter(CodePrinter):
         dexpr = expr.expr
         dvars = [i[0] if i[1] == 1 else i for i in expr.variable_count]
         return "Hold[D[" + ', '.join(self.doprint(a) for a in [dexpr] + dvars) + "]]"
+
+
+    def _get_comment(self, text):
+        return "(* {} *)".format(text)
 
 
 def mathematica_code(expr, **settings):

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -50,12 +50,25 @@ def test_Mul():
 
 
 def test_constants():
-    assert mcode(pi) == "Pi"
+    assert mcode(S.Zero) == "0"
+    assert mcode(S.One) == "1"
+    assert mcode(S.NegativeOne) == "-1"
+    assert mcode(S.Half) == "1/2"
+    assert mcode(S.ImaginaryUnit) == "I"
+
     assert mcode(oo) == "Infinity"
     assert mcode(S.NegativeInfinity) == "-Infinity"
+    assert mcode(S.ComplexInfinity) == "ComplexInfinity"
+    assert mcode(S.NaN) == "Indeterminate"
+
+    assert mcode(S.Exp1) == "E"
+    assert mcode(pi) == "Pi"
+    assert mcode(S.GoldenRatio) == "GoldenRatio"
+    assert mcode(S.TribonacciConstant) == \
+        "1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + " \
+        "(1/3)*(3*33^(1/2) + 19)^(1/3)"
     assert mcode(S.EulerGamma) == "EulerGamma"
     assert mcode(S.Catalan) == "Catalan"
-    assert mcode(S.Exp1) == "E"
 
 
 def test_containers():
@@ -68,31 +81,29 @@ def test_containers():
 
 
 def test_matrices():
-    from sympy.matrices import MutableDenseMatrix, MutableSparseMatrix
+    from sympy.matrices import MutableDenseMatrix, MutableSparseMatrix, \
+        ImmutableDenseMatrix, ImmutableSparseMatrix
     A = MutableDenseMatrix(
         [[1, -1, 0, 0],
-        [0, 1, -1, 0],
-        [0, 0, 1, -1],
-        [0, 0, 0, 1]]
+         [0, 1, -1, 0],
+         [0, 0, 1, -1],
+         [0, 0, 0, 1]]
     )
-    B = MutableSparseMatrix(
-        [[1, -1, 0, 0],
-        [0, 1, -1, 0],
-        [0, 0, 1, -1],
-        [0, 0, 0, 1]]
-    )
+    B = MutableSparseMatrix(A)
+    C = ImmutableDenseMatrix(A)
+    D = ImmutableSparseMatrix(A)
 
-    assert mcode(A) == """\
-{{1, -1, 0, 0}, \
-{0, 1, -1, 0}, \
-{0, 0, 1, -1}, \
-{0, 0, 0, 1}}\
-"""
-    assert mcode(B) == """\
-SparseArray[\
-{{1, 1} -> 1, {1, 2} -> -1, {2, 2} -> 1, {2, 3} -> -1, \
-{3, 3} -> 1, {3, 4} -> -1, {4, 4} -> 1}, {4, 4}]\
-"""
+    assert mcode(C) == mcode(A) == \
+        "{{1, -1, 0, 0}, " \
+        "{0, 1, -1, 0}, " \
+        "{0, 0, 1, -1}, " \
+        "{0, 0, 0, 1}}"
+
+    assert mcode(D) == mcode(B) == \
+        "SparseArray[{" \
+        "{1, 1} -> 1, {1, 2} -> -1, {2, 2} -> 1, {2, 3} -> -1, " \
+        "{3, 3} -> 1, {3, 4} -> -1, {4, 4} -> 1" \
+        "}, {4, 4}]"
 
     # Trivial cases of matrices
     assert mcode(MutableDenseMatrix(0, 0, [])) == '{}'
@@ -127,3 +138,9 @@ def test_Sum():
                      (y, -oo, oo))) == \
         "Hold[Sum[Exp[-x^2 - y^2], {x, -Infinity, Infinity}, " \
         "{y, -Infinity, Infinity}]]"
+
+
+def test_comment():
+    from sympy.printing.mathematica import MCodePrinter
+    assert MCodePrinter()._get_comment("Hello World") == \
+        "(* Hello World *)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

#7823 had made mathematica code printer to use `doprint` method from `StrPrinter`, but it is causing some issues like printing invalid code for numbers, and ignoring warnings for for unsupported classes.

I have added `language` attribute and `_get_comment` method, so that it is possible to print comments, and give warnings for unsupported classes, like other code printers do.

I have also added every basic number types to print, while I could not find `TribonacciConstant` equivalent one in Mathematica, so I have used the formula for that.

I changed Matrix implementation in #15792, to make it work, and also reformatted some tests.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed `mathematica_code` printing `ComplexInfinity` as `zoo`
  - Fixed `mathematica_code` printing `Indeterminate` as `nan`
  - Fixed `mathematica_code` printing `TribonacciConstant` as `TribonacciConstant`, now uses explicit formula.
  - `mathematica_code` will give warning `(* Not supported in Wolfram Language: *)` for classes not implemented or not printable.
<!-- END RELEASE NOTES -->
