### PR TITLE
Fixed issue with logplot range for x

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -146,8 +146,8 @@ class Plot(object):
     def __init__(self, *args, **kwargs):
         super(Plot, self).__init__()
 
-        #  Options for the graph as a whole.
-        #  The possible values for each option are described in the docstring of
+        # Options for the graph as a whole.
+        # The possible values for each option are described in the docstring of
         # Plot. They are based purely on convention, no checking is done.
         self.title = None
         self.xlabel = None
@@ -235,6 +235,7 @@ class Plot(object):
 
         See Also
         ========
+
         extend
 
         """
@@ -467,8 +468,8 @@ class BaseSeries(object):
     #   - get_meshes returning mesh_x (1D array), mesh_y(1D array,
     #     mesh_z (2D np.arrays)
     #   - get_points an alias for get_meshes
-    #Different from is_contour as the colormap in backend will be
-    #different
+    # Different from is_contour as the colormap in backend will be
+    # different
 
     is_parametric = False
     # The calculation of aesthetics expects:
@@ -577,12 +578,8 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         self.adaptive = kwargs.get('adaptive', True)
         self.depth = kwargs.get('depth', 12)
         self.line_color = kwargs.get('line_color', None)
-        self.xscale=kwargs.get('xscale','linear')
-        self.flag=0
-
-
-
-
+        self.xscale = kwargs.get('xscale', 'linear')
+        self.flag = 0
 
     def __str__(self):
         return 'cartesian line: %s for %s over %s' % (
@@ -598,8 +595,9 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
 
         References
         ==========
-        [1] Adaptive polygonal approximation of parametric curves,
-            Luiz Henrique de Figueiredo.
+
+        .. [1] Adaptive polygonal approximation of parametric curves,
+               Luiz Henrique de Figueiredo.
 
         """
 
@@ -608,41 +606,44 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         else:
             f = lambdify([self.var], self.expr)
             list_segments = []
-            np=import_module('numpy')
+            np = import_module('numpy')
             def sample(p, q, depth):
                 """ Samples recursively if three points are almost collinear.
                 For depth < 6, points are added irrespective of whether they
                 satisfy the collinearity condition or not. The maximum depth
                 allowed is 12.
                 """
-                np = import_module('numpy')
-                #Randomly sample to avoid aliasing.
+                # Randomly sample to avoid aliasing.
                 random = 0.45 + np.random.rand() * 0.1
-                xnew = p[0] + random * (q[0] - p[0])
+                if self.xscale == 'log':
+                    xnew = 10**(np.log10(p[0]) + random * (np.log10(q[0]) -
+                                                           np.log10(p[0])))
+                else:
+                    xnew = p[0] + random * (q[0] - p[0])
                 ynew = f(xnew)
                 new_point = np.array([xnew, ynew])
 
-                if self.flag==1:
+                if self.flag == 1:
                     return
-                #Maximum depth
+                # Maximum depth
                 if depth > self.depth:
                     if p[1] is None or q[1] is None:
-                        self.flag=1
+                        self.flag = 1
                         return
                     list_segments.append([p, q])
 
-                #Sample irrespective of whether the line is flat till the
-                #depth of 6. We are not using linspace to avoid aliasing.
+                # Sample irrespective of whether the line is flat till the
+                # depth of 6. We are not using linspace to avoid aliasing.
                 elif depth < 6:
                     sample(p, new_point, depth + 1)
                     sample(new_point, q, depth + 1)
 
-                #Sample ten points if complex values are encountered
-                #at both ends. If there is a real value in between, then
-                #sample those points further.
+                # Sample ten points if complex values are encountered
+                # at both ends. If there is a real value in between, then
+                # sample those points further.
                 elif p[1] is None and q[1] is None:
                     if self.xscale is 'log':
-                        xarray = np.logspace(p[0],q[0], 10)
+                        xarray = np.logspace(p[0], q[0], 10)
                     else:
                         xarray = np.linspace(p[0], q[0], 10)
                     yarray = list(map(f, xarray))
@@ -652,18 +653,14 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                                 sample([xarray[i], yarray[i]],
                                     [xarray[i + 1], yarray[i + 1]], depth + 1)
 
-                #Sample further if one of the end points in None( i.e. a complex
-                #value) or the three points are not almost collinear.
+                # Sample further if one of the end points in None (i.e. a
+                # complex value) or the three points are not almost collinear.
                 elif (p[1] is None or q[1] is None or new_point[1] is None
                         or not flat(p, new_point, q)):
                     sample(p, new_point, depth + 1)
                     sample(new_point, q, depth + 1)
                 else:
                     list_segments.append([p, q])
-
-            if self.xscale is 'log':
-                self.start=np.log10(self.start)
-                self.end=np.log10(self.end)
 
             f_start = f(self.start)
             f_end = f(self.end)
@@ -688,7 +685,6 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         f = vectorized_lambdify([self.var], self.expr)
         list_y = f(list_x)
         return (list_x, list_y)
-
 
 class Parametric2DLineSeries(Line2DBaseSeries):
     """Representation for a line consisting of two parametric sympy expressions
@@ -753,7 +749,7 @@ class Parametric2DLineSeries(Line2DBaseSeries):
             satisfy the collinearity condition or not. The maximum depth
             allowed is 12.
             """
-            #Randomly sample to avoid aliasing.
+            # Randomly sample to avoid aliasing.
             np = import_module('numpy')
             random = 0.45 + np.random.rand() * 0.1
             param_new = param_p + random * (param_q - param_p)
@@ -761,19 +757,19 @@ class Parametric2DLineSeries(Line2DBaseSeries):
             ynew = f_y(param_new)
             new_point = np.array([xnew, ynew])
 
-            #Maximum depth
+            # Maximum depth
             if depth > self.depth:
                 list_segments.append([p, q])
 
-            #Sample irrespective of whether the line is flat till the
-            #depth of 6. We are not using linspace to avoid aliasing.
+            # Sample irrespective of whether the line is flat till the
+            # depth of 6. We are not using linspace to avoid aliasing.
             elif depth < 6:
                 sample(param_p, param_new, p, new_point, depth + 1)
                 sample(param_new, param_q, new_point, q, depth + 1)
 
-            #Sample ten points if complex values are encountered
-            #at both ends. If there is a real value in between, then
-            #sample those points further.
+            # Sample ten points if complex values are encountered
+            # at both ends. If there is a real value in between, then
+            # sample those points further.
             elif ((p[0] is None and q[1] is None) or
                     (p[1] is None and q[1] is None)):
                 param_array = np.linspace(param_p, param_q, 10)
@@ -789,8 +785,8 @@ class Parametric2DLineSeries(Line2DBaseSeries):
                             sample(param_array[i], param_array[i], point_a,
                                    point_b, depth + 1)
 
-            #Sample further if one of the end points in None( ie a complex
-            #value) or the three points are not almost collinear.
+            # Sample further if one of the end points in None (i.e. a complex
+            # value) or the three points are not almost collinear.
             elif (p[0] is None or p[1] is None
                     or q[1] is None or q[0] is None
                     or not flat(p, new_point, q)):
@@ -1027,8 +1023,8 @@ class BaseBackend(object):
         self.parent = parent
 
 
-## don't have to check for the success of importing matplotlib in each case;
-## we will only be using this backend if we can successfully import matploblib
+# Don't have to check for the success of importing matplotlib in each case;
+# we will only be using this backend if we can successfully import matploblib
 class MatplotlibBackend(BaseBackend):
     def __init__(self, parent):
         super(MatplotlibBackend, self).__init__(parent)
@@ -1154,10 +1150,10 @@ class MatplotlibBackend(BaseBackend):
         if parent.xlim:
             from sympy.core.basic import Basic
             xlim = parent.xlim
-            if any(isinstance(i,Basic) and not i.is_real for i in xlim):
+            if any(isinstance(i, Basic) and not i.is_real for i in xlim):
                 raise ValueError(
                 "All numbers from xlim={} must be real".format(xlim))
-            if any(isinstance(i,Basic) and not i.is_finite for i in xlim):
+            if any(isinstance(i, Basic) and not i.is_finite for i in xlim):
                 raise ValueError(
                 "All numbers from xlim={} must be finite".format(xlim))
             xlim = (float(i) for i in xlim)
@@ -1167,6 +1163,7 @@ class MatplotlibBackend(BaseBackend):
                 starts = [s.start for s in parent._series]
                 ends = [s.end for s in parent._series]
                 ax.set_xlim(min(starts), max(ends))
+
         if parent.ylim:
             from sympy.core.basic import Basic
             ylim = parent.ylim
@@ -1296,10 +1293,10 @@ def centers_of_segments(array):
 def centers_of_faces(array):
     np = import_module('numpy')
     return np.mean(np.dstack((array[:-1, :-1],
-                                 array[1:, :-1],
-                                 array[:-1, 1: ],
-                                 array[:-1, :-1],
-                                 )), 2)
+                             array[1:, :-1],
+                             array[:-1, 1:],
+                             array[:-1, :-1],
+                             )), 2)
 
 
 def flat(x, y, z, eps=1e-3):
@@ -1316,7 +1313,6 @@ def flat(x, y, z, eps=1e-3):
     vector_b_norm = np.linalg.norm(vector_b)
     cos_theta = dot_product / (vector_a_norm * vector_b_norm)
     return abs(cos_theta + 1) < eps
-
 
 def _matplotlib_list(interval_list):
     """
@@ -1903,6 +1899,7 @@ def plot3d(*args, **kwargs):
 
     See Also
     ========
+
     Plot, SurfaceOver2DRangeSeries
 
     """
@@ -2007,6 +2004,7 @@ def plot3d_parametric_surface(*args, **kwargs):
 
     See Also
     ========
+
     Plot, ParametricSurfaceSeries
 
     """
@@ -2086,7 +2084,9 @@ def plot_contour(*args, **kwargs):
 
     See Also
     ========
+
     Plot, ContourSeries
+
     """
 
     args = list(map(sympify, args))
@@ -2178,7 +2178,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
             plots = [expr + ranges for expr in exprs]
             return plots
         else:
-            #Use default ranges.
+            # Use default ranges.
             default_range = Tuple(-10, 10)
             ranges = []
             for symbol in free_symbols:
@@ -2191,7 +2191,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
             return plots
 
     elif isinstance(args[0], Tuple) and len(args[0]) == expr_len + nb_of_free_symbols:
-        #Multiple plots with different ranges.
+        # Multiple plots with different ranges.
         for arg in args:
             for i in range(expr_len):
                 if not isinstance(arg[i], Expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixed issue on the mailing list: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/sympy/OlaX3Mt0b-0/lGTffIW1AgAJ

#### Brief description of what is fixed or changed
Earlier x-axis range was messed up.

```
plot(x, (x, .001,100), xscale='log')
```
gave
![image](https://user-images.githubusercontent.com/8114497/57469481-0c0f6e00-7287-11e9-8e5a-524d089555f5.png)

not
![image](https://user-images.githubusercontent.com/8114497/57469393-d9657580-7286-11e9-9a39-6cae18c3ddcc.png)
as it should (and does now).

#### Other comments
Some code formatting clean-ups as well.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Fixed issue with x-axis log scale range.
<!-- END RELEASE NOTES -->
