### PR TITLE
Created class for finite fourier series

### DIFF
--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -97,7 +97,7 @@ def finite_check(f, x, L):
         return x not in exprs.free_symbols
 
     def check_sincos(_expr, x, L):
-        if type(_expr) == sin or type(_expr) == cos:
+        if isinstance(_expr, (sin, cos)):
             sincos_args = _expr.args[0]
 
             if sincos_args.match(a*(pi/L)*x + b) is not None:
@@ -109,7 +109,7 @@ def finite_check(f, x, L):
     add_coeff = _expr.as_coeff_add()
 
     a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
-    b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
+    b = Wild('b', properties=[lambda k: x not in k.free_symbols, ])
 
     for s in add_coeff[1]:
         mul_coeffs = s.as_coeff_mul()[1]
@@ -456,9 +456,9 @@ class FiniteFourierSeries(FourierSeries):
        exprs: (a0, an, bn) or Expr
             a0 is the constant term a0 of the fourier series
             an is a dictionary of coefficients of cos terms
-             `an[k] = coefficient of cos(pi*(k/L)*x)`
+             an[k] = coefficient of cos(pi*(k/L)*x)
             bn is a dictionary of coefficients of sin terms
-             `bn[k] = coefficient of sin(pi*(k/L)*x)`
+             bn[k] = coefficient of sin(pi*(k/L)*x)
 
             or exprs can be an expression to be converted to fourier form
 
@@ -489,7 +489,7 @@ class FiniteFourierSeries(FourierSeries):
             L = abs(limits[2] - limits[1]) / 2
 
             a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
-            b = Wild('b', properties=[lambda k: x not in k.free_symbols or k == S.Zero, ])
+            b = Wild('b', properties=[lambda k: x not in k.free_symbols, ])
 
             an = dict()
             bn = dict()

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -178,6 +178,10 @@ class FourierSeries(SeriesBase):
     def length(self):
         return oo
 
+    @property
+    def L(self):
+        return abs(self.period[1] - self.period[0]) / 2
+
     def _eval_subs(self, old, new):
         x = self.x
         if old.has(x):
@@ -518,46 +522,10 @@ class FiniteFourierSeries(FourierSeries):
     def length(self):
         return self.stop - self.start
 
-    @property
-    def L(self):
-        return abs(self.period[1] - self.period[0]) / 2
-
     def truncate(self, n=oo):
-        """
-        Return the first n nonzero terms of the series if n is less than the size of the finite fourier series.
-
-        If n is None return an iterator.
-
-        See Also
-        ========
-
-        sympy.series.fourier.FourierSeries.truncate
-        """
-        if n is None:
-            return iter(self)
-
-        terms = []
-        for t in self:
-            if len(terms) == n:
-                break
-            if t is not S.Zero:
-                terms.append(t)
-
-        return Add(*terms)
+        return super().truncate(n)
 
     def shiftx(self, s):
-        """Shift x by a term independent of x.
-
-        f(x) -> f(x + s)
-
-        This is fast, if Fourier series of f(x) is already
-        computed.
-
-        See Also
-        ========
-        sympy.series.fourier.FourierSeries.shiftx
-
-        """
         s, x = sympify(s), self.x
 
         if x in s.free_symbols:
@@ -569,18 +537,6 @@ class FiniteFourierSeries(FourierSeries):
         return self.func(sfunc, self.args[1], _expr)
 
     def scale(self, s):
-        """Scale the function by a term independent of x.
-
-        f(x) -> s * f(x)
-
-        This is fast, if Fourier series of f(x) is already
-        computed.
-
-        See Also
-        ========
-        sympy.series.fourier.FourierSeries.scale
-
-        """
         s, x = sympify(s), self.x
 
         if x in s.free_symbols:
@@ -592,17 +548,6 @@ class FiniteFourierSeries(FourierSeries):
         return self.func(sfunc, self.args[1], _expr)
 
     def scalex(self, s):
-        """Scale x by a term independent of x.
-
-        f(x) -> f(s*x)
-
-        This is fast, if Fourier series of f(x) is already
-        computed.
-
-        See Also
-        ========
-        sympy.series.fourier.FourierSeries.scalex
-        """
         s, x = sympify(s), self.x
 
         if x in s.free_symbols:
@@ -636,9 +581,6 @@ class FiniteFourierSeries(FourierSeries):
                 return function
 
             return fourier_series(function, limits=self.args[1])
-
-    def __sub__(self, other):
-        return self.__add__(-other)
 
 
 def fourier_series(f, limits=None, finite=True):

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -522,9 +522,6 @@ class FiniteFourierSeries(FourierSeries):
     def length(self):
         return self.stop - self.start
 
-    def truncate(self, n=oo):
-        return super().truncate(n)
-
     def shiftx(self, s):
         s, x = sympify(s), self.x
 

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -465,7 +465,7 @@ class FiniteFourierSeries(FourierSeries):
                 else:
                     a0 += p
 
-            exprs = Tuple((a0, an, bn))
+            exprs = Tuple(a0, an, bn)
             args = (f, limits, exprs)
 
         return Expr.__new__(cls, *args)

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -480,22 +480,21 @@ class FiniteFourierSeries(FourierSeries):
         if not (type(exprs) == tuple and len(exprs) == 3):  # exprs is not of form (a0, an, bn)
 
             # Converts the expression to fourier form
-            exprs = exprs.as_coeff_add()
-            exprs = exprs[0] + Add(*[TR10(i) for i in exprs[1]])
-            exp_ls = exprs.expand(trig=False, power_base=False, power_exp=False, log=False).as_coeff_add()
+            c, e = exprs.as_coeff_add()
+            rexpr = c + Add(*[TR10(i) for i in e])
+            a0, exp_ls = rexpr.expand(trig=False, power_base=False, power_exp=False, log=False).as_coeff_add()
 
-            a0 = exp_ls[0]
             x = limits[0]
             L = abs(limits[2] - limits[1]) / 2
 
-            a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k != S.Zero, ])
+            a = Wild('a', properties=[lambda k: k.is_Integer, lambda k: k is not S.Zero, ])
             b = Wild('b', properties=[lambda k: x not in k.free_symbols, ])
 
             an = dict()
             bn = dict()
 
             # separates the coefficients of sin and cos terms in dictionaries an, and bn
-            for p in exp_ls[1]:
+            for p in exp_ls:
                 t = p.match(b * cos(a * (pi / L) * x))
                 q = p.match(b * sin(a * (pi / L) * x))
                 if t:

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -465,7 +465,7 @@ class FiniteFourierSeries(FourierSeries):
                 else:
                     a0 += p
 
-            exprs = (a0, an, bn)
+            exprs = Tuple((a0, an, bn))
             args = (f, limits, exprs)
 
         return Expr.__new__(cls, *args)

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -441,44 +441,42 @@ class FourierSeries(SeriesBase):
 class FiniteFourierSeries(FourierSeries):
     r"""Represents Finite Fourier sine/cosine series.
 
-       For how to compute Fourier series, see the :func:`fourier_series`
-       docstring.
+    For how to compute Fourier series, see the :func:`fourier_series`
+    docstring.
 
-       Parameters
-       ==========
-       f : Expr
-            Expression for finding fourier_series
+    Parameters
+    ==========
+    f : Expr
+        Expression for finding fourier_series
 
-       limits : ( x, start, stop)
-            x is the independent variable for the expression f
-            (start, stop) is the period of the fourier series
+    limits : ( x, start, stop)
+        x is the independent variable for the expression f
+        (start, stop) is the period of the fourier series
 
-       exprs: (a0, an, bn) or Expr
-            a0 is the constant term a0 of the fourier series
-            an is a dictionary of coefficients of cos terms
-             an[k] = coefficient of cos(pi*(k/L)*x)
-            bn is a dictionary of coefficients of sin terms
-             bn[k] = coefficient of sin(pi*(k/L)*x)
+    exprs: (a0, an, bn) or Expr
+        a0 is the constant term a0 of the fourier series
+        an is a dictionary of coefficients of cos terms
+         an[k] = coefficient of cos(pi*(k/L)*x)
+        bn is a dictionary of coefficients of sin terms
+         bn[k] = coefficient of sin(pi*(k/L)*x)
 
-            or exprs can be an expression to be converted to fourier form
+        or exprs can be an expression to be converted to fourier form
 
-       Methods
-       =======
-       This class is an extension of FourierSeries class.
-       Please refer to sympy.series.fourier.FourierSeries for
-       further information.
+    Methods
+    =======
+    This class is an extension of FourierSeries class.
+    Please refer to sympy.series.fourier.FourierSeries for
+    further information.
 
-       See Also
-       ========
+    See Also
+    ========
 
-       sympy.series.fourier.FourierSeries
-       sympy.series.fourier.fourier_series
-       """
+    sympy.series.fourier.FourierSeries
+    sympy.series.fourier.fourier_series
+    """
 
     def __new__(cls, f, limits, exprs):
-
         if not (type(exprs) == tuple and len(exprs) == 3):  # exprs is not of form (a0, an, bn)
-
             # Converts the expression to fourier form
             c, e = exprs.as_coeff_add()
             rexpr = c + Add(*[TR10(i) for i in e])

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -134,15 +134,17 @@ def test_FourierSeries__add__sub():
 
 def test_FourierSeries_finite():
 
-    assert fourier_series(sin(x)).truncate() == sin(x)
+    assert fourier_series(sin(x)).truncate(1) == sin(x)
     # assert type(fourier_series(sin(x)*log(x))).truncate() == FourierSeries
     # assert type(fourier_series(sin(x**2+6))).truncate() == FourierSeries
     assert fourier_series(sin(x)*log(y)*exp(z),(x,pi,-pi)).truncate() == sin(x)*log(y)*exp(z)
-    assert fourier_series(sin(x)**6).truncate() == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
+    assert fourier_series(sin(x)**6).truncate(oo) == -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 \
            + Rational(5, 16)
-    assert fourier_series(sin(4*x+3) + cos(3*x+4)).truncate() ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
+    assert fourier_series(sin(x) ** 6).truncate() == -15 * cos(2 * x) / 32 + 3 * cos(4 * x) / 16 \
+           + Rational(5, 16)
+    assert fourier_series(sin(4*x+3) + cos(3*x+4)).truncate(oo) ==  -sin(4)*sin(3*x) + sin(4*x)*cos(3) \
            + cos(4)*cos(3*x) + sin(3)*cos(4*x)
-    assert fourier_series(sin(x)+cos(x)*tan(x)).truncate() == 2*sin(x)
-    assert fourier_series(cos(pi*x), (x, -1, 1)).truncate() == cos(pi*x)
-    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x, -1, 1)).truncate() == -log(pi*y)*sin(4*pi*x)\
+    assert fourier_series(sin(x)+cos(x)*tan(x)).truncate(oo) == 2*sin(x)
+    assert fourier_series(cos(pi*x), (x, -1, 1)).truncate(oo) == cos(pi*x)
+    assert fourier_series(cos(3*pi*x + 4) - sin(4*pi*x)*log(pi*y) , (x, -1, 1)).truncate(oo) == -log(pi*y)*sin(4*pi*x)\
            - sin(4)*sin(3*pi*x) + cos(4)*cos(3*pi*x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
fixes #15701 follows #15979 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Following #15979 the FiniteFourierSeries class is improved to handle finite fourier series while keeping the API equivalent to FourierSeries class.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Improves fourier.FiniteFourierSeries class
<!-- END RELEASE NOTES -->
