### PR TITLE
[BUG] max replaced with sum in itermonomials

### DIFF
--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -73,7 +73,7 @@ def itermonomials(variables, max_degree, min_degree = 0):
             for variable in item:
                 if variable != 1:
                     powers[variable] += 1
-            if max(powers.values()) >= min_degree:
+            if sum(powers.values()) >= min_degree:
                 monomials_list_comm.append(Mul(*item))
         return set(monomials_list_comm)
     else:
@@ -85,7 +85,7 @@ def itermonomials(variables, max_degree, min_degree = 0):
             for variable in item:
                 if variable != 1:
                     powers[variable] += 1
-            if max(powers.values()) >= min_degree:
+            if sum(powers.values()) >= min_degree:
                 monomials_list_non_comm.append(Mul(*item))
         return set(monomials_list_non_comm)
 

--- a/sympy/polys/tests/test_monomials.py
+++ b/sympy/polys/tests/test_monomials.py
@@ -63,6 +63,10 @@ def test_monomials():
                         x * j**2, i * j**2, j**2 * i, j*i*j,
                         x * i * j, x * j * i,
                     }
+    assert itermonomials([x, y], 3, 0) == {1, x, x**2, x**2*y, x**3, x*y, x*y**2, y, y**2, y**3}
+    assert itermonomials([x, y], 3, 1) == {x, x**2, x**2*y, x**3, x*y, x*y**2, y, y**2, y**3}
+    assert itermonomials([x, y], 3, 2) == {x**2, x**2*y, x**3, x*y**2, y**2, y**3, x*y}
+    assert itermonomials([x, y], 3, 3) == {x**3, y**3, x**2*y, x*y**2}
 
 def test_monomial_count():
     assert monomial_count(2, 2) == 6


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Continues https://github.com/sympy/sympy/pull/15020/
[#14996 (comment)](https://github.com/sympy/sympy/issues/14996#issuecomment-483270147)


#### Brief description of what is fixed or changed
max has been replaced with sum in itermonomials
to correct the calculation of the degree of monomials.
A bug has also been removed by this replacement.
Associated tests have also been added.

#### Other comments
Thanks to @rpep for informing about the bug.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * corrects `itermonomials` by replacing max with sum 
<!-- END RELEASE NOTES -->
