### PR TITLE
Checked for iterable objects in subs as well as added tests

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -921,7 +921,7 @@ class Basic(with_metaclass(ManagedProperties)):
         from sympy import Dummy, Symbol
 
         if iterable(args):
-           args=list(args)
+           args = list(args)
         unordered = False
         if len(args) == 1:
             sequence = args[0]
@@ -1000,6 +1000,8 @@ class Basic(with_metaclass(ManagedProperties)):
                 if not isinstance(rv, Basic):
                     break
             return rv
+
+
 
     @cacheit
     def _subs(self, old, new, **hints):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -920,6 +920,8 @@ class Basic(with_metaclass(ManagedProperties)):
         from sympy.utilities import default_sort_key
         from sympy import Dummy, Symbol
 
+        if iterable(args):
+           args=list(args)
         unordered = False
         if len(args) == 1:
             sequence = args[0]

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1886,10 +1886,8 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        if iterable(args):
-            return self.applyfunc(lambda x: x.subs(*list(args), **kwargs))
-        else:
-            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+
 
     def trace(self):
         """

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -12,7 +12,7 @@ from inspect import isfunction
 from sympy.assumptions.refine import refine
 from sympy.core.basic import Atom
 from sympy.core.compatibility import (
-    Iterable, as_int, is_sequence, range, reduce)
+    Iterable, iterable,  as_int, is_sequence, range, reduce)
 from sympy.core.decorators import call_highest_priority
 from sympy.core.expr import Expr
 from sympy.core.function import count_ops
@@ -1886,12 +1886,10 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        try:
-            iter(args)
-        except TypeError:
-            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        if iterable(args):
+            return self.applyfunc(lambda x: x.subs(*list(args), **kwargs))
         else:
-            return self.applyfunc(lambda x: x.subs(list(args) , **kwargs))
+            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
 
     def trace(self):
         """

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1886,13 +1886,8 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        #return self.applyfunc(lambda x: x.subs(*args, **kwargs))
-        try:
-            iter(args)
-        except TypeError:
-            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
-        else:
-            return self.applyfunc(lambda x: x.subs(list(args) , **kwargs))
+        return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+
 
     def trace(self):
         """

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1886,6 +1886,8 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
+        if iterable(args):
+            args = list(args)
         return self.applyfunc(lambda x: x.subs(*args, **kwargs))
 
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1886,7 +1886,13 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        #return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        try:
+            iter(args)
+        except TypeError:
+            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        else:
+            return self.applyfunc(lambda x: x.subs(list(args) , **kwargs))
 
     def trace(self):
         """

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1886,8 +1886,12 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        return self.applyfunc(lambda x: x.subs(*args, **kwargs))
-
+        try:
+            iter(args)
+        except TypeError:
+            return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+        else:
+            return self.applyfunc(lambda x: x.subs(list(args) , **kwargs))
 
     def trace(self):
         """

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1522,3 +1522,6 @@ def test___eq__():
         [1, 1, 1]]) == {}) is False
 
 
+def test_issue_10589():
+    vect = Matrix([x,y])
+    assert vect.subs(zip([x,y] , [1,1])) == Matrix([[1],[1]])

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1524,4 +1524,4 @@ def test___eq__():
 
 def test_issue_10589():
     vect = Matrix([x,y])
-    assert vect.subs(zip([x,y] , [1,1])) == Matrix([[1],[1]])
+    assert vect.subs(zip([x,y] , [1,1])) == Matrix([[1], [1]])

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1522,7 +1522,3 @@ def test___eq__():
         [1, 1, 1]]) == {}) is False
 
 
-def test_issue_10589():
-    vect = Matrix([x,y])
-    assert vect.subs(zip([x,y] , [1,1])) == Matrix([[1],[1]])
-

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1520,3 +1520,9 @@ def test___eq__():
         [[0, 1, 1],
         [1, 0, 0],
         [1, 1, 1]]) == {}) is False
+
+
+def test_issue_10589():
+    vect = Matrix([x,y])
+    assert vect.subs(zip([x,y] , [1,1])) == Matrix([[1],[1]])
+

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -534,6 +534,8 @@ class Dyadic(object):
         2*(N.x|N.x)
 
         """
+        if iterable(args):
+            args = list(args)
         return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
                         for v in self.args], Dyadic(0))
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
-from sympy.core.compatibility import unicode
+from sympy.core.compatibility import unicode, iterable
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
 
@@ -534,9 +534,12 @@ class Dyadic(object):
         2*(N.x|N.x)
 
         """
-
-        return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
-                    for v in self.args], Dyadic(0))
+        if iterable(args):
+            return sum([Dyadic([(v[0].subs(*list(args), **kwargs), v[1], v[2])])
+                        for v in self.args], Dyadic(0))
+        else:
+            return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
+                        for v in self.args], Dyadic(0))
 
     def applyfunc(self, f):
         """Apply a function to each component of a Dyadic."""

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -534,11 +534,7 @@ class Dyadic(object):
         2*(N.x|N.x)
 
         """
-        if iterable(args):
-            return sum([Dyadic([(v[0].subs(*list(args), **kwargs), v[1], v[2])])
-                        for v in self.args], Dyadic(0))
-        else:
-            return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
+        return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
                         for v in self.args], Dyadic(0))
 
     def applyfunc(self, f):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -696,10 +696,7 @@ class Vector(object):
 
         d = {}
         for v in self.args:
-            if iterable(args):
-                d[v[1]] = v[0].subs(*list(args), **kwargs)
-            else:
-                d[v[1]] = v[0].subs(*args, **kwargs)
+            d[v[1]] = v[0].subs(*args, **kwargs)
         return Vector(d)
 
     def magnitude(self):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,7 +1,7 @@
 from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros,
     ImmutableMatrix as Matrix)
 from sympy import trigsimp
-from sympy.core.compatibility import unicode
+from sympy.core.compatibility import unicode, iterable
 from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']
@@ -696,7 +696,10 @@ class Vector(object):
 
         d = {}
         for v in self.args:
-            d[v[1]] = v[0].subs(*args, **kwargs)
+            if iterable(args):
+                d[v[1]] = v[0].subs(*list(args), **kwargs)
+            else:
+                d[v[1]] = v[0].subs(*args, **kwargs)
         return Vector(d)
 
     def magnitude(self):


### PR DESCRIPTION
The code in Matrix.subs only checked for non-iterable arguments passed. Since,iterable objects showed error I have changed the code. The code for subs module in core/basic needs to be modified. It uses isinstance to check if object is iterable,hence iterable objects who don't have _getitem_  gets neglected. So,shall I change it,too?

Fixes #10589
 
<!-- BEGIN RELEASE NOTES -->
* matrices
   * changed subs module for checking iterable objects
   * added tests in test_commonmatrix.py
<!-- END RELEASE NOTES -->
