### PR TITLE
fixes #16086

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -181,6 +181,7 @@ class ReprPrinter(Printer):
     def _print_str(self, expr):
         return repr(expr)
     
+    # XXX: Can be removed once Py2 support is dropped
     def _print_basestring(self, expr):
         return repr(expr)
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -166,7 +166,7 @@ class ReprPrinter(Printer):
             d['dummy_index'] = expr.dummy_index
 
         if d == {}:
-            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+            return "%s(%s)" % (expr.__class__.__name__, self._print(repr(expr.name)))
         else:
             attr = ['%s=%s' % (k, v) for k, v in d.items()]
             return "%s(%s, %s)" % (expr.__class__.__name__,
@@ -179,7 +179,7 @@ class ReprPrinter(Printer):
         return "%s(%s, %s)" % (expr.__class__.__name__, expr.func, expr.arg)
 
     def _print_str(self, expr):
-        return repr(expr)
+        return expr
 
     def _print_tuple(self, expr):
         if len(expr) == 1:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -166,7 +166,7 @@ class ReprPrinter(Printer):
             d['dummy_index'] = expr.dummy_index
 
         if d == {}:
-            return "%s(%s)" % (expr.__class__.__name__, self._print(repr(expr.name)))
+            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
         else:
             attr = ['%s=%s' % (k, v) for k, v in d.items()]
             return "%s(%s, %s)" % (expr.__class__.__name__,
@@ -179,7 +179,10 @@ class ReprPrinter(Printer):
         return "%s(%s, %s)" % (expr.__class__.__name__, expr.func, expr.arg)
 
     def _print_str(self, expr):
-        return expr
+        return repr(expr)
+    
+    def _print_basestring(self, expr):
+        return repr(expr)
 
     def _print_tuple(self, expr):
         if len(expr) == 1:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -180,7 +180,6 @@ class ReprPrinter(Printer):
 
     def _print_str(self, expr):
         return repr(expr)
-    
     # XXX: Can be removed once Py2 support is dropped
     def _print_basestring(self, expr):
         return repr(expr)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -134,6 +134,7 @@ def test_Symbol():
     sT(x, "Symbol('x')")
     sT(y, "Symbol('y')")
     sT(Symbol('x', negative=True), "Symbol('x', negative=True)")
+    sT(Symbol(u'text'), "Symbol(u'text')")
 
 
 def test_Symbol_two_assumptions():


### PR DESCRIPTION
Fixes #16086 


#### For printing symbol repr(expr.name) is passed to _print in _print_Symbol, this preserves u'text'. For correct output, repr is removed from _print_str.
Present output
```
>>> from sympy import *
>>> s = Symbol(u'text')
>>> print(srepr(s))
Symbol(text)
```
After this commit
```
>>> from sympy import *
>>> s = Symbol(u'text')
>>> print(srepr(s))
Symbol(u'text')
```
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->