### PR TITLE
Fix incorrect codegen with unused array arguments

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -706,9 +706,9 @@ class CodeGen(object):
 
         array_symbols = {}
         for array in expressions.atoms(Indexed) | local_expressions.atoms(Indexed):
-             array_symbols[array.base.label] = array
+            array_symbols[array.base.label] = array
         for array in expressions.atoms(MatrixSymbol) | local_expressions.atoms(MatrixSymbol):
-             array_symbols[array] = array
+            array_symbols[array] = array
 
         for symbol in sorted(symbols, key=str):
             if symbol in array_symbols:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -696,13 +696,9 @@ class CodeGen(object):
 
         # setup input argument list
 
-        # helper to add dimension data for array args
+        # helper to get dimensions for data for array-like args
         def dimensions(s):
-            dims = []
-            for dim in s.shape:
-                dims.append((S.Zero, dim - 1))
-
-            return dims
+            return [(S.Zero, dim - 1) for dim in s.shape]
 
         array_symbols = {}
         for array in expressions.atoms(Indexed) | local_expressions.atoms(Indexed):
@@ -746,7 +742,7 @@ class CodeGen(object):
                     new_args.append(name_arg_dict[symbol])
                 except KeyError:
                     if isinstance(symbol, (IndexedBase, MatrixSymbol)):
-                        metadata = {'dimensions':dimensions(symbol)}
+                        metadata = {'dimensions': dimensions(symbol)}
                     else:
                         metadata = {}
                     new_args.append(InputArgument(symbol, **metadata))

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -695,19 +695,25 @@ class CodeGen(object):
         arg_list = []
 
         # setup input argument list
+
+        # helper to add dimension data for array args
+        def dimensions(s):
+            dims = []
+            for dim in s.shape:
+                dims.append((S.Zero, dim - 1))
+
+            return dims
+
         array_symbols = {}
         for array in expressions.atoms(Indexed) | local_expressions.atoms(Indexed):
-            array_symbols[array.base.label] = array
+             array_symbols[array.base.label] = array
         for array in expressions.atoms(MatrixSymbol) | local_expressions.atoms(MatrixSymbol):
-            array_symbols[array] = array
+             array_symbols[array] = array
 
         for symbol in sorted(symbols, key=str):
             if symbol in array_symbols:
-                dims = []
                 array = array_symbols[symbol]
-                for dim in array.shape:
-                    dims.append((S.Zero, dim - 1))
-                metadata = {'dimensions': dims}
+                metadata = {'dimensions': dimensions(array)}
             else:
                 metadata = {}
 
@@ -739,7 +745,11 @@ class CodeGen(object):
                 try:
                     new_args.append(name_arg_dict[symbol])
                 except KeyError:
-                    new_args.append(InputArgument(symbol))
+                    if isinstance(symbol, (IndexedBase, MatrixSymbol)):
+                        metadata = {'dimensions':dimensions(symbol)}
+                    else:
+                        metadata = {}
+                    new_args.append(InputArgument(symbol, **metadata))
             arg_list = new_args
 
         return Routine(name, arg_list, return_val, local_vars, global_vars)

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -582,6 +582,24 @@ def test_ccode_cse():
     )
     assert source == expected
 
+def test_ccode_unused_array_arg():
+    x = MatrixSymbol('x', 2, 1)
+    # x does not appear in output
+    name_expr = ("test", 1.0)
+    generator = CCodeGen()
+    result = codegen(name_expr, code_gen=generator, header=False, empty=False, argument_sequence=(x,))
+    source = result[0][1]
+    expected = (
+        '#include "test.h"\n'
+        '#include <math.h>\n'
+        'double test(double *x) {\n'
+        '   double test_result;\n'
+        '   test_result = 1.0;\n'
+        '   return test_result;\n'
+        '}\n'
+    )
+    assert source == expected
+
 def test_empty_f_code():
     code_gen = FCodeGen()
     source = get_string(code_gen.dump_f95, [])

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -589,6 +589,7 @@ def test_ccode_unused_array_arg():
     generator = CCodeGen()
     result = codegen(name_expr, code_gen=generator, header=False, empty=False, argument_sequence=(x,))
     source = result[0][1]
+    # note: x should appear as (double *)
     expected = (
         '#include "test.h"\n'
         '#include <math.h>\n'


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #16791.

#### Brief description of what is fixed or changed
Changed `routine` generation so that all array-like `InputArgument` s to generated code have dimension information attached...even if the corresponding argument in `argument_sequence` does not appear in the `expr` for which we are generating code. 

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * fixes a bug in generated code with unused array arguments
<!-- END RELEASE NOTES -->
