### PR TITLE
Added methods to __all__ list in __init__.py for some modules

### DIFF
--- a/sympy/concrete/__init__.py
+++ b/sympy/concrete/__init__.py
@@ -1,2 +1,8 @@
 from .products import product, Product
 from .summations import summation, Sum
+
+__all__ = [
+'product', 'Product',
+
+'summation', 'Sum',
+]

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -14,9 +14,9 @@ from .power import Pow, integer_nthroot, integer_log
 from .mul import Mul, prod
 from .add import Add
 from .mod import Mod
-from .relational import ( Rel, Eq, Ne, Lt, Le, Gt, Ge,
+from .relational import (Rel, Eq, Ne, Lt, Le, Gt, Ge,
     Equality, GreaterThan, LessThan, Unequality, StrictGreaterThan,
-    StrictLessThan )
+    StrictLessThan)
 from .multidimensional import vectorize
 from .function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \
@@ -33,3 +33,54 @@ Catalan = S.Catalan
 EulerGamma = S.EulerGamma
 GoldenRatio = S.GoldenRatio
 TribonacciConstant = S.TribonacciConstant
+
+__all__ = [
+'sympify', 'SympifyError',
+
+'cacheit',
+
+'Basic', 'Atom', 'preorder_traversal',
+
+'S',
+
+'Expr', 'AtomicExpr', 'UnevaluatedExpr',
+
+'Symbol', 'Wild', 'Dummy', 'symbols', 'var',
+
+'Number', 'Float', 'Rational', 'Integer', 'NumberSymbol',
+'RealNumber', 'igcd', 'ilcm', 'seterr', 'E', 'I', 'nan', 'oo', 'pi', 'zoo',
+'AlgebraicNumber', 'comp', 'mod_inverse',
+
+'Pow', 'integer_nthroot', 'integer_log',
+
+'Mul', 'prod',
+
+'Add',
+
+'Mod',
+
+'Rel', 'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge',
+'Equality', 'GreaterThan', 'LessThan', 'Unequality', 'StrictGreaterThan',
+'StrictLessThan',
+
+'vectorize',
+
+'Lambda', 'WildFunction', 'Derivative', 'diff', 'FunctionClass',
+'Function', 'Subs', 'expand', 'PoleError', 'count_ops',
+'expand_mul', 'expand_log', 'expand_func',
+'expand_trig', 'expand_complex', 'expand_multinomial', 'nfloat',
+'expand_power_base', 'expand_power_exp', 'arity',
+
+'evalf', 'PrecisionExhausted', 'N',
+
+'Tuple', 'Dict',
+
+'gcd_terms', 'factor_terms', 'factor_nc',
+
+'evaluate',
+
+'Catalan',
+'EulerGamma',
+'GoldenRatio',
+'TribonacciConstant',
+]

--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -11,3 +11,10 @@ Convolutions - ``convolution``, ``convolution_fft``, ``convolution_ntt``,
 from .transforms import (fft, ifft, ntt, intt, fwht, ifwht,
     mobius_transform, inverse_mobius_transform)
 from .convolutions import convolution, covering_product, intersecting_product
+
+__all__ = [
+'fft', 'ifft', 'ntt', 'intt', 'fwht', 'ifwht',
+'mobius_transform', 'inverse_mobius_transform',
+
+'convolution', 'covering_product', 'intersecting_product',
+]

--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,3 +1,10 @@
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
     Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false)
 from .inference import satisfiable
+
+__all__ = [
+'to_cnf', 'to_dnf', 'to_nnf', 'And', 'Or', 'Not', 'Xor', 'Nand', 'Nor', 'Implies',
+'Equivalent', 'ITE', 'POSform', 'SOPform', 'simplify_logic', 'bool_map', 'true', 'false',
+
+'satisfiable',
+]

--- a/sympy/parsing/__init__.py
+++ b/sympy/parsing/__init__.py
@@ -1,1 +1,2 @@
 """Used for translating a string into a SymPy expression. """
+__all__ = []

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,6 +1,6 @@
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference)
-from .fancysets import ImageSet, Range, ComplexRegion, Reals
+from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet
 from .ordinals import Ordinal, OmegaPower, ord0
@@ -11,3 +11,26 @@ Naturals0 = S.Naturals0
 UniversalSet = S.UniversalSet
 Integers = S.Integers
 del S
+
+__all__ = [
+'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
+'Intersection', 'imageset', 'Complement', 'SymmetricDifference',
+
+'ImageSet', 'Range', 'ComplexRegion',
+
+'Contains',
+
+'ConditionSet',
+
+'Ordinal', 'OmegaPower', 'ord0',
+
+'Reals',
+
+'Naturals',
+
+'Naturals0',
+
+'UniversalSet',
+
+'Integers',
+]

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -31,3 +31,33 @@ from .combsimp import combsimp
 from .gammasimp import gammasimp
 
 from .ratsimp import ratsimp, ratsimpmodprime
+
+__all__ = [
+'simplify', 'hypersimp', 'hypersimilar',
+'logcombine', 'separatevars', 'posify', 'besselsimp',
+'signsimp', 'bottom_up', 'nsimplify',
+
+'FU', 'fu',
+
+'sqrtdenest',
+
+'cse',
+
+'use',
+
+'epath', 'EPath',
+
+'hyperexpand',
+
+'collect', 'rcollect', 'radsimp', 'collect_const', 'fraction', 'numer', 'denom',
+
+'trigsimp', 'exptrigsimp',
+
+'powsimp', 'powdenest',
+
+'combsimp',
+
+'gammasimp',
+
+'ratsimp', 'ratsimpmodprime',
+]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Improved the import structure by adding `__all__` lists to the `__init__.py` files for some classes. This is something that LGTM complains about and one could also see it as a bit of a deficiency that not all modules have this.

#### Other comments
I expect that some tests may fail as I've realized that imports are not always straightforward...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
