### PR TITLE
Remove Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ dist: trusty
 
 python:
   - 2.7
-  - 3.4
   - 3.5
 
 matrix:

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -9,7 +9,7 @@ recommended method of installation is through Anaconda, which includes
 mpmath, as well as several other useful libraries.  Alternatively, some Linux
 distributions have SymPy packages available.
 
-SymPy officially supports Python 2.7, 3.4, 3.5, 3.6 and PyPy.
+SymPy officially supports Python 2.7, 3.5, 3.6, 3.7, and PyPy.
 
 Anaconda
 ========

--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -37,7 +37,6 @@ $ACTIVITIES = [
     'copy_release_files',
     'compare_tar_against_git',
     'test_tarball27',
-    'test_tarball34',
     'test_tarball35',
     'test_tarball36',
     'test_tarball37',
@@ -116,10 +115,6 @@ def copy_release_files():
 @activity(deps={'source_tarball'})
 def test_tarball27():
     test_tarball('2.7')
-
-@activity(deps={'source_tarball'})
-def test_tarball34():
-    test_tarball('3.4')
 
 @activity(deps={'source_tarball'})
 def test_tarball35():
@@ -220,7 +215,7 @@ def _md5(print_=True, local=False):
         print(out)
     return out
 
-@activity(deps={'mailmap_update', 'md5', 'print_authors', 'source_tarball', 'build_docs', 'compare_tar_against_git', 'test_tarball27', 'test_tarball34', 'test_tarball35', 'test_tarball36', 'test_sympy'})
+@activity(deps={'mailmap_update', 'md5', 'print_authors', 'source_tarball', 'build_docs', 'compare_tar_against_git', 'test_tarball27', 'test_tarball35', 'test_tarball36', 'test_sympy'})
 def release():
     pass
 
@@ -254,8 +249,8 @@ def test_tarball(py_version):
     Test that the tarball can be unpacked and installed, and that sympy
     imports in the install.
     """
-    if py_version not in {'2.7', '3.4', '3.5', '3.6', '3.7'}: # TODO: Add win32
-        raise ValueError("release must be one of 2.7, 3.4, 3.5, 3.6, or 3.7 not %s" % py_version)
+    if py_version not in {'2.7', '3.5', '3.6', '3.7'}: # TODO: Add win32
+        raise ValueError("release must be one of 2.7, 3.5, 3.6, or 3.7 not %s" % py_version)
 
 
     with run_in_conda_env(['python=%s' % py_version], 'test-install-%s' % py_version):


### PR DESCRIPTION
Python 3.4 has reached its [end of life](https://devguide.python.org/#status-of-python-branches), so by our [Python version support policy](https://github.com/sympy/sympy/wiki/Python-version-support-policy) we are no longer supporting it.

SymPy 1.4 will be the last version to support Python 3.4. Now that the 1.4 release branch has been made, we no longer need to support it on master.

It is unlikely this will buy us anything in the way of Python features, since we still are supporting Python 2.7. However, it does mean fewer tests on Travis.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Python 3.4 support has been removed. See https://github.com/sympy/sympy/wiki/Python-version-support-policy.
<!-- END RELEASE NOTES -->
