### PR TITLE
codgen: Handle neg. exp. in create_expand_pow_optimization

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -35,6 +35,7 @@ from itertools import chain
 from sympy import log, exp, Max, Min, Wild, expand_log, Dummy
 from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
 from sympy.core.mul import Mul
+from sympy.core.power import Pow
 from sympy.utilities.iterables import sift
 
 
@@ -220,8 +221,11 @@ def create_expand_pow_optimization(limit):
 
     """
     return ReplaceOptim(
-        lambda e: e.is_Pow and e.base.is_symbol and e.exp.is_integer and e.exp.is_nonnegative and e.exp <= limit,
-        lambda p: Mul(*([p.base]*p.exp), evaluate=False)
+        lambda e: e.is_Pow and e.base.is_symbol and e.exp.is_integer and abs(e.exp) <= limit,
+        lambda p: (
+            Mul(*([p.base]*p.exp), evaluate=False) if p.exp.is_nonnegative else
+            Pow(Mul(*([p.base]*-p.exp), evaluate=False), -1, evaluate=False)
+        )
     )
 
 # Collections of optimizations:

--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -218,7 +218,7 @@ def create_expand_pow_optimization(limit):
     >>> expand_opt(x**5 + x**3)
     x**5 + x*x*x
     >>> expand_opt(x**5 + x**3 + sin(x)**3)
-    x**5 + x*x*x + sin(x)**3
+    x**5 + sin(x)**3 + x*x*x
 
     """
     return ReplaceOptim(

--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -34,6 +34,7 @@ from __future__ import (absolute_import, division, print_function)
 from itertools import chain
 from sympy import log, exp, Max, Min, Wild, expand_log, Dummy
 from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
+from sympy.core.expr import UnevaluatedExpr
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.utilities.iterables import sift
@@ -198,7 +199,7 @@ def create_expand_pow_optimization(limit):
     """ Creates an instance of :class:`ReplaceOptim` for expanding ``Pow``.
 
     The requirements for expansions are that the base needs to be a symbol
-    and the exponent needs to be an integer (and be less than or equal to
+    and the exponent needs to be an Integer (and be less than or equal to
     ``limit``).
 
     Parameters
@@ -221,12 +222,11 @@ def create_expand_pow_optimization(limit):
 
     """
     return ReplaceOptim(
-        lambda e: e.is_Pow and e.base.is_symbol and e.exp.is_integer and abs(e.exp) <= limit,
+        lambda e: e.is_Pow and e.base.is_symbol and e.exp.is_Integer and abs(e.exp) <= limit,
         lambda p: (
-            Mul(*([p.base]*p.exp), evaluate=False) if p.exp.is_nonnegative else
-            Pow(Mul(*([p.base]*-p.exp), evaluate=False), -1, evaluate=False)
-        )
-    )
+            UnevaluatedExpr(Mul(*([p.base]*+p.exp), evaluate=False)) if p.exp > 0 else
+            1/UnevaluatedExpr(Mul(*([p.base]*-p.exp), evaluate=False))
+        ))
 
 # Collections of optimizations:
 optims_c99 = (expm1_opt, log1p_opt, exp2_opt, log2_opt, log2const_opt)

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -158,25 +158,16 @@ def test_optims_c99():
 
 
 def test_create_expand_pow_optimization():
-    my_opt = create_expand_pow_optimization(4)
+    cc = lambda x: ccode(
+        optimize(x, [create_expand_pow_optimization(4)]))
     x = Symbol('x')
 
-    assert ccode(optimize(x**4, [my_opt])) == 'x*x*x*x'
-    assert ccode(optimize((x**4 + x**2), [my_opt])) == 'x*x + x*x*x*x'
-
-    x5x4 = x**5 + x**4
-    assert ccode(optimize(x5x4, [my_opt])) == 'pow(x, 5) + x*x*x*x'
-
-    sin4x = sin(x)**4
-    assert ccode(optimize(sin4x, [my_opt])) == 'pow(sin(x), 4)'
-
-    assert ccode(optimize((x**(-4)), [my_opt])) == '1.0/(x*x*x*x)'  # gh-15335
-    assert ccode(optimize((x**(-5)), [my_opt])) == 'pow(x, -5)'     # gh-15335
-
-
-@XFAIL
-def test_create_expand_pow_optimization__TODO():
-    opt4 = create_expand_pow_optimization(4)
-    x = Symbol('x')
-    assert ccode(optimize(-x**4, [opt4])) == '-x*x*x*x'              # gh-15335
-    assert ccode(optimize((x**4 - x**2), [opt4])) == 'x*x*x*x - x*x' # gh-15335
+    assert cc(x**4) == 'x*x*x*x'
+    assert cc(x**4 + x**2) == 'x*x + x*x*x*x'
+    assert cc(x**5 + x**4) == 'pow(x, 5) + x*x*x*x'
+    assert cc(sin(x)**4) == 'pow(sin(x), 4)'
+    # gh issue 15335
+    assert cc(x**(-4)) == '1.0/(x*x*x*x)'
+    assert cc(x**(-5)) == 'pow(x, -5)'
+    assert cc(-x**4) == '-x*x*x*x'
+    assert cc(x**4 - x**2) == '-x*x + x*x*x*x'

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -162,6 +162,7 @@ def test_create_expand_pow_optimization():
     x = Symbol('x')
 
     assert ccode(optimize(x**4, [my_opt])) == 'x*x*x*x'
+    assert ccode(optimize((x**4 + x**2), [my_opt])) == 'x*x + x*x*x*x'
 
     x5x4 = x**5 + x**4
     assert ccode(optimize(x5x4, [my_opt])) == 'pow(x, 5) + x*x*x*x'
@@ -169,4 +170,13 @@ def test_create_expand_pow_optimization():
     sin4x = sin(x)**4
     assert ccode(optimize(sin4x, [my_opt])) == 'pow(sin(x), 4)'
 
-    assert ccode(optimize((x**(-4)), [my_opt])) == 'pow(x, -4)'
+    assert ccode(optimize((x**(-4)), [my_opt])) == '1.0/(x*x*x*x)'  # gh-15335
+    assert ccode(optimize((x**(-5)), [my_opt])) == 'pow(x, -5)'     # gh-15335
+
+
+@XFAIL
+def test_create_expand_pow_optimization__TODO():
+    opt4 = create_expand_pow_optimization(4)
+    x = Symbol('x')
+    assert ccode(optimize(-x**4, [opt4])) == '-x*x*x*x'              # gh-15335
+    assert ccode(optimize((x**4 - x**2), [opt4])) == 'x*x*x*x - x*x' # gh-15335

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -161,7 +161,6 @@ def test_create_expand_pow_optimization():
     cc = lambda x: ccode(
         optimize(x, [create_expand_pow_optimization(4)]))
     x = Symbol('x')
-
     assert cc(x**4) == 'x*x*x*x'
     assert cc(x**4 + x**2) == 'x*x + x*x*x*x'
     assert cc(x**5 + x**4) == 'pow(x, 5) + x*x*x*x'
@@ -171,3 +170,5 @@ def test_create_expand_pow_optimization():
     assert cc(x**(-5)) == 'pow(x, -5)'
     assert cc(-x**4) == '-x*x*x*x'
     assert cc(x**4 - x**2) == '-x*x + x*x*x*x'
+    i = Symbol('i', integer=True)
+    assert cc(x**i - x**2) == 'pow(x, i) - x*x'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes gh-15335

#### Brief description of what is fixed or changed
~~We probably still need a subclass of Mul which doesn't "auto-evaluate" to fix remaining issues.~~ (no longer needed thanks to @smichr adding `UnevaluatedExpr`)

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* codegen
  * `create_expand_pow_optimization` is now more robust
<!-- END RELEASE NOTES -->
