### PR TITLE
solved subs problem when wrt and count are same and added test case

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1606,6 +1606,11 @@ class Derivative(Expr):
         # Derivative(expr, vars) for a variety of reasons
         # as handled below.
         if old in self._wrt_variables:
+            # first handle the counts
+            expr = self.func(self.expr, *[(v, c.subs(old, new))
+                for v, c in self.variable_count])
+            if expr != self:
+                return expr._eval_subs(old, new)
             # quick exit case
             if not getattr(new, '_diff_wrt', False):
                 # case (0): new is not a valid variable of

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,11 +1,23 @@
-from sympy import (Symbol, Rational, cos, sin, tan, cot, exp, log,
-    Function, Derivative, Expr, symbols, pi, I, S, diff, Piecewise,
-    Eq, ff, Sum, And, factorial, Max, NDimArray, re, im)
+from sympy.concrete.summations import Sum
+from sympy.core.expr import Expr
+from sympy.core.function import (Derivative, Function, diff, Subs)
+from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.relational import Eq
+from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.functions.combinatorial.factorials import (FallingFactorial,
+    factorial)
+from sympy.functions.elementary.complexes import (im, re)
+from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.miscellaneous import Max
+from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
+from sympy.logic.boolalg import And
+from sympy.tensor.array.ndim_array import NDimArray
 from sympy.utilities.pytest import raises
-
+from sympy.abc import a, b, c, x, y, z
 
 def test_diff():
-    x, y = symbols('x, y')
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero
     assert pi.diff(x) is S.Zero
@@ -20,9 +32,6 @@ def test_diff():
     assert (x**2).diff(x, y) == 0
     raises(ValueError, lambda: x.diff(1, x))
 
-    a = Symbol("a")
-    b = Symbol("b")
-    c = Symbol("c")
     p = Rational(5)
     e = a*b + b**p
     assert e.diff(a) == b
@@ -45,7 +54,6 @@ def test_diff2():
     n3 = Rational(3)
     n2 = Rational(2)
     n6 = Rational(6)
-    x, c = map(Symbol, 'xc')
 
     e = n3*(-n2 + x**n2)*cos(x) + x*(-n6 + x**n2)*sin(x)
     assert e == 3*(-2 + x**2)*cos(x) + x*(-6 + x**2)*sin(x)
@@ -60,7 +68,6 @@ def test_diff2():
 
 
 def test_diff3():
-    a, b, c = map(Symbol, 'abc')
     p = Rational(5)
     e = a*b + sin(b**p)
     assert e == a*b + sin(b**5)
@@ -85,7 +92,6 @@ def test_diff_no_eval_derivative():
         def __new__(cls, x):
             return Expr.__new__(cls, x)
 
-    x, y = symbols('x y')
     # My doesn't have its own _eval_derivative method
     assert My(x).diff(x).func is Derivative
     assert My(x).diff(x, 3).func is Derivative
@@ -98,23 +104,18 @@ def test_diff_no_eval_derivative():
 
 def test_speed():
     # this should return in 0.0s. If it takes forever, it's wrong.
-    x = Symbol("x")
     assert x.diff(x, 10**8) == 0
 
 
 def test_deriv_noncommutative():
     A = Symbol("A", commutative=False)
     f = Function("f")
-    x = Symbol("x")
     assert A*f(x)*A == f(x)*A**2
     assert A*f(x).diff(x)*A == f(x).diff(x) * A**2
 
 
 def test_diff_nth_derivative():
     f =  Function("f")
-    x = Symbol("x")
-    y = Symbol("y")
-    z = Symbol("z")
     n = Symbol("n", integer=True)
 
     expr = diff(sin(x), (x, n))
@@ -152,3 +153,10 @@ def test_diff_nth_derivative():
 
     assert (cos(x)*sin(y)).diff([[x, y, z]]) == NDimArray([
         -sin(x)*sin(y), cos(x)*cos(y), 0])
+
+
+def test_issue_16160():
+    assert Derivative(x**3, (x, x)).subs(x, 2) == Subs(
+        Derivative(x**3, (x, 2)), x, 2)
+    assert Derivative(1 + x**3, (x, x)).subs(x, 0
+        ) == Derivative(1 + y**3, (y, 0)).subs(y, 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16160

#### Brief description of what is fixed or changed
```
In [1]: f(x).diff((x,x)).subs(x,4)                                
Out[1]:
 
⎛  x      ⎞│   
⎜ d       ⎟│   
⎜───(f(x))⎟│   
⎜  x      ⎟│   
⎝dx       ⎠│x=4
```
now
```
In [1]: f(x).diff((x,x)).subs(x,4)                                
Out[1]:
 
⎛  4      ⎞│   
⎜ d       ⎟│   
⎜───(f(x))⎟│   
⎜  4      ⎟│   
⎝dx       ⎠│x=4
```
When wrt and count are the same and subs are applied then the derivative count is a variable so it is not possible to compute that derivative(we don't know how many time we have to differentiate ) so a solution is to substitute it first in the derivative count and evaluate derivative and then calculate it's  value.  

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - function: Derivative with `count == wrt` now responds to subs
<!-- END RELEASE NOTES -->
