### PR TITLE
replace `exact` flag only applies when symbols > 1

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1421,7 +1421,11 @@ class Basic(with_metaclass(ManagedProperties)):
                     "type or a callable")
         elif isinstance(query, Basic):
             _query = lambda expr: expr.match(query)
-            exact = len(query.atoms(Wild)) > 1 if exact is None else exact
+            nwild = len(query.atoms(Wild))
+            if exact and nwild == 1:
+                exact = False
+            elif exact is None and nwild > 1:
+                exact = True
 
             if isinstance(value, Basic):
                 if exact:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1290,11 +1290,15 @@ class Basic(with_metaclass(ManagedProperties)):
         subexpressions from the bottom to the top of the tree. The default
         approach is to do the replacement in a simultaneous fashion so
         changes made are targeted only once. If this is not desired or causes
-        problems, ``simultaneous`` can be set to False. In addition, if an
-        expression containing more than one Wild symbol is being used to match
-        subexpressions and  the ``exact`` flag is True, then the match will only
-        succeed if non-zero values are received for each Wild that appears in
-        the match pattern.
+        problems, ``simultaneous`` can be set to False.
+
+        In addition, if an expression containing more than one Wild symbol
+        is being used to match subexpressions and the ``exact`` flag is None
+        it will be set to True so the match will only succeed if all non-zero
+        values are received for each Wild that appears in the match pattern.
+        Setting this to False accepts a match of 0; while setting it True
+        accepts all matches that have a 0 in them. See example below for
+        cautions.
 
         The list of possible combinations of queries and replacement values
         is listed below:
@@ -1389,6 +1393,42 @@ class Basic(with_metaclass(ManagedProperties)):
             >>> e.replace(lambda x: x.is_Mul, lambda x: 2*x)
             2*x*(2*x*y + 1)
 
+        When matching a single symbol, `exact` will default to True, but
+        this may or may not be the behavior that is desired:
+
+        Here, we want `exact=False`:
+
+            >>> from sympy import Function
+            >>> f = Function('f')
+            >>> e = f(1) + f(0)
+            >>> q = f(a), lambda a: f(a + 1)
+            >>> e.replace(*q, exact=False)
+            f(1) + f(2)
+            >>> e.replace(*q, exact=True)
+            f(0) + f(2)
+
+        But here, the nature of matching makes selecting
+        the right setting tricky:
+
+            >>> e = x**(1 + y)
+            >>> (x**(1 + y)).replace(x**(1 + a), lambda a: x**-a, exact=False)
+            1
+            >>> (x**(1 + y)).replace(x**(1 + a), lambda a: x**-a, exact=True)
+            x**(-x - y + 1)
+            >>> (x**y).replace(x**(1 + a), lambda a: x**-a, exact=False)
+            1
+            >>> (x**y).replace(x**(1 + a), lambda a: x**-a, exact=True)
+            x**(1 - y)
+
+        It is probably better to use a different form of the query
+        that describes the target expression more precisely:
+
+            >>> (1 + x**(1 + y)).replace(
+            ... lambda x: x.is_Pow and x.exp.is_Add and x.exp.args[0] == 1,
+            ... lambda x: x.base**(1 - (x.exp - 1)))
+            ...
+            x**(1 - y) + 1
+
         See Also
         ========
         subs: substitution of subexpressions as defined by the objects
@@ -1421,11 +1461,8 @@ class Basic(with_metaclass(ManagedProperties)):
                     "type or a callable")
         elif isinstance(query, Basic):
             _query = lambda expr: expr.match(query)
-            nwild = len(query.atoms(Wild))
-            if exact and nwild == 1:
-                exact = False
-            elif exact is None and nwild > 1:
-                exact = True
+            if exact is None:
+                exact = (len(query.atoms(Wild)) > 1)
 
             if isinstance(value, Basic):
                 if exact:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -722,7 +722,9 @@ def test_replace():
     assert (n3*f(n2)).replace(f, lambda x: x) == n3*n2
 
     # issue 16725
-    assert S(0).replace(Wild('x'), 1, exact=True) == 1
+    assert S(0).replace(Wild('x'), 1) == 1
+    # let the user override the default decision of False
+    assert S(0).replace(Wild('x'), 1, exact=True) == 0
 
 
 def test_find():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -721,6 +721,9 @@ def test_replace():
     assert (n1*f(n2)).replace(f, lambda x: x) == n1*n2
     assert (n3*f(n2)).replace(f, lambda x: x) == n3*n2
 
+    # issue 16725
+    assert S(0).replace(Wild('x'), 1, exact=True) == 1
+
 
 def test_find():
     expr = (x + y + 2 + sin(3*x))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -161,10 +161,10 @@ def manual_subs(expr, *args):
             # that is, x**a = exp(a*y). Replace nontrivial powers of x
             # before subs turns them into `exp(y)**a`, but
             # do not replace x itself yet, to avoid `log(exp(y))`.
-            a = sympy.Wild('a')
-            expr = expr.replace(old.args[0]**(1 + a),
-                sympy.exp((1 + a)*new), exact=True)
-            new_subs.append((old.args[0], sympy.exp(new)))
+            x0 = old.args[0]
+            expr = expr.replace(lambda x: x.is_Pow and x.base == x0,
+                lambda x: sympy.exp(x.exp*new))
+            new_subs.append((x0, sympy.exp(new)))
 
     return expr.subs(list(sequence) + new_subs)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

close #16725 

#### Brief description of what is fixed or changed

The exact flag prevents an expression with a single Wild from matching a zero but the docstring says that it should only do that *if there is more than one Wild symbol in the expression.*

The doc string had been updated to indicate that setting the flag explicitly will override the default behavior.

#### Other comments

Very interesting that the `manual_subs` test failed in 3.7 but not in 3.6 when exact was set to false. The docstring shows the rather convoluted expression that will be obtained from non-atomic wild expressions.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - replace docstring updated to clarify use of exact flag
<!-- END RELEASE NOTES -->
