### PR TITLE
Rewriting signum to heaviside theta

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -392,7 +392,7 @@ class sign(Function):
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         from sympy.functions.special.delta_functions import Heaviside
         if arg.is_extended_real:
-            return Heaviside(arg)*2 - 1
+            return Heaviside(arg, H0=S(1)/2)*2-1
 
     def _eval_simplify(self, **kwargs):
         return self.func(self.args[0].factor())  # XXX include doit?

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -392,7 +392,7 @@ class sign(Function):
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         from sympy.functions.special.delta_functions import Heaviside
         if arg.is_extended_real:
-            return Heaviside(arg, H0=S(1)/2)*2-1
+            return Heaviside(arg, H0=S(1)/2) * 2 - 1
 
     def _eval_simplify(self, **kwargs):
         return self.func(self.args[0].factor())  # XXX include doit?

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -299,7 +299,7 @@ def test_sign():
     assert sign(x).rewrite(Piecewise) == \
         Piecewise((1, x > 0), (-1, x < 0), (0, True))
     assert sign(y).rewrite(Piecewise) == sign(y)
-    assert sign(x).rewrite(Heaviside) == 2*Heaviside(x)-1
+    assert sign(x).rewrite(Heaviside) == 2*Heaviside(x, H0=S(1)/2) - 1
     assert sign(y).rewrite(Heaviside) == sign(y)
 
     # evaluate what can be evaluated

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -4,7 +4,7 @@ from sympy.core import S, sympify, diff
 from sympy.core.decorators import deprecated
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_not
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.complexes import im, sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys.polyerrors import PolynomialError
@@ -581,8 +581,13 @@ class Heaviside(Function):
 
         """
         if arg.is_extended_real:
-            if H0 == S.Half:
-                return (sign(arg)+1)/2
+            pw1 = Piecewise(
+                ((sign(arg) + 1)/2, Ne(arg, 0)),
+                (Heaviside(0, H0=H0), True))
+            pw2 = Piecewise(
+                ((sign(arg) + 1)/2, Eq(Heaviside(0, H0=H0), S(1)/2)),
+                (pw1, True))
+            return pw2
 
     def _eval_rewrite_as_SingularityFunction(self, args, **kwargs):
         """

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -581,7 +581,7 @@ class Heaviside(Function):
 
         """
         if arg.is_extended_real:
-            if H0 is None or H0 == S.Half:
+            if H0 == S.Half:
                 return (sign(arg)+1)/2
 
     def _eval_rewrite_as_SingularityFunction(self, args, **kwargs):

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -554,16 +554,16 @@ class Heaviside(Function):
         >>> from sympy import Heaviside, Symbol, sign
         >>> x = Symbol('x', real=True)
 
-        >>> Heaviside(x).rewrite(sign)
+        >>> Heaviside(x, H0=S.Half).rewrite(sign)
         sign(x)/2 + 1/2
 
         >>> Heaviside(x, 0).rewrite(sign)
         Heaviside(x, 0)
 
-        >>> Heaviside(x - 2).rewrite(sign)
+        >>> Heaviside(x - 2, H0=S.Half).rewrite(sign)
         sign(x - 2)/2 + 1/2
 
-        >>> Heaviside(x**2 - 2*x + 1).rewrite(sign)
+        >>> Heaviside(x**2 - 2*x + 1, H0=S.Half).rewrite(sign)
         sign(x**2 - 2*x + 1)/2 + 1/2
 
         >>> y = Symbol('y')

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -451,10 +451,12 @@ class Heaviside(Function):
             raise ArgumentIndexError(self, argindex)
 
     def __new__(cls, arg, H0=None, **options):
+        if isinstance(H0, Heaviside) and len(H0.args) == 1:
+            H0 = None
+
         if H0 is None:
             return super(cls, cls).__new__(cls, arg, **options)
-        else:
-            return super(cls, cls).__new__(cls, arg, H0, **options)
+        return super(cls, cls).__new__(cls, arg, H0, **options)
 
     @classmethod
     def eval(cls, arg, H0=None):

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -558,7 +558,7 @@ class Heaviside(Function):
         sign(x)/2 + 1/2
 
         >>> Heaviside(x, 0).rewrite(sign)
-        Heaviside(x, 0)
+        Piecewise((sign(x)/2 + 1/2, Ne(x, 0)), (0, True))
 
         >>> Heaviside(x - 2, H0=S.Half).rewrite(sign)
         sign(x - 2)/2 + 1/2

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -551,7 +551,7 @@ class Heaviside(Function):
         Examples
         ========
 
-         >>> from sympy import Heaviside, Symbol, sign, S
+        >>> from sympy import Heaviside, Symbol, sign, S
         >>> x = Symbol('x', real=True)
 
         >>> Heaviside(x, H0=S.Half).rewrite(sign)

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -551,7 +551,7 @@ class Heaviside(Function):
         Examples
         ========
 
-        >>> from sympy import Heaviside, Symbol, sign
+         >>> from sympy import Heaviside, Symbol, sign, S
         >>> x = Symbol('x', real=True)
 
         >>> Heaviside(x, H0=S.Half).rewrite(sign)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -125,11 +125,13 @@ def test_rewrite():
         Piecewise((0, x < 0), (1, x >= 0)))
 
     assert Heaviside(x).rewrite(sign) == \
+        Heaviside(x, H0=Heaviside(0)).rewrite(sign) == \
         Piecewise(
             (sign(x)/2 + S(1)/2, Eq(Heaviside(0), S(1)/2)),
             (Piecewise(
                 (sign(x)/2 + S(1)/2, Ne(x, 0)), (Heaviside(0), True)), True)
         )
+
     assert Heaviside(y).rewrite(sign) == Heaviside(y)
     assert Heaviside(x, S.Half).rewrite(sign) == (sign(x)+1)/2
     assert Heaviside(x, y).rewrite(sign) == \

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -122,7 +122,7 @@ def test_rewrite():
     assert Heaviside(x, 1).rewrite(Piecewise) == (
         Piecewise((0, x < 0), (1, x >= 0)))
 
-    assert Heaviside(x).rewrite(sign) == (sign(x)+1)/2
+    assert Heaviside(x).rewrite(sign) == Heaviside(x)
     assert Heaviside(y).rewrite(sign) == Heaviside(y)
     assert Heaviside(x, S.Half).rewrite(sign) == (sign(x)+1)/2
     assert Heaviside(x, y).rewrite(sign) == Heaviside(x, y)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -1,6 +1,6 @@
 from sympy import (
     adjoint, conjugate, DiracDelta, Heaviside, nan, pi, sign, sqrt,
-    symbols, transpose, Symbol, Piecewise, I, S, Eq, oo,
+    symbols, transpose, Symbol, Piecewise, I, S, Eq, Ne, oo,
     SingularityFunction, signsimp
 )
 
@@ -122,10 +122,20 @@ def test_rewrite():
     assert Heaviside(x, 1).rewrite(Piecewise) == (
         Piecewise((0, x < 0), (1, x >= 0)))
 
-    assert Heaviside(x).rewrite(sign) == Heaviside(x)
+    assert Heaviside(x).rewrite(sign) == \
+        Piecewise(
+            (sign(x)/2 + S(1)/2, Eq(Heaviside(0), S(1)/2)),
+            (Piecewise(
+                (sign(x)/2 + S(1)/2, Ne(x, 0)), (Heaviside(0), True)), True)
+        )
     assert Heaviside(y).rewrite(sign) == Heaviside(y)
     assert Heaviside(x, S.Half).rewrite(sign) == (sign(x)+1)/2
-    assert Heaviside(x, y).rewrite(sign) == Heaviside(x, y)
+    assert Heaviside(x, y).rewrite(sign) == \
+        Piecewise(
+            (sign(x)/2 + S(1)/2, Eq(y, S(1)/2)),
+            (Piecewise(
+                (sign(x)/2 + S(1)/2, Ne(x, 0)), (y, True)), True)
+        )
 
     assert DiracDelta(y).rewrite(Piecewise) == Piecewise((DiracDelta(0), Eq(y, 0)), (0, True))
     assert DiracDelta(y, 1).rewrite(Piecewise) == DiracDelta(y, 1)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -90,8 +90,10 @@ def test_heaviside():
     assert Heaviside(0, nan) == nan
     assert Heaviside(x, None) == Heaviside(x)
     assert Heaviside(0, None) == Heaviside(0)
-    # we do not want None in the args:
-    assert None not in Heaviside(x, None).args
+
+    # we do not want None and Heaviside(0) in the args:
+    assert Heaviside(x, H0=None).args == (x,)
+    assert Heaviside(x, H0=Heaviside(0)).args == (x,)
 
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Signum is defined as following in sympy,
![image](https://user-images.githubusercontent.com/34944973/55774584-adf93a80-5ad0-11e9-8b62-64eb8a7b49e3.png)

And default `heaviside(x)` is undefined when `x=0` in sympy.

So rewriting should be (Updated to @asmeurer 's suggestion)
![image](https://user-images.githubusercontent.com/34944973/62187512-8d692f00-b3a4-11e9-87bf-781404b428e0.png)


rather than
![image](https://user-images.githubusercontent.com/34944973/55777585-48f71200-5adb-11e9-85d1-cd6630586aab.png)

The difference is that rewriting signum to heaviside, should set `H0=1/2` and rewriting heaviside to signum should be only possible in `H0=1/2`

#### Other comments


#### Release Notes


<!-- BEGIN RELEASE NOTES -->

- functions
  - Fixed `H0=Heaviside(0)` making the function to have `Heaviside(0)` as a second argument.
  - Rewriting `Heaviside` to `sign` will respect the definition of `Heaviside(0)`. Users should manually set `H0=1/2` or substitute the `Heaviside(0)` into a definition to yield previous result.
  - Rewriting `sign` to `Heaviside` will automatically set `H0=1/2` for `Heaviside`


<!-- END RELEASE NOTES -->
