### PR TITLE
polys: Remove leading term created by rounding error in long division

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1262,6 +1262,13 @@ def test_issue_2708():
         NonElementaryIntegral(exp(-1.2*n*s*z)*exp(1.2*n*s*z**2/t),
                                   (z, 0, x))
 
+
+def test_issue_2884():
+    f = (4.000002016020*x + 4.000002016020*y + 4.000006024032)*exp(10.0*x)
+    e = integrate(f, (x, 0.1, 0.2))
+    assert str(e) == '1.86831064982608*y + 2.16387491480008'
+
+
 def test_issue_8368():
     assert integrate(exp(-s*x)*cosh(x), (x, 0, oo)) == \
         Piecewise(

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -1449,6 +1449,12 @@ def dup_ff_div(f, g, K):
 
         if dr < dg:
             break
+        elif dr == _dr and not K.is_Exact:
+            # remove leading term created by rounding error
+            r = dup_strip(r[1:])
+            dr = dup_degree(r)
+            if dr < dg:
+                break
         elif not (dr < _dr):
             raise PolynomialDivisionFailed(f, g, K)
 

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -50,6 +50,13 @@ class FractionField(Field, CompositeDomain):
     def order(self):
         return self.field.order
 
+    @property
+    def is_Exact(self):
+        return self.domain.is_Exact
+
+    def get_exact(self):
+        return FractionField(self.domain.get_exact(), self.symbols)
+
     def __str__(self):
         return str(self.domain) + '(' + ','.join(map(str, self.symbols)) + ')'
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -982,7 +982,8 @@ def roots(f, *gens, **flags):
     result = {}
 
     if not f.is_ground:
-        if not f.get_domain().is_Exact:
+        dom = f.get_domain()
+        if not dom.is_Exact and dom.is_Numerical:
             for r in f.nroots():
                 _update_dict(result, r, 1)
         elif f.degree() == 1:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1732,6 +1732,12 @@ def test_div():
     assert q.get_domain().is_Frac and r.get_domain().is_Frac
 
 
+def test_issue_7864():
+    q, r = div(a, .408248290463863*a)
+    assert abs(q - 2.44948974278318) < 1e-14
+    assert r == 0
+
+
 def test_gcdex():
     f, g = 2*x, x**2 - 16
     s, t, h = x/32, -Rational(1, 16), 1

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3402,6 +3402,18 @@ def test_factoring_ode():
     assert soln == dsolve(eqn, f(x))
 
 
+def test_issue_11542():
+    m = 96
+    g = 9.8
+    k = .2
+    f1 = g * m
+    t = Symbol('t')
+    v = Function('v')
+    v_equation = dsolve(f1 - k * (v(t) ** 2) - m * Derivative(v(t)), 0)
+    assert str(v_equation) == \
+        'Eq(v(t), -68.585712797929/tanh(C1 - 0.142886901662352*t))'
+
+
 def test_issue_15913():
     eq = -C1/x - 2*x*f(x) - f(x) + Derivative(f(x), x)
     sol = C2*exp(x**2 + x) + exp(x**2 + x)*Integral(C1*exp(-x**2 - x)/x, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #2884
Fixes #7864
Fixes #11542
Expected to fix also #12870

#### Brief description of what is fixed or changed
In a long division step of polynomials, the leading coefficient  a
of the dividend  f  is divided by the leading coefficient  b  of the
divisor g and the remainder  `r = f - (a/b)*x**d*g`  is constructed.
This will cancel the leading term of  f  if  `a - (a/b)*b`  is zero.
However, in an inexact domain like RR there may remain a small nonzero
residue. This patch will replace it by zero.

#### Other comments
The same exception, PolynomialDivisionFailed, is also raised in several cases where
the expression domain EX is involved. It would probably be safe to remove the leading
term also in those cases (the coefficient expression should be zero but that could not be
detected). I have not done that as the resulting expressions are likely too complicated
to be useful.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
    - Remove leading term created by rounding error in long division
    - Define is_Exact and get_exact methods for FractionField
<!-- END RELEASE NOTES -->
