### PR TITLE
Fix for Mul.is_real

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1172,7 +1172,9 @@ class Mul(Expr, AssocOp):
         t_not_re_im = None
 
         for t in self.args:
-            if t.is_imaginary:  # I
+            if t.is_complex is False:
+                return False
+            elif t.is_imaginary:  # I
                 real = not real
             elif t.is_real:  # 2
                 if not zero:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1172,9 +1172,7 @@ class Mul(Expr, AssocOp):
         t_not_re_im = None
 
         for t in self.args:
-            if not t.is_complex:
-                return t.is_complex
-            elif t.is_imaginary:  # I
+            if t.is_imaginary:  # I
                 real = not real
             elif t.is_real:  # 2
                 if not zero:

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1026,3 +1026,13 @@ def test_issue_10302():
 
 def test_complex_reciprocal_imaginary():
     assert (1 / (4 + 3*I)).is_imaginary is False
+
+def test_issue_16313():
+    x = Symbol('x', real=False)
+    k = Symbol('k', real=True)
+    l = Symbol('l', real=True, zero=False)
+    assert (-x).is_real is False
+    assert (k*x).is_real is None  # k can be zero also
+    assert (l*x).is_real is False
+    assert (l*x*x).is_real is None  # since x*x can be a real number
+    assert (-x).is_positive is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16313 

#### Brief description of what is fixed or changed
Consider the following code:
```py
>>> from sympy import symbols
>>> x = symbols('x', real=False)
>>> (-x).is_real
>>>
```
Apparently the negation of a non-real should be non-real but I still don't know what non-real numbers do sympy support and what symbols with `real=False` could imply.

`Are there any non-real numbers when multiplied by -1 produces real numbers?`

But by understanding the code in `sympy.core.Mul.is_eval_real_imag()`, I could infer that since `complex = None` would mean either `complex=True` or `complex=False` in both of these cases the present code was giving result `False` with `real=False`. So the desired result is also `False`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
