### PR TITLE
Simplification of singularity-function to calculate shear_force, bending_moment, deflection etc at any point on beam

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -679,7 +679,7 @@ class Beam(object):
         self._hinge_beam_slope = slope_1*SingularityFunction(x, 0, 0) - slope_1*SingularityFunction(x, l, 0) + slope_2*SingularityFunction(x, l, 0)
         self._hinge_beam_deflection = def_1*SingularityFunction(x, 0, 0) - def_1*SingularityFunction(x, l, 0) + def_2*SingularityFunction(x, l, 0)
 
-    def solve_for_reaction_loads(self, *reactions, value=None):
+    def solve_for_reaction_loads(self, *reactions):
         """
         Solves for the reaction forces.
 
@@ -722,7 +722,7 @@ class Beam(object):
         l = self.length
         C3 = Symbol('C3')
         C4 = Symbol('C4')
-
+        value = None
         shear_curve = limit(self.shear_force(value), x, l)
         moment_curve = limit(self.bending_moment(value), x, l)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Singularity-function has been simplified to calculate shear_force, bending_moment, deflection etc at any point on beam.

Previously:

```
>>> b.shear_force()
−8⟨x⟩^0+6⟨x−10⟩^0+120⟨x−30⟩^−1+2⟨x−30⟩^0

>>> b.shear_force(15)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: shear_force() takes exactly 1 argument (2 given)

```
Now:
```
>>> b.shear_force(15)
-2

```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  physics.continuum_mechanics
   *  calculate shear_force, bending_moment, deflection etc at any point on beam
<!-- END RELEASE NOTES -->
