### PR TITLE
Merge duplicate functions orthogonalize and GramSchmidt

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1143,25 +1143,44 @@ def diag(*values, **kwargs):
 
 
 def GramSchmidt(vlist, orthonormal=False):
-    """
-    Apply the Gram-Schmidt process to a set of vectors.
+    """Apply the Gram-Schmidt process to a set of vectors.
 
-    see: https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
+    Parameters
+    ==========
+
+    vlist : List of Matrix
+        Vectors to be orthogonalized for.
+
+    orthonormal : Bool, optional
+        If true, return an orthonormal basis.
+
+    Returns
+    =======
+
+    vlist : List of Matrix
+        Orthogonalized vectors
+
+    Notes
+    =====
+
+    This routine is mostly duplicate from ``Matrix.orthogonalize``,
+    except for some difference that this always raises error when
+    linearly dependent vectors are found, and the keyword ``normalize``
+    has been named as ``orthonormal`` in this function.
+
+    See Also
+    ========
+
+    .matrices.MatrixSubspaces.orthogonalize
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
     """
-    out = []
-    m = len(vlist)
-    for i in range(m):
-        tmp = vlist[i]
-        for j in range(i):
-            tmp -= vlist[i].project(out[j])
-        if not tmp.values():
-            raise ValueError(
-                "GramSchmidt: vector set not linearly independent")
-        out.append(tmp)
-    if orthonormal:
-        for i in range(len(out)):
-            out[i] = out[i].normalized()
-    return out
+    return MutableDenseMatrix.orthogonalize(
+        *vlist, normalize=orthonormal, rankcheck=True
+    )
 
 
 def hessian(f, varlist, constraints=[]):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1037,10 +1037,33 @@ class MatrixSubspaces(MatrixReductions):
             vectors to be made orthogonal
 
         normalize : bool
-            If true, return an orthonormal basis.
-        """
+            If ``True``, return an orthonormal basis.
 
+        rankcheck : bool
+            If ``True``, the computation does not stop when encountering
+            linearly dependent vectors.
+
+            If ``False``, it will raise ``ValueError`` when any zero
+            or linearly dependent vectors are found.
+
+        Returns
+        =======
+
+        list
+            List of orthogonal (or orthonormal) basis vectors.
+
+        See Also
+        ========
+
+        MatrixBase.QRdecomposition
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
+        """
         normalize = kwargs.get('normalize', False)
+        rankcheck = kwargs.get('rankcheck', False)
 
         def project(a, b):
             return b * (a.dot(b) / b.dot(b))
@@ -1057,12 +1080,19 @@ class MatrixSubspaces(MatrixReductions):
         # make sure we start with a non-zero vector
         vecs = list(vecs)
         while len(vecs) > 0 and vecs[0].is_zero:
-            del vecs[0]
+            if rankcheck is False:
+                del vecs[0]
+            else:
+                raise ValueError(
+                    "GramSchmidt: vector set not linearly independent")
 
         for vec in vecs:
             perp = perp_to_subspace(vec, ret)
             if not perp.is_zero:
                 ret.append(perp)
+            elif rankcheck is True:
+                raise ValueError(
+                    "GramSchmidt: vector set not linearly independent")
 
         if normalize:
             ret = [vec / vec.norm() for vec in ret]

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1354,14 +1354,25 @@ def test_nullspace():
 def test_orthogonalize():
     m = Matrix([[1, 2], [3, 4]])
     assert m.orthogonalize(Matrix([[2], [1]])) == [Matrix([[2], [1]])]
-    assert m.orthogonalize(Matrix([[2], [1]]), normalize=True) == [Matrix([[2*sqrt(5)/5], [sqrt(5)/5]])]
-    assert m.orthogonalize(Matrix([[1], [2]]), Matrix([[-1], [4]])) == [Matrix([[1], [2]]), Matrix([[-S(12)/5], [S(6)/5]])]
-    assert m.orthogonalize(Matrix([[0], [0]]), Matrix([[-1], [4]])) == [Matrix([[-1], [4]])]
+    assert m.orthogonalize(Matrix([[2], [1]]), normalize=True) == \
+        [Matrix([[2*sqrt(5)/5], [sqrt(5)/5]])]
+    assert m.orthogonalize(Matrix([[1], [2]]), Matrix([[-1], [4]])) == \
+        [Matrix([[1], [2]]), Matrix([[-S(12)/5], [S(6)/5]])]
+    assert m.orthogonalize(Matrix([[0], [0]]), Matrix([[-1], [4]])) == \
+        [Matrix([[-1], [4]])]
     assert m.orthogonalize(Matrix([[0], [0]])) == []
 
     n = Matrix([[9, 1, 9], [3, 6, 10], [8, 5, 2]])
     vecs = [Matrix([[-5], [1]]), Matrix([[-5], [2]]), Matrix([[-5], [-2]])]
-    assert n.orthogonalize(*vecs) == [Matrix([[-5], [1]]), Matrix([[S(5)/26], [S(25)/26]])]
+    assert n.orthogonalize(*vecs) == \
+        [Matrix([[-5], [1]]), Matrix([[S(5)/26], [S(25)/26]])]
+
+    vecs = [Matrix([0, 0, 0]), Matrix([1, 2, 3]), Matrix([1, 4, 5])]
+    raises(ValueError, lambda: Matrix.orthogonalize(*vecs, rankcheck=True))
+
+    vecs = [Matrix([1, 2, 3]), Matrix([4, 5, 6]), Matrix([7, 8, 9])]
+    raises(ValueError, lambda: Matrix.orthogonalize(*vecs, rankcheck=True))
+
 
 
 # EigenOnlyMatrix tests


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I see both routines are almost identical, except for some difference that `orthogonalize` does not abort the computation when linearly dependent vectors are found, and `orthonormal` is renamed as `normalize`.

As in LU Decomposition, I see using `rankcheck` can easily satisfy both needs either to abort the computation or allow rank deficiency.

However, from the brief reading of history, I think `GramSchimidt` had been there in the first place, while I see `orthogonalize` added in #12708, however, I see no discussion in review.

But whatever, in my opinion, since orthogonalization is mostly equivalent to computing only Q from QR decomposition in computation cases, the better place would be inside matrices itself.

It also poses another question that, the API design would be cleaner if we make `orthogonalize` as an instance method, rather than a class method which accepts some list of vectors.
We can always treat a list of vectors as a Matrix, and the prior one can align with the QR decomposition more naturally, but I'm not sure if there exists a good way to make backward compatible change for this.

#### Other comments

I've also modified test codes in #16329 for 79-char limit

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added a keyword `rankcheck` for orthogonalize.
<!-- END RELEASE NOTES -->
