### PR TITLE
Increase matrices test coverage

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1054,6 +1054,7 @@ class MatrixSubspaces(MatrixReductions):
 
         ret = []
         # make sure we start with a non-zero vector
+        vecs = list(vecs)
         while len(vecs) > 0 and vecs[0].is_zero:
             del vecs[0]
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1309,6 +1309,19 @@ def test_nullspace():
     assert all(e.is_zero for e in m*basis[1])
 
 
+def test_orthogonalize():
+    m = Matrix([[1, 2], [3, 4]])
+    assert m.orthogonalize(Matrix([[2], [1]])) == [Matrix([[2], [1]])]
+    assert m.orthogonalize(Matrix([[2], [1]]), normalize=True) == [Matrix([[2*sqrt(5)/5], [sqrt(5)/5]])]
+    assert m.orthogonalize(Matrix([[1], [2]]), Matrix([[-1], [4]])) == [Matrix([[1], [2]]), Matrix([[-S(12)/5], [S(6)/5]])]
+    assert m.orthogonalize(Matrix([[0], [0]]), Matrix([[-1], [4]])) == [Matrix([[-1], [4]])]
+    assert m.orthogonalize(Matrix([[0], [0]])) == []
+
+    n = Matrix([[9, 1, 9], [3, 6, 10], [8, 5, 2]])
+    vecs = [Matrix([[-5], [1]]), Matrix([[-5], [2]]), Matrix([[-5], [-2]])]
+    assert n.orthogonalize(*vecs) == [Matrix([[-5], [1]]), Matrix([[S(5)/26], [S(25)/26]])]
+
+
 # EigenOnlyMatrix tests
 def test_eigenvals():
     M = EigenOnlyMatrix([[0, 1, 1],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2578,6 +2578,9 @@ def test_rotation_matrices():
 def test_DeferredVector():
     assert str(DeferredVector("vector")[4]) == "vector[4]"
     assert sympify(DeferredVector("d")) == DeferredVector("d")
+    raises(IndexError, lambda: DeferredVector("d")[-1])
+    assert str(DeferredVector("d")) == "d"
+    assert repr(DeferredVector("test")) == "DeferredVector('test')"
 
 def test_DeferredVector_not_iterable():
     assert not iterable(DeferredVector('X'))


### PR DESCRIPTION
Add tests for DeferredVector and orthogonalize. Fix a bug in orthogonalize where the code was attempting to delete the first element of a tuple. DeferredVector has an odd case `if i == -0:` on line 61 that I'm not sure how to test (or what the point of it is).

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
