### PR TITLE
Remove code quality test from doctests matrix

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -72,8 +72,6 @@ if not sympy.doctest():
 EOF
     cd ..
     bin/doctest doc/
-    # Run full code quality tests here, as they test non-installed files
-    bin/test quality
 fi
 
 if [[ "${TEST_SLOW}" == "true" ]]; then


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed

#16023 had introduced code quality test in a totally new stage, and it may should run once.
but I'm seeing that the quality test is being run every time in matrix containing doctests
https://github.com/sympy/sympy/blob/2dd1275d6050605f517b030c92e9ef30c75eab45/bin/test_travis.sh#L75-L76

It had been added in #14897, but is it still valid now?

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
