### PR TITLE
Update AUTHORS and .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -355,6 +355,7 @@ Peter Enenkel <peter.enenkel+git@gmail.com> <peter.enenkel+github@gmail.com>
 Jithin D. George <jithindgeorge93@gmail.com>
 Lev Chelyadinov <leva181777@gmail.com>
 Sourav Ghosh <souravghosh2197@gmail.com>
+Ethan Ward <etkewa@gmail.com> etkewa@gmail.com <qsRf9sGKy9rV>
 Ethan Ward <etkewa@gmail.com>
 Ethan Ward <etkewa@gmail.com> <ethanward@email.arizona.edu>
 Nilabja Bhattacharya <nilabja10201992@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -413,3 +413,7 @@ Bavish Kulur <bavishkulur@gmail.com> bavish2201 <bavishkulur@gmail.com>
 Divyanshu Thakur <divyanshu@iiitmanipur.ac.in> Divyanshu <divyanshu@iiitmanipur.ac.in>
 Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
+Salmista-94 <alejandrogroso@hotmail.com> alejandrogroso@hotmail.com <Salmista-94>
+Jack <ivanenko@ucu.edu.ua> LilJohny <ivanenko@ucu.edu.ua>
+Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.noreply.github.com>
+Rajiv Ranjan Singh <rajivperfect007@gmail.com> Rajiv Ranjan Singh <42106787+iamrajiv@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 823 authors.
+There are a total of 822 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -814,7 +814,6 @@ Parker Berry <parker.berry@marquette.edu>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
 Nabanita Dash <dashnabanita@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
-etkewa@gmail.com <qsRf9sGKy9rV>
 Ankit Pandey <pandeyan@grinnell.edu>
 Ritesh Kumar <ritesh99rakesh@gmail.com>
 kkkkx <709563092@qq.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,7 @@ those who explicitly didn't want to be mentioned. People with a * next
 to their names are not found in the metadata of the git history. This
 file is generated automatically by running `./bin/authors_update.py`.
 
-There are a total of 812 authors.
+There are a total of 823 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -785,7 +785,7 @@ Daniel Ingram <ingramds@appstate.edu>
 Jogi Miglani <jmig5776@gmail.com>
 Takumasa Nakamura <n.takumasa@gmail.com>
 Ritu Raj Singh <RituRajSingh878@gmail.com>
-Rajiv Ranjan Singh <42106787+iamrajiv@users.noreply.github.com>
+Rajiv Ranjan Singh <rajivperfect007@gmail.com>
 Vera Lozhkina <veralozhkina@gmail.com>
 adhoc-king <46354827+adhoc-king@users.noreply.github.com>
 Mikel Rouco <mikel.mrm@gmail.com>
@@ -808,13 +808,24 @@ dandiez <47832466+dandiez@users.noreply.github.com>
 Frédéric Chapoton <fchapoton2@gmail.com>
 jhanwar <f2015463@pilani.bits-pilani.ac.in>
 Noumbissi valere Gille Geovan <noumbissivalere@gmail.com>
-alejandrogroso@hotmail.com <Salmista-94>
+Salmista-94 <alejandrogroso@hotmail.com>
 Shivani Kohli <shivanikohli.09@gmail.com>
 Parker Berry <parker.berry@marquette.edu>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
-Nabanita Dash <31562743+Naba7@users.noreply.github.com>
+Nabanita Dash <dashnabanita@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
 etkewa@gmail.com <qsRf9sGKy9rV>
 Ankit Pandey <pandeyan@grinnell.edu>
 Ritesh Kumar <ritesh99rakesh@gmail.com>
 kkkkx <709563092@qq.com>
+wate123 <junlin0604@gmail.com>
+Corwinpro <corwinat@gmail.com>
+Anway De <anway1756@gmail.com>
+znxftw <vishnu2101@gmail.com>
+Jack <ivanenko@ucu.edu.ua>
+OrestisVaggelis <orestis22000@gmail.com>
+Nikhil Maan <nikhilmaan22@gmail.com>
+Abhinav Anand <abhinav.anand2807@gmail.com>
+sqs <googol.sqs@gmail.com>
+Juan Barbosa <js.barbosa10@uniandes.edu.co>
+Prionti Nasir <pdn3628@rit.edu>

--- a/bin/mailmap_update.py
+++ b/bin/mailmap_update.py
@@ -49,6 +49,11 @@ def author_name(line):
     assert line.endswith(">")
     return line.split("<", 1)[0].strip()
 
+def author_email(line):
+    assert line.count("<") == line.count(">") == 1
+    assert line.endswith(">")
+    return line.split("<", 1)[1][:-1].strip()
+
 sysexit = 0
 print(blue("checking git authors..."))
 
@@ -114,6 +119,41 @@ if multi:
         print()
         for e in sorted(dups[k]):
             print('\t%s' % e)
+
+bad_names = []
+bad_emails = []
+for i in git_people:
+    name = author_name(i)
+    email = author_email(i)
+    if '@' in name:
+        bad_names.append(i)
+    elif '@' not in email:
+        bad_emails.append(i)
+if bad_names:
+    print()
+    print(yellow(filldedent("""
+        The following people appear to have an email address
+        listed for their name. Entries should be added to
+        .mailmap so that names are formatted like
+        "Name <email address>".
+        """)))
+    for i in bad_names:
+        print("\t%s" % i)
+
+# TODO: Should we check for bad emails as well? Some people have empty email
+# addresses. The above check seems to catch people who get the name and email
+# backwards, so let's leave this alone for now.
+
+# if bad_emails:
+#     print()
+#     print(yellow(filldedent("""
+#         The following names do not appear to have valid
+#         emails. Entries should be added to .mailmap that
+#         use a proper email address. If there is no email
+#         address for a person, use "none@example.com".
+#         """)))
+#     for i in bad_emails:
+#         print("\t%s" % i)
 
 print()
 print(blue("checking .mailmap..."))


### PR DESCRIPTION
If anyone added here prefers a different name or email to be used, let me know.

I have also added a check to mailmap update for people whose names are email addresses (generally meaning they got the name and email fields backwards), and added some fixes to .mailmap.

We could also check for invalid emails (no @), but I have left this out for now as the above check seems sufficient. There is one person in the git history with an empty email, which would have to be replaced with a stand in email like none@example.com. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
