### PR TITLE
Fix Quantity._collect_factor_and_dimension for exp().

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -207,7 +207,7 @@ class Quantity(AtomicExpr):
                     raise ValueError(
                         'Dimension of "{0}" is {1}, '
                         'but it should be {2}'.format(
-                            addend, addend_dim.name, dim.name))
+                            addend, addend_dim, dim))
                 factor += addend_factor
             return factor, dim
         elif isinstance(expr, Derivative):

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -184,6 +184,7 @@ def test_check_unit_consistency():
     raises(ValueError, lambda: check_unit_consistency(u - w))
     raises(ValueError, lambda: check_unit_consistency(u + 1))
     raises(ValueError, lambda: check_unit_consistency(u - 1))
+    raises(ValueError, lambda: check_unit_consistency(1 - exp(u / w)))
 
 
 def test_mul_div():


### PR DESCRIPTION
Fixes #16751

Return `dim` instead of `dim.name` in error message of `Quantity._collect_factor_and_dimension()` to avoid error if `dim` is actually an expression, such as in `Quantity._collect_factor_and_dimension(1 - exp(u / v))`.
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->