### PR TITLE
MathML Presentation printer: added method for printing MatrixElement type objects

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1489,13 +1489,13 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_MatrixElement(self, e):
-    	x = self.dom.createElement('msub')
-    	x.appendChild(self._print(e.parent))
-    	if len(e.indices) == 1:
-    		x.appendChild(self._print(e.indices[0]))
-    		return x
-    	x.appendChild(self._print(e.indices))
-    	return x
+        x = self.dom.createElement('msub')
+        x.appendChild(self._print(e.parent))
+        if len(e.indices) == 1:
+            x.appendChild(self._print(e.indices[0]))
+            return x
+        x.appendChild(self._print(e.indices))
+        return x
 
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1554,10 +1554,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_MatrixElement(self, e):
         x = self.dom.createElement('msub')
-        x.appendChild(self._print(e.parent))
+        x.appendChild(self.parenthesize(e.parent, PRECEDENCE["Atom"], strict = True))
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute("open","")
-        brac.setAttribute("close","")
+        brac.setAttribute("open", "")
+        brac.setAttribute("close", "")
         for i in e.indices:
             brac.appendChild(self._print(i))
         x.appendChild(brac)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1488,6 +1488,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(self._print(e.indices))
         return x
 
+    def _print_MatrixElement(self, e):
+    	x = self.dom.createElement('msub')
+    	x.appendChild(self._print(e.parent))
+    	if len(e.indices) == 1:
+    		x.appendChild(self._print(e.indices[0]))
+    		return x
+    	x.appendChild(self._print(e.indices))
+    	return x
 
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1555,10 +1555,12 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_MatrixElement(self, e):
         x = self.dom.createElement('msub')
         x.appendChild(self._print(e.parent))
-        if len(e.indices) == 1:
-            x.appendChild(self._print(e.indices[0]))
-            return x
-        x.appendChild(self._print(e.indices))
+        brac = self.dom.createElement('mfenced')
+        brac.setAttribute("open","")
+        brac.setAttribute("close","")
+        for i in e.indices:
+            brac.appendChild(self._print(i))
+        x.appendChild(brac)
         return x
 
 def mathml(expr, printer='content', **settings):

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1381,11 +1381,11 @@ def test_print_MatrixElement():
     i,j = symbols('i j')
     A = MatrixSymbol('A', i, j)
     assert mathml(A[0,0],printer = 'presentation') == \
-        '<msub><mi>A</mi><mfenced><mn>0</mn><mn>0</mn></mfenced></msub>'
+        '<msub><mi>A</mi><mfenced close="" open=""><mn>0</mn><mn>0</mn></mfenced></msub>'
     assert mathml(A[i,j], printer = 'presentation') == \
-        '<msub><mi>A</mi><mfenced><mi>i</mi><mi>j</mi></mfenced></msub>'
+        '<msub><mi>A</mi><mfenced close="" open=""><mi>i</mi><mi>j</mi></mfenced></msub>'
     assert mathml(A[i*j,0], printer = 'presentation') == \
-        '<msub><mi>A</mi><mfenced><mrow><mi>i</mi><mo>&InvisibleTimes;</mo><mi>j</mi></mrow><mn>0</mn></mfenced></msub>'
+        '<msub><mi>A</mi><mfenced close="" open=""><mrow><mi>i</mi><mo>&InvisibleTimes;</mo><mi>j</mi></mrow><mn>0</mn></mfenced></msub>'
 
 
 def test_print_Vector():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2,7 +2,7 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
-    Lambda, IndexedBase, symbols
+    Lambda, IndexedBase, symbols, MatrixSymbol
 from sympy.core.containers import Tuple
 from sympy.functions.combinatorial.factorials import factorial, factorial2, \
     binomial
@@ -1344,6 +1344,16 @@ def test_print_Indexed():
         '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
     assert mathml(IndexedBase((a, b)), printer='presentation') == \
         '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'
+
+def test_print_MatrixElement():
+    i,j = symbols('i j')
+    A = MatrixSymbol('A', i, j)
+    assert mathml(A[0,0],printer = 'presentation') == \
+        '<msub><mi>A</mi><mfenced><mn>0</mn><mn>0</mn></mfenced></msub>'
+    assert mathml(A[i,j], printer = 'presentation') == \
+        '<msub><mi>A</mi><mfenced><mi>i</mi><mi>j</mi></mfenced></msub>'
+    assert mathml(A[i*j,0], printer = 'presentation') == \
+        '<msub><mi>A</mi><mfenced><mrow><mi>i</mi><mo>&InvisibleTimes;</mo><mi>j</mi></mrow><mn>0</mn></mfenced></msub>'
 
 
 def test_print_Vector():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2,7 +2,7 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
-    Lambda, IndexedBase, symbols, MatrixSymbol
+    Lambda, IndexedBase, symbols
 from sympy import elliptic_k, totient, reduced_totient, primenu, primeomega, \
     fresnelc, fresnels, Heaviside
 from sympy.calculus.util import AccumBounds


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#15974 


#### Brief description of what is fixed or changed
Added a method for printing matrix element objects using the MathML presentation printer.
Also Added some tests for the same in test_mathml.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Added support for printing MatrixElement type objects for MathML presentation printer

<!-- END RELEASE NOTES -->
