### PR TITLE
Raise an error if an Order object is differentiated

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1085,7 +1085,7 @@ def test_integrate_series():
     g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + x**10/3628800 + O(x**11)
 
     assert integrate(f, x) == g
-    assert diff(integrate(f, x), x) == f
+    raises(TypeError, lambda: diff(integrate(f, x), x))
 
     assert integrate(O(x**5), x) == O(x**6)
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -459,7 +459,7 @@ class Order(Expr):
             return self.func(expr, *self.args[1:])
 
     def _eval_derivative(self, x):
-        return self.func(self.expr.diff(x), *self.args[1:]) or self
+        raise TypeError('Derivative of Order objects cannot be evaluated')
 
     def _eval_transpose(self):
         expr = self.expr._eval_transpose()

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -496,8 +496,7 @@ def test_issue_5183():
     assert abs(x + x**2).series(n=2) == x + O(x**2)
     assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2
     assert (1 + 1/x).series() == 1 + 1/x
-    assert Derivative(exp(x).series(), x).doit() == \
-        1 + x + x**2/2 + x**3/6 + x**4/24 + O(x**5)
+    raises(TypeError, lambda : Derivative(exp(x).series(), x).doit())
 
 
 def test_issue_5654():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -262,7 +262,7 @@ def test_getn():
 
 
 def test_diff():
-    assert O(x**2).diff(x) == O(x)
+    raises(TypeError, lambda: O(x**2).diff(x))
 
 
 def test_getO():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15570


#### Brief description of what is fixed or changed
Previously you could get the derivative of an Order type object now it's been changed to raise a TypeError since Order type objects differentiation should remain unevaluated.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
    * Evaluating derivative of an Order object raises an Error.
<!-- END RELEASE NOTES -->
