### PR TITLE
Added check for dict flag

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+parallel = True
+branch = True
+source = sympy
+omit =
+    */tests/*
+    */benchmarks/*
+    */sympy/integrals/rubi/rules/*
+    */sympy/plotting/pygletplot/*
+    */conftest.py
+data_file = $TRAVIS_BUILD_DIR/.coverage
+
+[report]
+exclude_lines =
+    \#.*pragma:\s*no.?cover
+    ^\s*if SYMPY_DEBUG:
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ python:
   - 2.7
   - 3.4
   - 3.5
-  - 3.6
 
 matrix:
   include:
@@ -38,22 +37,12 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - SPLIT="1/4" TEST_SYMPY="true" TEST_COVERAGE="true"
+        - SPLIT="1/2" TEST_SYMPY="true"
     - python: 3.7
       dist: xenial
       sudo: true
       env:
-        - SPLIT="2/4" TEST_SYMPY="true" TEST_COVERAGE="true"
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env:
-        - SPLIT="3/4" TEST_SYMPY="true" TEST_COVERAGE="true"
-    - python: 3.7
-      dist: xenial
-      sudo: true
-      env:
-        - SPLIT="4/4" TEST_SYMPY="true" TEST_COVERAGE="true"
+        - SPLIT="2/2" TEST_SYMPY="true"
 
     - stage: test
       python: 2.7
@@ -128,6 +117,36 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="2/2"
+
+    # Code coverage tests
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_SYMPY="true"
+        - TEST_COVERAGE="true"
+        - SPLIT="1/4"
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_SYMPY="true"
+        - TEST_COVERAGE="true"
+        - SPLIT="2/4"
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_SYMPY="true"
+        - TEST_COVERAGE="true"
+        - SPLIT="3/4"
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_SYMPY="true"
+        - TEST_COVERAGE="true"
+        - SPLIT="4/4"
 
     # Everything here and below is in the allow_failures. The need to be
     # duplicated here and in that section below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,27 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
+        - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_COVERAGE="true"
     - python: 3.7
       dist: xenial
       sudo: true
       env:
-        - SPLIT="1/2" TEST_SYMPY="true"
+        - SPLIT="1/4" TEST_SYMPY="true" TEST_COVERAGE="true"
     - python: 3.7
       dist: xenial
       sudo: true
       env:
-        - SPLIT="2/2" TEST_SYMPY="true"
+        - SPLIT="2/4" TEST_SYMPY="true" TEST_COVERAGE="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="3/4" TEST_SYMPY="true" TEST_COVERAGE="true"
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env:
+        - SPLIT="4/4" TEST_SYMPY="true" TEST_COVERAGE="true"
 
     - stage: test
       python: 2.7
@@ -197,6 +207,10 @@ before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;
     fi
+  - if [[ "${TEST_COVERAGE}" == "true" ]]; then
+      pip install coverage;
+      coverage debug sys;
+    fi
   - |
     if [[ -n "${TEST_OPT_DEPENDENCY}" ]]; then
     # We do this conditionally because it saves us some downloading if the
@@ -268,6 +282,9 @@ script:
   - bin/test_travis.sh
   - if [[ "${TEST_SPHINX}" == "true" ]]; then
         doctr deploy dev --deploy-repo sympy/sympy_doc --command './generate_indexes.py';
+    fi
+  - if [[ "${TEST_COVERAGE}" == "true" ]]; then
+        bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
     fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_COVERAGE="true"
+        - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true"
     - python: 3.7
       dist: xenial
       sudo: true

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -42,6 +42,25 @@ fi
 mkdir empty
 cd empty
 
+if [[ "${TEST_COVERAGE}" == "true" ]]; then
+    rm -f $TRAVIS_BUILD_DIR/.coverage.* $TRAVIS_BUILD_DIR/.coverage
+    cat << EOF | python
+import distutils.sysconfig
+import os
+
+with open(os.path.join(distutils.sysconfig.get_python_lib(), 'coverage.pth'), 'w') as pth:
+    pth.write('import sys; exec(%r)\n' % '''\
+try:
+    import coverage
+except ImportError:
+    pass
+else:
+    coverage.process_startup()
+''')
+EOF
+    export COVERAGE_PROCESS_START=$TRAVIS_BUILD_DIR/.coveragerc
+fi
+
 if [[ "${TEST_ASCII}" == "true" ]]; then
     # Force Python to act like pre-3.7 where LC_ALL=C causes
     # UnicodeEncodeErrors. Once the lowest Python version we support is 3.7,
@@ -221,4 +240,7 @@ import sympy
 if not sympy.test(split='${SPLIT}'):
    raise Exception('Tests failed')
 EOF
+fi
+if [[ "${TEST_COVERAGE}" == "true" ]]; then
+    unset COVERAGE_PROCESS_START
 fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1541,10 +1541,8 @@ def classify_sysode(eq, funcs=None, **kwargs):
             for func_ in  func:
                 funcs.append(func_)
     funcs = list(set(funcs))
-    if len(funcs) < len(eq):
-        raise ValueError("Number of functions given is less than number of equations %s" % funcs)
-    if len(funcs) > len(eq):
-        raise ValueError("Number of functions given is more than number of equations %s" % funcs)
+    if len(funcs) != len(eq):
+        raise ValueError("Number of functions given is not equal to the number of equations %s" % funcs)
     func_dict = dict()
     for func in funcs:
         if not order.get(func, False):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1543,6 +1543,8 @@ def classify_sysode(eq, funcs=None, **kwargs):
     funcs = list(set(funcs))
     if len(funcs) < len(eq):
         raise ValueError("Number of functions given is less than number of equations %s" % funcs)
+    if len(funcs) > len(eq):
+        raise ValueError("Number of functions given is more than number of equations %s" % funcs)
     func_dict = dict()
     for func in funcs:
         if not order.get(func, False):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -716,7 +716,7 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
             for s in rv:
                 try:
                     solved_constants = solve_ics([s], [r['func']], cons(s), ics)
-                except NotImplementedError:
+                except ValueError:
                     continue
                 rv1.append(s.subs(solved_constants))
             if len(rv1) == 1:
@@ -817,7 +817,7 @@ def solve_ics(sols, funcs, constants, ics):
     # enough. If we could use solveset, this might be improvable, but for now,
     # we use NotImplementedError in this case.
     if not solved_constants:
-        raise NotImplementedError("Couldn't solve for initial conditions")
+        raise ValueError("Couldn't solve for initial conditions")
 
     if solved_constants == True:
         raise ValueError("Initial conditions did not produce any solutions for constants. Perhaps they are degenerate.")

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -919,7 +919,8 @@ def solve(f, *symbols, **flags):
                        )
                       )
     f, symbols = (_sympified_list(w) for w in [f, symbols])
-
+    if isinstance(f, list):
+        f = [s for s in f if s is not S.true and s is not True]
     implicit = flags.get('implicit', False)
 
     # preprocess symbol(s)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -29,7 +29,7 @@ from sympy.core.numbers import ilcm, Float, Rational
 from sympy.core.relational import Relational, Ge, _canonical
 from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.core.power import integer_log
-from sympy.logic.boolalg import And, Or, BooleanAtom, BooleanTrue
+from sympy.logic.boolalg import And, Or, BooleanAtom
 from sympy.core.basic import preorder_traversal
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, acos, asin, atan,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -29,7 +29,7 @@ from sympy.core.numbers import ilcm, Float, Rational
 from sympy.core.relational import Relational, Ge, _canonical
 from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.core.power import integer_log
-from sympy.logic.boolalg import And, Or, BooleanAtom
+from sympy.logic.boolalg import And, Or, BooleanAtom, BooleanTrue
 from sympy.core.basic import preorder_traversal
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, acos, asin, atan,
@@ -908,8 +908,6 @@ def solve(f, *symbols, **flags):
     # a dictionary of results will be returned.
     ###########################################################################
 
-    if isinstance(f, list):
-        f = [s for s in f if not isinstance(s, bool)]
     def _sympified_list(w):
         return list(map(sympify, w if iterable(w) else [w]))
     bare_f = not iterable(f)
@@ -921,7 +919,8 @@ def solve(f, *symbols, **flags):
                        )
                       )
     f, symbols = (_sympified_list(w) for w in [f, symbols])
-
+    if isinstance(f, list):
+        f = [s for s in f if s is not S.true and s is not True]
     implicit = flags.get('implicit', False)
 
     # preprocess symbol(s)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -908,6 +908,8 @@ def solve(f, *symbols, **flags):
     # a dictionary of results will be returned.
     ###########################################################################
 
+    if isinstance(f, list):
+        f = [s for s in f if not isinstance(s, bool)]
     def _sympified_list(w):
         return list(map(sympify, w if iterable(w) else [w]))
     bare_f = not iterable(f)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1075,7 +1075,7 @@ def test_classify_sysode():
 
 def test_solve_ics():
     # Basic tests that things work from dsolve.
-    assert dsolve(dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2})) == \
+    assert dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2}) == \
         Eq(f(x), sqrt(2 * x + 2))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(x).diff(x).subs(x, 0): 1}) == Eq(f(x), exp(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1127,7 +1127,7 @@ def test_solve_ics():
         [Eq(f(x), 0), Eq(f(x), x ** 3 / 6)]
 
     # XXX: Ought to be ValueError
-    raises(NotImplementedError, lambda: solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1, f(pi): 1}))
+    raises(ValueError, lambda: solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1, f(pi): 1}))
 
     # Degenerate case. f'(0) is identically 0.
     raises(ValueError, lambda: solve_ics([Eq(f(x), sqrt(C1 - x**2))], [f(x)], [C1], {f(x).diff(x).subs(x, 0): 0}))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3361,6 +3361,7 @@ def test_factoring_ode():
     assert checkodesol(eqn, soln, order=2, solve_for_func=False)[0]
     assert soln == dsolve(eqn, f(x))
 
+
 def test_issue_15913():
     eq = -C1/x - 2*x*f(x) - f(x) + Derivative(f(x), x)
     sol = C2*exp(x**2 + x) + exp(x**2 + x)*Integral(C1*exp(-x**2 - x)/x, x)
@@ -3368,3 +3369,8 @@ def test_issue_15913():
     sol = C1 + C2*exp(-x*y)
     eq = Derivative(y*f(x), x) + f(x).diff(x, 2)
     assert checkodesol(eq, sol, f(x)) == (True, 0)
+
+
+def test_issue_16146():
+    raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x), g(x), h(x)]))
+    raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x)]))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1112,8 +1112,8 @@ def test_solve_ics():
 
     assert dsolve(f(x).diff(x)*(f(x).diff(x, 2)-x), ics={f(0):0, f(x).diff(x).subs(x, 1):0}) == \
         [Eq(f(x), 0), Eq(f(x), x ** 3 / 6 - x / 2)]
-    assert dsolve(eq, ics={f(0):0, f(0):0}) == [Eq(f(x), 0), Eq(f(x), C2*x + x**3/6)]
-    assert dsolve(eq, ics={f(0):0, f(0):0}) == [Eq(f(x), 0), Eq(f(x), x**3/6)]
+    assert dsolve(f(x).diff(x)*(f(x).diff(x, 2)-x), ics={f(0):0}) == \
+        [Eq(f(x), 0), Eq(f(x), C2*x + x**3/6)]
 
     K, r, f0 = symbols('K r f0')
     sol = Eq(f(x), -K*f0*exp(r*x)/((K - f0)*(-f0*exp(r*x)/(K - f0) - 1)))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1075,6 +1075,8 @@ def test_classify_sysode():
 
 def test_solve_ics():
     # Basic tests that things work from dsolve.
+    assert dsolve(dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2})) == \
+        Eq(f(x), sqrt(2 * x + 2))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(x).diff(x).subs(x, 0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x, x) + f(x), f(x), ics={f(0): 1,
@@ -1103,11 +1105,29 @@ def test_solve_ics():
     assert solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2],
         {f(0): 1, f(x).diff(x).subs(x, 0): 1}) == {C1: 1, C2: 1}
 
-    # XXX: Ought to be ValueError
-    raises(NotImplementedError, lambda: solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1, f(pi): 1}))
+    assert solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1}) == \
+        {C2: 1}
+
+    # Some more complicated tests Refer to PR #16098
+
+    assert dsolve(f(x).diff(x)*(f(x).diff(x, 2)-x), ics={f(0):0, f(x).diff(x).subs(x, 1):0}) == \
+        [Eq(f(x), 0), Eq(f(x), x ** 3 / 6 - x / 2)]
+    assert dsolve(eq, ics={f(0):0, f(0):0}) == [Eq(f(x), 0), Eq(f(x), C2*x + x**3/6)]
+    assert dsolve(eq, ics={f(0):0, f(0):0}) == [Eq(f(x), 0), Eq(f(x), x**3/6)]
+
+    K, r, f0 = symbols('K r f0')
+    sol = Eq(f(x), -K*f0*exp(r*x)/((K - f0)*(-f0*exp(r*x)/(K - f0) - 1)))
+    assert (dsolve(Eq(f(x).diff(x), r * f(x) * (1 - f(x) / K)), f(x), ics={f(0): f0})) == sol
+
+
+    #Order dependent issues Refer to PR #16098
+    assert dsolve(f(x).diff(x)*(f(x).diff(x, 2)-x), ics={f(x).diff(x).subs(x,0):0, f(0):0}) == \
+        [Eq(f(x), 0), Eq(f(x), x ** 3 / 6)]
+    assert dsolve(f(x).diff(x)*(f(x).diff(x, 2)-x), ics={f(0):0, f(x).diff(x).subs(x,0):0}) == \
+        [Eq(f(x), 0), Eq(f(x), x ** 3 / 6)]
 
     # XXX: Ought to be ValueError
-    raises(ValueError, lambda: solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1}))
+    raises(NotImplementedError, lambda: solve_ics([Eq(f(x), C1*sin(x) + C2*cos(x))], [f(x)], [C1, C2], {f(0): 1, f(pi): 1}))
 
     # Degenerate case. f'(0) is identically 0.
     raises(ValueError, lambda: solve_ics([Eq(f(x), sqrt(C1 - x**2))], [f(x)], [C1], {f(x).diff(x).subs(x, 0): 0}))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #16138 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

List of equations in which one or more have been evaluated to `True` was ignoring the `set flags`. For e.g.

```
In [1]: solve([Eq(x, 0)], [x], dict=True)                                                                                                                     
Out[1]: [{x: 0}]
In [2]: solve([True, Eq(x, 0)], [x], dict=True)                                                                                                               
Out[2]: x = 0
```

But now the output is, 

```
In [1]: solve([Eq(x, 0)], [x], dict=True)                                                                                                                     
Out[1]: [{x: 0}]
In [2]: solve([True, Eq(x, 0)], [x], dict=True)                                                                                                               
Out[2]: [{x: 0}]
```

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
