### PR TITLE
Fix sympy parser for numeric strings

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -657,6 +657,7 @@ def convert_xor(tokens, local_dict, global_dict):
 
     return result
 
+
 def repeated_decimals(tokens, local_dict, global_dict):
     """
     Allows 0.2[1] notation to represent the repeated decimal 0.2111... (19/90)
@@ -747,6 +748,7 @@ def repeated_decimals(tokens, local_dict, global_dict):
 
     return result
 
+
 def auto_number(tokens, local_dict, global_dict):
     """
     Converts numeric literals to use SymPy equivalents.
@@ -779,6 +781,7 @@ def auto_number(tokens, local_dict, global_dict):
             result.append((toknum, tokval))
 
     return result
+
 
 def rationalize(tokens, local_dict, global_dict):
     """Converts floats into ``Rational``. Run AFTER ``auto_number``."""

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -399,26 +399,27 @@ def split_symbols_custom(predicate):
                     tok_type = result[-2][1]  # Symbol or Function
                     del result[-2:]  # Get rid of the call to Symbol
 
-                    for char in symbol[:-1]:
+                    i = 0
+                    while i < len(symbol):
+                        char = symbol[i]
                         if char in local_dict or char in global_dict:
                             result.extend([(NAME, "%s" % char)])
-                        elif char in '0123456789':
+                        elif char.isdigit():
+                            char = [char]
+                            iwas = i
+                            for i in range(i + 1, len(symbol)):
+                                if not symbol[i].isdigit():
+                                  i -= 1
+                                  break
+                                char.append(symbol[i])
+                            char = ''.join(char)
                             result.extend([(NAME, 'Number'), (OP, '('),
-                                           (NAME, "'%s'" % char), (OP, ')')])
+                                            (NAME, "'%s'" % char), (OP, ')')])
                         else:
-                            result.extend([(NAME, 'Symbol'), (OP, '('),
-                                           (NAME, "'%s'" % char), (OP, ')')])
-
-                    char = symbol[-1]
-
-                    if char in local_dict or char in global_dict:
-                        result.extend([(NAME, "%s" % char)])
-                    elif char in '0123456789':
-                        result.extend([(NAME, 'Number'), (OP, '('),
-                                       (NAME, "'%s'" % char), (OP, ')')])
-                    else:
-                        result.extend([(NAME, tok_type), (OP, '('),
-                                       (NAME, "'%s'" % char), (OP, ')')])
+                            use = tok_type if i == len(symbol) else 'Symbol'
+                            result.extend([(NAME, use), (OP, '('),
+                                (NAME, "'%s'" % char), (OP, ')')])
+                        i += 1
 
                     # Set split_previous=True so will skip
                     # the closing parenthesis of the original Symbol

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -410,7 +410,6 @@ def split_symbols_custom(predicate):
                             result.extend([(NAME, "%s" % char)])
                         elif char.isdigit():
                             char = [char]
-                            iwas = i
                             for i in range(i + 1, len(symbol)):
                                 if not symbol[i].isdigit():
                                   i -= 1
@@ -418,11 +417,11 @@ def split_symbols_custom(predicate):
                                 char.append(symbol[i])
                             char = ''.join(char)
                             result.extend([(NAME, 'Number'), (OP, '('),
-                                            (NAME, "'%s'" % char), (OP, ')')])
+                                           (NAME, "'%s'" % char), (OP, ')')])
                         else:
                             use = tok_type if i == len(symbol) else 'Symbol'
                             result.extend([(NAME, use), (OP, '('),
-                                (NAME, "'%s'" % char), (OP, ')')])
+                                           (NAME, "'%s'" % char), (OP, ')')])
                         i += 1
 
                     # Set split_previous=True so will skip

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -381,28 +381,43 @@ def split_symbols_custom(predicate):
         result = []
         split = False
         split_previous=False
+
         for tok in tokens:
             if split_previous:
                 # throw out closing parenthesis of Symbol that was split
                 split_previous=False
                 continue
             split_previous=False
+
             if tok[0] == NAME and tok[1] in ['Symbol', 'Function']:
                 split = True
+
             elif split and tok[0] == NAME:
                 symbol = tok[1][1:-1]
+
                 if predicate(symbol):
+
                     tok_type = result[-2][1]  # Symbol or Function
                     del result[-2:]  # Get rid of the call to Symbol
+
                     for char in symbol[:-1]:
+
                         if char in local_dict or char in global_dict:
                             result.extend([(NAME, "%s" % char)])
+                        elif char in '0123456789':
+                            result.extend([(NAME, 'Number'), (OP, '('),
+                                           (NAME, "'%s'" % char), (OP, ')')])
                         else:
                             result.extend([(NAME, 'Symbol'), (OP, '('),
                                            (NAME, "'%s'" % char), (OP, ')')])
+
                     char = symbol[-1]
+
                     if char in local_dict or char in global_dict:
                         result.extend([(NAME, "%s" % char)])
+                    elif char in '0123456789':
+                        result.extend([(NAME, 'Number'), (OP, '('),
+                                       (NAME, "'%s'" % char), (OP, ')')])
                     else:
                         result.extend([(NAME, tok_type), (OP, '('),
                                        (NAME, "'%s'" % char), (OP, ')')])
@@ -412,10 +427,14 @@ def split_symbols_custom(predicate):
                     split = False
                     split_previous = True
                     continue
+
                 else:
                     split = False
+
             result.append(tok)
+
         return result
+
     return _split_symbols
 
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -396,12 +396,10 @@ def split_symbols_custom(predicate):
                 symbol = tok[1][1:-1]
 
                 if predicate(symbol):
-
                     tok_type = result[-2][1]  # Symbol or Function
                     del result[-2:]  # Get rid of the call to Symbol
 
                     for char in symbol[:-1]:
-
                         if char in local_dict or char in global_dict:
                             result.extend([(NAME, "%s" % char)])
                         elif char in '0123456789':

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -219,14 +219,13 @@ def test_split_symbols_numeric():
         standard_transformations +
         (implicit_multiplication_application,))
 
+    n = Symbol('n')
     expr1 = parse_expr('2**n * 3**n')
     expr2 = parse_expr('2**n3**n', transformations=transformations)
+    assert expr1 == expr2 == 2**n*3**n
 
-    assert expr1 == expr2
-
-    n = Symbol('n')
     expr1 = parse_expr('n12n34', transformations=transformations)
-    assert expr1 == 24*n**2
+    assert expr1 == n*12*n*34
 
 
 def test_unicode_names():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -224,6 +224,10 @@ def test_split_symbols_numeric():
 
     assert expr1 == expr2
 
+    n = Symbol('n')
+    expr1 = parse_expr('n12n34', transformations=transformations)
+    assert expr1 == 24*n**2
+
 
 def test_unicode_names():
     if not PY3:

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -11,8 +11,9 @@ from sympy.utilities.pytest import raises, skip
 
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
-    split_symbols, implicit_multiplication, convert_equals_signs, convert_xor,
-    function_exponentiation,
+    split_symbols, implicit_multiplication,
+    implicit_multiplication_application,
+    convert_equals_signs, convert_xor, function_exponentiation,
 )
 
 
@@ -211,6 +212,17 @@ def test_parse_function_issue_3539():
     x = Symbol('x')
     f = Function('f')
     assert parse_expr('f(x)') == f(x)
+
+
+def test_split_symbols_numeric():
+    transformations = (
+        standard_transformations +
+        (implicit_multiplication_application,))
+
+    expr1 = parse_expr('2**n * 3**n')
+    expr2 = parse_expr('2**n3**n', transformations=transformations)
+
+    assert expr1 == expr2
 
 
 def test_unicode_names():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+
 import sys
+
 
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
 from sympy.core.compatibility import PY3
@@ -11,10 +13,10 @@ from sympy.utilities.pytest import raises, skip
 
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
-    split_symbols, implicit_multiplication,
+    split_symbols, implicit_multiplication, convert_equals_signs,
+    convert_xor, function_exponentiation,
     implicit_multiplication_application,
-    convert_equals_signs, convert_xor, function_exponentiation,
-)
+    )
 
 
 def test_sympy_parser():
@@ -49,9 +51,21 @@ def test_sympy_parser():
             evaluate=False),
         'Limit(sin(x), x, 0, dir="-")': Limit(sin(x), x, 0, dir='-'),
 
+
     }
     for text, result in inputs.items():
         assert parse_expr(text) == result
+
+    raises(TypeError, lambda:
+        parse_expr('x', standard_transformations))
+    raises(TypeError, lambda:
+        parse_expr('x', transformations=lambda x,y: 1))
+    raises(TypeError, lambda:
+        parse_expr('x', transformations=(lambda x,y: 1,)))
+    raises(TypeError, lambda: parse_expr('x', transformations=((),)))
+    raises(TypeError, lambda: parse_expr('x', {}, [], []))
+    raises(TypeError, lambda: parse_expr('x', [], [], {}))
+    raises(TypeError, lambda: parse_expr('x', [], [], {}))
 
 
 def test_rationalize():
@@ -66,6 +80,7 @@ def test_rationalize():
 def test_factorial_fail():
     inputs = ['x!!!', 'x!!!!', '(!)']
 
+
     for text in inputs:
         try:
             parse_expr(text)
@@ -78,17 +93,21 @@ def test_repeated_fail():
     inputs = ['1[1]', '.1e1[1]', '0x1[1]', '1.1j[1]', '1.1[1 + 1]',
         '0.1[[1]]', '0x1.1[1]']
 
+
     # All are valid Python, so only raise TypeError for invalid indexing
     for text in inputs:
         raises(TypeError, lambda: parse_expr(text))
+
 
     inputs = ['0.1[', '0.1[1', '0.1[]']
     for text in inputs:
         raises((TokenError, SyntaxError), lambda: parse_expr(text))
 
+
 def test_repeated_dot_only():
     assert parse_expr('.[1]') == Rational(1, 9)
     assert parse_expr('1 + .[1]') == Rational(10, 9)
+
 
 def test_local_dict():
     local_dict = {
@@ -138,6 +157,7 @@ def test_issue_7663():
     e = '2*(x+1)'
     assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
 
+
 def test_issue_10560():
     inputs = {
         '4*-3' : '(-3)*4',
@@ -145,6 +165,7 @@ def test_issue_10560():
     }
     for text, result in inputs.items():
         assert parse_expr(text, evaluate=False) == parse_expr(result, evaluate=False)
+
 
 def test_issue_10773():
     inputs = {
@@ -162,6 +183,7 @@ def test_split_symbols():
     y = Symbol('y')
     xy = Symbol('xy')
 
+
     assert parse_expr("xy") == xy
     assert parse_expr("xy", transformations=transformations) == x*y
 
@@ -173,6 +195,7 @@ def test_split_symbols_function():
     y = Symbol('y')
     a = Symbol('a')
     f = Function('f')
+
 
     assert parse_expr("ay(x+1)", transformations=transformations) == a*y*(x+1)
     assert parse_expr("af(x+1)", transformations=transformations,
@@ -196,6 +219,7 @@ def test_match_parentheses_implicit_multiplication():
     transformations = standard_transformations + \
                       (implicit_multiplication,)
     raises(TokenError, lambda: parse_expr('(1,2),(3,4]',transformations=transformations))
+
 
 def test_convert_equals_signs():
     transformations = standard_transformations + \
@@ -232,12 +256,15 @@ def test_unicode_names():
     if not PY3:
         skip("test_unicode_names can only pass in Python 3")
 
+
     assert parse_expr(u'α') == Symbol(u'α')
+
 
 def test_python3_features():
     # Make sure the tokenizer can handle Python 3-only features
     if sys.version_info < (3, 6):
         skip("test_python3_features requires Python 3.6 or newer")
+
 
     assert parse_expr("123_456") == 123456
     assert parse_expr("1.2[3_4]") == parse_expr("1.2[34]") == Rational(611, 495)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #16591
#16607

#### Brief description of what is fixed or changed

It is an alternative fix of #16607, and here I've modified `split_symbols` itself, so it properly gives number instead of symbol, if the name is numeric.

so for the origial problem
```python
from sympy.parsing.sympy_parser import ( parse_expr, standard_transformations, implicit_multiplication_application, )

transformations = (standard_transformations + (implicit_multiplication_application,))

expr1 = parse_expr('2**n * 3**n')
expr2 = parse_expr('2**n3**n', transformations=transformations)
```
those two lines can be equal if the parser is configured with `split_symbols`


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Fixed `parse_expr` not correctly parsing numeric strings to numbers if `split_symbols` is configured in  `transformations`
  - more user-friendly errors are raised when bad input is given to `parse_expr`
  - `split_symbols` transformation will recognize multi-digit integers
<!-- END RELEASE NOTES -->
