### PR TITLE
added OneMatrix for matrix expressions with only ones

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2688,6 +2688,12 @@ def test_sympy__matrices__expressions__matexpr__ZeroMatrix():
     from sympy.matrices.expressions.matexpr import ZeroMatrix
     assert _test_args(ZeroMatrix(3, 5))
 
+
+def test_sympy__matrices__expressions__matexpr__OneMatrix():
+    from sympy.matrices.expressions.matexpr import OneMatrix
+    assert _test_args(OneMatrix(3, 5))
+
+
 def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
     from sympy.matrices.expressions.matexpr import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -980,6 +980,45 @@ class GenericZeroMatrix(ZeroMatrix):
         return super(GenericZeroMatrix, self).__hash__()
 
 
+class OneMatrix(MatrixExpr):
+    """
+    Matrix whose all entries are ones.
+    """
+    def __new__(cls, m, n):
+        obj = super(OneMatrix, cls).__new__(cls, m, n)
+        return obj
+
+    @property
+    def shape(self):
+        return self._args
+
+    def as_explicit(self):
+        from sympy import ImmutableDenseMatrix
+        return ImmutableDenseMatrix.ones(*self.shape)
+
+    def _eval_transpose(self):
+        return OneMatrix(self.cols, self.rows)
+
+    def _eval_trace(self):
+        return S.One*self.rows
+
+    def _eval_determinant(self):
+        condition = Eq(self.shape[0], 1) & Eq(self.shape[1], 1)
+        if condition == True:
+            return S.One
+        elif condition == False:
+            return S.Zero
+        else:
+            from sympy import Determinant
+            return Determinant(self)
+
+    def conjugate(self):
+        return self
+
+    def _entry(self, i, j, **kwargs):
+        return S.One
+
+
 def matrix_symbols(expr):
     return [sym for sym in expr.free_symbols if sym.is_Matrix]
 

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -4,6 +4,7 @@ from sympy.matrices.expressions import (
     Identity, MatrixExpr, MatrixSymbol, Determinant,
     det, ZeroMatrix, Transpose
 )
+from sympy.matrices.expressions.matexpr import OneMatrix
 from sympy.utilities.pytest import raises
 from sympy import refine, Q
 
@@ -28,6 +29,9 @@ def test_det():
 def test_eval_determinant():
     assert det(Identity(n)) == 1
     assert det(ZeroMatrix(n, n)) == 0
+    assert det(OneMatrix(n, n)) == Determinant(OneMatrix(n, n))
+    assert det(OneMatrix(1, 1)) == 1
+    assert det(OneMatrix(2, 2)) == 0
     assert det(Transpose(A)) == det(A)
 
 

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -9,7 +9,7 @@ from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint)
 from sympy.matrices.expressions.matexpr import (MatrixElement,
-    GenericZeroMatrix, GenericIdentity)
+                                                GenericZeroMatrix, GenericIdentity, OneMatrix)
 from sympy.utilities.pytest import raises, XFAIL
 
 
@@ -74,6 +74,40 @@ def test_ZeroMatrix_doit():
     assert isinstance(Znn.rows, Add)
     assert Znn.doit() == ZeroMatrix(2*n, n)
     assert isinstance(Znn.doit().rows, Mul)
+
+
+def test_OneMatrix():
+    A = MatrixSymbol('A', n, m)
+    a = MatrixSymbol('a', n, 1)
+    U = OneMatrix(n, m)
+
+    assert U.shape == (n, m)
+
+    assert isinstance(A + U, Add)
+    # assert a*OneMatrix(n, 1) == a
+    # assert OneMatrix(n, 1)*a == a
+
+    assert transpose(U) == OneMatrix(m, n)
+    assert U.conjugate() == U
+
+    assert OneMatrix(n, n) ** 0 == Identity(n)
+    with raises(ShapeError):
+        U ** 0
+    with raises(ShapeError):
+        U ** 2
+
+    U = OneMatrix(n, n)
+    assert U[1, 2] == 1
+
+    U = OneMatrix(2, 3)
+    assert U.as_explicit() == ImmutableMatrix.ones(2, 3)
+
+
+def test_OneMatrix_doit():
+    Unn = OneMatrix(Add(n, n, evaluate=False), n)
+    assert isinstance(Unn.rows, Add)
+    assert Unn.doit() == OneMatrix(2 * n, n)
+    assert isinstance(Unn.doit().rows, Mul)
 
 
 def test_Identity():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -82,11 +82,7 @@ def test_OneMatrix():
     U = OneMatrix(n, m)
 
     assert U.shape == (n, m)
-
     assert isinstance(A + U, Add)
-    # assert a*OneMatrix(n, 1) == a
-    # assert OneMatrix(n, 1)*a == a
-
     assert transpose(U) == OneMatrix(m, n)
     assert U.conjugate() == U
 

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -6,6 +6,7 @@ from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
     ZeroMatrix, trace, MatPow, MatAdd, MatMul
 )
+from sympy.matrices.expressions.matexpr import OneMatrix
 from sympy.utilities.pytest import raises, XFAIL
 
 n = symbols('n', integer=True)
@@ -30,6 +31,9 @@ def test_Trace():
     # Some easy simplifications
     assert trace(Identity(5)) == 5
     assert trace(ZeroMatrix(5, 5)) == 0
+    assert trace(OneMatrix(1, 1)) == 1
+    assert trace(OneMatrix(2, 2)) == 2
+    assert trace(OneMatrix(n, n)) == n
     assert trace(2*A*B) == 2*Trace(A*B)
     assert trace(A.T) == trace(A)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Introduction of `OneMatrix`, a matrix symbol representing matrices of only 1 entries.
<!-- END RELEASE NOTES -->
