### PR TITLE
Increased coverage and fixed bugs in combinatorics

### DIFF
--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -52,7 +52,7 @@ class RewritingSystem(object):
         Set the maximum number of rules that can be defined
 
         '''
-        if self._max_exceeded and n > self.maxeqns:
+        if n > self.maxeqns:
             self._max_exceeded = False
         self.maxeqns = n
         return

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -53,10 +53,12 @@ class Subset(Basic):
         2
         """
         if len(subset) > len(superset):
-            raise ValueError('Invalid arguments have been provided. The superset must be larger than the subset.')
+            raise ValueError('Invalid arguments have been provided. The '
+                             'superset must be larger than the subset.')
         for elem in subset:
             if elem not in superset:
-                raise ValueError('The superset provided is invalid as it does not contain the element %i' % elem)
+                raise ValueError('The superset provided is invalid as it does '
+                                 'not contain the element {}'.format(elem))
         obj = Basic.__new__(cls)
         obj._subset = subset
         obj._superset = superset
@@ -506,7 +508,7 @@ class Subset(Basic):
         """
         bitlist = ['0'] * len(superset)
         if type(subset) is Subset:
-            subset = subset.args[0]
+            subset = subset.subset
         for i in Subset.subset_indices(subset, superset):
             bitlist[i] = '1'
         return ''.join(bitlist)

--- a/sympy/combinatorics/tests/test_generators.py
+++ b/sympy/combinatorics/tests/test_generators.py
@@ -1,6 +1,7 @@
-from sympy.combinatorics.generators import symmetric, cyclic, alternating, dihedral
+from sympy.combinatorics.generators import symmetric, cyclic, alternating, \
+    dihedral, rubik
 from sympy.combinatorics.permutations import Permutation
-
+from sympy.utilities.pytest import raises
 
 def test_generators():
 
@@ -100,3 +101,5 @@ def test_generators():
         Permutation([2, 1, 0, 4, 3]),
         Permutation([4, 0, 1, 2, 3]),
         Permutation([3, 2, 1, 0, 4])]
+
+    raises(ValueError, lambda: rubik(1))

--- a/sympy/combinatorics/tests/test_graycode.py
+++ b/sympy/combinatorics/tests/test_graycode.py
@@ -55,12 +55,15 @@ def test_graycode():
     assert get_subset_from_bitstring('abcd', '1001') == ['a', 'd']
     assert list(graycode_subsets(['a', 'b', 'c'])) == \
         [[], ['c'], ['b', 'c'], ['b'], ['a', 'b'], ['a', 'b', 'c'],
-    ['a', 'c'], ['a']]
+         ['a', 'c'], ['a']]
 
     raises(ValueError, lambda: GrayCode(0))
     raises(ValueError, lambda: GrayCode(2.2))
     raises(ValueError, lambda: GrayCode(2, start=[1, 1, 0]))
     raises(ValueError, lambda: GrayCode(2, rank=2.5))
+    raises(ValueError, lambda: get_subset_from_bitstring(['c', 'a', 'c'], '1100'))
+    raises(ValueError, lambda: list(GrayCode(3).generate_gray(start="1111")))
+
 
 def test_live_issue_117():
     assert bin_to_gray('0100') == '0110'

--- a/sympy/combinatorics/tests/test_named_groups.py
+++ b/sympy/combinatorics/tests/test_named_groups.py
@@ -1,5 +1,7 @@
 from sympy.combinatorics.named_groups import (SymmetricGroup, CyclicGroup,
-DihedralGroup, AlternatingGroup, AbelianGroup)
+                                              DihedralGroup, AlternatingGroup,
+                                              AbelianGroup, RubikGroup)
+from sympy.utilities.pytest import raises
 
 
 def test_SymmetricGroup():
@@ -62,3 +64,7 @@ def test_AbelianGroup():
     A = AbelianGroup(3, 3, 3)
     assert A.order() == 27
     assert A.is_abelian is True
+
+
+def test_RubikGroup():
+    raises(ValueError, lambda: RubikGroup(1))

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -25,6 +25,7 @@ def test_partition():
     assert a <= b
     assert (a > b) is False
     assert a != b
+    assert a < b
 
     assert (a + 2).partition == [[1, 2], [3, 4]]
     assert (b - 1).partition == [[1, 2, 4], [3]]

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -476,6 +476,7 @@ def test_minimal_block():
     assert P1.minimal_block([0, 2]) == [0, 1, 0, 1, 0, 1]
     assert P2.minimal_block([0, 2]) == [0, 1, 0, 1, 0, 1]
 
+
 def test_minimal_blocks():
     P = PermutationGroup(Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5))
     assert P.minimal_blocks() == [[0, 1, 0, 1, 0, 1], [0, 1, 2, 0, 1, 2]]
@@ -485,6 +486,7 @@ def test_minimal_blocks():
 
     P = PermutationGroup(Permutation(0, 3))
     assert P.minimal_blocks() == False
+
 
 def test_max_div():
     S = SymmetricGroup(10)
@@ -766,6 +768,8 @@ def test_is_group():
 
 def test_PermutationGroup():
     assert PermutationGroup() == PermutationGroup(Permutation())
+    assert (PermutationGroup() == 0) is False
+
 
 def test_coset_transvesal():
     G = AlternatingGroup(5)
@@ -775,6 +779,7 @@ def test_coset_transvesal():
          Permutation(1, 2, 4), Permutation(4)(1, 2, 3), Permutation(1, 3)(2, 4),
          Permutation(0, 1, 2, 3, 4), Permutation(0, 1, 2, 4, 3),
          Permutation(0, 1, 3, 2, 4), Permutation(0, 2, 4, 1, 3)]
+
 
 def test_coset_table():
     G = PermutationGroup(Permutation(0,1,2,3), Permutation(0,1,2),
@@ -788,10 +793,12 @@ def test_coset_table():
          [10, 9, 10, 7, 3, 11, 2, 2, 11, 11], [8, 7, 9, 9, 9, 9, 4, 4, 9, 9],
          [7, 8, 7, 8, 10, 10, 5, 5, 10, 10], [11, 11, 11, 11, 8, 7, 6, 6, 8, 8]]
 
+
 def test_subgroup():
     G = PermutationGroup(Permutation(0,1,2), Permutation(0,2,3))
     H = G.subgroup([Permutation(0,1,3)])
     assert H.is_subgroup(G)
+
 
 def test_generator_product():
     G = SymmetricGroup(5)
@@ -802,6 +809,7 @@ def test_generator_product():
     for g in gens:
         w = g*w
     assert w == p
+
 
 def test_sylow_subgroup():
     P = PermutationGroup(Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5))

--- a/sympy/combinatorics/tests/test_prufer.py
+++ b/sympy/combinatorics/tests/test_prufer.py
@@ -29,10 +29,17 @@ def test_prufer():
     assert sorted(Prufer(set(tree)).tree_repr) == sorted(tree_lists)
 
     raises(ValueError, lambda: Prufer([[1, 2], [3, 4]]))  # 0 is missing
+    raises(ValueError, lambda: Prufer([[2, 3], [3, 4]]))  # 0, 1 are missing
     assert Prufer(*Prufer.edges([1, 2], [3, 4])).prufer_repr == [1, 3]
     raises(ValueError, lambda: Prufer.edges(
         [1, 3], [3, 4]))  # a broken tree but edges doesn't care
     raises(ValueError, lambda: Prufer.edges([1, 2], [5, 6]))
+    raises(ValueError, lambda: Prufer([[]]))
+
+    a = Prufer([[0, 1], [0, 2], [0, 3]])
+    b = a.next()
+    assert b.tree_repr == [[0, 2], [0, 1], [1, 3]]
+    assert b.rank == 1
 
 
 def test_round_trip():

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -1,5 +1,7 @@
 from sympy.combinatorics.fp_groups import FpGroup
 from sympy.combinatorics.free_groups import free_group
+from sympy.utilities.pytest import raises
+
 
 def test_rewriting():
     F, a, b = free_group("a, b")
@@ -38,3 +40,10 @@ def test_rewriting():
     R.add_rule(a**2, b)
     assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
     assert R.reduce_using_automaton(a**4*b**-2*a**2*b**3) == b
+
+    R.set_max(15)
+    raises(RuntimeError, lambda:  R.add_rule(a**-3, b))
+    R.set_max(20)
+    R.add_rule(a**-3, b)
+
+    assert R.add_rule(a, a) == set()

--- a/sympy/combinatorics/tests/test_subsets.py
+++ b/sympy/combinatorics/tests/test_subsets.py
@@ -1,4 +1,5 @@
-from sympy.combinatorics import Subset
+from sympy.combinatorics.subsets import Subset, ksubsets
+from sympy.utilities.pytest import raises
 
 
 def test_subset():
@@ -13,6 +14,8 @@ def test_subset():
     assert a.rank_lexicographic == 14
     assert a.rank_gray == 2
     assert a.cardinality == 16
+    assert a.size == 2
+    assert Subset.bitlist_from_subset(a, ['a', 'b', 'c', 'd']) == '0011'
 
     a = Subset([2, 5, 7], [1, 2, 3, 4, 5, 6, 7])
     assert a.next_binary() == Subset([2, 5, 6], [1, 2, 3, 4, 5, 6, 7])
@@ -46,3 +49,13 @@ def test_subset():
         a = a.prev_lexicographic()
         i = i + 1
     assert i == 16
+
+    raises(ValueError, lambda: Subset(['a', 'b'], ['a']))
+    raises(ValueError, lambda: Subset(['a'], ['b', 'c']))
+    raises(ValueError, lambda: Subset.subset_from_bitlist(['a', 'b'], '010'))
+
+
+def test_ksubsets():
+    assert list(ksubsets([1, 2, 3], 2)) == [(1, 2), (1, 3), (2, 3)]
+    assert list(ksubsets([1, 2, 3, 4, 5], 2)) == [(1, 2), (1, 3), (1, 4),
+               (1, 5), (2, 3), (2, 4), (2, 5), (3, 4), (3, 5), (4, 5)]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #16318

#### Brief description of what is fixed or changed
Increased test coverage and fixed three minor bugs:
* Error message could not format correctly for non-integer set members
* Calling `bitlist_from_subset` with a Subset did not work
* Updating maximum length did require raising an error before, so a RewritingSystem with 15 rules would cause as error when calling:
```
r.setmax(15)
r.setmax(20)
r.add_rule(...) # Error here
```
but not when calling as
```
r.setmax(15)
r.add_rule(...) # Error here
r.setmax(20)
r.add_rule(...)  # But not here
```

now the top version works.

#### Other comments
The final issue caused problems in the tests although one can probably live with it as a user.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
