### PR TITLE
PEP8-fixes in MathML and LaTeX printers

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -14,7 +14,7 @@ from sympy.core.operations import AssocOp
 from sympy.core.sympify import SympifyError
 from sympy.logic.boolalg import true
 
-## sympy.printing imports
+# sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.printer import Printer
 from sympy.printing.conventions import split_super_sub, requires_partial
@@ -29,12 +29,14 @@ from sympy.utilities.iterables import has_variety
 import re
 
 # Hand-picked functions which can be used directly in both LaTeX and MathJax
-# Complete list at https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
+# Complete list at
+# https://docs.mathjax.org/en/latest/tex.html#supported-latex-commands
 # This variable only contains those functions which sympy uses.
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
-                    'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec', 'csc',
-                    'cot', 'coth', 're', 'im', 'frac', 'root', 'arg',
-                    ]
+                            'sinh', 'cosh', 'tanh', 'sqrt', 'ln', 'log', 'sec',
+                            'csc', 'cot', 'coth', 're', 'im', 'frac', 'root',
+                            'arg',
+                            ]
 
 tex_greek_dictionary = {
     'Alpha': 'A',
@@ -147,7 +149,7 @@ class LatexPrinter(Printer):
                            'equation*']
             if self._settings['mode'] not in valid_modes:
                 raise ValueError("'mode' must be one of 'inline', 'plain', "
-                    "'equation' or 'equation*'")
+                                 "'equation' or 'equation*'")
 
         if self._settings['fold_short_frac'] is None and \
                 self._settings['mode'] == 'inline':
@@ -255,7 +257,8 @@ class LatexPrinter(Printer):
         but also for some container objects that would not need brackets
         when appearing last in a Mul, e.g. an Integral. ``last=True``
         specifies that this expr is the last to appear in a Mul.
-        ``first=True`` specifies that this expr is the first to appear in a Mul.
+        ``first=True`` specifies that this expr is the first to appear in
+        a Mul.
         """
         from sympy import Integral, Product, Sum
 
@@ -271,11 +274,10 @@ class LatexPrinter(Printer):
         if any([expr.has(x) for x in (Mod,)]):
             return True
         if (not last and
-            any([expr.has(x) for x in (Integral, Product, Sum)])):
+                any([expr.has(x) for x in (Integral, Product, Sum)])):
             return True
 
         return False
-
 
     def _needs_add_brackets(self, expr):
         """
@@ -290,7 +292,6 @@ class LatexPrinter(Printer):
         if expr.is_Add:
             return True
         return False
-
 
     def _mul_is_clean(self, expr):
         for arg in expr.args:
@@ -308,8 +309,9 @@ class LatexPrinter(Printer):
             return expr
 
     def _print_Basic(self, expr):
-        l = [self._print(o) for o in expr.args]
-        return self._deal_with_super_sub(expr.__class__.__name__) + r"\left(%s\right)" % ", ".join(l)
+        ls = [self._print(o) for o in expr.args]
+        return self._deal_with_super_sub(expr.__class__.__name__) + \
+            r"\left(%s\right)" % ", ".join(ls)
 
     def _print_bool(self, e):
         return r"\mathrm{%s}" % e
@@ -401,7 +403,7 @@ class LatexPrinter(Printer):
         vec1 = expr._expr1
         vec2 = expr._expr2
         return r"%s \cdot %s" % (self.parenthesize(vec1, PRECEDENCE['Mul']),
-                                  self.parenthesize(vec2, PRECEDENCE['Mul']))
+                                 self.parenthesize(vec2, PRECEDENCE['Mul']))
 
     def _print_Gradient(self, expr):
         func = expr._expr
@@ -438,7 +440,8 @@ class LatexPrinter(Printer):
 
                 # If quantities are present append them at the back
                 args = sorted(args, key=lambda x: isinstance(x, Quantity) or
-                             (isinstance(x, Pow) and isinstance(x.base, Quantity)))
+                              (isinstance(x, Pow) and
+                               isinstance(x.base, Quantity)))
 
                 for i, term in enumerate(args):
                     term_tex = self._print(term)
@@ -468,8 +471,8 @@ class LatexPrinter(Printer):
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
             ratio = self._settings['long_frac_ratio']
-            if self._settings['fold_short_frac'] \
-                   and ldenom <= 2 and not "^" in sdenom:
+            if self._settings['fold_short_frac'] and ldenom <= 2 and \
+                    "^" not in sdenom:
                 # handle short fractions
                 if self._needs_mul_brackets(numer, last=False):
                     tex += r"\left(%s\right) / %s" % (snumer, sdenom)
@@ -509,7 +512,8 @@ class LatexPrinter(Printer):
 
     def _print_Pow(self, expr):
         # Treat x**Rational(1,n) as special case
-        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 and self._settings['root_notation']:
+        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 \
+                and self._settings['root_notation']:
             base = self._print(expr.base)
             expq = expr.exp.q
 
@@ -527,14 +531,16 @@ class LatexPrinter(Printer):
         elif self._settings['fold_frac_powers'] \
             and expr.exp.is_Rational \
                 and expr.exp.q != 1:
-            base, p, q = self.parenthesize(expr.base, PRECEDENCE['Pow']), expr.exp.p, expr.exp.q
+            base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+            p, q = expr.exp.p, expr.exp.q
             # issue #12886: add parentheses for superscripts raised to powers
             if '^' in base and expr.base.is_Symbol:
                 base = r"\left(%s\right)" % base
             if expr.base.is_Function:
                 return self._print(expr.base, exp="%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
-        elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_commutative:
+        elif expr.exp.is_Rational and expr.exp.is_negative and \
+                expr.base.is_commutative:
             # special case for 1^(-x), issue 9216
             if expr.base == 1:
                 return r"%s^{%s}" % (expr.base, expr.exp)
@@ -546,14 +552,15 @@ class LatexPrinter(Printer):
             else:
                 tex = r"%s^{%s}"
                 exp = self._print(expr.exp)
-                # issue #12886: add parentheses around superscripts raised to powers
+                # issue #12886: add parentheses around superscripts raised
+                # to powers
                 base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
                 if '^' in base and expr.base.is_Symbol:
                     base = r"\left(%s\right)" % base
-                elif isinstance(expr.base, Derivative
-                        ) and base.startswith(r'\left('
-                        ) and re.match(r'\\left\(\\d?d?dot', base
-                        ) and base.endswith(r'\right)'):
+                elif (isinstance(expr.base, Derivative)
+                        and base.startswith(r'\left(')
+                        and re.match(r'\\left\(\\d?d?dot', base)
+                        and base.endswith(r'\right)')):
                     # don't use parentheses around dotted derivative
                     base = base[6: -7]  # remove outermost added parens
 
@@ -565,14 +572,14 @@ class LatexPrinter(Printer):
     def _print_Sum(self, expr):
         if len(expr.limits) == 1:
             tex = r"\sum_{%s=%s}^{%s} " % \
-                tuple([ self._print(i) for i in expr.limits[0] ])
+                tuple([self._print(i) for i in expr.limits[0]])
         else:
             def _format_ineq(l):
                 return r"%s \leq %s \leq %s" % \
                     tuple([self._print(s) for s in (l[1], l[0], l[2])])
 
             tex = r"\sum_{\substack{%s}} " % \
-                str.join('\\\\', [ _format_ineq(l) for l in expr.limits ])
+                str.join('\\\\', [_format_ineq(l) for l in expr.limits])
 
         if isinstance(expr.function, Add):
             tex += r"\left(%s\right)" % self._print(expr.function)
@@ -584,14 +591,14 @@ class LatexPrinter(Printer):
     def _print_Product(self, expr):
         if len(expr.limits) == 1:
             tex = r"\prod_{%s=%s}^{%s} " % \
-                tuple([ self._print(i) for i in expr.limits[0] ])
+                tuple([self._print(i) for i in expr.limits[0]])
         else:
             def _format_ineq(l):
                 return r"%s \leq %s \leq %s" % \
                     tuple([self._print(s) for s in (l[1], l[0], l[2])])
 
             tex = r"\prod_{\substack{%s}} " % \
-                str.join('\\\\', [ _format_ineq(l) for l in expr.limits ])
+                str.join('\\\\', [_format_ineq(l) for l in expr.limits])
 
         if isinstance(expr.function, Add):
             tex += r"\left(%s\right)" % self._print(expr.function)
@@ -613,7 +620,7 @@ class LatexPrinter(Printer):
 
         for system, vect in items:
             inneritems = list(vect.components.items())
-            inneritems.sort(key = lambda x:x[0].__str__())
+            inneritems.sort(key=lambda x: x[0].__str__())
             for k, v in inneritems:
                 if v == 1:
                     o1.append(' + ' + k._latex_form)
@@ -659,7 +666,9 @@ class LatexPrinter(Printer):
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, dim, tex)
 
-        return r"%s %s" % (tex, self.parenthesize(expr.expr, PRECEDENCE["Mul"], strict=True))
+        return r"%s %s" % (tex, self.parenthesize(expr.expr,
+                                                  PRECEDENCE["Mul"],
+                                                  strict=True))
 
     def _print_Subs(self, subs):
         expr, old, new = subs.args
@@ -668,7 +677,8 @@ class LatexPrinter(Printer):
         latex_new = (self._print(e) for e in new)
         latex_subs = r'\\ '.join(
             e[0] + '=' + e[1] for e in zip(latex_old, latex_new))
-        return r'\left. %s \right|_{\substack{ %s }}' % (latex_expr, latex_subs)
+        return r'\left. %s \right|_{\substack{ %s }}' % (latex_expr,
+                                                         latex_subs)
 
     def _print_Integral(self, expr):
         tex, symbols = "", []
@@ -699,8 +709,10 @@ class LatexPrinter(Printer):
 
                 symbols.insert(0, r"\, d%s" % self._print(symbol))
 
-        return r"%s %s%s" % (tex,
-            self.parenthesize(expr.function, PRECEDENCE["Mul"], strict=True), "".join(symbols))
+        return r"%s %s%s" % (tex, self.parenthesize(expr.function,
+                                                    PRECEDENCE["Mul"],
+                                                    strict=True),
+                             "".join(symbols))
 
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args
@@ -747,10 +759,10 @@ class LatexPrinter(Printer):
         '''
         func = expr.func.__name__
         if hasattr(self, '_print_' + func) and \
-            not isinstance(expr, AppliedUndef):
+                not isinstance(expr, AppliedUndef):
             return getattr(self, '_print_' + func)(expr, exp)
         else:
-            args = [ str(self._print(arg)) for arg in expr.args ]
+            args = [str(self._print(arg)) for arg in expr.args]
             # How inverse trig functions should be displayed, formats are:
             # abbreviated: asin, full: arcsin, power: sin^-1
             inv_trig_style = self._settings['inv_trig_style']
@@ -840,7 +852,8 @@ class LatexPrinter(Printer):
     def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()), ", ".join(texargs))
+        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()),
+                                       ", ".join(texargs))
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
         else:
@@ -991,7 +1004,7 @@ class LatexPrinter(Printer):
     def _print_elliptic_pi(self, expr, exp=None):
         if len(expr.args) == 3:
             tex = r"\left(%s; %s\middle| %s\right)" % \
-                (self._print(expr.args[0]), self._print(expr.args[1]), \
+                (self._print(expr.args[0]), self._print(expr.args[1]),
                  self._print(expr.args[2]))
         else:
             tex = r"\left(%s\middle| %s\right)" % \
@@ -1377,7 +1390,8 @@ class LatexPrinter(Printer):
     _print_RandomSymbol = _print_Symbol
 
     def _print_MatrixSymbol(self, expr):
-        return self._print_Symbol(expr, style=self._settings['mat_symbol_style'])
+        return self._print_Symbol(expr,
+                                  style=self._settings['mat_symbol_style'])
 
     def _deal_with_super_sub(self, string):
         if '{' in string:
@@ -1415,7 +1429,7 @@ class LatexPrinter(Printer):
         }
 
         return "%s %s %s" % (self._print(expr.lhs),
-            charmap[expr.rel_op], self._print(expr.rhs))
+                             charmap[expr.rel_op], self._print(expr.rhs))
 
     def _print_Piecewise(self, expr):
         ecpairs = [r"%s & \text{for}\: %s" % (self._print(e), self._print(c))
@@ -1434,7 +1448,7 @@ class LatexPrinter(Printer):
         lines = []
 
         for line in range(expr.rows):  # horrible, should be 'rows'
-            lines.append(" & ".join([ self._print(i) for i in expr[line, :] ]))
+            lines.append(" & ".join([self._print(i) for i in expr[line, :]]))
 
         mat_str = self._settings['mat_str']
         if mat_str is None:
@@ -1461,11 +1475,8 @@ class LatexPrinter(Printer):
                            = _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
-        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) \
-            + '_{%s, %s}' % (
-            self._print(expr.i),
-            self._print(expr.j)
-        )
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True)\
+            + '_{%s, %s}' % (self._print(expr.i), self._print(expr.j))
 
     def _print_MatrixSlice(self, expr):
         def latexslice(x):
@@ -1507,7 +1518,8 @@ class LatexPrinter(Printer):
     def _print_MatMul(self, expr):
         from sympy import MatMul, Mul
 
-        parens = lambda x: self.parenthesize(x, precedence_traditional(expr), False)
+        parens = lambda x: self.parenthesize(x, precedence_traditional(expr),
+                                             False)
 
         args = expr.args
         if isinstance(args[0], Mul):
@@ -1526,10 +1538,13 @@ class LatexPrinter(Printer):
 
     def _print_Mod(self, expr, exp=None):
         if exp is not None:
-            return r'\left(%s\bmod{%s}\right)^{%s}' % (self.parenthesize(expr.args[0],
-                    PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]), self._print(exp))
+            return r'\left(%s\bmod{%s}\right)^{%s}' % \
+                (self.parenthesize(expr.args[0], PRECEDENCE['Mul'],
+                                   strict=True), self._print(expr.args[1]),
+                 self._print(exp))
         return r'%s\bmod{%s}' % (self.parenthesize(expr.args[0],
-                PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]))
+                                 PRECEDENCE['Mul'], strict=True),
+                                 self._print(expr.args[1]))
 
     def _print_HadamardProduct(self, expr):
         from sympy import Add, MatAdd, MatMul
@@ -1553,7 +1568,8 @@ class LatexPrinter(Printer):
         base, exp = expr.base, expr.exp
         from sympy.matrices import MatrixSymbol
         if not isinstance(base, MatrixSymbol):
-            return r"\left(%s\right)^{%s}" % (self._print(base), self._print(exp))
+            return r"\left(%s\right)^{%s}" % (self._print(base),
+                                              self._print(exp))
         else:
             return "%s^{%s}" % (self._print(base), self._print(exp))
 
@@ -1583,7 +1599,7 @@ class LatexPrinter(Printer):
             left_delim = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
             block_str = r'\left' + left_delim + block_str + \
-                      r'\right' + right_delim
+                        r'\right' + right_delim
 
         if expr.rank() == 0:
             return block_str % ""
@@ -1597,11 +1613,14 @@ class LatexPrinter(Printer):
                 if len(level_str[back_outer_i+1]) < expr.shape[back_outer_i]:
                     break
                 if even:
-                    level_str[back_outer_i].append(r" & ".join(level_str[back_outer_i+1]))
+                    level_str[back_outer_i].append(
+                        r" & ".join(level_str[back_outer_i+1]))
                 else:
-                    level_str[back_outer_i].append(block_str % (r"\\".join(level_str[back_outer_i+1])))
+                    level_str[back_outer_i].append(
+                        block_str % (r"\\".join(level_str[back_outer_i+1])))
                     if len(level_str[back_outer_i+1]) == 1:
-                        level_str[back_outer_i][-1] = r"\left[" + level_str[back_outer_i][-1] + r"\right]"
+                        level_str[back_outer_i][-1] = r"\left[" + \
+                            level_str[back_outer_i][-1] + r"\right]"
                 even = not even
                 level_str[back_outer_i+1] = []
 
@@ -1623,7 +1642,8 @@ class LatexPrinter(Printer):
         prev_map = None
         for index in indices:
             new_valence = index.is_up
-            if ((index in index_map) or prev_map) and last_valence == new_valence:
+            if ((index in index_map) or prev_map) and \
+                    last_valence == new_valence:
                 out_str += ","
             if last_valence != new_valence:
                 if last_valence is not None:
@@ -1681,7 +1701,7 @@ class LatexPrinter(Printer):
 
     def _print_tuple(self, expr):
         return r"\left( %s\right)" % \
-            r", \  ".join([ self._print(i) for i in expr ])
+            r", \  ".join([self._print(i) for i in expr])
 
     def _print_TensorProduct(self, expr):
         elements = [self._print(a) for a in expr.args]
@@ -1696,7 +1716,7 @@ class LatexPrinter(Printer):
 
     def _print_list(self, expr):
         return r"\left[ %s\right]" % \
-            r", \  ".join([ self._print(i) for i in expr ])
+            r", \  ".join([self._print(i) for i in expr])
 
     def _print_dict(self, d):
         keys = sorted(d.keys(), key=default_sort_key)
@@ -1793,9 +1813,9 @@ class LatexPrinter(Printer):
         else:
             printset = tuple(s)
 
-        return (r"\left\{"
-              + r", ".join(self._print(el) for el in printset)
-              + r"\right\}")
+        return (r"\left\{" +
+                r", ".join(self._print(el) for el in printset) +
+                r"\right\}")
 
     def _print_SeqFormula(self, s):
         if len(s.start.free_symbols) > 0 or len(s.stop.free_symbols) > 0:
@@ -1808,16 +1828,16 @@ class LatexPrinter(Printer):
         if s.start is S.NegativeInfinity:
             stop = s.stop
             printset = (r'\ldots', s.coeff(stop - 3), s.coeff(stop - 2),
-                s.coeff(stop - 1), s.coeff(stop))
+                        s.coeff(stop - 1), s.coeff(stop))
         elif s.stop is S.Infinity or s.length > 4:
             printset = s[:4]
             printset.append(r'\ldots')
         else:
             printset = tuple(s)
 
-        return (r"\left["
-              + r", ".join(self._print(el) for el in printset)
-              + r"\right]")
+        return (r"\left[" +
+                r", ".join(self._print(el) for el in printset) +
+                r"\right]")
 
     _print_SeqPer = _print_SeqFormula
     _print_SeqAdd = _print_SeqFormula
@@ -1878,7 +1898,7 @@ class LatexPrinter(Printer):
     def _print_ImageSet(self, s):
         sets = s.args[1:]
         varsets = [r"%s \in %s" % (self._print(var), self._print(setv))
-            for var, setv in zip(s.lamda.variables, sets)]
+                   for var, setv in zip(s.lamda.variables, sets)]
         return r"\left\{%s\; |\; %s\right\}" % (
             self._print(s.lamda.expr),
             ', '.join(varsets))
@@ -1886,9 +1906,8 @@ class LatexPrinter(Printer):
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
         if s.base_set is S.UniversalSet:
-            return r"\left\{%s \mid %s \right\}" % (
-            vars_print,
-            self._print(s.condition.as_expr()))
+            return r"\left\{%s \mid %s \right\}" % \
+                (vars_print, self._print(s.condition.as_expr()))
 
         return r"\left\{%s \mid %s \in %s \wedge %s \right\}" % (
             vars_print,
@@ -2011,7 +2030,8 @@ class LatexPrinter(Printer):
         if cls in accepted_latex_functions:
             return r"\%s {\left(%s, %d\right)}" % (cls, expr, index)
         else:
-            return r"\operatorname{%s} {\left(%s, %d\right)}" % (cls, expr, index)
+            return r"\operatorname{%s} {\left(%s, %d\right)}" % (cls, expr,
+                                                                 index)
 
     def _print_RootSum(self, expr):
         cls = expr.__class__.__name__
@@ -2023,7 +2043,8 @@ class LatexPrinter(Printer):
         if cls in accepted_latex_functions:
             return r"\%s {\left(%s\right)}" % (cls, ", ".join(args))
         else:
-            return r"\operatorname{%s} {\left(%s\right)}" % (cls, ", ".join(args))
+            return r"\operatorname{%s} {\left(%s\right)}" % (cls,
+                                                             ", ".join(args))
 
     def _print_PolyElement(self, poly):
         mul_symbol = self._settings['mul_symbol_latex']
@@ -2053,34 +2074,54 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_MellinTransform(self, expr):
-        return r"\mathcal{M}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{M}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseMellinTransform(self, expr):
-        return r"\mathcal{M}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{M}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_LaplaceTransform(self, expr):
-        return r"\mathcal{L}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{L}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseLaplaceTransform(self, expr):
-        return r"\mathcal{L}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{L}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_FourierTransform(self, expr):
-        return r"\mathcal{F}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{F}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseFourierTransform(self, expr):
-        return r"\mathcal{F}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{F}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_SineTransform(self, expr):
-        return r"\mathcal{SIN}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{SIN}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseSineTransform(self, expr):
-        return r"\mathcal{SIN}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{SIN}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_CosineTransform(self, expr):
-        return r"\mathcal{COS}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{COS}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_InverseCosineTransform(self, expr):
-        return r"\mathcal{COS}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+        return r"\mathcal{COS}^{-1}_{%s}\left[%s\right]\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]),
+             self._print(expr.args[2]))
 
     def _print_DMP(self, p):
         try:
@@ -2175,16 +2216,19 @@ class LatexPrinter(Printer):
     def _print_Quaternion(self, expr):
         # TODO: This expression is potentially confusing,
         # shall we print it as `Quaternion( ... )`?
-        s = [self.parenthesize(i, PRECEDENCE["Mul"], strict=True) for i in expr.args]
+        s = [self.parenthesize(i, PRECEDENCE["Mul"], strict=True)
+             for i in expr.args]
         a = [s[0]] + [i+" "+j for i, j in zip(s[1:], "ijk")]
         return " + ".join(a)
 
     def _print_QuotientRing(self, R):
         # TODO nicer fractions for few generators...
-        return r"\frac{%s}{%s}" % (self._print(R.ring), self._print(R.base_ideal))
+        return r"\frac{%s}{%s}" % (self._print(R.ring),
+                                   self._print(R.base_ideal))
 
     def _print_QuotientRingElement(self, x):
-        return r"{%s} + {%s}" % (self._print(x.data), self._print(x.ring.base_ideal))
+        return r"{%s} + {%s}" % (self._print(x.data),
+                                 self._print(x.ring.base_ideal))
 
     def _print_QuotientModuleElement(self, m):
         return r"{%s} + {%s}" % (self._print(m.data),
@@ -2197,7 +2241,8 @@ class LatexPrinter(Printer):
 
     def _print_MatrixHomomorphism(self, h):
         return r"{%s} : {%s} \to {%s}" % (self._print(h._sympy_matrix()),
-            self._print(h.domain), self._print(h.codomain))
+                                          self._print(h.domain),
+                                          self._print(h.codomain))
 
     def _print_BaseScalarField(self, field):
         string = field._coord_sys._names[field._index]
@@ -2218,20 +2263,20 @@ class LatexPrinter(Printer):
             return r'\mathrm{d}\left(%s\right)' % string
 
     def _print_Tr(self, p):
-        #Todo: Handle indices
+        # TODO: Handle indices
         contents = self._print(p.args[0])
         return r'\mbox{Tr}\left(%s\right)' % (contents)
 
     def _print_totient(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\phi\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\phi\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\phi\left(%s\right)' % self._print(expr.args[0])
 
     def _print_reduced_totient(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\lambda\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\lambda\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\lambda\left(%s\right)' % self._print(expr.args[0])
 
     def _print_divisor_sigma(self, expr, exp=None):
@@ -2256,14 +2301,14 @@ class LatexPrinter(Printer):
 
     def _print_primenu(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\nu\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\nu\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\nu\left(%s\right)' % self._print(expr.args[0])
 
     def _print_primeomega(self, expr, exp=None):
         if exp is not None:
-            return r'\left(\Omega\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
-                    self._print(exp))
+            return r'\left(\Omega\left(%s\right)\right)^{%s}' % \
+                (self._print(expr.args[0]), self._print(exp))
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
 
@@ -2298,11 +2343,11 @@ def translate(s):
 
 
 def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
-    fold_short_frac=None, inv_trig_style="abbreviated",
-    itex=False, ln_notation=False, long_frac_ratio=None,
-    mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
-    order=None, symbol_names=None, root_notation=True,
-    mat_symbol_style="plain", imaginary_unit="i"):
+          fold_short_frac=None, inv_trig_style="abbreviated",
+          itex=False, ln_notation=False, long_frac_ratio=None,
+          mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
+          order=None, symbol_names=None, root_notation=True,
+          mat_symbol_style="plain", imaginary_unit="i"):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2356,8 +2401,8 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
     symbol_names : dictionary of strings mapped to symbols, optional
         Dictionary of symbols and the custom strings they should be emitted as.
     root_notation : boolean, optional
-        If set to ``False``, exponents of the form 1/n are printed in fractonal form.
-        Default is ``True``, to print exponent in root form.
+        If set to ``False``, exponents of the form 1/n are printed in fractonal
+        form. Default is ``True``, to print exponent in root form.
     mat_symbol_style : string, optional
         Can be either ``plain`` (default) or ``bold``. If set to ``bold``,
         a MatrixSymbol A will be printed as ``\mathbf{A}``, otherwise as ``A``.
@@ -2476,22 +2521,22 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         symbol_names = {}
 
     settings = {
-        'fold_frac_powers' : fold_frac_powers,
-        'fold_func_brackets' : fold_func_brackets,
-        'fold_short_frac' : fold_short_frac,
-        'inv_trig_style' : inv_trig_style,
-        'itex' : itex,
-        'ln_notation' : ln_notation,
-        'long_frac_ratio' : long_frac_ratio,
-        'mat_delim' : mat_delim,
-        'mat_str' : mat_str,
-        'mode' : mode,
-        'mul_symbol' : mul_symbol,
-        'order' : order,
-        'symbol_names' : symbol_names,
-        'root_notation' : root_notation,
-        'mat_symbol_style' : mat_symbol_style,
-        'imaginary_unit' : imaginary_unit,
+        'fold_frac_powers': fold_frac_powers,
+        'fold_func_brackets': fold_func_brackets,
+        'fold_short_frac': fold_short_frac,
+        'inv_trig_style': inv_trig_style,
+        'itex': itex,
+        'ln_notation': ln_notation,
+        'long_frac_ratio': long_frac_ratio,
+        'mat_delim': mat_delim,
+        'mat_str': mat_str,
+        'mode': mode,
+        'mul_symbol': mul_symbol,
+        'order': order,
+        'symbol_names': symbol_names,
+        'root_notation': root_notation,
+        'mat_symbol_style': mat_symbol_style,
+        'imaginary_unit': imaginary_unit,
     }
 
     return LatexPrinter(settings).doprint(expr)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -7,11 +7,11 @@ from __future__ import print_function, division
 from sympy import sympify, S, Mul
 from sympy.core.compatibility import range, string_types, default_sort_key
 from sympy.core.function import _coeff_isneg
-from sympy.core.numbers import E
 from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.precedence import precedence_traditional, PRECEDENCE
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
+
 
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
@@ -36,12 +36,14 @@ class MathMLPrinterBase(Printer):
 
     def __init__(self, settings=None):
         Printer.__init__(self, settings)
-        from xml.dom.minidom import Document,Text
+        from xml.dom.minidom import Document, Text
 
         self.dom = Document()
 
         # Workaround to allow strings to remain unescaped
-        # Based on https://stackoverflow.com/questions/38015864/python-xml-dom-minidom-please-dont-escape-my-strings/38041194
+        # Based on
+        # https://stackoverflow.com/questions/38015864/python-xml-dom-minidom-\
+        #                              please-dont-escape-my-strings/38041194
         class RawText(Text):
             def writexml(self, writer, indent='', addindent='', newl=''):
                 if self.data:
@@ -68,8 +70,8 @@ class MathMLPrinterBase(Printer):
     def apply_patch(self):
         # Applying the patch of xml.dom.minidom bug
         # Date: 2011-11-18
-        # Description: http://ronrothman.com/public/leftbraned/xml-dom-minidom-\
-        #                   toprettyxml-and-silly-whitespace/#best-solution
+        # Description: http://ronrothman.com/public/leftbraned/xml-dom-minidom\
+        #                   -toprettyxml-and-silly-whitespace/#best-solution
         # Issue: http://bugs.python.org/issue4147
         # Patch: http://hg.python.org/cpython/rev/7262f8f276ff/
 
@@ -393,8 +395,10 @@ class MathMLContentPrinter(MathMLPrinterBase):
     _print_RandomSymbol = _print_Symbol
 
     def _print_Pow(self, e):
-        # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if self._settings['root_notation'] and e.exp.is_Rational and e.exp.p == 1:
+        # Here we use root instead of power if the exponent is the reciprocal
+        # of an integer
+        if (self._settings['root_notation'] and e.exp.is_Rational
+                and e.exp.p == 1):
             x = self.dom.createElement('apply')
             x.appendChild(self.dom.createElement('root'))
             if e.exp.q != 2:
@@ -490,7 +494,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         """Returns the MathML tag for an expression."""
         translate = {
             'Number': 'mn',
-            'Limit' : '&#x2192;',
+            'Limit': '&#x2192;',
             'Derivative': '&dd;',
             'int': 'mn',
             'Symbol': 'mi',
@@ -515,13 +519,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             'StrictGreaterThan': '>',
             'StrictLessThan': '<',
             'lerchphi': '&#x3A6;',
-            'BooleanTrue' : 'True',
-            'BooleanFalse' : 'False',
-            'NoneType' : 'None',
+            'BooleanTrue': 'True',
+            'BooleanFalse': 'False',
+            'NoneType': 'None',
         }
 
         def mul_symbol_selection():
-            if self._settings["mul_symbol"] is None or self._settings["mul_symbol"] == 'None':
+            if (self._settings["mul_symbol"] is None or
+                    self._settings["mul_symbol"] == 'None'):
                 return '&InvisibleTimes;'
             elif self._settings["mul_symbol"] == 'times':
                 return '&#xD7;'
@@ -658,7 +663,6 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         else:
             return x
 
-
     def _print_Rational(self, e):
         if e.q == 1:
             # don't divide
@@ -725,7 +729,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return mrow
 
     def _print_Integral(self, expr):
-        intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;" }
+        intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;"}
 
         mrow = self.dom.createElement('mrow')
         if len(expr.limits) <= 3 and all(len(lim) == 1 for lim in expr.limits):
@@ -752,7 +756,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                     msubsup.appendChild(self._print(lim[2]))
                     mrow.appendChild(msubsup)
         # print function
-        mrow.appendChild(self.parenthesize(expr.function, PRECEDENCE["Mul"], strict=True))
+        mrow.appendChild(self.parenthesize(expr.function, PRECEDENCE["Mul"],
+                                           strict=True))
         # print integration variables
         for lim in reversed(expr.limits):
             d = self.dom.createElement('mo')
@@ -847,7 +852,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_MatrixSymbol(self, sym):
-        return self._print_Symbol(sym, style=self._settings['mat_symbol_style'])
+        return self._print_Symbol(sym,
+                                  style=self._settings['mat_symbol_style'])
 
     _print_RandomSymbol = _print_Symbol
 
@@ -881,8 +887,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return brac
 
     def _print_Pow(self, e):
-        # Here we use root instead of power if the exponent is the reciprocal of an integer
-        if e.exp.is_Rational and abs(e.exp.p) == 1 and e.exp.q != 1 and self._settings['root_notation']:
+        # Here we use root instead of power if the exponent is the
+        # reciprocal of an integer
+        if (e.exp.is_Rational and abs(e.exp.p) == 1 and e.exp.q != 1 and
+                self._settings['root_notation']):
             if e.exp.q == 2:
                 x = self.dom.createElement('msqrt')
                 x.appendChild(self._print(e.base))
@@ -904,24 +912,28 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 top.appendChild(self._print(1))
                 x = self.dom.createElement('msup')
                 x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._get_printed_Rational(-e.exp, self._settings['fold_frac_powers']))
+                x.appendChild(self._get_printed_Rational(-e.exp,
+                                    self._settings['fold_frac_powers']))
                 top.appendChild(x)
-                return top;
+                return top
             else:
                 x = self.dom.createElement('msup')
                 x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._get_printed_Rational(e.exp, self._settings['fold_frac_powers']))
-                return x;
+                x.appendChild(self._get_printed_Rational(e.exp,
+                                    self._settings['fold_frac_powers']))
+                return x
 
         if e.exp.is_negative:
                 top = self.dom.createElement('mfrac')
                 top.appendChild(self._print(1))
-                x = self.dom.createElement('msup')
-                x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
-                x.appendChild(self._print(-e.exp))
-                top.appendChild(x)
-                return top;
-
+                if e.exp == -1:
+                    top.appendChild(self._print(e.base))
+                else:
+                    x = self.dom.createElement('msup')
+                    x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
+                    x.appendChild(self._print(-e.exp))
+                    top.appendChild(x)
+                return top
 
         x = self.dom.createElement('msup')
         x.appendChild(self.parenthesize(e.base, PRECEDENCE['Pow']))
@@ -942,7 +954,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
         # Determine denominator
         m = self.dom.createElement('mrow')
-        dim = 0 # Total diff dimension, for numerator
+        dim = 0  # Total diff dimension, for numerator
         for sym, num in reversed(e.variable_count):
             dim += num
             if num >= 2:
@@ -984,7 +996,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_Function(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mi')
-        if self.mathml_tag(e) == 'log' and self._settings["ln_notation"] == True:
+        if self.mathml_tag(e) == 'log' and self._settings["ln_notation"]:
             x.appendChild(self.dom.createTextNode('ln'))
         else:
             x.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
@@ -1046,8 +1058,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 brac.setAttribute('close', ')')
             else:
                 brac.setAttribute('close', ']')
-            brac.appendChild( self._print(i.start))
-            brac.appendChild( self._print(i.end))
+            brac.appendChild(self._print(i.start))
+            brac.appendChild(self._print(i.end))
 
         mrow.appendChild(brac)
         return mrow
@@ -1249,13 +1261,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         dom_element.appendChild(self.dom.createTextNode(str(p)))
         return dom_element
 
-
     def _print_Integers(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x2124;'))
         return x
-
 
     def _print_Complexes(self, e):
         x = self.dom.createElement('mi')
@@ -1263,20 +1273,17 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(self.dom.createTextNode('&#x2102;'))
         return x
 
-
     def _print_Reals(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x211D;'))
         return x
 
-
     def _print_Naturals(self, e):
         x = self.dom.createElement('mi')
         x.setAttribute('mathvariant', 'normal')
         x.appendChild(self.dom.createTextNode('&#x2115;'))
         return x
-
 
     def _print_Naturals0(self, e):
         sub = self.dom.createElement('msub')
@@ -1287,15 +1294,13 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         sub.appendChild(self._print(S.Zero))
         return sub
 
-
     def _print_EmptySet(self, e):
         x = self.dom.createElement('mo')
         x.appendChild(self.dom.createTextNode('&#x2205;'))
         return x
 
-
     def _print_floor(self, e):
-        mrow =  self.dom.createElement('mrow')
+        mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
         x.setAttribute('open', u'\u230A')
         x.setAttribute('close', u'\u230B')
@@ -1303,16 +1308,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mrow.appendChild(x)
         return mrow
 
-
     def _print_ceiling(self, e):
-        mrow =  self.dom.createElement('mrow')
+        mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
         x.setAttribute('open', u'\u2308')
         x.setAttribute('close', u'\u2309')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow
-
 
     def _print_Lambda(self, e):
         x = self.dom.createElement('mfenced')
@@ -1330,13 +1333,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(mrow)
         return x
 
-
     def _print_tuple(self, e):
         x = self.dom.createElement('mfenced')
         for i in e:
             x.appendChild(self._print(i))
         return x
-
 
     def _print_IndexedBase(self, e):
         return self._print(e.label)
@@ -1352,8 +1353,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
 
 def mathml(expr, printer='content', **settings):
-    """Returns the MathML representation of expr. If printer is presentation then
-     prints Presentation MathML else prints content MathML.
+    """Returns the MathML representation of expr. If printer is presentation
+    then prints Presentation MathML else prints content MathML.
     """
     if printer == 'presentation':
         return MathMLPresentationPrinter(settings).doprint(expr)
@@ -1397,5 +1398,6 @@ def print_mathml(expr, printer='content', **settings):
 
     print(pretty_xml)
 
-#For backward compatibility
+
+# For backward compatibility
 MathMLPrinter = MathMLContentPrinter

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,15 +17,17 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-     UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
+    UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary)
-from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
-                                MutableSparseNDimArray, MutableDenseNDimArray)
+from sympy.tensor.array import (ImmutableDenseNDimArray,
+                                ImmutableSparseNDimArray,
+                                MutableSparseNDimArray,
+                                MutableDenseNDimArray)
 from sympy.tensor.array import tensorproduct
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
@@ -41,8 +43,11 @@ from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
 from sympy.sets.setexpr import SetExpr
 
 import sympy as sym
+
+
 class lowergamma(sym.lowergamma):
     pass   # testing notation inheritance by a subclass with same name
+
 
 x, y, z, t, a, b, c = symbols('x y z t a b c')
 k, m, n = symbols('k m n', integer=True)
@@ -110,7 +115,8 @@ def test_latex_basic():
 
     assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
-    assert latex(1.5e20*x, mul_symbol='times') == r"1.5 \times 10^{20} \times x"
+    assert latex(1.5e20*x, mul_symbol='times') == \
+        r"1.5 \times 10^{20} \times x"
 
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left(x \right)}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left(x \right)}}"
@@ -156,31 +162,42 @@ def test_latex_builtins():
 
 
 def test_latex_SingularityFunction():
-    assert latex(SingularityFunction(x, 4, 5)) == r"{\left\langle x - 4 \right\rangle}^{5}"
-    assert latex(SingularityFunction(x, -3, 4)) == r"{\left\langle x + 3 \right\rangle}^{4}"
-    assert latex(SingularityFunction(x, 0, 4)) == r"{\left\langle x \right\rangle}^{4}"
-    assert latex(SingularityFunction(x, a, n)) == r"{\left\langle - a + x \right\rangle}^{n}"
-    assert latex(SingularityFunction(x, 4, -2)) == r"{\left\langle x - 4 \right\rangle}^{-2}"
-    assert latex(SingularityFunction(x, 4, -1)) == r"{\left\langle x - 4 \right\rangle}^{-1}"
+    assert latex(SingularityFunction(x, 4, 5)) == \
+        r"{\left\langle x - 4 \right\rangle}^{5}"
+    assert latex(SingularityFunction(x, -3, 4)) == \
+        r"{\left\langle x + 3 \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, 0, 4)) == \
+        r"{\left\langle x \right\rangle}^{4}"
+    assert latex(SingularityFunction(x, a, n)) == \
+        r"{\left\langle - a + x \right\rangle}^{n}"
+    assert latex(SingularityFunction(x, 4, -2)) == \
+        r"{\left\langle x - 4 \right\rangle}^{-2}"
+    assert latex(SingularityFunction(x, 4, -1)) == \
+        r"{\left\langle x - 4 \right\rangle}^{-1}"
+
 
 def test_latex_cycle():
     assert latex(Cycle(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
-    assert latex(Cycle(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
+    assert latex(Cycle(1, 2)(4, 5, 6)) == \
+        r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
     assert latex(Cycle()) == r"\left( \right)"
 
 
 def test_latex_permutation():
     assert latex(Permutation(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
-    assert latex(Permutation(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
+    assert latex(Permutation(1, 2)(4, 5, 6)) == \
+        r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"
     assert latex(Permutation()) == r"\left( \right)"
-    assert latex(Permutation(2, 4)*Permutation(5)) == r"\left( 2\; 4\right)\left( 5\right)"
+    assert latex(Permutation(2, 4)*Permutation(5)) == \
+        r"\left( 2\; 4\right)\left( 5\right)"
     assert latex(Permutation(5)) == r"\left( 5\right)"
 
 
 def test_latex_Float():
     assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"
     assert latex(Float(1.0e-100)) == r"1.0 \cdot 10^{-100}"
-    assert latex(Float(1.0e-100), mul_symbol="times") == r"1.0 \times 10^{-100}"
+    assert latex(Float(1.0e-100), mul_symbol="times") == \
+        r"1.0 \times 10^{-100}"
     assert latex(1.0*oo) == r"\infty"
     assert latex(-1.0*oo) == r"- \infty"
 
@@ -188,27 +205,43 @@ def test_latex_Float():
 def test_latex_vector_expressions():
     A = CoordSys3D('A')
 
-    assert latex(Cross(A.i, A.j*A.x*3+A.k)) == r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
-    assert latex(Cross(A.i, A.j)) == r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
-    assert latex(x*Cross(A.i, A.j)) == r"x \left(\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}\right)"
-    assert latex(Cross(x*A.i, A.j)) == r'- \mathbf{\hat{j}_{A}} \times \left((x)\mathbf{\hat{i}_{A}}\right)'
+    assert latex(Cross(A.i, A.j*A.x*3+A.k)) == \
+        r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+    assert latex(Cross(A.i, A.j)) == \
+        r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
+    assert latex(x*Cross(A.i, A.j)) == \
+        r"x \left(\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}\right)"
+    assert latex(Cross(x*A.i, A.j)) == \
+        r'- \mathbf{\hat{j}_{A}} \times \left((x)\mathbf{\hat{i}_{A}}\right)'
 
-    assert latex(Curl(3*A.x*A.j)) == r"\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Curl(3*A.x*A.j+A.i)) == r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Curl(3*x*A.x*A.j)) == r"\nabla\times \left((3 \mathbf{{x}_{A}} x)\mathbf{\hat{j}_{A}}\right)"
-    assert latex(x*Curl(3*A.x*A.j)) == r"x \left(\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+    assert latex(Curl(3*A.x*A.j)) == \
+        r"\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Curl(3*A.x*A.j+A.i)) == \
+        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Curl(3*x*A.x*A.j)) == \
+        r"\nabla\times \left((3 \mathbf{{x}_{A}} x)\mathbf{\hat{j}_{A}}\right)"
+    assert latex(x*Curl(3*A.x*A.j)) == \
+        r"x \left(\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
 
-    assert latex(Divergence(3*A.x*A.j+A.i)) == r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(Divergence(3*A.x*A.j)) == r"\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
-    assert latex(x*Divergence(3*A.x*A.j)) == r"x \left(\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+    assert latex(Divergence(3*A.x*A.j+A.i)) == \
+        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(Divergence(3*A.x*A.j)) == \
+        r"\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+    assert latex(x*Divergence(3*A.x*A.j)) == \
+        r"x \left(\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
 
-    assert latex(Dot(A.i, A.j*A.x*3+A.k)) == r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
-    assert latex(Dot(A.i, A.j)) == r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
-    assert latex(Dot(x*A.i, A.j)) == r"\mathbf{\hat{j}_{A}} \cdot \left((x)\mathbf{\hat{i}_{A}}\right)"
-    assert latex(x*Dot(A.i, A.j)) == r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
+    assert latex(Dot(A.i, A.j*A.x*3+A.k)) == \
+        r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+    assert latex(Dot(A.i, A.j)) == \
+        r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
+    assert latex(Dot(x*A.i, A.j)) == \
+        r"\mathbf{\hat{j}_{A}} \cdot \left((x)\mathbf{\hat{i}_{A}}\right)"
+    assert latex(x*Dot(A.i, A.j)) == \
+        r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
 
     assert latex(Gradient(A.x)) == r"\nabla \mathbf{{x}_{A}}"
-    assert latex(Gradient(A.x + 3*A.y)) == r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
+    assert latex(Gradient(A.x + 3*A.y)) == \
+        r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
     assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
     assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
 
@@ -244,8 +277,10 @@ def test_latex_symbols_failing():
     rho, mass, volume = symbols('rho, mass, volume')
     assert latex(
         volume * rho == mass) == r"\rho \mathrm{volume} = \mathrm{mass}"
-    assert latex(volume / mass * rho == 1) == r"\rho \mathrm{volume} {\mathrm{mass}}^{(-1)} = 1"
-    assert latex(mass**3 * volume**3) == r"{\mathrm{mass}}^{3} \cdot {\mathrm{volume}}^{3}"
+    assert latex(volume / mass * rho == 1) == \
+        r"\rho \mathrm{volume} {\mathrm{mass}}^{(-1)} = 1"
+    assert latex(mass**3 * volume**3) == \
+        r"{\mathrm{mass}}^{3} \cdot {\mathrm{volume}}^{3}"
 
 
 def test_latex_functions():
@@ -351,9 +386,12 @@ def test_latex_functions():
     assert latex(Order(x, x)) == r"O\left(x\right)"
     assert latex(Order(x, (x, 0))) == r"O\left(x\right)"
     assert latex(Order(x, (x, oo))) == r"O\left(x; x\rightarrow \infty\right)"
-    assert latex(Order(x - y, (x, y))) == r"O\left(x - y; x\rightarrow y\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
-    assert latex(Order(x, x, y)) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
+    assert latex(Order(x - y, (x, y))) == \
+        r"O\left(x - y; x\rightarrow y\right)"
+    assert latex(Order(x, x, y)) == \
+        r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
+    assert latex(Order(x, x, y)) == \
+        r"O\left(x; \left( x, \  y\right)\rightarrow \left( 0, \  0\right)\right)"
     assert latex(Order(x, (x, oo), (y, oo))) == r"O\left(x; \left( x, \  y\right)\rightarrow \left( \infty, \  \infty\right)\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(lowergamma(x, y)**2) == r'\gamma^{2}\left(x, y\right)'
@@ -403,49 +441,56 @@ def test_latex_functions():
     assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left(x \right)}'
     assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
     assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
-    assert latex(
-        jacobi(n, a, b, x)) == r'P_{n}^{\left(a,b\right)}\left(x\right)'
-    assert latex(jacobi(n, a, b, x)**2) == r'\left(P_{n}^{\left(a,b\right)}\left(x\right)\right)^{2}'
-    assert latex(
-        gegenbauer(n, a, x)) == r'C_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(gegenbauer(n, a, x)**2) == r'\left(C_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(jacobi(n, a, b, x)) == \
+        r'P_{n}^{\left(a,b\right)}\left(x\right)'
+    assert latex(jacobi(n, a, b, x)**2) == \
+        r'\left(P_{n}^{\left(a,b\right)}\left(x\right)\right)^{2}'
+    assert latex(gegenbauer(n, a, x)) == \
+        r'C_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(gegenbauer(n, a, x)**2) == \
+        r'\left(C_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(chebyshevt(n, x)) == r'T_{n}\left(x\right)'
-    assert latex(
-        chebyshevt(n, x)**2) == r'\left(T_{n}\left(x\right)\right)^{2}'
+    assert latex(chebyshevt(n, x)**2) == \
+        r'\left(T_{n}\left(x\right)\right)^{2}'
     assert latex(chebyshevu(n, x)) == r'U_{n}\left(x\right)'
-    assert latex(
-        chebyshevu(n, x)**2) == r'\left(U_{n}\left(x\right)\right)^{2}'
+    assert latex(chebyshevu(n, x)**2) == \
+        r'\left(U_{n}\left(x\right)\right)^{2}'
     assert latex(legendre(n, x)) == r'P_{n}\left(x\right)'
     assert latex(legendre(n, x)**2) == r'\left(P_{n}\left(x\right)\right)^{2}'
-    assert latex(
-        assoc_legendre(n, a, x)) == r'P_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(assoc_legendre(n, a, x)**2) == r'\left(P_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(assoc_legendre(n, a, x)) == \
+        r'P_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(assoc_legendre(n, a, x)**2) == \
+        r'\left(P_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(laguerre(n, x)) == r'L_{n}\left(x\right)'
     assert latex(laguerre(n, x)**2) == r'\left(L_{n}\left(x\right)\right)^{2}'
-    assert latex(
-        assoc_laguerre(n, a, x)) == r'L_{n}^{\left(a\right)}\left(x\right)'
-    assert latex(assoc_laguerre(n, a, x)**2) == r'\left(L_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
+    assert latex(assoc_laguerre(n, a, x)) == \
+        r'L_{n}^{\left(a\right)}\left(x\right)'
+    assert latex(assoc_laguerre(n, a, x)**2) == \
+        r'\left(L_{n}^{\left(a\right)}\left(x\right)\right)^{2}'
     assert latex(hermite(n, x)) == r'H_{n}\left(x\right)'
     assert latex(hermite(n, x)**2) == r'\left(H_{n}\left(x\right)\right)^{2}'
 
     theta = Symbol("theta", real=True)
     phi = Symbol("phi", real=True)
-    assert latex(Ynm(n,m,theta,phi)) == r'Y_{n}^{m}\left(\theta,\phi\right)'
-    assert latex(Ynm(n, m, theta, phi)**3) == r'\left(Y_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
-    assert latex(Znm(n,m,theta,phi)) == r'Z_{n}^{m}\left(\theta,\phi\right)'
-    assert latex(Znm(n, m, theta, phi)**3) == r'\left(Z_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
+    assert latex(Ynm(n, m, theta, phi)) == r'Y_{n}^{m}\left(\theta,\phi\right)'
+    assert latex(Ynm(n, m, theta, phi)**3) == \
+        r'\left(Y_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
+    assert latex(Znm(n, m, theta, phi)) == r'Z_{n}^{m}\left(\theta,\phi\right)'
+    assert latex(Znm(n, m, theta, phi)**3) == \
+        r'\left(Z_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
 
     # Test latex printing of function names with "_"
-    assert latex(
-        polar_lift(0)) == r"\operatorname{polar\_lift}{\left(0 \right)}"
-    assert latex(polar_lift(
-        0)**3) == r"\operatorname{polar\_lift}^{3}{\left(0 \right)}"
+    assert latex(polar_lift(0)) == \
+        r"\operatorname{polar\_lift}{\left(0 \right)}"
+    assert latex(polar_lift(0)**3) == \
+        r"\operatorname{polar\_lift}^{3}{\left(0 \right)}"
 
     assert latex(totient(n)) == r'\phi\left(n\right)'
     assert latex(totient(n) ** 2) == r'\left(\phi\left(n\right)\right)^{2}'
 
     assert latex(reduced_totient(n)) == r'\lambda\left(n\right)'
-    assert latex(reduced_totient(n) ** 2) == r'\left(\lambda\left(n\right)\right)^{2}'
+    assert latex(reduced_totient(n) ** 2) == \
+        r'\left(\lambda\left(n\right)\right)^{2}'
 
     assert latex(divisor_sigma(x)) == r"\sigma\left(x\right)"
     assert latex(divisor_sigma(x)**2) == r"\sigma^{2}\left(x\right)"
@@ -461,7 +506,8 @@ def test_latex_functions():
     assert latex(primenu(n) ** 2) == r'\left(\nu\left(n\right)\right)^{2}'
 
     assert latex(primeomega(n)) == r'\Omega\left(n\right)'
-    assert latex(primeomega(n) ** 2) == r'\left(\Omega\left(n\right)\right)^{2}'
+    assert latex(primeomega(n) ** 2) == \
+        r'\left(\Omega\left(n\right)\right)^{2}'
 
     assert latex(Mod(x, 7)) == r'x\bmod{7}'
     assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'
@@ -503,7 +549,8 @@ def test_hyper_printing():
 
 def test_latex_bessel():
     from sympy.functions.special.bessel import (besselj, bessely, besseli,
-            besselk, hankel1, hankel2, jn, yn, hn1, hn2)
+                                                besselk, hankel1, hankel2,
+                                                jn, yn, hn1, hn2)
     from sympy.abc import z
     assert latex(besselj(n, z**2)**k) == r'J^{k}_{n}\left(z^{2}\right)'
     assert latex(bessely(n, z)) == r'Y_{n}\left(z\right)'
@@ -536,12 +583,12 @@ def test_latex_indexed():
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
-    # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
+    # \\overline{{\\Psi}_{0}} {\\Psi}_{0}  vs.  \\Psi_{0} \\overline{\\Psi_{0}}
     assert symbol_latex == '\\Psi_{0} \\overline{\\Psi_{0}}'
     assert indexed_latex == '\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
-    assert latex(Indexed('x1',Symbol('i'))) == '{x_{1}}_{i}'
+    assert latex(Indexed('x1', Symbol('i'))) == '{x_{1}}_{i}'
     assert latex(IndexedBase('gamma')) == r'\gamma'
     assert latex(IndexedBase('a b')) == 'a b'
     assert latex(IndexedBase('a_b')) == 'a_{b}'
@@ -553,7 +600,8 @@ def test_latex_derivatives():
         r"\frac{d}{d x} x^{3}"
     assert latex(diff(sin(x) + x**2, x, evaluate=False)) == \
         r"\frac{d}{d x} \left(x^{2} + \sin{\left(x \right)}\right)"
-    assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False)) == \
+    assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False))\
+        == \
         r"\frac{d^{2}}{d x^{2}} \left(x^{2} + \sin{\left(x \right)}\right)"
     assert latex(diff(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False), evaluate=False)) == \
         r"\frac{d^{3}}{d x^{3}} \left(x^{2} + \sin{\left(x \right)}\right)"
@@ -570,14 +618,14 @@ def test_latex_derivatives():
 
     # mixed partial derivatives
     f = Function("f")
-    assert latex(diff(diff(f(x,y), x, evaluate=False), y, evaluate=False)) == \
-        r"\frac{\partial^{2}}{\partial y\partial x} " + latex(f(x,y))
+    assert latex(diff(diff(f(x, y), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{2}}{\partial y\partial x} " + latex(f(x, y))
 
-    assert latex(diff(diff(diff(f(x,y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
-        r"\frac{\partial^{3}}{\partial y\partial x^{2}} " + latex(f(x,y))
+    assert latex(diff(diff(diff(f(x, y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{3}}{\partial y\partial x^{2}} " + latex(f(x, y))
 
     # use ordinary d when one of the variables has been integrated out
-    assert latex(diff(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == \
+    assert latex(diff(Integral(exp(-x*y), (x, 0, oo)), y, evaluate=False)) == \
         r"\frac{d}{d y} \int\limits_{0}^{\infty} e^{- x y}\, dx"
 
     # Derivative wrapped in power:
@@ -598,12 +646,14 @@ def test_latex_subs():
 
 def test_latex_integrals():
     assert latex(Integral(log(x), x)) == r"\int \log{\left(x \right)}\, dx"
-    assert latex(Integral(x**2, (x, 0, 1))) == r"\int\limits_{0}^{1} x^{2}\, dx"
-    assert latex(Integral(x**2, (x, 10, 20))) == r"\int\limits_{10}^{20} x^{2}\, dx"
-    assert latex(Integral(
-        y*x**2, (x, 0, 1), y)) == r"\int\int\limits_{0}^{1} x^{2} y\, dx\, dy"
-    assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*') \
-        == r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
+    assert latex(Integral(x**2, (x, 0, 1))) == \
+        r"\int\limits_{0}^{1} x^{2}\, dx"
+    assert latex(Integral(x**2, (x, 10, 20))) == \
+        r"\int\limits_{10}^{20} x^{2}\, dx"
+    assert latex(Integral(y*x**2, (x, 0, 1), y)) == \
+        r"\int\int\limits_{0}^{1} x^{2} y\, dx\, dy"
+    assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*') == \
+        r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
     assert latex(Integral(y*x**2, (x, 0, 1), y), mode='equation*', itex=True) \
         == r"$$\int\int_{0}^{1} x^{2} y\, dx\, dy$$"
     assert latex(Integral(x, (x, 0))) == r"\int\limits^{0} x\, dx"
@@ -619,7 +669,8 @@ def test_latex_integrals():
     # fix issue #10806
     assert latex(Integral(z, z)**2) == r"\left(\int z\, dz\right)^{2}"
     assert latex(Integral(x + z, z)) == r"\int \left(x + z\right)\, dz"
-    assert latex(Integral(x+z/2, z)) == r"\int \left(x + \frac{z}{2}\right)\, dz"
+    assert latex(Integral(x+z/2, z)) == \
+        r"\int \left(x + \frac{z}{2}\right)\, dz"
     assert latex(Integral(x**y, z)) == r"\int x^{y}\, dz"
 
 
@@ -658,7 +709,8 @@ def test_latex_Range():
 
     assert latex(Range(oo, -2, -2)) == r'\left\{\infty, \ldots, 2, 0\right\}'
 
-    assert latex(Range(-2, -oo, -1)) == r'\left\{-2, -3, \ldots, -\infty\right\}'
+    assert latex(Range(-2, -oo, -1)) == \
+        r'\left\{-2, -3, \ldots, -\infty\right\}'
 
 
 def test_latex_sequences():
@@ -717,8 +769,10 @@ def test_latex_sequences():
     latex_str = r'\left[0, b, 4 b\right]'
     assert latex(s8) == latex_str
 
+
 def test_latex_FourierSeries():
-    latex_str = r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
+    latex_str = \
+        r'2 \sin{\left(x \right)} - \sin{\left(2 x \right)} + \frac{2 \sin{\left(3 x \right)}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
 
 
@@ -741,11 +795,13 @@ def test_latex_AccumuBounds():
     a = Symbol('a', real=True)
     assert latex(AccumBounds(0, 1)) == r"\left\langle 0, 1\right\rangle"
     assert latex(AccumBounds(0, a)) == r"\left\langle 0, a\right\rangle"
-    assert latex(AccumBounds(a + 1, a + 2)) == r"\left\langle a + 1, a + 2\right\rangle"
+    assert latex(AccumBounds(a + 1, a + 2)) == \
+        r"\left\langle a + 1, a + 2\right\rangle"
 
 
 def test_latex_emptyset():
     assert latex(S.EmptySet) == r"\emptyset"
+
 
 def test_latex_commutator():
     A = Operator('A')
@@ -767,12 +823,14 @@ def test_latex_intersection():
 
 
 def test_latex_symmetric_difference():
-    assert latex(SymmetricDifference(Interval(2,5), Interval(4,7), \
-        evaluate = False)) == r'\left[2, 5\right] \triangle \left[4, 7\right]'
+    assert latex(SymmetricDifference(Interval(2, 5), Interval(4, 7),
+                                     evaluate=False)) == \
+        r'\left[2, 5\right] \triangle \left[4, 7\right]'
 
 
 def test_latex_Complement():
-    assert latex(Complement(S.Reals, S.Naturals)) == r"\mathbb{R} \setminus \mathbb{N}"
+    assert latex(Complement(S.Reals, S.Naturals)) == \
+        r"\mathbb{R} \setminus \mathbb{N}"
 
 
 def test_latex_Complexes():
@@ -807,7 +865,8 @@ def test_latex_ImageSet():
         r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
     y = Symbol('y')
     imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
-    assert latex(imgset) == r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\}, y \in \left\{3, 4\right\}\right\}"
+    assert latex(imgset) == \
+        r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\}, y \in \left\{3, 4\right\}\right\}"
 
 
 def test_latex_ConditionSet():
@@ -860,22 +919,28 @@ def test_latex_limits():
     # issue 8175
     f = Function('f')
     assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left(x \right)}"
-    assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, "-")) == \
+        r"\lim_{x \to 0^-} f{\left(x \right)}"
 
     # issue #10806
-    assert latex(Limit(f(x), x, 0)**2) == r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
+    assert latex(Limit(f(x), x, 0)**2) == \
+        r"\left(\lim_{x \to 0^+} f{\left(x \right)}\right)^{2}"
     # bi-directional limit
-    assert latex(Limit(f(x), x, 0, dir='+-')) == r"\lim_{x \to 0} f{\left(x \right)}"
+    assert latex(Limit(f(x), x, 0, dir='+-')) == \
+        r"\lim_{x \to 0} f{\left(x \right)}"
 
 
 def test_latex_log():
     assert latex(log(x)) == r"\log{\left(x \right)}"
     assert latex(ln(x)) == r"\log{\left(x \right)}"
     assert latex(log(x), ln_notation=True) == r"\ln{\left(x \right)}"
-    assert latex(log(x)+log(y)) == r"\log{\left(x \right)} + \log{\left(y \right)}"
-    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left(x \right)} + \ln{\left(y \right)}"
-    assert latex(pow(log(x),x)) == r"\log{\left(x \right)}^{x}"
-    assert latex(pow(log(x),x), ln_notation=True) == r"\ln{\left(x \right)}^{x}"
+    assert latex(log(x)+log(y)) == \
+        r"\log{\left(x \right)} + \log{\left(y \right)}"
+    assert latex(log(x)+log(y), ln_notation=True) == \
+        r"\ln{\left(x \right)} + \ln{\left(y \right)}"
+    assert latex(pow(log(x), x)) == r"\log{\left(x \right)}^{x}"
+    assert latex(pow(log(x), x), ln_notation=True) == \
+        r"\ln{\left(x \right)}^{x}"
 
 
 def test_issue_3568():
@@ -899,18 +964,20 @@ def test_latex():
 
 def test_latex_dict():
     d = {Rational(1): 1, x**2: 2, x: 3, x**3: 4}
-    assert latex(d) == r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
+    assert latex(d) == \
+        r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
     D = Dict(d)
-    assert latex(D) == r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
+    assert latex(D) == \
+        r'\left\{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right\}'
 
 
 def test_latex_list():
-    l = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
-    assert latex(l) == r'\left[ \omega_{1}, \  a, \  \alpha\right]'
+    ll = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
+    assert latex(ll) == r'\left[ \omega_{1}, \  a, \  \alpha\right]'
 
 
 def test_latex_rational():
-    #tests issue 3973
+    # tests issue 3973
     assert latex(-Rational(1, 2)) == "- \\frac{1}{2}"
     assert latex(Rational(-1, 2)) == "- \\frac{1}{2}"
     assert latex(Rational(1, -2)) == "- \\frac{1}{2}"
@@ -921,7 +988,7 @@ def test_latex_rational():
 
 
 def test_latex_inverse():
-    #tests issue 4129
+    # tests issue 4129
     assert latex(1/x) == "\\frac{1}{x}"
     assert latex(1/(x + y)) == "\\frac{1}{x + y}"
 
@@ -946,12 +1013,14 @@ def test_latex_KroneckerDelta():
     assert latex(KroneckerDelta(x, y + 1)) == r"\delta_{x, y + 1}"
     # issue 6578
     assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{y, x + 1}"
-    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == r"\left(\delta_{x y}\right)^{2}"
+    assert latex(Pow(KroneckerDelta(x, y), 2, evaluate=False)) == \
+        r"\left(\delta_{x y}\right)^{2}"
 
 
 def test_latex_LeviCivita():
     assert latex(LeviCivita(x, y, z)) == r"\varepsilon_{x y z}"
-    assert latex(LeviCivita(x, y, z)**2) == r"\left(\varepsilon_{x y z}\right)^{2}"
+    assert latex(LeviCivita(x, y, z)**2) == \
+        r"\left(\varepsilon_{x y z}\right)^{2}"
     assert latex(LeviCivita(x, y, z + 1)) == r"\varepsilon_{x, y, z + 1}"
     assert latex(LeviCivita(x, y + 1, z)) == r"\varepsilon_{x, y + 1, z}"
     assert latex(LeviCivita(x + 1, y, z)) == r"\varepsilon_{x + 1, y, z}"
@@ -966,15 +1035,16 @@ def test_mode():
         expr, mode='equation*') == '\\begin{equation*}x + y\\end{equation*}'
     assert latex(
         expr, mode='equation') == '\\begin{equation}x + y\\end{equation}'
-    raises(ValueError, lambda : latex(expr, mode='foo'))
+    raises(ValueError, lambda: latex(expr, mode='foo'))
 
 
 def test_latex_Piecewise():
     p = Piecewise((x, x < 1), (x**2, True))
     assert latex(p) == "\\begin{cases} x & \\text{for}\\: x < 1 \\\\x^{2} &" \
                        " \\text{otherwise} \\end{cases}"
-    assert latex(p, itex=True) == "\\begin{cases} x & \\text{for}\\: x \\lt 1 \\\\x^{2} &" \
-                                  " \\text{otherwise} \\end{cases}"
+    assert latex(p, itex=True) == \
+        "\\begin{cases} x & \\text{for}\\: x \\lt 1 \\\\x^{2} &" \
+        " \\text{otherwise} \\end{cases}"
     p = Piecewise((x, x < 0), (0, x >= 0))
     assert latex(p) == '\\begin{cases} x & \\text{for}\\: x < 0 \\\\0 &' \
                        ' \\text{otherwise} \\end{cases}'
@@ -984,7 +1054,8 @@ def test_latex_Piecewise():
     assert latex(p) == s
     assert latex(A*p) == r"A \left(%s\right)" % s
     assert latex(p*A) == r"\left(%s\right) A" % s
-    assert latex(Piecewise((x, x < 1), (x**2, x <2))) == '\\begin{cases} x & ' \
+    assert latex(Piecewise((x, x < 1), (x**2, x < 2))) == \
+        '\\begin{cases} x & ' \
         '\\text{for}\\: x < 1 \\\\x^{2} & \\text{for}\\: x < 2 \\end{cases}'
 
 
@@ -1028,7 +1099,8 @@ def test_latex_matrix_with_functions():
 def test_latex_NDimArray():
     x, y, z, w = symbols("x y z w")
 
-    for ArrayType in (ImmutableDenseNDimArray, ImmutableSparseNDimArray, MutableDenseNDimArray, MutableSparseNDimArray):
+    for ArrayType in (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
+                      MutableDenseNDimArray, MutableSparseNDimArray):
         # Basic: scalar array
         M = ArrayType(x)
 
@@ -1040,27 +1112,34 @@ def test_latex_NDimArray():
         M2 = tensorproduct(M1, M)
         M3 = tensorproduct(M, M)
 
-        assert latex(M) == '\\left[\\begin{matrix}\\frac{1}{x} & y\\\\z & w\\end{matrix}\\right]'
-        assert latex(M1) == "\\left[\\begin{matrix}\\frac{1}{x} & y & z\\end{matrix}\\right]"
-        assert latex(M2) == r"\left[\begin{matrix}" \
-                            r"\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & " \
-                            r"\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right] & " \
-                            r"\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right]" \
-                            r"\end{matrix}\right]"
-        assert latex(M3) == r"""\left[\begin{matrix}"""\
-                r"""\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & """\
-                r"""\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right]\\"""\
-                r"""\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right] & """\
-                r"""\left[\begin{matrix}\frac{w}{x} & w y\\w z & w^{2}\end{matrix}\right]"""\
-                r"""\end{matrix}\right]"""
+        assert latex(M) == \
+            '\\left[\\begin{matrix}\\frac{1}{x} & y\\\\z & w\\end{matrix}\\right]'
+        assert latex(M1) == \
+            "\\left[\\begin{matrix}\\frac{1}{x} & y & z\\end{matrix}\\right]"
+        assert latex(M2) == \
+            r"\left[\begin{matrix}" \
+            r"\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & " \
+            r"\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right] & " \
+            r"\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right]" \
+            r"\end{matrix}\right]"
+        assert latex(M3) == \
+            r"""\left[\begin{matrix}"""\
+            r"""\left[\begin{matrix}\frac{1}{x^{2}} & \frac{y}{x}\\\frac{z}{x} & \frac{w}{x}\end{matrix}\right] & """\
+            r"""\left[\begin{matrix}\frac{y}{x} & y^{2}\\y z & w y\end{matrix}\right]\\"""\
+            r"""\left[\begin{matrix}\frac{z}{x} & y z\\z^{2} & w z\end{matrix}\right] & """\
+            r"""\left[\begin{matrix}\frac{w}{x} & w y\\w z & w^{2}\end{matrix}\right]"""\
+            r"""\end{matrix}\right]"""
 
         Mrow = ArrayType([[x, y, 1/z]])
         Mcolumn = ArrayType([[x], [y], [1/z]])
         Mcol2 = ArrayType([Mcolumn.tolist()])
 
-        assert latex(Mrow) == r"\left[\left[\begin{matrix}x & y & \frac{1}{z}\end{matrix}\right]\right]"
-        assert latex(Mcolumn) == r"\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]"
-        assert latex(Mcol2) == r'\left[\begin{matrix}\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]\end{matrix}\right]'
+        assert latex(Mrow) == \
+            r"\left[\left[\begin{matrix}x & y & \frac{1}{z}\end{matrix}\right]\right]"
+        assert latex(Mcolumn) == \
+            r"\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]"
+        assert latex(Mcol2) == \
+            r'\left[\begin{matrix}\left[\begin{matrix}x\\y\\\frac{1}{z}\end{matrix}\right]\end{matrix}\right]'
 
 
 def test_latex_mul_symbol():
@@ -1107,7 +1186,7 @@ def test_latex_pow_fraction():
     # Testing exp
     assert 'e^{-x}' in latex(exp(-x)/2).replace(' ', '')  # Remove Whitespace
 
-    # Testing just e^{-x} in case future changes alter behavior of muls or fracs
+    # Testing e^{-x} in case future changes alter behavior of muls or fracs
     # In particular current output is \frac{1}{2}e^{- x} but perhaps this will
     # change to \frac{e^{-x}}{2}
 
@@ -1131,6 +1210,7 @@ def test_latex_order():
         expr, order='rev-lex') == "y^{4} + 3 x y^{3} + x^{2} y + x^{3}"
     assert latex(expr, order='none') == "x^{3} + y^{4} + y x^{2} + 3 x y^{3}"
 
+
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
         r"\left( x \mapsto x + 1 \right)"
@@ -1139,25 +1219,31 @@ def test_latex_Lambda():
 
 
 def test_latex_PolyElement():
-    Ruv, u,v = ring("u,v", ZZ)
-    Rxyz, x,y,z = ring("x,y,z", Ruv)
+    Ruv, u, v = ring("u,v", ZZ)
+    Rxyz, x, y, z = ring("x,y,z", Ruv)
 
     assert latex(x - x) == r"0"
     assert latex(x - 1) == r"x - 1"
     assert latex(x + 1) == r"x + 1"
 
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + u + 1) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + u + 1"
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x"
-    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x + 1) == r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x + 1"
-    assert latex((-u**2 + 3*u*v - 1)*x**2*y - (u + 1)*x - 1) == r"-\left({u}^{2} - 3 u v + 1\right) {x}^{2} y - \left(u + 1\right) x - 1"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + u + 1) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + u + 1"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x"
+    assert latex((u**2 + 3*u*v + 1)*x**2*y + (u + 1)*x + 1) == \
+        r"\left({u}^{2} + 3 u v + 1\right) {x}^{2} y + \left(u + 1\right) x + 1"
+    assert latex((-u**2 + 3*u*v - 1)*x**2*y - (u + 1)*x - 1) == \
+        r"-\left({u}^{2} - 3 u v + 1\right) {x}^{2} y - \left(u + 1\right) x - 1"
 
-    assert latex(-(v**2 + v + 1)*x + 3*u*v + 1) == r"-\left({v}^{2} + v + 1\right) x + 3 u v + 1"
-    assert latex(-(v**2 + v + 1)*x - 3*u*v + 1) == r"-\left({v}^{2} + v + 1\right) x - 3 u v + 1"
+    assert latex(-(v**2 + v + 1)*x + 3*u*v + 1) == \
+        r"-\left({v}^{2} + v + 1\right) x + 3 u v + 1"
+    assert latex(-(v**2 + v + 1)*x - 3*u*v + 1) == \
+        r"-\left({v}^{2} + v + 1\right) x - 3 u v + 1"
 
 
 def test_latex_FracElement():
-    Fuv, u,v = field("u,v", ZZ)
-    Fxyzt, x,y,z,t = field("x,y,z,t", Fuv)
+    Fuv, u, v = field("u,v", ZZ)
+    Fxyzt, x, y, z, t = field("x,y,z,t", Fuv)
 
     assert latex(x - x) == r"0"
     assert latex(x - 1) == r"x - 1"
@@ -1176,8 +1262,10 @@ def test_latex_FracElement():
     assert latex(-y/(x + 1)) == r"\frac{-y}{x + 1}"
     assert latex(y*z/(x + 1)) == r"\frac{y z}{x + 1}"
 
-    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - 1)) == r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - 1}"
-    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - t*u*v - 1)) == r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - u v t - 1}"
+    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - 1)) == \
+        r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - 1}"
+    assert latex(((u + 1)*x*y + 1)/((v - 1)*z - t*u*v - 1)) == \
+        r"\frac{\left(u + 1\right) x y + 1}{\left(v - 1\right) z - u v t - 1}"
 
 
 def test_latex_Poly():
@@ -1194,7 +1282,8 @@ def test_latex_Poly_order():
         '\\operatorname{Poly}{\\left( a x^{5} + x^{4} + b x^{3} + 2 x^{2} + c x + 3, x, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
     assert latex(Poly([a, 1, b+c, 2, 3], x)) == \
         '\\operatorname{Poly}{\\left( a x^{4} + x^{3} + \\left(b + c\\right) x^{2} + 2 x + 3, x, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
-    assert latex(Poly(a*x**3 + x**2*y - x*y - c*y**3 - b*x*y**2 + y - a*x + b, (x, y))) == \
+    assert latex(Poly(a*x**3 + x**2*y - x*y - c*y**3 - b*x*y**2 + y - a*x + b,
+                      (x, y))) == \
         '\\operatorname{Poly}{\\left( a x^{3} + x^{2}y -  b xy^{2} - xy -  a x -  c y^{3} + y + b, x, y, domain=\\mathbb{Z}\\left[a, b, c\\right] \\right)}'
 
 
@@ -1256,24 +1345,24 @@ def test_matMul():
     A = MatrixSymbol('A', 5, 5)
     B = MatrixSymbol('B', 5, 5)
     x = Symbol('x')
-    l = LatexPrinter()
-    assert l._print_MatMul(2*A) == '2 A'
-    assert l._print_MatMul(2*x*A) == '2 x A'
-    assert l._print_MatMul(-2*A) == '- 2 A'
-    assert l._print_MatMul(1.5*A) == '1.5 A'
-    assert l._print_MatMul(sqrt(2)*A) == r'\sqrt{2} A'
-    assert l._print_MatMul(-sqrt(2)*A) == r'- \sqrt{2} A'
-    assert l._print_MatMul(2*sqrt(2)*x*A) == r'2 \sqrt{2} x A'
-    assert l._print_MatMul(-2*A*(A + 2*B)) in [r'- 2 A \left(A + 2 B\right)',
-        r'- 2 A \left(2 B + A\right)']
+    lp = LatexPrinter()
+    assert lp._print_MatMul(2*A) == '2 A'
+    assert lp._print_MatMul(2*x*A) == '2 x A'
+    assert lp._print_MatMul(-2*A) == '- 2 A'
+    assert lp._print_MatMul(1.5*A) == '1.5 A'
+    assert lp._print_MatMul(sqrt(2)*A) == r'\sqrt{2} A'
+    assert lp._print_MatMul(-sqrt(2)*A) == r'- \sqrt{2} A'
+    assert lp._print_MatMul(2*sqrt(2)*x*A) == r'2 \sqrt{2} x A'
+    assert lp._print_MatMul(-2*A*(A + 2*B)) in [r'- 2 A \left(A + 2 B\right)',
+                                                r'- 2 A \left(2 B + A\right)']
 
 
 def test_latex_MatrixSlice():
     from sympy.matrices.expressions import MatrixSymbol
     assert latex(MatrixSymbol('X', 10, 10)[:5, 1:9:2]) == \
-            r'X\left[:5, 1:9:2\right]'
+        r'X\left[:5, 1:9:2\right]'
     assert latex(MatrixSymbol('X', 10, 10)[5, :5:2]) == \
-            r'X\left[5, :5:2\right]'
+        r'X\left[5, :5:2\right]'
 
 
 def test_latex_RandomDomain():
@@ -1307,20 +1396,30 @@ def test_integral_transforms():
     a = Symbol("a")
     b = Symbol("b")
 
-    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(MellinTransform(f(x), x, k)) == \
+        r"\mathcal{M}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == \
+        r"\mathcal{M}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(LaplaceTransform(f(x), x, k)) == \
+        r"\mathcal{L}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == \
+        r"\mathcal{L}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(FourierTransform(f(x), x, k)) == \
+        r"\mathcal{F}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseFourierTransform(f(k), k, x)) == \
+        r"\mathcal{F}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(CosineTransform(f(x), x, k)) == \
+        r"\mathcal{COS}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseCosineTransform(f(k), k, x)) == \
+        r"\mathcal{COS}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
-    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
-    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
+    assert latex(SineTransform(f(x), x, k)) == \
+        r"\mathcal{SIN}_{x}\left[f{\left(x \right)}\right]\left(k\right)"
+    assert latex(InverseSineTransform(f(k), k, x)) == \
+        r"\mathcal{SIN}^{-1}_{k}\left[f{\left(k \right)}\right]\left(x\right)"
 
 
 def test_PolynomialRingBase():
@@ -1332,7 +1431,8 @@ def test_PolynomialRingBase():
 
 def test_categories():
     from sympy.categories import (Object, IdentityMorphism,
-        NamedMorphism, Category, Diagram, DiagramGrid)
+                                  NamedMorphism, Category, Diagram,
+                                  DiagramGrid)
 
     A1 = Object("A1")
     A2 = Object("A2")
@@ -1403,21 +1503,24 @@ def test_Modules():
     assert latex(I) == r"\left\langle {x^{2}},{y} \right\rangle"
 
     Q = F / M
-    assert latex(Q) == r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}"
+    assert latex(Q) == \
+        r"\frac{{\mathbb{Q}\left[x, y\right]}^{2}}{\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}"
     assert latex(Q.submodule([1, x**3/2], [2, y])) == \
         r"\left\langle {{\left[ {1},{\frac{x^{3}}{2}} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}},{{\left[ {2},{y} \right]} + {\left\langle {\left[ {x},{y} \right]},{\left[ {1},{x^{2}} \right]} \right\rangle}} \right\rangle"
 
-    h = homomorphism(QQ.old_poly_ring(x).free_module(2), QQ.old_poly_ring(x).free_module(2), [0, 0])
+    h = homomorphism(QQ.old_poly_ring(x).free_module(2),
+                     QQ.old_poly_ring(x).free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{matrix}0 & 0\\0 & 0\end{matrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == \
+        r"{\left[\begin{matrix}0 & 0\\0 & 0\end{matrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():
     from sympy.polys.domains import QQ
     R = QQ.old_poly_ring(x)/[x**2 + 1]
 
-    assert latex(
-        R) == r"\frac{\mathbb{Q}\left[x\right]}{\left\langle {x^{2} + 1} \right\rangle}"
+    assert latex(R) == \
+        r"\frac{\mathbb{Q}\left[x\right]}{\left\langle {x^{2} + 1} \right\rangle}"
     assert latex(R.one) == r"{1} + {\left\langle {x^{2} + 1} \right\rangle}"
 
 
@@ -1473,10 +1576,12 @@ def test_boolean_args_order():
     assert latex(expr) == 'a \\vee b \\vee c \\vee d \\vee e \\vee f'
 
     expr = Equivalent(*syms)
-    assert latex(expr) == 'a \\Leftrightarrow b \\Leftrightarrow c \\Leftrightarrow d \\Leftrightarrow e \\Leftrightarrow f'
+    assert latex(expr) == \
+        'a \\Leftrightarrow b \\Leftrightarrow c \\Leftrightarrow d \\Leftrightarrow e \\Leftrightarrow f'
 
     expr = Xor(*syms)
-    assert latex(expr) == 'a \\veebar b \\veebar c \\veebar d \\veebar e \\veebar f'
+    assert latex(expr) == \
+        'a \\veebar b \\veebar c \\veebar d \\veebar e \\veebar f'
 
 
 def test_imaginary():
@@ -1540,7 +1645,8 @@ def test_other_symbols():
 
 
 def test_modifiers():
-    # Test each modifier individually in the simplest case (with funny capitalizations)
+    # Test each modifier individually in the simplest case
+    # (with funny capitalizations)
     assert latex(symbols("xMathring")) == r"\mathring{x}"
     assert latex(symbols("xCheck")) == r"\check{x}"
     assert latex(symbols("xBreve")) == r"\breve{x}"
@@ -1588,8 +1694,10 @@ def test_modifiers():
     assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"
     assert latex(symbols("xHATNorm")) == r"\left\|{\hat{x}}\right\|"
     # Check a couple big, ugly combinations
-    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left|{\breve{z}}\right|}_{{\check{y}}'}"
-    assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
+    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == \
+        r"\boldsymbol{\mathring{x}}^{\left|{\breve{z}}\right|}_{{\check{y}}'}"
+    assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == \
+        r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
 
 
 def test_greek_symbols():
@@ -1673,25 +1781,25 @@ def test_issue_6853():
 
 def test_Mul():
     e = Mul(-2, x + 1, evaluate=False)
-    assert latex(e)  == r'- 2 \left(x + 1\right)'
+    assert latex(e) == r'- 2 \left(x + 1\right)'
     e = Mul(2, x + 1, evaluate=False)
-    assert latex(e)  == r'2 \left(x + 1\right)'
+    assert latex(e) == r'2 \left(x + 1\right)'
     e = Mul(S.One/2, x + 1, evaluate=False)
-    assert latex(e)  == r'\frac{x + 1}{2}'
+    assert latex(e) == r'\frac{x + 1}{2}'
     e = Mul(y, x + 1, evaluate=False)
-    assert latex(e)  == r'y \left(x + 1\right)'
+    assert latex(e) == r'y \left(x + 1\right)'
     e = Mul(-y, x + 1, evaluate=False)
-    assert latex(e)  == r'- y \left(x + 1\right)'
+    assert latex(e) == r'- y \left(x + 1\right)'
     e = Mul(-2, x + 1)
-    assert latex(e)  == r'- 2 x - 2'
+    assert latex(e) == r'- 2 x - 2'
     e = Mul(2, x + 1)
-    assert latex(e)  == r'2 x + 2'
+    assert latex(e) == r'2 x + 2'
 
 
 def test_Pow():
     e = Pow(2, 2, evaluate=False)
-    assert latex(e)  == r'2^{2}'
-    assert latex(x**(Rational(-1,3))) == r'\frac{1}{\sqrt[3]{x}}'
+    assert latex(e) == r'2^{2}'
+    assert latex(x**(Rational(-1, 3))) == r'\frac{1}{\sqrt[3]{x}}'
     x2 = Symbol(r'x^2')
     assert latex(x2**2) == r'\left(x^{2}\right)^{2}'
 
@@ -1743,7 +1851,8 @@ def test_issue_10489():
 
 def test_issue_12886():
     m__1, l__1 = symbols('m__1, l__1')
-    assert latex(m__1**2 + l__1**2) == r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
+    assert latex(m__1**2 + l__1**2) == \
+        r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
 
 
 def test_issue_13559():
@@ -1781,7 +1890,8 @@ def test_MatrixElement_printing():
     i, j, k = symbols("i j k")
     M = MatrixSymbol("M", k, k)
     N = MatrixSymbol("N", k, k)
-    assert latex((M*N)[i, j]) == r'\sum_{i_{1}=0}^{k - 1} M_{i, i_{1}} N_{i_{1}, j}'
+    assert latex((M*N)[i, j]) == \
+        r'\sum_{i_{1}=0}^{k - 1} M_{i, i_{1}} N_{i_{1}, j}'
 
 
 def test_MatrixSymbol_printing():
@@ -1804,9 +1914,9 @@ def test_KroneckerProduct_printing():
 def test_Quaternion_latex_printing():
     q = Quaternion(x, y, z, t)
     assert latex(q) == "x + y i + z j + t k"
-    q = Quaternion(x,y,z,x*t)
+    q = Quaternion(x, y, z, x*t)
     assert latex(q) == "x + y i + z j + t x k"
-    q = Quaternion(x,y,z,x+t)
+    q = Quaternion(x, y, z, x + t)
     assert latex(q) == r"x + y i + z j + \left(t + x\right) k"
 
 
@@ -1828,7 +1938,7 @@ def test_issue_14041():
     import sympy.physics.mechanics as me
 
     A_frame = me.ReferenceFrame('A')
-    thetad, phid  = me.dynamicsymbols('theta, phi', 1)
+    thetad, phid = me.dynamicsymbols('theta, phi', 1)
     L = Symbol('L')
 
     assert latex(L*(phid + thetad)**2*A_frame.x) == \
@@ -1851,6 +1961,7 @@ def test_issue_9216():
 
     expr_4 = Pow(1, -2, evaluate=False)
     assert latex(expr_4) == r"1^{-2}"
+
 
 def test_latex_printer_tensor():
     from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
@@ -1906,25 +2017,25 @@ def test_latex_printer_tensor():
     expr = A(i) + 3*B(i)
     assert latex(expr) == "3B{}^{i} + A{}^{i}"
 
-    ## Test ``TensorElement``:
+    # Test ``TensorElement``:
     from sympy.tensor.tensor import TensorElement
 
-    expr = TensorElement(K(i,j,k,l), {i:3, k:2})
+    expr = TensorElement(K(i, j, k, l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3,j,k=2,l}'
 
-    expr = TensorElement(K(i,j,k,l), {i:3})
+    expr = TensorElement(K(i, j, k, l), {i: 3})
     assert latex(expr) == 'K{}^{i=3,jkl}'
 
-    expr = TensorElement(K(i,-j,k,l), {i:3, k:2})
+    expr = TensorElement(K(i, -j, k, l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3}{}_{j}{}^{k=2,l}'
 
-    expr = TensorElement(K(i,-j,k,-l), {i:3, k:2})
+    expr = TensorElement(K(i, -j, k, -l), {i: 3, k: 2})
     assert latex(expr) == 'K{}^{i=3}{}_{j}{}^{k=2}{}_{l}'
 
-    expr = TensorElement(K(i,j,-k,-l), {i:3, -k:2})
+    expr = TensorElement(K(i, j, -k, -l), {i: 3, -k: 2})
     assert latex(expr) == 'K{}^{i=3,j}{}_{k=2,l}'
 
-    expr = TensorElement(K(i,j,-k,-l), {i:3})
+    expr = TensorElement(K(i, j, -k, -l), {i: 3})
     assert latex(expr) == 'K{}^{i=3,j}{}_{kl}'
 
 
@@ -1933,7 +2044,8 @@ def test_issue_15353():
     a, x = symbols('a x')
     # Obtained from nonlinsolve([(sin(a*x)),cos(a*x)],[x,a])
     sol = ConditionSet(Tuple(x, a), FiniteSet(sin(a*x), cos(a*x)), S.Complexes)
-    assert latex(sol) == r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in \mathbb{C} \wedge \left\{\sin{\left(a x \right)}, \cos{\left(a x \right)}\right\} \right\}'
+    assert latex(sol) == \
+        r'\left\{\left( x, \  a\right) \mid \left( x, \  a\right) \in \mathbb{C} \wedge \left\{\sin{\left(a x \right)}, \cos{\left(a x \right)}\right\} \right\}'
 
 
 def test_trace():
@@ -1948,7 +2060,8 @@ def test_print_basic():
     # Issue 15303
     from sympy import Basic, Expr
 
-    # dummy class for testing printing where the function is not implemented in latex.py
+    # dummy class for testing printing where the function is not
+    # implemented in latex.py
     class UnimplementedExpr(Expr):
         def __new__(cls, e):
             return Basic.__new__(cls, e)
@@ -1964,24 +2077,30 @@ def test_print_basic():
         return result
 
     assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
-    assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'
-    assert latex(unimplemented_expr_sup_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'
+    assert latex(unimplemented_expr(x**2)) == \
+        r'UnimplementedExpr\left(x^{2}\right)'
+    assert latex(unimplemented_expr_sup_sub(x)) == \
+        r'UnimplementedExpr^{1}_{x}\left(x\right)'
 
 
 def test_MatrixSymbol_bold():
     # Issue #15871
     from sympy import trace
     A = MatrixSymbol("A", 2, 2)
-    assert latex(trace(A), mat_symbol_style='bold') == r"\mathrm{tr}\left(\mathbf{A} \right)"
-    assert latex(trace(A), mat_symbol_style='plain') == r"\mathrm{tr}\left(A \right)"
+    assert latex(trace(A), mat_symbol_style='bold') == \
+        r"\mathrm{tr}\left(\mathbf{A} \right)"
+    assert latex(trace(A), mat_symbol_style='plain') == \
+        r"\mathrm{tr}\left(A \right)"
 
     A = MatrixSymbol("A", 3, 3)
     B = MatrixSymbol("B", 3, 3)
     C = MatrixSymbol("C", 3, 3)
 
     assert latex(-A, mat_symbol_style='bold') == r"- \mathbf{A}"
-    assert latex(A - A*B - B, mat_symbol_style='bold') == r"\mathbf{A} - \mathbf{A} \mathbf{B} - \mathbf{B}"
-    assert latex(-A*B - A*B*C - B, mat_symbol_style='bold') == r"- \mathbf{A} \mathbf{B} - \mathbf{A} \mathbf{B} \mathbf{C} - \mathbf{B}"
+    assert latex(A - A*B - B, mat_symbol_style='bold') == \
+        r"\mathbf{A} - \mathbf{A} \mathbf{B} - \mathbf{B}"
+    assert latex(-A*B - A*B*C - B, mat_symbol_style='bold') == \
+        r"- \mathbf{A} \mathbf{B} - \mathbf{A} \mathbf{B} \mathbf{C} - \mathbf{B}"
 
     A = MatrixSymbol("A_k", 3, 3)
     assert latex(A, mat_symbol_style='bold') == r"\mathbf{A_{k}}"

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,19 +1,21 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
-    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, S, \
-    MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
+    pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
+    S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
     Lambda, IndexedBase, symbols
 from sympy.core.containers import Tuple
-from sympy.functions.combinatorial.factorials import factorial, factorial2, binomial
+from sympy.functions.combinatorial.factorials import factorial, factorial2, \
+    binomial
 from sympy.functions.elementary.complexes import re, im, Abs, conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.zeta_functions import polylog, lerchphi
 from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
 from sympy.matrices.expressions.determinant import Determinant
-from sympy.printing.mathml import mathml, MathMLContentPrinter, MathMLPresentationPrinter, \
-    MathMLPrinter
-from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, SymmetricDifference
+from sympy.printing.mathml import mathml, MathMLContentPrinter, \
+    MathMLPresentationPrinter, MathMLPrinter
+from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
+    SymmetricDifference
 from sympy.stats.rv import RandomSymbol
 from sympy.sets.sets import Interval
 from sympy.utilities.pytest import raises
@@ -22,6 +24,7 @@ x = Symbol('x')
 y = Symbol('y')
 mp = MathMLContentPrinter()
 mpp = MathMLPresentationPrinter()
+
 
 def test_mathml_printer():
     m = MathMLPrinter()
@@ -109,6 +112,7 @@ def test_content_mathml_integrals():
     assert mml_1.childNodes[3].nodeName == 'uplimit'
     assert mml_1.childNodes[4].toxml() == mp._print(integrand).toxml()
 
+
 def test_content_mathml_matrices():
     A = Matrix([1, 2, 3])
     B = Matrix([[0, 5, 4], [2, 3, 1], [9, 7, 9]])
@@ -144,6 +148,7 @@ def test_content_mathml_matrices():
     assert mll_2.childNodes[2].childNodes[1].childNodes[0].nodeValue == '7'
     assert mll_2.childNodes[2].childNodes[2].nodeName == 'cn'
     assert mll_2.childNodes[2].childNodes[2].childNodes[0].nodeValue == '9'
+
 
 def test_content_mathml_sums():
     summand = x
@@ -404,7 +409,7 @@ def test_content_mathml_greek():
     assert mp.doprint(Symbol('omicron')) == '<ci>&#959;</ci>'
     assert mp.doprint(Symbol('pi')) == '<ci>&#960;</ci>'
     assert mp.doprint(Symbol('rho')) == '<ci>&#961;</ci>'
-    assert mp.doprint(Symbol('varsigma')) == '<ci>&#962;</ci>', mp.doprint(Symbol('varsigma'))
+    assert mp.doprint(Symbol('varsigma')) == '<ci>&#962;</ci>'
     assert mp.doprint(Symbol('sigma')) == '<ci>&#963;</ci>'
     assert mp.doprint(Symbol('tau')) == '<ci>&#964;</ci>'
     assert mp.doprint(Symbol('upsilon')) == '<ci>&#965;</ci>'
@@ -472,7 +477,11 @@ def test_content_settings():
 def test_presentation_printmethod():
     assert mpp.doprint(1 + x) == '<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>'
     assert mpp.doprint(x**2) == '<msup><mi>x</mi><mn>2</mn></msup>'
-    assert mpp.doprint(2*x) == '<mrow><mn>2</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(x**-1) == '<mfrac><mn>1</mn><mi>x</mi></mfrac>'
+    assert mpp.doprint(x**-2) == \
+        '<mfrac><mn>1</mn><msup><mi>x</mi><mn>2</mn></msup></mfrac>'
+    assert mpp.doprint(2*x) == \
+        '<mrow><mn>2</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow>'
 
 
 def test_presentation_mathml_core():
@@ -538,8 +547,10 @@ def test_print_derivative():
     f = Function('f')
     z = Symbol('z')
     d = Derivative(f(x, y, z), x, z, x, z, z, y)
-    assert mathml(d) == r'<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
-    assert mathml(d, printer='presentation') == r'<mrow><mfrac><mrow><msup><mo>&#x2202;</mo><mn>6</mn></msup></mrow><mrow><mo>&#x2202;</mo><mi>y</mi><msup><mo>&#x2202;</mo><mn>2</mn></msup><mi>z</mi><mo>&#x2202;</mo><mi>x</mi><mo>&#x2202;</mo><mi>z</mi><mo>&#x2202;</mo><mi>x</mi></mrow></mfrac><mrow><mi>f</mi><mfenced><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow></mrow>'
+    assert mathml(d) == \
+        '<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
+    assert mathml(d, printer='presentation') == \
+        '<mrow><mfrac><mrow><msup><mo>&#x2202;</mo><mn>6</mn></msup></mrow><mrow><mo>&#x2202;</mo><mi>y</mi><msup><mo>&#x2202;</mo><mn>2</mn></msup><mi>z</mi><mo>&#x2202;</mo><mi>x</mi><mo>&#x2202;</mo><mi>z</mi><mo>&#x2202;</mo><mi>x</mi></mrow></mfrac><mrow><mi>f</mi><mfenced><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow></mrow>'
 
 
 def test_presentation_mathml_limits():
@@ -560,14 +571,21 @@ def test_presentation_mathml_limits():
 
 
 def test_presentation_mathml_integrals():
-    assert mpp.doprint(Integral(x, (x, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(log(x), x)) == '<mrow><mo>&#x222B;</mo><mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x*y, x, y)) == '<mrow><mo>&#x222C;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, (x, 0, 1))) == \
+        '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(log(x), x)) == \
+        '<mrow><mo>&#x222B;</mo><mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y, x, y)) == \
+        '<mrow><mo>&#x222C;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
     z, w = symbols('z w')
-    assert mpp.doprint(Integral(x*y*z, x, y, z)) == '<mrow><mo>&#x222D;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x*y*z*w, x, y, z, w)) == '<mrow><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mrow><mi>w</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>w</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x, x, y, (z, 0, 1))) == '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mo>&#x222B;</mo><mo>&#x222B;</mo><mi>x</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Integral(x, (x, 0))) == '<mrow><msup><mo>&#x222B;</mo><mn>0</mn></msup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y*z, x, y, z)) == \
+        '<mrow><mo>&#x222D;</mo><mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x*y*z*w, x, y, z, w)) == \
+        '<mrow><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mo>&#x222B;</mo><mrow><mi>w</mi><mo>&InvisibleTimes;</mo><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi><mo>&InvisibleTimes;</mo><mi>z</mi></mrow><mo>&dd;</mo><mi>w</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, x, y, (z, 0, 1))) == \
+        '<mrow><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mo>&#x222B;</mo><mo>&#x222B;</mo><mi>x</mi><mo>&dd;</mo><mi>z</mi><mo>&dd;</mo><mi>y</mi><mo>&dd;</mo><mi>x</mi></mrow>'
+    assert mpp.doprint(Integral(x, (x, 0))) == \
+        '<mrow><msup><mo>&#x222B;</mo><mn>0</mn></msup><mi>x</mi><mo>&dd;</mo><mi>x</mi></mrow>'
 
 
 def test_presentation_mathml_matrices():
@@ -854,7 +872,7 @@ def test_presentation_mathml_greek():
     assert mpp.doprint(Symbol('omicron')) == '<mi>&#959;</mi>'
     assert mpp.doprint(Symbol('pi')) == '<mi>&#960;</mi>'
     assert mpp.doprint(Symbol('rho')) == '<mi>&#961;</mi>'
-    assert mpp.doprint(Symbol('varsigma')) == '<mi>&#962;</mi>', mp.doprint(Symbol('varsigma'))
+    assert mpp.doprint(Symbol('varsigma')) == '<mi>&#962;</mi>'
     assert mpp.doprint(Symbol('sigma')) == '<mi>&#963;</mi>'
     assert mpp.doprint(Symbol('tau')) == '<mi>&#964;</mi>'
     assert mpp.doprint(Symbol('upsilon')) == '<mi>&#965;</mi>'
@@ -916,49 +934,69 @@ def test_presentation_mathml_order():
 
 def test_print_intervals():
     a = Symbol('a', real=True)
-    assert mpp.doprint(Interval(0, a)) == '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, False, False)) == '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, True, False)) == '<mrow><mfenced close="]" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, False, True)) == '<mrow><mfenced close=")" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Interval(0, a, True, True)) == '<mrow><mfenced close=")" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a)) == \
+        '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, False, False)) == \
+        '<mrow><mfenced close="]" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, True, False)) == \
+        '<mrow><mfenced close="]" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, False, True)) == \
+        '<mrow><mfenced close=")" open="["><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Interval(0, a, True, True)) == \
+        '<mrow><mfenced close=")" open="("><mn>0</mn><mi>a</mi></mfenced></mrow>'
 
 
 def test_print_tuples():
     a = Symbol('a')
-    assert mpp.doprint(Tuple(0,)) == '<mrow><mfenced><mn>0</mn></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, a)) == '<mrow><mfenced><mn>0</mn><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, a, a)) == '<mrow><mfenced><mn>0</mn><mi>a</mi><mi>a</mi></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, 1, 2, 3, 4)) == '<mrow><mfenced><mn>0</mn><mn>1</mn><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow>'
-    assert mpp.doprint(Tuple(0, 1, Tuple(2, 3, 4))) == '<mrow><mfenced><mn>0</mn><mn>1</mn><mrow><mfenced><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0,)) == \
+        '<mrow><mfenced><mn>0</mn></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, a)) == \
+        '<mrow><mfenced><mn>0</mn><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, a, a)) == \
+        '<mrow><mfenced><mn>0</mn><mi>a</mi><mi>a</mi></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, 1, 2, 3, 4)) == \
+        '<mrow><mfenced><mn>0</mn><mn>1</mn><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow>'
+    assert mpp.doprint(Tuple(0, 1, Tuple(2, 3, 4))) == \
+        '<mrow><mfenced><mn>0</mn><mn>1</mn><mrow><mfenced><mn>2</mn><mn>3</mn><mn>4</mn></mfenced></mrow></mfenced></mrow>'
 
 
 def test_print_re_im():
     x = Symbol('x')
-    assert mpp.doprint(re(x)) == '<mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(im(x)) == '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(re(x + 1)) == '<mrow><mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow><mo>+</mo><mn>1</mn></mrow>'
-    assert mpp.doprint(im(x + 1)) == '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(re(x)) == \
+        '<mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(im(x)) == \
+        '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(re(x + 1)) == \
+        '<mrow><mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow><mo>+</mo><mn>1</mn></mrow>'
+    assert mpp.doprint(im(x + 1)) == \
+        '<mrow><mi mathvariant="fraktur">I</mi><mfenced><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_Abs():
     x = Symbol('x')
-    assert mpp.doprint(Abs(x)) == '<mrow><mfenced close="|" open="|"><mi>x</mi></mfenced></mrow>'
-    assert mpp.doprint(Abs(x + 1)) == '<mrow><mfenced close="|" open="|"><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced></mrow>'
+    assert mpp.doprint(Abs(x)) == \
+        '<mrow><mfenced close="|" open="|"><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(Abs(x + 1)) == \
+        '<mrow><mfenced close="|" open="|"><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced></mrow>'
 
 
 def test_print_Determinant():
-    assert mpp.doprint(Determinant(Matrix([[1, 2], [3, 4]]))) == '<mrow><mfenced close="|" open="|"><mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced></mfenced></mrow>'
+    assert mpp.doprint(Determinant(Matrix([[1, 2], [3, 4]]))) == \
+        '<mrow><mfenced close="|" open="|"><mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced></mfenced></mrow>'
 
 
 def test_presentation_settings():
-    raises(TypeError, lambda: mathml(Symbol("x"), printer='presentation',method="garbage"))
+    raises(TypeError, lambda: mathml(Symbol("x"), printer='presentation',
+                                     method="garbage"))
+
 
 def test_toprettyxml_hooking():
-    # test that the patch doesn't influence the behavior of the standard library
+    # test that the patch doesn't influence the behavior of the standard
+    # library
     import xml.dom.minidom
     doc1 = xml.dom.minidom.parseString(
         "<apply><plus/><ci>x</ci><cn>1</cn></apply>")
-    doc2 =  xml.dom.minidom.parseString(
+    doc2 = xml.dom.minidom.parseString(
         "<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>")
     prettyxml_old1 = doc1.toprettyxml()
     prettyxml_old2 = doc2.toprettyxml()
@@ -976,152 +1014,212 @@ def test_print_domains():
     assert mpp.doprint(Complexes) == '<mi mathvariant="normal">&#x2102;</mi>'
     assert mpp.doprint(Integers) == '<mi mathvariant="normal">&#x2124;</mi>'
     assert mpp.doprint(Naturals) == '<mi mathvariant="normal">&#x2115;</mi>'
-    assert mpp.doprint(Naturals0) == '<msub><mi mathvariant="normal">&#x2115;</mi><mn>0</mn></msub>'
+    assert mpp.doprint(Naturals0) == \
+        '<msub><mi mathvariant="normal">&#x2115;</mi><mn>0</mn></msub>'
     assert mpp.doprint(Reals) == '<mi mathvariant="normal">&#x211D;</mi>'
 
 
 def test_print_expression_with_minus():
     assert mpp.doprint(-x) == '<mrow><mo>-</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(-x/y) == '<mrow><mo>-</mo><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow>'
-    assert mpp.doprint(-Rational(1,2)) == '<mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow>'
+    assert mpp.doprint(-x/y) == \
+        '<mrow><mo>-</mo><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow>'
+    assert mpp.doprint(-Rational(1, 2)) == \
+        '<mrow><mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac></mrow>'
 
 
 def test_print_AssocOp():
     from sympy.core.operations import AssocOp
+
     class TestAssocOp(AssocOp):
         identity = 0
 
     expr = TestAssocOp(1, 2)
-    mpp.doprint(expr) == '<mrow><mi>testassocop</mi><mn>2</mn><mn>1</mn></mrow>'
+    mpp.doprint(expr) == \
+        '<mrow><mi>testassocop</mi><mn>2</mn><mn>1</mn></mrow>'
 
 
 def test_print_basic():
     expr = Basic(1, 2)
-    assert mpp.doprint(expr) == '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
+    assert mpp.doprint(expr) == \
+        '<mrow><mi>basic</mi><mfenced><mn>1</mn><mn>2</mn></mfenced></mrow>'
     assert mp.doprint(expr) == '<basic><cn>1</cn><cn>2</cn></basic>'
 
 
 def test_mat_delim_print():
     expr = Matrix([[1, 2], [3, 4]])
-    assert mathml(expr, printer='presentation', mat_delim='[') == '<mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
-    assert mathml(expr, printer='presentation', mat_delim='(') == '<mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
-    assert mathml(expr, printer='presentation', mat_delim='') == '<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>'
+    assert mathml(expr, printer='presentation', mat_delim='[') == \
+        '<mfenced close="]" open="["><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
+    assert mathml(expr, printer='presentation', mat_delim='(') == \
+        '<mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>'
+    assert mathml(expr, printer='presentation', mat_delim='') == \
+        '<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>'
 
 
 def test_ln_notation_print():
     expr = log(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mathml(expr, printer='presentation', ln_notation=False) == '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
-    assert mathml(expr, printer='presentation', ln_notation=True) == '<mrow><mi>ln</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation', ln_notation=False) == \
+        '<mrow><mi>log</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation', ln_notation=True) == \
+        '<mrow><mi>ln</mi><mfenced><mi>x</mi></mfenced></mrow>'
 
 
 def test_mul_symbol_print():
     expr = x * y
-    assert mathml(expr, printer='presentation') == '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol=None) == '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='dot') == '<mrow><mi>x</mi><mo>&#xB7;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='ldot') == '<mrow><mi>x</mi><mo>&#x2024;</mo><mi>y</mi></mrow>'
-    assert mathml(expr, printer='presentation', mul_symbol='times') == '<mrow><mi>x</mi><mo>&#xD7;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol=None) == \
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='dot') == \
+        '<mrow><mi>x</mi><mo>&#xB7;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='ldot') == \
+        '<mrow><mi>x</mi><mo>&#x2024;</mo><mi>y</mi></mrow>'
+    assert mathml(expr, printer='presentation', mul_symbol='times') == \
+        '<mrow><mi>x</mi><mo>&#xD7;</mo><mi>y</mi></mrow>'
 
 
 def test_print_lerchphi():
-    assert mpp.doprint(lerchphi(1, 2, 3)) == '<mrow><mi>&#x3A6;</mi><mfenced><mn>1</mn><mn>2</mn><mn>3</mn></mfenced></mrow>'
+    assert mpp.doprint(lerchphi(1, 2, 3)) == \
+        '<mrow><mi>&#x3A6;</mi><mfenced><mn>1</mn><mn>2</mn><mn>3</mn></mfenced></mrow>'
 
 
 def test_print_polylog():
-    assert mp.doprint(polylog(x, y)) == '<apply><polylog/><ci>x</ci><ci>y</ci></apply>'
-    assert mpp.doprint(polylog(x, y)) == '<mrow><msub><mi>Li</mi><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
+    assert mp.doprint(polylog(x, y)) == \
+        '<apply><polylog/><ci>x</ci><ci>y</ci></apply>'
+    assert mpp.doprint(polylog(x, y)) == \
+        '<mrow><msub><mi>Li</mi><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
 
 
 def test_print_set_frozenset():
     f = frozenset({1, 5, 3})
-    assert mpp.doprint(f) == '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mn>5</mn></mfenced>'
+    assert mpp.doprint(f) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mn>5</mn></mfenced>'
     s = set({1, 2, 3})
-    assert mpp.doprint(s) == '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
+    assert mpp.doprint(s) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
 
 
 def test_print_FiniteSet():
     f1 = FiniteSet(x, 1, 3)
-    assert mpp.doprint(f1) == '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
+    assert mpp.doprint(f1) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
 
 
 def test_print_SetOp():
     f1 = FiniteSet(x, 1, 3)
     f2 = FiniteSet(y, 2, 4)
 
-    assert mpp.doprint(Union(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Intersection(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2229;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Complement(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(SymmetricDifference(f1, f2, evaluate=False)) == '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Union(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Intersection(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2229;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Complement(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(SymmetricDifference(f1, f2, evaluate=False)) == \
+    '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mn>2</mn><mn>4</mn><mi>y</mi></mfenced></mrow>'
 
 
 def test_print_logic():
-    assert mpp.doprint(And(x, y)) == '<mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Or(x, y)) == '<mrow><mi>x</mi><mo>&#x2228;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Xor(x, y)) == '<mrow><mi>x</mi><mo>&#x22BB;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Implies(x, y)) == '<mrow><mi>x</mi><mo>&#x21D2;</mo><mi>y</mi></mrow>'
-    assert mpp.doprint(Equivalent(x, y)) == '<mrow><mi>x</mi><mo>&#x21D4;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(And(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Or(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x2228;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Xor(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x22BB;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Implies(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x21D2;</mo><mi>y</mi></mrow>'
+    assert mpp.doprint(Equivalent(x, y)) == \
+        '<mrow><mi>x</mi><mo>&#x21D4;</mo><mi>y</mi></mrow>'
 
-    assert mpp.doprint(And(Eq(x, y), x > 4)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
-    assert mpp.doprint(And(Eq(x, 3), y < 3, x > y + 1)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2227;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow>'
-    assert mpp.doprint(Or(Eq(x, y), x > 4)) == '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2228;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
-    assert mpp.doprint(And(Eq(x, 3), Or(y < 3, x > y + 1))) == '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mfenced><mrow><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2228;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow></mfenced></mrow>'
+    assert mpp.doprint(And(Eq(x, y), x > 4)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
+    assert mpp.doprint(And(Eq(x, 3), y < 3, x > y + 1)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2227;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow>'
+    assert mpp.doprint(Or(Eq(x, y), x > 4)) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mi>y</mi></mrow><mo>&#x2228;</mo><mrow><mi>x</mi><mo>></mo><mn>4</mn></mrow></mrow>'
+    assert mpp.doprint(And(Eq(x, 3), Or(y < 3, x > y + 1))) == \
+        '<mrow><mrow><mi>x</mi><mo>=</mo><mn>3</mn></mrow><mo>&#x2227;</mo><mfenced><mrow><mrow><mi>x</mi><mo>></mo><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></mrow><mo>&#x2228;</mo><mrow><mi>y</mi><mo><</mo><mn>3</mn></mrow></mrow></mfenced></mrow>'
 
     assert mpp.doprint(Not(x)) == '<mrow><mo>&#xAC;</mo><mi>x</mi></mrow>'
-    assert mpp.doprint(Not(And(x, y))) == '<mrow><mo>&#xAC;</mo><mfenced><mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow></mfenced></mrow>'
+    assert mpp.doprint(Not(And(x, y))) == \
+        '<mrow><mo>&#xAC;</mo><mfenced><mrow><mi>x</mi><mo>&#x2227;</mo><mi>y</mi></mrow></mfenced></mrow>'
+
 
 def test_root_notation_print():
-    assert mathml(x**(S(1)/3), printer='presentation') == '<mroot><mi>x</mi><mn>3</mn></mroot>'
-    assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) == '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
-    assert mathml(x**(S(1)/3), printer='content') == '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
-    assert mathml(x**(S(1)/3), printer='content', root_notation=False) == '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
-    assert mathml(x**(-S(1)/3), printer='presentation') == '<mfrac><mn>1</mn><mroot><mi>x</mi><mn>3</mn></mroot></mfrac>'
-    assert mathml(x**(-S(1)/3), printer='presentation', root_notation=False) == '<mfrac><mn>1</mn><msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup></mfrac>'
+    assert mathml(x**(S(1)/3), printer='presentation') == \
+        '<mroot><mi>x</mi><mn>3</mn></mroot>'
+    assert mathml(x**(S(1)/3), printer='presentation', root_notation=False) ==\
+        '<msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup>'
+    assert mathml(x**(S(1)/3), printer='content') == \
+        '<apply><root/><degree><ci>3</ci></degree><ci>x</ci></apply>'
+    assert mathml(x**(S(1)/3), printer='content', root_notation=False) == \
+        '<apply><power/><ci>x</ci><apply><divide/><cn>1</cn><cn>3</cn></apply></apply>'
+    assert mathml(x**(-S(1)/3), printer='presentation') == \
+        '<mfrac><mn>1</mn><mroot><mi>x</mi><mn>3</mn></mroot></mfrac>'
+    assert mathml(x**(-S(1)/3), printer='presentation', root_notation=False) \
+        == '<mfrac><mn>1</mn><msup><mi>x</mi><mfrac><mn>1</mn><mn>3</mn></mfrac></msup></mfrac>'
 
 
 def test_fold_frac_powers_print():
     expr = x ** Rational(5, 2)
-    assert mathml(expr, printer='presentation') == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
-    assert mathml(expr, printer='presentation', fold_frac_powers=True) == '<msup><mi>x</mi><mfrac bevelled="true"><mn>5</mn><mn>2</mn></mfrac></msup>'
-    assert mathml(expr, printer='presentation', fold_frac_powers=False) == '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation') == \
+        '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=True) == \
+        '<msup><mi>x</mi><mfrac bevelled="true"><mn>5</mn><mn>2</mn></mfrac></msup>'
+    assert mathml(expr, printer='presentation', fold_frac_powers=False) == \
+        '<msup><mi>x</mi><mfrac><mn>5</mn><mn>2</mn></mfrac></msup>'
 
 
 def test_fold_short_frac_print():
     expr = Rational(2, 5)
-    assert mathml(expr, printer='presentation') == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
-    assert mathml(expr, printer='presentation', fold_short_frac=True) == '<mfrac bevelled="true"><mn>2</mn><mn>5</mn></mfrac>'
-    assert mathml(expr, printer='presentation', fold_short_frac=False) == '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=True) == \
+        '<mfrac bevelled="true"><mn>2</mn><mn>5</mn></mfrac>'
+    assert mathml(expr, printer='presentation', fold_short_frac=False) == \
+        '<mfrac><mn>2</mn><mn>5</mn></mfrac>'
 
 
 def test_print_factorials():
     assert mpp.doprint(factorial(x)) == '<mrow><mi>x</mi><mo>!</mo></mrow>'
-    assert mpp.doprint(factorial(x + 1)) == '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!</mo></mrow>'
+    assert mpp.doprint(factorial(x + 1)) == \
+        '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!</mo></mrow>'
     assert mpp.doprint(factorial2(x)) == '<mrow><mi>x</mi><mo>!!</mo></mrow>'
-    assert mpp.doprint(factorial2(x + 1)) == '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!!</mo></mrow>'
-    assert mpp.doprint(binomial(x, y)) == '<mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced>'
-    assert mpp.doprint(binomial(4, x + y)) == '<mfenced><mfrac linethickness="0"><mn>4</mn><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mfrac></mfenced>'
+    assert mpp.doprint(factorial2(x + 1)) == \
+        '<mrow><mfenced><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfenced><mo>!!</mo></mrow>'
+    assert mpp.doprint(binomial(x, y)) == \
+        '<mfenced><mfrac linethickness="0"><mi>x</mi><mi>y</mi></mfrac></mfenced>'
+    assert mpp.doprint(binomial(4, x + y)) == \
+        '<mfenced><mfrac linethickness="0"><mn>4</mn><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mfrac></mfenced>'
 
 
 def test_print_floor():
     expr = floor(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mfenced close="&#8971;" open="&#8970;"><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mfenced close="&#8971;" open="&#8970;"><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_ceiling():
     expr = ceiling(x)
-    assert mathml(expr, printer='presentation') == '<mrow><mfenced close="&#8969;" open="&#8968;"><mi>x</mi></mfenced></mrow>'
+    assert mathml(expr, printer='presentation') == \
+        '<mrow><mfenced close="&#8969;" open="&#8968;"><mi>x</mi></mfenced></mrow>'
 
 
 def test_print_Lambda():
     expr = Lambda(x, x+1)
-    assert mathml(expr, printer='presentation') == '<mfenced><mrow><mi>x</mi><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mrow></mfenced>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfenced><mrow><mi>x</mi><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mrow></mfenced>'
     expr = Lambda((x, y), x + y)
-    assert mathml(expr, printer='presentation') == '<mfenced><mrow><mrow><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mrow></mfenced>'
+    assert mathml(expr, printer='presentation') == \
+        '<mfenced><mrow><mrow><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow><mo>&#x21A6;</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></mrow></mfenced>'
 
 
 def test_print_conjugate():
-    assert mpp.doprint(conjugate(x)) == '<menclose notation="top"><mi>x</mi></menclose>'
-    assert mpp.doprint(conjugate(x + 1)) == '<mrow><menclose notation="top"><mi>x</mi></menclose><mo>+</mo><mn>1</mn></mrow>'
+    assert mpp.doprint(conjugate(x)) == \
+        '<menclose notation="top"><mi>x</mi></menclose>'
+    assert mpp.doprint(conjugate(x + 1)) == \
+        '<mrow><menclose notation="top"><mi>x</mi></menclose><mo>+</mo><mn>1</mn></mrow>'
 
 
 def test_mathml_builtins():
@@ -1133,33 +1231,48 @@ def test_mathml_builtins():
 def test_mathml_Range():
     assert mpp.doprint(Range(1, 51)) == \
         '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mi>&#8230;</mi><mn>50</mn></mfenced>'
-    assert mpp.doprint(Range(1, 4)) == '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
-    assert mpp.doprint(Range(0, 3, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mn>2</mn></mfenced>'
-    assert mpp.doprint(Range(0, 30, 1)) == '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mi>&#8230;</mi><mn>29</mn></mfenced>'
-    assert mpp.doprint(Range(30, 1, -1)) == '<mfenced close="}" open="{"><mn>30</mn><mn>29</mn><mi>&#8230;</mi><mn>2</mn></mfenced>'
-    assert mpp.doprint(Range(0, oo, 2)) == '<mfenced close="}" open="{"><mn>0</mn><mn>2</mn><mi>&#8230;</mi><mi>&#x221E;</mi></mfenced>'
-    assert mpp.doprint(Range(oo, -2, -2)) == '<mfenced close="}" open="{"><mi>&#x221E;</mi><mi>&#8230;</mi><mn>2</mn><mn>0</mn></mfenced>'
-    assert mpp.doprint(Range(-2, -oo, -1)) == '<mfenced close="}" open="{"><mn>-2</mn><mn>-3</mn><mi>&#8230;</mi><mrow><mo>-</mo><mi>&#x221E;</mi></mrow></mfenced>'
+    assert mpp.doprint(Range(1, 4)) == \
+        '<mfenced close="}" open="{"><mn>1</mn><mn>2</mn><mn>3</mn></mfenced>'
+    assert mpp.doprint(Range(0, 3, 1)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, 30, 1)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>1</mn><mi>&#8230;</mi><mn>29</mn></mfenced>'
+    assert mpp.doprint(Range(30, 1, -1)) == \
+        '<mfenced close="}" open="{"><mn>30</mn><mn>29</mn><mi>&#8230;</mi><mn>2</mn></mfenced>'
+    assert mpp.doprint(Range(0, oo, 2)) == \
+        '<mfenced close="}" open="{"><mn>0</mn><mn>2</mn><mi>&#8230;</mi><mi>&#x221E;</mi></mfenced>'
+    assert mpp.doprint(Range(oo, -2, -2)) == \
+        '<mfenced close="}" open="{"><mi>&#x221E;</mi><mi>&#8230;</mi><mn>2</mn><mn>0</mn></mfenced>'
+    assert mpp.doprint(Range(-2, -oo, -1)) == \
+        '<mfenced close="}" open="{"><mn>-2</mn><mn>-3</mn><mi>&#8230;</mi><mrow><mo>-</mo><mi>&#x221E;</mi></mrow></mfenced>'
 
 
 def test_print_exp():
-    assert mpp.doprint(exp(x)) == '<msup><mi>&ExponentialE;</mi><mi>x</mi></msup>'
-    assert mpp.doprint(exp(1) + exp(2)) == '<mrow><mi>&ExponentialE;</mi><mo>+</mo><msup><mi>&ExponentialE;</mi><mn>2</mn></msup></mrow>'
+    assert mpp.doprint(exp(x)) == \
+        '<msup><mi>&ExponentialE;</mi><mi>x</mi></msup>'
+    assert mpp.doprint(exp(1) + exp(2)) == \
+        '<mrow><mi>&ExponentialE;</mi><mo>+</mo><msup><mi>&ExponentialE;</mi><mn>2</mn></msup></mrow>'
 
 
 def test_print_MinMax():
-    assert mpp.doprint(Min(x, y)) == '<mrow><mo>min</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Min(x, 2, x**3)) == '<mrow><mo>min</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
-    assert mpp.doprint(Max(x, y)) == '<mrow><mo>max</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Max(x, 2, x**3)) == '<mrow><mo>max</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
+    assert mpp.doprint(Min(x, y)) == \
+        '<mrow><mo>min</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Min(x, 2, x**3)) == \
+        '<mrow><mo>min</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
+    assert mpp.doprint(Max(x, y)) == \
+        '<mrow><mo>max</mo><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mpp.doprint(Max(x, 2, x**3)) == \
+        '<mrow><mo>max</mo><mfenced><mn>2</mn><mi>x</mi><msup><mi>x</mi><mn>3</mn></msup></mfenced></mrow>'
 
 
 def test_print_matrix_symbol():
     A = MatrixSymbol('A', 1, 2)
     assert mpp.doprint(A) == '<mi>A</mi>'
     assert mp.doprint(A) == '<ci>A</ci>'
-    assert mathml(A, printer='presentation', mat_symbol_style="bold" )== '<mi mathvariant="bold">A</mi>'
-    assert mathml(A, mat_symbol_style="bold" )== '<ci>A</ci>' # No effect in content printer
+    assert mathml(A, printer='presentation', mat_symbol_style="bold") == \
+        '<mi mathvariant="bold">A</mi>'
+    # No effect in content printer
+    assert mathml(A, mat_symbol_style="bold") == '<ci>A</ci>'
 
 
 def test_print_random_symbol():
@@ -1169,14 +1282,20 @@ def test_print_random_symbol():
 
 
 def test_print_IndexedBase():
-    a,b,c,d,e = symbols('a b c d e')
-    assert mathml(IndexedBase(a)[b],printer='presentation') == '<msub><mi>a</mi><mi>b</mi></msub>'
-    assert mathml(IndexedBase(a)[b,c,d],printer = 'presentation') == '<msub><mi>a</mi><mfenced><mi>b</mi><mi>c</mi><mi>d</mi></mfenced></msub>'
-    assert mathml(IndexedBase(a)[b]*IndexedBase(c)[d]*IndexedBase(e),printer = 'presentation') == '<mrow><msub><mi>a</mi><mi>b</mi></msub><mo>&InvisibleTimes;</mo><msub><mi>c</mi><mi>d</mi></msub><mo>&InvisibleTimes;</mo><mi>e</mi></mrow>'
+    a, b, c, d, e = symbols('a b c d e')
+    assert mathml(IndexedBase(a)[b], printer='presentation') == \
+        '<msub><mi>a</mi><mi>b</mi></msub>'
+    assert mathml(IndexedBase(a)[b, c, d], printer='presentation') == \
+        '<msub><mi>a</mi><mfenced><mi>b</mi><mi>c</mi><mi>d</mi></mfenced></msub>'
+    assert mathml(IndexedBase(a)[b]*IndexedBase(c)[d]*IndexedBase(e),
+                  printer='presentation') == \
+                  '<mrow><msub><mi>a</mi><mi>b</mi></msub><mo>&InvisibleTimes;</mo><msub><mi>c</mi><mi>d</mi></msub><mo>&InvisibleTimes;</mo><mi>e</mi></mrow>'
 
 
 def test_print_Indexed():
-    a,b,c = symbols('a b c')
-    assert mathml(IndexedBase(a),printer = 'presentation') == '<mi>a</mi>'
-    assert mathml(IndexedBase(a/b),printer = 'presentation') == '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
-    assert mathml(IndexedBase((a,b)),printer = 'presentation') == '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'
+    a, b, c = symbols('a b c')
+    assert mathml(IndexedBase(a), printer='presentation') == '<mi>a</mi>'
+    assert mathml(IndexedBase(a/b), printer='presentation') == \
+        '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
+    assert mathml(IndexedBase((a, b)), printer='presentation') == \
+        '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Just found the PEP8-warnings in my editor so went ahead on two files. Still some lines are more than 80 characters, but that requires more work. Huge diffs as there were many things. Most relates to breaking long tests after the == though.

Also fixed an issue in the MathML presentation printer where x**-1 was printed as 1/(x^1). Now it is 1/x.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
