### PR TITLE
speed up Line/Segment intersections

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -533,7 +533,9 @@ class LinearEntity(GeometrySet):
                 if isinstance(self, Line) and isinstance(other, Line):
                     return [line_intersection]
 
-                if self.contains(line_intersection) and other.contains(line_intersection):
+                if ((isinstance(self, Line) or
+                        self.contains(line_intersection)) and
+                        other.contains(line_intersection)):
                     return [line_intersection]
                 return []
             else:
@@ -1586,6 +1588,19 @@ class Segment(LinearEntity):
             other = Point(other, dim=self.ambient_dimension)
         if isinstance(other, Point):
             if Point.is_collinear(other, self.p1, self.p2):
+                if isinstance(self, Segment2D):
+                    # if it is collinear and is in the bounding box of the
+                    # segment then it must be on the segment
+                    vert = self.slope.equals(S.Infinity)
+                    if vert is False:
+                        isin = (self.p1.x - other.x)*(self.p2.x - other.x) <= 0
+                        if isin in (True, False):
+                            return isin
+                    if vert is True:
+                        isin = (self.p1.y - other.y)*(self.p2.y - other.y) <= 0
+                        if isin in (True, False):
+                            return isin
+                # use the triangle inequality
                 d1, d2 = other - self.p1, other - self.p2
                 d = self.p2 - self.p1
                 # without the call to simplify, sympy cannot tell that an expression

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1591,7 +1591,7 @@ class Segment(LinearEntity):
                 if isinstance(self, Segment2D):
                     # if it is collinear and is in the bounding box of the
                     # segment then it must be on the segment
-                    vert = self.slope.equals(S.Infinity)
+                    vert = (1/self.slope).equals(0)
                     if vert is False:
                         isin = (self.p1.x - other.x)*(self.p2.x - other.x) <= 0
                         if isin in (True, False):

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -2200,8 +2200,8 @@ class Triangle(Polygon):
 
         """
         # use lines containing sides so containment check during
-        # intersection calculation can be avoided
-        # This would reduce the processing time for calculating the bisectors
+        # intersection calculation can be avoided, thus reducing
+        # the processing time for calculating the bisectors
         s = [Line(l) for l in self.sides]
         v = self.vertices
         c = self.incenter

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -494,6 +494,51 @@ def test_intersection_2d():
     assert s1.intersection(s2) == [s2]
     assert s2.intersection(s1) == [s2]
 
+    assert asa(120, 8, 52) == \
+           Triangle(
+               Point(0, 0),
+               Point(8, 0),
+               Point(-4 * cos(19 * pi / 90) / sin(2 * pi / 45),
+                     4 * sqrt(3) * cos(19 * pi / 90) / sin(2 * pi / 45)))
+    assert Line((0, 0), (1, 1)).intersection(Ray((1, 0), (1, 2))) == [Point(1, 1)]
+    assert Line((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == [Point(1, 1)]
+    assert Ray((0, 0), (1, 1)).intersection(Ray((1, 0), (1, 2))) == [Point(1, 1)]
+    assert Ray((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == [Point(1, 1)]
+    assert Ray((0, 0), (10, 10)).contains(Segment((1, 1), (2, 2))) is True
+    assert Segment((1, 1), (2, 2)) in Line((0, 0), (10, 10))
+
+    # 16628 - this should be fast
+    p0 = Point2D(S(249)/5, S(497999)/10000)
+    p1 = Point2D((-58977084786*sqrt(405639795226) + 2030690077184193 +
+        20112207807*sqrt(630547164901) + 99600*sqrt(255775022850776494562626))
+        /(2000*sqrt(255775022850776494562626) + 1991998000*sqrt(405639795226)
+        + 1991998000*sqrt(630547164901) + 1622561172902000),
+        (-498000*sqrt(255775022850776494562626) - 995999*sqrt(630547164901) +
+        90004251917891999 +
+        496005510002*sqrt(405639795226))/(10000*sqrt(255775022850776494562626)
+        + 9959990000*sqrt(405639795226) + 9959990000*sqrt(630547164901) +
+        8112805864510000))
+    p2 = Point2D(S(497)/10, -S(497)/10)
+    p3 = Point2D(-S(497)/10, -S(497)/10)
+    l = Line(p0, p1)
+    s = Segment(p2, p3)
+    n = (-52673223862*sqrt(405639795226) - 15764156209307469 -
+        9803028531*sqrt(630547164901) +
+        33200*sqrt(255775022850776494562626))
+    d = sqrt(405639795226) + 315274080450 + 498000*sqrt(
+        630547164901) + sqrt(255775022850776494562626)
+    assert intersection(l, s) == [
+        Point2D(n/d*S(3)/2000, -S(497)/10)]
+
+
+@slow
+def test_line_intersection():
+    x0 = tan(13*pi/45)
+    x1 = sqrt(3)
+    x2 = x0**2
+    x, y = [8*x0/(x0 + x1), (24*x0 - 8*x1*x2)/(x2 - 3)]
+    assert Line(Point(0, 0), Point(1, -sqrt(3))).contains(Point(x, y)) is True
+
 
 def test_intersection_3d():
     p1 = Point3D(0, 0, 0)
@@ -586,25 +631,6 @@ def test_is_similar():
     assert s1.is_similar(r2) is False
     assert r1.is_similar(Line3D(Point3D(1, 1, 1), Point3D(1, 0, 0))) is True
     assert r1.is_similar(Line3D(Point3D(0, 0, 0), Point3D(0, 1, 0))) is False
-
-
-@slow
-def test_line_intersection():
-    assert asa(120, 8, 52) == \
-           Triangle(
-               Point(0, 0),
-               Point(8, 0),
-               Point(-4 * cos(19 * pi / 90) / sin(2 * pi / 45),
-                     4 * sqrt(3) * cos(19 * pi / 90) / sin(2 * pi / 45)))
-    assert Line((0, 0), (1, 1)).intersection(Ray((1, 0), (1, 2))) == [Point(1, 1)]
-    assert Line((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == [Point(1, 1)]
-    assert Ray((0, 0), (1, 1)).intersection(Ray((1, 0), (1, 2))) == [Point(1, 1)]
-    assert Ray((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == [Point(1, 1)]
-    assert Ray((0, 0), (10, 10)).contains(Segment((1, 1), (2, 2))) is True
-    assert Segment((1, 1), (2, 2)) in Line((0, 0), (10, 10))
-    x = 8 * tan(13 * pi / 45) / (tan(13 * pi / 45) + sqrt(3))
-    y = (-8 * sqrt(3) * tan(13 * pi / 45) ** 2 + 24 * tan(13 * pi / 45)) / (-3 + tan(13 * pi / 45) ** 2)
-    assert Line(Point(0, 0), Point(1, -sqrt(3))).contains(Point(x, y)) is True
 
 
 def test_length():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16628

#### Brief description of what is fixed or changed

Intersections will return more quickly for Line/Segment interactions in 2D because a redundant check that the point is in the line has been eliminated.

Point containment in a 2D Segment now uses a quick check before using the triangle inequality.

#### Other comments

Some tests which were quite fast already were moved out of the slow test.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- geometry
  * improved response time of 2D Line/Segement interactions and Segment containment of Point
<!-- END RELEASE NOTES -->
