### PR TITLE
Remove sorting from dotprint, and clean up some code

### DIFF
--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -220,7 +220,7 @@ def dotprint(expr,
         The default is ``None``, meaning no limit.
 
     repeat : boolean, optional
-        Whether to different nodes for separate common subexpressions.
+        Whether to use different nodes for common subexpressions.
 
         The default is ``True``.
 

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -11,9 +11,10 @@ from sympy.printing.repr import srepr
 
 __all__ = ['dotprint']
 
-default_styles = ((Basic, {'color': 'blue', 'shape': 'ellipse'}),
-          (Expr,  {'color': 'black'}))
-
+default_styles = (
+    (Basic, {'color': 'blue', 'shape': 'ellipse'}),
+    (Expr,  {'color': 'black'})
+)
 
 slotClasses = (Symbol, Integer, Rational, Float)
 def purestr(x, with_args=False):
@@ -141,38 +142,59 @@ template = \
 
 _graphstyle = {'rankdir': 'TD', 'ordering': 'out'}
 
-def dotprint(expr, styles=default_styles, atom=lambda x: not isinstance(x,
-    Basic), maxdepth=None, repeat=True, labelfunc=str, **kwargs):
-    """
-    DOT description of a SymPy expression tree
+def dotprint(expr,
+    styles=default_styles, atom=lambda x: not isinstance(x, Basic),
+    maxdepth=None, repeat=True, labelfunc=str, **kwargs):
+    """DOT description of a SymPy expression tree
 
-    Options are
+    Parameters
+    ==========
 
-    ``styles``: Styles for different classes.  The default is::
+    styles : list of lists composed of (Class, mapping), optional
+        Styles for different classes.
 
-        [(Basic, {'color': 'blue', 'shape': 'ellipse'}),
-        (Expr, {'color': 'black'})]``
+        The default is:
+        ``(
+            (Basic, {'color': 'blue', 'shape': 'ellipse'}),
+            (Expr,  {'color': 'black'})
+        )``
 
-    ``atom``: Function used to determine if an arg is an atom.  The default is
-          ``lambda x: not isinstance(x, Basic)``.  Another good choice is
-          ``lambda x: not x.args``.
+    atom : function, optional
+        Function used to determine if an arg is an atom.
 
-    ``maxdepth``: The maximum depth.  The default is None, meaning no limit.
+        A good choice is ``lambda x: not x.args``.
 
-    ``repeat``: Whether to different nodes for separate common subexpressions.
-          The default is True.  For example, for ``x + x*y`` with
-          ``repeat=True``, it will have two nodes for ``x`` and with
-          ``repeat=False``, it will have one (warning: even if it appears
-          twice in the same object, like Pow(x, x), it will still only appear
-          once.  Hence, with repeat=False, the number of arrows out of an
-          object might not equal the number of args it has).
+        The default is ``lambda x: not isinstance(x, Basic)``.
 
-    ``labelfunc``: How to label leaf nodes.  The default is ``str``.  Another
-          good option is ``srepr``. For example with ``str``, the leaf nodes
-          of ``x + 1`` are labeled, ``x`` and ``1``.  With ``srepr``, they
-          are labeled ``Symbol('x')`` and ``Integer(1)``.
+    maxdepth : integer, optional
+        The maximum depth.
 
-    Additional keyword arguments are included as styles for the graph.
+        The default is None, meaning no limit.
+
+    repeat : boolean, optional
+        Whether to different nodes for separate common subexpressions.
+
+        The default is ``True``.
+
+        For example, for ``x + x*y`` with ``repeat=True``, it will have two
+        nodes for ``x`` and with ``repeat=False``, it will have one
+        (warning: even if it appears twice in the same object, like Pow(x, x),
+        it will still only appear once.  Hence, with repeat=False, the number
+        of arrows out of an object might not equal the number of args it has).
+
+    labelfunc : function, optional
+        How to label leaf nodes.
+
+        The default is ``str``.
+
+        Another good option is ``srepr``.
+
+        For example with ``str``, the leaf nodes of ``x + 1`` are labeled,
+        ``x`` and ``1``.  With ``srepr``, they are labeled ``Symbol('x')``
+        and ``Integer(1)``.
+
+    **kwargs : optional
+        Additional keyword arguments are included as styles for the graph.
 
     Examples
     ========

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -25,9 +25,6 @@ def purestr(x, with_args=False):
         rv = srepr(x)
     else:
         args = x.args
-        if isinstance(x, Add) or \
-                isinstance(x, Mul) and x.is_commutative:
-            args = sorted(args, key=default_sort_key)
         sargs = tuple(map(purestr, args))
         rv = "%s(%s)"%(type(x).__name__, ', '.join(sargs))
     if with_args:

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -18,7 +18,34 @@ default_styles = (
 
 slotClasses = (Symbol, Integer, Rational, Float)
 def purestr(x, with_args=False):
-    """ A string that follows obj = type(obj)(*obj.args) exactly """
+    """A string that follows ```obj = type(obj)(*obj.args)``` exactly.
+
+    Parameters
+    ==========
+
+    with_args : boolean, optional
+        If ``True``, there will be a second argument for the return value,
+        which the individual string representation for each subnodes
+        from the symbolic object tree accessed via ``.args``.
+
+        If ``False``, it will only return the string representation part,
+        described in the summary above.
+
+        Default is ``False``
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol
+    >>> from sympy.printing.dot import purestr
+
+    >>> purestr(Symbol('x'))
+    "Symbol('x')"
+
+    >>> purestr(Float(2))
+    "Float('2.0', precision=53)"
+
+    """
     sargs = ()
     if not isinstance(x, Basic):
         rv = str(x)
@@ -153,11 +180,11 @@ def dotprint(expr,
     styles : list of lists composed of (Class, mapping), optional
         Styles for different classes.
 
-        The default is:
-        ``(
-            (Basic, {'color': 'blue', 'shape': 'ellipse'}),
-            (Expr,  {'color': 'black'})
-        )``
+        The default is .. code-block:: python
+            (
+                (Basic, {'color': 'blue', 'shape': 'ellipse'}),
+                (Expr,  {'color': 'black'})
+            )
 
     atom : function, optional
         Function used to determine if an arg is an atom.
@@ -169,7 +196,7 @@ def dotprint(expr,
     maxdepth : integer, optional
         The maximum depth.
 
-        The default is None, meaning no limit.
+        The default is ``None``, meaning no limit.
 
     repeat : boolean, optional
         Whether to different nodes for separate common subexpressions.

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -199,7 +199,9 @@ def dotprint(expr,
         Styles for different classes.
 
         The default is
+
         .. code-block:: python
+
             (
                 (Basic, {'color': 'blue', 'shape': 'ellipse'}),
                 (Expr,  {'color': 'black'})
@@ -227,9 +229,9 @@ def dotprint(expr,
         node.
 
         .. warning::
-            Even if it appears twice in the same object, like Pow(x, x),
-            it will still only appear once.
-            Hence, with repeat=False, the number of arrows out of an
+            Even if it appears twice in the same object like
+            ``Pow(x, x)``, it will still only appear once.
+            Hence, with ``repeat=False``, the number of arrows out of an
             object might not equal the number of args it has.
 
     labelfunc : function, optional

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -229,7 +229,7 @@ def dotprint(expr,
         node.
 
         .. warning::
-            Even if it appears twice in the same object like
+            Even if a node appears twice in the same object like ``x`` in
             ``Pow(x, x)``, it will still only appear once.
             Hence, with ``repeat=False``, the number of arrows out of an
             object might not equal the number of args it has.

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -235,7 +235,7 @@ def dotprint(expr,
             object might not equal the number of args it has.
 
     labelfunc : function, optional
-        How to label leaf nodes.
+        A function to create a label for a given leaf node.
 
         The default is ``str``.
 

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -24,27 +24,45 @@ def purestr(x, with_args=False):
     ==========
 
     with_args : boolean, optional
-        If ``True``, there will be a second argument for the return value,
-        which the individual string representation for each subnodes
-        from the symbolic object tree accessed via ``.args``.
+        If ``True``, there will be a second argument for the return
+        value, which is a tuple containing ``purestr`` applied to each
+        subnodes.
 
-        If ``False``, it will only return the string representation part,
-        described in the summary above.
+        If ``False``, there will not be a second argument for the
+        return.
 
         Default is ``False``
 
     Examples
     ========
 
-    >>> from sympy import Symbol
+    >>> from sympy import Integer, Float, Symbol, MatrixSymbol
     >>> from sympy.printing.dot import purestr
 
-    >>> purestr(Symbol('x'))
+    Applying ``purestr`` for basic symbolic object:
+    >>> code = purestr(Symbol('x'))
+    >>> code
     "Symbol('x')"
+    >>> eval(code) == Symbol('x')
+    True
 
+    For basic numeric object:
     >>> purestr(Float(2))
     "Float('2.0', precision=53)"
 
+    For matrix symbol:
+    >>> code = purestr(MatrixSymbol('x', 2, 2))
+    >>> code
+    "MatrixSymbol(Symbol('x'), Integer(2), Integer(2))"
+    >>> eval(code) == MatrixSymbol('x', 2, 2)
+    True
+
+    With ``with_args=True``:
+    >>> purestr(Float(2), with_args=True)
+    ("Float('2.0', precision=53)", ())
+    >>> purestr(MatrixSymbol('x', 2, 2), with_args=True)
+    ("MatrixSymbol(Symbol('x'), Integer(2), Integer(2))",
+     ("Symbol('x')", 'Integer(2)', 'Integer(2)'))
     """
     sargs = ()
     if not isinstance(x, Basic):
@@ -180,7 +198,8 @@ def dotprint(expr,
     styles : list of lists composed of (Class, mapping), optional
         Styles for different classes.
 
-        The default is .. code-block:: python
+        The default is
+        .. code-block:: python
             (
                 (Basic, {'color': 'blue', 'shape': 'ellipse'}),
                 (Expr,  {'color': 'black'})
@@ -203,11 +222,15 @@ def dotprint(expr,
 
         The default is ``True``.
 
-        For example, for ``x + x*y`` with ``repeat=True``, it will have two
-        nodes for ``x`` and with ``repeat=False``, it will have one
-        (warning: even if it appears twice in the same object, like Pow(x, x),
-        it will still only appear once.  Hence, with repeat=False, the number
-        of arrows out of an object might not equal the number of args it has).
+        For example, for ``x + x*y`` with ``repeat=True``, it will have
+        two nodes for ``x`` and with ``repeat=False``, it will have one
+        node.
+
+        .. warning::
+            Even if it appears twice in the same object, like Pow(x, x),
+            it will still only appear once.
+            Hence, with repeat=False, the number of arrows out of an
+            object might not equal the number of args it has.
 
     labelfunc : function, optional
         How to label leaf nodes.

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -225,7 +225,7 @@ def dotprint(expr,
         The default is ``True``.
 
         For example, for ``x + x*y`` with ``repeat=True``, it will have
-        two nodes for ``x`` and with ``repeat=False``, it will have one
+        two nodes for ``x``; with ``repeat=False``, it will have one
         node.
 
         .. warning::

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -26,7 +26,7 @@ def purestr(x, with_args=False):
     with_args : boolean, optional
         If ``True``, there will be a second argument for the return
         value, which is a tuple containing ``purestr`` applied to each
-        subnodes.
+        of the subnodes.
 
         If ``False``, there will not be a second argument for the
         return.

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -76,7 +76,31 @@ def test_dotprint_depth():
 def test_Matrix_and_non_basics():
     from sympy import MatrixSymbol
     n = Symbol('n')
-    assert dotprint(MatrixSymbol('X', n, n))
+    assert dotprint(MatrixSymbol('X', n, n)) == \
+"""digraph{
+
+# Graph style
+"ordering"="out"
+"rankdir"="TD"
+
+#########
+# Nodes #
+#########
+
+"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" ["color"="black", "label"="MatrixSymbol", "shape"="ellipse"];
+"Symbol('X')_(0,)" ["color"="black", "label"="X", "shape"="ellipse"];
+"Symbol('n')_(1,)" ["color"="black", "label"="n", "shape"="ellipse"];
+"Symbol('n')_(2,)" ["color"="black", "label"="n", "shape"="ellipse"];
+
+#########
+# Edges #
+#########
+
+"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('X')_(0,)";
+"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(1,)";
+"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(2,)";
+}"""
+
 
 def test_labelfunc():
     text = dotprint(x + 2, labelfunc=srepr)

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -29,21 +29,25 @@ def test_attrprint():
 
 def test_dotnode():
 
-    assert dotnode(x, repeat=False) ==\
-            '"Symbol(\'x\')" ["color"="black", "label"="x", "shape"="ellipse"];'
+    assert dotnode(x, repeat=False) == \
+        '"Symbol(\'x\')" ["color"="black", "label"="x", "shape"="ellipse"];'
     assert dotnode(x+2, repeat=False) == \
-            '"Add(Integer(2), Symbol(\'x\'))" ["color"="black", "label"="Add", "shape"="ellipse"];', dotnode(x+2,repeat=0)
+        '"Add(Integer(2), Symbol(\'x\'))" ' \
+        '["color"="black", "label"="Add", "shape"="ellipse"];', \
+        dotnode(x+2,repeat=0)
 
     assert dotnode(x + x**2, repeat=False) == \
-        '"Add(Symbol(\'x\'), Pow(Symbol(\'x\'), Integer(2)))" ["color"="black", "label"="Add", "shape"="ellipse"];'
+        '"Add(Symbol(\'x\'), Pow(Symbol(\'x\'), Integer(2)))" ' \
+        '["color"="black", "label"="Add", "shape"="ellipse"];'
     assert dotnode(x + x**2, repeat=True) == \
-        '"Add(Symbol(\'x\'), Pow(Symbol(\'x\'), Integer(2)))_()" ["color"="black", "label"="Add", "shape"="ellipse"];'
+        '"Add(Symbol(\'x\'), Pow(Symbol(\'x\'), Integer(2)))_()" ' \
+        '["color"="black", "label"="Add", "shape"="ellipse"];'
 
 def test_dotedges():
     assert sorted(dotedges(x+2, repeat=False)) == [
         '"Add(Integer(2), Symbol(\'x\'))" -> "Integer(2)";',
         '"Add(Integer(2), Symbol(\'x\'))" -> "Symbol(\'x\')";'
-        ]
+    ]
     assert sorted(dotedges(x + 2, repeat=True)) == [
         '"Add(Integer(2), Symbol(\'x\'))_()" -> "Integer(2)_(0,)";',
         '"Add(Integer(2), Symbol(\'x\'))_()" -> "Symbol(\'x\')_(1,)";'
@@ -52,18 +56,28 @@ def test_dotedges():
 def test_dotprint():
     text = dotprint(x+2, repeat=False)
     assert all(e in text for e in dotedges(x+2, repeat=False))
-    assert all(n in text for n in [dotnode(expr, repeat=False) for expr in (x, Integer(2), x+2)])
+    assert all(
+        n in text for n in [dotnode(expr, repeat=False)
+        for expr in (x, Integer(2), x+2)])
     assert 'digraph' in text
+
     text = dotprint(x+x**2, repeat=False)
     assert all(e in text for e in dotedges(x+x**2, repeat=False))
-    assert all(n in text for n in [dotnode(expr, repeat=False) for expr in (x, Integer(2), x**2)])
+    assert all(
+        n in text for n in [dotnode(expr, repeat=False)
+        for expr in (x, Integer(2), x**2)])
     assert 'digraph' in text
+
     text = dotprint(x+x**2, repeat=True)
     assert all(e in text for e in dotedges(x+x**2, repeat=True))
-    assert all(n in text for n in [dotnode(expr, pos=()) for expr in [x + x**2]])
+    assert all(
+        n in text for n in [dotnode(expr, pos=())
+        for expr in [x + x**2]])
+
     text = dotprint(x**x, repeat=True)
     assert all(e in text for e in dotedges(x**x, repeat=True))
-    assert all(n in text for n in [dotnode(x, pos=(0,)), dotnode(x, pos=(1,))])
+    assert all(
+        n in text for n in [dotnode(x, pos=(0,)), dotnode(x, pos=(1,))])
     assert 'digraph' in text
 
 def test_dotprint_depth():

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -9,6 +9,11 @@ def test_purestr():
     assert purestr(Basic(1, 2)) == "Basic(1, 2)"
     assert purestr(Float(2)) == "Float('2.0', precision=53)"
 
+    assert purestr(Symbol('x'), with_args=True) == ("Symbol('x')", ())
+    assert purestr(Basic(1, 2), with_args=True) == ('Basic(1, 2)', ('1', '2'))
+    assert purestr(Float(2), with_args=True) == \
+        ("Float('2.0', precision=53)", ())
+
 
 def test_styleof():
     styles = [(Basic, {'color': 'blue', 'shape': 'ellipse'}),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16781

#### Brief description of what is fixed or changed

As I've noted in #16781, `Add`, `Mul` already sorts the arguments, so we do not have to sort twice, or things may turn invalid if the sorting scheme is changed from the core.

I've also made some cleanup for `default_styles` to make it more PEP-8, added some docstring about ``purestr`` for developers reference, and reformatted the docstring of ``dotprint`` to make it numpydoc format.
Only the `dotprint` is visible for public.

![image](https://user-images.githubusercontent.com/34944973/57526796-55d08500-7369-11e9-979f-368200ca477c.png)

Also, I've made the test code fit into 78 characters if possible,
and added a proper test for ``dotprint(MatrixSymbol('X', n, n))`` because the previous one did not check anything about the output.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
