### PR TITLE
Added MathML printing for sympy.vector classes

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1367,8 +1367,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mrow.appendChild(mo)
         mrow.appendChild(self.parenthesize(expr._expr, PRECEDENCE['Mul']))
         return mrow
-        vec = expr._expr
-        return r"\nabla\times %s" % self.parenthesize(vec, PRECEDENCE['Mul'])
 
     def _print_Divergence(self, expr):
         mrow = self.dom.createElement('mrow')

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1251,6 +1251,91 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return dom_element
 
 
+    def _print_BaseScalar(self, e):
+        msub = self.dom.createElement('msub')
+        index, system = e._id
+        mi = self.dom.createElement('mi')
+        mi.setAttribute('mathvariant', 'bold')
+        mi.appendChild(self.dom.createTextNode(system._variable_names[index]))
+        msub.appendChild(mi)
+        mi = self.dom.createElement('mi')
+        mi.setAttribute('mathvariant', 'bold')
+        mi.appendChild(self.dom.createTextNode(system._name))
+        msub.appendChild(mi)
+        return msub
+
+    def _print_BaseVector(self, e):
+        msub = self.dom.createElement('msub')
+        index, system = e._id
+        mover = self.dom.createElement('mover')
+        mi = self.dom.createElement('mi')
+        mi.setAttribute('mathvariant', 'bold')
+        mi.appendChild(self.dom.createTextNode(system._vector_names[index]))
+        mover.appendChild(mi)
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('^'))
+        mover.appendChild(mo)
+        msub.appendChild(mover)
+        mi = self.dom.createElement('mi')
+        mi.setAttribute('mathvariant', 'bold')
+        mi.appendChild(self.dom.createTextNode(system._name))
+        msub.appendChild(mi)
+        return msub
+
+    def _print_Cross(self, expr):
+        mrow = self.dom.createElement('mrow')
+        vec1 = expr._expr1
+        vec2 = expr._expr2
+        mrow.appendChild(self.parenthesize(vec1, PRECEDENCE['Mul']))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#xD7;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self.parenthesize(vec2, PRECEDENCE['Mul']))
+        return mrow
+
+    def _print_Curl(self, expr):
+        mrow = self.dom.createElement('mrow')
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#x2207;'))
+        mrow.appendChild(mo)
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#xD7;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self.parenthesize(expr._expr, PRECEDENCE['Mul']))
+        return mrow
+        vec = expr._expr
+        return r"\nabla\times %s" % self.parenthesize(vec, PRECEDENCE['Mul'])
+
+    def _print_Divergence(self, expr):
+        mrow = self.dom.createElement('mrow')
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#x2207;'))
+        mrow.appendChild(mo)
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#xB7;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self.parenthesize(expr._expr, PRECEDENCE['Mul']))
+        return mrow
+
+    def _print_Dot(self, expr):
+        mrow = self.dom.createElement('mrow')
+        vec1 = expr._expr1
+        vec2 = expr._expr2
+        mrow.appendChild(self.parenthesize(vec1, PRECEDENCE['Mul']))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#xB7;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self.parenthesize(vec2, PRECEDENCE['Mul']))
+        return mrow
+
+    def _print_Gradient(self, expr):
+        mrow = self.dom.createElement('mrow')
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#x2207;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self.parenthesize(expr._expr, PRECEDENCE['Mul']))
+        return mrow
+
     def _print_Integers(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -17,6 +17,7 @@ from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, Symmetri
 from sympy.stats.rv import RandomSymbol
 from sympy.sets.sets import Interval
 from sympy.utilities.pytest import raises
+from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
 
 x = Symbol('x')
 y = Symbol('y')
@@ -1182,3 +1183,45 @@ def test_print_Indexed():
     assert mathml(IndexedBase(a),printer = 'presentation') == '<mi>a</mi>'
     assert mathml(IndexedBase(a/b),printer = 'presentation') == '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
     assert mathml(IndexedBase((a,b)),printer = 'presentation') == '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'
+
+
+def test_print_Vector():
+    ACS = CoordSys3D('A')
+    assert mathml(Cross(ACS.i, ACS.j*ACS.x*3 + ACS.k), printer='presentation') == \
+    '<mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>+</mo><msub><mover><mi mathvariant="bold">k</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(Cross(ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'
+    assert mathml(x*Cross(ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+    assert mathml(Cross(x*ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><mo>-</mo><mrow><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><mfenced><mrow><mfenced><mi>x</mi></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow></mrow>'
+    assert mathml(Curl(3*ACS.x*ACS.j), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(Curl(3*x*ACS.x*ACS.j), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo><mi>x</mi></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(x*Curl(3*ACS.x*ACS.j), printer='presentation') == \
+    '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow></mrow>'
+    assert mathml(Curl(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>+</mo><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo><mi>x</mi></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(Divergence(3*ACS.x*ACS.j), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mo>&#xB7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(x*Divergence(3*ACS.x*ACS.j), printer='presentation') == \
+    '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo><mo>&#xB7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow></mrow>'
+    assert mathml(Divergence(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mo>&#xB7;</mo><mfenced><mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>+</mo><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo><mi>x</mi></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(Dot(ACS.i, ACS.j*ACS.x*3+ACS.k), printer='presentation') == \
+    '<mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>+</mo><msub><mover><mi mathvariant="bold">k</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(Dot(ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'
+    assert mathml(Dot(x*ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><mfenced><mrow><mfenced><mi>x</mi></mfenced><mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
+    assert mathml(x*Dot(ACS.i, ACS.j), printer='presentation') == \
+    '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover><mi mathvariant="bold">i</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><msub><mover><mi mathvariant="bold">j</mi><mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+    assert mathml(Gradient(ACS.x), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow>'
+    assert mathml(Gradient(ACS.x + 3*ACS.y), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mfenced><mrow><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub><mo>+</mo><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">y</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow></mfenced></mrow>'
+    assert mathml(x*Gradient(ACS.x), printer='presentation') == \
+    '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+    assert mathml(Gradient(x*ACS.x), printer='presentation') == \
+    '<mrow><mo>&#x2207;</mo><mfenced><mrow><msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo><mi>x</mi></mrow></mfenced></mrow>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1475,3 +1475,7 @@ def test_print_Vector():
         '<mi>x</mi></mrow></mfenced></mrow>'
     assert mathml(Cross(ACS.x, ACS.z) + Cross(ACS.z, ACS.x), printer='presentation') == \
         '<mover><mi mathvariant="bold">0</mi><mo>^</mo></mover>'
+    assert mathml(Cross(ACS.z, ACS.x), printer='presentation') == \
+        '<mrow><mo>-</mo><mrow><msub><mi mathvariant="bold">x</mi>'\
+        '<mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub>'\
+        '<mi mathvariant="bold">z</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow>'

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -353,7 +353,8 @@ class BaseVector(Vector, AtomicExpr):
         obj._pretty_form = u'' + pretty_str
         obj._latex_form = latex_str
         obj._system = system
-
+        # The _id is used for printing purposes
+        obj._id = (index, system)
         assumptions = {'commutative': True}
         obj._assumptions = StdFactKB(assumptions)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
MathML Presentation printing for `BaseVector`, `BaseScalar`, `Curl`, `Cross`, `Gradient`, `Divergence`, `Dot`, and vector mul and add.

Output:
![image](https://user-images.githubusercontent.com/8114497/54084584-d3a8ed80-4332-11e9-829b-c64fbb01a1d1.png)

(Previously it look really like crap so no point adding a picture)

#### Other comments
Some brackets are missing wen compared to LaTeX (but not pretty), but that is a problem of the printing of Mul rather than this (there are some other cases as well since a bracket function was only recently introduced so not all code makes use of it).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * MathML presentation printing of classes in sympy.vector
<!-- END RELEASE NOTES -->
