### PR TITLE
fix-beam-position

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -396,10 +396,11 @@ class Beam(object):
         start = sympify(start)
         order = sympify(order)
 
-        if start.is_real and start > self.length or (end != None and end.is_real and end > self.length):
-            msg = ("Start and End of load application must be less than "
-                   "the length of the Beam.")
-            raise ValueError(msg)
+        if start.is_real:
+            if start > self.length or (end != None and end > self.length):
+                msg = ("Start and End of load application must be less than "
+                       "the length of the Beam.")
+                raise ValueError(msg)
 
         self._applied_loads.append((value, start, order, end))
         self._load += value*SingularityFunction(x, start, order)

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -396,7 +396,7 @@ class Beam(object):
         start = sympify(start)
         order = sympify(order)
 
-        if start.is_real and start > self.length or (end != None and end > self.length):
+        if start.is_real and start > self.length or (end != None and end.is_real and end > self.length):
             msg = ("Start and End of load application must be less than "
                    "the length of the Beam.")
             raise ValueError(msg)

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -396,6 +396,11 @@ class Beam(object):
         start = sympify(start)
         order = sympify(order)
 
+        if start.is_real and start > self.length or (end != None and end > self.length):
+            msg = ("Start and End of load application must be less than "
+                   "the length of the Beam.")
+            raise ValueError(msg)
+
         self._applied_loads.append((value, start, order, end))
         self._load += value*SingularityFunction(x, start, order)
 

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -602,3 +602,12 @@ def test_parabolic_loads():
     loading = beam.load.xreplace({L: 10, E: 20, I: 30, P: 40})
     assert loading.xreplace({x: 5}) == 40 * 5**8
     assert loading.xreplace({x: 15}) == 0
+
+
+def test_location():
+    E, I, L = symbols('E, I, L', positive=True)
+    beam = Beam(L, E, I)
+    R= symbols('R', real=True)
+
+    raises(ValueError, lambda: beam.apply_load(-R, L+1, -1))
+    raises(ValueError, lambda: beam.apply_load(R, L, -1, end=2*L))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Previously the application of load beyond the length of the beam was possible. This has been fixed now by generating a value error.

Previously:
```
b = Beam(9, E, I)
b.apply_load(-12, 10, -1)
b.apply_load(-8, 0, 0, end=20)
valid 
```

Now:
`ValueError`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  physics.continuum_mechanics
   *  ValueError for position of apply_load is greater than length of beam
<!-- END RELEASE NOTES -->
