### PR TITLE
added separable method

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -33,6 +33,38 @@ from sympy.utilities.iterables import has_variety
 import mpmath
 
 
+def separable(expr, symbols=[]):
+    """Return the subset of symbols which appear in expr that
+    test as being positively separable from other symbols in expr
+    and those that do not test as being unseparable.
+
+    If `f(x, y)` is separable in `x` then `f(x, y).diff(x)/f(x, y)`
+    should be constant wrt y.
+
+    Examples
+    ========
+
+    >>> from sympy.simplify.simplify import separable
+    >>> from sympy import cos
+    >>> from sympy.abc import x, y
+    >>> eq = cos(x + y) + cos(x - y)
+    >>> separable(eq)
+    {x, y}, {}
+    """
+    s = []
+    u = set()
+    free = expr.free_symbols
+    symbols = set(symbols) or free
+    present = free & set(symbols)
+    for x in present:
+        free.remove(x)
+        separable = (expr.diff(x)/expr).is_constant(*free, **dict(simplify=True))
+        if separable:
+            s.append(x)
+        elif separable is not False:
+            u.add(x)
+        free.add(x)
+    return set(s), set(u)
 
 def separatevars(expr, symbols=[], dict=False, force=False):
     """

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -51,20 +51,24 @@ def separable(expr, symbols=[]):
     >>> separable(eq)
     ({x, y}, set())
     """
-    s = []
+    s = set()
     u = set()
     free = expr.free_symbols
-    symbols = set(symbols) or free
-    present = free & set(symbols)
+    symbols = set(symbols)
+    present = set(free)
+    if len(present) == 1:
+        return present.intersection(symbols), set()
+    if symbols:
+        present = present.intersection(symbols)
     for x in present:
         free.remove(x)
-        separable = (expr.diff(x)/expr).is_constant(*free, **dict(simplify=True))
+        separable = (expr.diff(x)/expr).is_constant(*free, simplify=True)
         if separable:
-            s.append(x)
+            s.add(x)
         elif separable is not False:
             u.add(x)
         free.add(x)
-    return set(s), set(u)
+    return s, u
 
 def separatevars(expr, symbols=[], dict=False, force=False):
     """

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -49,7 +49,7 @@ def separable(expr, symbols=[]):
     >>> from sympy.abc import x, y
     >>> eq = cos(x + y) + cos(x - y)
     >>> separable(eq)
-    {x, y}, {}
+    ({x, y}, set())
     """
     s = []
     u = set()

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -34,9 +34,8 @@ import mpmath
 
 
 def separable(expr, symbols=[]):
-    """Return the subset of symbols which appear in expr that
-    test as being positively separable from other symbols in expr
-    and those that do not test as being unseparable.
+    """Return the set of symbols that are separable and the set of symbols
+    that cannot be determined as either separable or unseparable
 
     If `f(x, y)` is separable in `x` then `f(x, y).diff(x)/f(x, y)`
     should be constant wrt y.

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -33,7 +33,7 @@ from sympy.utilities.iterables import has_variety
 import mpmath
 
 
-def separable(expr, symbols=None):
+def separable(expr, symbols=set()):
     """Return the set of symbols that are separable and the set of symbols
     that cannot be determined as either separable or unseparable
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -33,7 +33,7 @@ from sympy.utilities.iterables import has_variety
 import mpmath
 
 
-def separable(expr, symbols=[]):
+def separable(expr, symbols=None):
     """Return the set of symbols that are separable and the set of symbols
     that cannot be determined as either separable or unseparable
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -9,7 +9,7 @@ from sympy import (
     sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan, tanh,
     zoo)
 from sympy.core.mul import _keep_coeff
-from sympy.simplify.simplify import nthroot, inversecombine
+from sympy.simplify.simplify import nthroot, inversecombine, separable
 from sympy.utilities.pytest import XFAIL, slow
 from sympy.core.compatibility import range
 
@@ -793,3 +793,11 @@ def test_nc_simplify():
     assert nc_simplify(expr) == (1-c)**-1
     # commutative expressions should be returned without an error
     assert nc_simplify(2*x**2) == 2*x**2
+
+def test_separable_issue_16291():
+    eq1 = exp(x**2 +y**2) * (cos(x+y) - cos(x-y))
+    eq2 = sin(x+y) + sin(x-y)
+    eq3 = sin(x) + cos(y)
+    assert separable(eq1, [x, y]) == ({x, y}, set())
+    assert separable(eq2 ,[x, y, z]) == ({x, y}, set())
+    assert separable(eq3, [x, y]) == (set(), {x, y})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -798,6 +798,8 @@ def test_separable_issue_16291():
     eq1 = exp(x**2 +y**2) * (cos(x+y) - cos(x-y))
     eq2 = sin(x+y) + sin(x-y)
     eq3 = sin(x) + cos(y)
+    eq4 = x+y
     assert separable(eq1, [x, y]) == ({x, y}, set())
     assert separable(eq2 ,[x, y, z]) == ({x, y}, set())
     assert separable(eq3, [x, y]) == (set(), {x, y})
+    assert separable(eq4, [x, y]) == (set(), set())

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -255,15 +255,15 @@ def test_linear_2eq_order2():
     assert dsolve(eq7) == sol7
     # FIXME: assert checksysodesol(eq7, sol7) == (True, [0, 0])
 
-    eq8 = (Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t))))
-    sol8 = ("[Eq(x(t), -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
-    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
-    "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]")
-    assert str(dsolve(eq8)) == sol8
+    eq8 = Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t)))
+    sol8 = [Eq(x(t), -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + \
+    C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + \
+    C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + \
+    4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + \
+    4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + \
+    sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) +
+    C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]
+    assert dsolve(eq8) == sol8
     # FIXME: assert checksysodesol(eq8, sol8) == (True, [0, 0])
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -255,15 +255,15 @@ def test_linear_2eq_order2():
     assert dsolve(eq7) == sol7
     # FIXME: assert checksysodesol(eq7, sol7) == (True, [0, 0])
 
-    eq8 = Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t)))
-    sol8 = [Eq(x(t), -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + \
-    C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + \
-    C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + \
-    4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + \
-    4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + \
-    sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) +
-    C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]
-    assert dsolve(eq8) == sol8
+    eq8 = (Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t))))
+    sol8 = ("[Eq(x(t), -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
+    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
+    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
+    "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
+    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]")
+    assert str(dsolve(eq8)) == sol8
     # FIXME: assert checksysodesol(eq8, sol8) == (True, [0, 0])
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16291 

#### Brief description of what is fixed or changed

I am adding a new method for finding if the given symbol in an expression are separable or not.

```
In [42]: from sympy.simplify.simplify import separable
In [43]: separable(exp(x**2+y**2)*(cos(x+y)+cos(x-y)))                                                                                                                                                       
Out[43]: ({x, y}, set())
```
full description is it's self define in the function and you can see the issue also for more information. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
  - added a method that returns a set of symbols(given) which are separable and set of symbols(given) that may separate. 
<!-- END RELEASE NOTES -->
