### PR TITLE
Added code for divergent summation series

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -200,6 +200,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 else:
                     return self.func(f, *self.limits[n:])
             f = newf
+        if !(self.fucntion.is_convergent):
+            return oo
 
         if hints.get('deep', True):
             # eval_sum could return partially unevaluated

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -189,7 +189,6 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if dif.is_integer and (dif < 0) == True:
                 a, b = b + 1, a - 1
                 f = -f
-
             newf = eval_sum(f, (i, a, b))
             if newf is None:
                 if f == self.function:
@@ -200,11 +199,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 else:
                     return self.func(f, *self.limits[n:])
             f = newf
-        if !(self.function.is_convergent) and self.function.is_positive:
-            return oo
-        elif !(self.function.is_convergent) and self.function.is_negative:
-            return -oo
-
+        
         if hints.get('deep', True):
             # eval_sum could return partially unevaluated
             # result with Piecewise.  In this case we won't
@@ -950,12 +945,19 @@ def eval_sum(f, limits):
         return eval_sum_direct(f, (i, a, b))
     if isinstance(f, Piecewise):
         return None
+    #If the number of terms is infinite and series is convergent
+    if !(f.is_convergent) and expr.subs(1,a+1)is_positive:
+        return oo
+    elif !(f.is_convergent) and expr.subs(i,a+1).is_negative:
+        return -oo
+
     # Try to do it symbolically. Even when the number of terms is known,
     # this can save time when b-a is big.
     # We should try to transform to partial fractions
-    value = eval_sum_symbolic(f.expand(), (i, a, b))
-    if value is not None:
-        return value
+    if b != oo:
+        value = eval_sum_symbolic(f.expand(), (i, a, b))
+        if value is not None:
+            return value
     # Do it directly
     if definite:
         return eval_sum_direct(f, (i, a, b))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -946,9 +946,9 @@ def eval_sum(f, limits):
     if isinstance(f, Piecewise):
         return None
     #If the number of terms is infinite and series is convergent
-    if !(f.is_convergent) and expr.subs(1,a+1)is_positive:
+    if not(f.is_convergent) and expr.subs(1,a+1)is_positive:
         return oo
-    elif !(f.is_convergent) and expr.subs(i,a+1).is_negative:
+    elif not(f.is_convergent) and expr.subs(i,a+1).is_negative:
         return -oo
 
     # Try to do it symbolically. Even when the number of terms is known,
@@ -957,7 +957,7 @@ def eval_sum(f, limits):
     if b != oo:
         value = eval_sum_symbolic(f.expand(), (i, a, b))
         if value is not None:
-            return value
+           return value
     # Do it directly
     if definite:
         return eval_sum_direct(f, (i, a, b))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -200,8 +200,12 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 else:
                     return self.func(f, *self.limits[n:])
             f = newf
-        if !(self.fucntion.is_convergent):
-            return oo
+        for n,limit in enumerate(self.limits):
+            i,a,b =limit
+            if !(self.function.is_convergent) and b.is_positive:
+                return oo
+            elif !(self.function.is_convergent) and b.is_negative:
+                return -oo
 
         if hints.get('deep', True):
             # eval_sum could return partially unevaluated

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -200,12 +200,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 else:
                     return self.func(f, *self.limits[n:])
             f = newf
-        for n,limit in enumerate(self.limits):
-            i,a,b =limit
-            if !(self.function.is_convergent) and b.is_positive:
-                return oo
-            elif !(self.function.is_convergent) and b.is_negative:
-                return -oo
+        if !(self.function.is_convergent) and self.function.is_positive:
+            return oo
+        elif !(self.function.is_convergent) and self.function.is_negative:
+            return -oo
 
         if hints.get('deep', True):
             # eval_sum could return partially unevaluated

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1089,3 +1089,6 @@ def test_Sum_dummy_eq():
 
 def test_issue_15852():
     assert summation(x**y*y, (y, -oo, oo)).doit() == Sum(x**y*y, (y, -oo, oo))
+def test_issue_16250():
+    assert  Sum(sqrt(x), (x,1,oo)).doit() == oo
+    assert Sum(-sqrt(n), (n, 1, oo)) == -oo

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1090,5 +1090,6 @@ def test_Sum_dummy_eq():
 def test_issue_15852():
     assert summation(x**y*y, (y, -oo, oo)).doit() == Sum(x**y*y, (y, -oo, oo))
 def test_issue_16250():
-    assert  Sum(sqrt(x), (x,1,oo)).doit() == oo
-    assert Sum(-sqrt(n), (n, 1, oo)) == -oo
+    assert Sum(sqrt(x), (x,1,oo)).doit() == oo
+    assert Sum(-sqrt(x), (x, 1, oo)) == -oo
+    assert Sum(x**2.0, (x, 1, oo)) == oo


### PR DESCRIPTION
Sum(sqrt(n), (n, 1, oo)) didn't calculate or simplified previously.It gave only its corresponding symbolic representation.As discussed in the issue thread,positive divergent series should return oo. Fixed in line 203-204.
Fixes #14579

<!-- BEGIN RELEASE NOTES -->
* series 
     * added check for positive divergent series in doit() of summation.py
<!-- END RELEASE NOTES -->
