### PR TITLE
SOPform and POSform accepts terms as integers

### DIFF
--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,3 +1,3 @@
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
-    Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false)
+    Equivalent, ITE, POSform, SOPform, POSform__int, SOPform__int, mask, simplify_logic, bool_map, true, false)
 from .inference import satisfiable

--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,3 +1,3 @@
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
-    Equivalent, ITE, POSform, SOPform, POSform__int, SOPform__int, mask, simplify_logic, bool_map, true, false)
+    Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false)
 from .inference import satisfiable

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2154,7 +2154,7 @@ def POSform(variables, minterms, dontcares=None):
     >>> minterms = [4, 7, 11, [1, 1, 1, 1]]
     >>> dontcares = [{w : 0, x : 0, y: 0}, 5]
     >>> POSform([w, x, y, z], minterms, dontcares)
-    (w | x) & (x | z) & (y | ~w) & (z | ~y)
+    (w | x) & (y | ~w) & (z | ~y)
 
 
     References

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1876,7 +1876,7 @@ def _input_to_binlist(inputlist, variables):
         if isinstance(val, int):
             binlist.append(ibin(val, bits))
         elif isinstance(val, dict):
-            nonspecvars = variables.copy()
+            nonspecvars = list(variables)
             for key in val.keys():
                 nonspecvars.remove(key)
             for t in product([0, 1], repeat=len(nonspecvars)):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -17,7 +17,7 @@ from sympy.core.compatibility import (ordered, range, with_metaclass,
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
 from sympy.utilities.misc import filldedent
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, ibin
 
 
 def as_Boolean(e):
@@ -1870,10 +1870,10 @@ def _rem_redundancy(l1, terms):
     return essential
 
 def _binary_from_list_or_number(lon, bits):
-        def tobin(n, bits):
-            return [(n >> k) & 1 for k in reversed(range(0, bits))]
         if isinstance(lon, int):
-            return tobin(lon, bits)
+            return ibin(lon, bits)
+        if len(lon) != bits:
+            raise ValueError("Each term must contain {} bits as there are {} variables\n(or be an integer)".format(bits, bits))
         return list(lon)
 
 def SOPform(variables, minterms, dontcares=None):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1492,7 +1492,8 @@ def to_cnf(expr, simplify=False):
     """
     Convert a propositional logical sentence s to conjunctive normal form.
     That is, of the form ((A | ~B | ...) & (B | C | ...) & ...)
-    If simplify is True, the expr is evaluated to its simplest CNF form.
+    If simplify is True, the expr is evaluated to its simplest CNF form  using
+    the Quine-McCluskey algorithm.
 
     Examples
     ========
@@ -1524,7 +1525,8 @@ def to_dnf(expr, simplify=False):
     """
     Convert a propositional logical sentence s to disjunctive normal form.
     That is, of the form ((A & ~B & ...) | (B & C & ...) | ...)
-    If simplify is True, the expr is evaluated to its simplest DNF form.
+    If simplify is True, the expr is evaluated to its simplest DNF form using
+    the Quine-McCluskey algorithm.
 
     Examples
     ========

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -493,7 +493,7 @@ class BooleanFunction(Application, Boolean):
         return Derivative(self, *symbols, **assumptions)
 
     def _eval_derivative(self, x):
-        from sympy.core.relational import Eq, Relational
+        from sympy.core.relational import Eq
         from sympy.functions.elementary.piecewise import Piecewise
         if x in self.binary_symbols:
             return Piecewise(
@@ -1869,6 +1869,12 @@ def _rem_redundancy(l1, terms):
 
     return essential
 
+def _binary_from_list_or_number(lon, bits):
+        def tobin(n, bits):
+            return [(n >> k) & 1 for k in reversed(range(0, bits))]
+        if isinstance(lon, int):
+            return tobin(lon, bits)
+        return list(lon)
 
 def SOPform(variables, minterms, dontcares=None):
     """
@@ -1897,6 +1903,20 @@ def SOPform(variables, minterms, dontcares=None):
     >>> SOPform([w, x, y, z], minterms, dontcares)
     (y & z) | (z & ~w)
 
+    The terms can also be represented as integers:
+
+    >>> minterms = [1, 3, 7, 11, 15]
+    >>> dontcares = [0, 2, 5]
+    >>> SOPform([w, x, y, z], minterms, dontcares)
+    (y & z) | (z & ~w)
+
+    Or a combination:
+
+    >>> minterms = [1, 3, 7, 11, [1, 1, 1, 1]]
+    >>> dontcares = [[0, 0, 0, 0], 2, 5]
+    >>> SOPform([w, x, y, z], minterms, dontcares)
+    (y & z) | (z & ~w)
+
     References
     ==========
 
@@ -1907,8 +1927,9 @@ def SOPform(variables, minterms, dontcares=None):
     if minterms == []:
         return false
 
-    minterms = [list(i) for i in minterms]
-    dontcares = [list(i) for i in (dontcares or [])]
+    bits = len(variables)
+    minterms = [_binary_from_list_or_number(i, bits) for i in minterms]
+    dontcares = [_binary_from_list_or_number(i, bits) for i in (dontcares or [])]
     for d in dontcares:
         if d in minterms:
             raise ValueError('%s in minterms is also in dontcares' % d)
@@ -1949,6 +1970,20 @@ def POSform(variables, minterms, dontcares=None):
     >>> POSform([w, x, y, z], minterms, dontcares)
     z & (y | ~w)
 
+    The terms can also be represented as integers:
+
+    >>> minterms = [1, 3, 7, 11, 15]
+    >>> dontcares = [0, 2, 5]
+    >>> POSform([w, x, y, z], minterms, dontcares)
+    z & (y | ~w)
+
+    Or a combination:
+
+    >>> minterms = [1, 3, 7, 11, [1, 1, 1, 1]]
+    >>> dontcares = [[0, 0, 0, 0], 2, 5]
+    >>> POSform([w, x, y, z], minterms, dontcares)
+    z & (y | ~w)
+
     References
     ==========
 
@@ -1959,8 +1994,9 @@ def POSform(variables, minterms, dontcares=None):
     if minterms == []:
         return false
 
-    minterms = [list(i) for i in minterms]
-    dontcares = [list(i) for i in (dontcares or [])]
+    bits = len(variables)
+    minterms = [_binary_from_list_or_number(i, bits) for i in minterms]
+    dontcares = [_binary_from_list_or_number(i, bits) for i in (dontcares or [])]
     for d in dontcares:
         if d in minterms:
             raise ValueError('%s in minterms is also in dontcares' % d)
@@ -1977,68 +2013,6 @@ def POSform(variables, minterms, dontcares=None):
         new = _simplified_pairs(old)
     essential = _rem_redundancy(new, maxterms)
     return And(*[_convert_to_varsPOS(x, variables) for x in essential])
-
-
-
-
-def mask(num, i):
-    return bool(num & 2**i)
-
-
-def SOPform__int(variables, minterms, dontcares=None):
-    """
-    The SOPform function uses simplified_pairs and a redundant group-
-    eliminating algorithm to convert the list of all input combos that
-    generate '1' (the minterms) into the smallest Sum of Products form.
-    The variables must be given as the first argument.
-    Return a logical Or function (i.e., the "sum of products" or "SOP"
-    form) that gives the desired outcome. If there are inputs that can
-    be ignored, pass them as a list, too.
-    The result will be one of the (perhaps many) functions that satisfy
-    the conditions.
-    Examples
-    ========
-    >>> from sympy.logic import SOPform__int
-    >>> minterms = [1, 3, 7, 11, 15]
-    >>> dontcares = [0, 2, 5]
-    >>> SOPform__int(['w','x','y','z'], minterms, dontcares)
-    Or(And(Not(w), z), And(y, z))
-    References
-    ==========
-    .. [1] en.wikipedia.org/wiki/Quine-McCluskey_algorithm
-    """
-    cnt = len(variables)
-    return SOPform(variables, [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in minterms],\
-        [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in dontcares] if dontcares else None)
-
-
-def POSform__int(variables, minterms, dontcares=None):
-    """
-    The POSform function uses simplified_pairs and a redundant-group
-    eliminating algorithm to convert the list of all input combinations
-    that generate '1' (the minterms) into the smallest Product of Sums form.
-    The variables must be given as the first argument.
-    Return a logical And function (i.e., the "product of sums" or "POS"
-    form) that gives the desired outcome. If there are inputs that can
-    be ignored, pass them as a list, too.
-    The result will be one of the (perhaps many) functions that satisfy
-    the conditions.
-    Examples
-    ========
-    >>> from sympy.logic import POSform__int
-    >>> minterms = [1, 3, 7, 11, 15]
-    >>> dontcares = [0, 2, 5]
-    >>> POSform__int(['w','x','y','z'], minterms, dontcares)
-    And(Or(Not(w), y), z)
-    References
-    ==========
-    .. [1] en.wikipedia.org/wiki/Quine-McCluskey_algorithm
-    """
-    cnt = len(variables)
-    return POSform(variables, [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in minterms],\
-        [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in dontcares] if dontcares else None)
-
-
 
 
 def _find_predicates(expr):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1669,6 +1669,68 @@ def POSform(variables, minterms, dontcares=None):
     return And(*[_convert_to_varsPOS(x, variables) for x in essential])
 
 
+
+
+def mask(num, i):
+    return bool(num & 2**i)
+
+
+def SOPform__int(variables, minterms, dontcares=None):
+    """
+    The SOPform function uses simplified_pairs and a redundant group-
+    eliminating algorithm to convert the list of all input combos that
+    generate '1' (the minterms) into the smallest Sum of Products form.
+    The variables must be given as the first argument.
+    Return a logical Or function (i.e., the "sum of products" or "SOP"
+    form) that gives the desired outcome. If there are inputs that can
+    be ignored, pass them as a list, too.
+    The result will be one of the (perhaps many) functions that satisfy
+    the conditions.
+    Examples
+    ========
+    >>> from sympy.logic import SOPform__int
+    >>> minterms = [1, 3, 7, 11, 15]
+    >>> dontcares = [0, 2, 5]
+    >>> SOPform__int(['w','x','y','z'], minterms, dontcares)
+    Or(And(Not(w), z), And(y, z))
+    References
+    ==========
+    .. [1] en.wikipedia.org/wiki/Quine-McCluskey_algorithm
+    """
+    cnt = len(variables)
+    return SOPform(variables, [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in minterms],\
+        [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in dontcares] if dontcares else None)
+
+
+def POSform__int(variables, minterms, dontcares=None):
+    """
+    The POSform function uses simplified_pairs and a redundant-group
+    eliminating algorithm to convert the list of all input combinations
+    that generate '1' (the minterms) into the smallest Product of Sums form.
+    The variables must be given as the first argument.
+    Return a logical And function (i.e., the "product of sums" or "POS"
+    form) that gives the desired outcome. If there are inputs that can
+    be ignored, pass them as a list, too.
+    The result will be one of the (perhaps many) functions that satisfy
+    the conditions.
+    Examples
+    ========
+    >>> from sympy.logic import POSform__int
+    >>> minterms = [1, 3, 7, 11, 15]
+    >>> dontcares = [0, 2, 5]
+    >>> POSform__int(['w','x','y','z'], minterms, dontcares)
+    And(Or(Not(w), y), z)
+    References
+    ==========
+    .. [1] en.wikipedia.org/wiki/Quine-McCluskey_algorithm
+    """
+    cnt = len(variables)
+    return POSform(variables, [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in minterms],\
+        [[mask(number,i) for i in range(cnt-1,-1, -1)] for number in dontcares] if dontcares else None)
+
+
+
+
 def _find_predicates(expr):
     """Helper to find logical predicates in BooleanFunctions.
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -241,6 +241,11 @@ def test_simplification():
         Or(And(Not(w), z), And(y, z)))
     assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
+
+    minterms = [[0, 0, 0]]
+    raises(ValueError, lambda : SOPform([w, x, y, z], minterms))
+    raises(ValueError, lambda : POSform([w, x, y, z], minterms))
+
     # test simplification
     ans = And(A, Or(B, C))
     assert simplify_logic(A & (B | C)) == ans

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -858,8 +858,27 @@ def test_binary_symbols():
 def test_BooleanFunction_diff():
     assert And(x, y).diff(x) == Piecewise((0, Eq(y, False)), (1, True))
 
-@XFAIL
+
 def test_issue_14700():
+    A, B, C, D, E, F, G, H = symbols('A B C D E F G H')
+    q = ((B & D & H & ~F) | (B & H & ~C & ~D) | (B & H & ~C & ~F) |
+            (B & H & ~D & ~G) | (B & H & ~F & ~G) | (C & G & ~B & ~D) |
+            (C & G & ~D & ~H) | (C & G & ~F & ~H) | (D & F & H & ~B) |
+            (D & F & ~G & ~H) | (B & D & F & ~C & ~H) | (D & E & F & ~B & ~C) |
+            (D & F & ~A & ~B & ~C) | (D & F & ~A & ~C & ~H) |
+            (A & B & D & F & ~E & ~H))
+    soldnf = ((B & D & H & ~F) | (D & F & H & ~B) | (B & H & ~C & ~D) |
+            (B & H & ~D & ~G) | (C & G & ~B & ~D) | (C & G & ~D & ~H) |
+            (C & G & ~F & ~H) | (D & F & ~G & ~H) | (D & E & F & ~C & ~H) |
+            (D & F & ~A & ~C & ~H) | (A & B & D & F & ~E & ~H))
+    solcnf = ((B | C | D) & (B | D | G) & (C | D | H) & (C | F | H) &
+              (D | G | H) & (F | G | H) & (B | F | ~D | ~H) &
+              (~B | ~D | ~F | ~H) & (D | ~B | ~C | ~G | ~H) &
+              (A | H | ~C | ~D | ~F | ~G) & (H | ~C | ~D | ~E | ~F | ~G) &
+              (B | E | H | ~A | ~D | ~F | ~G))
+    assert simplify_logic(q, "dnf") == soldnf
+    assert simplify_logic(q, "cnf") == solcnf
+
     minterms = [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 1, 0], [0, 1, 1, 1], [0, 0, 1, 1], [1, 0, 1, 1]]
     dontcares = [[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0], [1, 1, 0, 1]]
     assert SOPform([w, x, y, z], minterms) == (x & ~w) | (y & z & ~x)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -241,10 +241,14 @@ def test_simplification():
         Or(And(Not(w), z), And(y, z)))
     assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
+    minterms = [{y : 1, z: 1}, 1]
+    dontcares = [[0, 0, 0, 0]]
 
     minterms = [[0, 0, 0]]
     raises(ValueError, lambda : SOPform([w, x, y, z], minterms))
     raises(ValueError, lambda : POSform([w, x, y, z], minterms))
+
+    raises(TypeError, lambda : POSform([w, x, y, z], ["abcdefg"]))
 
     # test simplification
     ans = And(A, Or(B, C))
@@ -853,3 +857,11 @@ def test_binary_symbols():
 
 def test_BooleanFunction_diff():
     assert And(x, y).diff(x) == Piecewise((0, Eq(y, False)), (1, True))
+
+@XFAIL
+def test_issue_14700():
+    minterms = [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 1, 0], [0, 1, 1, 1], [0, 0, 1, 1], [1, 0, 1, 1]]
+    dontcares = [[1, 0, 0, 0], [1, 0, 0, 1], [1, 1, 0, 0], [1, 1, 0, 1]]
+    assert SOPform([w, x, y, z], minterms) == (x & ~w) | (y & z & ~x)
+    # Should not be more complicated with don't cares
+    assert SOPform([w, x, y, z], minterms, dontcares) == (x & ~w) | (y & z & ~x)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -226,6 +226,21 @@ def test_simplification():
         Or(And(Not(w), z), And(y, z)))
     assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
 
+    minterms = [1, 3, 7, 11, 15]
+    dontcares = [0, 2, 5]
+    assert (
+        SOPform([w, x, y, z], minterms, dontcares) ==
+        Or(And(Not(w), z), And(y, z)))
+    assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
+
+    minterms = [1, [0, 0, 1, 1], 7, [1, 0, 1, 1],
+        [1, 1, 1, 1]]
+    dontcares = [0, [0, 0, 1, 0], 5]
+    assert (
+        SOPform([w, x, y, z], minterms, dontcares) ==
+        Or(And(Not(w), z), And(y, z)))
+    assert POSform([w, x, y, z], minterms, dontcares) == And(Or(Not(w), y), z)
+
     # test simplification
     ans = And(A, Or(B, C))
     assert simplify_logic(A & (B | C)) == ans


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #11464 
Closes #14700 

#### Brief description of what is fixed or changed
`SOPform` and `POSform` can now take integers and dicts as inputs as well as lists of binary numbers.

I also ended up fixing an issue with the minimization code, which didn't always result in fewest terms as outlined in #14700 

Good thing is that I now sort of understand the Quine-McCluskey algorithm.

#### Other comments
There is basically no code left from #11464 but better to have a liberate interpretation of building on previous PRs.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic 
   * `SOPform` and `POSform` can now use integers and dicts to indicate terms.
  * Boolean simplification algorithm fixed to reduce the number of terms.
<!-- END RELEASE NOTES -->
