### PR TITLE
[WIP] Sets: Fix relational between Cartesian Product and Finite Sets

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -289,27 +289,16 @@ class Relational(Boolean, Expr, EvalfMixin):
         r = self
         r = r.func(*[i.simplify(**kwargs) for i in r.args])
         if r.is_Relational:
-            from sympy.sets.sets import Set
-
             dif = r.lhs - r.rhs
-            if isinstance(dif, Set):
-                v = None
-                if dif.equals(S.EmptySet):
-                    v = S.EmptySet
-                if v is not None:
-                    r = r.func._eval_relation(v, S.EmptySet)
-
-            else:
-                # replace dif with a valid Number that will
-                # allow a definitive comparison with 0
-                v = None
-                if dif.is_comparable:
-                    v = dif.n(2)
-                elif dif.equals(0):  # XXX this is expensive
-                    v = S.Zero
-                if v is not None:
-                    r = r.func._eval_relation(v, S.Zero)
-
+            # replace dif with a valid Number that will
+            # allow a definitive comparison with 0
+            v = None
+            if dif.is_comparable:
+                v = dif.n(2)
+            elif dif.equals(0):  # XXX this is expensive
+                v = S.Zero
+            if v is not None:
+                r = r.func._eval_relation(v, S.Zero)
             r = r.canonical
             # If there is only one symbol in the expression,
             # try to write it on a simplified form

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -289,16 +289,27 @@ class Relational(Boolean, Expr, EvalfMixin):
         r = self
         r = r.func(*[i.simplify(**kwargs) for i in r.args])
         if r.is_Relational:
+            from sympy.sets.sets import Set
+
             dif = r.lhs - r.rhs
-            # replace dif with a valid Number that will
-            # allow a definitive comparison with 0
-            v = None
-            if dif.is_comparable:
-                v = dif.n(2)
-            elif dif.equals(0):  # XXX this is expensive
-                v = S.Zero
-            if v is not None:
-                r = r.func._eval_relation(v, S.Zero)
+            if isinstance(dif, Set):
+                v = None
+                if dif.equals(S.EmptySet):
+                    v = S.EmptySet
+                if v is not None:
+                    r = r.func._eval_relation(v, S.EmptySet)
+
+            else:
+                # replace dif with a valid Number that will
+                # allow a definitive comparison with 0
+                v = None
+                if dif.is_comparable:
+                    v = dif.n(2)
+                elif dif.equals(0):  # XXX this is expensive
+                    v = S.Zero
+                if v is not None:
+                    r = r.func._eval_relation(v, S.Zero)
+
             r = r.canonical
             # If there is only one symbol in the expression,
             # try to write it on a simplified form

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -7,7 +7,7 @@ from sympy.core.compatibility import with_metaclass, range, PY3
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
-from sympy.core.logic import fuzzy_not, fuzzy_or
+from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.core.numbers import oo, Integer
 from sympy.core.relational import Eq
 from sympy.core.singleton import Singleton, S
@@ -35,7 +35,6 @@ class Rationals(with_metaclass(Singleton, Set)):
     >>> [next(iterable) for i in range(12)]
     [0, 1, -1, 1/2, 2, -1/2, -2, 1/3, 3, -1/3, -3, 2/3]
     """
-
     is_iterable = True
     _inf = S.NegativeInfinity
     _sup = S.Infinity
@@ -97,7 +96,6 @@ class Naturals(with_metaclass(Singleton, Set)):
     Naturals0 : non-negative integers (i.e. includes 0, too)
     Integers : also includes negative integers
     """
-
     is_iterable = True
     _inf = S.One
     _sup = S.Infinity
@@ -190,7 +188,6 @@ class Integers(with_metaclass(Singleton, Set)):
     Naturals0 : non-negative integers
     Integers : positive and negative integers and zero
     """
-
     is_iterable = True
     is_empty = False
     is_finite_set = False
@@ -260,6 +257,8 @@ class Reals(with_metaclass(Singleton, Interval)):
 
     ComplexRegion
     """
+    is_finite_set = False
+
     def __new__(cls):
         return Interval.__new__(cls, S.NegativeInfinity, S.Infinity)
 
@@ -358,6 +357,10 @@ class ImageSet(Set):
 
     lamda = property(lambda self: self.args[0])
     base_sets = property(lambda self: self.args[1:])
+
+    @property
+    def is_empty(self):
+        return fuzzy_or([s.is_empty for s in self.base_sets])
 
     @property
     def base_set(self):
@@ -1077,6 +1080,8 @@ class ComplexRegion(Set):
 
     """
     is_ComplexRegion = True
+    is_finite_set = False
+
 
     def __new__(cls, sets, polar=False):
         if polar is False:

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -1,7 +1,7 @@
 from sympy import S
 from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
-from sympy.sets.sets import FiniteSet, Interval, Set, Union
+from sympy.sets.sets import FiniteSet, Interval, Set, Union, ProductSet
 from sympy.sets.fancysets import Complexes, Naturals, Reals, Range, Rationals
 from sympy.multipledispatch import dispatch
 
@@ -99,3 +99,24 @@ def is_subset_sets(a, b):
 @dispatch(Rationals, Range)
 def is_subset_sets(a, b):
     return False
+
+@dispatch(ProductSet, ProductSet)
+def is_subset_sets(a, b):
+    a_args = a.args
+    b_args = b.args
+    if len(a_args) != len(b_args):
+        return None
+
+    def gen():
+        for s1, s2 in zip(a_args, b_args):
+            yield s1.is_subset(s2)
+
+    return fuzzy_and(gen())
+
+@dispatch(FiniteSet, ProductSet)
+def is_subset_sets(a, b):
+    return a.is_subset(b.rewrite(FiniteSet))
+
+@dispatch(ProductSet, FiniteSet)
+def is_subset_sets(a, b):
+    return a.rewrite(FiniteSet).is_subset(b)

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -115,8 +115,19 @@ def is_subset_sets(a, b):
 
 @dispatch(FiniteSet, ProductSet)
 def is_subset_sets(a, b):
-    return a.is_subset(b.rewrite(FiniteSet))
+    def gen():
+        for x in a:
+            yield fuzzy_bool(b.contains(x))
+    return fuzzy_and(gen())
 
 @dispatch(ProductSet, FiniteSet)
 def is_subset_sets(a, b):
-    return a.rewrite(FiniteSet).is_subset(b)
+    is_finite_set = a.is_finite_set
+    if is_finite_set is True:
+        def gen():
+            for x in a:
+                yield fuzzy_bool(b.contains(x))
+        return fuzzy_and(gen())
+
+    elif a.is_finite_set is False:
+        return False

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -85,7 +85,7 @@ class PowerSet(Set):
 
     def _eval_rewrite_as_FiniteSet(self, *args, **kwargs):
         arg = self.arg
-        if arg.is_FiniteSet:
+        if arg.is_finite_set:
             return arg.powerset()
         return None
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -636,13 +636,6 @@ class Set(Basic):
         """
         return self - self.boundary
 
-    def simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
-        """See the simplify function in sympy.simplify"""
-        from sympy.simplify import simplify
-        from sympy.core.function import count_ops
-        measure = measure or count_ops
-        return simplify(self, ratio, measure)
-
     @property
     def _boundary(self):
         raise NotImplementedError()

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1407,3 +1407,51 @@ def test_issue_16878b():
     # that handles the base_set of S.Reals like there is
     # for Integers
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
+
+
+def test_finite_product_set_rewrite():
+    a = FiniteSet(1, 2)
+    b = FiniteSet(1, 2, 3)
+    c = ProductSet(a, b)
+    assert c.rewrite(FiniteSet) == \
+        FiniteSet((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3))
+
+
+def test_subset_ProuctSet_ProductSet():
+    a = FiniteSet(1, 2)
+    b = FiniteSet(1, 2, 3)
+
+    c = ProductSet(a, a)
+    d = ProductSet(b, b)
+    assert c.is_subset(d)
+    assert d.is_subset(c)
+
+    a = S.Integers
+    b = S.Reals
+
+    c = ProductSet(a, a)
+    d = ProductSet(b, b)
+    assert c.is_subset(d)
+    assert d.is_subset(c)
+
+    a = FiniteSet(1, 2)
+    b = S.Reals
+
+    c = ProductSet(a, a)
+    d = ProductSet(b, b)
+    assert c.is_subset(d)
+    assert d.is_subset(c)
+
+
+def test_finite_set_product_set_subset():
+    a = FiniteSet(1, 2)
+    b = FiniteSet(1, 2, 3)
+    c = ProductSet(a, b)
+    assert FiniteSet((1, 1)).is_subset(c)
+    assert FiniteSet((1, 1), (1, 2), (1, 3)).is_subset(c)
+    assert c.is_subset(
+        FiniteSet((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3))
+    )
+    assert c.is_subset(
+        FiniteSet((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (10, 10))
+    )

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1455,3 +1455,7 @@ def test_finite_set_product_set_subset():
     assert c.is_subset(
         FiniteSet((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (10, 10))
     )
+
+    d = ProductSet(FiniteSet(1, 2), S.Integers)
+    assert FiniteSet((1, 1)).is_subset(d) is True
+    assert d.is_subset(FiniteSet(1, 1)) is False

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1423,24 +1423,24 @@ def test_subset_ProuctSet_ProductSet():
 
     c = ProductSet(a, a)
     d = ProductSet(b, b)
-    assert c.is_subset(d)
-    assert d.is_subset(c)
+    assert c.is_subset(d) is True
+    assert d.is_subset(c) is False
 
     a = S.Integers
     b = S.Reals
 
     c = ProductSet(a, a)
     d = ProductSet(b, b)
-    assert c.is_subset(d)
-    assert d.is_subset(c)
+    assert c.is_subset(d) is True
+    assert d.is_subset(c) is False
 
     a = FiniteSet(1, 2)
     b = S.Reals
 
     c = ProductSet(a, a)
     d = ProductSet(b, b)
-    assert c.is_subset(d)
-    assert d.is_subset(c)
+    assert c.is_subset(d) is True
+    assert d.is_subset(c) is False
 
 
 def test_finite_set_product_set_subset():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

1. `is_subset` gives a wrong result
```python
>>> from sympy import *

>>> a = FiniteSet(1, 2)
>>> b = ProductSet(a, a)
>>> c = FiniteSet((1, 1), (1, 2), (2, 1), (2, 2))
>>> b.intersection(c) == c.intersection(b)
True
>>> b.is_subset(c)
False
>>> c.is_subset(b)
True
```

2. Calling `Eq.simplify` for sets gives `AttributeError`
```python
>>> Eq(b, c).simplify()
```
```AttributeError: 'ProductSet' object has no attribute 'simplify'```

3. Rewriting `ProductSet` to `FiniteSet` does not work
```python
>>> b.rewrite(FiniteSet)
{1, 2} x {1, 2}
```

I think there have to be some assumption handler for detecting if the set is a finite set, instead of using `is_iterable`. I see `is_iterable` is being used in some infinite sets like `Integers`.
I may consider `is_FiniteSet`, but is it intended for use in other place than having strict assumption.

Also, there had to be things modified for core Relational class

#### Other comments

- Made line spacings consistent in the module

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed `Eq.simplify()` not working with relationals involving sets. 
- sets
  - Added `simplify` method for sets.
  - Fixed `is_subset` giving wrong result between `FiniteSet` and its `ProductSet`
  - Added rewriting method for `ProductSet` to `FiniteSet`.

<!-- END RELEASE NOTES -->
