### PR TITLE
MathML presentation printer: Added more printing methods

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1498,8 +1498,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     	return x
 
     def _print_elliptic_f(self, e):
-        x = self.dom.createElement('mi')
-        x.appendChild(self.dom.createTextNode('&#x1d5a5;'))
+        x = self.dom.createElement('mrow')
+        mi = self.dom.createElement('mi')
+        mi.appendChild(self.dom.createTextNode('&#x1d5a5;'))
+        x.appendChild(mi)
         y = self.dom.createElement('mfenced')
         y.setAttribute("separators", "|")
         for i in e.args:
@@ -1508,8 +1510,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_elliptic_e(self, e):
-        x = self.dom.createElement('mi')
-        x.appendChild(self.dom.createTextNode('&#x1d5a4;'))
+        x = self.dom.createElement('mrow')
+        mi = self.dom.createElement('mi')
+        mi.appendChild(self.dom.createTextNode('&#x1d5a4;'))
+        x.appendChild(mi)
         y = self.dom.createElement('mfenced')
         y.setAttribute("separators", "|")
         for i in e.args:
@@ -1518,8 +1522,10 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
     def _print_elliptic_pi(self, e):
-        x = self.dom.createElement('mi')
-        x.appendChild(self.dom.createTextNode('&#x1d6f1;'))
+        x = self.dom.createElement('mrow')
+        mi = self.dom.createElement('mi')
+        mi.appendChild(self.dom.createTextNode('&#x1d6f1;'))
+        x.appendChild(mi)
         y = self.dom.createElement('mfenced')
         if len(e.args) == 2:
             y.setAttribute("separators", "|")
@@ -1532,14 +1538,18 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_Ei(self, e):
         x = self.dom.createElement('mrow')
-        x.appendChild(self.dom.createTextNode('Ei'))
+        mi = self.dom.createElement('mi')
+        mi.appendChild(self.dom.createTextNode('Ei'))
+        x.appendChild(mi)
         x.appendChild(self._print(e.args))
         return x
 
     def _print_expint(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('E'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('E'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))
@@ -1548,7 +1558,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_jacobi(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msubsup')
-        y.appendChild(self.dom.createTextNode('P'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         y.appendChild(self._print(e.args[1:3]))
         x.appendChild(y)
@@ -1558,7 +1570,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_gegenbauer(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msubsup')
-        y.appendChild(self.dom.createTextNode('C'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('C'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         y.appendChild(self._print(e.args[1:2]))
         x.appendChild(y)
@@ -1568,7 +1582,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_chebyshevt(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('T'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('T'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))
@@ -1577,7 +1593,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_chebyshevu(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('U'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('U'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))
@@ -1586,7 +1604,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_legendre(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('P'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))
@@ -1595,7 +1615,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_assoc_legendre(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msubsup')
-        y.appendChild(self.dom.createTextNode('P'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         y.appendChild(self._print(e.args[1:2]))
         x.appendChild(y)
@@ -1605,7 +1627,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_laguerre(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('L'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('L'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))
@@ -1614,7 +1638,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_assoc_laguerre(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msubsup')
-        y.appendChild(self.dom.createTextNode('L'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('L'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         y.appendChild(self._print(e.args[1:2]))
         x.appendChild(y)
@@ -1624,7 +1650,9 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_hermite(self, e):
         x = self.dom.createElement('mrow')
         y = self.dom.createElement('msub')
-        y.appendChild(self.dom.createTextNode('H'))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('H'))
+        y.appendChild(mo)
         y.appendChild(self._print(e.args[0]))
         x.appendChild(y)
         x.appendChild(self._print(e.args[1:]))

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1497,6 +1497,140 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     	x.appendChild(self._print(e.indices))
     	return x
 
+    def _print_elliptic_f(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x1d5a5;'))
+        y = self.dom.createElement('mfenced')
+        y.setAttribute("separators", "|")
+        for i in e.args:
+            y.appendChild(self._print(i))
+        x.appendChild(y)
+        return x
+
+    def _print_elliptic_e(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x1d5a4;'))
+        y = self.dom.createElement('mfenced')
+        y.setAttribute("separators", "|")
+        for i in e.args:
+            y.appendChild(self._print(i))
+        x.appendChild(y)
+        return x
+
+    def _print_elliptic_pi(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x1d6f1;'))
+        y = self.dom.createElement('mfenced')
+        if len(e.args) == 2:
+            y.setAttribute("separators", "|")
+        else:
+            y.setAttribute("separators", ";|")
+        for i in e.args:
+            y.appendChild(self._print(i))
+        x.appendChild(y)
+        return x
+
+    def _print_Ei(self, e):
+        x = self.dom.createElement('mrow')
+        x.appendChild(self.dom.createTextNode('Ei'))
+        x.appendChild(self._print(e.args))
+        return x
+
+    def _print_expint(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('E'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+    def _print_jacobi(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msubsup')
+        y.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(self._print(e.args[0]))
+        y.appendChild(self._print(e.args[1:3]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[3:]))
+        return x
+
+    def _print_gegenbauer(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msubsup')
+        y.appendChild(self.dom.createTextNode('C'))
+        y.appendChild(self._print(e.args[0]))
+        y.appendChild(self._print(e.args[1:2]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[2:]))
+        return x
+
+    def _print_chebyshevt(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('T'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+    def _print_chebyshevu(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('U'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+    def _print_legendre(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+    def _print_assoc_legendre(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msubsup')
+        y.appendChild(self.dom.createTextNode('P'))
+        y.appendChild(self._print(e.args[0]))
+        y.appendChild(self._print(e.args[1:2]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[2:]))
+        return x
+
+    def _print_laguerre(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('L'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+    def _print_assoc_laguerre(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msubsup')
+        y.appendChild(self.dom.createTextNode('L'))
+        y.appendChild(self._print(e.args[0]))
+        y.appendChild(self._print(e.args[1:2]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[2:]))
+        return x
+
+    def _print_hermite(self, e):
+        x = self.dom.createElement('mrow')
+        y = self.dom.createElement('msub')
+        y.appendChild(self.dom.createTextNode('H'))
+        y.appendChild(self._print(e.args[0]))
+        x.appendChild(y)
+        x.appendChild(self._print(e.args[1:]))
+        return x
+
+
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation
     then prints Presentation MathML else prints content MathML.

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2,7 +2,9 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float, Matrix, Basic, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
-    Lambda, IndexedBase, symbols, MatrixSymbol
+    Lambda, IndexedBase, symbols, elliptic_f, elliptic_e, elliptic_pi, Ei, \
+    expint, jacobi, gegenbauer, chebyshevt, chebyshevu, legendre, assoc_legendre, \
+    laguerre, assoc_laguerre, hermite
 from sympy.core.containers import Tuple
 from sympy.functions.combinatorial.factorials import factorial, factorial2, \
     binomial
@@ -1346,7 +1348,7 @@ def test_print_Indexed():
         '<mrow><mfenced><mi>a</mi><mi>b</mi></mfenced></mrow>'
 
 def test_print_MatrixElement():
-    i,j = symbols('i j')
+    i, j = symbols('i j')
     A = MatrixSymbol('A', i, j)
     assert mathml(A[0,0],printer = 'presentation') == \
         '<msub><mi>A</mi><mfenced><mn>0</mn><mn>0</mn></mfenced></msub>'
@@ -1489,3 +1491,83 @@ def test_print_Vector():
         '<mrow><mo>-</mo><mrow><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub>'\
         '<mi mathvariant="bold">z</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+
+def test_print_elliptic_f():
+    x, y = symbols('x y')
+    assert mathml(elliptic_f(x, y), printer = 'presentation') == \
+        '<mrow><mi>&#x1d5a5;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mathml(elliptic_f(x/y, y), printer = 'presentation') == \
+        '<mrow><mi>&#x1d5a5;</mi><mfenced separators="|"><mrow><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow><mi>y</mi></mfenced></mrow>'
+
+def test_print_elliptic_e():
+    x, y = symbols('x y')
+    assert mathml(elliptic_e(x), printer = 'presentation') == \
+        '<mrow><mi>&#x1d5a4;</mi><mfenced separators="|"><mi>x</mi></mfenced></mrow>'
+    assert mathml(elliptic_e(x, y), printer = 'presentation') == \
+        '<mrow><mi>&#x1d5a4;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
+
+def test_print_elliptic_pi():
+    x, y, z = symbols('x y z')
+    assert mathml(elliptic_pi(x, y), printer = 'presentation') == \
+        '<mrow><mi>&#x1d6f1;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
+    assert mathml(elliptic_pi(x, y, z), printer = 'presentation') == \
+        '<mrow><mi>&#x1d6f1;</mi><mfenced separators=";|"><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow>'
+
+def test_print_Ei():
+    x, y = symbols('x y')
+    assert mathml(Ei(x), printer = 'presentation') == \
+        '<mrow><mi>Ei</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mathml(Ei(x**y), printer = 'presentation') == \
+        '<mrow><mi>Ei</mi><mfenced><msup><mi>x</mi><mi>y</mi></msup></mfenced></mrow>'
+
+def test_print_expint():
+    x, y = symbols('x y')
+    assert mathml(expint(x, y), printer = 'presentation') == \
+        '<mrow><msub><mo>E</mo><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
+    assert mathml(expint(IndexedBase(x)[1], IndexedBase(x)[2]), printer = 'presentation') == \
+        '<mrow><msub><mo>E</mo><msub><mi>x</mi><mn>1</mn></msub></msub><mfenced><msub><mi>x</mi><mn>2</mn></msub></mfenced></mrow>'
+
+def test_print_jacobi():
+    n, a, b, x = symbols('n a b x')
+    assert mathml(jacobi(n, a, b, x), printer = 'presentation') == \
+        '<mrow><msubsup><mo>P</mo><mi>n</mi><mfenced><mi>a</mi><mi>b</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_gegenbauer():
+    n, a, x = symbols('n a x')
+    assert mathml(gegenbauer(n, a, x), printer = 'presentation') == \
+        '<mrow><msubsup><mo>C</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_chebyshevt():
+    n, x = symbols('n x')
+    assert mathml(chebyshevt(n, x), printer = 'presentation') == \
+        '<mrow><msub><mo>T</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_chebyshevu():
+    n, x = symbols('n x')
+    assert mathml(chebyshevu(n, x), printer = 'presentation') == \
+        '<mrow><msub><mo>U</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_legendre():
+    n, x = symbols('n x')
+    assert mathml(legendre(n, x), printer = 'presentation') == \
+        '<mrow><msub><mo>P</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_assoc_legendre():
+    n, a, x = symbols('n a x')
+    assert mathml(assoc_legendre(n, a, x), printer = 'presentation') == \
+        '<mrow><msubsup><mo>P</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_laguerre():
+    n, x = symbols('n x')
+    assert mathml(laguerre(n, x), printer = 'presentation') == \
+        '<mrow><msub><mo>L</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_assoc_laguerre():
+    n, a, x = symbols('n a x')
+    assert mathml(assoc_laguerre(n, a, x), printer = 'presentation') == \
+        '<mrow><msubsup><mo>L</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
+
+def test_print_hermite():
+    n, x = symbols('n x')
+    assert mathml(hermite(n, x), printer = 'presentation') == \
+        '<mrow><msub><mo>H</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -28,8 +28,7 @@ from sympy.stats.rv import RandomSymbol
 from sympy.utilities.pytest import raises
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
 
-x = Symbol('x')
-y = Symbol('y')
+x, y, z, a, b, c, d, e, n = symbols('x:z a:e n')
 mp = MathMLContentPrinter()
 mpp = MathMLPresentationPrinter()
 
@@ -289,7 +288,7 @@ def test_content_mathml_relational():
 
 
 def test_content_symbol():
-    mml = mp._print(Symbol("x"))
+    mml = mp._print(x)
     assert mml.nodeName == 'ci'
     assert mml.childNodes[0].nodeValue == 'x'
     del mml
@@ -479,7 +478,7 @@ def test_content_mathml_order():
 
 
 def test_content_settings():
-    raises(TypeError, lambda: mathml(Symbol("x"), method="garbage"))
+    raises(TypeError, lambda: mathml(x, method="garbage"))
 
 
 def test_presentation_printmethod():
@@ -553,7 +552,6 @@ def test_presentation_mathml_functions():
 
 def test_print_derivative():
     f = Function('f')
-    z = Symbol('z')
     d = Derivative(f(x, y, z), x, z, x, z, z, y)
     assert mathml(d) == \
         '<apply><partialdiff/><bvar><ci>y</ci><ci>z</ci><degree><cn>2</cn></degree><ci>x</ci><ci>z</ci><ci>x</ci></bvar><apply><f/><ci>x</ci><ci>y</ci><ci>z</ci></apply></apply>'
@@ -785,7 +783,7 @@ def test_presentation_mathml_relational():
 
 
 def test_presentation_symbol():
-    mml = mpp._print(Symbol("x"))
+    mml = mpp._print(x)
     assert mml.nodeName == 'mi'
     assert mml.childNodes[0].nodeValue == 'x'
     del mml
@@ -971,7 +969,6 @@ def test_print_intervals():
 
 
 def test_print_tuples():
-    a = Symbol('a')
     assert mpp.doprint(Tuple(0,)) == \
         '<mrow><mfenced><mn>0</mn></mfenced></mrow>'
     assert mpp.doprint(Tuple(0, a)) == \
@@ -986,7 +983,6 @@ def test_print_tuples():
 
 
 def test_print_re_im():
-    x = Symbol('x')
     assert mpp.doprint(re(x)) == \
         '<mrow><mi mathvariant="fraktur">R</mi><mfenced><mi>x</mi></mfenced></mrow>'
     assert mpp.doprint(im(x)) == \
@@ -999,7 +995,6 @@ def test_print_re_im():
 
 
 def test_print_Abs():
-    x = Symbol('x')
     assert mpp.doprint(Abs(x)) == \
         '<mrow><mfenced close="|" open="|"><mi>x</mi></mfenced></mrow>'
     assert mpp.doprint(Abs(x + 1)) == \
@@ -1012,7 +1007,7 @@ def test_print_Determinant():
 
 
 def test_presentation_settings():
-    raises(TypeError, lambda: mathml(Symbol("x"), printer='presentation',
+    raises(TypeError, lambda: mathml(x, printer='presentation',
                                      method="garbage"))
 
 
@@ -1370,7 +1365,6 @@ def test_print_random_symbol():
 
 
 def test_print_IndexedBase():
-    a, b, c, d, e = symbols('a b c d e')
     assert mathml(IndexedBase(a)[b], printer='presentation') == \
         '<msub><mi>a</mi><mi>b</mi></msub>'
     assert mathml(IndexedBase(a)[b, c, d], printer='presentation') == \
@@ -1382,7 +1376,6 @@ def test_print_IndexedBase():
 
 
 def test_print_Indexed():
-    a, b, c = symbols('a b c')
     assert mathml(IndexedBase(a), printer='presentation') == '<mi>a</mi>'
     assert mathml(IndexedBase(a/b), printer='presentation') == \
         '<mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow>'
@@ -1535,88 +1528,72 @@ def test_print_Vector():
         '<mi mathvariant="bold">z</mi><mi mathvariant="bold">A</mi></msub></mrow></mrow>'
 
 def test_print_elliptic_f():
-    x, y = symbols('x y')
     assert mathml(elliptic_f(x, y), printer = 'presentation') == \
         '<mrow><mi>&#x1d5a5;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
     assert mathml(elliptic_f(x/y, y), printer = 'presentation') == \
         '<mrow><mi>&#x1d5a5;</mi><mfenced separators="|"><mrow><mfrac><mi>x</mi><mi>y</mi></mfrac></mrow><mi>y</mi></mfenced></mrow>'
 
 def test_print_elliptic_e():
-    x, y = symbols('x y')
     assert mathml(elliptic_e(x), printer = 'presentation') == \
         '<mrow><mi>&#x1d5a4;</mi><mfenced separators="|"><mi>x</mi></mfenced></mrow>'
     assert mathml(elliptic_e(x, y), printer = 'presentation') == \
         '<mrow><mi>&#x1d5a4;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
 
 def test_print_elliptic_pi():
-    x, y, z = symbols('x y z')
     assert mathml(elliptic_pi(x, y), printer = 'presentation') == \
         '<mrow><mi>&#x1d6f1;</mi><mfenced separators="|"><mi>x</mi><mi>y</mi></mfenced></mrow>'
     assert mathml(elliptic_pi(x, y, z), printer = 'presentation') == \
         '<mrow><mi>&#x1d6f1;</mi><mfenced separators=";|"><mi>x</mi><mi>y</mi><mi>z</mi></mfenced></mrow>'
 
 def test_print_Ei():
-    x, y = symbols('x y')
     assert mathml(Ei(x), printer = 'presentation') == \
         '<mrow><mi>Ei</mi><mfenced><mi>x</mi></mfenced></mrow>'
     assert mathml(Ei(x**y), printer = 'presentation') == \
         '<mrow><mi>Ei</mi><mfenced><msup><mi>x</mi><mi>y</mi></msup></mfenced></mrow>'
 
 def test_print_expint():
-    x, y = symbols('x y')
     assert mathml(expint(x, y), printer = 'presentation') == \
         '<mrow><msub><mo>E</mo><mi>x</mi></msub><mfenced><mi>y</mi></mfenced></mrow>'
     assert mathml(expint(IndexedBase(x)[1], IndexedBase(x)[2]), printer = 'presentation') == \
         '<mrow><msub><mo>E</mo><msub><mi>x</mi><mn>1</mn></msub></msub><mfenced><msub><mi>x</mi><mn>2</mn></msub></mfenced></mrow>'
 
 def test_print_jacobi():
-    n, a, b, x = symbols('n a b x')
     assert mathml(jacobi(n, a, b, x), printer = 'presentation') == \
         '<mrow><msubsup><mo>P</mo><mi>n</mi><mfenced><mi>a</mi><mi>b</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_gegenbauer():
-    n, a, x = symbols('n a x')
     assert mathml(gegenbauer(n, a, x), printer = 'presentation') == \
         '<mrow><msubsup><mo>C</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_chebyshevt():
-    n, x = symbols('n x')
     assert mathml(chebyshevt(n, x), printer = 'presentation') == \
         '<mrow><msub><mo>T</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_chebyshevu():
-    n, x = symbols('n x')
     assert mathml(chebyshevu(n, x), printer = 'presentation') == \
         '<mrow><msub><mo>U</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_legendre():
-    n, x = symbols('n x')
     assert mathml(legendre(n, x), printer = 'presentation') == \
         '<mrow><msub><mo>P</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_assoc_legendre():
-    n, a, x = symbols('n a x')
     assert mathml(assoc_legendre(n, a, x), printer = 'presentation') == \
         '<mrow><msubsup><mo>P</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_laguerre():
-    n, x = symbols('n x')
     assert mathml(laguerre(n, x), printer = 'presentation') == \
         '<mrow><msub><mo>L</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_assoc_laguerre():
-    n, a, x = symbols('n a x')
     assert mathml(assoc_laguerre(n, a, x), printer = 'presentation') == \
         '<mrow><msubsup><mo>L</mo><mi>n</mi><mfenced><mi>a</mi></mfenced></msubsup><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_print_hermite():
-    n, x = symbols('n x')
     assert mathml(hermite(n, x), printer = 'presentation') == \
         '<mrow><msub><mo>H</mo><mi>n</mi></msub><mfenced><mi>x</mi></mfenced></mrow>'
 
 def test_mathml_SingularityFunction():
-    a = Symbol('a')
-    n = Symbol('n')
     assert mathml(SingularityFunction(x, 4, 5), printer='presentation') == \
         '<msup><mfenced close="&#10217;" open="&#10216;"><mrow><mi>x</mi>' \
         '<mo>-</mo><mn>4</mn></mrow></mfenced><mn>5</mn></msup>'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
This has reference to #16036 

#### Brief description of what is fixed or changed

Some new methods have been added that required MathML presentation printer's support

#### Other comments
I haven't added the tests yet because the functions may require some changes, thus I'll add the tests once the functions are reviewed.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Added printing methods for elliptic_e, elliptic_f, elliptic_pi, Ei, expint, jacobi, gegenbauer, chebyshevt, chebyshevu, legendre, assoc_legendre, laguerre, assoc_laguerre and hermite type objects for MathML presentation printer


<!-- END RELEASE NOTES -->
