### PR TITLE
Symbolic dimensions can be passed to Multinomial, NegativeMultinomial

### DIFF
--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -24,11 +24,14 @@ def intersection_sets(a, b):
 
 @dispatch(Integers, Interval)
 def intersection_sets(a, b):
-    from sympy.functions.elementary.integers import floor, ceiling
-    if b._inf == S.NegativeInfinity and b._sup == S.Infinity:
-        return a
-    s = Range(ceiling(b.left), floor(b.right) + 1)
-    return intersection_sets(s, b)  # take out endpoints if open interval
+    try:
+        from sympy.functions.elementary.integers import floor, ceiling
+        if b._inf == S.NegativeInfinity and b._sup == S.Infinity:
+            return a
+        s = Range(ceiling(b.left), floor(b.right) + 1)
+        return intersection_sets(s, b)  # take out endpoints if open interval
+    except ValueError:
+        return None
 
 @dispatch(ComplexRegion, Set)
 def intersection_sets(self, other):

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -26,7 +26,7 @@ def intersection_sets(a, b):
 def intersection_sets(a, b):
     try:
         from sympy.functions.elementary.integers import floor, ceiling
-        if b._inf == S.NegativeInfinity and b._sup == S.Infinity:
+        if b._inf is S.NegativeInfinity and b._sup is S.Infinity:
             return a
         s = Range(ceiling(b.left), floor(b.right) + 1)
         return intersection_sets(s, b)  # take out endpoints if open interval

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -24,11 +24,14 @@ def intersection_sets(a, b):
 
 @dispatch(Integers, Interval)
 def intersection_sets(a, b):
-    from sympy.functions.elementary.integers import floor, ceiling
-    if b._inf == S.NegativeInfinity and b._sup == S.Infinity:
-        return a
-    s = Range(ceiling(b.left), floor(b.right) + 1)
-    return intersection_sets(s, b)  # take out endpoints if open interval
+    try:
+        from sympy.functions.elementary.integers import floor, ceiling
+        if b._inf is S.NegativeInfinity and b._sup is S.Infinity:
+            return a
+        s = Range(ceiling(b.left), floor(b.right) + 1)
+        return intersection_sets(s, b)  # take out endpoints if open interval
+    except ValueError:
+        return None
 
 @dispatch(ComplexRegion, Set)
 def intersection_sets(self, other):

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -101,7 +101,6 @@ class JointPSpace(ProductPSpace):
         if self.distribution.is_Continuous:
             f = Lambda(sym, integrate(self.distribution(*all_syms), *limits))
         elif self.distribution.is_Discrete:
-            # limits = [(limit[0], limit[1].inf, limit[1].sup) for limit in limits]
             f = Lambda(sym, summation(self.distribution(*all_syms), *limits))
         return f.xreplace(replace_dict)
 

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -101,7 +101,7 @@ class JointPSpace(ProductPSpace):
         if self.distribution.is_Continuous:
             f = Lambda(sym, integrate(self.distribution(*all_syms), *limits))
         elif self.distribution.is_Discrete:
-            limits = [(limit[0], limit[1].inf, limit[1].sup) for limit in limits]
+            # limits = [(limit[0], limit[1].inf, limit[1].sup) for limit in limits]
             f = Lambda(sym, summation(self.distribution(*all_syms), *limits))
         return f.xreplace(replace_dict)
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -409,7 +409,7 @@ class MultinomialDistribution(JointDistribution):
         for p_k in p:
             _value_check((p_k >= 0, p_k <= 1),
                         "probability must be at least a positive symbol.")
-        _value_check(Eq(sum(p), 1) != False,
+        _value_check(Eq(sum(p), 1),
                         "probabilities must sum to 1")
 
     @property

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -407,7 +407,7 @@ class MultinomialDistribution(JointDistribution):
         _value_check(n > 0,
                         "number of trials must be a positve integer")
         for p_k in p:
-            _value_check((p_k >= 0) != False and (p_k <= 1) != False,
+            _value_check((p_k >= 0, p_k <= 1),
                         "probability must be at least a positive symbol.")
         _value_check(Eq(sum(p), 1) != False,
                         "probabilities must sum to 1")

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,6 +1,6 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt, IndexedBase,
                     besselk, gamma, Interval, Range, factorial, Mul, Integer,
-                    Add, rf, Eq, Piecewise, Symbol, imageset)
+                    Add, rf, Eq, Piecewise, Symbol, imageset, Intersection)
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
@@ -414,8 +414,8 @@ class MultinomialDistribution(JointDistribution):
 
     @property
     def set(self):
-        i = Symbol('i', negative=False, integer=True)
-        return imageset(i, i, Interval(0, self.n))**len(self.p)
+        i = Symbol('i', negative=False, positive=True)
+        return imageset(i, i, Intersection(S.Naturals0, Interval(0, self.n)))**len(self.p)
 
     def pdf(self, *x):
         n, p = self.n, self.p

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -444,7 +444,6 @@ def Multinomial(syms, n, *p):
     >>> from sympy.stats import density
     >>> from sympy.stats.joint_rv import marginal_distribution
     >>> from sympy.stats.joint_rv_types import Multinomial
-    >>> from sympy import Symbol
     >>> from sympy import symbols
     >>> x1, x2, x3 = symbols('x1, x2, x3', nonnegative=True, integer=True)
     >>> p1, p2, p3 = symbols('p1, p2, p3', positive=True)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,6 +1,6 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt, IndexedBase,
                     besselk, gamma, Interval, Range, factorial, Mul, Integer,
-                    Add, rf, Eq, Piecewise)
+                    Add, rf, Eq, Piecewise, Symbol, imageset)
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
@@ -414,7 +414,8 @@ class MultinomialDistribution(JointDistribution):
 
     @property
     def set(self):
-        return Interval(0, self.n)**len(self.p)
+        i = Symbol('i', negative=False, integer=True)
+        return imageset(i, i, Interval(0, self.n))**len(self.p)
 
     def pdf(self, *x):
         n, p = self.n, self.p

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -408,7 +408,7 @@ class MultinomialDistribution(JointDistribution):
                         "number of trials must be a positve integer")
         for p_k in p:
             _value_check((p_k >= 0, p_k <= 1),
-                        "probability must be at least a positive symbol.")
+                        "probability must be in range [0, 1]")
         _value_check(Eq(sum(p), 1),
                         "probabilities must sum to 1")
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -361,7 +361,7 @@ def MultivariateEwens(syms, n, theta):
     Parameters
     ==========
 
-    n: postive integer of class Integer,
+    n: positive integer of class Integer,
             size of the sample or the integer whose partitions are considered
     theta: mutation rate, must be positive real number.
 
@@ -430,7 +430,7 @@ def Multinomial(syms, n, *p):
 
     Parameters
     ==========
-    n: postive integer of class Integer,
+    n: positive integer of class Integer,
        number of trials
     p: event probabilites, >= 0 and <= 1
 
@@ -498,7 +498,7 @@ def NegativeMultinomial(syms, k0, *p):
 
     Parameters
     ==========
-    k0: postive integer of class Integer,
+    k0: positive integer of class Integer,
         number of failures before the experiment is stopped
     p: event probabilites, >= 0 and <= 1
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -472,12 +472,12 @@ class NegativeMultinomialDistribution(JointDistribution):
     is_Discrete = True
 
     def check(self, k0, p):
-        _value_check(((k0 > 0) != False),
+        _value_check(k0 > 0,
                         "number of failures must be a positve integer")
         for p_k in p:
-            _value_check((p_k >= 0) != False,
-                        "probability must be at least a positive symbol.")
-        _value_check((sum(p) <= 1) != False,
+            _value_check((p_k >= 0, p_k <= 1),
+                        "probability must be in range [0, 1].")
+        _value_check(sum(p) <= 1,
                         "success probabilities must not be greater than 1.")
 
     @property

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -415,7 +415,7 @@ class MultinomialDistribution(JointDistribution):
     @property
     def set(self):
         i = Symbol('i', negative=False, positive=True)
-        return imageset(i, i, Intersection(S.Naturals0, Interval(0, self.n)))**len(self.p)
+        return Intersection(S.Naturals0, Interval(0, self.n))**len(self.p)
 
     def pdf(self, *x):
         n, p = self.n, self.p

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -404,7 +404,7 @@ class MultinomialDistribution(JointDistribution):
     is_Discrete = True
 
     def check(self, n, p):
-        _value_check(((n > 0) != False),
+        _value_check(n > 0,
                         "number of trials must be a positve integer")
         for p_k in p:
             _value_check((p_k >= 0) != False and (p_k <= 1) != False,

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,6 +1,6 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt, IndexedBase,
                     besselk, gamma, Interval, Range, factorial, Mul, Integer,
-                    Add, rf, Eq, Piecewise)
+                    Add, rf, Eq, Piecewise, Symbol, imageset, Intersection)
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
@@ -404,17 +404,17 @@ class MultinomialDistribution(JointDistribution):
     is_Discrete = True
 
     def check(self, n, p):
-        _value_check(((n > 0) != False),
+        _value_check(n > 0,
                         "number of trials must be a positve integer")
         for p_k in p:
-            _value_check((p_k >= 0) != False and (p_k <= 1) != False,
+            _value_check((p_k >= 0, p_k <= 1),
                         "probability must be at least a positive symbol.")
-        _value_check(Eq(sum(p), 1) != False,
+        _value_check(Eq(sum(p), 1),
                         "probabilities must sum to 1")
 
     @property
     def set(self):
-        return Interval(0, self.n)**len(self.p)
+        return Intersection(S.Naturals0, Interval(0, self.n))**len(self.p)
 
     def pdf(self, *x):
         n, p = self.n, self.p
@@ -443,7 +443,6 @@ def Multinomial(syms, n, *p):
     >>> from sympy.stats import density
     >>> from sympy.stats.joint_rv import marginal_distribution
     >>> from sympy.stats.joint_rv_types import Multinomial
-    >>> from sympy import Symbol
     >>> from sympy import symbols
     >>> x1, x2, x3 = symbols('x1, x2, x3', nonnegative=True, integer=True)
     >>> p1, p2, p3 = symbols('p1, p2, p3', positive=True)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, factorial,
-                    simplify, gamma)
+                    simplify, gamma, Piecewise, Eq, Sum)
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
 from sympy.stats.joint_rv_types import JointRV
@@ -58,15 +58,20 @@ def test_Multinomial():
     from sympy.stats.joint_rv_types import Multinomial
     n, x1, x2, x3, x4 = symbols('n, x1, x2, x3, x4', nonnegative=True, integer=True)
     p1, p2, p3, p4 = symbols('p1, p2, p3, p4', positive=True)
-    p1_f = symbols('p1_f', negative=True)
-    M = Multinomial('M', 3, [p1, p2, p3, p4])
-    M_c = Multinomial('C', 3, 0.5, 0.4, 0.3, 0.2)
+    p1_f, n_f = symbols('p1_f, n_f', negative=True)
+    M = Multinomial('M', n, [p1, p2, p3, p4])
+    C = Multinomial('C', n, p1, p2, p3)
     f = factorial
-    assert simplify(density(M)(x1, x2, x3, x4) -
-            S(6)*p1**x1*p2**x2*p3**x3*p4**x4/(f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert marginal_distribution(M_c, M_c[0])(1).round(2) == 7.29
+    assert density(M)(x1, x2, x3, x4) == Piecewise((p1**x1*p2**x2*p3**x3*p4**x4*
+                                            f(n)/(f(x1)*f(x2)*f(x3)*f(x4)),
+                                            Eq(n, x1 + x2 + x3 + x4)), (0, True))
+    marg = Sum(Piecewise((p1**x1*p2**C[1]*p3**C[2]*factorial(n)/(factorial(x1)*
+            factorial(C[1])*factorial(C[2])), Eq(n, x1 + C[1] + C[2])), (0, True)
+            ), (C[1], 0, n), (C[2], 0, n))
+    assert str(marginal_distribution(C, C[0])(x1)) == str(marg)
     raises(ValueError, lambda: Multinomial('b1', 5, [p1, p2, p3, p1_f]))
-    raises(ValueError, lambda: Multinomial('b2', n, [p1, p2, p3, p4]))
+    raises(ValueError, lambda: Multinomial('b2', n_f, [p1, p2, p3, p4]))
+    raises(ValueError, lambda: Multinomial('b3', n, 0.5, 0.4, 0.3, 0.1))
 
 def test_NegativeMultinomial():
     from sympy.stats.joint_rv_types import NegativeMultinomial
@@ -74,15 +79,15 @@ def test_NegativeMultinomial():
     p1, p2, p3, p4 = symbols('p1, p2, p3, p4', positive=True)
     p1_f = symbols('p1_f', negative=True)
     N = NegativeMultinomial('N', 4, [p1, p2, p3, p4])
-    N_c = NegativeMultinomial('C', 4, 0.1, 0.2, 0.3)
+    C = NegativeMultinomial('C', 4, 0.1, 0.2, 0.3)
     g = gamma
     f = factorial
     assert simplify(density(N)(x1, x2, x3, x4) -
             p1**x1*p2**x2*p3**x3*p4**x4*(-p1 - p2 - p3 - p4 + 1)**4*g(x1 + x2 +
             x3 + x4 + 4)/(6*f(x1)*f(x2)*f(x3)*f(x4))) == S(0)
-    assert marginal_distribution(N_c, N_c[0])(1).evalf().round(2) == 0.33
+    assert marginal_distribution(C, C[0])(1).evalf().round(2) == 0.33
     raises(ValueError, lambda: NegativeMultinomial('b1', 5, [p1, p2, p3, p1_f]))
-    raises(ValueError, lambda: NegativeMultinomial('b2', k0, [p1, p2, p3, p4]))
+    raises(ValueError, lambda: NegativeMultinomial('b2', k0, 0.5, 0.4, 0.3, 0.4))
 
 def test_JointPSpace_margial_distribution():
     from sympy.stats.joint_rv_types import MultivariateT

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -95,15 +95,15 @@ def test_Multinomial():
     p1, p2, p3, p4 = symbols('p1, p2, p3, p4', positive=True)
     p1_f, n_f = symbols('p1_f, n_f', negative=True)
     M = Multinomial('M', n, [p1, p2, p3, p4])
-    C = Multinomial('C', n, p1, p2, p3)
+    C = Multinomial('C', 3, p1, p2, p3)
     f = factorial
     assert density(M)(x1, x2, x3, x4) == Piecewise((p1**x1*p2**x2*p3**x3*p4**x4*
                                             f(n)/(f(x1)*f(x2)*f(x3)*f(x4)),
                                             Eq(n, x1 + x2 + x3 + x4)), (0, True))
-    marg = Sum(Piecewise((p1**x1*p2**C[1]*p3**C[2]*factorial(n)/(factorial(x1)*
-            factorial(C[1])*factorial(C[2])), Eq(n, x1 + C[1] + C[2])), (0, True)
-            ), (C[1], 0, n), (C[2], 0, n))
-    assert str(marginal_distribution(C, C[0])(x1)) == str(marg)
+    assert marginal_distribution(C, C[0])(x1).subs(x1, 1) ==\
+                                                            3*p1*p2**2 +\
+                                                            6*p1*p2*p3 +\
+                                                            3*p1*p3**2
     raises(ValueError, lambda: Multinomial('b1', 5, [p1, p2, p3, p1_f]))
     raises(ValueError, lambda: Multinomial('b2', n_f, [p1, p2, p3, p4]))
     raises(ValueError, lambda: Multinomial('b3', n, 0.5, 0.4, 0.3, 0.1))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Enhances https://github.com/sympy/sympy/pull/16808
Discussion at https://gitter.im/sympy/stats

#### Brief description of what is fixed or changed
N/A

#### Other comments
@sidhantnagpal 's comment:
 I have a couple of comments about the merged sympy/sympy#16808 for Multinomial distribution. Firstly, there should be additional conditions to check if sum(x) = n(the PMF could be 0 if this is not the case) and sum(p) = 1. Secondly, as @Upabjojr mentioned we should allow symbolic number of trials n. This is currently what happens:
```
In [4]: n = Symbol('n')                                                        
In [5]: x, p = map(symbols, ('x:4', 'p:4'))                                    
In [6]: X = Multinomial('X', n, *p) 
ValueError: number of trials must be a positve integer
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
