### PR TITLE
Fix bin/coverage_doctest.py by including skip_paths

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -565,6 +565,9 @@ if __name__ == "__main__":
     if os.path.isdir(sympy_dir):
         sys.path.insert(0, sympy_top)
 
+    # No paths are skipped, however this is included in coverage tests
+    skip_paths = []
+
     usage = "usage: ./bin/doctest_coverage.py PATHS"
 
     parser = ArgumentParser(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fix coverage_doctest.py [here](https://github.com/sympy/sympy/blob/master/bin/coverage_doctest.py) by including `skip_paths = []` (empty list)
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16716 

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Fixed a bug in coverage_doctest
<!-- END RELEASE NOTES -->
