### PR TITLE
16803: piecewise simplification error and printing

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -274,9 +274,13 @@ def deltasummation(f, limit, no_piecewise=False):
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))
     1
     >>> deltasummation(KroneckerDelta(i, k), (k, 0, oo))
-    Piecewise((1, i >= 0), (0, True))
+    Piecewise(
+        (1, i >= 0),
+        (0, True))
     >>> deltasummation(KroneckerDelta(i, k), (k, 1, 3))
-    Piecewise((1, (i >= 1) & (i <= 3)), (0, True))
+    Piecewise(
+        (1, (i >= 1) & (i <= 3)),
+        (0, True))
     >>> deltasummation(k*KroneckerDelta(i, j)*KroneckerDelta(j, k), (k, -oo, oo))
     j*KroneckerDelta(i, j)
     >>> deltasummation(j*KroneckerDelta(i, j), (j, -oo, oo))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -94,7 +94,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
     >>> Sum(x**k, (k, 0, oo))
     Sum(x**k, (k, 0, oo))
     >>> Sum(x**k, (k, 0, oo)).doit()
-    Piecewise((1/(1 - x), Abs(x) < 1), (Sum(x**k, (k, 0, oo)), True))
+    Piecewise(
+        (1/(1 - x), Abs(x) < 1),
+        (Sum(x**k, (k, 0, oo)), True))
     >>> Sum(x**k/factorial(k), (k, 0, oo)).doit()
     exp(x)
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -95,13 +95,17 @@ class Piecewise(Function):
     Booleans can contain Piecewise elements:
 
     >>> cond = (x < y).subs(x, Piecewise((2, x < 0), (3, True))); cond
-    Piecewise((2, x < 0), (3, True)) < y
+    Piecewise(
+        (2, x < 0),
+        (3, True)) < y
 
     The folded version of this results in a Piecewise whose
     expressions are Booleans:
 
     >>> folded_cond = piecewise_fold(cond); folded_cond
-    Piecewise((2 < y, x < 0), (3 < y, True))
+    Piecewise(
+        (2 < y, x < 0),
+        (3 < y, True))
 
     When a Boolean containing Piecewise (like cond) or a Piecewise
     with Boolean expressions (like folded_cond) is used as a condition,
@@ -415,7 +419,10 @@ class Piecewise(Function):
         >>> from sympy.abc import x
         >>> p = Piecewise((0, x < 0), (1, x < 1), (2, True))
         >>> p.piecewise_integrate(x)
-        Piecewise((0, x < 0), (x, x < 1), (2*x, True))
+        Piecewise(
+            (0, x < 0),
+            (x, x < 1),
+            (2*x, True))
 
         Note that this does not give a continuous function, e.g.
         at x = 1 the 3rd condition applies and the antiderivative
@@ -429,7 +436,10 @@ class Piecewise(Function):
         the point of interest, however:
 
         >>> p.integrate(x)
-        Piecewise((0, x < 0), (x, x < 1), (2*x - 1, True))
+        Piecewise(
+            (0, x < 0),
+            (x, x < 1),
+            (2*x - 1, True))
         >>> _.subs(x, 1)
         1
 
@@ -535,9 +545,15 @@ class Piecewise(Function):
         >>> from sympy.abc import x
         >>> p = Piecewise((0, x < 0), (1, x < 1), (2, True))
         >>> p.integrate(x)
-        Piecewise((0, x < 0), (x, x < 1), (2*x - 1, True))
+        Piecewise(
+            (0, x < 0),
+            (x, x < 1),
+            (2*x - 1, True))
         >>> p.piecewise_integrate(x)
-        Piecewise((0, x < 0), (x, x < 1), (2*x, True))
+        Piecewise(
+            (0, x < 0),
+            (x, x < 1),
+            (2*x, True))
 
         See Also
         ========
@@ -1033,7 +1049,9 @@ def piecewise_fold(expr):
     >>> from sympy.abc import x
     >>> p = Piecewise((x, x < 1), (1, S(1) <= x))
     >>> piecewise_fold(x*p)
-    Piecewise((x**2, x < 1), (x, True))
+    Piecewise(
+        (x**2, x < 1),
+        (x, True))
 
     See Also
     ========

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1165,10 +1165,13 @@ def _clip(A, B, k):
     if a != c:
         p.append((a, c, -1))
     else:
+        # match at start
         pass
     if c != d:
         p.append((c, d, k))
     else:
+        # point in B that is not in A
+        # and will be reported below
         pass
     if b != d:
         if d == c and p and p[-1][-1] == -1:
@@ -1176,6 +1179,7 @@ def _clip(A, B, k):
         else:
             p.append((d, b, -1))
     else:
+        # match at end
         pass
 
     return p

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1208,7 +1208,8 @@ def test_issue_14240():
 def test_issue_14787():
     x = Symbol('x')
     f = Piecewise((x, x < 1), ((S(58) / 7), True))
-    assert str(f.evalf()) == "Piecewise((x, x < 1), (8.28571428571429, True))"
+    assert list(map(str, f.evalf().args)) == [
+        "(x, x < 1)", "(8.28571428571429, True)"]
 
 
 def test_issue_8458():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1035,10 +1035,19 @@ def test_issue_4313():
 
 def test__intervals():
     assert Piecewise((x + 2, Eq(x, 3)))._intervals(x) == []
-    assert Piecewise(
+    # univarariate will allow null-width results but when called
+    # from _intervals, these are filtered out
+    assert Piecewise((x + 2, Eq(x, 3)))._univariate_intervals() == [
+        (3, 3, x + 2, 0)]
+    one = symbols('1', positive=True)
+    p = Piecewise(
         (1, x > x + 1),
-        (Piecewise((1, x < x + 1)), 2*x < 2*x + 1),
-        (1, True))._intervals(x) == [(-oo, oo, 1, 1)]
+        (Piecewise((1, x < x + 1)), 2*x < 2*x + one),
+        (1, True))
+    # multivariate
+    assert p._intervals(x) == [(-oo, oo, Piecewise((1, x < x + 1)), 1)]
+    # univariate
+    assert p.subs(one, 1)._intervals(x) == [(-oo, oo, Piecewise((1, x < x + 1)), 1)]
     assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == [
         (-oo, oo, 1, 0)]
     assert Piecewise((-cos(x), sin(x) >= 0), (cos(x), True)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -445,6 +445,14 @@ def test_piecewise_simplify():
     f = Function('f')
     assert Piecewise(*args).simplify() == ans
     assert Piecewise(*args.subs(x, f(x))).simplify() == ans.subs(x, f(x))
+    # 16804
+    # check that simplify doesn't fail and that it doesn't
+    # collapse to 0
+    assert Piecewise(
+        (0, (x > 3) | (x < 0) | ((x > 0) & (x < 3))),
+        (-1, Ne(x, 0)),
+        (0, Ne(x, 3)),
+        (-S(1)/2, True)).simplify().subs(x, 3) == -1
 
 
 def test_piecewise_solve():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1232,3 +1232,51 @@ def test_issue_8458():
     # Test for problem highlighted during review
     p3 = Piecewise((x+1, Eq(x, -1)), (4*x + (y-2)**4, Eq(x, 0) & Eq(x+y, 2)), (sin(x), True))
     assert p3.simplify() == Piecewise((0, Eq(x, -1)), (sin(x), True))
+
+
+def test_cascade():
+    nan = Undefined
+    assert Piecewise((1, (x <= 3) | (x > 4))).cascade() == Piecewise(
+        (nan, Eq(x, 4)),
+        (1, True))
+    assert Piecewise(
+        (0, (x > 3) | (x < 0) | ((x > 0) & (x < 3))),
+        (-1, Ne(x, 0)),
+        (0, Ne(x, 3)),
+        (-2, True)).cascade() == Piecewise(
+        (-1, Eq(x, 3)),
+        (0, True))
+    assert Piecewise(
+        (1, x <= 3),
+        (nan, x > 4)).cascade() == Piecewise(
+        (1, x <= 3),
+        (nan, True))
+    assert Piecewise(
+        (nan, x < 4),
+        (1, x <= 3),
+        (5, x > 4)).cascade() == Piecewise(
+        (nan, x <= 4),
+        (5, True))
+    assert Piecewise(
+        (5, x < 4),
+        (1, x <= 3),
+        (5, x > 4)).cascade() == Piecewise(
+        (nan, Eq(x, 4)),
+        (5, True))
+    assert Piecewise(
+        (4, x < 4),
+        (1, x <= 3),
+        (5, x > 4)).cascade() == Piecewise(
+        (4, x < 4),
+        (nan, Eq(x, 4)),
+        (5, True))
+    assert Piecewise(
+        (1, x < 3),
+        (2, And(x > 4, x < 5)),
+        (3, Eq(y, x)),
+        (6,True)).cascade(x) == Piecewise(
+        (1, x < 3),
+        (3, Eq(x, 3) & Eq(y, 3)),
+        (2, x < 5),
+        (3, Eq(x, 5) & Eq(y, 5)),
+        (6, True))

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2867,7 +2867,9 @@ class atan2(InverseTrigonometricFunction):
 
     >>> from sympy import atan
     >>> atan2(y, x).rewrite(atan)
-    Piecewise((2*atan(y/(x + sqrt(x**2 + y**2))), Ne(y, 0)), (pi, x < 0), (0, x > 0), (nan, True))
+    Piecewise(
+        (2*atan(y/(x + sqrt(x**2 + y**2))), Ne(y, 0)),
+        (pi, x < 0), (0, x > 0), (nan, True))
 
     but note that this form is undefined on the negative real axis.
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -87,7 +87,9 @@ def bspline_basis(d, knots, n, x):
         >>> d = 0
         >>> knots = tuple(range(5))
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1, (x >= 0) & (x <= 1)), (0, True))
+        Piecewise(
+            (1, (x >= 0) & (x <= 1)),
+            (0, True))
 
     For a given ``(d, knots)`` there are ``len(knots)-d-1`` B-splines
     defined, that are indexed by ``n`` (starting at 0).
@@ -95,14 +97,12 @@ def bspline_basis(d, knots, n, x):
     Here is an example of a cubic B-spline:
 
         >>> bspline_basis(3, tuple(range(5)), 0, x)
-        Piecewise((x**3/6, (x >= 0) & (x <= 1)),
-                  (-x**3/2 + 2*x**2 - 2*x + 2/3,
-                  (x >= 1) & (x <= 2)),
-                  (x**3/2 - 4*x**2 + 10*x - 22/3,
-                  (x >= 2) & (x <= 3)),
-                  (-x**3/6 + 2*x**2 - 8*x + 32/3,
-                  (x >= 3) & (x <= 4)),
-                  (0, True))
+        Piecewise(
+            (x**3/6, (x >= 0) & (x <= 1)),
+            (-x**3/2 + 2*x**2 - 2*x + 2/3, (x >= 1) & (x <= 2)),
+            (x**3/2 - 4*x**2 + 10*x - 22/3, (x >= 2) & (x <= 3)),
+            (-x**3/6 + 2*x**2 - 8*x + 32/3, (x >= 3) & (x <= 4)),
+            (0, True))
 
     By repeating knot points, you can introduce discontinuities in the
     B-splines and their derivatives:
@@ -110,7 +110,9 @@ def bspline_basis(d, knots, n, x):
         >>> d = 1
         >>> knots = (0, 0, 2, 3, 4)
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1 - x/2, (x >= 0) & (x <= 2)), (0, True))
+        Piecewise(
+            (1 - x/2, (x >= 0) & (x <= 2)),
+            (0, True))
 
     It is quite time consuming to construct and evaluate B-splines. If
     you need to evaluate a B-splines many times, it is best to
@@ -184,14 +186,16 @@ def bspline_basis_set(d, knots, x):
     >>> knots = range(5)
     >>> splines = bspline_basis_set(d, knots, x)
     >>> splines
-    [Piecewise((x**2/2, (x >= 0) & (x <= 1)),
-               (-x**2 + 3*x - 3/2, (x >= 1) & (x <= 2)),
-               (x**2/2 - 3*x + 9/2, (x >= 2) & (x <= 3)),
-               (0, True)),
-    Piecewise((x**2/2 - x + 1/2, (x >= 1) & (x <= 2)),
-              (-x**2 + 5*x - 11/2, (x >= 2) & (x <= 3)),
-              (x**2/2 - 4*x + 8, (x >= 3) & (x <= 4)),
-              (0, True))]
+    [Piecewise(
+        (x**2/2, (x >= 0) & (x <= 1)),
+        (-x**2 + 3*x - 3/2, (x >= 1) & (x <= 2)),
+        (x**2/2 - 3*x + 9/2, (x >= 2) & (x <= 3)),
+        (0, True)),
+    Piecewise(
+        (x**2/2 - x + 1/2, (x >= 1) & (x <= 2)),
+        (-x**2 + 5*x - 11/2, (x >= 2) & (x <= 3)),
+        (x**2/2 - 4*x + 8, (x >= 3) & (x <= 4)),
+        (0, True))]
 
     See Also
     ========
@@ -217,12 +221,14 @@ def interpolating_spline(d, x, X, Y):
     >>> from sympy import interpolating_spline
     >>> from sympy.abc import x
     >>> interpolating_spline(1, x, [1, 2, 4, 7], [3, 6, 5, 7])
-    Piecewise((3*x, (x >= 1) & (x <= 2)),
-            (7 - x/2, (x >= 2) & (x <= 4)),
-            (2*x/3 + 7/3, (x >= 4) & (x <= 7)))
+    Piecewise(
+        (3*x, (x >= 1) & (x <= 2)),
+        (7 - x/2, (x >= 2) & (x <= 4)),
+        (2*x/3 + 7/3, (x >= 4) & (x <= 7)))
     >>> interpolating_spline(3, x, [-2, 0, 1, 3, 4], [4, 2, 1, 1, 3])
-    Piecewise((7*x**3/117 + 7*x**2/117 - 131*x/117 + 2, (x >= -2) & (x <= 1)),
-            (10*x**3/117 - 2*x**2/117 - 122*x/117 + 77/39, (x >= 1) & (x <= 4)))
+    Piecewise(
+        (7*x**3/117 + 7*x**2/117 - 131*x/117 + 2, (x >= -2) & (x <= 1)),
+        (10*x**3/117 - 2*x**2/117 - 122*x/117 + 77/39, (x >= 1) & (x <= 4)))
 
     See Also
     ========

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -327,13 +327,19 @@ class DiracDelta(Function):
            >>> x = Symbol('x')
 
            >>> DiracDelta(x).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x, 0)), (0, True))
+           Piecewise(
+               (DiracDelta(0), Eq(x, 0)),
+               (0, True))
 
            >>> DiracDelta(x - 5).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x - 5, 0)), (0, True))
+           Piecewise(
+               (DiracDelta(0), Eq(x - 5, 0)),
+               (0, True))
 
            >>> DiracDelta(x**2 - 5).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x**2 - 5, 0)), (0, True))
+           Piecewise(
+               (DiracDelta(0), Eq(x**2 - 5, 0)),
+               (0, True))
 
            >>> DiracDelta(x - 5, 4).rewrite(Piecewise)
            DiracDelta(x - 5, 4)
@@ -525,13 +531,22 @@ class Heaviside(Function):
            >>> x = Symbol('x')
 
            >>> Heaviside(x).rewrite(Piecewise)
-           Piecewise((0, x < 0), (Heaviside(0), Eq(x, 0)), (1, x > 0))
+           Piecewise(
+               (0, x < 0),
+               (Heaviside(0), Eq(x, 0)),
+               (1, x > 0))
 
            >>> Heaviside(x - 5).rewrite(Piecewise)
-           Piecewise((0, x - 5 < 0), (Heaviside(0), Eq(x - 5, 0)), (1, x - 5 > 0))
+           Piecewise(
+            (0, x - 5 < 0),
+            (Heaviside(0), Eq(x - 5, 0)),
+            (1, x - 5 > 0))
 
            >>> Heaviside(x**2 - 1).rewrite(Piecewise)
-           Piecewise((0, x**2 - 1 < 0), (Heaviside(0), Eq(x**2 - 1, 0)), (1, x**2 - 1 > 0))
+           Piecewise(
+            (0, x**2 - 1 < 0),
+            (Heaviside(0), Eq(x**2 - 1, 0)),
+            (1, x**2 - 1 > 0))
 
         """
         if H0 is None:

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -51,7 +51,9 @@ class SingularityFunction(Function):
     >>> diff(SingularityFunction(x, 4, 0), x, 2)
     SingularityFunction(x, 4, -2)
     >>> SingularityFunction(x, 4, 5).rewrite(Piecewise)
-    Piecewise(((x - 4)**5, x - 4 > 0), (0, True))
+    Piecewise(
+        ((x - 4)**5, x - 4 > 0),
+        (0, True))
     >>> expr = SingularityFunction(x, a, n)
     >>> y = Symbol('y', positive=True)
     >>> n = Symbol('n', nonnegative=True)

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -116,7 +116,9 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     >>> heurisch(cos(n*x), x)
     sin(n*x)/n
     >>> heurisch_wrapper(cos(n*x), x)
-    Piecewise((sin(n*x)/n, Ne(n, 0)), (x, True))
+    Piecewise(
+        (sin(n*x)/n, Ne(n, 0)),
+        (x, True))
 
     See Also
     ========

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -366,8 +366,9 @@ class Integral(AddWithLimits):
         >>> from sympy import Integral
         >>> from sympy.abc import x, i
         >>> Integral(x**i, (i, 1, 3)).doit()
-        Piecewise((x**3/log(x) - x/log(x),
-            (x > 1) | ((x >= 0) & (x < 1))), (2, True))
+        Piecewise(
+            (x**3/log(x) - x/log(x), (x > 1) | ((x >= 0) & (x < 1))),
+            (2, True))
 
         See Also
         ========
@@ -1458,7 +1459,8 @@ def integrate(*args, **kwargs):
     in interactive sessions and should be avoided in library code.
 
     >>> integrate(x**a*exp(-x), (x, 0, oo)) # same as conds='piecewise'
-    Piecewise((gamma(a + 1), re(a) > -1),
+    Piecewise(
+        (gamma(a + 1), re(a) > -1),
         (Integral(x**a*exp(-x), (x, 0, oo)), True))
 
     >>> integrate(x**a*exp(-x), (x, 0, oo), conds='none')

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -548,7 +548,7 @@ class BooleanFunction(Application, Boolean):
                            binary=True)
         if len(Rel) <= 1:
             return rv
-        Rel, nonRealRel = sift(rv.args, lambda i: all(s.is_real is not False
+        Rel, nonRealRel = sift(Rel, lambda i: all(s.is_real is not False
                                                       for s in i.free_symbols),
                                binary=True)
         Rel = [i.canonical for i in Rel]

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -328,7 +328,8 @@ def test_matrixelement_diff():
     assert w[k, p].diff(w[k, p]) == 1
     assert w[k, p].diff(w[0, 0]) == KroneckerDelta(0, k)*KroneckerDelta(0, p)
     assert str(dexpr) == "Sum(KroneckerDelta(_i_1, p)*D[k, _i_1], (_i_1, 0, n - 1))"
-    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (p >= 0) & (p <= n - 1)), (0, True))'
+    assert list(map(str, dexpr.doit().args)) == [
+        '(D[k, p], (p >= 0) & (p <= n - 1))', '(0, True)']
     # TODO: bug with .dummy_eq( ), the previous 2 lines should be replaced by:
     return  # stop eval
     _i_1 = Dummy("_i_1")

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -60,9 +60,13 @@ class Beam(object):
     >>> b.deflection()
     (7*x - SingularityFunction(x, 0, 3)/2 + SingularityFunction(x, 2, 4)/4 - 3*SingularityFunction(x, 4, 3)/2)/(E*I)
     >>> b.deflection().rewrite(Piecewise)
-    (7*x - Piecewise((x**3, x > 0), (0, True))/2
-         - 3*Piecewise(((x - 4)**3, x - 4 > 0), (0, True))/2
-         + Piecewise(((x - 2)**4, x - 2 > 0), (0, True))/4)/(E*I)
+    (7*x - Piecewise(
+        (x**3, x > 0),
+        (0, True))/2 - 3*Piecewise(
+        ((x - 4)**3, x - 4 > 0),
+        (0, True))/2 + Piecewise(
+        ((x - 2)**4, x - 2 > 0),
+        (0, True))/4)/(E*I)
     """
 
     def __init__(self, length, elastic_modulus, second_moment, variable=Symbol('x'), base_char='C'):

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -82,12 +82,15 @@ def _sort_gens(gens, **args):
             except ValueError:
                 pass
 
-        name, index = _re_gen.match(gen).groups()
-
-        if index:
-            index = int(index)
+        if '\n' in gen:
+            # multiline string form (Matrix, Piecewise, ...)
+            name, index = gen, 0
         else:
-            index = 0
+            name, index = _re_gen.groups()
+            if index:
+                index = int(index)
+            else:
+                index = 0
 
         try:
             return ( gens_order[name], name, index)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -394,6 +394,13 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
+    def _print_Piecewise(self, obj):
+        if len(obj.args) == 1:
+            return "Piecewise(%s)" % ', '.join(
+                map(self._print, obj.args))
+        return "Piecewise(\n    %s)" % ',\n    '.join(
+            map(self._print, obj.args))
+
     def _print_Subs(self, obj):
         expr, old, new = obj.args
         if len(obj.point) == 1:

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,8 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, log, MatrixSymbol)
+    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, log, MatrixSymbol,
+    Piecewise)
 from sympy.core import Expr, Mul
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ, lex, grlex
@@ -252,6 +253,12 @@ def test_Order():
     assert str(O(x, x, y)) == "O(x, x, y)"
     assert str(O(x, x, y)) == "O(x, x, y)"
     assert str(O(x, (x, oo), (y, oo))) == "O(x, (x, oo), (y, oo))"
+
+
+def test_Piecewise():
+    assert str(Piecewise((1, x < 2))) == 'Piecewise((1, x < 2))'
+    assert str(Piecewise((1, x < 2), (2, True))) == \
+        'Piecewise(\n    (1, x < 2),\n    (3, True))'
 
 
 def test_Permutation_Cycle():

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -489,11 +489,14 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
     >>> from sympy.abc import x, k
 
     >>> rh(exp(x), x, -S.One, (k + 1), k, 1)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise(
+        (1/factorial(k), Eq(Mod(k, 1), 0)),
+        (0, True)), 1, 1)
 
     >>> rh(ln(1 + x), x, k**2, k*(k + 1), k, 1)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(
+        ((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)),
+        (0, True)), x, 2)
 
     References
     ==========
@@ -673,11 +676,14 @@ def solve_de(f, x, DE, order, g, k):
     >>> f = Function('f')
 
     >>> solve_de(exp(x), x, D(f(x), x) - f(x), 1, f, k)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise(
+        (1/factorial(k), Eq(Mod(k, 1), 0)),
+        (0, True)), 1, 1)
 
     >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), 2, f, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(
+        ((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)),
+        (0, True)), x, 2)
     """
     sol = None
     syms = DE.free_symbols.difference({g, x})
@@ -718,11 +724,14 @@ def hyper_algorithm(f, x, k, order=4):
     >>> from sympy.abc import x, k
 
     >>> hyper_algorithm(exp(x), x, k)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise(
+        (1/factorial(k), Eq(Mod(k, 1), 0)),
+        (0, True)), 1, 1)
 
     >>> hyper_algorithm(ln(1 + x), x, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(
+        ((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)),
+        (0, True)), x, 2)
 
     See Also
     ========

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -211,9 +211,10 @@ def Arcsin(name, a=0, b=1):
     1/(pi*sqrt((-a + z)*(b - z)))
 
     >>> cdf(X)(z)
-    Piecewise((0, a > z),
-            (2*asin(sqrt((-a + z)/(-a + b)))/pi, b >= z),
-            (1, True))
+    Piecewise(
+        (0, a > z),
+        (2*asin(sqrt((-a + z)/(-a + b)))/pi, b >= z),
+        (1, True))
 
 
     References
@@ -299,8 +300,9 @@ def Benini(name, alpha, beta, sigma):
     \  z             z        /
 
     >>> cdf(X)(z)
-    Piecewise((1 - exp(-alpha*log(z/sigma) - beta*log(z/sigma)**2), sigma <= z),
-            (0, True))
+    Piecewise(
+        (1 - exp(-alpha*log(z/sigma) - beta*log(z/sigma)**2), sigma <= z),
+        (0, True))
 
 
     References
@@ -834,7 +836,9 @@ def Dagum(name, p, a, b):
     a*p*(z/b)**(a*p)*((z/b)**a + 1)**(-p - 1)/z
 
     >>> cdf(X)(z)
-    Piecewise(((1 + (z/b)**(-a))**(-p), z >= 0), (0, True))
+    Piecewise(
+        ((1 + (z/b)**(-a))**(-p), z >= 0),
+        (0, True))
 
 
     References
@@ -989,7 +993,9 @@ def Exponential(name, rate):
     lambda*exp(-lambda*z)
 
     >>> cdf(X)(z)
-    Piecewise((1 - exp(-lambda*z), z >= 0), (0, True))
+    Piecewise(
+        (1 - exp(-lambda*z), z >= 0),
+        (0, True))
 
     >>> quantile(X)(p)
     -log(1 - p)/lambda
@@ -1237,7 +1243,9 @@ def Frechet(name, a, s=1, m=0):
     a*((-m + z)/s)**(-a - 1)*exp(-((-m + z)/s)**(-a))/s
 
     >>> cdf(X)(z)
-     Piecewise((exp(-((-m + z)/s)**(-a)), m <= z), (0, True))
+    Piecewise(
+        (exp(-((-m + z)/s)**(-a)), m <= z),
+        (0, True))
 
     References
     ==========
@@ -1437,7 +1445,9 @@ def GammaInverse(name, a, b):
        Gamma(a)
 
     >>> cdf(X)(z)
-    Piecewise((uppergamma(a, b/z)/gamma(a), z > 0), (0, True))
+    Piecewise(
+        (uppergamma(a, b/z)/gamma(a), z > 0),
+        (0, True))
 
 
     References
@@ -1654,7 +1664,10 @@ def Kumaraswamy(name, a, b):
     a*b*z     *\1 - z /
 
     >>> cdf(X)(z)
-    Piecewise((0, z < 0), (1 - (1 - z**a)**b, z <= 1), (1, True))
+    Piecewise(
+        (0, z < 0),
+        (1 - (1 - z**a)**b, z <= 1),
+        (1, True))
 
     References
     ==========
@@ -1727,7 +1740,9 @@ def Laplace(name, mu, b):
     exp(-Abs(mu - z)/b)/(2*b)
 
     >>> cdf(X)(z)
-    Piecewise((exp((-mu + z)/b)/2, mu > z), (1 - exp((mu - z)/b)/2, True))
+    Piecewise(
+        (exp((-mu + z)/b)/2, mu > z),
+        (1 - exp((mu - z)/b)/2, True))
 
     >>> L = Laplace('L', [1, 2], [[1, 0], [0, 1]])
     >>> pprint(density(L)(1, 2), use_unicode=False)
@@ -2058,8 +2073,9 @@ def Nakagami(name, mu, omega):
             Gamma(mu)*Gamma(mu + 1)
 
     >>> cdf(X)(z)
-    Piecewise((lowergamma(mu, mu*z**2/omega)/gamma(mu), z > 0),
-            (0, True))
+    Piecewise(
+        (lowergamma(mu, mu*z**2/omega)/gamma(mu), z > 0),
+        (0, True))
 
 
     References
@@ -2922,7 +2938,10 @@ def Uniform(name, left, right):
     >>> X = Uniform("x", a, b)
 
     >>> density(X)(z)
-    Piecewise((1/(-a + b), (b >= z) & (a <= z)), (0, True))
+    Piecewise(
+        (1/(-a + b),
+        (b >= z) & (a <= z)),
+        (0, True))
 
     >>> cdf(X)(z)  # doctest: +SKIP
     -a/(-a + b) + z/(-a + b)
@@ -3022,8 +3041,11 @@ def UniformSum(name, n):
                 (n - 1)!
 
     >>> cdf(X)(z)
-    Piecewise((0, z < 0), (Sum((-1)**_k*(-_k + z)**n*binomial(n, _k),
-                    (_k, 0, floor(z)))/factorial(n), n >= z), (1, True))
+    Piecewise(
+        (0, z < 0),
+        (Sum((-1)**_k*(-_k + z)**n*binomial(n, _k),
+        (_k, 0, floor(z)))/factorial(n), n >= z),
+        (1, True))
 
 
     Compute cdf with specific 'x' and 'n' values as follows :


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fix #16803

#### Brief description of what is fixed or changed


#### Other comments

If the new printing style is accepted it will give new visual meaning to "piecewise_fold":
```python
>>> Piecewise((1,2<x),(3,True))+Piecewise((1,x>5),(4,True))
Piecewise(
    (1, x > 2),
    (3, True)) + Piecewise(
    (1, x > 5),
    (4, True))
>>> piecewise_fold(_)
Piecewise(
    (2, x > 5),
    (5, x > 2),
    (7, True))
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
    - Piecewise bug fix and Matrix-like printing
<!-- END RELEASE NOTES -->
