### PR TITLE
Omit calculation of derived_series() if Order is odd

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2027,7 +2027,7 @@ class PermutationGroup(Basic):
 
         """
         if self._is_solvable is None:
-            if self._order is not None and self._order % 2 != 0:
+            if self.order() % 2 != 0:
                 return True
             ds = self.derived_series()
             terminator = ds[len(ds) - 1]

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2027,6 +2027,8 @@ class PermutationGroup(Basic):
 
         """
         if self._is_solvable is None:
+            if self._order is not None and self._order % 2 != 0:
+                return True
             ds = self.derived_series()
             terminator = ds[len(ds) - 1]
             gens = terminator.generators

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -346,6 +346,8 @@ def test_is_solvable():
     b = Permutation([1, 0, 2])
     G = PermutationGroup([a, b])
     assert G.is_solvable
+    G = PermutationGroup([a])
+    assert G.is_solvable
     a = Permutation([1, 2, 3, 4, 0])
     b = Permutation([1, 0, 2, 3, 4])
     G = PermutationGroup([a, b])

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -352,7 +352,9 @@ def test_is_solvable():
     b = Permutation([1, 0, 2, 3, 4])
     G = PermutationGroup([a, b])
     assert not G.is_solvable
-
+    P = SymmetricGroup(10)
+    S = P.sylow_subgroup(3)
+    assert S.is_solvable
 
 def test_rubik1():
     gens = rubik_cube_generators()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
[Feit–Thompson theorem](https://en.wikipedia.org/wiki/Feit%E2%80%93Thompson_theorem), or `odd order theorem`, states that every finite group of `odd order` is `solvable`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  combinatorics
   *  To check solvability omit calculation of derived_series() if Order is odd
<!-- END RELEASE NOTES -->
