### PR TITLE
added tests for particle and rigidbody in physics/mechanics

### DIFF
--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -164,6 +164,7 @@ def test_Lagrangian():
     raises(TypeError, lambda: Lagrangian(N, N, Pa))
     assert Lagrangian(N, Pa, A) == -M*g*h - g*h*m + 350
 
+
 def test_msubs():
     a, b = symbols('a, b')
     x, y, z = dynamicsymbols('x, y, z')

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -5,7 +5,7 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
                                      inertia, inertia_of_point_mass,
                                      kinetic_energy, linear_momentum,
                                      outer, potential_energy, msubs,
-                                     find_dynamicsymbols)
+                                     find_dynamicsymbols, Lagrangian)
 
 from sympy.physics.mechanics.functions import gravity, center_of_mass
 from sympy.physics.vector.vector import Vector
@@ -26,6 +26,7 @@ def test_inertia():
     assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
             (N.y | N.y) + izz * (N.z | N.z))
     assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
+    raises(TypeError, lambda: inertia(0, 0, 0, 0))
     assert inertia(N, ixx, iyy, izz, ixy, iyz, izx) == (ixx * (N.x | N.x) +
             ixy * (N.x | N.y) + izx * (N.x | N.z) + ixy * (N.y | N.x) + iyy *
         (N.y | N.y) + iyz * (N.y | N.z) + izx * (N.z | N.x) + iyz * (N.z |
@@ -70,6 +71,8 @@ def test_linear_momentum():
     P = Point('P')
     Pa = Particle('Pa', P, 1)
     Pa.point.set_vel(N, 10 * N.x)
+    raises(TypeError, lambda: linear_momentum(A, A, Pa))
+    raises(TypeError, lambda: linear_momentum(N, N, Pa))
     assert linear_momentum(N, A, Pa) == 10 * N.x + 500 * N.y
 
 
@@ -93,6 +96,9 @@ def test_angular_momentum_and_linear_momentum():
     A = RigidBody('A', Ac, a, M, (I * outer(N.z, N.z), Ac))
     expected = 2 * m * omega * l * N.y + M * l * omega * N.y
     assert linear_momentum(N, A, Pa) == expected
+    raises(TypeError, lambda: angular_momentum(N, N, A, Pa))
+    raises(TypeError, lambda: angular_momentum(O, O, A, Pa))
+    raises(TypeError, lambda: angular_momentum(O, N, O, Pa))
     expected = (I + M * l**2 + 4 * m * l**2) * omega * N.z
     assert angular_momentum(O, N, A, Pa) == expected
 
@@ -112,6 +118,8 @@ def test_kinetic_energy():
     Pa = Particle('Pa', P, m)
     I = outer(N.z, N.z)
     A = RigidBody('A', Ac, a, M, (I, Ac))
+    raises(TypeError, lambda: kinetic_energy(Pa, Pa, A))
+    raises(TypeError, lambda: kinetic_energy(N, N, A))
     assert 0 == (kinetic_energy(N, Pa, A) - (M*l1**2*omega**2/2
             + 2*l1**2*m*omega**2 + omega**2/2)).expand()
 
@@ -135,6 +143,26 @@ def test_potential_energy():
     A.potential_energy = M * g * H
     assert potential_energy(A, Pa) == m * g * h + M * g * H
 
+
+def test_Lagrangian():
+    M, m, g, h = symbols('M m g h')
+    N = ReferenceFrame('N')
+    O = Point('O')
+    O.set_vel(N, 0 * N.x)
+    P = O.locatenew('P', 1 * N.x)
+    P.set_vel(N, 10 * N.x)
+    Pa = Particle('Pa', P, 1)
+    Ac = O.locatenew('Ac', 2 * N.y)
+    Ac.set_vel(N, 5 * N.y)
+    a = ReferenceFrame('a')
+    a.set_ang_vel(N, 10 * N.z)
+    I = outer(N.z, N.z)
+    A = RigidBody('A', Ac, a, 20, (I, Ac))
+    Pa.potential_energy = m * g * h
+    A.potential_energy = M * g * h
+    raises(TypeError, lambda: Lagrangian(A, A, Pa))
+    raises(TypeError, lambda: Lagrangian(N, N, Pa))
+    assert Lagrangian(N, Pa, A) == -M*g*h - g*h*m + 350
 
 def test_msubs():
     a, b = symbols('a, b')

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -162,7 +162,6 @@ def test_Lagrangian():
     A.potential_energy = M * g * h
     raises(TypeError, lambda: Lagrangian(A, A, Pa))
     raises(TypeError, lambda: Lagrangian(N, N, Pa))
-    assert Lagrangian(N, Pa, A) == -M*g*h - g*h*m + 350
 
 
 def test_msubs():

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,12 +1,15 @@
 from sympy import symbols
 from sympy.physics.mechanics import Point, Particle, ReferenceFrame
 
+from sympy.utilities.pytest import raises
+
 
 def test_particle():
     m, m2, v1, v2, v3, r, g, h = symbols('m m2 v1 v2 v3 r g h')
     P = Point('P')
     P2 = Point('P2')
     p = Particle('pa', P, m)
+    assert p.__str__() == 'pa'
     assert p.mass == m
     assert p.point == P
     # Test the mass setter
@@ -20,6 +23,8 @@ def test_particle():
     O = Point('O')
     P2.set_pos(O, r * N.y)
     P2.set_vel(N, v1 * N.x)
+    raises(TypeError, lambda: Particle(P, P, m))
+    raises(TypeError, lambda: Particle('pa', m, m))
     assert p.linear_momentum(N) == m2 * v1 * N.x
     assert p.angular_momentum(O, N) == -m2 * r *v1 * N.z
     P2.set_vel(N, v2 * N.y)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -4,6 +4,8 @@ from sympy.physics.mechanics import dynamicsymbols, outer, inertia
 from sympy.physics.mechanics import inertia_of_point_mass
 from sympy.core.backend import expand
 
+from sympy.utilities.pytest import raises
+
 
 def test_rigidbody():
     m, m2, v1, v2, v3, omega = symbols('m m2 v1 v2 v3 omega')
@@ -23,6 +25,11 @@ def test_rigidbody():
     B.frame = A2
     B.masscenter = P2
     B.inertia = (I2, B.masscenter)
+    raises(TypeError, lambda: RigidBody(P, P, A, m, (I, P)))
+    raises(TypeError, lambda: RigidBody('B', P, P, m, (I, P)))
+    raises(TypeError, lambda: RigidBody('B', P, A, m, (P, P)))
+    raises(TypeError, lambda: RigidBody('B', P, A, m, (I, I)))
+    assert B.__str__() == 'B'
     assert B.mass == m2
     assert B.frame == A2
     assert B.masscenter == P2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Related to #16318 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added tests for `particle.py` and `rigidbody.py` under `physics/mechanics`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
