### PR TITLE
Idempotence assumption

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -81,7 +81,6 @@ class AssumptionKeys(object):
         .. [1] https://en.wikipedia.org/wiki/Idempotence
 
         """
-        # TODO: Add examples
         return Predicate('idempotent')
 
     @predicate_memo

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -73,7 +73,7 @@ class AssumptionKeys(object):
         """
         Idempotent predicate.
 
-        ``Q.idempotent(x)`` is true iff ``x^n=x`` for non-negative ``x``. 
+        ``Q.idempotent(x)`` is true iff ``x^n=x`` for positive ``n``.
 
         References
         ==========

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -69,6 +69,22 @@ class AssumptionKeys(object):
         return Predicate('antihermitian')
 
     @predicate_memo
+    def idempotent(self):
+        """
+        Idempotent predicate.
+
+        ``Q.idempotent(x)`` is true iff ``x^n=x`` for non-negative ``x``. 
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Idempotence
+
+        """
+        # TODO: Add examples
+        return Predicate('idempotent')
+
+    @predicate_memo
     def real(self):
         r"""
         Real number predicate.
@@ -1424,6 +1440,7 @@ def compute_known_facts(known_facts, known_facts_keys):
 _val_template = 'sympy.assumptions.handlers.%s'
 _handlers = [
     ("antihermitian",     "sets.AskAntiHermitianHandler"),
+    ("idempotent",        "sets.AskIdempotentHandler"),
     ("finite",           "calculus.AskFiniteHandler"),
     ("commutative",       "AskCommutativeHandler"),
     ("complex",           "sets.AskComplexHandler"),

--- a/sympy/assumptions/ask_generated.py
+++ b/sympy/assumptions/ask_generated.py
@@ -103,6 +103,7 @@ def get_known_facts_dict():
         Q.finite: set([Q.finite]),
         Q.fullrank: set([Q.fullrank]),
         Q.hermitian: set([Q.hermitian]),
+        Q.idempotent: set([Q.idempotent]),
         Q.imaginary: set([Q.antihermitian, Q.complex, Q.imaginary]),
         Q.infinite: set([Q.extended_real, Q.infinite]),
         Q.integer: set([Q.algebraic, Q.complex, Q.extended_real, Q.hermitian,

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -126,8 +126,11 @@ class AskIdempotentHandler(CommonHandler):
                 nccount += 1
                 if nccount > 1:
                     break
-        else:
+
+        if result:
             return result
+        else:
+            return None
 
 
 class AskRationalHandler(CommonHandler):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -101,6 +101,10 @@ class AskIdempotentHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_idempotent
+
+    @staticmethod
     def Add(expr, assumptions):
         """
         Idempotent + Idempotent not necessarily Idempotent

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -94,6 +94,38 @@ class AskIntegerHandler(CommonHandler):
     Determinant = Trace = MatrixElement
 
 
+class AskIdempotentHandler(CommonHandler):
+    """
+    Handler for Q.idempotent
+    Test that an expression belongs to the field of Idempotent operators
+    """
+
+    @staticmethod
+    def Add(expr, assumptions):
+        """
+        Idempotent + Idempotent not necessarily Idempotent
+        """
+        return None
+
+    @staticmethod
+    def Mul(expr, assumptions):
+        """
+        As long as there is at most only one noncommutative term:
+        Idempotent*Idempotent -> Idempotent
+        """
+        nccount = 0
+        result = True
+        for arg in expr.args:
+            if ask(Q.idempotent(arg), assumptions):
+                result = result ^ True
+            if ask(~Q.commutative(arg), assumptions):
+                nccount += 1
+                if nccount > 1:
+                    break
+        else:
+            return result
+
+
 class AskRationalHandler(CommonHandler):
     """
     Handler for Q.rational

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -107,14 +107,14 @@ class AskIdempotentHandler(CommonHandler):
     @staticmethod
     def Add(expr, assumptions):
         """
-        Idempotent + Idempotent not necessarily Idempotent
+        Idempotent + Idempotent generally not Idempotent
         """
         return None
 
     @staticmethod
     def Mul(expr, assumptions):
         """
-        As long as there is at most only one noncommutative term:
+        As long as there is at most one noncommutative term:
         Idempotent*Idempotent -> Idempotent
         """
         nccount = 0

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -97,11 +97,15 @@ class AskIntegerHandler(CommonHandler):
 class AskIdempotentHandler(CommonHandler):
     """
     Handler for Q.idempotent
-    Test that an expression belongs to the field of Idempotent operators
+    Test that an expression is idempotent
     """
 
     @staticmethod
     def Symbol(expr, assumptions):
+        return expr.is_idempotent
+
+    @staticmethod
+    def Expr(expr, assumptions):
         return expr.is_idempotent
 
     @staticmethod
@@ -115,7 +119,8 @@ class AskIdempotentHandler(CommonHandler):
     def Mul(expr, assumptions):
         """
         As long as there is at most one noncommutative term:
-        Idempotent*Idempotent -> Idempotent
+        Idempotent*Idempotent  -> Idempotent
+        Idempotent*?Idempotent -> ?Idempotent
         """
         nccount = 0
         result = True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2255,7 +2255,7 @@ def test_autosimp_used_to_fail():
 def test_idempotence():
     t = symbols('x', idempotent=True)
     s = symbols('s')
-    
+
     assert ask(Q.idempotent(t)) is True
     assert ask(Q.idempotent(s)) is None
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2251,3 +2251,14 @@ def test_autosimp_used_to_fail():
     assert ask(Q.imaginary(0**(-I))) is False
     assert ask(Q.real(0**I)) is False
     assert ask(Q.real(0**(-I))) is False
+
+def test_idempotence():
+    t = symbols('x', idempotent=True)
+    s = symbols('s')
+    
+    assert ask(Q.idempotent(t)) is True
+    assert ask(Q.idempotent(s)) is None
+
+    assert ask(Q.idempotent(x+y), Q.idempotent(x) & Q.idempotent(y)) is None
+    assert ask(Q.idempotent(x*y), Q.idempotent(x) & Q.idempotent(y)) is True
+    assert ask(Q.idempotent(x*z), Q.idempotent(x)) is None

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -107,7 +107,7 @@ Here follows a list of possible assumption names:
         (antihermitian) operators.
 
     idempotent
-        non-zero power of the element is equal
+        positive power of the element is equal
         to the element
 
 Examples

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -106,6 +106,10 @@ Here follows a list of possible assumption names:
         object belongs to the field of hermitian
         (antihermitian) operators.
 
+    idempotent
+        non-zero power of the element is equal
+        to the element
+
 Examples
 ========
 
@@ -199,9 +203,9 @@ _assume_rules = FactRules([
     'noninteger     ==  real & !integer',
     'nonzero        ==  real & !zero',
 ])
-
 _assume_defined = _assume_rules.defined_facts.copy()
 _assume_defined.add('polar')
+_assume_defined.add('idempotent')
 _assume_defined = frozenset(_assume_defined)
 
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -263,10 +263,7 @@ class Pow(Expr):
                     b = -b
                 elif e.is_odd:
                     return -Pow(-b, e)
-            if b.is_idempotent:
-                if e is S.Zero:
-                    return S.One
-                else:
+            if b.is_idempotent and e.is_positive:
                     return b
             if S.NaN in (b, e):  # XXX S.NaN**x -> S.NaN under assumption that x != 0
                 return S.NaN

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -263,6 +263,11 @@ class Pow(Expr):
                     b = -b
                 elif e.is_odd:
                     return -Pow(-b, e)
+            if b.is_idempotent:
+                if e is S.Zero:
+                    return S.One
+                else:
+                    return b
             if S.NaN in (b, e):  # XXX S.NaN**x -> S.NaN under assumption that x != 0
                 return S.NaN
             elif b is S.One:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -263,8 +263,11 @@ class Pow(Expr):
                     b = -b
                 elif e.is_odd:
                     return -Pow(-b, e)
-            if b.is_idempotent and e.is_positive:
+            if b.is_idempotent:
+                if e.is_positive:
                     return b
+                elif e.is_negative:
+                    raise ValueError('idempotent elements are non-invertible')
             if S.NaN in (b, e):  # XXX S.NaN**x -> S.NaN under assumption that x != 0
                 return S.NaN
             elif b is S.One:

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -464,10 +464,9 @@ def test_idempotence():
     assert x**n     == x
     assert x**(n+1) == x
 
-    # not-necessarily-positive powers are left untouched
-    assert x**(-1)  != x
-    assert x**(-12) != x
-    assert x**y     != x
-
     # empty product
     assert x**0     == 1
+
+    # not-necessarily-positive powers are left untouched
+    assert x**y     != x
+

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -469,4 +469,3 @@ def test_idempotence():
 
     # not-necessarily-positive powers are left untouched
     assert x**y     != x
-

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -468,4 +468,5 @@ def test_idempotence():
     assert x**0     == 1
 
     # not-necessarily-positive powers are left untouched
+    assert x**y     == Pow(x, y, evaluate=False)
     assert x**y     != x

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -452,3 +452,22 @@ def test_better_sqrt():
     assert sqrt(-I/2) == Mul(S.Half, 1 - I, evaluate=False)
     # fractional im part
     assert Pow(-9*I/2, 3/S(2)) == 27*(1 - I)**3/8
+
+def test_idempotence():
+    x = Symbol('x', idempotent=True)
+    n = Symbol('n', positive=True)
+    y = Symbol('y')
+
+    # positive powers equal the element
+    assert x**2     == x
+    assert x**125   == x
+    assert x**n     == x
+    assert x**(n+1) == x
+
+    # not-necessarily-positive powers are left untouched
+    assert x**(-1)  != x
+    assert x**(-12) != x
+    assert x**y     != x
+
+    # empty product
+    assert x**0     == 1

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -13,6 +13,12 @@ class MatPow(MatrixExpr):
         base = _sympify(base)
         if not base.is_Matrix:
             raise TypeError("Function parameter should be a matrix")
+        if base.is_idempotent:
+            if exp.is_positive:
+                return b
+            elif exp.is_negative:
+                raise ValueError('idempotent elements are non-invertible')
+
         exp = _sympify(exp)
         return super(MatPow, cls).__new__(cls, base, exp)
 

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -15,7 +15,7 @@ class MatPow(MatrixExpr):
             raise TypeError("Function parameter should be a matrix")
         if base.is_idempotent:
             if exp.is_positive:
-                return b
+                return base
             elif exp.is_negative:
                 raise ValueError('idempotent elements are non-invertible')
 

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -504,3 +504,14 @@ def test_simplify_matrix_expressions():
     a = gcd_terms(2*C*D + 4*D*C)
     assert type(a) == MatMul
     assert a.args == (2, (C*D + 2*D*C))
+
+def test_assumptions():
+
+    T = MatrixSymbol('T', n, n, idempotent=True)
+    assert T.is_idempotent
+
+    K = MatrixSymbol('K', n, n, hermitian=True)
+    assert K.is_hermitian
+
+    M = MatrixSymbol('M', n, n, antihermitian=True)
+    assert M.is_antihermitian

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -137,3 +137,21 @@ def test_transpose_power():
 
     assert ((D*C)**-5).T**-5 == ((D*C)**25).T
     assert (((D*C)**l).T**k).T == (D*C)**(l*k)
+
+
+def test_idempotence():
+
+    F = MatrixSymbol('F', n, n, idempotent=True)
+    t = symbols('t', positive=True)
+
+    # positive powers equal the element
+    assert F**2     == F
+    assert F**125   == F
+    assert F**t     == F
+    assert F**(t+1) == F
+
+    # empty product
+    assert type(F**0) is Identity
+
+    # not-necessarily-positive powers are left untouched
+    assert F**m     != F


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed
Implemented `idempotent` assumption.

#### Other comments
When a symbol `x` is assumed to be `idempotent`, any non-zero power `x^k` will evaluate to x.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * implemented `idempotency` assumption
* matrices
  * implemented assumptions in `MatrixSymbol`

<!-- END RELEASE NOTES -->
