### PR TITLE
Handle Pow in Commutator expansion.

### DIFF
--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy import S, Expr, Mul, Add
+from sympy import S, Expr, Mul, Add, Pow
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.dagger import Dagger
@@ -117,6 +117,22 @@ class Commutator(Expr):
         if a.compare(b) == 1:
             return S.NegativeOne*cls(b, a)
 
+    def _expand_pow(self, A, B, sign):
+        exp = A.exp
+        if not exp.is_integer or not exp.is_constant() or abs(exp) <= 1:
+            # nothing to do
+            return self
+        base = A.base
+        if exp.is_negative:
+            base = A.base**-1
+            exp = -exp
+        comm = Commutator(base, B).expand(commutator=True)
+
+        result = base**(exp - 1) * comm
+        for i in range(1, exp):
+            result += base**(exp - 1 - i) * comm * base**i
+        return sign*result.expand()
+
     def _eval_expand_commutator(self, **hints):
         A = self.args[0]
         B = self.args[1]
@@ -167,6 +183,12 @@ class Commutator(Expr):
             first = Mul(comm1, c)
             second = Mul(b, comm2)
             return Add(first, second)
+        elif isinstance(A, Pow):
+            # [A**n, C] -> A**(n - 1)*[A, C] + A**(n - 2)*[A, C]*A + ... + [A, C]*A**(n-1)
+            return self._expand_pow(A, B, 1)
+        elif isinstance(B, Pow):
+            # [A, C**n] -> C**(n - 1)*[C, A] + C**(n - 2)*[C, A]*C + ... + [C, A]*C**(n-1)
+            return self._expand_pow(B, A, -1)
 
         # No changes, so return self
         return self

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -6,6 +6,7 @@ from sympy.physics.quantum.operator import Operator
 
 
 a, b, c = symbols('a,b,c')
+n = symbols('n', integer=True)
 A, B, C, D = symbols('A,B,C,D', commutative=False)
 
 
@@ -25,9 +26,17 @@ def test_commutator_identities():
     assert Comm(A, B*C).expand(commutator=True) == Comm(A, B)*C + B*Comm(A, C)
     assert Comm(A*B, C*D).expand(commutator=True) == \
         A*C*Comm(B, D) + A*Comm(B, C)*D + C*Comm(A, D)*B + Comm(A, C)*D*B
+    assert Comm(A, B**2).expand(commutator=True) == Comm(A, B)*B + B*Comm(A, B)
+    assert Comm(A**2, C**2).expand(commutator=True) == \
+        Comm(A*B, C*D).expand(commutator=True).replace(B, A).replace(D, C) == \
+        A*C*Comm(A, C) + A*Comm(A, C)*C + C*Comm(A, C)*A + Comm(A, C)*C*A
+    assert Comm(A, C**-2).expand(commutator=True) == \
+        Comm(A, (1/C)*(1/D)).expand(commutator=True).replace(D, C)
     assert Comm(A + B, C + D).expand(commutator=True) == \
         Comm(A, C) + Comm(A, D) + Comm(B, C) + Comm(B, D)
     assert Comm(A, B + C).expand(commutator=True) == Comm(A, B) + Comm(A, C)
+    assert Comm(A**n, B).expand(commutator=True) == Comm(A**n, B)
+
     e = Comm(A, Comm(B, C)) + Comm(B, Comm(C, A)) + Comm(C, Comm(A, B))
     assert e.doit().expand() == 0
 
@@ -64,3 +73,8 @@ def test_eval_commutator():
     assert Comm(F, T).doit() == -1
     assert Comm(T, F).doit() == 1
     assert Comm(B, T).doit() == B*T - T*B
+    assert Comm(F**2, B).expand(commutator=True).doit() == 0
+    assert Comm(F**2, T).expand(commutator=True).doit() == -2*F
+    assert Comm(F, T**2).expand(commutator=True).doit() == -2*T
+    assert Comm(T**2, F).expand(commutator=True).doit() == 2*T
+    assert Comm(T**2, F**3).expand(commutator=True).doit() == 2*F*T*F + 2*F**2*T + 2*T*F**2


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Handle expansion of commutators like
```
[A**2, C] = [A*A, C] -> A*[A, C] + [A, C]*A
```
but for arbitrary integer exponent.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
   * Pow expressions handled in Commutator expansion
<!-- END RELEASE NOTES -->
