### PR TITLE
Make var names in generated Cython code unique

### DIFF
--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -185,6 +185,26 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
 
     TmpFileManager.cleanup()
 
+def test_cython_wrapper_unique_dummyvars():
+    from sympy import Dummy, Equality
+    x, y, z = Dummy('x'), Dummy('y'), Dummy('z')
+    x_id, y_id, z_id = [str(d.dummy_index) for d in [x, y, z]]
+    expr = Equality(z, x + y)
+    routine = make_routine("test", expr)
+    code_gen = CythonCodeWrapper(CCodeGen())
+    source = get_string(code_gen.dump_pyx, [routine])
+    expected_template = (
+        "cdef extern from 'file.h':\n"
+        "    void test(double x_{x_id}, double y_{y_id}, double *z_{z_id})\n"
+        "\n"
+        "def test_c(double x_{x_id}, double y_{y_id}):\n"
+        "\n"
+        "    cdef double z_{z_id} = 0\n"
+        "    test(x_{x_id}, y_{y_id}, &z_{z_id})\n"
+        "    return z_{z_id}")
+    expected = expected_template.format(x_id=x_id, y_id=y_id, z_id=z_id)
+    assert source == expected
+
 def test_autowrap_dummy():
     x, y, z = symbols('x y z')
 


### PR DESCRIPTION
Previously, the following call to `unfuncify` would result in non-compiling
Cython code due to a variable clash:

    >>> unfuncify((x, y), x + y, backend='Cython')

This was because the resulting Cython code looked something like:

    def autofunc_c(np.ndarray[np.double_t, ndim=1] _x, np.ndarray[np.double_t, ndim=1] _y):
        cdef int _m = _y.shape[0]
        cdef np.ndarray[np.double_t, ndim=1] _y = np.empty((_m))

where the argument `_y` is declared in the function body even though it is
already passed as an argument. This commit leverages `doprint` within the C code
generator to make sure that generated variable names are unique.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15628

#### Brief description of what is fixed or changed

Add a new method to `CythonCodeWrapper` that converts unique dummy variables into distinct strings and pass every expression that emits variable names through this expression. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * make variable names in generated cython code unique
<!-- END RELEASE NOTES -->
