### PR TITLE
Fixed printing of minus-signs in MathML presentation

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -561,11 +561,13 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 xden = self._print(denom)
                 frac.appendChild(xnum)
                 frac.appendChild(xden)
-                return frac
+                mrow.appendChild(frac)
+                return mrow
 
             coeff, terms = expr.as_coeff_mul()
             if coeff is S.One and len(terms) == 1:
-                return self._print(terms[0])
+                mrow.appendChild(self._print(terms[0]))
+                return mrow
             if self.order != 'old':
                 terms = Mul._from_args(terms).as_ordered_factors()
 
@@ -635,19 +637,26 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_Rational(self, e):
         if e.q == 1:
             # don't divide
-            x = self.dom.createElement('mn')
-            x.appendChild(self.dom.createTextNode(str(e.p)))
-            return x
+            return self._print(e.p)
+
+        if e.p < 0:
+            p = -e.p
+        else:
+            p = e.p
         x = self.dom.createElement('mfrac')
         if self._settings["fold_frac_powers"]:
             x.setAttribute('bevelled', 'true')
-        num = self.dom.createElement('mn')
-        num.appendChild(self.dom.createTextNode(str(e.p)))
-        x.appendChild(num)
-        den = self.dom.createElement('mn')
-        den.appendChild(self.dom.createTextNode(str(e.q)))
-        x.appendChild(den)
-        return x
+        x.appendChild(self._print(p))
+        x.appendChild(self._print(e.q))
+        if e.p < 0:
+            mrow = self.dom.createElement('mrow')
+            mo = self.dom.createElement('mo')
+            mo.appendChild(self.dom.createTextNode('-'))
+            mrow.appendChild(mo)
+            mrow.appendChild(x)
+            return mrow
+        else:
+            return x
 
     def _print_Limit(self, e):
         mrow = self.dom.createElement('mrow')

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1076,6 +1076,8 @@ def test_root_notation_print():
     assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) == '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
     assert mathml(x**(S(1)/3), printer='content') == '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
     assert mathml(x**(S(1)/3), printer='content', root_notation=False) == '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
+    assert mathml(x**(-S(1)/3), printer='presentation') == '<mfrac><mn>1</mn><mroot><mi>x</mi><mn>3</mn></mroot></mfrac>'
+    assert mathml(x**(-S(1)/3), printer='presentation', root_notation=False) == '<mfrac><mn>1</mn><msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup></mfrac>'
 
 
 def test_fold_frac_powers_print():
@@ -1086,10 +1088,10 @@ def test_fold_frac_powers_print():
 
 
 def test_fold_short_frac_print():
-    expr = 1 / y ** 2
-    assert mathml(expr, printer='presentation') == '<msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>-2</mn></msup>'
-    assert mathml(expr, printer='presentation', fold_short_frac=True) == '<mfrac bevelled="true"><mn>1</mn><msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>2</mn></msup></mfrac>'
-    assert mathml(expr, printer='presentation', fold_short_frac=False) == '<msup><mrow><mfenced><mi>y</mi></mfenced></mrow><mn>-2</mn></msup>'
+    expr = Rational(2, 5)
+    assert mathml(expr, printer='presentation') == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=True) == '<mfrac bevelled="true"><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=False) == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
 
 
 def test_print_factorials():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -981,6 +981,12 @@ def test_print_domains():
     assert mpp.doprint(Reals) == '<mi mathvariant="normal">&#x211D;</mi>'
 
 
+def test_print_expression_with_minus():
+    assert mpp.doprint(-x) == '<mrow><mo>-</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(-x/y) == '<mrow><mo>-</mo><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow>'
+    assert mpp.doprint(-Rational(1,2)) == '<mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow>'
+
+
 def test_print_AssocOp():
     from sympy.core.operations import AssocOp
     class TestAssocOp(AssocOp):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
There was a few issues with printing minus signs in the MathML presentation printer. Sometimes they disappeared, sometimes they were printed in a less ideal position.

Before:
<img width="277" alt="beforeminusfix" src="https://user-images.githubusercontent.com/8114497/53683884-9f1bad00-3d06-11e9-9d24-7f2c8adda83f.PNG">

After:
<img width="281" alt="afterminusfix" src="https://user-images.githubusercontent.com/8114497/53683886-a5aa2480-3d06-11e9-8577-01b820b99afa.PNG">

This is fixed and tests are added. (And a bit of rewrite of the code.)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Issue with printing of minus signs in MathML presentation printer corrected.
   * MathML printing pf negative powers more consistent with LaTeX output.
<!-- END RELEASE NOTES -->
