### PR TITLE
Remove most examples of except AttributeError from the codebase

### DIFF
--- a/bin/test_external_imports.py
+++ b/bin/test_external_imports.py
@@ -65,13 +65,8 @@ def test_external_imports():
         if mod in sys.builtin_module_names:
             continue
 
-        # if not hasattr(mod, '__file__'):
-        #     # bad.append(mod)
-        #     continue
-
-        try:
-            fname = sys.modules[mod].__file__
-        except AttributeError:
+        fname = getattr(sys.modules[mod], "__file__", None)
+        if fname is None:
             bad.append(mod)
             continue
 

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -538,18 +538,17 @@ class ClassDoc(NumpyDocString):
                 if not self[field]:
                     doc_list = []
                     for name in sorted(items):
-                        try:
-                            doc_item = pydoc.getdoc(getattr(self._cls, name))
+                        clsname = getattr(self._cls, name, None)
+                        if clsname is not None:
+                            doc_item = pydoc.getdoc(clsname)
                             doc_list.append((name, '', splitlines_x(doc_item)))
-                        except AttributeError:
-                            pass  # method doesn't exist
                     self[field] = doc_list
 
     @property
     def methods(self):
         if self._cls is None:
             return []
-        return [name for name, func in inspect_getmembers(self._cls)
+        return [name for name, func in inspect.getmembers(self._cls)
                 if ((not name.startswith('_')
                      or name in self.extra_public_methods)
                     and callable(func))]
@@ -558,33 +557,5 @@ class ClassDoc(NumpyDocString):
     def properties(self):
         if self._cls is None:
             return []
-        return [name for name, func in inspect_getmembers(self._cls)
+        return [name for name, func in inspect.getmembers(self._cls)
                 if not name.startswith('_') and func is None]
-
-
-# This function was taken verbatim from Python 2.7 inspect.getmembers() from
-# the standard library. The difference from Python < 2.7 is that there is the
-# try/except AttributeError clause added, which catches exceptions like this
-# one: https://gist.github.com/1471949
-def inspect_getmembers(object, predicate=None):
-    """
-    Return all members of an object as (name, value) pairs sorted by name.
-    Optionally, only return members that satisfy a given predicate.
-    """
-    results = []
-    for key in dir(object):
-        try:
-            value = getattr(object, key)
-        except AttributeError:
-            continue
-        if not predicate or predicate(value):
-            results.append((key, value))
-    results.sort()
-    return results
-
-    def _is_show_member(self, name):
-        if self.show_inherited_members:
-            return True  # show all class members
-        if name not in self._cls.__dict__:
-            return False  # class member is inherited, we do not show it
-        return True

--- a/examples/intermediate/sample.py
+++ b/examples/intermediate/sample.py
@@ -24,7 +24,7 @@ def sample2d(f, x_args):
         raise ValueError("f could not be interpretted as a SymPy function")
     try:
         x, x_min, x_max, x_n = x_args
-    except AttributeError:
+    except (TypeError, IndexError):
         raise ValueError("x_args must be a tuple of the form (var, min, max, n)")
 
     x_l = float(x_max - x_min)
@@ -58,7 +58,7 @@ def sample3d(f, x_args, y_args):
     try:
         x, x_min, x_max, x_n = x_args
         y, y_min, y_max, y_n = y_args
-    except AttributeError:
+    except (TypeError, IndexError):
         raise ValueError("x_args and y_args must be tuples of the form (var, min, max, intervals)")
 
     x_l = float(x_max - x_min)

--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -43,11 +43,7 @@ from fabric.contrib.files import exists
 from fabric.colors import blue, red, green
 from fabric.utils import error, warn
 
-try:
-    # Only works in newer versions of fabric
-    env.colorize_errors = True
-except AttributeError:
-    pass
+env.colorize_errors = True
 
 try:
     import requests

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1340,9 +1340,10 @@ def register_handler(key, handler):
     """
     if type(key) is Predicate:
         key = key.name
-    try:
-        getattr(Q, key).add_handler(handler)
-    except AttributeError:
+    Qkey = getattr(Q, key, None)
+    if Qkey is not None:
+        Qkey.add_handler(handler)
+    else:
         setattr(Q, key, Predicate(key, handlers=[handler]))
 
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -186,11 +186,10 @@ class Predicate(Boolean):
         for handler in self.handlers:
             cls = get_class(handler)
             for subclass in mro:
-                try:
-                    eval = getattr(cls, subclass.__name__)
-                except AttributeError:
+                eval_ = getattr(cls, subclass.__name__, None)
+                if eval_ is None:
                     continue
-                res = eval(expr, assumptions)
+                res = eval_(expr, assumptions)
                 # Do not stop if value returned is None
                 # Try to check for higher classes
                 if res is None:

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -327,10 +327,9 @@ class ManagedProperties(BasicMeta):
 
         defs = {}
         for base in reversed(cls.__bases__):
-            try:
-                defs.update(base._explicit_class_assumptions)
-            except AttributeError:
-                pass
+            assumptions = getattr(base, '_explicit_class_assumptions', None)
+            if assumptions is not None:
+                defs.update(assumptions)
         defs.update(local_defs)
 
         cls._explicit_class_assumptions = defs
@@ -338,10 +337,9 @@ class ManagedProperties(BasicMeta):
 
         cls._prop_handler = {}
         for k in _assume_defined:
-            try:
-                cls._prop_handler[k] = getattr(cls, '_eval_is_%s' % k)
-            except AttributeError:
-                pass
+            eval_is_meth = getattr(cls, '_eval_is_%s' % k, None)
+            if eval_is_meth is not None:
+                cls._prop_handler[k] = eval_is_meth
 
         # Put definite results directly into the class dict, for speed
         for k, v in cls.default_assumptions.items():
@@ -350,10 +348,11 @@ class ManagedProperties(BasicMeta):
         # protection e.g. for Integer.is_even=F <- (Rational.is_integer=F)
         derived_from_bases = set()
         for base in cls.__bases__:
-            try:
-                derived_from_bases |= set(base.default_assumptions)
-            except AttributeError:
-                continue  # not an assumption-aware class
+            default_assumptions = getattr(base, 'default_assumptions', None)
+            # is an assumption-aware class
+            if default_assumptions is not None:
+                derived_from_bases.update(default_assumptions)
+
         for fact in derived_from_bases - set(cls.default_assumptions):
             pname = as_property(fact)
             if pname not in cls.__dict__:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1191,11 +1191,12 @@ class Basic(with_metaclass(ManagedProperties)):
             args = []
             changed = False
             for a in self.args:
-                try:
-                    a_xr = a._xreplace(rule)
+                _xreplace = getattr(a, '_xreplace', None)
+                if _xreplace is not None:
+                    a_xr = _xreplace(rule)
                     args.append(a_xr[0])
                     changed |= a_xr[1]
-                except AttributeError:
+                else:
                     args.append(a)
             args = tuple(args)
             if changed:
@@ -1263,10 +1264,11 @@ class Basic(with_metaclass(ManagedProperties)):
             return any(isinstance(arg, pattern)
             for arg in preorder_traversal(self))
 
-        try:
-            match = pattern._has_matcher()
+        _has_matcher = getattr(pattern, '_has_matcher', None)
+        if _has_matcher is not None:
+            match = _has_matcher()
             return any(match(arg) for arg in preorder_traversal(self))
-        except AttributeError:
+        else:
             return any(arg == pattern for arg in preorder_traversal(self))
 
     def _has_matcher(self):
@@ -1899,9 +1901,8 @@ def _atomic(e, recursive=False):
     pot = preorder_traversal(e)
     seen = set()
     if isinstance(e, Basic):
-        try:
-            free = e.free_symbols
-        except AttributeError:
+        free = getattr(e, "free_symbols", None)
+        if free is None:
             return {e}
     else:
         return set()

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -123,11 +123,8 @@ def call_highest_priority(method_name):
         def binary_op_wrapper(self, other):
             if hasattr(other, '_op_priority'):
                 if other._op_priority > self._op_priority:
-                    try:
-                        f = getattr(other, method_name)
-                    except AttributeError:
-                        pass
-                    else:
+                    f = getattr(other, method_name, None)
+                    if f is not None:
                         return f(self)
             return func(self, other)
         return binary_op_wrapper

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -365,22 +365,11 @@ def get_integer_part(expr, no, options, return_ints=False):
             # expression
             s = options.get('subs', False)
             if s:
-                doit = True
-                from sympy.core.compatibility import as_int
-                # use strict=False with as_int because we take
-                # 2.0 == 2
-                for v in s.values():
-                    try:
-                        as_int(v, strict=False)
-                    except ValueError:
-                        try:
-                            [as_int(i, strict=False) for i in v.as_real_imag()]
-                            continue
-                        except (ValueError, AttributeError):
-                            doit = False
-                            break
-                if doit:
-                    re_im = re_im.subs(s)
+                re_im = re_im.subs(s)
+                # XXX: There was a load more code here that was added in
+                # https://github.com/sympy/sympy/pull/10346
+                # I guess something has changed because now I can delete it
+                # without apparently affecting anything...
 
             re_im = Add(re_im, -nint, evaluate=False)
             x, _, x_acc, _ = evalf(re_im, 10, options)
@@ -1308,33 +1297,36 @@ def evalf(x, prec, options):
         rf = evalf_table[x.func]
         r = rf(x, prec, options)
     except KeyError:
-        try:
-            # Fall back to ordinary evalf if possible
-            if 'subs' in options:
-                x = x.subs(evalf_subs(prec, options['subs']))
-            xe = x._eval_evalf(prec)
-            re, im = xe.as_real_imag()
-            if re.has(re_) or im.has(im_):
-                raise NotImplementedError
-            if re == 0:
-                re = None
-                reprec = None
-            elif re.is_number:
-                re = re._to_mpmath(prec, allow_ints=False)._mpf_
-                reprec = prec
-            else:
-                raise NotImplementedError
-            if im == 0:
-                im = None
-                imprec = None
-            elif im.is_number:
-                im = im._to_mpmath(prec, allow_ints=False)._mpf_
-                imprec = prec
-            else:
-                raise NotImplementedError
-            r = re, im, reprec, imprec
-        except AttributeError:
+        # Fall back to ordinary evalf if possible
+        if 'subs' in options:
+            x = x.subs(evalf_subs(prec, options['subs']))
+        xe = x._eval_evalf(prec)
+        if xe is None:
             raise NotImplementedError
+        as_real_imag = getattr(xe, "as_real_imag", None)
+        if as_real_imag is None:
+            raise NotImplementedError # e.g. FiniteSet(-1.0, 1.0).evalf()
+        re, im = as_real_imag()
+        if re.has(re_) or im.has(im_):
+            raise NotImplementedError
+        if re == 0:
+            re = None
+            reprec = None
+        elif re.is_number:
+            re = re._to_mpmath(prec, allow_ints=False)._mpf_
+            reprec = prec
+        else:
+            raise NotImplementedError
+        if im == 0:
+            im = None
+            imprec = None
+        elif im.is_number:
+            im = im._to_mpmath(prec, allow_ints=False)._mpf_
+            imprec = prec
+        else:
+            raise NotImplementedError
+        r = re, im, reprec, imprec
+
     if options.get("verbose"):
         print("### input", x)
         print("### output", to_str(r[0] or fzero, 50))

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -806,17 +806,16 @@ class Expr(Basic, EvalfMixin):
         if self.is_number:
             if self.is_real is False:
                 return False
-            try:
-                # check to see that we can get a value
-                n2 = self._eval_evalf(2)
-                if n2 is None:
-                    raise AttributeError
-                if n2._prec == 1:  # no significance
-                    raise AttributeError
-                if n2 == S.NaN:
-                    raise AttributeError
-            except (AttributeError, ValueError):
+
+            # check to see that we can get a value
+            n2 = self._eval_evalf(2)
+            if n2 is None:
                 return None
+            if getattr(n2, '_prec', 1) == 1:  # no significance
+                return None
+            if n2 == S.NaN:
+                return None
+
             n, i = self.evalf(2).as_real_imag()
             if not i.is_Number or not n.is_Number:
                 return False
@@ -966,11 +965,11 @@ class Expr(Basic, EvalfMixin):
         """Parse and configure the ordering of terms. """
         from sympy.polys.orderings import monomial_key
 
-        try:
-            reverse = order.startswith('rev-')
-        except AttributeError:
+        startswith = getattr(order, "startswith", None)
+        if startswith is None:
             reverse = False
         else:
+            reverse = startswith('rev-')
             if reverse:
                 order = order[4:]
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -779,7 +779,13 @@ class Expr(Basic, EvalfMixin):
                 return False
 
             # check to see that we can get a value
-            n2 = self._eval_evalf(2)
+            try:
+                n2 = self._eval_evalf(2)
+            # XXX: This shouldn't be caught here
+            # Catches ValueError: hypsum() failed to converge to the requested
+            # 34 bits of accuracy
+            except ValueError:
+                return None
             if n2 is None:
                 return None
             if getattr(n2, '_prec', 1) == 1:  # no significance
@@ -808,7 +814,13 @@ class Expr(Basic, EvalfMixin):
                 return False
 
             # check to see that we can get a value
-            n2 = self._eval_evalf(2)
+            try:
+                n2 = self._eval_evalf(2)
+            # XXX: This shouldn't be caught here
+            # Catches ValueError: hypsum() failed to converge to the requested
+            # 34 bits of accuracy
+            except ValueError:
+                return None
             if n2 is None:
                 return None
             if getattr(n2, '_prec', 1) == 1:  # no significance

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -777,17 +777,16 @@ class Expr(Basic, EvalfMixin):
         if self.is_number:
             if self.is_real is False:
                 return False
-            try:
-                # check to see that we can get a value
-                n2 = self._eval_evalf(2)
-                if n2 is None:
-                    raise AttributeError
-                if n2._prec == 1:  # no significance
-                    raise AttributeError
-                if n2 == S.NaN:
-                    raise AttributeError
-            except (AttributeError, ValueError):
+
+            # check to see that we can get a value
+            n2 = self._eval_evalf(2)
+            if n2 is None:
                 return None
+            if getattr(n2, '_prec', 1) == 1:  # no significance
+                return None
+            if n2 == S.NaN:
+                return None
+
             n, i = self.evalf(2).as_real_imag()
             if not i.is_Number or not n.is_Number:
                 return False

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -393,10 +393,10 @@ class Factors(object):
                             raise ValueError('unexpected factor in i1: %s' % a)
 
         self.factors = factors
-        try:
-            self.gens = frozenset(factors.keys())
-        except AttributeError:
+        keys = getattr(factors, 'keys', None)
+        if keys is None:
             raise TypeError('expecting Expr or dictionary')
+        self.gens = frozenset(keys())
 
     def __hash__(self):  # Factors
         keys = tuple(ordered(self.factors.keys()))

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -22,12 +22,10 @@ __all__ = (
 
 def _canonical(cond):
     # return a condition in which all relationals are canonical
-    try:
-        reps = dict([(r, r.canonical)
-            for r in cond.atoms(Relational)])
-        return cond.xreplace(reps)
-    except AttributeError:
-        return cond
+    reps = {r: r.canonical for r in cond.atoms(Relational)}
+    return cond.xreplace(reps)
+    # XXX: AttributeError was being caught here but it wasn't triggered by any of
+    # the tests so I've removed it...
 
 
 class Relational(Boolean, Expr, EvalfMixin):

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -95,11 +95,8 @@ class SingletonRegistry(Registry):
 
     def register(self, cls):
         # Make sure a duplicate class overwrites the old one
-        try:
-            if getattr(self, cls.__name__):
-                delattr(self, cls.__name__)
-        except AttributeError:
-            pass
+        if hasattr(self, cls.__name__):
+            delattr(self, cls.__name__)
         self._classes_to_install[cls.__name__] = cls
 
     def __getattr__(self, name):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -318,10 +318,15 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if not isinstance(a, string_types):
         for coerce in (float, int):
             try:
-                return sympify(coerce(a))
-            # XXX: Attribute error was being caught here but it doesn't seem
-            # to be needed...
-            except (TypeError, ValueError, SympifyError):
+                coerced = coerce(a)
+            except (TypeError, ValueError):
+                continue
+            # XXX: AttributeError only needed here for Py2
+            except AttributeError:
+                continue
+            try:
+                return sympify(coerced)
+            except SympifyError:
                 continue
 
     if strict:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -303,7 +303,13 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     _sympy_ = getattr(a, "_sympy_", None)
     if _sympy_ is not None:
-        return a._sympy_()
+        try:
+            return a._sympy_()
+        # XXX: Catches AttributeError: 'SympyConverter' object has no
+        # attribute 'tuple'
+        # This is probably a bug somewhere but for now we catch it here.
+        except AttributeError:
+            pass
 
     if not strict:
         # Put numpy array conversion _before_ float/int, see

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -596,17 +596,14 @@ def test_sympify_numpy():
     assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
     assert equal(sympify(np.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
 
-    try:
+    #float96 does not exist on all platforms
+    if hasattr(np, 'float96'):
         assert equal(sympify(np.float96(1.123456789)),
                     Float(1.123456789, precision=80))
-    except AttributeError:  #float96 does not exist on all platforms
-        pass
-
-    try:
+    #float128 does not exist on all platforms
+    if hasattr(np, 'float128'):
         assert equal(sympify(np.float128(1.123456789123)),
                     Float(1.123456789123, precision=80))
-    except AttributeError:  #float128 does not exist on all platforms
-        pass
 
 
 @XFAIL

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -22,6 +22,7 @@ import sympy
 import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.utilities.pytest import raises
 
 
 # first, systematically check, that all operations are implemented and don't
@@ -230,11 +231,8 @@ def test_lambdify():
     f = lambdify(x, sin(x), "numpy")
     prec = 1e-15
     assert -prec < f(0.2) - sin02 < prec
-    try:
+    with raises(AttributeError):
         f(x)  # if this succeeds, it can't be a numpy function
-        assert False
-    except AttributeError:
-        pass
 
 
 def test_lambdify_matrix():

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -161,16 +161,16 @@ def are_similar(e1, e2):
 
     if e1 == e2:
         return True
-    try:
-        return e1.is_similar(e2)
-    except AttributeError:
-        try:
-            return e2.is_similar(e1)
-        except AttributeError:
-            n1 = e1.__class__.__name__
-            n2 = e2.__class__.__name__
-            raise GeometryError(
-                "Cannot test similarity between %s and %s" % (n1, n2))
+    is_similar1 = getattr(e1, 'is_similar', None)
+    if is_similar1:
+        return is_similar1(e2)
+    is_similar2 = getattr(e2, 'is_similar', None)
+    if is_similar2:
+        return is_similar2(e1)
+    n1 = e1.__class__.__name__
+    n2 = e2.__class__.__name__
+    raise GeometryError(
+        "Cannot test similarity between %s and %s" % (n1, n2))
 
 
 def centroid(*args):

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -2619,11 +2619,8 @@ def _extend_y0(Holonomic, n):
             sol = 0
             for a, b in zip(y1, list_red):
                 r = DMFsubs(b, Holonomic.x0)
-                try:
-                    if not r.is_finite:
-                        return y0
-                except AttributeError:
-                    pass
+                if not getattr(r, 'is_finite', True):
+                    return y0
                 if isinstance(r, (PolyElement, FracElement)):
                     r = r.as_expr()
                 sol += a * r

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -43,16 +43,17 @@ class DenseMatrix(MatrixBase):
     _class_priority = 4
 
     def __eq__(self, other):
-        try:
-            other = sympify(other)
-            if self.shape != other.shape:
-                return False
-            if isinstance(other, Matrix):
-                return _compare_sequence(self._mat,  other._mat)
-            elif isinstance(other, MatrixBase):
-                return _compare_sequence(self._mat, Matrix(other)._mat)
-        except AttributeError:
+        other = sympify(other)
+        self_shape = getattr(self, 'shape', None)
+        other_shape = getattr(other, 'shape', None)
+        if None in (self_shape, other_shape):
             return False
+        if self_shape != other_shape:
+            return False
+        if isinstance(other, Matrix):
+            return _compare_sequence(self._mat,  other._mat)
+        elif isinstance(other, MatrixBase):
+            return _compare_sequence(self._mat, Matrix(other)._mat)
 
     def __getitem__(self, key):
         """Return portion of self defined by key. If the key involves a slice
@@ -396,20 +397,21 @@ class DenseMatrix(MatrixBase):
         ========
         sympy.core.expr.equals
         """
-        try:
-            if self.shape != other.shape:
-                return False
-            rv = True
-            for i in range(self.rows):
-                for j in range(self.cols):
-                    ans = self[i, j].equals(other[i, j], failing_expression)
-                    if ans is False:
-                        return False
-                    elif ans is not True and rv is True:
-                        rv = ans
-            return rv
-        except AttributeError:
+        self_shape = getattr(self, 'shape', None)
+        other_shape = getattr(other, 'shape', None)
+        if None in (self_shape, other_shape):
             return False
+        if self_shape != other_shape:
+            return False
+        rv = True
+        for i in range(self.rows):
+            for j in range(self.cols):
+                ans = self[i, j].equals(other[i, j], failing_expression)
+                if ans is False:
+                    return False
+                elif ans is not True and rv is True:
+                    rv = ans
+        return rv
 
 
 def _force_mutable(x):

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -97,10 +97,13 @@ def conjugate_row(row, K):
     """
     result = []
     for r in row:
-        try:
-            result.append(r.conjugate())
-        except AttributeError:
-            result.append(r)
+        conj = getattr(r, 'conjugate', None)
+        if conj is not None:
+            conjrow = conj()
+        else:
+            conjrow = r
+        result.append(conjrow)
+
     return result
 
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -295,9 +295,10 @@ def block_collapse(expr):
              Inverse: bc_inverse,
              BlockMatrix: do_one(bc_unpack, deblock)})))))
     result = rule(expr)
-    try:
-        return result.doit()
-    except AttributeError:
+    doit = getattr(result, 'doit', None)
+    if doit is not None:
+        return doit()
+    else:
         return result
 
 def bc_unpack(expr):

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -427,7 +427,8 @@ def combine_kronecker(expr):
              MatMul: kronecker_mat_mul,
              MatPow: kronecker_mat_pow})))))
     result = rule(expr)
-    try:
-        return result.doit()
-    except AttributeError:
+    doit = getattr(result, 'doit', None)
+    if doit is not None:
+        return doit()
+    else:
         return result

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -36,10 +36,11 @@ class Transpose(MatrixExpr):
         arg = self.arg
         if hints.get('deep', True) and isinstance(arg, Basic):
             arg = arg.doit(**hints)
-        try:
-            result = arg._eval_transpose()
+        _eval_transpose = getattr(arg, '_eval_transpose', None)
+        if _eval_transpose is not None:
+            result = _eval_transpose()
             return result if result is not None else Transpose(arg)
-        except AttributeError:
+        else:
             return Transpose(arg)
 
     @property

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -32,10 +32,7 @@ from .common import (
 
 def _iszero(x):
     """Returns True if x is zero."""
-    try:
-        return x.is_zero
-    except AttributeError:
-        return None
+    return getattr(x, 'is_zero', None)
 
 
 def _is_zero_after_expand_mul(x):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -90,15 +90,16 @@ class SparseMatrix(MatrixBase):
         return self
 
     def __eq__(self, other):
-        try:
-            if self.shape != other.shape:
-                return False
-            if isinstance(other, SparseMatrix):
-                return self._smat == other._smat
-            elif isinstance(other, MatrixBase):
-                return self._smat == MutableSparseMatrix(other)._smat
-        except AttributeError:
+        self_shape = getattr(self, 'shape', None)
+        other_shape = getattr(other, 'shape', None)
+        if None in (self_shape, other_shape):
             return False
+        if self_shape != other_shape:
+            return False
+        if isinstance(other, SparseMatrix):
+            return self._smat == other._smat
+        elif isinstance(other, MatrixBase):
+            return self._smat == MutableSparseMatrix(other)._smat
 
     def __getitem__(self, key):
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -233,25 +233,22 @@ def multiplicity(p, n):
         p, n = as_int(p), as_int(n)
     except ValueError:
         if all(isinstance(i, (SYMPY_INTS, Rational)) for i in (p, n)):
-            try:
-                p = Rational(p)
-                n = Rational(n)
-                if p.q == 1:
-                    if n.p == 1:
-                        return -multiplicity(p.p, n.q)
-                    return multiplicity(p.p, n.p) - multiplicity(p.p, n.q)
-                elif p.p == 1:
-                    return multiplicity(p.q, n.q)
-                else:
-                    like = min(
-                        multiplicity(p.p, n.p),
-                        multiplicity(p.q, n.q))
-                    cross = min(
-                        multiplicity(p.q, n.p),
-                        multiplicity(p.p, n.q))
-                    return like - cross
-            except AttributeError:
-                pass
+            p = Rational(p)
+            n = Rational(n)
+            if p.q == 1:
+                if n.p == 1:
+                    return -multiplicity(p.p, n.q)
+                return multiplicity(p.p, n.p) - multiplicity(p.p, n.q)
+            elif p.p == 1:
+                return multiplicity(p.q, n.q)
+            else:
+                like = min(
+                    multiplicity(p.p, n.p),
+                    multiplicity(p.q, n.q))
+                cross = min(
+                    multiplicity(p.q, n.p),
+                    multiplicity(p.p, n.q))
+                return like - cross
         raise ValueError('expecting ints or fractions, got %s and %s' % (p, n))
 
     if n == 0:

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -4,16 +4,17 @@ import warnings
 
 from sympy.external import import_module
 
-AutolevParser = AutolevLexer = AutolevListener = None
-try:
-    AutolevParser = import_module('sympy.parsing.autolev._antlr.autolevparser',
-                                  __import__kwargs={'fromlist': ['AutolevParser']}).AutolevParser
-    AutolevLexer = import_module('sympy.parsing.autolev._antlr.autolevlexer',
-                                 __import__kwargs={'fromlist': ['AutolevLexer']}).AutolevLexer
-    AutolevListener = import_module('sympy.parsing.autolev._antlr.autolevlistener',
-                                    __import__kwargs={'fromlist': ['AutolevListener']}).AutolevListener
-except AttributeError:
-    pass
+autolevparser = import_module('sympy.parsing.autolev._antlr.autolevparser',
+                              __import__kwargs={'fromlist': ['AutolevParser']})
+autolevlexer = import_module('sympy.parsing.autolev._antlr.autolevlexer',
+                             __import__kwargs={'fromlist': ['AutolevLexer']})
+autolevlistener = import_module('sympy.parsing.autolev._antlr.autolevlistener',
+                                __import__kwargs={'fromlist': ['AutolevListener']})
+
+AutolevParser = getattr(autolevparser, 'AutolevParser', None)
+AutolevLexer = getattr(autolevlexer, 'AutolevLexer', None)
+AutolevListener = getattr(autolevlistener, 'AutolevListener', None)
+
 
 def strfunc(z):
     if z == 0:

--- a/sympy/parsing/autolev/_parse_autolev_antlr.py
+++ b/sympy/parsing/autolev/_parse_autolev_antlr.py
@@ -1,16 +1,17 @@
 import sys
 from sympy.external import import_module
 
-AutolevParser = AutolevLexer = AutolevListener = None
-try:
-    AutolevParser = import_module('sympy.parsing.autolev._antlr.autolevparser',
-                                  __import__kwargs={'fromlist': ['AutolevParser']}).AutolevParser
-    AutolevLexer = import_module('sympy.parsing.autolev._antlr.autolevlexer',
-                                 __import__kwargs={'fromlist': ['AutolevLexer']}).AutolevLexer
-    AutolevListener = import_module('sympy.parsing.autolev._antlr.autolevlistener',
-                                    __import__kwargs={'fromlist': ['AutolevListener']}).AutolevListener
-except AttributeError:
-    pass
+
+autolevparser = import_module('sympy.parsing.autolev._antlr.autolevparser',
+                              __import__kwargs={'fromlist': ['AutolevParser']})
+autolevlexer = import_module('sympy.parsing.autolev._antlr.autolevlexer',
+                             __import__kwargs={'fromlist': ['AutolevLexer']})
+autolevlistener = import_module('sympy.parsing.autolev._antlr.autolevlistener',
+                                __import__kwargs={'fromlist': ['AutolevListener']})
+
+AutolevParser = getattr(autolevparser, 'AutolevParser', None)
+AutolevLexer = getattr(autolevlexer, 'AutolevLexer', None)
+AutolevListener = getattr(autolevlistener, 'AutolevListener', None)
 
 
 def parse_autolev(autolev_code, include_numeric):

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -373,9 +373,8 @@ def gravity(acceleration, *bodies):
         raise TypeError("No bodies(instances of Particle or Rigidbody) were passed.")
 
     for e in bodies:
-        try:
-            point = e.masscenter
-        except AttributeError:
+        point = getattr(e, 'masscenter', None)
+        if point is None:
             point = e.point
 
         gravity_force.append((point, e.mass*acceleration))
@@ -422,10 +421,12 @@ def center_of_mass(point, *bodies):
     vec = Vector(0)
     for i in bodies:
         total_mass += i.mass
-        try:
-            vec += i.mass*i.masscenter.pos_from(point)
-        except AttributeError:
-            vec += i.mass*i.point.pos_from(point)
+
+        masscenter = getattr(i, 'masscenter', None)
+        if masscenter is None:
+            masscenter = i.point
+        vec += i.mass*masscenter.pos_from(point)
+
     return vec/total_mass
 
 

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -363,13 +363,13 @@ class SymbolicSystem(object):
         calculation can potentially take awhile to compute."""
         if self._comb_explicit_rhs is not None:
             raise AttributeError("comb_explicit_rhs is already formed.")
+
+        inter1 = getattr(self, 'kin_explicit_rhs', None)
+        if inter1 is not None:
+            inter2 = self._dyn_implicit_mat.LUsolve(self._dyn_implicit_rhs)
+            out = inter1.col_join(inter2)
         else:
-            try:
-                inter1 = self.kin_explicit_rhs
-                inter2 = self._dyn_implicit_mat.LUsolve(self._dyn_implicit_rhs)
-                out = inter1.col_join(inter2)
-            except AttributeError:
-                out = self._comb_implicit_mat.LUsolve(self._comb_implicit_rhs)
+            out = self._comb_implicit_mat.LUsolve(self._comb_implicit_rhs)
 
         self._comb_explicit_rhs = out
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -126,24 +126,22 @@ class Dagger(Expr):
         The eval() method is called automatically.
 
         """
-        try:
-            d = arg._dagger_()
-        except AttributeError:
-            if isinstance(arg, Basic):
-                if arg.is_Add:
-                    return Add(*tuple(map(Dagger, arg.args)))
-                if arg.is_Mul:
-                    return Mul(*tuple(map(Dagger, reversed(arg.args))))
-                if arg.is_Number:
-                    return arg
-                if arg.is_Pow:
-                    return Pow(Dagger(arg.args[0]), arg.args[1])
-                if arg == I:
-                    return -arg
-            else:
-                return None
+        dagger = getattr(arg, '_dagger_', None)
+        if dagger is not None:
+            return dagger()
+        if isinstance(arg, Basic):
+            if arg.is_Add:
+                return Add(*tuple(map(Dagger, arg.args)))
+            if arg.is_Mul:
+                return Mul(*tuple(map(Dagger, reversed(arg.args))))
+            if arg.is_Number:
+                return arg
+            if arg.is_Pow:
+                return Pow(Dagger(arg.args[0]), arg.args[1])
+            if arg == I:
+                return -arg
         else:
-            return d
+            return None
 
     def _dagger_(self):
         return self.args[0]

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -79,6 +79,9 @@ class ImplicitSeries(BaseSeries):
         try:
             temp = func(xinterval, yinterval)
         except AttributeError:
+            # XXX: AttributeError("'list' object has no attribute 'is_real'")
+            # That needs fixing somehow - we shouldn't be catching
+            # AttributeError here.
             if self.use_interval_math:
                 warnings.warn("Adaptive meshing could not be applied to the"
                             " expression. Using uniform meshing.")

--- a/sympy/plotting/pygletplot/plot_camera.py
+++ b/sympy/plotting/pygletplot/plot_camera.py
@@ -41,17 +41,15 @@ class PlotCamera(object):
         self.init_rot_matrix()
         try:
             r = self.rot_presets[preset_name]
-        # XXX: I'm unable to test this but it doesn't look like it should
-        # raise AttributeError so I'm changing it to IndexError
-        except IndexError:
+        except AttributeError:
             raise ValueError(
                 "%s is not a valid rotation preset." % preset_name)
-        # XXX: The block below had try/except and AttributeError: pass around it
-        # but I don't see any good reason to cathc AttributeError so I removed
-        # it...
-        self.euler_rotate(r[0], 1, 0, 0)
-        self.euler_rotate(r[1], 0, 1, 0)
-        self.euler_rotate(r[2], 0, 0, 1)
+        try:
+            self.euler_rotate(r[0], 1, 0, 0)
+            self.euler_rotate(r[1], 0, 1, 0)
+            self.euler_rotate(r[2], 0, 0, 1)
+        except AttributeError:
+            pass
 
     def reset(self):
         self._dist = 0.0

--- a/sympy/plotting/pygletplot/plot_camera.py
+++ b/sympy/plotting/pygletplot/plot_camera.py
@@ -41,15 +41,17 @@ class PlotCamera(object):
         self.init_rot_matrix()
         try:
             r = self.rot_presets[preset_name]
-        except AttributeError:
+        # XXX: I'm unable to test this but it doesn't look like it should
+        # raise AttributeError so I'm changing it to IndexError
+        except IndexError:
             raise ValueError(
                 "%s is not a valid rotation preset." % preset_name)
-        try:
-            self.euler_rotate(r[0], 1, 0, 0)
-            self.euler_rotate(r[1], 0, 1, 0)
-            self.euler_rotate(r[2], 0, 0, 1)
-        except AttributeError:
-            pass
+        # XXX: The block below had try/except and AttributeError: pass around it
+        # but I don't see any good reason to cathc AttributeError so I removed
+        # it...
+        self.euler_rotate(r[0], 1, 0, 0)
+        self.euler_rotate(r[1], 0, 1, 0)
+        self.euler_rotate(r[2], 0, 0, 1)
 
     def reset(self):
         self._dist = 0.0

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1007,10 +1007,7 @@ class RootSum(Expr):
         if func is None:
             func = Lambda(poly.gen, poly.gen)
         else:
-            try:
-                is_func = func.is_Function
-            except AttributeError:
-                is_func = False
+            is_func = getattr(func, 'is_Function', False)
 
             if is_func and 1 in func.nargs:
                 if not isinstance(func, Lambda):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1905,12 +1905,7 @@ class PrettyPrinter(Printer):
             _and = 'and'
 
         variables = self._print_seq(Tuple(ts.sym))
-        try:
-            cond = self._print(ts.condition.as_expr())
-        except AttributeError:
-            cond = self._print(ts.condition)
-            if self._use_unicode:
-                cond = self._print_seq(cond, "(", ")")
+        cond = self._print(ts.condition.as_expr())
 
         bar = self._print("|")
 
@@ -1995,6 +1990,10 @@ class PrettyPrinter(Printer):
                     # first element
                     s = pform
                 else:
+                    # XXX: Under the tests from #15686 this raises:
+                    # AttributeError: 'Fake' object has no attribute 'baseline'
+                    # This is caught below but that is not the right way to
+                    # fix it.
                     s = prettyForm(*stringPict.next(s, delimiter))
                     s = prettyForm(*stringPict.next(s, pform))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1905,7 +1905,13 @@ class PrettyPrinter(Printer):
             _and = 'and'
 
         variables = self._print_seq(Tuple(ts.sym))
-        cond = self._print(ts.condition.as_expr())
+        as_expr = getattr(ts.condition, 'as_expr', None)
+        if as_expr is not None:
+            cond = self._print(ts.condition.as_expr())
+        else:
+            cond = self._print(ts.condition)
+            if self._use_unicode:
+                cond = self._print_seq(cond, "(", ")")
 
         bar = self._print("|")
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -161,9 +161,7 @@ class TheanoPrinter(Printer):
         return self._get_or_create(X, dtype=dtype, broadcastable=(None, None))
 
     def _print_DenseMatrix(self, X, **kwargs):
-        try:
-            tt.stacklists
-        except AttributeError:
+        if not hasattr(tt, 'stacklists'):
             raise NotImplementedError(
                "Matrix translation not yet supported in this version of Theano")
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -513,10 +513,9 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     """
     expr = sympify(expr)
 
-    try:
-        return expr._eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
-    except AttributeError:
-        pass
+    _eval_simplify = getattr(expr, '_eval_simplify', None)
+    if _eval_simplify is not None:
+        return _eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
 
     original_expr = expr = signsimp(expr)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -555,7 +555,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         floats = True
         expr = nsimplify(expr, rational=True)
 
-    expr = bottom_up(expr, lambda w: w.normal())
+    expr = bottom_up(expr, lambda w: getattr(w, 'normal', lambda: w)())
     expr = Mul(*powsimp(expr).as_content_primitive())
     _e = cancel(expr)
     expr1 = shorter(_e, _mexpand(_e).cancel())  # issue 6829
@@ -1078,16 +1078,16 @@ def bottom_up(rv, F, atoms=False, nonbasic=False):
     bottom up. If ``atoms`` is True, apply ``F`` even if there are no args;
     if ``nonbasic`` is True, try to apply ``F`` to non-Basic objects.
     """
-    try:
-        if rv.args:
-            args = tuple([bottom_up(a, F, atoms, nonbasic)
-                for a in rv.args])
+    args = getattr(rv, 'args', None)
+    if args is not None:
+        if args:
+            args = tuple([bottom_up(a, F, atoms, nonbasic) for a in args])
             if args != rv.args:
                 rv = rv.func(*args)
             rv = F(rv)
         elif atoms:
             rv = F(rv)
-    except AttributeError:
+    else:
         if nonbasic:
             try:
                 rv = F(rv)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -471,10 +471,9 @@ def trigsimp(expr, **opts):
 
     expr = sympify(expr)
 
-    try:
-        return expr._eval_trigsimp(**opts)
-    except AttributeError:
-        pass
+    _eval_trigsimp = getattr(expr, '_eval_trigsimp', None)
+    if _eval_trigsimp is not None:
+        return _eval_trigsimp(**opts)
 
     old = opts.pop('old', False)
     if not old:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -92,9 +92,10 @@ def recast_to_symbols(eqs, symbols):
             new_symbols[i] = swap_sym[s]
     new_f = []
     for i in eqs:
-        try:
-            new_f.append(i.subs(swap_sym))
-        except AttributeError:
+        isubs = getattr(i, 'subs', None)
+        if isubs is not None:
+            new_f.append(isubs(swap_sym))
+        else:
             new_f.append(i)
     swap_sym = {v: k for k, v in swap_sym.items()}
     return new_f, new_symbols, swap_sym
@@ -1475,12 +1476,10 @@ def _solve(f, *symbols, **flags):
                     continue
                 try:
                     v = cond.subs(symbol, candidate)
-                    try:
-                        # unconditionally take the simplification of v
-                        v = v._eval_simpify(
-                            ratio=2, measure=lambda x: 1)
-                    except AttributeError:
-                        pass
+                    _eval_simpify = getattr(v, '_eval_simpify', None)
+                    if _eval_simpify is not None:
+                        # unconditionally take the simpification of v
+                        v = _eval_simpify(ratio=2, measure=lambda x: 1)
                 except TypeError:
                     # incompatible type with condition(s)
                     continue
@@ -2507,15 +2506,14 @@ def det_perm(M):
     args = []
     s = True
     n = M.rows
-    try:
-        list = M._mat
-    except AttributeError:
-        list = flatten(M.tolist())
+    list_ = getattr(M, '_mat', None)
+    if list_ is None:
+        list_ = flatten(M.tolist())
     for perm in generate_bell(n):
         fac = []
         idx = 0
         for j in perm:
-            fac.append(list[idx + j])
+            fac.append(list_[idx + j])
             idx += n
         term = Mul(*fac) # disaster with unevaluated Mul -- takes forever for n=7
         args.append(term if s else -term)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2347,10 +2347,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                'Not type %s: %s')
         raise TypeError(filldedent(msg % (type(symbols), symbols)))
 
-    try:
-        sym = symbols[0].is_Symbol
-    except AttributeError:
-        sym = False
+    sym = getattr(symbols[0], 'is_Symbol', False)
 
     if not sym:
         msg = ('Iterable of symbols must be given as '

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -505,9 +505,10 @@ def random_symbols(expr):
     """
     Returns all RandomSymbols within a SymPy Expression.
     """
-    try:
-        return list(expr.atoms(RandomSymbol))
-    except AttributeError:
+    atoms = getattr(expr, 'atoms', None)
+    if atoms is not None:
+        return list(atoms(RandomSymbol))
+    else:
         return []
 
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1054,9 +1054,11 @@ class _EvaluatorPrinter(object):
         from sympy.matrices import DeferredVector
         from sympy import sympify
 
-        try:
-            expr = sympify(expr).xreplace(dummies_dict)
-        except AttributeError:
+        expr = sympify(expr)
+        xreplace = getattr(expr, 'xreplace', None)
+        if xreplace is not None:
+            expr = xreplace(dummies_dict)
+        else:
             if isinstance(expr, DeferredVector):
                 pass
             elif isinstance(expr, dict):

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -117,9 +117,11 @@ def _randrange(seed=None):
                 raise ValueError('_randrange got empty range')
             try:
                 x = seq.pop()
-            except AttributeError:
+            except AttributeError as e:
+                import pdb;pdb.set_trace()
                 raise ValueError('_randrange expects a list-like sequence')
-            except IndexError:
+            except IndexError as e:
+                import pdb;pdb.set_trace()
                 raise ValueError('_randrange sequence was too short')
             if a <= x < b:
                 return x

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -117,11 +117,7 @@ def _randrange(seed=None):
                 raise ValueError('_randrange got empty range')
             try:
                 x = seq.pop()
-            except AttributeError as e:
-                import pdb;pdb.set_trace()
-                raise ValueError('_randrange expects a list-like sequence')
             except IndexError as e:
-                import pdb;pdb.set_trace()
                 raise ValueError('_randrange sequence was too short')
             if a <= x < b:
                 return x
@@ -168,8 +164,6 @@ def _randint(seed=None):
                 raise ValueError('_randint got empty range')
             try:
                 x = seq.pop()
-            except AttributeError:
-                raise ValueError('_randint expects a list-like sequence')
             except IndexError:
                 raise ValueError('_randint sequence was too short')
             if a <= x <= b:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -716,8 +716,11 @@ def test_imps_errors():
     # Test errors that implemented functions can return, and still be able to
     # form expressions.
     # See: https://github.com/sympy/sympy/issues/10810
-    for val, error_class in product((0, 0., 2, 2.0),
-                                    (AttributeError, TypeError, ValueError)):
+    #
+    # XXX: Removed AttributeError here. This test was added due to issue 10810
+    # but that issue was about ValueError. It doesn't seem reasonable to
+    # "support" catching AttributeError in the same context...
+    for val, error_class in product((0, 0., 2, 2.0), (TypeError, ValueError)):
 
         def myfunc(a):
             if a == 0:

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -123,7 +123,7 @@ class BasisDependent(Expr):
         expression -> a/b -> a, b
 
         """
-        return self, 1
+        return self, S.One
 
     def factor(self, *args, **kwargs):
         """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #11668 

#### Brief description of what is fixed or changed

Replaces most examples of `except AttributeError` in the codebase with `getattr`/`hasattr`.

An `AttributeError` can often result from a typo in the code. There are many places around the codebase that wrap large amounts of code in `try/except AttributeError` which can mask bugs. Exception handling should be more specific than simply wrapping a block in `try/except`. Usually the best way would be to test the expected type of object first.

Code that uses broad try/except is difficult to understand. As a result it is difficult for me to know what the best replacement for some of the examples would be. AttributeError is so broad that it could be raised anywhere. I have tried to replace these examples with code that only catches the expected AttributeErrors.

In many cases there were no comments indicating the purpose of the `except` handler so the only way I could infer its purpose was by running the tests. Note that this is in itself a good reason to remove this kind of thing from the code. In other cases I can see what the AttributeError is for but without running the tests I don't know whether it also catches something unintended. There were examples as I went through in which unintended exceptions were being caught.

There were a few places where I thought that catching AttributeError was correct or where it was difficult to remove the except handler.

Before this patch:
```console
$ git grep 'except AttributeError' | wc -l
      79
```
After:
```console
$ git grep 'except AttributeError' | wc -l
       7
```
(I used that grep to find examples for this patch - other exampels such as `except (TypeError, AttributeError` might have been missed)

#### Other comments

This patch is large. I can break it into smaller comments or separate PRs for easier review. For now I'm just pushing it up to run the full tests.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
