### PR TITLE
allow matrix expression to be derived by scalar

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1666,7 +1666,7 @@ class Basic(with_metaclass(ManagedProperties)):
         # Types are (base: array/matrix, self: scalar)
         # Base is some kind of array/matrix,
         # it should have `.applyfunc(lambda x: x.diff(self)` implemented:
-        return base._eval_derivative(self)
+        return base._eval_derivative_array(self)
 
     def _eval_derivative_n_times(self, s, n):
         # This is the default evaluator for derivatives (as called by `diff`

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1331,7 +1331,7 @@ class Derivative(Expr):
             if zero:
                 if isinstance(expr, (MatrixCommon, NDimArray)):
                     return expr.zeros(*expr.shape)
-                else:
+                elif expr.is_scalar:
                     return S.Zero
 
             # make the order of symbols canonical

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -85,17 +85,17 @@ class HadamardProduct(MatrixExpr):
             diagonal = [(0, 2), (3, 4)]
             diagonal = [e for j, e in enumerate(diagonal) if self.shape[j] != 1]
             for i in d:
-                ptr1 = i.first_pointer
-                ptr2 = i.second_pointer
+                l1 = i._lines[i._first_line_index]
+                l2 = i._lines[i._second_line_index]
                 subexpr = ExprBuilder(
                     CodegenArrayDiagonal,
                     [
                         ExprBuilder(
                             CodegenArrayTensorProduct,
                             [
-                                ExprBuilder(_make_matrix, [i._lines[0]]),
+                                ExprBuilder(_make_matrix, [l1]),
                                 hadam,
-                                ExprBuilder(_make_matrix, [i._lines[1]]),
+                                ExprBuilder(_make_matrix, [l2]),
                             ]
                         ),
                     ] + diagonal,  # turn into *diagonal after dropping Python 2.7
@@ -176,19 +176,19 @@ class HadamardPower(MatrixExpr):
 
         lr = self.base._eval_derivative_matrix_lines(x)
         for i in lr:
-            ptr1 = i.first_pointer
-            ptr2 = i.second_pointer
             diagonal = [(1, 2), (3, 4)]
             diagonal = [e for j, e in enumerate(diagonal) if self.base.shape[j] != 1]
+            l1 = i._lines[i._first_line_index]
+            l2 = i._lines[i._second_line_index]
             subexpr = ExprBuilder(
                 CodegenArrayDiagonal,
                 [
                     ExprBuilder(
                         CodegenArrayTensorProduct,
                         [
-                            ExprBuilder(_make_matrix, [ptr1]),
+                            ExprBuilder(_make_matrix, [l1]),
                             self.exp*hadamard_power(self.base, self.exp-1),
-                            ExprBuilder(_make_matrix, [ptr2]),
+                            ExprBuilder(_make_matrix, [l2]),
                         ]
                     ),
                 ] + diagonal,  # turn into *diagonal after dropping Python 2.7
@@ -196,7 +196,9 @@ class HadamardPower(MatrixExpr):
             )
             i._first_pointer_parent = subexpr.args[0].args[0].args
             i._first_pointer_index = 0
+            i._first_line_index = 0
             i._second_pointer_parent = subexpr.args[0].args[2].args
-            i._second_pointer_index = 2
+            i._second_pointer_index = 0
+            i._second_line_index = 0
             i._lines = [subexpr]
         return lr

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -69,6 +69,7 @@ class MatrixExpr(Expr):
     is_commutative = False
     is_number = False
     is_symbol = False
+    is_scalar = False
 
     def __new__(cls, *args, **kwargs):
         args = map(_sympify, args)
@@ -197,7 +198,14 @@ class MatrixExpr(Expr):
         return Adjoint(self)
 
     def _eval_derivative(self, x):
-        return _matrix_derivative(self, x)
+        # x is a scalar:
+        return ZeroMatrix(self.shape[0], self.shape[1])
+
+    def _eval_derivative_array(self, x):
+        if isinstance(x, MatrixExpr):
+            return _matrix_derivative(self, x)
+        else:
+            return self._eval_derivative(x)
 
     def _eval_derivative_n_times(self, x, n):
         return Basic._eval_derivative_n_times(self, x, n)
@@ -1041,8 +1049,10 @@ class _LeftRightArgs(object):
         self._lines = [i for i in lines]
         self._first_pointer_parent = self._lines
         self._first_pointer_index = 0
+        self._first_line_index = 0
         self._second_pointer_parent = self._lines
         self._second_pointer_index = 1
+        self._second_line_index = 1
         self.higher = higher
 
     @property
@@ -1074,6 +1084,7 @@ class _LeftRightArgs(object):
     def transpose(self):
         self._first_pointer_parent, self._second_pointer_parent = self._second_pointer_parent, self._first_pointer_parent
         self._first_pointer_index, self._second_pointer_index = self._second_pointer_index, self._first_pointer_index
+        self._first_line_index, self._second_line_index = self._second_line_index, self._first_line_index
         return self
 
     @staticmethod

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -10,6 +10,7 @@ from sympy import MatAdd, Identity, MatMul, ZeroMatrix
 from sympy.matrices.expressions import hadamard_power
 
 k = symbols("k")
+i, j = symbols("i j")
 
 X = MatrixSymbol("X", k, k)
 x = MatrixSymbol("x", k, 1)
@@ -39,6 +40,13 @@ def _check_derivative_with_explicit_matrix(expr, x, diffexpr, dim=2):
     diffexpr = diffexpr.as_explicit()
 
     assert expr.diff(x).reshape(*diffexpr.shape).tomatrix() == diffexpr
+
+
+def test_matrix_derivative_by_scalar():
+    assert A.diff(i) == ZeroMatrix(k, k)
+    assert (A*(X + B)*c).diff(i) == ZeroMatrix(k, 1)
+    assert x.diff(i) == ZeroMatrix(k, 1)
+    assert (x.T*y).diff(i) == ZeroMatrix(1, 1)
 
 
 def test_matrix_derivative_non_matrix_result():
@@ -376,6 +384,9 @@ def test_derivatives_of_hadamard_expressions():
     # Hadamard Power
 
     expr = hadamard_power(x, 2)
+    assert expr.diff(x).doit() == 2*DiagonalizeVector(x)
+
+    expr = hadamard_power(x.T, 2)
     assert expr.diff(x).doit() == 2*DiagonalizeVector(x)
 
     expr = hadamard_power(x, S.Half)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -246,6 +246,9 @@ class NDimArray(object):
         return Basic._eval_derivative_n_times(self, s, n)
 
     def _eval_derivative(self, arg):
+        return self.applyfunc(lambda x: x.diff(arg))
+
+    def _eval_derivative_array(self, arg):
         from sympy import derive_by_array
         from sympy import Tuple
         from sympy.matrices.common import MatrixCommon


### PR DESCRIPTION
…d derivatives

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Allow matrix expressions to be derived by a scalar.
<!-- END RELEASE NOTES -->
