### PR TITLE
Canonicalization of Hadamard Product

### DIFF
--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -27,4 +27,4 @@ from .expressions import (
     Transpose, ZeroMatrix, blockcut, block_collapse, matrix_symbols, Adjoint,
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagonalizeVector, DiagonalMatrix, DiagonalOf, trace,
-    DotProduct, kronecker_product, KroneckerProduct)
+    DotProduct, kronecker_product, KroneckerProduct, OneMatrix)

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,7 +6,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix,
-                      matrix_symbols)
+                      matrix_symbols, OneMatrix)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -68,10 +68,8 @@ class HadamardProduct(MatrixExpr):
         check = kwargs.get('check', True)
         if check:
             validate(*args)
-        if len(args) == 1:
-            return args[0]
-        else:
-            return super(HadamardProduct, cls).__new__(cls, *args)
+
+        return super(HadamardProduct, cls).__new__(cls, *args)
 
     @property
     def shape(self):

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -131,6 +131,8 @@ def validate(*args):
             raise ShapeError("Matrices %s and %s are not aligned" % (A, B))
 
 
+# TODO Implement algorithm for rewriting Hadamard product as diagonal matrix
+# if matmul identy matrix is multiplied.
 def canonicalize(x):
     """Canonicalize the Hadamard product ``x`` with mathematical properties.
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -49,11 +49,6 @@ class HadamardProduct(MatrixExpr):
     >>> isinstance(hadamard_product(A, B), HadamardProduct)
     True
 
-    Hadamard product with only one argument:
-
-    >>> HadamardProduct(A) == A
-    True
-
     Notes
     =====
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -245,12 +245,8 @@ def canonicalize(x):
 
     # Rewriting with HadamardPower
     if isinstance(x, HadamardProduct):
-        tally = dict()
-        for arg in x.args:
-            if arg in tally:
-                tally[arg] += 1
-            else:
-                tally[arg] = 1
+        from collections import Counter
+        tally = Counter(x.args)
 
         new_arg = []
         for base, exp in tally.items():

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -225,7 +225,7 @@ def canonicalize(x):
     # Absorbing by Zero Matrix
     def absorb(x):
         if any(isinstance(c, ZeroMatrix) for c in x.args):
-            return ZeroMatrix(*x.shape)
+            return HadamardProduct(ZeroMatrix(*x.shape))
         else:
             return x
     fun = condition(
@@ -233,6 +233,26 @@ def canonicalize(x):
             absorb
         )
     x = fun(x)
+
+    # Rewriting with HadamardPower
+    if isinstance(x, HadamardProduct):
+        tally = dict()
+        for arg in x.args:
+            if arg in tally:
+                tally[arg] += 1
+            else:
+                tally[arg] = 1
+
+        new_arg = []
+        for base, exp in tally.items():
+            if exp == 1:
+                new_arg.append(base)
+            else:
+                from .hadamard import HadamardPower
+                new_arg.append(HadamardPower(base, exp))
+
+        from sympy.strategies.util import new
+        x = new(x.__class__, *new_arg)
 
     # Unpacking
     x = unpack(x)

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -251,7 +251,7 @@ def canonicalize(x):
                 new_arg.append(HadamardPower(base, exp))
 
         from sympy.strategies.util import new
-        x = new(x.__class__, new_arg)
+        x = new(x.__class__, *new_arg)
 
     # Commutativity
     fun = condition(

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -144,12 +144,12 @@ def canonicalize(x):
     >>> A = MatrixSymbol('A', 2, 2)
     >>> B = MatrixSymbol('B', 2, 2)
     >>> C = MatrixSymbol('C', 2, 2)
-    >>> Z = ZeroMatrix(2, 2)
-    >>> O = OneMatrix(2, 2)
 
     Hadamard product associativity:
 
     >>> X = HadamardProduct(A, HadamardProduct(B, C))
+    >>> X
+    A.*(B.*C)
     >>> canonicalize(X)
     A.*B.*C
 
@@ -162,15 +162,23 @@ def canonicalize(x):
 
     Hadamard product identity:
 
-    >>> X = HadamardProduct(A, O)
+    >>> X = HadamardProduct(A, OneMatrix(2, 2))
     >>> canonicalize(X) == A
     True
 
     Absorbing element of Hadamard product:
 
-    >>> X = HadamardProduct(A, Z)
-    >>> canonicalize(X) == Z
+    >>> X = HadamardProduct(A, ZeroMatrix(2, 2))
+    >>> canonicalize(X) == ZeroMatrix(2, 2)
     True
+
+    Rewriting to Hadamard Power
+
+    >>> X = HadamardProduct(A, A, A)
+    >>> X
+    A.*A.*A
+    >>> canonicalize(X)
+    A.**3
 
     Notes
     =====

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -230,11 +230,10 @@ def canonicalize(x):
             return ZeroMatrix(*x.shape)
         else:
             return x
-    rule = condition(
+    fun = condition(
             lambda x: isinstance(x, HadamardProduct),
             absorb
         )
-    fun = exhaust(rule)
     x = fun(x)
 
     # Unpacking

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -202,7 +202,7 @@ def canonicalize(x):
     """
     from sympy.core.compatibility import default_sort_key
 
-    # Flattening
+    # Associativity
     rule = condition(
             lambda x: isinstance(x, HadamardProduct),
             flatten

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -220,7 +220,7 @@ def canonicalize(x):
     # Absorbing by Zero Matrix
     def absorb(x):
         if any(isinstance(c, ZeroMatrix) for c in x.args):
-            return HadamardProduct(ZeroMatrix(*x.shape))
+            return ZeroMatrix(*x.shape)
         else:
             return x
     fun = condition(
@@ -243,7 +243,6 @@ def canonicalize(x):
             if exp == 1:
                 new_arg.append(base)
             else:
-                from .hadamard import HadamardPower
                 new_arg.append(HadamardPower(base, exp))
 
         from sympy.strategies.util import new

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -196,6 +196,8 @@ def canonicalize(x):
 
     Matrix of only zeros will make Hadamard product zero.
 
+    Duplicate elements can be collected and rewritten as HadamardPower
+
     References
     ==========
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -159,20 +159,30 @@ def canonicalize(x):
 
     >>> X = HadamardProduct(A, B)
     >>> Y = HadamardProduct(B, A)
-    >>> canonicalize(X) == canonicalize(Y)
-    True
+    >>> X
+    A.*B
+    >>> Y
+    B.*A
+    >>> canonicalize(X)
+    A.*B
+    >>> canonicalize(Y)
+    A.*B
 
     Hadamard product identity:
 
     >>> X = HadamardProduct(A, OneMatrix(2, 2))
-    >>> canonicalize(X) == A
-    True
+    >>> X
+    A.*OneMatrix(2, 2)
+    >>> canonicalize(X)
+    A
 
     Absorbing element of Hadamard product:
 
     >>> X = HadamardProduct(A, ZeroMatrix(2, 2))
-    >>> canonicalize(X) == ZeroMatrix(2, 2)
-    True
+    >>> X
+    A.*0
+    >>> canonicalize(X)
+    0
 
     Rewriting to Hadamard Power
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -250,8 +250,7 @@ def canonicalize(x):
             else:
                 new_arg.append(HadamardPower(base, exp))
 
-        from sympy.strategies.util import new
-        x = new(x.__class__, *new_arg)
+        x = HadamardProduct(*new_arg)
 
     # Commutativity
     fun = condition(

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -222,13 +222,6 @@ def canonicalize(x):
         )
     x = fun(x)
 
-    # Commutativity
-    fun = condition(
-            lambda x: isinstance(x, HadamardProduct),
-            sort(default_sort_key)
-        )
-    x = fun(x)
-
     # Absorbing by Zero Matrix
     def absorb(x):
         if any(isinstance(c, ZeroMatrix) for c in x.args):
@@ -258,7 +251,14 @@ def canonicalize(x):
                 new_arg.append(HadamardPower(base, exp))
 
         from sympy.strategies.util import new
-        x = new(x.__class__, *sorted(new_arg, key=default_sort_key))
+        x = new(x.__class__, new_arg)
+
+    # Commutativity
+    fun = condition(
+            lambda x: isinstance(x, HadamardProduct),
+            sort(default_sort_key)
+        )
+    x = fun(x)
 
     # Unpacking
     x = unpack(x)

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -197,16 +197,15 @@ def canonicalize(x):
     Notes
     =====
 
-    As Hadamard product is associative, all the nested products can be
-    flattened to the level 1.
+    As the Hadamard product is associative, nested products can be flattened.
 
-    As Hadamard product is commutative, all the arguments can be sorted to
-    the canonical form.
+    The Hadamard product is commutative so that factors can be sorted for
+    canonical form.
 
-    Matrix of only ones is an identity for Hadamard product,
-    so every ``OneMatrix`` can be removed.
+    A matrix of only ones is an identity for Hadamard product,
+    so every matrices of only ones can be removed.
 
-    Matrix of only zeros will make Hadamard product zero.
+    Any zero matrix will make the whole product a zero matrix.
 
     Duplicate elements can be collected and rewritten as HadamardPower
 
@@ -214,8 +213,6 @@ def canonicalize(x):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Hadamard_product_(matrices)
-
-    .. [2] https://en.wikipedia.org/wiki/Multiplication
     """
     from sympy.core.compatibility import default_sort_key
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -246,7 +246,7 @@ def canonicalize(x):
                 new_arg.append(HadamardPower(base, exp))
 
         from sympy.strategies.util import new
-        x = new(x.__class__, *new_arg)
+        x = new(x.__class__, *sorted(new_arg, key=default_sort_key))
 
     # Unpacking
     x = unpack(x)

--- a/sympy/matrices/expressions/tests/test_hadamard.py
+++ b/sympy/matrices/expressions/tests/test_hadamard.py
@@ -1,4 +1,4 @@
-from sympy import Identity
+from sympy import Identity, OneMatrix, ZeroMatrix
 from sympy.core import symbols
 from sympy.utilities.pytest import raises
 
@@ -37,12 +37,21 @@ def test_mixed_indexing():
     assert (X*HadamardProduct(Y, Z))[0, 0] == \
             X[0, 0]*Y[0, 0]*Z[0, 0] + X[0, 1]*Y[1, 0]*Z[1, 0]
 
+
 def test_canonicalize():
     X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
     expr = HadamardProduct(X, check=False)
     assert isinstance(expr, HadamardProduct)
     expr2 = expr.doit() # unpack is called
     assert isinstance(expr2, MatrixSymbol)
+    Z = ZeroMatrix(2, 2)
+    U = OneMatrix(2, 2)
+    assert HadamardProduct(Z, X).doit() == Z
+    assert HadamardProduct(U, X, X, U).doit() == HadamardPower(X, 2)
+    assert HadamardProduct(X, U, Y).doit() == HadamardProduct(X, Y)
+    assert HadamardProduct(X, Z, U, Y).doit() == Z
+
 
 def test_hadamard():
     m, n, p = symbols('m, n, p', integer=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

With matrix of ones implemented in #16676, we may use the identity to make hadamard product more canonical.

- [X] Associative (Default)
- [X] Commutative
- [X] Identity for Hadamard product by one matrix
- [X] Absorbing to zero matrix when multiplied with zero matrix
- [x] Rewriting to Hadamard power when repetitive matrices are multiplied.
- [ ] (Optional) Reduce to diagonal matrix when multiplied with `IdentityMatrix` (Or any rectangular `eye`) After the decision is made for #16682 

#### Other comments

This is still work in progress, and I will add some tests if the design is set

I also think that `HadamardProduct` can automatically unpack its argument, if given a single argument, like in SymPy's `Add`, `Mul`.
As it is confusing that
`HadamardProduct(A) == A` is giving `False` because it does not unpacks single arguent
but `hadamard_product(A) == A` is giving `True`.
And the printing is not suggestive that `HadamardProduct` is wrapped on this.
Though changing this would make some tests fail, and there may be some discussion for design change?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Improved canonicalization for `HadamardProduct`
  - Deleted `rules` from `matrices.expressions.hadamard`
<!-- END RELEASE NOTES -->
