### PR TITLE
combine single unknown log with others

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -967,6 +967,10 @@ def logcombine(expr, force=False):
                 else:
                     other.append(a)
 
+        # if there is only one log in other, put it with the
+        # good logs
+        if len(other) == 1 and isinstance(other[0], log):
+            log1[()].append(([], other.pop()))
         # if there is only one log at each coefficient and none have
         # an exponent to place inside the log then there is nothing to do
         if not logs and all(len(log1[k]) == 1 and log1[k][0] == [] for k in log1):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -464,6 +464,12 @@ def test_logcombine_1():
     assert logcombine(3*log(w) + 3*log(z)) == log(w**3*z**3)
     assert logcombine(x*(y + 1) + log(2) + log(3)) == x*(y + 1) + log(6)
     assert logcombine((x + y)*log(w) + (-x - y)*log(3)) == (x + y)*log(w/3)
+    # a single unknown can combine
+    assert logcombine(log(x) + log(2)) == log(2*x)
+    eq = log(abs(x)) + log(abs(y))
+    assert logcombine(eq) == eq
+    reps = {x: 0, y: 0}
+    assert log(abs(x)*abs(y)).subs(reps) != eq.subs(reps)
 
 
 def test_logcombine_complex_coeff():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1564,8 +1564,8 @@ def test_lambert_multivariate():
     x1 = LambertW(S(1)/3)
     x2 = a**(-5)
     x3 = 3**(S(1)/3)
-    x4 = 3**(5/6)*I
-    x5 = x1**(1/3)*x2**(1/3)/2
+    x4 = 3**(S(5)/6)*I
+    x5 = x1**(S(1)/3)*x2**(S(1)/3)/2
     ans = solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x)
     assert ans == [
         x0*log(3*x1*x2)/3, x0*log(-x5*(x3 - x4)), x0*log(-x5*(x3 + x4))]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1561,13 +1561,14 @@ def test_lambert_multivariate():
     raises(NotImplementedError, lambda: solve(x - sin(x)*log(y - x), x))
 
     x0 = 1/log(a)
-    x1 = a**(-5)
-    x2 = LambertW(S(1)/3)
+    x1 = LambertW(S(1)/3)
+    x2 = a**(-5)
     x3 = 3**(S(1)/3)
-    x4 = 3**(S(5)/6)*I
-    x5 = x1**(S(1)/3)*x2**(S(1)/3)*S(1)/2
+    x4 = 3**(5/6)*I
+    x5 = x1**(1/3)*x2**(1/3)/2
     ans = solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x)
-    assert ans == [x0*(log(x1) + log(3*x2))/3, x0*log(-x5*(x3 - x4)), x0*log(-x5*(x3 + x4))]
+    assert ans == [
+        x0*log(3*x1*x2)/3, x0*log(-x5*(x3 - x4)), x0*log(-x5*(x3 + x4))]
 
     # check collection
     K = ((b + 3)*LambertW(1/(b + 3))/a**5)**(S(1)/3)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -694,12 +694,8 @@ def test_checking():
 def test_issue_4671_4463_4467():
     assert solve((sqrt(x**2 - 1) - 2)) in ([sqrt(5), -sqrt(5)],
                                            [-sqrt(5), sqrt(5)])
-    # This is probably better than the form below but equivalent:
-    #assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [-sqrt(x*log(1 + I*pi/log(2)))
-    #                                                    , sqrt(x*log(1 + I*pi/log(2)))]
     assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [
-         sqrt(x*(log((log(2) + I*pi)/log(2)))),
-        -sqrt(-x*(log((log(2) + I*pi)/log(2))))]
+        -sqrt(x*log(1 + I*pi/log(2))), sqrt(x*log(1 + I*pi/log(2)))]
 
     C1, C2 = symbols('C1 C2')
     f = Function('f')

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1560,17 +1560,17 @@ def test_lambert_multivariate():
     # coverage test
     raises(NotImplementedError, lambda: solve(x - sin(x)*log(y - x), x))
 
-    _13 = S(1)/3
-    _56 = S(5)/6
-    _53 = S(5)/3
-    K = (a**(-5))**(_13)*LambertW(_13)**(_13)/-2
-    assert solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == [
-        (log(a**(-5)) + log(3*LambertW(_13)))/(3*log(a)),
-        log((3**(_13) - 3**(_56)*I)*K)/log(a),
-        log((3**(_13) + 3**(_56)*I)*K)/log(a)]
+    x0 = 1/log(a)
+    x1 = a**(-5)
+    x2 = LambertW(S(1)/3)
+    x3 = 3**(S(1)/3)
+    x4 = 3**(S(5)/6)*I
+    x5 = x1**(S(1)/3)*x2**(S(1)/3)*S(1)/2
+    ans = solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x)
+    assert ans == [x0*(log(x1) + log(3*x2))/3, x0*log(-x5*(x3 - x4)), x0*log(-x5*(x3 + x4))]
 
     # check collection
-    K = ((b + 3)*LambertW(1/(b + 3))/a**5)**(_13)
+    K = ((b + 3)*LambertW(1/(b + 3))/a**5)**(S(1)/3)
     assert solve(
             3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5),
             x) == [

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -698,8 +698,8 @@ def test_issue_4671_4463_4467():
     #assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [-sqrt(x*log(1 + I*pi/log(2)))
     #                                                    , sqrt(x*log(1 + I*pi/log(2)))]
     assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [
-         sqrt(x*(-log(log(2)) + log(log(2) + I*pi))),
-        -sqrt(-x*(log(log(2)) - log(log(2) + I*pi)))]
+         sqrt(x*(log((log(2) + I*pi)/log(2)))),
+        -sqrt(-x*(log((log(2) + I*pi)/log(2))))]
 
     C1, C2 = symbols('C1 C2')
     f = Function('f')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixes #6770 
`log(x) + log(2)` is `log(x*2)` regardless of the sign of x so it is now combined with logcombine.
#### Other comments
@smichr 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * logcombine: log(x) + log(2) will now combine without the use of `force`
<!-- END RELEASE NOTES -->
