### PR TITLE
merge common.diag and dense.diag

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -104,7 +104,7 @@ class ArgumentIndexError(ValueError):
                (self.args[1], self.args[0]))
 
 
-# Python 2 and 3 compatible version that do not raise a Deprecation warning.
+# Python 2/3 version that does not raise a Deprecation warning
 def arity(cls):
     """Return the arity of the function if it is known, else None.
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -23,6 +23,7 @@ from sympy.functions import Abs
 from sympy.simplify import simplify as _simplify
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
+from sympy.utilities.misc import filldedent
 
 
 class MatrixError(Exception):
@@ -613,7 +614,7 @@ class MatrixSpecial(MatrixRequired):
         """diag_dict is a defaultdict containing
         all the entries of the diagonal matrix."""
         def entry(i, j):
-            return diag_dict[(i,j)]
+            return diag_dict[(i, j)]
         return cls._new(rows, cols, entry)
 
     @classmethod
@@ -669,6 +670,12 @@ class MatrixSpecial(MatrixRequired):
 
         cls : class for the resulting matrix
 
+        unpack : bool which, when True (default), unpacks a single
+        sequence rather than interpreting it as a Matrix.
+
+        strict : bool which, when False (default), allows Matrices to
+        have variable-length rows.
+
         Examples
         ========
 
@@ -678,87 +685,111 @@ class MatrixSpecial(MatrixRequired):
         [1, 0, 0],
         [0, 2, 0],
         [0, 0, 3]])
-        >>> Matrix.diag([1, 2, 3])
+
+        The current default is to unpack a single sequence. If this is
+        not desired, set `unpack=False` and it will be interpreted as
+        a matrix.
+
+        >>> Matrix.diag([1, 2, 3]) == Matrix.diag(1, 2, 3)
+        True
+
+        When more than one element is passed, each is interpreted as
+        something to put on the diagonal. Lists are converted to
+        matricecs. Filling of the diagonal always continues from
+        the bottom right hand corner of the previous item: this
+        will create a block-diagonal matrix whether the matrices
+        are square or not.
+
+        >>> col = [1, 2, 3]
+        >>> row = [[4, 5]]
+        >>> Matrix.diag(col, row)
         Matrix([
         [1, 0, 0],
-        [0, 2, 0],
-        [0, 0, 3]])
+        [2, 0, 0],
+        [3, 0, 0],
+        [0, 4, 5]])
 
-        The diagonal elements can be matrices; diagonal filling will
-        continue on the diagonal from the last element of the matrix:
+        Elements within a list need not all be of the same length unless
+        `strict` is set to True:
 
-        >>> from sympy.abc import x, y, z
-        >>> a = Matrix([x, y, z])
-        >>> b = Matrix([[1, 2], [3, 4]])
-        >>> c = Matrix([[5, 6]])
-        >>> Matrix.diag(a, 7, b, c)
+        >>> Matrix.diag([[1, 2, 3], [4, 5], [6]], unpack=False)
         Matrix([
-        [x, 0, 0, 0, 0, 0],
-        [y, 0, 0, 0, 0, 0],
-        [z, 0, 0, 0, 0, 0],
-        [0, 7, 0, 0, 0, 0],
-        [0, 0, 1, 2, 0, 0],
-        [0, 0, 3, 4, 0, 0],
-        [0, 0, 0, 0, 5, 6]])
+        [1, 2, 3],
+        [4, 5, 0],
+        [6, 0, 0]])
 
-        A given band off the diagonal can be made by padding with a
-        vertical or horizontal "kerning" vector:
-
-        >>> hpad = Matrix(0, 2, [])
-        >>> vpad = Matrix(2, 0, [])
-        >>> Matrix.diag(vpad, 1, 2, 3, hpad) + Matrix.diag(hpad, 4, 5, 6, vpad)
-        Matrix([
-        [0, 0, 4, 0, 0],
-        [0, 0, 0, 5, 0],
-        [1, 0, 0, 0, 6],
-        [0, 2, 0, 0, 0],
-        [0, 0, 3, 0, 0]])
-
-        The type of the resulting matrix can be affected with the ``cls``
+        The type of the returned matrix can be set with the ``cls``
         keyword.
 
-        >>> type(Matrix.diag(1))
-        <class 'sympy.matrices.dense.MutableDenseMatrix'>
         >>> from sympy.matrices import ImmutableMatrix
-        >>> type(Matrix.diag(1, cls=ImmutableMatrix))
-        <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>
-        """
+        >>> from sympy.utilities.misc import func_name
+        >>> func_name(Matrix.diag(1, cls=ImmutableMatrix))
+        'ImmutableDenseMatrix'
 
+        A zero dimension matrix can be used to position the start of
+        the filling at the start of an arbitrary row or column:
+
+        >>> from sympy import ones
+        >>> r2 = ones(0, 2)
+        >>> Matrix.diag(r2, 1, 2)
+        Matrix([
+        [0, 0, 1, 0],
+        [0, 0, 0, 2]])
+        """
+        from sympy.matrices.matrices import MatrixBase
+        from sympy.matrices.dense import Matrix
         klass = kwargs.get('cls', kls)
-        # allow a sequence to be passed in as the only argument
-        if len(args) == 1 and is_sequence(args[0]) and not getattr(args[0], 'is_Matrix', False):
+        strict = kwargs.get('strict', False) # lists -> Matrices
+        unpack = kwargs.get('unpack', True)  # unpack single sequence
+        if unpack and len(args) == 1 and is_sequence(args[0]) and \
+                not isinstance(args[0], MatrixBase):
             args = args[0]
 
-        def size(m):
-            """Compute the size of the diagonal block"""
-            if hasattr(m, 'rows'):
-                return m.rows, m.cols
-            return 1, 1
-        diag_rows = sum(size(m)[0] for m in args)
-        diag_cols =  sum(size(m)[1] for m in args)
-        rows = kwargs.get('rows', diag_rows)
-        cols = kwargs.get('cols', diag_cols)
-        if rows < diag_rows or cols < diag_cols:
-            raise ValueError("A {} x {} diagnal matrix cannot accommodate a"
-                             "diagonal of size at least {} x {}.".format(rows, cols,
-                                                                         diag_rows, diag_cols))
-
         # fill a default dict with the diagonal entries
-        diag_entries = defaultdict(lambda: S.Zero)
-        row_pos, col_pos = 0, 0
+        diag_entries = defaultdict(int)
+        R = C = 0  # keep track of the biggest index seen
         for m in args:
-            if hasattr(m, 'rows'):
-                # in this case, we're a matrix
-                for i in range(m.rows):
-                    for j in range(m.cols):
-                        diag_entries[(i + row_pos, j + col_pos)] = m[i, j]
-                row_pos += m.rows
-                col_pos += m.cols
+            if hasattr(m, 'rows') or isinstance(m, list):
+                # in this case, we're a matrix or list
+                if hasattr(m, 'rows'):
+                    # convert to list of lists
+                    r, c = m.shape
+                    m = m.tolist()
+                else:
+                    # make sure all list elements are lists
+                    r = len(m)
+                    if strict:
+                        # let Matrix raise the error
+                        m = Matrix(m)
+                        c = m.cols
+                        m = m.tolist()
+                    else:
+                        m = [mi if isinstance(mi, list) else [mi]
+                            for mi in m]
+                        c = max(map(len, m))
+                # process list of lists
+                for i in range(len(m)):
+                    for j, mij in enumerate(m[i]):
+                        diag_entries[(i + R, j + C)] = mij
+                R += r
+                C += c
             else:
                 # in this case, we're a single value
-                diag_entries[(row_pos, col_pos)] = m
-                row_pos += 1
-                col_pos += 1
+                diag_entries[(R, C)] = m
+                R += 1
+                C += 1
+        rows = kwargs.get('rows', None)
+        cols = kwargs.get('cols', None)
+        if rows is None:
+            rows, cols = cols, rows
+        if rows is None:
+            rows, cols = R, C
+        else:
+            cols = rows if cols is None else cols
+        if rows < R or cols < C:
+            raise ValueError(filldedent('''
+                The constructed matrix is {} x {} but a size of {} x {}
+                was specified.'''.format(R, C, rows, cols)))
         return klass._eval_diag(rows, cols, diag_entries)
 
     @classmethod
@@ -2243,7 +2274,7 @@ class _MinimalMatrix(object):
     """Class providing the minimum functionality
     for a matrix-like object and implementing every method
     required for a `MatrixRequired`.  This class does not have everything
-    needed to become a full-fledged sympy object, but it will satisfy the
+    needed to become a full-fledged SymPy object, but it will satisfy the
     requirements of anything inheriting from `MatrixRequired`.  If you wish
     to make a specialized matrix type, make sure to implement these
     methods and properties with the exception of `__init__` and `__repr__`

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -657,7 +657,7 @@ class MatrixSpecial(MatrixRequired):
     def diag(kls, *args, **kwargs):
         """Returns a matrix with the specified diagonal.
         If matrices are passed, a block-diagonal matrix
-        is created.
+        is created (i.e. the "direct sum" of the matrices).
 
         kwargs
         ======

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1103,103 +1103,44 @@ def eye(*args, **kwargs):
 
 
 def diag(*values, **kwargs):
-    """Create a sparse, diagonal matrix from a list of diagonal values.
-
-    Notes
-    =====
-
-    When arguments are matrices they are fitted in resultant matrix.
-
-    The returned matrix is a mutable, dense matrix. To make it a different
-    type, send the desired class for keyword ``cls``.
+    """Returns a matrix with the provided values placed on the
+    diagonal. If non-square matrices are included, they will
+    produce a block-diagonal matrix.
 
     Examples
     ========
 
-    >>> from sympy.matrices import diag, Matrix, ones
-    >>> diag(1, 2, 3)
+    This version of diag is a thin wrapper to Matrix.diag that differs
+    in that it treats all lists like matrices -- even when a single list
+    is given. If this is not desired, either put a `*` before the list or
+    set `unpack=True`.
+
+    >>> from sympy import diag
+
+    >>> diag([1, 2, 3], unpack=True)  # = diag(1,2,3) or diag(*[1,2,3])
     Matrix([
     [1, 0, 0],
     [0, 2, 0],
     [0, 0, 3]])
-    >>> diag(*[1, 2, 3])
+
+    >>> diag([1, 2, 3])  # a column vector
     Matrix([
-    [1, 0, 0],
-    [0, 2, 0],
-    [0, 0, 3]])
-
-    The diagonal elements can be matrices; diagonal filling will
-    continue on the diagonal from the last element of the matrix:
-
-    >>> from sympy.abc import x, y, z
-    >>> a = Matrix([x, y, z])
-    >>> b = Matrix([[1, 2], [3, 4]])
-    >>> c = Matrix([[5, 6]])
-    >>> diag(a, 7, b, c)
-    Matrix([
-    [x, 0, 0, 0, 0, 0],
-    [y, 0, 0, 0, 0, 0],
-    [z, 0, 0, 0, 0, 0],
-    [0, 7, 0, 0, 0, 0],
-    [0, 0, 1, 2, 0, 0],
-    [0, 0, 3, 4, 0, 0],
-    [0, 0, 0, 0, 5, 6]])
-
-    When diagonal elements are lists, they will be treated as arguments
-    to Matrix:
-
-    >>> diag([1, 2, 3], 4)
-    Matrix([
-    [1, 0],
-    [2, 0],
-    [3, 0],
-    [0, 4]])
-    >>> diag([[1, 2, 3]], 4)
-    Matrix([
-    [1, 2, 3, 0],
-    [0, 0, 0, 4]])
-
-    A given band off the diagonal can be made by padding with a
-    vertical or horizontal "kerning" vector:
-
-    >>> hpad = ones(0, 2)
-    >>> vpad = ones(2, 0)
-    >>> diag(vpad, 1, 2, 3, hpad) + diag(hpad, 4, 5, 6, vpad)
-    Matrix([
-    [0, 0, 4, 0, 0],
-    [0, 0, 0, 5, 0],
-    [1, 0, 0, 0, 6],
-    [0, 2, 0, 0, 0],
-    [0, 0, 3, 0, 0]])
-
-
-
-    The type is mutable by default but can be made immutable by setting
-    the ``mutable`` flag to False:
-
-    >>> type(diag(1))
-    <class 'sympy.matrices.dense.MutableDenseMatrix'>
-    >>> from sympy.matrices import ImmutableMatrix
-    >>> type(diag(1, cls=ImmutableMatrix))
-    <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>
+    [1],
+    [2],
+    [3]])
 
     See Also
     ========
-
     eye
+    sympy.matrices.common.diag
     """
-
     from .dense import Matrix
-
-    # diag assumes any lists passed in are to be interpreted
-    # as arguments to Matrix, so apply Matrix to any list arguments
-    def normalize(m):
-        if is_sequence(m) and not isinstance(m, MatrixBase):
-            return Matrix(m)
-        return m
-    values = (normalize(m) for m in values)
-
-    return Matrix.diag(*values, **kwargs)
+    # Extract any setting so we don't duplicate keywords sent
+    # as named parameters:
+    kw = kwargs.copy()
+    strict = kw.pop('strict', True)  # lists will be converted to Matrices
+    unpack = kw.pop('unpack', False)
+    return Matrix.diag(*values, strict=strict, unpack=unpack, **kw)
 
 
 def GramSchmidt(vlist, orthonormal=False):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -25,6 +25,7 @@ from sympy.simplify import nsimplify
 from sympy.simplify import simplify as _simplify
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, numbered_symbols
+from sympy.utilities.misc import filldedent
 
 from .common import (
     MatrixCommon, MatrixError, NonSquareMatrixError, ShapeError, a2idx)
@@ -2305,21 +2306,34 @@ class MatrixBase(MatrixDeprecated,
                         try:
                             ncol.add(len(row))
                         except TypeError:
-                            ncol.add(1)
+                            ncol.add(-1)
                 if len(ncol) > 1:
-                    raise ValueError("Got rows of variable lengths: %s" %
-                                     sorted(list(ncol)))
+                    nolen = False
+                    if -1 in ncol:
+                        ncol.remove(-1)
+                        nolen = True
+                    nums = ', '.join(sorted([str(i) for i in ncol]))
+                    if nolen:
+                        nums  = 'none, ' + nums
+                    raise ValueError(
+                        "Got rows of variable lengths: %s" % nums)
+                if -1 in ncol:
+                    ncol = [1]
                 cols = ncol.pop() if ncol else 0
                 rows = len(in_mat) if cols else 0
-                if rows:
-                    if not is_sequence(in_mat[0]):
+                if not rows:
+                    flat_list = []
+                else:
+                    # how many of the rows are sequences? All or none are ok.
+                    nseq = sum([is_sequence(i) for i in in_mat])
+                    if not nseq:
                         cols = 1
                         flat_list = [cls._sympify(i) for i in in_mat]
-                        return rows, cols, flat_list
-                flat_list = []
-                for j in range(rows):
-                    for i in range(cols):
-                        flat_list.append(cls._sympify(in_mat[j][i]))
+                    elif nseq == rows:
+                        flat_list = [cls._sympify(in_mat[j][i]) for
+                                     j in range(rows) for i in range(cols)]
+                    else:
+                        pass  # flat_list is still None; error raised below
 
         elif len(args) == 3:
             rows = as_int(args[0])
@@ -2354,7 +2368,9 @@ class MatrixBase(MatrixDeprecated,
             flat_list = []
 
         if flat_list is None:
-            raise TypeError("Data type not understood")
+            raise TypeError(filldedent('''
+                Data type not understood; expecting list of lists
+                or lists of values.'''))
 
         return rows, cols, flat_list
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1193,6 +1193,9 @@ def test_diag_make():
     a = Matrix([x, y, z])
     b = Matrix([[1, 2], [3, 4]])
     c = Matrix([[5, 6]])
+    # this "wandering diagonal" is what makes this
+    # a block diagonal where each block is independent
+    # of the others
     assert diag(a, 7, b, c) == Matrix([
         [x, 0, 0, 0, 0, 0],
         [y, 0, 0, 0, 0, 0],
@@ -1200,20 +1203,40 @@ def test_diag_make():
         [0, 7, 0, 0, 0, 0],
         [0, 0, 1, 2, 0, 0],
         [0, 0, 3, 4, 0, 0],
-        [0, 0, 0, 0, 5, 6],
-    ])
-    assert SpecialOnlyMatrix.diag([2, 3]) == Matrix([
+        [0, 0, 0, 0, 5, 6]])
+    raises(ValueError, lambda: diag(a, 7, b, c, rows=5))
+    assert diag(1) == Matrix([[1]])
+    assert diag(1, rows=2) == Matrix([[1, 0], [0, 0]])
+    assert diag(1, cols=2) == Matrix([[1, 0], [0, 0]])
+    assert diag(1, rows=3, cols=2) == Matrix([[1, 0], [0, 0], [0, 0]])
+    assert diag(*[2, 3]) == Matrix([
         [2, 0],
         [0, 3]])
-    assert SpecialOnlyMatrix.diag(Matrix([2, 3])) == Matrix([
+    assert diag(Matrix([2, 3])) == Matrix([
         [2],
         [3]])
-    assert SpecialOnlyMatrix.diag(1, rows=3, cols=2) == Matrix([
+    assert diag([1, [2, 3], 4], unpack=False) == \
+            diag([[1], [2, 3], [4]], unpack=False) == Matrix([
         [1, 0],
+        [2, 3],
+        [4, 0]])
+    assert type(diag(1)) == SpecialOnlyMatrix
+    assert type(diag(1, cls=Matrix)) == Matrix
+    assert Matrix.diag([1, 2, 3]) == Matrix.diag(1, 2, 3)
+    assert Matrix.diag([1, 2, 3], unpack=False).shape == (3, 1)
+    assert Matrix.diag([[1, 2, 3]]).shape == (3, 1)
+    assert Matrix.diag([[1, 2, 3]], unpack=False).shape == (1, 3)
+    assert Matrix.diag([[[1, 2, 3]]]).shape == (1, 3)
+    # kerning can be used to move the starting point
+    assert Matrix.diag(ones(0, 2), 1, 2) == Matrix([
+        [0, 0, 1, 0],
+        [0, 0, 0, 2]])
+    assert Matrix.diag(ones(2, 0), 1, 2) == Matrix([
         [0, 0],
-        [0, 0]])
-    assert type(SpecialOnlyMatrix.diag(1)) == SpecialOnlyMatrix
-    assert type(SpecialOnlyMatrix.diag(1, cls=Matrix)) == Matrix
+        [0, 0],
+        [1, 0],
+        [0, 2]])
+
 
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1522,52 +1522,11 @@ def test_vech_errors():
 
 
 def test_diag():
-    a = Matrix([[1, 2], [2, 3]])
-    b = Matrix([[3, x], [y, 3]])
-    c = Matrix([[3, x, 3], [y, 3, z], [x, y, z]])
-    assert diag(a, b, b) == Matrix([
-        [1, 2, 0, 0, 0, 0],
-        [2, 3, 0, 0, 0, 0],
-        [0, 0, 3, x, 0, 0],
-        [0, 0, y, 3, 0, 0],
-        [0, 0, 0, 0, 3, x],
-        [0, 0, 0, 0, y, 3],
-    ])
-    assert diag(a, b, c) == Matrix([
-        [1, 2, 0, 0, 0, 0, 0],
-        [2, 3, 0, 0, 0, 0, 0],
-        [0, 0, 3, x, 0, 0, 0],
-        [0, 0, y, 3, 0, 0, 0],
-        [0, 0, 0, 0, 3, x, 3],
-        [0, 0, 0, 0, y, 3, z],
-        [0, 0, 0, 0, x, y, z],
-    ])
-    assert diag(a, c, b) == Matrix([
-        [1, 2, 0, 0, 0, 0, 0],
-        [2, 3, 0, 0, 0, 0, 0],
-        [0, 0, 3, x, 3, 0, 0],
-        [0, 0, y, 3, z, 0, 0],
-        [0, 0, x, y, z, 0, 0],
-        [0, 0, 0, 0, 0, 3, x],
-        [0, 0, 0, 0, 0, y, 3],
-    ])
-    a = Matrix([x, y, z])
-    b = Matrix([[1, 2], [3, 4]])
-    c = Matrix([[5, 6]])
-    assert diag(a, 7, b, c) == Matrix([
-        [x, 0, 0, 0, 0, 0],
-        [y, 0, 0, 0, 0, 0],
-        [z, 0, 0, 0, 0, 0],
-        [0, 7, 0, 0, 0, 0],
-        [0, 0, 1, 2, 0, 0],
-        [0, 0, 3, 4, 0, 0],
-        [0, 0, 0, 0, 5, 6],
-    ])
-    assert diag(1, [2, 3], [[4, 5]]) == Matrix([
-        [1, 0, 0, 0],
-        [0, 2, 0, 0],
-        [0, 3, 0, 0],
-        [0, 0, 4, 5]])
+    # mostly tested in testcommonmatrix.py
+    assert diag([1, 2, 3]) == Matrix([1, 2, 3])
+    m = [1, 2, [3]]
+    raises(ValueError, lambda: diag(m))
+    assert diag(m, strict=False) == Matrix([1, 2, 3])
 
 
 def test_get_diag_blocks1():
@@ -1623,6 +1582,7 @@ def test_creation_args():
     assert ones(long(3), Integer(4)) == ones(3, 4)
     raises(TypeError, lambda: Matrix(5))
     raises(TypeError, lambda: Matrix(1, 2))
+    raises(ValueError, lambda: Matrix([1, [2]]))
 
 
 def test_diagonal_symmetrical():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
- Matrix([1, [2]]) now raises an error
- diag shape defaults to square if only rows or cols is given
- keywords allow control of Matrix.diag since dense.diag behaved different than common.diag and the two are now merged.

The publicly facing `diag` and private `Matrix.diag` now have controls:

1. a single list can be unpacked instead of being converted to a matrix with keyword `unpack`
```python
>>> diag([1, 2, 3])
Matrix([
[1],
[2],
[3]])
>>> diag([1, 2, 3], unpack=True) # = diag(*[1, 2, 3]) = diag(1, 2, 3) = Matrix.diag([1, 2, 3])
Matrix([
[1, 0, 0],
[0, 2, 0],
[0, 0, 3]]
```

2. The conversion of lists to matrices can be relaxed so list of ragged rows can be accepted:
```python
>>> diag([[1, 2, 3], 4], strict=False)
Matrix([
[1, 2, 3],
[4, 0, 0]])
```
This is the default behavior of Matrix.diag (but unpack must be False for such a single list or an additional level of brackets must be added)
```python
>>> Matrix.diag([[1, 2, 3], 4], unpack=False)
Matrix([
[1, 2, 3],
[4, 0, 0]])
>>> Matrix.diag([  [[1, 2, 3], 4]  ])
Matrix([
[1, 2, 3],
[4, 0, 0]])
```

(Such input, formerly, put list-literals into the resulting matrix, making it non-functional.)

#### Other comments


During previous cleanup of the matrix files structure, two versions
of `diag` were left behind. The one that is public facing via
`from sympy import *` is the one in `dense.py`. It differs from
that in `common.py` a.k.a `Matrix.diag` by converting an input list to a matrix
rather than unpacking it. Hence, it is strict about matrix structure.

The `Matrix.diag` was not strict and actually could produce non-functional
matrices. An aspect of non-strictness is retained while doing the right thing
more often; an option to strictly convert lists to matrices is controlled with
the keyword `strict`. It is True for the public `diag` and False for the private `Matrix.diag`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
    - matrix creation detects singleton lists in matrices so Matrix([1, [2]]) now raises an error
    - diag matrix shape defaults to square if only rows or cols is given
    - diag unpacking of lists (conversion of single lists to matrices) can be controlled with keyword `unpack`; dense.diag defaults to True while Matrix.diag (common.diag) defaults to False; `Matrix.diag(*[1, 2, 3]) == Matrix.diag([1, 2, 3], unpack=True)`)
    - diag accepts variable-length rows if keyword `strict` is set to False
<!-- END RELEASE NOTES -->
