### PR TITLE
Changes to improve performance of min/max.

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -557,25 +557,15 @@ class MinMaxBase(Expr, LatticeOp):
                     localzeros.update([v])
             return localzeros
         else:
+            localzeros = set()
             values_ = sorted(generator_values)
             min_val = values_[0]
             max_val = values_[len(values_)-1]
-            index_begin = 0
-            while(1):
-                if values_[index_begin] == min_val:
-                    del values_[index_begin]
-                else:
-                    break
-            index_last = len(values_)-1
-            while(1):
-                if values_[index_last] == max_val:
-                    del values_[index_last]
-                    index_last -= 1
-                else:
-                    break
-            localzeros = set(values_)
+            if cls == Min:
+                localzeros.add(min_val)
+            if cls == Max:
+                localzeros.add(max_val)
             return(localzeros)
-
     @classmethod
     def _is_connected(cls, x, y):
         """

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -538,7 +538,7 @@ class MinMaxBase(Expr, LatticeOp):
         appended to the localzeros.
         """
         generator_values = list(values)
-        if len(generator_values)!=0 and all((str(type(generator_values[i])) != "<class 'sympy.core.symbol.Symbol'>") for i in range(len(generator_values))):
+        if len(generator_values)!=0 and all((str(type(generator_values[i])) == "<class 'sympy.core.numbers.Integer'>") for i in range(len(generator_values))):
             localzeros = set()
             values_ = sorted(generator_values)
             min_val = values_[0]

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -538,7 +538,17 @@ class MinMaxBase(Expr, LatticeOp):
         appended to the localzeros.
         """
         generator_values = list(values)
-        if str(type(generator_values[0])) == "<class 'sympy.core.symbol.Symbol'>":
+        if len(generator_values)!=0 and all((str(type(generator_values[i])) != "<class 'sympy.core.symbol.Symbol'>") for i in range(len(generator_values))):
+            localzeros = set()
+            values_ = sorted(generator_values)
+            min_val = values_[0]
+            max_val = values_[len(values_)-1]
+            if cls == Min:
+                localzeros.add(min_val)
+            if cls == Max:
+                localzeros.add(max_val)
+            return(localzeros)
+        else:
             localzeros = set()
             for v in generator_values:
                 is_newzero = True
@@ -556,16 +566,7 @@ class MinMaxBase(Expr, LatticeOp):
                 if is_newzero:
                     localzeros.update([v])
             return localzeros
-        else:
-            localzeros = set()
-            values_ = sorted(generator_values)
-            min_val = values_[0]
-            max_val = values_[len(values_)-1]
-            if cls == Min:
-                localzeros.add(min_val)
-            if cls == Max:
-                localzeros.add(max_val)
-            return(localzeros)
+        
     @classmethod
     def _is_connected(cls, x, y):
         """

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -538,7 +538,7 @@ class MinMaxBase(Expr, LatticeOp):
         appended to the localzeros.
         """
         generator_values = list(values)
-        if len(generator_values)!=0 and all((str(type(generator_values[i])) == "<class 'sympy.core.numbers.Integer'>") for i in range(len(generator_values))):
+        if len(generator_values) != 0 and all((str(type(generator_values[i])) == "<class 'sympy.core.numbers.Integer'>") for i in range(len(generator_values))):
             localzeros = set()
             values_ = sorted(generator_values)
             min_val = values_[0]

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -538,7 +538,7 @@ class MinMaxBase(Expr, LatticeOp):
         appended to the localzeros.
         """
         generator_values = list(values)
-        if len(generator_values) != 0 and all((str(type(generator_values[i])) == "<class 'sympy.core.numbers.Integer'>") for i in range(len(generator_values))):
+        if len(generator_values) != 0 and all((sympify(generator_values[i]).is_number) for i in range(len(generator_values))):
             localzeros = set()
             values_ = sorted(generator_values)
             min_val = values_[0]

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -566,7 +566,6 @@ class MinMaxBase(Expr, LatticeOp):
                 if is_newzero:
                     localzeros.update([v])
             return localzeros
-        
     @classmethod
     def _is_connected(cls, x, y):
         """


### PR DESCRIPTION
Fixes issue #16249.

```javascript
>>>Min(*[1,1,3,67,45,45,37,39,34,57,38,37,39,23,4,523,23,56,23,45,56,23,4,56,90,56,34,23,45,67,78,34,23,45,67,34,56,78,23,45,56,78,92,34,54,22,33,44,55,11,3,4,7,2,6,9,45,34,23,23],evaluate = False)
```
Computation time for above input:
Before Changes: --- 0.018165111541748047 seconds ---
After Changes: --- 0.009451150894165039 seconds ---


<!-- BEGIN RELEASE NOTES -->
* functions
    * Made changes  in _find_localzeroes function to improve computation time when the number of arguments in Min/Max is large.It improves computation time when the type of arguments passed is  not <class 'sympy.core.symbol.Symbol'>.
<!-- END RELEASE NOTES -->
