### PR TITLE
Fix duplicate plot in beam_problems

### DIFF
--- a/doc/src/modules/physics/continuum_mechanics/beam_problems.rst
+++ b/doc/src/modules/physics/continuum_mechanics/beam_problems.rst
@@ -5,7 +5,7 @@ Solving Beam Bending Problems using Singularity Functions
 To make this document easier to read, enable pretty printing:
 
 .. plot::
-   :context:
+   :context: reset
    :format: doctest
    :include-source: True
 

--- a/doc/src/modules/physics/continuum_mechanics/beam_problems.rst
+++ b/doc/src/modules/physics/continuum_mechanics/beam_problems.rst
@@ -866,7 +866,7 @@ from the top at a distance of ``2*l`` from starting point.
                         E⋅I                                               E⋅I                                                                             E⋅I
 
 Example 11
-==========
+----------
 
 Any type of load defined by a polynomial can be applied to the beam. This
 allows approximation of arbitrary load distributions. The following example


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16664

#### Brief description of what is fixed or changed

I have tested locally that duplicate plots are generated after sphinx `2.0.1` and `2.0.0`, 
and it gets cleaned up if I use `:context: reset` in the first code block.

See if it works.

#### Other comments

Also, the markdown for example 11 should be corrected, to fix table of contents

<img src=https://user-images.githubusercontent.com/34944973/56344314-11354c00-61f8-11e9-846d-9144045d51f3.png width=256px>


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
