### PR TITLE
Matrices : Extend pseudoinverse capability

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4024,12 +4024,83 @@ class MatrixBase(MatrixDeprecated,
             arbitrary_matrix = self.__class__(cols, rows, w).T
         return A_pinv * B + (eye(A.cols) - A_pinv * A) * arbitrary_matrix
 
-    def pinv(self):
+    def _eval_pinv_full_rank(self):
+        """Subroutine for full row or column rank matrices.
+
+        For full row rank matrices, inverse of ``A * A.H`` Exists.
+        For full column rank matrices, inverse of ``A.H * A`` Exists.
+
+        This routine can apply for both cases by checking the shape
+        and have small decision.
+        """
+        if self.is_zero:
+            return self
+
+        if self.rows >= self.cols:
+            return (self.H * self).inv() * self.H
+        else:
+            return self.H * (self * self.H).inv()
+
+    def _eval_pinv_rank_decomposition(self):
+        """Subroutine for rank decomposition
+
+        With rank decompositions, `A` can be decomposed into two full-
+        rank matrices, and each matrix can take pseudoinverse
+        individually.
+        """
+        if self.is_zero:
+            return self
+
+        B, C = self.rank_decomposition()
+
+        Bp = B._eval_pinv_full_rank()
+        Cp = C._eval_pinv_full_rank()
+
+        return Cp * Bp
+
+    def _eval_pinv_diagonalization(self):
+        """Subroutine using diagonalization
+
+        This routine can sometimes fail if SymPy's eigenvalue
+        computation is not reliable.
+        """
+        if self.is_zero:
+            return self
+
+        A = self
+        AH = self.H
+
+        try:
+            if self.rows >= self.cols:
+                P, D = (AH * A).diagonalize(normalize=True)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
+                return P * D_pinv * P.H * AH
+            else:
+                P, D = (A * AH).diagonalize(normalize=True)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
+                return AH * P * D_pinv * P.H
+        except MatrixError:
+            raise NotImplementedError(
+                'pinv for rank-deficient matrices where '
+                'diagonalization of A.H*A fails is not supported yet.')
+
+
+    def pinv(self, method='RD'):
         """Calculate the Moore-Penrose pseudoinverse of the matrix.
 
         The Moore-Penrose pseudoinverse exists and is unique for any matrix.
         If the matrix is invertible, the pseudoinverse is the same as the
         inverse.
+
+        Parameters
+        ==========
+
+        method : String, optional
+            Specifies the method for computing the pseudoinverse.
+
+            If ``'RD'``, Rank-Decomposition will be used.
+
+            If ``'diag'``, Diagonalization will be used.
 
         Examples
         ========
@@ -4053,32 +4124,15 @@ class MatrixBase(MatrixDeprecated,
         .. [1] https://en.wikipedia.org/wiki/Moore-Penrose_pseudoinverse
 
         """
-        A = self
-        AH = self.H
+
         # Trivial case: pseudoinverse of all-zero matrix is its transpose.
-        if A.is_zero:
-            return AH
-        try:
-            if self.rows >= self.cols:
-                return (AH * A).inv() * AH
-            else:
-                return AH * (A * AH).inv()
-        except ValueError:
-            # Matrix is not full rank, so A*AH cannot be inverted.
-            pass
-        try:
-            # However, A*AH is Hermitian, so we can diagonalize it.
-            if self.rows >= self.cols:
-                P, D = (AH * A).diagonalize(normalize=True)
-                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
-                return P * D_pinv * P.H * AH
-            else:
-                P, D = (A * AH).diagonalize(normalize=True)
-                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
-                return AH * P * D_pinv * P.H
-        except MatrixError:
-            raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '
-                                      'of A.H*A fails is not supported yet.')
+        if self.is_zero:
+            return self
+
+        if method == 'RD':
+            return self._eval_pinv_rank_decomposition()
+        elif method == 'diag':
+            return self._eval_pinv_diagonalization()
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4034,7 +4034,7 @@ class MatrixBase(MatrixDeprecated,
         and have small decision.
         """
         if self.is_zero:
-            return self
+            return self.H
 
         if self.rows >= self.cols:
             return (self.H * self).inv() * self.H
@@ -4049,7 +4049,7 @@ class MatrixBase(MatrixDeprecated,
         individually.
         """
         if self.is_zero:
-            return self
+            return self.H
 
         B, C = self.rank_decomposition()
 
@@ -4065,7 +4065,7 @@ class MatrixBase(MatrixDeprecated,
         computation is not reliable.
         """
         if self.is_zero:
-            return self
+            return self.H
 
         A = self
         AH = self.H
@@ -4137,10 +4137,9 @@ class MatrixBase(MatrixDeprecated,
         .. [1] https://en.wikipedia.org/wiki/Moore-Penrose_pseudoinverse
 
         """
-
         # Trivial case: pseudoinverse of all-zero matrix is its transpose.
         if self.is_zero:
-            return self
+            return self.H
 
         if method == 'RD':
             return self._eval_pinv_rank_decomposition()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4100,7 +4100,7 @@ class MatrixBase(MatrixDeprecated,
 
             If ``'RD'``, Rank-Decomposition will be used.
 
-            If ``'diag'``, Diagonalization will be used.
+            If ``'ED'``, Diagonalization will be used.
 
         Examples
         ========
@@ -4117,7 +4117,7 @@ class MatrixBase(MatrixDeprecated,
 
         Computing pseudoinverse by diagonalization :
 
-        >>> B = A.pinv(method='diag')
+        >>> B = A.pinv(method='ED')
         >>> B.simplify()
         >>> B
         Matrix([
@@ -4143,8 +4143,10 @@ class MatrixBase(MatrixDeprecated,
 
         if method == 'RD':
             return self._eval_pinv_rank_decomposition()
-        elif method == 'diag':
+        elif method == 'ED':
             return self._eval_pinv_diagonalization()
+        else:
+            raise ValueError()
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4105,8 +4105,21 @@ class MatrixBase(MatrixDeprecated,
         Examples
         ========
 
+        Computing pseudoinverse by rank decomposition :
+
         >>> from sympy import Matrix
-        >>> Matrix([[1, 2, 3], [4, 5, 6]]).pinv()
+        >>> A = Matrix([[1, 2, 3], [4, 5, 6]])
+        >>> A.pinv()
+        Matrix([
+        [-17/18,  4/9],
+        [  -1/9,  1/9],
+        [ 13/18, -2/9]])
+
+        Computing pseudoinverse by diagonalization :
+
+        >>> B = A.pinv(method='diag')
+        >>> B.simplify()
+        >>> B
         Matrix([
         [-17/18,  4/9],
         [  -1/9,  1/9],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2933,19 +2933,19 @@ def test_pinv():
     # assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
 
     import random
+    from sympy.core.numbers import comp
     q = A1.pinv(method="ED")
     w = A1.inv()
     v = (a, b, c, d)
-    for do in range(5):
-        while True:
-            reps = \
-                dict(zip(v, (random.randint(-10**5, 10**5) for i in v)))
-            if reps[a] * reps[d] - reps[b] * reps[c] != 0:
-                break
-        assert all(
-            i.n() == j.n()
-            for i, j in zip(q.subs(reps), w.subs(reps))
-            )
+    while True:
+        reps = \
+            dict(zip(v, (random.randint(-10**5, 10**5) for i in v)))
+        if (a*d - b*c).subs(reps) != 0:
+            break
+    assert all(
+        comp(i.n(), j.n())
+        for i, j in zip(q.subs(reps), w.subs(reps))
+        )
 
 def test_pinv_solve():
     # Fully determined system (unique result, identical to other solvers).

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2931,17 +2931,11 @@ def test_pinv():
     # is too complicated to simplify.
     # A1 = Matrix([[a, b], [c, d]])
     # assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
-
-    import random
+    # so this is tested numerically at a fixed random point
     from sympy.core.numbers import comp
     q = A1.pinv(method="ED")
     w = A1.inv()
-    v = (a, b, c, d)
-    while True:
-        reps = \
-            dict(zip(v, (random.randint(-10**5, 10**5) for i in v)))
-        if (a*d - b*c).subs(reps) != 0:
-            break
+    reps = {a: -73633, b: 11362, c: 55486, d: 62570}
     assert all(
         comp(i.n(), j.n())
         for i, j in zip(q.subs(reps), w.subs(reps))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2903,11 +2903,6 @@ def test_pinv():
     A1 = Matrix([[a, b], [c, d]])
     assert simplify(A1.pinv(method="RD")) == simplify(A1.inv())
 
-    # XXX Computing pinv using diagonalization makes an expression that
-    # is too complicated to simplify.
-    # A1 = Matrix([[a, b], [c, d]])
-    # assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
-
     # Test the four properties of the pseudoinverse for various matrices.
     As = [Matrix([[13, 104], [2212, 3], [-3, 5]]),
           Matrix([[1, 7, 9], [11, 17, 19]]),
@@ -2931,6 +2926,26 @@ def test_pinv():
         assert simplify(ApA * A_pinv) == A_pinv
         assert AAp.H == AAp
         assert ApA.H == ApA
+
+    # XXX Computing pinv using diagonalization makes an expression that
+    # is too complicated to simplify.
+    # A1 = Matrix([[a, b], [c, d]])
+    # assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
+
+    import random
+    q = A1.pinv(method="ED")
+    w = A1.inv()
+    v = (a, b, c, d)
+    for do in range(5):
+        while True:
+            reps = \
+                dict(zip(v, (random.randint(-10**5, 10**5) for i in v)))
+            if reps[a] * reps[d] - reps[b] * reps[c] != 0:
+                break
+        assert all(
+            i.n() == j.n()
+            for i, j in zip(q.subs(reps), w.subs(reps))
+            )
 
 def test_pinv_solve():
     # Fully determined system (unique result, identical to other solvers).

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2901,13 +2901,26 @@ def test_atoms():
 def test_pinv():
     # Pseudoinverse of an invertible matrix is the inverse.
     A1 = Matrix([[a, b], [c, d]])
-    assert simplify(A1.pinv()) == simplify(A1.inv())
+    assert simplify(A1.pinv(method="RD")) == simplify(A1.inv())
+    A1 = Matrix([[a, b], [c, d]])
+    assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
+
     # Test the four properties of the pseudoinverse for various matrices.
     As = [Matrix([[13, 104], [2212, 3], [-3, 5]]),
           Matrix([[1, 7, 9], [11, 17, 19]]),
           Matrix([a, b])]
+
     for A in As:
-        A_pinv = A.pinv()
+        A_pinv = A.pinv(method="RD")
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
+
+    for A in As:
+        A_pinv = A.pinv(method="ED")
         AAp = A * A_pinv
         ApA = A_pinv * A
         assert simplify(AAp * A) == A
@@ -2953,14 +2966,25 @@ def test_pinv_rank_deficient():
     As = [Matrix([[1, 1, 1], [2, 2, 2]]),
           Matrix([[1, 0], [0, 0]]),
           Matrix([[1, 2], [2, 4], [3, 6]])]
+
     for A in As:
-        A_pinv = A.pinv()
+        A_pinv = A.pinv(method="RD")
         AAp = A * A_pinv
         ApA = A_pinv * A
         assert simplify(AAp * A) == A
         assert simplify(ApA * A_pinv) == A_pinv
         assert AAp.H == AAp
         assert ApA.H == ApA
+
+    for A in As:
+        A_pinv = A.pinv(method="ED")
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
+
     # Test solving with rank-deficient matrices.
     A = Matrix([[1, 0], [0, 0]])
     # Exact, non-unique solution.
@@ -2990,7 +3014,7 @@ def test_pinv_rank_deficient_when_diagonalization_fails():
         [ 7, 30, 10, 48, 90, 0],
         [0,0,0,0,0,0]])]
     for A in As:
-        A_pinv = A.pinv()
+        A_pinv = A.pinv(method="ED")
         AAp = A * A_pinv
         ApA = A_pinv * A
         assert simplify(AAp * A) == A
@@ -2998,6 +3022,23 @@ def test_pinv_rank_deficient_when_diagonalization_fails():
         assert AAp.H == AAp
         assert ApA.H == ApA
 
+def test_pinv_rank_deficient_when_diagonalization_fails():
+    # Test rank decomposition method of pseudoinverse succeeding
+    As = [Matrix([
+        [61, 89, 55, 20, 71, 0],
+        [62, 96, 85, 85, 16, 0],
+        [69, 56, 17,  4, 54, 0],
+        [10, 54, 91, 41, 71, 0],
+        [ 7, 30, 10, 48, 90, 0],
+        [0,0,0,0,0,0]])]
+    for A in As:
+        A_pinv = A.pinv(method="RD")
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
 
 def test_gauss_jordan_solve():
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3022,7 +3022,7 @@ def test_pinv_rank_deficient_when_diagonalization_fails():
         assert AAp.H == AAp
         assert ApA.H == ApA
 
-def test_pinv_rank_deficient_when_diagonalization_fails():
+def test_pinv_succeeds_with_rank_decomposition_method():
     # Test rank decomposition method of pseudoinverse succeeding
     As = [Matrix([
         [61, 89, 55, 20, 71, 0],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2902,8 +2902,11 @@ def test_pinv():
     # Pseudoinverse of an invertible matrix is the inverse.
     A1 = Matrix([[a, b], [c, d]])
     assert simplify(A1.pinv(method="RD")) == simplify(A1.inv())
-    A1 = Matrix([[a, b], [c, d]])
-    assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
+
+    # XXX Computing pinv using diagonalization makes an expression that
+    # is too complicated to simplify.
+    # A1 = Matrix([[a, b], [c, d]])
+    # assert simplify(A1.pinv(method="ED")) == simplify(A1.inv())
 
     # Test the four properties of the pseudoinverse for various matrices.
     As = [Matrix([[13, 104], [2212, 3], [-3, 5]]),
@@ -2919,8 +2922,9 @@ def test_pinv():
         assert AAp.H == AAp
         assert ApA.H == ApA
 
+    # XXX Pinv with diagonalization makes expression too complicated.
     for A in As:
-        A_pinv = A.pinv(method="ED")
+        A_pinv = simplify(A.pinv(method="ED"))
         AAp = A * A_pinv
         ApA = A_pinv * A
         assert simplify(AAp * A) == A


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

#16209

#### Brief description of what is fixed or changed

With rank decomposition, we can finally get a valid routine that can apply for the most generic cases.

I don't think the gamble like
https://github.com/sympy/sympy/blob/6979792bd194c385a851a8e44925b522630d04de/sympy/matrices/matrices.py#L4061-L4069
this offers any significant performance boost or such at this point, so I had rather added `method` option and made the specific routine to private, so it can internally be used in some cases where matrix is guaranteed to be full rank.

I have named rank-decomposition as `RD` and diagonalization as `diag`, but I would open a discussion about the naming.
I also have an idea of naming diagonalization as `ED` when used in keywords, which stands for Eigen-decomposition
https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix#Eigendecomposition_of_a_matrix

Also, I see the failing pseudoinverse test succeeding after this change, so I will further work on the tests, one for adding some tests for each methods, and the other for adding the failing test specific for the diagonalization routine.

At this point, SymPy's eigen solver is giving too verbose result, and quite poor in numeric stability after cubic polynomial roots formula is used.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `Matrix.pinv` will use rank decomposition by default.
  - Added `method` option for `Matrix.pinv`

<!-- END RELEASE NOTES -->
