### PR TITLE
Calculus: Added functions to evaluate stationary points and maximum/minimum

### DIFF
--- a/doc/src/modules/calculus/index.rst
+++ b/doc/src/modules/calculus/index.rst
@@ -10,5 +10,8 @@ Calculus
 .. automodule:: sympy.calculus.singularities
     :members:
 
-.. automodule :: sympy.calculus.finite_diff
+.. automodule:: sympy.calculus.finite_diff
+    :members:
+
+.. automodule:: sympy.calculus.util
     :members:

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -6,7 +6,7 @@ from .singularities import (singularities, is_increasing,
                             is_strictly_decreasing, is_monotonic)
 from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff, differentiate_finite
 from .util import (periodicity, not_empty_in, AccumBounds, is_convex,
-                   stationary_points, minimize, maximize)
+                   stationary_points, minimum, maximum)
 
 __all__ = [
 'euler_equations',
@@ -18,5 +18,5 @@ __all__ = [
 'finite_diff_weights', 'apply_finite_diff', 'as_finite_diff', 'differentiate_finite',
 
 'periodicity', 'not_empty_in', 'AccumBounds', 'is_convex', 'stationary_points',
-'minimize', 'maximize'
+'minimum', 'maximum'
 ]

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -5,7 +5,8 @@ from .singularities import (singularities, is_increasing,
                             is_strictly_increasing, is_decreasing,
                             is_strictly_decreasing, is_monotonic)
 from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff, differentiate_finite
-from .util import periodicity, not_empty_in, AccumBounds, is_convex
+from .util import (periodicity, not_empty_in, AccumBounds, is_convex,
+                   stationary_points, minimize, maximize)
 
 __all__ = [
 'euler_equations',
@@ -16,5 +17,6 @@ __all__ = [
 
 'finite_diff_weights', 'apply_finite_diff', 'as_finite_diff', 'differentiate_finite',
 
-'periodicity', 'not_empty_in', 'AccumBounds', 'is_convex'
+'periodicity', 'not_empty_in', 'AccumBounds', 'is_convex', 'stationary_points',
+'minimize', 'maximize'
 ]

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,9 +1,12 @@
 from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
-                   cot, sec, csc, Abs, symbols, I, re)
+                   cot, sec, csc, Abs, symbols, I, re, Lambda, simplify,
+                   ImageSet)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
-                                 periodicity, lcim, AccumBounds, is_convex)
+                                 periodicity, lcim, AccumBounds, is_convex,
+                                 stationary_points, minimize, maximize)
 from sympy.core import Add, Mul, Pow
-from sympy.sets.sets import Interval, FiniteSet, Complement, Union
+from sympy.sets.sets import (Interval, FiniteSet, EmptySet, Complement,
+                            Union, Intersection)
 from sympy.utilities.pytest import raises
 from sympy.abc import x
 
@@ -179,6 +182,79 @@ def test_is_convex():
     assert is_convex(1/x, x, domain=Interval(-oo, 0)) == False
     assert is_convex(x**2, x, domain=Interval(0, oo)) == True
     assert is_convex(log(x), x) == False
+
+def test_stationary_points():
+    x, y = symbols('x y')
+
+    assert stationary_points(sin(x), x, Interval(-pi/2, pi/2)
+        ) == {-pi/2, pi/2}
+    assert  stationary_points(sin(x), x, Interval.Ropen(0, pi/4)
+        ) == EmptySet()
+    assert stationary_points(tan(x), x,
+        ) == EmptySet()
+    assert stationary_points(sin(x)*cos(x), x, Interval(0, pi)
+        ) == {pi/4, 3*pi/4}
+    assert stationary_points(sec(x), x, Interval(0, pi)
+        ) == {0, pi}
+    assert stationary_points((x+3)*(x-2), x
+        ) == FiniteSet(-S.Half)
+    assert stationary_points((x + 3)/(x - 2), x, Interval(-5, 5)
+        ) == EmptySet()
+    assert stationary_points((x**2+3)/(x-2), x
+        ) == {2 - sqrt(7), 2 + sqrt(7)}
+    assert stationary_points((x**2+3)/(x-2), x, Interval(0, 5)
+        ) == {2 + sqrt(7)}
+    assert stationary_points(x**4 + x**3 - 5*x**2, x, S.Reals
+        ) == FiniteSet(-2, 0, S(5)/4)
+    assert stationary_points(exp(x), x
+        ) == EmptySet()
+    assert stationary_points(log(x) - x, x, S.Reals
+        ) == {1}
+    assert stationary_points(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
+        ) == {0, -pi, pi}
+    assert stationary_points(y, x, S.Reals
+        ) == S.Reals
+
+def test_maximize():
+    x, y = symbols('x y')
+    assert maximize(sin(x), x) == 1
+    assert maximize(sin(x), x, Interval(0, 1)) == sin(1)
+    assert maximize(tan(x), x) == oo
+    assert maximize(tan(x), x, Interval(-pi/4, pi/4)) == 1
+    assert maximize(sin(x)*cos(x), x, S.Reals) == 1/2
+    assert simplify(maximize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
+        ) == sqrt(2)/4
+    assert maximize((x+3)*(x-2), x) == oo
+    assert maximize((x+3)*(x-2), x, Interval(-5, 0)) == 14
+    assert maximize((x+3)/(x-2), x, Interval(-5, 0)) == 2/7
+    assert simplify(maximize(-x**4-x**3+x**2+10, x)
+        ) == 41*sqrt(41)/512 + 5419/512
+    assert maximize(exp(x), x, Interval(-oo, 2)) == exp(2)
+    assert maximize(log(x) - x, x, S.Reals) == -1
+    assert maximize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
+        ) == 1
+    assert maximize(cos(x)-sin(x), x, S.Reals) == sqrt(2)
+    assert maximize(y, x, S.Reals) == y
+
+def test_minimize():
+    x, y = symbols('x y')
+
+    assert minimize(sin(x), x) == -1
+    assert minimize(sin(x), x, Interval(1, 4)) == sin(4)
+    assert minimize(tan(x), x) == -oo
+    assert minimize(tan(x), x, Interval(-pi/4, pi/4)) == -1
+    assert minimize(sin(x)*cos(x), x, S.Reals) == -1/2
+    assert simplify(minimize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
+        ) == -sqrt(2)/4
+    assert minimize((x+3)*(x-2), x) == -25/4
+    assert minimize((x+3)/(x-2), x, Interval(-5, 0)) == -3/2
+    assert minimize(x**4-x**3+x**2+10, x) == 10
+    assert minimize(exp(x), x, Interval(-2, oo)) == exp(-2)
+    assert minimize(log(x) - x, x, S.Reals) == -oo
+    assert minimize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
+        ) == -1
+    assert minimize(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
+    assert minimize(y, x, S.Reals) == y
 
 def test_AccumBounds():
     assert AccumBounds(1, 2).args == (1, 2)

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -217,42 +217,42 @@ def test_stationary_points():
 
 def test_maximize():
     x, y = symbols('x y')
-    assert maximize(sin(x), x) == 1
+    assert maximize(sin(x), x) == S.One
     assert maximize(sin(x), x, Interval(0, 1)) == sin(1)
     assert maximize(tan(x), x) == oo
-    assert maximize(tan(x), x, Interval(-pi/4, pi/4)) == 1
-    assert maximize(sin(x)*cos(x), x, S.Reals) == 1/2
+    assert maximize(tan(x), x, Interval(-pi/4, pi/4)) == S.One
+    assert maximize(sin(x)*cos(x), x, S.Reals) == S.Half
     assert simplify(maximize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
         ) == sqrt(2)/4
     assert maximize((x+3)*(x-2), x) == oo
-    assert maximize((x+3)*(x-2), x, Interval(-5, 0)) == 14
-    assert maximize((x+3)/(x-2), x, Interval(-5, 0)) == 2/7
+    assert maximize((x+3)*(x-2), x, Interval(-5, 0)) == S(14)
+    assert maximize((x+3)/(x-2), x, Interval(-5, 0)) == S(2)/7
     assert simplify(maximize(-x**4-x**3+x**2+10, x)
-        ) == 41*sqrt(41)/512 + 5419/512
+        ) == 41*sqrt(41)/512 + S(5419)/512
     assert maximize(exp(x), x, Interval(-oo, 2)) == exp(2)
-    assert maximize(log(x) - x, x, S.Reals) == -1
+    assert maximize(log(x) - x, x, S.Reals) == -S.One
     assert maximize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
-        ) == 1
+        ) == S.One
     assert maximize(cos(x)-sin(x), x, S.Reals) == sqrt(2)
     assert maximize(y, x, S.Reals) == y
 
 def test_minimize():
     x, y = symbols('x y')
 
-    assert minimize(sin(x), x) == -1
+    assert minimize(sin(x), x) == -S.One
     assert minimize(sin(x), x, Interval(1, 4)) == sin(4)
     assert minimize(tan(x), x) == -oo
-    assert minimize(tan(x), x, Interval(-pi/4, pi/4)) == -1
-    assert minimize(sin(x)*cos(x), x, S.Reals) == -1/2
+    assert minimize(tan(x), x, Interval(-pi/4, pi/4)) == -S.One
+    assert minimize(sin(x)*cos(x), x, S.Reals) == -S.Half
     assert simplify(minimize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
         ) == -sqrt(2)/4
-    assert minimize((x+3)*(x-2), x) == -25/4
-    assert minimize((x+3)/(x-2), x, Interval(-5, 0)) == -3/2
-    assert minimize(x**4-x**3+x**2+10, x) == 10
+    assert minimize((x+3)*(x-2), x) == -S(25)/4
+    assert minimize((x+3)/(x-2), x, Interval(-5, 0)) == -S(3)/2
+    assert minimize(x**4-x**3+x**2+10, x) == S(10)
     assert minimize(exp(x), x, Interval(-2, oo)) == exp(-2)
     assert minimize(log(x) - x, x, S.Reals) == -oo
     assert minimize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
-        ) == -1
+        ) == -S.One
     assert minimize(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
     assert minimize(y, x, S.Reals) == y
 

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -236,6 +236,13 @@ def test_maximum():
     assert maximum(cos(x)-sin(x), x, S.Reals) == sqrt(2)
     assert maximum(y, x, S.Reals) == y
 
+    raises(ValueError, lambda : maximum(sin(x), x, S.EmptySet))
+    raises(ValueError, lambda : maximum(log(cos(x)), x, S.EmptySet))
+    raises(ValueError, lambda : maximum(1/(x**2 + y**2 + 1), x, S.EmptySet))
+    raises(ValueError, lambda : maximum(sin(x), sin(x)))
+    raises(ValueError, lambda : maximum(sin(x), x*y, S.EmptySet))
+    raises(ValueError, lambda : maximum(sin(x), S(1)))
+
 def test_minimum():
     x, y = symbols('x y')
 
@@ -255,6 +262,13 @@ def test_minimum():
         ) == -S.One
     assert minimum(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
     assert minimum(y, x, S.Reals) == y
+
+    raises(ValueError, lambda : minimum(sin(x), x, S.EmptySet))
+    raises(ValueError, lambda : minimum(log(cos(x)), x, S.EmptySet))
+    raises(ValueError, lambda : minimum(1/(x**2 + y**2 + 1), x, S.EmptySet))
+    raises(ValueError, lambda : minimum(sin(x), sin(x)))
+    raises(ValueError, lambda : minimum(sin(x), x*y, S.EmptySet))
+    raises(ValueError, lambda : minimum(sin(x), S(1)))
 
 def test_AccumBounds():
     assert AccumBounds(1, 2).args == (1, 2)

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -3,7 +3,7 @@ from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
                    ImageSet)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex,
-                                 stationary_points, minimize, maximize)
+                                 stationary_points, minimum, maximum)
 from sympy.core import Add, Mul, Pow
 from sympy.sets.sets import (Interval, FiniteSet, EmptySet, Complement,
                             Union, Intersection)
@@ -215,46 +215,46 @@ def test_stationary_points():
     assert stationary_points(y, x, S.Reals
         ) == S.Reals
 
-def test_maximize():
+def test_maximum():
     x, y = symbols('x y')
-    assert maximize(sin(x), x) == S.One
-    assert maximize(sin(x), x, Interval(0, 1)) == sin(1)
-    assert maximize(tan(x), x) == oo
-    assert maximize(tan(x), x, Interval(-pi/4, pi/4)) == S.One
-    assert maximize(sin(x)*cos(x), x, S.Reals) == S.Half
-    assert simplify(maximize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
+    assert maximum(sin(x), x) == S.One
+    assert maximum(sin(x), x, Interval(0, 1)) == sin(1)
+    assert maximum(tan(x), x) == oo
+    assert maximum(tan(x), x, Interval(-pi/4, pi/4)) == S.One
+    assert maximum(sin(x)*cos(x), x, S.Reals) == S.Half
+    assert simplify(maximum(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
         ) == sqrt(2)/4
-    assert maximize((x+3)*(x-2), x) == oo
-    assert maximize((x+3)*(x-2), x, Interval(-5, 0)) == S(14)
-    assert maximize((x+3)/(x-2), x, Interval(-5, 0)) == S(2)/7
-    assert simplify(maximize(-x**4-x**3+x**2+10, x)
+    assert maximum((x+3)*(x-2), x) == oo
+    assert maximum((x+3)*(x-2), x, Interval(-5, 0)) == S(14)
+    assert maximum((x+3)/(x-2), x, Interval(-5, 0)) == S(2)/7
+    assert simplify(maximum(-x**4-x**3+x**2+10, x)
         ) == 41*sqrt(41)/512 + S(5419)/512
-    assert maximize(exp(x), x, Interval(-oo, 2)) == exp(2)
-    assert maximize(log(x) - x, x, S.Reals) == -S.One
-    assert maximize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
+    assert maximum(exp(x), x, Interval(-oo, 2)) == exp(2)
+    assert maximum(log(x) - x, x, S.Reals) == -S.One
+    assert maximum(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
         ) == S.One
-    assert maximize(cos(x)-sin(x), x, S.Reals) == sqrt(2)
-    assert maximize(y, x, S.Reals) == y
+    assert maximum(cos(x)-sin(x), x, S.Reals) == sqrt(2)
+    assert maximum(y, x, S.Reals) == y
 
-def test_minimize():
+def test_minimum():
     x, y = symbols('x y')
 
-    assert minimize(sin(x), x) == -S.One
-    assert minimize(sin(x), x, Interval(1, 4)) == sin(4)
-    assert minimize(tan(x), x) == -oo
-    assert minimize(tan(x), x, Interval(-pi/4, pi/4)) == -S.One
-    assert minimize(sin(x)*cos(x), x, S.Reals) == -S.Half
-    assert simplify(minimize(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
+    assert minimum(sin(x), x) == -S.One
+    assert minimum(sin(x), x, Interval(1, 4)) == sin(4)
+    assert minimum(tan(x), x) == -oo
+    assert minimum(tan(x), x, Interval(-pi/4, pi/4)) == -S.One
+    assert minimum(sin(x)*cos(x), x, S.Reals) == -S.Half
+    assert simplify(minimum(sin(x)*cos(x), x, Interval(3*pi/8, 5*pi/8))
         ) == -sqrt(2)/4
-    assert minimize((x+3)*(x-2), x) == -S(25)/4
-    assert minimize((x+3)/(x-2), x, Interval(-5, 0)) == -S(3)/2
-    assert minimize(x**4-x**3+x**2+10, x) == S(10)
-    assert minimize(exp(x), x, Interval(-2, oo)) == exp(-2)
-    assert minimize(log(x) - x, x, S.Reals) == -oo
-    assert minimize(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
+    assert minimum((x+3)*(x-2), x) == -S(25)/4
+    assert minimum((x+3)/(x-2), x, Interval(-5, 0)) == -S(3)/2
+    assert minimum(x**4-x**3+x**2+10, x) == S(10)
+    assert minimum(exp(x), x, Interval(-2, oo)) == exp(-2)
+    assert minimum(log(x) - x, x, S.Reals) == -oo
+    assert minimum(cos(x), x, Union(Interval(0, 5), Interval(-6, -3))
         ) == -S.One
-    assert minimize(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
-    assert minimize(y, x, S.Reals) == y
+    assert minimum(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
+    assert minimum(y, x, S.Reals) == y
 
 def test_AccumBounds():
     assert AccumBounds(1, 2).args == (1, 2)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -756,7 +756,7 @@ def stationary_points(f, symbol, domain=S.Reals):
     return set
 
 
-def maximize(f, symbol, domain=S.Reals):
+def maximum(f, symbol, domain=S.Reals):
     """
     Returns the maximum value of a function in the given domain.
 
@@ -774,18 +774,18 @@ def maximize(f, symbol, domain=S.Reals):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, sin, cos, pi, maximize
+    >>> from sympy import Symbol, S, sin, cos, pi, maximum
     >>> from sympy.sets import Interval
     >>> x = Symbol('x')
 
     >>> f = -x**2 + 2*x + 5
-    >>> maximize(f, x, S.Reals)
+    >>> maximum(f, x, S.Reals)
     6
 
-    >>> maximize(sin(x), x, Interval(-pi, pi/4))
+    >>> maximum(sin(x), x, Interval(-pi, pi/4))
     sqrt(2)/2
 
-    >>> maximize(sin(x)*cos(x), x)
+    >>> maximum(sin(x)*cos(x), x)
     1/2
 
     """
@@ -795,7 +795,7 @@ def maximize(f, symbol, domain=S.Reals):
     return function_range(f, symbol, domain).sup
 
 
-def minimize(f, symbol, domain=S.Reals):
+def minimum(f, symbol, domain=S.Reals):
     """
     Returns the minimum value of a function in the given domain.
 
@@ -813,18 +813,18 @@ def minimize(f, symbol, domain=S.Reals):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, sin, cos, minimize
+    >>> from sympy import Symbol, S, sin, cos, minimum
     >>> from sympy.sets import Interval
     >>> x = Symbol('x')
 
     >>> f = x**2 + 2*x + 5
-    >>> minimize(f, x, S.Reals)
+    >>> minimum(f, x, S.Reals)
     4
 
-    >>> minimize(sin(x), x, Interval(2, 3))
+    >>> minimum(sin(x), x, Interval(2, 3))
     sin(3)
 
-    >>> minimize(sin(x)*cos(x), x)
+    >>> minimum(sin(x)*cos(x), x)
     -1/2
 
     """

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -709,6 +709,133 @@ def is_convex(f, *syms, **kwargs):
         return False
     return True
 
+
+def stationary_points(f, symbol, domain = S.Reals):
+    """
+    Returns the stationary points of a function in the given domain.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The concerned function.
+    symbol : Symbol
+        The variable for which the stationary points are to be determined.
+    domain : Interval
+        The domain over which the stationary points have to be checked.
+        If unspecified, S.Reals will be the default domain.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, S, sin, log, pi, pprint
+    >>> from sympy.sets import Interval
+    >>> from sympy.calculus.util import stationary_points
+    >>> x = Symbol('x')
+
+    >>> stationary_points(1/x, x, S.Reals)
+    EmptySet()
+
+    >>> pprint(stationary_points(sin(x), x), use_unicode=False)
+              pi                              3*pi
+    {2*n*pi + -- | n in Integers} U {2*n*pi + ---- | n in Integers}
+              2                                2
+
+    >>> stationary_points(sin(x),x, Interval(0, 4*pi))
+    {pi/2, 3*pi/2, 5*pi/2, 7*pi/2}
+
+    """
+    from sympy import solveset, diff
+
+    if isinstance(domain, EmptySet):
+        return S.EmptySet
+
+    #domain = continuous_domain(f, symbol, domain)
+    set = solveset(diff(f, symbol), symbol, domain)
+
+    return set
+
+
+def maximize(f, symbol, domain = S.Reals):
+    """
+    Returns the maximum value of a function in the given domain.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The concerned function.
+    symbol : Symbol
+        The variable for maximum value needs to be determined.
+    domain : Interval
+        The domain over which the maximum have to be checked.
+        If unspecified, then Global maximum is returned.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, S, sin, cos, pi
+    >>> from sympy.sets import Interval
+    >>> from sympy.calculus.util import maximize
+    >>> x = Symbol('x')
+
+    >>> f = -x**2 + 2*x + 5
+    >>> maximize(f, x, S.Reals)
+    6
+
+    >>> maximize(sin(x), x, Interval(-pi, pi/4))
+    sqrt(2)/2
+
+    >>> maximize(sin(x)*cos(x), x)
+    1/2
+
+    """
+    if isinstance(domain, EmptySet):
+        return S.EmptySet
+
+    return function_range(f, symbol, domain).sup
+
+
+def minimize(f, symbol, domain = S.Reals):
+    """
+    Returns the minimum value of a function in the given domain.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The concerned function.
+    symbol : Symbol
+        The variable for minimum value needs to be determined.
+    domain : Interval
+        The domain over which the minimum have to be checked.
+        If unspecified, then Global minimum is returned.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, S, sin, cos
+    >>> from sympy.sets import Interval
+    >>> from sympy.calculus.util import minimize
+    >>> x = Symbol('x')
+
+    >>> f = x**2 + 2*x + 5
+    >>> minimize(f, x, S.Reals)
+    4
+
+    >>> minimize(sin(x), x, Interval(2, 3))
+    sin(3)
+
+    >>> minimize(sin(x)*cos(x), x)
+    -1/2
+
+    """
+    if isinstance(domain, EmptySet):
+        return S.EmptySet
+
+    return function_range(f, symbol, domain).inf
+
+
 class AccumulationBounds(AtomicExpr):
     r"""
     # Note AccumulationBounds has an alias: AccumBounds

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -789,7 +789,7 @@ def maximum(f, symbol, domain=S.Reals):
     1/2
 
     """
-    if type(symbol) == Symbol:
+    if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Maximum value not defined for empty domain.")
 
@@ -831,7 +831,7 @@ def minimum(f, symbol, domain=S.Reals):
     -1/2
 
     """
-    if type(symbol) == Symbol:
+    if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Minimum value not defined for empty domain.")
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -789,7 +789,7 @@ def maximum(f, symbol, domain=S.Reals):
     1/2
 
     """
-    if isinstance(symbol, Symbol):
+    if symbol.is_Symbol:
         if isinstance(domain, EmptySet):
             raise ValueError("Maximum value not defined for empty domain.")
 
@@ -831,7 +831,7 @@ def minimum(f, symbol, domain=S.Reals):
     -1/2
 
     """
-    if isinstance(symbol, Symbol):
+    if symbol.is_Symbol:
         if isinstance(domain, EmptySet):
             raise ValueError("Minimum value not defined for empty domain.")
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -789,7 +789,9 @@ def maximum(f, symbol, domain=S.Reals):
     1/2
 
     """
-    if symbol.is_Symbol:
+    from sympy import Symbol
+
+    if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Maximum value not defined for empty domain.")
 
@@ -831,7 +833,9 @@ def minimum(f, symbol, domain=S.Reals):
     -1/2
 
     """
-    if symbol.is_Symbol:
+    from sympy import Symbol
+
+    if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Minimum value not defined for empty domain.")
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -789,10 +789,13 @@ def maximum(f, symbol, domain=S.Reals):
     1/2
 
     """
-    if isinstance(domain, EmptySet):
-        return S.EmptySet
+    if type(symbol) == Symbol:
+        if isinstance(domain, EmptySet):
+            raise ValueError("Maximum value not defined for empty domain.")
 
-    return function_range(f, symbol, domain).sup
+        return function_range(f, symbol, domain).sup
+    else:
+        raise ValueError("%s is not a valid symbol." % symbol)
 
 
 def minimum(f, symbol, domain=S.Reals):
@@ -828,10 +831,13 @@ def minimum(f, symbol, domain=S.Reals):
     -1/2
 
     """
-    if isinstance(domain, EmptySet):
-        return S.EmptySet
+    if type(symbol) == Symbol:
+        if isinstance(domain, EmptySet):
+            raise ValueError("Minimum value not defined for empty domain.")
 
-    return function_range(f, symbol, domain).inf
+        return function_range(f, symbol, domain).inf
+    else:
+        raise ValueError("%s is not a valid symbol." % symbol)
 
 
 class AccumulationBounds(AtomicExpr):

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -710,9 +710,10 @@ def is_convex(f, *syms, **kwargs):
     return True
 
 
-def stationary_points(f, symbol, domain = S.Reals):
+def stationary_points(f, symbol, domain=S.Reals):
     """
-    Returns the stationary points of a function in the given domain.
+    Returns the stationary points of a function (where derivative of the
+    function is 0) in the given domain.
 
     Parameters
     ==========
@@ -728,9 +729,8 @@ def stationary_points(f, symbol, domain = S.Reals):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, sin, log, pi, pprint
+    >>> from sympy import Symbol, S, sin, log, pi, pprint, stationary_points
     >>> from sympy.sets import Interval
-    >>> from sympy.calculus.util import stationary_points
     >>> x = Symbol('x')
 
     >>> stationary_points(1/x, x, S.Reals)
@@ -750,13 +750,13 @@ def stationary_points(f, symbol, domain = S.Reals):
     if isinstance(domain, EmptySet):
         return S.EmptySet
 
-    #domain = continuous_domain(f, symbol, domain)
+    domain = continuous_domain(f, symbol, domain)
     set = solveset(diff(f, symbol), symbol, domain)
 
     return set
 
 
-def maximize(f, symbol, domain = S.Reals):
+def maximize(f, symbol, domain=S.Reals):
     """
     Returns the maximum value of a function in the given domain.
 
@@ -774,9 +774,8 @@ def maximize(f, symbol, domain = S.Reals):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, sin, cos, pi
+    >>> from sympy import Symbol, S, sin, cos, pi, maximize
     >>> from sympy.sets import Interval
-    >>> from sympy.calculus.util import maximize
     >>> x = Symbol('x')
 
     >>> f = -x**2 + 2*x + 5
@@ -796,7 +795,7 @@ def maximize(f, symbol, domain = S.Reals):
     return function_range(f, symbol, domain).sup
 
 
-def minimize(f, symbol, domain = S.Reals):
+def minimize(f, symbol, domain=S.Reals):
     """
     Returns the minimum value of a function in the given domain.
 
@@ -814,9 +813,8 @@ def minimize(f, symbol, domain = S.Reals):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, sin, cos
+    >>> from sympy import Symbol, S, sin, cos, minimize
     >>> from sympy.sets import Interval
-    >>> from sympy.calculus.util import minimize
     >>> x = Symbol('x')
 
     >>> f = x**2 + 2*x + 5

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -53,7 +53,7 @@ from sympy.core.compatibility import range, PY3
 from itertools import islice, takewhile
 from sympy.series.formal import fps
 from sympy.series.fourier import fourier_series
-from sympy.calculus.util import minimize
+from sympy.calculus.util import minimum
 
 
 R = Rational

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2250,7 +2250,7 @@ def test_U12():
 
 
 def test_U13():
-    assert minimize(x**4 - x + 1, x) == -3*2**Rational(1,3)/8 + 1
+    assert minimum(x**4 - x + 1, x) == -3*2**Rational(1,3)/8 + 1
 
 
 @XFAIL

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -53,6 +53,7 @@ from sympy.core.compatibility import range, PY3
 from itertools import islice, takewhile
 from sympy.series.formal import fps
 from sympy.series.fourier import fourier_series
+from sympy.calculus.util import minimize
 
 
 R = Rational
@@ -2248,10 +2249,8 @@ def test_U12():
         "External diff of differential form not supported")
 
 
-@XFAIL
 def test_U13():
-    #assert minimize(x**4 - x + 1, x)== -3*2**Rational(1,3)/8 + 1
-    raise NotImplementedError("minimize() not supported")
+    assert minimize(x**4 - x + 1, x) == -3*2**Rational(1,3)/8 + 1
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16239 

#### Brief description of what is fixed or changed
In `calculus/util.py`

* Added `stationary_points()`: This function evaluates and returns set of
all the stationary points (where the slope of function is 0) of a function in
the given domain.

* Added `minimum()`: This function returns the minimum value of a function
in the given domain. If no domain is passed, then global minimum is returned.

* Added `maximum()`: This function returns the maximum value of a function
in the given domain. If no domain is passed, then global maximum is returned.


#### Other comments
I haven't added test cases as of now. I will add them after this PR is reviewed and changes are proposed in it.

Also, should failing tests be added?
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Added a function `stationary_points` to find stationary points of an expression in a given domain
  * Added functions `minimum` and `maximum` to find minimum and maximum values of an expression in a given domain
<!-- END RELEASE NOTES -->
