### PR TITLE
Added -q flag in travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -258,7 +258,7 @@ install:
       ~/.venv-no-setuptools/bin/pip uninstall -y setuptools;
       ~/.venv-no-setuptools/bin/python -We:invalid setup.py -q install;
     fi
-    python -We:invalid -m compileall -f sympy/;
+    python -We:invalid -m compileall -f -q sympy/;
     python -We:invalid setup.py -q install;
     pip list --format=columns;
 


### PR DESCRIPTION
The -q flags outputs only error messages; reducing the output log.
It makes it easy to understand where the compilation error actually is,
since it outputs where the syntax error occurs

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16097 

#### Brief description of what is fixed or changed
-q flag added in compileall line (line no. 261; .travis.yml). Shows only error in output log

#### Other comments
Wasn't sure how to test if it was correct. Ran `python -m compileall -f sympy` in the terminal which showed every compilation steps. `python -m compileall -f -q sympy` showed no such output; just completion of process successfully. Ran `bin/test core` and `bin/test/assumptions` which gave no error.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
