### PR TITLE
fix dcm diff error

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -259,15 +259,13 @@ class ReferenceFrame(object):
     def _w_diff_dcm(self, otherframe):
         """Angular velocity from time differentiating the DCM. """
         from sympy.physics.vector.functions import dynamicsymbols
-        dcm2diff = self.dcm(otherframe)
+        dcm2diff = otherframe.dcm(self)
         diffed = dcm2diff.diff(dynamicsymbols._t)
-        # angvelmat = diffed * dcm2diff.T
-        # This one seems to produce the correct result when I checked using Autolev.
-        angvelmat = dcm2diff*diffed.T
+        angvelmat = diffed * dcm2diff.T
         w1 = trigsimp(expand(angvelmat[7]), recursive=True)
         w2 = trigsimp(expand(angvelmat[2]), recursive=True)
         w3 = trigsimp(expand(angvelmat[3]), recursive=True)
-        return -Vector([(Matrix([w1, w2, w3]), self)])
+        return Vector([(Matrix([w1, w2, w3]), otherframe)])
 
     def variable_map(self, otherframe):
         """

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -189,7 +189,7 @@ def test_w_diff_dcm2():
     D = N.orientnew('D', 'DCM', DCM)
 
     assert D.dcm(N) == C.dcm(N)
-    assert (D.ang_vel_in(N) - C.ang_vel_in(N)).simplify().express(N) == 0
+    assert (D.ang_vel_in(N) - C.ang_vel_in(N)).simplify() == 0
 
 def test_orientnew_respects_parent_class():
     class MyReferenceFrame(ReferenceFrame):

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -196,8 +196,8 @@ def test_w_diff_dcm1():
 
     # Equation (2.1.21)
     expr = (  (c12*c13d + c22*c23d + c32*c33d)*B.x
-            + (c13*c11d + c23*c21d + c33*c31d)*B.y +
-              (c11*c12d + c21*c22d + c31*c32d)*B.z)
+            + (c13*c11d + c23*c21d + c33*c31d)*B.y
+            + (c11*c12d + c21*c22d + c31*c32d)*B.z)
     assert B.ang_vel_in(A) - expr == 0
 
 def test_w_diff_dcm2():

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -213,7 +213,13 @@ def test_w_diff_dcm2():
     # Frames D and C are the same ReferenceFrame,
     # since they have equal DCM respect to frame N.
     # Therefore, D and C should have same angle velocity in N.
-    assert D.dcm(N) == C.dcm(N)
+    assert D.dcm(N) == C.dcm(N) == Matrix([
+        [cos(q2)*cos(q3), sin(q1)*sin(q2)*cos(q3) +
+        sin(q3)*cos(q1), sin(q1)*sin(q3) -
+        sin(q2)*cos(q1)*cos(q3)], [-sin(q3)*cos(q2),
+        -sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3),
+        sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)],
+        [sin(q2), -sin(q1)*cos(q2), cos(q1)*cos(q2)]])
     assert (D.ang_vel_in(N) - C.ang_vel_in(N)).express(N).simplify() == 0
 
 def test_orientnew_respects_parent_class():

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -214,7 +214,7 @@ def test_w_diff_dcm2():
     # since they have equal DCM respect to frame N.
     # Therefore, D and C should have same angle velocity in N.
     assert D.dcm(N) == C.dcm(N)
-    assert (D.ang_vel_in(N) - C.ang_vel_in(N)).simplify() == 0
+    assert (D.ang_vel_in(N) - C.ang_vel_in(N)).express(N).simplify() == 0
 
 def test_orientnew_respects_parent_class():
     class MyReferenceFrame(ReferenceFrame):

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -163,13 +163,7 @@ def test_dcm():
         sin(q2)*cos(q1)*cos(q3), - sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1),
          cos(q1)*cos(q2)]])
 
-
-# This test has been added to test the _w_diff_dcm() function
-# for which a test was previously not included.
-# Also note that the _w_diff_dcm() function was changed as part of
-# PR #14758 as it was observed to be giving incorrect results
-# when compared with Autolev results.
-def test_w_diff_dcm():
+def test_w_diff_dcm1():
     a = ReferenceFrame('a')
     b = ReferenceFrame('b')
     c11, c12, c13, c21, c22, c23, c31, c32, c33 = dynamicsymbols('c11 c12 c13 c21 c22 c23 c31 c32 c33')
@@ -184,6 +178,18 @@ def test_w_diff_dcm():
            (c11*c12d + c21*c22d + c31*c32d)*b.z)
     assert b.ang_vel_in(a) - expr == 0
 
+def test_w_diff_dcm2():
+    q1, q2, q3 = dynamicsymbols('q1:4')
+    N = ReferenceFrame('N')
+    A = N.orientnew('A', 'axis', [q1, N.x])
+    B = A.orientnew('B', 'axis', [q2, A.y])
+    C = B.orientnew('C', 'axis', [q3, B.z])
+
+    DCM = C.dcm(N).T
+    D = N.orientnew('D', 'DCM', DCM)
+
+    assert D.dcm(N) == C.dcm(N)
+    assert (D.ang_vel_in(N) - C.ang_vel_in(N)).simplify().express(N) == 0
 
 def test_orientnew_respects_parent_class():
     class MyReferenceFrame(ReferenceFrame):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fix ReferenceFrame DCM diff error #16824 

#### Brief description of what is fixed or changed

Fix angular velocity from time differentiating the DCM.

```
from sympy import symbols
from sympy.physics.mechanics import ReferenceFrame, dynamicsymbols

q1, q2, q3 = dynamicsymbols('q1:4')

N = ReferenceFrame('N')
A = N.orientnew('A', 'axis', [q1, N.x])
B = A.orientnew('B', 'axis', [q2, A.y])
C = B.orientnew('C', 'axis', [q3, B.z])

DCM = C.dcm(N).T

D = N.orientnew('D', 'DCM', DCM)

print('DCM diff:', D.dcm(N) - C.dcm(N))
print('ang vel diff:', (D.ang_vel_in(N) - C.ang_vel_in(N)).simplify().express(N))
```

Result:

```
DCM diff: Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
ang vel diff: 0
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * fix ReferenceFrame ```_w_diff_dcm``` method

<!-- END RELEASE NOTES -->
