### PR TITLE
reject nan, oo, -oo at Rational instantiation

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1477,6 +1477,7 @@ class Rational(Number):
 
     @cacheit
     def __new__(cls, p, q=None, gcd=None):
+        from sympy.polys.polyutils import _not_a_coeff
         if q is None:
             if isinstance(p, Rational):
                 return p
@@ -1484,10 +1485,11 @@ class Rational(Number):
             if isinstance(p, SYMPY_INTS):
                 pass
             else:
-                if isinstance(p, (float, Float)):
+                if _not_a_coeff(p):  # nan, oo, -oo
+                    pass  # error will raise below
+                elif isinstance(p, (float, Float)):
                     return Rational(*_as_integer_ratio(p))
-
-                if not isinstance(p, string_types):
+                elif not isinstance(p, string_types):
                     try:
                         p = sympify(p)
                     except (SympifyError, SyntaxError):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #16738

#### Brief description of what is fixed or changed

all(Rational(float(i)) == 0 for i in ('inf', '-inf', 'nan')) != True; a TypeError is raised for each case now.

#### Other comments

needs tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Rational no longer accepts nan, oo or -oo as input
<!-- END RELEASE NOTES -->
