### PR TITLE
indexed matrix expressions will now have different dummies in summations

### DIFF
--- a/sympy/matrices/expressions/adjoint.py
+++ b/sympy/matrices/expressions/adjoint.py
@@ -47,8 +47,8 @@ class Adjoint(MatrixExpr):
     def shape(self):
         return self.arg.shape[::-1]
 
-    def _entry(self, i, j):
-        return conjugate(self.arg._entry(j, i))
+    def _entry(self, i, j, **kwargs):
+        return conjugate(self.arg._entry(j, i, **kwargs))
 
     def _eval_adjoint(self):
         return self.arg

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -235,7 +235,7 @@ class BlockMatrix(MatrixExpr):
         """
         return self._eval_transpose()
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         # Find row entry
         for row_block, numrows in enumerate(self.rowblocksizes):
             if (i < numrows) != False:

--- a/sympy/matrices/expressions/diagonal.py
+++ b/sympy/matrices/expressions/diagonal.py
@@ -70,7 +70,7 @@ class DiagonalMatrix(MatrixExpr):
                 m = None
         return m
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         if self.diagonal_length is not None:
             if Ge(i, self.diagonal_length) is S.true:
                 return S.Zero
@@ -151,8 +151,8 @@ class DiagonalOf(MatrixExpr):
     def diagonal_length(self):
         return self.shape[0]
 
-    def _entry(self, i, j):
-        return self.arg[i, i]
+    def _entry(self, i, j, **kwargs):
+        return self.arg._entry(i, i, **kwargs)
 
 
 class DiagonalizeVector(MatrixExpr):
@@ -177,9 +177,9 @@ class DiagonalizeVector(MatrixExpr):
 
     def _entry(self, i, j, **kwargs):
         if self._iscolumn:
-            result = self._vector._entry(i, 0)
+            result = self._vector._entry(i, 0, **kwargs)
         else:
-            result = self._vector._entry(0, j)
+            result = self._vector._entry(0, j, **kwargs)
         if i != j:
             result *= KroneckerDelta(i, j)
         return result

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -8,7 +8,7 @@ class DFT(MatrixExpr):
     n = property(lambda self: self.args[0])
     shape = property(lambda self: (self.n, self.n))
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         w = exp(-2*S.Pi*I/self.n)
         return w**(i*j) / sqrt(self.n)
 
@@ -17,7 +17,7 @@ class DFT(MatrixExpr):
 
 class IDFT(DFT):
     """ Inverse Discrete Fourier Transform """
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         w = exp(-2*S.Pi*I/self.n)
         return w**(-i*j) / sqrt(self.n)
 

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -40,7 +40,7 @@ class FunctionMatrix(MatrixExpr):
     def lamda(self):
         return self.args[2]
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         return self.lamda(i, j)
 
     def _eval_trace(self):

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -59,8 +59,8 @@ class HadamardProduct(MatrixExpr):
     def shape(self):
         return self.args[0].shape
 
-    def _entry(self, i, j):
-        return Mul(*[arg._entry(i, j) for arg in self.args])
+    def _entry(self, i, j, **kwargs):
+        return Mul(*[arg._entry(i, j, **kwargs) for arg in self.args])
 
     def _eval_transpose(self):
         from sympy.matrices.expressions.transpose import transpose
@@ -120,7 +120,7 @@ class HadamardPower(MatrixExpr):
         return self.base.shape
 
     def _entry(self, i, j, **kwargs):
-        return self.base[i, j]**self.exp
+        return self.base._entry(i, j, **kwargs)**self.exp
 
     def _eval_transpose(self):
         from sympy.matrices.expressions.transpose import transpose

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -126,7 +126,7 @@ class KroneckerProduct(MatrixExpr):
             cols *= mat.cols
         return (rows, cols)
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         result = 1
         for mat in reversed(self.args):
             i, m = divmod(i, mat.rows)

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -52,8 +52,8 @@ class MatAdd(MatrixExpr, Add):
     def shape(self):
         return self.args[0].shape
 
-    def _entry(self, i, j, expand=None):
-        return Add(*[arg._entry(i, j) for arg in self.args])
+    def _entry(self, i, j, **kwargs):
+        return Add(*[arg._entry(i, j, **kwargs) for arg in self.args])
 
     def _eval_transpose(self):
         return MatAdd(*[transpose(arg) for arg in self.args]).doit()

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -55,7 +55,7 @@ class MatMul(MatrixExpr, Mul):
         matrices = [arg for arg in self.args if arg.is_Matrix]
         return (matrices[0].rows, matrices[-1].cols)
 
-    def _entry(self, i, j, expand=True):
+    def _entry(self, i, j, expand=True, **kwargs):
         from sympy import Dummy, Sum, Mul, ImmutableMatrix, Integer
 
         coeff, matrices = self.as_coeff_matrices()
@@ -67,11 +67,21 @@ class MatMul(MatrixExpr, Mul):
         ind_ranges = [None]*(len(matrices) - 1)
         indices[0] = i
         indices[-1] = j
+
+        def f():
+            counter = 1
+            while True:
+                yield Dummy("i_%i" % counter)
+                counter += 1
+
+        dummy_generator = kwargs.get("dummy_generator", f())
+
         for i in range(1, len(matrices)):
-            indices[i] = Dummy("i_%i" % i)
+            indices[i] = next(dummy_generator)
+
         for i, arg in enumerate(matrices[:-1]):
             ind_ranges[i] = arg.shape[1] - 1
-        matrices = [arg[indices[i], indices[i+1]] for i, arg in enumerate(matrices)]
+        matrices = [arg._entry(indices[i], indices[i+1], dummy_generator=dummy_generator) for i, arg in enumerate(matrices)]
         expr_in_sum = Mul.fromiter(matrices)
         if any(v.has(ImmutableMatrix) for v in matrices):
             expand = True

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -76,9 +76,10 @@ class MatrixSlice(MatrixExpr):
         cols = cols if self.colslice[2] == 1 else floor(cols/self.colslice[2])
         return rows, cols
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         return self.parent._entry(i*self.rowslice[2] + self.rowslice[0],
-                                  j*self.colslice[2] + self.colslice[0])
+                                  j*self.colslice[2] + self.colslice[0],
+                                  **kwargs)
 
     @property
     def on_diag(self):

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -12,6 +12,11 @@ X = MatrixSymbol('X', l, m)
 Y = MatrixSymbol('Y', l, m)
 Z = MatrixSymbol('Z', m, n)
 
+X1 = MatrixSymbol('X1', m, m)
+X2 = MatrixSymbol('X2', m, m)
+X3 = MatrixSymbol('X3', m, m)
+X4 = MatrixSymbol('X4', m, m)
+
 A = MatrixSymbol('A', 2, 2)
 B = MatrixSymbol('B', 2, 2)
 x = MatrixSymbol('x', 1, 2)
@@ -124,6 +129,12 @@ def test_matrix_expression_to_indices():
     expr = A*B**2*A
     #assert replace_dummies(expr._entry(i, j)) == \
     #        Sum(A[i, i1]*B[i1, i2]*B[i2, i3]*A[i3, j], (i1, 0, 1), (i2, 0, 1), (i3, 0, 1))
+
+    # Check that different dummies are used in sub-multiplications:
+    expr = (X1*X2 + X2*X1)*X3
+    assert replace_dummies(expr._entry(i, j)) == \
+           Sum((Sum(X1[i, i2] * X2[i2, i1], (i2, 0, m - 1)) + Sum(X1[i3, i1] * X2[i, i3], (i3, 0, m - 1))) * X3[
+               i1, j], (i1, 0, m - 1))
 
 
 def test_matrix_expression_from_index_summation():

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -52,8 +52,8 @@ class Transpose(MatrixExpr):
     def shape(self):
         return self.arg.shape[::-1]
 
-    def _entry(self, i, j, expand=False):
-        return self.arg._entry(j, i, expand=expand)
+    def _entry(self, i, j, expand=False, **kwargs):
+        return self.arg._entry(j, i, expand=expand, **kwargs)
 
     def _eval_adjoint(self):
         return conjugate(self.arg)

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -68,7 +68,7 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
         # so return the internal tuple.
         return self.args[2].args
 
-    def _entry(self, i, j):
+    def _entry(self, i, j, **kwargs):
         return DenseMatrix.__getitem__(self, (i, j))
 
     def __setitem__(self, *args):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Matrix expressions expressed as summations will now have differently named dummy variables.
<!-- END RELEASE NOTES -->
