### PR TITLE
Rewrote Abs as sign in another way

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -594,7 +594,7 @@ class Abs(Function):
             return Piecewise((arg, arg >= 0), (-arg, True))
 
     def _eval_rewrite_as_sign(self, arg, **kwargs):
-        return arg/sign(arg)
+        return arg*sign(arg)
 
 
 class arg(Function):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16217 

#### Brief description of what is fixed or changed
I may be to tired, but I think that this is valid so let us see if it breaks something else...

#### Other comments
To be honest, I do not fully understand how 0/sign(0) evaluates to 0 anyway since sign(0) = 0 ...,

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
