### PR TITLE
base units deprecation and definitions

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -43,28 +43,15 @@ angular_mil.set_dimension(One)
 angular_mil.set_scale_factor(2*pi/6400)
 
 
-# Base units:
+# Base units have a scale factor of 1
 
 m = meter = meters = Quantity("meter", abbrev="m")
 meter.set_dimension(length)
 meter.set_scale_factor(One)
 
-# gram; used to define its prefixed units
-g = gram = grams = Quantity("gram", abbrev="g")
-gram.set_dimension(mass)
-gram.set_scale_factor(One)
-
-# NOTE: the `kilogram` has scale factor 1000. In SI, kg is a base unit, but
-# nonetheless we are trying to be compatible with the `kilo` prefix. In a
-# similar manner, people using CGS or gaussian units could argue that the
-# `centimeter` rather than `meter` is the fundamental unit for length, but the
-# scale factor of `centimeter` will be kept as 1/100 to be compatible with the
-# `centi` prefix.  The current state of the code assumes SI unit dimensions, in
-# the future this module will be modified in order to be unit system-neutral
-# (that is, support all kinds of unit systems).
 kg = kilogram = kilograms = Quantity("kilogram", abbrev="kg")
 kilogram.set_dimension(mass)
-kilogram.set_scale_factor(kilo*gram)
+kilogram.set_scale_factor(One)
 
 s = second = seconds = Quantity("second", abbrev="s")
 second.set_dimension(time)
@@ -86,6 +73,9 @@ cd = candela = candelas = Quantity("candela", abbrev="cd")
 candela.set_dimension(luminous_intensity)
 candela.set_scale_factor(One)
 
+g = gram = grams = Quantity("gram", abbrev="g")
+gram.set_dimension(mass)
+gram.set_scale_factor(kg/kilo)
 
 mg = milligram = milligrams = Quantity("milligram", abbrev="mg")
 milligram.set_dimension(mass)

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -5,6 +5,7 @@ from sympy.physics.units.definitions import c, kg, m, s
 from sympy.physics.units.dimensions import (
     Dimension, DimensionSystem, action, current, length, mass, time, velocity)
 from sympy.physics.units.quantities import Quantity
+from sympy.physics.units.util import convert_to
 from sympy.physics.units.unitsystem import UnitSystem
 from sympy.utilities.pytest import raises
 
@@ -41,7 +42,7 @@ def test_str_repr():
     assert repr(UnitSystem((m, s))) == "<UnitSystem: (%s, %s)>" % (m, s)
 
 
-def test_print_unit_base():
+def test_convert_to():
     A = Quantity("A")
     A.set_dimension(current)
     A.set_scale_factor(S.One)
@@ -51,8 +52,7 @@ def test_print_unit_base():
     Js.set_scale_factor(S.One)
 
     mksa = UnitSystem((m, kg, s, A), (Js,))
-    with warns_deprecated_sympy():
-        assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
+    assert convert_to(Js, mksa) == kg*m**2/(1000*s)
 
 
 def test_extend():

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -52,7 +52,7 @@ def test_convert_to():
     Js.set_scale_factor(S.One)
 
     mksa = UnitSystem((m, kg, s, A), (Js,))
-    assert convert_to(Js, mksa) == kg*m**2/(1000*s)
+    assert convert_to(Js, mksa) == kg*m**2/s
 
 
 def test_extend():

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -8,7 +8,7 @@ from sympy.physics.units import (
     planck_length, planck_mass, planck_temperature, planck_time, radians,
     second, speed_of_light, steradian, time, km)
 from sympy.physics.units.dimensions import dimsys_default
-from sympy.physics.units.unitsystems import MKS
+from sympy.physics.units.systems.mks import MKS
 from sympy.physics.units.util import convert_to, dim_simplify, check_dimensions
 from sympy.utilities.pytest import raises
 

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -8,6 +8,7 @@ from sympy.physics.units import (
     planck_length, planck_mass, planck_temperature, planck_time, radians,
     second, speed_of_light, steradian, time, km)
 from sympy.physics.units.dimensions import dimsys_default
+from sympy.physics.units.unitsystems import MKS
 from sympy.physics.units.util import convert_to, dim_simplify, check_dimensions
 from sympy.utilities.pytest import raises
 
@@ -88,6 +89,8 @@ def test_convert_to_quantities():
     assert convert_to(radians, [meter, degree]) == 180*degree/pi
     assert convert_to(pi*radians, degree) == 180*degree
     assert convert_to(pi, degree) == 180*degree
+
+    assert convert_to(inch, MKS) == 127*meter/5000
 
 
 def test_convert_to_tuples_of_quantities():

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -8,7 +8,7 @@ from sympy.physics.units import (
     planck_length, planck_mass, planck_temperature, planck_time, radians,
     second, speed_of_light, steradian, time, km)
 from sympy.physics.units.dimensions import dimsys_default
-from sympy.physics.units.systems.mks import MKS
+from sympy.physics.units.systems import MKS
 from sympy.physics.units.util import convert_to, dim_simplify, check_dimensions
 from sympy.utilities.pytest import raises
 

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -71,25 +71,6 @@ class UnitSystem(object):
 
         return UnitSystem(base, units, name, description)
 
-    def print_unit_base(self, unit):
-        """
-        Useless method.
-
-        DO NOT USE, use instead ``convert_to``.
-
-        Give the string expression of a unit in term of the basis.
-
-        Units are displayed by decreasing power.
-        """
-        SymPyDeprecationWarning(
-            deprecated_since_version="1.2",
-            issue=13336,
-            feature="print_unit_base",
-            useinstead="convert_to",
-        ).warn()
-        from sympy.physics.units import convert_to
-        return convert_to(unit, self._base_units)
-
     @property
     def dim(self):
         """

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -37,7 +37,7 @@ class UnitSystem(object):
         # this is possible since we have already verified that the base units
         # form a coherent system
         base_dict = dict((u.dimension, u) for u in base)
-        # order the base units in the same order than the dimensions in the
+        # order the base units in the same order as the dimensions in the
         # associated system, in order to ensure that we get always the same
         self._base_units = tuple(base_dict[d] for d in self._system.base_dims)
 

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -129,7 +129,9 @@ def convert_to(expr, target_units):
         return expr
 
     expr_scale_factor = get_total_scale_factor(expr)
-    return expr_scale_factor * Mul.fromiter((1/get_total_scale_factor(u) * u) ** p for u, p in zip(target_units, depmat))
+    scale = Mul.fromiter((u/get_total_scale_factor(u))**p
+        for u, p in zip(target_units, depmat))
+    return expr_scale_factor * scale
 
 
 def quantity_simplify(expr):

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -29,8 +29,8 @@ def dim_simplify(expr):
         deprecated_since_version="1.2",
         feature="dimensional simplification function",
         issue=13336,
-        useinstead="don't use",
-    ).warn()
+        useinstead=("something else (or this beta-function which will "
+            "probably be removed in the future)."),).warn()
     _, expr = Quantity._collect_factor_and_dimension(expr)
     return expr
 

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -100,6 +100,10 @@ def convert_to(expr, target_units):
     7.62950196312651e-20*gravitational_constant**(-0.5)*hbar**0.5*speed_of_light**0.5
 
     """
+    from sympy.physics.units import UnitSystem
+    if isinstance(target_units, UnitSystem):
+        target_units = target_units._base_units
+
     if not isinstance(target_units, (Iterable, Tuple)):
         target_units = [target_units]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #15647
closes #16651 if we can agree on this

#### Brief description of what is fixed or changed

* All SI base units have a scale factor of 1
* `convert_to` can accept a UnitSystem to supply the target units.

#### Other comments

When looking for how to access base units I found that there was no public facing method, nor was there a method to convert a quantity in one system to the units in another system (without having to specify the units but by only giving the system). There is a deprecated function for this purpose, however, so I added the ability to use a UnitSystem with `convert_to`
```python
>>> convert_to(inch, MKS)
127*meter/5000
```

When looking at the deprecated test, however, I saw that the factor of 1000 was appearing in the conversion. I am not sure this is right.

I understand that base units need not have a scale factor of 1 -- e.g. the `natural` system includes `c` as the base unit, but it seems this test is written with the assumption that the scale factors are 1. If this is not the right assumption it would be good to hear an explanation of what someone trying to create such a system should have known and how they should have done it correctly.

This PR is offered with bias that `scale_factor` --namely, the assumption that base units have a scale factor of 1 -- is perhaps more significant than suggested in the discussion at #15647 by myself and others.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
    - `convert_to` will accept a UnitSystem which will supply the target units
    - all base units of the SI system have a scale factor of 1 (though this is not a general requirement of UnitSystems)
<!-- END RELEASE NOTES -->
