### PR TITLE
Solves Issues #12558 : manualintegrate of sec(4*x)**2 doesn't give tan(4*x)/4

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -678,12 +678,7 @@ def trig_rule(integral):
             func = 'cos'
 
         return TrigRule(func, arg, integrand, symbol)
-    if (len(integrand.args) <= 2 and isinstance(integrand.args[0], (sympy.sec, sympy.csc)) or isinstance(integrand, (sympy.sec, sympy.csc))):
-        if isinstance(integrand, sympy.sec):
-            return TrigRule('sec', integrand.args[0], integrand, symbol)
-        elif isinstance(integrand, sympy.csc):
-            return TrigRule('csc', integrand.args[0], integrand, symbol)
-
+    if (len(integrand.args) <= 2 and isinstance(integrand.args[0], (sympy.sec, sympy.csc))):
         if (integrand.args[0] == symbol):
             if integrand == sympy.sec(symbol)**2:
                 return TrigRule('sec**2', symbol, integrand, symbol)
@@ -698,6 +693,16 @@ def trig_rule(integral):
 
     if isinstance(integrand, sympy.tan):
         rewritten = sympy.sin(*integrand.args) / sympy.cos(*integrand.args)
+    elif isinstance(integrand, sympy.cot):
+        rewritten = sympy.cos(*integrand.args) / sympy.sin(*integrand.args)
+    elif isinstance(integrand, sympy.sec):
+        arg = integrand.args[0]
+        rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) /
+                     (sympy.sec(arg) + sympy.tan(arg)))
+    elif isinstance(integrand, sympy.csc):
+        arg = integrand.args[0]
+        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
+                     (sympy.csc(arg) + sympy.cot(arg)))    
     else:
         return
 
@@ -1320,10 +1325,6 @@ def eval_trig(func, arg, integrand, symbol):
         return sympy.sec(arg)
     elif func == 'csc*cot':
         return sympy.csc(arg)
-    elif func == 'sec':
-        return sympy.log(sympy.sec(arg) + sympy.tan(arg)) / arg.diff(symbol)
-    elif func == 'csc':
-        return -sympy.log(sympy.csc(arg) + sympy.cot(arg)) / arg.diff(symbol)
     elif func == 'sec**2':
         return sympy.tan(arg) / arg.diff(symbol)
     elif func == 'csc**2':

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -701,7 +701,8 @@ def trig_rule(integral):
                      (sympy.sec(arg) + sympy.tan(arg)))
     elif isinstance(integrand, sympy.csc):
         arg = integrand.args[0]
-        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) / (sympy.csc(arg) + sympy.cot(arg)))    
+        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) / 
+                     (sympy.csc(arg) + sympy.cot(arg)))    
     else:
         return
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -699,7 +699,7 @@ def trig_rule(integral):
         arg = integrand.args[0]
         rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) /
                      (sympy.sec(arg) + sympy.tan(arg)))
-    elif isinstance(ntegrand, sympy.csc):
+    elif isinstance(integrand, sympy.csc):
         arg = integrand.args[0]
         rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
                      (sympy.csc(arg) + sympy.cot(arg)))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -678,11 +678,7 @@ def trig_rule(integral):
             func = 'cos'
 
         return TrigRule(func, arg, integrand, symbol)
-    if (len(integrand.args) <= 2 and isinstance(integrand.args[0], (sympy.sec, sympy.csc)) or isinstance(integrand, (sympy.sec, sympy.csc))):
-        if isinstance(integrand, sympy.sec):
-            return TrigRule('sec', integrand.args[0], integrand, symbol)
-        elif isinstance(integrand, sympy.csc):
-            return TrigRule('csc', integrand.args[0], integrand, symbol)
+    if (len(integrand.args) <= 2 and isinstance(integrand.args[0], (sympy.sec, sympy.csc))):
 
         if (integrand.args[0] == symbol):
             if integrand == sympy.sec(symbol)**2:
@@ -698,6 +694,15 @@ def trig_rule(integral):
 
     if isinstance(integrand, sympy.tan):
         rewritten = sympy.sin(*integrand.args) / sympy.cos(*integrand.args)
+    elif isinstance(integrand, sympy.cot):
+        rewritten = sympy.cos(*integrand.args) / sympy.sin(*integrand.args)
+    elif isinstance(integrand, sympy.sec):
+        arg = integrand.args[0]
+        rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) /
+                     (sympy.sec(arg) + sympy.tan(arg)))
+    elif isinstance(integrand, sympy.csc):
+        arg = integrand.args[0]
+        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) / (sympy.csc(arg) + sympy.cot(arg)))    
     else:
         return
 
@@ -1320,10 +1325,6 @@ def eval_trig(func, arg, integrand, symbol):
         return sympy.sec(arg)
     elif func == 'csc*cot':
         return sympy.csc(arg)
-    elif func == 'sec':
-        return sympy.log(sympy.sec(arg) + sympy.tan(arg)) / arg.diff(symbol)
-    elif func == 'csc':
-        return -sympy.log(sympy.csc(arg) + sympy.cot(arg)) / arg.diff(symbol)
     elif func == 'sec**2':
         return sympy.tan(arg) / arg.diff(symbol)
     elif func == 'csc**2':

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -697,12 +697,12 @@ def trig_rule(integral):
         rewritten = sympy.cos(*integrand.args) / sympy.sin(*integrand.args)
     elif isinstance(integrand, sympy.sec):
         arg = integrand.args[0]
-        rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) / 
+        rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) /
                      (sympy.sec(arg) + sympy.tan(arg)))
-    elif isinstance(integrand, sympy.csc):
+    elif isinstance(ntegrand, sympy.csc):
         arg = integrand.args[0]
-        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) / 
-                     (sympy.csc(arg) + sympy.cot(arg)))    
+        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
+                     (sympy.csc(arg) + sympy.cot(arg)))
     else:
         return
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -678,25 +678,26 @@ def trig_rule(integral):
             func = 'cos'
 
         return TrigRule(func, arg, integrand, symbol)
+    if (len(integrand.args) <= 2 and isinstance(integrand.args[0], (sympy.sec, sympy.csc)) or isinstance(integrand, (sympy.sec, sympy.csc))):
+        if isinstance(integrand, sympy.sec):
+            return TrigRule('sec', integrand.args[0], integrand, symbol)
+        elif isinstance(integrand, sympy.csc):
+            return TrigRule('csc', integrand.args[0], integrand, symbol)
 
-    sym = integrand.args[0].args[0]
-    if integrand == sympy.sec(sym)**2:
-        return TrigRule('sec**2', sym, integrand, symbol)
-    elif integrand == sympy.csc(sym)**2:
-        return TrigRule('csc**2', sym, integrand, symbol)
+        if (integrand.args[0] == symbol):
+            if integrand == sympy.sec(symbol)**2:
+                return TrigRule('sec**2', symbol, integrand, symbol)
+            elif integrand == sympy.csc(symbol)**2:
+                return TrigRule('csc**2', symbol, integrand, symbol)
+        else:
+            sym = integrand.args[0].args[0]
+            if integrand == sympy.sec(sym)**2:
+                return TrigRule('sec**2', sym, integrand, symbol)
+            elif integrand == sympy.csc(sym)**2:
+                return TrigRule('csc**2', sym, integrand, symbol)
 
     if isinstance(integrand, sympy.tan):
         rewritten = sympy.sin(*integrand.args) / sympy.cos(*integrand.args)
-    elif isinstance(integrand, sympy.cot):
-        rewritten = sympy.cos(*integrand.args) / sympy.sin(*integrand.args)
-    elif isinstance(integrand, sympy.sec):
-        arg = integrand.args[0]
-        rewritten = ((sympy.sec(arg)**2 + sympy.tan(arg) * sympy.sec(arg)) /
-                     (sympy.sec(arg) + sympy.tan(arg)))
-    elif isinstance(integrand, sympy.csc):
-        arg = integrand.args[0]
-        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
-                     (sympy.csc(arg) + sympy.cot(arg)))
     else:
         return
 
@@ -928,7 +929,6 @@ def trig_cotcsc_rule(integral):
         match = integrand.match(pattern)
         if not match:
             return
-
         return multiplexer({
             cotcsc_cotodd_condition: cotcsc_cotodd,
             cotcsc_csceven_condition: cotcsc_csceven
@@ -1320,10 +1320,14 @@ def eval_trig(func, arg, integrand, symbol):
         return sympy.sec(arg)
     elif func == 'csc*cot':
         return sympy.csc(arg)
+    elif func == 'sec':
+        return sympy.log(sympy.sec(arg) + sympy.tan(arg)) / arg.diff(symbol)
+    elif func == 'csc':
+        return -sympy.log(sympy.csc(arg) + sympy.cot(arg)) / arg.diff(symbol)
     elif func == 'sec**2':
-        return sympy.tan(arg)/arg.diff(symbol)
+        return sympy.tan(arg) / arg.diff(symbol)
     elif func == 'csc**2':
-        return -sympy.cot(arg)/arg.diff(symbol)
+        return -sympy.cot(arg) / arg.diff(symbol)
 
 @evaluates(ArctanRule)
 def eval_arctan(a, b, c, integrand, symbol):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -701,8 +701,7 @@ def trig_rule(integral):
                      (sympy.sec(arg) + sympy.tan(arg)))
     elif isinstance(integrand, sympy.csc):
         arg = integrand.args[0]
-        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) /
-                     (sympy.csc(arg) + sympy.cot(arg)))    
+        rewritten = ((sympy.csc(arg)**2 + sympy.cot(arg) * sympy.csc(arg)) / (sympy.csc(arg) + sympy.cot(arg)))    
     else:
         return
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -679,10 +679,11 @@ def trig_rule(integral):
 
         return TrigRule(func, arg, integrand, symbol)
 
-    if integrand == sympy.sec(symbol)**2:
-        return TrigRule('sec**2', symbol, integrand, symbol)
-    elif integrand == sympy.csc(symbol)**2:
-        return TrigRule('csc**2', symbol, integrand, symbol)
+    sym = integrand.args[0].args[0]
+    if integrand == sympy.sec(sym)**2:
+        return TrigRule('sec**2', sym, integrand, symbol)
+    elif integrand == sympy.csc(sym)**2:
+        return TrigRule('csc**2', sym, integrand, symbol)
 
     if isinstance(integrand, sympy.tan):
         rewritten = sympy.sin(*integrand.args) / sympy.cos(*integrand.args)
@@ -1320,9 +1321,9 @@ def eval_trig(func, arg, integrand, symbol):
     elif func == 'csc*cot':
         return sympy.csc(arg)
     elif func == 'sec**2':
-        return sympy.tan(arg)
+        return sympy.tan(arg)/arg.diff(symbol)
     elif func == 'csc**2':
-        return -sympy.cot(arg)
+        return -sympy.cot(arg)/arg.diff(symbol)
 
 @evaluates(ArctanRule)
 def eval_arctan(a, b, c, integrand, symbol):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -75,6 +75,7 @@ def test_manualintegrate_trigonometry():
     assert manualintegrate(csc(2*x)**2, x) == -cot(2*x)/2
     assert manualintegrate(sec(2*x), x) == log(tan(2*x) + sec(2*x)) / 2
     assert manualintegrate(csc(4*x), x) == -log(cot(4*x) + csc(4*x)) / 4
+    assert manualintegrate(sec(x**2)**2, x) == tan(x**2) / 2*x
 
     assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -70,6 +70,8 @@ def test_manualintegrate_trigonometry():
 
     assert manualintegrate(sec(x), x) == log(sec(x) + tan(x))
     assert manualintegrate(csc(x), x) == -log(csc(x) + cot(x))
+    #Test for Issue#12558
+    assert manualintegrate(sec(4*x)**2, x) == tan(4*x)/4
 
     assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -72,6 +72,9 @@ def test_manualintegrate_trigonometry():
     assert manualintegrate(csc(x), x) == -log(csc(x) + cot(x))
     #Test for Issue#12558
     assert manualintegrate(sec(4*x)**2, x) == tan(4*x)/4
+    assert manualintegrate(csc(2*x)**2, x) == -cot(2*x)/2
+    assert manualintegrate(sec(2*x), x) == log(tan(2*x) + sec(2*x)) / 2
+    assert manualintegrate(csc(4*x), x) == -log(cot(4*x) + csc(4*x)) / 4
 
     assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -75,7 +75,7 @@ def test_manualintegrate_trigonometry():
     assert manualintegrate(csc(2*x)**2, x) == -cot(2*x)/2
     assert manualintegrate(sec(2*x), x) == log(tan(2*x) + sec(2*x)) / 2
     assert manualintegrate(csc(4*x), x) == -log(cot(4*x) + csc(4*x)) / 4
-    assert manualintegrate(sec(x**2)**2, x) == tan(x**2) / 2*x
+    assert manualintegrate(sec(x**2)**2, x) == (tan(x**2)) / (2*x)
 
     assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Updated integrals : manualintegrate.py 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #12558 



#### Brief description of what is fixed or changed
Updated manualintegrate.py and test_manual.py 
By adding conditions to trig_rule(integral) and 
new test for the issue #12558 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  integrals
   *  Added suitable conditions to manualintegrate.py for integration of type `sec(a*x)**2` and `csc(a*x)**2`
<!-- END RELEASE NOTES -->
