### PR TITLE
Change return type of sort_key function

### DIFF
--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -88,7 +88,7 @@ class Partition(FiniteSet):
         else:
             members = tuple(sorted(self.members,
                              key=lambda w: default_sort_key(w, order)))
-        return list(map(default_sort_key, (self.size, members, self.rank)))
+        return tuple(map(default_sort_key, (self.size, members, self.rank)))
 
     @property
     def partition(self):

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -1,9 +1,10 @@
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, ordered
 from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             RGS_enum, RGS_unrank, RGS_rank,
                                             random_integer_partition)
 from sympy.utilities.pytest import raises
 from sympy.utilities.iterables import default_sort_key, partitions
+from sympy.sets.sets import Set
 
 
 def test_partition():
@@ -98,3 +99,8 @@ def test_rgs():
     assert RGS_unrank(7, 5) == [0, 0, 1, 0, 2]
     assert RGS_unrank(23, 14) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 2]
     assert RGS_rank(RGS_unrank(40, 100)) == 40
+
+def test_ordered_partition_9608():
+    a = Partition([1, 2, 3], [4])
+    b = Partition([1, 2], [3, 4])
+    assert list(ordered([a,b], Set._infimum_key))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #9608

#### Brief description of what is fixed or changed
This function defined in `partitions.py` was returning a list which is not hashable.
So I changed the return value into a tuple (since they are immutable).
I wrote a test in `test_partitions.py` and it passed when I ran it with `bin/test`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
