### PR TITLE
Added dict flag for inequalities in solve

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -992,13 +992,9 @@ def reduce_inequalities(inequalities, symbols=[], dict_flag=False):
     if not dict_flag:
         return res
 
-    if isinstance(res, (And, Or)):
-        if dict_flag:
-            raise NotImplementedError("Cannot represent inequalities as dict type")
-        else:
-            return res
-
-    if isinstance(res, list):
+    if isinstance(res, (And, Or)) and dict_flag:
+        raise NotImplementedError("Cannot represent inequalities as dict type")
+    elif isinstance(res, list):
         return [{s.lhs: s.rhs} for s in res]
     else:
         return [{res.lhs: res.rhs}]

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -929,7 +929,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, dict_flag, symbols=[]):
+def reduce_inequalities(inequalities, symbols=[], dict_flag=False):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -13,7 +13,7 @@ from sympy.core.singleton import S
 from sympy.core.function import expand_mul
 
 from sympy.functions import Abs
-from sympy.logic import And
+from sympy.logic import And, Or
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
 from sympy.utilities.iterables import sift
@@ -929,7 +929,7 @@ def _reduce_inequalities(inequalities, symbols):
     return And(*(poly_reduced + abs_reduced + other))
 
 
-def reduce_inequalities(inequalities, symbols=[]):
+def reduce_inequalities(inequalities, dict_flag, symbols=[]):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
@@ -986,5 +986,19 @@ def reduce_inequalities(inequalities, symbols=[]):
     # solve system
     rv = _reduce_inequalities(inequalities, symbols)
 
-    # restore original symbols and return
-    return rv.xreplace({v: k for k, v in recast.items()})
+    # restore original symbols
+    res = rv.xreplace({v: k for k, v in recast.items()})
+
+    if not dict_flag:
+        return res
+
+    if isinstance(res, (And, Or)):
+        if dict_flag:
+            raise NotImplementedError("Cannot represent inequalities as dict type")
+        else:
+            return res
+
+    if isinstance(res, list):
+        return [{s.lhs: s.rhs} for s in res]
+    else:
+        return [{res.lhs: res.rhs}]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -982,7 +982,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if fi.is_Relational:
-            return reduce_inequalities(f, flags.get('dict', False), symbols=symbols)
+            return reduce_inequalities(f, dict_flag=flags.get('dict', False), symbols=symbols)
 
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -982,7 +982,7 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if fi.is_Relational:
-            return reduce_inequalities(f, symbols=symbols)
+            return reduce_inequalities(f, flags.get('dict', False), symbols=symbols)
 
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -172,6 +172,10 @@ def test_solve_args():
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
     assert solve(True, x) == []
     assert solve([x-1, False], [x], set=True) == ([], set())
+    # dict flag set for inequalities
+    assert solve([Eq(x-1,0),Gt(x,0)],(x,), dict=True) == [{x: 1}]
+    assert solve([x + y < 2, y - 1], [x]) == Eq(y, 1) & (x < 2 - y)
+    raises(NotImplementedError, lambda: solve([x + y < 2, y - 1], [x], dict=True))
 
 
 def test_solve_polynomial1():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #13534 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Earlier `dict` flag was ignored for `inequalities` in solve, in this PR `dict` flag is considered and an `error` is raised if answer is in inequalities (as @asmeurer suggested in [comment](https://github.com/sympy/sympy/pull/16190#issuecomment-471099067)). For e.g. 
Earlier the output was, 

```
In [23]: solve([Eq(x**2-1,0),Gt(x,0)],(x,),dict=True)
Out[23]: x = 1
In [24]: solve([x + y < 2, y - 1], [x], dict=True)
Out[24]: Eq(y, 1) & (x < 2 - y)
```

Now the output is,

```
In [23]: solve([Eq(x**2-1,0),Gt(x,0)],(x,),dict=True)
Out[23]: [{x: 1}]
In [24]: solve([x + y < 2, y - 1], [x], dict=True)
Out[24]: NotImplementedError: Cannot represent inequalities as dict type
```
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
