### PR TITLE
Possible fix for Posify

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -251,7 +251,7 @@ def posify(eq):
             eq[i] = e.subs(reps)
         return f(eq), {r: s for s, r in reps.items()}
 
-    reps = {s: Dummy(s.name, positive=True)
+    reps = {s: Dummy(s.name, positive=True, **s.assumptions0)
                  for s in eq.free_symbols if s.is_positive is None}
     eq = eq.subs(reps)
     return eq, {r: s for s, r in reps.items()}

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -505,6 +505,13 @@ def test_posify():
     assert str(Sum(posify(1/x**n)[0], (n,1,3)).expand()) == \
         'Sum(_x**(-n), (n, 1, 3))'
 
+    # issue 16438
+    k = Symbol('k', finite=True)
+    eq, rep = posify(k)
+    assert eq.assumptions0 == {'positive': True, 'zero': False, 'imaginary': False,
+     'nonpositive': False, 'commutative': True, 'hermitian': True, 'real': True, 'nonzero': True,
+     'nonnegative': True, 'negative': False, 'complex': True, 'finite': True, 'infinite': False}
+
 
 def test_issue_4194():
     # simplify should call cancel


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16438 

#### Brief description of what is fixed or changed
Now symbols retain other assumptions while `posify` is applied on them.
Earlier
```py
>>> from sympy import symbols, posify
>>> k = symbols('k', finite=True)
>>> k.assumptions0
{'finite': True, 'infinite': False, 'commutative': True}
>>> eq, _ = posify(k)
>>> eq.assumptions0
{'positive': True, 'zero': False, 'commutative': True, 'imaginary': False, 'complex': True, 'negative': False, 'nonpositive': False
, 'hermitian': True, 'nonzero': True, 'real': True, 'nonnegative': True} # finite = True assumptions is discarded
>>>
```

Now 
```py
>>> eq.assumptions0
{'positive': True, 'negative': False, 'nonpositive': False, 'zero': False, 'imaginary': False, 'nonzero': True, 'real': True, 'herm
itian': True, 'commutative': True, 'complex': True, 'nonnegative': True, 'finite': True, 'infinite': False}
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
   * Improves the code for posify
<!-- END RELEASE NOTES -->
