### PR TITLE
AssocOp.flatten reverses the operands

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -123,7 +123,7 @@ class AssocOp(Basic):
         # apply associativity, no commutativity property is used
         new_seq = []
         while seq:
-            o = seq.pop()
+            o = seq.pop(0)
             if o.__class__ is cls:  # classes must match exactly
                 seq.extend(o.args)
             else:

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -125,7 +125,7 @@ class AssocOp(Basic):
         while seq:
             o = seq.pop(0)
             if o.__class__ is cls:  # classes must match exactly
-                seq.extend(o.args)
+                seq = list(o.args) + seq
             else:
                 new_seq.append(o)
         # c_part, nc_part, order_symbols

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -123,11 +123,13 @@ class AssocOp(Basic):
         # apply associativity, no commutativity property is used
         new_seq = []
         while seq:
-            o = seq.pop(0)
+            o = seq.pop()
             if o.__class__ is cls:  # classes must match exactly
-                seq = list(o.args) + seq
+                seq.extend(o.args)
             else:
                 new_seq.append(o)
+        new_seq.reverse()
+
         # c_part, nc_part, order_symbols
         return [], new_seq, None
 

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -1,5 +1,5 @@
 from sympy import Integer, S, symbols, Mul
-from sympy.core.operations import LatticeOp
+from sympy.core.operations import AssocOp, LatticeOp
 from sympy.utilities.pytest import raises
 from sympy.core.sympify import SympifyError
 from sympy.core.add import Add
@@ -46,3 +46,12 @@ def test_issue_14025():
     assert Mul(a, b, c).has(c*b) == False
     assert Mul(a, b, c).has(b*c) == True
     assert Mul(a, b, c, d).has(b*c*d) == True
+
+
+def test_AssocOp_flatten():
+    a, b, c, d = symbols('a,b,c,d')
+
+    class MyAssoc(AssocOp):
+        identity = S(1)
+
+    assert MyAssoc(a, b, c).args == (a, b, c)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -58,4 +58,9 @@ def test_AssocOp_flatten():
         MyAssoc(MyAssoc(a, b), c).args == \
         MyAssoc(MyAssoc(a, b, c)).args == \
         MyAssoc(a, b, c).args == \
-        (a, b, c)
+            (a, b, c)
+    u = MyAssoc(b, c)
+    v = MyAssoc(u, d, evaluate=False)
+    assert v.args == (u, d)
+    # like Add, any unevaluated outer call will flatten inner args
+    assert MyAssoc(a, v).args == (a, b, c, d)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -54,4 +54,8 @@ def test_AssocOp_flatten():
     class MyAssoc(AssocOp):
         identity = S(1)
 
-    assert MyAssoc(a, b, c).args == (a, b, c)
+    assert MyAssoc(a, MyAssoc(b, c)).args == \
+        MyAssoc(MyAssoc(a, b), c).args == \
+        MyAssoc(MyAssoc(a, b, c)).args == \
+        MyAssoc(a, b, c).args == \
+        (a, b, c)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I found this while experimenting with custom operator

```
from sympy import *
from sympy.core.operations import AssocOp

x, y, z = symbols('x y z')

class MyAssoc(AssocOp):
    identity = S(1)

MyAssoc(x, y, z).args
```

Because of this line, it reverses even if it is not commutative

https://github.com/sympy/sympy/blob/fb98dbb5a50dc13489b365ea6558e1efc5e62377/sympy/core/operations.py#L126

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed `AssocOp` reversing the order of operands
<!-- END RELEASE NOTES -->
