### PR TITLE
Added expand() method for SeqFormula

### DIFF
--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -716,8 +716,8 @@ class SeqFormula(SeqExpr):
     def expand(self, deep = True, modulus = None, mul = True, multinomial = True, basic = True,
      trig = True, log = True, power_exp = True, power_base = True):
 
-        return expand(self.formula, deep = deep, modulus = modulus, mul = mul, trig = trig, log = log, multinomial = multinomial,
-            power_exp = power_exp, power_base = power_base, basic = True)
+        return SeqFormula(expand(self.formula, deep = deep, modulus = modulus, mul = mul, trig = trig, log = log, multinomial = multinomial,
+            power_exp = power_exp, power_base = power_base, basic = True), self.args[1])
 
 class RecursiveSeq(SeqBase):
     """A finite degree recursive sequence.

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -603,7 +603,7 @@ class SeqPer(SeqExpr):
 
 
 class SeqFormula(SeqExpr):
-    """Represents sequence based on a formula.  
+    """Represents sequence based on a formula.
 
     Elements are generated using a formula.
 

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -713,8 +713,11 @@ class SeqFormula(SeqExpr):
         formula = self.formula * coeff
         return SeqFormula(formula, self.args[1])
 
-    def expand(self, trig = True, log = True, power_exp = True, power_base = True):
-        return expand(self.formula, trig = trig, log = log, power_exp = power_exp, power_base = power_base)
+    def expand(self,deep = True, modulus = None, mul = True, multinomial = True, basic = True, 
+     trig = True, log = True, power_exp = True, power_base = True):
+
+        return expand(self.formula, deep = deep, modulus = modulus, mul = mul, trig = trig, log = log, multinomial = multinomial,
+            power_exp = power_exp, power_base = power_base, basic = True)
 
 
 class RecursiveSeq(SeqBase):

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -713,12 +713,11 @@ class SeqFormula(SeqExpr):
         formula = self.formula * coeff
         return SeqFormula(formula, self.args[1])
 
-    def expand(self,deep = True, modulus = None, mul = True, multinomial = True, basic = True, 
+    def expand(self, deep = True, modulus = None, mul = True, multinomial = True, basic = True,
      trig = True, log = True, power_exp = True, power_base = True):
 
         return expand(self.formula, deep = deep, modulus = modulus, mul = mul, trig = trig, log = log, multinomial = multinomial,
             power_exp = power_exp, power_base = power_base, basic = True)
-
 
 class RecursiveSeq(SeqBase):
     """A finite degree recursive sequence.

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -713,11 +713,8 @@ class SeqFormula(SeqExpr):
         formula = self.formula * coeff
         return SeqFormula(formula, self.args[1])
 
-    def expand(self, deep=True, modulus=None, mul=True, multinomial=True, basic=True,
-     trig=True, log=True, power_exp=True, power_base=True):
-
-        return SeqFormula(expand(self.formula, deep=deep, modulus=modulus, mul=mul, trig=trig, log=log, multinomial=multinomial,
-            power_exp=power_exp, power_base=power_base, basic=True), self.args[1])
+    def expand(self, *args, **kwargs):
+        return SeqFormula(expand(self.formula, *args, **kwargs), self.args[1])
 
 class RecursiveSeq(SeqBase):
     """A finite degree recursive sequence.

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -603,7 +603,7 @@ class SeqPer(SeqExpr):
 
 
 class SeqFormula(SeqExpr):
-    """Represents sequence based on a formula.
+    """Represents sequence based on a formula.  
 
     Elements are generated using a formula.
 
@@ -712,6 +712,9 @@ class SeqFormula(SeqExpr):
         coeff = sympify(coeff)
         formula = self.formula * coeff
         return SeqFormula(formula, self.args[1])
+
+    def expand(self, trig = True, log = True, power_exp = True, power_base = True):
+        return expand(self.formula, trig = trig, log = log, power_exp = power_exp, power_base = power_base)
 
 
 class RecursiveSeq(SeqBase):

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -713,11 +713,11 @@ class SeqFormula(SeqExpr):
         formula = self.formula * coeff
         return SeqFormula(formula, self.args[1])
 
-    def expand(self, deep = True, modulus = None, mul = True, multinomial = True, basic = True,
-     trig = True, log = True, power_exp = True, power_base = True):
+    def expand(self, deep=True, modulus=None, mul=True, multinomial=True, basic=True,
+     trig=True, log=True, power_exp=True, power_base=True):
 
-        return SeqFormula(expand(self.formula, deep = deep, modulus = modulus, mul = mul, trig = trig, log = log, multinomial = multinomial,
-            power_exp = power_exp, power_base = power_base, basic = True), self.args[1])
+        return SeqFormula(expand(self.formula, deep=deep, modulus=modulus, mul=mul, trig=trig, log=log, multinomial=multinomial,
+            power_exp=power_exp, power_base=power_base, basic=True), self.args[1])
 
 class RecursiveSeq(SeqBase):
     """A finite degree recursive sequence.

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -78,10 +78,10 @@ def test_SeqFormula():
     seq = SeqFormula(x*(y**2 + z), (z, 1, 100))
     assert seq.expand() == SeqFormula(x*y**2 + x*z, (z, 1, 100))
     seq = SeqFormula(sin(x*(y**2 + z)),(z, 1, 100))
-    assert seq.expand() == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
+    assert seq.expand(trig=True) == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
     assert seq.expand(trig=False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
     seq = SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
-    assert seq.expand() == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
+    assert seq.expand(power_exp=True) == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
     assert seq.expand(power_exp=False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))
     assert seq.expand(mul=False, power_exp=False) == SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
 

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -79,11 +79,11 @@ def test_SeqFormula():
     assert seq.expand() == SeqFormula(x*y**2 + x*z, (z, 1, 100))
     seq = SeqFormula(sin(x*(y**2 + z)),(z, 1, 100))
     assert seq.expand() == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
-    assert seq.expand(trig = False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
+    assert seq.expand(trig=False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
     seq = SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
     assert seq.expand() == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
-    assert seq.expand(power_exp = False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))
-    assert seq.expand(mul = False, power_exp = False) == SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
+    assert seq.expand(power_exp=False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))
+    assert seq.expand(mul=False, power_exp=False) == SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
 
 def test_sequence():
     form = SeqFormula(n**2, (n, 0, 5))

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -79,9 +79,9 @@ def test_SeqFormula():
     assert seq.expand() == SeqFormula(x*y**2 + x*z, (z, 1, 100))
     seq = SeqFormula(sin(x*(y**2 + z)),(z, 1, 100))
     assert seq.expand(trig=True) == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
-    assert seq.expand(trig=False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
+    assert seq.expand() == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
     seq = SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
-    assert seq.expand(power_exp=True) == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
+    assert seq.expand() == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
     assert seq.expand(power_exp=False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))
     assert seq.expand(mul=False, power_exp=False) == SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
 

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -80,6 +80,7 @@ def test_SeqFormula():
     seq = SeqFormula(sin(x*(y**2 + z)),(z, 1, 100))
     assert seq.expand(trig=True) == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
     assert seq.expand() == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
+    assert seq.expand(trig=False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
     seq = SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
     assert seq.expand() == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
     assert seq.expand(power_exp=False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -1,6 +1,6 @@
 from sympy import (S, Tuple, symbols, Interval, EmptySequence, oo, SeqPer,
                    SeqFormula, sequence, SeqAdd, SeqMul, Indexed, Idx, sqrt,
-                   fibonacci, tribonacci)
+                   fibonacci, tribonacci, sin, cos, exp)
 from sympy.series.sequences import SeqExpr, SeqExprOp
 from sympy.utilities.pytest import raises, slow
 
@@ -75,6 +75,15 @@ def test_SeqFormula():
     raises(ValueError, lambda: SeqFormula(n**2, (n, -oo, oo)))
     raises(ValueError, lambda: SeqFormula(m*n**2, (0, oo)))
 
+    seq = SeqFormula(x*(y**2 + z), (z, 1, 100))
+    assert seq.expand() == SeqFormula(x*y**2 + x*z, (z, 1, 100))
+    seq = SeqFormula(sin(x*(y**2 + z)),(z, 1, 100))
+    assert seq.expand() == SeqFormula(sin(x*y**2)*cos(x*z) + sin(x*z)*cos(x*y**2), (z, 1, 100))
+    assert seq.expand(trig = False) == SeqFormula(sin(x*y**2 + x*z), (z, 1, 100))
+    seq = SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
+    assert seq.expand() == SeqFormula(exp(x*y**2)*exp(x*z), (z, 1, 100))
+    assert seq.expand(power_exp = False) == SeqFormula(exp(x*y**2 + x*z), (z, 1, 100))
+    assert seq.expand(mul = False, power_exp = False) == SeqFormula(exp(x*(y**2 + z)), (z, 1, 100))
 
 def test_sequence():
     form = SeqFormula(n**2, (n, 0, 5))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #12634 

#### Brief description of what is fixed or changed
Now we can get an expansion of the sequence formula,
By doing-
```python
>>> x = Symbol('x')
>>> y = Symbol('y', integer = True)
>>> seq = SeqFormula(sin(x*(x+y)), (y,1,5))
>>>expand(seq)
SeqFormula(sin(x**2)*cos(x*y) + sin(x*y)*cos(x**2), (y, 1, 5))
>>> seq.expand()
SeqFormula(sin(x**2)*cos(x*y) + sin(x*y)*cos(x**2), (y, 1, 5))
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
    * Added expand method for SeqFormula
<!-- END RELEASE NOTES -->
