### PR TITLE
Matrices : Faster matrices creation

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -453,6 +453,22 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         self._mat = flat_list
         return self
 
+    @classmethod
+    def _from_flattened_list(cls, rows, cols, flat_list):
+        """Private matrix creation method without sympify.
+
+        Parameters
+        ==========
+
+        rows, cols : Integer
+        mat : list
+        """
+        self = object.__new__(cls)
+        self.rows = rows
+        self.cols = cols
+        self._mat = flat_list
+        return self
+
     def __setitem__(self, key, value):
         """
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2656,11 +2656,7 @@ class MatrixBase(MatrixDeprecated,
         the row are matrices
         """
         def ismat(i):
-            if evaluate:
-                return isinstance(i, MatrixBase)
-            return isinstance(i, MatrixBase) and \
-                (isinstance(i, BlockMatrix) or \
-                isinstance(i, MatrixSymbol))
+            return isinstance(i, MatrixBase)
 
         flat_list = []
         ncol = set()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2448,6 +2448,21 @@ class MatrixBase(MatrixDeprecated,
     def _handle_creation_inputs(cls, *args, **kwargs):
         """Return the number of rows, cols and flat matrix elements.
 
+        Parameters
+        ==========
+
+        callback_sympy_indices : Boolean, optional
+            If ``True``, it passes SymPy ``Integer`` type as arguments
+            for the callback function.
+
+            If ``False``, it passes python's ``int`` type as arguments
+            for the callback function.
+
+            It only affects the creation of a matrix from the 3
+            arguments, specified as ``rows, cols, func``.
+
+            Default is ``True``
+
         Examples
         ========
 
@@ -2636,9 +2651,19 @@ class MatrixBase(MatrixDeprecated,
 
             # Matrix(2, 2, lambda i, j: i+j)
             if len(args) == 3 and isinstance(args[2], Callable):
+                callback_sympy_indices = \
+                    kwargs.get('callback_sympy_indices', True)
+
                 op = args[2]
                 flat_list = []
-                rows_range = cols_range = [cls._sympify(i) for i in range(max(rows, cols))]
+
+                if callback_sympy_indices:
+                    rows_range = cols_range = \
+                        [cls._sympify(i) for i in range(max(rows, cols))]
+                else:
+                    rows_range = cols_range = \
+                        [i for i in range(max(rows, cols))]
+
                 if rows < cols:
                     rows_range = rows_range[:rows]
                 elif cols < rows:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2446,7 +2446,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _eval_handle_creation_inputs_ndarray(cls, arg):
+    def _handle_ndarray(cls, arg):
         """NumPy array or matrix or some other object that implements
         __array__. So let's first use this method to get a numpy.array()
         and then make a python list out of it.
@@ -2698,7 +2698,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _eval_handle_creation_inputs_sequence(cls, arg, evaluate=True):
+    def _handle_sequence(cls, arg, evaluate=True):
         from sympy.matrices.expressions.matexpr import MatrixSymbol
         from sympy.matrices.expressions.blockmatrix import BlockMatrix
 
@@ -2851,13 +2851,12 @@ class MatrixBase(MatrixDeprecated,
 
             # Matrix(numpy.ones((2, 2)))
             if hasattr(args[0], "__array__"):
-                return cls._eval_handle_creation_inputs_ndarray(args[0])
+                return cls._handle_ndarray(args[0])
 
             # Matrix([1, 2, 3]) or Matrix([[1, 2], [3, 4]])
             if is_sequence(args[0]) and \
                 not isinstance(args[0], DeferredVector):
-                return cls._eval_handle_creation_inputs_sequence(
-                    args[0], evaluate=evaluate)
+                return cls._handle_sequence(args[0], evaluate=evaluate)
 
         elif len(args) == 3:
             rows = as_int(args[0])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2470,7 +2470,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_column_vector(cls, dat):
+    def _handle_column_vector(cls, dat, evaluate=True):
         """Creation input handler for a 1D list containing scalars or
         matrix-like entries.
 
@@ -2565,7 +2565,7 @@ class MatrixBase(MatrixDeprecated,
         flat_list = []
 
         for i in dat:
-            if ismat(i):
+            if ismat(i) and evaluate:
                 flat_list.extend(i._mat)
                 if any(i.shape):
                     ncol.add(i.cols)
@@ -2592,7 +2592,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_row_vector(cls, dat):
+    def _handle_row_vector(cls, dat, evaluate=True):
         # Transpose every matrix entries before passig to the column
         # vector processor and transpose it back to get the row
         # vector form.
@@ -2604,7 +2604,7 @@ class MatrixBase(MatrixDeprecated,
             else:
                 dat_new.append(i)
 
-        rows, cols, flat_list = cls._handle_column_vector(dat_new)
+        rows, cols, flat_list = cls._handle_column_vector(dat_new, evaluate=evaluate)
 
         T = reshape(flat_list, [cols])
         flat_list = [T[i][j] for j in range(cols) for i in range(rows)]
@@ -2613,7 +2613,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_list_of_lists(cls, dat):
+    def _handle_list_of_lists(cls, dat, evaluate=True):
         """Creation handler for a 2D structure.
 
         Parameters
@@ -2642,6 +2642,9 @@ class MatrixBase(MatrixDeprecated,
         def ismat(i):
             return isinstance(i, MatrixBase)
 
+        def raw(i):
+            return is_sequence(i) and not ismat(i)
+
         flat_list = []
         ncol = set()
         rows = cols = 0
@@ -2650,12 +2653,12 @@ class MatrixBase(MatrixDeprecated,
             if not row:
                 continue
 
-            if ismat(row):
+            if ismat(row) and evaluate:
                 r, c = row.shape
                 flat = row._mat
 
-            elif is_sequence(row):
-                r, c, flat = cls._handle_row_vector(row)
+            elif raw(row):
+                r, c, flat = cls._handle_row_vector(row, evaluate=evaluate)
 
             else:
                 r = c = 1
@@ -2709,7 +2712,7 @@ class MatrixBase(MatrixDeprecated,
         if dat == [] or dat == [[]]:
             return 0, 0, []
 
-        return cls._handle_list_of_lists(dat)
+        return cls._handle_list_of_lists(dat, evaluate=evaluate)
 
 
     @classmethod

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2638,8 +2638,11 @@ class MatrixBase(MatrixDeprecated,
             if len(args) == 3 and isinstance(args[2], Callable):
                 op = args[2]
                 flat_list = []
-                rows_range = [cls._sympify(i) for i in range(rows)]
-                cols_range = [cls._sympify(j) for j in range(cols)]
+                rows_range = cols_range = [cls._sympify(i) for i in range(max(rows, cols))]
+                if rows < cols:
+                    rows_range = rows_range[:rows]
+                elif cols < rows:
+                    cols_range = cols_range[:cols]
                 for i in rows_range:
                     flat_list.extend(
                         [cls._sympify(op(i, j)) for j in cols_range])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2622,8 +2622,7 @@ class MatrixBase(MatrixDeprecated,
 
         for i in dat:
             if ismat(i):
-                flat_list.extend(
-                    [k for j in i.tolist() for k in j])
+                flat_list.extend(i._mat)
                 if any(i.shape):
                     ncol.add(i.cols)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2574,6 +2574,11 @@ class MatrixBase(MatrixDeprecated,
                 if i:
                     ncol.add(len(i))
                     flat_list.extend(i)
+                else:
+                    # XXX Hack to allow empty container to be used
+                    # as a matrix element
+                    ncol.add(1)
+                    flat_list.append(i)
 
             else:
                 ncol.add(1)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2640,7 +2640,7 @@ class MatrixBase(MatrixDeprecated,
                 flat_list = []
                 for i in range(rows):
                     flat_list.extend(
-                        [cls._sympify(op(cls._sympify(i), cls._sympify(j)))
+                        [cls._sympify(op(i, j))
                          for j in range(cols)])
 
             # Matrix(2, 2, [1, 2, 3, 4])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2655,9 +2655,6 @@ class MatrixBase(MatrixDeprecated,
         rows = cols = 0
 
         for row in dat:
-            if not row:
-                continue
-
             if ismat(row) and evaluate:
                 r, c = row.shape
                 flat = row._mat

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2675,7 +2675,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_list_of_lists(cls, dat, evaluate=True):
+    def _handle_list_of_lists(cls, dat):
         """Creation handler for a 2D structure.
 
         Parameters
@@ -2791,7 +2791,7 @@ class MatrixBase(MatrixDeprecated,
         if evaluate and any(ismat(i) for i in dat):
             return cls._handle_list_of_matrixlikes(dat)
 
-        return cls._handle_list_of_lists(dat, evaluate=evaluate)
+        return cls._handle_list_of_lists(dat)
 
 
     @classmethod

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2708,6 +2708,8 @@ class MatrixBase(MatrixDeprecated,
 
             dat = do(dat)
 
+        dat = cls._sympify(dat)
+
         # Empty matrix
         if dat == [] or dat == [[]]:
             return 0, 0, []

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2658,6 +2658,28 @@ class MatrixBase(MatrixDeprecated,
         dat : list of lists
             Each sublist is a logical row which might consist of many
             rows if the values in the row are matrices.
+
+        Examples
+        ========
+
+        A row block matrix:
+
+        >>> from sympy.matrices import Matrix
+        >>> Matrix._handle_list_of_lists(
+        ...     [[Matrix([[1, 2], [3, 4]]), Matrix([[5, 6], [7, 8]])]])
+        (2, 4, [1, 2, 5, 6, 3, 4, 7, 8])
+
+        A column block matrix:
+
+        >>> Matrix._handle_list_of_lists(
+        ...     [Matrix([[1, 2], [3, 4]]), Matrix([[5, 6], [7, 8]])])
+        (2, 1, [Matrix([
+            [1, 2],
+            [3, 4]]), Matrix([
+            [5, 6],
+            [7, 8]])])
+
+        TODO Possible logic flaw
         """
         def ismat(i):
             return isinstance(i, MatrixBase)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2526,7 +2526,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_list_of_matrixlikes(cls, dat):
+    def _handle_column_vector(cls, dat):
         """Creation input handler for a 1D list containing scalars or
         matrix-like entries.
 
@@ -2551,58 +2551,58 @@ class MatrixBase(MatrixDeprecated,
             Creating a matrix from explicit matrices:
 
             >>> from sympy.matrices import Matrix, ones, zeros
-            >>> Matrix._handle_list_of_matrixlikes(
+            >>> Matrix._handle_column_vector(
             ...     [ones(2, 2), zeros(1, 2)])
             (3, 2, [1, 1, 1, 1, 0, 0])
 
             Truncating empty matrices:
 
-            >>> Matrix._handle_list_of_matrixlikes(
+            >>> Matrix._handle_column_vector(
             ...     [ones(2, 2), ones(0, 0)])
             (2, 2, [1, 1, 1, 1])
 
             Pure lists:
 
-            >>> Matrix._handle_list_of_matrixlikes(
+            >>> Matrix._handle_column_vector(
             ...     [[1, 2], [3, 4], [5, 6]])
             (3, 2, [1, 2, 3, 4, 5, 6])
 
             Matrices mixed with lists:
 
-            >>> Matrix._handle_list_of_matrixlikes([ones(2, 2), [0, 0]])
+            >>> Matrix._handle_column_vector([ones(2, 2), [0, 0]])
             (3, 2, [1, 1, 1, 1, 0, 0])
 
             Empty matrix:
 
-            >>> Matrix._handle_list_of_matrixlikes([list(), Matrix()])
+            >>> Matrix._handle_column_vector([list(), Matrix()])
             (0, 0, [])
 
         Examples with scalars:
 
             Only scalars:
 
-            >>> Matrix._handle_list_of_matrixlikes([1, 2, 3])
+            >>> Matrix._handle_column_vector([1, 2, 3])
             (3, 1, [1, 2, 3])
 
             Scalars mixed with 1*1 matrices:
 
-            >>> Matrix._handle_list_of_matrixlikes([Matrix([1]), 2, 3])
+            >>> Matrix._handle_column_vector([Matrix([1]), 2, 3])
             (3, 1, [1, 2, 3])
 
             Scalars mixed with empty matrices:
 
-            >>> Matrix._handle_list_of_matrixlikes([Matrix(), 2, 3])
+            >>> Matrix._handle_column_vector([Matrix(), 2, 3])
             (2, 1, [2, 3])
 
             Scalars mixed with column vector:
 
-            >>> Matrix._handle_list_of_matrixlikes(
+            >>> Matrix._handle_column_vector(
             ...     [Matrix([1, 2]), 3, 4])
             (4, 1, [1, 2, 3, 4])
 
             Salars mixed with matrix-like sequence:
 
-            >>> Matrix._handle_list_of_matrixlikes([[1], 2, 3])
+            >>> Matrix._handle_column_vector([[1], 2, 3])
             (3, 1, [1, 2, 3])
 
         See Also
@@ -2777,7 +2777,7 @@ class MatrixBase(MatrixDeprecated,
 
         # A column as a list of matrix-like values
         if evaluate and any(ismat(i) for i in dat):
-            return cls._handle_list_of_matrixlikes(dat)
+            return cls._handle_column_vector(dat)
 
         return cls._handle_list_of_lists(dat)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2699,13 +2699,7 @@ class MatrixBase(MatrixDeprecated,
 
         >>> Matrix._handle_list_of_lists(
         ...     [Matrix([[1, 2], [3, 4]]), Matrix([[5, 6], [7, 8]])])
-        (2, 1, [Matrix([
-            [1, 2],
-            [3, 4]]), Matrix([
-            [5, 6],
-            [7, 8]])])
-
-        TODO Possible logic flaw
+        (4, 2, [1, 2, 3, 4, 5, 6, 7, 8])
         """
         def ismat(i):
             return isinstance(i, MatrixBase)
@@ -2723,10 +2717,9 @@ class MatrixBase(MatrixDeprecated,
             if not row:
                 continue
 
-            # XXX WIP for flattening single matrix
             if is_Matrix:
-                r = c = 1
-                flat = [row]
+                r, c = row.shape
+                flat = row._mat
             else:
                 r, c, flat = cls._handle_list_of_matrixlikes_row(row)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2650,10 +2650,14 @@ class MatrixBase(MatrixDeprecated,
 
     @classmethod
     def _handle_list_of_lists(cls, dat, evaluate=True):
-        """
-        list of lists; each sublist is a logical row
-        which might consist of many rows if the values in
-        the row are matrices
+        """Creation handler for a 2D structure.
+
+        Parameters
+        ==========
+
+        dat : list of lists
+            Each sublist is a logical row which might consist of many
+            rows if the values in the row are matrices.
         """
         def ismat(i):
             return isinstance(i, MatrixBase)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2638,10 +2638,11 @@ class MatrixBase(MatrixDeprecated,
             if len(args) == 3 and isinstance(args[2], Callable):
                 op = args[2]
                 flat_list = []
-                for i in range(rows):
+                rows_range = [cls._sympify(i) for i in range(rows)]
+                cols_range = [cls._sympify(j) for j in range(cols)]
+                for i in rows_range:
                     flat_list.extend(
-                        [cls._sympify(op(i, j))
-                         for j in range(cols)])
+                        [cls._sympify(op(i, j)) for j in cols_range])
 
             # Matrix(2, 2, [1, 2, 3, 4])
             elif len(args) == 3 and is_sequence(args[2]):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2468,8 +2468,12 @@ class MatrixBase(MatrixDeprecated,
 
             If ``False``, it skips the process.
 
-            This flag is unsafe for use if the input is not guaranteed
-            to be sanitized.
+            This flag is unsafe for use if the callabck returns python
+            ``int``, or ``float`` other than SymPy's ``Integer`` or
+            ``Float``, or any other SymPy's native types.
+
+            It only affects the creation of a matrix from the 3
+            arguments, specified as ``rows, cols, func``.
 
             Default is ``True``.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2470,7 +2470,7 @@ class MatrixBase(MatrixDeprecated,
 
 
     @classmethod
-    def _handle_list_of_matrices(cls, dat, evaluate=True):
+    def _handle_list_of_matrices(cls, dat):
         """A creation input handler for a 1D list purely containing
         matrices.
 

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -128,8 +128,13 @@ class SparseMatrix(MatrixBase):
 
             if isinstance(args[2], Callable):
                 op = args[2]
-                rows_range = [cls._sympify(i) for i in range(self.rows)]
-                cols_range = [cls._sympify(j) for j in range(self.cols)]
+                rows = self.rows
+                cols = self.cols
+                rows_range = cols_range = [cls._sympify(i) for i in range(max(rows, cols))]
+                if rows < cols:
+                    rows_range = rows_range[:rows]
+                elif cols < rows:
+                    cols_range = cols_range[:cols]
                 for i in rows_range:
                     for j in cols_range:
                         value = self._sympify(op(i, j))

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -130,8 +130,7 @@ class SparseMatrix(MatrixBase):
                 op = args[2]
                 for i in range(self.rows):
                     for j in range(self.cols):
-                        value = self._sympify(
-                            op(self._sympify(i), self._sympify(j)))
+                        value = self._sympify(op(i, j))
                         if value:
                             self._smat[i, j] = value
             elif isinstance(args[2], (dict, Dict)):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -128,8 +128,8 @@ class SparseMatrix(MatrixBase):
 
             if isinstance(args[2], Callable):
                 op = args[2]
-                rows_range = [cls._sympify(i) for i in range(rows)]
-                cols_range = [cls._sympify(j) for j in range(cols)]
+                rows_range = [cls._sympify(i) for i in range(self.rows)]
+                cols_range = [cls._sympify(j) for j in range(self.cols)]
                 for i in rows_range:
                     for j in cols_range:
                         value = self._sympify(op(i, j))

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -128,8 +128,10 @@ class SparseMatrix(MatrixBase):
 
             if isinstance(args[2], Callable):
                 op = args[2]
-                for i in range(self.rows):
-                    for j in range(self.cols):
+                rows_range = [cls._sympify(i) for i in range(rows)]
+                cols_range = [cls._sympify(j) for j in range(cols)]
+                for i in rows_range:
+                    for j in cols_range:
                         value = self._sympify(op(i, j))
                         if value:
                             self._smat[i, j] = value

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -42,8 +42,12 @@ class SparseMatrix(MatrixBase):
 
         If ``False``, it skips the process.
 
-        This flag is unsafe for use if the input is not guaranteed
-        to be sanitized.
+        This flag is unsafe for use if the callabck returns python
+        ``int``, or ``float`` other than SymPy's ``Integer`` or
+        ``Float``, or any other SymPy's native types.
+
+        It only affects the creation of a matrix from the 3
+        arguments, specified as ``rows, cols, func``.
 
         Default is ``True``.
 

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -22,6 +22,21 @@ class SparseMatrix(MatrixBase):
     """
     A sparse matrix (a matrix with a large number of zero elements).
 
+    Parameters
+    ==========
+
+    callback_sympy_indices : Boolean, optional
+        If ``True``, it passes SymPy ``Integer`` type as arguments for
+        the callback function.
+
+        If ``False``, it passes python's ``int`` type as arguments for
+        the callback function.
+
+        It only affects the creation of a matrix from the 3 arguments,
+        specified as ``rows, cols, func``.
+
+        Default is ``True``
+
     Examples
     ========
 
@@ -130,7 +145,17 @@ class SparseMatrix(MatrixBase):
                 op = args[2]
                 rows = self.rows
                 cols = self.cols
-                rows_range = cols_range = [cls._sympify(i) for i in range(max(rows, cols))]
+
+                callback_sympy_indices = \
+                    kwargs.get('callback_sympy_indices', True)
+
+                if callback_sympy_indices:
+                    rows_range = cols_range = \
+                        [cls._sympify(i) for i in range(max(rows, cols))]
+                else:
+                    rows_range = cols_range = \
+                        [i for i in range(max(rows, cols))]
+
                 if rows < cols:
                     rows_range = rows_range[:rows]
                 elif cols < rows:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -379,7 +379,7 @@ def test_creation_16723():
             sympify_callback_arguments=False,
             sympify_callback_return=True
             ).tolist() == \
-                [[S(1), S(1)/2], [S(1)/2, S(1)/3]]
+                [[1, 1/2], [1/2, 1/3]]
 
     assert Matrix(
             2, 2, lambda i, j: 1 / (i + j + 1),

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -330,6 +330,65 @@ def test_creation():
     raises(ValueError, lambda: Matrix([ones(2), ones(3, 0)]))
 
 
+def test_creation_16723():
+    # Tests for callback input and output sanitization
+    assert Matrix(
+            2, 2, lambda i, j: i + j,
+            sympify_callback_arguments=True,
+            sympify_callback_return=True
+            ).tolist() == \
+                [[S(0), S(1)], [S(1), S(2)]]
+
+    assert Matrix(
+            2, 2, lambda i, j: i + j,
+            sympify_callback_arguments=True,
+            sympify_callback_return=False
+            ).tolist() == \
+                [[S(0), S(1)], [S(1), S(2)]]
+
+    assert Matrix(
+            2, 2, lambda i, j: i + j,
+            sympify_callback_arguments=False,
+            sympify_callback_return=True
+            ).tolist() == \
+                [[S(0), S(1)], [S(1), S(2)]]
+
+    assert Matrix(
+            2, 2, lambda i, j: i + j,
+            sympify_callback_arguments=False,
+            sympify_callback_return=False
+            ).tolist() == \
+                [[0, 1], [1, 2]]
+
+    assert Matrix(
+            2, 2, lambda i, j: 1 / (i + j + 1),
+            sympify_callback_arguments=True,
+            sympify_callback_return=True
+            ).tolist() == \
+                [[S(1), S(1)/2], [S(1)/2, S(1)/3]]
+
+    assert Matrix(
+            2, 2, lambda i, j: 1 / (i + j + 1),
+            sympify_callback_arguments=True,
+            sympify_callback_return=False
+            ).tolist() == \
+                [[S(1), S(1)/2], [S(1)/2, S(1)/3]]
+
+    assert Matrix(
+            2, 2, lambda i, j: 1 / (i + j + 1),
+            sympify_callback_arguments=False,
+            sympify_callback_return=True
+            ).tolist() == \
+                [[S(1), S(1)/2], [S(1)/2, S(1)/3]]
+
+    assert Matrix(
+            2, 2, lambda i, j: 1 / (i + j + 1),
+            sympify_callback_arguments=False,
+            sympify_callback_return=False
+            ).tolist() == \
+                [[1, 1/2], [1/2, 1/3]]
+
+
 def test_irregular_block():
     assert Matrix.irregular(3, ones(2,1), ones(3,3)*2, ones(2,2)*3,
         ones(1,1)*4, ones(2,2)*5, ones(1,2)*6, ones(1,2)*7) == Matrix([


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16374

#### Brief description of what is fixed or changed

There are some slowdowns in creating the matrix, and I think one is from `sympify`
```python
from sympy import *
from pyinstrument import Profiler

profiler = Profiler()
profiler.start()

MutableDenseMatrix(1000, 1000, lambda i, j: i+j)

profiler.stop()

print(profiler.output_text(unicode=True, color=True))
```
```

  _     ._   __/__   _ _  _  _ _/_   Recorded: 04:48:46  Samples:  4116
 /_//_/// /_\ / //_// / //_'/ //     Duration: 6.645     CPU time: 6.609
/   _/                      v3.0.1

6.655 run_code  IPython\core\interactiveshell.py:3259
└─ 6.655 <module>  <ipython-input-2-3baea188ae1d>:7
   └─ 6.608 __new__  sympy\matrices\dense.py:432
      └─ 6.608 _new  sympy\matrices\dense.py:435
         └─ 6.591 _handle_creation_inputs  sympy\matrices\matrices.py:2287
            └─ 6.531 <listcomp>  sympy\matrices\matrices.py:2483
               ├─ 3.578 sympify  sympy\core\sympify.py:78
               │  ├─ 2.023 [self]  
               │  ├─ 1.436 wrapper  sympy\core\cache.py:92
               │  │  ├─ 1.025 __new__  sympy\core\numbers.py:1930
               │  │  │  ├─ 0.750 __new__  sympy\core\basic.py:96
               │  │  │  └─ 0.275 [self]  
               │  │  └─ 0.411 [self]  
               │  └─ 0.120 __hash__  sympy\core\numbers.py:2128
               ├─ 1.781 <lambda>  <ipython-input-2-3baea188ae1d>:7
               │  ├─ 1.603 __add__  sympy\core\numbers.py:2003
               │  │  ├─ 1.036 wrapper  sympy\core\cache.py:92
               │  │  │  ├─ 0.743 __new__  sympy\core\numbers.py:1930
               │  │  │  │  ├─ 0.457 [self]  
               │  │  │  │  └─ 0.286 __new__  sympy\core\basic.py:96
               │  │  │  └─ 0.293 [self]  
               │  │  └─ 0.567 [self]  
               │  └─ 0.178 [self]  
               └─ 1.171 [self]  
```
I have replaced `sympify` with `_sympify`, regarding the comment in https://github.com/sympy/sympy/issues/15416#issuecomment-453690358
~~and also removed sympifying the index, which is not needed for lambdas written in pure python integer operations.~~
and also made it to iterate over already simpified list, which will make `sympify` call `M + N` times rather than calling sympify `M * N` times while iterating over all the matrix elements as previous.

Things seems like going faster with the creation input of index and lambda.
But I think that it is more contributed by the latter change, rather than the prior change though

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 14:10:44  Samples:  1509
 /_//_/// /_\ / //_// / //_'/ //     Duration: 2.177     CPU time: 2.156
/   _/                      v3.0.1
```

I had confirmed that Sparse Matrix follows the same speedup.
and it may need some performance investigation for, other ways of matrix creation from list or such.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Improved speed for matrix constructor using rows, cols, and function.
<!-- END RELEASE NOTES -->
