### PR TITLE
Cleanup of imports in sets

### DIFF
--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,11 +1,10 @@
 from __future__ import print_function, division
 
 from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
-from .transpose import Transpose
-from sympy.core.sympify import _sympify
+from sympy.core import S
 from sympy.core.compatibility import range
+from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from sympy.core import S, Basic
 
 
 class MatPow(MatrixExpr):
@@ -90,6 +89,7 @@ class MatPow(MatrixExpr):
 
     def _eval_derivative_matrix_lines(self, x):
         from .matmul import MatMul
+        from .inverse import Inverse
         exp = self.exp
         if (exp > 0) == True:
             newexpr = MatMul.fromiter([self.base for i in range(exp)])

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 from sympy import S
-from sympy.sets.contains import Contains
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
@@ -9,11 +8,10 @@ from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
 from sympy.core.symbol import Symbol, Dummy
 from sympy.logic.boolalg import And, as_Boolean
-from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
-                             FiniteSet)
+from sympy.sets.contains import Contains
+from sympy.sets.sets import Set, EmptySet, Union, FiniteSet
 from sympy.utilities.iterables import sift
 from sympy.utilities.misc import filldedent
-from sympy.multipledispatch import dispatch
 
 
 class ConditionSet(Set):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1,20 +1,15 @@
 from __future__ import print_function, division
 
-from sympy.logic.boolalg import And
-from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.core.expr import Expr
-from sympy.core.function import Lambda, _coeff_isneg
+from sympy.core.function import Lambda
 from sympy.core.singleton import Singleton, S
-from sympy.core.decorators import deprecated
-from sympy.multipledispatch import dispatch
-from sympy.core.symbol import Dummy, symbols, Wild
+from sympy.core.symbol import Dummy, symbols
 from sympy.core.sympify import _sympify, sympify, converter
-from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
-                             FiniteSet, imageset)
-from sympy.sets.conditionset import ConditionSet
-from sympy.utilities.misc import filldedent, func_name
+from sympy.logic.boolalg import And
+from sympy.sets.sets import Set, Interval, Union, FiniteSet
+from sympy.utilities.misc import filldedent
 
 
 class Naturals(with_metaclass(Singleton, Set)):
@@ -41,6 +36,7 @@ class Naturals(with_metaclass(Singleton, Set)):
 
     See Also
     ========
+
     Naturals0 : non-negative integers (i.e. includes 0, too)
     Integers : also includes negative integers
     """
@@ -74,6 +70,7 @@ class Naturals0(Naturals):
 
     See Also
     ========
+
     Naturals : positive integers; does not include 0
     Integers : also includes the negative integers
     """
@@ -114,6 +111,7 @@ class Integers(with_metaclass(Singleton, Set)):
 
     See Also
     ========
+
     Naturals0 : non-negative integers
     Integers : positive and negative integers and zero
     """
@@ -215,6 +213,7 @@ class ImageSet(Set):
 
     See Also
     ========
+
     sympy.sets.sets.imageset
     """
     def __new__(cls, flambda, *sets):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -1,10 +1,6 @@
-from sympy.core import Basic, Expr, Function, Add, Mul, Pow, Dummy, Integer
-from sympy import latex, Min, Max, Set, sympify, Lambda, symbols
-from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
-        ProductSet)
+from sympy.core import Expr
 from sympy.core.decorators import call_highest_priority, _sympifyit
-from sympy.utilities.iterables import sift
-from sympy.multipledispatch import dispatch, Dispatcher
+from sympy.sets import ImageSet
 from sympy.sets.sets import set_add, set_sub, set_mul, set_div, set_pow, set_function
 
 class SetExpr(Expr):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2,28 +2,27 @@ from __future__ import print_function, division
 
 from itertools import product
 
-from sympy.core.sympify import (_sympify, sympify, converter,
-    SympifyError)
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
-from sympy.core.singleton import Singleton, S
-from sympy.core.evalf import EvalfMixin
-from sympy.core.logic import fuzzy_bool
-from sympy.core.numbers import Float
 from sympy.core.compatibility import (iterable, with_metaclass,
     ordered, range, PY3)
+from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
+from sympy.core.expr import Expr
 from sympy.core.function import FunctionClass
+from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
+from sympy.core.numbers import Float
 from sympy.core.relational import Eq, Ne
+from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
+from sympy.core.sympify import _sympify, sympify, converter
+from sympy.logic.boolalg import And, Or, Not, true, false
 from sympy.sets.contains import Contains
+from sympy.utilities import subsets
 from sympy.utilities.iterables import sift
 from sympy.utilities.misc import func_name, filldedent
+
 from mpmath import mpi, mpf
-from sympy.logic.boolalg import And, Or, Not, true, false
-from sympy.utilities import subsets
-from sympy.multipledispatch import dispatch
 
 class Set(Basic):
     """

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,6 +1,6 @@
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
     EmptySet, Union)
-from sympy import (Symbol, Eq, Lt, S, Abs, sin, pi, Lambda, Interval,
+from sympy import (Symbol, Eq, S, Abs, sin, pi, Interval,
     And, Mod, oo, Function)
 from sympy.utilities.pytest import raises
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,14 +1,14 @@
 from sympy.core.compatibility import range, PY3
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
-from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
+from sympy.sets.sets import (FiniteSet, Interval, imageset, Union,
                              Intersection)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, exp, Abs, I, Tuple, eye)
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.abc import x, y, z, t
+from sympy.abc import x, y, t
 
 import itertools
 

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -1,8 +1,7 @@
 from sympy.sets.setexpr import SetExpr
-from sympy.utilities.pytest import XFAIL
 from sympy.sets import Interval, FiniteSet, Intersection, ImageSet, Union
-from sympy import (Expr, Set, exp, log, sin, cos, Symbol, Min, Max, S, oo,
-        symbols, Lambda, sqrt, Pow, Dummy, tan, pi, Mul)
+from sympy import (Expr, Set, exp, log, cos, Symbol, Min, Max, S, oo,
+        symbols, Lambda, Dummy)
 
 I = Interval(0, 2)
 a, x = symbols("a, x")

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -822,8 +822,6 @@ def test_issue_5724_7680():
 
 
 def test_boundary():
-    x = Symbol('x', real=True)
-    y = Symbol('y', real=True)
     assert FiniteSet(1).boundary == FiniteSet(1)
     assert all(Interval(0, 1, left_open, right_open).boundary == FiniteSet(0, 1)
             for left_open in (true, false) for right_open in (true, false))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Cleanup and sorting of imports in sets
Removal of some unused variables

#### Other comments
Added import of Inverse in MatPow, but I cannot really figure out how to reach that piece of code (it is not tested, as the import is required...)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
