### PR TITLE
replace is exact by default

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1276,7 +1276,7 @@ class Basic(with_metaclass(ManagedProperties)):
         """Helper for .has()"""
         return lambda other: self == other
 
-    def replace(self, query, value, map=False, simultaneous=True, exact=False):
+    def replace(self, query, value, map=False, simultaneous=True, exact=None):
         """
         Replace matching subexpressions of ``self`` with ``value``.
 
@@ -1339,7 +1339,7 @@ class Basic(with_metaclass(ManagedProperties)):
             Replace subexpressions matching ``pattern`` with the expression
             written in terms of the Wild symbols in ``pattern``.
 
-            >>> a = Wild('a')
+            >>> a, b = map(Wild, 'ab')
             >>> f.replace(sin(a), tan(a))
             log(tan(x)) + tan(tan(x**2))
             >>> f.replace(sin(a), tan(a/2))
@@ -1349,21 +1349,19 @@ class Basic(with_metaclass(ManagedProperties)):
             >>> (x*y).replace(a*x, a)
             y
 
-            When the default value of False is used with patterns that have
-            more than one Wild symbol, non-intuitive results may be obtained:
+            Matching is exact by default when more than one Wild symbol
+            is used: matching fails unless the match gives non-zero
+            values for all Wild symbols:
 
-            >>> b = Wild('b')
-            >>> (2*x).replace(a*x + b, b - a)
-            2/x
-
-            For this reason, the ``exact`` option can be used to make the
-            replacement only when the match gives non-zero values for all
-            Wild symbols:
-
-            >>> (2*x + y).replace(a*x + b, b - a, exact=True)
+            >>> (2*x + y).replace(a*x + b, b - a)
             y - 2
-            >>> (2*x).replace(a*x + b, b - a, exact=True)
+            >>> (2*x).replace(a*x + b, b - a)
             2*x
+
+            When set to False, the results may be non-intuitive:
+
+            >>> (2*x).replace(a*x + b, b - a, exact=False)
+            2/x
 
         2.2. pattern -> func
             obj.replace(pattern(wild), lambda wild: expr(wild))
@@ -1399,7 +1397,7 @@ class Basic(with_metaclass(ManagedProperties)):
                   using matching rules
 
         """
-        from sympy.core.symbol import Dummy
+        from sympy.core.symbol import Dummy, Wild
         from sympy.simplify.simplify import bottom_up
 
         try:
@@ -1423,18 +1421,12 @@ class Basic(with_metaclass(ManagedProperties)):
                     "type or a callable")
         elif isinstance(query, Basic):
             _query = lambda expr: expr.match(query)
+            exact = len(query.atoms(Wild)) > 1 if exact is None else exact
 
-            # XXX remove the exact flag and make multi-symbol
-            # patterns use exact=True semantics; to do this the query must
-            # be tested to find out how many Wild symbols are present.
-            # See https://groups.google.com/forum/
-            # ?fromgroups=#!topic/sympy/zPzo5FtRiqI
-            # for a method of inspecting a function to know how many
-            # parameters it has.
             if isinstance(value, Basic):
                 if exact:
                     _value = lambda expr, result: (value.subs(result)
-                        if all(val for val in result.values()) else expr)
+                        if all(result.values()) else expr)
                 else:
                     _value = lambda expr, result: value.subs(result)
             elif callable(value):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -674,9 +674,11 @@ def test_replace():
         sin(a), lambda a: sin(2*a)) == log(sin(2*x)) + tan(sin(2*x**2))
     # test exact
     assert (2*x).replace(a*x + b, b - a, exact=True) == 2*x
-    assert (2*x).replace(a*x + b, b - a) == 2/x
+    assert (2*x).replace(a*x + b, b - a) == 2*x
+    assert (2*x).replace(a*x + b, b - a, exact=False) == 2/x
     assert (2*x).replace(a*x + b, lambda a, b: b - a, exact=True) == 2*x
-    assert (2*x).replace(a*x + b, lambda a, b: b - a) == 2/x
+    assert (2*x).replace(a*x + b, lambda a, b: b - a) == 2*x
+    assert (2*x).replace(a*x + b, lambda a, b: b - a, exact=False) == 2/x
 
     g = 2*sin(x**3)
 

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -2,7 +2,6 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, erf, tan, asin, asinh, acos, atan, Function, Derivative, diff, simplify, \
     LambertW, Eq, Ne, Piecewise, Symbol, Add, ratsimp, Integral, Sum, \
     besselj, besselk, bessely, jn, tanh
-from sympy.core.compatibility import PY3
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
 from sympy.integrals.integrals import integrate
@@ -246,17 +245,12 @@ def test_pmint_logexp():
     assert ratsimp(heurisch(f, x)) == g
 
 
-# @XFAIL  # there's a hash dependent failure lurking here
-# Seems to work on Python 3, but keeping the comment above just in case
+@XFAIL  # there's a hash dependent failure lurking here
 def test_pmint_erf():
     f = exp(-x**2)*erf(x)/(erf(x)**3 - erf(x)**2 - erf(x) + 1)
     g = sqrt(pi)*log(erf(x) - 1)/8 - sqrt(pi)*log(erf(x) + 1)/8 - sqrt(pi)/(4*erf(x) - 4)
 
     assert ratsimp(heurisch(f, x)) == g
-
-
-if not PY3:
-    test_pmint_erf = XFAIL(test_pmint_erf)
 
 def test_pmint_LambertW():
     f = LambertW(x)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2321,7 +2321,12 @@ class _MinimalMatrix(object):
         return self.mat[key]
 
     def __eq__(self, other):
-        return self.shape == other.shape and list(self) == list(other)
+        try:
+            classof(self, other)
+        except TypeError:
+            return False
+        return (
+            self.shape == other.shape and list(self) == list(other))
 
     def __len__(self):
         return self.rows*self.cols

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -7,7 +7,7 @@ etc.).
 from __future__ import division, print_function
 
 from collections import defaultdict
-from types import FunctionType
+from inspect import isfunction
 
 from sympy.assumptions.refine import refine
 from sympy.core.basic import Atom
@@ -1178,7 +1178,7 @@ class MatrixProperties(MatrixRequired):
         """
         # accept custom simplification
         simpfunc = simplify
-        if not isinstance(simplify, FunctionType):
+        if not isfunction(simplify):
             simpfunc = _simplify if simplify else lambda x: x
 
         if not self.is_square:
@@ -1261,7 +1261,7 @@ class MatrixProperties(MatrixRequired):
             return False
 
         simpfunc = simplify
-        if not isinstance(simplify, FunctionType):
+        if not isfunction(simplify):
             simpfunc = _simplify if simplify else lambda x: x
 
         return self._eval_is_matrix_hermitian(simpfunc)
@@ -1441,7 +1441,7 @@ class MatrixProperties(MatrixRequired):
         True
         """
         simpfunc = simplify
-        if not isinstance(simplify, FunctionType):
+        if not isfunction(simplify):
             simpfunc = _simplify if simplify else lambda x: x
 
         if not self.is_square:
@@ -2261,7 +2261,7 @@ class _MinimalMatrix(object):
         return cls(*args, **kwargs)
 
     def __init__(self, rows, cols=None, mat=None):
-        if isinstance(mat, FunctionType):
+        if isfunction(mat):
             # if we passed in a function, use that to populate the indices
             mat = list(mat(i, j) for i in range(rows) for j in range(cols))
         if cols is None and mat is None:

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1486,13 +1486,22 @@ def test_jacobian2():
     raises(TypeError, lambda: m.jacobian(Matrix([1,2])))
     raises(TypeError, lambda: m2.jacobian(m))
 
+
 def test_limit():
     x, y = symbols('x y')
     m = CalculusOnlyMatrix(2, 1, [1/x, y])
     assert m.limit(x, 5) == Matrix(2, 1, [S(1)/5, y])
+
 
 def test_issue_13774():
     M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     v = [1,1,1]
     raises(TypeError, lambda: M*v)
     raises(TypeError, lambda: v*M)
+
+
+def test___eq__():
+    assert (EigenOnlyMatrix(
+        [[0, 1, 1],
+        [1, 0, 0],
+        [1, 1, 1]]) == {}) is False

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -5,8 +5,6 @@ from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols
 from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint)
 
-# TODO : Figure out how to make the pretty printing tests readable like the
-# ones in sympy.printing.pretty.tests.test_printing.
 
 a, b, c = symbols('a, b, c')
 alpha, omega, beta = dynamicsymbols('alpha, omega, beta')

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -283,7 +283,7 @@ def find_executable(executable, path=None):
 
 
 def func_name(x, short=False):
-    '''Return function name of `x` (if defined) else the `type(x)`.
+    """Return function name of `x` (if defined) else the `type(x)`.
     If short is True and there is a shorter alias for the result,
     return the alias.
 
@@ -291,7 +291,10 @@ def func_name(x, short=False):
     ========
 
     >>> from sympy.utilities.misc import func_name
+    >>> from sympy import Matrix
     >>> from sympy.abc import x
+    >>> func_name(Matrix.eye(3))
+    'MutableDenseMatrix'
     >>> func_name(x < 1)
     'StrictLessThan'
     >>> func_name(x < 1, short=True)
@@ -300,7 +303,7 @@ def func_name(x, short=False):
     See Also
     ========
     sympy.core.compatibility get_function_name
-    '''
+    """
     alias = {
     'GreaterThan': 'Ge',
     'StrictGreaterThan': 'Gt',
@@ -315,6 +318,8 @@ def func_name(x, short=False):
     elif str(typ).startswith("<class '"):
         typ = str(typ).split("'")[1].split("'")[0]
     rv = getattr(getattr(x, 'func', x), '__name__', typ)
+    if '.' in rv:
+        rv = rv.split('.')[-1]
     if short:
         rv = alias.get(rv, rv)
     return rv


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Formerly, when there was more than one match symbol used
the matching was not exact unless explicitly made so; this
can lead to very non-intuitive results. To obtain those
results now, one must explicitly set `exact=False`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->




#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - replace with more than one symbol is exact unless `exact` is explicitly made False
<!-- END RELEASE NOTES -->