### PR TITLE
indicate that rot_order can be int; use translate

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -3,6 +3,7 @@ from sympy.core.backend import (diff, expand, sin, cos, sympify,
 from sympy import (trigsimp, solve, Symbol, Dummy)
 from sympy.core.compatibility import string_types, range
 from sympy.physics.vector.vector import Vector, _check_vector
+from sympy.utilities.misc import translate
 
 __all__ = ['CoordinateSym', 'ReferenceFrame']
 
@@ -437,7 +438,7 @@ class ReferenceFrame(object):
             The quantities that the orientation matrix will be defined by.
             In case of rot_type='DCM', value must be a
             sympy.matrices.MatrixBase object (or subclasses of it).
-        rot_order : str
+        rot_order : str or int
             If applicable, the order of a series of rotations.
 
         Examples
@@ -455,7 +456,7 @@ class ReferenceFrame(object):
         3, expressed in XYZ or 123, and cannot have a rotation about about an
         axis twice in a row.
 
-        >>> B.orient(N, 'Body', [q1, q2, q3], '123')
+        >>> B.orient(N, 'Body', [q1, q2, q3], 123)
         >>> B.orient(N, 'Body', [q1, q2, 0], 'ZXZ')
         >>> B.orient(N, 'Body', [0, 0, 0], 'XYX')
 
@@ -522,13 +523,9 @@ class ReferenceFrame(object):
 
         approved_orders = ('123', '231', '312', '132', '213', '321', '121',
                            '131', '212', '232', '313', '323', '')
-        rot_order = str(
-            rot_order).upper()  # Now we need to make sure XYZ = 123
+        # make sure XYZ => 123 and rot_type is in upper case
+        rot_order = translate(str(rot_order), 'XYZxyz', '123123')
         rot_type = rot_type.upper()
-        rot_order = [i.replace('X', '1') for i in rot_order]
-        rot_order = [i.replace('Y', '2') for i in rot_order]
-        rot_order = [i.replace('Z', '3') for i in rot_order]
-        rot_order = ''.join(rot_order)
         if not rot_order in approved_orders:
             raise TypeError('The supplied order is not an approved type')
         parent_orient = []

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -9,6 +9,7 @@ from .frame import CoordinateSym, _check_frame
 from .dyadic import Dyadic
 from .printing import vprint, vsprint, vpprint, vlatex, init_vprinting
 from sympy.utilities.iterables import iterable
+from sympy.utilities.misc import translate
 
 __all__ = ['cross', 'dot', 'express', 'time_derivative', 'outer',
            'kinematic_equations', 'get_motion_params', 'partial_velocity',
@@ -237,7 +238,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
     rot_type : str
         The type of rotation used to create the equations. Body, Space, or
         Quaternion only
-    rot_order : str
+    rot_order : str or int
         If applicable, the order of a series of rotations.
 
     Examples
@@ -256,12 +257,9 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
     # Code below is checking and sanitizing input
     approved_orders = ('123', '231', '312', '132', '213', '321', '121', '131',
                        '212', '232', '313', '323', '1', '2', '3', '')
-    rot_order = str(rot_order).upper()  # Now we need to make sure XYZ = 123
-    rot_type = rot_type.upper()
-    rot_order = [i.replace('X', '1') for i in rot_order]
-    rot_order = [i.replace('Y', '2') for i in rot_order]
-    rot_order = [i.replace('Z', '3') for i in rot_order]
-    rot_order = ''.join(rot_order)
+    # make sure XYZ => 123 and rot_type is in lower case
+    rot_order = translate(str(rot_order), 'XYZxyz', '123123')
+    rot_type = rot_type.lower()
 
     if not isinstance(speeds, (list, tuple)):
         raise TypeError('Need to supply speeds in a list')
@@ -269,7 +267,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         raise TypeError('Need to supply 3 body-fixed speeds')
     if not isinstance(coords, (list, tuple)):
         raise TypeError('Need to supply coordinates in a list')
-    if rot_type.lower() in ['body', 'space']:
+    if rot_type in ['body', 'space']:
         if rot_order not in approved_orders:
             raise ValueError('Not an acceptable rotation order')
         if len(coords) != 3:
@@ -282,7 +280,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         q1d, q2d, q3d = [diff(i, dynamicsymbols._t) for i in coords]
         s1, s2, s3 = [sin(q1), sin(q2), sin(q3)]
         c1, c2, c3 = [cos(q1), cos(q2), cos(q3)]
-        if rot_type.lower() == 'body':
+        if rot_type == 'body':
             if rot_order == '123':
                 return [q1d - (w1 * c3 - w2 * s3) / c2, q2d - w1 * s3 - w2 *
                         c3, q3d - (-w1 * c3 + w2 * s3) * s2 / c2 - w3]
@@ -319,7 +317,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
             if rot_order == '323':
                 return [q1d - (-w1 * c3 + w2 * s3) / s2, q2d - w1 * s3 - w2 *
                         c3, q3d - (w1 * c3 - w2 * s3) * c2 / s2 - w3]
-        if rot_type.lower() == 'space':
+        if rot_type == 'space':
             if rot_order == '123':
                 return [q1d - w1 - (w2 * s1 + w3 * c1) * s2 / c2, q2d - w2 *
                         c1 + w3 * s1, q3d - (w2 * s1 + w3 * c1) / c2]
@@ -356,7 +354,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
             if rot_order == '323':
                 return [q1d - (w1 * c1 - w2 * s1) * c2 / s2 - w3, q2d - w1 *
                         s1 - w2 * c1, q3d - (-w1 * c1 + w2 * s1) / s2]
-    elif rot_type.lower() == 'quaternion':
+    elif rot_type == 'quaternion':
         if rot_order != '':
             raise ValueError('Cannot have rotation order for quaternion')
         if len(coords) != 4:

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -122,7 +122,7 @@ def test_ang_vel():
         2 * (q2d * q0 + q3d * q1 - q1d * q3 - q0d * q2) * E.y +
         2 * (q3d * q0 + q1d * q2 - q2d * q1 - q0d * q3) * E.z)
 
-    F = N.orientnew('F', 'Body', (q1, q2, q3), '313')
+    F = N.orientnew('F', 'Body', (q1, q2, q3), 313)
     assert F.ang_vel_in(N) == ((sin(q2)*sin(q3)*q1d + cos(q3)*q2d)*F.x +
         (sin(q2)*cos(q3)*q1d - sin(q3)*q2d)*F.y + (cos(q2)*q1d + q3d)*F.z)
     G = N.orientnew('G', 'Axis', (q1, N.x + N.y))

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -437,6 +437,8 @@ def test_kin_eqs():
     q0, q1, q2, q3 = dynamicsymbols('q0 q1 q2 q3')
     q0d, q1d, q2d, q3d = dynamicsymbols('q0 q1 q2 q3', 1)
     u1, u2, u3 = dynamicsymbols('u1 u2 u3')
+    ke = kinematic_equations([u1,u2,u3], [q1,q2,q3], 'body', 313)
+    assert ke == kinematic_equations([u1,u2,u3], [q1,q2,q3], 'body', '313')
     kds = kinematic_equations([u1, u2, u3], [q0, q1, q2, q3], 'quaternion')
     assert kds == [-0.5 * q0 * u1 - 0.5 * q2 * u3 + 0.5 * q3 * u2 + q1d,
             -0.5 * q0 * u2 + 0.5 * q1 * u3 - 0.5 * q3 * u1 + q2d,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Just some of the cleanup that was included in unmerged #12698.

No functionality has changed. The docstring was updated to reflect the behavior of the code (i.e. that `rot_order` is made a string if it is passed as an int like 123 instead of '123'.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
