### PR TITLE
Fixed latex printing of BaseScalar

### DIFF
--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6255,17 +6255,17 @@ def test_degree_printing():
 def test_vector_expr_pretty_printing():
     A = CoordSys3D('A')
 
-    assert upretty(Cross(A.i, A.x*A.i+3*A.y*A.j)) == u("(A_i)×((A_x) A_i + (3⋅A_y) A_j)")
-    assert upretty(x*Cross(A.i, A.j)) == u('x⋅(A_i)×(A_j)')
+    assert upretty(Cross(A.i, A.x*A.i+3*A.y*A.j)) == u("(i_A)×((x_A) i_A + (3⋅y_A) j_A)")
+    assert upretty(x*Cross(A.i, A.j)) == u('x⋅(i_A)×(j_A)')
 
-    assert upretty(Curl(A.x*A.i + 3*A.y*A.j)) == u("∇×((A_x) A_i + (3⋅A_y) A_j)")
+    assert upretty(Curl(A.x*A.i + 3*A.y*A.j)) == u("∇×((x_A) i_A + (3⋅y_A) j_A)")
 
-    assert upretty(Divergence(A.x*A.i + 3*A.y*A.j)) == u("∇⋅((A_x) A_i + (3⋅A_y) A_j)")
+    assert upretty(Divergence(A.x*A.i + 3*A.y*A.j)) == u("∇⋅((x_A) i_A + (3⋅y_A) j_A)")
 
-    assert upretty(Dot(A.i, A.x*A.i+3*A.y*A.j)) == u("(A_i)⋅((A_x) A_i + (3⋅A_y) A_j)")
+    assert upretty(Dot(A.i, A.x*A.i+3*A.y*A.j)) == u("(i_A)⋅((x_A) i_A + (3⋅y_A) j_A)")
 
-    assert upretty(Gradient(A.x+3*A.y)) == u("∇(A_x + 3⋅A_y)")
-    assert upretty(Laplacian(A.x+3*A.y)) == u("∆(A_x + 3⋅A_y)")
+    assert upretty(Gradient(A.x+3*A.y)) == u("∇(x_A + 3⋅y_A)")
+    assert upretty(Laplacian(A.x+3*A.y)) == u("∆(x_A + 3⋅y_A)")
     # TODO: add support for ASCII pretty.
 
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6208,7 +6208,7 @@ def test_issue_12675():
     ucode_str = \
 u("""\
 ⎛   t⎞    \n\
-⎜⎛x⎞ ⎟ e_j\n\
+⎜⎛x⎞ ⎟ j_e\n\
 ⎜⎜─⎟ ⎟    \n\
 ⎝⎝y⎠ ⎠    \
 """)
@@ -6216,7 +6216,7 @@ u("""\
     ucode_str = \
 u("""\
 ⎛1⎞    \n\
-⎜─⎟ e_j\n\
+⎜─⎟ j_e\n\
 ⎝y⎠    \
 """)
     assert upretty((1/y)*e.j) == ucode_str

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -200,7 +200,7 @@ class CoordSys3D(Basic):
         vector_names = list(vector_names)
         latex_vects = [(r'\mathbf{\hat{%s}_{%s}}' % (x, name)) for
                            x in vector_names]
-        pretty_vects = [(name + '_' + x) for x in vector_names]
+        pretty_vects = ['%s_%s' % (x, name) for x in vector_names]
 
         obj._vector_names = vector_names
 
@@ -216,7 +216,7 @@ class CoordSys3D(Basic):
         variable_names = list(variable_names)
         latex_scalars = [(r"\mathbf{{%s}_{%s}}" % (x, name)) for
                          x in variable_names]
-        pretty_scalars = [(name + '_' + x) for x in variable_names]
+        pretty_scalars = ['%s_%s' % (x, name) for x in variable_names]
 
         obj._variable_names = variable_names
         obj._vector_names = vector_names

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -38,14 +38,14 @@ v.append(N.j - (Integral(f(b)) - C.x**2)*N.k)
 upretty_v_8 = u(
 """\
       ⎛   2   ⌠        ⎞    \n\
-N_j + ⎜C_x  - ⎮ f(b) db⎟ N_k\n\
+j_N + ⎜x_C  - ⎮ f(b) db⎟ k_N\n\
       ⎝       ⌡        ⎠    \
 """)
 pretty_v_8 = u(
     """\
-N_j + /         /       \\\n\
+j_N + /         /       \\\n\
       |   2    |        |\n\
-      |C_x  -  | f(b) db|\n\
+      |x_C  -  | f(b) db|\n\
       |        |        |\n\
       \\       /         / \
 """)
@@ -56,13 +56,13 @@ v.append((a**2 + b)*N.i + (Integral(f(b)))*N.k)
 upretty_v_11 = u(
 """\
 ⎛ 2    ⎞        ⎛⌠        ⎞    \n\
-⎝a  + b⎠ N_i  + ⎜⎮ f(b) db⎟ N_k\n\
+⎝a  + b⎠ i_N  + ⎜⎮ f(b) db⎟ k_N\n\
                 ⎝⌡        ⎠    \
 """)
 pretty_v_11 = u(
 """\
 / 2    \\ + /  /       \\\n\
-\\a  + b/ N_i| |        |\n\
+\\a  + b/ i_N| |        |\n\
            | | f(b) db|\n\
            | |        |\n\
            \\/         / \
@@ -74,23 +74,23 @@ s = 3*N.x**2*C.y
 upretty_s = u(
 """\
          2\n\
-3⋅C_y⋅N_x \
+3⋅y_C⋅x_N \
 """)
 pretty_s = u(
 """\
          2\n\
-3*C_y*N_x \
+3*y_C*x_N \
 """)
 
 # This is the pretty form for ((a**2 + b)*N.i + 3*(C.y - c)*N.k) | N.k
 upretty_d_7 = u(
 """\
 ⎛ 2    ⎞                                     \n\
-⎝a  + b⎠ (N_i|N_k)  + (3⋅C_y - 3⋅c) (N_k|N_k)\
+⎝a  + b⎠ (i_N|k_N)  + (3⋅y_C - 3⋅c) (k_N|k_N)\
 """)
 pretty_d_7 = u(
 """\
-/ 2    \\ (N_i|N_k) + (3*C_y - 3*c) (N_k|N_k)\n\
+/ 2    \\ (i_N|k_N) + (3*y_C - 3*c) (k_N|k_N)\n\
 \\a  + b/                                    \
 """)
 
@@ -114,32 +114,32 @@ def test_str_printing():
 @XFAIL
 def test_pretty_printing_ascii():
     assert pretty(v[0]) == u'0'
-    assert pretty(v[1]) == u'N_i'
-    assert pretty(v[5]) == u'(a) N_i + (-b) N_j'
+    assert pretty(v[1]) == u'i_N'
+    assert pretty(v[5]) == u'(a) i_N + (-b) j_N'
     assert pretty(v[8]) == pretty_v_8
-    assert pretty(v[2]) == u'(-1) N_i'
+    assert pretty(v[2]) == u'(-1) i_N'
     assert pretty(v[11]) == pretty_v_11
     assert pretty(s) == pretty_s
     assert pretty(d[0]) == u'(0|0)'
-    assert pretty(d[5]) == u'(a) (N_i|N_k) + (-b) (N_j|N_k)'
+    assert pretty(d[5]) == u'(a) (i_N|k_N) + (-b) (j_N|k_N)'
     assert pretty(d[7]) == pretty_d_7
-    assert pretty(d[10]) == u'(cos(a)) (C_i|N_k) + (-sin(a)) (C_j|N_k)'
+    assert pretty(d[10]) == u'(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
 
 
-def test_pretty_print_unicode():
+def test_pretty_print_unicode_v():
     assert upretty(v[0]) == u'0'
-    assert upretty(v[1]) == u'N_i'
-    assert upretty(v[5]) == u'(a) N_i + (-b) N_j'
+    assert upretty(v[1]) == u'i_N'
+    assert upretty(v[5]) == u'(a) i_N + (-b) j_N'
     # Make sure the printing works in other objects
-    assert upretty(v[5].args) == u'((a) N_i, (-b) N_j)'
+    assert upretty(v[5].args) == u'((a) i_N, (-b) j_N)'
     assert upretty(v[8]) == upretty_v_8
-    assert upretty(v[2]) == u'(-1) N_i'
+    assert upretty(v[2]) == u'(-1) i_N'
     assert upretty(v[11]) == upretty_v_11
     assert upretty(s) == upretty_s
     assert upretty(d[0]) == u'(0|0)'
-    assert upretty(d[5]) == u'(a) (N_i|N_k) + (-b) (N_j|N_k)'
+    assert upretty(d[5]) == u'(a) (i_N|k_N) + (-b) (j_N|k_N)'
     assert upretty(d[7]) == upretty_d_7
-    assert upretty(d[10]) == u'(cos(a)) (C_i|N_k) + (-sin(a)) (C_j|N_k)'
+    assert upretty(d[10]) == u'(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
 
 
 def test_latex_printing():
@@ -171,7 +171,7 @@ def test_custom_names():
                    variable_names=['i', 'j', 'k'])
     assert A.i.__str__() == 'A.i'
     assert A.x.__str__() == 'A.x'
-    assert A.i._pretty_form == 'A_i'
-    assert A.x._pretty_form == 'A_x'
+    assert A.i._pretty_form == 'i_A'
+    assert A.x._pretty_form == 'x_A'
     assert A.i._latex_form == r'\mathbf{{i}_{A}}'
     assert A.x._latex_form == r"\mathbf{\hat{x}_{A}}"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
closes #16323

#### Brief description of what is fixed or changed
Change the pretty printing of BaseScalar and BaseVector from 'A_i' to 'i_A' to match latex forms


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
    - pretty printing of BaseScalar and BaseVector matches the latex form with CoordSys as subscript
<!-- END RELEASE NOTES -->
