### PR TITLE
Boolean objects ignores set flags in solve

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -13,7 +13,7 @@ from sympy.core.singleton import S
 from sympy.core.function import expand_mul
 
 from sympy.functions import Abs
-from sympy.logic import And, Or
+from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
 from sympy.utilities.iterables import sift

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -13,7 +13,7 @@ from sympy.core.singleton import S
 from sympy.core.function import expand_mul
 
 from sympy.functions import Abs
-from sympy.logic import And
+from sympy.logic import And, Or
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
 from sympy.utilities.iterables import sift
@@ -929,7 +929,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, dict_flag, symbols=[]):
+def reduce_inequalities(inequalities, symbols=[]):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
@@ -986,15 +986,5 @@ def reduce_inequalities(inequalities, dict_flag, symbols=[]):
     # solve system
     rv = _reduce_inequalities(inequalities, symbols)
 
-    # restore original symbols
-    solution = rv.xreplace({v: k for k, v in recast.items()})
-
-    if not dict_flag:
-        return solution
-
-    if isinstance(solution, list):
-        solution = [{s.lhs: s.rhs} for s in solution]
-    else:
-        solution = [{solution.lhs: solution.rhs}]
-
-    return solution
+    # restore original symbols and return
+    return rv.xreplace({v: k for k, v in recast.items()})

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -929,7 +929,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, symbols=[], **flags):
+def reduce_inequalities(inequalities, dict_flag, symbols=[]):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
@@ -985,12 +985,11 @@ def reduce_inequalities(inequalities, symbols=[], **flags):
 
     # solve system
     rv = _reduce_inequalities(inequalities, symbols)
-    as_dict = flags.get('dict', False)
 
     # restore original symbols
     solution = rv.xreplace({v: k for k, v in recast.items()})
 
-    if not as_dict:
+    if not dict_flag:
         return solution
 
     if isinstance(solution, list):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -878,7 +878,7 @@ def _solve_inequality(ie, s, linear=False):
     conds.append(rv)
     return And(*conds)
 
-def _reduce_inequalities(inequalities, symbols, **flags):
+def _reduce_inequalities(inequalities, symbols):
     # helper for reduce_inequalities
 
     poly_part, abs_part = {}, {}
@@ -998,5 +998,4 @@ def reduce_inequalities(inequalities, symbols=[], **flags):
     else:
         solution = [{solution.lhs: solution.rhs}]
 
-    if as_dict:
-        return solution
+    return solution

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -878,7 +878,7 @@ def _solve_inequality(ie, s, linear=False):
     conds.append(rv)
     return And(*conds)
 
-def _reduce_inequalities(inequalities, symbols):
+def _reduce_inequalities(inequalities, symbols, **flags):
     # helper for reduce_inequalities
 
     poly_part, abs_part = {}, {}
@@ -929,7 +929,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, symbols=[]):
+def reduce_inequalities(inequalities, symbols=[], **flags):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
@@ -985,6 +985,18 @@ def reduce_inequalities(inequalities, symbols=[]):
 
     # solve system
     rv = _reduce_inequalities(inequalities, symbols)
+    as_dict = flags.get('dict', False)
 
-    # restore original symbols and return
-    return rv.xreplace({v: k for k, v in recast.items()})
+    # restore original symbols
+    solution = rv.xreplace({v: k for k, v in recast.items()})
+
+    if not as_dict:
+        return solution
+
+    if isinstance(solution, list):
+        solution = [{s.lhs: s.rhs} for s in solution]
+    else:
+        solution = [{solution.lhs: solution.rhs}]
+
+    if as_dict:
+        return solution

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -919,7 +919,8 @@ def solve(f, *symbols, **flags):
                        )
                       )
     f, symbols = (_sympified_list(w) for w in [f, symbols])
-
+    if isinstance(f, list):
+        f = [s for s in f if s is not S.true and s is not True]
     implicit = flags.get('implicit', False)
 
     # preprocess symbol(s)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -981,7 +981,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:
-            return reduce_inequalities(f, flags.get('dict', False), symbols=symbols)
+            return reduce_inequalities(f, symbols=symbols)
 
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -921,6 +921,9 @@ def solve(f, *symbols, **flags):
     f, symbols = (_sympified_list(w) for w in [f, symbols])
     if isinstance(f, list):
         f = [s for s in f if s is not S.true and s is not True]
+        for s in f:
+            if isinstance(s, BooleanAtom):
+                return []
     implicit = flags.get('implicit', False)
 
     # preprocess symbol(s)
@@ -980,7 +983,7 @@ def solve(f, *symbols, **flags):
                     fi = fi.rewrite(Add, evaluate=False)
             f[i] = fi
 
-        if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:
+        if fi.is_Relational:
             return reduce_inequalities(f, symbols=symbols)
 
         if isinstance(fi, Poly):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -981,7 +981,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:
-            return reduce_inequalities(f, symbols=symbols)
+            return reduce_inequalities(f, symbols=symbols, **flags)
 
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -919,11 +919,9 @@ def solve(f, *symbols, **flags):
                        )
                       )
     f, symbols = (_sympified_list(w) for w in [f, symbols])
+    bool_check = False
     if isinstance(f, list):
         f = [s for s in f if s is not S.true and s is not True]
-        for s in f:
-            if isinstance(s, BooleanAtom):
-                return []
     implicit = flags.get('implicit', False)
 
     # preprocess symbol(s)
@@ -989,6 +987,9 @@ def solve(f, *symbols, **flags):
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()
 
+        if not fi:
+            bool_check = True
+
         # rewrite hyperbolics in terms of exp
         f[i] = f[i].replace(lambda w: isinstance(w, HyperbolicFunction),
                 lambda w: w.rewrite(exp))
@@ -1012,6 +1013,9 @@ def solve(f, *symbols, **flags):
                 f[i: i + 1] = [fr, fi]
 
     # real/imag handling -----------------------------
+    if bool_check:
+        return []
+
     w = Dummy('w')
     piece = Lambda(w, Piecewise((w, Ge(w, 0)), (-w, True)))
     for i, fi in enumerate(f):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1011,6 +1011,8 @@ def solve(f, *symbols, **flags):
 
     # real/imag handling -----------------------------
     if any(isinstance(fi, (bool, BooleanAtom)) for fi in f):
+        if flags.get('set', False):
+            return [], set()
         return []
 
     w = Dummy('w')

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -987,7 +987,7 @@ def solve(f, *symbols, **flags):
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()
 
-        if not fi:
+        if not fi and isinstance(fi, BooleanAtom):
             bool_check = True
 
         # rewrite hyperbolics in terms of exp

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -920,7 +920,6 @@ def solve(f, *symbols, **flags):
                        )
                       )
     f, symbols = (_sympified_list(w) for w in [f, symbols])
-    bool_check = False
     if isinstance(f, list):
         f = [s for s in f if s is not S.true and s is not True]
     implicit = flags.get('implicit', False)
@@ -988,9 +987,6 @@ def solve(f, *symbols, **flags):
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()
 
-        if not fi and isinstance(fi, BooleanAtom):
-            bool_check = True
-
         # rewrite hyperbolics in terms of exp
         f[i] = f[i].replace(lambda w: isinstance(w, HyperbolicFunction),
                 lambda w: w.rewrite(exp))
@@ -1014,7 +1010,7 @@ def solve(f, *symbols, **flags):
                 f[i: i + 1] = [fr, fi]
 
     # real/imag handling -----------------------------
-    if bool_check:
+    if any(isinstance(fi, (bool, BooleanAtom)) for fi in f):
         return []
 
     w = Dummy('w')

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -466,7 +466,8 @@ def solve(f, *symbols, **flags):
     * f
         - a single Expr or Poly that must be zero,
         - an Equality
-        - a Relational expression or boolean
+        - a Relational expression
+        - a Boolean
         - iterable of one or more of the above
 
     * symbols (object(s) to solve for) specified as

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -981,7 +981,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:
-            return reduce_inequalities(f, symbols=symbols, **flags)
+            return reduce_inequalities(f, flags.get('dict', False), symbols=symbols)
 
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,6 +167,8 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
+    assert solve(Eq(x, x+1), x<2) == False
+    assert solve([Eq(x, x), Eq(x, x+1)]) == []
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -164,6 +164,9 @@ def test_solve_args():
     assert solve([(x + y)**2 - 4, x + y - 2]) == [{x: -y + 2}]
     # - linear
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
+    # When one or more args are Boolean
+    assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
+    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == False
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,9 +167,6 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == False
-    # Tests for relational cases See Issue #13534
-    assert solve([Eq(x**2-1, 0), Gt(x, 0)], [x]) == Eq(x, 1)
-    assert solve([Eq(x**2-1, 0), Gt(x, 0)], [x], dict=True) == [{x: 1}]
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -170,6 +170,7 @@ def test_solve_args():
     assert solve([Eq(x, x+1), x < 2], x) == False
     assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
+    assert solve(True, x) == []
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,6 +167,9 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == False
+    # Tests for relational cases See Issue #13534
+    assert solve([Eq(x**2-1, 0), Gt(x, 0)], [x]) == Eq(x, 1)
+    assert solve([Eq(x**2-1, 0), Gt(x, 0)], [x], dict=True) == [{x: 1}]
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -171,6 +171,7 @@ def test_solve_args():
     assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
     assert solve(True, x) == []
+    assert solve([x-1, False], [x], set=True) == ([], set())
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,7 +167,7 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
-    assert solve([Eq(x, x+1), x < 2], x) is False
+    assert not solve([Eq(x, x+1), x < 2], x)
     assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
     assert solve(True, x) == []

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,8 +167,9 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
-    assert solve(Eq(x, x+1), x<2) == False
-    assert solve([Eq(x, x), Eq(x, x+1)]) == []
+    assert solve([Eq(x, x+1), x < 2], x) == False
+    assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
+    assert solve([Eq(x, x), Eq(x, x+1)], x) == []
 
 
 def test_solve_polynomial1():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -167,7 +167,7 @@ def test_solve_args():
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
-    assert solve([Eq(x, x+1), x < 2], x) == False
+    assert solve([Eq(x, x+1), x < 2], x) is False
     assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
     assert solve(True, x) == []

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -166,7 +166,7 @@ def test_solve_args():
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
     # When one or more args are Boolean
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
-    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == False
+    assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
 
 
 def test_solve_polynomial1():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #16138 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

List of equations in which one or more have been evaluated to `True` was ignoring the `set flags`. For e.g.

```
In [1]: solve([Eq(x, 0)], [x], dict=True)                                                                                                                     
Out[1]: [{x: 0}]
In [2]: solve([True, Eq(x, 0)], [x], dict=True)                                                                                                               
Out[2]: x = 0
```

But now the output is, 

```
In [1]: solve([Eq(x, 0)], [x], dict=True)                                                                                                                     
Out[1]: [{x: 0}]
In [2]: solve([True, Eq(x, 0)], [x], dict=True)                                                                                                               
Out[2]: [{x: 0}]
```

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
