### PR TITLE
sympify handles iterable contents

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -42,7 +42,7 @@ Moved modules:
     * `reduce()`
     * `StringIO()`
     * `cStringIO()` (same as `StingIO()` in Python 3)
-    * Python 2 `__builtins__`, access with Python 3 name, `builtins`
+    * Python 2 `__builtin__`, access with Python 3 name, `builtins`
 
 Iterator/list changes:
     * `xrange` renamed as `range` in Python 3, import `range` for Python 2/3

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -268,6 +268,8 @@ class Dict(Basic):
         from sympy.utilities import default_sort_key
         return tuple(sorted(self.args, key=default_sort_key))
 
+converter[dict] = lambda d: Dict(*d.items())
+
 
 class OrderedSet(MutableSet):
     def __init__(self, iterable=None):

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function, division
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range, MutableSet
@@ -269,6 +269,12 @@ class Dict(Basic):
         return tuple(sorted(self.args, key=default_sort_key))
 
 converter[dict] = lambda d: Dict(*d.items())
+# a user can pass defaultdict to Dict but the
+# result is dict-like not defaultdict-like
+# so if strict is False we will process defaultdict
+# and return it as the same but if strict is True
+# an error will raise
+converter[defaultdict] = None
 
 
 class OrderedSet(MutableSet):

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1536,4 +1536,4 @@ def N(x, n=15, **options):
     1.291
 
     """
-    return sympify(x).evalf(n, **options)
+    return sympify(x, evaluate=False).evalf(n, **options)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3010,7 +3010,7 @@ def count_ops(expr, visual=False):
             if not a.is_Symbol:
                 args.extend(a.args)
 
-    elif type(expr) is dict:
+    elif isinstance(expr, Dict):
         ops = [count_ops(k, visual=visual) +
                count_ops(v, visual=visual) for k, v in expr.items()]
     elif iterable(expr):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -298,7 +298,7 @@ class AssocOp(Basic):
         was a number with no functions it would have been evaluated, but
         it wasn't so we must judiciously extract the numbers and reconstruct
         the object. This is *not* simply replacing numbers with evaluated
-        numbers. Nunmbers should be handled in the largest pure-number
+        numbers. Numbers should be handled in the largest pure-number
         expression as possible. So the code below separates ``self`` into
         number and non-number parts and evaluates the number parts and
         walks the args of the non-number part recursively (doing the same

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -78,7 +78,7 @@ def _convert_numpy_types(a):
 
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
-        evaluate=None):
+        evaluate=None, deep=False):
     """Converts an arbitrary expression to a type that can be used inside SymPy.
 
     For example, it will convert Python ints into instances of sympy.Integer,
@@ -244,6 +244,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     Notes
     =====
 
+    The keywords ``rational`` and ``convert_xor`` are ignored only used
+    when the input is a string unless ``deep`` is True.
+
     Sometimes autosimplification during sympification results in expressions
     that are very different in structure than what was entered. Until such
     autosimplification is no longer done, the ``kernS`` function might be of
@@ -388,14 +391,14 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         if not known and not strict and iterable(a, exclude=None):
             return iwalk(a, lambda i: sympify(i, **kw))
         elif known:
-            if not convert_xor:
+            if deep and not convert_xor:
                 def do(a):
                     if isinstance(a, string_types):
                         return _sympify_str(a, **kw)
                     return a
                 a = iwalk(a, do)
             rv = known(a)
-            if rational:
+            if deep and rational:
                 rv = sympify(rv, rational=True, strict=strict)
             return rv
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -266,6 +266,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     """
     from .basic import Basic
     from .numbers import Integer, Rational, Float
+    from .rules import Transform
     from sympy.utilities.misc import filldedent
     from sympy.utilities.iterables import iwalk
 
@@ -365,12 +366,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         # handle the rational flag as expediently as
         # possible on this SymPy object
         if rational:
-            f = done.atoms(Float)
-            r = list(f)
-            if rational == 'str':
-                r = map(str, r)
-            r = map(Rational, r)
-            return done.xreplace(dict(zip(f, r)))
+            return done.xreplace(Transform(
+                lambda x: Rational(str(x) if rational=='str' else x),
+                lambda x: x.is_Float))
         # otherwise it was a SymPy object and
         # we haven't made modifications so we
         # don't raise a CantSympify error

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -270,7 +270,14 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     # let `a` do it
     _sympy_ = getattr(a, "_sympy_", None)
     if _sympy_ is not None:
-        return a._sympy_()
+        try:
+            return a._sympy_()
+        # XXX: Catches AttributeError: 'SympyConverter' object has no
+        # attribute 'tuple'
+        # This is probably a bug somewhere but for now we catch it here.
+        # See commit message for full traceback.
+        except AttributeError:
+            pass
 
     # True/False/None/float/int quick exits
     if a is None:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -558,3 +558,8 @@ def test_issue_11151():
     expr1 = Sum(0, (x, 1, 2))
     expr2 = expr1/expr0
     assert simplify(factor(expr2) - expr2) == 0
+
+
+def test_issue_13425():
+    assert N('2**.5', 30) == N('sqrt(2)', 30)
+    assert N('x - x', 30) == 0

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -2,7 +2,7 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
         Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise, Indexed,
-        Matrix, Basic, Dict)
+        Matrix, Basic, Dict, Line)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.basic import _aresame
 from sympy.core.function import PoleError, _mexpand, arity
@@ -857,6 +857,13 @@ def test_nfloat():
     assert nfloat(Eq((3 - I)**2/2 + I, 0)) == S.false
     # pass along kwargs
     assert nfloat([{S.Half: x}], dkeys=True) == [{Float(0.5): x}]
+    # handle all objects
+    assert str(nfloat(1 + pi, 2)) == '4.1'
+    line = Line((123456, 1.1234), (pi + sqrt(2), Rational(3, 12345)))
+    assert str(nfloat(line, 2)) == \
+        'Line2D(Point2D(1.2e+5, 1.1), Point2D(4.6, 0.00024))'
+    assert sstr(nfloat(Line((1, sqrt(2) + pi),(3, 4)), 2)) == \
+        'Line2D(Point2D(1.0, 4.6), Point2D(3.0, 4.0))'
 
 
 def test_issue_7068():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -862,7 +862,7 @@ def test_nfloat():
     line = Line((123456, 1.1234), (pi + sqrt(2), Rational(3, 12345)))
     assert str(nfloat(line, 2)) == \
         'Line2D(Point2D(1.2e+5, 1.1), Point2D(4.6, 0.00024))'
-    assert sstr(nfloat(Line((1, sqrt(2) + pi),(3, 4)), 2)) == \
+    assert str(nfloat(Line((1, sqrt(2) + pi),(3, 4)), 2)) == \
         'Line2D(Point2D(1.0, 4.6), Point2D(3.0, 4.0))'
 
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -616,7 +616,8 @@ def test_issue_10295():
     assert sympify(a2) == ImmutableDenseNDimArray([i for i in range(24)], (2, 4, 3))
 
     A = numpy.array([0.5])
-    assert S(A, rational=True)[0] is S.Half
+    assert S(A, rational=True)[0] is not S.Half
+    assert S(A, rational=True, deep=True)[0] is S.Half
 
 
 def test_Range():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -737,3 +737,7 @@ def test_CantSympify():
     raises(SympifyError, lambda: sympify(m))
     # error raises within container, too
     raises(SympifyError, lambda: sympify([1, m]))
+    # and string
+    class my(str, CantSympify):
+        pass
+    raises(SympifyError, lambda: sympify(my(123)))

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -741,3 +741,7 @@ def test_CantSympify():
     class my(str, CantSympify):
         pass
     raises(SympifyError, lambda: sympify(my(123)))
+    class my(float):
+        def _sympy_(self):
+            return Float(self, 2)
+    assert str(sympify(my(1.2345))) == '1.2'

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -600,6 +600,9 @@ def test_issue_10295():
     assert sympify(a1) == ImmutableDenseNDimArray([1, 2, 3])
     assert sympify(a2) == ImmutableDenseNDimArray([i for i in range(24)], (2, 4, 3))
 
+    A = numpy.array([0.5])
+    assert S(A, rational=True)[0] is S.Half
+
 
 def test_Range():
     # Only works in Python 3 where range returns a range type

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -211,8 +211,12 @@ def test_sympyify_iterables():
     L = sympify(['.5'], rational=True)
     assert isinstance(L, list) and L[0] is S.Half
     T = sympify(tuple(['.5']), rational=True)
+    assert isinstance(T, Tuple) and T[0] is not S.Half
+    T = sympify(tuple(['.5']), rational=True, deep=True)
     assert isinstance(T, Tuple) and T[0] is S.Half
     D = sympify({1: .5}, rational=True)
+    assert D[1] is not S.Half and list(D.keys())[0] is S.One
+    D = sympify({1: .5}, rational=True, deep=True)
     assert D[1] is S.Half and list(D.keys())[0] is S.One
     D = sympify(defaultdict(int, {1: .5}), rational=True)
     assert list(D.keys())[0] is S.One
@@ -222,7 +226,18 @@ def test_sympyify_iterables():
     ans = [.5]
     F = sympify(set(ans), rational=True)
     assert isinstance(F, FiniteSet)
+    assert list(F).pop() is not S.Half
+    F = sympify(set(ans), rational=True, deep=True)
+    assert isinstance(F, FiniteSet)
     assert list(F).pop() is S.Half
+    # check deep handling of xor
+    a = 'x^2'
+    p = x**2
+    xor = S(a, convert_xor=False)
+    assert xor != p
+    assert sympify(('x^2',), convert_xor=True) == (p,)
+    assert sympify(('x^2',), convert_xor=False) == (p,)
+    assert sympify(('x^2',), convert_xor=False, deep=True) == (xor,)
 
 
 def test_sympify4():

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -738,7 +738,13 @@ class Ellipse(GeometrySet):
             else:
                 return False
         elif isinstance(o, Line2D):
-            return len(self.intersection(o)) == 1
+            hits = self.intersection(o)
+            if not hits:
+                return False
+            if len(hits) == 1:
+                return True
+            assert len(hits) == 2
+            return hits[0].equals(hits[1])  # XXX should we raise Undecidable if None?
         elif isinstance(o, Ray2D):
             intersect = self.intersection(o)
             if len(intersect) == 1:

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -475,8 +475,19 @@ def test_issue_15259():
 def test_issue_15797():
     Ri = 0.024127189424130748
     Ci = (0.0864931002830291, 0.0819863295239654)
-    A = Point(0, 0.0578591400998346)
+    A = Point(0, 0.0578591400998346, evaluate=False)
+    B = Point(0, 0.0578591400998346)
     c = Circle(Ci, Ri)  # evaluated
+    for x in (A, B):
+        print()
+        for li in c.tangent_lines(x):
+            from sympy import nfloat
+            print(c.is_tangent(li))
+            try:
+                print(nfloat(c.intersection(li), 3))
+            except:
+                print('fail', nfloat(li, 3))
+    assert c.is_tangent(c.tangent_lines(B)[0]) == True
     assert c.is_tangent(c.tangent_lines(A)[0]) == True
     assert c.center.x.is_Rational
     assert c.center.y.is_Rational

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -478,17 +478,8 @@ def test_issue_15797():
     A = Point(0, 0.0578591400998346, evaluate=False)
     B = Point(0, 0.0578591400998346)
     c = Circle(Ci, Ri)  # evaluated
-    for x in (A, B):
-        print()
-        for li in c.tangent_lines(x):
-            from sympy import nfloat
-            print(c.is_tangent(li))
-            try:
-                print(nfloat(c.intersection(li), 3))
-            except:
-                print('fail', nfloat(li, 3))
     assert c.is_tangent(c.tangent_lines(B)[0]) == True
-    assert c.is_tangent(c.tangent_lines(A)[0]) == True
+    assert c.is_tangent(c.tangent_lines(A)[0]) == False
     assert c.center.x.is_Rational
     assert c.center.y.is_Rational
     assert c.radius.is_Rational

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -1,4 +1,4 @@
-from sympy import I, Rational, Symbol, pi, sqrt
+from sympy import I, Rational, Symbol, pi, sqrt, S
 from sympy.geometry import Line, Point, Point2D, Point3D, Line3D, Plane
 from sympy.geometry.entity import rotate, scale, translate
 from sympy.matrices import Matrix
@@ -103,7 +103,7 @@ def test_point():
 
     a, b = Rational(1, 2), Rational(1, 3)
     assert Point(a, b).evalf(2) == \
-        Point(a.n(2), b.n(2))
+        Point(a.n(2), b.n(2), evaluate=False)
     raises(ValueError, lambda: Point(1, 2) + 1)
 
     # test transformations
@@ -181,7 +181,7 @@ def test_point3D():
 
     a, b = Rational(1, 2), Rational(1, 3)
     assert Point(a, b).evalf(2) == \
-        Point(a.n(2), b.n(2))
+        Point(a.n(2), b.n(2), evaluate=False)
     raises(ValueError, lambda: Point(1, 2) + 1)
 
     # test transformations
@@ -351,11 +351,11 @@ def test_arguments():
     # test evaluate=False for ops
     x = Symbol('x')
     a = Point(0, 1)
-    assert a + (0.1, x) == Point(0.1, 1 + x)
+    assert a + (0.1, x) == Point(0.1, 1 + x, evaluate=False)
     a = Point(0, 1)
-    assert a/10.0 == Point(0.0, 0.1)
+    assert a/10.0 == Point(0.0, 0.1, evaluate=False)
     a = Point(0, 1)
-    assert a*10.0 == Point(0.0, 10.0)
+    assert a*10.0 == Point(0.0, 10.0, evaluate=False)
 
     # test evaluate=False when changing dimensions
     u = Point(.1, .2, evaluate=False)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -9,7 +9,7 @@ from mpmath import mpi
 from sympy.core.compatibility import range
 from sympy.utilities.pytest import raises, XFAIL
 
-from sympy.abc import x, y, z, m, n
+from sympy.abc import x, y, z, m, n, H, T
 
 
 def test_imageset():
@@ -655,7 +655,6 @@ def test_powerset():
 
 
 def test_product_basic():
-    H, T = 'H', 'T'
     unit_line = Interval(0, 1)
     d6 = FiniteSet(1, 2, 3, 4, 5, 6)
     d4 = FiniteSet(1, 2, 3, 4)
@@ -668,8 +667,7 @@ def test_product_basic():
     assert (H, T) in coin ** 2
     assert (.5, .5, .5) in square * unit_line
     assert (H, 3, 3) in coin * d6* d6
-    HH, TT = sympify(H), sympify(T)
-    assert set(coin**2) == set(((HH, HH), (HH, TT), (TT, HH), (TT, TT)))
+    assert set(coin**2) == set(((H, H), (H, T), (T, H), (T, T)))
 
     assert (d4*d4).is_subset(d6*d6)
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -148,7 +148,9 @@ class Indexed(Expr):
             base = IndexedBase(base)
         elif not hasattr(base, '__getitem__') and not isinstance(base, IndexedBase):
             raise TypeError(filldedent("""
-                Indexed expects string, Symbol, or IndexedBase as base."""))
+                The base can only be replaced with a string, Symbol,
+                IndexedBase or an object with a method for getting
+                items (i.e. a `__getitem__` method)."""))
         args = list(map(sympify, args))
         if isinstance(base, (NDimArray, Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
             if len(args) == 1:

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -182,8 +182,9 @@ def test_IndexedBase_subs():
     A = IndexedBase(a)
     B = IndexedBase(b)
     C = IndexedBase(c)
+    D = {1: 2}
     assert A[i] == B[i].subs(b, a)
-    assert isinstance(C[1].subs(C, {1: 2}), type(A[1]))
+    assert D[1] == C[1].subs(C, D)
 
 
 def test_IndexedBase_shape():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2586,10 +2586,11 @@ def rotations(s, dir=1):
         seq = rotate_left(seq, dir)
 
 
-def iwalk(a, do=None, sanitize=None):
+def iwalk(a, do=None, sanitize=None, dkeys=True):
     """Return input after applying `do` to items in Python builtin
     containers. If ``sanitize`` is provided, apply that to a
-    container before applying ``do`` to its contents.
+    container before applying ``do`` to its contents. If ``dkeys``
+    is True (default) then process dictionary values and keys.
 
     Examples
     ========
@@ -2622,7 +2623,7 @@ def iwalk(a, do=None, sanitize=None):
     elif isinstance(a, dict):
         a = sanitize(a) if sanitize else a
         kv = [(
-            iwalk(k, do, sanitize),
+            iwalk(k, do, sanitize) if dkeys else k,
             iwalk(v, do, sanitize))
             for k, v in a.items()]
         if isinstance(a, defaultdict):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -16,7 +16,7 @@ from sympy.utilities.iterables import (
     permutations, postfixes, postorder_traversal, prefixes, reshape,
     rotate_left, rotate_right, runs, sift, strongly_connected_components,
     subsets, take, topological_sort, unflatten, uniq, variations,
-    ordered_partitions, rotations)
+    ordered_partitions, rotations, iwalk)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -783,3 +783,24 @@ def test_ibin():
     assert ibin(3, 3, str=True) == '011'
     assert list(ibin(2, 'all')) == [(0, 0), (0, 1), (1, 0), (1, 1)]
     assert list(ibin(2, 'all', str=True)) == ['00', '01', '10', '11']
+
+
+def test_iwalk():
+    tup = lambda x: tuple(x) if type(x) is list else x
+    add = lambda x: x + 1 if isinstance(x, int) else x
+    input = [3, [.1, 2]]
+    x = iwalk(input, do=tup)
+    saw = []
+    def who(i, saw=saw):
+        saw.append(type(i))
+        return i
+    ok = iwalk(x, do=who, sanitize=who)
+    assert saw == [list, int, list, float, int]
+    saw[:] = []
+    ok = iwalk(x, sanitize=who)
+    assert saw == [list, list]
+    saw[:] = []
+    ok = iwalk(x, do=who)
+    assert saw == [int, float, int]
+    assert iwalk(input, sanitize=tup) == (3, (0.1, 2))
+    assert iwalk(input, do=add, sanitize=tup) == (4, (0.1, 3))

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -804,3 +804,5 @@ def test_iwalk():
     assert saw == [int, float, int]
     assert iwalk(input, sanitize=tup) == (3, (0.1, 2))
     assert iwalk(input, do=add, sanitize=tup) == (4, (0.1, 3))
+    assert iwalk({(1, 2): (3, 4)}, do=lambda i: i*10,
+        dkeys=False) == {(1, 2): (30, 40)}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16769 
closes #16772
fix #13425 
#### Brief description of what is fixed or changed

```python
"""
dict is now converted to Dict, keys and values
"""
>>> isinstance(S({1:2}), Dict)  # converter added for Dict
True
"""
All handled containers get their contents sympified according
to the settings (rational and xor were formerly missed):
"""
>>> all(list(sympify(_([.5])))[0] is S.Half for _ in (list, set, tuple))  # formerly Float(.5)
True
"""
raw Python numbers are converted with regard to rational setting, too
"""
>>> S(.1, rational=True) == Rational(.1)  # formerly Float(.1)
True
```
#### Other comments

The order of events is more strictly ordered according to desired outcomes:
1. deal quickly with Python primitives
1. if a routine doesn't want to be sympified, honor that quickly
1. if a routine wants to handle sympification, let it

There was an interesting test failure that highlights the corner cases for `sympify`. Formerly,
```python
>>> srepr(sympify(('x', 'y'), strict=True))
"Tuple(Symbol('x', Symbol('y'))"
```
But now this raises a SympificationError. The test that gave the error checked whether `tuple('HT')` was in a set rather than `Tuple(*'HT')` in set.

The addition of `iwalk` has allowed new handling in `sympify` and `nfloat`. It could probably be used as a decorator so all SymPy functions would just work when fed an iterable (but that won't be part of this PR). 

`nfloat` formerly gave
```python
>>> nfloat(Line((1,2),(3,4)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\leslie\sympy\sympy\core\function.py", line 3123, in nfloat
    rv = rv.n(n)
AttributeError: 'Line2D' object has no attribute 'n'
```
But now gives
```python
>>> nfloat(Line((1,2),(3,4)),2)
Line2D(Point2D(1.0, 2.0), Point2D(3.0, 4.0))
```
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core 
    - `sympify`
        - honor `rational` and `convert_xor` flags for floats and iterable contents
        - when specifying `rational=''` the conversion to Rational will use the string form of the number so S(.1, rational='') and S('.1') will both give 1/10.
        - dict is now converted to Dict; to avoid sympification of keys and values, pass only items and rebuild dict locally
        - if `strict` is False then defaultdict can also be processed but it is not returned as Dict
        - when `strict` is true, passing a tuple with strings will no longer return a Tuple of sympified objects; use `Tuple(*map(sympify, tuple))` instead (or `Tuple(*'abc')` or `symbols('a:c')` to create a list of Symbols).
    - `nfloat` in `functions` should now work on any Basic object
    - `N`, when given a string, will parse it with `evaluate=False` before make the evaluation so `0.5` and `1/2` will behave the same during evaluation. Other non-binary-exact decimals will suffer from precision loss, however, and it is better to sympify input first -- passing strings to SymPy functions is generally an anti-pattern -- as `N(S('0.1*pi', rational=True), 22)`. 
- utilities
    - `iwalk` has been added to `iterables` to traverse, from top down, an arbitrary Python expression, apply a function to the arguments and (optionally) to the iterable itself.
<!-- END RELEASE NOTES -->
