### PR TITLE
Add has_module(numpy) in runtest_issue_15537

### DIFF
--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -143,6 +143,7 @@ def runtest_issue_10274(language, backend):
 
 
 def runtest_issue_15337(language, backend):
+    has_module('numpy')
     # NOTE : autowrap was originally designed to only accept an iterable for
     # the kwarg "helpers", but in issue 10274 the user mistakenly thought that
     # if there was only a single helper it did not need to be passed via an


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Adds a missing `has_module('numpy')` in `test_autowrap.py` [here](https://github.com/sympy/sympy/blob/b176f6a1d9890b42dc361857c887992315e3d5ad/sympy/external/tests/test_autowrap.py#L145)
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16728 


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
