### PR TITLE
Fix matrix-matrix hadamard power

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -34,6 +34,10 @@ Matrix Expressions Core Reference
    :members:
 .. autoclass:: MatPow
    :members:
+.. autoclass:: HadamardProduct
+   :members:
+.. autoclass:: HadamardPower
+   :members:
 .. autoclass:: Inverse
    :members:
 .. autoclass:: Transpose

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -307,7 +307,7 @@ class HadamardPower(MatrixExpr):
     Notes
     =====
 
-    There are four definitions for the hadamard power to be used
+    There are four definitions for the hadamard power which can be used.
     Let's consider `A, B` as `(m, n)` matrices, and `a, b` as scalars.
 
     Matrix raised to a scalar exponent:

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -317,7 +317,7 @@ class HadamardPower(MatrixExpr):
         A_{0, 0}^b   & A_{0, 1}^b   & \cdots & A_{0, n-1}^b   \\
         A_{1, 0}^b   & A_{1, 1}^b   & \cdots & A_{1, n-1}^b   \\
         \vdots       & \vdots       & \ddots & \vdots         \\
-        A_{m-1, 0}^b & A_{m-1, 1}^b & \hdots & A_{m-1, n-1}^b
+        A_{m-1, 0}^b & A_{m-1, 1}^b & \cdots & A_{m-1, n-1}^b
         \end{bmatrix}
 
     Scalar raised to a matrix exponent:
@@ -327,7 +327,7 @@ class HadamardPower(MatrixExpr):
         a^{B_{0, 0}}   & a^{B_{0, 1}}   & \cdots & a^{B_{0, n-1}}   \\
         a^{B_{1, 0}}   & a^{B_{1, 1}}   & \cdots & a^{B_{1, n-1}}   \\
         \vdots         & \vdots         & \ddots & \vdots           \\
-        a^{B_{m-1, 0}} & a^{B_{m-1, 1}} & \hdots & a^{B_{m-1, n-1}}
+        a^{B_{m-1, 0}} & a^{B_{m-1, 1}} & \cdots & a^{B_{m-1, n-1}}
         \end{bmatrix}
 
     Matrix raised to a matrix exponent:
@@ -341,7 +341,7 @@ class HadamardPower(MatrixExpr):
         \vdots                  & \vdots                  &
         \ddots & \vdots                      \\
         A_{m-1, 0}^{B_{m-1, 0}} & A_{m-1, 1}^{B_{m-1, 1}} &
-        \hdots & A_{m-1, n-1}^{B_{m-1, n-1}}
+        \cdots & A_{m-1, n-1}^{B_{m-1, n-1}}
         \end{bmatrix}
 
     Scalar raised to a scalar exponent:

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -347,7 +347,7 @@ class HadamardPower(MatrixExpr):
     Scalar raised to a scalar exponent:
 
     .. math::
-        a^{\circ B} = a^b
+        a^{\circ b} = a^b
     """
 
     def __new__(cls, base, exp):

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -294,13 +294,75 @@ def hadamard_power(base, exp):
 
 
 class HadamardPower(MatrixExpr):
-    """
+    r"""
     Elementwise power of matrix expressions
+
+    Parameters
+    ==========
+
+    base : scalar or matrix
+
+    exp : scalar or matrix
+
+    Notes
+    =====
+
+    There are four definitions for the hadamard power to be used
+    Let's consider `A, B` as `(m, n)` matrices, and `a, b` as scalars.
+
+    Matrix raised to a scalar exponent:
+
+    .. math::
+        A^{\circ b} = \begin{bmatrix}
+        A_{0, 0}^b   & A_{0, 1}^b   & \cdots & A_{0, n-1}^b   \\
+        A_{1, 0}^b   & A_{1, 1}^b   & \cdots & A_{1, n-1}^b   \\
+        \vdots       & \vdots       & \ddots & \vdots         \\
+        A_{m-1, 0}^b & A_{m-1, 1}^b & \hdots & A_{m-1, n-1}^b
+        \end{bmatrix}
+
+    Scalar raised to a matrix exponent:
+
+    .. math::
+        a^{\circ B} = \begin{bmatrix}
+        a^{B_{0, 0}}   & a^{B_{0, 1}}   & \cdots & a^{B_{0, n-1}}   \\
+        a^{B_{1, 0}}   & a^{B_{1, 1}}   & \cdots & a^{B_{1, n-1}}   \\
+        \vdots         & \vdots         & \ddots & \vdots           \\
+        a^{B_{m-1, 0}} & a^{B_{m-1, 1}} & \hdots & a^{B_{m-1, n-1}}
+        \end{bmatrix}
+
+    Matrix raised to a matrix exponent:
+
+    .. math::
+        A^{\circ B} = \begin{bmatrix}
+        A_{0, 0}^{B_{0, 0}}     & A_{0, 1}^{B_{0, 1}}     &
+        \cdots & A_{0, n-1}^{B_{0, n-1}}     \\
+        A_{1, 0}^{B_{1, 0}}     & A_{1, 1}^{B_{1, 1}}     &
+        \cdots & A_{1, n-1}^{B_{1, n-1}}     \\
+        \vdots                  & \vdots                  &
+        \ddots & \vdots                      \\
+        A_{m-1, 0}^{B_{m-1, 0}} & A_{m-1, 1}^{B_{m-1, 1}} &
+        \hdots & A_{m-1, n-1}^{B_{m-1, n-1}}
+        \end{bmatrix}
+
+    Scalar raised to a scalar exponent:
+
+    .. math::
+        a^{\circ B} = a^b
     """
 
     def __new__(cls, base, exp):
         base = sympify(base)
         exp = sympify(exp)
+        if base.is_scalar and exp.is_scalar:
+            return base ** exp
+
+        if base.is_Matrix and exp.is_Matrix and base.shape != exp.shape:
+            raise ValueError(
+                'The shape of the base {} and '
+                'the shape of the exponent {} do not match.'
+                .format(base.shape, exp.shape)
+                )
+
         obj = super(HadamardPower, cls).__new__(cls, base, exp)
         return obj
 
@@ -314,10 +376,31 @@ class HadamardPower(MatrixExpr):
 
     @property
     def shape(self):
-        return self.base.shape
+        if self.base.is_Matrix:
+            return self.base.shape
+        return self.exp.shape
 
     def _entry(self, i, j, **kwargs):
-        return self.base._entry(i, j, **kwargs)**self.exp
+        base = self.base
+        exp = self.exp
+
+        if base.is_Matrix:
+            a = base._entry(i, j, **kwargs)
+        elif base.is_scalar:
+            a = base
+        else:
+            raise ValueError(
+                'The base {} must be a scalar or a matrix.'.format(base))
+
+        if exp.is_Matrix:
+            b = exp._entry(i, j, **kwargs)
+        elif exp.is_scalar:
+            b = exp
+        else:
+            raise ValueError(
+                'The exponent {} must be a scalar or a matrix.'.format(exp))
+
+        return a ** b
 
     def _eval_transpose(self):
         from sympy.matrices.expressions.transpose import transpose

--- a/sympy/matrices/expressions/tests/test_hadamard.py
+++ b/sympy/matrices/expressions/tests/test_hadamard.py
@@ -11,6 +11,7 @@ A = MatrixSymbol('A', n, m)
 B = MatrixSymbol('B', n, m)
 C = MatrixSymbol('C', m, k)
 
+
 def test_HadamardProduct():
     assert HadamardProduct(A, B, A).shape == A.shape
 
@@ -26,8 +27,10 @@ def test_HadamardProduct():
 
     assert set(HadamardProduct(A, B, A).T.args) == set((A.T, A.T, B.T))
 
+
 def test_HadamardProduct_isnt_commutative():
     assert HadamardProduct(A, B) != HadamardProduct(B, A)
+
 
 def test_mixed_indexing():
     X = MatrixSymbol('X', 2, 2)
@@ -51,6 +54,7 @@ def test_canonicalize():
     assert HadamardProduct(U, X, X, U).doit() == HadamardPower(X, 2)
     assert HadamardProduct(X, U, Y).doit() == HadamardProduct(X, Y)
     assert HadamardProduct(X, Z, U, Y).doit() == Z
+
 
 
 def test_hadamard():
@@ -82,3 +86,27 @@ def test_hadamard_power():
     assert hadamard_power(A, n)[0, 0] == A[0, 0]**n
     assert hadamard_power(m, n) == m**n
     raises(ValueError, lambda: hadamard_power(A, A))
+
+
+def test_hadamard_power_explicit():
+    from sympy.matrices import Matrix
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    a, b = symbols('a b')
+
+    assert HadamardPower(a, b) == a**b
+
+    assert HadamardPower(a, B).as_explicit() == \
+        Matrix([
+            [a**B[0, 0], a**B[0, 1]],
+            [a**B[1, 0], a**B[1, 1]]])
+
+    assert HadamardPower(A, b).as_explicit() == \
+        Matrix([
+            [A[0, 0]**b, A[0, 1]**b],
+            [A[1, 0]**b, A[1, 1]**b]])
+
+    assert HadamardPower(A, B).as_explicit() == \
+        Matrix([
+            [A[0, 0]**B[0, 0], A[0, 1]**B[0, 1]],
+            [A[1, 0]**B[1, 0], A[1, 1]**B[1, 1]]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16505

#### Brief description of what is fixed or changed

If both base and exponent are matrix, hadamard power can be defined from hadamard exponential and logarithm as usual definition for the matrix power. 
![image](https://user-images.githubusercontent.com/34944973/63642286-eb650a00-c6f7-11e9-87d2-96f4e7922cb9.png)


And since hadamard exponential and hadamard log are elementwise exponential and logarithm, it can be reduced to
![image](https://user-images.githubusercontent.com/34944973/55284069-53fac580-53aa-11e9-9560-cdc6ebdd1579.png)
for each matrix elements.

Still the definition for the hadamard power between a matrix and a scalar is unclear, however, if it is defined as usual matrix-scalar product, it can easily be reduced to the elementwise power.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `HadamardProduct.as_explicit` now supports matrix to matrix power.
  - Added missing doc for `HadamardProduct` and `HadamardPower`.
<!-- END RELEASE NOTES -->
