### PR TITLE
Increase test coverage of LaTeX printer

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1075,7 +1075,7 @@ class LatexPrinter(Printer):
         tex = r"!%s" % self.parenthesize(expr.args[0], PRECEDENCE["Func"])
 
         if exp is not None:
-            return r"%s^{%s}" % (tex, exp)
+            return r"\left(%s\right)^{%s}" % (tex, exp)
         else:
             return tex
 
@@ -1740,7 +1740,7 @@ class LatexPrinter(Printer):
             tex = r'\delta_{%s %s}' % (i, j)
         else:
             tex = r'\delta_{%s, %s}' % (i, j)
-        if exp:
+        if exp is not None:
             tex = r'\left(%s\right)^{%s}' % (tex, exp)
         return tex
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,7 +17,7 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-     UnevaluatedExpr, Quaternion, I)
+     UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -272,6 +272,7 @@ def test_latex_functions():
     # not to be confused with the beta function
     assert latex(mybeta(x, y, z)) == r"\beta{\left(x,y,z \right)}"
     assert latex(beta(x, y)) == r'\operatorname{B}\left(x, y\right)'
+    assert latex(beta(x, y)**2) == r'\operatorname{B}^{2}\left(x, y\right)'
     assert latex(mybeta(x)) == r"\beta{\left(x \right)}"
     assert latex(mybeta) == r"\beta"
 
@@ -311,29 +312,38 @@ def test_latex_functions():
 
     assert latex(factorial(k)) == r"k!"
     assert latex(factorial(-k)) == r"\left(- k\right)!"
+    assert latex(factorial(k)**2) == r"k!^{2}"
 
     assert latex(subfactorial(k)) == r"!k"
     assert latex(subfactorial(-k)) == r"!\left(- k\right)"
+    assert latex(subfactorial(k)**2) == r"\left(!k\right)^{2}"
 
     assert latex(factorial2(k)) == r"k!!"
     assert latex(factorial2(-k)) == r"\left(- k\right)!!"
+    assert latex(factorial2(k)**2) == r"k!!^{2}"
 
     assert latex(binomial(2, k)) == r"{\binom{2}{k}}"
+    assert latex(binomial(2, k)**2) == r"{\binom{2}{k}}^{2}"
 
     assert latex(FallingFactorial(3, k)) == r"{\left(3\right)}_{k}"
     assert latex(RisingFactorial(3, k)) == r"{3}^{\left(k\right)}"
 
     assert latex(floor(x)) == r"\left\lfloor{x}\right\rfloor"
     assert latex(ceiling(x)) == r"\left\lceil{x}\right\rceil"
+    assert latex(floor(x)**2) == r"\left\lfloor{x}\right\rfloor^{2}"
+    assert latex(ceiling(x)**2) == r"\left\lceil{x}\right\rceil^{2}"
     assert latex(Min(x, 2, x**3)) == r"\min\left(2, x, x^{3}\right)"
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"
     assert latex(Max(x, y)**2) == r"\max\left(x, y\right)^{2}"
     assert latex(Abs(x)) == r"\left|{x}\right|"
+    assert latex(Abs(x)**2) == r"\left|{x}\right|^{2}"
     assert latex(re(x)) == r"\Re{\left(x\right)}"
     assert latex(re(x + y)) == r"\Re{\left(x\right)} + \Re{\left(y\right)}"
     assert latex(im(x)) == r"\Im{x}"
     assert latex(conjugate(x)) == r"\overline{x}"
+    assert latex(conjugate(x)**2) == r"\overline{x}^{2}"
+    assert latex(conjugate(x**2)) == r"\overline{x}^{2}"
     assert latex(gamma(x)) == r"\Gamma\left(x\right)"
     w = Wild('w')
     assert latex(gamma(w)) == r"\Gamma\left(w\right)"
@@ -346,7 +356,9 @@ def test_latex_functions():
     assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
     assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( \infty, \  \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
+    assert latex(lowergamma(x, y)**2) == r'\gamma^{2}\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
+    assert latex(uppergamma(x, y)**2) == r'\Gamma^{2}\left(x, y\right)'
 
     assert latex(cot(x)) == r'\cot{\left(x \right)}'
     assert latex(coth(x)) == r'\coth{\left(x \right)}'
@@ -384,6 +396,7 @@ def test_latex_functions():
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
     assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'
+    assert latex(expint(x, y)) == r'\operatorname{E}_{x}\left(y\right)'
     assert latex(expint(x, y)**2) == r'\operatorname{E}_{x}^{2}\left(y\right)'
     assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left(x \right)}'
     assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left(x \right)}'
@@ -748,6 +761,11 @@ def test_latex_union():
         r"\left\{1, 2\right\} \cup \left[3, 4\right]"
 
 
+def test_latex_intersection():
+    assert latex(Intersection(Interval(0, 1), Interval(x, y))) == \
+        r"\left[0, 1\right] \cap \left[x, y\right]"
+
+
 def test_latex_symmetric_difference():
     assert latex(SymmetricDifference(Interval(2,5), Interval(4,7), \
         evaluate = False)) == r'\left[2, 5\right] \triangle \left[4, 7\right]'
@@ -928,6 +946,7 @@ def test_latex_KroneckerDelta():
     assert latex(KroneckerDelta(x, y + 1)) == r"\delta_{x, y + 1}"
     # issue 6578
     assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{y, x + 1}"
+    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == r"\left(\delta_{x y}\right)^{2}"
 
 
 def test_latex_LeviCivita():
@@ -947,6 +966,7 @@ def test_mode():
         expr, mode='equation*') == '\\begin{equation*}x + y\\end{equation*}'
     assert latex(
         expr, mode='equation') == '\\begin{equation}x + y\\end{equation}'
+    raises(ValueError, lambda : latex(expr, mode='foo'))
 
 
 def test_latex_Piecewise():
@@ -964,6 +984,8 @@ def test_latex_Piecewise():
     assert latex(p) == s
     assert latex(A*p) == r"A \left(%s\right)" % s
     assert latex(p*A) == r"\left(%s\right) A" % s
+    assert latex(Piecewise((x, x < 1), (x**2, x <2))) == '\\begin{cases} x & ' \
+        '\\text{for}\\: x < 1 \\\\x^{2} & \\text{for}\\: x < 2 \\end{cases}'
 
 
 def test_latex_Matrix():
@@ -1102,12 +1124,12 @@ def test_noncommutative():
 
 
 def test_latex_order():
-    expr = x**3 + x**2*y + 3*x*y**3 + y**4
+    expr = x**3 + x**2*y + y**4 + 3*x*y**3
 
     assert latex(expr, order='lex') == "x^{3} + x^{2} y + 3 x y^{3} + y^{4}"
     assert latex(
         expr, order='rev-lex') == "y^{4} + 3 x y^{3} + x^{2} y + x^{3}"
-
+    assert latex(expr, order='none') == "x^{3} + y^{4} + y x^{2} + 3 x y^{3}"
 
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
@@ -1436,6 +1458,11 @@ def test_ZeroMatrix():
     assert latex(ZeroMatrix(1, 1)) == r"\mathbb{0}"
 
 
+def test_Identity():
+    from sympy import Identity
+    assert latex(Identity(1)) == r"\mathbb{I}"
+
+
 def test_boolean_args_order():
     syms = symbols('a:f')
 
@@ -1664,6 +1691,9 @@ def test_Mul():
 def test_Pow():
     e = Pow(2, 2, evaluate=False)
     assert latex(e)  == r'2^{2}'
+    assert latex(x**(Rational(-1,3))) == r'\frac{1}{\sqrt[3]{x}}'
+    x2 = Symbol(r'x^2')
+    assert latex(x2**2) == r'\left(x^{2}\right)^{2}'
 
 
 def test_issue_7180():
@@ -1763,6 +1793,12 @@ def test_MatrixSymbol_printing():
     assert latex(-A) == r"- A"
     assert latex(A - A*B - B) == r"A - A B - B"
     assert latex(-A*B - A*B*C - B) == r"- A B - A B C - B"
+
+
+def test_KroneckerProduct_printing():
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 2, 2)
+    assert latex(KroneckerProduct(A, B)) == r'A \otimes B'
 
 
 def test_Quaternion_latex_printing():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Increase test coverage of LaTeX printer

#### Brief description of what is fixed or changed
Increase test coverage of LaTeX printer

A change is that the subfactorial to a power is now printed with brackets. Earlier it printed `!k^2` which is potentially ambiguous (although `subfactorial(k**2)` prints as  `!(k^2)` so not strictly)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
