### PR TITLE
Finish nth_order_reducible

### DIFF
--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -112,6 +112,10 @@ the various ODE solving methods. For this reason, they are documented here.
 ^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_algebraic
 
+:obj:`nth_order_reducible`
+^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.ode.ode_nth_order_reducible
+
 :obj:`separable`
 ^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_separable

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -113,7 +113,7 @@ the various ODE solving methods. For this reason, they are documented here.
 .. autofunction:: sympy.solvers.ode.ode_nth_algebraic
 
 :obj:`nth_order_reducible`
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_order_reducible
 
 :obj:`separable`

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4066,7 +4066,7 @@ def ode_nth_order_reducible(eq, func, order, match):
     >>> from sympy import Function, dsolve, Eq
     >>> from sympy.abc import x
     >>> f = Function('f')
-    >>> eq = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
+    >>> eq = Eq(x*f(x).diff(x)**2 + f(x).diff(x, 2))
     >>> dsolve(eq, f(x), hint='nth_order_reducible')
     ... # doctest: +NORMALIZE_WHITESPACE
     Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -308,7 +308,7 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters",
     "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters",
     "Liouville",
-    "order_reducible",
+    "nth_order_reducible",
     "2nd_power_series_ordinary",
     "2nd_power_series_regular",
     "nth_algebraic_Integral",
@@ -1359,9 +1359,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         # repeated integration e.g.:
         # `d^2/dx^2(y) + x*d/dx(y) = constant
         #f'(x) must be finite for this to work
-        r = _order_reducible_match(reduced_eq, func)
+        r = _nth_order_reducible_match(reduced_eq, func)
         if r:
-            matching_hints['order_reducible'] = r
+            matching_hints['nth_order_reducible'] = r
 
         # Any ODE that can be solved with a combination of algebra and
         # integrals e.g.:
@@ -4027,7 +4027,7 @@ def _frobenius(n, m, p0, q0, p, q, x0, x, c, check=None):
 
     return frobdict
 
-def _order_reducible_match(eq, func):
+def _nth_order_reducible_match(eq, func):
     r"""
     Matches any differential equation that can be rewritten with a smaller
     order. Only derivatives of ``func`` alone, wrt a single variable,
@@ -4048,12 +4048,29 @@ def _order_reducible_match(eq, func):
         return
     return {'n': smallest}
 
-def ode_order_reducible(eq, func, order, match):
+def ode_nth_order_reducible(eq, func, order, match):
     r"""
-    Substitutes lowest order derivate in equation to function with order
-    of derivative as `f^(n)(x) = g(x)`, where `n` (`match['n']`)
-    is the least-order derivative. The solution for `f(x)` is the n-times
-    integrated value of `g(x)`.
+    Solves ODEs that only involve derivatives of the dependent variable using
+    a substitution of the form `f^n(x) = g(x)`.
+
+    For example any second order ODE of the form `f''(x) = h(f'(x), x)` can be
+    transformed into a pair of 1st order ODEs `g'(x) = h(g(x), x)` and
+    `f'(x) = g(x)`. Usually the 1st order ODE for `g` is easier to solve. If
+    that gives an explicit solution for `g` then `f` is found simply by
+    integration.
+
+
+    Examples
+    ========
+
+    >>> from sympy import Function, dsolve, Eq
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> eq = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
+    >>> dsolve(eq, f(x), hint='nth_order_reducible')
+    ... # doctest: +NORMALIZE_WHITESPACE
+    Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
+
     """
     x = func.args[0]
     f = func.func
@@ -4068,7 +4085,18 @@ def ode_order_reducible(eq, func, order, match):
     w = f(x).diff(x, n)
     geq = eq.subs(w, g(x))
     gsol = dsolve(geq, g(x))
-    fsol = dsolve(gsol.subs(g(x), w), f(x))  # or do integration n times
+
+    if not isinstance(gsol, list):
+        gsol = [gsol]
+
+    # Might be multiple solutions to the reduced ODE:
+    fsol = []
+    for gsoli in gsol:
+        fsoli = dsolve(gsoli.subs(g(x), w), f(x))  # or do integration n times
+        fsol.append(fsoli)
+
+    if len(fsol) == 1:
+        fsol = fsol[0]
 
     return fsol
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3152,17 +3152,17 @@ def test_sysode_linear_neq_order1():
     assert checksysodesol(eq, sols_eq) == (True, [0, 0, 0, 0])
 
 
-def test_order_reducible():
-    from sympy.solvers.ode import _order_reducible_match
+def test_nth_order_reducible():
+    from sympy.solvers.ode import _nth_order_reducible_match
 
     eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
     sol = Eq(f(x),
              C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
-    assert sol == dsolve(eqn, f(x), hint='order_reducible')
+    assert sol == dsolve(eqn, f(x), hint='nth_order_reducible')
     assert sol == dsolve(eqn, f(x))
 
-    F = lambda eq: _order_reducible_match(eq, f(x))
+    F = lambda eq: _nth_order_reducible_match(eq, f(x))
     D = Derivative
     assert F(D(y*f(x), x, y) + D(f(x), x)) is None
     assert F(D(y*f(y), y, y) + D(f(y), y)) is None
@@ -3175,27 +3175,27 @@ def test_order_reducible():
     sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x))
-    assert sol == dsolve(eqn, f(x), hint='order_reducible')
+    assert sol == dsolve(eqn, f(x), hint='nth_order_reducible')
 
     eqn = Eq(sqrt(2) * f(x).diff(x,x,x) + f(x).diff(x), 0)
     sol = Eq(f(x), C1 + C2*sin(2**(S(3)/4)*x/2) + C3*cos(2**(S(3)/4)*x/2))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert sol == dsolve(eqn, f(x))
-    assert sol == dsolve(eqn, f(x), hint='order_reducible')
+    assert sol == dsolve(eqn, f(x), hint='nth_order_reducible')
 
     eqn = f(x).diff(x, 2) + 2*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-2*x))
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 3) + f(x).diff(x, 2) - 6*f(x).diff(x)
     sol = Eq(f(x), C1 + C2*exp(-3*x) + C3*exp(2*x))
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) - f(x).diff(x, 3) - 4*f(x).diff(x, 2) + \
         4*f(x).diff(x)
@@ -3203,28 +3203,28 @@ def test_order_reducible():
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 3*f(x).diff(x, 3)
     sol = Eq(f(x), C1 + C2*x + C3*x**2 + C4*exp(-3*x))
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) - 2*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*x + C3*exp(x*sqrt(2)) + C4*exp(-x*sqrt(2)))
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     sol = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol, sols)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
     eqn = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x)
     # These are equivalent:
@@ -3235,7 +3235,16 @@ def test_order_reducible():
     assert checkodesol(eqn, sol1, order=2, solve_for_func=False) == (True, 0)
     assert checkodesol(eqn, sol2, order=2, solve_for_func=False) == (True, 0)
     assert dsolve(eqn, f(x)) in (sol1, sol1s)
-    assert dsolve(eqn, f(x), hint='order_reducible') in (sol2, sol2s)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol2, sol2s)
+
+    # In this case the reduced ODE has two distinct solutions
+    eqn = f(x).diff(x, 2) - f(x).diff(x)**3
+    sol = [Eq(f(x), C2 - sqrt(2)*I*(C1 + x)*sqrt(1/(C1 + x))),
+           Eq(f(x), C2 + sqrt(2)*I*(C1 + x)*sqrt(1/(C1 + x)))]
+    sols = constant_renumber(sol)
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False) == [(True, 0), (True, 0)]
+    assert dsolve(eqn, f(x)) in (sol1, sol1s)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol2, sol2s)
 
 
 def test_nth_algebraic():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3243,8 +3243,8 @@ def test_nth_order_reducible():
            Eq(f(x), C2 + sqrt(2)*I*(C1 + x)*sqrt(1/(C1 + x)))]
     sols = constant_renumber(sol)
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == [(True, 0), (True, 0)]
-    assert dsolve(eqn, f(x)) in (sol1, sol1s)
-    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol2, sol2s)
+    assert dsolve(eqn, f(x)) in (sol, sols)
+    assert dsolve(eqn, f(x), hint='nth_order_reducible') in (sol, sols)
 
 
 def test_nth_algebraic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Finishes #15992

#### Brief description of what is fixed or changed

Finishes the order_reducible solver in dsolve.
1. Rename the solver to nth_order_reducible
2. Add a docstring with doctests and add to main docs
3. Ensure that multiple solutions from the reduced ODE are handled.

#### Other comments

This handles the case where multiple solutions are returned from the substituted ODE. In principle it would also be possible to get multiple solutions from solving the substitution ODE:
1. We have an ODE like `f''(x) = h(f'(x), x)`
2. We use substitution `f'(x) = g(x)` and solve getting a unique implicit solution for `g(x)`.
3. The implicit solution for `g(x)` could then lead to multiple solutions for `f(x)`.
I can't think of an example where this can happen without being impossible to solve anyway: we get an implicit solutions because solve can't isolate `g(x)`. It's very unlikely that `dsolve` would be able to solve the same equation with `f'(x)` instead of `g(x)`. It would be good to think about that though because handling that situation is the main thing missing from this solver right now.

I'm not sure what to do with the release note here. Ideally I'd just edit the previous release note...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * Rename order_reducible to nth_order_reducible
<!-- END RELEASE NOTES -->
