### PR TITLE
log(-oo) -> oo + I*pi

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -544,14 +544,15 @@ class log(Function):
             elif arg is S.Infinity:
                 return S.Infinity
             elif arg is S.NegativeInfinity:
-                return S.Infinity
+                return S.Infinity + S.Pi*S.ImaginaryUnit
             elif arg is S.NaN:
                 return S.NaN
             elif arg.is_Rational and arg.p == 1:
                 return -cls(arg.q)
 
         if arg is S.ComplexInfinity:
-                return S.ComplexInfinity
+            return S.ComplexInfinity
+
         if isinstance(arg, exp) and arg.args[0].is_real:
             return arg.args[0]
         elif isinstance(arg, exp_polar):
@@ -563,12 +564,9 @@ class log(Function):
                 return
         elif isinstance(arg, SetExpr):
             return arg._eval_func(cls)
-
-        if arg.is_number:
+        elif arg.is_number:
             if arg.is_negative:
-                return S.Pi * S.ImaginaryUnit + cls(-arg)
-            elif arg is S.ComplexInfinity:
-                return S.ComplexInfinity
+                return S.Pi*S.ImaginaryUnit + cls(-arg)
             elif arg is S.Exp1:
                 return S.One
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -147,9 +147,13 @@ def test_exp_MatrixSymbol():
 
 def test_log_values():
     assert log(nan) == nan
+    assert log(float('nan')) == nan
 
     assert log(oo) == oo
-    assert log(-oo) == oo
+    assert log(float('inf')) == oo
+
+    assert log(-oo) == oo + I*pi
+    assert log(float('-inf')) == oo + I*pi
 
     assert log(zoo) == zoo
     assert log(-zoo) == zoo


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
close #16737

#### Brief description of what is fixed or changed
log(-oo) now gives oo + I*pi instead of oo

This is consistent with log(float(-inf')) in master.

#### Other comments

Also removed a redundant handling of `zoo` and included an `if` in the `if-else` block.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * log(-oo) now returns complex `oo + I*pi`
<!-- END RELEASE NOTES -->
