### PR TITLE
EmptySet with S

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -836,7 +836,7 @@ def test_sympy__sets__ordinals__OrdinalZero():
     assert _test_args(OrdinalZero())
 
 def test_sympy__sets__sets__EmptySet():
-    from sympy.sets.sets import EmptySet
+    from sympy import EmptySet
     assert _test_args(EmptySet())
 
 

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,4 +1,4 @@
-from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
+from .sets import (Set, Interval, Union, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference)
 from .fancysets import ImageSet, Range, ComplexRegion, Reals
 from .contains import Contains
@@ -10,4 +10,5 @@ Naturals = S.Naturals
 Naturals0 = S.Naturals0
 UniversalSet = S.UniversalSet
 Integers = S.Integers
+EmptySet = S.EmptySet
 del S


### PR DESCRIPTION
Since,Singleton classes have instances that are the same name as the class.So,
EmptySet should return its instance rather than its class name.
As well,I changed the test_args.py to test ``if S.EmptySet is EmptySet()``.
Fixes #16337


<!-- BEGIN RELEASE NOTES -->
* sets
    * changed __init__.py to show instance of EmptySet when being called rather than showing its classname.
<!-- END RELEASE NOTES -->
