### PR TITLE
Added OneMatrix str, pretty, and MathML presentation printing

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1591,20 +1591,20 @@ class LatexPrinter(Printer):
             return "%s^{%s}" % (self._print(base), self._print(exp))
 
     def _print_MatrixSymbol(self, expr):
-        return self._print_Symbol(expr,
-                                  style=self._settings['mat_symbol_style'])
+        return self._print_Symbol(expr, style=self._settings[
+            'mat_symbol_style'])
 
     def _print_ZeroMatrix(self, Z):
-        return r"\mathbb{0}" if not self._settings['mat_symbol_style'
-            ] else r"\mathbf{0}"
+        return r"\mathbb{0}" if self._settings[
+            'mat_symbol_style'] == 'plain' else r"\mathbf{0}"
 
     def _print_OneMatrix(self, O):
-        return r"\mathbb{1}" if not self._settings['mat_symbol_style'
-            ] else r"\mathbf{1}"
+        return r"\mathbb{1}" if not self._settings[
+            'mat_symbol_style'] == 'plain' else r"\mathbf{1}"
 
     def _print_Identity(self, I):
-        return r"\mathbb{I}" if not self._settings['mat_symbol_style'
-            ] else r"\mathbf{I}"
+        return r"\mathbb{I}" if not self._settings[
+            'mat_symbol_style'] == 'plain' else r"\mathbf{I}"
 
     def _print_NDimArray(self, expr):
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1408,10 +1408,6 @@ class LatexPrinter(Printer):
 
     _print_RandomSymbol = _print_Symbol
 
-    def _print_MatrixSymbol(self, expr):
-        return self._print_Symbol(expr,
-                                  style=self._settings['mat_symbol_style'])
-
     def _deal_with_super_sub(self, string):
         if '{' in string:
             return string
@@ -1594,14 +1590,21 @@ class LatexPrinter(Printer):
         else:
             return "%s^{%s}" % (self._print(base), self._print(exp))
 
+    def _print_MatrixSymbol(self, expr):
+        return self._print_Symbol(expr,
+                                  style=self._settings['mat_symbol_style'])
+
     def _print_ZeroMatrix(self, Z):
-        return r"\mathbb{0}"
+        return r"\mathbb{0}" if not self._settings['mat_symbol_style'
+            ] else r"\mathbf{0}"
 
     def _print_OneMatrix(self, O):
-        return r"\mathbb{1}"
+        return r"\mathbb{1}" if not self._settings['mat_symbol_style'
+            ] else r"\mathbf{1}"
 
     def _print_Identity(self, I):
-        return r"\mathbb{I}"
+        return r"\mathbb{I}" if not self._settings['mat_symbol_style'
+            ] else r"\mathbf{I}"
 
     def _print_NDimArray(self, expr):
 

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1679,6 +1679,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x.appendChild(self.dom.createTextNode('&#x1D7D8'))
         return x
 
+    def _print_OneMatrix(self, Z):
+        x = self.dom.createElement('mn')
+        x.appendChild(self.dom.createTextNode('&#x1D7D9'))
+        return x
+
     def _print_Identity(self, I):
         x = self.dom.createElement('mi')
         x.appendChild(self.dom.createTextNode('&#x1D540;'))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -862,6 +862,24 @@ class PrettyPrinter(Printer):
 
         return prettyForm.__mul__(*args)
 
+    def _print_Identity(self, expr):
+        if self._use_unicode:
+            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL I}')
+        else:
+            return prettyForm('I')
+
+    def _print_ZeroMatrix(self, expr):
+        if self._use_unicode:
+            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO}')
+        else:
+            return prettyForm('0')
+
+    def _print_OneMatrix(self, expr):
+        if self._use_unicode:
+            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ONE}')
+        else:
+            return prettyForm('1')
+
     def _print_DotProduct(self, expr):
         args = list(expr.args)
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6686,3 +6686,13 @@ def test_imaginary_unit():
 
     raises(TypeError, lambda: pretty(I, imaginary_unit=I))
     raises(ValueError, lambda: pretty(I, imaginary_unit="kkk"))
+
+
+def test_str_special_matrices():
+    from sympy.matrices import Identity, ZeroMatrix, OneMatrix
+    assert pretty(Identity(4)) == 'I'
+    assert upretty(Identity(4)) == u'𝕀'
+    assert pretty(ZeroMatrix(2, 2)) == '0'
+    assert upretty(ZeroMatrix(2, 2)) == u'𝟘'
+    assert pretty(OneMatrix(2, 2)) == '1'
+    assert upretty(OneMatrix(2, 2)) == u'𝟙'

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -731,6 +731,9 @@ class StrPrinter(Printer):
     def _print_ZeroMatrix(self, expr):
         return "0"
 
+    def _print_OneMatrix(self, expr):
+        return "1"
+
     def _print_Predicate(self, expr):
         return "Q.%s" % expr.name
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1629,16 +1629,19 @@ def test_ElementwiseApplyFunction():
 def test_ZeroMatrix():
     from sympy import ZeroMatrix
     assert latex(ZeroMatrix(1, 1)) == r"\mathbb{0}"
+    assert latex(ZeroMatrix(1, 1, mat_symbol_style='bold')) == r"\mathbf{0}"
 
 
 def test_OneMatrix():
     from sympy import OneMatrix
     assert latex(OneMatrix(3, 4)) == r"\mathbb{1}"
+    assert latex(OneMatrix(3, 4), mat_symbol_style='bold') == r"\mathbf{1}"
 
 
 def test_Identity():
     from sympy import Identity
     assert latex(Identity(1)) == r"\mathbb{I}"
+    assert latex(Identity(1), mat_symbol_style='bold') == r"\mathbf{I}"
 
 
 def test_boolean_args_order():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1628,19 +1628,19 @@ def test_ElementwiseApplyFunction():
 
 def test_ZeroMatrix():
     from sympy import ZeroMatrix
-    assert latex(ZeroMatrix(1, 1)) == r"\mathbb{0}"
-    assert latex(ZeroMatrix(1, 1, mat_symbol_style='bold')) == r"\mathbf{0}"
+    assert latex(ZeroMatrix(1, 1), mat_symbol_style='plain') == r"\mathbb{0}"
+    assert latex(ZeroMatrix(1, 1), mat_symbol_style='bold') == r"\mathbf{0}"
 
 
 def test_OneMatrix():
     from sympy import OneMatrix
-    assert latex(OneMatrix(3, 4)) == r"\mathbb{1}"
+    assert latex(OneMatrix(3, 4), mat_symbol_style='plain') == r"\mathbb{1}"
     assert latex(OneMatrix(3, 4), mat_symbol_style='bold') == r"\mathbf{1}"
 
 
 def test_Identity():
     from sympy import Identity
-    assert latex(Identity(1)) == r"\mathbb{I}"
+    assert latex(Identity(1), mat_symbol_style='plain') == r"\mathbb{I}"
     assert latex(Identity(1), mat_symbol_style='bold') == r"\mathbf{I}"
 
 

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1727,6 +1727,7 @@ def test_mathml_matrix_functions():
 
 
 def test_mathml_special_matrices():
-    from sympy.matrices import Identity, ZeroMatrix
+    from sympy.matrices import Identity, ZeroMatrix, OneMatrix
     assert mathml(Identity(4), printer='presentation') == '<mi>&#x1D540;</mi>'
     assert mathml(ZeroMatrix(2, 2), printer='presentation') == '<mn>&#x1D7D8</mn>'
+    assert mathml(OneMatrix(2, 2), printer='presentation') == '<mn>&#x1D7D9</mn>'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -811,8 +811,16 @@ def test_Subs_printing():
     assert str(Subs(x, (x,), (1,))) == 'Subs(x, x, 1)'
     assert str(Subs(x + y, (x, y), (1, 2))) == 'Subs(x + y, (x, y), (1, 2))'
 
+
 def test_issue_15716():
     x = Symbol('x')
     e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
     assert str(Integral(e, (x, -oo, oo)).doit()) ==  '-(Integral(-3*3**x/factorial(x), (x, -oo, oo))' \
     ' + Integral(3**x*log(3**x/factorial(x))/factorial(x), (x, -oo, oo)))*exp(-3)'
+
+
+def test_str_special_matrices():
+    from sympy.matrices import Identity, ZeroMatrix, OneMatrix
+    assert str(Identity(4)) == 'I'
+    assert str(ZeroMatrix(2, 2)) == '0'
+    assert str(OneMatrix(2, 2)) == '1'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Follow up to #16692

#### Brief description of what is fixed or changed
Added printing of `OneMatrix` to str, pretty and MathML presentation printers
Also improved unicode pretty printing of ZeroMatrix and Identity to use unicode double struck characters.

Before:
<img width="373" alt="beforezeroone" src="https://user-images.githubusercontent.com/8114497/56459244-1ed20980-6391-11e9-81fa-1a7618691c47.PNG">

After:
<img width="249" alt="afterzeroone" src="https://user-images.githubusercontent.com/8114497/56459247-28f40800-6391-11e9-9f98-fe99377c6447.PNG">

(Not clear why the LaTeX renders as it does, it is a correct LaTeX expression...)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Added printing of OneMatrix to str, pretty, and MathML presentation printers.
<!-- END RELEASE NOTES -->
