### PR TITLE
Changed mpf(0) to None in evalf_sum

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1186,7 +1186,7 @@ def evalf_sum(expr, prec, options):
     if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     if func is S.Zero:
-        return mpf(0), None, None, None
+        return None, None, None, None
     prec2 = prec + 10
     try:
         n, a, b = limits[0]

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1186,7 +1186,7 @@ def evalf_sum(expr, prec, options):
     if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     if func is S.Zero:
-        return None, None, None, None
+        return None, None, prec, None
     prec2 = prec + 10
     try:
         n, a, b = limits[0]

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -537,4 +537,4 @@ def test_issue_14601():
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
 def test_issue_11151():
     e=Sum(0,(x,1,2))
-    assert evalf.evalf(e,15,{}) == evalf.evalf(S(0),15,{})
+    assert n.evalf(e,15,{}) == n.evalf(S(0),15,{})

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -11,6 +11,7 @@ from sympy.utilities.pytest import raises, XFAIL
 from sympy.core import evalf
 from sympy.abc import n, x, y
 
+
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)
 
@@ -535,6 +536,12 @@ def test_issue_14601():
     e2 = e.evalf(subs=subst)
     assert float(e2) == 0.0
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
+
+
 def test_issue_11151():
     e=Sum(0,(x,1,2))
-    assert n.evalf(e,15,{}) == n.evalf(S(0),15,{})
+    array1=[]
+    array2=[]
+    array1.append(evalf.evalf(e, 15, {}))
+    array2.append(evalf.evalf(S(0), 15, {}))
+    assert array1 == array2

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -545,7 +545,7 @@ def test_issue_11151():
     assert evalf(e, 15, {}) == \
         evalf(z, 15, {}) == (None, None, 15, None)
     # so this shouldn't fail
-    assert (e/2).n() == 0 
+    assert (e/2).n() == 0
     # this was where the issue appeared
     expr0 = Sum(x**2 + x, (x, 1, 2))
     expr1 = Sum(0, (x, 1, 2))

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -535,3 +535,5 @@ def test_issue_14601():
     e2 = e.evalf(subs=subst)
     assert float(e2) == 0.0
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
+def test_issue_11151():
+	assert evalf.evalf(Sum(0,(a,1,2)) , 15 , {}) == evalf.evalf(S(0) , 15 , {})

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
-from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp,
+from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
     integrate, log, Mul, N, oo, pi, Pow, product, Product,
-    Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
+    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath)
 from mpmath import inf, ninf
@@ -9,7 +9,7 @@ from mpmath.libmp.libmpf import from_float
 from sympy.core.compatibility import long, range
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core import evalf
-from sympy.abc import n, x, y
+from sympy.abc import n, x, y, a
 
 
 def NS(e, n=15, **options):
@@ -539,9 +539,10 @@ def test_issue_14601():
 
 
 def test_issue_11151():
-    e=Sum(0,(x,1,2))
-    array1=[]
-    array2=[]
-    array1.append(evalf.evalf(e, 15, {}))
-    array2.append(evalf.evalf(S(0), 15, {}))
-    assert array1 == array2
+    expr0 = Sum(a**2+a,(a,1,2))
+    expr1 = Sum(0,(a,1,2))
+    expr2 = expr1/expr0
+    expr3 = factor(expr2)
+    expr4 = expr3-expr2
+    expr5 = simplify(expr4)
+    assert expr5 == 0 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -539,10 +539,29 @@ def test_issue_14601():
 
 
 def test_issue_11151():
+    e=Sum(0,(x,1,2))
+    array1=[]
+    array2=[]
+    array1.append(evalf.evalf(e, 15, {}))
+    array2.append(evalf.evalf(S(0), 15, {}))
+    assert array1 == array2
+
+
+def test_issue_11151_1():
     expr0 = Sum(a**2+a,(a,1,2))
     expr1 = Sum(0,(a,1,2))
     expr2 = expr1/expr0
     expr3 = factor(expr2)
     expr4 = expr3-expr2
     expr5 = simplify(expr4)
-    assert expr5 == 0 
+    assert expr5 == 0
+
+
+def test_issue_11151_2():
+   z = S.Zero
+   e = Sum(z, (a, 1, 2))
+   assert e != z  # it shouldn't evaluate
+   # when it does evaluate, this is what it should give
+   assert evalf.evalf(e, 15, {}) == evalf.evalf(z, 15, {}) == (None, None, 15, None)
+   # so this shouldn't fail
+   assert (e/2).n() == 0 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -536,4 +536,4 @@ def test_issue_14601():
     assert float(e2) == 0.0
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
 def test_issue_11151():
-	assert evalf.evalf(Sum(0,(a,1,2)) , 15 , {}) == evalf.evalf(S(0) , 15 , {})
+    assert evalf.evalf(Sum(0,(a,1,2)) , 15 , {}) == evalf.evalf(S(0) , 15 , {})

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -9,7 +9,7 @@ from mpmath.libmp.libmpf import from_float
 from sympy.core.compatibility import long, range
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core import evalf
-from sympy.abc import n, x, y, a
+from sympy.abc import n, x, y
 
 
 def NS(e, n=15, **options):
@@ -539,29 +539,16 @@ def test_issue_14601():
 
 
 def test_issue_11151():
-    e=Sum(0,(x,1,2))
-    array1=[]
-    array2=[]
-    array1.append(evalf.evalf(e, 15, {}))
-    array2.append(evalf.evalf(S(0), 15, {}))
-    assert array1 == array2
-
-
-def test_issue_11151_1():
-    expr0 = Sum(a**2+a,(a,1,2))
-    expr1 = Sum(0,(a,1,2))
+    z = S.Zero
+    e = Sum(z, (x, 1, 2))
+    assert e != z  # it shouldn't evaluate
+    # when it does evaluate, this is what it should give
+    assert evalf.evalf(e, 15, {}) == \
+        evalf.evalf(z, 15, {}) == (None, None, 15, None)
+    # so this shouldn't fail
+    assert (e/2).n() == 0 
+    # this was where the issue appeared
+    expr0 = Sum(x**2 + x, (x, 1, 2))
+    expr1 = Sum(0, (x, 1, 2))
     expr2 = expr1/expr0
-    expr3 = factor(expr2)
-    expr4 = expr3-expr2
-    expr5 = simplify(expr4)
-    assert expr5 == 0
-
-
-def test_issue_11151_2():
-   z = S.Zero
-   e = Sum(z, (a, 1, 2))
-   assert e != z  # it shouldn't evaluate
-   # when it does evaluate, this is what it should give
-   assert evalf.evalf(e, 15, {}) == evalf.evalf(z, 15, {}) == (None, None, 15, None)
-   # so this shouldn't fail
-   assert (e/2).n() == 0 
+    assert simplify(factor(expr2) - expr2) == 0

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -3,12 +3,11 @@ from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     integrate, log, Mul, N, oo, pi, Pow, product, Product,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
-    scaled_zero, get_integer_part, as_mpmath)
+    scaled_zero, get_integer_part, as_mpmath, evalf)
 from mpmath import inf, ninf
 from mpmath.libmp.libmpf import from_float
 from sympy.core.compatibility import long, range
 from sympy.utilities.pytest import raises, XFAIL
-from sympy.core import evalf
 from sympy.abc import n, x, y
 
 
@@ -543,8 +542,8 @@ def test_issue_11151():
     e = Sum(z, (x, 1, 2))
     assert e != z  # it shouldn't evaluate
     # when it does evaluate, this is what it should give
-    assert evalf.evalf(e, 15, {}) == \
-        evalf.evalf(z, 15, {}) == (None, None, 15, None)
+    assert evalf(e, 15, {}) == \
+        evalf(z, 15, {}) == (None, None, 15, None)
     # so this shouldn't fail
     assert (e/2).n() == 0 
     # this was where the issue appeared

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -8,7 +8,7 @@ from mpmath import inf, ninf
 from mpmath.libmp.libmpf import from_float
 from sympy.core.compatibility import long, range
 from sympy.utilities.pytest import raises, XFAIL
-
+from sympy.core import evalf
 from sympy.abc import n, x, y
 
 def NS(e, n=15, **options):
@@ -536,4 +536,5 @@ def test_issue_14601():
     assert float(e2) == 0.0
     assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0
 def test_issue_11151():
-    assert evalf.evalf(Sum(0,(a,1,2)) , 15 , {}) == evalf.evalf(S(0) , 15 , {})
+    e=Sum(0,(x,1,2))
+    assert evalf.evalf(e,15,{}) == evalf.evalf(S(0),15,{})


### PR DESCRIPTION
As discussed in #11151,S.Zero returned mpf(0) and Sum(0,(a,1,2)) gave
untraceable results of mpf objects.This has to be same as S(0) which gives
none.

Fixes #11151 

<!-- BEGIN RELEASE NOTES -->
* core
     * changed mpf(0) in evalf_sum to None
<!-- END RELEASE NOTES -->
