### PR TITLE
Remove exception handler for ints in evalf.py

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -360,12 +360,12 @@ def get_integer_part(expr, no, options, return_ints=False):
                 is_int = (p == 0)
                 nint = int(to_int(nexpr, rnd))
         if not is_int:
-            # if there are subs and they all contain integer re/im parts
-            # then we can (hopefully) safely substitute them into the
-            # expression
+            # if there are subs they can (hopefully) be substituted them
+            # into the expression; in general this is a bad idea because
+            # they cannot be re-substituted later with higher precision.
             s = options.get('subs', False)
             if s:
-                re_im = re_im.subs(s)
+                re_im = re_im.subs(options.get('subs', {}))
 
             re_im = Add(re_im, -nint, evaluate=False)
             x, _, x_acc, _ = evalf(re_im, 10, options)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -365,22 +365,7 @@ def get_integer_part(expr, no, options, return_ints=False):
             # expression
             s = options.get('subs', False)
             if s:
-                doit = True
-                from sympy.core.compatibility import as_int
-                # use strict=False with as_int because we take
-                # 2.0 == 2
-                for v in s.values():
-                    try:
-                        as_int(v, strict=False)
-                    except ValueError:
-                        try:
-                            [as_int(i, strict=False) for i in v.as_real_imag()]
-                            continue
-                        except (ValueError, AttributeError):
-                            doit = False
-                            break
-                if doit:
-                    re_im = re_im.subs(s)
+                re_im = re_im.subs(s)
 
             re_im = Add(re_im, -nint, evaluate=False)
             x, _, x_acc, _ = evalf(re_im, 10, options)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -256,6 +256,8 @@ def test_evalf_integer_parts():
     assert ceiling(x).evalf(subs={x: 3.}) == 3
     assert ceiling(x).evalf(subs={x: 3.*I}) == 3*I
     assert ceiling(x).evalf(subs={x: 2. + 3*I}) == 2 + 3*I
+    assert ceiling(x - 4.2).evalf(subs={x: 4.2}) == 0
+    assert ceiling(x - I).evalf(subs={x: I}) == 0
 
     assert float((floor(1.5, evaluate=False)+1/9).evalf()) == 1 + 1/9
     assert float((floor(0.5, evaluate=False)+20).evalf()) == 20


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

From #16164 

This is following up from [https://github.com/sympy/sympy/pull/16164#discussion_r262651639](https://github.com/sympy/sympy/pull/16164#discussion_r262651639)

#### Brief description of what is fixed or changed

This removes code that was added in #10346 but no longer appears to be necessary. I'm splitting this change out to be reviewed separately from the rest of #16164.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
