### PR TITLE
SparseMatrix: accept values that are matrix-like

### DIFF
--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -51,7 +51,7 @@ class SparseMatrix(MatrixBase):
     >>> SparseMatrix(2, 2, [1, 2])
     Traceback (most recent call last):
     ...
-    ValueError: List length (1) != rows*columns (4)
+    ValueError: List length (2) != rows*columns (4)
 
     Here, an error is not raised because the list is not flat and no
     element is out of range:
@@ -67,7 +67,7 @@ class SparseMatrix(MatrixBase):
     >>> SparseMatrix(2, 2, [[1, 2, 3]])
     Traceback (most recent call last):
     ...
-    ValueError: The location (0, 2) is out of the designated shape: (2, 2)
+    ValueError: The location (0, 2) is out of designated range: (1, 1)
 
     To autosize the matrix, pass None for rows:
 
@@ -179,9 +179,10 @@ class SparseMatrix(MatrixBase):
             else:
                 for i, j in self._smat.keys():
                     if i and i >= self.rows or j and j >= self.cols:
+                        r, c = self.shape
                         raise ValueError(filldedent('''
-                            The location %s is out of the designated
-                            shape: %s''' % ((i, j), self.shape)))
+                            The location %s is out of designated
+                            range: %s''' % ((i, j), (r - 1, c - 1))))
         else:
             if (len(args) == 1 and isinstance(args[0], (list, tuple))):
                 # list of values or lists

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -176,6 +176,12 @@ def test_sparse_matrix():
     raises(ValueError, lambda: SparseMatrix(2, 2, [1]))
     raises(ValueError, lambda: SparseMatrix(1, 1, [[1, 2]]))
     assert SparseMatrix([.1]).has(Float)
+    # autosizing
+    assert SparseMatrix(None, {(0, 1): 0}).shape == (0, 0)
+    assert SparseMatrix(None, {(0, 1): 1}).shape == (1, 2)
+    assert SparseMatrix(None, None, {(0, 1): 1}).shape == (1, 2)
+    raises(ValueError, lambda: SparseMatrix(None, 1, [[1, 2]]))
+    raises(ValueError, lambda: SparseMatrix(1, None, [[1, 2]]))
 
     # test_determinant
     x, y = Symbol('x'), Symbol('y')

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -1,5 +1,6 @@
-from sympy import Abs, S, Symbol, I, Rational, PurePoly
-from sympy.matrices import Matrix, SparseMatrix, eye, zeros, ShapeError
+from sympy import Abs, S, Symbol, I, Rational, PurePoly, Float
+from sympy.matrices import (Matrix, SparseMatrix, eye, ones, zeros,
+    ShapeError)
 from sympy.utilities.pytest import raises
 
 def test_sparse_matrix():
@@ -154,6 +155,27 @@ def test_sparse_matrix():
     assert a == SparseMatrix(0, 2, [])
     b.col_del(1)
     assert b == SparseMatrix(1, 1, [1])
+
+    assert SparseMatrix([[1, 2, 3], [1, 2], [1]]) == Matrix([
+        [1, 2, 3],
+        [1, 2, 0],
+        [1, 0, 0]])
+    assert SparseMatrix(4, 4, {(1, 1): ones(2), (2, 2): 2*ones(2)}) == Matrix([
+        [0, 0, 0, 0],
+        [0, 1, 1, 0],
+        [0, 1, 2, 2],
+        [0, 0, 2, 2]])
+    assert SparseMatrix(4, 4, {(1, 1): sparse_eye(2)}) == Matrix([
+        [0, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 0]])
+    raises(ValueError, lambda: SparseMatrix(1, 1, {(1, 1): 1}))
+    assert SparseMatrix(1, 2, [1, 2]).tolist() == [[1, 2]]
+    assert SparseMatrix(2, 2, [1, [2, 3]]).tolist() == [[1, 0], [2, 3]]
+    raises(ValueError, lambda: SparseMatrix(2, 2, [1]))
+    raises(ValueError, lambda: SparseMatrix(1, 1, [[1, 2]]))
+    assert SparseMatrix([.1]).has(Float)
 
     # test_determinant
     x, y = Symbol('x'), Symbol('y')

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -160,11 +160,6 @@ def test_sparse_matrix():
         [1, 2, 3],
         [1, 2, 0],
         [1, 0, 0]])
-    assert SparseMatrix(4, 4, {(1, 1): ones(2), (2, 2): 2*ones(2)}) == Matrix([
-        [0, 0, 0, 0],
-        [0, 1, 1, 0],
-        [0, 1, 2, 2],
-        [0, 0, 2, 2]])
     assert SparseMatrix(4, 4, {(1, 1): sparse_eye(2)}) == Matrix([
         [0, 0, 0, 0],
         [0, 1, 0, 0],
@@ -182,6 +177,7 @@ def test_sparse_matrix():
     assert SparseMatrix(None, None, {(0, 1): 1}).shape == (1, 2)
     raises(ValueError, lambda: SparseMatrix(None, 1, [[1, 2]]))
     raises(ValueError, lambda: SparseMatrix(1, None, [[1, 2]]))
+    raises(ValueError, lambda: SparseMatrix(3, 3, {(0, 0): ones(2), (1, 1): 2}))
 
     # test_determinant
     x, y = Symbol('x'), Symbol('y')


### PR DESCRIPTION
#### Brief description of what is fixed or changed
SparseMatrix instantiation is enhanced to parse values that are matrix-like.

From the new docstring:
```
    Values that are themselves a Matrix are automatically expanded:

    >>> SparseMatrix(4, 4, {(1, 1): ones(2)})
    Matrix([
    [0, 0, 0, 0],
    [0, 1, 1, 0],
    [0, 1, 1, 0],
    [0, 0, 0, 0]])

    A SparseMatrix can be instantiated from a ragged list of lists:

    >>> SparseMatrix([[1, 2, 3], [1, 2], [1]])
    Matrix([
    [1, 2, 3],
    [1, 2, 0],
    [1, 0, 0]])

    For safety, one may include the expected size and then an error
    will be raised if the indices of any element are out of range or
    (for a flat list) if the total number of elements does not match
    the expected shape:

    >>> SparseMatrix(2, 2, [1, 2])
    Traceback (most recent call last):
    ...
    ValueError: List length (2) != rows*columns (4)
```
#### Other Comments

This will be used to provide a simple method of instantiating banded matrices as in #16180 .

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
    - SparseMatrix will accept a list of lists with or without size specified
    - SparseMatrix values in the instantiation dictionary can now be matrices (or lists that are interpreted like matrices but do not need to contain row x col elements, i.e. a list of ragged lists is acceptable)
<!-- END RELEASE NOTES -->
