### PR TITLE
importtools: Use LooseVersion instead of StrictVersion

### DIFF
--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 import sys
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 # Override these in the module to change the default warning behavior.
 # For example, you might set both to False before running the tests so that
@@ -156,10 +156,7 @@ def import_module(module, min_module_version=None, min_python_version=None,
         modversion = getattr(mod, module_version_attr)
         if module_version_attr_call_args is not None:
             modversion = modversion(*module_version_attr_call_args)
-        # NOTE: StrictVersion() is use here to make sure a comparison like
-        # '1.11.2' < '1.6.1' doesn't fail. There is not a straight forward way
-        # to create a unit test for this.
-        if StrictVersion(modversion) < StrictVersion(min_module_version):
+        if LooseVersion(modversion) < LooseVersion(min_module_version):
             if warn_old_version:
                 # Attempt to create a pretty string version of the version
                 from ..core.compatibility import string_types


### PR DESCRIPTION
#### References to other Issues or PRs
See #13383 and #15642.

#### Brief description of what is fixed or changed


#### Other comments

This is just a quick hack. I guess the proper solution would be to use the `packaging` module (https://packaging.pypa.io/en/latest/version/), but I don't know what's SymPy's policy regarding adding new dependencies.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* external
  * Use `LooseVersion` instead of `StrictVersion` for checking external module dependencies
<!-- END RELEASE NOTES -->
