### PR TITLE
Changed mpf(0) in evalf_sum to None

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1186,7 +1186,7 @@ def evalf_sum(expr, prec, options):
     if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     if func is S.Zero:
-        return mpf(0), None, None, None
+        return None, None, None, None
     prec2 = prec + 10
     try:
         n, a, b = limits[0]

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -535,3 +535,5 @@ def test_issue_14601():
     e2 = e.evalf(subs=subst)
     assert float(e2) == 0.0
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
+def test_issue_11151():
+	assert evalf.evalf(Sum(0,(a,1,2)) , 15 , {}) == evalf.evalf(S(0) , 15 , {})


### PR DESCRIPTION
As discussed in #11151,S.Zero returned mpf(0) and Sum(0,(a,1,2)) gave
untraceable results of mpf objects.This has to be same as S(0) which gives
none.

Fixes #11151 


<!-- BEGIN RELEASE NOTES -->
* core
        * changed mpf(0) in evalf_sum to None
<!-- END RELEASE NOTES -->
