### PR TITLE
raise errors when parser gets bad input

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -9,27 +9,12 @@ from keyword import iskeyword
 
 import ast
 import unicodedata
-import re
-import string
 
-from sympy.core.compatibility import (exec_, StringIO, iterable, PY3,
-    string_types)
+from sympy.core.compatibility import exec_, StringIO, iterable
 from sympy.core.basic import Basic
-from sympy.core.function import arity
-from sympy.core.singleton import S
 from sympy.core import Symbol
 from sympy.utilities.misc import filldedent, func_name
 
-
-_py2name = re.compile(r'^[a-zA-Z_]\w*$')
-def valid_name(name):
-    if not isinstance(name, string_types):
-        return False
-    if iskeyword(name):
-        return False
-    if PY3:
-        return name.isidentifier()
-    return _py2name.match(name)
 
 
 def _token_splittable(token):
@@ -988,30 +973,18 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
         for _ in transformations:
             if not callable(_):
                 raise TypeError(filldedent('''
-                    expected a function in transformations,
+                    expected a function in `transformations`,
                     not %s''' % func_name(_)))
             if arity(_) != 3:
                 raise TypeError(filldedent('''
-                    transformations should be functions that
-                    takes 3 arguments.'''))
+                    a transformation should be function that
+                    takes 3 arguments'''))
     code = stringify_expr(s, local_dict, global_dict, transformations)
 
     if not evaluate:
         code = compile(evaluateFalse(code), '<string>', 'eval')
 
-    rv = eval_expr(code, local_dict, global_dict)
-    def check(e):
-        # check to see that all symbols have valid names;
-        # if they don't this might represent a parsing issue
-        if iterable(e):
-            for i in e:
-                check(i)
-        elif isinstance(e, Basic):
-            for i in e.free_symbols:
-                if not valid_name(i.name):
-                    raise SyntaxError('invalid name: %s' % i.name)
-    check(rv)
-    return rv
+    return eval_expr(code, local_dict, global_dict)
 
 
 def evaluateFalse(s):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -987,23 +987,19 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
         code = compile(evaluateFalse(code), '<string>', 'eval')
 
     rv = eval_expr(code, local_dict, global_dict)
-    known = set(local_dict.keys()) | set(global_dict.keys())
     def check(e):
         if type(e) in (list, tuple, set):
             for i in e:
                 check(i)
         elif isinstance(e, Basic):
             for i in e.atoms(Symbol):
-                if i.name not in known and \
-                        i.name[0] in string.digits and \
+                if i.name[0] in string.digits and \
                         S(i.name).is_Number:
                     raise SyntaxError(filldedent('''
                         %s was parsed as a Symbol; space may be needed
-                        to disambiguate a symbol from this number.'''
+                        to disambiguate this number from a preceeding
+                        Symbol.'''
                         % i.name))
-        else:
-            raise NotImplementedError(
-                'expected list, set, tuple or Basic, not %s' % e)
     check(rv)
     return rv
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -13,6 +13,7 @@ import unicodedata
 from sympy.core.compatibility import exec_, StringIO, iterable
 from sympy.core.basic import Basic
 from sympy.core import Symbol
+from sympy.core.function import arity
 from sympy.utilities.misc import filldedent, func_name
 
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -988,7 +988,7 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     rv = eval_expr(code, local_dict, global_dict)
     def check(e):
-        if type(e) in (list, tuple, set):
+        if iterable(e):
             for i in e:
                 check(i)
         elif isinstance(e, Basic):

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -9,13 +9,13 @@ from sympy.core.compatibility import PY3
 from sympy.functions import exp, factorial, factorial2, sin
 from sympy.logic import And
 from sympy.series import Limit
-from sympy.utilities.pytest import raises, skip, XFAIL
+from sympy.utilities.pytest import raises, skip
 
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
     split_symbols, implicit_multiplication, convert_equals_signs,
     convert_xor, function_exponentiation,
-    implicit_multiplication_application, valid_name,
+    implicit_multiplication_application,
     )
 
 
@@ -66,14 +66,6 @@ def test_sympy_parser():
     raises(TypeError, lambda: parse_expr('x', {}, [], []))
     raises(TypeError, lambda: parse_expr('x', [], [], {}))
     raises(TypeError, lambda: parse_expr('x', [], [], {}))
-
-
-@XFAIL  # raises SyntaxError
-def test_issue_16591():
-    x = Symbol('x')
-    x3 = Symbol('x3')
-    t = standard_transformations + (implicit_multiplication_application,)
-    assert parse_expr('2**x3**x', transformations=t) == 2**(x3**x)
 
 
 def test_rationalize():
@@ -266,12 +258,3 @@ def test_python3_features():
     assert parse_expr('.[3_4]') == parse_expr('.[34]') == Rational(34, 99)
     assert parse_expr('.1[3_4]') == parse_expr('.1[34]') == Rational(133, 990)
     assert parse_expr('123_123.123_123[3_4]') == parse_expr('123123.123123[34]') == Rational(12189189189211, 99000000)
-
-
-def test_valid_name():
-    assert not valid_name(3)
-    assert not valid_name('3')
-    assert not valid_name(' x')
-    assert not valid_name('a=b')
-    assert not valid_name('for')
-    assert valid_name('_ok2')

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 
+
 import sys
+
 
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
 from sympy.core.compatibility import PY3
 from sympy.functions import exp, factorial, factorial2, sin
 from sympy.logic import And
 from sympy.series import Limit
-from sympy.utilities.pytest import raises, skip
+from sympy.utilities.pytest import raises, skip, XFAIL
+
 
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
@@ -48,15 +51,11 @@ def test_sympy_parser():
             evaluate=False),
         'Limit(sin(x), x, 0, dir="-")': Limit(sin(x), x, 0, dir='-'),
 
+
     }
     for text, result in inputs.items():
         assert parse_expr(text) == result
 
-    # issue 16591
-    t = standard_transformations + (implicit_multiplication_application,)
-    raises(SyntaxError, lambda: parse_expr('2**x3**x', transformations=t))
-    # not sure that it's possible to make '3' become a Symbol
-    assert parse_expr('2**x3**x', {'3': 3}, transformations=t) == 6**x
     raises(TypeError, lambda:
         parse_expr('x', standard_transformations))
     raises(TypeError, lambda:
@@ -67,6 +66,14 @@ def test_sympy_parser():
     raises(TypeError, lambda: parse_expr('x', {}, [], []))
     raises(TypeError, lambda: parse_expr('x', [], [], {}))
     raises(TypeError, lambda: parse_expr('x', [], [], {}))
+
+
+@XFAIL  # raises SyntaxError
+def test_issue_16591():
+    x = Symbol('x')
+    x3 = Symbol('x3')
+    t = standard_transformations + (implicit_multiplication_application,)
+    assert parse_expr('2**x3**x', transformations=t) == 2**(x3**x)
 
 
 def test_rationalize():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -12,7 +12,7 @@ from sympy.utilities.pytest import raises, skip
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
     split_symbols, implicit_multiplication, convert_equals_signs, convert_xor,
-    function_exponentiation,
+    function_exponentiation, implicit_multiplication_application,
 )
 
 
@@ -51,6 +51,20 @@ def test_sympy_parser():
     }
     for text, result in inputs.items():
         assert parse_expr(text) == result
+
+    # issue 16591
+    t = standard_transformations + (implicit_multiplication_application,)
+    raises(SyntaxError, lambda: parse_expr('2**x3**x', transformations=t))
+    raises(TypeError, lambda:
+        parse_expr('x', standard_transformations))
+    raises(TypeError, lambda:
+        parse_expr('x', transformations=lambda x,y: 1))
+    raises(TypeError, lambda:
+        parse_expr('x', transformations=(lambda x,y: 1,)))
+    raises(TypeError, lambda: parse_expr('x', transformations=((),)))
+    raises(TypeError, lambda: parse_expr('x', {}, [], []))
+    raises(TypeError, lambda: parse_expr('x', [], [], {}))
+    raises(TypeError, lambda: parse_expr('x', [], [], {}))
 
 
 def test_rationalize():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -11,12 +11,12 @@ from sympy.logic import And
 from sympy.series import Limit
 from sympy.utilities.pytest import raises, skip, XFAIL
 
-
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
-    split_symbols, implicit_multiplication, convert_equals_signs, convert_xor,
-    function_exponentiation, implicit_multiplication_application,
-)
+    split_symbols, implicit_multiplication, convert_equals_signs,
+    convert_xor, function_exponentiation,
+    implicit_multiplication_application, valid_name,
+    )
 
 
 def test_sympy_parser():
@@ -266,3 +266,12 @@ def test_python3_features():
     assert parse_expr('.[3_4]') == parse_expr('.[34]') == Rational(34, 99)
     assert parse_expr('.1[3_4]') == parse_expr('.1[34]') == Rational(133, 990)
     assert parse_expr('123_123.123_123[3_4]') == parse_expr('123123.123123[34]') == Rational(12189189189211, 99000000)
+
+
+def test_valid_name():
+    assert not valid_name(3)
+    assert not valid_name('3')
+    assert not valid_name(' x')
+    assert not valid_name('a=b')
+    assert not valid_name('for')
+    assert valid_name('_ok2')

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -55,6 +55,8 @@ def test_sympy_parser():
     # issue 16591
     t = standard_transformations + (implicit_multiplication_application,)
     raises(SyntaxError, lambda: parse_expr('2**x3**x', transformations=t))
+    # not sure that it's possible to make '3' become a Symbol
+    assert parse_expr('2**x3**x', {'3': 3}, transformations=t) == 6**x
     raises(TypeError, lambda:
         parse_expr('x', standard_transformations))
     raises(TypeError, lambda:

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -88,6 +88,7 @@ def test_rationalize():
 def test_factorial_fail():
     inputs = ['x!!!', 'x!!!!', '(!)']
 
+
     for text in inputs:
         try:
             parse_expr(text)
@@ -100,17 +101,21 @@ def test_repeated_fail():
     inputs = ['1[1]', '.1e1[1]', '0x1[1]', '1.1j[1]', '1.1[1 + 1]',
         '0.1[[1]]', '0x1.1[1]']
 
+
     # All are valid Python, so only raise TypeError for invalid indexing
     for text in inputs:
         raises(TypeError, lambda: parse_expr(text))
+
 
     inputs = ['0.1[', '0.1[1', '0.1[]']
     for text in inputs:
         raises((TokenError, SyntaxError), lambda: parse_expr(text))
 
+
 def test_repeated_dot_only():
     assert parse_expr('.[1]') == Rational(1, 9)
     assert parse_expr('1 + .[1]') == Rational(10, 9)
+
 
 def test_local_dict():
     local_dict = {
@@ -160,6 +165,7 @@ def test_issue_7663():
     e = '2*(x+1)'
     assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
 
+
 def test_issue_10560():
     inputs = {
         '4*-3' : '(-3)*4',
@@ -167,6 +173,7 @@ def test_issue_10560():
     }
     for text, result in inputs.items():
         assert parse_expr(text, evaluate=False) == parse_expr(result, evaluate=False)
+
 
 def test_issue_10773():
     inputs = {
@@ -184,6 +191,7 @@ def test_split_symbols():
     y = Symbol('y')
     xy = Symbol('xy')
 
+
     assert parse_expr("xy") == xy
     assert parse_expr("xy", transformations=transformations) == x*y
 
@@ -195,6 +203,7 @@ def test_split_symbols_function():
     y = Symbol('y')
     a = Symbol('a')
     f = Function('f')
+
 
     assert parse_expr("ay(x+1)", transformations=transformations) == a*y*(x+1)
     assert parse_expr("af(x+1)", transformations=transformations,
@@ -219,6 +228,7 @@ def test_match_parentheses_implicit_multiplication():
                       (implicit_multiplication,)
     raises(TokenError, lambda: parse_expr('(1,2),(3,4]',transformations=transformations))
 
+
 def test_convert_equals_signs():
     transformations = standard_transformations + \
                         (convert_equals_signs, )
@@ -240,12 +250,15 @@ def test_unicode_names():
     if not PY3:
         skip("test_unicode_names can only pass in Python 3")
 
+
     assert parse_expr(u'α') == Symbol(u'α')
+
 
 def test_python3_features():
     # Make sure the tokenizer can handle Python 3-only features
     if sys.version_info < (3, 6):
         skip("test_python3_features requires Python 3.6 or newer")
+
 
     assert parse_expr("123_456") == 123456
     assert parse_expr("1.2[3_4]") == parse_expr("1.2[34]") == Rational(611, 495)


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

motivated by #16591 but does not fix that issue

#### Brief description of what is fixed or changed


Argument checking has been improved so errors are raised when unexpected types are encountered.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - more user-friendly errors are raised when bad input is given to `parse_expr`
<!-- END RELEASE NOTES -->
