### PR TITLE
correct diffrent behaviour of diff on symbol and function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1540,7 +1540,10 @@ class Derivative(Expr):
         if hints.get('deep', True):
             expr = expr.doit(**hints)
         hints['evaluate'] = True
-        return self.func(expr, *self.variable_count, **hints)
+        rv = self.func(expr, *self.variable_count, **hints)
+        if rv!= self and rv.has(Derivative):
+            rv =  rv.doit(**hints)
+        return rv
 
     @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -301,11 +301,9 @@ def test_Subs():
         ).doit() == 2*exp(x)
     assert Subs(Derivative(g(x)**2, g(x), x), g(x), exp(x)
         ).doit(deep=False) == 2*Derivative(exp(x), x)
-
-    assert Derivative(f(x, g(x)), x).doit() == Derivative(g(x), x
-        )*Subs(Derivative(f(x, y), y), y, g(x)
-        ) + Subs(Derivative(f(y, g(x)), y), y, x)
-
+    assert Derivative(f(x, g(x)), x).doit() == Derivative(
+        f(x, g(x)), g(x))*Derivative(g(x), x) + Subs(Derivative(
+        f(y, g(x)), y), y, x)
 
 def test_doitdoit():
     done = Derivative(f(x, g(x)), x, g(x)).doit()

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -577,9 +577,10 @@ class Abs(Function):
         if self.args[0].is_real or self.args[0].is_imaginary:
             return Derivative(self.args[0], x, evaluate=True) \
                 * sign(conjugate(self.args[0]))
-        return (re(self.args[0]) * Derivative(re(self.args[0]), x,
+        rv = (re(self.args[0]) * Derivative(re(self.args[0]), x,
             evaluate=True) + im(self.args[0]) * Derivative(im(self.args[0]),
                 x, evaluate=True)) / Abs(self.args[0])
+        return rv.rewrite(sign)
 
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         # Note this only holds for real arg (since Heaviside is not defined

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -3,7 +3,7 @@ from sympy import (
     Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
     sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
     Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
-    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda)
+    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda, Derivative)
 from sympy.utilities.pytest import XFAIL, raises
 
 
@@ -907,3 +907,9 @@ def test_zero_assumptions():
 
     assert re(nzni).is_zero is False
     assert im(nzni).is_zero is None
+
+def test_issue_15893():
+    f = Function('f', real=True)
+    x = Symbol('x', real=True)
+    eq = Derivative(Abs(f(x)), f(x))
+    assert (eq.doit()).doit() == sign(f(x))

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -912,4 +912,4 @@ def test_issue_15893():
     f = Function('f', real=True)
     x = Symbol('x', real=True)
     eq = Derivative(Abs(f(x)), f(x))
-    assert (eq.doit()).doit() == sign(f(x))
+    assert eq.doit() == sign(f(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15893 

#### Brief description of what is fixed or changed
```
In [12]:  f=Function('f', real=True) 
    ...:var('x',real=True) 
    ...:  f(x).is_scalar=True                                                                                        

In [13]: eq=Derivative(Abs(f(x)), f(x)) 
    ...:  print((eq.doit()).doit())                                                                                  
f(x)/Abs(f(x))
```
As` f(x)/Abs(f(x))
`this can change into `sign(f(x))` and for Symbol it is changing in sympy master
```
In [14]:  eq=Derivative(Abs(x), (x)) 
    ...: print((eq.doit()).doit())                                                                                  
sign(x)
```



so for thiis some code modified to give same answer as with Symbol.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - differentiation of abs(function) automatically attempts to rewrite in terms of sign
  - a second doit will be done automatically if the first changed a Derivative but left Derivatives behind
<!-- END RELEASE NOTES -->
