### PR TITLE
Added class to represent unevaluated laplacian.

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4522,6 +4522,13 @@ def test_sympy__vector__operators__Curl():
     assert _test_args(Curl(C.i))
 
 
+def test_sympy__vector__operators__Laplacian():
+    from sympy.vector.operators import Laplacian
+    from sympy.vector.coordsysrect import CoordSys3D
+    C = CoordSys3D('C')
+    assert _test_args(Laplacian(C.i))
+
+
 def test_sympy__vector__operators__Divergence():
     from sympy.vector.operators import Divergence
     from sympy.vector.coordsysrect import CoordSys3D

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -13,4 +13,4 @@ from sympy.vector.functions import (express, matrix_to_vector,
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.vector.operators import Gradient, Divergence, Curl, gradient, curl, divergence
+from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,11 +1,11 @@
 from sympy.vector.coordsysrect import CoordSys3D
-from sympy.vector.deloperator import Del
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
+from sympy.vector.deloperator import Del
 
 
 def express(expr, system, system2=None, variables=False):
@@ -198,6 +198,7 @@ def laplacian(expr):
     2*R.i + 6*R.y*R.j + 12*R.z**2*R.k
 
     """
+
     delop = Del()
     if expr.is_Vector:
         return (gradient(divergence(expr)) - curl(curl(expr))).doit()

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,11 +1,11 @@
 from sympy.vector.coordsysrect import CoordSys3D
+from sympy.vector.deloperator import Del
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
-from sympy.vector.deloperator import Del
 
 
 def express(expr, system, system2=None, variables=False):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -9,7 +9,6 @@ from sympy.core.function import Derivative
 from sympy import Add, Mul
 
 
-
 def _get_coord_systems(expr):
     g = preorder_traversal(expr)
     ret = set([])

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -340,8 +340,6 @@ class Laplacian(Expr):
     >>> v = 3*R.x**3*R.y**2*R.z**3
     >>> Laplacian(v)
     Laplacian(3*R.x**3*R.y**2*R.z**3)
-    >>> Laplacian(v).doit()
-    18*R.x*R.y**2*R.z**3 + 6*R.x**3*R.z**3 + 18*R.x**3*R.y**2*R.z
 
     """
 

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -9,6 +9,7 @@ from sympy.core.function import Derivative
 from sympy import Add, Mul
 
 
+
 def _get_coord_systems(expr):
     g = preorder_traversal(expr)
     ret = set([])
@@ -325,6 +326,34 @@ def gradient(scalar_field, coord_sys=None, doit=True):
             s = _split_mul_args_wrt_coordsys(scalar_field)
             return VectorAdd.fromiter(scalar_field / i * gradient(i) for i in s)
         return Gradient(scalar_field)
+
+
+class Laplacian(Expr):
+    """
+    Represents unevaluated Laplacian.
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSys3D, Laplacian
+    >>> R = CoordSys3D('R')
+    >>> v = 3*R.x**3*R.y**2*R.z**3
+    >>> Laplacian(v)
+    Laplacian(3*R.x**3*R.y**2*R.z**3)
+    >>> Laplacian(v).doit()
+    18*R.x*R.y**2*R.z**3 + 6*R.x**3*R.z**3 + 18*R.x**3*R.y**2*R.z
+
+    """
+
+    def __new__(cls, expr):
+        expr = sympify(expr)
+        obj = Expr.__new__(cls, expr)
+        obj._expr = expr
+        return obj
+
+    def doit(self, **kwargs):
+        from sympy.vector.functions import laplacian
+        return laplacian(self._expr)
 
 
 def _diff_conditional(expr, base_scalar, coeff_1, coeff_2):

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,11 +1,12 @@
-from sympy.vector import CoordSys3D, Gradient, Divergence, Curl, VectorZero
-
+from sympy.vector import CoordSys3D, Gradient, Divergence, Curl, VectorZero, Laplacian
 
 R = CoordSys3D('R')
 s1 = R.x*R.y*R.z
 s2 = R.x + 3*R.y**2
+s3 = R.x**2 + R.y**2 + R.z**2
 v1 = R.x*R.i + R.z*R.z*R.j
 v2 = R.x*R.i + R.y*R.j + R.z*R.k
+v3 = R.x**2*R.i + R.y**2*R.j + R.z**2*R.k
 
 
 def test_Gradient():
@@ -27,3 +28,10 @@ def test_Curl():
     assert Curl(v2) == Curl(R.x*R.i + R.y*R.j + R.z*R.k)
     assert Curl(v1).doit() == (-2*R.z)*R.i
     assert Curl(v2).doit() == VectorZero()
+
+
+def test_Laplacian():
+    assert Laplacian(s3) == Laplacian(R.x**2 + R.y**2 + R.z**2)
+    assert Laplacian(v3) == Laplacian(R.x**2*R.i + R.y**2*R.j + R.z**2*R.k)
+    assert Laplacian(s3).doit() == 6
+    assert Laplacian(v3).doit() == 2*R.i + 2*R.j + 2*R.k

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,4 +1,5 @@
 from sympy.vector import CoordSys3D, Gradient, Divergence, Curl, VectorZero, Laplacian
+from sympy.printing.repr import srepr
 
 R = CoordSys3D('R')
 s1 = R.x*R.y*R.z
@@ -35,3 +36,5 @@ def test_Laplacian():
     assert Laplacian(v3) == Laplacian(R.x**2*R.i + R.y**2*R.j + R.z**2*R.k)
     assert Laplacian(s3).doit() == 6
     assert Laplacian(v3).doit() == 2*R.i + 2*R.j + 2*R.k
+    assert srepr(Laplacian(s3)) == \
+            'Laplacian(Add(Pow(R.x, Integer(2)), Pow(R.y, Integer(2)), Pow(R.z, Integer(2))))'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #13664 

#### Brief description of what is fixed or changed
`Laplacian` class added to represent unevaluated Laplacian in `vector/operators.py`.
```
>>> from sympy.vector import Laplacian, CoordSys3D
>>> R = CoordSys3D('R')
>>> v = R.x**3 + R.y**3 + R.z**3
>>> Laplacian(v)
Laplacian(R.x**3 + R.y**3 + R.z**3)
>>> Laplacian(v).doit()
6*R.x + 6*R.y + 6*R.z
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * added Laplacian class to represent unevaluated laplacian.
<!-- END RELEASE NOTES -->
