### PR TITLE
Caught and fixed a potential bug in sympy.stats.joint_rv

### DIFF
--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -98,11 +98,10 @@ class JointPSpace(ProductPSpace):
                 limits[index].append(self.distribution.set.args[i])
                 limits[index] = tuple(limits[index])
                 index += 1
-        limits = tuple(limits)
         if self.distribution.is_Continuous:
-            f = Lambda(sym, integrate(self.distribution(*all_syms), limits))
+            f = Lambda(sym, integrate(self.distribution(*all_syms), *limits))
         elif self.distribution.is_Discrete:
-            f = Lambda(sym, summation(self.distribution(all_syms), limits))
+            f = Lambda(sym, summation(self.distribution(*all_syms), *limits))
         return f.xreplace(replace_dict)
 
     def compute_expectation(self, expr, rvs=None, evaluate=False, **kwargs):

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -61,7 +61,7 @@ def test_JointPSpace_margial_distribution():
         8*polar_lift(x**2/2 + 1)**(S(5)/2))
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
     t = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)
-    assert marginal_distribution(t, 0)(1).evalf() == 0.206748335783172
+    assert marginal_distribution(t, 0)(1).evalf().round(1) == 0.2
 
 
 def test_JointRV():

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -60,6 +60,9 @@ def test_JointPSpace_margial_distribution():
     assert marginal_distribution(T, T[1])(x) == sqrt(2)*(x**2 + 2)/(
         8*polar_lift(x**2/2 + 1)**(S(5)/2))
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
+    t = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)
+    assert marginal_distribution(t, 0)(1).evalf() == 0.206748335783172
+
 
 def test_JointRV():
     from sympy.stats.joint_rv import JointDistributionHandmade


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
N/A

#### Brief description of what is fixed or changed 
There was a potential bug with marginal_distribution in sympy.stats.joint_rv. The method wasn't working for joint distributions of three or more variables due to the invalid formats of limit passed to integrate and summation methods.
Discussion for adding tests is needed.

#### Other comments
Code:
```
from sympy import *
from sympy.stats import *
from sympy.stats.joint_rv_types import *
from sympy.stats.joint_rv import *
x = symbols('x', real=True)
t3 = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)
print(marginal_distribution(t3, t3[0])(x))
```

Output Before Fix:
```
Traceback (most recent call last):
  File "/home/gagandeep/sympy_debug.py", line 236, in <module>
    print(marginal_distribution(t3, t3[0])(x))
  File "/home/gagandeep/sympy/sympy/stats/joint_rv.py", line 236, in marginal_distribution
    return prob_space.marginal_distribution(*indices)
  File "/home/gagandeep/sympy/sympy/stats/joint_rv.py", line 103, in marginal_distribution
    f = Lambda(sym, integrate(self.distribution(*all_syms), limits))
  File "/home/gagandeep/sympy/sympy/integrals/integrals.py", line 1474, in integrate
    integral = Integral(*args, **kwargs)
  File "/home/gagandeep/sympy/sympy/integrals/integrals.py", line 80, in __new__
    obj = AddWithLimits.__new__(cls, function, *symbols, **assumptions)
  File "/home/gagandeep/sympy/sympy/concrete/expr_with_limits.py", line 356, in __new__
    pre = _common_new(cls, function, *symbols, **assumptions)
  File "/home/gagandeep/sympy/sympy/concrete/expr_with_limits.py", line 38, in _common_new
    limits, orientation = _process_limits(*symbols)
  File "/home/gagandeep/sympy/sympy/concrete/expr_with_limits.py", line 123, in _process_limits
    raise ValueError('Invalid limits given: %s' % str(symbols))
ValueError: Invalid limits given: (((T[1], Reals), (T[2], Reals)),)

```
After Fix:
```
Integral(Piecewise(((x**2/polar_lift(x**2/3 + T[2]**2/3 + 1)**(7/2) + T[2]**2/polar_lift(x**2/3 + T[2]**2/3 + 1)**(7/2) + 3/polar_lift(x**2/3 + T[2]**2/3 + 1)**(7/2))/(6*pi), (Abs(arg(x**2/3 + T[2]**2/3 + 1)) < pi) | ((Abs(arg(x**2/3 + T[2]**2/3 + 1)) < pi) & Ne(Abs(arg(x**2/3 + T[2]**2/3 + 1)), pi) & Ne(1/(3*(x**2/3 + T[2]**2/3 + 1)), 0))), (Integral(4*sqrt(3)/(9*pi**2*(x**2/3 + T[1]**2/3 + T[2]**2/3 + 1)**3), (T[1], -oo, oo)), True)), (T[2], -oo, oo))
```

As is visible from the output of the marginal distribution of `MultivariateT` , it is quite complicated and hence most probably cannot be added to `sympy.stats.tests.test_joint_rv`. Can we discuss a good tests that can be added for avoiding this bug in feature.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
   * removed bug in `marginal_distribution` for joint distributions of three or more variables
<!-- END RELEASE NOTES -->
