### PR TITLE
Improved printing of units for 1.4

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -16,7 +16,7 @@ One = S.One
 
 # Dimensionless:
 
-percent = percents = Quantity("percent")
+percent = percents = Quantity("percent", latex_repr="\%")
 percent.set_dimension(One)
 percent.set_scale_factor(Rational(1, 100))
 
@@ -27,11 +27,11 @@ permille.set_scale_factor(Rational(1, 1000))
 
 # Angular units (dimensionless)
 
-rad = radian = radians = Quantity("radian")
+rad = radian = radians = Quantity("radian", abbrev="rad")
 radian.set_dimension(One)
 radian.set_scale_factor(One)
 
-deg = degree = degrees = Quantity("degree", abbrev="deg")
+deg = degree = degrees = Quantity("degree", abbrev="deg", latex_repr=r"^\circ")
 degree.set_dimension(One)
 degree.set_scale_factor(pi/180)
 
@@ -86,7 +86,7 @@ mg = milligram = milligrams = Quantity("milligram", abbrev="mg")
 milligram.set_dimension(mass)
 milligram.set_scale_factor(milli*gram)
 
-ug = microgram = micrograms = Quantity("microgram", abbrev="ug")
+ug = microgram = micrograms = Quantity("microgram", abbrev="ug", latex_repr=r"\mu\text{g}")
 microgram.set_dimension(mass)
 microgram.set_scale_factor(micro*gram)
 
@@ -123,7 +123,7 @@ volt = volts = v = V = Quantity("volt", abbrev='V')
 volt.set_dimension(voltage)
 volt.set_scale_factor(joule/coulomb)
 
-ohm = ohms = Quantity("ohm", abbrev='ohm')
+ohm = ohms = Quantity("ohm", abbrev='ohm', latex_repr=r"\Omega")
 ohm.set_dimension(impedance)
 ohm.set_scale_factor(volt/ampere)
 
@@ -150,16 +150,16 @@ weber.set_scale_factor(joule/ampere)
 
 # Other derived units:
 
-optical_power = dioptre = D = Quantity("dioptre")
+optical_power = dioptre = diopter = D = Quantity("dioptre")
 dioptre.set_dimension(1/length)
 dioptre.set_scale_factor(1/meter)
 
-lux = lx = Quantity("lux")
+lux = lx = Quantity("lux", abbrev="lx")
 lux.set_dimension(luminous_intensity/length**2)
 lux.set_scale_factor(steradian*candela/meter**2)
 
 # katal is the SI unit of catalytic activity
-katal = kat = Quantity("katal")
+katal = kat = Quantity("katal", abbrev="kat")
 katal.set_dimension(amount_of_substance/time)
 katal.set_scale_factor(mol/second)
 
@@ -169,7 +169,7 @@ gray.set_dimension(energy/mass)
 gray.set_scale_factor(meter**2/second**2)
 
 # becquerel is the SI unit of radioactivity
-becquerel = Bq = Quantity("becquerel")
+becquerel = Bq = Quantity("becquerel", abbrev="Bq")
 becquerel.set_dimension(1/time)
 becquerel.set_scale_factor(1/second)
 
@@ -192,11 +192,12 @@ mm = millimeter = millimeters = Quantity("millimeter", abbrev="mm")
 millimeter.set_dimension(length)
 millimeter.set_scale_factor(milli*meter)
 
-um = micrometer = micrometers = micron = microns = Quantity("micrometer", abbrev="um")
+um = micrometer = micrometers = micron = microns = \
+    Quantity("micrometer", abbrev="um", latex_repr=r'\mu\text{m}')
 micrometer.set_dimension(length)
 micrometer.set_scale_factor(micro*meter)
 
-nm = nanometer = nanometers = Quantity("nanometer", abbrev="nn")
+nm = nanometer = nanometers = Quantity("nanometer", abbrev="nm")
 nanometer.set_dimension(length)
 nanometer.set_scale_factor(nano*meter)
 
@@ -251,7 +252,7 @@ ms = millisecond = milliseconds = Quantity("millisecond", abbrev="ms")
 millisecond.set_dimension(time)
 millisecond.set_scale_factor(milli*second)
 
-us = microsecond = microseconds = Quantity("microsecond", abbrev="us")
+us = microsecond = microseconds = Quantity("microsecond", abbrev="us", latex_repr=r'\mu\text{s}')
 microsecond.set_dimension(time)
 microsecond.set_scale_factor(micro*second)
 
@@ -400,12 +401,13 @@ vacuum_permittivity.set_dimension(capacitance/length)
 vacuum_permittivity.set_scale_factor(1/(u0 * c**2))
 
 # vacuum impedance:
-Z0 = vacuum_impedance = Quantity("vacuum_impedance", abbrev='Z_0')
+Z0 = vacuum_impedance = Quantity("vacuum_impedance", abbrev='Z_0', latex_repr=r'Z_{0}')
 vacuum_impedance.set_dimension(impedance)
 vacuum_impedance.set_scale_factor(u0 * c)
 
 # Coulomb's constant:
-coulomb_constant = coulombs_constant = electric_force_constant = Quantity("coulomb_constant", abbrev="k_e")
+coulomb_constant = coulombs_constant = electric_force_constant = \
+    Quantity("coulomb_constant", abbrev="k_e")
 coulomb_constant.set_dimension(force*length**2/charge**2)
 coulomb_constant.set_scale_factor(1/(4*pi*vacuum_permittivity))
 
@@ -457,23 +459,24 @@ astronomical_unit.set_scale_factor(149597870691*meter)
 
 
 # Fundamental Planck units:
-planck_mass = Quantity("planck_mass", abbrev="m_P")
+planck_mass = Quantity("planck_mass", abbrev="m_P", latex_repr=r'm_\text{P}')
 planck_mass.set_dimension(mass)
 planck_mass.set_scale_factor(sqrt(hbar*speed_of_light/G))
 
-planck_time = Quantity("planck_time", abbrev="t_P")
+planck_time = Quantity("planck_time", abbrev="t_P", latex_repr=r't_\text{P}')
 planck_time.set_dimension(time)
 planck_time.set_scale_factor(sqrt(hbar*G/speed_of_light**5))
 
-planck_temperature = Quantity("planck_temperature", abbrev="T_P")
+planck_temperature = Quantity("planck_temperature", abbrev="T_P",
+                              latex_repr=r'T_\text{P}')
 planck_temperature.set_dimension(temperature)
 planck_temperature.set_scale_factor(sqrt(hbar*speed_of_light**5/G/boltzmann**2))
 
-planck_length = Quantity("planck_length", abbrev="l_P")
+planck_length = Quantity("planck_length", abbrev="l_P", latex_repr=r'l_\text{P}')
 planck_length.set_dimension(length)
 planck_length.set_scale_factor(sqrt(hbar*G/speed_of_light**3))
 
-planck_charge = Quantity("planck_charge", abbrev="q_P")
+planck_charge = Quantity("planck_charge", abbrev="q_P", latex_repr=r'q_\text{P}')
 planck_charge.set_dimension(charge)
 planck_charge.set_scale_factor(sqrt(4*pi*electric_constant*hbar*speed_of_light))
 
@@ -491,19 +494,19 @@ planck_momentum = Quantity("planck_momentum")
 planck_momentum.set_dimension(mass*velocity)
 planck_momentum.set_scale_factor(planck_mass * speed_of_light)
 
-planck_energy = Quantity("planck_energy", abbrev="E_P")
+planck_energy = Quantity("planck_energy", abbrev="E_P", latex_repr=r'E_\text{P}')
 planck_energy.set_dimension(energy)
 planck_energy.set_scale_factor(planck_mass * speed_of_light**2)
 
-planck_force = Quantity("planck_force", abbrev="F_P")
+planck_force = Quantity("planck_force", abbrev="F_P", latex_repr=r'F_\text{P}')
 planck_force.set_dimension(force)
 planck_force.set_scale_factor(planck_energy / planck_length)
 
-planck_power = Quantity("planck_power", abbrev="P_P")
+planck_power = Quantity("planck_power", abbrev="P_P", latex_repr=r'P_\text{P}')
 planck_power.set_dimension(power)
 planck_power.set_scale_factor(planck_energy / planck_time)
 
-planck_density = Quantity("planck_density", abbrev="rho_P")
+planck_density = Quantity("planck_density", abbrev="rho_P", latex_repr=r'\rho_\text{P}')
 planck_density.set_dimension(mass/length**3)
 planck_density.set_scale_factor(planck_mass / planck_length**3)
 
@@ -511,31 +514,33 @@ planck_energy_density = Quantity("planck_energy_density", abbrev="rho^E_P")
 planck_energy_density.set_dimension(energy / length**3)
 planck_energy_density.set_scale_factor(planck_energy / planck_length**3)
 
-planck_intensity = Quantity("planck_intensity", abbrev="I_P")
+planck_intensity = Quantity("planck_intensity", abbrev="I_P", latex_repr=r'I_\text{P}')
 planck_intensity.set_dimension(mass * time**(-3))
 planck_intensity.set_scale_factor(planck_energy_density * speed_of_light)
 
-planck_angular_frequency = Quantity("planck_angular_frequency", abbrev="omega_P")
+planck_angular_frequency = Quantity("planck_angular_frequency", abbrev="omega_P",
+                                    latex_repr=r'\omega_\text{P}')
 planck_angular_frequency.set_dimension(1 / time)
 planck_angular_frequency.set_scale_factor(1 / planck_time)
 
-planck_pressure = Quantity("planck_pressure", abbrev="p_P")
+planck_pressure = Quantity("planck_pressure", abbrev="p_P", latex_repr=r'p_\text{P}')
 planck_pressure.set_dimension(pressure)
 planck_pressure.set_scale_factor(planck_force / planck_length**2)
 
-planck_current = Quantity("planck_current", abbrev="I_P")
+planck_current = Quantity("planck_current", abbrev="I_P", latex_repr=r'I_\text{P}')
 planck_current.set_dimension(current)
 planck_current.set_scale_factor(planck_charge / planck_time)
 
-planck_voltage = Quantity("planck_voltage", abbrev="V_P")
+planck_voltage = Quantity("planck_voltage", abbrev="V_P", latex_repr=r'V_\text{P}')
 planck_voltage.set_dimension(voltage)
 planck_voltage.set_scale_factor(planck_energy / planck_charge)
 
-planck_impedance = Quantity("planck_impedance", abbrev="Z_P")
+planck_impedance = Quantity("planck_impedance", abbrev="Z_P", latex_repr=r'Z_\text{P}')
 planck_impedance.set_dimension(impedance)
 planck_impedance.set_scale_factor(planck_voltage / planck_current)
 
-planck_acceleration = Quantity("planck_acceleration", abbrev="a_P")
+planck_acceleration = Quantity("planck_acceleration", abbrev="a_P",
+                               latex_repr=r'a_\text{P}')
 planck_acceleration.set_dimension(acceleration)
 planck_acceleration.set_scale_factor(speed_of_light / planck_time)
 
@@ -573,6 +578,14 @@ exbibyte = exbibytes = Quantity("exbibyte")
 exbibyte.set_dimension(information)
 exbibyte.set_scale_factor(exbi*byte)
 
+# Older units for radioactivity
+curie = Ci = Quantity("curie", abbrev="Ci")
+curie.set_dimension(1/time)
+curie.set_scale_factor(37000000000*becquerel)
+
+rutherford = Rd = Quantity("rutherford", abbrev="Rd")
+rutherford.set_dimension(1/time)
+rutherford.set_scale_factor(1000000*becquerel)
 
 # check that scale factors are the right SI dimensions:
 for _scale_factor, _dimension in zip(

--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -16,7 +16,7 @@ One = S.One
 
 # Dimensionless:
 
-percent = percents = Quantity("percent", latex_repr="\%")
+percent = percents = Quantity("percent", latex_repr=r"\%")
 percent.set_dimension(One)
 percent.set_scale_factor(Rational(1, 100))
 

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -26,7 +26,10 @@ class Quantity(AtomicExpr):
     is_nonzero = True
     _diff_wrt = True
 
-    def __new__(cls, name, abbrev=None, dimension=None, scale_factor=None, **assumptions):
+    def __new__(cls, name, abbrev=None, dimension=None, scale_factor=None,
+                latex_repr=None, pretty_unicode_repr=None,
+                pretty_ascii_repr=None, mathml_presentation_repr=None,
+                **assumptions):
 
         if not isinstance(name, Symbol):
             name = Symbol(name)
@@ -61,6 +64,10 @@ class Quantity(AtomicExpr):
         obj = AtomicExpr.__new__(cls, name, abbrev)
         obj._name = name
         obj._abbrev = abbrev
+        obj._latex_repr = latex_repr
+        obj._unicode_repr = pretty_unicode_repr
+        obj._ascii_repr = pretty_ascii_repr
+        obj._mathml_repr = mathml_presentation_repr
 
         if dimension is not None:
             # TODO: remove after deprecation:
@@ -222,6 +229,13 @@ class Quantity(AtomicExpr):
             return 1, expr
         else:
             return expr, Dimension(1)
+
+    def _latex(self, printer):
+        if self._latex_repr:
+            return self._latex_repr
+        else:
+            return r'\text{{{}}}'.format(self.args[1] \
+                          if len(self.args) >= 2 else self.args[0])
 
     def convert_to(self, other):
         """

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -36,7 +36,7 @@ from sympy.functions.combinatorial.numbers import bernoulli, bell, lucas, \
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
-from sympy.physics.units import degree, radian, kg, meter, gibibyte
+from sympy.physics.units import degree, radian, kg, meter, gibibyte, microgram, second
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -2178,5 +2178,6 @@ def test_DiffGeomMethods():
 
 
 def test_unit_ptinting():
-    assert latex(5*meter) == '5 \\text{ m}'
-    assert latex(3*gibibyte) == '3 \\text{ gibibyte}'
+    assert latex(5*meter) == r'5 \text{m}'
+    assert latex(3*gibibyte) == r'3 \text{gibibyte}'
+    assert latex(4*microgram/second) == r'\frac{4 \mu\text{g}}{\text{s}}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -36,7 +36,7 @@ from sympy.functions.combinatorial.numbers import bernoulli, bell, lucas, \
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
-from sympy.physics.units import degree, radian, kg, meter
+from sympy.physics.units import degree, radian, kg, meter, gibibyte
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -2175,3 +2175,8 @@ def test_DiffGeomMethods():
     s_field = g(R2.x, R2.y)
     assert latex(Differential(s_field)) == \
         r'\operatorname{d}\left(g{\left(\mathbf{x},\mathbf{y} \right)}\right)'
+
+
+def test_unit_ptinting():
+    assert latex(5*meter) == '5 \\text{ m}'
+    assert latex(3*gibibyte) == '3 \\text{ gibibyte}'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Relates to #16060 (while not closing it completely, at least enough for 1.4)

#### Brief description of what is fixed or changed
The LaTeX printing of units is improved. Primarily, all units are now printed within `\text{}` making them non-italic (and with better kerning).

In addition, an initial implementation of special printing of some units (and constant) have been implemented such that it is possible to provide a specific LaTeX string. One example is microgram which earlier printed as `ug` and now as `\mu text{g}`.

Still to fix is to print the units separately in case of a rational expression. This will also allow to introduce a space in the correct position between the number and the unit.

Also, similar support for other printers can be added (pretty, presentation MathML, ...)

#### Other comments
In addition, some abbreviations were introduced/corrected, the American English spelling of dioptre (diopter) was added, and two older units for radioactivity was added (Curie and Rutherford).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Units are printed in a slightly better format in the LaTeX printer
<!-- END RELEASE NOTES -->
