### PR TITLE
Enabled a few tests in Python 3

### DIFF
--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -2,6 +2,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, erf, tan, asin, asinh, acos, atan, Function, Derivative, diff, simplify, \
     LambertW, Eq, Ne, Piecewise, Symbol, Add, ratsimp, Integral, Sum, \
     besselj, besselk, bessely, jn, tanh
+from sympy.core.compatibility import PY3
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
 from sympy.integrals.integrals import integrate
@@ -244,12 +245,15 @@ def test_pmint_logexp():
 
     assert ratsimp(heurisch(f, x)) == g
 
-@XFAIL  # there's a hash dependent failure lurking here
-def test_pmint_erf():
-    f = exp(-x**2)*erf(x)/(erf(x)**3 - erf(x)**2 - erf(x) + 1)
-    g = sqrt(pi)*log(erf(x) - 1)/8 - sqrt(pi)*log(erf(x) + 1)/8 - sqrt(pi)/(4*erf(x) - 4)
 
-    assert ratsimp(heurisch(f, x)) == g
+#@XFAIL  # there's a hash dependent failure lurking here
+# Seems to work on Python 3, but keeping the comment above just in case
+def test_pmint_erf():
+    if PY3:
+        f = exp(-x**2)*erf(x)/(erf(x)**3 - erf(x)**2 - erf(x) + 1)
+        g = sqrt(pi)*log(erf(x) - 1)/8 - sqrt(pi)*log(erf(x) + 1)/8 - sqrt(pi)/(4*erf(x) - 4)
+
+        assert ratsimp(heurisch(f, x)) == g
 
 def test_pmint_LambertW():
     f = LambertW(x)

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -246,14 +246,17 @@ def test_pmint_logexp():
     assert ratsimp(heurisch(f, x)) == g
 
 
-#@XFAIL  # there's a hash dependent failure lurking here
+# @XFAIL  # there's a hash dependent failure lurking here
 # Seems to work on Python 3, but keeping the comment above just in case
 def test_pmint_erf():
-    if PY3:
-        f = exp(-x**2)*erf(x)/(erf(x)**3 - erf(x)**2 - erf(x) + 1)
-        g = sqrt(pi)*log(erf(x) - 1)/8 - sqrt(pi)*log(erf(x) + 1)/8 - sqrt(pi)/(4*erf(x) - 4)
+    f = exp(-x**2)*erf(x)/(erf(x)**3 - erf(x)**2 - erf(x) + 1)
+    g = sqrt(pi)*log(erf(x) - 1)/8 - sqrt(pi)*log(erf(x) + 1)/8 - sqrt(pi)/(4*erf(x) - 4)
 
-        assert ratsimp(heurisch(f, x)) == g
+    assert ratsimp(heurisch(f, x)) == g
+
+
+if not PY3:
+    test_pmint_erf = XFAIL(test_pmint_erf)
 
 def test_pmint_LambertW():
     f = LambertW(x)

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -1,5 +1,6 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from sympy import Poly, S, symbols, oo, I
+from sympy.core.compatibility import PY3
 from sympy.integrals.risch import (DifferentialExtension,
     NonElementaryIntegralException)
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
@@ -83,15 +84,16 @@ def test_special_denom():
         (Poly(1, t0), Poly(I*k, t0), Poly(t0, t0), Poly(1, t0))
 
 
-@XFAIL
+# @XFAIL
+# Probably only fails in Python 2.7
 def test_bound_degree_fail():
-    # Probably only fails in Python 2.7
     # Primitive
-    DE = DifferentialExtension(extension={'D': [Poly(1, x),
-        Poly(t0/x**2, t0), Poly(1/x, t)]})
-    assert bound_degree(Poly(t**2, t), Poly(-(1/x**2*t**2 + 1/x), t),
-        Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/2*x*t**2 + x*t,
-        t), DE) == 3
+    if PY3:
+        DE = DifferentialExtension(extension={'D': [Poly(1, x),
+            Poly(t0/x**2, t0), Poly(1/x, t)]})
+        assert bound_degree(Poly(t**2, t), Poly(-(1/x**2*t**2 + 1/x), t),
+            Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/2*x*t**2 + x*t,
+            t), DE) == 3
 
 
 def test_bound_degree():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -88,12 +88,15 @@ def test_special_denom():
 # Probably only fails in Python 2.7
 def test_bound_degree_fail():
     # Primitive
-    if PY3:
-        DE = DifferentialExtension(extension={'D': [Poly(1, x),
-            Poly(t0/x**2, t0), Poly(1/x, t)]})
-        assert bound_degree(Poly(t**2, t), Poly(-(1/x**2*t**2 + 1/x), t),
-            Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/2*x*t**2 + x*t,
-            t), DE) == 3
+    DE = DifferentialExtension(extension={'D': [Poly(1, x),
+        Poly(t0/x**2, t0), Poly(1/x, t)]})
+    assert bound_degree(Poly(t**2, t), Poly(-(1/x**2*t**2 + 1/x), t),
+        Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/2*x*t**2 + x*t,
+        t), DE) == 3
+
+
+if not PY3:
+    test_bound_degree_fail = XFAIL(test_bound_degree_fail)
 
 
 def test_bound_degree():

--- a/sympy/physics/quantum/tests/test_identitysearch.py
+++ b/sympy/physics/quantum/tests/test_identitysearch.py
@@ -1,5 +1,6 @@
 from sympy.external import import_module
 from sympy import Mul, Integer
+from sympy.core.compatibility import PY3
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import (X, Y, Z, H, CNOT,
         IdentityGate, CGate, PhaseGate, TGate)
@@ -483,10 +484,12 @@ def test_bfs_identity_search():
     assert bfs_identity_search(gate_list, 1, max_depth=4) == id_set
 
 
-@XFAIL
+# @XFAIL
+# Seems to fail on Python 2.7, but not 3.X
 def test_bfs_identity_search_xfail():
-    s = PhaseGate(0)
-    t = TGate(0)
-    gate_list = [Dagger(s), t]
-    id_set = {GateIdentity(Dagger(s), t, t)}
-    assert bfs_identity_search(gate_list, 1, max_depth=3) == id_set
+    if PY3:
+        s = PhaseGate(0)
+        t = TGate(0)
+        gate_list = [Dagger(s), t]
+        id_set = {GateIdentity(Dagger(s), t, t)}
+        assert bfs_identity_search(gate_list, 1, max_depth=3) == id_set

--- a/sympy/physics/quantum/tests/test_identitysearch.py
+++ b/sympy/physics/quantum/tests/test_identitysearch.py
@@ -485,9 +485,12 @@ def test_bfs_identity_search():
 
 
 # @XFAIL
-# Seems to fail on Python 2.7, but not 3.X
+# Seems to fail on Python 2.7, but not 3.X, unless scipy is installed
 def test_bfs_identity_search_xfail():
     if PY3:
+        scipy = import_module('scipy', __import__kwargs={'fromlist': ['sparse']})
+        if scipy:
+            skip("scipy installed.")
         s = PhaseGate(0)
         t = TGate(0)
         gate_list = [Dagger(s), t]

--- a/sympy/physics/quantum/tests/test_identitysearch.py
+++ b/sympy/physics/quantum/tests/test_identitysearch.py
@@ -487,12 +487,15 @@ def test_bfs_identity_search():
 # @XFAIL
 # Seems to fail on Python 2.7, but not 3.X, unless scipy is installed
 def test_bfs_identity_search_xfail():
-    if PY3:
-        scipy = import_module('scipy', __import__kwargs={'fromlist': ['sparse']})
-        if scipy:
-            skip("scipy installed.")
-        s = PhaseGate(0)
-        t = TGate(0)
-        gate_list = [Dagger(s), t]
-        id_set = {GateIdentity(Dagger(s), t, t)}
-        assert bfs_identity_search(gate_list, 1, max_depth=3) == id_set
+    scipy = import_module('scipy', __import__kwargs={'fromlist': ['sparse']})
+    if scipy:
+        skip("scipy installed.")
+    s = PhaseGate(0)
+    t = TGate(0)
+    gate_list = [Dagger(s), t]
+    id_set = {GateIdentity(Dagger(s), t, t)}
+    assert bfs_identity_search(gate_list, 1, max_depth=3) == id_set
+
+
+if not PY3:
+    test_bfs_identity_search_xfail = XFAIL(test_bfs_identity_search_xfail)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -56,7 +56,7 @@ from sympy import (
     exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
 
 from sympy.core.basic import _aresame
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, PY3
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.simplify import simplify
@@ -3209,12 +3209,14 @@ def test_keep_coeff():
     assert _keep_coeff(x + 1, S(2)) == u
 
 
-@XFAIL
+# @XFAIL
+# Seems to pass on Python 3.X, but not on Python 2.7
 def test_poly_matching_consistency():
     # Test for this issue:
     # https://github.com/sympy/sympy/issues/5514
-    assert I * Poly(x, x) == Poly(I*x, x)
-    assert Poly(x, x) * I == Poly(I*x, x)
+    if PY3:
+        assert I * Poly(x, x) == Poly(I*x, x)
+        assert Poly(x, x) * I == Poly(I*x, x)
 
 
 @XFAIL

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3214,9 +3214,12 @@ def test_keep_coeff():
 def test_poly_matching_consistency():
     # Test for this issue:
     # https://github.com/sympy/sympy/issues/5514
-    if PY3:
-        assert I * Poly(x, x) == Poly(I*x, x)
-        assert Poly(x, x) * I == Poly(I*x, x)
+    assert I * Poly(x, x) == Poly(I*x, x)
+    assert Poly(x, x) * I == Poly(I*x, x)
+
+
+if not PY3:
+    test_poly_matching_consistency = XFAIL(test_poly_matching_consistency)
 
 
 @XFAIL

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -411,7 +411,6 @@ def test_fps__symbolic():
          O(x**(n - 6), (x, oo)))
 
 
-@slow
 def test_fps__slow():
     f = x*exp(x)*sin(2*x)  # TODO: rsolve needs improvement
     assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -92,7 +92,6 @@ def test_multiple_normal():
     assert variance(X, Eq(X + Y, 0)) == S.Half
 
 
-@slow
 def test_symbolic():
     mu1, mu2 = symbols('mu1 mu2', real=True, finite=True)
     s1, s2 = symbols('sigma1 sigma2', real=True, finite=True, positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Three XFAIL tests seems to consistently pass in Python 3, so I removed XFAIL and used PY3 instead.

Two slow tests are not so slow anymore.

`test_order_reducible` in `test_ode.py` takes about 20 seconds, but since it consists of several smaller tests and none is very time consuming when running it manually I decided to keep it as is. There may be other slow tests where the same thing happens, so splitting it into several smaller ones does not lead to actually slow tests. This may be something to revisit when it comes to marking slow tests. (The fewer the better from a coverage perspective.)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
