### PR TITLE
WIP - Use connected components to split systems in solve

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -25,8 +25,8 @@ from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
                           Derivative, AppliedUndef, UndefinedFunction, nfloat,
                           Function, expand_power_exp, Lambda, _mexpand, expand)
 from sympy.integrals.integrals import Integral
-from sympy.core.numbers import ilcm, Float, Rational
-from sympy.core.relational import Relational, Ge, _canonical
+from sympy.core.numbers import ilcm, Float, Rational, pi, nan
+from sympy.core.relational import Relational, Eq, Ge, _canonical, Ne
 from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.core.power import integer_log
 from sympy.logic.boolalg import And, Or, BooleanAtom
@@ -1033,8 +1033,21 @@ def solve(f, *symbols, **flags):
 
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]
-        fi = fi.xreplace(dict(list(zip(_arg,
-            [atan(im(a.args[0])/re(a.args[0])) for a in _arg]))))
+
+        # This is not intended to stay. Really atan2.rewrite should do this
+        # so arg(a).rewrite(atan2).rewrite(atan) should give piecewise if
+        # necessary. Actually we shouldn't have to go via atan2 so
+        # arg(a).rewrite(atan) should go straight to Piecewise.
+        def _newarg(a):
+            x = re(a)
+            y = im(a)
+            return Piecewise(
+                (2*atan(y / (sqrt(x**2 + y**2) + x)), Or(x>0, Ne(y, 0))),
+                (pi, And(x<0, Eq(y, 0))),
+                (nan, True),
+                    )
+
+        fi = fi.xreplace(dict(list(zip(_arg, [_newarg(a.args[0]) for a in _arg]))))
 
         # save changes
         f[i] = fi

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1768,12 +1768,14 @@ def _solve_system(exprs, symbols, **flags):
 
     # Split the system into connected components?
     V = exprs
-    exprsyms = {e: {s for s in symbols if e.has(s)} for e in exprs}
+    #exprsyms = {e: {s for s in symbols if e.has(s)} for e in exprs}
+    symsset = set(symbols)
+    exprsyms = {e: e.free_symbols & symsset for e in exprs}
     E = []
     for n, e1 in enumerate(exprs):
         for e2 in exprs[:n]:
             # Equations are connected if they share a symbol
-            if any(s in exprsyms[e1] and s in exprsyms[e2] for s in symbols):
+            if exprsyms[e1] & exprsyms[e2]:
                 E.append((e1, e2))
     G = V, E
     subexprs = connected_components(G)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1792,10 +1792,7 @@ def _solve_system(exprs, symbols, **flags):
         sols = []
         for soldicts in cartes(*subsols):
             sols.append(dict(item for sd in soldicts for item in sd.items()))
-        #if flags.get('set', False):
-        #    sols = [set(sd.values()) for sd in sols]
-        #elif not flags.get('dict', False):
-        #    sols = [[sol[s] for s in symbols] for sol in sols]
+        # Return a single dict if it would be a list of one dicts
         if len(sols) == 1:
             return sols[0]
         return sols

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1040,22 +1040,24 @@ def solve(f, *symbols, **flags):
         f[i] = fi
 
     # see if re(s) or im(s) appear
-    irf = []
-    for s in symbols:
-        if s.is_real or s.is_imaginary:
-            continue  # neither re(x) nor im(x) will appear
-        # if re(s) or im(s) appear, the auxiliary equation must be present
-        if any(fi.has(re(s), im(s)) for fi in f):
-            irf.append((s, re(s) + S.ImaginaryUnit*im(s)))
-    if irf:
-        for s, rhs in irf:
-            for i, fi in enumerate(f):
-                f[i] = fi.xreplace({s: rhs})
-            f.append(s - rhs)
-            symbols.extend([re(s), im(s)])
-        if bare_f:
-            bare_f = False
-        flags['dict'] = True
+    freim = [fi for fi in f if fi.has('re', 'im')]
+    if freim:
+        irf = []
+        for s in symbols:
+            if s.is_real or s.is_imaginary:
+                continue  # neither re(x) nor im(x) will appear
+            # if re(s) or im(s) appear, the auxiliary equation must be present
+            if any(fi.has(re(s), im(s)) for fi in freim):
+                irf.append((s, re(s) + S.ImaginaryUnit*im(s)))
+        if irf:
+            for s, rhs in irf:
+                for i, fi in enumerate(f):
+                    f[i] = fi.xreplace({s: rhs})
+                f.append(s - rhs)
+                symbols.extend([re(s), im(s)])
+            if bare_f:
+                bare_f = False
+            flags['dict'] = True
     # end of real/imag handling  -----------------------------
 
     symbols = list(uniq(symbols))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1783,6 +1783,7 @@ def _solve_system(exprs, symbols, **flags):
             subsyms = set()
             for e in subexpr:
                 subsyms |= exprsyms[e]
+            subsyms = sorted(subsyms, key=default_sort_key)
             subsol = _solve_system(subexpr, subsyms, **flags)
             if not isinstance(subsol, list):
                 subsol = [subsol]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1093,7 +1093,7 @@ def solve(f, *symbols, **flags):
         # to be obtained to queries like solve((x - y, y), x); without
         # this mod the return value is []
         ok = False
-        if fi.has(*symset):
+        if fi.free_symbols & symset:
             ok = True
         else:
             if fi.is_number:
@@ -1233,8 +1233,7 @@ def solve(f, *symbols, **flags):
             not isinstance(solution, dict) and
             all(isinstance(sol, dict) for sol in solution)
     ):
-        solution = [tuple([r.get(s, s).subs(r) for s in symbols])
-                    for r in solution]
+        solution = [tuple([r.get(s, s) for s in symbols]) for r in solution]
 
     # Get assumptions about symbols, to filter solutions.
     # Note that if assumptions about a solution can't be verified, it is still
@@ -1342,7 +1341,7 @@ def solve(f, *symbols, **flags):
         if isinstance(solution, dict):
             solution = [solution]
         elif iterable(solution[0]):
-            solution = [dict(list(zip(symbols, s))) for s in solution]
+            solution = [dict(zip(symbols, s)) for s in solution]
         elif isinstance(solution[0], dict):
             pass
         else:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1491,14 +1491,7 @@ def test_issues_6819_6820_6821_6248_8692():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
-    # This example fails with this PR. On master it passes due to a
-    # cancellation of two bugs. Somewhere earlier in solve the arg(x)-pi
-    # equation is turned into -pi (i.e. arg(x) becomes 0). Then the
-    # _solve_system code ignores that equation even though it has no
-    # solutions.
-    # This PR currently returns [] as a result. The tested result is also
-    # incorrect though since arg(2)=0.
-    #assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,), (2,)]
+    assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,)]
     assert set(solve(abs(x - 7) - 8)) == set([-S(1), S(15)])
 
     # issue 8692

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1484,7 +1484,14 @@ def test_issues_6819_6820_6821_6248_8692():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
-    assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,), (2,)]
+    # This example fails with this PR. On master it passes due to a
+    # cancellation of two bugs. Somewhere earlier in solve the arg(x)-pi
+    # equation is turned into -pi (i.e. arg(x) becomes 0). Then the
+    # _solve_system code ignores that equation even though it has no
+    # solutions.
+    # This PR currently returns [] as a result. The tested result is also
+    # incorrect though since arg(2)=0.
+    #assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,), (2,)]
     assert set(solve(abs(x - 7) - 8)) == set([-S(1), S(15)])
 
     # issue 8692

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -149,10 +149,10 @@ def test_solve_args():
         NotImplementedError, lambda: solve(exp(x) + sin(x) + exp(y) + sin(y)))
     # failed system
     # --  when no symbols given, 1 fails
-    assert solve([y, exp(x) + x]) == [{x: -LambertW(1), y: 0}]
+    assert solve([y, exp(x) + x]) == {x: -LambertW(1), y: 0}
     #     both fail
     assert solve(
-        (exp(x) - x, exp(y) - y)) == [{x: -LambertW(-1), y: -LambertW(-1)}]
+        (exp(x) - x, exp(y) - y)) == {x: -LambertW(-1), y: -LambertW(-1)}
     # --  when symbols given
     solve([y, exp(x) + x], x, y) == [(-LambertW(1), 0)]
     # symbol is a number
@@ -1217,7 +1217,14 @@ def test_issue_5849_matrix():
         2*I3 + 2*I5 + 3*I6 - Q2,
         I4 - 2*I5 + 2*Q4 + dI4
     )
-    assert solve(e, I1, I4, Q2, Q4, dI1, dI4, dQ2, dQ4) == {
+    # This system is overdetermined. We need I1 = I2 + I3 and I1 = I2 + I6 but
+    # those two are most likely inconsistent. I don't know how this works
+    # without this PR but this fails with the PR because e.g.:
+    #
+    # In [1]: solve([x-y, x-z], [x])
+    # Out[1]: []
+    assert solve(e, I1, I4, Q2, Q4, dI1, dI4, dQ2, dQ4) == []
+    posible_sol = {
         dI4: -I3 + 3*I5 - 2*Q4,
         dI1: -4*I2 - 8*I3 - 4*I5 - 6*I6 + 24,
         dQ2: I2,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

Uses the new connected_components function from #16225 to split systems of equations in solve. As an example a system like
```
solve([a-b, a+b+1, c-d, c-d+e, e-2], [a, b, c, d, e])
```
would be split into two parts:
```
solve([a-b, a+b+1], [a, b])
solve([c-d, c-d+e, e-2], [c, d, e])
```
The solution set for the full system is then the Cartesian product of the solution sets for the individual subsystems. Where it is possible to split the system like this solve should be faster as a result of this PR.

#### Other comments

I'm putting this up now as a work in progress to see how it fairs on the whole test suite.

I'm still working on making it as fast as possible. I'll show some example timings in the comments below.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
