### PR TITLE
patching parse_expr for floats and j

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -499,8 +499,7 @@ def test_issue_6540_6552():
 
 def test_issue_6046():
     assert str(S("Q & C", locals=_clash1)) == 'C & Q'
-    assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
-    assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
+    raises(TypeError, lambda: S('pi(x)', locals=_clash2))
     locals = {}
     exec_("from sympy.abc import Q, C", locals)
     assert str(S('C&Q', locals)) == 'C & Q'

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -556,10 +556,9 @@ def auto_symbol(tokens, local_dict, global_dict):
                 continue
             elif name in local_dict:
                 if isinstance(local_dict[name], Symbol) and nextTokVal == '(':
-                    result.extend([(NAME, 'Function'),
-                                   (OP, '('),
-                                   (NAME, repr(str(local_dict[name]))),
-                                   (OP, ')')])
+                    s = local_dict[name]
+                    raise TypeError(
+                        "Symbol('%s') object is not callable" % s)
                 else:
                     result.append((NAME, name))
                 continue

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -3,7 +3,8 @@
 from __future__ import print_function, division
 
 from tokenize import (generate_tokens, untokenize, TokenError,
-    NUMBER, STRING, NAME, OP, ENDMARKER, ERRORTOKEN, NEWLINE)
+    NUMBER, STRING, NAME, OP, ENDMARKER, ERRORTOKEN, NEWLINE,
+    Floatnumber, Intnumber, group)
 
 from keyword import iskeyword
 
@@ -907,8 +908,8 @@ def eval_expr(code, local_dict, global_dict):
 
     return expr
 
-
-_refloat = regex.compile(r"(((\d*\.\d+)|(\d+\.?\d?))([eE][-+]?\d+)?)")
+_refloat = regex.compile(group(Floatnumber, Intnumber))
+del group
 _num_underscores = regex.compile(r'(\d+)_(\d+)')
 _py2name = regex.compile(r'^[a-zA-Z_]\w*$')
 def valid_name(name):

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -65,10 +65,10 @@ def test_implicit_application():
 
     multiplication = ['x y', 'x sin x', '2x']
     for case in multiplication:
-        raises(SyntaxError,
-               lambda: parse_expr(case, transformations=transformations2, default=''))
-    raises(TypeError,
-           lambda: parse_expr('sin**2(x)', transformations=transformations2))
+        raises(SyntaxError, lambda:
+            parse_expr(case, transformations=transformations2, pre=''))
+    raises(TypeError, lambda:
+        parse_expr('sin**2(x)', transformations=transformations2))
 
 
 
@@ -88,8 +88,8 @@ def test_function_exponentiation():
     other_implicit = ['x y', 'x sin x', '2x', 'sin x',
                       'cos 2*x', 'sin cos x']
     for case in other_implicit:
-        raises(SyntaxError,
-               lambda: parse_expr(case, transformations=transformations2, default=''))
+        raises(SyntaxError, lambda:
+            parse_expr(case, transformations=transformations2, pre=''))
 
     assert parse_expr('x**2', local_dict={ 'x': sympy.Symbol('x') },
                       transformations=transformations2) == parse_expr('x**2')

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -182,4 +182,4 @@ def test_all_implicit_steps():
     for case in cases:
         implicit = parse_expr(case, transformations=transformations2)
         normal = parse_expr(cases[case], transformations=transformations)
-        assert(implicit == normal)
+        assert implicit == normal

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -66,7 +66,7 @@ def test_implicit_application():
     multiplication = ['x y', 'x sin x', '2x']
     for case in multiplication:
         raises(SyntaxError,
-               lambda: parse_expr(case, transformations=transformations2))
+               lambda: parse_expr(case, transformations=transformations2, default=''))
     raises(TypeError,
            lambda: parse_expr('sin**2(x)', transformations=transformations2))
 
@@ -89,7 +89,7 @@ def test_function_exponentiation():
                       'cos 2*x', 'sin cos x']
     for case in other_implicit:
         raises(SyntaxError,
-               lambda: parse_expr(case, transformations=transformations2))
+               lambda: parse_expr(case, transformations=transformations2, default=''))
 
     assert parse_expr('x**2', local_dict={ 'x': sympy.Symbol('x') },
                       transformations=transformations2) == parse_expr('x**2')
@@ -182,4 +182,4 @@ def test_all_implicit_steps():
     for case in cases:
         implicit = parse_expr(case, transformations=transformations2)
         normal = parse_expr(cases[case], transformations=transformations)
-        assert implicit == normal
+        assert implicit == normal, (implicit, normal)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -293,22 +293,19 @@ def test_split_symbols_numeric():
     raises(SyntaxError, lambda: do('--'))
 
     assert parse_expr('3e4') == 3e4
-    assert parse_expr('3e1', pre='e') == 30.0
-    e1x = Symbol('e1x')
     assert parse_expr('2x') == 2*x
     assert parse_expr('2_3x') == 23*x
-    _x = Symbol('_x')
-    assert parse_expr('2_x') == 2*_x
+    assert parse_expr('_2') == Symbol('_2')
+    assert parse_expr('2_x') == 2*Symbol('_x')
     assert parse_expr('2x') == 2*x
-    assert parse_expr('2e1x') == 2*e1x
-    assert parse_expr('2e1x', pre='e') == 20.0*x
-    assert parse_expr('2.e1x') == 2.0*e1x
-    assert parse_expr('2.e1x', pre='e') == 20.0*x
+    assert parse_expr('x1e2', pre='') == Symbol('x1e2')
+    raises(SyntaxError, lambda: parse_expr('1e2x', pre=''))
+    assert parse_expr('2e1x') == 20.0*x
+    assert parse_expr('2.e1x', pre='D') == 2.0*Symbol('e1x')
+    assert parse_expr('2.e1x') == 20.0*x
     raises(SyntaxError, lambda: parse_expr('.e1x'))
-    raises(SyntaxError, lambda: parse_expr('.e1x', pre='e'))
-    E1x = Symbol('E1x')
-    assert parse_expr('2.E1x') == 2.0*E1x
-    assert parse_expr('2.E1x', pre='e') == 20.0*x
+    assert parse_expr('2.E1x', pre='D') == 2.0*Symbol('E1x')
+    assert parse_expr('2.E1x') == 20.0*x
 
 
 def test_unicode_names():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -235,9 +235,9 @@ def test_parse_function_issue_3539():
 
 
 def test_split_symbols_numeric():
-    T = standard_transformations + (
+    SI = standard_transformations + (
         implicit_multiplication_application,)
-    do = lambda x: parse_expr(x, transformations=T)
+    do = lambda x: parse_expr(x, transformations=SI, _number_kern=True)
 
     n = Symbol('n')
     assert parse_expr('2**n * 3**n') == do('2**n3**n') == 2**n*3**n
@@ -256,7 +256,20 @@ def test_split_symbols_numeric():
     assert do('x_3yz') == x_3*y*z
     assert do('n1.1n22') == n*1.1*n*22
     assert parse_expr('log10(3.2x)', dict(log10=log),
-        transformations=T) == log(3.2*x)
+        transformations=SI) == log(3.2*x)
+    assert parse_expr('x3y',
+        transformations=standard_transformations) == Symbol('x3y')
+    assert do('x3y') == 3*x*y
+    # a helpful error message is raised when the _number_kern
+    # option succeeds
+    try:
+        parse_expr('3.2*x*y')
+    except SyntaxError as e:
+        assert '3.2*x*y' in e
+    try:
+        parse_expr('3.2*x*y', _number_kern=False)
+    except SyntaxError as e:
+        assert '3.2*x*y' not in e
 
 
 def test_unicode_names():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -128,9 +128,8 @@ def test_local_dict_symbol_to_fcn():
     x = Symbol('x')
     d = {'foo': Function('bar')}
     assert parse_expr('foo(x)', local_dict=d) == d['foo'](x)
-    # XXX: bit odd, but would be error if parser left the Symbol
     d = {'foo': Symbol('baz')}
-    assert parse_expr('foo(x)', local_dict=d) == Function('baz')(x)
+    raises(TypeError, lambda: parse_expr('foo(x)', local_dict=d))
 
 
 def test_global_dict():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16639 

#### Brief description of what is fixed or changed

With enough work on the tokenizer, perhaps this would not be necessary. This
is offered as hack to carry over until then.

#### Other comments

Using a Symbol as a function has been disabled since f1847a857dbb3cc902a0ffb3b85e139a3fc9f656. Now a loophole via user-supplied dicts has been eliminated.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  * there is better detection of floating point numbers in parsed expressions
  * Symbols in the user-defined dictionaries no longer morph to be Functions when called
<!-- END RELEASE NOTES -->
