### PR TITLE
Crypto : Improve speed of RSA

### DIFF
--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1215,7 +1215,7 @@ def rsa_public_key(p, q, e):
     """
     n = p*q
     if isprime(p) and isprime(q):
-        phi = totient(n)
+        phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             return n, e
     return False
@@ -1241,7 +1241,7 @@ def rsa_private_key(p, q, e):
     """
     n = p*q
     if isprime(p) and isprime(q):
-        phi = totient(n)
+        phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             d = mod_inverse(e, phi)
             return n, d

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1218,7 +1218,7 @@ def rsa_public_key(p, q, e):
         if p != q:
             phi = (p - 1) * (q - 1)
         else:
-            phi = p * (q - 1)
+            phi = p * (p - 1)
         if gcd(e, phi) == 1:
             return n, e
     return False
@@ -1247,7 +1247,7 @@ def rsa_private_key(p, q, e):
         if p != q:
             phi = (p - 1) * (q - 1)
         else:
-            phi = p * (q - 1)
+            phi = p * (p - 1)
         if gcd(e, phi) == 1:
             d = mod_inverse(e, phi)
             return n, d

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1199,7 +1199,7 @@ def bifid6_square(key=None):
 def rsa_public_key(p, q, e):
     r"""
     Return the RSA *public key* pair, `(n, e)`, where `n`
-    is a product of two distinct primes and `e` is relatively
+    is a product of two primes and `e` is relatively
     prime (coprime) to the Euler totient `\phi(n)`. False
     is returned if any assumption is violated.
 
@@ -1219,6 +1219,7 @@ def rsa_public_key(p, q, e):
         if p == q:
             SymPyDeprecationWarning(
                 feature="Using non-distinct primes for rsa_public_key",
+                useinstead="distinct primes",
                 issue=16162,
                 deprecated_since_version="1.4").warn()
             phi = p * (p - 1)
@@ -1232,7 +1233,7 @@ def rsa_public_key(p, q, e):
 def rsa_private_key(p, q, e):
     r"""
     Return the RSA *private key*, `(n,d)`, where `n`
-    is a product of two distinct primes and `d` is the inverse of
+    is a product of two primes and `d` is the inverse of
     `e` (mod `\phi(n)`). False is returned if any assumption
     is violated.
 
@@ -1251,6 +1252,7 @@ def rsa_private_key(p, q, e):
         if p == q:
             SymPyDeprecationWarning(
                 feature="Using non-distinct primes for rsa_public_key",
+                useinstead="distinct primes",
                 issue=16162,
                 deprecated_since_version="1.4").warn()
             phi = p * (p - 1)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1198,7 +1198,7 @@ def bifid6_square(key=None):
 def rsa_public_key(p, q, e):
     r"""
     Return the RSA *public key* pair, `(n, e)`, where `n`
-    is a product of two primes and `e` is relatively
+    is a product of two distinct primes and `e` is relatively
     prime (coprime) to the Euler totient `\phi(n)`. False
     is returned if any assumption is violated.
 
@@ -1213,12 +1213,11 @@ def rsa_public_key(p, q, e):
     False
 
     """
+    if p == q:
+        return False
     n = p*q
     if isprime(p) and isprime(q):
-        if p != q:
-            phi = (p - 1) * (q - 1)
-        else:
-            phi = p * (p - 1)
+        phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             return n, e
     return False
@@ -1227,7 +1226,7 @@ def rsa_public_key(p, q, e):
 def rsa_private_key(p, q, e):
     r"""
     Return the RSA *private key*, `(n,d)`, where `n`
-    is a product of two primes and `d` is the inverse of
+    is a product of two distinct primes and `d` is the inverse of
     `e` (mod `\phi(n)`). False is returned if any assumption
     is violated.
 
@@ -1242,12 +1241,11 @@ def rsa_private_key(p, q, e):
     False
 
     """
+    if p == q:
+        return False
     n = p*q
     if isprime(p) and isprime(q):
-        if p != q:
-            phi = (p - 1) * (q - 1)
-        else:
-            phi = p * (p - 1)
+        phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             d = mod_inverse(e, phi)
             return n, d

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1215,7 +1215,10 @@ def rsa_public_key(p, q, e):
     """
     n = p*q
     if isprime(p) and isprime(q):
-        phi = (p - 1) * (q - 1)
+        if p != q:
+            phi = (p - 1) * (q - 1)
+        else:
+            phi = p * (q - 1)
         if gcd(e, phi) == 1:
             return n, e
     return False
@@ -1241,7 +1244,10 @@ def rsa_private_key(p, q, e):
     """
     n = p*q
     if isprime(p) and isprime(q):
-        phi = (p - 1) * (q - 1)
+        if p != q:
+            phi = (p - 1) * (q - 1)
+        else:
+            phi = p * (q - 1)
         if gcd(e, phi) == 1:
             d = mod_inverse(e, phi)
             return n, d

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -29,6 +29,7 @@ from sympy.polys.polytools import gcd, Poly
 from sympy.utilities.misc import filldedent, translate
 from sympy.utilities.iterables import uniq
 from sympy.utilities.randtest import _randrange, _randint
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 def AZ(s=None):
@@ -1211,15 +1212,18 @@ def rsa_public_key(p, q, e):
     (15, 7)
     >>> rsa_public_key(p, q, 30)
     False
-    >>> rsa_public_key(q, q, e)
-    False
 
     """
-    if p == q:
-        return False
     n = p*q
     if isprime(p) and isprime(q):
-        phi = (p - 1) * (q - 1)
+        if p == q:
+            SymPyDeprecationWarning(
+                feature="Using non-distinct primes for RSA keys",
+                issue=16162,
+                deprecated_since_version="1.4").warn()
+            phi = p * (p - 1)
+        else:
+            phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             return n, e
     return False
@@ -1241,15 +1245,17 @@ def rsa_private_key(p, q, e):
     (15, 7)
     >>> rsa_private_key(p, q, 30)
     False
-    >>> rsa_private_key(q, q, e)
-    False
-
     """
-    if p == q:
-        return False
     n = p*q
     if isprime(p) and isprime(q):
-        phi = (p - 1) * (q - 1)
+        if p == q:
+            SymPyDeprecationWarning(
+                feature="Using non-distinct primes for RSA keys",
+                issue=16162,
+                deprecated_since_version="1.4").warn()
+            phi = p * (p - 1)
+        else:
+            phi = (p - 1) * (q - 1)
         if gcd(e, phi) == 1:
             d = mod_inverse(e, phi)
             return n, d

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1211,6 +1211,8 @@ def rsa_public_key(p, q, e):
     (15, 7)
     >>> rsa_public_key(p, q, 30)
     False
+    >>> rsa_public_key(q, q, e)
+    False
 
     """
     if p == q:
@@ -1238,6 +1240,8 @@ def rsa_private_key(p, q, e):
     >>> rsa_private_key(p, q, e)
     (15, 7)
     >>> rsa_private_key(p, q, 30)
+    False
+    >>> rsa_private_key(q, q, e)
     False
 
     """

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1218,7 +1218,7 @@ def rsa_public_key(p, q, e):
     if isprime(p) and isprime(q):
         if p == q:
             SymPyDeprecationWarning(
-                feature="Using non-distinct primes for RSA keys",
+                feature="Using non-distinct primes for rsa_public_key",
                 issue=16162,
                 deprecated_since_version="1.4").warn()
             phi = p * (p - 1)
@@ -1250,7 +1250,7 @@ def rsa_private_key(p, q, e):
     if isprime(p) and isprime(q):
         if p == q:
             SymPyDeprecationWarning(
-                feature="Using non-distinct primes for RSA keys",
+                feature="Using non-distinct primes for rsa_public_key",
                 issue=16162,
                 deprecated_since_version="1.4").warn()
             phi = p * (p - 1)

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -165,7 +165,7 @@ def test_rsa_private_key():
 
     raises(SymPyDeprecationWarning, lambda: rsa_private_key(2, 2, 1))
     with warns_deprecated_sympy():
-        assert rsa_private_key(2, 2, 1) == (4, 1)    
+        assert rsa_private_key(2, 2, 1) == (4, 1)
 
 
 def test_rsa_large_key():

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -19,7 +19,8 @@ from sympy.matrices import Matrix
 from sympy.ntheory import isprime, is_primitive_root
 from sympy.polys.domains import FF
 
-from sympy.utilities.pytest import raises, slow
+from sympy.utilities.pytest import raises, slow, warns_deprecated_sympy
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from random import randrange
 
@@ -147,18 +148,24 @@ def test_bifid6_square():
 
 
 def test_rsa_public_key():
-    assert rsa_public_key(2, 2, 1) is False
     assert rsa_public_key(2, 3, 1) == (6, 1)
     assert rsa_public_key(5, 3, 3) == (15, 3)
     assert rsa_public_key(8, 8, 8) is False
 
+    raises(SymPyDeprecationWarning, lambda: rsa_public_key(2, 2, 1))
+    with warns_deprecated_sympy():
+        assert rsa_public_key(2, 2, 1) == (4, 1)
+
 
 def test_rsa_private_key():
-    assert rsa_private_key(2, 2, 1) is False
     assert rsa_private_key(2, 3, 1) == (6, 1)
     assert rsa_private_key(5, 3, 3) == (15, 3)
     assert rsa_private_key(23,29,5) == (667,493)
     assert rsa_private_key(8, 8, 8) is False
+
+    raises(SymPyDeprecationWarning, lambda: rsa_private_key(2, 2, 1))
+    with warns_deprecated_sympy():
+        assert rsa_private_key(2, 2, 1) == (4, 1)    
 
 
 def test_rsa_large_key():
@@ -182,12 +189,20 @@ def test_encipher_rsa():
     puk = rsa_public_key(5, 3, 3)
     assert encipher_rsa(2, puk) == 8
 
+    with warns_deprecated_sympy():
+        puk = rsa_public_key(2, 2, 1)
+        assert encipher_rsa(2, puk) == 2
+
 
 def test_decipher_rsa():
     prk = rsa_private_key(2, 3, 1)
     assert decipher_rsa(2, prk) == 2
     prk = rsa_private_key(5, 3, 3)
     assert decipher_rsa(8, prk) == 2
+
+    with warns_deprecated_sympy():
+        prk = rsa_private_key(2, 2, 1)
+        assert decipher_rsa(2, prk) == 2
 
 
 def test_kid_rsa_public_key():

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -147,14 +147,14 @@ def test_bifid6_square():
 
 
 def test_rsa_public_key():
-    assert rsa_public_key(2, 2, 1) == (4, 1)
+    assert rsa_public_key(2, 2, 1) is False
     assert rsa_public_key(2, 3, 1) == (6, 1)
     assert rsa_public_key(5, 3, 3) == (15, 3)
     assert rsa_public_key(8, 8, 8) is False
 
 
 def test_rsa_private_key():
-    assert rsa_private_key(2, 2, 1) == (4, 1)
+    assert rsa_private_key(2, 2, 1) is False
     assert rsa_private_key(2, 3, 1) == (6, 1)
     assert rsa_private_key(5, 3, 3) == (15, 3)
     assert rsa_private_key(23,29,5) == (667,493)
@@ -177,8 +177,6 @@ def test_rsa_large_key():
 
 
 def test_encipher_rsa():
-    puk = rsa_public_key(2, 2, 1)
-    assert encipher_rsa(2, puk) == 2
     puk = rsa_public_key(2, 3, 1)
     assert encipher_rsa(2, puk) == 2
     puk = rsa_public_key(5, 3, 3)
@@ -186,8 +184,6 @@ def test_encipher_rsa():
 
 
 def test_decipher_rsa():
-    prk = rsa_private_key(2, 2, 1)
-    assert decipher_rsa(2, prk) == 2
     prk = rsa_private_key(2, 3, 1)
     assert decipher_rsa(2, prk) == 2
     prk = rsa_private_key(5, 3, 3)

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -161,6 +161,21 @@ def test_rsa_private_key():
     assert rsa_private_key(8, 8, 8) is False
 
 
+def test_rsa_large_key():
+    # Sample from
+    # http://www.herongyang.com/Cryptography/JCE-Public-Key-RSA-Private-Public-Key-Pair-Sample.html
+    p = int('101565610013301240713207239558950144682174355406589305284428666'\
+        '903702505233009')
+    q = int('894687191887545488935455605955948413812376003053143521429242133'\
+        '12069293984003')
+    e = int('65537')
+    d = int('893650581832704239530398858744759129594796235440844479456143566'\
+        '6999402846577625762582824202269399672579058991442587406384754958587'\
+        '400493169361356902030209')
+    assert rsa_public_key(p, q, e) == (p*q, e)
+    assert rsa_private_key(p, q, e) == (p*q, d)
+
+
 def test_encipher_rsa():
     puk = rsa_public_key(2, 2, 1)
     assert encipher_rsa(2, puk) == 2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

https://github.com/sympy/sympy/blob/cf7322f5dba866c85ab3cfa2ad237e573b008a43/sympy/crypto/crypto.py#L1218

It is slow to compute Euler Totient in this way, if the numbers are large.

```
from sympy import *
from sympy.crypto import rsa_public_key, rsa_private_key
import cProfile

p = S(24516021043835088623)
q = S(30129830626086539899)
e = S(65537)

cProfile.run('rsa_public_key(p, q, e)')
``` 

Using special formula improves the speed from
`39508155 function calls (39507218 primitive calls) in 24.688 seconds`
to 
`651 function calls in 0.001 seconds`

Though the `totient` seems to get cached after subsequent computation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- crypto
  - Improved speed for `rsa_public_key` and `rsa_private_key`
  - Raise deprecation warning if same prime numbers are given to `rsa_public_key` and `rsa_private_key`
<!-- END RELEASE NOTES -->

- [ ] When deprecation is complete, return False when the primes are the same and consider allowing a keyword that would override the checks so, for educational purposes, non-prime or `p==q` values could be used.