### PR TITLE
Refine(): Added new function for MatrixElement of symmetric matrix

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -240,7 +240,7 @@ def refine_Relational(expr, assumptions):
     return ask(Q.is_true(expr), assumptions)
 
 
-def refine_matrixelement(expr, assumptions):
+def refine_MatrixElement(expr, assumptions):
     if ask(Q.symmetric(expr.parent), assumptions):
         if expr.args[1] > expr.args[2]:
             return expr.func(*(expr.parent, expr.args[2], expr.args[1]))
@@ -257,5 +257,5 @@ handlers_dict = {
     'LessThan': refine_Relational,
     'StrictGreaterThan': refine_Relational,
     'StrictLessThan': refine_Relational,
-    'MatrixElement': refine_matrixelement
+    'MatrixElement': refine_MatrixElement
 }

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+#from sympy.matrices import MatrixExpr
 from sympy.core import S, Add, Expr, Basic, Mul
 from sympy.assumptions import Q, ask
 
@@ -239,6 +240,16 @@ def refine_Relational(expr, assumptions):
     """
     return ask(Q.is_true(expr), assumptions)
 
+def refine_matrixelement(expr,assumptions):
+
+
+
+    x=expr.parent
+    if (ask(Q.symmetric(x),assumptions)==True):
+        if(expr.args[1]+expr.args[2]>2*expr.args[2]):
+            return(expr.func(*(x,expr.args[2],expr.args[1])))
+    return(expr)
+
 
 handlers_dict = {
     'Abs': refine_abs,
@@ -249,5 +260,6 @@ handlers_dict = {
     'GreaterThan': refine_Relational,
     'LessThan': refine_Relational,
     'StrictGreaterThan': refine_Relational,
-    'StrictLessThan': refine_Relational
+    'StrictLessThan': refine_Relational,
+    'MatrixElement': refine_matrixelement
 }

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -243,7 +243,7 @@ def refine_Relational(expr, assumptions):
 
 def refine_matrixelement(expr, assumptions):
     if (ask(Q.symmetric(expr.parent), assumptions)==True):
-        if(expr.args[1]+expr.args[2]>2*expr.args[2]):
+        if(expr.args[1]>expr.args[2]):
             return(expr.func(*(expr.parent, expr.args[2], expr.args[1])))
     return(expr)
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -240,14 +240,11 @@ def refine_Relational(expr, assumptions):
     """
     return ask(Q.is_true(expr), assumptions)
 
+
 def refine_matrixelement(expr,assumptions):
-
-
-
-    x=expr.parent
-    if (ask(Q.symmetric(x),assumptions)==True):
+    if (ask(Q.symmetric(expr.parent),assumptions)==True):
         if(expr.args[1]+expr.args[2]>2*expr.args[2]):
-            return(expr.func(*(x,expr.args[2],expr.args[1])))
+            return(expr.func(*(expr.parent,expr.args[2],expr.args[1])))
     return(expr)
 
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 
-#from sympy.matrices import MatrixExpr
 from sympy.core import S, Add, Expr, Basic, Mul
 from sympy.assumptions import Q, ask
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -241,10 +241,10 @@ def refine_Relational(expr, assumptions):
     return ask(Q.is_true(expr), assumptions)
 
 
-def refine_matrixelement(expr,assumptions):
-    if (ask(Q.symmetric(expr.parent),assumptions)==True):
+def refine_matrixelement(expr, assumptions):
+    if (ask(Q.symmetric(expr.parent), assumptions)==True):
         if(expr.args[1]+expr.args[2]>2*expr.args[2]):
-            return(expr.func(*(expr.parent,expr.args[2],expr.args[1])))
+            return(expr.func(*(expr.parent, expr.args[2], expr.args[1])))
     return(expr)
 
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -241,10 +241,10 @@ def refine_Relational(expr, assumptions):
 
 
 def refine_matrixelement(expr, assumptions):
-    if (ask(Q.symmetric(expr.parent), assumptions)==True):
-        if(expr.args[1]>expr.args[2]):
-            return(expr.func(*(expr.parent, expr.args[2], expr.args[1])))
-    return(expr)
+    if ask(Q.symmetric(expr.parent), assumptions):
+        if expr.args[1] > expr.args[2]:
+            return expr.func(*(expr.parent, expr.args[2], expr.args[1]))
+    return expr
 
 
 handlers_dict = {

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -4,6 +4,7 @@ from sympy.abc import x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.utilities.pytest import slow
+from sympy.matrices.expressions.matexpr import MatrixSymbol
 
 
 def test_Abs():
@@ -143,6 +144,12 @@ def test_atan2():
     assert refine(atan2(y, x), Q.positive(y) & Q.zero(x)) == pi/2
     assert refine(atan2(y, x), Q.negative(y) & Q.zero(x)) == -pi/2
     assert refine(atan2(y, x), Q.zero(y) & Q.zero(x)) == nan
+
+def test_matrixelement():
+    x=MatrixSymbol('x',8,8)
+    assert refine(x[0,1],Q.symmetric(x)) == x[0,1]
+    assert refine(x[1,0],Q.symmetric(x)) == x[0,1]
+    assert refine(x[5,5],Q.symmetric(x)) == x[5,5]
 
 
 def test_func_args():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -146,10 +146,10 @@ def test_atan2():
     assert refine(atan2(y, x), Q.zero(y) & Q.zero(x)) == nan
 
 def test_matrixelement():
-    x=MatrixSymbol('x',8,8)
-    assert refine(x[0,1],Q.symmetric(x)) == x[0,1]
-    assert refine(x[1,0],Q.symmetric(x)) == x[0,1]
-    assert refine(x[5,5],Q.symmetric(x)) == x[5,5]
+    x = MatrixSymbol('x', 8, 8)
+    assert refine(x[0, 1], Q.symmetric(x)) == x[0, 1]
+    assert refine(x[1, 0], Q.symmetric(x)) == x[0, 1]
+    assert refine(x[5, 5], Q.symmetric(x)) == x[5, 5]
 
 
 def test_func_args():


### PR DESCRIPTION
Added feature for giving corresponding equal above-diagonal elements for input of elements below diagonal.

Example:

>>>x=MatrixSymbol('x',5,5)
>>>refine(x[0,1],Q.symmetric(x))
x[0,1]
>>>refine(x[1,0],Q.symmetric(x))
x[0,1]

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a new function refine_matrixelement(expression,assumptions) to refine.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * added new function in refine
<!-- END RELEASE NOTES -->
