### PR TITLE
give an _eval_trigsimp method to Relational

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -301,6 +301,10 @@ class Relational(Boolean, Expr, EvalfMixin):
         else:
             return self
 
+    def _eval_trigsimp(self, **opts):
+        from sympy.simplify import trigsimp
+        return self.func(trigsimp(self.lhs, **opts), trigsimp(self.rhs, **opts))
+
     def __nonzero__(self):
         raise TypeError("cannot determine truth value of Relational")
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16736 

#### Brief description of what is fixed or changed
Gives an `_eval_trigsimp` method to Relational so that `trigsimp` with different methods can be applied to relation types.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added an `eval_trigsimp` method to relational.
<!-- END RELEASE NOTES -->
