### PR TITLE
Range accepts numbers, symbols as parameters

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -381,16 +381,11 @@ class Range(Set):
         >>> from sympy import Range, symbols
         >>> list(Range(3))
         [0, 1, 2]
-        >>> sr, sp, st = symbols('sr, sp, st', positive=True)
-        >>> R = Range(sr, sp, st)
-        >>> R
-        Range(sr, sp, st)
-        >>> R.subs(sr, 0)
-        Range(0, sp, st)
-        >>> R.subs(sp, 20)
-        Range(sr, 20, st)
-        >>> R.subs(st, 1)
-        Range(sr, sp, 1)
+        >>> r, p, t = symbols('r, p, t', positive=True)
+        >>> Range(r, p, t)
+        Range(r, p, t)
+        >>> (_).subs(r, 0)
+        Range(0, p, t)
 
     The step can also be negative:
 
@@ -459,10 +454,6 @@ class Range(Set):
 
         start, stop, step = map(_sympify, [start, stop, step])
 
-        tmp_obj = Basic(start, stop, step)
-        if tmp_obj.atoms(Float) and (not tmp_obj.atoms(Symbol)):
-            raise ValueError('Floats are not permitted in Range.')
-
         if step.is_infinite:
             raise ValueError(filldedent('''
     Range cannot have an infinite step size.'''))
@@ -482,8 +473,11 @@ class Range(Set):
                 end = stop
             else:
                 ref = start if start.is_finite else stop
+                if any(i.is_number and i.has(Float) for i in (step, stop - ref)):
+                    raise ValueError(filldedent('''
+    Only symbolic and integervalues are allowed in Range.'''))
                 n = ceiling((stop - ref)/step)
-                if n <= 0:
+                if (n <= 0) == True:
                     # null Range
                     start = end = S.Zero
                     step = S.One

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -469,14 +469,14 @@ class Range(Set):
         if start.is_infinite:
             end = stop
         else:
+            t = Tuple(step, stop, start)
+            if not t.atoms(Symbol, Integer, S.Infinity, S.NegativeInfinity) == t.atoms():
+                raise ValueError(filldedent('''
+Only Symbol and Integer are permitted in Range.'''))
             if not all(w.is_number for w in [start, stop, step]):
                 end = stop
             else:
                 ref = start if start.is_finite else stop
-                t = Tuple(step, stop, ref)
-                if not t.atoms(Symbol, Integer, S.Infinity, S.NegativeInfinity) == t.atoms():
-                    raise ValueError(filldedent('''
-    Only Symbol and Integer are permitted in Range.'''))
                 n = ceiling((stop - ref)/step)
                 if (n <= 0) == True:
                     # null Range

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -11,6 +11,7 @@ from sympy.logic.boolalg import And
 from sympy.sets.sets import Set, Interval, Union, FiniteSet
 from sympy.utilities.misc import filldedent
 from sympy.core.numbers import Float
+from sympy.core.containers import Tuple
 
 
 class Naturals(with_metaclass(Singleton, Set)):
@@ -473,9 +474,9 @@ class Range(Set):
                 end = stop
             else:
                 ref = start if start.is_finite else stop
-                if any(i.is_number and i.has(Float) for i in (step, stop - ref)):
+                if Tuple(step, stop, ref).has(Float):
                     raise ValueError(filldedent('''
-    Only symbolic and integervalues are allowed in Range.'''))
+    Floats are not permitted in Range.'''))
                 n = ceiling((stop - ref)/step)
                 if (n <= 0) == True:
                     # null Range

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -154,6 +154,9 @@ def test_Range_set():
     assert Range(15, 5, -1).inf == 6
     assert Range(10, 67, 10).sup == 60
     assert Range(60, 7, -10).inf == 10
+    n, m = symbols('n, m', positive=True)
+    assert Range(m, n + 2, 1).sup == n + 1
+    assert Range(m, n, 1).inf == m
 
     assert len(Range(10, 38, 10)) == 3
 
@@ -163,7 +166,6 @@ def test_Range_set():
     raises(ValueError, lambda: Range(-oo, oo))
     raises(ValueError, lambda: Range(oo, -oo, -1))
     raises(ValueError, lambda: Range(-oo, oo, 2))
-    raises(ValueError, lambda: Range(0, pi, 1))
     raises(ValueError, lambda: Range(1, 10, 0))
 
     assert 5 in Range(0, oo, 5)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -9,6 +9,7 @@ from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, t
+from sympy.functions.elementary.integers import floor
 
 import itertools
 
@@ -157,6 +158,7 @@ def test_Range_set():
     n, m = symbols('n, m', positive=True)
     assert Range(m, n + 2, 1).sup == n + 1
     assert Range(m, n, 1).inf == m
+    assert Range(n, m, 1).size == Abs(floor(m - n))
 
     assert len(Range(10, 38, 10)) == 3
 
@@ -167,6 +169,7 @@ def test_Range_set():
     raises(ValueError, lambda: Range(oo, -oo, -1))
     raises(ValueError, lambda: Range(-oo, oo, 2))
     raises(ValueError, lambda: Range(1, 10, 0))
+    raises(ValueError, lambda: Range(0, pi, 1))
 
     assert 5 in Range(0, oo, 5)
     assert -5 in Range(-oo, 0, 5)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes https://github.com/sympy/sympy/issues/16833

#### Brief description of what is fixed or changed
Range now accepts a wider domain of parameters like, `Symbol` Expressions and `Integer`, as start, stop, step. Original conditions of infinity are unchanged. When, symbolic parameters are passed the `Range` is kept unevaluated.

### Example
#### Code
```
from sympy import *
n, m, s, x = symbols('n, m, s, x', positive=True)
r1 = Range(m, n, s)
i = Interval(0, n)
print("Range -", r1)
print("Sum -", summation(x, (x, r1)))
```
#### Before
```
Traceback (most recent call last):
  File "/home/gagandeep/sympy/sympy/core/compatibility.py", line 419, in as_int
    raise TypeError
TypeError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gagandeep/sympy/sympy/sets/fancysets.py", line 453, in __new__
    for w in (start, stop, step)]
  File "/home/gagandeep/sympy/sympy/sets/fancysets.py", line 453, in <listcomp>
    for w in (start, stop, step)]
  File "/home/gagandeep/sympy/sympy/core/compatibility.py", line 425, in as_int
    raise ValueError('%s is not an integer' % (n,))
ValueError: m is not an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gagandeep/sympy_debug.py", line 351, in <module>
    r1 = Range(m, n, s)
  File "/home/gagandeep/sympy/sympy/sets/fancysets.py", line 458, in __new__
    [0, 1/10, 1/5].'''))
ValueError: 
Finite arguments to Range must be integers; `imageset` can define
other cases, e.g. use `imageset(i, i/10, Range(3))` to give [0, 1/10,
1/5].
```
#### After
```
Range - Range(m, n, s)
Sum - m*(floor((-m + n - s)/s) + 1) + s*(floor(-m/s + n/s)**2/2 - floor(-m/s + n/s)/2)
```

#### Other comments
Please don't close this PR. Comment your suggestions, send a PR to my branch or make direct commits. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Range has been made to accept broader domain of parameters like `Symbol` Expressions.
<!-- END RELEASE NOTES -->
