### PR TITLE
Fix warnings and warning handling code under pytest

### DIFF
--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -82,8 +82,8 @@ def test_invertible():
     A = MatrixSymbol('A', 5, 5)
     B = MatrixSymbol('B', 5, 5)
     assert satask(Q.invertible(A*B), Q.invertible(A) & Q.invertible(B)) is True
-    assert satask(Q.invertible(A), Q.invertible(A*B))
-    assert satask(Q.invertible(A) & Q.invertible(B), Q.invertible(A*B))
+    assert satask(Q.invertible(A), Q.invertible(A*B)) is True
+    assert satask(Q.invertible(A) & Q.invertible(B), Q.invertible(A*B)) is True
 
 
 def test_prime():

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -20,7 +20,6 @@ from sympy.ntheory import isprime, is_primitive_root
 from sympy.polys.domains import FF
 
 from sympy.utilities.pytest import raises, slow, warns_deprecated_sympy
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from random import randrange
 
@@ -152,7 +151,6 @@ def test_rsa_public_key():
     assert rsa_public_key(5, 3, 3) == (15, 3)
     assert rsa_public_key(8, 8, 8) is False
 
-    raises(SymPyDeprecationWarning, lambda: rsa_public_key(2, 2, 1))
     with warns_deprecated_sympy():
         assert rsa_public_key(2, 2, 1) == (4, 1)
 
@@ -163,7 +161,6 @@ def test_rsa_private_key():
     assert rsa_private_key(23,29,5) == (667,493)
     assert rsa_private_key(8, 8, 8) is False
 
-    raises(SymPyDeprecationWarning, lambda: rsa_private_key(2, 2, 1))
     with warns_deprecated_sympy():
         assert rsa_private_key(2, 2, 1) == (4, 1)
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -25,7 +25,6 @@ from sympy.matrices import (Matrix, diag, eye,
 from sympy.polys.polytools import Poly
 from sympy.simplify.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
 from sympy.utilities.pytest import (raises, XFAIL, slow, skip,
     warns_deprecated_sympy)
@@ -1242,11 +1241,13 @@ def test_jordan_block():
         eigenvalue=2, eigenval=4))
 
     # Deprecated feature
-    raises(SymPyDeprecationWarning,
-    lambda: SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2))
+    with warns_deprecated_sympy():
+        assert (SpecialOnlyMatrix.jordan_block(cols=3, eigenvalue=2) ==
+                SpecialOnlyMatrix(3, 3, (2, 1, 0, 0, 2, 1, 0, 0, 2)))
 
-    raises(SymPyDeprecationWarning,
-    lambda: SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2))
+    with warns_deprecated_sympy():
+        assert (SpecialOnlyMatrix.jordan_block(rows=3, eigenvalue=2) ==
+                SpecialOnlyMatrix(3, 3, (2, 1, 0, 0, 2, 1, 0, 0, 2)))
 
     with warns_deprecated_sympy():
         assert SpecialOnlyMatrix.jordan_block(3, 2) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

A few tweaks to the tests to ensure that all non-slow tests run under pytest.

One commit fixes erroneous use of warning tests. The other commit stops xfail tests from asserting None. That leads to a warning under pytest but is also poor practice. `assert f() is True` should be used if the expected answer is True.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
