### PR TITLE
Stats: Added check on the parameters of F Distribution

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1022,8 +1022,10 @@ class FDistributionDistribution(SingleContinuousDistribution):
 
     @staticmethod
     def check(d1, d2):
-        _value_check(d1 > 0 and d1.is_integer, "Degrees of freedom d1 must be positive integer.")
-        _value_check(d2 > 0 and d2.is_integer, "Degrees of freedom d2 must be positive integer.")
+        _value_check(d1 > 0 and d1.is_integer, \
+            "Degrees of freedom d1 must be positive integer.")
+        _value_check(d2 > 0 and d2.is_integer, \
+            "Degrees of freedom d2 must be positive integer.")
 
     def pdf(self, x):
         d1, d2 = self.d1, self.d2

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1020,6 +1020,11 @@ class FDistributionDistribution(SingleContinuousDistribution):
 
     set = Interval(0, oo)
 
+    @staticmethod
+    def check(d1, d2):
+        _value_check(d1 > 0 and d1.is_integer, "Degrees of freedom d1 must be positive integer.")
+        _value_check(d2 > 0 and d2.is_integer, "Degrees of freedom d2 must be positive integer.")
+
     def pdf(self, x):
         d1, d2 = self.d1, self.d2
         return (sqrt((d1*x)**d1*d2**d2 / (d1*x+d2)**(d1+d2))

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -364,6 +364,20 @@ def test_f_distribution():
     assert density(X)(x) == (d2**(d2/2)*sqrt((d1*x)**d1*(d1*x + d2)**(-d1 - d2))
                              /(x*beta(d1/2, d2/2)))
 
+    d1 = Symbol("d1", positive=False)
+    raises(ValueError, lambda: FDistribution('x', d1, d1))
+
+    d1 = Symbol("d1", positive=True, integer=False)
+    raises(ValueError, lambda: FDistribution('x', d1, d1))
+
+    d1 = Symbol("d1", positive=True)
+    d2 = Symbol("d2", positive=False)
+    raises(ValueError, lambda: FDistribution('x', d1, d2))
+
+    d2 = Symbol("d2", positive=True, integer=False)
+    raises(ValueError, lambda: FDistribution('x', d1, d2))
+
+
 def test_fisher_z():
     d1 = Symbol("d1", positive=True)
     d2 = Symbol("d2", positive=True)


### PR DESCRIPTION
F Distribution takes two parameters as input which are both positive and
integers. Added checks for this in `crv_types.py` and relevant tests in
`test_continuous_rv.py` of stats module

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Improves #16183

#### Brief description of what is fixed or changed


#### Other comments
Docs have not been changed. If needed can be changed. Please tell me

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Improved paramter handling by F Distribution
<!-- END RELEASE NOTES -->
