### PR TITLE
Solves issue with Range 16817

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -476,8 +476,8 @@ class Range(Set):
             n = ceiling((stop - ref)/step)
             if n <= 0:
                 # null Range
-                start = end = 0
-                step = 1
+                start = end = S.Zero
+                step = S.One
             else:
                 end = ref + n*step
         return Basic.__new__(cls, start, end, step)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -182,6 +182,7 @@ def test_Range_set():
     assert Range(oo, 1, -1)[-1] == 2
     assert Range(0, -oo, -2)[-1] == -oo
     assert Range(1, 10, 1)[-1] == 9
+    assert all(i.is_Integer for i in Range(0, -1, 1))
 
     it = iter(Range(-oo, 0, 2))
     raises(ValueError, lambda: next(it))
@@ -189,6 +190,7 @@ def test_Range_set():
     assert empty.intersect(S.Integers) == empty
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals) == Range(1, 10, 1)
+
 
     # test slicing
     assert Range(1, 10, 1)[5] == 6


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16817 

#### Brief description of what is fixed or changed
Replaces 0 with S.Zero and 1 with S.One in `sympy/sets/fancysets.py`
Latex is now giving correct results.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
    - arguments of null Range(0, 0, 1) are now Integers (solves printing problem)
<!-- END RELEASE NOTES -->