### PR TITLE
Matrix __mod__ and diagonal defined

### DIFF
--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -325,6 +325,31 @@ but we can also apply functions to our matrix entries using ``applyfunc()``. Her
     [       ]
     [0  0  2]
 
+If you want to extract a common factor from a matrix you can do so by
+applying ``gcd`` to the data of the matrix:
+
+    >>> from sympy.abc import x, y
+    >>> from sympy import gcd
+    >>> m = Matrix([[x, y], [1, x*y]]).inv(); m
+    [  -x*y          y     ]
+    [----------  ----------]
+    [   2           2      ]
+    [- x *y + y  - x *y + y]
+    [                      ]
+    [    1          -x     ]
+    [----------  ----------]
+    [   2           2      ]
+    [- x *y + y  - x *y + y]
+    >>> gcd(tuple(_))
+        1
+    ----------
+       2
+    - x *y + y
+    >>> m/_
+    [-x*y  y ]
+    [        ]
+    [ 1    -x]
+
 One more useful matrix-wide entry application function is the substitution function. Let's declare a matrix with symbolic entries then substitute a value. Remember we can substitute anything - even another symbol!:
 
     >>> from sympy import Symbol

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2126,6 +2126,9 @@ class MatrixArithmetic(MatrixRequired):
 
         return self.__mul__(other)
 
+    def __mod__(self, other):
+        return self.applyfunc(lambda x: x % other)
+
     @call_highest_priority('__rmul__')
     def __mul__(self, other):
         """Return self*other where other is either a scalar or a matrix

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -486,32 +486,46 @@ class MatrixShaping(MatrixRequired):
                 "`self` and `rhs` must have the same number of rows.")
         return self._eval_row_join(other)
 
-    def diagonal(self, k):
-        """Return a tuple of the the kth diagonal.
+    def diagonal(self, k=0):
+        """Returns the kth diagonal of self. The main diagonal
+        corresponds to `k=0`; diagonals above and below correspond to
+        `k > 0` and `k < 0`, respectively. The values of `self[i, j]`
+        for which `j - i = k`, are returned in order of increasing
+        `i + j`, starting with `i + j = |k|`.
 
         Examples
         ========
 
-        >>> from sympy import Matrix
-        >>> Matrix(3, 3, lambda i, j: j - i)
+        >>> from sympy import Matrix, SparseMatrix
+        >>> m = Matrix(3, 3, lambda i, j: j - i); m
         Matrix([
         [ 0,  1, 2],
         [-1,  0, 1],
         [-2, -1, 0]])
-        >>> _.diagonal(1)
-        (1, 1)
+        >>> _.diagonal()
+        Matrix([[0, 0, 0]])
+        >>> m.diagonal(1)
+        Matrix([[1, 1]])
+        >>> m.diagonal(-2)
+        Matrix([[-2]])
+
+        Even though the diagonal is returned as a Matrix, the element
+        retrieval can be done with a single index:
+
+        >>> Matrix.diag(1, 2, 3).diagonal()[1]  # instead of [0, 1]
+        2
         """
         rv = []
         k = as_int(k)
         r = 0 if k > 0 else -k
-        c = k if k > 0 else 0
+        c = 0 if r else k
         for i in range(min(self.shape) - max(r, c)):
             rv.append(self[r + i, c + i])
         if not rv:
             raise ValueError(filldedent('''
             The %s diagonal is out of range [%s, %s]''' % (
             k, 1 - self.rows, self.cols - 1)))
-        return tuple(rv)
+        return self._new(1, len(rv), rv)
 
     def row(self, i):
         """Elementary row selector.

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -486,6 +486,33 @@ class MatrixShaping(MatrixRequired):
                 "`self` and `rhs` must have the same number of rows.")
         return self._eval_row_join(other)
 
+    def diagonal(self, k):
+        """Return a tuple of the the kth diagonal.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> Matrix(3, 3, lambda i, j: j - i)
+        Matrix([
+        [ 0,  1, 2],
+        [-1,  0, 1],
+        [-2, -1, 0]])
+        >>> _.diagonal(1)
+        (1, 1)
+        """
+        rv = []
+        k = as_int(k)
+        r = 0 if k > 0 else -k
+        c = k if k > 0 else 0
+        for i in range(min(self.shape) - max(r, c)):
+            rv.append(self[r + i, c + i])
+        if not rv:
+            raise ValueError(filldedent('''
+            The %s diagonal is out of range [%s, %s]''' % (
+            k, 1 - self.rows, self.cols - 1)))
+        return tuple(rv)
+
     def row(self, i):
         """Elementary row selector.
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1543,3 +1543,10 @@ def test___eq__():
         [[0, 1, 1],
         [1, 0, 0],
         [1, 1, 1]]) == {}) is False
+
+
+def test_diagonal():
+    A = Matrix(3, 3, lambda i, j: j - i)
+    for i in range(-2, 3):
+        assert A.diagonal(i) == (i,)*(3 - abs(i))
+    raises(ValueError, lambda: A.diagonal(3))

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -21,7 +21,7 @@ from sympy.matrices.common import (ShapeError, MatrixError, NonSquareMatrixError
 from sympy.matrices.matrices import (MatrixDeterminant,
     MatrixReductions, MatrixSubspaces, MatrixEigen, MatrixCalculus)
 from sympy.matrices import (Matrix, diag, eye,
-    matrix_multiply_elementwise, ones, zeros)
+    matrix_multiply_elementwise, ones, zeros, SparseMatrix)
 from sympy.polys.polytools import Poly
 from sympy.simplify.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
@@ -1238,6 +1238,20 @@ def test_diag_make():
         [0, 2]])
 
 
+def test_diagonal():
+    m = Matrix(3, 3, range(9))
+    d = m.diagonal()
+    assert d == m.diagonal(0)
+    assert tuple(d) == (0, 4, 8)
+    assert tuple(m.diagonal(1)) == (1, 5)
+    assert tuple(m.diagonal(-1)) == (3, 7)
+    assert tuple(m.diagonal(2)) == (2,)
+    assert type(m.diagonal()) == type(m)
+    s = SparseMatrix(3, 3, {(1, 1): 1})
+    assert type(s.diagonal()) == type(s)
+    assert type(m) != type(s)
+
+
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \
             == SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) \
@@ -1543,10 +1557,3 @@ def test___eq__():
         [[0, 1, 1],
         [1, 0, 0],
         [1, 1, 1]]) == {}) is False
-
-
-def test_diagonal():
-    A = Matrix(3, 3, lambda i, j: j - i)
-    for i in range(-2, 3):
-        assert A.diagonal(i) == (i,)*(3 - abs(i))
-    raises(ValueError, lambda: A.diagonal(3))

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1250,6 +1250,9 @@ def test_diagonal():
     s = SparseMatrix(3, 3, {(1, 1): 1})
     assert type(s.diagonal()) == type(s)
     assert type(m) != type(s)
+    raises(ValueError, lambda: m.diagonal(3))
+    raises(ValueError, lambda: m.diagonal(-3))
+    raises(ValueError, lambda: m.diagonal(pi))
 
 
 def test_jordan_block():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1305,7 +1305,8 @@ def test_O10():
 
 
 def test_P1():
-    assert Matrix(3, 3, lambda i, j: j - i).diagonal(-1) == (-1,)*2
+    assert Matrix(3, 3, lambda i, j: j - i).diagonal(-1) == Matrix(
+        1, 2, [-1, -1])
 
 
 def test_P2():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1348,20 +1348,11 @@ def test_P4():
     raise NotImplementedError("Block matrix diagonalization not supported")
 
 
-@XFAIL
 def test_P5():
     M = Matrix([[7, 11],
                 [3, 8]])
-    # Raises exception % not supported for matrices
     assert  M % 2 == Matrix([[1, 1],
                              [1, 0]])
-
-
-def test_P5_workaround():
-    M = Matrix([[7, 11],
-                [3, 8]])
-    assert  M.applyfunc(lambda i: i % 2) == Matrix([[1, 1],
-                                                    [1, 0]])
 
 
 def test_P6():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1304,11 +1304,8 @@ def test_O10():
                               [S(-423)/706]])]
 
 
-@XFAIL
 def test_P1():
-    raise NotImplementedError("Matrix property/function to extract Nth \
-diagonal not implemented. See Matlab diag(A,k) \
-http://www.mathworks.de/de/help/symbolic/diag.html")
+    assert Matrix(3, 3, lambda i, j: j - i).diagonal(-1) == (-1,)*2
 
 
 def test_P2():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -20,7 +20,7 @@ from sympy import (Rational, symbols, Dummy, factorial, sqrt, log, exp, oo, zoo,
     continued_fraction_reduce as cf_r, FiniteSet, elliptic_e, elliptic_f,
     powsimp, hessian, wronskian, fibonacci, sign, Lambda, Piecewise, Subs,
     residue, Derivative, logcombine, Symbol, Intersection, Union,
-    EmptySet, Interval, Integral, idiff, ImageSet, acos, Max)
+    EmptySet, Interval, Integral, idiff, ImageSet, acos, Max, MatMul)
 
 import mpmath
 from sympy.functions.combinatorial.numbers import stirling
@@ -1401,6 +1401,14 @@ def test_P11():
     assert Matrix([[x, y],
                    [1, x*y]]).inv() == (1/(x**2 - 1))*Matrix([[x, -1],
                                                               [-1/y, x/y]])
+
+
+def test_P11_workaround():
+    M = Matrix([[x, y], [1, x*y]]).inv()
+    c = gcd(tuple(M))
+    assert MatMul(c, M/c, evaluate=False) == MatMul(c, Matrix([
+        [-x*y,  y],
+        [   1, -x]]), evaluate=False)
 
 
 def test_P12():


### PR DESCRIPTION
#### Comments

I find the current Matrix structure a little confusing in terms of knowing where to add something. Someone more in tune with what is expected should look at this carefully.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
    - Matrix.`__mod__` is now defined so `ones(2) % 2 -> ones(2)`
    - method `diagonal` extracts the kth diagonal like `row` and `col` extract the kth row or column.
<!-- END RELEASE NOTES -->
```python
>>> ones(2).diagonal()
Matrix(1, 2, [1, 1])
```
(see added test and docstring for other examples)