### PR TITLE
reject nan, oo, -oo at Rational instantiation

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1477,6 +1477,7 @@ class Rational(Number):
 
     @cacheit
     def __new__(cls, p, q=None, gcd=None):
+        from sympy.polys.polyutils import _not_a_coeff
         if q is None:
             if isinstance(p, Rational):
                 return p
@@ -1484,10 +1485,11 @@ class Rational(Number):
             if isinstance(p, SYMPY_INTS):
                 pass
             else:
-                if isinstance(p, (float, Float)):
+                if _not_a_coeff(p):  # nan, oo, -oo
+                    pass  # error will raise below
+                elif isinstance(p, (float, Float)):
                     return Rational(*_as_integer_ratio(p))
-
-                if not isinstance(p, string_types):
+                elif not isinstance(p, string_types):
                     try:
                         p = sympify(p)
                     except (SympifyError, SyntaxError):
@@ -1955,7 +1957,7 @@ class Integer(Rational):
         # be made into an int or whether an error should be raised.
         try:
             ival = int(i)
-        except TypeError:
+        except (TypeError, ValueError, OverflowError):
             raise TypeError(
                 "Argument of Integer should be of numeric type, got %s." % i)
         # We only work with well-behaved integer types. This converts, for

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -176,6 +176,7 @@ def test_divmod():
     assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
     assert divmod(S(-8), S(-2.5) ) == Tuple(3 , -0.5)
 
+
 def test_igcd():
     assert igcd(0, 0) == 0
     assert igcd(0, 1) == 1
@@ -218,12 +219,14 @@ def test_igcd_lehmer():
     # swapping argmument
     assert igcd_lehmer(1, 2) == igcd_lehmer(2, 1)
 
+
 def test_igcd2():
     # short loop
     assert igcd2(2**100 - 1, 2**99 - 1) == 1
     # Lehmer's algorithm
     a, b = int(fibonacci(10001)), int(fibonacci(10000))
     assert igcd2(a, b) == 1
+
 
 def test_ilcm():
     assert ilcm(0, 0) == 0
@@ -271,6 +274,12 @@ def _test_rational_new(cls):
     assert _strictly_equal(i, cls(i))
 
     raises(TypeError, lambda: cls(Symbol('x')))
+    raises(TypeError, lambda: cls(float('nan')))
+    raises(TypeError, lambda: cls(float('inf')))
+    raises(TypeError, lambda: cls(float('-inf')))
+    raises(TypeError, lambda: cls(S.NaN))
+    raises(TypeError, lambda: cls(oo))
+    raises(TypeError, lambda: cls(-oo))
 
 
 def test_Integer_new():
@@ -281,7 +290,7 @@ def test_Integer_new():
 
     assert _strictly_equal(Integer(0.9), S.Zero)
     assert _strictly_equal(Integer(10.5), Integer(10))
-    raises(ValueError, lambda: Integer("10.5"))
+    raises(TypeError, lambda: Integer("10.5"))  # as_int will raise ValueError
     assert Integer(Rational('1.' + '9'*20)) == 1
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #16738
closes #16740 (not sure how to update a pr created online)

#### Brief description of what is fixed or changed

all(Rational(float(i)) == 0 for i in ('inf', '-inf', 'nan')) != True; a TypeError is raised for each case now.

#### Other comments

needs tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Rational no longer accepts nan, oo or -oo as input
<!-- END RELEASE NOTES -->
