### PR TITLE
fixed incorrect literal_float regex

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -149,7 +149,7 @@ def _decimal_to_Rational_prec(dec):
 
 def _literal_float(f):
     """Return True if n can be interpreted as a floating point number."""
-    pat = r"[-+]?((\d*\.\d+)|(\d+\.?))(eE[-+]?\d+)?"
+    pat = r"[-+]?((\d*\.\d+)|(\d+\.?))([eE][-+]?\d+)?"
     return bool(regex.match(pat, f))
 
 # (a,b) -> gcd(a,b)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -147,10 +147,10 @@ def _decimal_to_Rational_prec(dec):
     return rv, prec
 
 
+_floatpat = regex.compile(r"[-+]?((\d*\.\d+)|(\d+\.?))")
 def _literal_float(f):
-    """Return True if n can be interpreted as a floating point number."""
-    pat = r"[-+]?((\d*\.\d+)|(\d+\.?))([eE][-+]?\d+)?"
-    return bool(regex.match(pat, f))
+    """Return True if n starts like a floating point number."""
+    return bool(_floatpat.match(f))
 
 # (a,b) -> gcd(a,b)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #16407 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Changed
`pat = r"[-+]?((\d*\.\d+)|(\d+\.?))(eE[-+]?\d+)?"`
to
`pat = r"[-+]?((\d*\.\d+)|(\d+\.?))([eE][-+]?\d+)?"`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
