### PR TITLE
Fixed LaTeX, pretty, MathML Presentation, and str printing of UniversalSet

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -331,7 +331,7 @@ class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
 
         >>> from sympy import true
         >>> true.as_set()
-        UniversalSet()
+        UniversalSet
         """
         return S.UniversalSet
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1710,7 +1710,7 @@ class LatexPrinter(Printer):
         )
 
     def _print_UniversalSet(self, expr):
-        return r"\text{UniversalSet}"
+        return r"\mathbb{U}"
 
     def _print_tuple(self, expr):
         return r"\left( %s\right)" % \

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1709,6 +1709,9 @@ class LatexPrinter(Printer):
             self._print(expr.args[0])
         )
 
+    def _print_UniversalSet(self, expr):
+        return r"\text{UniversalSet}"
+
     def _print_tuple(self, expr):
         return r"\left( %s\right)" % \
             r", \  ".join([self._print(i) for i in expr])

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1576,6 +1576,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(self.dom.createTextNode('&#x2205;'))
         return x
 
+    def _print_UniversalSet(self, e):
+        x = self.dom.createElement('mo')
+        x.appendChild(self.dom.createTextNode('&#x1D54C;'))
+        return x
+
     def _print_Adjoint(self, expr):
         from sympy.matrices import MatrixSymbol
         mat = expr.arg

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2105,7 +2105,10 @@ class PrettyPrinter(Printer):
         return pretty
 
     def _print_UniversalSet(self, s):
-        return prettyForm('UniversalSet')
+        if self._use_unicode:
+            return prettyForm(u"\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL U}")
+        else:
+            return prettyForm('UniversalSet')
 
     def _print_PolyRing(self, ring):
         return prettyForm(sstr(ring))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2104,6 +2104,9 @@ class PrettyPrinter(Printer):
         pretty = prettyForm(*stringPict.next(type(s).__name__, pretty))
         return pretty
 
+    def _print_UniversalSet(self, s):
+        return prettyForm('UniversalSet')
+
     def _print_PolyRing(self, ring):
         return prettyForm(sstr(ring))
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4174,6 +4174,11 @@ GroebnerBasis⎝⎣2⋅x - y  - y + 1, y  + 2⋅y  - 3⋅y  - 16⋅y + 7⎦, x, 
     assert upretty(expr) == ucode_str
 
 
+def test_pretty_UniversalSet():
+    assert pretty(S.UniversalSet) == "UniversalSet"
+    assert upretty(S.UniversalSet) == u"UniversalSet"
+
+
 def test_pretty_Boolean():
     expr = Not(x, evaluate=False)
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4176,7 +4176,7 @@ GroebnerBasis⎝⎣2⋅x - y  - y + 1, y  + 2⋅y  - 3⋅y  - 16⋅y + 7⎦, x, 
 
 def test_pretty_UniversalSet():
     assert pretty(S.UniversalSet) == "UniversalSet"
-    assert upretty(S.UniversalSet) == u"UniversalSet"
+    assert upretty(S.UniversalSet) == u'𝕌'
 
 
 def test_pretty_Boolean():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -529,6 +529,9 @@ class StrPrinter(Printer):
     def _print_ProductSet(self, p):
         return ' x '.join(self._print(set) for set in p.sets)
 
+    def _print_UniversalSet(self, p):
+        return 'UniversalSet'
+
     def _print_AlgebraicNumber(self, expr):
         if expr.is_aliased:
             return self._print(expr.as_poly().as_expr())

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -813,6 +813,10 @@ def test_latex_emptyset():
     assert latex(S.EmptySet) == r"\emptyset"
 
 
+def test_latex_universalset():
+    assert latex(S.UniversalSet) == r"\text{UniversalSet}"
+
+
 def test_latex_commutator():
     A = Operator('A')
     B = Operator('B')

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -814,7 +814,7 @@ def test_latex_emptyset():
 
 
 def test_latex_universalset():
-    assert latex(S.UniversalSet) == r"\text{UniversalSet}"
+    assert latex(S.UniversalSet) == r"\mathbb{U}"
 
 
 def test_latex_commutator():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1137,6 +1137,10 @@ def test_print_EmptySet():
     assert mpp.doprint(EmptySet()) == '<mo>&#x2205;</mo>'
 
 
+def test_print_UniversalSet():
+    assert mpp.doprint(S.UniversalSet) == '<mo>&#x1D54C;</mo>'
+
+
 def test_print_SetOp():
     f1 = FiniteSet(x, 1, 3)
     f2 = FiniteSet(y, 2, 4)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -713,6 +713,10 @@ def test_FiniteSet():
     assert str(FiniteSet(*range(1, 6))) == '{1, 2, 3, 4, 5}'
 
 
+def test_UniversalSet():
+    assert str(S.UniversalSet) == 'UniversalSet'
+
+
 def test_PrettyPoly():
     from sympy.polys.domains import QQ
     F = QQ.frac_field(x, y)

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -82,7 +82,7 @@ class ConditionSet(Set):
     If no base set is specified, the universal set is implied:
 
     >>> ConditionSet(x, x < 1).base_set
-    UniversalSet()
+    UniversalSet
 
     Although expressions other than symbols may be used, this
     is discouraged and will raise an error if the expression

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -153,7 +153,7 @@ class Set(Basic):
         Union(Interval.open(-oo, 0), Interval.open(1, oo))
 
         >>> Interval(0, 1).complement(S.UniversalSet)
-        UniversalSet() \ Interval(0, 1)
+        UniversalSet \ Interval(0, 1)
 
         """
         return Complement(universe, self)
@@ -1454,7 +1454,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
 
     >>> from sympy import S, Interval
     >>> S.UniversalSet
-    UniversalSet()
+    UniversalSet
 
     >>> Interval(1, 2).intersect(S.UniversalSet)
     Interval(1, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes the printing part of #16337 

#### Brief description of what is fixed or changed
`S.UniversalSet` now prints without `()` for LaTeX and pretty.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Added printing of `UniversalSet()` for LaTeX ,pretty, MathML presentation, and str printers.
<!-- END RELEASE NOTES -->
