### PR TITLE
.terms() missing from g in is_reduced(G, ring)

### DIFF
--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -777,7 +777,7 @@ def is_reduced(G, ring):
         if g.LC != domain.one:
             return False
 
-        for term in g:
+        for term in g.terms():
             for h in G[:i] + G[i + 1:]:
                 if monomial_divides(h.LM, term[0]):
                     return False


### PR DESCRIPTION
Need to return the 0th element of term, the monomial tuple. g is a PolyElement object.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Add .terms() method to g in is_groebner(G, ring).

is_groebner(G, ring) fails to iterate over the term 
tuples of g in G.

#### Other comments
Love the project, currently working on extending this 
package with F4 reduction, found this during 
testing.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
