### PR TITLE
misc: add strlines

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -7,7 +7,8 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from sympy.core.compatibility import get_function_name, range, as_int
+from sympy.core.compatibility import (get_function_name, range, as_int,
+    string_types)
 
 
 
@@ -24,13 +25,71 @@ def filldedent(s, w=70):
 
     Empty line stripping serves to deal with docstrings like this one that
     start with a newline after the initial triple quote, inserting an empty
-    line at the beginning of the string."""
+    line at the beginning of the string.
+
+    See Also
+    ========
+    strlines, rawlines
+    """
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w)
+
+
+def strlines(s, c=64, short=False):
+    """Return a cut-and-pastable string that, when printed, is
+    equivalent to the input.  The lines will be surrounded by
+    parentheses and no line will be longer than c (default 64)
+    characters. If the line contains newlines characters, the
+    `rawlines` result will be returned.  If ``short`` is True
+    (default is False) then if there is one line it will be
+    returned without bounding parentheses.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.misc import strlines
+    >>> q = 'this is a long string that should be broken into shorter lines'
+    >>> print(strlines(q, 40))
+    (
+    'this is a long string that should be b'
+    'roken into shorter lines'
+    )
+    >>> q == (
+    ... 'this is a long string that should be b'
+    ... 'roken into shorter lines'
+    ... )
+    True
+
+    See Also
+    ========
+    filldedent, rawlines
+    """
+    if type(s) not in string_types:
+        raise ValueError('expecting string input')
+    if '\n' in s:
+        return rawlines(s)
+    q = '"' if repr(s).startswith('"') else "'"
+    q = (q,)*2
+    if '\\' in s:  # use r-string
+        m = '(\nr%s%%s%s\n)' % q
+        j = '%s\nr%s' % q
+        c -= 3
+    else:
+        m = '(\n%s%%s%s\n)' % q
+        j = '%s\n%s' % q
+        c -= 2
+    out = []
+    while s:
+        out.append(s[:c])
+        s=s[c:]
+    if short and len(out) == 1:
+        return (m % out[0]).splitlines()[1]  # strip bounding (\n...\n)
+    return m % j.join(out)
 
 
 def rawlines(s):
     """Return a cut-and-pastable string that, when printed, is equivalent
-    to the input. The string returned is formatted so it can be indented
+    to the input. Use this when there is more than one line in the
+    string. The string returned is formatted so it can be indented
     nicely within tests; in some cases it is wrapped in the dedent
     function which has to be imported from textwrap.
 
@@ -82,22 +141,26 @@ def rawlines(s):
         'that\\n'
         '    '
     )
+
+    See Also
+    ========
+    filldedent, strlines
     """
     lines = s.split('\n')
     if len(lines) == 1:
         return repr(lines[0])
     triple = ["'''" in s, '"""' in s]
     if any(li.endswith(' ') for li in lines) or '\\' in s or all(triple):
-        rv = ["("]
+        rv = []
         # add on the newlines
         trailing = s.endswith('\n')
         last = len(lines) - 1
         for i, li in enumerate(lines):
             if i != last or trailing:
-                rv.append(repr(li)[:-1] + '\\n\'')
+                rv.append(repr(li + '\n'))
             else:
                 rv.append(repr(li))
-        return '\n    '.join(rv) + '\n)'
+        return '(\n    %s\n)' % '\n    '.join(rv)
     else:
         rv = '\n    '.join(lines)
         if triple[0]:

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -1,5 +1,6 @@
+from textwrap import dedent
 from sympy.core.compatibility import range, unichr
-from sympy.utilities.misc import translate, replace, ordinal, rawlines
+from sympy.utilities.misc import translate, replace, ordinal, rawlines, strlines
 
 def test_translate():
     abc = 'abc'
@@ -41,3 +42,45 @@ def test_ordinal():
 def test_rawlines():
     assert rawlines('a a\na') == "dedent('''\\\n    a a\n    a''')"
     assert rawlines('a a') == "'a a'"
+    assert rawlines(strlines('\\le"ft')) == (
+        '(\n'
+        "    '(\\n'\n"
+        '    \'r\\\'\\\\le"ft\\\'\\n\'\n'
+        "    ')'\n"
+        ')')
+
+
+def test_strlines():
+    q = 'this quote (") is in the middle'
+    # the following assert rhs was prepared with
+    # print(rawlines(strlines(q, 10)))
+    assert strlines(q, 10) == dedent('''\
+        (
+        'this quo'
+        'te (") i'
+        's in the'
+        ' middle'
+        )''')
+    assert q == (
+        'this quo'
+        'te (") i'
+        's in the'
+        ' middle'
+        )
+    q = "this quote (') is in the middle"
+    assert strlines(q, 20) == dedent('''\
+        (
+        "this quote (') is "
+        "in the middle"
+        )''')
+    assert strlines('\\left') == (
+        '(\n'
+        "r'\\left'\n"
+        ')')
+    assert strlines('\\left', short=True) == r"r'\left'"
+    assert strlines('\\le"ft') == (
+        '(\n'
+        'r\'\\le"ft\'\n'
+        ')')
+    q = 'this\nother line'
+    assert strlines(q) == rawlines(q)


### PR DESCRIPTION
When wanting to test the output that is a long string and needing to keep lines under 72 characters, it is a bit tedious to split the line and add the quotes. `strlines` can help in the process. It will use rawlines if
necessary, too.
```
Given: func(s) -> longstring
print(strlines(func(s)))
<copy what was printed>
Now you can test
func(s) == <paste>
```
Here is an example of it wrapping a string to a width of 30
```python
>>> q = 'this is a long string that just needs to be shorter'
>>> print(strlines(q, 30))
(
'this is a long string that j'
'ust needs to be shorter'
)
>>> q == (
... 'this is a long string that j'
... 'ust needs to be shorter'
... )
True
```
A quoting issue was fixed for rawlines, too. Instead of adding
a quote character, the repr form is used.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments

`strlines` will automatically call rawlines if there is more than one logical line in the input

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
    - `strlines` added: prints a string into shorter lines in a format that can be copied and used in an equality test

<!-- END RELEASE NOTES -->
