### PR TITLE
core.relational.py: Eq without rhs now raises ValueError

### DIFF
--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -98,6 +98,6 @@ def euler_equations(L, funcs=(), vars=()):
         for i in range(1, order + 1):
             for p in combinations_with_replacement(vars, i):
                 eq = eq + S.NegativeOne**i*diff(L, diff(f, *p), *p)
-        eqns.append(Eq(eq))
+        eqns.append(Eq(eq, 0))
 
     return eqns

--- a/sympy/calculus/tests/test_euler.py
+++ b/sympy/calculus/tests/test_euler.py
@@ -11,15 +11,15 @@ def test_euler_interface():
     raises(TypeError, lambda: euler(D(x(t), t)*y(t), [x(t), y]))
     raises(ValueError, lambda: euler(D(x(t), t)*x(y), [x(t), x(y)]))
     raises(TypeError, lambda: euler(D(x(t), t)**2, x(0)))
-    assert euler(D(x(t), t)**2/2, {x(t)}) == [Eq(-D(x(t), t, t))]
-    assert euler(D(x(t), t)**2/2, x(t), {t}) == [Eq(-D(x(t), t, t))]
+    assert euler(D(x(t), t)**2/2, {x(t)}) == [Eq(-D(x(t), t, t), 0)]
+    assert euler(D(x(t), t)**2/2, x(t), {t}) == [Eq(-D(x(t), t, t), 0)]
 
 
 def test_euler_pendulum():
     x = Function('x')
     t = Symbol('t')
     L = D(x(t), t)**2/2 + cos(x(t))
-    assert euler(L, x(t), t) == [Eq(-sin(x(t)) - D(x(t), t, t))]
+    assert euler(L, x(t), t) == [Eq(-sin(x(t)) - D(x(t), t, t), 0)]
 
 
 def test_euler_henonheiles():
@@ -29,9 +29,9 @@ def test_euler_henonheiles():
     L = sum(D(z(t), t)**2/2 - z(t)**2/2 for z in [x, y])
     L += -x(t)**2*y(t) + y(t)**3/3
     assert euler(L, [x(t), y(t)], t) == [Eq(-2*x(t)*y(t) - x(t) -
-                                            D(x(t), t, t)),
+                                            D(x(t), t, t), 0),
                                          Eq(-x(t)**2 + y(t)**2 -
-                                            y(t) - D(y(t), t, t))]
+                                            y(t) - D(y(t), t, t), 0)]
 
 
 def test_euler_sineg():
@@ -41,7 +41,7 @@ def test_euler_sineg():
     L = D(psi(t, x), t)**2/2 - D(psi(t, x), x)**2/2 + cos(psi(t, x))
     assert euler(L, psi(t, x), [t, x]) == [Eq(-sin(psi(t, x)) -
                                               D(psi(t, x), t, t) +
-                                              D(psi(t, x), x, x))]
+                                              D(psi(t, x), x, x), 0)]
 
 
 def test_euler_high_order():
@@ -54,10 +54,10 @@ def test_euler_high_order():
     L = (m*D(x(t), t)**2/2 + m*D(y(t), t)**2/2 -
          k*D(x(t), t)*D(y(t), t, t) + k*D(y(t), t)*D(x(t), t, t))
     assert euler(L, [x(t), y(t)]) == [Eq(2*k*D(y(t), t, t, t) -
-                                         m*D(x(t), t, t)),
+                                         m*D(x(t), t, t), 0),
                                       Eq(-2*k*D(x(t), t, t, t) -
-                                         m*D(y(t), t, t))]
+                                         m*D(y(t), t, t), 0)]
 
     w = Symbol('w')
     L = D(x(t, w), t, w)**2/2
-    assert euler(L) == [Eq(D(x(t, w), t, t, w, w))]
+    assert euler(L) == [Eq(D(x(t, w), t, t, w, w), 0)]

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from .add import _unevaluated_Add, Add
 from .basic import S
 from .compatibility import ordered
@@ -388,7 +389,13 @@ class Equality(Relational):
         from sympy.simplify.simplify import clear_coefficients
 
         if rhs is None:
-            raise ValueError("rhs must be provided")
+            SymPyDeprecationWarning(
+                feature="Eq(expr) with rhs default to 0",
+                useinstead="Eq(expr, 0)",
+                issue=16587,
+                deprecated_since_version="1.5"
+            ).warn()
+            rhs = 0
 
         lhs = _sympify(lhs)
         rhs = _sympify(rhs)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -381,11 +381,14 @@ class Equality(Relational):
 
     is_Equality = True
 
-    def __new__(cls, lhs, rhs=0, **options):
+    def __new__(cls, lhs, rhs=None, **options):
         from sympy.core.add import Add
         from sympy.core.logic import fuzzy_bool
         from sympy.core.expr import _n2
         from sympy.simplify.simplify import clear_coefficients
+
+        if rhs == None:
+            raise ValueError("rhs must be provided")
 
         lhs = _sympify(lhs)
         rhs = _sympify(rhs)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -387,7 +387,7 @@ class Equality(Relational):
         from sympy.core.expr import _n2
         from sympy.simplify.simplify import clear_coefficients
 
-        if rhs == None:
+        if rhs is None:
             raise ValueError("rhs must be provided")
 
         lhs = _sympify(lhs)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -184,6 +184,16 @@ def test_doit():
 def test_new_relational():
     x = Symbol('x')
 
+    assert Eq(x, 0) == Relational(x, 0)       # None ==> Equality
+    assert Eq(x, 0) == Relational(x, 0, '==')
+    assert Eq(x, 0) == Relational(x, 0, 'eq')
+    assert Eq(x, 0) == Equality(x, 0)
+
+    assert Eq(x, 0) != Relational(x, 1)       # None ==> Equality
+    assert Eq(x, 0) != Relational(x, 1, '==')
+    assert Eq(x, 0) != Relational(x, 1, 'eq')
+    assert Eq(x, 0) != Equality(x, 1)
+
     assert Eq(x, -1) == Relational(x, -1)       # None ==> Equality
     assert Eq(x, -1) == Relational(x, -1, '==')
     assert Eq(x, -1) == Relational(x, -1, 'eq')

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,4 +1,5 @@
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
     log, cos, sin, Add, floor, ceiling)
@@ -90,8 +91,8 @@ def test_Eq():
 
     assert Eq(x, x)  # issue 5719
 
-    raises(ValueError, lambda: Eq(x))
-    raises(ValueError, lambda: Eq(x**2))
+    with raises(SymPyDeprecationWarning):
+        Eq(x) == Eq(x, 0)
 
     # issue 6116
     p = Symbol('p', positive=True)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -87,10 +87,11 @@ def test_wrappers():
 
 
 def test_Eq():
-    assert Eq(x**2) == Eq(x**2, 0)
-    assert Eq(x**2) != Eq(x**2, 1)
 
     assert Eq(x, x)  # issue 5719
+
+    raises(ValueError, lambda: Eq(x))
+    raises(ValueError, lambda: Eq(x**2))
 
     # issue 6116
     p = Symbol('p', positive=True)
@@ -183,18 +184,10 @@ def test_doit():
 def test_new_relational():
     x = Symbol('x')
 
-    assert Eq(x) == Relational(x, 0)       # None ==> Equality
-    assert Eq(x) == Relational(x, 0, '==')
-    assert Eq(x) == Relational(x, 0, 'eq')
-    assert Eq(x) == Equality(x, 0)
     assert Eq(x, -1) == Relational(x, -1)       # None ==> Equality
     assert Eq(x, -1) == Relational(x, -1, '==')
     assert Eq(x, -1) == Relational(x, -1, 'eq')
     assert Eq(x, -1) == Equality(x, -1)
-    assert Eq(x) != Relational(x, 1)       # None ==> Equality
-    assert Eq(x) != Relational(x, 1, '==')
-    assert Eq(x) != Relational(x, 1, 'eq')
-    assert Eq(x) != Equality(x, 1)
     assert Eq(x, -1) != Relational(x, 1)       # None ==> Equality
     assert Eq(x, -1) != Relational(x, 1, '==')
     assert Eq(x, -1) != Relational(x, 1, 'eq')

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,5 +1,4 @@
-from sympy.utilities.pytest import XFAIL, raises
-from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
     log, cos, sin, Add, floor, ceiling)
@@ -91,8 +90,8 @@ def test_Eq():
 
     assert Eq(x, x)  # issue 5719
 
-    with raises(SymPyDeprecationWarning):
-        Eq(x) == Eq(x, 0)
+    with warns_deprecated_sympy():
+        assert Eq(x) == Eq(x, 0)
 
     # issue 6116
     p = Symbol('p', positive=True)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4588,7 +4588,7 @@ def ode_almost_linear(eq, func, order, match):
         >>> from sympy import Function, dsolve, Eq, pprint
         >>> from sympy.abc import x, y, n
         >>> f, g, k, l = map(Function, ['f', 'g', 'k', 'l'])
-        >>> genform = Eq(f(x)*(l(y).diff(y)) + k(x)*l(y) + g(x))
+        >>> genform = Eq(f(x)*(l(y).diff(y)) + k(x)*l(y) + g(x), 0)
         >>> pprint(genform)
              d
         f(x)*--(l(y)) + g(x) + k(x)*l(y) = 0

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -157,7 +157,7 @@ def pdsolve(eq, func=None, hint='default', dict=False, solvefun=None, **kwargs):
     >>> u = f(x, y)
     >>> ux = u.diff(x)
     >>> uy = u.diff(y)
-    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
+    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)), 0)
     >>> pdsolve(eq)
     Eq(f(x, y), F(3*x - 2*y)*exp(-2*x/13 - 3*y/13))
 
@@ -264,7 +264,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     >>> u = f(x, y)
     >>> ux = u.diff(x)
     >>> uy = u.diff(y)
-    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
+    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)), 0)
     >>> classify_pde(eq)
     ('1st_linear_constant_coeff_homogeneous',)
     """
@@ -873,7 +873,7 @@ def pde_separate(eq, fun, sep, strategy='mul'):
 
     if isinstance(eq, Equality):
         if eq.rhs != 0:
-            return pde_separate(Eq(eq.lhs - eq.rhs), fun, sep, strategy)
+            return pde_separate(Eq(eq.lhs - eq.rhs, 0), fun, sep, strategy)
     else:
         return pde_separate(Eq(eq, 0), fun, sep, strategy)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1096,7 +1096,7 @@ def _solve_exponential(lhs, rhs, symbol, domain):
 
     This form can be easily handed by ``solveset``.
     """
-    unsolved_result = ConditionSet(symbol, Eq(lhs - rhs), domain)
+    unsolved_result = ConditionSet(symbol, Eq(lhs - rhs, 0), domain)
     newlhs = powdenest(lhs)
     if lhs != newlhs:
         # it may also be advantageous to factor the new expr

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -58,7 +58,7 @@ def test_nsolve():
         return root
     assert list(map(round, getroot((1, 1, 1)))) == [2.0, 1.0, 0.0]
     assert nsolve([Eq(
-        f1), Eq(f2), Eq(f3)], [x, y, z], (1, 1, 1))  # just see that it works
+        f1, 0), Eq(f2, 0), Eq(f3, 0)], [x, y, z], (1, 1, 1))  # just see that it works
     a = Symbol('a')
     assert abs(nsolve(1/(0.001 + a)**3 - 6/(0.9 - a)**3, a, 0.3) -
         mpf('0.31883011387318591')) < 1e-15

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -641,7 +641,7 @@ def test_checkodesol():
     assert checkodesol(diff(sol1.lhs, x, 3), Eq(f(x), x*log(x))) == \
         (False, 60*x**4*((log(x) + 1)**2 + log(x))*(
         log(x) + 1)*log(x)**2 - 5*x**4*log(x)**4 - 9)
-    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x)) == \
+    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x, 0)) == \
         (True, 0)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x),
         solve_for_func=False) == (True, 0)
@@ -3155,7 +3155,7 @@ def test_sysode_linear_neq_order1():
 def test_order_reducible():
     from sympy.solvers.ode import _order_reducible_match
 
-    eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2))
+    eqn = Eq(x*Derivative(f(x), x)**2 + Derivative(f(x), x, 2), 0)
     sol = Eq(f(x),
              C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False) == (True, 0)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -643,7 +643,7 @@ def test_checkodesol():
         log(x) + 1)*log(x)**2 - 5*x**4*log(x)**4 - 9)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x, 0)) == \
         (True, 0)
-    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x),
+    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x, 0),
         solve_for_func=False) == (True, 0)
     assert checkodesol(f(x).diff(x, 2), [Eq(f(x), C1 + C2*x),
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)]) == \

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -33,7 +33,7 @@ def test_pde_separate_mul():
     r, theta, z = symbols('r,theta,z')
 
     # Something simple :)
-    eq = Eq(D(F(x, y, z), x) + D(F(x, y, z), y) + D(F(x, y, z), z))
+    eq = Eq(D(F(x, y, z), x) + D(F(x, y, z), y) + D(F(x, y, z), z), 0)
 
     # Duplicate arguments in functions
     raises(
@@ -56,7 +56,7 @@ def test_pde_separate_mul():
 
     # Laplace equation in cylindrical coords
     eq = Eq(1/r * D(Phi(r, theta, z), r) + D(Phi(r, theta, z), r, 2) +
-            1/r**2 * D(Phi(r, theta, z), theta, 2) + D(Phi(r, theta, z), z, 2))
+            1/r**2 * D(Phi(r, theta, z), theta, 2) + D(Phi(r, theta, z), z, 2), 0)
     # Separate z
     res = pde_separate_mul(eq, Phi(r, theta, z), [Z(z), u(theta, r)])
     assert res == [D(Z(z), z, z)/Z(z),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16562 

#### Brief description of what is fixed or changed
Before this commit, rhs was assumed to be zero if it was not provided by user.
```
>> Eq(x)
Eq(x, 0)
```

Now `ValueError` is raised.
```
>> Eq(x)
ValueError("rhs must be provided")
```
#### Other comments
This is backward incompatible change.

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Eq(expr) now raises ValueError. Eq(expr, 0) should be used instead.
<!-- END RELEASE NOTES -->
