### PR TITLE
Fix error while transposing matrix multiplied with scalar symbol

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -109,7 +109,8 @@ class MatMul(MatrixExpr, Mul):
         return coeff, MatMul(*matrices)
 
     def _eval_transpose(self):
-        return MatMul(*[transpose(arg) for arg in self.args[::-1]]).doit()
+        coeff, matrices = self.as_coeff_matrices()
+        return MatMul(coeff, *[transpose(arg) for arg in matrices]).doit()
 
     def _eval_adjoint(self):
         return MatMul(*[adjoint(arg) for arg in self.args[::-1]]).doit()

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -109,8 +109,27 @@ class MatMul(MatrixExpr, Mul):
         return coeff, MatMul(*matrices)
 
     def _eval_transpose(self):
+        """Transposition of matrix multiplication.
+
+        Notes
+        =====
+
+        The following rules are applied.
+
+        Transposition for matrix multiplied with another matrix:
+        `\\left(A B\\right)^{T} = B^{T} A^{T}`
+
+        Transposition for matrix multiplied with scalar:
+        `\\left(c A\\right)^{T} = c A^{T}`
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Transpose
+        """
         coeff, matrices = self.as_coeff_matrices()
-        return MatMul(coeff, *[transpose(arg) for arg in matrices]).doit()
+        return MatMul(
+            coeff, *[transpose(arg) for arg in matrices[::-1]]).doit()
 
     def _eval_adjoint(self):
         return MatMul(*[adjoint(arg) for arg in self.args[::-1]]).doit()

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -40,6 +40,7 @@ def test_transpose():
     MT = Matrix(2, 2, [1, 3, 2 + I, 4])
     assert transpose(M) == MT
     assert transpose(2*M) == 2*MT
+    assert transpose(x*M) == x*MT
     assert transpose(MatMul(2, M)) == MatMul(2, MT).doit()
 
 

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -38,6 +38,8 @@ def test_transpose():
 
 def test_transpose_MatAdd_MatMul():
     # Issue 16807
+    from sympy.functions.elementary.trigonometric import cos
+
     x = symbols('x')
     M = MatrixSymbol('M', 3, 3)
     N = MatrixSymbol('N', 3, 3)

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -38,7 +38,7 @@ def test_transpose():
 
 def test_transpose_MatAdd_MatMul():
     # Issue 16807
-    x = Symbol('x')
+    x = symbols('x')
     M = MatrixSymbol('M', 3, 3)
     N = MatrixSymbol('N', 3, 3)
 

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -36,6 +36,15 @@ def test_transpose():
     assert Transpose(A*B).doit() == Transpose(B) * Transpose(A)
 
 
+def test_transpose_MatAdd_MatMul():
+    # Issue 16807
+    x = Symbol('x')
+    M = MatrixSymbol('M', 3, 3)
+    N = MatrixSymbol('N', 3, 3)
+
+    assert (N + (cos(x) * M)).T == cos(x)*M.T + N.T
+
+
 def test_refine():
     assert refine(C.T, Q.symmetric(C)) == C
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16807

#### Brief description of what is fixed or changed

I've added a rule to properly handle matrix-scalar multiplication.
Probably, I think that transpose should be made invalid for scalars.

Also see the comment in #16807 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fix `AttributeError` raised while `Transpose` is applied for matrix-scalar multiplication containing symbolic scalar.
<!-- END RELEASE NOTES -->
