### PR TITLE
rubi.utility_function exp is updated to rubi_exp in rubi.py file

### DIFF
--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -125,7 +125,7 @@ def rubi_powsimp(expr):
     lst_non_pow = []
     if isinstance(expr, Mul):
         for i in expr.args:
-            if isinstance(i, (Pow, exp, sym_exp)):
+            if isinstance(i, (Pow, rubi_exp, sym_exp)):
                 lst_pow.append(i)
             else:
                 lst_non_pow.append(i)

--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -84,8 +84,8 @@ def process_final_integral(expr):
     '''
     When there is recursion for more than 10 rules or in total 20 rules have been applied
     rubi returns `Integrate` in order to stop any further matching. After complete integration,
-    Integrate needs to be replaced back to Integral. Also rubi's `exp` need to be replaced back
-    to sympy's general `exp`.
+    Integrate needs to be replaced back to Integral. Also rubi's `rubi_exp`
+     need to be replaced back to sympy's general `exp`.
 
     Examples
     ========
@@ -147,7 +147,7 @@ def rubi_integrate(expr, var, showsteps=False):
 
     Returns Integral object if unable to integrate.
     '''
-    expr = expr.replace(sym_exp, exp)
+    expr = expr.replace(sym_exp, rubi_exp)
     rules_applied[:] = []
     expr = process_trig(expr)
     expr = rubi_powsimp(expr)
@@ -167,7 +167,7 @@ def rubi_integrate(expr, var, showsteps=False):
 @doctest_depends_on(modules=('matchpy',))
 def util_rubi_integrate(expr, var, showsteps=False):
     expr = process_trig(expr)
-    expr = expr.replace(sym_exp, exp)
+    expr = expr.replace(sym_exp, rubi_exp)
     if isinstance(expr, (int, Integer)) or isinstance(expr, (float, Float)):
         return S(expr)*var
     if isinstance(expr, Add):

--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -85,7 +85,7 @@ def process_final_integral(expr):
     When there is recursion for more than 10 rules or in total 20 rules have been applied
     rubi returns `Integrate` in order to stop any further matching. After complete integration,
     Integrate needs to be replaced back to Integral. Also rubi's `rubi_exp`
-     need to be replaced back to sympy's general `exp`.
+    need to be replaced back to sympy's general `exp`.
 
     Examples
     ========

--- a/sympy/integrals/rubi/tests/test_rubi_integrate.py
+++ b/sympy/integrals/rubi/tests/test_rubi_integrate.py
@@ -14,12 +14,10 @@ from sympy.functions import log
 from sympy import (sqrt, simplify, S, atanh, hyper, I, atan, pi, Sum, cos, sin,
     log, atan)
 from sympy.integrals.rubi.utility_function import rubi_test
-from sympy.utilities.pytest import SKIP
-# from sympy.integrals.rubi.rubi import rubi_integrate
+from sympy.integrals.rubi.rubi import rubi_integrate
 
 a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, imaginary=False)
 
-@SKIP
 def test_rubi_integrate():
     assert rubi_integrate(x, x) == x**2/2
     assert rubi_integrate(x**a, x) == x**(a + S(1))/(a + S(1))

--- a/sympy/integrals/rubi/tests/test_rubi_integrate.py
+++ b/sympy/integrals/rubi/tests/test_rubi_integrate.py
@@ -21,7 +21,7 @@ a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, im
 def test_rubi_integrate():
     assert rubi_integrate(x, x) == x**2/2
     assert rubi_integrate(x**2,x) == x**3/3
-    assert rubi_integrate(x**3,x) == x**4/4  
+    assert rubi_integrate(x**3,x) == x**4/4
     assert rubi_integrate(x**a, x) == x**(a + S(1))/(a + S(1))
     assert rubi_integrate(S(1)/x, x) == log(x)
     assert rubi_integrate(a*x, x) == a*(S(1)/S(2))*x**S(2)

--- a/sympy/integrals/rubi/tests/test_rubi_integrate.py
+++ b/sympy/integrals/rubi/tests/test_rubi_integrate.py
@@ -14,13 +14,14 @@ from sympy.functions import log
 from sympy import (sqrt, simplify, S, atanh, hyper, I, atan, pi, Sum, cos, sin,
     log, atan)
 from sympy.integrals.rubi.utility_function import rubi_test
-from sympy.integrals.rubi.rubi import rubi_integrate
 from sympy.utilities.pytest import SKIP
 
 a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, imaginary=False)
 
 @SKIP
 def test_rubi_integrate():
+    from sympy.integrals.rubi.rubi import rubi_integrate
+
     assert rubi_integrate(x, x) == x**2/2
     assert rubi_integrate(x**2,x) == x**3/3
     assert rubi_integrate(x**3,x) == x**4/4

--- a/sympy/integrals/rubi/tests/test_rubi_integrate.py
+++ b/sympy/integrals/rubi/tests/test_rubi_integrate.py
@@ -20,6 +20,8 @@ a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, im
 
 def test_rubi_integrate():
     assert rubi_integrate(x, x) == x**2/2
+    assert rubi_integrate(x**2,x) == x**3/3
+    assert rubi_integrate(x**3,x) == x**4/4  
     assert rubi_integrate(x**a, x) == x**(a + S(1))/(a + S(1))
     assert rubi_integrate(S(1)/x, x) == log(x)
     assert rubi_integrate(a*x, x) == a*(S(1)/S(2))*x**S(2)

--- a/sympy/integrals/rubi/tests/test_rubi_integrate.py
+++ b/sympy/integrals/rubi/tests/test_rubi_integrate.py
@@ -15,9 +15,11 @@ from sympy import (sqrt, simplify, S, atanh, hyper, I, atan, pi, Sum, cos, sin,
     log, atan)
 from sympy.integrals.rubi.utility_function import rubi_test
 from sympy.integrals.rubi.rubi import rubi_integrate
+from sympy.utilities.pytest import SKIP
 
 a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, imaginary=False)
 
+@SKIP
 def test_rubi_integrate():
     assert rubi_integrate(x, x) == x**2/2
     assert rubi_integrate(x**2,x) == x**3/3


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/16547

#### References to other Issues or PRs

https://github.com/sympy/sympy/pull/16472 has renamed the Rubi `exp` to `rubi_exp`.


#### Brief description of what is fixed or changed

rubi.utility_function exp is updated to rubi_exp in rubi.py file

#### Other comments

```
In [1]:  
   ...: from sympy.core.symbol import symbols, Symbol 
   ...: from sympy.integrals.rubi.rubi import rubi_integrate 
   ...:  
   ...: a, b, c, d, e, f, x, m, n, p, k = symbols('a b c d e f x m n p k', real=True, imaginary=False) 
   ...:  
   ...: rubi_integrate(x, x) == x**2/2                                                                                                                                                                        
Out[1]: False

In [2]: rubi_integrate(x,x)                                                                                                                                                                                   
Out[2]: 
⌠     
⎮ x dx
⌡     

In [3]: rubi_integrate(x,x).doit()                                                                                                                                                                            
Out[3]: 
 2
x 
──
2 

In [4]: rubi_integrate(x**2,x)                                                                                                                                                                                
Out[4]: 
 3
x 
──
3 

In [5]: rubi_integrate(x**3,x)                                                                                                                                                                                
Out[5]: 
 4
x 
──
4 

```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
    * `rubi.utility_function`, `exp` is renamed to `rubi_exp` in rubi.py file

<!-- END RELEASE NOTES -->
