### PR TITLE
Improve coverage_report.py

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -60,11 +60,8 @@ def generate_covered_files(top_dir):
 
 def make_report(source_dir, report_dir, use_cache=False, slow=False):
     # code adapted from /bin/test
-    bin_dir = os.path.abspath(os.path.dirname(__file__))  # bin/
-    sympy_top = os.path.split(bin_dir)[0]  # ../
-    sympy_dir = os.path.join(sympy_top, 'sympy')  # ../sympy/
-    if os.path.isdir(sympy_dir):
-        sys.path.insert(0, sympy_top)
+    from get_sympy import path_hack
+    sympy_top = path_hack()
     os.chdir(sympy_top)
 
     cov = coverage.coverage()

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -99,7 +99,8 @@ if __name__ == '__main__':
     parser.add_option('-c', '--use-cache', action='store_true', default=False,
                       help='Use cached data.')
     parser.add_option('-d', '--report-dir', default='covhtml',
-                      help='Directory to put the generated report in.')
+                      help='Directory to put the generated report in.',
+                      dest='report_dir')
     parser.add_option("--slow", action="store_true", dest="slow",
                       default=False, help="Run slow functions also.")
 
@@ -112,6 +113,10 @@ if __name__ == '__main__':
 
     make_report(source_dir, **options.__dict__)
 
+    report_dir = options.report_dir
+
     print("The generated coverage report is in covhtml directory.")
-    print("Open %s in your web browser to view the report" % os.sep.join(
-        'sympy covhtml index.html'.split()))
+    print(
+        "Open %s in your web browser to view the report" %
+        os.sep.join([report_dir, 'index.html'])
+    )

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -79,6 +79,7 @@ def make_report(source_dir, report_dir, use_cache=False, slow=False):
             sympy.test(source_dir, subprocess=False, slow=slow)
         #sympy.doctest()  # coverage doesn't play well with doctests
         cov.stop()
+        cov.save()
 
     covered_files = list(generate_covered_files(source_dir))
 

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -84,7 +84,6 @@ def make_report(source_dir, report_dir, use_cache=False, slow=False):
             sympy.test(source_dir, subprocess=False, slow=slow)
         #sympy.doctest()  # coverage doesn't play well with doctests
         cov.stop()
-        cov.save()
 
     covered_files = list(generate_covered_files(source_dir))
 

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -59,7 +59,9 @@ def generate_covered_files(top_dir):
 
 
 def make_report(
-    source_dir, report_dir, test_args, use_cache=False, slow=False):
+    test_args, source_dir='sympy/', report_dir='covhtml', use_cache=False,
+    slow=False
+    ):
     # code adapted from /bin/test
     from get_sympy import path_hack
     sympy_top = path_hack()
@@ -90,10 +92,10 @@ def make_report(
 
     covered_files = list(generate_covered_files(source_dir))
 
-    if report_dir in os.listdir(os.curdir):
-        for f in os.listdir(report_dir):
-            if f.split('.')[-1] in ['html', 'css', 'js']:
-                os.remove(os.path.join(report_dir, f))
+    #if report_dir in os.listdir(os.curdir):
+    #    for f in os.listdir(report_dir):
+    #        if f.split('.')[-1] in ['html', 'css', 'js']:
+    #            os.remove(os.path.join(report_dir, f))
 
     cov.html_report(morfs=covered_files, directory=report_dir)
 
@@ -110,12 +112,11 @@ parser.add_argument(
 options, args = parser.parse_known_args()
 
 if __name__ == '__main__':
-    source_dir = 'sympy/'
     report_dir = options.report_dir
     use_cache = options.use_cache
     slow = options.slow
     make_report(
-        source_dir, report_dir, args, use_cache=use_cache, slow=slow)
+        args, report_dir=report_dir, use_cache=use_cache, slow=slow)
 
     print("The generated coverage report is in covhtml directory.")
     print(

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -27,7 +27,7 @@ from __future__ import print_function
 import os
 import re
 import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 minver = '3.4'
 try:
@@ -89,26 +89,28 @@ def make_report(source_dir, report_dir, use_cache=False, slow=False):
 
     cov.html_report(morfs=covered_files, directory=report_dir)
 
+parser = ArgumentParser()
+parser.add_argument(
+    '-c', '--use-cache', action='store_true', default=False,
+    help='Use cached data.')
+parser.add_argument(
+    '-d', '--report-dir', default='covhtml',
+    help='Directory to put the generated report in.')
+parser.add_argument(
+    "--slow", action="store_true", dest="slow", default=False,
+    help="Run slow functions also.")
+options, args = parser.parse_known_args()
+
 if __name__ == '__main__':
-    parser = OptionParser()
-    parser.add_option('-c', '--use-cache', action='store_true', default=False,
-                      help='Use cached data.')
-    parser.add_option('-d', '--report-dir', default='covhtml',
-                      help='Directory to put the generated report in.',
-                      dest='report_dir')
-    parser.add_option("--slow", action="store_true", dest="slow",
-                      default=False, help="Run slow functions also.")
-
-    options, args = parser.parse_args()
-
     if args:
         source_dir = args[0]
     else:
         source_dir = 'sympy/'
 
-    make_report(source_dir, **options.__dict__)
-
     report_dir = options.report_dir
+    use_cache = options.use_cache
+    slow = options.slow
+    make_report(source_dir, report_dir, use_cache=use_cache, slow=slow)
 
     print("The generated coverage report is in covhtml directory.")
     print(

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -41,8 +41,6 @@ except ImportError:
         "https://launchpad.net/ubuntu/+source/python-coverage/" % minver)
     sys.exit(-1)
 
-REPORT_DIR = "covhtml"
-REFRESH = False
 
 omit_dir_patterns = ['.*tests', 'benchmark', 'examples',
                      'pyglet', 'test_external']

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -91,12 +91,6 @@ def make_report(
             )
 
     covered_files = list(generate_covered_files(source_dir))
-
-    #if report_dir in os.listdir(os.curdir):
-    #    for f in os.listdir(report_dir):
-    #        if f.split('.')[-1] in ['html', 'css', 'js']:
-    #            os.remove(os.path.join(report_dir, f))
-
     cov.html_report(morfs=covered_files, directory=report_dir)
 
 parser = ArgumentParser()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Some refactorings:

1. `optparse` is deprecated, updated to `argparse`

2.  https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L44-L45 is unused

3. https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L65-L69 can be refactored with `path_hack()`

4. https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L82-L84 can be redundant check

5. https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L117-L118 was hardcoded, so it had given same information even if `report-dir` is specified else.

Some changes and fixes:

1. I had made the changes to how it handles `source_dir`. I think this module can support commands as much as `bin/test` can do.
It had previously taken the first argument and discarded all others
https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L109-L110
but now I made changes to properly handle multiple arguments like
`python bin/coverage_report.py algebras strategies`.

2. https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L87
I think there is a bug here for giving `PermissionError` for my system.
I have made it under exception catching statement, because I think that the HTML report can be generated regardless of `.save()` succeeding or failing.
Do anyone else experiencing similar issue for this?

3. There was a bug for deleting some html reports, after subsequently calling coverage report for the same test.
If you run `python bin/coverage_report.py sympy/algebras` twice, some html files are gone.
I have commented out this line, which could probably be causing the issue https://github.com/sympy/sympy/blob/967df3b9dc4a5b98a019d18883d72ac14a5955d6/bin/coverage_report.py#L91-L94

4. I have made `source_dir` hardcoded to `sympy/` now, so it may make report generating process more slower as it tracks down every files in sympy. 
I think there should be an improvement for how it handles source folders as well, it may cause false negatives for indicating the proper modules.

Any feedbacks are welcomed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
