### PR TITLE
Fixes float misplace decimal issue

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1013,6 +1013,7 @@ class Float(Number):
         if isinstance(num, float):
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):
+        # next line is workaround for https://github.com/fredrik-johansson/mpmath/issues/377
             num = num.replace('_','')
             _mpf_ = mlib.from_str(num, precision, rnd)
         elif isinstance(num, decimal.Decimal):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -809,7 +809,7 @@ class Float(Number):
     is sent for the precision; spaces or underscores are also allowed. (Auto-
     counting is only allowed for strings, ints and longs).
 
-    >>> Float('123 456 789 ._123_456', '')
+    >>> Float('123 456 789.123_456', '')
     123456789.123456
     >>> Float('12e-3', '')
     0.012

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -806,10 +806,10 @@ class Float(Number):
     100.0
 
     Float can automatically count significant figures if a null string
-    is sent for the precision; space are also allowed in the string. (Auto-
+    is sent for the precision; spaces or underscores are also allowed. (Auto-
     counting is only allowed for strings, ints and longs).
 
-    >>> Float('123 456 789 . 123 456', '')
+    >>> Float('123 456 789 ._123_456', '')
     123456789.123456
     >>> Float('12e-3', '')
     0.012
@@ -944,6 +944,9 @@ class Float(Number):
 
         if isinstance(num, string_types):
             num = num.replace(' ', '')
+            if num.startswith('_'):
+                raise ValueError('underscore not allowed at the start of a number')
+            num = num.replace('_', '')
             if num.startswith('.') and len(num) > 1:
                 num = '0' + num
             elif num.startswith('-.') and len(num) > 2:
@@ -1013,8 +1016,13 @@ class Float(Number):
         if isinstance(num, float):
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):
-        # next line is workaround for https://github.com/fredrik-johansson/mpmath/issues/377
-            num = num.replace('_','')
+       # workaround for https://github.com/fredrik-johansson/mpmath/issues/377
+            if '_' in num:
+                float(num)  # passes if it is a valid float in Py >= 3.6
+            # older versions of mpmath do not properly handle the _ past
+            # the decimal, so delete them all since we already know the
+            # form is a valid Python float
+            num = num.replace('_', '')
             _mpf_ = mlib.from_str(num, precision, rnd)
         elif isinstance(num, decimal.Decimal):
             if num.is_finite():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1013,6 +1013,7 @@ class Float(Number):
         if isinstance(num, float):
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):
+            num = num.replace('_','')
             _mpf_ = mlib.from_str(num, precision, rnd)
         elif isinstance(num, decimal.Decimal):
             if num.is_finite():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -487,6 +487,10 @@ def test_Float():
     Rational('123 456.123 456') == Rational('123456.123456')
     assert Float(' .3e2') == Float('0.3e2')
 
+    #allow underscore
+    assert Float('1_23.4_56') == Float('123.456')
+    assert Float('1_23.4_5_6', 12) == Float('123.456', 12)
+
     # allow auto precision detection
     assert Float('.1', '') == Float(.1, 1)
     assert Float('.125', '') == Float(.125, 3)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -487,9 +487,15 @@ def test_Float():
     Rational('123 456.123 456') == Rational('123456.123456')
     assert Float(' .3e2') == Float('0.3e2')
 
-    #allow underscore
+    # allow underscore
     assert Float('1_23.4_56') == Float('123.456')
     assert Float('1_23.4_5_6', 12) == Float('123.456', 12)
+    # ...but not in all cases (per Py 3.6)
+    raises(ValueError, lambda: Float('_1'))
+    raises(ValueError, lambda: Float('1_'))
+    raises(ValueError, lambda: Float('1_.'))
+    raises(ValueError, lambda: Float('1._'))
+    raises(ValueError, lambda: Float('1__2'))
 
     # allow auto precision detection
     assert Float('.1', '') == Float(.1, 1)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #13638

#### Brief description of what is fixed or changed
* Fixed the misplaced, now output
In [52]: Float('1_234.345678', 24)
Out[52]: 1234.34567800000000000000

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
  * string input to Float with underscores past the decimal and specified precision, e.g. Float('1.234_5', 12), now parsed correctly
<!-- END RELEASE NOTES -->