### PR TITLE
MathML printing of matrix functions, constants and SingularityFunction

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1506,9 +1506,9 @@ class LatexPrinter(Printer):
         mat = expr.arg
         from sympy.matrices import MatrixSymbol
         if not isinstance(mat, MatrixSymbol):
-            return r"\left(%s\right)^T" % self._print(mat)
+            return r"\left(%s\right)^{T}" % self._print(mat)
         else:
-            return "%s^T" % self._print(mat)
+            return "%s^{T}" % self._print(mat)
 
     def _print_Trace(self, expr):
         mat = expr.arg
@@ -1518,9 +1518,9 @@ class LatexPrinter(Printer):
         mat = expr.arg
         from sympy.matrices import MatrixSymbol
         if not isinstance(mat, MatrixSymbol):
-            return r"\left(%s\right)^\dagger" % self._print(mat)
+            return r"\left(%s\right)^{\dagger}" % self._print(mat)
         else:
-            return r"%s^\dagger" % self._print(mat)
+            return r"%s^{\dagger}" % self._print(mat)
 
     def _print_MatMul(self, expr):
         from sympy import MatMul, Mul

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1551,20 +1551,20 @@ def test_Adjoint():
     from sympy.matrices import MatrixSymbol, Adjoint, Inverse, Transpose
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
-    assert latex(Adjoint(X)) == r'X^\dagger'
-    assert latex(Adjoint(X + Y)) == r'\left(X + Y\right)^\dagger'
-    assert latex(Adjoint(X) + Adjoint(Y)) == r'X^\dagger + Y^\dagger'
-    assert latex(Adjoint(X*Y)) == r'\left(X Y\right)^\dagger'
-    assert latex(Adjoint(Y)*Adjoint(X)) == r'Y^\dagger X^\dagger'
-    assert latex(Adjoint(X**2)) == r'\left(X^{2}\right)^\dagger'
-    assert latex(Adjoint(X)**2) == r'\left(X^\dagger\right)^{2}'
-    assert latex(Adjoint(Inverse(X))) == r'\left(X^{-1}\right)^\dagger'
-    assert latex(Inverse(Adjoint(X))) == r'\left(X^\dagger\right)^{-1}'
-    assert latex(Adjoint(Transpose(X))) == r'\left(X^T\right)^\dagger'
-    assert latex(Transpose(Adjoint(X))) == r'\left(X^\dagger\right)^T'
-    assert latex(Transpose(Adjoint(X) + Y)) == r'\left(X^\dagger + Y\right)^T'
-    assert latex(Transpose(X)) == r'X^T'
-    assert latex(Transpose(X + Y)) == r'\left(X + Y\right)^T'
+    assert latex(Adjoint(X)) == r'X^{\dagger}'
+    assert latex(Adjoint(X + Y)) == r'\left(X + Y\right)^{\dagger}'
+    assert latex(Adjoint(X) + Adjoint(Y)) == r'X^{\dagger} + Y^{\dagger}'
+    assert latex(Adjoint(X*Y)) == r'\left(X Y\right)^{\dagger}'
+    assert latex(Adjoint(Y)*Adjoint(X)) == r'Y^{\dagger} X^{\dagger}'
+    assert latex(Adjoint(X**2)) == r'\left(X^{2}\right)^{\dagger}'
+    assert latex(Adjoint(X)**2) == r'\left(X^{\dagger}\right)^{2}'
+    assert latex(Adjoint(Inverse(X))) == r'\left(X^{-1}\right)^{\dagger}'
+    assert latex(Inverse(Adjoint(X))) == r'\left(X^{\dagger}\right)^{-1}'
+    assert latex(Adjoint(Transpose(X))) == r'\left(X^{T}\right)^{\dagger}'
+    assert latex(Transpose(Adjoint(X))) == r'\left(X^{\dagger}\right)^{T}'
+    assert latex(Transpose(Adjoint(X) + Y)) == r'\left(X^{\dagger} + Y\right)^{T}'
+    assert latex(Transpose(X)) == r'X^{T}'
+    assert latex(Transpose(X + Y)) == r'\left(X + Y\right)^{T}'
 
 
 def test_Hadamard():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1562,6 +1562,9 @@ def test_Adjoint():
     assert latex(Inverse(Adjoint(X))) == r'\left(X^\dagger\right)^{-1}'
     assert latex(Adjoint(Transpose(X))) == r'\left(X^T\right)^\dagger'
     assert latex(Transpose(Adjoint(X))) == r'\left(X^\dagger\right)^T'
+    assert latex(Transpose(Adjoint(X) + Y)) == r'\left(X^\dagger + Y\right)^T'
+    assert latex(Transpose(X)) == r'X^T'
+    assert latex(Transpose(X + Y)) == r'\left(X + Y\right)^T'
 
 
 def test_Hadamard():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1550,20 +1550,38 @@ def test_mathml_matrix_functions():
     from sympy.matrices import MatrixSymbol, Adjoint, Inverse, Transpose
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
-    assert mathml(Adjoint(X), printer='presentation') == '<msup><mi>X</mi><mo>&#x2020;</mo></msup>'
-    assert mathml(Adjoint(X + Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
-    assert mathml(Adjoint(X) + Adjoint(Y), printer='presentation') == '<mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup><mo>+</mo><msup><mi>Y</mi><mo>&#x2020;</mo></msup></mrow>'
-    assert mathml(Adjoint(X*Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>&InvisibleTimes;</mo><mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
-    assert mathml(Adjoint(Y)*Adjoint(X), printer='presentation') == '<mrow><msup><mi>Y</mi><mo>&#x2020;</mo></msup><mo>&InvisibleTimes;</mo><msup><mi>X</mi><mo>&#x2020;</mo></msup></mrow>'
-    assert mathml(Adjoint(X**2), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mn>2</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
-    assert mathml(Adjoint(X)**2, printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>2</mn></msup>'
-    assert mathml(Adjoint(Inverse(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mn>-1</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
-    assert mathml(Inverse(Adjoint(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>-1</mn></msup>'
-    assert mathml(Adjoint(Transpose(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>T</mo></msup></mfenced><mo>&#x2020;</mo></msup>'
-    assert mathml(Transpose(Adjoint(X)), printer='presentation') ==  '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mo>T</mo></msup>'
-    assert mathml(Transpose(Adjoint(X) + Y), printer='presentation') ==  '<msup><mfenced><mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
-    assert mathml(Transpose(X), printer='presentation') == '<msup><mi>X</mi><mo>T</mo></msup>'
-    assert mathml(Transpose(X + Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
+    assert mathml(Adjoint(X), printer='presentation') == \
+        '<msup><mi>X</mi><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X + Y), printer='presentation') == \
+        '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X) + Adjoint(Y), printer='presentation') == \
+        '<mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup><mo>+</mo><msup>' \
+        '<mi>Y</mi><mo>&#x2020;</mo></msup></mrow>'
+    assert mathml(Adjoint(X*Y), printer='presentation') == \
+        '<msup><mfenced><mrow><mi>X</mi><mo>&InvisibleTimes;</mo>' \
+        '<mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(Y)*Adjoint(X), printer='presentation') == \
+        '<mrow><msup><mi>Y</mi><mo>&#x2020;</mo></msup><mo>&InvisibleTimes;' \
+        '</mo><msup><mi>X</mi><mo>&#x2020;</mo></msup></mrow>'
+    assert mathml(Adjoint(X**2), printer='presentation') == \
+        '<msup><mfenced><msup><mi>X</mi><mn>2</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X)**2, printer='presentation') == \
+        '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>2</mn></msup>'
+    assert mathml(Adjoint(Inverse(X)), printer='presentation') == \
+        '<msup><mfenced><msup><mi>X</mi><mn>-1</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Inverse(Adjoint(X)), printer='presentation') == \
+        '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>-1</mn></msup>'
+    assert mathml(Adjoint(Transpose(X)), printer='presentation') == \
+        '<msup><mfenced><msup><mi>X</mi><mo>T</mo></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Transpose(Adjoint(X)), printer='presentation') ==  \
+        '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mo>T</mo></msup>'
+    assert mathml(Transpose(Adjoint(X) + Y), printer='presentation') ==  \
+        '<msup><mfenced><mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup>' \
+        '<mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
+    assert mathml(Transpose(X), printer='presentation') == \
+        '<msup><mi>X</mi><mo>T</mo></msup>'
+    assert mathml(Transpose(X + Y), printer='presentation') == \
+        '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
 
 
 def test_mathml_special_matrices():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2,7 +2,7 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
-    Lambda, IndexedBase, symbols
+    Lambda, IndexedBase, symbols, zoo
 from sympy import elliptic_k, totient, reduced_totient, primenu, primeomega, \
     fresnelc, fresnels, Heaviside
 from sympy.calculus.util import AccumBounds
@@ -13,13 +13,14 @@ from sympy.functions.elementary.complexes import re, im, Abs, conjugate
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.gamma_functions import gamma, lowergamma, uppergamma
+from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import polylog, lerchphi, zeta, dirichlet_eta
 from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
 from sympy.matrices.expressions.determinant import Determinant
 from sympy.printing.mathml import mathml, MathMLContentPrinter, \
     MathMLPresentationPrinter, MathMLPrinter
 from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
-    SymmetricDifference, Interval
+    SymmetricDifference, Interval, EmptySet
 from sympy.stats.rv import RandomSymbol
 from sympy.utilities.pytest import raises
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
@@ -699,6 +700,10 @@ def test_presentation_mathml_constants():
 
     assert mathml(GoldenRatio, printer='presentation') == '<mi>&#x3A6;</mi>'
 
+    assert mathml(zoo, printer='presentation') == \
+        '<mover><mo>&#x221E;</mo><mo>~</mo></mover>'
+
+    assert mathml(S.NaN, printer='presentation') == '<mi>NaN</mi>'
 
 def test_presentation_mathml_trig():
     mml = mpp._print(sin(x))
@@ -1128,6 +1133,10 @@ def test_print_FiniteSet():
         '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
 
 
+def test_print_EmptySet():
+    assert mpp.doprint(EmptySet()) == '<mo>&#x2205;</mo>'
+
+
 def test_print_SetOp():
     f1 = FiniteSet(x, 1, 3)
     f2 = FiniteSet(y, 2, 4)
@@ -1511,3 +1520,53 @@ def test_print_Vector():
         '<mrow><mo>-</mo><mrow><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub>'\
         '<mi mathvariant="bold">z</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+
+
+def test_mathml_SingularityFunction():
+    a = Symbol('a')
+    n = Symbol('n')
+    assert mathml(SingularityFunction(x, 4, 5), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mi>x</mi>' \
+        '<mo>-</mo><mn>4</mn></mrow></mfenced><mn>5</mn></msup>'
+    assert mathml(SingularityFunction(x, -3, 4), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mi>x</mi>' \
+        '<mo>+</mo><mn>3</mn></mrow></mfenced><mn>4</mn></msup>'
+    assert mathml(SingularityFunction(x, 0, 4), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mi>x</mi></mfenced>' \
+        '<mn>4</mn></msup>'
+    assert mathml(SingularityFunction(x, a, n), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mrow>' \
+        '<mo>-</mo><mi>a</mi></mrow><mo>+</mo><mi>x</mi></mrow></mfenced>' \
+        '<mi>n</mi></msup>'
+    assert mathml(SingularityFunction(x, 4, -2), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mi>x</mi>' \
+        '<mo>-</mo><mn>4</mn></mrow></mfenced><mn>-2</mn></msup>'
+    assert mathml(SingularityFunction(x, 4, -1), printer='presentation') == \
+        '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mi>x</mi>' \
+        '<mo>-</mo><mn>4</mn></mrow></mfenced><mn>-1</mn></msup>'
+
+
+def test_mathml_matrix_functions():
+    from sympy.matrices import MatrixSymbol, Adjoint, Inverse, Transpose
+    X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
+    assert mathml(Adjoint(X), printer='presentation') == '<msup><mi>X</mi><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X + Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X) + Adjoint(Y), printer='presentation') == '<mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup><mo>+</mo><msup><mi>Y</mi><mo>&#x2020;</mo></msup></mrow>'
+    assert mathml(Adjoint(X*Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>&InvisibleTimes;</mo><mi>Y</mi></mrow></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(Y)*Adjoint(X), printer='presentation') == '<mrow><msup><mi>Y</mi><mo>&#x2020;</mo></msup><mo>&InvisibleTimes;</mo><msup><mi>X</mi><mo>&#x2020;</mo></msup></mrow>'
+    assert mathml(Adjoint(X**2), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mn>2</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Adjoint(X)**2, printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>2</mn></msup>'
+    assert mathml(Adjoint(Inverse(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mn>-1</mn></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Inverse(Adjoint(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mn>-1</mn></msup>'
+    assert mathml(Adjoint(Transpose(X)), printer='presentation') == '<msup><mfenced><msup><mi>X</mi><mo>T</mo></msup></mfenced><mo>&#x2020;</mo></msup>'
+    assert mathml(Transpose(Adjoint(X)), printer='presentation') ==  '<msup><mfenced><msup><mi>X</mi><mo>&#x2020;</mo></msup></mfenced><mo>T</mo></msup>'
+    assert mathml(Transpose(Adjoint(X) + Y), printer='presentation') ==  '<msup><mfenced><mrow><msup><mi>X</mi><mo>&#x2020;</mo></msup><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
+    assert mathml(Transpose(X), printer='presentation') == '<msup><mi>X</mi><mo>T</mo></msup>'
+    assert mathml(Transpose(X + Y), printer='presentation') == '<msup><mfenced><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></mfenced><mo>T</mo></msup>'
+
+
+def test_mathml_special_matrices():
+    from sympy.matrices import Identity, ZeroMatrix
+    assert mathml(Identity(4), printer='presentation') == '<mi>&#x1D540;</mi>'
+    assert mathml(ZeroMatrix(2, 2), printer='presentation') == '<mn>&#x1D7D8</mn>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #16036 

#### Brief description of what is fixed or changed
Added MathML presentation printing for SingularityFunction, MatMul, MatPow, Inverse, Adjoint, Transpose, Identity, ZeroMatrix, NaN, ComplexInfinity

Before:
<img width="514" alt="beforef2" src="https://user-images.githubusercontent.com/8114497/54474903-2bd86780-47eb-11e9-9308-875c7830a04b.PNG">

After:
<img width="498" alt="afterf2" src="https://user-images.githubusercontent.com/8114497/54474914-414d9180-47eb-11e9-8a65-6f6f59b1b581.PNG">

(not sure why ZeroMatrix prints like that in the LaTeX printer, the code is `\mathbb{0}`...)
#### Other comments
Encapsulated T and \dagger in {} for the LaTeX printers of Adjoint and Transpose to reduce the risk for future issues.

Added a test for MathML presentation printing of EmptySet.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added MathML presentation printing for `nan` and `zoo`
  * Added MathML presentation printing for matrix functions (e.g. `Adjoint`) and special matrices (e.g. `Identity`)
  * Added MathML presentation printing for `SingularityFunction`
<!-- END RELEASE NOTES -->
