### PR TITLE
Fix latex printing of BaseScalar

### DIFF
--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -208,7 +208,7 @@ def test_latex_vector_expressions():
     A = CoordSys3D('A')
 
     assert latex(Cross(A.i, A.j*A.x*3+A.k)) == \
-        r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+        r"\mathbf{\hat{i}_{A}} \times \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
     assert latex(Cross(A.i, A.j)) == \
         r"\mathbf{\hat{i}_{A}} \times \mathbf{\hat{j}_{A}}"
     assert latex(x*Cross(A.i, A.j)) == \
@@ -217,23 +217,23 @@ def test_latex_vector_expressions():
         r'- \mathbf{\hat{j}_{A}} \times \left((x)\mathbf{\hat{i}_{A}}\right)'
 
     assert latex(Curl(3*A.x*A.j)) == \
-        r"\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)"
     assert latex(Curl(3*A.x*A.j+A.i)) == \
-        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)"
     assert latex(Curl(3*x*A.x*A.j)) == \
-        r"\nabla\times \left((3 \mathbf{{x}_{A}} x)\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\times \left((3 \mathbf{{A}_{x}} x)\mathbf{\hat{j}_{A}}\right)"
     assert latex(x*Curl(3*A.x*A.j)) == \
-        r"x \left(\nabla\times \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+        r"x \left(\nabla\times \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)\right)"
 
     assert latex(Divergence(3*A.x*A.j+A.i)) == \
-        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\cdot \left(\mathbf{\hat{i}_{A}} + (3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)"
     assert latex(Divergence(3*A.x*A.j)) == \
-        r"\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)"
+        r"\nabla\cdot \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)"
     assert latex(x*Divergence(3*A.x*A.j)) == \
-        r"x \left(\nabla\cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}}\right)\right)"
+        r"x \left(\nabla\cdot \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}}\right)\right)"
 
     assert latex(Dot(A.i, A.j*A.x*3+A.k)) == \
-        r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{x}_{A}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
+        r"\mathbf{\hat{i}_{A}} \cdot \left((3 \mathbf{{A}_{x}})\mathbf{\hat{j}_{A}} + \mathbf{\hat{k}_{A}}\right)"
     assert latex(Dot(A.i, A.j)) == \
         r"\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}"
     assert latex(Dot(x*A.i, A.j)) == \
@@ -241,17 +241,17 @@ def test_latex_vector_expressions():
     assert latex(x*Dot(A.i, A.j)) == \
         r"x \left(\mathbf{\hat{i}_{A}} \cdot \mathbf{\hat{j}_{A}}\right)"
 
-    assert latex(Gradient(A.x)) == r"\nabla \mathbf{{x}_{A}}"
+    assert latex(Gradient(A.x)) == r"\nabla \mathbf{{A}_{x}}"
     assert latex(Gradient(A.x + 3*A.y)) == \
-        r"\nabla \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{x}_{A}}\right)"
-    assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{x}_{A}} x\right)"
+        r"\nabla \left(\mathbf{{A}_{x}} + 3 \mathbf{{A}_{y}}\right)"
+    assert latex(x*Gradient(A.x)) == r"x \left(\nabla \mathbf{{A}_{x}}\right)"
+    assert latex(Gradient(x*A.x)) == r"\nabla \left(\mathbf{{A}_{x}} x\right)"
 
-    assert latex(Laplacian(A.x)) == r"\triangle \mathbf{{x}_{A}}"
+    assert latex(Laplacian(A.x)) == r"\triangle \mathbf{{A}_{x}}"
     assert latex(Laplacian(A.x + 3*A.y)) == \
-        r"\triangle \left(\mathbf{{x}_{A}} + 3 \mathbf{{y}_{A}}\right)"
-    assert latex(x*Laplacian(A.x)) == r"x \left(\triangle \mathbf{{x}_{A}}\right)"
-    assert latex(Laplacian(x*A.x)) == r"\triangle \left(\mathbf{{x}_{A}} x\right)"
+        r"\triangle \left(\mathbf{{A}_{x}} + 3 \mathbf{{A}_{y}}\right)"
+    assert latex(x*Laplacian(A.x)) == r"x \left(\triangle \mathbf{{A}_{x}}\right)"
+    assert latex(Laplacian(x*A.x)) == r"\triangle \left(\mathbf{{A}_{x}} x\right)"
 
 def test_latex_symbols():
     Gamma, lmbda, rho = symbols('Gamma, lambda, rho')

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -214,7 +214,7 @@ class CoordSys3D(Basic):
 
         _check_strings('variable_names', vector_names)
         variable_names = list(variable_names)
-        latex_scalars = [(r"\mathbf{{%s}_{%s}}" % (x, name)) for
+        latex_scalars = [(r"\mathbf{{%s}_{%s}}" % (name, x)) for
                          x in variable_names]
         pretty_scalars = [(name + '_' + x) for x in variable_names]
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -148,12 +148,12 @@ def test_latex_printing():
     assert latex(v[2]) == '- \\mathbf{\\hat{i}_{N}}'
     assert latex(v[5]) == ('(a)\\mathbf{\\hat{i}_{N}} + ' +
                            '(- b)\\mathbf{\\hat{j}_{N}}')
-    assert latex(v[6]) == ('(\\mathbf{{x}_{N}} + a^{2})\\mathbf{\\hat{i}_' +
+    assert latex(v[6]) == ('(\\mathbf{{N}_{x}} + a^{2})\\mathbf{\\hat{i}_' +
                           '{N}} + \\mathbf{\\hat{k}_{N}}')
-    assert latex(v[8]) == ('\\mathbf{\\hat{j}_{N}} + (\\mathbf{{x}_' +
-                           '{C}}^{2} - \\int f{\\left(b \\right)}\\,' +
+    assert latex(v[8]) == ('\\mathbf{\\hat{j}_{N}} + (\\mathbf{{C}_' +
+                           '{x}}^{2} - \\int f{\\left(b \\right)}\\,' +
                            ' db)\\mathbf{\\hat{k}_{N}}')
-    assert latex(s) == '3 \\mathbf{{y}_{C}} \\mathbf{{x}_{N}}^{2}'
+    assert latex(s) == '3 \\mathbf{{C}_{y}} \\mathbf{{N}_{x}}^{2}'
     assert latex(d[0]) == '(\\mathbf{\\hat{0}}|\\mathbf{\\hat{0}})'
     assert latex(d[4]) == ('(a)(\\mathbf{\\hat{i}_{N}}{|}\\mathbf' +
                            '{\\hat{k}_{N}})')
@@ -173,5 +173,5 @@ def test_custom_names():
     assert A.x.__str__() == 'A.x'
     assert A.i._pretty_form == 'A_i'
     assert A.x._pretty_form == 'A_x'
-    assert A.i._latex_form == r'\mathbf{{i}_{A}}'
+    assert A.i._latex_form == r'\mathbf{{A}_{i}}'
     assert A.x._latex_form == r"\mathbf{\hat{x}_{A}}"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16323

#### Brief description of what is fixed or changed

This originally seems like fixing some ordering issue in
https://github.com/sympy/sympy/blob/356a73cd676e0c3f1a1c3057a6895db0d82a1be7/sympy/vector/coordsysrect.py#L217-L218

But after seeing the test cases, I think it can also be a bit of redesign.

Also, it seems like base vectors should also be modified, after seeing this example.

<img src=https://user-images.githubusercontent.com/34944973/54574847-3dad4b00-4a35-11e9-9db3-518885475c1d.png width="512px">

Pretty printer is also printing base vector as `A_i`

So, I will continue moving on if this is decided.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fix latex render of `BaseScalar`. Now, it will render as `<CoordSysName>_<ScalarName>`
<!-- END RELEASE NOTES -->
