### PR TITLE
Breaking up the Rational Factors

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -9,7 +9,7 @@ from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal
 from sympy.core.expr import Expr
 from sympy.core.sympify import sympify
-from sympy.core.numbers import Rational, Integer, Number, I, Half
+from sympy.core.numbers import Rational, Integer, Number, I
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.coreerrors import NonCommutativeExpression

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -356,7 +356,7 @@ class Factors(object):
             factors = dict(Mul._from_args(c).as_powers_dict())
             # Handle all rational Coefficients
             for f in list(factors.keys()):
-                if isinstance(f, Rational):
+                if isinstance(f, Rational) and not isinstance(f, Integer):
                     p, q = Integer(f.p), Integer(f.q)
                     factors[p] = (factors[p] if p in factors else 0) + factors[f]
                     factors[q] = (factors[q] if q in factors else 0) - factors[f]

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -9,7 +9,7 @@ from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal
 from sympy.core.expr import Expr
 from sympy.core.sympify import sympify
-from sympy.core.numbers import Rational, Integer, Number, I
+from sympy.core.numbers import Rational, Integer, Number, I, Half
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.coreerrors import NonCommutativeExpression
@@ -322,7 +322,6 @@ class Factors(object):
         """
         if isinstance(factors, (SYMPY_INTS, float)):
             factors = S(factors)
-
         if isinstance(factors, Factors):
             factors = factors.factors.copy()
         elif factors is None or factors is S.One:
@@ -355,6 +354,12 @@ class Factors(object):
             for _ in range(i):
                 c.remove(I)
             factors = dict(Mul._from_args(c).as_powers_dict())
+            # Handle all rational Coefficients
+            for f in list(factors.keys()):
+                if type(f) is Rational or type(f) is Half:
+                    factors[f.p] = (factors[f.p] if f.p in factors else 0) + factors[f]
+                    factors[f.q] = (factors[f.q] if f.q in factors else 0) - factors[f]
+                    factors.pop(f)
             if i:
                 factors[I] = S.One*i
             if nc:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -356,9 +356,10 @@ class Factors(object):
             factors = dict(Mul._from_args(c).as_powers_dict())
             # Handle all rational Coefficients
             for f in list(factors.keys()):
-                if type(f) is Rational or type(f) is Half:
-                    factors[f.p] = (factors[f.p] if f.p in factors else 0) + factors[f]
-                    factors[f.q] = (factors[f.q] if f.q in factors else 0) - factors[f]
+                if isinstance(f, Rational):
+                    p, q = Integer(f.p), Integer(f.q)
+                    factors[p] = (factors[p] if p in factors else 0) + factors[f]
+                    factors[q] = (factors[q] if q in factors else 0) - factors[f]
                     factors.pop(f)
             if i:
                 factors[I] = S.One*i

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -128,7 +128,7 @@ def test_Factors():
         (Factors({x: x}), Factors({x: y + 1}))
 
     assert Factors(3 * x / 2) == Factors({3: 1, 2: -1, x: 1})
-    assert Factors(x * x / y) == Factors({x: 2, y: 1})
+    assert Factors(x * x / y) == Factors({x: 2, y: -1})
     assert Factors(27 * x / y**9) == Factors({27: 1, x: 1, y: -9})
 
 

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -127,6 +127,10 @@ def test_Factors():
     assert Factors(n).div(x**(y + 4)) == \
         (Factors({x: x}), Factors({x: y + 1}))
 
+    assert Factors(3 * x / 2) == Factors({3: 1, 2: -1, x: 1})
+    assert Factors(x * x / y) == Factors({x: 2, y: 1})
+    assert Factors(27 * x / y**9) == Factors({27: 1, x: 1, y: -9})
+
 
 def test_Term():
     a = Term(4*x*y**2/z/t**3)

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -342,6 +342,9 @@ def test_collect_const():
     assert collect_sqrt(eq + 2) == \
         2*sqrt(sqrt(2) + 3)*(sqrt(5)*x + y) + 2
 
+    # issue 16296
+    assert collect_const(a + b + x/2 + y/2) != a + b + (x/2 + y/2)
+
 
 def test_issue_13143():
     f = Function('f')

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -343,7 +343,7 @@ def test_collect_const():
         2*sqrt(sqrt(2) + 3)*(sqrt(5)*x + y) + 2
 
     # issue 16296
-    assert collect_const(a + b + x/2 + y/2) != a + b + (x/2 + y/2)
+    assert collect_const(a + b + x/2 + y/2) == a + b + Mul(S.Half, x + y, evaluate=False)
 
 
 def test_issue_13143():


### PR DESCRIPTION
`Factors()` splits rational factors into its numerator and denominator.
`collect_const()` can now collect the common dividing factors in an expression.
 
#### References to other Issues or PRs
Fixes #16296 

#### Brief description of what is fixed or changed
Breaks down the numerator and denominator of Rational factors in a multiplicative expression, fixing the denominator collection issue that collect_const() was having.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * sympy.core.exprtools.Factors() now splits each rational factor into a seaprate numerator and denominator
<!-- END RELEASE NOTES -->
