### PR TITLE
Matrices : Add rank factorization

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -879,7 +879,8 @@ class MatrixReductions(MatrixDeterminant):
 
     def rank_decomposition(self,
         iszerofunc=_iszero, simplify=False, format='original'):
-        r"""Returns the rank-factorized form of `A`, as `C` and `F`.
+        r"""Returns a pair of matrices (`C`, `F`) with matching rank
+        such that `A = C \cdot F`.
 
         Parameters
         ==========
@@ -893,10 +894,9 @@ class MatrixReductions(MatrixDeterminant):
             pivot. By default SymPy's ``simplify`` is used.
 
         format : String, optional
-            If 'original', additional zeros would be appended to the
-            `C` and `F` to keep the shape of `F` as same as the
-            original matrix.
-            It is also corresponding to the format as ``rref`` function.
+            If 'original', the returned matrices will have the same
+            shape as the original matrix. This is similar to the
+            return value of the ``rref`` function.
 
             If `reduced`, it will truncate trivial zero rows from `F`,
             and zero columns from `C`.
@@ -905,9 +905,9 @@ class MatrixReductions(MatrixDeterminant):
         =======
 
         (C, F) : Matrices
-            `F` is the RREF of `A`, and `C` is the inverse of the
-            product of the elimination matrices, which can restore
-            `A = C \cdot F`
+            `F` is the reduced row echelon form (RREF) of `A`, and `C`
+            has the same rank as `F` and its product with `C` restores `A`:
+            `A = C \cdot F`.
 
             See Notes for additional mathematical details.
 
@@ -963,19 +963,17 @@ class MatrixReductions(MatrixDeterminant):
             E_n \cdot E_{n-1} \cdot ... \cdot E_1 \cdot A = F
 
         where `E_n, E_{n-1}, ... , E_1` are the elimination matrices or
-        permutation matrices equivant to each row reduction steps.
+        permutation matrices equivalent to each row-reduction step.
 
-        As putting a matrix in a row echeolon form introduces the
-        concept of the LU decomposition, similarly, putting a matrix in
-        a reduced row echeolon form introduces the matrix
+        The inverse of the same product of elimination matrices gives
+        `C`:
 
         .. math::
             C = (E_n \cdot E_{n-1} \cdot ... \cdot E_1)^{-1}
 
-        However, in actual computation, we can simplify the procedure
-        by taking the columns from the original matrix, where the
-        column indices are the indices of the pivot columns of the `F`
-        matrix.
+        It is not necessary, however, to actually compute the inverse:
+        the columns of `C` are those from the original matrix with the
+        same column indices as the indices of the pivot columns of `F`.
 
         References
         ==========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4262,7 +4262,7 @@ class MatrixBase(MatrixDeprecated,
 
     def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
         r"""Returns a pair of matrices (`C`, `F`) with matching rank
-        such that `A = C \cdot F`.
+        such that `A = C F`.
 
         Parameters
         ==========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -877,8 +877,7 @@ class MatrixReductions(MatrixDeterminant):
         echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
         return len(pivots)
 
-    def rank_decomposition(self,
-        iszerofunc=_iszero, simplify=False, format='original'):
+    def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
         r"""Returns a pair of matrices (`C`, `F`) with matching rank
         such that `A = C \cdot F`.
 
@@ -892,14 +891,6 @@ class MatrixReductions(MatrixDeterminant):
         simplify : Bool or Function, optional
             A function used to simplify elements when looking for a
             pivot. By default SymPy's ``simplify`` is used.
-
-        format : String, optional
-            If 'original', the returned matrices will have the same
-            shape as the original matrix. This is similar to the
-            return value of the ``rref`` function.
-
-            If `reduced`, it will truncate trivial zero rows from `F`,
-            and zero columns from `C`.
 
         Returns
         =======
@@ -922,23 +913,6 @@ class MatrixReductions(MatrixDeterminant):
         ...     [1, 2, 0, 8]
         ... ])
         >>> C, F = A.rank_decomposition()
-        >>> C
-        Matrix([
-        [1, 3, 4, 0],
-        [2, 7, 9, 0],
-        [1, 5, 1, 0],
-        [1, 2, 8, 0]])
-        >>> F
-        Matrix([
-        [1, 0, -2, 0],
-        [0, 1,  1, 0],
-        [0, 0,  0, 1],
-        [0, 0,  0, 0]])
-        >>> C * F == A
-        True
-
-        Format the result to make it compact:
-        >>> C, F = A.rank_decomposition(format='reduced')
         >>> C
         Matrix([
         [1, 3, 4],
@@ -989,21 +963,14 @@ class MatrixReductions(MatrixDeterminant):
 
         rref
         """
-        cls = self.__class__
-        mat = self.as_mutable()
-
-        (F, pivot_cols) = mat.rref(
+        (F, pivot_cols) = self.rref(
             simplify=simplify, iszerofunc=iszerofunc, pivots=True)
         rank = len(pivot_cols)
 
-        if format == 'original':
-            C = mat.extract(range(self.rows), pivot_cols)
-            C = C.row_join(C.zeros(C.rows, F.rows - C.cols))
-        elif format == 'reduced':
-            C = mat.extract(range(self.rows), pivot_cols)
-            F = F[:rank, :]
+        C = self.extract(range(self.rows), pivot_cols)
+        F = F[:rank, :]
 
-        return (cls(C), cls(F))
+        return (C, F)
 
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True, normalize_last=True):
         """Return reduced row-echelon form of matrix and indices of pivot vars.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -877,101 +877,6 @@ class MatrixReductions(MatrixDeterminant):
         echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
         return len(pivots)
 
-    def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
-        r"""Returns a pair of matrices (`C`, `F`) with matching rank
-        such that `A = C \cdot F`.
-
-        Parameters
-        ==========
-
-        iszerofunc : Function, optional
-            A function used for detecting whether an element can
-            act as a pivot.  ``lambda x: x.is_zero`` is used by default.
-
-        simplify : Bool or Function, optional
-            A function used to simplify elements when looking for a
-            pivot. By default SymPy's ``simplify`` is used.
-
-        Returns
-        =======
-
-        (C, F) : Matrices
-            `F` is the reduced row echelon form (RREF) of `A`, and `C`
-            has the same rank as `F` and its product with `C` restores `A`:
-            `A = C \cdot F`.
-
-            See Notes for additional mathematical details.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import Matrix
-        >>> A = Matrix([
-        ...     [1, 3, 1, 4],
-        ...     [2, 7, 3, 9],
-        ...     [1, 5, 3, 1],
-        ...     [1, 2, 0, 8]
-        ... ])
-        >>> C, F = A.rank_decomposition()
-        >>> C
-        Matrix([
-        [1, 3, 4],
-        [2, 7, 9],
-        [1, 5, 1],
-        [1, 2, 8]])
-        >>> F
-        Matrix([
-        [1, 0, -2, 0],
-        [0, 1,  1, 0],
-        [0, 0,  0, 1]])
-        >>> C * F == A
-        True
-
-        Notes
-        =====
-
-        Obtaining `F`, an RREF of `A`, is equivalent to creating a
-        product
-
-        .. math::
-            E_n \cdot E_{n-1} \cdot ... \cdot E_1 \cdot A = F
-
-        where `E_n, E_{n-1}, ... , E_1` are the elimination matrices or
-        permutation matrices equivalent to each row-reduction step.
-
-        The inverse of the same product of elimination matrices gives
-        `C`:
-
-        .. math::
-            C = (E_n \cdot E_{n-1} \cdot ... \cdot E_1)^{-1}
-
-        It is not necessary, however, to actually compute the inverse:
-        the columns of `C` are those from the original matrix with the
-        same column indices as the indices of the pivot columns of `F`.
-
-        References
-        ==========
-
-        .. [1] https://en.wikipedia.org/wiki/Rank_factorization
-
-        .. [2] Piziak, R.; Odell, P. L. (1 June 1999).
-            "Full Rank Factorization of Matrices".
-            Mathematics Magazine. 72 (3): 193. doi:10.2307/2690882
-
-        See Also
-        ========
-
-        rref
-        """
-        (F, pivot_cols) = self.rref(
-            simplify=simplify, iszerofunc=iszerofunc, pivots=True)
-        rank = len(pivot_cols)
-
-        C = self.extract(range(self.rows), pivot_cols)
-        F = F[:rank, :]
-
-        return (C, F)
-
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True, normalize_last=True):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 
@@ -4354,6 +4259,101 @@ class MatrixBase(MatrixDeprecated,
                 tmp -= R[j, k] * x[n - 1 - k]
             x.append(tmp / R[j, j])
         return self._new([row._mat for row in reversed(x)])
+
+    def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
+        r"""Returns a pair of matrices (`C`, `F`) with matching rank
+        such that `A = C \cdot F`.
+
+        Parameters
+        ==========
+
+        iszerofunc : Function, optional
+            A function used for detecting whether an element can
+            act as a pivot.  ``lambda x: x.is_zero`` is used by default.
+
+        simplify : Bool or Function, optional
+            A function used to simplify elements when looking for a
+            pivot. By default SymPy's ``simplify`` is used.
+
+        Returns
+        =======
+
+        (C, F) : Matrices
+            `F` is the reduced row echelon form (RREF) of `A`, and `C`
+            has the same rank as `F` and its product with `C` restores `A`:
+            `A = C \cdot F`.
+
+            See Notes for additional mathematical details.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import Matrix
+        >>> A = Matrix([
+        ...     [1, 3, 1, 4],
+        ...     [2, 7, 3, 9],
+        ...     [1, 5, 3, 1],
+        ...     [1, 2, 0, 8]
+        ... ])
+        >>> C, F = A.rank_decomposition()
+        >>> C
+        Matrix([
+        [1, 3, 4],
+        [2, 7, 9],
+        [1, 5, 1],
+        [1, 2, 8]])
+        >>> F
+        Matrix([
+        [1, 0, -2, 0],
+        [0, 1,  1, 0],
+        [0, 0,  0, 1]])
+        >>> C * F == A
+        True
+
+        Notes
+        =====
+
+        Obtaining `F`, an RREF of `A`, is equivalent to creating a
+        product
+
+        .. math::
+            E_n \cdot E_{n-1} \cdot ... \cdot E_1 \cdot A = F
+
+        where `E_n, E_{n-1}, ... , E_1` are the elimination matrices or
+        permutation matrices equivalent to each row-reduction step.
+
+        The inverse of the same product of elimination matrices gives
+        `C`:
+
+        .. math::
+            C = (E_n \cdot E_{n-1} \cdot ... \cdot E_1)^{-1}
+
+        It is not necessary, however, to actually compute the inverse:
+        the columns of `C` are those from the original matrix with the
+        same column indices as the indices of the pivot columns of `F`.
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Rank_factorization
+
+        .. [2] Piziak, R.; Odell, P. L. (1 June 1999).
+            "Full Rank Factorization of Matrices".
+            Mathematics Magazine. 72 (3): 193. doi:10.2307/2690882
+
+        See Also
+        ========
+
+        rref
+        """
+        (F, pivot_cols) = self.rref(
+            simplify=simplify, iszerofunc=iszerofunc, pivots=True)
+        rank = len(pivot_cols)
+
+        C = self.extract(range(self.rows), pivot_cols)
+        F = F[:rank, :]
+
+        return (C, F)
 
     def solve_least_squares(self, rhs, method='CH'):
         """Return the least-square fit to the data.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -877,6 +877,40 @@ class MatrixReductions(MatrixDeterminant):
         echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
         return len(pivots)
 
+    def Rankdecomposition(self, iszerofunc=_iszero, simplify=False):
+        """Returns rank-factorized form of A as A = C*F where F is in reduced
+        row echelon form.
+
+        Parameters
+        ==========
+
+        iszerofunc : Function, optional
+
+        simplify : Bool or Function, optional
+
+        Returns
+        =======
+
+        (C, F) : Matrices
+
+        Examples
+        ========
+
+        See Also
+        ========
+        rref
+        rank
+        """
+        cls = self.__class__
+        mat = self.as_mutable()
+
+        (F, pivot_cols) = mat.rref(simplify=simplify, pivots=True)
+
+        C = mat.extract(range(self.rows), pivot_cols)
+        C = C.row_join(C.zeros(C.rows, F.rows - C.cols))
+
+        return (cls(C), cls(F))
+
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True, normalize_last=True):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -877,29 +877,89 @@ class MatrixReductions(MatrixDeterminant):
         echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
         return len(pivots)
 
-    def Rankdecomposition(self, iszerofunc=_iszero, simplify=False):
-        """Returns rank-factorized form of A as A = C*F where F is in reduced
-        row echelon form.
+    def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
+        """Returns the rank-factorized form of `A`, as `C` and `F`.
 
         Parameters
         ==========
 
         iszerofunc : Function, optional
+            A function used for detecting whether an element can
+            act as a pivot.  ``lambda x: x.is_zero`` is used by default.
 
         simplify : Bool or Function, optional
+            A function used to simplify elements when looking for a
+            pivot. By default SymPy's ``simplify`` is used.
 
         Returns
         =======
 
         (C, F) : Matrices
+            `F` is the RREF of `A`, and `C` is the inverse of the
+            product of the elimination matrices, which can restore
+            `A = C \cdot F`
+
+            See Notes for additional mathematical details.
 
         Examples
         ========
 
+        >>> from sympy.matrices import Matrix
+        >>> A = Matrix([
+        ...     [1, 3, 1, 4],
+        ...     [2, 7, 3, 9],
+        ...     [1, 5, 3, 1],
+        ...     [1, 2, 0, 8]
+        ... ])
+        >>> C, F = A.rank_decomposition()
+        >>> C
+        Matrix([
+        [1, 3, 4, 0],
+        [2, 7, 9, 0],
+        [1, 5, 1, 0],
+        [1, 2, 8, 0]])
+        >>> F
+        Matrix([
+        [1, 0, -2, 0],
+        [0, 1,  1, 0],
+        [0, 0,  0, 1],
+        [0, 0,  0, 0]])
+        >>> C * F == A
+        True
+
+        Notes
+        =====
+
+        Obtaining `F`, an RREF of `A`, is equivalent to creating a
+        product
+
+        .. math::
+            E_n \cdot E_{n-1} \cdot ... \cdot E_1 \cdot A = F
+
+        where `E_n, E_{n-1}, ... , E_1` are the elimination matrices or
+        permutation matrices equivant to each row reduction steps.
+
+        As putting a matrix in a row echeolon form introduces the
+        concept of the LU decomposition, similarly, putting a matrix in
+        a reduced row echeolon form introduces the matrix
+
+        .. math::
+            C = (E_n \cdot E_{n-1} \cdot ... \cdot E_1)^{-1}
+
+        However, in actual computation, we can simplify the procedure
+        by taking the columns from the original matrix, where the
+        column indices are the indices of the pivot columns of the `F`
+        matrix.
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Rank_factorization
+
         See Also
         ========
+
         rref
-        rank
         """
         cls = self.__class__
         mat = self.as_mutable()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4279,9 +4279,8 @@ class MatrixBase(MatrixDeprecated,
         =======
 
         (C, F) : Matrices
-            `F` is the reduced row echelon form (RREF) of `A`, and `C`
-            has the same rank as `F` and its product with `C` restores `A`:
-            `A = C \cdot F`.
+            `C` and `F` are full-rank matrices with rank as same as `A`,
+            whose product gives `A`.
 
             See Notes for additional mathematical details.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -878,7 +878,7 @@ class MatrixReductions(MatrixDeterminant):
         return len(pivots)
 
     def rank_decomposition(self, iszerofunc=_iszero, simplify=False):
-        """Returns the rank-factorized form of `A`, as `C` and `F`.
+        r"""Returns the rank-factorized form of `A`, as `C` and `F`.
 
         Parameters
         ==========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -956,6 +956,10 @@ class MatrixReductions(MatrixDeterminant):
 
         .. [1] https://en.wikipedia.org/wiki/Rank_factorization
 
+        .. [2] Piziak, R.; Odell, P. L. (1 June 1999).
+            "Full Rank Factorization of Matrices".
+            Mathematics Magazine. 72 (3): 193. doi:10.2307/2690882
+
         See Also
         ========
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4316,7 +4316,7 @@ class MatrixBase(MatrixDeprecated,
         product
 
         .. math::
-            E_n \cdot E_{n-1} \cdot ... \cdot E_1 \cdot A = F
+            E_n E_{n-1} ... E_1 A = F
 
         where `E_n, E_{n-1}, ... , E_1` are the elimination matrices or
         permutation matrices equivalent to each row-reduction step.
@@ -4325,7 +4325,7 @@ class MatrixBase(MatrixDeprecated,
         `C`:
 
         .. math::
-            C = (E_n \cdot E_{n-1} \cdot ... \cdot E_1)^{-1}
+            C = (E_n E_{n-1} ... E_1)^{-1}
 
         It is not necessary, however, to actually compute the inverse:
         the columns of `C` are those from the original matrix with the

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3329,6 +3329,11 @@ def test_rank_decomposition():
     assert f.is_echelon
     assert c * f == a
 
+    c, f = a.rank_decomposition(format='reduced')
+    assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
+    assert c * f == a
+
 @slow
 def test_issue_11238():
     from sympy import Point

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3308,16 +3308,19 @@ def test_rank_decomposition():
     a = Matrix(0, 0, [])
     c, f = a.rank_decomposition()
     assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
     assert c * f == a
 
     a = Matrix(1, 1, [5])
     c, f = a.rank_decomposition()
     assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
     assert c * f == a
 
     a = Matrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
     c, f = a.rank_decomposition()
     assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
     assert c * f == a
 
     a = Matrix([
@@ -3326,10 +3329,6 @@ def test_rank_decomposition():
         [0, 0, -2, -3, -3, 8, -5],
         [-1, 5, 0, -1, -2, 1, 0]])
     c, f = a.rank_decomposition()
-    assert f.is_echelon
-    assert c * f == a
-
-    c, f = a.rank_decomposition(format='reduced')
     assert f.is_echelon
     assert c.cols == f.rows == a.rank()
     assert c * f == a

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3304,6 +3304,30 @@ def test_iszero_substitution():
     # if a zero-substitution wasn't made, this entry will be -1.11022302462516e-16
     assert m_rref[2,2] == 0
 
+def test_rank_decomposition():
+    a = Matrix(0, 0, [])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c * f == a
+
+    a = Matrix(1, 1, [5])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c * f == a
+
+    a = Matrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c * f == a
+
+    a = Matrix([
+        [0, 0, 1, 2, 2, -5, 3],
+        [-1, 5, 2, 2, 1, -7, 5],
+        [0, 0, -2, -3, -3, 8, -5],
+        [-1, 5, 0, -1, -2, 1, 0]])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c * f == a
 
 @slow
 def test_issue_11238():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

https://en.wikipedia.org/wiki/Rank_factorization

Similarly to gaussian elimination introducing LU decomposition, gauss-jordan elimination introduces rank decomposition, and it can be easily computed by taking the pivot columns of the original matrix.

Though I rarely see this feature implemented in most computer algebra or numeric analysis softwares.

I have added under `MatrixReductions` class, but still I think most of the decomposition methods are uncategorized in `MatrixBase`.

<img src=https://user-images.githubusercontent.com/34944973/54493462-ba480880-4913-11e9-91ff-6b869a3654f9.png width="512px">

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Added a new function ``rank_decomposition``.

<!-- END RELEASE NOTES -->
