### PR TITLE
Add hadamard power latex printing

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1571,9 +1571,15 @@ class LatexPrinter(Printer):
         prec = PRECEDENCE_VALUES['HadamardPower']
         parens = self.parenthesize
 
+        def parens_exp(exp, prec, strict=True):
+            if exp.is_Integer:
+                return self._print(exp)
+            else:
+                return parens(exp, prec, strict=strict)
+
         return r'{}^{{\circ {{{}}}}}'.format(
-            parens(base, prec, strict=True),
-            parens(exp, prec, strict=True))
+            parens(base, prec, strict=False),
+            parens_exp(exp, prec, strict=False))
 
     def _print_KroneckerProduct(self, expr):
         args = expr.args
@@ -1588,9 +1594,15 @@ class LatexPrinter(Printer):
         prec = PRECEDENCE_VALUES['MatPow']
         parens = self.parenthesize
 
+        def parens_exp(exp, prec, strict=True):
+            if exp.is_Integer:
+                return self._print(exp)
+            else:
+                return parens(exp, prec, strict=strict)
+
         return "%s^{%s}" % (
-            parens(base, prec, strict=True),
-            parens(exp, prec, strict=True))
+            parens(base, prec, strict=False),
+            parens_exp(exp, prec, strict=False))
 
     def _print_ZeroMatrix(self, Z):
         return r"\mathbb{0}"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1567,18 +1567,14 @@ class LatexPrinter(Printer):
 
     def _print_HadamardPower(self, expr):
         base, exp = expr.base, expr.exp
-        prec = PRECEDENCE['Pow']
-        parens = self.parenthesize
-
-        def parens_exp(exp, prec, strict=True):
-            if exp.is_Integer:
-                return self._print(exp)
-            else:
-                return parens(exp, prec, strict=strict)
-
-        return r'{}^{{\circ {{{}}}}}'.format(
-            parens(base, prec, strict=False),
-            parens_exp(exp, prec, strict=False))
+        from sympy.matrices import MatrixSymbol
+        if not isinstance(base, MatrixSymbol):
+            return r'{}^{{\circ {{{}}}}}'.format(
+                r"\left({}\right)".format(self._print(base)),
+                self._print(exp))
+        else:
+            return r'{}^{{\circ {{{}}}}}'.format(
+                self._print(base), self._print(exp))
 
     def _print_KroneckerProduct(self, expr):
         args = expr.args
@@ -1590,18 +1586,12 @@ class LatexPrinter(Printer):
 
     def _print_MatPow(self, expr):
         base, exp = expr.base, expr.exp
-        prec = PRECEDENCE['Pow']
-        parens = self.parenthesize
-
-        def parens_exp(exp, prec, strict=True):
-            if exp.is_Integer:
-                return self._print(exp)
-            else:
-                return parens(exp, prec, strict=strict)
-
-        return "%s^{%s}" % (
-            parens(base, prec, strict=False),
-            parens_exp(exp, prec, strict=False))
+        from sympy.matrices import MatrixSymbol
+        if not isinstance(base, MatrixSymbol):
+            return "\\left(%s\\right)^{%s}" % (self._print(base),
+                                              self._print(exp))
+        else:
+            return "%s^{%s}" % (self._print(base), self._print(exp))
 
     def _print_ZeroMatrix(self, Z):
         return r"\mathbb{0}"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -18,8 +18,7 @@ from sympy.logic.boolalg import true
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.printer import Printer
 from sympy.printing.conventions import split_super_sub, requires_partial
-from sympy.printing.precedence import (
-    precedence, PRECEDENCE, PRECEDENCE_VALUES)
+from sympy.printing.precedence import precedence, PRECEDENCE
 
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
@@ -1560,7 +1559,7 @@ class LatexPrinter(Printer):
 
     def _print_HadamardProduct(self, expr):
         args = expr.args
-        prec = PRECEDENCE_VALUES['HadamardProduct']
+        prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
         return r' \circ '.join(
@@ -1568,7 +1567,7 @@ class LatexPrinter(Printer):
 
     def _print_HadamardPower(self, expr):
         base, exp = expr.base, expr.exp
-        prec = PRECEDENCE_VALUES['HadamardPower']
+        prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
         def parens_exp(exp, prec, strict=True):
@@ -1583,7 +1582,7 @@ class LatexPrinter(Printer):
 
     def _print_KroneckerProduct(self, expr):
         args = expr.args
-        prec = PRECEDENCE_VALUES['KroneckerProduct']
+        prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
         return r' \otimes '.join(
@@ -1591,7 +1590,7 @@ class LatexPrinter(Printer):
 
     def _print_MatPow(self, expr):
         base, exp = expr.base, expr.exp
-        prec = PRECEDENCE_VALUES['MatPow']
+        prec = PRECEDENCE['Pow']
         parens = self.parenthesize
 
         def parens_exp(exp, prec, strict=True):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -18,7 +18,8 @@ from sympy.logic.boolalg import true
 from sympy.printing.precedence import precedence_traditional
 from sympy.printing.printer import Printer
 from sympy.printing.conventions import split_super_sub, requires_partial
-from sympy.printing.precedence import precedence, PRECEDENCE
+from sympy.printing.precedence import (
+    precedence, PRECEDENCE, PRECEDENCE_VALUES)
 
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
@@ -1558,40 +1559,38 @@ class LatexPrinter(Printer):
                                  self._print(expr.args[1]))
 
     def _print_HadamardProduct(self, expr):
-        from sympy import Add, MatAdd, MatMul
+        args = expr.args
+        prec = PRECEDENCE_VALUES['HadamardProduct']
+        parens = self.parenthesize
 
-        def parens(x):
-            if isinstance(x, (Add, MatAdd, MatMul)):
-                return r"\left(%s\right)" % self._print(x)
-            return self._print(x)
-        return r' \circ '.join(map(parens, expr.args))
+        return r' \circ '.join(
+            map(lambda arg: parens(arg, prec, strict=True), args))
 
     def _print_HadamardPower(self, expr):
-        from sympy import Add, MatAdd, MatMul
+        base, exp = expr.base, expr.exp
+        prec = PRECEDENCE_VALUES['HadamardPower']
+        parens = self.parenthesize
 
-        def parens(x):
-            if isinstance(x, (Add, MatAdd, MatMul)):
-                return r"\left(%s\right)" % self._print(x)
-            return self._print(x)
-        return r'{}^{{\circ {{{}}}}}'.format(*map(parens, expr.args))
+        return r'{}^{{\circ {{{}}}}}'.format(
+            parens(base, prec, strict=True),
+            parens(exp, prec, strict=True))
 
     def _print_KroneckerProduct(self, expr):
-        from sympy import Add, MatAdd, MatMul
+        args = expr.args
+        prec = PRECEDENCE_VALUES['KroneckerProduct']
+        parens = self.parenthesize
 
-        def parens(x):
-            if isinstance(x, (Add, MatAdd, MatMul)):
-                return r"\left(%s\right)" % self._print(x)
-            return self._print(x)
-        return r' \otimes '.join(map(parens, expr.args))
+        return r' \otimes '.join(
+            map(lambda arg: parens(arg, prec, strict=True), args))
 
     def _print_MatPow(self, expr):
         base, exp = expr.base, expr.exp
-        from sympy.matrices import MatrixSymbol
-        if not isinstance(base, MatrixSymbol):
-            return r"\left(%s\right)^{%s}" % (self._print(base),
-                                              self._print(exp))
-        else:
-            return "%s^{%s}" % (self._print(base), self._print(exp))
+        prec = PRECEDENCE_VALUES['MatPow']
+        parens = self.parenthesize
+
+        return "%s^{%s}" % (
+            parens(base, prec, strict=True),
+            parens(exp, prec, strict=True))
 
     def _print_ZeroMatrix(self, Z):
         return r"\mathbb{0}"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1566,6 +1566,15 @@ class LatexPrinter(Printer):
             return self._print(x)
         return r' \circ '.join(map(parens, expr.args))
 
+    def _print_HadamardPower(self, expr):
+        from sympy import Add, MatAdd, MatMul
+
+        def parens(x):
+            if isinstance(x, (Add, MatAdd, MatMul)):
+                return r"\left(%s\right)" % self._print(x)
+            return self._print(x)
+        return r'{}^{{\circ {{{}}}}}'.format(*map(parens, expr.args))
+
     def _print_KroneckerProduct(self, expr):
         from sympy import Add, MatAdd, MatMul
 

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -47,6 +47,7 @@ PRECEDENCE_VALUES = {
     "KroneckerProduct": PRECEDENCE["Mul"],
     "Equality": PRECEDENCE["Mul"],
     "Unequality": PRECEDENCE["Mul"],
+    "Adjoint": PRECEDENCE["Pow"]
 }
 
 # Sometimes it's not enough to assign a fixed precedence value to a

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -143,13 +143,15 @@ def precedence_traditional(item):
     """
     # Integral, Sum, Product, Limit have the precedence of Mul in LaTeX,
     # the precedence of Atom for other printers:
-    from sympy import Integral, Sum, Product, Limit, Derivative
+    from sympy import Integral, Sum, Product, Limit, Derivative, Transpose, Adjoint
     from sympy.core.expr import UnevaluatedExpr
     from sympy.tensor.functions import TensorProduct
 
     if isinstance(item, (Integral, Sum, Product, Limit, Derivative, TensorProduct)):
         return PRECEDENCE["Mul"]
-    if (item.__class__.__name__ in ("Dot", "Cross", "Gradient", "Divergence",
+    elif isinstance(item, (Transpose, Adjoint)):
+        return PRECEDENCE["Pow"]
+    elif (item.__class__.__name__ in ("Dot", "Cross", "Gradient", "Divergence",
                                     "Curl", "Laplacian")):
         return PRECEDENCE["Mul"]-1
     elif isinstance(item, UnevaluatedExpr):

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -24,6 +24,7 @@ PRECEDENCE = {
 # A dictionary assigning precedence values to certain classes. These values are
 # treated like they were inherited, so not every single class has to be named
 # here.
+# Do not use this with printers other than StrPrinter
 PRECEDENCE_VALUES = {
     "Equivalent": PRECEDENCE["Xor"],
     "Xor": PRECEDENCE["Xor"],
@@ -47,8 +48,6 @@ PRECEDENCE_VALUES = {
     "KroneckerProduct": PRECEDENCE["Mul"],
     "Equality": PRECEDENCE["Mul"],
     "Unequality": PRECEDENCE["Mul"],
-    "Adjoint": PRECEDENCE["Pow"],
-    "Transpose": PRECEDENCE["Pow"]
 }
 
 # Sometimes it's not enough to assign a fixed precedence value to a
@@ -117,8 +116,9 @@ PRECEDENCE_FUNCTIONS = {
 
 
 def precedence(item):
-    """
-    Returns the precedence of a given object.
+    """Returns the precedence of a given object.
+
+    This is the precedence for StrPrinter.
     """
     if hasattr(item, "precedence"):
         return item.precedence
@@ -136,9 +136,10 @@ def precedence(item):
 
 
 def precedence_traditional(item):
-    """
-    Returns the precedence of a given object according to the traditional rules
-    of mathematics. This is the precedence for the LaTeX and pretty printer.
+    """Returns the precedence of a given object according to the
+    traditional rules of mathematics.
+
+    This is the precedence for the LaTeX and pretty printer.
     """
     # Integral, Sum, Product, Limit have the precedence of Mul in LaTeX,
     # the precedence of Atom for other printers:

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -47,7 +47,8 @@ PRECEDENCE_VALUES = {
     "KroneckerProduct": PRECEDENCE["Mul"],
     "Equality": PRECEDENCE["Mul"],
     "Unequality": PRECEDENCE["Mul"],
-    "Adjoint": PRECEDENCE["Pow"]
+    "Adjoint": PRECEDENCE["Pow"],
+    "Transpose": PRECEDENCE["Pow"]
 }
 
 # Sometimes it's not enough to assign a fixed precedence value to a

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1584,11 +1584,19 @@ def test_Adjoint():
 
 
 def test_Hadamard():
-    from sympy.matrices import MatrixSymbol, HadamardProduct
+    from sympy.matrices import MatrixSymbol, HadamardProduct, HadamardPower
+    from sympy.matrices.expressions import MatAdd, MatMul
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
     assert latex(HadamardProduct(X, Y*Y)) == r'X \circ Y^{2}'
     assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \circ Y\right) Y'
+
+    assert latex(HadamardPower(X, 2)) == r'X^{\circ {2}}'
+    assert latex(HadamardPower(X, -1)) == r'X^{\circ {-1}}'
+    assert latex(HadamardPower(MatAdd(X, Y), 2)) == \
+        r'\left(X + Y\right)^{\circ {2}}'
+    assert latex(HadamardPower(MatMul(X, Y), 2)) == \
+        r'\left(X Y\right)^{\circ {2}}'
 
 
 def test_ZeroMatrix():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1579,8 +1579,23 @@ def test_Adjoint():
     assert latex(Adjoint(Transpose(X))) == r'\left(X^{T}\right)^{\dagger}'
     assert latex(Transpose(Adjoint(X))) == r'\left(X^{\dagger}\right)^{T}'
     assert latex(Transpose(Adjoint(X) + Y)) == r'\left(X^{\dagger} + Y\right)^{T}'
+
+
+def test_Transpose():
+    from sympy.matrices import Transpose, MatPow, HadamardPower
+    X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
     assert latex(Transpose(X)) == r'X^{T}'
     assert latex(Transpose(X + Y)) == r'\left(X + Y\right)^{T}'
+
+    assert latex(Transpose(HadamardPower(X, 2))) == \
+        r'\left(X^{\circ {2}}\right)^{T}'
+    assert latex(HadamardPower(Transpose(X), 2)) == \
+        r'\left(X^{T}\right)^{\circ {2}}'
+    assert latex(Transpose(MatPow(X, 2))) == \
+        r'\left(X^{2}\right)^{T}'
+    assert latex(MatPow(Transpose(X), 2)) == \
+        r'\left(X^{T}\right)^{2}'
 
 
 def test_Hadamard():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1585,7 +1585,7 @@ def test_Adjoint():
 
 def test_Hadamard():
     from sympy.matrices import MatrixSymbol, HadamardProduct, HadamardPower
-    from sympy.matrices.expressions import MatAdd, MatMul
+    from sympy.matrices.expressions import MatAdd, MatMul, MatPow
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
     assert latex(HadamardProduct(X, Y*Y)) == r'X \circ Y^{2}'
@@ -1597,6 +1597,11 @@ def test_Hadamard():
         r'\left(X + Y\right)^{\circ {2}}'
     assert latex(HadamardPower(MatMul(X, Y), 2)) == \
         r'\left(X Y\right)^{\circ {2}}'
+
+    assert latex(HadamardPower(MatPow(X, -1), -1)) == \
+        r'\left(X^{-1}\right)^{\circ {-1}}'
+    assert latex(MatPow(HadamardPower(X, -1), -1)) == \
+        r'\left(X^{\circ {-1}}\right)^{-1}'
 
 
 def test_ZeroMatrix():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16470 

#### Brief description of what is fixed or changed

Partially fixes #16470 by adding latex printing.

<img src=https://user-images.githubusercontent.com/34944973/55160471-c307cc80-51a6-11e9-8809-aaa9c1b9c747.png width=384px>


#### Other comments

+ Some cleanups for latex matrix expression printers using precedence table
+ Added some notes in `precedence.py` for developers

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added support for `HadamardPower` in latex printer.

<!-- END RELEASE NOTES -->
