### PR TITLE
Added code and tests to make is_scalar for a matrix as False

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -41,7 +41,6 @@ class DenseMatrix(MatrixBase):
 
     _op_priority = 10.01
     _class_priority = 4
-    is_scalar = False
 
     def __eq__(self, other):
         other = sympify(other)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -41,6 +41,7 @@ class DenseMatrix(MatrixBase):
 
     _op_priority = 10.01
     _class_priority = 4
+    is_scalar = False
 
     def __eq__(self, other):
         other = sympify(other)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -69,6 +69,7 @@ class MatrixExpr(Expr):
     is_commutative = False
     is_number = False
     is_symbol = False
+    is_scalar = False
 
     def __new__(cls, *args, **kwargs):
         args = map(sympify, args)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -373,6 +373,10 @@ def test_issue_7842():
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True
 
+def test_issue_16510():
+    A = MatrixSymbol('A', 3, 1)
+    assert A.is_scalar == False
+
 
 def test_generic_zero_matrix():
     z = GenericZeroMatrix()

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -373,9 +373,13 @@ def test_issue_7842():
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True
 
+
 def test_issue_16510():
     A = MatrixSymbol('A', 3, 1)
+    B = MatrixSymbol('B', 1, 1)
+
     assert A.is_scalar == False
+    assert B.is_scalar == False
 
 
 def test_generic_zero_matrix():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -17,6 +17,7 @@ class Vector(BasisDependent):
     """
 
     is_Vector = True
+    is_scalar = False
     _op_priority = 12.0
 
     @property


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16510

#### Brief description of what is fixed or changed
Added is_scalar for matrices to be False always
Added test

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Set is_scalar = False for matrices
<!-- END RELEASE NOTES -->
