### PR TITLE
Add Elementary and Polycyclic groups in Permutation groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3,8 +3,6 @@ from __future__ import print_function, division
 from random import randrange, choice
 from math import log
 
-from sympy import S
-from sympy.ntheory import isprime
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
     _af_rmul, _af_rmuln, _af_pow, Cycle)
@@ -1680,7 +1678,7 @@ class PermutationGroup(Basic):
                     return False
         return True
 
-    def is_elementary_group(self):
+    def is_elementary(self, p):
         """Return ``True`` if the group is elementary abelian. An elementary
         abelian group is a finite abelian group, where every nontrivial
         element has order `p`, where `p` is a prime.
@@ -1692,37 +1690,18 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([0, 2, 1])
         >>> G = PermutationGroup([a])
-        >>> G.is_elementary_group()
+        >>> G.is_elementary(2)
         True
         >>> a = Permutation([0, 2, 1, 3])
         >>> b = Permutation([3, 1, 2, 0])
         >>> G = PermutationGroup([a, b])
-        >>> G.is_elementary_group()
+        >>> G.is_elementary(2)
         True
+        >>> G.is_elementary(3)
+        False
 
         """
-        if not self.is_abelian:
-            return False
-        elif self.is_trivial:
-            return True
-        elif self.order == S.Infinity:
-            return False
-
-        else:
-            i = 0
-            while i < len(self.generators):
-                p = self.generators[i].order()
-                if p < 2:
-                    break
-                i = i + 1
-        if not isprime(p):
-            return False
-        else:
-            for i in range(len(self.generators)):
-                g = self.generators[i].order()
-                if g != p:
-                    return False
-            return True
+        return self.is_abelian and all(g.order() == p for g in self.generators)
 
     def is_alt_sym(self, eps=0.05, _random_prec=None):
         r"""Monte Carlo test for the symmetric/alternating group for degrees
@@ -2135,10 +2114,7 @@ class PermutationGroup(Basic):
         True
 
         """
-        if not (self.is_solvable):
-            return False
-        if self.order != S.Infinity:
-            return self.is_solvable
+        return self.is_solvable
 
     def is_transitive(self, strict=True):
         """Test if the group is transitive.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -155,7 +155,6 @@ class PermutationGroup(Basic):
         obj._is_trivial = None
         obj._transitivity_degree = None
         obj._max_div = None
-        obj._is_polycyclic = None
         obj._r = len(obj._generators)
         obj._degree = obj._generators[0].size
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division
 from random import randrange, choice
 from math import log
 
+from sympy import S
+from sympy.ntheory import isprime
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
     _af_rmul, _af_rmuln, _af_pow, Cycle)
@@ -1678,6 +1680,50 @@ class PermutationGroup(Basic):
                     return False
         return True
 
+    def is_elementary_group(self):
+        """Return ``True`` if the group is elementary abelian. An elementary
+        abelian group is a finite abelian group, where every nontrivial
+        element has order `p`, where `p` is a prime.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation
+        >>> from sympy.combinatorics.perm_groups import PermutationGroup
+        >>> a = Permutation([0, 2, 1])
+        >>> G = PermutationGroup([a])
+        >>> G.is_elementary_group()
+        True
+        >>> a = Permutation([0, 2, 1, 3])
+        >>> b = Permutation([3, 1, 2, 0])
+        >>> G = PermutationGroup([a, b])
+        >>> G.is_elementary_group()
+        True
+
+        """
+        if not self.is_abelian:
+            return False
+        elif self.is_trivial:
+            return True
+        elif self.order == S.Infinity:
+            return False
+
+        else:
+            i = 0
+            while i < len(self.generators):
+                p = self.generators[i].order()
+                if p < 2:
+                    break
+                i = i + 1
+        if not isprime(p):
+            return False
+        else:
+            for i in range(len(self.generators)):
+                g = self.generators[i].order()
+                if g != p:
+                    return False
+            return True
+
     def is_alt_sym(self, eps=0.05, _random_prec=None):
         r"""Monte Carlo test for the symmetric/alternating group for degrees
         >= 8.
@@ -2072,6 +2118,27 @@ class PermutationGroup(Basic):
         else:
             return False
         return all(G.contains(g, strict=strict) for g in gens)
+
+    def is_polycyclic(self):
+        """Return ``True`` if a group is polycyclic. A group is polycyclic if
+        it has a subnormal series with cyclic factors. For finite groups,
+        this is the same as if the group is solvable.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, PermutationGroup
+        >>> a = Permutation([0, 2, 1, 3])
+        >>> b = Permutation([2, 0, 1, 3])
+        >>> G = PermutationGroup([a, b])
+        >>> G.is_polycyclic()
+        True
+
+        """
+        if not (self.is_solvable):
+            return False
+        if self.order != S.Infinity:
+            return self.is_solvable
 
     def is_transitive(self, strict=True):
         """Test if the group is transitive.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -155,6 +155,7 @@ class PermutationGroup(Basic):
         obj._is_trivial = None
         obj._transitivity_degree = None
         obj._max_div = None
+        obj._is_polycyclic = None
         obj._r = len(obj._generators)
         obj._degree = obj._generators[0].size
 
@@ -2098,6 +2099,7 @@ class PermutationGroup(Basic):
             return False
         return all(G.contains(g, strict=strict) for g in gens)
 
+    @property
     def is_polycyclic(self):
         """Return ``True`` if a group is polycyclic. A group is polycyclic if
         it has a subnormal series with cyclic factors. For finite groups,
@@ -2110,7 +2112,7 @@ class PermutationGroup(Basic):
         >>> a = Permutation([0, 2, 1, 3])
         >>> b = Permutation([2, 0, 1, 3])
         >>> G = PermutationGroup([a, b])
-        >>> G.is_polycyclic()
+        >>> G.is_polycyclic
         True
 
         """

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -894,12 +894,12 @@ def test_polycyclic():
     a = Permutation([0, 1, 2])
     b = Permutation([2, 1, 0])
     G = PermutationGroup([a, b])
-    assert G.is_polycyclic() == True
+    assert G.is_polycyclic == True
 
     a = Permutation([1, 2, 3, 4, 0])
     b = Permutation([1, 0, 2, 3, 4])
     G = PermutationGroup([a, b])
-    G.is_polycyclic() == False
+    assert G.is_polycyclic == False
 
 
 def test_elementary():

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -914,3 +914,8 @@ def test_elementary():
     c = Permutation(4, 5, 6)
     G = PermutationGroup([a, b, c])
     assert G.is_elementary(2) == False
+
+    G = SymmetricGroup(4).sylow_subgroup(2)
+    assert G.is_elementary(2) == False
+    H = AlternatingGroup(4).sylow_subgroup(2)
+    assert H.is_elementary(2) == True

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -902,15 +902,15 @@ def test_polycyclic():
     G.is_polycyclic() == False
 
 
-def test_is_elementary_group():
+def test_elementary():
     a = Permutation([1, 5, 2, 0, 3, 6, 4])
     G = PermutationGroup([a])
-    assert G.is_elementary_group() == False
+    assert G.is_elementary(7) == False
 
     a = Permutation(0, 1)(2, 3)
     b = Permutation(0, 2)(3, 1)
     G = PermutationGroup([a, b])
-    assert G.is_elementary_group() == True
+    assert G.is_elementary(2) == True
     c = Permutation(4, 5, 6)
     G = PermutationGroup([a, b, c])
-    assert G.is_elementary_group() == False
+    assert G.is_elementary(2) == False

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -888,3 +888,29 @@ def test_presentation():
     c = Permutation(4,5)
     P = PermutationGroup(c, a, b)
     assert _strong_test(P)
+
+
+def test_polycyclic():
+    a = Permutation([0, 1, 2])
+    b = Permutation([2, 1, 0])
+    G = PermutationGroup([a, b])
+    assert G.is_polycyclic() == True
+
+    a = Permutation([1, 2, 3, 4, 0])
+    b = Permutation([1, 0, 2, 3, 4])
+    G = PermutationGroup([a, b])
+    G.is_polycyclic() == False
+
+
+def test_is_elementary_group():
+    a = Permutation([1, 5, 2, 0, 3, 6, 4])
+    G = PermutationGroup([a])
+    assert G.is_elementary_group() == False
+
+    a = Permutation(0, 1)(2, 3)
+    b = Permutation(0, 2)(3, 1)
+    G = PermutationGroup([a, b])
+    assert G.is_elementary_group() == True
+    c = Permutation(4, 5, 6)
+    G = PermutationGroup([a, b, c])
+    assert G.is_elementary_group() == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`Elementary` and `Polycyclic` groups has been implemented where `Elementary Group` is defined as a finite `abelian group`, where every `nontrivial` element has an order of `p`, where `p` is a `prime` and `Polycyclic Group` for a finite group is same as `solvable group`. One TODO task may be implementing polycyclic_group for infiite groups.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  combinatorics
   *  elementary and polycyclic groups has been added to perm_groups.py 
<!-- END RELEASE NOTES -->
