### PR TITLE
Modify the instantiation of Lambda

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1855,10 +1855,28 @@ class Lambda(Expr):
     >>> f(*p)
     x + y*z
 
+    For having a function as its parameter:
+
+    >>> f = Lambda(lambda x, y: (x + y)**2)
+    >>> print(f)
+    Lambda((x, y), (x + y)**2)
+    >>> f(2,3)
+    25
+
     """
     is_Function = True
 
-    def __new__(cls, variables, expr):
+    def __new__(cls, *args):
+        if len(args) != 1:
+            variables, expr = args
+        else:
+            func = args[0]
+            if not callable(func):
+                raise ValueError('when passing 1 argument, it should be callable')
+            from .symbol import Symbol
+            variables = [Symbol(i) for i in func.__code__.co_varnames]
+            expr = func(*variables)
+
         from sympy.sets.sets import FiniteSet
         v = list(variables) if iterable(variables) else [variables]
         for i in v:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Reimplement the work in #16656 because it was closed.

#### Brief description of what is fixed or changed
Modified the instantiation of `Lambda` to allow it called with a function as its parameter as follows:
```
>>> from sympy import Lambda
>>> f = Lambda(lambda x, y: (x + y)**2)
>>> print(f)
Lambda((x, y), (x + y)**2)
>>> f(2,3)
25
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Modified `Lambda.__new__` to allow it called with a function.
<!-- END RELEASE NOTES -->
