### PR TITLE
Reduced repeated code in sympy.stats.symbolic_probability

### DIFF
--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,5 +1,5 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt,
-    IndexedBase, log, E, I)
+    IndexedBase)
 from sympy.stats.rv import _value_check, random_symbols
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
@@ -103,7 +103,6 @@ class MultivariateNormalDistribution(JointDistribution):
         return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
             -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
                 (_mu - sym)))[0])
-
 
 #-------------------------------------------------------------------------------
 # Multivariate Laplace distribution ---------------------------------------------------------

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -104,19 +104,6 @@ class MultivariateNormalDistribution(JointDistribution):
             -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
                 (_mu - sym)))[0])
 
-    def entropy(self):
-        sigma = self.sigma
-        return log(2*pi*E*det(sigma))/2
-
-    def mgf(self, *args):
-        mu, sigma = self.mu, self.sigma
-        t = ImmutableMatrix(args)
-        return exp(mu.transpose()*t + t.transpose()*(sigma*t)/2)
-
-    def cf(self, *args):
-        mu, sigma = self.mu, self.sigma
-        t = ImmutableMatrix(args)
-        return exp(I*(mu.transpose()*t) - t.transpose()*(sigma*t)/2)
 
 #-------------------------------------------------------------------------------
 # Multivariate Laplace distribution ---------------------------------------------------------

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,5 +1,5 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt,
-    IndexedBase)
+    IndexedBase, log, E, I)
 from sympy.stats.rv import _value_check, random_symbols
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
@@ -103,6 +103,20 @@ class MultivariateNormalDistribution(JointDistribution):
         return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
             -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
                 (_mu - sym)))[0])
+
+    def entropy(self):
+        sigma = self.sigma
+        return log(2*pi*E*det(sigma))/2
+
+    def mgf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        t = ImmutableMatrix(args)
+        return exp(mu.transpose()*t + t.transpose()*(sigma*t)/2)
+
+    def cf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        t = ImmutableMatrix(args)
+        return exp(I*(mu.transpose()*t) - t.transpose()*(sigma*t)/2)
 
 #-------------------------------------------------------------------------------
 # Multivariate Laplace distribution ---------------------------------------------------------

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -11,6 +11,9 @@ from sympy.stats.rv import RandomSymbol, probability, expectation
 
 __all__ = ['Probability', 'Expectation', 'Variance', 'Covariance']
 
+# the following line is added for avoiding
+# repetiion of the code in this file
+ _eval_rewrite_as_Integral = _eval_rewrite_as_Sum
 
 class Probability(Expr):
     """
@@ -47,9 +50,6 @@ class Probability(Expr):
         return obj
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
-        return probability(arg, condition, evaluate=False)
-
-    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
         return probability(arg, condition, evaluate=False)
 
     def evaluate_integral(self):
@@ -163,9 +163,6 @@ class Expectation(Expr):
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return expectation(arg, condition=condition, evaluate=False)
 
-    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
-        return expectation(arg, condition=condition, evaluate=False)
-
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
 
@@ -271,9 +268,6 @@ class Variance(Expr):
         return self.rewrite(Expectation).rewrite(Probability)
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
-        return variance(self.args[0], self._condition, evaluate=False)
-
-    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
         return variance(self.args[0], self._condition, evaluate=False)
 
     def evaluate_integral(self):
@@ -404,9 +398,6 @@ class Covariance(Expr):
         return self.rewrite(Expectation).rewrite(Probability)
 
     def _eval_rewrite_as_Integral(self, arg1, arg2, condition=None, **kwargs):
-        return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
-
-    def _eval_rewrite_as_Sum(self, arg1, arg2, condition=None, **kwargs):
         return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
 
     def evaluate_integral(self):

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -11,10 +11,6 @@ from sympy.stats.rv import RandomSymbol, probability, expectation
 
 __all__ = ['Probability', 'Expectation', 'Variance', 'Covariance']
 
-# the following line is added for avoiding
-# repetiion of the code in this file
- _eval_rewrite_as_Integral = _eval_rewrite_as_Sum
-
 class Probability(Expr):
     """
     Symbolic expression for the probability.
@@ -51,6 +47,8 @@ class Probability(Expr):
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return probability(arg, condition, evaluate=False)
+
+    _eval_rewrite_as_Sum = _eval_rewrite_as_Integral
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
@@ -163,6 +161,8 @@ class Expectation(Expr):
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return expectation(arg, condition=condition, evaluate=False)
 
+    _eval_rewrite_as_Sum = _eval_rewrite_as_Integral
+
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
 
@@ -269,6 +269,8 @@ class Variance(Expr):
 
     def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return variance(self.args[0], self._condition, evaluate=False)
+
+    _eval_rewrite_as_Sum = _eval_rewrite_as_Integral
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
@@ -399,6 +401,8 @@ class Covariance(Expr):
 
     def _eval_rewrite_as_Integral(self, arg1, arg2, condition=None, **kwargs):
         return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
+
+    _eval_rewrite_as_Sum = _eval_rewrite_as_Integral
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -11,6 +11,7 @@ from sympy.stats.rv import RandomSymbol, probability, expectation
 
 __all__ = ['Probability', 'Expectation', 'Variance', 'Covariance']
 
+
 class Probability(Expr):
     """
     Symbolic expression for the probability.

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -164,7 +164,7 @@ class Expectation(Expr):
         return expectation(arg, condition=condition, evaluate=False)
 
     def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
-        return self.rewrite(Integral)
+        return expectation(arg, condition=condition, evaluate=False)
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
@@ -274,7 +274,7 @@ class Variance(Expr):
         return variance(self.args[0], self._condition, evaluate=False)
 
     def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
-        return self.rewrite(Integral)
+        return variance(self.args[0], self._condition, evaluate=False)
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()
@@ -407,7 +407,7 @@ class Covariance(Expr):
         return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
 
     def _eval_rewrite_as_Sum(self, arg1, arg2, condition=None, **kwargs):
-        return self.rewrite(Integral)
+        return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
 
     def evaluate_integral(self):
         return self.rewrite(Integral).doit()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Continued https://github.com/sympy/sympy/pull/15610


#### Brief description of what is fixed or changed
Earlier in `sympy.stats.symbolic_probability` the code was duplicate for `_eval_rewrite_as_Integral` and `_eval_rewrite_as_Sum`. However, now that is removed by using alias for the method names.
Thanks to @oscargus and @Upabjojr for the suggestions for the related work.

#### Other comments
N/A

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
