### PR TITLE
Printing : N-Dimensional Array for Mathematica

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -160,6 +160,53 @@ class MCodePrinter(CodePrinter):
 
         return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
 
+    def _print_ImmutableDenseNDimArray(self, expr):
+        return self._print_list(expr.tolist())
+
+    def _print_ImmutableSparseNDimArray(self, expr):
+        def to_mathematica_index(*args):
+            """Helper function to change Python style indexing to
+            Pathematica indexing.
+
+            Python indexing (0, 1 ... n-1)
+            -> Mathematica indexing (1, 2 ... n)
+            """
+            return tuple(i + 1 for i in args)
+
+        def print_rule(pos, val):
+            """Helper function to print a rule of Mathematica"""
+            return '{} -> {}'.format(
+            self.doprint(pos), self.doprint(val))
+
+        def print_data():
+            """Helper function to print data part of Mathematica
+            sparse array.
+
+            It uses the fourth notation ``SparseArray[data,{d1,d2,…}]``
+            from
+            https://reference.wolfram.com/language/ref/SparseArray.html
+
+            ``data`` must be formatted with rule.
+            """
+            return self._print_list(
+                [print_rule(
+                    to_mathematica_index(*(expr._get_tuple_index(key))),
+                    value)
+                for key, value in sorted(expr._sparse_array.items())]
+            )
+
+        def print_dims():
+            """Helper function to print dimensions part of Mathematica
+            sparse array.
+
+            It uses the fourth notation ``SparseArray[data,{d1,d2,…}]``
+            from
+            https://reference.wolfram.com/language/ref/SparseArray.html
+            """
+            return self._print_list(expr.shape)
+
+        return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
+
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_mfunc = self.known_functions[expr.func.__name__]

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -161,9 +161,12 @@ class MCodePrinter(CodePrinter):
         return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
 
     def _print_ImmutableDenseNDimArray(self, expr):
-        return self._print_list(expr.tolist())
+        return self.doprint(expr.tolist())
 
     def _print_ImmutableSparseNDimArray(self, expr):
+        def print_string_list(string_list):
+            return '{' + ', '.join(a for a in string_list) + '}'
+
         def to_mathematica_index(*args):
             """Helper function to change Python style indexing to
             Pathematica indexing.
@@ -175,8 +178,7 @@ class MCodePrinter(CodePrinter):
 
         def print_rule(pos, val):
             """Helper function to print a rule of Mathematica"""
-            return '{} -> {}'.format(
-            self.doprint(pos), self.doprint(val))
+            return '{} -> {}'.format(self.doprint(pos), self.doprint(val))
 
         def print_data():
             """Helper function to print data part of Mathematica
@@ -188,7 +190,7 @@ class MCodePrinter(CodePrinter):
 
             ``data`` must be formatted with rule.
             """
-            return self._print_list(
+            return print_string_list(
                 [print_rule(
                     to_mathematica_index(*(expr._get_tuple_index(key))),
                     value)
@@ -203,7 +205,7 @@ class MCodePrinter(CodePrinter):
             from
             https://reference.wolfram.com/language/ref/SparseArray.html
             """
-            return self._print_list(expr.shape)
+            return self.doprint(expr.shape)
 
         return 'SparseArray[{}, {}]'.format(print_data(), print_dims())
 

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -113,6 +113,58 @@ def test_matrices():
     assert mcode(MutableDenseMatrix(3, 0, [])) == '{{}, {}, {}}'
     assert mcode(MutableSparseMatrix(3, 0, [])) == 'SparseArray[{}, {3, 0}]'
 
+def test_NDArray():
+    from sympy.tensor.array import (
+        MutableDenseNDimArray, ImmutableDenseNDimArray,
+        MutableSparseNDimArray, ImmutableSparseNDimArray)
+
+    example = MutableDenseNDimArray(
+        [[[1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12]],
+         [[13, 14, 15, 16],
+          [17, 18, 19, 20],
+          [21, 22, 23, 24]]]
+    )
+
+    assert mcode(example) == \
+    "{{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}, " \
+    "{{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}}"
+
+    example = ImmutableDenseNDimArray(example)
+
+    assert mcode(example) == \
+    "{{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}, " \
+    "{{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}}"
+
+    example = MutableSparseNDimArray(example)
+
+    assert mcode(example) == \
+    "SparseArray[{" \
+        "{1, 1, 1} -> 1, {1, 1, 2} -> 2, {1, 1, 3} -> 3, " \
+        "{1, 1, 4} -> 4, {1, 2, 1} -> 5, {1, 2, 2} -> 6, " \
+        "{1, 2, 3} -> 7, {1, 2, 4} -> 8, {1, 3, 1} -> 9, " \
+        "{1, 3, 2} -> 10, {1, 3, 3} -> 11, {1, 3, 4} -> 12, " \
+        "{2, 1, 1} -> 13, {2, 1, 2} -> 14, {2, 1, 3} -> 15, " \
+        "{2, 1, 4} -> 16, {2, 2, 1} -> 17, {2, 2, 2} -> 18, " \
+        "{2, 2, 3} -> 19, {2, 2, 4} -> 20, {2, 3, 1} -> 21, " \
+        "{2, 3, 2} -> 22, {2, 3, 3} -> 23, {2, 3, 4} -> 24" \
+        "}, {2, 3, 4}]"
+
+    example = ImmutableSparseNDimArray(example)
+
+    assert mcode(example) == \
+    "SparseArray[{" \
+        "{1, 1, 1} -> 1, {1, 1, 2} -> 2, {1, 1, 3} -> 3, " \
+        "{1, 1, 4} -> 4, {1, 2, 1} -> 5, {1, 2, 2} -> 6, " \
+        "{1, 2, 3} -> 7, {1, 2, 4} -> 8, {1, 3, 1} -> 9, " \
+        "{1, 3, 2} -> 10, {1, 3, 3} -> 11, {1, 3, 4} -> 12, " \
+        "{2, 1, 1} -> 13, {2, 1, 2} -> 14, {2, 1, 3} -> 15, " \
+        "{2, 1, 4} -> 16, {2, 2, 1} -> 17, {2, 2, 2} -> 18, " \
+        "{2, 2, 3} -> 19, {2, 2, 4} -> 20, {2, 3, 1} -> 21, " \
+        "{2, 3, 2} -> 22, {2, 3, 3} -> 23, {2, 3, 4} -> 24" \
+        "}, {2, 3, 4}]"
+
 
 def test_Integral():
     assert mcode(Integral(sin(sin(x)), x)) == "Hold[Integrate[Sin[Sin[x]], x]]"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15618

#### Brief description of what is fixed or changed

Finally, I have added NDArrays for mathematica printers.
Though some helper functions are duplicate to the implementation in #15792, I left some boilerplates before any good way to support Mathematica's rules system, strings, or such are discovered.

Reference for mathematica sparse array
https://reference.wolfram.com/language/ref/SparseArray.html

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added support for `DenseNDimArray` and `SparseNDimArray` for `mathematica_code`
<!-- END RELEASE NOTES -->
