### PR TITLE
Added hypersphere_volume function

### DIFF
--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -6,7 +6,7 @@ Special - gamma, zeta,spherical harmonics...
 """
 
 from sympy.functions.combinatorial.factorials import (factorial, factorial2,
-        rf, ff, binomial, RisingFactorial, FallingFactorial, subfactorial)
+        rf, ff, binomial, RisingFactorial, FallingFactorial, subfactorial, stirling)
 from sympy.functions.combinatorial.numbers import (carmichael, fibonacci, lucas, tribonacci,
         harmonic, bernoulli, bell, euler, catalan, genocchi, partition)
 from sympy.functions.elementary.miscellaneous import (sqrt, root, Min, Max,

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -26,7 +26,7 @@ from sympy.functions.special.error_functions import (erf, erfc, erfi, erf2,
         erfinv, erfcinv, erf2inv, Ei, expint, E1, li, Li, Si, Ci, Shi, Chi,
         fresnels, fresnelc)
 from sympy.functions.special.gamma_functions import (gamma, lowergamma,
-        uppergamma, polygamma, loggamma, digamma, trigamma,applications.hypersphere_volume)
+        uppergamma, polygamma, loggamma, digamma, trigamma, hypersphere_volume)
 from sympy.functions.special.zeta_functions import (dirichlet_eta, zeta,
         lerchphi, polylog, stieltjes)
 from sympy.functions.special.tensor_functions import (Eijk, LeviCivita,

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -6,7 +6,7 @@ Special - gamma, zeta,spherical harmonics...
 """
 
 from sympy.functions.combinatorial.factorials import (factorial, factorial2,
-        rf, ff, binomial, RisingFactorial, FallingFactorial, subfactorial, stirling)
+        rf, ff, binomial, RisingFactorial, FallingFactorial, subfactorial)
 from sympy.functions.combinatorial.numbers import (carmichael, fibonacci, lucas, tribonacci,
         harmonic, bernoulli, bell, euler, catalan, genocchi, partition)
 from sympy.functions.elementary.miscellaneous import (sqrt, root, Min, Max,

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -26,7 +26,7 @@ from sympy.functions.special.error_functions import (erf, erfc, erfi, erf2,
         erfinv, erfcinv, erf2inv, Ei, expint, E1, li, Li, Si, Ci, Shi, Chi,
         fresnels, fresnelc)
 from sympy.functions.special.gamma_functions import (gamma, lowergamma,
-        uppergamma, polygamma, loggamma, digamma, trigamma)
+        uppergamma, polygamma, loggamma, digamma, trigamma,applications.hypersphere_volume)
 from sympy.functions.special.zeta_functions import (dirichlet_eta, zeta,
         lerchphi, polylog, stieltjes)
 from sympy.functions.special.tensor_functions import (Eijk, LeviCivita,

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -299,8 +299,6 @@ class FactorialApproximation:
         """
         f = float(_sqrt(2*pi*n)*(n/E)**n)
         return f
-
-
 class MultiFactorial(CombinatorialFunction):
     pass
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -267,9 +267,7 @@ class factorial(CombinatorialFunction):
         if x.is_nonnegative or x.is_noninteger:
             return True
 class stirling(CombinatorialFunction):
-    @classmethod
-    def approx(n):
-        """
+     r"""
         The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
         It is typically writtern as:
      
@@ -294,7 +292,10 @@ class stirling(CombinatorialFunction):
         >>>FactorialApproximation.stirling(5)
         >>>118.01916795759008
         
-        """
+    """
+    @classmethod
+    def approx(n):
+       
         f = float(_sqrt(2*pi*n)*(n/E)**n)
         return f
 class MultiFactorial(CombinatorialFunction):

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -267,6 +267,7 @@ class factorial(CombinatorialFunction):
         if x.is_nonnegative or x.is_noninteger:
             return True
 class stirling(CombinatorialFunction):
+    @classmethod
     def approx(n):
         """
         The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -266,39 +266,36 @@ class factorial(CombinatorialFunction):
         x = self.args[0]
         if x.is_nonnegative or x.is_noninteger:
             return True
-class FactorialApproximation:
-    '''
-    The approxiamate value of a factorial can be found out in finite polynomial time using the following methods.   
-    '''
-    def stirling(n):
-        """
-        The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
-        It is typically writtern as:
-        
-        .. math:: ln(n!) = n ln(n) - n + O(ln(n))
 
-        It can be approximated to:
+def stirling(n):
+    """
+    The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
+    It is typically writtern as:
+     
+    .. math:: ln(n!) = n ln(n) - n + O(ln(n))
+
+    It can be approximated to:
    
-        .. math:: n! ~ sqrt(2*pi*n) pow(n/E,n)
+    .. math:: n! ~ sqrt(2*pi*n) pow(n/E,n)
 
-        The error in  approximation increases as n reach large values.
+    The error in  approximation increases as n reach large values.
 
-        References
-        ==========
+    References
+    ==========
 
-        .. [1] https://en.wikipedia.org/wiki/Stirling%27s_approximation
-        .. [2] https://ocw.mit.edu/courses/mathematics/18-104-seminar-in-analysis-applications-to-number-theory-fall-2006/projects/talk_gilbertson.pdf
+    .. [1] https://en.wikipedia.org/wiki/Stirling%27s_approximation
+    .. [2] https://ocw.mit.edu/courses/mathematics/18-104-seminar-in-analysis-applications-to-number-theory-fall-2006/projects/talk_gilbertson.pdf
 
-        Examples
-        ========
+    Examples
+    ========
 
-        >>>from sympy import FactorialApproximation
-        >>>FactorialApproximation.stirling(5)
-        >>>118.01916795759008
+    >>>from sympy import FactorialApproximation
+    >>>FactorialApproximation.stirling(5)
+    >>>118.01916795759008
         
-        """
-        f = float(_sqrt(2*pi*n)*(n/E)**n)
-        return f
+    """
+    f = float(_sqrt(2*pi*n)*(n/E)**n)
+    return f
 class MultiFactorial(CombinatorialFunction):
     pass
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -9,6 +9,7 @@ from sympy.core.numbers import Integer, pi
 from sympy.core.relational import Eq
 from sympy.ntheory import sieve
 from sympy.polys.polytools import Poly
+from sympy import sqrt, pi, E
 
 from math import sqrt as _sqrt
 
@@ -172,6 +173,7 @@ class factorial(CombinatorialFunction):
 
                     return Integer(result)
 
+
     def _facmod(self, n, q):
         res, N = 1, int(_sqrt(n))
 
@@ -264,6 +266,42 @@ class factorial(CombinatorialFunction):
         x = self.args[0]
         if x.is_nonnegative or x.is_noninteger:
             return True
+
+        
+class FactorialApproximation:
+    """
+    The approxiamate value of a factorial can be found out in finite polynomial time using the following methods.   
+    """
+    def stirling(n):
+        """
+        The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
+        It is typically writtern as:
+        
+        .. math:: ln(n!) = n ln(n) - n + O(ln(n))
+
+        It can be approximated to:
+   
+        .. math:: n! ~ sqrt(2*pi*n) pow(n/E,n)
+
+        The error in  approximation increases as n reach large values.
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Stirling%27s_approximation
+        .. [2] https://ocw.mit.edu/courses/mathematics/18-104-seminar-in-analysis-applications-to-number-theory-fall-2006/projects/talk_gilbertson.pdf
+
+        Examples
+        ========
+
+        >>>from sympy import FactorialApproximation
+        >>>FactorialApproximation.stirling(5)
+        >>>118.01916795759008
+        
+        """
+        f = float(sqrt(2*pi*n)*(n/E)**n)
+        return f
+
 
 class MultiFactorial(CombinatorialFunction):
     pass
@@ -1027,3 +1065,5 @@ class binomial(CombinatorialFunction):
                 return True
             elif k.is_even is False:
                 return  False
+
+

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -9,7 +9,7 @@ from sympy.core.numbers import Integer, pi
 from sympy.core.relational import Eq
 from sympy.ntheory import sieve
 from sympy.polys.polytools import Poly
-from sympy import sqrt, pi, E
+from sympy import pi, E
 
 from math import sqrt as _sqrt
 
@@ -299,7 +299,7 @@ class FactorialApproximation:
         >>>118.01916795759008
         
         """
-        f = float(sqrt(2*pi*n)*(n/E)**n)
+        f = float(_sqrt(2*pi*n)*(n/E)**n)
         return f
 
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -266,36 +266,36 @@ class factorial(CombinatorialFunction):
         x = self.args[0]
         if x.is_nonnegative or x.is_noninteger:
             return True
-
-def stirling(n):
-    """
-    The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
-    It is typically writtern as:
+class stirling(CombinatorialFunction):
+    def approx(n):
+        """
+        The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.
+        It is typically writtern as:
      
-    .. math:: ln(n!) = n ln(n) - n + O(ln(n))
+        .. math:: ln(n!) = n ln(n) - n + O(ln(n))
 
-    It can be approximated to:
+        It can be approximated to:
    
-    .. math:: n! ~ sqrt(2*pi*n) pow(n/E,n)
+        .. math:: n! ~ sqrt(2*pi*n) pow(n/E,n)
 
-    The error in  approximation increases as n reach large values.
+        The error in  approximation increases as n reach large values.
 
-    References
-    ==========
+        References
+        ==========
 
-    .. [1] https://en.wikipedia.org/wiki/Stirling%27s_approximation
-    .. [2] https://ocw.mit.edu/courses/mathematics/18-104-seminar-in-analysis-applications-to-number-theory-fall-2006/projects/talk_gilbertson.pdf
+        .. [1] https://en.wikipedia.org/wiki/Stirling%27s_approximation
+        .. [2] https://ocw.mit.edu/courses/mathematics/18-104-seminar-in-analysis-applications-to-number-theory-fall-2006/projects/talk_gilbertson.pdf
 
-    Examples
-    ========
+        Examples
+        ========
 
-    >>>from sympy import FactorialApproximation
-    >>>FactorialApproximation.stirling(5)
-    >>>118.01916795759008
+        >>>from sympy import FactorialApproximation
+        >>>FactorialApproximation.stirling(5)
+        >>>118.01916795759008
         
-    """
-    f = float(_sqrt(2*pi*n)*(n/E)**n)
-    return f
+        """
+        f = float(_sqrt(2*pi*n)*(n/E)**n)
+        return f
 class MultiFactorial(CombinatorialFunction):
     pass
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -267,9 +267,9 @@ class factorial(CombinatorialFunction):
         if x.is_nonnegative or x.is_noninteger:
             return True
 class FactorialApproximation:
-    """
+    '''
     The approxiamate value of a factorial can be found out in finite polynomial time using the following methods.   
-    """
+    '''
     def stirling(n):
         """
         The Stirling's approximation approximates the value of factorials in polynomial time developed by Abraham De Moivre and James Stirling.

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -266,8 +266,6 @@ class factorial(CombinatorialFunction):
         x = self.args[0]
         if x.is_nonnegative or x.is_noninteger:
             return True
-
-        
 class FactorialApproximation:
     """
     The approxiamate value of a factorial can be found out in finite polynomial time using the following methods.   

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -292,12 +292,11 @@ class stirling(CombinatorialFunction):
         >>>FactorialApproximation.stirling(5)
         >>>118.01916795759008
         
-    """
-    @classmethod
-    def approx(n):
-       
-        f = float(_sqrt(2*pi*n)*(n/E)**n)
-        return f
+     """
+     @classmethod
+     def approx(n):
+            f = float(_sqrt(2*pi*n)*(n/E)**n)
+            return f
 class MultiFactorial(CombinatorialFunction):
     pass
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -5,8 +5,8 @@ from sympy.core.compatibility import range
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
-from .zeta_functions import zeta
-from .error_functions import erf, erfc
+from sympy.functions.special.zeta_functions import zeta
+from sympy.functions.special.error_functions import erf, erfc
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -1009,3 +1009,32 @@ def trigamma(x):
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
     return polygamma(1, x)
+
+
+class applications:
+    """
+    These methods are used to implement gamma function and related functions in real world conditions
+    """
+    def hypersphere_volume(n, r):
+        """
+        The volume of a hypersphere in n dimensional Euclidean space is given by V(n,r) = pi^{n/2}r^{n}/gamma(n/2 + 1)
+
+        Examples
+        ========
+
+        >>>from sympy import applications
+        >>>applications.hypersphere_volume(2,1)
+        >>>3.141592653589793
+
+        References
+        ==========
+        
+        ..[1] https://en.wikipedia.org/wiki/Volume_of_an_n-ball
+        ..[2] https://sites.math.washington.edu/~morrow/336_10/papers/joel.pdf
+        ..[3] https://www.mathpages.com/home/kmath163/kmath163.htm
+        ..[4] http://mathworld.wolfram.com/Hypersphere.html
+        """
+        vol = float((Pow(pi,n/2)*Pow(r,n))/gamma((n/2)+1))
+        return vol
+    
+    

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1011,32 +1011,24 @@ def trigamma(x):
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
     return polygamma(1, x)
-
-
-class applications:
+def hypersphere_volume(n, r):
     """
-    These methods are used to implement gamma function and related functions in real world conditions
-    """
-    def hypersphere_volume(n, r):
-        """
-        The volume of a hypersphere in n dimensional Euclidean space is given by V(n,r) = pi^{n/2}r^{n}/gamma(n/2 + 1)
+    The volume of a hypersphere in n dimensional Euclidean space is given by V(n,r) = pi^{n/2}r^{n}/gamma(n/2 + 1)
 
-        Examples
-        ========
+    Examples
+    ========
 
-        >>>from sympy import applications
-        >>>applications.hypersphere_volume(2,1)
-        >>>3.141592653589793
+    >>>from sympy import applications
+    >>>applications.hypersphere_volume(2,1)
+    >>>3.141592653589793
 
-        References
-        ==========
+    References
+    ==========
         
-        ..[1] https://en.wikipedia.org/wiki/Volume_of_an_n-ball
-        ..[2] https://sites.math.washington.edu/~morrow/336_10/papers/joel.pdf
-        ..[3] https://www.mathpages.com/home/kmath163/kmath163.htm
-        ..[4] http://mathworld.wolfram.com/Hypersphere.html
-        """
-        vol = float((Pow(pi,n/2)*Pow(r,n))/gamma((n/2)+1))
-        return vol
-    
-    
+    ..[1] https://en.wikipedia.org/wiki/Volume_of_an_n-ball
+    ..[2] https://sites.math.washington.edu/~morrow/336_10/papers/joel.pdf
+    ..[3] https://www.mathpages.com/home/kmath163/kmath163.htm
+    ..[4] http://mathworld.wolfram.com/Hypersphere.html
+    """
+    vol = float((Pow(pi,n/2)*Pow(r,n))/gamma((n/2)+1))
+    return vol

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -5,8 +5,10 @@ from sympy.core.compatibility import range
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
-from sympy.functions.special.zeta_functions import zeta
-from sympy.functions.special.error_functions import erf, erfc
+#from sympy.functions.special.zeta_functions import zeta
+#from sympy.functions.special.error_functions import erf, erfc
+from .zeta_functions import zeta
+from .error_functions import erf, erfc
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import sqrt


### PR DESCRIPTION
Fixed from .zeta_function and from .error_function errors.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Changed from .zeta_functions import zeta to from sympy.functions.special.zeta_functions import zeta.
Changed from .error_functions import erf, erfc to from sympy.functions.special.error_functions import erf, erfc.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Added hypersphere_volume() function.
  * Fixed from .zeta_functions import zeta error.
  * Fixed from .error_functions import erf, erfc error.

<!-- END RELEASE NOTES -->
