### PR TITLE
deleted unused param "session" from process_split

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -10,7 +10,7 @@ import re
 
 sp = re.compile(r'([0-9]+)/([1-9][0-9]*)')
 
-def process_split(session, config, items):
+def process_split(config, items):
     split = config.getoption("--split")
     if not split:
         return
@@ -56,10 +56,10 @@ def pytest_addoption(parser):
         help="split tests")
 
 
-def pytest_collection_modifyitems(session, config, items):
+def pytest_collection_modifyitems(config, items):
     """ pytest hook. """
     # handle splits
-    process_split(session, config, items)
+    process_split(config, items)
 
 
 @pytest.fixture(autouse=True, scope='module')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
closes #16594

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * removed unused parameter from process_split function
<!-- END RELEASE NOTES -->
