### PR TITLE
Added ROT13 and Atbash to sympy.crypto

### DIFF
--- a/doc/src/modules/crypto.rst
+++ b/doc/src/modules/crypto.rst
@@ -50,9 +50,17 @@ substitutions at different times in the message.
 
 .. autofunction:: decipher_shift
 
+.. autofunction:: encipher_rot13
+
+.. autofunction:: decipher_rot13
+
 .. autofunction:: encipher_affine
 
 .. autofunction:: decipher_affine
+
+.. autofunction:: encipher_atbash
+
+.. autofunction:: decipher_atbash
 
 .. autofunction:: encipher_substitution
 

--- a/sympy/crypto/__init__.py
+++ b/sympy/crypto/__init__.py
@@ -12,4 +12,4 @@ from sympy.crypto.crypto import (cycle_list,
         padded_key, encipher_bifid, decipher_bifid, bifid_square, bifid5,
         bifid6, bifid10, decipher_gm, encipher_gm, gm_public_key,
         gm_private_key, bg_private_key, bg_public_key, encipher_bg, decipher_bg,
-		encipher_rot13, decipher_rot13, encipher_atbash, decipher_atbash)
+        encipher_rot13, decipher_rot13, encipher_atbash, decipher_atbash)

--- a/sympy/crypto/__init__.py
+++ b/sympy/crypto/__init__.py
@@ -11,4 +11,5 @@ from sympy.crypto.crypto import (cycle_list,
         encipher_elgamal, dh_private_key, dh_public_key, dh_shared_key,
         padded_key, encipher_bifid, decipher_bifid, bifid_square, bifid5,
         bifid6, bifid10, decipher_gm, encipher_gm, gm_public_key,
-        gm_private_key, bg_private_key, bg_public_key, encipher_bg, decipher_bg)
+        gm_private_key, bg_private_key, bg_public_key, encipher_bg, decipher_bg,
+		encipher_rot13, decipher_rot13, encipher_atbash, decipher_atbash)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -260,53 +260,53 @@ def decipher_shift(msg, key, symbols=None):
     return encipher_shift(msg, -key, symbols)
 
 def encipher_rot13(msg, symbols=None):
-	"""
-	Performs the ROT13 encryption on a given plaintext ```msg```.
-	
-	Notes
-	=====
-	
-	ROT13 is a substitution cipher which substitutes each letter
-	in the plaintext message for the letter furthest away from it
-	in the English alphabet.
-	
-	Equivalently, it is just a Caeser (shift) cipher with a shift
-	key of 13 (midway point of the alphabet).
-	
-	See Also
-	========
-	decipher_rot13
-	"""
-	return encipher_shift(msg, 13, symbols)
+    """
+    Performs the ROT13 encryption on a given plaintext ```msg```.
+    
+    Notes
+    =====
+    
+    ROT13 is a substitution cipher which substitutes each letter
+    in the plaintext message for the letter furthest away from it
+    in the English alphabet.
+    
+    Equivalently, it is just a Caeser (shift) cipher with a shift
+    key of 13 (midway point of the alphabet).
+    
+    See Also
+    ========
+    decipher_rot13
+    """
+    return encipher_shift(msg, 13, symbols)
 
 def decipher_rot13(msg, symbols=None):
-	"""
-	Performs the ROT13 decryption on a given plaintext ```msg```.
-	
-	Notes
-	=====
-	
-	```decipher_rot13``` is equivalent to ```encipher_rot13``` as both
-	```decipher_shift``` with a key of 13 and ```encipher_shift``` key with a
-	key of 13 will return the same results. Nonetheless,
-	```decipher_rot13``` has nonetheless been explicitly defined here for
-	consistency.
-	
-	Examples
-	========
-	
-	>>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
-	>>> msg = 'GONAVYBEATARMY'
-	>>> ciphertext = encipher_rot13(msg);ciphertext
-	'TBANILORNGNEZL'
-	>>> decipher_rot13(ciphertext)
-	'GONAVYBEATARMY'
-	>>> encipher_rot13(msg) == decipher_rot13(msg)
-	True
-	>>> msg == decipher_rot13(ciphertext)
-	True
-	"""
-	return decipher_shift(msg, 13, symbols)
+    """
+    Performs the ROT13 decryption on a given plaintext ```msg```.
+    
+    Notes
+    =====
+    
+    ```decipher_rot13``` is equivalent to ```encipher_rot13``` as both
+    ```decipher_shift``` with a key of 13 and ```encipher_shift``` key with a
+    key of 13 will return the same results. Nonetheless,
+    ```decipher_rot13``` has nonetheless been explicitly defined here for
+    consistency.
+    
+    Examples
+    ========
+    
+    >>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
+    >>> msg = 'GONAVYBEATARMY'
+    >>> ciphertext = encipher_rot13(msg);ciphertext
+    'TBANILORNGNEZL'
+    >>> decipher_rot13(ciphertext)
+    'GONAVYBEATARMY'
+    >>> encipher_rot13(msg) == decipher_rot13(msg)
+    True
+    >>> msg == decipher_rot13(ciphertext)
+    True
+    """
+    return decipher_shift(msg, 13, symbols)
 
 ######## affine cipher examples ############
 
@@ -398,48 +398,48 @@ def decipher_affine(msg, key, symbols=None):
     return encipher_affine(msg, key, symbols, _inverse=True)
 	
 def encipher_atbash(msg, symbols=None):
-	r"""
-	Enciphers a given ```msg``` into its Atbash ciphertext and returns it.
-	
-	Notes
-	=====
-	Atbash is a substitution cipher originally used to encrypt the Hebrew 
-	alphabet. Atbash works on the principle of mapping each alphabet to its
-	reverse / counterpart (i.e. a would map to z, b to y etc.)
-	
-	Atbash is functionally equivalent to the affine cipher with ```a = 25```
-	and ```b = 25```
-	
-	See Also
-	========
-	decipher_atbash
-	"""
-	return encipher_affine(msg, (25,25), symbols)
+    r"""
+    Enciphers a given ```msg``` into its Atbash ciphertext and returns it.
+    
+    Notes
+    =====
+    Atbash is a substitution cipher originally used to encrypt the Hebrew 
+    alphabet. Atbash works on the principle of mapping each alphabet to its
+    reverse / counterpart (i.e. a would map to z, b to y etc.)
+    
+    Atbash is functionally equivalent to the affine cipher with ```a = 25```
+    and ```b = 25```
+    
+    See Also
+    ========
+    decipher_atbash
+    """
+    return encipher_affine(msg, (25,25), symbols)
 	
 def decipher_atbash(msg, symbols=None):
-	r"""
-	Deciphers a given ```msg``` using Atbash cipher and returns it.
-	
-	Notes
-	=====
-	```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
-	However, it has still been added as a separate function to maintain
-	consistency.
-	
-	Examples
-	========
-	>>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash
-	>>> msg = 'GONAVYBEATARMY'
-	>>> encipher_atbash(msg)
-	'TLMZEBYVZGZINB'
-	>>> decipher_atbash(msg)
-	'TLMZEBYVZGZINB'
-	>>> encipher_atbash(msg) == decipher_atbash(msg)
-	True
-	>>> msg == encipher_atbash(encipher_atbash(msg))
-	True
-	"""
-	return decipher_affine(msg, (25,25), symbols)
+    r"""
+    Deciphers a given ```msg``` using Atbash cipher and returns it.
+    
+    Notes
+    =====
+    ```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
+    However, it has still been added as a separate function to maintain
+    consistency.
+    
+    Examples
+    ========
+    >>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash
+    >>> msg = 'GONAVYBEATARMY'
+    >>> encipher_atbash(msg)
+    'TLMZEBYVZGZINB'
+    >>> decipher_atbash(msg)
+    'TLMZEBYVZGZINB'
+    >>> encipher_atbash(msg) == decipher_atbash(msg)
+    True
+    >>> msg == encipher_atbash(encipher_atbash(msg))
+    True
+    """
+    return decipher_affine(msg, (25,25), symbols)
 
 #################### substitution cipher ###########################
 

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -275,6 +275,7 @@ def encipher_rot13(msg, symbols=None):
 
     See Also
     ========
+	
     decipher_rot13
     """
     return encipher_shift(msg, 13, symbols)
@@ -403,6 +404,7 @@ def encipher_atbash(msg, symbols=None):
 
     Notes
     =====
+	
     Atbash is a substitution cipher originally used to encrypt the Hebrew
     alphabet. Atbash works on the principle of mapping each alphabet to its
     reverse / counterpart (i.e. a would map to z, b to y etc.)
@@ -412,6 +414,7 @@ def encipher_atbash(msg, symbols=None):
 
     See Also
     ========
+	
     decipher_atbash
     """
     return encipher_affine(msg, (25,25), symbols)
@@ -422,12 +425,14 @@ def decipher_atbash(msg, symbols=None):
 
     Notes
     =====
+	
     ```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
     However, it has still been added as a separate function to maintain
     consistency.
 
     Examples
     ========
+	
     >>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash
     >>> msg = 'GONAVYBEATARMY'
     >>> encipher_atbash(msg)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -286,13 +286,15 @@ def decipher_rot13(msg, symbols=None):
 	Notes
 	=====
 	
-	decipher_rot13 is equivalent to encipher_rot13 as both
-	decipher_shift with a key of 13 and encipher key with a
+	```decipher_rot13``` is equivalent to ```encipher_rot13``` as both
+	```decipher_shift``` with a key of 13 and ```encipher_shift``` key with a
 	key of 13 will return the same results. Nonetheless,
-	decipher_rot13 has been explicitly defined here for ease of use.
+	```decipher_rot13``` has nonetheless been explicitly defined here for
+	consistency.
 	
 	Examples
 	========
+	
 	>>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
 	>>> msg = 'GONAVYBEATARMY'
 	>>> ciphertext = encipher_rot13(msg);ciphertext
@@ -420,8 +422,9 @@ def decipher_atbash(msg, symbols=None):
 	
 	Notes
 	=====
-	decipher_atbash is functionally equivalent to encipher_atbash.
-	However, it has still been added as a separate to avoid inconsistency
+	```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
+	However, it has still been added as a separate function to maintain
+	consistency.
 	
 	Examples
 	========

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -262,17 +262,17 @@ def decipher_shift(msg, key, symbols=None):
 def encipher_rot13(msg, symbols=None):
     """
     Performs the ROT13 encryption on a given plaintext ```msg```.
-    
+
     Notes
     =====
-    
+
     ROT13 is a substitution cipher which substitutes each letter
     in the plaintext message for the letter furthest away from it
     in the English alphabet.
-    
+
     Equivalently, it is just a Caeser (shift) cipher with a shift
     key of 13 (midway point of the alphabet).
-    
+
     See Also
     ========
     decipher_rot13
@@ -282,19 +282,19 @@ def encipher_rot13(msg, symbols=None):
 def decipher_rot13(msg, symbols=None):
     """
     Performs the ROT13 decryption on a given plaintext ```msg```.
-    
+
     Notes
     =====
-    
+
     ```decipher_rot13``` is equivalent to ```encipher_rot13``` as both
     ```decipher_shift``` with a key of 13 and ```encipher_shift``` key with a
     key of 13 will return the same results. Nonetheless,
     ```decipher_rot13``` has nonetheless been explicitly defined here for
     consistency.
-    
+
     Examples
     ========
-    
+
     >>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
     >>> msg = 'GONAVYBEATARMY'
     >>> ciphertext = encipher_rot13(msg);ciphertext
@@ -396,36 +396,36 @@ def decipher_affine(msg, key, symbols=None):
 
     """
     return encipher_affine(msg, key, symbols, _inverse=True)
-	
+
 def encipher_atbash(msg, symbols=None):
     r"""
     Enciphers a given ```msg``` into its Atbash ciphertext and returns it.
-    
+
     Notes
     =====
-    Atbash is a substitution cipher originally used to encrypt the Hebrew 
+    Atbash is a substitution cipher originally used to encrypt the Hebrew
     alphabet. Atbash works on the principle of mapping each alphabet to its
     reverse / counterpart (i.e. a would map to z, b to y etc.)
-    
+
     Atbash is functionally equivalent to the affine cipher with ```a = 25```
     and ```b = 25```
-    
+
     See Also
     ========
     decipher_atbash
     """
     return encipher_affine(msg, (25,25), symbols)
-	
+
 def decipher_atbash(msg, symbols=None):
     r"""
     Deciphers a given ```msg``` using Atbash cipher and returns it.
-    
+
     Notes
     =====
     ```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
     However, it has still been added as a separate function to maintain
     consistency.
-    
+
     Examples
     ========
     >>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -275,7 +275,7 @@ def encipher_rot13(msg, symbols=None):
 
     See Also
     ========
-	
+
     decipher_rot13
     """
     return encipher_shift(msg, 13, symbols)
@@ -404,7 +404,7 @@ def encipher_atbash(msg, symbols=None):
 
     Notes
     =====
-	
+
     Atbash is a substitution cipher originally used to encrypt the Hebrew
     alphabet. Atbash works on the principle of mapping each alphabet to its
     reverse / counterpart (i.e. a would map to z, b to y etc.)
@@ -414,7 +414,7 @@ def encipher_atbash(msg, symbols=None):
 
     See Also
     ========
-	
+
     decipher_atbash
     """
     return encipher_affine(msg, (25,25), symbols)
@@ -425,14 +425,14 @@ def decipher_atbash(msg, symbols=None):
 
     Notes
     =====
-	
+
     ```decipher_atbash``` is functionally equivalent to ```encipher_atbash```.
     However, it has still been added as a separate function to maintain
     consistency.
 
     Examples
     ========
-	
+
     >>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash
     >>> msg = 'GONAVYBEATARMY'
     >>> encipher_atbash(msg)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -261,7 +261,7 @@ def decipher_shift(msg, key, symbols=None):
 
 def encipher_rot13(msg, symbols=None):
 	"""
-	Performs the ROT13 encryption on a given plaintext msg.
+	Performs the ROT13 encryption on a given plaintext ```msg```.
 	
 	Notes
 	=====
@@ -272,12 +272,16 @@ def encipher_rot13(msg, symbols=None):
 	
 	Equivalently, it is just a Caeser (shift) cipher with a shift
 	key of 13 (midway point of the alphabet).
+	
+	See Also
+	========
+	decipher_rot13
 	"""
 	return encipher_shift(msg, 13, symbols)
 
 def decipher_rot13(msg, symbols=None):
 	"""
-	Performs the ROT13 decryption on a given plaintext msg.
+	Performs the ROT13 decryption on a given plaintext ```msg```.
 	
 	Notes
 	=====
@@ -288,7 +292,7 @@ def decipher_rot13(msg, symbols=None):
 	decipher_rot13 has been explicitly defined here for ease of use.
 	
 	Examples
-	=========
+	========
 	>>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
 	>>> msg = 'GONAVYBEATARMY'
 	>>> ciphertext = encipher_rot13(msg);ciphertext
@@ -390,7 +394,49 @@ def decipher_affine(msg, key, symbols=None):
 
     """
     return encipher_affine(msg, key, symbols, _inverse=True)
-
+	
+def encipher_atbash(msg, symbols=None):
+	r"""
+	Enciphers a given ```msg``` into its Atbash ciphertext and returns it.
+	
+	Notes
+	=====
+	Atbash is a substitution cipher originally used to encrypt the Hebrew 
+	alphabet. Atbash works on the principle of mapping each alphabet to its
+	reverse / counterpart (i.e. a would map to z, b to y etc.)
+	
+	Atbash is functionally equivalent to the affine cipher with ```a = 25```
+	and ```b = 25```
+	
+	See Also
+	========
+	decipher_atbash
+	"""
+	return encipher_affine(msg, (25,25), symbols)
+	
+def decipher_atbash(msg, symbols=None):
+	r"""
+	Deciphers a given ```msg``` using Atbash cipher and returns it.
+	
+	Notes
+	=====
+	decipher_atbash is functionally equivalent to encipher_atbash.
+	However, it has still been added as a separate to avoid inconsistency
+	
+	Examples
+	========
+	>>> from sympy.crypto.crypto import encipher_atbash, decipher_atbash
+	>>> msg = 'GONAVYBEATARMY'
+	>>> encipher_atbash(msg)
+	'TLMZEBYVZGZINB'
+	>>> decipher_atbash(msg)
+	'TLMZEBYVZGZINB'
+	>>> encipher_atbash(msg) == decipher_atbash(msg)
+	True
+	>>> msg == encipher_atbash(encipher_atbash(msg))
+	True
+	"""
+	return decipher_affine(msg, (25,25), symbols)
 
 #################### substitution cipher ###########################
 

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -259,6 +259,48 @@ def decipher_shift(msg, key, symbols=None):
     """
     return encipher_shift(msg, -key, symbols)
 
+def encipher_rot13(msg, symbols=None):
+	"""
+	Performs the ROT13 encryption on a given plaintext msg.
+	
+	Notes
+	=====
+	
+	ROT13 is a substitution cipher which substitutes each letter
+	in the plaintext message for the letter furthest away from it
+	in the English alphabet.
+	
+	Equivalently, it is just a Caeser (shift) cipher with a shift
+	key of 13 (midway point of the alphabet).
+	"""
+	return encipher_shift(msg, 13, symbols)
+
+def decipher_rot13(msg, symbols=None):
+	"""
+	Performs the ROT13 decryption on a given plaintext msg.
+	
+	Notes
+	=====
+	
+	decipher_rot13 is equivalent to encipher_rot13 as both
+	decipher_shift with a key of 13 and encipher key with a
+	key of 13 will return the same results. Nonetheless,
+	decipher_rot13 has been explicitly defined here for ease of use.
+	
+	Examples
+	=========
+	>>> from sympy.crypto.crypto import encipher_rot13, decipher_rot13
+	>>> msg = 'GONAVYBEATARMY'
+	>>> ciphertext = encipher_rot13(msg);ciphertext
+	'TBANILORNGNEZL'
+	>>> decipher_rot13(ciphertext)
+	'GONAVYBEATARMY'
+	>>> encipher_rot13(msg) == decipher_rot13(msg)
+	True
+	>>> msg == decipher_rot13(ciphertext)
+	True
+	"""
+	return decipher_shift(msg, 13, symbols)
 
 ######## affine cipher examples ############
 

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -14,7 +14,8 @@ from sympy.crypto.crypto import (cycle_list,
       dh_shared_key, decipher_shift, decipher_affine, encipher_bifid,
       decipher_bifid, bifid_square, padded_key, uniq, decipher_gm,
       encipher_gm, gm_public_key, gm_private_key, encipher_bg, decipher_bg,
-      bg_private_key, bg_public_key)
+      bg_private_key, bg_public_key, encipher_rot13, decipher_rot13, 
+	  encipher_atbash, decipher_atbash)
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, is_primitive_root
 from sympy.polys.domains import FF
@@ -36,6 +37,12 @@ def test_encipher_shift():
     assert encipher_shift("ABC", 1) == "BCD"
     assert encipher_shift("ABC", -1) == "ZAB"
     assert decipher_shift("ZAB", -1) == "ABC"
+	
+def test_encipher_rot13():
+	assert encipher_rot13("ABC") == "NOP"
+	assert encipher_rot13("NOP") == "ABC"
+	assert decipher_rot13("ABC") == "NOP"
+	assert decipher_rot13("NOP") == "ABC"
 
 
 def test_encipher_affine():
@@ -47,6 +54,11 @@ def test_encipher_affine():
     assert encipher_affine("ABC", (3, 16)) == "QTW"
     assert decipher_affine("QTW", (3, 16)) == "ABC"
 
+def test_encipher_atbash():
+	assert encipher_atbash("ABC") == "ZYX"
+	assert encipher_atbash("ZYX") == "ABC"
+	assert decipher_atbash("ABC") == "ZYX"
+	assert decipher_atbash("ZYX") == "ABC"
 
 def test_encipher_substitution():
     assert encipher_substitution("ABC", "BAC", "ABC") == "BAC"

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -14,8 +14,8 @@ from sympy.crypto.crypto import (cycle_list,
       dh_shared_key, decipher_shift, decipher_affine, encipher_bifid,
       decipher_bifid, bifid_square, padded_key, uniq, decipher_gm,
       encipher_gm, gm_public_key, gm_private_key, encipher_bg, decipher_bg,
-      bg_private_key, bg_public_key, encipher_rot13, decipher_rot13, 
-	  encipher_atbash, decipher_atbash)
+      bg_private_key, bg_public_key, encipher_rot13, decipher_rot13,
+      encipher_atbash, decipher_atbash)
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, is_primitive_root
 from sympy.polys.domains import FF
@@ -37,12 +37,12 @@ def test_encipher_shift():
     assert encipher_shift("ABC", 1) == "BCD"
     assert encipher_shift("ABC", -1) == "ZAB"
     assert decipher_shift("ZAB", -1) == "ABC"
-	
+
 def test_encipher_rot13():
-	assert encipher_rot13("ABC") == "NOP"
-	assert encipher_rot13("NOP") == "ABC"
-	assert decipher_rot13("ABC") == "NOP"
-	assert decipher_rot13("NOP") == "ABC"
+    assert encipher_rot13("ABC") == "NOP"
+    assert encipher_rot13("NOP") == "ABC"
+    assert decipher_rot13("ABC") == "NOP"
+    assert decipher_rot13("NOP") == "ABC"
 
 
 def test_encipher_affine():
@@ -55,10 +55,10 @@ def test_encipher_affine():
     assert decipher_affine("QTW", (3, 16)) == "ABC"
 
 def test_encipher_atbash():
-	assert encipher_atbash("ABC") == "ZYX"
-	assert encipher_atbash("ZYX") == "ABC"
-	assert decipher_atbash("ABC") == "ZYX"
-	assert decipher_atbash("ZYX") == "ABC"
+    assert encipher_atbash("ABC") == "ZYX"
+    assert encipher_atbash("ZYX") == "ABC"
+    assert decipher_atbash("ABC") == "ZYX"
+    assert decipher_atbash("ZYX") == "ABC"
 
 def test_encipher_substitution():
     assert encipher_substitution("ABC", "BAC", "ABC") == "BAC"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16495 

#### Brief description of what is fixed or changed
- Added ```encipher_rot13``` , ```decipher_rot13```
- Added ```encipher_atbash```, ```decipher_atbash```
- Updated tests and documentation for both.

#### Other comments
- Both encipher and decipher do the same thing, in theory. However I made them different functions because they are intended for different uses even though they are functionally equivalent, and would also maintain code quality and prevent ambiguity in future.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* crypto
  * added ```rot13``` and ```atbash``` ciphers
<!-- END RELEASE NOTES -->
