### PR TITLE
_getnargs->arity works with user defined and lambda

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -22,7 +22,7 @@ from .function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \
     expand_mul, expand_log, expand_func, \
     expand_trig, expand_complex, expand_multinomial, nfloat, \
-    expand_power_base, expand_power_exp
+    expand_power_base, expand_power_exp, arity
 from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -5,7 +5,7 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         Matrix, Basic)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.basic import _aresame
-from sympy.core.function import PoleError, _mexpand
+from sympy.core.function import PoleError, _mexpand, arity
 from sympy.core.sympify import sympify
 from sympy.sets.sets import FiniteSet
 from sympy.solvers.solveset import solveset
@@ -156,6 +156,16 @@ def test_nargs():
     assert Function('f', nargs=(0, 1)).nargs == FiniteSet(0, 1)
     assert Function('f', nargs=None).nargs == S.Naturals0
     raises(ValueError, lambda: Function('f', nargs=()))
+
+
+def test_arity():
+    f = lambda x, y: 1
+    assert arity(f) == 2
+    def f(x, y, z=None):
+        pass
+    assert arity(f) == (2, 3)
+    assert arity(lambda *x: x) is None
+    assert arity(log) == (1, 2)
 
 
 def test_Lambda():

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -30,6 +30,7 @@ import sys
 
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
 from sympy.external import import_module
+from sympy.core.function import arity
 from sympy.core.compatibility import range, Callable
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)
@@ -56,16 +57,6 @@ def unset_show():
 ##############################################################################
 # The public interface
 ##############################################################################
-
-def _arity(f):
-    """
-    Python 2 and 3 compatible version that do not raise a Deprecation warning.
-    """
-    if sys.version_info < (3,):
-        return len(inspect.getargspec(f)[0])
-    else:
-       param = inspect.signature(f).parameters.values()
-       return len([p for p in param if p.kind == p.POSITIONAL_OR_KEYWORD])
 
 
 class Plot(object):
@@ -406,15 +397,15 @@ class Line2DBaseSeries(BaseSeries):
         c = self.line_color
         if hasattr(c, '__call__'):
             f = np.vectorize(c)
-            arity = _arity(c)
-            if arity == 1 and self.is_parametric:
+            nargs = arity(c)
+            if nargs == 1 and self.is_parametric:
                 x = self.get_parameter_points()
                 return f(centers_of_segments(x))
             else:
                 variables = list(map(centers_of_segments, self.get_points()))
-                if arity == 1:
+                if nargs == 1:
                     return f(variables[0])
-                elif arity == 2:
+                elif nargs == 2:
                     return f(*variables[:2])
                 else:  # only if the line is 3D (otherwise raises an error)
                     return f(*variables)
@@ -750,17 +741,17 @@ class SurfaceBaseSeries(BaseSeries):
         c = self.surface_color
         if isinstance(c, Callable):
             f = np.vectorize(c)
-            arity = _arity(c)
+            nargs = arity(c)
             if self.is_parametric:
                 variables = list(map(centers_of_faces, self.get_parameter_meshes()))
-                if arity == 1:
+                if nargs == 1:
                     return f(variables[0])
-                elif arity == 2:
+                elif nargs == 2:
                     return f(*variables)
             variables = list(map(centers_of_faces, self.get_meshes()))
-            if arity == 1:
+            if nargs == 1:
                 return f(variables[0])
-            elif arity == 2:
+            elif nargs == 2:
                 return f(*variables[:2])
             else:
                 return f(*variables)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Currently, `_getnargs` does not work with user-defined or lambdas.
```python
>>> from sympy.core.function import _getnargs
>>> _getnargs(lambda x:x)
>>> def f(x):pass
...
>>> _getnargs(f)
>>>
```
With this PR, they will and `_getnargs` is now a public function called `arity`:
```
    >>> arity(lambda x: x)
    1
    >>> arity(log)
    (1, 2)
    >>> arity(lambda *x: sum(x)) is None
    True
``` 

#### Other comments

As a point of interest: the builtin `callable` will tell you if something can be called. 
```python
>>> callable(log)
True
>>> callable(lambda x:x)
True
>>> def f(x): pass
...
>>> callable(f)
True
```
If it is callable it can be sent to `arity`. But classes that have an eval method will fail the `isfunction`
method of inspect (but they can be sent to `arity`):
```python
>>> from inspect import isfunction
>>> isfunction(log)
False
>>> isfunction(lambda x:x)
True
>>> isfunction(f)
True
```
#### Release Notes
    
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - arity function added to core.functions
<!-- END RELEASE NOTES -->
