### PR TITLE
Removing unicode from coset_table and fp_groups

### DIFF
--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import print_function, division
 
 from sympy.combinatorics.free_groups import free_group

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -17,7 +17,7 @@ class CosetTable(DefaultPrinting):
     #               represented using a list of lists
     # alpha: Mathematically a coset (precisely, a live coset)
     #       represented by an integer between i with 1 <= i <= n
-    #       α ∈ c
+    #       alpha in c
     # x: Mathematically an element of "A" (set of generators and
     #   their inverses), represented using "FpGroupElement"
     # fp_grp: Finitely Presented Group with < X|R > as presentation.
@@ -61,7 +61,7 @@ class CosetTable(DefaultPrinting):
         self.fp_group = fp_grp
         self.subgroup = subgroup
         self.coset_table_limit = max_cosets
-        # "p" is setup independent of Ω and n
+        # "p" is setup independent of Omega and n
         self.p = [0]
         # a list of the form `[gen_1, gen_1^{-1}, ... , gen_k, gen_k^{-1}]`
         self.A = list(chain.from_iterable((gen, gen**-1) \
@@ -78,8 +78,8 @@ class CosetTable(DefaultPrinting):
             else:
                 self.A_dict_inv[x] = self.A_dict[x] - 1
         # used in the coset-table based method of coset enumeration. Each of
-        # the element is called a "deduction" which is the form (α, x) whenever
-        # a value is assigned to α^x during a definition or "deduction process"
+        # the element is called a "deduction" which is the form (alpha, x) whenever
+        # a value is assigned to alpha^x during a definition or "deduction process"
         self.deduction_stack = []
         # Attributes for modified methods.
         H = self.subgroup
@@ -210,10 +210,10 @@ class CosetTable(DefaultPrinting):
         scan, scan_check, scan_and_fill, scan_and_fill_c
 
         """
-        # α is an integer representing a "coset"
+        # alpha is an integer representing a "coset"
         # since scanning can be in two cases
-        # 1. for α=0 and w in Y (i.e generating set of H)
-        # 2. α in Ω (set of live cosets), w in R (relators)
+        # 1. for alpha=0 and w in Y (i.e generating set of H)
+        # 2. alpha in Omega (set of live cosets), w in R (relators)
         A_dict = self.A_dict
         A_dict_inv = self.A_dict_inv
         table = self.table
@@ -244,7 +244,7 @@ class CosetTable(DefaultPrinting):
             self.deduction_stack.append((f, word[i]))
         # otherwise scan is incomplete and yields no information
 
-    # α, β coincide, i.e. α, β represent the pair of cosets where
+    # alpha, beta coincide, i.e. alpha, beta represent the pair of cosets where
     # coincidence occurs
     def coincidence_c(self, alpha, beta):
         """
@@ -326,10 +326,10 @@ class CosetTable(DefaultPrinting):
         Performed when the default argument modified=True
 
         """
-        # α is an integer representing a "coset"
+        # alpha is an integer representing a "coset"
         # since scanning can be in two cases
-        # 1. for α=0 and w in Y (i.e generating set of H)
-        # 2. α in Ω (set of live cosets), w in R (relators)
+        # 1. for alpha=0 and w in Y (i.e generating set of H)
+        # 2. alpha in Omega (set of live cosets), w in R (relators)
         A_dict = self.A_dict
         A_dict_inv = self.A_dict_inv
         table = self.table
@@ -395,10 +395,10 @@ class CosetTable(DefaultPrinting):
         scan, scan_c, scan_and_fill, scan_and_fill_c
 
         """
-        # α is an integer representing a "coset"
+        # alpha is an integer representing a "coset"
         # since scanning can be in two cases
-        # 1. for α=0 and w in Y (i.e generating set of H)
-        # 2. α in Ω (set of live cosets), w in R (relators)
+        # 1. for alpha=0 and w in Y (i.e generating set of H)
+        # 2. alpha in Omega (set of live cosets), w in R (relators)
         A_dict = self.A_dict
         A_dict_inv = self.A_dict_inv
         table = self.table
@@ -535,7 +535,7 @@ class CosetTable(DefaultPrinting):
                 rho = p[mu]
         return lamda
 
-    # α, β coincide, i.e. α, β represent the pair of cosets
+    # alpha, beta coincide, i.e. alpha, beta represent the pair of cosets
     # where coincidence occurs
     def coincidence(self, alpha, beta, w=None, modified=False):
         r"""
@@ -629,7 +629,7 @@ class CosetTable(DefaultPrinting):
         i = 0
         b = alpha
         j = r - 1
-        # loop until it has filled the α row in the table.
+        # loop until it has filled the alpha row in the table.
         while True:
             # do the forward scanning
             while i <= j and table[f][A_dict[word[i]]] is not None:
@@ -815,7 +815,7 @@ class CosetTable(DefaultPrinting):
         for alpha in self.omega:
             gamma += 1
             if gamma != alpha:
-                # replace α by γ in coset table
+                # replace alpha by gamma in coset table
                 for x in A:
                     beta = table[alpha][A_dict[x]]
                     table[gamma][A_dict[x]] = beta
@@ -920,7 +920,7 @@ class CosetTable(DefaultPrinting):
         ==========
 
         'k', 'lamda' -- the two class representatives to be merged.
-        q -- queue of length l of elements to be deleted from Ω *.
+        q -- queue of length l of elements to be deleted from `\Omega` *.
         w -- Word in (YUY^-1)
 
         See Also
@@ -949,7 +949,7 @@ class CosetTable(DefaultPrinting):
         Parameters
         ==========
 
-        A coincident pair \alpha,\beta \in \Omega, w \in (Y∪Y^–1)
+        A coincident pair \alpha,\beta \in \Omega, w \in `Y \cup Y^{-1}`
 
         See Also
         ========
@@ -1148,7 +1148,7 @@ def coset_enumeration_r(fp_grp, Y, max_cosets=None, draft=None,
                         _scan_and_fill(alpha, w, C._grp.identity)
                     else:
                         _scan_and_fill(alpha, w)
-                    # if α was eliminated during the scan then break
+                    # if alpha was eliminated during the scan then break
                     if p[alpha] < alpha:
                         break
                 if p[alpha] == alpha:

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -948,7 +948,7 @@ class CosetTable(DefaultPrinting):
         Parameters
         ==========
 
-        A coincident pair \alpha,\beta \in \Omega, w \in `Y \cup Y^{-1}`
+        A coincident pair `\alpha, \beta \in \Omega, w \in Y \cup Y^{-1}`
 
         See Also
         ========

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -761,7 +761,7 @@ def descendant_subgroups(S, C, R1_c_list, x, R2, N, Y):
                 undefined_coset, undefined_gen = alpha, x
                 break
         # for filling up the undefine entry we try all possible values
-        # of β ∈ Ω or β = n where β^(undefined_gen^-1) is undefined
+        # of beta in Omega or beta = n where beta^(undefined_gen^-1) is undefined
         reach = C.omega + [C.n]
         for beta in reach:
             if beta < N:
@@ -837,25 +837,25 @@ def first_in_class(C, Y=[]):
 
     # TODO:: Sims points out in [Sim94] that performance can be improved by
     # remembering some of the information computed by ``first_in_class``. If
-    # the ``continue α`` statement is executed at line 14, then the same thing
-    # will happen for that value of α in any descendant of the table C, and so
-    # the values the values of α for which this occurs could profitably be
+    # the ``continue alpha`` statement is executed at line 14, then the same thing
+    # will happen for that value of alpha in any descendant of the table C, and so
+    # the values the values of alpha for which this occurs could profitably be
     # stored and passed through to the descendants of C. Of course this would
     # make the code more complicated.
 
     # The code below is taken directly from the function on page 208 of [Sim94]
-    # ν[α]
+    # nu[alpha]
 
     """
     n = C.n
-    # lamda is the largest numbered point in Ω_c_α which is currently defined
+    # lamda is the largest numbered point in Omega_c_alpha which is currently defined
     lamda = -1
-    # for α ∈ Ω_c, ν[α] is the point in Ω_c_α corresponding to α
+    # for alpha in Omega_c, nu[alpha] is the point in Omega_c_alpha corresponding to alpha
     nu = [None]*n
-    # for α ∈ Ω_c_α, μ[α] is the point in Ω_c corresponding to α
+    # for alpha in Omega_c_alpha, mu[alpha] is the point in Omega_c corresponding to alpha
     mu = [None]*n
-    # mutually ν and μ are the mutually-inverse equivalence maps between
-    # Ω_c_α and Ω_c
+    # mutually nu and mu are the mutually-inverse equivalence maps between
+    # Omega_c_alpha and Omega_c
     next_alpha = False
     # For each 0≠α ∈ [0 .. nc-1], we start by constructing the equivalent
     # standardized coset table C_α corresponding to H_α

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -857,50 +857,50 @@ def first_in_class(C, Y=[]):
     # mutually nu and mu are the mutually-inverse equivalence maps between
     # Omega_c_alpha and Omega_c
     next_alpha = False
-    # For each 0≠α ∈ [0 .. nc-1], we start by constructing the equivalent
-    # standardized coset table C_α corresponding to H_α
+    # For each 0!=alpha in [0 .. nc-1], we start by constructing the equivalent
+    # standardized coset table C_alpha corresponding to H_alpha
     for alpha in range(1, n):
-        # reset ν to "None" after previous value of α
+        # reset v to "None" after previous value of alpha
         for beta in range(lamda+1):
             nu[mu[beta]] = None
         # we only want to reject our current table in favour of a preceding
-        # table in the ordering in which 1 is replaced by α, if the subgroup
-        # G_α corresponding to this preceding table definitely contains the
+        # table in the ordering in which 1 is replaced by alpha, if the subgroup
+        # G_alpha corresponding to this preceding table definitely contains the
         # given subgroup
         for w in Y:
             # TODO: this should support input of a list of general words
             # not just the words which are in "A" (i.e gen and gen^-1)
             if C.table[alpha][C.A_dict[w]] != alpha:
-                # continue with α
+                # continue with alpha
                 next_alpha = True
                 break
         if next_alpha:
             next_alpha = False
             continue
-        # try α as the new point 0 in Ω_C_α
+        # try alpha as the new point 0 in Omega_C_alpha
         mu[0] = alpha
         nu[alpha] = 0
-        # compare corresponding entries in C and C_α
+        # compare corresponding entries in C and C_alpha
         lamda = 0
         for beta in range(n):
             for x in C.A:
                 gamma = C.table[beta][C.A_dict[x]]
                 delta = C.table[mu[beta]][C.A_dict[x]]
                 # if either of the entries is undefined,
-                # we move with next α
+                # we move with next alpha
                 if gamma is None or delta is None:
-                    # continue with α
+                    # continue with alpha
                     next_alpha = True
                     break
                 if nu[delta] is None:
-                    # delta becomes the next point in Ω_C_α
+                    # delta becomes the next point in Omega_C_alpha
                     lamda += 1
                     nu[delta] = lamda
                     mu[lamda] = delta
                 if nu[delta] < gamma:
                     return False
                 if nu[delta] > gamma:
-                    # continue with α
+                    # continue with alpha
                     next_alpha = True
                     break
             if next_alpha:
@@ -1181,13 +1181,13 @@ def rewrite(C, alpha, w):
     ==========
 
     C: CosetTable
-    α: A live coset
+    alpha: A live coset
     w: A word in `A*`
 
     Returns
     =======
 
-    ρ(τ(α), w)
+    rho(tau(alpha), w)
 
     Examples
     ========

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -859,7 +859,7 @@ def first_in_class(C, Y=[]):
     # For each 0!=alpha in [0 .. nc-1], we start by constructing the equivalent
     # standardized coset table C_alpha corresponding to H_alpha
     for alpha in range(1, n):
-        # reset v to "None" after previous value of alpha
+        # reset nu to "None" after previous value of alpha
         for beta in range(lamda+1):
             nu[mu[beta]] = None
         # we only want to reject our current table in favour of a preceding

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Finitely Presented Groups and its algorithms. """
 
 from __future__ import print_function, division


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

#16272

#### Brief description of what is fixed or changed

With the implementation in #16272, I could pinpoint the modules using unicode.
And I find many SymPy module already using lots of unicode for math notations or historic figures, or such.

I have partially done some cleanups, and am showcasing here at this point, because lots of things would be clear and repetitive after the decision made, and it is not yet fully decided that this work should be continued.

To summarize the previous discussions, we had reached the that the unicode charcters should be avoided in most cases, because of the different editors or fonts people are using.

But there may be some argument about this, like using ascii can make some formula verbose and less intuitive, or such.

Though my opinion, is pro about not using unicode in the generic codebase.
Because there is an alternative option to move such verbose comments, like full algorithm or math formula explanations, into the docstring as LaTeX.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
