### PR TITLE
improve Float/Rational relations

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -10,6 +10,7 @@ from sympy.concrete.expr_with_intlimits import ReorderError
 from sympy.utilities.pytest import XFAIL, raises, slow
 from sympy.matrices import Matrix
 from sympy.core.mod import Mod
+from sympy.core.numbers import comp
 from sympy.core.compatibility import range
 
 n = Symbol('n', integer=True)
@@ -265,7 +266,7 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.25**n, (n, 1, oo)).doit()
-    assert abs(result - 1.0/3) < 1e-11
+    assert comp(result, 1/3.0)
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -265,7 +265,7 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.25**n, (n, 1, oo)).doit()
-    assert result == 1/3
+    assert abs(result - 1.0/3) < 1e-11
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -265,7 +265,7 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.25**n, (n, 1, oo)).doit()
-    assert result == S(1)/3
+    assert result == 1/3
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -10,7 +10,6 @@ from sympy.concrete.expr_with_intlimits import ReorderError
 from sympy.utilities.pytest import XFAIL, raises, slow
 from sympy.matrices import Matrix
 from sympy.core.mod import Mod
-from sympy.core.numbers import comp
 from sympy.core.compatibility import range
 
 n = Symbol('n', integer=True)
@@ -266,7 +265,7 @@ def test_geometric_sums():
     assert result.is_Float
 
     result = Sum(0.25**n, (n, 1, oo)).doit()
-    assert comp(result, 1/3.0)
+    assert result == 1/3.
     assert result.is_Float
 
     result = Sum(0.99999**n, (n, 1, oo)).doit()

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1883,21 +1883,28 @@ def _aresame(a, b):
     Examples
     ========
 
-    To SymPy, 2.0 == 2:
+    In SymPy (as in Python) two numbers compare the same if they
+    have the same underlying base-2 representation even though
+    they may not be the same type:
 
     >>> from sympy import S
     >>> 2.0 == S(2)
     True
+    >>> 0.5 == S.Half
+    True
 
-    Since a simple 'same or not' result is sometimes useful, this routine was
-    written to provide that query:
+    This routine was written to provide a query for such cases that
+    would give false when the types do not match:
 
     >>> from sympy.core.basic import _aresame
     >>> _aresame(S(2.0), S(2))
     False
 
     """
+    from .numbers import Number
     from .function import AppliedUndef, UndefinedFunction as UndefFunc
+    if isinstance(a, Number) and isinstance(b, Number):
+        return a == b and a.__class__ == b.__class__
     for i, j in zip_longest(preorder_traversal(a), preorder_traversal(b)):
         if i != j or type(i) != type(j):
             if ((isinstance(i, UndefFunc) and isinstance(j, UndefFunc)) or

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -801,68 +801,38 @@ class Expr(Basic, EvalfMixin):
         return None
 
     def _eval_is_positive(self):
-        from sympy.polys.numberfields import minimal_polynomial
-        from sympy.polys.polyerrors import NotAlgebraic
-        if self.is_number:
-            if self.is_real is False:
-                return False
-
-            # check to see that we can get a value
-            try:
-                n2 = self._eval_evalf(2)
-            # XXX: This shouldn't be caught here
-            # Catches ValueError: hypsum() failed to converge to the requested
-            # 34 bits of accuracy
-            except ValueError:
-                return None
-            if n2 is None:
-                return None
-            if getattr(n2, '_prec', 1) == 1:  # no significance
-                return None
-            if n2 == S.NaN:
-                return None
-
-            n, i = self.evalf(2).as_real_imag()
-            if not i.is_Number or not n.is_Number:
-                return False
-            if n._prec != 1 and i._prec != 1:
-                return bool(not i and n > 0)
-            elif n._prec == 1 and (not i or i._prec == 1) and \
-                    self.is_algebraic and not self.has(Function):
-                try:
-                    if minimal_polynomial(self).is_Symbol:
-                        return False
-                except (NotAlgebraic, NotImplementedError):
-                    pass
+        return self._eval_is_sign(lambda x: x > 0)
 
     def _eval_is_negative(self):
+        return self._eval_is_sign(lambda x: x < 0)
+
+    def _eval_is_sign(self, op):
+        from sympy.functions.elementary.complexes import re, im
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
+        from .symbol import Symbol
         if self.is_number:
+            if self.has(Symbol):
+                return None  # let user doit first
             if self.is_real is False:
                 return False
-
-            # check to see that we can get a value
-            try:
-                n2 = self._eval_evalf(2)
-            # XXX: This shouldn't be caught here
-            # Catches ValueError: hypsum() failed to converge to the requested
-            # 34 bits of accuracy
-            except ValueError:
+            # does this evaluate to a Float?
+            n2 = self._eval_evalf(2)
+            if n2 is None or n2 is S.NaN:
                 return None
-            if n2 is None:
-                return None
-            if getattr(n2, '_prec', 1) == 1:  # no significance
-                return None
-            if n2 == S.NaN:
-                return None
-
-            n, i = self.evalf(2).as_real_imag()
-            if not i.is_Number or not n.is_Number:
+            elif not getattr(n2, 'is_Float', False):
+                # can it be split into real and imaginary?
+                r, i = self.as_real_imag()
+                if isinstance(r, re) or isinstance(i, im):
+                    return None
+                r, i = [_.evalf(2) for _ in (r, i)]
+            else:
+                r, i = self.evalf(2).as_real_imag()
+            if not i.is_Number or not r.is_Number:
                 return False
-            if n._prec != 1 and i._prec != 1:
-                return bool(not i and n < 0)
-            elif n._prec == 1 and (not i or i._prec == 1) and \
+            if r._prec != 1 and i._prec != 1:
+                return bool(not i and op(n))
+            elif r._prec == 1 and (not i or i._prec == 1) and \
                     self.is_algebraic and not self.has(Function):
                 try:
                     if minimal_polynomial(self).is_Symbol:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -831,7 +831,7 @@ class Expr(Basic, EvalfMixin):
             if not i.is_Number or not r.is_Number:
                 return False
             if r._prec != 1 and i._prec != 1:
-                return bool(not i and op(n))
+                return bool(not i and op(r))
             elif r._prec == 1 and (not i or i._prec == 1) and \
                     self.is_algebraic and not self.has(Function):
                 try:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3407,7 +3407,7 @@ class Expr(Basic, EvalfMixin):
                 i *= -1
             return i*m
 
-        digits_to_decimal = _mag(x)
+        digits_to_decimal = _mag(x)  # _mag(12) = 2, _mag(.012) = -1
         allow = digits_needed = digits_to_decimal + p
         precs = [f._prec for f in x.atoms(Float)]
         dps = prec_to_dps(max(precs)) if precs else None
@@ -3491,7 +3491,7 @@ class Expr(Basic, EvalfMixin):
             if n is None:  # the single-arg case
                 return rv
             # use str or else it won't be a float
-            return Float(str(rv), digits_needed)
+            return Float(str(rv), dps)  # keep same precision
         else:
             if not allow and rv > self:
                 allow += 1

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -750,10 +750,7 @@ class Expr(Basic, EvalfMixin):
                     # we will handle the checking ourselves using nsimplify
                     # to see if we are in the right ballpark or not and if so
                     # *then* the simplification will be attempted.
-                    if s.is_Symbol:
-                        sol = list(solveset(diff, s))
-                    else:
-                        sol = solve(diff, s)
+                    sol = solve(diff, s, simplify=False)
                     if sol:
                         if s in sol:
                             # the self-consistent result is present

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -681,6 +681,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy.simplify.simplify import nsimplify, simplify
         from sympy.solvers.solveset import solveset
+        from sympy.solvers.solvers import solve
         from sympy.polys.polyerrors import NotAlgebraic
         from sympy.polys.numberfields import minimal_polynomial
 
@@ -707,15 +708,19 @@ class Expr(Basic, EvalfMixin):
         if constant is False:
             return False
 
-        if constant is None and not diff.is_number:
-            # e.g. unless the right simplification is done, a symbolic
-            # zero is possible (see expression of issue 6829: without
-            # simplification constant will be None).
-            return
+        if not diff.is_number:
+            if constant is None:
+                # e.g. unless the right simplification is done, a symbolic
+                # zero is possible (see expression of issue 6829: without
+                # simplification constant will be None).
+                return
 
         if constant is True:
+            # this gives a number whether there are free symbols or not
             ndiff = diff._random()
-            if ndiff:
+            # is_comparable will work whether the result is real
+            # or complex; it could be None, however.
+            if ndiff and ndiff.is_comparable:
                 return False
 
         # sometimes we can use a simplified result to give a clue as to
@@ -723,47 +728,70 @@ class Expr(Basic, EvalfMixin):
         # then we should have been able to compute that and so now
         # we can just consider the cases where the approximation appears
         # to be zero -- we try to prove it via minimal_polynomial.
+        #
+        # removed
+        # ns = nsimplify(diff)
+        # if diff.is_number and (not ns or ns == diff):
+        #
+        # The thought was that if it nsimplifies to 0 that's a sure sign
+        # to try the following to prove it; or if it changed but wasn't
+        # zero that might be a sign that it's not going to be easy to
+        # prove. But tests seem to be working without that logic.
+        #
         if diff.is_number:
-            approx = diff.nsimplify()
-            if not approx or approx == diff:
-                # try to prove via self-consistency
-                surds = [s for s in diff.atoms(Pow) if s.args[0].is_Integer]
-                # it seems to work better to try big ones first
-                surds.sort(key=lambda x: -x.args[0])
-                for s in surds:
-                    try:
-                        # simplify is False here -- this expression has already
-                        # been identified as being hard to identify as zero;
-                        # we will handle the checking ourselves using nsimplify
-                        # to see if we are in the right ballpark or not and if so
-                        # *then* the simplification will be attempted.
-                        if s.is_Symbol:
-                            sol = list(solveset(diff, s))
-                        else:
-                            sol = [s]
-                        if sol:
-                            if s in sol:
-                                return True
-                            if s.is_real:
-                                if any(nsimplify(si, [s]) == s and simplify(si) == s
-                                        for si in sol):
-                                    return True
-                    except NotImplementedError:
-                        pass
-
-                # try to prove with minimal_polynomial but know when
-                # *not* to use this or else it can take a long time. e.g. issue 8354
-                if True:  # change True to condition that assures non-hang
-                    try:
-                        mp = minimal_polynomial(diff)
-                        if mp.is_Symbol:
+            # try to prove via self-consistency
+            surds = [s for s in diff.atoms(Pow) if s.args[0].is_Integer]
+            # it seems to work better to try big ones first
+            surds.sort(key=lambda x: -x.args[0])
+            for s in surds:
+                try:
+                    # simplify is False here -- this expression has already
+                    # been identified as being hard to identify as zero;
+                    # we will handle the checking ourselves using nsimplify
+                    # to see if we are in the right ballpark or not and if so
+                    # *then* the simplification will be attempted.
+                    if s.is_Symbol:
+                        sol = list(solveset(diff, s))
+                    else:
+                        sol = solve(diff, s)
+                    if sol:
+                        if s in sol:
+                            # the self-consistent result is present
                             return True
-                        return False
-                    except (NotAlgebraic, NotImplementedError):
-                        pass
+                        if all(si.is_Integer for si in sol):
+                            # perfect powers are removed at instantiation
+                            # so surd s cannot be an integer
+                            return False
+                        if all(i.is_algebraic is False for i in sol):
+                            # a surd is algebraic
+                            return False
+                        if any(si in surds for si in sol):
+                            # it wasn't equal to s but it is in surds
+                            # and different surds are not equal
+                            return False
+                        if any(nsimplify(s - si) == 0 and
+                                simplify(s - si) == 0 for si in sol):
+                            return True
+                        if s.is_real:
+                            if any(nsimplify(si, [s]) == s and simplify(si) == s
+                                    for si in sol):
+                                return True
+                except NotImplementedError:
+                    pass
+
+            # try to prove with minimal_polynomial but know when
+            # *not* to use this or else it can take a long time. e.g. issue 8354
+            if True:  # change True to condition that assures non-hang
+                try:
+                    mp = minimal_polynomial(diff)
+                    if mp.is_Symbol:
+                        return True
+                    return False
+                except (NotAlgebraic, NotImplementedError):
+                    pass
 
         # diff has not simplified to zero; constant is either None, True
-        # or the number with significance (prec != 1) that was randomly
+        # or the number with significance (is_comparable) that was randomly
         # calculated twice as the same value.
         if constant not in (True, None) and constant != 0:
             return False

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -725,7 +725,7 @@ class Expr(Basic, EvalfMixin):
         # to be zero -- we try to prove it via minimal_polynomial.
         if diff.is_number:
             approx = diff.nsimplify()
-            if not approx:
+            if not approx or approx == diff:
                 # try to prove via self-consistency
                 surds = [s for s in diff.atoms(Pow) if s.args[0].is_Integer]
                 # it seems to work better to try big ones first

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1348,35 +1348,33 @@ class Float(Number):
                 s = Float._new([fnone, fzero, fone][sign(self) + 1], 1, zero=False)
                 o = Float._new([fnone, fzero, fone][sign(other) + 1], 1, zero=False)
             else:
-                s = self
-                o = Float._new(other._as_mpf_val(self._prec), self._prec, zero=False)
-                if Rational(o) != other:
-                    # other either had a high-precision numerator or
-                    # denominator that was not a power of 2
-                    if s == other:
-                        if op(fone, fone):
-                            # == is permited by op
-                            return S.true
-                        return S.false
-                    else:
-                        # self and other have the same sign and other
-                        # requires more precision than self to be
-                        # represented fully: how is m*2**e is related to a/b?
-                        swap = False
-                        if sign(other) < 0:
-                            swap = True
-                            s = -s
-                            other = -other
-                        # log(m*2**e, 2) <?> log(a, 2) - log(b, 2)
-                        # log(m, 2) + e <?> log(a, 2) - log(b, 2)
-                        # e <?> log(a, 2) - log(b, 2) - log(m, 2)
-                        _, m, e, _ = s._mpf_
-                        s = Float._new(fzero, 1, zero=False)
-                        o = Float._new(fone, 1)
-                        if e > log(other.p, 2) - log(other.q, 2) - log(m, 2):
-                            swap = not swap
-                        if swap:
-                            s, o = o, s
+               # other either had a high-precision numerator or
+                # denominator that was not a power of 2
+                if self == other:
+                    if op(fone, fone):
+                        # == is permited by op
+                        return S.true
+                    return S.false
+                else:
+                    # self and other have the same sign and other
+                    # requires more precision than self to be
+                    # represented fully: how is m*2**e is related to a/b?
+                    swap = False
+                    s = self
+                    if sign(other) < 0:
+                        swap = True
+                        s = -s
+                        other = -other
+                    # log(m*2**e, 2) <?> log(a, 2) - log(b, 2)
+                    # log(m, 2) + e <?> log(a, 2) - log(b, 2)
+                    # e <?> log(a, 2) - log(b, 2) - log(m, 2)
+                    _, m, e, _ = s._mpf_
+                    s = Float._new(fzero, 1, zero=False)
+                    o = Float._new(fone, 1)
+                    if e > log(other.p, 2) - log(other.q, 2) - log(m, 2):
+                        swap = not swap
+                    if swap:
+                        s, o = o, s
             return _sympify(bool(op(s._mpf_, o._mpf_)))
         elif other.is_Float:
             return _sympify(bool(

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1096,12 +1096,6 @@ class Float(Number):
                         assert all(type(i) is int for i in num)
                     except AssertionError:
                         raise ValueError('malformed mpf: %s' % num)
-                    if num == _mpf_nan[:3]:
-                       return S.NaN
-                    elif num == _mpf_inf[:3]:
-                        return S.Infinity
-                    elif num == _mpf_ninf[:3]:
-                        return S.NegativeInfinity
                     else:
                         # don't compute number or else it may
                         # over/underflow

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1351,7 +1351,8 @@ class Float(Number):
                 o = Float(sign(other))
             else:
                 s = self
-                o = Float._new(other._as_mpf_val(self._prec), self._prec)
+                o = Float._new(other._as_mpf_val(self._prec),
+                    self._prec, zero=False)
                 if Rational(o) != other:
                     # other either had a high-precision numerator or
                     # denominator that was not a power of 2

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -529,6 +529,15 @@ class Number(AtomicExpr):
         if isinstance(obj, (float, mpmath.mpf, decimal.Decimal)):
             return Float(obj)
         if isinstance(obj, string_types):
+            _obj = obj.lower()  # float('INF') == float('inf')
+            if _obj == 'nan':
+                return S.NaN
+            elif _obj == 'inf':
+                return S.Infinity
+            elif _obj == '+inf':
+                return S.Infinity
+            elif _obj == '-inf':
+                return S.NegativeInfinity
             val = sympify(obj)
             if isinstance(val, Number):
                 return val

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2218,7 +2218,7 @@ class Integer(Rational):
         the argument which is not done here for sake of speed.
 
         """
-        from sympy import perfect_power
+        from sympy.ntheory.factor_ import perfect_power
 
         if expt is S.Infinity:
             if self.p > S.One:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1093,7 +1093,7 @@ class Float(Number):
                     try:
                         assert num[0] in (0, 1)
                         assert num[1] >= 0
-                        assert all(type(i) is int for i in num)
+                        assert all(type(i) in (long, int) for i in num)
                     except AssertionError:
                         raise ValueError('malformed mpf: %s' % num)
                     else:
@@ -1311,14 +1311,9 @@ class Float(Number):
                 return False
             return other.__eq__(self)
         if other.is_Float:
-            # compare at the same precision
-            # so Float(.1, 3) == Float(.1, 33)
-            a, b = self._mpf_, other._mpf_
-            if self._prec != other._prec:
-                p = min(self._prec, other._prec)
-                a = mpf_norm(a, p)
-                b = mpf_norm(b, p)
-            return bool(mlib.mpf_eq(a, b))
+            # comparison is exact
+            # so Float(.1, 3) != Float(.1, 33)
+            return self._mpf_ == other._mpf_
         if other.is_Rational:
             return other.__eq__(self)
         if other.is_Number:
@@ -1781,6 +1776,10 @@ class Rational(Number):
             other = _sympify(other)
         except SympifyError:
             return NotImplemented
+        if not isinstance(other, Number):
+            # S(0) == S.false is False
+            # S(0) == False is True
+            return False
         if not self:
             return not other
         if other.is_NumberSymbol:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1379,10 +1379,11 @@ class Float(Number):
         elif other.is_Float:
             return _sympify(bool(
                         op(self._mpf_, other._mpf_)))
-        elif other.is_comparable:
+        elif other.is_comparable and other not in (
+                S.Infinity, S.NegativeInfinity):
             other = other.evalf(prec_to_dps(self._prec))
             if other._prec > 1:
-                if other.is_Number and other is not S.NaN:
+                if other.is_Number:
                     return _sympify(bool(
                         op(self._mpf_, other._as_mpf_val(self._prec))))
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1015,7 +1015,7 @@ class Float(Number):
             elif num == '-inf':
                 return S.NegativeInfinity
         elif isinstance(num, float) and num == 0:
-            num = fzero
+            num = '0'
         elif isinstance(num, float) and num == float('inf'):
             return S.Infinity
         elif isinstance(num, float) and num == float('-inf'):
@@ -1023,7 +1023,7 @@ class Float(Number):
         elif isinstance(num, float) and num == float('nan'):
             return S.NaN
         elif isinstance(num, (SYMPY_INTS, Integer)):
-            num = mlib.from_int(num)
+            num = str(num)
         elif num is S.Infinity:
             return num
         elif num is S.NegativeInfinity:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1340,14 +1340,20 @@ class Float(Number):
             return other
         elif other.is_Rational:
             from sympy.functions.elementary.complexes import sign
-            # Try to identify easy cases before using multiplication.
+            from sympy.functions.elementary.exponential import log
+            # we don't want to lose precision in other when making
+            # the comparison and we don't want to express Float
+            # as a Rational because it has the potential to create
+            # very large Rationals, so we try identify easy cases
+            # and finally use logarithms to make the determination
             if sign(self) != sign(other):
-                s = mlib.from_int(sign(self))
-                o = mlib.from_int(sign(other))
+                s = Float(sign(self))
+                o = Float(sign(other))
             else:
-                s = self._mpf_
-                o = other._as_mpf_val(self._prec)
-                if Rational(Float._new(o, self._prec)) != other:
+                s = self
+                o = Float._new(other._as_mpf_val(self._prec),
+                    self._prec, zero=False)
+                if Rational(o) != other:
                     # other either had a high-precision numerator or
                     # denominator that was not a power of 2
                     if s == other:
@@ -1356,9 +1362,25 @@ class Float(Number):
                             return S.true
                         return S.false
                     else:
-                        s = mlib.mpf_mul(self._mpf_, mlib.from_int(other.q))
-                        o = mlib.from_int(other.p)
-            return _sympify(bool(op(s, o)))
+                        # self and other have the same sign and other
+                        # requires more precision than self to be
+                        # represented fully: how is m*2**e is related to a/b?
+                        swap = False
+                        if sign(other) < 0:
+                            swap = True
+                            s = -s
+                            other = -other
+                        # log(m*2**e, 2) <?> log(a, 2) - log(b, 2)
+                        # log(m, 2) + e <?> log(a, 2) - log(b, 2)
+                        # e <?> log(a, 2) - log(b, 2) - log(m, 2)
+                        _, m, e, _ = s._mpf_
+                        s = Float(0)
+                        o = Float(1)
+                        if e > log(other.p, 2) - log(other.q, 2) - log(m, 2):
+                            swap = not swap
+                        if swap:
+                            s, o = o, s
+            return _sympify(bool(op(s._mpf_, o._mpf_)))
         elif other.is_Float:
             return _sympify(bool(
                         op(self._mpf_, other._mpf_)))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1875,6 +1875,10 @@ class Rational(Number):
             # so we can just check equivalence of args
             return self.p == other.p and self.q == other.q
         if other.is_Float:
+            # all Floats have a denominator that is a power of 2
+            # so if self doesn't, it can't be equal to other
+            if self.q & (self.q - 1):
+                return False
             s, m, t = other._mpf_[:3]
             if s:
                 m = -m

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -256,6 +256,8 @@ class Pow(Expr):
                 return S.One
             elif e is S.One:
                 return b
+            elif e == -1 and not b:
+                return S.ComplexInfinity
             # Only perform autosimplification if exponent or base is a Symbol or number
             elif (b.is_Symbol or b.is_number) and (e.is_Symbol or e.is_number) and\
                 e.is_integer and _coeff_isneg(b):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -677,7 +677,7 @@ class Pow(Expr):
                     # Allow fractional powers for commutative objects
                     pow = coeff1/coeff2
                     try:
-                        pow = as_int(pow, strict=False)
+                        as_int(pow, strict=False)
                         combines = True
                     except ValueError:
                         combines = isinstance(Pow._eval_power(

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -18,6 +18,7 @@ __all__ = (
 )
 
 
+
 # Note, see issue 4986.  Ideally, we wouldn't want to subclass both Boolean
 # and Expr.
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -271,7 +271,7 @@ def test_pow_im():
 
 
 def test_real_mul():
-    assert Float(0) * pi * x == Float(0)
+    assert Float(0) * pi * x == 0
     assert set((Float(1) * pi * x).args) == {Float(1), pi, x}
 
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -852,6 +852,16 @@ def test_Add_is_negative_positive():
     assert z.is_zero
     z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))
     assert z.is_zero
+    # a root from issue 2897
+    s = (sqrt(842721)/9 + 102)**(-1*S(1)/3)/(
+        -S(3)/2 - 3*sqrt(3)*I/2) - 2 + (
+        sqrt(842721)/9 + 102)**(S(1)/3)*(-S(1)/2 - sqrt(3)*I/2)
+    assert s.is_positive is False
+    # these will hopefully evaluate at some point
+    # since there is a non-zero imaginary part
+    assert s.is_real is None
+    assert s.is_zero is None
+
 
 def test_Add_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -852,16 +852,6 @@ def test_Add_is_negative_positive():
     assert z.is_zero
     z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))
     assert z.is_zero
-    # a root from issue 2897
-    s = (sqrt(842721)/9 + 102)**(-1*S(1)/3)/(
-        -S(3)/2 - 3*sqrt(3)*I/2) - 2 + (
-        sqrt(842721)/9 + 102)**(S(1)/3)*(-S(1)/2 - sqrt(3)*I/2)
-    assert s.is_positive is False
-    # these will hopefully evaluate at some point
-    # since there is a non-zero imaginary part
-    assert s.is_real is None
-    assert s.is_zero is None
-
 
 def test_Add_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,4 @@
-from sympy import I, sqrt, log, exp, cos, sin, asin, factorial, Mod, pi
+from sympy import I, sqrt, log, exp, sin, asin, factorial, Mod, pi
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions
 from sympy import simplify
@@ -1063,9 +1063,9 @@ def test_issue_10024():
 def test_issue_10302():
     x = Symbol('x')
     r = Symbol('r', real=True)
-    u = cos(1)**2 + sin(1)**2 - 1
+    u = -(3*2**pi)**(1/pi) + 2*3**(1/pi)
     i = u + u*I
-    assert i.is_real is None  # w/o simplification must fail
+    assert i.is_real is None  # w/o simplification this should fail
     assert (u + i).is_zero is None
     assert (1 + i).is_zero is False
     a = Dummy('a', zero=True)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,4 @@
-from sympy import I, sqrt, log, exp, sin, asin, factorial, Mod, pi
+from sympy import I, sqrt, log, exp, cos, sin, asin, factorial, Mod, pi
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions
 from sympy import simplify
@@ -1063,9 +1063,9 @@ def test_issue_10024():
 def test_issue_10302():
     x = Symbol('x')
     r = Symbol('r', real=True)
-    u = -(3*2**pi)**(1/pi) + 2*3**(1/pi)
+    u = cos(1)**2 + sin(1)**2 - 1
     i = u + u*I
-    assert i.is_real is None  # w/o simplification this should fail
+    assert i.is_real is None  # w/o simplification must fail
     assert (u + i).is_zero is None
     assert (1 + i).is_zero is False
     a = Dummy('a', zero=True)

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -94,7 +94,7 @@ def test_evalc():
 
 def test_pythoncomplex():
     x = Symbol("x")
-    assert 4j*x != 4*x*I
+    assert 4j*x == 4*x*I
     assert 4j*x == 4.0*x*I
     assert 4.1j*x != 4*x*I
 

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -94,7 +94,7 @@ def test_evalc():
 
 def test_pythoncomplex():
     x = Symbol("x")
-    assert 4j*x == 4*x*I
+    assert 4j*x != 4*x*I
     assert 4j*x == 4.0*x*I
     assert 4.1j*x != 4*x*I
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
-    integrate, log, Mul, N, oo, pi, Pow, product, Product,
+    integrate, log, Mul, N, oo, pi, Pow, product, Product, ln,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
@@ -561,3 +561,9 @@ def test_issue_11151():
     expr1 = Sum(0, (x, 1, 2))
     expr2 = expr1/expr0
     assert simplify(factor(expr2) - expr2) == 0
+
+
+def test_issue_10073():
+    # formerly an error in handling n2 value calculated
+    assert (1/(-ln(35) + 2*sqrt(4)) > 0.1) == True
+    assert (1/(-ln(35) + 2*sqrt(3)) > 0.1) == False

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
-    integrate, log, Mul, N, oo, pi, Pow, product, Product, ln,
+    integrate, log, Mul, N, oo, pi, Pow, product, Product,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
@@ -561,9 +561,3 @@ def test_issue_11151():
     expr1 = Sum(0, (x, 1, 2))
     expr2 = expr1/expr0
     assert simplify(factor(expr2) - expr2) == 0
-
-
-def test_issue_10073():
-    # formerly an error in handling n2 value calculated
-    assert (1/(-ln(35) + 2*sqrt(4)) > 0.1) == True
-    assert (1/(-ln(35) + 2*sqrt(3)) > 0.1) == False

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -234,6 +234,7 @@ def test_evalf_bugs():
     #issue 13076
     assert NS(Mul(Max(0, y), x, evaluate=False).evalf()) == 'x*Max(0, y)'
 
+
 def test_evalf_integer_parts():
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)
     b = floor(log(8)/log(2), evaluate=False)
@@ -252,14 +253,15 @@ def test_evalf_integer_parts():
                .evalf(1000)) == fibonacci(1000)
 
     assert ceiling(x).evalf(subs={x: 3}) == 3
-    assert ceiling(x).evalf(subs={x: 3*I}) == 3*I
-    assert ceiling(x).evalf(subs={x: 2 + 3*I}) == 2 + 3*I
+    assert ceiling(x).evalf(subs={x: 3*I}) == 3.0*I
+    assert ceiling(x).evalf(subs={x: 2 + 3*I}) == 2.0 + 3.0*I
     assert ceiling(x).evalf(subs={x: 3.}) == 3
-    assert ceiling(x).evalf(subs={x: 3.*I}) == 3*I
-    assert ceiling(x).evalf(subs={x: 2. + 3*I}) == 2 + 3*I
+    assert ceiling(x).evalf(subs={x: 3.*I}) == 3.0*I
+    assert ceiling(x).evalf(subs={x: 2. + 3*I}) == 2.0 + 3.0*I
 
     assert float((floor(1.5, evaluate=False)+1/9).evalf()) == 1 + 1/9
     assert float((floor(0.5, evaluate=False)+20).evalf()) == 20
+
 
 def test_evalf_trig_zero_detection():
     a = sin(160*pi, evaluate=False)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -2,6 +2,7 @@ from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
     integrate, log, Mul, N, oo, pi, Pow, product, Product,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
+from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath, evalf)
 from mpmath import inf, ninf
@@ -301,7 +302,7 @@ def test_evalf_divergent_series():
 
 def test_evalf_product():
     assert Product(n, (n, 1, 10)).evalf() == 3628800.
-    assert Product(1 - S.Half**2/n**2, (n, 1, oo)).evalf(5)==0.63662
+    assert comp(Product(1 - S.Half**2/n**2, (n, 1, oo)), 0.63662, 10**-5)
     assert Product(n, (n, -1, 3)).evalf() == 0
 
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -302,7 +302,7 @@ def test_evalf_divergent_series():
 
 def test_evalf_product():
     assert Product(n, (n, 1, 10)).evalf() == 3628800.
-    assert comp(Product(1 - S.Half**2/n**2, (n, 1, oo)), 0.63662, 10**-5)
+    assert comp(Product(1 - S.Half**2/n**2, (n, 1, oo)).n(5), 0.63662)
     assert Product(n, (n, -1, 3)).evalf() == 0
 
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1652,15 +1652,15 @@ def test_random():
 def test_round():
     from sympy.abc import x
 
-    assert Float('0.1249999').round(2) == 0.12
+    assert str(Float('0.1249999').round(2)) == '0.12'
     d20 = 12345678901234567890
     ans = S(d20).round(2)
     assert ans.is_Integer and ans == d20
     ans = S(d20).round(-2)
     assert ans.is_Integer and ans == 12345678901234567900
-    assert S('1/7').round(4) == 0.1429
-    assert S('.[12345]').round(4) == 0.1235
-    assert S('.1349').round(2) == 0.13
+    assert str(S('1/7').round(4)) == '0.1429'
+    assert str(S('.[12345]').round(4)) == '0.1235'
+    assert str(S('.1349').round(2)) == '0.13'
     n = S(12345)
     ans = n.round()
     assert ans.is_Integer
@@ -1678,10 +1678,10 @@ def test_round():
 
     assert n.round(-5) == 0
 
-    assert (pi + sqrt(2)).round(2) == 4.56
+    assert str((pi + sqrt(2)).round(2)) == '4.56'
     assert (10*(pi + sqrt(2))).round(-1) == 50
     raises(TypeError, lambda: round(x + 2, 2))
-    assert S(2.3).round(1) == 2.3
+    assert str(S(2.3).round(1)) == '2.3'
     # rounding in SymPy (as in Decimal) should be
     # exact for the given precision; we check here
     # that when a 5 follows the last digit that
@@ -1706,8 +1706,8 @@ def test_round():
     assert (pi + 2*E*I).round() == 3 + 5*I
     # don't let request for extra precision give more than
     # what is known (in this case, only 3 digits)
-    assert (Float(.03, 3) + 2*pi/100).round(5) == 0.0928
-    assert (Float(.03, 3) + 2*pi/100).round(4) == 0.0928
+    assert str((Float(.03, 3) + 2*pi/100).round(5)) == '0.0928'
+    assert str((Float(.03, 3) + 2*pi/100).round(4)) == '0.0928'
 
     assert S.Zero.round() == 0
 
@@ -1736,8 +1736,8 @@ def test_round():
     # then coerce the floats to the same precision) or re-create
     # the floats
     assert str((pi/10 + E*I).round(2)) == '0.31 + 2.72*I'
-    assert (pi/10 + E*I).round(2).as_real_imag() == (0.31, 2.72)
-    assert (pi/10 + E*I).round(2) == Float(0.31, 2) + I*Float(2.72, 3)
+    assert str((pi/10 + E*I).round(2).as_real_imag()) == '(0.31, 2.72)'
+    assert str((pi/10 + E*I).round(2)) == '0.31 + 2.72*I'
 
     # issue 6914
     assert (I**(I + 3)).round(3) == Float('-0.208', '')*I

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1675,9 +1675,6 @@ def test_round():
 
     r = Float(str(n)).round(-4)
     assert r == 10000
-    # in fact, it should equal many values since __eq__
-    # compares at equal precision
-    assert all(r == i for i in range(9984, 10049))
 
     assert n.round(-5) == 0
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -136,7 +136,7 @@ def test_divmod():
     assert divmod(S("3/2"), S("0.1")) == Tuple(S("15"), S("0"))
     assert divmod(S("0.1"), S("3/2")) == Tuple(S("0"), S("0.1"))
     assert divmod(S("3/2"), 2) == Tuple(S("0"), S("3/2"))
-    assert divmod(2, S("3/2")) == Tuple(S("1"), S("0.5"))
+    assert divmod(2, S("3/2")) == Tuple(S("1"), S("1/2"))
     assert divmod(S("3/2"), 1.5) == Tuple(S("1"), S("0"))
     assert divmod(1.5, S("3/2")) == Tuple(S("1"), S("0"))
     assert divmod(S("3/2"), 0.3) == Tuple(S("5"), S("0"))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1622,16 +1622,25 @@ def test_Catalan_EulerGamma_prec():
     assert n._as_mpf_val(20) == f._mpf_
 
 
+def test_bool_eq():
+    assert 0 == False
+    assert S(0) == False
+    assert S(0) != S.false
+    assert 1 == True
+    assert S(1) == True
+    assert S(1) != S.true
+
+
 def test_Float_eq():
     # all .5 values are the same
     assert Float(.5, 10) == Float(.5, 11) == Float(.5, 1)
-    # and even floats that aren't exact in base-2 still
-    # compare the same because they are compared at the
-    # same precision
-    assert Float(.12, 3) == Float(.12, 4)
-    assert Float(.12, 3) == .12
-    assert 0.12 == Float(.12, 3)
-    assert Float('.12', 22) == .12
+    # but floats that aren't exact in base-2 still
+    # don't compare the same because they have different
+    # underlying mpf values
+    assert Float(.12, 3) != Float(.12, 4)
+    assert Float(.12, 3) != .12
+    assert 0.12 != Float(.12, 3)
+    assert Float('.12', 22) != .12
     # issue 11707
     # but Float/Rational -- except for 0 --
     # are exact so Rational(x) = Float(y) only if

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1732,17 +1732,38 @@ def test_Float_idempotence():
     assert not same_and_same_prec(z, x)
 
 
-def test_comp():
+def test_comp1():
     # sqrt(2) = 1.414213 5623730950...
     a = sqrt(2).n(7)
     assert comp(a, 1.41421346) is False
     assert comp(a, 1.41421347)
+    #                  ...
     assert comp(a, 1.41421366)
     assert comp(a, 1.41421367) is False
     assert comp(sqrt(2).n(2), '1.4')
     assert comp(sqrt(2).n(2), Float(1.4, 2), '')
-    raises(ValueError, lambda: comp(sqrt(2).n(2), 1.4, ''))
+    assert comp(sqrt(2).n(2), 1.4, '')
     assert comp(sqrt(2).n(2), Float(1.4, 3), '') is False
+    assert comp(sqrt(2) + sqrt(3)*I, 1.4 + 1.7*I, .1)
+    assert not comp(sqrt(2) + sqrt(3)*I, (1.5 + 1.7*I)*0.89, .1)
+    assert comp(sqrt(2) + sqrt(3)*I, (1.5 + 1.7*I)*0.90, .1)
+    assert comp(sqrt(2) + sqrt(3)*I, (1.5 + 1.7*I)*1.07, .1)
+    assert not comp(sqrt(2) + sqrt(3)*I, (1.5 + 1.7*I)*1.08, .1)
+    assert [(i, j)
+            for i in range(130, 150)
+            for j in range(170, 180)
+            if comp((sqrt(2)+ I*sqrt(3)).n(2), i/100. + I*j/100.)] == [
+        (141, 173), (141, 174), (142, 173), (142, 174)]
+    raises(ValueError, lambda: comp(t, '1'))
+    raises(ValueError, lambda: comp(t, 1))
+    assert comp(0, 0.0)
+    assert comp(.5, S.Half)
+    assert comp(2 + sqrt(2), 2.0 + sqrt(2))
+    assert not comp(0, 1)
+    assert not comp(2, sqrt(2))
+    assert not comp(2 + I, 2.0 + sqrt(2))
+    assert not comp(2.0 + sqrt(2), 2 + I)
+    assert not comp(2.0 + sqrt(2), sqrt(3))
 
 
 def test_issue_9491():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -184,7 +184,6 @@ def test_divmod():
     OO = float('inf')
     ANS = [tuple(map(float, i)) for i in ans]
     assert [divmod(i, oo) for i in range(-2, 3)] == ans
-    assert [divmod(i, OO) for i in range(-2, 3)] ==  ANS
     ans = [(0, -2), (0, -1), (0, 0), (-1, -oo), (-1, -oo)]
     ANS = [tuple(map(float, i)) for i in ans]
     assert [divmod(i, -oo) for i in range(-2, 3)] == ans
@@ -1752,11 +1751,11 @@ def test_Float_idempotence():
 def test_comp1():
     # sqrt(2) = 1.414213 5623730950...
     a = sqrt(2).n(7)
-    assert comp(a, 1.41421346) is False
-    assert comp(a, 1.41421347)
+    assert comp(a, 1.4142129) is False
+    assert comp(a, 1.4142130)
     #                  ...
-    assert comp(a, 1.41421366)
-    assert comp(a, 1.41421367) is False
+    assert comp(a, 1.4142141)
+    assert comp(a, 1.4142142) is False
     assert comp(sqrt(2).n(2), '1.4')
     assert comp(sqrt(2).n(2), Float(1.4, 2), '')
     assert comp(sqrt(2).n(2), 1.4, '')
@@ -1769,8 +1768,8 @@ def test_comp1():
     assert [(i, j)
             for i in range(130, 150)
             for j in range(170, 180)
-            if comp((sqrt(2)+ I*sqrt(3)).n(2), i/100. + I*j/100.)] == [
-        (141, 173), (141, 174), (142, 173), (142, 174)]
+            if comp((sqrt(2)+ I*sqrt(3)).n(3), i/100. + I*j/100.)] == [
+        (141, 173), (142, 173)]
     raises(ValueError, lambda: comp(t, '1'))
     raises(ValueError, lambda: comp(t, 1))
     assert comp(0, 0.0)
@@ -1781,6 +1780,8 @@ def test_comp1():
     assert not comp(2 + I, 2.0 + sqrt(2))
     assert not comp(2.0 + sqrt(2), 2 + I)
     assert not comp(2.0 + sqrt(2), sqrt(3))
+    assert comp(1/pi.n(4), 0.3183, 1e-5)
+    assert not comp(1/pi.n(4), 0.3183, 8e-6)
 
 
 def test_issue_9491():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -414,27 +414,27 @@ def test_Float():
     a = Float(2) ** Float(4)
     assert eq(a.evalf(), Float(16))
     assert (S(.3) == S(.5)) is False
-    x_str = Float((0, '13333333333333', -52, 53))
-    x2_str = Float((0, '26666666666666', -53, 53))
+    mpf = (0, 5404319552844595, -52, 53)
+    x_str =  Float((0, '13333333333333', -52, 53))
+    x2_str = Float((0, '26666666666666', -53, 54))
     x_hex = Float((0, long(0x13333333333333), -52, 53))
-    x_dec = Float((0, 5404319552844595, -52, 53))
+    x_dec = Float(mpf)
     assert x_str == x_hex == x_dec == Float(1.2)
-    # This looses a binary digit of precision, so it isn't equal to the above,
-    # but check that it normalizes correctly
-    x2_hex = Float((0, long(0x13333333333333)*2, -53, 53))
-    assert x2_hex._mpf_ == (0, 5404319552844595, -52, 52)
-    # XXX: Should this test also hold?
-    # assert x2_hex._prec == 52
-
-    # x2_str and 1.2 are superficially the same
-    assert str(x2_str) == str(Float(1.2))
-    # but are different at the mpf level
-    assert Float(1.2)._mpf_ == (0, long(5404319552844595), -52, 53)
-    assert x2_str._mpf_ == (0, long(10808639105689190), -53, 53)
+    # x2_str was entered slightly malformed in that the mantissa
+    # was even -- it should be odd and the even part should be
+    # included with the exponent, but this is resolved by normalization
+    # ONLY IF REQUIREMENTS of mpf_norm are met: the bitcount must
+    # be exact: double the mantissa ==> increase bc by 1
+    assert Float(1.2)._mpf_ == mpf
+    assert x2_str._mpf_ == mpf
 
     assert Float((0, long(0), -123, -1)) is S.NaN
     assert Float((0, long(0), -456, -2)) is S.Infinity
     assert Float((1, long(0), -789, -3)) is S.NegativeInfinity
+    # if you don't give the full signature, it's not special
+    assert Float((0, long(0), -123)) == Float(0)
+    assert Float((0, long(0), -456)) == Float(0)
+    assert Float((1, long(0), -789)) == Float(0)
 
     raises(ValueError, lambda: Float((0, 7, 1, 3), ''))
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -987,12 +987,14 @@ def test_integer_log():
     assert integer_log(-49, 7) == (0, False)
     assert integer_log(-49, -7) == (2, False)
 
+
 def test_isqrt():
     from math import sqrt as _sqrt
     limit = 17984395633462800708566937239551
     assert int(_sqrt(limit)) == integer_nthroot(limit, 2)[0]
     assert int(_sqrt(limit + 1)) != integer_nthroot(limit + 1, 2)[0]
     assert isqrt(limit + 1) == integer_nthroot(limit + 1, 2)[0]
+    assert isqrt(limit + 1 - S.Half) == integer_nthroot(limit + 1, 2)[0]
     assert isqrt(limit + 1 + S.Half) == integer_nthroot(limit + 1, 2)[0]
 
 
@@ -1838,22 +1840,10 @@ def test_comparisons_with_unknown_type():
         raises(TypeError, lambda: bar <= n)
 
 def test_NumberSymbol_comparison():
+    from sympy.core.tests.test_relational import rel_check
     rpi = Rational('905502432259640373/288230376151711744')
     fpi = Float(float(pi))
-
-    assert (rpi == pi) == (pi == rpi)
-    assert (rpi != pi) == (pi != rpi)
-    assert (rpi < pi) == (pi > rpi)
-    assert (rpi <= pi) == (pi >= rpi)
-    assert (rpi > pi) == (pi < rpi)
-    assert (rpi >= pi) == (pi <= rpi)
-
-    assert (fpi == pi) == (pi == fpi)
-    assert (fpi != pi) == (pi != fpi)
-    assert (fpi < pi) == (pi > fpi)
-    assert (fpi <= pi) == (pi >= fpi)
-    assert (fpi > pi) == (pi < fpi)
-    assert (fpi >= pi) == (pi <= fpi)
+    assert rel_check(rpi, fpi)
 
 def test_Integer_precision():
     # Make sure Integer inputs for keyword args work

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -348,6 +348,10 @@ def test_Number_new():
     raises(TypeError, lambda: Number(cos))
     a = Rational(3, 5)
     assert Number(a) is a  # Check idempotence on Numbers
+    u = '-inf', 'inf', '+inf', 'nan', 'Inf'  # etc...
+    v = [Float(i) for i in u]
+    for i, a in zip(u, v):
+        assert Number(i) is a, (i, Number(i), a)
 
 
 def test_Number_cmp():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -56,7 +56,7 @@ def test_mod():
 
     a = Float(2.6)
 
-    assert (a % .2) == 0
+    assert (a % .2) == 0.0
     assert (a % 2).round(15) == 0.6
     assert (a % 0.5).round(15) == 0.1
 
@@ -83,7 +83,7 @@ def test_mod():
 
     s = S.Zero
 
-    assert s % float(1) == S.Zero
+    assert s % float(1) == 0.0
 
     # No rounding required since these numbers can be represented
     # exactly.
@@ -407,6 +407,13 @@ def test_Float():
     def eq(a, b):
         t = Float("1.0E-15")
         return (-t < a - b < t)
+
+    zeros = (0, S(0), 0., Float(0))
+    for i, j in permutations(zeros, 2):
+        assert i == j
+    for z in zeros:
+        assert z in zeros
+    assert S(0).is_zero
 
     a = Float(2) ** Float(3)
     assert eq(a.evalf(), Float(8))
@@ -814,13 +821,13 @@ def test_Mul_Infinity_Zero():
 
 def test_Div_By_Zero():
     assert 1/S(0) == zoo
-    assert 1/Float(0) == _inf
+    assert 1/Float(0) == zoo
     assert 0/S(0) == nan
     assert 0/Float(0) == nan
     assert S(0)/0 == nan
     assert Float(0)/0 == nan
     assert -1/S(0) == zoo
-    assert -1/Float(0) == _ninf
+    assert -1/Float(0) == zoo
 
 
 def test_Infinity_inequations():
@@ -1616,18 +1623,21 @@ def test_Catalan_EulerGamma_prec():
 
 
 def test_Float_eq():
-    assert Float(.12, 3) != Float(.12, 4)
-    assert Float(.12, 3) == .12
-    assert 0.12 == Float(.12, 3)
-    assert Float('.12', 22) != .12
-    # issue 11707
-    assert Float('1.1') != Rational(11, 10)
-    assert Rational(11, 10) != Float('1.1')
-    # to precision 10 and 11, the float value of
-    # 1.1 is not the same
-    assert Float(1.1, 10) != Float(1.1, 11)
     # all .5 values are the same
     assert Float(.5, 10) == Float(.5, 11) == Float(.5, 1)
+    # and even floats that aren't exact in base-2 still
+    # compare the same because they are compared at the
+    # same precision
+    assert Float(.12, 3) == Float(.12, 4)
+    assert Float(.12, 3) == .12
+    assert 0.12 == Float(.12, 3)
+    assert Float('.12', 22) == .12
+    # issue 11707
+    # but Float/Rational -- except for 0 --
+    # are exact so Rational(x) = Float(y) only if
+    # Rational(x) == Rational(Float(y))
+    assert Float('1.1') != Rational(11, 10)
+    assert Rational(11, 10) != Float('1.1')
     # coverage
     assert not Float(3) == 2
     assert not Float(2**2) == S.Half

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -348,8 +348,8 @@ def test_Number_new():
     raises(TypeError, lambda: Number(cos))
     a = Rational(3, 5)
     assert Number(a) is a  # Check idempotence on Numbers
-    u = '-inf', 'inf', '+inf', 'nan', 'Inf'  # etc...
-    v = [Float(i) for i in u]
+    u = ['inf', '-inf', 'nan', 'iNF', '+inf']
+    v = [oo, -oo, nan, oo, oo]
     for i, a in zip(u, v):
         assert Number(i) is a, (i, Number(i), a)
 
@@ -435,8 +435,6 @@ def test_Float():
     assert Float((0, long(0), -123, -1)) is S.NaN
     assert Float((0, long(0), -456, -2)) is S.Infinity
     assert Float((1, long(0), -789, -3)) is S.NegativeInfinity
-    assert Float(oo) is Float('+_inf') is S.Infinity
-    assert Float(-oo) is Float('-_inf') is S.NegativeInfinity
 
     raises(ValueError, lambda: Float((0, 7, 1, 3), ''))
 
@@ -493,6 +491,7 @@ def test_Float():
     raises(ValueError, lambda: Float('1_.'))
     raises(ValueError, lambda: Float('1._'))
     raises(ValueError, lambda: Float('1__2'))
+    raises(ValueError, lambda: Float('_inf'))
 
     # allow auto precision detection
     assert Float('.1', '') == Float(.1, 1)
@@ -551,6 +550,13 @@ def test_Float():
     # from NumberSymbol
     assert same_and_same_prec(Float(pi, 32), pi.evalf(32))
     assert same_and_same_prec(Float(Catalan), Catalan.evalf())
+
+    # oo and nan
+    u = ['inf', '-inf', 'nan', 'iNF', '+inf']
+    v = [oo, -oo, nan, oo, oo]
+    for i, a in zip(u, v):
+        assert Float(i) is a
+
 
 
 @conserve_mpmath_dps

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -131,7 +131,7 @@ def test_divmod():
     assert divmod(0.3, S("2")) == Tuple(S("0"), S("0.3"))
     assert divmod(S("3/2"), S("3.5")) == Tuple(S("0"), S("3/2"))
     assert divmod(S("3.5"), S("3/2")) == Tuple(S("2"), S("0.5"))
-    assert divmod(S("3/2"), S("1/3")) == Tuple(S("4"), Float("1/6"))
+    assert divmod(S("3/2"), S("1/3")) == Tuple(S("4"), S("1/6"))
     assert divmod(S("1/3"), S("3/2")) == Tuple(S("0"), S("1/3"))
     assert divmod(S("3/2"), S("0.1")) == Tuple(S("15"), S("0"))
     assert divmod(S("0.1"), S("3/2")) == Tuple(S("0"), S("0.1"))
@@ -1608,6 +1608,31 @@ def test_Float_eq():
     assert Float(.12, 3) == .12
     assert 0.12 == Float(.12, 3)
     assert Float('.12', 22) != .12
+    # issue 11707
+    assert Float('1.1') != Rational(11, 10)
+    assert Rational(11, 10) != Float('1.1')
+    # to precision 10 and 11, the float value of
+    # 1.1 is not the same
+    assert Float(1.1, 10) != Float(1.1, 11)
+    # all .5 values are the same
+    assert Float(.5, 10) == Float(.5, 11) == Float(.5, 1)
+    # coverage
+    assert not Float(3) == 2
+    assert not Float(2**2) == S.Half
+    assert Float(2**2) == 4
+    assert not Float(2**-2) == 1
+    assert Float(2**-1) == S.Half
+    assert not Float(2*3) == 3
+    assert not Float(2*3) == S.Half
+    assert Float(2*3) == 6
+    assert not Float(2*3) == 8
+    assert Float(.75) == S(3)/4
+    assert Float(5/18) == 5/18
+    # 4473
+    assert t**2 == t**2.0
+    assert Float(2.) != 3
+    assert Float((0,1,-3)) == S(1)/8
+    assert Float((0,1,-3)) != S(1)/9
 
 
 def test_int_NumberSymbols():

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -275,10 +275,7 @@ def test_issue_6100_12942_4473():
     assert x*y != (x*y)**1.0
     # Pow != Symbol
     assert (x**1.0)**1.0 != x
-    # in expressions, numerical comparisons are strict
-    a, b = (x**1.0)**2.0, x**2
-    assert a != b
-    assert a.args == b.args
+    assert (x**1.0)**2.0 == x**2
     b = Basic()
     assert Pow(b, 1.0, evaluate=False) != b
     # if the following gets distributed as a Mul (x**1.0*y**1.0 then

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -264,7 +264,7 @@ def test_pow_as_base_exp():
     assert Pow(1, 2, evaluate=False).as_base_exp() == (S(1), S(2))
 
 
-def test_issue_6100_12942():
+def test_issue_6100_12942_4473():
     x = Symbol('x')
     y = Symbol('y')
     assert x**1.0 != x
@@ -273,8 +273,12 @@ def test_issue_6100_12942():
     assert x**1.0 is not True
     assert x is not True
     assert x*y != (x*y)**1.0
+    # Pow != Symbol
     assert (x**1.0)**1.0 != x
-    assert (x**1.0)**2.0 == x**2
+    # in expressions, numerical comparisons are strict
+    a, b = (x**1.0)**2.0, x**2
+    assert a != b
+    assert a.args == b.args
     b = Basic()
     assert Pow(b, 1.0, evaluate=False) != b
     # if the following gets distributed as a Mul (x**1.0*y**1.0 then

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -586,9 +586,21 @@ def test_issue_8245():
     a = S("6506833320952669167898688709329/5070602400912917605986812821504")
     assert rel_check(a, a.n(10))
     assert rel_check(a, a.n(20))
-    # this will fail if self._prec is not used when converting
-    # the Rational to the Float
     assert rel_check(a, a.n())
+    # prec of 30 is enough to fully capture a as mpf
+    assert Float(a, 30) == Float(str(a.p), '')/Float(str(a.q), '')
+    for i in range(31):
+        r = Rational(Float(a, i))
+        f = Float(r)
+        assert (f < a) == (Rational(f) < a)
+    # test sign handling
+    assert (-f < -a) == (Rational(-f) < -a)
+    # test equivalence handling
+    isa = Float(a.p,'')/Float(a.q,'')
+    assert isa <= a
+    assert not isa < a
+    assert isa >= a
+    assert not isa > a
 
     a = sqrt(2)
     r = Rational(str(a.n(30)))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -14,6 +14,34 @@ from itertools import combinations
 x, y, z, t = symbols('x,y,z,t')
 
 
+def rel_check(a, b):
+    from sympy.utilities.pytest import raises
+    assert a.is_number and b.is_number
+    for do in range(len(set([type(a), type(b)]))):
+        if S.NaN in (a, b):
+            v = [(a == b), (a != b)]
+            assert len(set(v)) == 1 and v[0] == False
+            assert not (a != b) and not (a == b)
+            assert raises(TypeError, lambda: a < b)
+            assert raises(TypeError, lambda: a <= b)
+            assert raises(TypeError, lambda: a > b)
+            assert raises(TypeError, lambda: a >= b)
+        else:
+            E = [(a == b), (a != b)]
+            assert len(set(E)) == 2
+            v = [(a < b), (a <= b), (a > b), (a >= b)]
+            i = [
+            [True, True, False, False],
+            [False, True, False, True],
+            [False, False, True, True]].index(v)
+            if i != 1:
+                assert E[1]
+            else:
+                assert E[0]
+        a, b = b, a
+    return True
+
+
 def test_rel_ne():
     assert Relational(x, y, '!=') == Ne(x, y)
 
@@ -555,30 +583,19 @@ def test_ineq_avoid_wild_symbol_flip():
 
 def test_issue_8245():
     a = S("6506833320952669167898688709329/5070602400912917605986812821504")
-    q = a.n(10)
-    assert (a == q) is True
-    assert (a != q) is False
-    assert (a > q) == False
-    assert (a < q) == False
-    assert (a >= q) == True
-    assert (a <= q) == True
+    assert rel_check(a, a.n(10))
+    assert rel_check(a, a.n(20))
+    # this will fail if self._prec is not used when converting
+    # the Rational to the Float
+    assert rel_check(a, a.n())
 
     a = sqrt(2)
     r = Rational(str(a.n(30)))
-    assert (r == a) is False
-    assert (r != a) is True
-    assert (r > a) == True
-    assert (r < a) == False
-    assert (r >= a) == True
-    assert (r <= a) == False
+    assert rel_check(a, r)
+
     a = sqrt(2)
     r = Rational(str(a.n(29)))
-    assert (r == a) is False
-    assert (r != a) is True
-    assert (r > a) == False
-    assert (r < a) == True
-    assert (r >= a) == False
-    assert (r <= a) == True
+    assert rel_check(a, r)
 
     assert Eq(log(cos(2)**2 + sin(2)**2), 0) == True
 
@@ -758,22 +775,11 @@ def test_issues_13081_12583_12534():
     # pick one such precision and affirm that the reversed operation
     # gives the opposite result, i.e. if x < y is true then x > y
     # must be false
-    p = 20
-    # Rational vs NumberSymbol
-    G = [Rational(pi.n(i)) > pi for i in (p, p + 1)]
-    L = [Rational(pi.n(i)) < pi for i in (p, p + 1)]
-    assert G == [False, True]
-    assert all(i is not j for i, j in zip(L, G))
-    # Float vs NumberSymbol
-    G = [pi.n(i) > pi for i in (p, p + 1)]
-    L = [pi.n(i) < pi for i in (p, p + 1)]
-    assert G == [False, True]
-    assert all(i is not j for i, j in zip(L, G))
-    # Float vs Float
-    G = [pi.n(p) > pi.n(p + 1)]
-    L = [pi.n(p) < pi.n(p + 1)]
-    assert G == [True]
-    assert all(i is not j for i, j in zip(L, G))
+    for i in (20, 21):
+        v = pi.n(i)
+        assert rel_check(Rational(v), pi)
+        assert rel_check(v, pi)
+    assert rel_check(pi.n(20), pi.n(21))
     # Float vs Rational
     # the rational form is less than the floating representation
     # at the same precision

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -29,15 +29,16 @@ def rel_check(a, b):
         else:
             E = [(a == b), (a != b)]
             assert len(set(E)) == 2
-            v = [(a < b), (a <= b), (a > b), (a >= b)]
+            v = [
+            (a < b), (a <= b), (a > b), (a >= b)]
             i = [
-            [True, True, False, False],
-            [False, True, False, True],
-            [False, False, True, True]].index(v)
-            if i != 1:
-                assert E[1]
+            [True,    True,     False,   False],
+            [False,   True,     False,   True], # <-- i == 1
+            [False,   False,    True,    True]].index(v)
+            if i == 1:
+                assert E[0] or (a.is_Float != b.is_Float) # ugh
             else:
-                assert E[0]
+                assert E[1]
         a, b = b, a
     return True
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -601,6 +601,7 @@ def test_issue_8245():
     assert not isa < a
     assert isa >= a
     assert not isa > a
+    assert isa > 0
 
     a = sqrt(2)
     r = Rational(str(a.n(30)))

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -2,7 +2,8 @@ from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, N, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
     Pow, Or, true, false, Abs, pi, Range, Xor)
 from sympy.abc import x, y
-from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
+from sympy.core.sympify import (sympify, _sympify, SympifyError, kernS,
+    CantSympify)
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, XFAIL, skip
@@ -171,7 +172,17 @@ def test_issue_16772():
     # args are only sympified without the flags being passed
     # along; list, on the other hand, is not converted
     # with a converter so its args are traversed later
+    ans = [Rational(3, 10), Rational(1, 5)]
     assert sympify(tuple(['.3', '.2']), rational=True) == Tuple(*ans)
+
+
+@XFAIL
+def test_issue_16859():
+    # because there is a converter for float, the
+    # CantSympify class designation is ignored
+    class no(float, CantSympify):
+        pass
+    raises(SympifyError, lambda: sympify(no(1.2)))
 
 
 def test_sympify4():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -161,9 +161,17 @@ def test_sympify_bool():
 def test_sympyify_iterables():
     ans = [Rational(3, 10), Rational(1, 5)]
     assert sympify(['.3', '.2'], rational=True) == ans
-    assert sympify(tuple(['.3', '.2']), rational=True) == Tuple(*ans)
     assert sympify(dict(x=0, y=1)) == {x: 0, y: 1}
     assert sympify(['1', '2', ['3', '4']]) == [S(1), S(2), [S(3), S(4)]]
+
+
+@XFAIL
+def test_issue_16772():
+    # because there is a converter for tuple, the
+    # args are only sympified without the flags being passed
+    # along; list, on the other hand, is not converted
+    # with a converter so its args are traversed later
+    assert sympify(tuple(['.3', '.2']), rational=True) == Tuple(*ans)
 
 
 def test_sympify4():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -14,7 +14,7 @@ a, b, c, d, x, y = symbols('a:d, x, y')
 z = symbols('z', nonzero=True)
 
 
-def test_piecewise():
+def test_piecewise1():
 
     # Test canonicalization
     assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
@@ -144,8 +144,8 @@ def test_piecewise():
         (x**3/3 + S(4)/3, x < 0),
         (x*log(x) - x + S(4)/3, True))
     p = Piecewise((x, x < 1), (x**2, -1 <= x), (x, 3 < x))
-    assert integrate(p, (x, -2, 2)) == 5/6.0
-    assert integrate(p, (x, 2, -2)) == -5/6.0
+    assert integrate(p, (x, -2, 2)) == S(5)/6
+    assert integrate(p, (x, 2, -2)) == -S(5)/6
     p = Piecewise((0, x < 0), (1, x < 1), (0, x < 2), (1, x < 3), (0, True))
     assert integrate(p, (x, -oo, oo)) == 2
     p = Piecewise((x, x < -10), (x**2, x <= -1), (x, 1 < x))
@@ -546,10 +546,9 @@ def test_piecewise_fold():
 def test_piecewise_fold_piecewise_in_cond():
     p1 = Piecewise((cos(x), x < 0), (0, True))
     p2 = Piecewise((0, Eq(p1, 0)), (p1 / Abs(p1), True))
-    p3 = piecewise_fold(p2)
-    assert(p2.subs(x, -pi/2) == 0.0)
-    assert(p2.subs(x, 1) == 0.0)
-    assert(p2.subs(x, -pi/4) == 1.0)
+    assert p2.subs(x, -pi/2) == 0
+    assert p2.subs(x, 1) == 0
+    assert p2.subs(x, -pi/4) == 1
     p4 = Piecewise((0, Eq(p1, 0)), (1,True))
     ans = piecewise_fold(p4)
     for i in range(-1, 1):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -738,7 +738,13 @@ class Ellipse(GeometrySet):
             else:
                 return False
         elif isinstance(o, Line2D):
-            return len(self.intersection(o)) == 1
+            hit = self.intersection(o)
+            if not hit:
+                return False
+            if len(hit) == 1:
+                return True
+            # might return None if it can't decide
+            return hit[0].equals(hit[1])
         elif isinstance(o, Ray2D):
             intersect = self.intersection(o)
             if len(intersect) == 1:

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -324,7 +324,9 @@ class Point(GeometryEntity):
         points = [i - origin for i in points[1:]]
 
         m = Matrix([i.args for i in points])
-        return m.rank()
+        # XXX fragile -- what is a better way?
+        return m.rank(iszerofunc = lambda x:
+            abs(x.n(2)) < 1e-12 if x.is_number else x.is_zero)
 
     @property
     def ambient_dimension(self):

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -472,7 +472,7 @@ def test_issue_15259():
     assert Circle((1, 2), 0) == Point(1, 2)
 
 
-def test_issue_15797():
+def test_issue_15797_equals():
     Ri = 0.024127189424130748
     Ci = (0.0864931002830291, 0.0819863295239654)
     A = Point(0, 0.0578591400998346)

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -531,8 +531,8 @@ def test_intersection_2d():
         Point2D(n/d*S(3)/2000, -S(497)/10)]
 
 
-@slow
 def test_line_intersection():
+    # see also test_issue_11238 in test_matrices.py
     x0 = tan(13*pi/45)
     x1 = sqrt(3)
     x2 = x0**2

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -103,7 +103,7 @@ def test_point():
 
     a, b = Rational(1, 2), Rational(1, 3)
     assert Point(a, b).evalf(2) == \
-        Point(a.n(2), b.n(2))
+        Point(a.n(2), b.n(2), evaluate=False)
     raises(ValueError, lambda: Point(1, 2) + 1)
 
     # test transformations
@@ -179,10 +179,10 @@ def test_point3D():
     assert Point3D(x*(x - 1), y, 2) - Point3D(x**2 - x, y + 1, 1) == \
         Point3D(0, -1, 1)
 
-    a, b = Rational(1, 2), Rational(1, 3)
-    assert Point(a, b).evalf(2) == \
-        Point(a.n(2), b.n(2))
-    raises(ValueError, lambda: Point(1, 2) + 1)
+    a, b, c = Rational(1, 2), Rational(1, 3), Rational(1, 4)
+    assert Point3D(a, b, c).evalf(2) == \
+        Point(a.n(2), b.n(2), c.n(2), evaluate=False)
+    raises(ValueError, lambda: Point3D(1, 2, 3) + 1)
 
     # test transformations
     p = Point3D(1, 1, 1)
@@ -194,7 +194,6 @@ def test_point3D():
 
     # Test __new__
     assert Point3D(0.1, 0.2, evaluate=False, on_morph='ignore').args[0].is_Float
-
 
     # Test length property returns correctly
     assert p.length == 0
@@ -351,11 +350,11 @@ def test_arguments():
     # test evaluate=False for ops
     x = Symbol('x')
     a = Point(0, 1)
-    assert a + (0.1, x) == Point(0.1, 1 + x)
+    assert a + (0.1, x) == Point(0.1, 1 + x, evaluate=False)
     a = Point(0, 1)
-    assert a/10.0 == Point(0.0, 0.1)
+    assert a/10.0 == Point(0, 0.1, evaluate=False)
     a = Point(0, 1)
-    assert a*10.0 == Point(0.0, 10.0)
+    assert a*10.0 == Point(0.0, 10.0, evaluate=False)
 
     # test evaluate=False when changing dimensions
     u = Point(.1, .2, evaluate=False)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3359,9 +3359,13 @@ def test_issue_11238():
     m2 = Matrix([p1 - p0, p2 - p0])
     m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])
 
-    assert m1.rank(simplify=True) == 1
-    assert m2.rank(simplify=True) == 1
-    assert m3.rank(simplify=True) == 1
+    # This system has expressions which are zero and
+    # cannot be easily proved to be such, so without
+    # numerical testing, these assertions will fail.
+    Z = lambda x: abs(x.n()) < 1e-20
+    assert m1.rank(simplify=True, iszerofunc=Z) == 1
+    assert m2.rank(simplify=True, iszerofunc=Z) == 1
+    assert m3.rank(simplify=True, iszerofunc=Z) == 1
 
 def test_as_real_imag():
     m1 = Matrix(2,2,[1,2,3,4])

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -285,20 +285,21 @@ def multiplicity(p, n):
 def perfect_power(n, candidates=None, big=True, factor=True):
     """
     Return ``(b, e)`` such that ``n`` == ``b**e`` if ``n`` is a
-    perfect power; otherwise return ``False``.
+    perfect power with ``e > 1``, else ``False``. A ValueError is
+    raised if ``n`` is not an integer or is not positive.
 
     By default, the base is recursively decomposed and the exponents
     collected so the largest possible ``e`` is sought. If ``big=False``
     then the smallest possible ``e`` (thus prime) will be chosen.
 
-    If ``candidates`` for exponents are given, they are assumed to be sorted
-    and the first one that is larger than the computed maximum will signal
-    failure for the routine.
+    If ``candidates`` for exponents are given, they are assumed to be
+    sorted and the first one that is larger than the computed maximum
+    will signal failure for the routine.
 
-    If ``factor=True`` then simultaneous factorization of n is attempted
-    since finding a factor indicates the only possible root for n. This
-    is True by default since only a few small factors will be tested in
-    the course of searching for the perfect power.
+    If ``factor=True`` then simultaneous factorization of n is
+    attempted since finding a factor indicates the only possible root
+    for n. This is True by default since only a few small factors will
+    be tested in the course of searching for the perfect power.
 
     Examples
     ========
@@ -306,11 +307,22 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     >>> from sympy import perfect_power
     >>> perfect_power(16)
     (2, 4)
-    >>> perfect_power(16, big = False)
+    >>> perfect_power(16, big=False)
     (4, 2)
+
+    Notes
+    =====
+
+    To know whether an integer is a perfect power of 2 use
+
+    >>> is2pow = lambda n: bool(n and not n & (n - 1))
+    >>> [(i, is2pow(i)) for i in range(5)]
+    [(0, False), (1, True), (2, True), (3, False), (4, True)]
     """
-    n = int(n)
+    n = as_int(n)
     if n < 3:
+        if n < 1:
+            raise ValueError('expecting positive n')
         return False
     logn = math.log(n, 2)
     max_possible = int(logn) + 2  # only check values less than this

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -112,7 +112,8 @@ def test_multiplicity():
 
 
 def test_perfect_power():
-    assert perfect_power(0) is False
+    raises(ValueError, lambda: perfect_power(0))
+    raises(ValueError, lambda: perfect_power(Rational(25, 4)))
     assert perfect_power(1) is False
     assert perfect_power(2) is False
     assert perfect_power(3) is False

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -70,7 +70,7 @@ def R_nl(n, l, r, Z=1):
 
     """
     # sympify arguments
-    n, l, r, Z = S(n), S(l), S(r), S(Z)
+    n, l, r, Z = map(S, [n, l, r, Z])
     # radial quantum number
     n_r = n - l - 1
     # rescaled "r"
@@ -82,6 +82,7 @@ def R_nl(n, l, r, Z=1):
     # some books. Both coefficients seem to be the same fast:
     # C =  S(2)/n**2 * sqrt(1/a**3 * factorial(n_r) / (factorial(n+l)))
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
+
 
 def Psi_nlm(n, l, m, r, phi, theta, Z=1):
     """
@@ -129,17 +130,16 @@ def Psi_nlm(n, l, m, r, phi, theta, Z=1):
     """
 
     # sympify arguments
-    n, l, m, r, phi, theta, Z = S(n), S(l), S(m), S(r), S(phi), S(theta), S(Z)
+    n, l, m, r, phi, theta, Z = map(S, [n, l, m, r, phi, theta, Z])
     # check if values for n,l,m make physically sense
-    if n.is_integer and n<1:
+    if n.is_integer and n < 1:
         raise ValueError("'n' must be positive integer")
     if l.is_integer and not (n > l):
         raise ValueError("'n' must be greater than 'l'")
-    if m.is_integer and not (abs(m)<=l):
+    if m.is_integer and not (abs(m) <= l):
         raise ValueError("|'m'| must be less or equal 'l'")
     # return the hydrogen wave function
-    return R_nl(n, l, r, Z)*Ynm(l,m,theta,phi).expand(func=True)
-
+    return R_nl(n, l, r, Z)*Ynm(l, m, theta, phi).expand(func=True)
 
 
 def E_nl(n, Z=1):
@@ -217,6 +217,7 @@ def E_nl_dirac(n, l, spin_up=True, Z=1, c=Float("137.035999037")):
     -0.0555558020932949
 
     """
+    n, l, Z, c = map(S, [n, l, Z, c])
     if not (l >= 0):
         raise ValueError("'l' must be positive or zero")
     if not (n > l):
@@ -228,6 +229,5 @@ def E_nl_dirac(n, l, spin_up=True, Z=1, c=Float("137.035999037")):
         skappa = -l - 1
     else:
         skappa = -l
-    c = S(c)
     beta = sqrt(skappa**2 - Z**2/c**2)
     return c**2/sqrt(1 + Z**2/(n + skappa + beta)**2/c**2) - c**2

--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -1,3 +1,4 @@
+from sympy.core.numbers import comp
 from sympy.physics.optics.utils import (refraction_angle, fresnel_coefficients,
         deviation, brewster_angle, critical_angle, lens_makers_formula,
         mirror_formula, lens_formula, hyperfocal_distance,
@@ -14,6 +15,8 @@ from sympy.core import S
 
 from sympy.utilities.pytest import raises
 
+
+ae = lambda a, b, n: comp(a, b, 10**-n)
 
 def test_refraction_angle():
     n1, n2 = symbols('n1, n2')
@@ -63,8 +66,8 @@ def test_refraction_angle():
     assert refraction_angle(r1, 1.33, 1, plane=P) == 0  # TIR
     assert refraction_angle(r1, 1, 1, normal_ray) == \
         Ray3D(Point3D(0, 0, 0), direction_ratio=[1, 1, -1])
-    assert round(refraction_angle(0.5, 1, 2), 5) == 0.24207
-    assert round(refraction_angle(0.5, 2, 1), 5) == 1.28293
+    assert ae(refraction_angle(0.5, 1, 2), 0.24207, 5)
+    assert ae(refraction_angle(0.5, 2, 1), 1.28293, 5)
     raises(ValueError, lambda: refraction_angle(r1, m1, m2, normal_ray, P))
     raises(TypeError, lambda: refraction_angle(m1, m1, m2)) # can add other values for arg[0]
     raises(TypeError, lambda: refraction_angle(r1, m1, m2, None, i))
@@ -72,17 +75,22 @@ def test_refraction_angle():
 
 
 def test_fresnel_coefficients():
-    assert list(round(i, 5) for i in fresnel_coefficients(0.5, 1, 1.33)) == \
-        [0.11163, -0.17138, 0.83581, 0.82862]
-    assert list(round(i, 5) for i in fresnel_coefficients(0.5, 1.33, 1)) == \
-            [-0.07726, 0.20482, 1.22724, 1.20482]
+    assert all(ae(i, j, 5) for i, j in zip(
+        fresnel_coefficients(0.5, 1, 1.33),
+        [0.11163, -0.17138, 0.83581, 0.82862]))
+    assert all(ae(i, j, 5) for i, j in zip(
+        fresnel_coefficients(0.5, 1.33, 1),
+        [-0.07726, 0.20482, 1.22724, 1.20482]))
     m1 = Medium('m1')
     m2 = Medium('m2', n=2)
-    assert list(round(i, 5) for i in fresnel_coefficients(0.3, m1, m2)) == \
-        [0.31784, -0.34865, 0.65892, 0.65135]
-    assert list(list(round(j, 5) for j in i.as_real_imag()) for i in \
-            fresnel_coefficients(0.6, m2, m1)) == \
-        [[-0.23563, -0.97184], [0.81648, -0.57738]]
+    assert all(ae(i, j, 5) for i, j in zip(
+        fresnel_coefficients(0.3, m1, m2),
+        [0.31784, -0.34865, 0.65892, 0.65135]))
+    ans = [[-0.23563, -0.97184], [0.81648, -0.57738]]
+    got = fresnel_coefficients(0.6, m2, m1)
+    for i, j in zip(got, ans):
+        for a, b in zip(i.as_real_imag(), j):
+            assert ae(a, b, 5)
 
 
 def test_deviation():
@@ -99,24 +107,24 @@ def test_deviation():
     assert deviation(r1, 1.33, 1, plane=P) is None  # TIR
     assert deviation(r1, 1, 1, normal=[0, 0, 1]) == 0
     assert deviation([-1, -1, -1], 1, 1, normal=[0, 0, 1]) == 0
-    assert round(deviation(0.5, 1, 2), 5) == -0.25793
-    assert round(deviation(0.5, 2, 1), 5) == 0.78293
+    assert ae(deviation(0.5, 1, 2), -0.25793, 5)
+    assert ae(deviation(0.5, 2, 1), 0.78293, 5)
 
 
 def test_brewster_angle():
     m1 = Medium('m1', n=1)
     m2 = Medium('m2', n=1.33)
-    assert round(brewster_angle(m1, m2), 2) == 0.93
+    assert ae(brewster_angle(m1, m2), 0.93, 2)
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert round(brewster_angle(m1, m2), 2) == 0.93
-    assert round(brewster_angle(1, 1.33), 2) == 0.93
+    assert ae(brewster_angle(m1, m2), 0.93, 2)
+    assert ae(brewster_angle(1, 1.33), 0.93, 2)
 
 
 def test_critical_angle():
     m1 = Medium('m1', n=1)
     m2 = Medium('m2', n=1.33)
-    assert round(critical_angle(m2, m1), 2) == 0.85
+    assert ae(critical_angle(m2, m1), 0.85, 2)
 
 
 def test_lens_makers_formula():
@@ -124,8 +132,8 @@ def test_lens_makers_formula():
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
     assert lens_makers_formula(n1, n2, 10, -10) == 5*n2/(n1 - n2)
-    assert round(lens_makers_formula(m1, m2, 10, -10), 2) == -20.15
-    assert round(lens_makers_formula(1.33, 1, 10, -10), 2) == 15.15
+    assert ae(lens_makers_formula(m1, m2, 10, -10), -20.15, 2)
+    assert ae(lens_makers_formula(1.33, 1, 10, -10),  15.15, 2)
 
 
 def test_mirror_formula():
@@ -166,7 +174,7 @@ def test_lens_formula():
 def test_hyperfocal_distance():
     f, N, c = symbols('f, N, c')
     assert hyperfocal_distance(f=f, N=N, c=c) == f**2/(N*c)
-    assert round(hyperfocal_distance(f=0.5, N=8, c=0.0033), 2) == 9.47
+    assert ae(hyperfocal_distance(f=0.5, N=8, c=0.0033), 9.47, 2)
 
 def test_transverse_magnification():
     si, so = symbols('si, so')

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -63,7 +63,7 @@ def test_dim_simplify_dimless():
 def test_convert_to_quantities():
     assert convert_to(3, meter) == 3
 
-    assert convert_to(mile, kilometer) == 1.609344*kilometer
+    assert convert_to(mile, kilometer) == 25146*kilometer/15625
     assert convert_to(meter/second, speed_of_light) == speed_of_light/299792458
     assert convert_to(299792458*meter/second, speed_of_light) == speed_of_light
     assert convert_to(2*299792458*meter/second, speed_of_light) == 2*speed_of_light

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -71,12 +71,12 @@ def test_convert_to_quantities():
     assert convert_to(2*speed_of_light, meter/second) == 599584916*meter/second
     assert convert_to(day, second) == 86400*second
     assert convert_to(2*hour, minute) == 120*minute
-    assert convert_to(mile, meter) == 1609.344*meter
+    assert convert_to(mile, meter) == 201168*meter/125
     assert convert_to(mile/hour, kilometer/hour) == 25146*kilometer/(15625*hour)
     assert convert_to(3*newton, meter/second) == 3*newton
     assert convert_to(3*newton, kilogram*meter/second**2) == 3*meter*kilogram/second**2
-    assert convert_to(kilometer + mile, meter) == 2609.344*meter
-    assert convert_to(2*kilometer + 3*mile, meter) == 6828.032*meter
+    assert convert_to(kilometer + mile, meter) == 326168*meter/125
+    assert convert_to(2*kilometer + 3*mile, meter) == 853504*meter/125
     assert convert_to(inch**2, meter**2) == 16129*meter**2/25000000
     assert convert_to(3*inch**2, meter) == 48387*meter**2/25000000
     assert convert_to(2*kilometer/hour + 3*mile/hour, meter/second) == 53344*meter/(28125*second)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -512,7 +512,7 @@ def test_Float():
     assert str(pi.evalf(1 + 14)) == '3.14159265358979'
     assert str(pi.evalf(1 + 64)) == ('3.141592653589793238462643383279'
                                      '5028841971693993751058209749445923')
-    assert str(pi.round(-1)) == '0.'
+    assert str(pi.round(-1)) == '0.0'
     assert str((pi**400 - (pi**400).round(1)).n(2)) == '-0.e+88'
 
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -518,7 +518,9 @@ def test_ComplexRegion_contains():
     r1 = Interval(0, 1)
     theta1 = Interval(0, 2*S.Pi)
     c3 = ComplexRegion(r1*theta1, polar=True)
-    assert 0.5 + 0.6*I in c3
+    #assert (0.5 + 6*I/10) in c3
+    assert (S.Half + .6*I) in c3
+    assert (S.Half + 6*I/10) in c3
     assert I in c3
     assert 1 in c3
     assert 0 in c3

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -518,9 +518,10 @@ def test_ComplexRegion_contains():
     r1 = Interval(0, 1)
     theta1 = Interval(0, 2*S.Pi)
     c3 = ComplexRegion(r1*theta1, polar=True)
-    #assert (0.5 + 6*I/10) in c3
-    assert (S.Half + .6*I) in c3
+    assert (0.5 + 6*I/10) in c3
     assert (S.Half + 6*I/10) in c3
+    assert (S.Half + .6*I) in c3
+    assert (0.5 + .6*I) in c3
     assert I in c3
     assert 1 in c3
     assert 0 in c3

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4055,7 +4055,7 @@ def ode_nth_order_reducible(eq, func, order, match):
     >>> from sympy import Function, dsolve, Eq
     >>> from sympy.abc import x
     >>> f = Function('f')
-    >>> eq = Eq(x*f(x).diff(x)**2 + f(x).diff(x, 2))
+    >>> eq = Eq(x*f(x).diff(x)**2 + f(x).diff(x, 2), 0)
     >>> dsolve(eq, f(x), hint='nth_order_reducible')
     ... # doctest: +NORMALIZE_WHITESPACE
     Eq(f(x), C1 - sqrt(-1/C2)*log(-C2*sqrt(-1/C2) + x) + sqrt(-1/C2)*log(C2*sqrt(-1/C2) + x))

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,5 +1,6 @@
 from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, Rational,
                     simplify, Piecewise, factorial, Eq, gamma)
+from sympy.core.numbers import comp
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
 from sympy.stats.joint_rv_types import JointRV
@@ -99,7 +100,7 @@ def test_Multinomial():
     f = factorial
     assert simplify(density(M)(x1, x2, x3, x4) -
             S(6)*p1**x1*p2**x2*p3**x3*p4**x4/(f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert marginal_distribution(M_c, M_c[0])(1).round(2) == 7.29
+    assert comp(marginal_distribution(M_c, M_c[0])(1), 7.29, 10**-2)
     raises(ValueError, lambda: Multinomial('b1', 5, [p1, p2, p3, p1_f]))
     raises(ValueError, lambda: Multinomial('b2', n, [p1, p2, p3, p4]))
 
@@ -115,11 +116,12 @@ def test_NegativeMultinomial():
     assert simplify(density(N)(x1, x2, x3, x4) -
             p1**x1*p2**x2*p3**x3*p4**x4*(-p1 - p2 - p3 - p4 + 1)**4*g(x1 + x2 +
             x3 + x4 + 4)/(6*f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert marginal_distribution(N_c, N_c[0])(1).evalf().round(2) == 0.33
+    assert comp(marginal_distribution(N_c, N_c[0])(1).evalf(), 0.33, 10**-2)
     raises(ValueError, lambda: NegativeMultinomial('b1', 5, [p1, p2, p3, p1_f]))
     raises(ValueError, lambda: NegativeMultinomial('b2', k0, [p1, p2, p3, p4]))
 
-def test_JointPSpace_margial_distribution():
+
+def test_JointPSpace_marginal_distribution():
     from sympy.stats.joint_rv_types import MultivariateT
     from sympy import polar_lift
     T = MultivariateT('T', [0, 0], [[1, 0], [0, 1]], 2)
@@ -127,7 +129,7 @@ def test_JointPSpace_margial_distribution():
         8*polar_lift(x**2/2 + 1)**(S(5)/2))
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
     t = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)
-    assert marginal_distribution(t, 0)(1).evalf().round(1) == 0.2
+    assert comp(marginal_distribution(t, 0)(1).evalf(), 0.2, 10**-1)
 
 
 def test_JointRV():

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -100,7 +100,7 @@ def test_Multinomial():
     f = factorial
     assert simplify(density(M)(x1, x2, x3, x4) -
             S(6)*p1**x1*p2**x2*p3**x3*p4**x4/(f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert comp(marginal_distribution(M_c, M_c[0])(1), 7.29, 10**-2)
+    assert comp(marginal_distribution(M_c, M_c[0])(1), 7.29, .01)
     raises(ValueError, lambda: Multinomial('b1', 5, [p1, p2, p3, p1_f]))
     raises(ValueError, lambda: Multinomial('b2', n, [p1, p2, p3, p4]))
 
@@ -116,7 +116,7 @@ def test_NegativeMultinomial():
     assert simplify(density(N)(x1, x2, x3, x4) -
             p1**x1*p2**x2*p3**x3*p4**x4*(-p1 - p2 - p3 - p4 + 1)**4*g(x1 + x2 +
             x3 + x4 + 4)/(6*f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert comp(marginal_distribution(N_c, N_c[0])(1).evalf(), 0.33, 10**-2)
+    assert comp(marginal_distribution(N_c, N_c[0])(1).evalf(), 0.33, .01)
     raises(ValueError, lambda: NegativeMultinomial('b1', 5, [p1, p2, p3, p1_f]))
     raises(ValueError, lambda: NegativeMultinomial('b2', k0, [p1, p2, p3, p4]))
 
@@ -129,7 +129,7 @@ def test_JointPSpace_marginal_distribution():
         8*polar_lift(x**2/2 + 1)**(S(5)/2))
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
     t = MultivariateT('T', [0, 0, 0], [[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3)
-    assert comp(marginal_distribution(t, 0)(1).evalf(), 0.2, 10**-1)
+    assert comp(marginal_distribution(t, 0)(1).evalf(), 0.2, .01)
 
 
 def test_JointRV():

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -109,13 +109,14 @@ def test_IndependentProductPSpace():
 def test_E():
     assert E(5) == 5
 
+
 def test_H():
     X = Normal('X', 0, 1)
     D = Die('D', sides = 4)
     G = Geometric('G', 0.5)
     assert H(X, X > 0) == -log(2)/2 + S(1)/2 + log(pi)/2
     assert H(D, D > 2) == log(2)
-    assert comp(H(G).evalf().round(2), 1.39, 10**-2)
+    assert comp(H(G).evalf().round(2), 1.39)
 
 
 def test_Sample():

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
         DiracDelta, Lambda, log, pi)
+from sympy.core.numbers import comp
 from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance, covariance,
         skewness, density, given, independent, dependent, where, pspace,
         random_symbols, sample, Geometric)
@@ -114,7 +115,7 @@ def test_H():
     G = Geometric('G', 0.5)
     assert H(X, X > 0) == -log(2)/2 + S(1)/2 + log(pi)/2
     assert H(D, D > 2) == log(2)
-    assert H(G).evalf().round(2) == 1.39
+    assert comp(H(G).evalf().round(2), 1.39, 10**-2)
 
 
 def test_Sample():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Not marking as closed until this is stable

closes #4473
 does not change #11707 since `Float(1,3) == Float(1,10)` but the hashes are different
closes #11072

#### Brief description of what is fixed or changed

Comparisons between Float and Rational were tightened up so results are more precise, e.g. `Float('1/3') != S(1)/3`...but this is currently under discussion.

#### Other comments

Initially this PR enforced a strict comparison of Float/Rational in expressions and a loose enforcement when comparing Numbers. This identified places in the code that weren't keeping track of whether the result should be a Float or Rational as in the subs `(x**(4.*y)).subs(x**(2.0*y), z)` which gave `z**2` instead of `z**2.0`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - comparison of Rational and Floats is more accurate
    - subs involving Float exponents will now retain the float as in `(x**(4.*y)).subs(x**(2.0*y), z) -> z**2.0` instead of `z**2`.
    - `equals` corrected to not make decisions based on numbers that evaluate without precision; self consistency based on solving for surds and an attempt to find minpoly are now attempted for all numberical expressions
    - Number can be used to instantiate oo and nan from strings
    - more stringent checks on the use of underscores in numbers passed as strings to Float are now made
    - checks for malformed mpf values passed to Float are now made
    - `1/S(0)` now returns `zoo`
- geometry
    - `ellipse.is_tangent` is more careful about deciding if a line that intersects at two points is not tangent -- it is possible to calculate an intersection as two point that are symbolically different but actually represent the same point in which case the line is tangent
    - `Point.affine_rank` now uses an `iszerofunc` that assumes numbers less than 1e-12 are zero during rank calculation.
<!-- END RELEASE NOTES -->
