### PR TITLE
fix unicode handling of replacement string in subs()

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -945,7 +945,8 @@ class Basic(with_metaclass(ManagedProperties)):
                 # when old is a string we prefer Symbol
                 s = Symbol(s[0]), s[1]
             try:
-                s = [sympify(_, strict=type(_) is not str) for _ in s]
+                s = [sympify(_, strict=not isinstance(_, string_types))
+                     for _ in s]
             except SympifyError:
                 # if it can't be sympified, skip it
                 sequence[i] = None

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -120,6 +120,15 @@ def test_subs():
     assert Symbol(u"text").subs({u"text": b1}) == b1
 
 
+def test_subs_with_unicode_symbols():
+    expr = Symbol('var1')
+    replaced = expr.subs('var1', u'x')
+    assert replaced.name == 'x'
+
+    replaced = expr.subs('var1', 'x')
+    assert replaced.name == 'x'
+
+
 def test_atoms():
     assert b21.atoms() == set()
 


### PR DESCRIPTION
#### References to other Issues or PRs
Related to already merged #16093 


#### Brief description of what is fixed or changed
When replacing expressions with a string the replacement was not done under if replacement string is an unicode string and not a binary string. 
`Symbol('x').subs('x', 'y')` works but `Symbol('x').subs('x', u'y')` not:
```
In [3]: Symbol('x').subs('x', 'y')
Out[3]: y

In [4]: Symbol('x').subs('x', u'y')
Out[4]: x
```

#### Other comments
This is symmetric of #16093. There is fixed the handling of symbol to be replaced when it is a unicode string, here is fixed the replacement expression. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
    * improve of unicode strings by subs in python 2
<!-- END RELEASE NOTES -->
