### PR TITLE
dsolve: power_series bug

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3911,7 +3911,7 @@ def ode_2nd_power_series_regular(eq, func, order, match):
         if not term.has(x):
             indicial.append(term)
         else:
-            term = series(term, n=1, x0=x0)
+            term = series(term,x, n=1, x0=x0)
             if isinstance(term, Order):
                 indicial.append(S(0))
             else:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3911,7 +3911,7 @@ def ode_2nd_power_series_regular(eq, func, order, match):
         if not term.has(x):
             indicial.append(term)
         else:
-            term = series(term,x, n=1, x0=x0)
+            term = series(term, x, n=1, x0=x0)
             if isinstance(term, Order):
                 indicial.append(S(0))
             else:


### PR DESCRIPTION
dsolve: Fixing bug regarding power_series

At #16531 it was observed that the command dsolve(ODE,R(r)) where
ODE = -\lambda r R(r) + r \frac{d^2R(r)}{dr^2} + \frac{dR}{dr}
and \lambda is a negative real parameter returns ValueError.

The problem seems to be that the function call series(term,n=1,x0=x0) within the
ode_2nd_power_series_regular() does NOT takes as an argument the symbol in terms
 of which the 'term' expression will be expanded.
(the 'term' has 2 symbol objects, lambda AND r, so the function does not 'know' which
one is the desired)

The series function is a wrapper of the expr.series method. In the relevant docstring
[https://docs.sympy.org/latest/_modules/sympy/core/expr.html]
we read:

> If ``x=None`` and ``self`` is univariate, the univariate symbol will
> be supplied, otherwise an error will be raised.

Indeed, by replacing the above func. call to series(term,x,n=1,x0=x0)
we get the correct result, that is: 

R(r) = C_1 \left( \frac{\lambda^2 r^4 }{64} + \frac{\lambda^2 r^2}{4} + 1 \left) + \mathcal{O}(r^6)


#### Brief description of what is fixed or changed
Specified the exact symbol in terms of which the 
series expansion must performed

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * ode: bug fixed in ode_2nd_power_series_regular

<!-- END RELEASE NOTES -->
