### PR TITLE
Added functions to evaluate maxima and minima

### DIFF
--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -6,7 +6,7 @@ from .singularities import (singularities, is_increasing,
                             is_strictly_decreasing, is_monotonic)
 from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff, differentiate_finite
 from .util import (periodicity, not_empty_in, AccumBounds, is_convex,
-                   stationary_points, minimum, maximum)
+                   stationary_points, minimum, maximum, maxima, minima)
 
 __all__ = [
 'euler_equations',
@@ -18,5 +18,5 @@ __all__ = [
 'finite_diff_weights', 'apply_finite_diff', 'as_finite_diff', 'differentiate_finite',
 
 'periodicity', 'not_empty_in', 'AccumBounds', 'is_convex', 'stationary_points',
-'minimum', 'maximum'
+'minimum', 'maximum', 'maxima', 'minima'
 ]

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -3,7 +3,7 @@ from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
                    ImageSet)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex,
-                                 stationary_points, minimum, maximum)
+                                 stationary_points, minimum, maximum, maxima, minima)
 from sympy.core import Add, Mul, Pow
 from sympy.sets.sets import (Interval, FiniteSet, EmptySet, Complement,
                             Union, Intersection)
@@ -269,6 +269,52 @@ def test_minimum():
     raises(ValueError, lambda : minimum(sin(x), sin(x)))
     raises(ValueError, lambda : minimum(sin(x), x*y, S.EmptySet))
     raises(ValueError, lambda : minimum(sin(x), S(1)))
+
+def test_maxima():
+    from sympy import Integers
+    x, y, n = symbols('x y n')
+    assert maxima(sin(x), x) == ImageSet(Lambda(n, 2*pi*n + pi/2), Integers)
+    assert maxima(sin(x), x, Interval(0, 2*pi)) == {pi/2}
+    assert maxima(sin(x)-x, x) == EmptySet()
+    assert maxima(x - x**3, x, Interval(0, 2)) == {sqrt(3)/3} 
+    assert maxima(sin(x)**2, x, Interval(-2*pi, 2*pi)) == {-3*pi/2, -pi/2, pi/2, 3*pi/2}
+    assert maxima(sin(x)*cos(x), x, Interval(0,2*pi)) == {pi/4, 5*pi/4}
+    assert maxima((x+3)*(x-2), x) == EmptySet()
+    assert maxima((x+3)/(x-2), x) == EmptySet()
+    #assert maxima(x**5-3*x**3+2*x**2+6, x) == {-1/2 + sqrt(105)/10, -sqrt(105)/10 - 1/2}
+    assert maxima(exp(x), x) == EmptySet()
+    assert maxima(log(x) - x, x) == {1}
+    assert maxima(y, x) == EmptySet()
+
+    raises(ValueError, lambda : maxima(sin(x), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(log(cos(x)), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(1/(x**2 + y**2 + 1), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(sin(x), sin(x)))
+    raises(ValueError, lambda : maxima(sin(x), x*y, S.EmptySet))
+    raises(ValueError, lambda : maxima(sin(x), S(1)))
+
+def test_minima():
+    from sympy import Integers
+    x, y, n = symbols('x y n')
+    assert minima(sin(x), x) == ImageSet(Lambda(n, 2*pi*n + 3*pi/2), Integers)
+    assert minima(sin(x), x, Interval(0, 2*pi)) == {3*pi/2}
+    assert minima(sin(x)-x, x) == EmptySet()
+    assert minima(x - x**3, x, Interval(-1, 2)) == {-sqrt(3)/3}
+    assert minima(sin(x)**2, x, Interval(-pi/2, pi/2)) == {0}
+    assert minima(sin(x)*cos(x), x, Interval(0,2*pi)) == {3*pi/4, 7*pi/4}
+    #assert minima((x+3)*(x-2), x) == {-1/2}
+    assert minima((x+3)/(x-2), x) == EmptySet()
+    assert minima(x**5-3*x**3+2*x**2+6, x) == {0, 1}
+    assert minima(exp(x), x) == EmptySet()
+    assert minima(log(x) - x, x) == EmptySet()
+    assert minima(y, x) == EmptySet()
+
+    raises(ValueError, lambda : maxima(sin(x), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(log(cos(x)), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(1/(x**2 + y**2 + 1), x, S.EmptySet))
+    raises(ValueError, lambda : maxima(sin(x), sin(x)))
+    raises(ValueError, lambda : maxima(sin(x), x*y, S.EmptySet))
+    raises(ValueError, lambda : maxima(sin(x), S(1)))
 
 def test_AccumBounds():
     assert AccumBounds(1, 2).args == (1, 2)

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -276,9 +276,9 @@ def test_maxima():
     assert maxima(sin(x), x) == ImageSet(Lambda(n, 2*pi*n + pi/2), Integers)
     assert maxima(sin(x), x, Interval(0, 2*pi)) == {pi/2}
     assert maxima(sin(x)-x, x) == EmptySet()
-    assert maxima(x - x**3, x, Interval(0, 2)) == {sqrt(3)/3} 
+    assert maxima(x - x**3, x, Interval(0, 2)) == {sqrt(3)/3}
     assert maxima(sin(x)**2, x, Interval(-2*pi, 2*pi)) == {-3*pi/2, -pi/2, pi/2, 3*pi/2}
-    assert maxima(sin(x)*cos(x), x, Interval(0,2*pi)) == {pi/4, 5*pi/4}
+    assert maxima(sin(x)*cos(x), x, Interval(0, 2*pi)) == {pi/4, 5*pi/4}
     assert maxima((x+3)*(x-2), x) == EmptySet()
     assert maxima((x+3)/(x-2), x) == EmptySet()
     #assert maxima(x**5-3*x**3+2*x**2+6, x) == {-1/2 + sqrt(105)/10, -sqrt(105)/10 - 1/2}
@@ -301,7 +301,7 @@ def test_minima():
     assert minima(sin(x)-x, x) == EmptySet()
     assert minima(x - x**3, x, Interval(-1, 2)) == {-sqrt(3)/3}
     assert minima(sin(x)**2, x, Interval(-pi/2, pi/2)) == {0}
-    assert minima(sin(x)*cos(x), x, Interval(0,2*pi)) == {3*pi/4, 7*pi/4}
+    assert minima(sin(x)*cos(x), x, Interval(0, 2*pi)) == {3*pi/4, 7*pi/4}
     #assert minima((x+3)*(x-2), x) == {-1/2}
     assert minima((x+3)/(x-2), x) == EmptySet()
     assert minima(x**5-3*x**3+2*x**2+6, x) == {0, 1}

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -883,7 +883,7 @@ def maxima(f, symbol, domain=S.Reals):
     if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Maxima not defined for empty domain.")
-        
+
         diff1 = diff(f, symbol)
         period = periodicity(diff1, symbol)
         diff2 = diff(diff1, symbol)
@@ -898,8 +898,7 @@ def maxima(f, symbol, domain=S.Reals):
                 n = Symbol('n')
                 solution += imageset(n, n*period+x, S.Integers)
             return solution
-        
-        
+
     else:
         raise ValueError("%s is not a valid symbol." % symbol)
 
@@ -947,7 +946,7 @@ def minima(f, symbol, domain=S.Reals):
     if isinstance(symbol, Symbol):
         if isinstance(domain, EmptySet):
             raise ValueError("Minima not defined for empty domain.")
-        
+
         diff1 = diff(f, symbol)
         period = periodicity(diff1, symbol)
         diff2 = diff(diff1, symbol)
@@ -962,7 +961,7 @@ def minima(f, symbol, domain=S.Reals):
                 n = Symbol('n')
                 solution += imageset(n, n*period+x, S.Integers)
             return solution
-        
+
     else:
         raise ValueError("%s is not a valid symbol." % symbol)
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -840,6 +840,131 @@ def minimum(f, symbol, domain=S.Reals):
     else:
         raise ValueError("%s is not a valid symbol." % symbol)
 
+def maxima(f, symbol, domain=S.Reals):
+    """
+    Returns the maxima of a function in the given domain.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The concerned function.
+    symbol : Symbol
+        The variable for maxima needs to be determined.
+    domain : Interval
+        The domain over which the maxima have to be checked.
+        If unspecified, S.Reals will be the default domain.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, S, sin, cos, pi, maxima
+    >>> from sympy.sets import Interval
+    >>> x = Symbol('x')
+
+    >>> f = x**3 - x**2 + 1
+    >>> maxima(f, x)
+    {0}
+
+    >>> maxima(sin(x), x, Interval(-2*pi, 7*pi))
+    {-3*pi/2, pi/2, 5*pi/2, 9*pi/2, 13*pi/2}
+
+    >>> maxima(sin(x)*cos(x), x)
+    ImageSet(Lambda(n, pi*n + pi/4), Integers)
+
+    >>> maxima(sin(x)*cos(x) + x, x)
+    EmptySet()
+
+    """
+    from sympy import Symbol, diff
+    from sympy.solvers.solveset import solveset
+    from sympy.sets.sets import imageset
+
+    if isinstance(symbol, Symbol):
+        if isinstance(domain, EmptySet):
+            raise ValueError("Maxima not defined for empty domain.")
+        
+        diff1 = diff(f, symbol)
+        period = periodicity(diff1, symbol)
+        diff2 = diff(diff1, symbol)
+        if period is None or domain is not S.Reals:
+            stationary_points_set = solveset(diff1, symbol, domain)
+            return solveset(diff2 < 0, symbol, stationary_points_set)
+        else:
+            stationary_points_set = solveset(diff1, symbol, Interval(0, period))
+            maxima_in_one_period = solveset(diff2 < 0, symbol, stationary_points_set)
+            solution = EmptySet()
+            for x in maxima_in_one_period:
+                n = Symbol('n')
+                solution += imageset(n, n*period+x, S.Integers)
+            return solution
+        
+        
+    else:
+        raise ValueError("%s is not a valid symbol." % symbol)
+
+
+def minima(f, symbol, domain=S.Reals):
+    """
+    Returns the minima of a function in the given domain.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The concerned function.
+    symbol : Symbol
+        The variable for minima needs to be determined.
+    domain : Interval
+        The domain over which the minima have to be checked.
+        If unspecified, S.Reals will be the default domain.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, S, sin, cos, pi, minima
+    >>> from sympy.sets import Interval
+    >>> x = Symbol('x')
+
+    >>> f = x**3 - x**2 + 1
+    >>> minima(f, x)
+    {2/3}
+
+    >>> minima(sin(x), x, Interval(-2*pi, 7*pi))
+    {-pi/2, 3*pi/2, 7*pi/2, 11*pi/2}
+
+    >>> minima(sin(x)*cos(x), x)
+    ImageSet(Lambda(n, pi*n + 3*pi/4), Integers)
+
+    >>> minima(sin(x)*cos(x) + x, x)
+    EmptySet()
+
+    """
+    from sympy import Symbol, diff
+    from sympy.solvers.solveset import solveset
+    from sympy.sets.sets import imageset
+
+    if isinstance(symbol, Symbol):
+        if isinstance(domain, EmptySet):
+            raise ValueError("Minima not defined for empty domain.")
+        
+        diff1 = diff(f, symbol)
+        period = periodicity(diff1, symbol)
+        diff2 = diff(diff1, symbol)
+        if period is None or domain is not S.Reals:
+            stationary_points_set = solveset(diff1, symbol, domain)
+            return solveset(diff2 > 0, symbol, stationary_points_set)
+        else:
+            stationary_points_set = solveset(diff1, symbol, Interval(0, period))
+            maxima_in_one_period = solveset(diff2 > 0, symbol, stationary_points_set)
+            solution = EmptySet()
+            for x in maxima_in_one_period:
+                n = Symbol('n')
+                solution += imageset(n, n*period+x, S.Integers)
+            return solution
+        
+    else:
+        raise ValueError("%s is not a valid symbol." % symbol)
 
 class AccumulationBounds(AtomicExpr):
     r"""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Implement part of #16520

#### Brief description of what is fixed or changed
In `calculus/util.py`

- Added maxima(): This function returns set of maxima of a function in the given domain.
- Added minima(): This function returns set of minima of a function in the given domain.

In `calculus/tests/test_util.py`
- Added test_maxima(): This function tests the correctness of maxima.
- Added test_minima(): This function tests the correctness of minima.
#### Other comments
1. The maxima and minima currently only work when the function is second order differentiable.
2. In some cases, the function returns correct result but the equal return false. (I commented out line 284 and line 305 in the file sympy/calculus/tests/test_util.) I will be very grateful if anyone could tell me the reason.
```
>>> minima((x+3)*(x-2), x) 
{-1/2}
>>> minima((x+3)*(x-2), x) == {-1/2}
False
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * Added `minima` and `maxima` to find minima and maxima, respectively of a function in a given domain

<!-- END RELEASE NOTES -->
