### PR TITLE
add See Also entries to diag*

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -514,6 +514,10 @@ class MatrixShaping(MatrixRequired):
 
         >>> Matrix.diag(1, 2, 3).diagonal()[1]  # instead of [0, 1]
         2
+
+        See Also
+        ========
+        diag - to create a diagonal matrix
         """
         rv = []
         k = as_int(k)
@@ -776,7 +780,14 @@ class MatrixSpecial(MatrixRequired):
         Matrix([
         [0, 0, 1, 0],
         [0, 0, 0, 2]])
-        """
+
+        See Also
+        ========
+        eye
+        diagonal - to extract a diagonal
+        .dense.diag
+        .expressions.blockmatrix.BlockMatrix
+       """
         from sympy.matrices.matrices import MatrixBase
         from sympy.matrices.dense import Matrix
         klass = kwargs.get('cls', kls)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1131,9 +1131,9 @@ def diag(*values, **kwargs):
 
     See Also
     ========
-    .common.eye
-    .common.diagonal - to extract a diagonal
-    .common.diag
+    .common.MatrixCommon.eye
+    .common.MatrixCommon.diagonal - to extract a diagonal
+    .common.MatrixCommon.diag
     .expressions.blockmatrix.BlockMatrix
     """
     from .dense import Matrix

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1131,8 +1131,10 @@ def diag(*values, **kwargs):
 
     See Also
     ========
-    eye
-    sympy.matrices.common.diag
+    .common.eye
+    .common.diagonal - to extract a diagonal
+    .common.diag
+    .expressions.blockmatrix.BlockMatrix
     """
     from .dense import Matrix
     # Extract any setting so we don't duplicate keywords sent


### PR DESCRIPTION
It pains me a bit to have this `diag` method duplicated in dense and common.

Is it necessary to keep the `common.diag` which would allow users to call `Matrix.diag`? Is it considered user facing?

Because if it weren't, `diagonal` could become `Matrix.diag` -- a method to extract the diagonal like `row` and `col` extract a row and column -- and `diag` function, like `eye` function (and method), would create a diagonal matrix.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
