### PR TITLE
Improve intersection and distance methods for Plane

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -282,27 +282,11 @@ class Plane(GeometryEntity):
         if self.intersection(o) != []:
             return S.Zero
 
-        if isinstance(o, Point3D):
-           x, y, z = map(Dummy, 'xyz')
-           k = self.equation(x, y, z)
-           a, b, c = [k.coeff(i) for i in (x, y, z)]
-           d = k.xreplace({x: o.args[0], y: o.args[1], z: o.args[2]})
-           t = abs(d/sqrt(a**2 + b**2 + c**2))
-           return t
-        if isinstance(o, LinearEntity3D):
-            a, b = o.p1, self.p1
-            c = Matrix(a.direction_ratio(b))
-            d = Matrix(self.normal_vector)
-            e = c.dot(d)
-            f = sqrt(sum([i**2 for i in self.normal_vector]))
-            return abs(e / f)
-        if isinstance(o, Plane):
-            a, b = o.p1, self.p1
-            c = Matrix(a.direction_ratio(b))
-            d = Matrix(self.normal_vector)
-            e = c.dot(d)
-            f = sqrt(sum([i**2 for i in self.normal_vector]))
-            return abs(e / f)
+        # following code handles `Point3D`, `LinearEntity3D`, `Plane`
+        a = o if isinstance(o, Point3D) else o.p1
+        n = Point3D(self.normal_vector).unit
+        d = (a - self.p1).dot(n)
+        return abs(d)
 
 
     def equals(self, o):
@@ -404,13 +388,12 @@ class Plane(GeometryEntity):
                     raise ValueError('unhandled linear entity: %s' % o.func)
                 return [o]
             else:
-                x, y, z = map(Dummy, 'xyz')
                 t = Dummy()  # unnamed else it may clash with a symbol in o
                 a = Point3D(o.arbitrary_point(t))
-                b = self.equation(x, y, z)
+                p1, n = self.p1, Point3D(self.normal_vector)
 
                 # TODO: Replace solve with solveset, when this line is tested
-                c = solve(b.subs(list(zip((x, y, z), a.args))), t)
+                c = solve((a - p1).dot(n), t)
                 if not c:
                     return []
                 else:

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -282,6 +282,17 @@ class Plane(GeometryEntity):
         if self.intersection(o) != []:
             return S.Zero
 
+        if isinstance(o, (Segment3D, Ray3D)):
+            a, b = o.p1, o.p2
+            pi, = self.intersection(Line3D(a, b))
+            if pi in o:
+                return self.distance(pi)
+            elif a in Segment3D(pi, b):
+                return self.distance(a)
+            else:
+                assert isinstance(o, Segment3D) is True
+                return self.distance(b)
+
         # following code handles `Point3D`, `LinearEntity3D`, `Plane`
         a = o if isinstance(o, Point3D) else o.p1
         n = Point3D(self.normal_vector).unit

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -415,7 +415,7 @@ class Plane(GeometryEntity):
                     return []
                 else:
                     p = a.subs(t, c[0])
-                    if p not in self:
+                    if p not in o:
                         return []  # e.g. a segment might not intersect a plane
                     return [p]
         if isinstance(o, Plane):

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -90,7 +90,14 @@ def test_plane():
     assert pl6.distance(pl6.p1) == 0
     assert pl7.distance(pl6) == 0
     assert pl7.distance(l1) == 0
-    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 4*sqrt(3)/3
+    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == \
+        pl6.distance(Point3D(1, 3, 4)) == 4*sqrt(3)/3
+    assert pl6.distance(Segment3D(Point3D(1, 3, 4), Point3D(0, 3, 7))) == \
+        pl6.distance(Point3D(0, 3, 7)) == 2*sqrt(3)/3
+    assert pl6.distance(Segment3D(Point3D(0, 3, 7), Point3D(-1, 3, 10))) == 0
+    assert pl6.distance(Segment3D(Point3D(-1, 3, 10), Point3D(-2, 3, 13))) == 0
+    assert pl6.distance(Segment3D(Point3D(-2, 3, 13), Point3D(-3, 3, 16))) == \
+        pl6.distance(Point3D(-2, 3, 13)) == 2*sqrt(3)/3
     assert pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
     assert pl6.distance(Ray3D(Point3D(1, 3, 4), direction_ratio=[1, 0, -3])) == 4*sqrt(3)/3
     assert pl6.distance(Ray3D(Point3D(2, 3, 1), direction_ratio=[-1, 0, 3])) == 0

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -91,7 +91,7 @@ def test_plane():
     assert pl7.distance(pl6) == 0
     assert pl7.distance(l1) == 0
     assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 0
-    pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
+    assert pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
 
     assert pl6.angle_between(pl3) == pi/2
     assert pl6.angle_between(pl6) == 0
@@ -155,8 +155,7 @@ def test_plane():
         ) == [Line3D(Point3D(-24, -12, 0), Point3D(-25, -13, -1))]
     assert pl6.intersection(Ray3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == [
         Point3D(-1, 3, 10)]
-    assert pl6.intersection(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == [
-        Point3D(-1, 3, 10)]
+    assert pl6.intersection(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == []
     assert pl7.intersection(Line(Point(2, 3), Point(4, 2))) == [
         Point3D(S(13)/2, S(3)/4, 0)]
     r = Ray(Point(2, 3), Point(4, 2))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -90,8 +90,11 @@ def test_plane():
     assert pl6.distance(pl6.p1) == 0
     assert pl7.distance(pl6) == 0
     assert pl7.distance(l1) == 0
-    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 0
+    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 4*sqrt(3)/3
     assert pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
+    assert pl6.distance(Ray3D(Point3D(1, 3, 4), direction_ratio=[1, 0, -3])) == 4*sqrt(3)/3
+    assert pl6.distance(Ray3D(Point3D(2, 3, 1), direction_ratio=[-1, 0, 3])) == 0
+
 
     assert pl6.angle_between(pl3) == pi/2
     assert pl6.angle_between(pl6) == 0


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #15069
Closes #15102

#### Brief description of what is fixed or changed
- Adds handling of `Segment3D` and `Ray3D` for distance calculation in `Plane`
- Improves and simplifies the logic of intersection, distance calculation for primitives using parametric form
- Fixes the containment check for obtaining the intersection (see https://github.com/sympy/sympy/pull/15102#discussion_r212788516)


#### Release Notes
<!-- BEGIN RELEASE NOTES -->
- geometry
  - `Plane.distance` can now return the minimum distance w.r.t to a `Segment` or a `Ray`
  - Fixed a bug in `Plane.intersection` which was leading to erroneous intersection points
<!-- END RELEASE NOTES -->
