### PR TITLE
Add hadamard product printing for mathml

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1661,6 +1661,19 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         sup.appendChild(self._print(exp))
         return sup
 
+    def _print_HadamardProduct(self, expr):
+        x = self.dom.createElement('mrow')
+        args = expr.args
+        for arg in args[:-1]:
+            x.appendChild(
+                self.parenthesize(arg, precedence_traditional(expr), False))
+            mo = self.dom.createElement('mo')
+            mo.appendChild(self.dom.createTextNode('&#x2218;'))
+            x.appendChild(mo)
+        x.appendChild(
+            self.parenthesize(args[-1], precedence_traditional(expr), False))
+        return x
+
     def _print_ZeroMatrix(self, Z):
         x = self.dom.createElement('mn')
         x.appendChild(self.dom.createTextNode('&#x1D7D8'))

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1376,6 +1376,29 @@ def test_print_matrix_symbol():
     assert mathml(A, mat_symbol_style="bold") == '<ci>A</ci>'
 
 
+def test_print_hadamard():
+    from sympy.matrices.expressions import HadamardProduct
+
+    X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
+
+    assert mathml(HadamardProduct(X, Y*Y), printer="presentation") == \
+        '<mrow>' \
+        '<mi>X</mi>' \
+        '<mo>&#x2218;</mo>' \
+        '<msup><mi>Y</mi><mn>2</mn></msup>' \
+        '</mrow>'
+
+    assert mathml(HadamardProduct(X, Y)*Y, printer="presentation") == \
+        '<mrow>' \
+        '<mfenced>' \
+        '<mrow><mi>X</mi><mo>&#x2218;</mo><mi>Y</mi></mrow>' \
+        '</mfenced>' \
+        '<mo>&InvisibleTimes;</mo><mi>Y</mi>' \
+        '</mrow>'
+
+
+
 def test_print_random_symbol():
     R = RandomSymbol(Symbol('R'))
     assert mpp.doprint(R) == '<mi>R</mi>'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1378,6 +1378,7 @@ def test_print_matrix_symbol():
 
 def test_print_hadamard():
     from sympy.matrices.expressions import HadamardProduct
+    from sympy.matrices.expressions import Transpose
 
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
@@ -1397,6 +1398,21 @@ def test_print_hadamard():
         '<mo>&InvisibleTimes;</mo><mi>Y</mi>' \
         '</mrow>'
 
+    assert mathml(HadamardProduct(X, Y, Y), printer="presentation") == \
+        '<mrow>' \
+        '<mi>X</mi><mo>&#x2218;</mo>' \
+        '<mi>Y</mi><mo>&#x2218;</mo>' \
+        '<mi>Y</mi>' \
+        '</mrow>'
+
+    assert mathml(
+        Transpose(HadamardProduct(X, Y)), printer="presentation") == \
+            '<msup>' \
+            '<mfenced>' \
+            '<mrow><mi>X</mi><mo>&#x2218;</mo><mi>Y</mi></mrow>' \
+            '</mfenced>' \
+            '<mo>T</mo>' \
+            '</msup>'
 
 
 def test_print_random_symbol():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I'm not sure if anything exists for mathml content printer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Add support for `HadamardProduct` in mathml presentation printer.
<!-- END RELEASE NOTES -->
