### PR TITLE
Stats: Added a standard function `mean` to compute arithmetic average

### DIFF
--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -17,12 +17,13 @@ Queries on random expressions can be made using the functions
  ``density(expression)``   Probability Density Function
  ``sample(expression)``    Produce a realization
  ``where(condition)``      Where the condition is true
+ ``mean(expression)``      Arithmetic average value
 ========================= =============================
 
 Examples
 ========
 
->>> from sympy.stats import P, E, variance, Die, Normal
+>>> from sympy.stats import P, E, variance, mean, Die, Normal
 >>> from sympy import Eq, simplify
 >>> X, Y = Die('X', 6), Die('Y', 6) # Define two six sided dice
 >>> Z = Normal('Z', 0, 1) # Declare a Normal random variable with mean 0, std 1
@@ -34,6 +35,8 @@ Examples
 35/6
 >>> simplify(P(Z>1)) # Probability of Z being greater than 1
 1/2 - erf(sqrt(2)/2)/2
+>>> mean(X) # Average value of outcome of dice
+7/2
 """
 
 __all__ = []
@@ -43,6 +46,7 @@ from .rv_interface import (
     cdf, characteristic_function, covariance, density, dependent, E, given, independent, P, pspace,
     random_symbols, sample, sample_iter, skewness, std, variance, where,
     correlation, moment, cmoment, smoment, sampling_density, moment_generating_function,
+    mean
 )
 __all__.extend(rv_interface.__all__)
 

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -8,7 +8,7 @@ from sympy import sqrt
 __all__ = ['P', 'E', 'density', 'where', 'given', 'sample', 'cdf', 'characteristic_function', 'pspace',
         'sample_iter', 'variance', 'std', 'skewness', 'covariance',
         'dependent', 'independent', 'random_symbols', 'correlation',
-        'moment', 'cmoment', 'sampling_density', 'moment_generating_function']
+        'moment', 'cmoment', 'sampling_density', 'moment_generating_function', 'mean']
 
 
 
@@ -211,3 +211,4 @@ def skewness(X, condition=None, **kwargs):
 
 P = probability
 E = expectation
+mean = expectation

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -15,7 +15,7 @@ from sympy.stats import (P, E, where, density, variance, covariance, skewness,
                          QuadraticU, RaisedCosine, Rayleigh, ShiftedGompertz,
                          StudentT, Trapezoidal, Triangular, Uniform, UniformSum,
                          VonMises, Weibull, WignerSemicircle, correlation,
-                         moment, cmoment, smoment)
+                         moment, cmoment, smoment, mean)
 from sympy.stats.crv_types import NormalDistribution
 from sympy.stats.joint_rv import JointPSpace
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
@@ -343,6 +343,7 @@ def test_exponential():
     X = Exponential('x', rate)
 
     assert E(X) == 1/rate
+    assert mean(X) == 1/rate
     assert variance(X) == 1/rate**2
     assert skewness(X) == 2
     assert skewness(X) == smoment(X, 3)

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -4,7 +4,7 @@ from sympy import (FiniteSet, S, Symbol, sqrt,
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
-    Hypergeometric, Rademacher, P, E, variance, covariance, skewness, sample,
+    Hypergeometric, Rademacher, P, E, mean, variance, covariance, skewness, sample,
     density, where, FiniteRV, pspace, cdf,
     correlation, moment, cmoment, smoment, characteristic_function, moment_generating_function)
 from sympy.stats.frv_types import DieDistribution
@@ -51,6 +51,7 @@ def test_dice():
     a, b, t = symbols('a b t')
 
     assert E(X) == 3 + S.Half
+    assert mean(X) == S(7)/2
     assert variance(X) == S(35)/12
     assert E(X + Y) == 7
     assert E(X + X) == 7
@@ -156,6 +157,7 @@ def test_bernoulli():
     assert density(X)[b] == 1 - p
     assert characteristic_function(X)(t) == p * exp(I * a * t) + (-p + 1) * exp(I * b * t)
     assert moment_generating_function(X)(t) == p * exp(a * t) + (-p + 1) * exp(b * t)
+    assert mean(X) == a*p + b*(-p + 1)
 
     X = Bernoulli('B', p, 1, 0)
 


### PR DESCRIPTION
Till now, mean in Sympy could be found using `E`(expectation).
Keeping end users in mind, added a function `mean` which essentially
does the same thing but can be more easy to understand for new users.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
I am not sure about the change in `init.py` https://github.com/supreet11agrawal/sympy/blob/7561a336c4923e0dfcac8c11475c9efd5acaf52e/sympy/stats/__init__.py#L20
This can be removed as well. This is added here to show functioning

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Added a standard function `mean` for computing arithmetic average
<!-- END RELEASE NOTES -->
