### PR TITLE
[WIP] Make positive imply finite without new facts

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2182,7 +2182,7 @@ def test_check_old_assumption():
     assert ask(Q.real(x)) is None
     assert ask(Q.complex(x)) is True
 
-    x = symbols('x', positive=True)
+    x = symbols('x', positive=True, finite=True)
     assert ask(Q.positive(x)) is True
     assert ask(Q.negative(x)) is False
     assert ask(Q.real(x)) is True

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -889,7 +889,8 @@ class AccumulationBounds(AtomicExpr):
     _op_priority = 11.0
 
     def _eval_is_real(self):
-        return fuzzy_and([a.is_real for a in self.args])
+        if self.min.is_real and self.max.is_real:
+            return True
 
     @property
     def min(self):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -234,11 +234,11 @@ class Add(Expr, AssocOp):
         # oo, -oo
         if coeff is S.Infinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonnegative or f.is_real and f.is_finite)]
+                      (f.is_nonnegative or f.is_extended_real and f.is_finite)]
 
         elif coeff is S.NegativeInfinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonpositive or f.is_real and f.is_finite)]
+                      (f.is_nonpositive or f.is_extended_real and f.is_finite)]
 
         if coeff is S.ComplexInfinity:
             # zoo might be
@@ -250,7 +250,7 @@ class Add(Expr, AssocOp):
             # in a NaN condition if it had sign opposite of the infinite
             # portion of zoo, e.g., infinite_real - infinite_real.
             newseq = [c for c in newseq if not (c.is_finite and
-                                                c.is_real is not None)]
+                                                c.is_extended_real is not None)]
 
         # process O(x)
         if order_factors:
@@ -493,8 +493,8 @@ class Add(Expr, AssocOp):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
     # assumption methods
-    _eval_is_real = lambda self: _fuzzy_group(
-        (a.is_real for a in self.args), quick_exit=True)
+    _eval_is_extended_real = lambda self: _fuzzy_group(
+        (a.is_extended_real for a in self.args), quick_exit=True)
     _eval_is_complex = lambda self: _fuzzy_group(
         (a.is_complex for a in self.args), quick_exit=True)
     _eval_is_antihermitian = lambda self: _fuzzy_group(
@@ -516,7 +516,7 @@ class Add(Expr, AssocOp):
         nz = []
         im_I = []
         for a in self.args:
-            if a.is_real:
+            if a.is_extended_real:
                 if a.is_zero:
                     pass
                 elif a.is_zero is False:
@@ -525,7 +525,7 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im_I.append(a*S.ImaginaryUnit)
-            elif (S.ImaginaryUnit*a).is_real:
+            elif (S.ImaginaryUnit*a).is_extended_real:
                 im_I.append(a*S.ImaginaryUnit)
             else:
                 return
@@ -545,7 +545,7 @@ class Add(Expr, AssocOp):
         im_or_z = False
         im = False
         for a in self.args:
-            if a.is_real:
+            if a.is_extended_real:
                 if a.is_zero:
                     z += 1
                 elif a.is_zero is False:
@@ -554,7 +554,7 @@ class Add(Expr, AssocOp):
                     return
             elif a.is_imaginary:
                 im = True
-            elif (S.ImaginaryUnit*a).is_real:
+            elif (S.ImaginaryUnit*a).is_extended_real:
                 im_or_z = True
             else:
                 return

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -178,15 +178,15 @@ _assume_rules = FactRules([
     'odd            ==  integer & !even',
     'even           ==  integer & !odd',
 
-    'extended_real  ==  negative | zero | positive',
+    'real           ==  negative | zero | positive',
     'transcendental ==  complex & !algebraic & finite',
 
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',
 
-    'nonpositive    ==  extended_real & !positive',
-    'nonnegative    ==  extended_real & !negative',
+    'nonpositive    ==  real & !positive',
+    'nonnegative    ==  real & !negative',
 
     'zero           ->  even & finite',
 
@@ -199,8 +199,8 @@ _assume_rules = FactRules([
     'imaginary      ->  !extended_real',
 
     'infinite       ->  !finite',
-    'noninteger     ==  extended_real & !integer',
-    'nonzero        ==  extended_real & !zero',
+    'noninteger     ==  real & !integer',
+    'nonzero        ==  real & !zero',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -163,10 +163,12 @@ from random import shuffle
 _assume_rules = FactRules([
 
     'integer        ->  rational',
-    'rational       ->  real & finite',
+    'rational       ->  real',
     'rational       ->  algebraic',
     'algebraic      ->  complex & finite',
-    'real           ->  complex',
+    'extended_real  ->  complex',
+    'real           ->  extended_real & finite',
+    'extended_real  ->  real | infinite',
     'real           ->  hermitian',
     'imaginary      ->  complex',
     'imaginary      ->  antihermitian',
@@ -175,15 +177,15 @@ _assume_rules = FactRules([
     'odd            ==  integer & !even',
     'even           ==  integer & !odd',
 
-    'real           ==  negative | zero | positive',
+    'extended_real  ==  negative | zero | positive',
     'transcendental ==  complex & !algebraic & finite',
 
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',
 
-    'nonpositive    ==  real & !positive',
-    'nonnegative    ==  real & !negative',
+    'nonpositive    ==  extended_real & !positive',
+    'nonnegative    ==  extended_real & !negative',
 
     'zero           ->  even & finite',
 
@@ -191,13 +193,13 @@ _assume_rules = FactRules([
     'composite      ->  integer & positive & !prime',
     '!composite     ->  !positive | !even | prime',
 
-    'irrational     ==  real & !rational & finite',
+    'irrational     ==  real & !rational',
 
-    'imaginary      ->  !real',
+    'imaginary      ->  !extended_real',
 
     'infinite       ->  !finite',
-    'noninteger     ==  real & !integer',
-    'nonzero        ==  real & !zero',
+    'noninteger     ==  extended_real & !integer',
+    'nonzero        ==  extended_real & !zero',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -170,7 +170,7 @@ _assume_rules = FactRules([
     'real           ==  extended_real & finite',
     'extended_real  ->  real | infinite',
     'real           ->  hermitian',
-    'imaginary      ->  complex',
+    'imaginary      ->  complex & finite',
     'imaginary      ->  antihermitian',
     'extended_real  ->  commutative',
     'complex        ->  commutative',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -166,7 +166,7 @@ _assume_rules = FactRules([
     'rational       ->  real',
     'rational       ->  algebraic',
     'algebraic      ->  complex & finite',
-    'extended_real  ->  complex',
+    'real           ->  complex',
     'real           ==  extended_real & finite',
     'extended_real  ->  real | infinite',
     'real           ->  hermitian',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -198,7 +198,7 @@ _assume_rules = FactRules([
     'imaginary      ->  !extended_real',
 
     'infinite       ->  !finite',
-    'noninteger     ==  real & !integer',
+    'noninteger     ==  extended_real & !integer',
     'nonzero        ==  extended_real & !zero',
 ])
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -167,7 +167,7 @@ _assume_rules = FactRules([
     'rational       ->  algebraic',
     'algebraic      ->  complex & finite',
     'extended_real  ->  complex',
-    'real           ->  extended_real & finite',
+    'real           ==  extended_real & finite',
     'extended_real  ->  real | infinite',
     'real           ->  hermitian',
     'imaginary      ->  complex',
@@ -184,8 +184,8 @@ _assume_rules = FactRules([
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',
 
-    'nonpositive    ==  extended_real & !positive',
-    'nonnegative    ==  extended_real & !negative',
+    'nonpositive    ==  real & !positive',
+    'nonnegative    ==  real & !negative',
 
     'zero           ->  even & finite',
 
@@ -198,8 +198,8 @@ _assume_rules = FactRules([
     'imaginary      ->  !extended_real',
 
     'infinite       ->  !finite',
-    'noninteger     ==  extended_real & !integer',
-    'nonzero        ==  extended_real & !zero',
+    'noninteger     ==  real & !integer',
+    'nonzero        ==  real & !zero',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -172,6 +172,7 @@ _assume_rules = FactRules([
     'real           ->  hermitian',
     'imaginary      ->  complex',
     'imaginary      ->  antihermitian',
+    'extended_real  ->  commutative',
     'complex        ->  commutative',
 
     'odd            ==  integer & !even',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -199,7 +199,7 @@ _assume_rules = FactRules([
 
     'infinite       ->  !finite',
     'noninteger     ==  real & !integer',
-    'nonzero        ==  real & !zero',
+    'nonzero        ==  extended_real & !zero',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -184,8 +184,8 @@ _assume_rules = FactRules([
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',
 
-    'nonpositive    ==  real & !positive',
-    'nonnegative    ==  real & !negative',
+    'nonpositive    ==  extended_real & !positive',
+    'nonnegative    ==  extended_real & !negative',
 
     'zero           ->  even & finite',
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -676,8 +676,8 @@ class Basic(with_metaclass(ManagedProperties)):
         1
 
         """
-        is_real = self.is_real
-        if is_real is False:
+        is_extended_real = self.is_extended_real
+        if is_extended_real is False:
             return False
         if not self.is_number:
             return False

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -159,10 +159,9 @@ class Basic(with_metaclass(ManagedProperties)):
         {'commutative': True}
         >>> x = Symbol("x", positive=True)
         >>> x.assumptions0
-        {'commutative': True, 'complex': True, 'hermitian': True,
-        'imaginary': False, 'negative': False, 'nonnegative': True,
-        'nonpositive': False, 'nonzero': True, 'positive': True, 'real': True,
-        'zero': False}
+        {'commutative': True, 'extended_real': True, 'imaginary': False,
+        'negative': False, 'nonnegative': True, 'nonpositive': False,
+        'nonzero': True, 'positive': True, 'zero': False}
 
         """
         return {}

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -291,14 +291,14 @@ class Expr(Basic, EvalfMixin):
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
         for me in (self, other):
-            if me.is_complex and me.is_real is False:
+            if me.is_complex and me.is_extended_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 >= 0)
-        if self.is_real or other.is_real:
+        if self.is_extended_real or other.is_extended_real:
             dif = self - other
             if dif.is_nonnegative is not None and \
                     dif.is_nonnegative is not dif.is_negative:
@@ -312,14 +312,14 @@ class Expr(Basic, EvalfMixin):
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
         for me in (self, other):
-            if me.is_complex and me.is_real is False:
+            if me.is_complex and me.is_extended_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 <= 0)
-        if self.is_real or other.is_real:
+        if self.is_extended_real or other.is_extended_real:
             dif = self - other
             if dif.is_nonpositive is not None and \
                     dif.is_nonpositive is not dif.is_positive:
@@ -333,14 +333,14 @@ class Expr(Basic, EvalfMixin):
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
         for me in (self, other):
-            if me.is_complex and me.is_real is False:
+            if me.is_complex and me.is_extended_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 > 0)
-        if self.is_real or other.is_real:
+        if self.is_extended_real or other.is_extended_real:
             dif = self - other
             if dif.is_positive is not None and \
                     dif.is_positive is not dif.is_nonpositive:
@@ -354,14 +354,14 @@ class Expr(Basic, EvalfMixin):
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
         for me in (self, other):
-            if me.is_complex and me.is_real is False:
+            if me.is_complex and me.is_extended_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 < 0)
-        if self.is_real or other.is_real:
+        if self.is_extended_real or other.is_extended_real:
             dif = self - other
             if dif.is_negative is not None and \
                     dif.is_negative is not dif.is_nonnegative:
@@ -743,7 +743,7 @@ class Expr(Basic, EvalfMixin):
                         if sol:
                             if s in sol:
                                 return True
-                            if s.is_real:
+                            if s.is_extended_real:
                                 if any(nsimplify(si, [s]) == s and simplify(si) == s
                                         for si in sol):
                                     return True
@@ -775,7 +775,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
-            if self.is_real is False:
+            if self.is_extended_real is False:
                 return False
 
             # check to see that we can get a value
@@ -810,7 +810,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
-            if self.is_real is False:
+            if self.is_extended_real is False:
                 return False
 
             # check to see that we can get a value
@@ -933,7 +933,7 @@ class Expr(Basic, EvalfMixin):
         return None
 
     def _eval_conjugate(self):
-        if self.is_real:
+        if self.is_extended_real:
             return self
         elif self.is_imaginary:
             return -self
@@ -3382,7 +3382,7 @@ class Expr(Basic, EvalfMixin):
                     getattr(getattr(x,'func', x), '__name__', type(x)))
         elif x in (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
             return x
-        if not x.is_real:
+        if not x.is_extended_real:
             i, r = x.as_real_imag()
             return i.round(p) + S.ImaginaryUnit*r.round(p)
         if not x:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -286,6 +286,8 @@ class Expr(Basic, EvalfMixin):
 
     def __ge__(self, other):
         from sympy import GreaterThan
+        from sympy.functions.elementary.complexes import arg
+        from sympy.core.numbers import pi
         try:
             other = _sympify(other)
         except SympifyError:
@@ -299,18 +301,17 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 >= 0)
         if self.is_extended_real or other.is_extended_real:
-            if other is S.NegativeInfinity:
-                return True
-            elif other is S.Infinity:
-                return self is S.Infinity
             dif = self - other
-            if dif.is_nonnegative is not None and \
-                    dif.is_nonnegative is not dif.is_negative:
-                return sympify(dif.is_nonnegative)
+            if dif.is_nonnegative or arg(dif).is_zero:
+                return S.true
+            elif dif.is_negative or (arg(dif)-pi).is_zero:
+                return S.false
         return GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
         from sympy import LessThan
+        from sympy.functions.elementary.complexes import arg
+        from sympy.core.numbers import pi
         try:
             other = _sympify(other)
         except SympifyError:
@@ -324,18 +325,17 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 <= 0)
         if self.is_extended_real or other.is_extended_real:
-            if other is S.Infinity:
-                return True
-            elif other is S.NegativeInfinity:
-                return self is S.NegativeInfinity
             dif = self - other
-            if dif.is_nonpositive is not None and \
-                    dif.is_nonpositive is not dif.is_positive:
-                return sympify(dif.is_nonpositive)
+            if dif.is_nonpositive or (arg(dif)-pi).is_zero:
+                return S.true
+            elif dif.is_positive or arg(dif).is_zero:
+                return S.false
         return LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
         from sympy import StrictGreaterThan
+        from sympy.functions.elementary.complexes import arg
+        from sympy.core.numbers import pi
         try:
             other = _sympify(other)
         except SympifyError:
@@ -349,18 +349,17 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 > 0)
         if self.is_extended_real or other.is_extended_real:
-            if self is not S.NegativeInfinity and other is S.NegativeInfinity:
-                return True
-            elif self is not S.Infinity and other is S.Infinity:
-                return False
             dif = self - other
-            if dif.is_positive is not None and \
-                    dif.is_positive is not dif.is_nonpositive:
-                return sympify(dif.is_positive)
+            if dif.is_positive or arg(dif).is_zero:
+                return S.true
+            elif dif.is_nonpositive or (arg(dif)-pi).is_zero:
+                return S.false
         return StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
         from sympy import StrictLessThan
+        from sympy.functions.elementary.complexes import arg
+        from sympy.core.numbers import pi
         try:
             other = _sympify(other)
         except SympifyError:
@@ -374,14 +373,11 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 < 0)
         if self.is_extended_real or other.is_extended_real:
-            if self is not S.NegativeInfinity and other is S.NegativeInfinity:
-                return False
-            elif self is not S.Infinity and other is S.Infinity:
-                return True
             dif = self - other
-            if dif.is_negative is not None and \
-                    dif.is_negative is not dif.is_nonnegative:
-                return sympify(dif.is_negative)
+            if dif.is_negative or (arg(dif)-pi).is_zero:
+                return S.true
+            elif dif.is_nonnegative or arg(dif).is_zero:
+                return S.false
         return StrictLessThan(self, other, evaluate=False)
 
     def __trunc__(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -299,6 +299,10 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 >= 0)
         if self.is_extended_real or other.is_extended_real:
+            if other is S.NegativeInfinity:
+                return True
+            elif other is S.Infinity:
+                return self is S.Infinity
             dif = self - other
             if dif.is_nonnegative is not None and \
                     dif.is_nonnegative is not dif.is_negative:
@@ -320,6 +324,10 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 <= 0)
         if self.is_extended_real or other.is_extended_real:
+            if other is S.Infinity:
+                return True
+            elif other is S.NegativeInfinity:
+                return self is S.NegativeInfinity
             dif = self - other
             if dif.is_nonpositive is not None and \
                     dif.is_nonpositive is not dif.is_positive:
@@ -341,6 +349,10 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 > 0)
         if self.is_extended_real or other.is_extended_real:
+            if self is not S.NegativeInfinity and other is S.NegativeInfinity:
+                return True
+            elif self is not S.Infinity and other is S.Infinity:
+                return False
             dif = self - other
             if dif.is_positive is not None and \
                     dif.is_positive is not dif.is_nonpositive:
@@ -362,6 +374,10 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 < 0)
         if self.is_extended_real or other.is_extended_real:
+            if self is not S.NegativeInfinity and other is S.NegativeInfinity:
+                return False
+            elif self is not S.Infinity and other is S.Infinity:
+                return True
             dif = self - other
             if dif.is_negative is not None and \
                     dif.is_negative is not dif.is_nonnegative:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1239,7 +1239,7 @@ class Expr(Basic, EvalfMixin):
 
         if c and split_1 and (
             c[0].is_Number and
-            c[0].is_negative and
+            (c[0].is_negative or c[0] is S.NegativeInfinity) and
                 c[0] is not S.NegativeOne):
             c[:1] = [S.NegativeOne, -c[0]]
 

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -65,7 +65,7 @@ def _monotonic_sign(self):
     2
     >>> F(nn - 1)  # could be negative, zero or positive
     """
-    if not self.is_real:
+    if not self.is_extended_real:
         return
 
     if (-self).is_Symbol:
@@ -124,7 +124,7 @@ def _monotonic_sign(self):
                     try:
                         currentroots = real_roots(d)
                     except (PolynomialError, NotImplementedError):
-                        currentroots = [r for r in roots(d, x) if r.is_real]
+                        currentroots = [r for r in roots(d, x) if r.is_extended_real]
                 y = self.subs(x, x0)
                 if x.is_nonnegative and all(r <= x0 for r in currentroots):
                     if y.is_nonnegative and d.is_positive:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1096,12 +1096,17 @@ class Mul(Expr, AssocOp):
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
-    _eval_is_finite = lambda self: _fuzzy_group(
-        a.is_finite for a in self.args)
     _eval_is_commutative = lambda self: _fuzzy_group(
         a.is_commutative for a in self.args)
     _eval_is_complex = lambda self: _fuzzy_group(
         (a.is_complex for a in self.args), quick_exit=True)
+
+    def _eval_is_finite(self):
+        if all(a.is_finite for a in self.args):
+            return True
+        if any(a.is_infinite for a in self.args):
+            if all(a.is_zero is False for a in self.args):
+                return False
 
     def _eval_is_infinite(self):
         if any(a.is_infinite for a in self.args):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -581,9 +581,9 @@ class Mul(Expr, AssocOp):
             #   infinite_real + infinite_im
             # and non-zero real or imaginary will not change that status.
             c_part = [c for c in c_part if not (fuzzy_not(c.is_zero) and
-                                                c.is_real is not None)]
+                                                c.is_extended_real is not None)]
             nc_part = [c for c in nc_part if not (fuzzy_not(c.is_zero) and
-                                                  c.is_real is not None)]
+                                                  c.is_extended_real is not None)]
 
         # 0
         elif coeff is S.Zero:
@@ -1159,7 +1159,7 @@ class Mul(Expr, AssocOp):
         return has_polar and \
             all(arg.is_polar or arg.is_positive for arg in self.args)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         return self._eval_real_imag(True)
 
     def _eval_real_imag(self, real):
@@ -1171,7 +1171,7 @@ class Mul(Expr, AssocOp):
                 return False
             elif t.is_imaginary:  # I
                 real = not real
-            elif t.is_real:  # 2
+            elif t.is_extended_real:  # 2
                 if not zero:
                     z = t.is_zero
                     if not z and zero is False:
@@ -1180,7 +1180,7 @@ class Mul(Expr, AssocOp):
                         if all(a.is_finite for a in self.args):
                             return True
                         return
-            elif t.is_real is False:
+            elif t.is_extended_real is False:
                 # symbolic or literal like `2 + I` or symbolic imaginary
                 if t_not_re_im:
                     return  # complex terms might cancel
@@ -1193,7 +1193,7 @@ class Mul(Expr, AssocOp):
                 return
 
         if t_not_re_im:
-            if t_not_re_im.is_real is False:
+            if t_not_re_im.is_extended_real is False:
                 if real:  # like 3
                     return zero  # 3*(smthng like 2 + I or i) is not real
             if t_not_re_im.is_imaginary is False:  # symbolic 2 or 2 + I

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -755,7 +755,7 @@ class Mul(Expr, AssocOp):
         if args[0].is_Number:
             if not rational or args[0].is_Rational:
                 return args[0], args[1:]
-            elif args[0].is_negative:
+            elif args[0].is_negative or args[0] is S.NegativeInfinity:
                 return S.NegativeOne, (-args[0],) + args[1:]
         return S.One, args
 
@@ -769,7 +769,7 @@ class Mul(Expr, AssocOp):
                     return coeff, args[0]
                 else:
                     return coeff, self._new_rawargs(*args)
-            elif coeff.is_negative:
+            elif coeff.is_negative or coeff is S.NegativeInfinity:
                 return S.NegativeOne, self._new_rawargs(*((-coeff,) + args))
         return S.One, self
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1167,7 +1167,7 @@ class Mul(Expr, AssocOp):
         t_not_re_im = None
 
         for t in self.args:
-            if t.is_complex is False:
+            if t.is_complex is False and t.is_extended_real is False:
                 return False
             elif t.is_imaginary:  # I
                 real = not real

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2656,7 +2656,7 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     is_extended_real = True
     is_commutative = True
-    is_positive = True
+    is_positive = False
     is_infinite = True
     is_number = True
     is_prime = False
@@ -2814,6 +2814,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid comparison %s < %s" % (self, other))
         if other.is_extended_real:
             return S.false
+        import pdb; pdb.set_trace()
         return Expr.__lt__(self, other)
 
     def __le__(self, other):
@@ -2880,7 +2881,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     """
 
     is_commutative = True
-    is_negative = True
+    is_negative = False
     is_infinite = True
     is_number = True
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2821,7 +2821,9 @@ class Infinity(with_metaclass(Singleton, Number)):
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if other.is_extended_real:
-            if other.is_finite or other is S.NegativeInfinity:
+            if other is S.Infinity:
+                return S.true
+            elif other.is_finite or other is S.NegativeInfinity:
                 return S.false
             elif other.is_nonpositive:
                 return S.false
@@ -2835,7 +2837,9 @@ class Infinity(with_metaclass(Singleton, Number)):
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
         if other.is_extended_real:
-            if other.is_finite or other is S.NegativeInfinity:
+            if other is S.Infinity:
+                return S.false
+            elif other.is_finite or other is S.NegativeInfinity:
                 return S.true
             elif other.is_nonpositive:
                 return S.true
@@ -3034,7 +3038,9 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
         if other.is_extended_real:
-            if other.is_finite or other is S.Infinity:
+            if other is S.NegativeInfinity:
+                return S.false
+            elif other.is_finite or other is S.Infinity:
                 return S.true
             elif other.is_nonnegative:
                 return S.true
@@ -3066,6 +3072,8 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
         if other.is_extended_real:
+            if other is S.NegativeInfinity:
+                return S.true
             if other.is_finite or other is S.Infinity:
                 return S.false
             elif other.is_nonnegative:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2656,7 +2656,6 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     is_extended_real = True
     is_commutative = True
-    is_positive = False
     is_infinite = True
     is_number = True
     is_prime = False
@@ -2814,7 +2813,6 @@ class Infinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid comparison %s < %s" % (self, other))
         if other.is_extended_real:
             return S.false
-        import pdb; pdb.set_trace()
         return Expr.__lt__(self, other)
 
     def __le__(self, other):
@@ -2880,10 +2878,11 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     Infinity
     """
 
+    is_extended_real = True
     is_commutative = True
-    is_negative = False
     is_infinite = True
     is_number = True
+    is_prime = False
 
     __slots__ = []
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1670,7 +1670,7 @@ class Rational(Number):
         if isinstance(expt, Number):
             if isinstance(expt, Float):
                 return self._eval_evalf(expt._prec)**expt
-            if expt.is_negative:
+            if expt.is_negative or expt is S.NegativeInfinity:
                 # (3/4)**-2 -> (4/3)**2
                 ne = -expt
                 if (ne is S.One):
@@ -2654,13 +2654,10 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] https://en.wikipedia.org/wiki/Infinity
     """
 
-    is_commutative = True
     is_number = True
     is_complex = False
     is_extended_real = True
     is_infinite = True
-    is_positive = True
-    is_prime = False
 
     __slots__ = []
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2654,10 +2654,11 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] https://en.wikipedia.org/wiki/Infinity
     """
 
-    is_extended_real = True
     is_commutative = True
-    is_infinite = True
     is_number = True
+    is_extended_real = True
+    is_infinite = True
+    is_positive = True
     is_prime = False
 
     __slots__ = []

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2452,7 +2452,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
     def _eval_power(self, expt):
         if expt.is_positive:
             return self
-        if expt.is_negative:
+        if expt.is_negative or expt is S.NegativeInfinity:
             return S.ComplexInfinity
         if expt.is_extended_real is False:
             return S.NaN

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2656,6 +2656,7 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     is_commutative = True
     is_number = True
+    is_complex = False
     is_extended_real = True
     is_infinite = True
     is_positive = True
@@ -2884,6 +2885,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     """
 
     is_extended_real = True
+    is_complex = False
     is_commutative = True
     is_infinite = True
     is_number = True

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2826,7 +2826,7 @@ class Infinity(with_metaclass(Singleton, Number)):
                 return S.false
             elif other.is_nonpositive:
                 return S.false
-            elif other.is_infinite and other.is_positive:
+            elif other.is_infinite and bool(other > 0):
                 return S.true
         return Expr.__le__(self, other)
 
@@ -2842,7 +2842,7 @@ class Infinity(with_metaclass(Singleton, Number)):
                 return S.true
             elif other.is_nonpositive:
                 return S.true
-            elif other.is_infinite and other.is_positive:
+            elif other.is_infinite and bool(other > 0):
                 return S.false
         return Expr.__gt__(self, other)
 
@@ -3044,7 +3044,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
                 return S.true
             elif other.is_nonnegative:
                 return S.true
-            elif other.is_infinite and other.is_negative:
+            elif other.is_infinite and bool(other < 0):
                 return S.false
         return Expr.__lt__(self, other)
 
@@ -3078,7 +3078,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
                 return S.false
             elif other.is_nonnegative:
                 return S.false
-            elif other.is_infinite and other.is_negative:
+            elif other.is_infinite and bool(other < 0):
                 return S.true
         return Expr.__ge__(self, other)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2942,7 +2942,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
                 else:
                     return Float('inf')
             else:
-                if other.is_positive:
+                if other > 0:
                     return S.NegativeInfinity
                 else:
                     return S.Infinity

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -923,7 +923,7 @@ class Float(Number):
     is_irrational = None
     is_number = True
 
-    is_real = True
+    is_extended_real = True
 
     is_Float = True
 
@@ -1762,7 +1762,7 @@ class Rational(Number):
             if other.is_Float:
                 return _sympify(bool(mlib.mpf_gt(
                     self._as_mpf_val(other._prec), other._mpf_)))
-        elif other.is_number and other.is_real:
+        elif other.is_number and other.is_extended_real:
             expr, other = Integer(self.p), self.q*other
         return Expr.__gt__(expr, other)
 
@@ -1780,7 +1780,7 @@ class Rational(Number):
             if other.is_Float:
                 return _sympify(bool(mlib.mpf_ge(
                     self._as_mpf_val(other._prec), other._mpf_)))
-        elif other.is_number and other.is_real:
+        elif other.is_number and other.is_extended_real:
             expr, other = Integer(self.p), self.q*other
         return Expr.__ge__(expr, other)
 
@@ -1798,7 +1798,7 @@ class Rational(Number):
             if other.is_Float:
                 return _sympify(bool(mlib.mpf_lt(
                     self._as_mpf_val(other._prec), other._mpf_)))
-        elif other.is_number and other.is_real:
+        elif other.is_number and other.is_extended_real:
             expr, other = Integer(self.p), self.q*other
         return Expr.__lt__(expr, other)
 
@@ -1816,7 +1816,7 @@ class Rational(Number):
             if other.is_Float:
                 return _sympify(bool(mlib.mpf_le(
                     self._as_mpf_val(other._prec), other._mpf_)))
-        elif other.is_number and other.is_real:
+        elif other.is_number and other.is_extended_real:
             expr, other = Integer(self.p), self.q*other
         return Expr.__le__(expr, other)
 
@@ -2454,7 +2454,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
             return self
         if expt.is_negative:
             return S.ComplexInfinity
-        if expt.is_real is False:
+        if expt.is_extended_real is False:
             return S.NaN
         # infinities are already handled with pos and neg
         # tests above; now throw away leading numbers on Mul
@@ -2654,6 +2654,7 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] https://en.wikipedia.org/wiki/Infinity
     """
 
+    is_extended_real = True
     is_commutative = True
     is_positive = True
     is_infinite = True
@@ -2779,7 +2780,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             return S.NaN
         if expt is S.ComplexInfinity:
             return S.NaN
-        if expt.is_real is False and expt.is_number:
+        if expt.is_extended_real is False and expt.is_number:
             expt_real = re(expt)
             if expt_real.is_positive:
                 return S.ComplexInfinity
@@ -2811,7 +2812,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             return S.false
         return Expr.__lt__(self, other)
 
@@ -2820,7 +2821,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.false
             elif other.is_nonpositive:
@@ -2834,7 +2835,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.true
             elif other.is_nonpositive:
@@ -2848,7 +2849,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             return S.true
         return Expr.__ge__(self, other)
 
@@ -3032,7 +3033,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             if other.is_finite or other is S.Infinity:
                 return S.true
             elif other.is_nonnegative:
@@ -3046,7 +3047,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             return S.true
         return Expr.__le__(self, other)
 
@@ -3055,7 +3056,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             return S.false
         return Expr.__gt__(self, other)
 
@@ -3064,7 +3065,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_real:
+        if other.is_extended_real:
             if other.is_finite or other is S.Infinity:
                 return S.false
             elif other.is_nonnegative:
@@ -3131,6 +3132,7 @@ class NaN(with_metaclass(Singleton, Number)):
 
     """
     is_commutative = True
+    is_extended_real = None
     is_real = None
     is_rational = None
     is_algebraic = None
@@ -3240,7 +3242,7 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
     is_number = True
     is_prime = False
     is_complex = True
-    is_real = False
+    is_extended_real = False
 
     __slots__ = []
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -483,7 +483,10 @@ class Pow(Expr):
                 return False
         elif self.base.is_zero is False:
             if self.exp.is_finite:
-                return False
+                if self.exp.is_negative:
+                    return self.base.is_infinite
+                elif self.exp.is_nonnegative:
+                    return False
             elif self.exp.is_infinite:
                 if (1 - abs(self.base)).is_positive:
                     return self.exp.is_positive

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -325,7 +325,7 @@ class Pow(Expr):
             s = 1
         elif b.is_polar:  # e.g. exp_polar, besselj, var('p', polar=True)...
             s = 1
-        elif e.is_real is not None:
+        elif e.is_extended_real is not None:
             # helper functions ===========================
             def _half(e):
                 """Return True if the exponent has a literal 2 as the
@@ -345,7 +345,7 @@ class Pow(Expr):
                 except PrecisionExhausted:
                     pass
             # ===================================================
-            if e.is_real:
+            if e.is_extended_real:
                 # we need _half(other) with constant floor or
                 # floor(S.Half - e*arg(b)/2/pi) == 0
 
@@ -355,10 +355,10 @@ class Pow(Expr):
                     if _half(other):
                         if b.is_negative is True:
                             return S.NegativeOne**other*Pow(-b, e*other)
-                        if b.is_real is False:
+                        if b.is_extended_real is False:
                             return Pow(b.conjugate()/Abs(b)**2, other)
                 elif e.is_even:
-                    if b.is_real:
+                    if b.is_extended_real:
                         b = abs(b)
                     if b.is_imaginary:
                         b = abs(im(b))*S.ImaginaryUnit
@@ -374,12 +374,12 @@ class Pow(Expr):
                 elif _half(other):
                     s = exp(2*S.Pi*S.ImaginaryUnit*other*floor(
                         S.Half - e*arg(b)/(2*S.Pi)))
-                    if s.is_real and _n2(sign(s) - s) == 0:
+                    if s.is_extended_real and _n2(sign(s) - s) == 0:
                         s = sign(s)
                     else:
                         s = None
             else:
-                # e.is_real is False requires:
+                # e.is_extended_real is False requires:
                 #     _half(other) with constant floor or
                 #     floor(S.Half - im(e*log(b))/2/pi) == 0
                 try:
@@ -387,7 +387,7 @@ class Pow(Expr):
                         floor(S.Half - im(e*log(b))/2/S.Pi))
                     # be careful to test that s is -1 or 1 b/c sign(I) == I:
                     # so check that s is real
-                    if s.is_real and _n2(sign(s) - s) == 0:
+                    if s.is_extended_real and _n2(sign(s) - s) == 0:
                         s = sign(s)
                     else:
                         s = None
@@ -430,7 +430,7 @@ class Pow(Expr):
             if self.base.is_nonnegative:
                 return True
         elif self.base.is_positive:
-            if self.exp.is_real:
+            if self.exp.is_extended_real:
                 return True
         elif self.base.is_negative:
             if self.exp.is_even:
@@ -438,7 +438,7 @@ class Pow(Expr):
             if self.exp.is_odd:
                 return False
         elif self.base.is_zero:
-            if self.exp.is_real:
+            if self.exp.is_extended_real:
                 return self.exp.is_zero
         elif self.base.is_nonpositive:
             if self.exp.is_odd:
@@ -460,10 +460,10 @@ class Pow(Expr):
             if self.exp.is_even:
                 return False
         elif self.base.is_positive:
-            if self.exp.is_real:
+            if self.exp.is_extended_real:
                 return False
         elif self.base.is_zero:
-            if self.exp.is_real:
+            if self.exp.is_extended_real:
                 return False
         elif self.base.is_nonnegative:
             if self.exp.is_nonnegative:
@@ -471,7 +471,7 @@ class Pow(Expr):
         elif self.base.is_nonpositive:
             if self.exp.is_even:
                 return False
-        elif self.base.is_real:
+        elif self.base.is_extended_real:
             if self.exp.is_even:
                 return False
 
@@ -510,14 +510,14 @@ class Pow(Expr):
             check = self.func(*self.args)
             return check.is_Integer
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         from sympy import arg, exp, log, Mul
-        real_b = self.base.is_real
+        real_b = self.base.is_extended_real
         if real_b is None:
             if self.base.func == exp and self.base.args[0].is_imaginary:
                 return self.exp.is_imaginary
             return
-        real_e = self.exp.is_real
+        real_e = self.exp.is_extended_real
         if real_e is None:
             return
         if real_b and real_e:
@@ -533,7 +533,7 @@ class Pow(Expr):
                     if self.exp.is_Rational:
                         return False
         if real_e and self.exp.is_negative:
-            return Pow(self.base, -self.exp).is_real
+            return Pow(self.base, -self.exp).is_extended_real
         im_b = self.base.is_imaginary
         im_e = self.exp.is_imaginary
         if im_b:
@@ -548,7 +548,7 @@ class Pow(Expr):
                 c, a = self.exp.as_coeff_Add()
                 if c and c.is_Integer:
                     return Mul(
-                        self.base**c, self.base**a, evaluate=False).is_real
+                        self.base**c, self.base**a, evaluate=False).is_extended_real
             elif self.base in (-S.ImaginaryUnit, S.ImaginaryUnit):
                 if (self.exp/2).is_integer is False:
                     return False
@@ -583,7 +583,7 @@ class Pow(Expr):
             if imlog is not None:
                 return False  # I**i -> real; (2*I)**i -> complex ==> not imaginary
 
-        if self.base.is_real and self.exp.is_real:
+        if self.base.is_extended_real and self.exp.is_extended_real:
             if self.base.is_positive:
                 return False
             else:
@@ -598,7 +598,7 @@ class Pow(Expr):
                         return self.base.is_negative
                     return half
 
-        if self.base.is_real is False:  # we already know it's not imag
+        if self.base.is_extended_real is False:  # we already know it's not imag
             i = arg(self.base)*self.exp/S.Pi
             isodd = (2*i).is_odd
             if isodd is not None:
@@ -755,7 +755,7 @@ class Pow(Expr):
                     new_l.append(Pow(self.base, expo, evaluate=False) if expo != 1 else self.base)
                     return Mul(*new_l)
 
-        if isinstance(old, exp) and self.exp.is_real and self.base.is_positive:
+        if isinstance(old, exp) and self.exp.is_extended_real and self.base.is_positive:
             ct1 = old.args[0].as_independent(Symbol, as_Add=False)
             ct2 = (self.exp*log(self.base)).as_independent(
                 Symbol, as_Add=False)
@@ -813,7 +813,7 @@ class Pow(Expr):
             expanded = expand_complex(self)
             if expanded != self:
                 return c(expanded)
-        if self.is_real:
+        if self.is_extended_real:
             return self
 
     def _eval_transpose(self):
@@ -873,7 +873,7 @@ class Pow(Expr):
             nc = [Mul(*nc)]
 
         # sift the commutative bases
-        other, maybe_real = sift(cargs, lambda x: x.is_real is False,
+        other, maybe_real = sift(cargs, lambda x: x.is_extended_real is False,
             binary=True)
         def pred(x):
             if x is S.ImaginaryUnit:
@@ -1163,7 +1163,7 @@ class Pow(Expr):
         base = base._evalf(prec)
         if not exp.is_Integer:
             exp = exp._evalf(prec)
-        if exp.is_negative and base.is_number and base.is_real is False:
+        if exp.is_negative and base.is_number and base.is_extended_real is False:
             base = base.conjugate() / (base * base.conjugate())._evalf(prec)
             exp = -exp
             return self.func(base, exp).expand()
@@ -1274,7 +1274,7 @@ class Pow(Expr):
         # sqrt(a/b) != sqrt(a)/sqrt(b) when a=1 and b=-1. But if the
         # denominator is negative the numerator and denominator can
         # be negated and the denominator (now positive) separated.
-        if not (d.is_real or int_exp):
+        if not (d.is_extended_real or int_exp):
             n = base
             d = S.One
         dnonpos = d.is_nonpositive
@@ -1482,7 +1482,7 @@ class Pow(Expr):
 
             nuse = n - ei
 
-            if e.is_real and e.is_positive:
+            if e.is_extended_real and e.is_positive:
                 lt = b.as_leading_term(x)
 
                 # Try to correct nuse (= m) guess from:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -429,7 +429,7 @@ class Pow(Expr):
         if self.base == self.exp:
             if self.base.is_nonnegative:
                 return True
-        elif self.base.is_positive:
+        elif self.base.is_positive and self.base.is_finite:
             if self.exp.is_extended_real:
                 return True
         elif self.base.is_negative:
@@ -455,11 +455,11 @@ class Pow(Expr):
 
     def _eval_is_negative(self):
         if self.base.is_negative:
-            if self.exp.is_odd:
+            if self.exp.is_odd and self.base.is_finite:
                 return True
             if self.exp.is_even:
                 return False
-        elif self.base.is_positive:
+        elif self.base.is_positive and self.base.is_finite:
             if self.exp.is_extended_real:
                 return False
         elif self.base.is_zero:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -476,6 +476,8 @@ class Pow(Expr):
                 return False
 
     def _eval_is_zero(self):
+        from sympy.functions.elementary.complexes import arg
+        from sympy.core.numbers import pi
         if self.base.is_zero:
             if self.exp.is_positive:
                 return True
@@ -489,9 +491,9 @@ class Pow(Expr):
                     return False
             elif self.exp.is_infinite:
                 if (1 - abs(self.base)).is_positive:
-                    return self.exp.is_positive
+                    return arg(self.exp).is_zero
                 elif (1 - abs(self.base)).is_negative:
-                    return self.exp.is_negative
+                    return arg(self.exp - pi).is_zero
         else:
             # when self.base.is_zero is None
             return None
@@ -620,7 +622,7 @@ class Pow(Expr):
                 return True
 
     def _eval_is_finite(self):
-        if self.exp.is_negative:
+        if self.exp.is_negative or self.exp is S.NegativeInfinity:
             if self.base.is_zero:
                 return False
             if self.base.is_infinite or self.base.is_nonzero:
@@ -1214,7 +1216,7 @@ class Pow(Expr):
                 # when the operation is not allowed
                 return False
 
-        if self.base.is_zero or _is_one(self.base):
+        if self.base.is_zero or _is_one(self.base) and self.exp.is_finite:
             return True
         elif self.exp.is_rational:
             if self.base.is_algebraic is False:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -429,8 +429,8 @@ class Pow(Expr):
         if self.base == self.exp:
             if self.base.is_nonnegative:
                 return True
-        elif self.base.is_positive and self.base.is_finite:
-            if self.exp.is_extended_real:
+        elif self.base.is_positive:
+            if self.exp.is_real:
                 return True
         elif self.base.is_negative:
             if self.exp.is_even:
@@ -493,7 +493,7 @@ class Pow(Expr):
                 if (1 - abs(self.base)).is_positive:
                     return arg(self.exp).is_zero
                 elif (1 - abs(self.base)).is_negative:
-                    return arg(self.exp - pi).is_zero
+                    return (arg(self.exp) - pi).is_zero
         else:
             # when self.base.is_zero is None
             return None

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -459,7 +459,7 @@ class Pow(Expr):
                 return True
             if self.exp.is_even:
                 return False
-        elif self.base.is_positive and self.base.is_finite:
+        elif self.base.is_positive:
             if self.exp.is_extended_real:
                 return False
         elif self.base.is_zero:
@@ -623,7 +623,7 @@ class Pow(Expr):
         if self.exp.is_negative:
             if self.base.is_zero:
                 return False
-            if self.base.is_infinite:
+            if self.base.is_infinite or self.base.is_nonzero:
                 return True
         c1 = self.base.is_finite
         if c1 is None:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1222,8 +1222,8 @@ def test_Pow_is_nonpositive_nonnegative():
 def test_Mul_is_imaginary_real():
     r = Symbol('r', real=True)
     p = Symbol('p', positive=True)
-    i = Symbol('i', imaginary=True)
-    ii = Symbol('ii', imaginary=True)
+    i = Symbol('i', imaginary=True, finite=True)
+    ii = Symbol('ii', imaginary=True, finite=True)
     x = Symbol('x')
 
     assert I.is_imaginary is True
@@ -1267,7 +1267,7 @@ def test_Mul_is_imaginary_real():
     assert (r*i*ii).is_real is True
 
     # Github's issue 5874:
-    nr = Symbol('nr', real=False, complex=True)  # e.g. I or 1 + I
+    nr = Symbol('nr', real=False, complex=True, finite=True)  # e.g. I or 1 + I
     a = Symbol('a', real=True, nonzero=True)
     b = Symbol('b', real=True)
     assert (i*nr).is_real is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -504,7 +504,7 @@ def test_Mul_is_rational():
     # issue 8008
     z = Symbol('z', zero=True)
     i = Symbol('i', imaginary=True)
-    assert (z*i).is_rational is None
+    assert (z*i).is_rational is True
     bi = Symbol('i', imaginary=True, finite=True)
     assert (z*bi).is_zero is True
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1221,7 +1221,7 @@ def test_Pow_is_nonpositive_nonnegative():
 
 def test_Mul_is_imaginary_real():
     r = Symbol('r', real=True)
-    p = Symbol('p', positive=True)
+    p = Symbol('p', positive=True, finite=True)
     i = Symbol('i', imaginary=True, finite=True)
     ii = Symbol('ii', imaginary=True, finite=True)
     x = Symbol('x')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -378,7 +378,7 @@ def test_Add_Mul_is_integer():
 
 
 def test_Add_Mul_is_finite():
-    x = Symbol('x', real=True, finite=False)
+    x = Symbol('x', extended_real=True, finite=False)
 
     assert sin(x).is_finite is True
     assert (x*sin(x)).is_finite is False
@@ -554,7 +554,7 @@ def test_Add_is_even_odd():
 
 def test_Mul_is_negative_positive():
     x = Symbol('x', real=True)
-    y = Symbol('y', real=False, complex=True)
+    y = Symbol('y', extended_real=False, complex=True)
     z = Symbol('z', zero=True)
 
     e = 2*z
@@ -999,28 +999,28 @@ def test_Pow_is_real():
 
     i = Symbol('i', imaginary=True)
     assert (i**i).is_real is None
-    assert (I**i).is_real is True
-    assert ((-I)**i).is_real is True
+    assert (I**i).is_extended_real is True
+    assert ((-I)**i).is_extended_real is True
     assert (2**i).is_real is None  # (2**(pi/log(2) * I)) is real, 2**I is not
     assert (2**I).is_real is False
     assert (2**-I).is_real is False
-    assert (i**2).is_real is True
-    assert (i**3).is_real is False
+    assert (i**2).is_extended_real is True
+    assert (i**3).is_extended_real is False
     assert (i**x).is_real is None  # could be (-I)**(2/3)
     e = Symbol('e', even=True)
     o = Symbol('o', odd=True)
     k = Symbol('k', integer=True)
-    assert (i**e).is_real is True
-    assert (i**o).is_real is False
+    assert (i**e).is_extended_real is True
+    assert (i**o).is_extended_real is False
     assert (i**k).is_real is None
-    assert (i**(4*k)).is_real is True
+    assert (i**(4*k)).is_extended_real is True
 
-    x = Symbol("x", nonnegative=True)
-    y = Symbol("y", nonnegative=True)
+    x = Symbol("x", nonnegative=True, finite=True)
+    y = Symbol("y", nonnegative=True, finite=True)
     assert im(x**y).expand(complex=True) is S.Zero
     assert (x**y).is_real is True
     i = Symbol('i', imaginary=True)
-    assert (exp(i)**I).is_real is True
+    assert (exp(i)**I).is_extended_real is True
     assert log(exp(i)).is_imaginary is None  # i could be 2*pi*I
     c = Symbol('c', complex=True)
     assert log(c).is_real is None  # c could be 0 or 2, too
@@ -1039,7 +1039,7 @@ def test_real_Pow():
 
 
 def test_Pow_is_finite():
-    x = Symbol('x', real=True)
+    x = Symbol('x', extended_real=True)
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
 
@@ -1208,7 +1208,7 @@ def test_Pow_is_nonpositive_nonnegative():
 
 
     assert (x**2).is_nonnegative is True
-    i = symbols('i', imaginary=True)
+    i = symbols('i', imaginary=True, finite=True)
     assert (i**2).is_nonpositive is True
     assert (i**4).is_nonpositive is False
     assert (i**3).is_nonpositive is False
@@ -1250,7 +1250,7 @@ def test_Mul_is_imaginary_real():
     assert (e**-1).is_real is False
     assert (e**2).is_real is False
     assert (e**3).is_real is False
-    assert (e**4).is_real
+    assert (e**4).is_extended_real is True
     assert (e**5).is_real is False
     assert (e**3).is_complex
 
@@ -1261,7 +1261,7 @@ def test_Mul_is_imaginary_real():
     assert (x*i).is_real is None
 
     assert (i*ii).is_imaginary is False
-    assert (i*ii).is_real is True
+    assert (i*ii).is_extended_real is True
 
     assert (r*i*ii).is_imaginary is False
     assert (r*i*ii).is_real is True
@@ -1919,17 +1919,17 @@ def test_mul_zero_detection():
     # real is True
     def test(z, b, e):
         if z.is_zero and not b.is_finite:
-            assert e.is_real is None
+            assert e.is_extended_real is None
         else:
-            assert e.is_real
+            assert e.is_extended_real is True
 
     for iz, ib in cartes(*[[True, False, None]]*2):
-        z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', finite=ib, real=True)
+        z = Dummy('z', nonzero=iz, extended_real=True)
+        b = Dummy('b', finite=ib, extended_real=True)
         e = Mul(z, b, evaluate=False)
         test(z, b, e)
-        z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', finite=ib, real=True)
+        z = Dummy('z', nonzero=iz, extended_real=True)
+        b = Dummy('b', finite=ib, extended_real=True)
         e = Mul(b, z, evaluate=False)
         test(z, b, e)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1774,7 +1774,11 @@ def test_add_flatten():
     b = oo - I*oo
     assert a + b == nan
     assert a - b == nan
-    assert (1/a).simplify() == (1/b).simplify() == 0
+    # This evaluates as:
+    #   >>> 1/a
+    #   0*(oo + oo*I)
+    # which should not simplify to 0...
+    #assert (1/a).simplify() == (1/b).simplify() == 0
 
     a = Pow(2, 3, evaluate=False)
     assert a + a == 16

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -381,14 +381,14 @@ def test_Add_Mul_is_finite():
     x = Symbol('x', extended_real=True, finite=False)
 
     assert sin(x).is_finite is True
-    assert (x*sin(x)).is_finite is False
+    assert (x*sin(x)).is_finite is None
     assert (1024*sin(x)).is_finite is True
-    assert (sin(x)*exp(x)).is_finite is not True
+    assert (sin(x)*exp(x)).is_finite is None
     assert (sin(x)*cos(x)).is_finite is True
-    assert (x*sin(x)*exp(x)).is_finite is not True
+    assert (x*sin(x)*exp(x)).is_finite is None
 
     assert (sin(x) - 67).is_finite is True
-    assert (sin(x) + exp(x)).is_finite is not True
+    assert (sin(x) + exp(x)).is_finite is None
     assert (1 + x).is_finite is False
     assert (1 + x**2 + (1 + x)*(1 - x)).is_finite is None
     assert (sqrt(2)*(1 + x)).is_finite is False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1094,7 +1094,7 @@ def test_complex_reciprocal_imaginary():
     assert (1 / (4 + 3*I)).is_imaginary is False
 
 def test_issue_16313():
-    x = Symbol('x', real=False)
+    x = Symbol('x', extended_real=False)
     k = Symbol('k', real=True)
     l = Symbol('l', real=True, zero=False)
     assert (-x).is_real is False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -323,9 +323,22 @@ def test_I():
     assert z.is_composite is False
 
 
-def test_symbol_real():
+def test_symbol_real_false():
     # issue 3848
     a = Symbol('a', real=False)
+
+    assert a.is_real is False
+    assert a.is_integer is False
+    assert a.is_negative is None
+    assert a.is_positive is None
+    assert a.is_nonnegative is None
+    assert a.is_nonpositive is None
+    assert a.is_zero is False
+
+
+def test_symbol_extended_real_false():
+    # issue 3848
+    a = Symbol('a', extended_real=False)
 
     assert a.is_real is False
     assert a.is_integer is False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -105,13 +105,13 @@ def test_infinity():
     assert oo.is_extended_real is True
     assert oo.is_real is False
     assert oo.is_complex is False
-    assert oo.is_noninteger is True
+    assert oo.is_noninteger is False
     assert oo.is_irrational is False
     assert oo.is_imaginary is False
-    assert oo.is_positive is True
+    assert oo.is_positive is False
     assert oo.is_negative is False
     assert oo.is_nonpositive is False
-    assert oo.is_nonnegative is True
+    assert oo.is_nonnegative is False
     assert oo.is_even is False
     assert oo.is_odd is False
     assert oo.is_finite is False
@@ -133,12 +133,12 @@ def test_neg_infinity():
     assert mm.is_extended_real is True
     assert mm.is_real is False
     assert mm.is_complex is False
-    assert mm.is_noninteger is True
+    assert mm.is_noninteger is False
     assert mm.is_irrational is False
     assert mm.is_imaginary is False
     assert mm.is_positive is False
-    assert mm.is_negative is True
-    assert mm.is_nonpositive is True
+    assert mm.is_negative is False
+    assert mm.is_nonpositive is False
     assert mm.is_nonnegative is False
     assert mm.is_even is False
     assert mm.is_odd is False
@@ -329,10 +329,10 @@ def test_symbol_real_false():
 
     assert a.is_real is False
     assert a.is_integer is False
-    assert a.is_negative is None
-    assert a.is_positive is None
-    assert a.is_nonnegative is None
-    assert a.is_nonpositive is None
+    assert a.is_negative is False
+    assert a.is_positive is False
+    assert a.is_nonnegative is False
+    assert a.is_nonpositive is False
     assert a.is_zero is False
 
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -718,31 +718,8 @@ def test_hash_vs_eq():
 
 
 def test_Add_is_pos_neg():
-    # these cover lines not covered by the rest of tests in core
-    n = Symbol('n', negative=True, infinite=True)
-    nn = Symbol('n', nonnegative=True, infinite=True)
-    np = Symbol('n', nonpositive=True, infinite=True)
-    p = Symbol('p', positive=True, infinite=True)
-    r = Dummy(extended_real=True, finite=False)
     x = Symbol('x')
-    xf = Symbol('xb', finite=True)
-    assert (n + p).is_positive is None
-    assert (n + x).is_positive is None
-    assert (p + x).is_positive is None
-    assert (n + p).is_negative is None
-    assert (n + x).is_negative is None
-    assert (p + x).is_negative is None
-
-    assert (n + xf).is_positive is False
-    assert (p + xf).is_positive is True
-    assert (n + xf).is_negative is True
-    assert (p + xf).is_negative is False
-
     assert (x - S.Infinity).is_negative is None  # issue 7798
-    # issue 8046, 16.2
-    assert (p + nn).is_positive
-    assert (n + np).is_negative
-    assert (p + r).is_positive is None
 
 
 def test_Add_is_imaginary():
@@ -875,13 +852,13 @@ def test_Mul_is_infinite():
     from sympy import Mul
     assert (x*f).is_finite is None
     assert (x*i).is_finite is None
-    assert (f*i).is_finite is False
+    assert (f*i).is_finite is None
     assert (x*f*i).is_finite is None
-    assert (z*i).is_finite is False
+    assert (z*i).is_finite is None
     assert (nzf*i).is_finite is False
     assert (z*f).is_finite is True
     assert Mul(0, f, evaluate=False).is_finite is True
-    assert Mul(0, i, evaluate=False).is_finite is False
+    assert Mul(0, i, evaluate=False).is_finite is None
 
     assert (x*f).is_infinite is None
     assert (x*i).is_infinite is None

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -102,7 +102,8 @@ def test_infinity():
     assert oo.is_rational is False
     assert oo.is_algebraic is False
     assert oo.is_transcendental is False
-    assert oo.is_real is True
+    assert oo.is_extended_real is True
+    assert oo.is_real is False
     assert oo.is_complex is True
     assert oo.is_noninteger is True
     assert oo.is_irrational is False
@@ -129,7 +130,8 @@ def test_neg_infinity():
     assert mm.is_rational is False
     assert mm.is_algebraic is False
     assert mm.is_transcendental is False
-    assert mm.is_real is True
+    assert mm.is_extended_real is True
+    assert mm.is_real is False
     assert mm.is_complex is True
     assert mm.is_noninteger is True
     assert mm.is_irrational is False
@@ -708,7 +710,7 @@ def test_Add_is_pos_neg():
     nn = Symbol('n', nonnegative=True, infinite=True)
     np = Symbol('n', nonpositive=True, infinite=True)
     p = Symbol('p', positive=True, infinite=True)
-    r = Dummy(real=True, finite=False)
+    r = Dummy(extended_real=True, finite=False)
     x = Symbol('x')
     xf = Symbol('xb', finite=True)
     assert (n + p).is_positive is None

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -104,7 +104,7 @@ def test_infinity():
     assert oo.is_transcendental is False
     assert oo.is_extended_real is True
     assert oo.is_real is False
-    assert oo.is_complex is True
+    assert oo.is_complex is False
     assert oo.is_noninteger is True
     assert oo.is_irrational is False
     assert oo.is_imaginary is False
@@ -132,7 +132,7 @@ def test_neg_infinity():
     assert mm.is_transcendental is False
     assert mm.is_extended_real is True
     assert mm.is_real is False
-    assert mm.is_complex is True
+    assert mm.is_complex is False
     assert mm.is_noninteger is True
     assert mm.is_irrational is False
     assert mm.is_imaginary is False

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1809,7 +1809,7 @@ def test_issue_7426():
 
 
 def test_issue_1112():
-    x = Symbol('x', positive=False)
+    x = Symbol('x', positive=False, real=True)
     assert (x > 0) is S.false
 
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1538,7 +1538,7 @@ def test_zoo():
 
 def test_issue_4122():
     x = Symbol('x', nonpositive=True)
-    assert (oo + x).is_Add
+    assert (oo + x) == oo
     x = Symbol('x', finite=True)
     assert (oo + x).is_Add  # x could be imaginary
     x = Symbol('x', nonnegative=True)
@@ -1548,7 +1548,7 @@ def test_issue_4122():
 
     # similarly for negative infinity
     x = Symbol('x', nonnegative=True)
-    assert (-oo + x).is_Add
+    assert (-oo + x) == -oo
     x = Symbol('x', finite=True)
     assert (-oo + x).is_Add
     x = Symbol('x', nonpositive=True)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1504,7 +1504,7 @@ def test_zoo():
             assert (zoo + i) is S.NaN
             assert (zoo - i) is S.NaN
 
-        if fuzzy_not(i.is_zero) and (i.is_real or i.is_imaginary):
+        if fuzzy_not(i.is_zero) and (i.is_extended_real or i.is_imaginary):
             assert i*zoo is zoo
             assert zoo*i is zoo
         elif i.is_zero:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -386,7 +386,7 @@ def test_imaginary_compare_raises_TypeError():
 def test_complex_compare_not_real():
     # two cases which are not real
     y = Symbol('y', imaginary=True)
-    z = Symbol('z', complex=True, real=False)
+    z = Symbol('z', complex=True, extended_real=False)
     for w in (y, z):
         assert_all_ineq_raise_TypeError(2, w)
     # some cases which should remain un-evaluated

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -169,7 +169,7 @@ def test_Wild_properties():
     integerp = lambda k: k.is_integer
     positivep = lambda k: k.is_positive
     symbolp = lambda k: k.is_Symbol
-    realp = lambda k: k.is_real
+    realp = lambda k: k.is_extended_real
 
     S = Wild("S", properties=[symbolp])
     R = Wild("R", properties=[realp])

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -421,7 +421,7 @@ class Abs(Function):
     """
 
     is_extended_real = True
-    is_negative = False
+    is_nonnegative = True
     unbranched = True
 
     def fdiff(self, argindex=1):

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -534,6 +534,10 @@ class Abs(Function):
             if not unk or not all(conj.has(conjugate(u)) for u in unk):
                 return sqrt(expand_mul(arg*conj))
 
+    def _eval_is_real(self):
+        if self.args[0].is_finite:
+            return True
+
     def _eval_is_integer(self):
         if self.args[0].is_extended_real:
             return self.args[0].is_integer

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -113,6 +113,12 @@ class re(Function):
         # is_imaginary implies nonzero
         return fuzzy_or([self.args[0].is_imaginary, self.args[0].is_zero])
 
+    def _eval_is_complex(self):
+        if self.args[0].is_finite:
+            return True
+        else:
+            return None
+
     def _sage_(self):
         import sage.all as sage
         return sage.real_part(self.args[0]._sage_())
@@ -222,6 +228,12 @@ class im(Function):
 
     def _eval_is_zero(self):
         return self.args[0].is_extended_real
+
+    def _eval_is_complex(self):
+        if self.args[0].is_finite:
+            return True
+        else:
+            return None
 
 ###############################################################################
 ############### SIGN, ABSOLUTE VALUE, ARGUMENT and CONJUGATION ################

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -46,7 +46,7 @@ class re(Function):
     im
     """
 
-    is_real = True
+    is_extended_real = True
     unbranched = True  # implicitly works on the projection to C
 
     @classmethod
@@ -55,9 +55,9 @@ class re(Function):
             return S.NaN
         elif arg is S.ComplexInfinity:
             return S.NaN
-        elif arg.is_real:
+        elif arg.is_extended_real:
             return arg
-        elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:
+        elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_extended_real:
             return S.Zero
         elif arg.is_Matrix:
             return arg.as_real_imag()[0]
@@ -71,9 +71,9 @@ class re(Function):
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 
                 if coeff is not None:
-                    if not coeff.is_real:
+                    if not coeff.is_extended_real:
                         reverted.append(coeff)
-                elif not term.has(S.ImaginaryUnit) and term.is_real:
+                elif not term.has(S.ImaginaryUnit) and term.is_extended_real:
                     excluded.append(term)
                 else:
                     # Try to do some advanced expansion.  If
@@ -97,7 +97,7 @@ class re(Function):
         return (self, S.Zero)
 
     def _eval_derivative(self, x):
-        if x.is_real or self.args[0].is_real:
+        if x.is_extended_real or self.args[0].is_extended_real:
             return re(Derivative(self.args[0], x, evaluate=True))
         if x.is_imaginary or self.args[0].is_imaginary:
             return -S.ImaginaryUnit \
@@ -146,7 +146,7 @@ class im(Function):
     re
     """
 
-    is_real = True
+    is_extended_real = True
     unbranched = True  # implicitly works on the projection to C
 
     @classmethod
@@ -155,9 +155,9 @@ class im(Function):
             return S.NaN
         elif arg is S.ComplexInfinity:
             return S.NaN
-        elif arg.is_real:
+        elif arg.is_extended_real:
             return S.Zero
-        elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:
+        elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_extended_real:
             return -S.ImaginaryUnit * arg
         elif arg.is_Matrix:
             return arg.as_real_imag()[1]
@@ -170,11 +170,11 @@ class im(Function):
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 
                 if coeff is not None:
-                    if not coeff.is_real:
+                    if not coeff.is_extended_real:
                         reverted.append(coeff)
                     else:
                         excluded.append(coeff)
-                elif term.has(S.ImaginaryUnit) or not term.is_real:
+                elif term.has(S.ImaginaryUnit) or not term.is_extended_real:
                     # Try to do some advanced expansion.  If
                     # impossible, don't try to do im(arg) again
                     # (because this is what we are trying to do now).
@@ -204,7 +204,7 @@ class im(Function):
         return (self, S.Zero)
 
     def _eval_derivative(self, x):
-        if x.is_real or self.args[0].is_real:
+        if x.is_extended_real or self.args[0].is_extended_real:
             return im(Derivative(self.args[0], x, evaluate=True))
         if x.is_imaginary or self.args[0].is_imaginary:
             return -S.ImaginaryUnit \
@@ -221,7 +221,7 @@ class im(Function):
         return self.args[0].is_algebraic
 
     def _eval_is_zero(self):
-        return self.args[0].is_real
+        return self.args[0].is_extended_real
 
 ###############################################################################
 ############### SIGN, ABSOLUTE VALUE, ARGUMENT and CONJUGATION ################
@@ -331,7 +331,7 @@ class sign(Function):
         return sign(conjugate(self.args[0]))
 
     def _eval_derivative(self, x):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             from sympy.functions.special.delta_functions import DiracDelta
             return 2 * Derivative(self.args[0], x, evaluate=True) \
                 * DiracDelta(self.args[0])
@@ -352,7 +352,7 @@ class sign(Function):
         return self.args[0].is_imaginary
 
     def _eval_is_integer(self):
-        return self.args[0].is_real
+        return self.args[0].is_extended_real
 
     def _eval_is_zero(self):
         return self.args[0].is_zero
@@ -370,12 +370,12 @@ class sign(Function):
         return sage.sgn(self.args[0]._sage_())
 
     def _eval_rewrite_as_Piecewise(self, arg, **kwargs):
-        if arg.is_real:
+        if arg.is_extended_real:
             return Piecewise((1, arg > 0), (-1, arg < 0), (0, True))
 
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         from sympy.functions.special.delta_functions import Heaviside
-        if arg.is_real:
+        if arg.is_extended_real:
             return Heaviside(arg)*2-1
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
@@ -420,7 +420,7 @@ class Abs(Function):
     sign, conjugate
     """
 
-    is_real = True
+    is_extended_real = True
     is_negative = False
     unbranched = True
 
@@ -472,7 +472,7 @@ class Abs(Function):
             return S.Infinity
         if arg.is_Pow:
             base, exponent = arg.as_base_exp()
-            if base.is_real:
+            if base.is_extended_real:
                 if exponent.is_integer:
                     if exponent.is_even:
                         return arg
@@ -518,12 +518,12 @@ class Abs(Function):
         if arg != conj and arg != -conj:
             ignore = arg.atoms(Abs)
             abs_free_arg = arg.xreplace({i: Dummy(real=True) for i in ignore})
-            unk = [a for a in abs_free_arg.free_symbols if a.is_real is None]
+            unk = [a for a in abs_free_arg.free_symbols if a.is_extended_real is None]
             if not unk or not all(conj.has(conjugate(u)) for u in unk):
                 return sqrt(expand_mul(arg*conj))
 
     def _eval_is_integer(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_integer
 
     def _eval_is_nonzero(self):
@@ -538,22 +538,22 @@ class Abs(Function):
             return not is_z
 
     def _eval_is_rational(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_rational
 
     def _eval_is_even(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_even
 
     def _eval_is_odd(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_odd
 
     def _eval_is_algebraic(self):
         return self.args[0].is_algebraic
 
     def _eval_power(self, exponent):
-        if self.args[0].is_real and exponent.is_integer:
+        if self.args[0].is_extended_real and exponent.is_integer:
             if exponent.is_even:
                 return self.args[0]**exponent
             elif exponent is not S.NegativeOne and exponent.is_Integer:
@@ -574,7 +574,7 @@ class Abs(Function):
         return sage.abs_symbolic(self.args[0]._sage_())
 
     def _eval_derivative(self, x):
-        if self.args[0].is_real or self.args[0].is_imaginary:
+        if self.args[0].is_extended_real or self.args[0].is_imaginary:
             return Derivative(self.args[0], x, evaluate=True) \
                 * sign(conjugate(self.args[0]))
         rv = (re(self.args[0]) * Derivative(re(self.args[0]), x,
@@ -586,11 +586,11 @@ class Abs(Function):
         # Note this only holds for real arg (since Heaviside is not defined
         # for complex arguments).
         from sympy.functions.special.delta_functions import Heaviside
-        if arg.is_real:
+        if arg.is_extended_real:
             return arg*(Heaviside(arg) - Heaviside(-arg))
 
     def _eval_rewrite_as_Piecewise(self, arg, **kwargs):
-        if arg.is_real:
+        if arg.is_extended_real:
             return Piecewise((arg, arg >= 0), (-arg, True))
 
     def _eval_rewrite_as_sign(self, arg, **kwargs):
@@ -616,7 +616,7 @@ class arg(Function):
 
     """
 
-    is_real = True
+    is_extended_real = True
     is_finite = True
 
     @classmethod
@@ -695,7 +695,7 @@ class conjugate(Function):
         return self.args[0]
 
     def _eval_derivative(self, x):
-        if x.is_real:
+        if x.is_extended_real:
             return conjugate(Derivative(self.args[0], x, evaluate=True))
         elif x.is_imaginary:
             return -conjugate(Derivative(self.args[0], x, evaluate=True))

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -173,8 +173,8 @@ class exp_polar(ExpBase):
     def _eval_power(self, other):
         return self.func(self.args[0]*other)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
 
     def as_base_exp(self):
@@ -379,8 +379,8 @@ class exp(ExpBase):
             return new**self.exp._subs(old, new)
         return Function._eval_subs(self, old, new)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
         elif self.args[0].is_imaginary:
             arg2 = -S(2) * S.ImaginaryUnit * self.args[0] / S.Pi
@@ -398,7 +398,7 @@ class exp(ExpBase):
             return s.is_algebraic
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return not self.args[0] is S.NegativeInfinity
         elif self.args[0].is_imaginary:
             arg2 = -S.ImaginaryUnit * self.args[0] / S.Pi
@@ -552,7 +552,7 @@ class log(Function):
 
         if arg is S.ComplexInfinity:
                 return S.ComplexInfinity
-        if isinstance(arg, exp) and arg.args[0].is_real:
+        if isinstance(arg, exp) and arg.args[0].is_extended_real:
             return arg.args[0]
         elif isinstance(arg, exp_polar):
             return unpolarify(arg.exp)
@@ -643,7 +643,7 @@ class log(Function):
                     nonpos.append(x)
             return Add(*expr) + log(Mul(*nonpos))
         elif arg.is_Pow or isinstance(arg, exp):
-            if force or (arg.exp.is_real and (arg.base.is_positive or ((arg.exp+1)
+            if force or (arg.exp.is_extended_real and (arg.base.is_positive or ((arg.exp+1)
                 .is_positive and (arg.exp-1).is_nonpositive))) or arg.base.is_polar:
                 b = arg.base
                 e = arg.exp
@@ -724,7 +724,7 @@ class log(Function):
         else:
             return s.is_algebraic
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         return self.args[0].is_positive
 
     def _eval_is_finite(self):
@@ -860,7 +860,7 @@ class LambertW(Function):
 
         raise ArgumentIndexError(self, argindex)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         x = self.args[0]
         if len(self.args) == 1:
             k = S.Zero
@@ -877,7 +877,7 @@ class LambertW(Function):
             elif x.is_nonpositive or (x + 1/S.Exp1).is_nonnegative:
                 return False
         elif fuzzy_not(k.is_zero) and fuzzy_not((k + 1).is_zero):
-            if x.is_real:
+            if x.is_extended_real:
                 return False
 
     def _eval_is_algebraic(self):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -880,6 +880,9 @@ class LambertW(Function):
             if x.is_extended_real:
                 return False
 
+    def _eval_is_finite(self):
+        return self.args[0].is_finite
+
     def _eval_is_algebraic(self):
         s = self.func(*self.args)
         if s.func == self.func:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -398,8 +398,8 @@ class exp(ExpBase):
             return s.is_algebraic
 
     def _eval_is_positive(self):
-        if self.args[0].is_extended_real:
-            return not self.args[0] is S.NegativeInfinity
+        if self.args[0].is_real:
+            return self.args[0] is not S.NegativeInfinity
         elif self.args[0].is_imaginary:
             arg2 = -S.ImaginaryUnit * self.args[0] / S.Pi
             return arg2.is_even

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -166,7 +166,7 @@ class sinh(HyperbolicFunction):
         Returns this function as a complex coordinate.
         """
         from sympy import cos, sin
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -225,16 +225,16 @@ class sinh(HyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_positive
 
     def _eval_is_negative(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_negative
 
     def _eval_is_finite(self):
@@ -326,7 +326,7 @@ class cosh(HyperbolicFunction):
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import cos, sin
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -387,7 +387,7 @@ class cosh(HyperbolicFunction):
             return self.func(arg)
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return True
 
     def _eval_is_finite(self):
@@ -494,7 +494,7 @@ class tanh(HyperbolicFunction):
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import cos, sin
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -533,21 +533,21 @@ class tanh(HyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_positive
 
     def _eval_is_negative(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_negative
 
     def _eval_is_finite(self):
         arg = self.args[0]
-        if arg.is_real:
+        if arg.is_extended_real:
             return True
 
 
@@ -644,7 +644,7 @@ class coth(HyperbolicFunction):
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import cos, sin
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -675,11 +675,11 @@ class coth(HyperbolicFunction):
         return 1/tanh(arg)
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_positive
 
     def _eval_is_negative(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_negative
 
     def _eval_as_leading_term(self, x):
@@ -756,8 +756,8 @@ class ReciprocalHyperbolicFunction(HyperbolicFunction):
     def _eval_as_leading_term(self, x):
         return (1/self._reciprocal_of(self.args[0]))._eval_as_leading_term(x)
 
-    def _eval_is_real(self):
-        return self._reciprocal_of(self.args[0]).is_real
+    def _eval_is_extended_real(self):
+        return self._reciprocal_of(self.args[0]).is_extended_real
 
     def _eval_is_finite(self):
         return (1/self._reciprocal_of(self.args[0])).is_finite
@@ -810,11 +810,11 @@ class csch(ReciprocalHyperbolicFunction):
         return S.ImaginaryUnit / cosh(arg + S.ImaginaryUnit * S.Pi / 2)
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_positive
 
     def _eval_is_negative(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return self.args[0].is_negative
 
     def _sage_(self):
@@ -857,7 +857,7 @@ class sech(ReciprocalHyperbolicFunction):
         return S.ImaginaryUnit / sinh(arg + S.ImaginaryUnit * S.Pi /2)
 
     def _eval_is_positive(self):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             return True
 
     def _sage_(self):
@@ -1022,7 +1022,7 @@ class acosh(InverseHyperbolicFunction):
             }
 
             if arg in cst_table:
-                if arg.is_real:
+                if arg.is_extended_real:
                     return cst_table[arg]*S.ImaginaryUnit
                 return cst_table[arg]
 
@@ -1316,7 +1316,7 @@ class asech(InverseHyperbolicFunction):
             }
 
             if arg in cst_table:
-                if arg.is_real:
+                if arg.is_extended_real:
                     return cst_table[arg]*S.ImaginaryUnit
                 return cst_table[arg]
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -516,7 +516,7 @@ class MinMaxBase(Expr, LatticeOp):
         for arg in arg_sequence:
 
             # pre-filter, checking comparability of arguments
-            if not isinstance(arg, Expr) or arg.is_real is False or (
+            if not isinstance(arg, Expr) or arg.is_extended_real is False or (
                     arg.is_number and
                     not arg.is_comparable):
                 raise ValueError("The argument '%s' is not comparable." % arg)
@@ -638,6 +638,7 @@ class MinMaxBase(Expr, LatticeOp):
     _eval_is_prime = lambda s: _torf(i.is_prime for i in s.args)
     _eval_is_rational = lambda s: _torf(i.is_rational for i in s.args)
     _eval_is_real = lambda s: _torf(i.is_real for i in s.args)
+    _eval_is_extended_real = lambda s: _torf(i.is_extended_real for i in s.args)
     _eval_is_transcendental = lambda s: _torf(i.is_transcendental for i in s.args)
     _eval_is_zero = lambda s: _torf(i.is_zero for i in s.args)
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -916,6 +916,7 @@ class Piecewise(Function):
     _eval_is_odd = lambda self: self._eval_template_is_attr('is_odd')
     _eval_is_polar = lambda self: self._eval_template_is_attr('is_polar')
     _eval_is_positive = lambda self: self._eval_template_is_attr('is_positive')
+    _eval_is_extended_real = lambda self: self._eval_template_is_attr('is_extended_real')
     _eval_is_real = lambda self: self._eval_template_is_attr('is_real')
     _eval_is_zero = lambda self: self._eval_template_is_attr(
         'is_zero')

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -841,7 +841,7 @@ def test_principal_branch():
     from sympy import principal_branch, polar_lift, exp_polar
     p = Symbol('p', positive=True)
     x = Symbol('x')
-    neg = Symbol('x', negative=True)
+    neg = Symbol('x', negative=True, finite=True)
 
     assert principal_branch(polar_lift(x), p) == principal_branch(x, p)
     assert principal_branch(polar_lift(2 + I), p) == principal_branch(2 + I, p)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -473,19 +473,19 @@ def test_Abs_real():
 
 def test_Abs_properties():
     x = Symbol('x')
-    assert Abs(x).is_real is True
+    assert Abs(x).is_extended_real is True
     assert Abs(x).is_rational is None
     assert Abs(x).is_positive is None
     assert Abs(x).is_nonnegative is True
 
     z = Symbol('z', complex=True, zero=False)
-    assert Abs(z).is_real is True
+    assert Abs(z).is_extended_real is True
     assert Abs(z).is_rational is None
     assert Abs(z).is_positive is True
     assert Abs(z).is_zero is False
 
     p = Symbol('p', positive=True)
-    assert Abs(p).is_real is True
+    assert Abs(p).is_extended_real is True
     assert Abs(p).is_rational is None
     assert Abs(p).is_positive is True
     assert Abs(p).is_zero is False
@@ -536,7 +536,7 @@ def test_arg():
     f = Function('f')
     assert not arg(f(0) + I*f(1)).atoms(re)
 
-    p = Symbol('p', positive=True)
+    p = Symbol('p', positive=True, finite=True)
     assert arg(p) == 0
 
     n = Symbol('n', negative=True)
@@ -895,7 +895,7 @@ def test_issue_14238():
     assert Abs(r + Piecewise((0, r > 0), (1 - r, True)))
 
 def test_zero_assumptions():
-    nr = Symbol('nonreal', real=False)
+    nr = Symbol('nonreal', real=False, finite=True)
     ni = Symbol('nonimaginary', imaginary=False)
     # imaginary implies not zero
     nzni = Symbol('nonzerononimaginary', zero=False, imaginary=False)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -387,7 +387,7 @@ def test_lambertw():
 
     assert LambertW(-1).is_real is False  # issue 5215
     assert LambertW(2, evaluate=False).is_real
-    p = Symbol('p', positive=True)
+    p = Symbol('p', positive=True, finite=True)
     assert LambertW(p, evaluate=False).is_real
     assert LambertW(p - 1, evaluate=False).is_real is None
     assert LambertW(-p - 2/S.Exp1, evaluate=False).is_real is False

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -250,7 +250,7 @@ def test_exp_assumptions():
         assert e(i).is_imaginary is None
         assert e(r).is_real is True
         assert e(r).is_imaginary is False
-        assert e(re(x)).is_real is True
+        assert e(re(x)).is_extended_real is True
         assert e(re(x)).is_imaginary is False
 
     assert exp(0, evaluate=False).is_algebraic

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -338,7 +338,7 @@ def test_csch():
 
     assert csch(k*pi*I/2) == -1/sin(k*pi/2)*I
 
-    assert csch(n).is_real is True
+    assert csch(n).is_extended_real is True
 
 
 def test_csch_series():
@@ -401,7 +401,7 @@ def test_sech():
     assert sech(k*pi*I) == 1/cos(k*pi)
     assert sech(17*k*pi*I) == 1/cos(17*k*pi)
 
-    assert sech(n).is_real is True
+    assert sech(n).is_extended_real is True
 
 
 def test_sech_series():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -850,7 +850,7 @@ def test_holes():
     # this also tests that the integrate method is used on non-Piecwise
     # arguments in _eval_integral
     A, B = symbols("A B")
-    a, b = symbols('a b', finite=True)
+    a, b = symbols('a b', real=True)
     assert Piecewise((A, And(x < 0, a < 1)), (B, Or(x < 1, a > 2))
         ).integrate(x) == Piecewise(
         (B*x, a > 2),

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -471,7 +471,7 @@ def test_tan():
 
     assert tan(k*pi*I) == tanh(k*pi)*I
 
-    assert tan(r).is_real is True
+    assert tan(r).is_extended_real is True
 
     assert tan(0, evaluate=False).is_algebraic
     assert tan(a).is_algebraic is None
@@ -613,7 +613,7 @@ def test_cot():
     assert cot(x*I) == -coth(x)*I
     assert cot(k*pi*I) == -coth(k*pi)*I
 
-    assert cot(r).is_real is True
+    assert cot(r).is_extended_real is True
 
     assert cot(a).is_algebraic is None
     assert cot(na).is_algebraic is False
@@ -849,7 +849,7 @@ def test_atan():
     assert atan(oo) == pi/2
     assert atan(x).diff(x) == 1/(1 + x**2)
 
-    assert atan(r).is_real is True
+    assert atan(r).is_extended_real is True
 
     assert atan(-2*I) == -I*atanh(2)
     assert atan(p).is_positive is True
@@ -944,7 +944,7 @@ def test_acot():
     assert acot(-1/sqrt(3)) == -pi/3
     assert acot(x).diff(x) == -1/(1 + x**2)
 
-    assert acot(r).is_real is True
+    assert acot(r).is_extended_real is True
 
     assert acot(I*pi) == -I*acoth(pi)
     assert acot(-2*I) == I*acoth(2)
@@ -1344,7 +1344,7 @@ def test_sec():
     assert sec(x).expand(trig=True) == 1/cos(x)
     assert sec(2*x).expand(trig=True) == 1/(2*cos(x)**2 - 1)
 
-    assert sec(x).is_real == True
+    assert sec(x).is_extended_real == True
     assert sec(z).is_real == None
 
     assert sec(a).is_algebraic is None
@@ -1426,7 +1426,7 @@ def test_csc():
     assert csc(x).expand(trig=True) == 1/sin(x)
     assert csc(2*x).expand(trig=True) == 1/(2*sin(x)*cos(x))
 
-    assert csc(x).is_real == True
+    assert csc(x).is_extended_real == True
     assert csc(z).is_real == None
 
     assert csc(a).is_algebraic is None
@@ -1474,10 +1474,10 @@ def test_asec():
 def test_asec_is_real():
     assert asec(S(1)/2).is_real is False
     n = Symbol('n', positive=True, integer=True)
-    assert asec(n).is_real is True
+    assert asec(n).is_extended_real is True
     assert asec(x).is_real is None
     assert asec(r).is_real is None
-    t = Symbol('t', real=False)
+    t = Symbol('t', real=False, finite=True)
     assert asec(t).is_real is False
 
 
@@ -1554,7 +1554,7 @@ def test_issue_11864():
     assert F.rewrite(sinc) == soln
 
 def test_real_assumptions():
-    z = Symbol('z', real=False)
+    z = Symbol('z', real=False, finite=True)
     assert sin(z).is_real is None
     assert cos(z).is_real is None
     assert tan(z).is_real is False

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -53,7 +53,7 @@ class TrigonometricFunction(Function):
         return re_part + im_part*S.ImaginaryUnit
 
     def _as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.args[0].expand(deep, **hints), S.Zero)
@@ -464,13 +464,13 @@ class sin(TrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
 
     def _eval_is_finite(self):
         arg = self.args[0]
-        if arg.is_real:
+        if arg.is_extended_real:
             return True
 
 
@@ -890,14 +890,14 @@ class cos(TrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        if self.args[0].is_real:
+    def _eval_is_extended_real(self):
+        if self.args[0].is_extended_real:
             return True
 
     def _eval_is_finite(self):
         arg = self.args[0]
 
-        if arg.is_real:
+        if arg.is_extended_real:
             return True
 
 
@@ -1189,8 +1189,8 @@ class tan(TrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_is_finite(self):
         arg = self.args[0]
@@ -1445,8 +1445,8 @@ class cot(TrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_expand_trig(self, **hints):
         from sympy import im, re
@@ -1595,8 +1595,8 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
     def _eval_expand_trig(self, **hints):
         return self._calculate_reciprocal("_eval_expand_trig", **hints)
 
-    def _eval_is_real(self):
-        return self._reciprocal_of(self.args[0])._eval_is_real()
+    def _eval_is_extended_real(self):
+        return self._reciprocal_of(self.args[0])._eval_is_extended_real()
 
     def _eval_as_leading_term(self, x):
         return (1/self._reciprocal_of(self.args[0]))._eval_as_leading_term(x)
@@ -1914,10 +1914,10 @@ class asin(InverseTrigonometricFunction):
             return s.is_rational
 
     def _eval_is_positive(self):
-        return self._eval_is_real() and self.args[0].is_positive
+        return self._eval_is_extended_real() and self.args[0].is_positive
 
     def _eval_is_negative(self):
-        return self._eval_is_real() and self.args[0].is_negative
+        return self._eval_is_extended_real() and self.args[0].is_negative
 
     @classmethod
     def eval(cls, arg):
@@ -2033,9 +2033,9 @@ class asin(InverseTrigonometricFunction):
     def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return acsc(1/arg)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         x = self.args[0]
-        return x.is_real and (1 - abs(x)).is_nonnegative
+        return x.is_extended_real and (1 - abs(x)).is_nonnegative
 
     def inverse(self, argindex=1):
         """
@@ -2173,12 +2173,12 @@ class acos(InverseTrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         x = self.args[0]
-        return x.is_real and (1 - abs(x)).is_nonnegative
+        return x.is_extended_real and (1 - abs(x)).is_nonnegative
 
     def _eval_is_nonnegative(self):
-        return self._eval_is_real()
+        return self._eval_is_extended_real()
 
     def _eval_nseries(self, x, n, logx):
         return self._eval_rewrite_as_log(self.args[0])._eval_nseries(x, n, logx)
@@ -2211,9 +2211,9 @@ class acos(InverseTrigonometricFunction):
     def _eval_conjugate(self):
         z = self.args[0]
         r = self.func(self.args[0].conjugate())
-        if z.is_real is False:
+        if z.is_extended_real is False:
             return r
-        elif z.is_real and (z + 1).is_nonnegative and (z - 1).is_nonpositive:
+        elif z.is_extended_real and (z + 1).is_nonnegative and (z - 1).is_nonpositive:
             return r
 
 
@@ -2357,8 +2357,8 @@ class atan(InverseTrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_rewrite_as_log(self, x, **kwargs):
         return S.ImaginaryUnit/2 * (log(S(1) - S.ImaginaryUnit * x)
@@ -2434,8 +2434,8 @@ class acot(InverseTrigonometricFunction):
     def _eval_is_negative(self):
         return self.args[0].is_negative
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     @classmethod
     def eval(cls, arg):
@@ -2659,9 +2659,9 @@ class asec(InverseTrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         x = self.args[0]
-        if x.is_real is False:
+        if x.is_extended_real is False:
             return False
         return fuzzy_or(((x - 1).is_nonnegative, (-x - 1).is_nonnegative))
 
@@ -2899,7 +2899,7 @@ class atan2(InverseTrigonometricFunction):
             x = im(x)
             y = im(y)
 
-        if x.is_real and y.is_real:
+        if x.is_extended_real and y.is_extended_real:
             if x.is_positive:
                 return atan(y / x)
             elif x.is_negative:
@@ -2914,7 +2914,7 @@ class atan2(InverseTrigonometricFunction):
                     return -S.Pi/2
                 elif y.is_zero:
                     return S.NaN
-        if y.is_zero and x.is_real and fuzzy_not(x.is_zero):
+        if y.is_zero and x.is_extended_real and fuzzy_not(x.is_zero):
             return S.Pi * (S.One - Heaviside(x))
         if x.is_number and y.is_number:
             return -S.ImaginaryUnit*log(
@@ -2928,15 +2928,15 @@ class atan2(InverseTrigonometricFunction):
 
     def _eval_rewrite_as_arg(self, y, x, **kwargs):
         from sympy import arg
-        if x.is_real and y.is_real:
+        if x.is_extended_real and y.is_extended_real:
             return arg(x + y*S.ImaginaryUnit)
         I = S.ImaginaryUnit
         n = x + I*y
         d = x**2 + y**2
         return arg(n/sqrt(d)) - I*log(abs(n)/sqrt(abs(d)))
 
-    def _eval_is_real(self):
-        return self.args[0].is_real and self.args[1].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real and self.args[1].is_extended_real
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate(), self.args[1].conjugate())
@@ -2954,5 +2954,5 @@ class atan2(InverseTrigonometricFunction):
 
     def _eval_evalf(self, prec):
         y, x = self.args
-        if x.is_real and y.is_real:
+        if x.is_extended_real and y.is_extended_real:
             super(atan2, self)._eval_evalf(prec)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2271,8 +2271,14 @@ class atan(InverseTrigonometricFunction):
     def _eval_is_positive(self):
         return self.args[0].is_positive
 
+    def _eval_is_negative(self):
+        return self.args[0].is_negative
+
     def _eval_is_nonnegative(self):
         return self.args[0].is_nonnegative
+
+    def _eval_is_nonpositive(self):
+        return self.args[0].is_nonpositive
 
     @classmethod
     def eval(cls, arg):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -65,12 +65,12 @@ class BesselBase(Function):
 
     def _eval_conjugate(self):
         z = self.argument
-        if (z.is_real and z.is_negative) is False:
+        if (z.is_extended_real and z.is_negative) is False:
             return self.__class__(self.order.conjugate(), z.conjugate())
 
     def _eval_expand_func(self, **hints):
         nu, z, f = self.order, self.argument, self.__class__
-        if nu.is_real:
+        if nu.is_extended_real:
             if (nu - 1).is_positive:
                 return (-self._a*self._b*f(nu - 2, z)._eval_expand_func() +
                         2*self._a*(nu - 1)*f(nu - 1, z)._eval_expand_func()/z)
@@ -200,9 +200,9 @@ class besselj(BesselBase):
     def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return sqrt(2*z/pi)*jn(nu - S.Half, self.argument)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         nu, z = self.args
-        if nu.is_integer and z.is_real:
+        if nu.is_integer and z.is_extended_real:
             return True
 
     def _sage_(self):
@@ -279,7 +279,7 @@ class bessely(BesselBase):
     def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
@@ -379,9 +379,9 @@ class besseli(BesselBase):
     def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return self._eval_rewrite_as_besselj(*self.args).rewrite(jn)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         nu, z = self.args
-        if nu.is_integer and z.is_real:
+        if nu.is_integer and z.is_extended_real:
             return True
 
     def _sage_(self):
@@ -463,7 +463,7 @@ class besselk(BesselBase):
         if ay:
             return ay.rewrite(yn)
 
-    def _eval_is_real(self):
+    def _eval_is_extended_real(self):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
@@ -512,7 +512,7 @@ class hankel1(BesselBase):
 
     def _eval_conjugate(self):
         z = self.argument
-        if (z.is_real and z.is_negative) is False:
+        if (z.is_extended_real and z.is_negative) is False:
             return hankel2(self.order.conjugate(), z.conjugate())
 
 
@@ -556,7 +556,7 @@ class hankel2(BesselBase):
 
     def _eval_conjugate(self):
         z = self.argument
-        if (z.is_real and z.is_negative) is False:
+        if (z.is_extended_real and z.is_negative) is False:
             return hankel1(self.order.conjugate(), z.conjugate())
 
 
@@ -990,11 +990,11 @@ class AiryBase(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -504,9 +504,9 @@ class Heaviside(Function):
         """
         H0 = sympify(H0)
         arg = sympify(arg)
-        if arg.is_negative:
+        if arg.is_negative or arg is S.NegativeInfinity:
             return S.Zero
-        elif arg.is_positive:
+        elif arg.is_positive or arg is S.Infinity:
             return S.One
         elif arg.is_zero:
             return H0

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -156,7 +156,7 @@ class erf(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_extended_real(self):
+    def _eval_is_real(self):
         return self.args[0].is_extended_real
 
     def _eval_rewrite_as_uppergamma(self, z, **kwargs):
@@ -345,7 +345,7 @@ class erfc(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_extended_real(self):
+    def _eval_is_real(self):
         return self.args[0].is_extended_real
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -156,8 +156,8 @@ class erf(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
@@ -199,7 +199,7 @@ class erf(Function):
             return self.func(arg)
 
     def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -345,8 +345,8 @@ class erfc(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True)
@@ -391,7 +391,7 @@ class erfc(Function):
             return self.func(arg)
 
     def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -526,8 +526,8 @@ class erfi(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True)
@@ -563,7 +563,7 @@ class erfi(Function):
         return self.rewrite(erf)
 
     def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)
@@ -679,8 +679,8 @@ class erf2(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate(), self.args[1].conjugate())
 
-    def _eval_is_real(self):
-        return self.args[0].is_real and self.args[1].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real and self.args[1].is_extended_real
 
     def _eval_rewrite_as_erf(self, x, y, **kwargs):
         return erf(y) - erf(x)
@@ -788,12 +788,12 @@ class erfinv(Function):
         elif z is S.One:
             return S.Infinity
 
-        if isinstance(z, erf) and z.args[0].is_real:
+        if isinstance(z, erf) and z.args[0].is_extended_real:
             return z.args[0]
 
         # Try to pull out factors of -1
         nz = z.extract_multiplicatively(-1)
-        if nz is not None and (isinstance(nz, erf) and (nz.args[0]).is_real):
+        if nz is not None and (isinstance(nz, erf) and (nz.args[0]).is_extended_real):
             return -nz.args[0]
 
     def _eval_rewrite_as_erfcinv(self, z, **kwargs):
@@ -1409,7 +1409,7 @@ class li(Function):
     def _eval_conjugate(self):
         z = self.args[0]
         # Exclude values on the branch cut (-oo, 0)
-        if not (z.is_real and z.is_negative):
+        if not (z.is_extended_real and z.is_negative):
             return self.func(z.conjugate())
 
     def _eval_rewrite_as_Li(self, z, **kwargs):
@@ -2034,14 +2034,14 @@ class FresnelIntegral(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_is_real(self):
-        return self.args[0].is_real
+    def _eval_is_extended_real(self):
+        return self.args[0].is_extended_real
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
     def _as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_real:
+        if self.args[0].is_extended_real:
             if deep:
                 hints['complex'] = False
                 return (self.expand(deep, **hints), S.Zero)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -159,6 +159,12 @@ class erf(Function):
     def _eval_is_real(self):
         return self.args[0].is_extended_real
 
+    def _eval_is_finite(self):
+        if self.args[0].is_finite:
+            return True
+        else:
+            return self.args[0].is_extended_real
+
     def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return sqrt(z**2)/z*(S.One - uppergamma(S.Half, z**2)/sqrt(S.Pi))

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -192,14 +192,14 @@ def test_expand():
     i = Symbol('i', integer=True)
 
     for besselx in [besselj, bessely, besseli, besselk]:
-        assert besselx(i, p).is_real
-        assert besselx(i, x).is_real is None
-        assert besselx(x, z).is_real is None
+        assert besselx(i, p).is_extended_real
+        assert besselx(i, x).is_extended_real is None
+        assert besselx(x, z).is_extended_real is None
 
     for besselx in [besselj, besseli]:
-        assert besselx(i, r).is_real
+        assert besselx(i, r).is_extended_real
     for besselx in [bessely, besselk]:
-        assert besselx(i, r).is_real is None
+        assert besselx(i, r).is_extended_real is None
 
 
 def test_fn():
@@ -338,7 +338,7 @@ def test_bessel_nan():
 
 def test_conjugate():
     from sympy import conjugate, I, Symbol
-    n, z, x = Symbol('n'), Symbol('z', real=False), Symbol('x', real=True)
+    n, z, x = Symbol('n'), Symbol('z', extended_real=False), Symbol('x', real=True)
     y, t = Symbol('y', real=True, positive=True), Symbol('t', negative=True)
 
     for f in [besseli, besselj, besselk, bessely, hankel1, hankel2]:
@@ -407,7 +407,7 @@ def test_airy_base():
     y = Symbol('y', real=True)
 
     assert conjugate(airyai(z)) == airyai(conjugate(z))
-    assert airyai(x).is_real
+    assert airyai(x).is_extended_real
 
     assert airyai(x+I*y).as_real_imag() == (
         airyai(x - I*x*Abs(y)/Abs(x))/2 + airyai(x + I*x*Abs(y)/Abs(x))/2,

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -587,7 +587,7 @@ def test_fresnel():
     assert fresnels(z).series(z, n=15) == \
         pi*z**3/6 - pi**3*z**7/336 + pi**5*z**11/42240 + O(z**15)
 
-    assert fresnels(w).is_real is True
+    assert fresnels(w).is_extended_real is True
 
     assert fresnels(z).as_real_imag() == \
         ((fresnels(re(z) - I*re(z)*Abs(im(z))/Abs(re(z)))/2 +
@@ -644,7 +644,7 @@ def test_fresnel():
     assert ((2*fresnels(3*z)).series(z, oo) - 2*fs.subs(z, 3*z)).expand().is_Order
     assert ((3*fresnelc(2*z)).series(z, oo) - 3*fc.subs(z, 2*z)).expand().is_Order
 
-    assert fresnelc(w).is_real is True
+    assert fresnelc(w).is_extended_real is True
 
     assert fresnelc(z).as_real_imag() == \
         ((fresnelc(re(z) - I*re(z)*Abs(im(z))/Abs(re(z)))/2 +

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -460,8 +460,8 @@ class Integral(AddWithLimits):
                 continue
 
             if function.has(Abs, sign) and (
-                (len(xab) < 3 and all(x.is_real for x in xab)) or
-                (len(xab) == 3 and all(x.is_real and not x.is_infinite for
+                (len(xab) < 3 and all(x.is_extended_real for x in xab)) or
+                (len(xab) == 3 and all(x.is_extended_real and not x.is_infinite for
                  x in xab[1:]))):
                     # some improper integrals are better off with Abs
                     xr = Dummy("xr", real=True)
@@ -518,7 +518,7 @@ class Integral(AddWithLimits):
 
                 meijerg1 = meijerg
                 if (meijerg is not False and
-                        len(xab) == 3 and xab[1].is_real and xab[2].is_real
+                        len(xab) == 3 and xab[1].is_extended_real and xab[2].is_extended_real
                         and not function.is_Poly and
                         (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
                     ret = try_meijerg(function, xab)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1788,7 +1788,7 @@ def meijerint_definite(f, x, a, b):
         _debug('  Sensible splitting points:', innermost)
         for c in sorted(innermost, key=default_sort_key, reverse=True) + [S(0)]:
             _debug('  Trying to split at', c)
-            if not c.is_real:
+            if not c.is_extended_real:
                 _debug('  Non-real splitting point.')
                 continue
             res1 = _meijerint_definite_2(f.subs(x, x + c), x)

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -80,7 +80,7 @@ def ratint(f, x, **flags):
                 atoms = p.atoms() | q.atoms()
 
             for elt in atoms - {x}:
-                if not elt.is_real:
+                if not elt.is_extended_real:
                     real = False
                     break
             else:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -593,7 +593,7 @@ def test_integrate_max_min():
     assert integrate(Min(exp(x), exp(-x))**2, x) == Piecewise( \
         (exp(2*x)/2, x <= 0), (1 - exp(-2*x)/2, True))
     # issue 7907
-    c = symbols('c', real=True)
+    c = symbols('c', extended_real=True)
     int1 = integrate(Max(c, x)*exp(-x**2), (x, -oo, oo))
     int2 = integrate(c*exp(-x**2), (x, -oo, c))
     int3 = integrate(x*exp(-x**2), (x, c, oo))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -343,7 +343,7 @@ def test_issue_6746():
         Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), \
         (-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), \
         (-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
-    b = Symbol('b', negative=True)
+    b = Symbol('b', negative=True, finite=True)
     assert manualintegrate(1/(a + b*x**2), x) == \
         atan(x/(sqrt(-a)*sqrt(-1/b)))/(b*sqrt(-a)*sqrt(-1/b))
     assert manualintegrate(1/((x**a + y**b + 4)*sqrt(a*x**2 + 1)), x) == \

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -144,7 +144,7 @@ def test_meijerint():
     meijerint_definite((x + 1)**3*exp(-x), x, 0, oo) == (16, True)
 
     # Again, how about simplifications?
-    sigma, mu = symbols('sigma mu', positive=True)
+    sigma, mu = symbols('sigma mu', positive=True, finite=True)
     i, c = meijerint_definite(exp(-((x - mu)/(2*sigma))**2), x, 0, oo)
     assert simplify(i) == sqrt(pi)*sigma*(2 - erfc(mu/(2*sigma)))
     assert c == True
@@ -211,7 +211,7 @@ def test_meijerint():
         lowergamma(n + 1, x)
 
     # Test a bug with argument 1/x
-    alpha = symbols('alpha', positive=True)
+    alpha = symbols('alpha', positive=True, finite=True)
     assert meijerint_definite((2 - x)**alpha*sin(alpha/x), x, 0, 2) == \
         (sqrt(pi)*alpha*gamma(alpha + 1)*meijerg(((), (alpha/2 + S(1)/2,
         alpha/2 + 1)), ((0, 0, S(1)/2), (-S(1)/2,)), alpha**S(2)/16)/4, True)
@@ -479,7 +479,7 @@ def test_probability():
                     meijerg=True)) == 2*sqrt(2)/sqrt(k)
 
     # Dagum distribution
-    a, b, p = symbols('a b p', positive=True)
+    a, b, p = symbols('a b p', positive=True, finite=True)
     # XXX (x/b)**a does not work
     dagum = a*p/x*(x/b)**(a*p)/(1 + x**a/b**a)**(p + 1)
     assert simplify(integrate(dagum, (x, 0, oo), meijerg=True)) == 1
@@ -493,7 +493,7 @@ def test_probability():
                     (a*p + 2)*gamma(p))
 
     # F-distribution
-    d1, d2 = symbols('d1 d2', positive=True)
+    d1, d2 = symbols('d1 d2', positive=True, finite=True)
     f = sqrt(((d1*x)**d1 * d2**d2)/(d1*x + d2)**(d1 + d2))/x \
         /gamma(d1/2)/gamma(d2/2)*gamma((d1 + d2)/2)
     assert simplify(integrate(f, (x, 0, oo), meijerg=True)) == 1
@@ -506,7 +506,7 @@ def test_probability():
     # TODO gamma, rayleigh
 
     # inverse gaussian
-    lamda, mu = symbols('lamda mu', positive=True)
+    lamda, mu = symbols('lamda mu', positive=True, finite=True)
     dist = sqrt(lamda/2/pi)*x**(-S(3)/2)*exp(-lamda*(x - mu)**2/x/2/mu**2)
     mysimp = lambda expr: simplify(expr.rewrite(exp))
     assert mysimp(integrate(dist, (x, 0, oo))) == 1
@@ -582,7 +582,7 @@ def test_expint():
                      conds='none').rewrite(expint).expand() == \
         expint(3, z).rewrite(Ei).rewrite(expint).expand()
 
-    t = Symbol('t', positive=True)
+    t = Symbol('t', positive=True, finite=True)
     assert integrate(-cos(x)/x, (x, t, oo), meijerg=True).expand() == Ci(t)
     assert integrate(-sin(x)/x, (x, t, oo), meijerg=True).expand() == \
         Si(t) - pi/2

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -523,7 +523,9 @@ def test_probability():
     # log-logistic
     distn = (beta/alpha)*x**(beta - 1)/alpha**(beta - 1)/ \
         (1 + x**beta/alpha**beta)**2
-    assert simplify(integrate(distn, (x, 0, oo))) == 1
+    # FIXME: Seems to hang. The line below commented out in
+    #    https://github.com/sympy/sympy/pull/16603
+    #assert simplify(integrate(distn, (x, 0, oo))) == 1
     # NOTE the conditions are a mess, but correctly state beta > 1
     assert simplify(integrate(x*distn, (x, 0, oo), conds='none')) == \
         pi*alpha/beta/sin(pi/beta)
@@ -541,14 +543,14 @@ def test_probability():
 
     # rice distribution
     from sympy import besseli
-    nu, sigma = symbols('nu sigma', positive=True)
+    nu, sigma = symbols('nu sigma', positive=True, finite=True)
     rice = x/sigma**2*exp(-(x**2 + nu**2)/2/sigma**2)*besseli(0, x*nu/sigma**2)
     assert integrate(rice, (x, 0, oo), meijerg=True) == 1
     # can someone verify higher moments?
 
     # Laplace distribution
     mu = Symbol('mu', real=True)
-    b = Symbol('b', positive=True)
+    b = Symbol('b', positive=True, finite=True)
     laplace = exp(-abs(x - mu)/b)/2/b
     assert integrate(laplace, (x, -oo, oo), meijerg=True) == 1
     assert integrate(x*laplace, (x, -oo, oo), meijerg=True) == mu

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -521,11 +521,13 @@ def test_probability():
     # higher moments oo
 
     # log-logistic
+    alpha, beta = symbols('alpha beta', positive=True, finite=True)
     distn = (beta/alpha)*x**(beta - 1)/alpha**(beta - 1)/ \
         (1 + x**beta/alpha**beta)**2
-    # FIXME: Seems to hang. The line below commented out in
+    # FIXME: If alpha, beta are not declared as finite the line below hangs
+    # after the changes in:
     #    https://github.com/sympy/sympy/pull/16603
-    #assert simplify(integrate(distn, (x, 0, oo))) == 1
+    assert simplify(integrate(distn, (x, 0, oo))) == 1
     # NOTE the conditions are a mess, but correctly state beta > 1
     assert simplify(integrate(x*distn, (x, 0, oo), conds='none')) == \
         pi*alpha/beta/sin(pi/beta)

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -309,7 +309,7 @@ def test_inversion_conditional_output():
 def test_inversion_exp_real_nonreal_shift():
     from sympy import Symbol, DiracDelta
     r = Symbol('r', real=True)
-    c = Symbol('c', real=False)
+    c = Symbol('c', extended_real=False)
     a = 1 + 2*I
     z = Symbol('z')
     assert not meijerint_inversion(exp(r*s), s, t).is_Piecewise

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -118,7 +118,7 @@ def test_issue_5249():
 
 
 def test_issue_5817():
-    a, b, c = symbols('a,b,c', positive=True)
+    a, b, c = symbols('a,b,c', positive=True, finite=True)
 
     assert simplify(ratint(a/(b*c*x**2 + a**2 + b*a), x)) == \
         sqrt(a)*atan(sqrt(
@@ -135,7 +135,7 @@ def test_issue_10488():
 
 
 def test_issues_8246_12050_13501_14080():
-    a = symbols('a', real=True)
+    a = symbols('a', real=True, zero=False)
     assert integrate(a/(x**2 + a**2), x) == atan(x/a)
     assert integrate(1/(x**2 + a**2), x) == atan(x/a)/a
     assert integrate(1/(1 + a**2*x**2), x) == atan(a*x)/a
@@ -148,7 +148,7 @@ def test_issue_6308():
 
 
 def test_issue_5907():
-    a = symbols('a', real=True)
+    a = symbols('a', real=True, zero=False)
     assert integrate(1/(x**2 + a**2)**2, x) == \
          x/(2*a**4 + 2*a**2*x**2) + atan(x/a)/(2*a**3)
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -90,7 +90,7 @@ def test_mellin_transform():
     from sympy import Max, Min
     MT = mellin_transform
 
-    bpos = symbols('b', positive=True)
+    bpos = symbols('b', positive=True, finite=True)
 
     # 8.4.2
     assert MT(x**nu*Heaviside(x - 1), x, s) == \
@@ -607,7 +607,7 @@ def test_inverse_laplace_transform_delta_cond():
     assert ILT(exp(z*s), s, t, noconds=False) == \
         (DiracDelta(t + z), Eq(im(z), 0))
     # inversion does not exist: verify it doesn't evaluate to DiracDelta
-    for z in (Symbol('z', real=False),
+    for z in (Symbol('z', extended_real=False),
               Symbol('z', imaginary=True, zero=False)):
         f = ILT(exp(z*s), s, t, noconds=False)
         f = f[0] if isinstance(f, tuple) else f
@@ -630,7 +630,7 @@ def test_fourier_transform():
     f = Function("f")
 
     # TODO for this to work with real a, need to expand abs(a*x) to abs(a)*abs(x)
-    a = symbols('a', positive=True)
+    a = symbols('a', positive=True, finite=True)
     b = symbols('b', positive=True)
 
     posk = symbols('posk', positive=True)
@@ -838,6 +838,6 @@ def test_issue_12591():
 
 
 def test_issue_14692():
-    b = Symbol('b', negative=True)
+    b = Symbol('b', negative=True, finite=True)
     assert laplace_transform(1/(I*x - b), x, s) == \
         (-I*exp(I*b*s)*expint(1, b*s*exp_polar(I*pi/2)), 0, True)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -453,7 +453,7 @@ def test_inverse_mellin_transform():
 def test_laplace_transform():
     from sympy import fresnels, fresnelc
     LT = laplace_transform
-    a, b, c, = symbols('a b c', positive=True)
+    a, b, c, = symbols('a b c', positive=True, finite=True)
     t = symbols('t')
     w = Symbol("w")
     f = Function("f")

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -712,7 +712,7 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
         assumes x to be real and positive. """
     from sympy import (expand, expand_mul, hyperexpand, meijerg,
                        arg, pi, re, factor, Heaviside, gamma, Add)
-    x = _dummy('t', 'inverse-mellin-transform', F, positive=True)
+    x = _dummy('t', 'inverse-mellin-transform', F, positive=True, finite=True)
     # Actually, we won't try integration at all. Instead we use the definition
     # of the Meijer G function as a fairly general inverse mellin transform.
     F = F.rewrite(gamma)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -515,7 +515,7 @@ def _rewrite_gamma(f, s, a, b):
             arg = arg.as_independent(s)[1]
         coeff, _ = arg.as_coeff_mul(s)
         s_multipliers += [coeff/pi]
-    s_multipliers = [abs(x) if x.is_real else x for x in s_multipliers]
+    s_multipliers = [abs(x) if x.is_extended_real else x for x in s_multipliers]
     common_coefficient = S(1)
     for x in s_multipliers:
         if not x.is_Rational:
@@ -523,7 +523,7 @@ def _rewrite_gamma(f, s, a, b):
             break
     s_multipliers = [x/common_coefficient for x in s_multipliers]
     if (any(not x.is_Rational for x in s_multipliers) or
-        not common_coefficient.is_real):
+        not common_coefficient.is_extended_real):
         raise IntegralTransformError("Gamma", None, "Nonrational multiplier")
     s_multiplier = common_coefficient/reduce(ilcm, [S(x.q)
                                              for x in s_multipliers], S(1))

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -855,8 +855,8 @@ def test_issue_8571():
 
 
 def test_expand_relational():
-    n = symbols('n', negative=True)
-    p, q = symbols('p q', positive=True)
+    n = symbols('n', negative=True, finite=True)
+    p, q = symbols('p q', positive=True, finite=True)
     r = ((n + q*(-n/q + 1))/(q*(-n/q + 1)) < 0)
     assert r is not S.false
     assert r.expand() is S.false

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -668,7 +668,7 @@ class Wavefunction(Function):
         >>> from sympy import symbols, pi, diff
         >>> from sympy.functions import sqrt, sin
         >>> from sympy.physics.quantum.state import Wavefunction
-        >>> x, L = symbols('x,L', positive=True)
+        >>> x, L = symbols('x,L', positive=True, finite=True)
         >>> n = symbols('n', integer=True, positive=True)
         >>> g = sqrt(2/L)*sin(n*pi*x/L)
         >>> f = Wavefunction(g, (x, 0, L))
@@ -858,7 +858,7 @@ class Wavefunction(Function):
             >>> from sympy import symbols, pi
             >>> from sympy.functions import sqrt, sin
             >>> from sympy.physics.quantum.state import Wavefunction
-            >>> x, L = symbols('x,L', positive=True)
+            >>> x, L = symbols('x,L', positive=True, finite=True)
             >>> n = symbols('n', integer=True, positive=True)
             >>> g = sqrt(2/L)*sin(n*pi*x/L)
             >>> f = Wavefunction(g, (x, 0, L))
@@ -884,7 +884,7 @@ class Wavefunction(Function):
             >>> from sympy import symbols, pi
             >>> from sympy.functions import sqrt, sin
             >>> from sympy.physics.quantum.state import Wavefunction
-            >>> x, L = symbols('x,L', positive=True)
+            >>> x, L = symbols('x,L', positive=True, finite=True)
             >>> n = symbols('n', integer=True, positive=True)
             >>> g = sqrt(2/L)*sin(n*pi*x/L)
             >>> f = Wavefunction(g, (x, 0, L))
@@ -918,7 +918,7 @@ class Wavefunction(Function):
             >>> from sympy.functions import sqrt, sin
             >>> from sympy.physics.quantum.state import Wavefunction
             >>> x = symbols('x', real=True)
-            >>> L = symbols('L', positive=True)
+            >>> L = symbols('L', positive=True, finite=True)
             >>> n = symbols('n', integer=True, positive=True)
             >>> g = sin(n*pi*x/L)
             >>> f = Wavefunction(g, (x, 0, L))

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -178,7 +178,7 @@ def test_bra_ket_dagger():
 
 def test_wavefunction():
     x, y = symbols('x y', real=True)
-    L = symbols('L', positive=True)
+    L = symbols('L', positive=True, finite=True)
     n = symbols('n', integer=True, positive=True)
 
     f = Wavefunction(x**2, x)

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -288,6 +288,7 @@ class ComplexRootOf(RootOf):
     __slots__ = ['index']
     is_complex = True
     is_number = True
+    is_finite = True
 
     def __new__(cls, f, x, index=None, radicals=False, expand=True):
         """ Construct an indexed complex root of a polynomial.

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -90,6 +90,7 @@ def print_tree(node):
     | commutative: True
     | complex: True
     | even: True
+    | extended_real: True
     | finite: True
     | hermitian: True
     | imaginary: False
@@ -106,6 +107,7 @@ def print_tree(node):
       commutative: True
       complex: True
       even: False
+      extended_real: True
       finite: True
       hermitian: True
       imaginary: False

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -503,6 +503,8 @@ def test_issue_12555():
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) == oo
 
 
+# Added XFAIL in https://github.com/sympy/sympy/pull/16603
+@XFAIL
 def test_issue_12564():
     assert limit(x**2 + x*sin(x) + cos(x), x, -oo) == oo
     assert limit(x**2 + x*sin(x) + cos(x), x, oo) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -424,8 +424,8 @@ def test_issue_6560():
 
 
 def test_issue_5172():
-    n = Symbol('n')
-    r = Symbol('r', positive=True)
+    n = Symbol('n', finite=True)
+    r = Symbol('r', positive=True, finite=True)
     c = Symbol('c')
     p = Symbol('p', positive=True)
     m = Symbol('m', negative=True)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -503,8 +503,6 @@ def test_issue_12555():
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) == oo
 
 
-# Added XFAIL in https://github.com/sympy/sympy/pull/16603
-@XFAIL
 def test_issue_12564():
     assert limit(x**2 + x*sin(x) + cos(x), x, -oo) == oo
     assert limit(x**2 + x*sin(x) + cos(x), x, oo) == oo

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,7 +1,7 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
     S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
     Function, Add)
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy.abc import w, x, y, z
 
 
@@ -132,6 +132,8 @@ def test_contains_3():
     assert Order(x**2*y).contains(Order(x*y**2)) is None
 
 
+# XFAIL added in https://github.com/sympy/sympy/pull/16603
+@XFAIL
 def test_contains_4():
     assert Order(sin(1/x**2)).contains(Order(cos(1/x**2))) is None
     assert Order(cos(1/x**2)).contains(Order(sin(1/x**2))) is None

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -768,8 +768,8 @@ class Interval(Set, EvalfMixin):
                 "got %s and %s" % (left_open, right_open))
 
         inftys = [S.Infinity, S.NegativeInfinity]
-        # Only allow real intervals (use symbols with 'is_real=True').
-        if not all(i.is_real is not False or i in inftys for i in (start, end)):
+        # Only allow real intervals (use symbols with 'is_extended_real=True').
+        if not all(i.is_extended_real is not False or i in inftys for i in (start, end)):
             raise ValueError("Non-real intervals are not supported")
 
         # evaluate if possible
@@ -905,12 +905,12 @@ class Interval(Set, EvalfMixin):
                 other is S.Infinity or
                 other is S.NegativeInfinity or
                 other is S.NaN or
-                other is S.ComplexInfinity) or other.is_real is False:
+                other is S.ComplexInfinity) or other.is_extended_real is False:
             return false
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
-            if not other.is_real is None:
-                return other.is_real
+            if not other.is_extended_real is None:
+                return other.is_extended_real
 
         if self.left_open:
             expr = other > self.start

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -56,7 +56,7 @@ def test_interval_arguments():
     assert isinstance(Interval(0, Symbol('a')), Interval)
     assert Interval(Symbol('a', real=True, positive=True), 0) == S.EmptySet
     raises(ValueError, lambda: Interval(0, S.ImaginaryUnit))
-    raises(ValueError, lambda: Interval(0, Symbol('z', real=False)))
+    raises(ValueError, lambda: Interval(0, Symbol('z', extended_real=False)))
 
     raises(NotImplementedError, lambda: Interval(0, 1, And(x, y)))
     raises(NotImplementedError, lambda: Interval(0, 1, False, And(x, y)))
@@ -1020,7 +1020,7 @@ def test_issue_10326():
         assert i not in interval
 
     x = Symbol('x', real=True)
-    nr = Symbol('nr', real=False)
+    nr = Symbol('nr', extended_real=False)
     assert x + 1 in Interval(x, x + 4)
     assert nr not in Interval(x, x + 4)
     assert Interval(1, 2) in FiniteSet(Interval(0, 5), Interval(1, 2))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -194,7 +194,7 @@ def _separatevars_dict(expr, symbols):
 def _is_sum_surds(p):
     args = p.args if p.is_Add else [p]
     for y in args:
-        if not ((y**2).is_Rational and y.is_real):
+        if not ((y**2).is_Rational and y.is_extended_real):
             return False
     return True
 
@@ -930,7 +930,7 @@ def logcombine(expr, force=False):
             # bool to tell whether the leading ``a`` in ``a*log(x)``
             # could appear as log(x**a)
             return (a is not S.NegativeOne and  # -1 *could* go, but we disallow
-                (a.is_real or force and a.is_real is not False))
+                (a.is_extended_real or force and a.is_extended_real is not False))
 
         def goodlog(l):
             # bool to tell whether log ``l``'s argument can combine with others

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -457,7 +457,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     For example:
 
     >>> from sympy import symbols, log
-    >>> a, b = symbols('a b', positive=True)
+    >>> a, b = symbols('a b', positive=True, finite=True)
     >>> g = log(a) + log(b) + log(a)*log(1/b)
     >>> h = simplify(g)
     >>> h

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -161,6 +161,7 @@ def test_powdenest():
     from sympy import powdenest
     from sympy.abc import x, y, z, a, b
     p, q = symbols('p q', positive=True)
+    pf, qf = symbols('pf qf', positive=True, finite=True)
     i, j = symbols('i,j', integer=True)
 
     assert powdenest(x) == x
@@ -169,7 +170,6 @@ def test_powdenest():
     assert powdenest((x**(2*a/3))**(3*x)) == ((x**(2*a/3))**(3*x))
     assert powdenest(exp(3*x*log(2))) == 2**(3*x)
     assert powdenest(sqrt(p**2)) == p
-    i, j = symbols('i,j', integer=True)
     eq = p**(2*i)*q**(4*i)
     assert powdenest(eq) == (p*q**2)**(2*i)
     # -X-> (x**x)**i*(x**x)**j == x**(x*(i + j))
@@ -182,7 +182,7 @@ def test_powdenest():
     assert powdenest(((x**(2*a/3))**(3*y/i))**x) == \
         (((x**(2*a/3))**(3*y/i))**x)
     assert powdenest((x**(2*i)*y**(4*i))**z, force=True) == (x*y**2)**(2*i*z)
-    assert powdenest((p**(2*i)*q**(4*i))**j) == (p*q**2)**(2*i*j)
+    assert powdenest((pf**(2*i)*qf**(4*i))**j) == (pf*qf**2)**(2*i*j)
     e = ((p**(2*a))**(3*y))**x
     assert powdenest(e) == e
     e = ((x**2*y**4)**a)**(x*y)
@@ -197,7 +197,8 @@ def test_powdenest():
     x, y = symbols('x,y', positive=True)
     assert powdenest((x**2*y**6)**i) == (x*y**3)**(2*i)
 
-    assert powdenest((x**(2*i/3)*y**(i/2))**(2*i)) == (x**(S(4)/3)*y)**(i**2)
+    xf, yf = symbols('xf,yf', positive=True, finite=True)
+    assert powdenest((xf**(2*i/3)*yf**(i/2))**(2*i)) == (xf**(S(4)/3)*yf)**(i**2)
     assert powdenest(sqrt(x**(2*i)*y**(6*i))) == (x*y**3)**i
 
     assert powdenest(4**x) == 2**(2*x)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -516,7 +516,8 @@ def test_posify():
     eq, rep = posify(k)
     assert eq.assumptions0 == {'positive': True, 'zero': False, 'imaginary': False,
      'nonpositive': False, 'commutative': True, 'hermitian': True, 'real': True, 'nonzero': True,
-     'nonnegative': True, 'negative': False, 'complex': True, 'finite': True, 'infinite': False}
+     'nonnegative': True, 'negative': False, 'complex': True, 'finite': True,
+     'infinite': False, 'extended_real':True}
 
 
 def test_issue_4194():

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -204,7 +204,7 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     >>> from sympy import Poly, Symbol
     >>> from sympy.solvers.inequalities import reduce_rational_inequalities
 
-    >>> x = Symbol('x', real=True)
+    >>> x = Symbol('x', extended_real=True)
 
     >>> reduce_rational_inequalities([[x**2 <= 0]], x)
     Eq(x, 0)
@@ -368,7 +368,7 @@ def reduce_abs_inequalities(exprs, gen):
     >>> from sympy import Abs, Symbol
     >>> from sympy.abc import x
     >>> from sympy.solvers.inequalities import reduce_abs_inequalities
-    >>> x = Symbol('x', real=True)
+    >>> x = Symbol('x', extended_real=True)
 
     >>> reduce_abs_inequalities([(Abs(3*x - 5) - 7, '<'),
     ... (Abs(x + 25) - 13, '>')], x)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -298,7 +298,7 @@ def reduce_abs_inequality(expr, rel, gen):
 
     reduce_abs_inequalities
     """
-    if gen.is_real is False:
+    if gen.is_extended_real is False:
          raise TypeError(filldedent('''
             can't solve inequalities with absolute values containing
             non-real variables.
@@ -456,11 +456,11 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     # real.
     _gen = gen
     _domain = domain
-    if gen.is_real is False:
+    if gen.is_extended_real is False:
         rv = S.EmptySet
         return rv if not relational else rv.as_relational(_gen)
-    elif gen.is_real is None:
-        gen = Dummy('gen', real=True)
+    elif gen.is_extended_real is None:
+        gen = Dummy('gen', extended_real=True)
         try:
             expr = expr.xreplace({_gen: gen})
         except TypeError:
@@ -544,7 +544,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     r = S.false
                 if r in (S.true, S.false):
                     return r
-                if v.is_real is False:
+                if v.is_extended_real is False:
                     return S.false
                 else:
                     v = v.n(2)
@@ -573,7 +573,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if all(r.is_number for r in critical_points):
                     reals = _nsort(critical_points, separated=True)[0]
                 else:
-                    sifted = sift(critical_points, lambda x: x.is_real)
+                    sifted = sift(critical_points, lambda x: x.is_extended_real)
                     if sifted[None]:
                         # there were some roots that weren't known
                         # to be real
@@ -597,7 +597,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     a = solveset(im(expanded_e), gen, domain)
                     if not isinstance(a, Interval):
                         for z in a:
-                            if z not in singularities and valid(z) and z.is_real:
+                            if z not in singularities and valid(z) and z.is_extended_real:
                                 im_sol += FiniteSet(z)
                     else:
                         start, end = a.inf, a.sup
@@ -606,7 +606,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                             if start != end:
                                 valid_z = valid(z)
                                 pt = _pt(start, z)
-                                if pt not in singularities and pt.is_real and valid(pt):
+                                if pt not in singularities and pt.is_extended_real and valid(pt):
                                     if valid_start and valid_z:
                                         im_sol += Interval(start, z)
                                     elif valid_start:
@@ -953,14 +953,14 @@ def reduce_inequalities(inequalities, symbols=[]):
     if not iterable(symbols):
         symbols = [symbols]
     symbols = (set(symbols) or gens) & gens
-    if any(i.is_real is False for i in symbols):
+    if any(i.is_extended_real is False for i in symbols):
         raise TypeError(filldedent('''
             inequalities cannot contain symbols that are not real.
             '''))
 
     # make vanilla symbol real
-    recast = {i: Dummy(i.name, real=True)
-        for i in gens if i.is_real is None}
+    recast = {i: Dummy(i.name, extended_real=True)
+        for i in gens if i.is_extended_real is None}
     inequalities = [i.xreplace(recast) for i in inequalities]
     symbols = {i.xreplace(recast) for i in symbols}
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3419,7 +3419,7 @@ def homogeneous_order(eq, *symbols):
             eq.args[0], *tuple(symset)) != 0 else S.Zero
 
     # make the replacement of x with x*t and see if t can be factored out
-    t = Dummy('t', positive=True)  # It is sufficient that t > 0
+    t = Dummy('t', positive=True, finite=True)  # It is sufficient that t > 0
     eqs = separatevars(eq.subs([(i, t*i) for i in symset]), [t], dict=True)[t]
     if eqs is S.One:
         return S.Zero  # there was no term with only t

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -999,7 +999,7 @@ def solve(f, *symbols, **flags):
 
         # if we can split it into real and imaginary parts then do so
         freei = f[i].free_symbols
-        if freei and all(s.is_real or s.is_imaginary for s in freei):
+        if freei and all(s.is_extended_real or s.is_imaginary for s in freei):
             fr, fi = f[i].as_real_imag()
             # accept as long as new re, im, arg or atan2 are not introduced
             had = f[i].atoms(re, im, arg, atan2)
@@ -1023,10 +1023,10 @@ def solve(f, *symbols, **flags):
         for a in fi.atoms(Abs):
             if not a.has(*symbols):
                 continue
-            if a.args[0].is_real is None:
+            if a.args[0].is_extended_real is None:
                 raise NotImplementedError('solving %s when the argument '
                     'is not real or imaginary.' % a)
-            reps.append((a, piece(a.args[0]) if a.args[0].is_real else \
+            reps.append((a, piece(a.args[0]) if a.args[0].is_extended_real else \
                 piece(a.args[0]*S.ImaginaryUnit)))
         fi = fi.subs(reps)
 
@@ -1041,7 +1041,7 @@ def solve(f, *symbols, **flags):
     # see if re(s) or im(s) appear
     irf = []
     for s in symbols:
-        if s.is_real or s.is_imaginary:
+        if s.is_extended_real or s.is_imaginary:
             continue  # neither re(x) nor im(x) will appear
         # if re(s) or im(s) appear, the auxiliary equation must be present
         if any(fi.has(re(s), im(s)) for fi in f):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2914,7 +2914,7 @@ def nonlinsolve(system, *symbols):
 
     >>> from sympy import pprint
     >>> from sympy.polys.polytools import is_zero_dimensional
-    >>> a, b, c, d = symbols('a, b, c, d', real=True)
+    >>> a, b, c, d = symbols('a, b, c, d', extended_real=True)
     >>> eq1 =  a + b + c + d
     >>> eq2 = a*b + b*c + c*d + d*a
     >>> eq3 = a*b*c + b*c*d + c*d*a + d*a*b

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -191,7 +191,7 @@ def test_reduce_abs_inequalities():
     assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7) == \
         Or(And(S(-2) < x, x < -1), And(S(1)/2 < x, x < 4))
 
-    nr = Symbol('nr', real=False)
+    nr = Symbol('nr', extended_real=False)
     raises(TypeError, lambda: reduce_inequalities(abs(nr - 5) < 3))
     assert reduce_inequalities(x < 3, symbols=[x, nr]) == And(-oo < x, x < 3)
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -299,7 +299,7 @@ def test_solve_univariate_inequality():
 
     n = Dummy('n')
     raises(NotImplementedError, lambda: isolve(Abs(x) <= n, x, relational=False))
-    c1 = Dummy("c1", positive=True)
+    c1 = Dummy("c1", positive=True, finite=True)
     raises(NotImplementedError, lambda: isolve(n/c1 < 0, c1))
     n = Dummy('n', negative=True)
     assert isolve(n/c1 > -2, c1) == (-n/2 < c1)
@@ -312,7 +312,7 @@ def test_solve_univariate_inequality():
         x**2 < zero*I, x))
     raises(NotImplementedError, lambda: isolve(1/(x - y) < 2, x))
     raises(NotImplementedError, lambda: isolve(1/(x - y) < 0, x))
-    raises(TypeError, lambda: isolve(x - I < 0, x))
+    raises(ValueError, lambda: isolve(x - I < 0, x))
 
     zero = x**2 + x - x*(x + 1)
     assert isolve(zero < 0, x, relational=False) is S.EmptySet

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1607,7 +1607,7 @@ def test_1st_homogeneous_coeff_corner_case():
 def test_nth_linear_constant_coeff_homogeneous():
     # From Exercise 20, in Ordinary Differential Equations,
     #                      Tenenbaum and Pollard, pg. 220
-    a = Symbol('a', positive=True)
+    a = Symbol('a', positive=True, finite=True)
     k = Symbol('k', real=True)
     eq1 = f(x).diff(x, 2) + 2*f(x).diff(x)
     eq2 = f(x).diff(x, 2) - 3*f(x).diff(x) + 2*f(x)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1339,7 +1339,8 @@ def test_failing_assumptions():
     assert failing_assumptions(6*x + y, **x.assumptions0) == \
     {'real': None, 'imaginary': None, 'complex': None, 'hermitian': None,
     'positive': None, 'nonpositive': None, 'nonnegative': None, 'nonzero': None,
-    'negative': None, 'zero': None}
+    'negative': None, 'zero': None, 'extended_real': None, 'finite': None,
+    'infinite': None}
 
 def test_issue_6056():
     assert solve(tanh(x + 3)*tanh(x - 3) - 1) == []

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1265,7 +1265,7 @@ def test_trig_system_fail():
 
 
 def test_nonlinsolve_positive_dimensional():
-    x, y, z, a, b, c, d = symbols('x, y, z, a, b, c, d', real = True)
+    x, y, z, a, b, c, d = symbols('x, y, z, a, b, c, d', extended_real = True)
     assert nonlinsolve([x*y, x*y - x], [x, y]) == FiniteSet((0, y))
 
     system = [a**2 + a*c, a - b]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1902,7 +1902,7 @@ def test_expo_conditionset():
 
 
 def test_exponential_symbols():
-    x, y, z = symbols('x y z', positive=True)
+    x, y, z = symbols('x y z', positive=True, finite=True)
     from sympy import simplify
 
     assert solveset(z**x - y, x, S.Reals) == Intersection(

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -191,7 +191,9 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
         if not inverse_cdf or len(inverse_cdf) != 1:
             raise NotImplementedError("Could not invert CDF")
 
-        return Lambda(z, inverse_cdf[0])
+        (icdf,) = inverse_cdf
+
+        return Lambda(z, icdf)
 
     @cacheit
     def compute_cdf(self, **kwargs):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1947,7 +1947,7 @@ def Maxwell(name, a):
     >>> from sympy.stats import Maxwell, density, E, variance
     >>> from sympy import Symbol, simplify
 
-    >>> a = Symbol("a", positive=True)
+    >>> a = Symbol("a", positive=True, finite=True)
     >>> z = Symbol("z")
 
     >>> X = Maxwell("x", a)
@@ -2020,7 +2020,7 @@ def Nakagami(name, mu, omega):
     >>> from sympy import Symbol, simplify, pprint
 
     >>> mu = Symbol("mu", positive=True)
-    >>> omega = Symbol("omega", positive=True)
+    >>> omega = Symbol("omega", positive=True, finite=True)
     >>> z = Symbol("z")
 
     >>> X = Nakagami("x", mu, omega)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -3143,8 +3143,8 @@ def Weibull(name, alpha, beta):
     >>> from sympy.stats import Weibull, density, E, variance
     >>> from sympy import Symbol, simplify
 
-    >>> l = Symbol("lambda", positive=True)
-    >>> k = Symbol("k", positive=True)
+    >>> l = Symbol("lambda", positive=True, finite=True)
+    >>> k = Symbol("k", positive=True, finite=True)
     >>> z = Symbol("z")
 
     >>> X = Weibull("x", l, k)

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -63,7 +63,7 @@ class Expectation(Expr):
     >>> from sympy.stats import Expectation, Normal, Probability
     >>> from sympy import symbols, Integral
     >>> mu = symbols("mu")
-    >>> sigma = symbols("sigma", positive=True)
+    >>> sigma = symbols("sigma", positive=True, finite=True)
     >>> X = Normal("X", mu, sigma)
     >>> Expectation(X)
     Expectation(X)
@@ -176,7 +176,7 @@ class Variance(Expr):
     >>> from sympy import symbols, Integral
     >>> from sympy.stats import Normal, Expectation, Variance, Probability
     >>> mu = symbols("mu", positive=True)
-    >>> sigma = symbols("sigma", positive=True)
+    >>> sigma = symbols("sigma", positive=True, finite=True)
     >>> X = Normal("X", mu, sigma)
     >>> Variance(X)
     Variance(X)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -508,7 +508,7 @@ def test_lognormal():
 
 
 def test_maxwell():
-    a = Symbol("a", positive=True)
+    a = Symbol("a", positive=True, finite=True)
 
     X = Maxwell('x', a)
 
@@ -522,7 +522,7 @@ def test_maxwell():
 
 def test_nakagami():
     mu = Symbol("mu", positive=True)
-    omega = Symbol("omega", positive=True)
+    omega = Symbol("omega", positive=True, finite=True)
 
     X = Nakagami('x', mu, omega)
     assert density(X)(x) == (2*x**(2*mu - 1)*mu**mu*omega**(-mu)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -696,7 +696,10 @@ def test_von_mises():
 
 
 def test_weibull():
-    a, b = symbols('a b', positive=True)
+    a, b = symbols('a b', positive=True, finite=True)
+    # FIXME: simplify(E(X)) seems to hang without the finite=True
+    # On a Linux machine this had a rapid memory leak...
+    # a, b = symbols('a b', positive=True)
     X = Weibull('x', a, b)
 
     assert simplify(E(X)) == simplify(a * gamma(1 + 1/b))

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2864,7 +2864,7 @@ def test_Y2():
     w = symbols('w', real=True)
     s = symbols('s')
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
-    assert f == cos(t*(w - 1))
+    assert f == cos(t*w - t)
 
 
 def test_Y3():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2864,7 +2864,7 @@ def test_Y2():
     w = symbols('w', real=True)
     s = symbols('s')
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
-    assert f == cos(t*w - t)
+    assert f == cos(t*(w - 1))
 
 
 def test_Y3():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2538,6 +2538,9 @@ def test_W22():
         (-sin(Min(1, u)) + sin(Min(2, u)), True))
 
 
+# The test below was XFAILED in:
+#    https://github.com/sympy/sympy/pull/16603
+@XFAIL
 @slow
 def test_W23():
     a, b = symbols('a b', real=True, positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Based on #16603 

#### Brief description of what is fixed or changed

This PR represents what I think is a failed attempt to continue the work in #16603 and make positive imply finite. #16603 makes real imply finite. This has the unfortunate result that positive no longer implies real because oo and -oo are considered positive but not real.

As described in [this comment](https://github.com/sympy/sympy/pull/16603#issuecomment-480963605) I think that making positive imply finite doesn't change the need for something corresponding to the current positive on master so maybe new fact such as is_extended_positive would need to be introduced. In this PR I have tried a different approach though and have attempted to make positive imply finite without introducing new facts like is_extended_positive.

So far I have fixed test failures in core but there are many more failures. In general it is clunky to try to replace is_positive in many places without having something like is_extended_positive. I've ended up trying to use things like sign or arg as replacements but they cannot in general replace is_extended_positive.

As a specific example of something that doesn't easily work consider that on master we have
```julia
In [1]: x = Symbol('x')                                                                                                                        

In [2]: sqrt(-re(x)**2)                                                                                                                        
Out[2]: ⅈ⋅│re(x)│
```
This PR currently gives
```julia
In [1]: x = Symbol('x')                                                                                                                        

In [2]: sqrt(-re(x)**2)                                                                                                                        
Out[2]: 
   _________
  ╱    2    
╲╱  -re (x) 
```
The reason this doesn't work is the is_nonnegative check here:
[https://github.com/sympy/sympy/blob/54b108d354fe22023dccfca9a7f44c38b39a9881/sympy/core/power.py#L885](https://github.com/sympy/sympy/blob/54b108d354fe22023dccfca9a7f44c38b39a9881/sympy/core/power.py#L885)

Currently in this PR we have that `(re(x)**2).is_nonnegative` gives None and I can't see a way to fix that. There needs to be a way to decide if an expression is in the closed interval `[0, oo]` (as is done by is_nonnegative on master) but I can't see one:
1. I can't use is_nonnegative since oo.is_nonnegative is False so `(re(x**2)).is_nonnegative` has to be None.
2. I can't use `expr.is_nonnegative or expr is S.Infinity` since both have to be None.
3. I can't use `arg(expr).is_zero` since arg(0) is nan.
4. I can't use `sign(expr)==1` since sign(0) is 0.
5. I can't use `bool(expr >= 0)` since `Expr.__ge__` suffers the same problem in this PR:
```julia
In [2]: re(x)**2 >= 0                                                                                                                          
Out[2]: 
  2       
re (x) ≥ 0

In [3]: bool(re(x)**2 >= 0)                                                                                                                    
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent
...
TypeError: cannot determine truth value of Relational
```

I don't think I should be trying to use things like arg or sign or `Expr.__ge__` in the assumptions system: they should be built on top of the core assumptions system. I think that means that the core assumptions system needs something that corresponds to the current is_positive. We can still make positive -> real -> finite but I think that to do so we need to also have is_extended_positive, is_extended_nonnegative etc to handle examples like the one above.

#### Other comments

I am leaving this PR here for now but I will make a new attempt using new facts like is_extended_positive. Any comments/suggestions welcome.

You could take this as evidence that making positive -> finite is misguided. I still think that very often users want `Symbol('x', positive=True)` to give a finite real number. There are already many bugs in SymPy itself where it is assumed that positive -> finite. If you look at the changes in #16603 you can see many examples of `Symbol('x', positive=True, finite=True)` where the `finite=True` is needed once other bugs in assumptions (`Pow.is_zero` etc) are fixed. I still think it is probably worthwhile to have positive imply finite but the existing notion of positive in master is not something that can be removed entirely.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
