### PR TITLE
added `fraction` flag in `factor()`

### DIFF
--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -722,6 +722,16 @@ class Method(with_metaclass(OptionType, Flag)):
             raise OptionError("expected a string, got %s" % method)
 
 
+class Fraction(with_metaclass(OptionType, Flag)):
+    """``fraction`` flag to polynomial manipulation functions. """
+
+    option = 'fraction'
+
+    @classmethod
+    def default(cls):
+        return True
+
+
 def build_options(gens, args=None):
     """Construct options from keyword arguments or ... options. """
     if args is None:

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -722,16 +722,6 @@ class Method(with_metaclass(OptionType, Flag)):
             raise OptionError("expected a string, got %s" % method)
 
 
-class Fraction(with_metaclass(OptionType, Flag)):
-    """``fraction`` flag to polynomial manipulation functions. """
-
-    option = 'fraction'
-
-    @classmethod
-    def default(cls):
-        return True
-
-
 def build_options(gens, args=None):
     """Construct options from keyword arguments or ... options. """
     if args is None:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6014,8 +6014,10 @@ def _generic_factor_list(expr, gens, args, method):
 
 def _generic_factor(expr, gens, args, method):
     """Helper function for :func:`sqf` and :func:`factor`. """
-    options.allowed_flags(args, ['fraction'])
+    fraction = args.pop('fraction', True)
+    options.allowed_flags(args, [])
     opt = options.build_options(gens, args)
+    opt['fraction'] = fraction
     return _symbolic_factor(sympify(expr), opt, method)
 
 
@@ -6274,7 +6276,7 @@ def factor(f, *gens, **args):
     Examples
     ========
 
-    >>> from sympy import factor, sqrt
+    >>> from sympy import factor, sqrt, exp
     >>> from sympy.abc import x, y
 
     >>> factor(2*x**5 + 2*x**4*y + 4*x**3 + 4*x**2*y + 2*x + 2*y)
@@ -6306,6 +6308,14 @@ def factor(f, *gens, **args):
 
     >>> factor(eq, deep=True)
     2**((x + 1)**2)
+
+    If the ``fraction`` flag is False then rational expressions
+    won't be combined. By default it is True.
+
+    >>> factor(5*x + 3*exp(2 - 7*x), deep=True)
+    (5*x*exp(7*x) + 3*exp(2))*exp(-7*x)
+    >>> factor(5*x + 3*exp(2 - 7*x), deep=True, fraction=False)
+    5*x + 3*exp(2)*exp(-7*x)
 
     See Also
     ========

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5961,7 +5961,7 @@ def _symbolic_factor(expr, opt, method):
     if isinstance(expr, Expr) and not expr.is_Relational:
         if hasattr(expr,'_eval_factor'):
             return expr._eval_factor()
-        coeff, factors = _symbolic_factor_list(together(expr), opt, method)
+        coeff, factors = _symbolic_factor_list(together(expr, fraction=opt.get('fraction', True)), opt, method)
         return _keep_coeff(coeff, _factors_product(factors))
     elif hasattr(expr, 'args'):
         return expr.func(*[_symbolic_factor(arg, opt, method) for arg in expr.args])
@@ -6014,7 +6014,7 @@ def _generic_factor_list(expr, gens, args, method):
 
 def _generic_factor(expr, gens, args, method):
     """Helper function for :func:`sqf` and :func:`factor`. """
-    options.allowed_flags(args, [])
+    options.allowed_flags(args, ['fraction'])
     opt = options.build_options(gens, args)
     return _symbolic_factor(sympify(expr), opt, method)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5961,7 +5961,7 @@ def _symbolic_factor(expr, opt, method):
     if isinstance(expr, Expr) and not expr.is_Relational:
         if hasattr(expr,'_eval_factor'):
             return expr._eval_factor()
-        coeff, factors = _symbolic_factor_list(together(expr, fraction=opt.get('fraction', True)), opt, method)
+        coeff, factors = _symbolic_factor_list(together(expr, fraction=opt['fraction']), opt, method)
         return _keep_coeff(coeff, _factors_product(factors))
     elif hasattr(expr, 'args'):
         return expr.func(*[_symbolic_factor(arg, opt, method) for arg in expr.args])

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -8,7 +8,7 @@ from sympy.core.exprtools import gcd_terms
 from sympy.utilities import public
 
 @public
-def together(expr, deep=False):
+def together(expr, deep=False, fraction=True):
     """
     Denest and combine rational expressions using symbolic methods.
 
@@ -65,7 +65,7 @@ def together(expr, deep=False):
             if expr.is_Atom or (expr.is_Function and not deep):
                 return expr
             elif expr.is_Add:
-                return gcd_terms(list(map(_together, Add.make_args(expr))))
+                return gcd_terms(list(map(_together, Add.make_args(expr))), fraction=fraction)
             elif expr.is_Pow:
                 base = _together(expr.base)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2476,6 +2476,11 @@ def test_factor():
     assert factor(eq, x, deep=True) == (x + 3)*(x + 4)*(y**2 + 11*y + 30)
     assert factor(eq, y, deep=True) == (y + 5)*(y + 6)*(x**2 + 7*x + 12)
 
+    # fraction option
+    f = 5*x + 3*exp(2 - 7*x)
+    assert factor(f, deep=True) == factor(f, deep=True, fraction=True)
+    factor(f, deep=True, fraction=False) == 5*x + 3*exp(2)*exp(-7*x)
+
 
 def test_factor_large():
     f = (x**2 + 4*x + 4)**10000000*(x**2 + 1)*(x**2 + 2*x + 1)**1234567

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2479,7 +2479,7 @@ def test_factor():
     # fraction option
     f = 5*x + 3*exp(2 - 7*x)
     assert factor(f, deep=True) == factor(f, deep=True, fraction=True)
-    factor(f, deep=True, fraction=False) == 5*x + 3*exp(2)*exp(-7*x)
+    assert factor(f, deep=True, fraction=False) == 5*x + 3*exp(2)*exp(-7*x)
 
 
 def test_factor_large():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
fixes: #16263 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
passing `fraction=False` directly to `together` seems to disturb few existing tests, like:

```python
In [5]: f = -1 + 1/(x**2 + 2*x + 1/x) 
In [6]: factor(f)
Out[6]: -1 + 1/(x**2 + 2*x + 1/x)
# instead of `-((1 - x + 2*x**2 + x**3)/(1 + 2*x**2 + x**3))`
```

so it would perhaps be better to have an extra flag to `factor`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - added `fraction` flag in `factor()`
<!-- END RELEASE NOTES -->
