### PR TITLE
Fix mathematica code user_functions argument

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -59,11 +59,11 @@ class MCodePrinter(CodePrinter):
         """Register function mappings supplied by user"""
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
-        userfuncs = settings.get('user_functions', {})
+        userfuncs = settings.get('user_functions', {}).copy()
         for k, v in userfuncs.items():
             if not isinstance(v, list):
                 userfuncs[k] = [(lambda *x: True, v)]
-                self.known_functions.update(userfuncs)
+        self.known_functions.update(userfuncs)
 
     def _format_code(self, lines):
         return lines

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -196,3 +196,24 @@ def test_comment():
     from sympy.printing.mathematica import MCodePrinter
     assert MCodePrinter()._get_comment("Hello World") == \
         "(* Hello World *)"
+
+def test_userfuncs():
+    # Dictionary mutation test
+    some_function = symbols("some_function", cls=Function)
+    my_user_functions = {"some_function": "SomeFunction"}
+    assert mcode(
+        some_function(z),
+        user_functions=my_user_functions) == \
+        'SomeFunction[z]'
+    assert mcode(
+        some_function(z),
+        user_functions=my_user_functions) == \
+        'SomeFunction[z]'
+
+    # List argument test
+    my_user_functions = \
+        {"some_function": [(lambda x: True, "SomeOtherFunction")]}
+    assert mcode(
+        some_function(z),
+        user_functions=my_user_functions) == \
+        'SomeOtherFunction[z]'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16306

#### Brief description of what is fixed or changed

The problem was calling `userfuncs[k]` that had mutated the original dictionary,
and `self.known_functions.update(userfuncs)` located inside the check.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed `mathematica_code` mutating the dictionary passed to the argument `userfuncs`
  - Fixed `mathematica_code` ignoring list items passed to `userfuncs`.

<!-- END RELEASE NOTES -->
