### PR TITLE
Matrices : Faster Singular Values Computation

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1739,8 +1739,8 @@ class MatrixEigen(MatrixSubspaces):
 
         # Pad with zeros if singular values are computed in reverse way,
         # to give consistent format.
-        if len(vals) < self.rows:
-            vals += [S.Zero] * (self.rows - len(vals))
+        if len(vals) < self.cols:
+            vals += [S.Zero] * (self.cols - len(vals))
 
         # sort them in descending order
         vals.sort(reverse=True, key=default_sort_key)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1727,13 +1727,21 @@ class MatrixEigen(MatrixSubspaces):
         condition_number
         """
         mat = self
-        # Compute eigenvalues of A.H A
-        valmultpairs = (mat.H * mat).eigenvals()
+        if self.rows >= self.cols:
+            valmultpairs = (mat.H * mat).eigenvals()
+        else:
+            valmultpairs = (mat * mat.H).eigenvals()
 
         # Expands result from eigenvals into a simple list
         vals = []
         for k, v in valmultpairs.items():
             vals += [sqrt(k)] * v  # dangerous! same k in several spots!
+
+        # Pad with zeros if singular values are computed in reverse way,
+        # to give consistent format.
+        if len(vals) < self.rows:
+            vals += [S.Zero] * (self.rows - len(vals))
+
         # sort them in descending order
         vals.sort(reverse=True, key=default_sort_key)
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1364,6 +1364,17 @@ def test_singular_values():
     vals = [sv.trigsimp() for sv in A.singular_values()]
     assert vals == [S(1), S(1)]
 
+    A = EigenOnlyMatrix([
+        [2, 4],
+        [1, 3],
+        [0, 0],
+        [0, 0]
+        ])
+    assert A.singular_values() == \
+        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0]
+    assert A.T.singular_values() == \
+        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221))]
+
 
 # CalculusOnlyMatrix tests
 @XFAIL

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1371,9 +1371,9 @@ def test_singular_values():
         [0, 0]
         ])
     assert A.singular_values() == \
-        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0]
-    assert A.T.singular_values() == \
         [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221))]
+    assert A.T.singular_values() == \
+        [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0]
 
 
 # CalculusOnlyMatrix tests


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Singular values can be calculated either by using `A.H * A` or `A * A.H`,
but for matrices with more columns than rows, the latter one is usually better way.

Because for the latter one, there will be `m * m * n` matrix multiplication operations and you have to compute eigenvalues of `m * m` matrix, than for using the prior one, which takes `n * n * m` for matmul operations and you have to compute eigenvalues of `n * n` matrix,
where `(m, n)` denotes `(rows, cols)`.

And then, zeros can be padded to the list to preserve the format, because singular values are always zero after the matrix rank.

The worst case for the prior implementation, would be a matrix with extremely small rows and large columns.

```python
from sympy import *
import cProfile

m = Matrix(2, 30, lambda i, j: 1/(i+j+1))
cProfile.run('m.singular_values()')
```

And it had improved from
`22936690 function calls (22188012 primitive calls) in 17.972 seconds`
to
`31223 function calls (30807 primitive calls) in 0.021 seconds`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Improved speed for `singular_values` for matrices 
<!-- END RELEASE NOTES -->
