### PR TITLE
Derivative ignores `evaluate=False` for nested derivative

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1336,7 +1336,7 @@ class Derivative(Expr):
             variable_count = cls._sort_variable_count(variable_count)
 
         # denest
-        if isinstance(expr, Derivative):
+        if isinstance(expr, Derivative) and evaluate:
             variable_count = list(expr.variable_count) + variable_count
             return expr.func(expr.expr, *variable_count, **kwargs)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1339,7 +1339,7 @@ class Derivative(Expr):
         if isinstance(expr, Derivative):
             variable_count = list(expr.variable_count) + variable_count
             expr = expr.expr
-            return Derivative(expr, *variable_count, **kwargs)
+            return self.func(expr, *variable_count, **kwargs)
 
         # we return here if evaluate is False or if there is no
         # _eval_derivative method

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1291,7 +1291,7 @@ class Derivative(Expr):
         if len(variable_count) == 0:
             return expr
 
-        evaluate = kwargs.get('evaluate', False)
+        evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         if evaluate:
             if isinstance(expr, Derivative):
@@ -1335,11 +1335,10 @@ class Derivative(Expr):
             #TODO: check if assumption of discontinuous derivatives exist
             variable_count = cls._sort_variable_count(variable_count)
 
-        # denest
-        if isinstance(expr, Derivative):
-            variable_count = list(expr.variable_count) + variable_count
-            expr = expr.expr
-            return self.func(expr, *variable_count, **kwargs)
+            # denest
+            if isinstance(expr, Derivative):
+                variable_count = list(expr.variable_count) + variable_count
+                return expr.func(expr.expr, *variable_count, **kwargs)
 
         # we return here if evaluate is False or if there is no
         # _eval_derivative method

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1335,10 +1335,10 @@ class Derivative(Expr):
             #TODO: check if assumption of discontinuous derivatives exist
             variable_count = cls._sort_variable_count(variable_count)
 
-            # denest
-            if isinstance(expr, Derivative):
-                variable_count = list(expr.variable_count) + variable_count
-                return expr.func(expr.expr, *variable_count, **kwargs)
+        # denest
+        if isinstance(expr, Derivative):
+            variable_count = list(expr.variable_count) + variable_count
+            return expr.func(expr.expr, *variable_count, **kwargs)
 
         # we return here if evaluate is False or if there is no
         # _eval_derivative method


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16350


#### Brief description of what is fixed or changed
As earlier the derivaties was ignoring "evaluate = FALSE" for nested derivaties so initially it is being checked in conditional statement by evaluate
It is achieved by using "and" Evaluate in the if statement


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * functions
        

<!-- END RELEASE NOTES -->
 