### PR TITLE
Fixed make 'indices' parameter optional

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2123,8 +2123,7 @@ class TensExpr(Expr):
             dictionary containing the replacement rules for tensors.
         indices
             the index order with respect to which the array is read. The
-            original index order will be used if the default value '[]' is
-            passed.
+            original index order will be used if no value is passed.
 
         Examples
         ========

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2110,7 +2110,7 @@ class TensExpr(Expr):
 
         return free_ind2, array
 
-    def replace_with_arrays(self, replacement_dict, indices):
+    def replace_with_arrays(self, replacement_dict, indices=[]):
         """
         Replace the tensorial expressions with arrays. The final array will
         correspond to the N-dimensional array with indices arranged according
@@ -2122,7 +2122,9 @@ class TensExpr(Expr):
         replacement_dict
             dictionary containing the replacement rules for tensors.
         indices
-            the index order with respect to which the array is read.
+            the index order with respect to which the array is read. The
+            original index order will be used if the default value '[]' is
+            passed.
 
         Examples
         ========

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2110,7 +2110,7 @@ class TensExpr(Expr):
 
         return free_ind2, array
 
-    def replace_with_arrays(self, replacement_dict, indices=[]):
+    def replace_with_arrays(self, replacement_dict, indices=None):
         """
         Replace the tensorial expressions with arrays. The final array will
         correspond to the N-dimensional array with indices arranged according
@@ -2171,6 +2171,7 @@ class TensExpr(Expr):
         """
         from .array import Array
 
+        indices = indices or []
         replacement_dict = {tensor: Array(array) for tensor, array in replacement_dict.items()}
 
         # Check dimensions of replaced arrays:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2137,15 +2137,22 @@ class TensExpr(Expr):
         >>> A = tensorhead("A", [L], [[1]])
         >>> A(i).replace_with_arrays({A(i): [1, 2]}, [i])
         [1, 2]
+
+        Since 'indices' is optional, we can also call replace_with_arrays by
+        this way if no specific index order is needed:
+
+        >>> A(i).replace_with_arrays({A(i): [1, 2]})
+        [1, 2]
+
         >>> expr = A(i)*A(j)
-        >>> expr.replace_with_arrays({A(i): [1, 2]}, [i, j])
+        >>> expr.replace_with_arrays({A(i): [1, 2]})
         [[1, 2], [2, 4]]
 
         For contractions, specify the metric of the ``TensorIndexType``, which
         in this case is ``L``, in its covariant form:
 
         >>> expr = A(i)*A(-i)
-        >>> expr.replace_with_arrays({A(i): [1, 2], L: diag(1, -1)}, [])
+        >>> expr.replace_with_arrays({A(i): [1, 2], L: diag(1, -1)})
         -3
 
         Symmetrization of an array:
@@ -2153,14 +2160,14 @@ class TensExpr(Expr):
         >>> H = tensorhead("H", [L, L], [[1], [1]])
         >>> a, b, c, d = symbols("a b c d")
         >>> expr = H(i, j)/2 + H(j, i)/2
-        >>> expr.replace_with_arrays({H(i, j): [[a, b], [c, d]]}, [i, j])
+        >>> expr.replace_with_arrays({H(i, j): [[a, b], [c, d]]})
         [[a, b/2 + c/2], [b/2 + c/2, d]]
 
         Anti-symmetrization of an array:
 
         >>> expr = H(i, j)/2 - H(j, i)/2
         >>> repl = {H(i, j): [[a, b], [c, d]]}
-        >>> expr.replace_with_arrays(repl, [i, j])
+        >>> expr.replace_with_arrays(repl)
         [[0, b/2 - c/2], [-b/2 + c/2, 0]]
 
         The same expression can be read as the transpose by inverting ``i`` and

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2123,7 +2123,8 @@ class TensExpr(Expr):
             dictionary containing the replacement rules for tensors.
         indices
             the index order with respect to which the array is read. The
-            original index order will be used if no value is passed.
+            original index order will be used if the default value '[]' is
+            passed.
 
         Examples
         ========

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1906,6 +1906,8 @@ def test_tensor_replacement():
     assert expr.replace_with_arrays(repl, [j, -i]) == Array([[1, -3], [-2, 4]])
     assert expr.replace_with_arrays(repl, [-j, i]) == Array([[1, 3], [2, 4]])
     assert expr.replace_with_arrays(repl, [-j, -i]) == Array([[1, -3], [2, -4]])
+    # Test stability of optional parameter 'indices'
+    assert expr.replace_with_arrays(repl) == Array([[1, -2], [3, -4]])
 
     expr = H(i,j)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1897,6 +1897,7 @@ def test_tensor_replacement():
     repl = {H(i,-j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, j], Array([[1, -2], [3, -4]]))
 
+    assert expr.replace_with_arrays(repl) == Array([[1, -2], [3, -4]])
     assert expr.replace_with_arrays(repl, [i, j]) == Array([[1, -2], [3, -4]])
     assert expr.replace_with_arrays(repl, [i, -j]) == Array([[1, 2], [3, 4]])
     assert expr.replace_with_arrays(repl, [-i, j]) == Array([[1, -2], [-3, 4]])
@@ -1910,6 +1911,7 @@ def test_tensor_replacement():
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, j], Array([[1, 2], [3, 4]]))
 
+    assert expr.replace_with_arrays(repl) == Array([[1, 2], [3, 4]])
     assert expr.replace_with_arrays(repl, [i, j]) == Array([[1, 2], [3, 4]])
     assert expr.replace_with_arrays(repl, [i, -j]) == Array([[1, -2], [3, -4]])
     assert expr.replace_with_arrays(repl, [-i, j]) == Array([[1, 2], [-3, -4]])


### PR DESCRIPTION
Make 'indices' parameter optional in .replace_with_arrays
Add tests about this change

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15277

#### Brief description of what is fixed or changed
Make the parameter 'indices' optional by setting a default value '[]'. When the default value is used, the array will be read by the original order: i,j,k... as we define the tensor indices in the first place.
Some test for this optional parameter have been added to test_tensor



#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Make the 'indices' parameter in .replace_with_arrays optional.
<!-- END RELEASE NOTES -->
