### PR TITLE
Workaround for __subclasses__ in core module

### DIFF
--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -102,3 +102,8 @@ class BasicMeta(type):
         if cls.__cmp__(other) == 1:
             return True
         return False
+
+    # XXX Workaround for IPython errors when calling __subclasses__
+    @classmethod
+    def __subclasses__(cls):
+        return type.__subclasses__(cls)

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -74,3 +74,15 @@ def test_ordered():
     assert list(ordered(l, warn=True)) == [[1], [1], [2]]
     raises(ValueError, lambda: list(ordered(['a', 'ab'], keys=[lambda x: x[0]],
         default=False, warn=True)))
+
+def test_subclasses():
+    from sympy.core.assumptions import ManagedProperties
+    from sympy.core.core import BasicMeta
+    from sympy.core.function import FunctionClass, UndefinedFunction
+    from sympy.core.singleton import Singleton
+
+    BasicMeta.__subclasses__()
+    FunctionClass.__subclasses__()
+    ManagedProperties.__subclasses__()
+    Singleton.__subclasses__()
+    UndefinedFunction.__subclasses__()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16227

#### Brief description of what is fixed or changed

I made some workaround. But I'm not sure if it is a good patch.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed IPython `%pinfo` magic throwing error with `UndefinedFunction`, `FunctionClass`, `ManagedProperties`, `BasicMeta`, `Singleton`
<!-- END RELEASE NOTES -->
