### PR TITLE
Added apart to inverse_laplace_transform

### DIFF
--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1244,7 +1244,7 @@ class InverseLaplaceTransform(IntegralTransform):
         return Integral(exp(s*t)*F, (s, c - I*oo, c + I*oo))/(2*S.Pi*S.ImaginaryUnit)
 
 
-def inverse_laplace_transform(F, s, t, plane=None, part=False, **hints):
+def inverse_laplace_transform(F, s, t, plane=None, **hints):
     r"""
     Compute the inverse Laplace transform of `F(s)`, defined as
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -717,7 +717,7 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
     # Actually, we won't try integration at all. Instead we use the definition
     # of the Meijer G function as a fairly general inverse mellin transform.
     F = F.rewrite(gamma)
-    for g in [factor(F), expand_mul(F), expand(F)]:
+    for g in [factor(F), expand_mul(F), expand(F), apart(F)]:
         if g.is_Add:
             # do all terms separately
             ress = [_inverse_mellin_transform(G, s, x, strip, as_meijerg,
@@ -1282,8 +1282,6 @@ def inverse_laplace_transform(F, s, t, plane=None, part=False, **hints):
     laplace_transform
     hankel_transform, inverse_hankel_transform
     """
-    if apart:
-        F = apart(F)
     if isinstance(F, MatrixBase) and hasattr(F, 'applyfunc'):
         return F.applyfunc(lambda Fij: inverse_laplace_transform(Fij, s, t, plane, **hints))
     return InverseLaplaceTransform(F, s, t, plane).doit(**hints)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1282,11 +1282,6 @@ def inverse_laplace_transform(F, s, t, plane=None, part=False, **hints):
     laplace_transform
     hankel_transform, inverse_hankel_transform
     """
-<<<<<<< HEAD
-=======
-    if part:
-        F = apart(F)
->>>>>>> 968e2f92f1a64b3da822d228101f5eda5c9194e1
     if isinstance(F, MatrixBase) and hasattr(F, 'applyfunc'):
         return F.applyfunc(lambda Fij: inverse_laplace_transform(Fij, s, t, plane, **hints))
     return InverseLaplaceTransform(F, s, t, plane).doit(**hints)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1282,7 +1282,7 @@ def inverse_laplace_transform(F, s, t, plane=None, part=False, **hints):
     laplace_transform
     hankel_transform, inverse_hankel_transform
     """
-    if apart:
+    if part:
         F = apart(F)
     if isinstance(F, MatrixBase) and hasattr(F, 'applyfunc'):
         return F.applyfunc(lambda Fij: inverse_laplace_transform(Fij, s, t, plane, **hints))

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -14,6 +14,7 @@ from sympy.logic.boolalg import to_cnf, conjuncts, disjuncts, Or, And
 from sympy.simplify import simplify
 from sympy.utilities import default_sort_key
 from sympy.matrices.matrices import MatrixBase
+from sympy.polys.partfrac import apart
 
 
 ##########################################################################
@@ -1243,7 +1244,7 @@ class InverseLaplaceTransform(IntegralTransform):
         return Integral(exp(s*t)*F, (s, c - I*oo, c + I*oo))/(2*S.Pi*S.ImaginaryUnit)
 
 
-def inverse_laplace_transform(F, s, t, plane=None, **hints):
+def inverse_laplace_transform(F, s, t, plane=None, part=False, **hints):
     r"""
     Compute the inverse Laplace transform of `F(s)`, defined as
 
@@ -1281,6 +1282,8 @@ def inverse_laplace_transform(F, s, t, plane=None, **hints):
     laplace_transform
     hankel_transform, inverse_hankel_transform
     """
+    if apart:
+        F = apart(F)
     if isinstance(F, MatrixBase) and hasattr(F, 'applyfunc'):
         return F.applyfunc(lambda Fij: inverse_laplace_transform(Fij, s, t, plane, **hints))
     return InverseLaplaceTransform(F, s, t, plane).doit(**hints)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References
[1] https://groups.google.com/d/msg/sympy/UqjtordI3M4/p05zms55AgAJ


#### Brief description of what is fixed or changed
Added partial fraction decomposition to inverse laplace transform. It helps to give the output of the transfer function as shown in link in references.

#### Other comments
I think this `hint` should be added in `doit()` method, since, sometimes ad-hoc techniques are helpful when generic algorithm is unable to produce the output. This makes the code slower but since it is added as an optional parameter, so it will not affect the code in all cases. 
If there is a better way to solve this problem, then please mention in the comments.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * apart function added to sympy.stats.integrals.transforms.inverse_laplace_transfrom
<!-- END RELEASE NOTES -->
