### PR TITLE
Set the keyword check=True for MatAdd

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1085,7 +1085,17 @@ class Basic(with_metaclass(ManagedProperties)):
                     hit = True
                     args[i] = arg
             if hit:
-                rv = self.func(*args)
+                # XXX Hack for substituting a matrix with a non-matrix
+                # in MatAdd
+                from sympy.matrices.expressions.matadd import MatAdd
+                if isinstance(self, MatAdd):
+                    try:
+                        rv = self.func(*args, check=True)
+                    except TypeError:
+                        rv = self.func(*args, check=False)
+                else:
+                    rv = self.func(*args)
+
                 hack2 = hints.get('hack2', False)
                 if hack2 and self.is_Mul and not rv.is_Mul:  # 2-arg hack
                     coeff = S.One

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -73,7 +73,7 @@ class MatAdd(MatrixExpr, Add):
 
         obj = Basic.__new__(cls, *args)
         if check:
-            if all(not isinstance(i, MatrixExpr) for i in args):
+            if any(not isinstance(i, MatrixExpr) for i in args):
                 return Add.fromiter(args)
             validate(*args)
         return obj

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -19,9 +19,44 @@ class MatAdd(MatrixExpr, Add):
 
     MatAdd inherits from and operates like SymPy Add
 
+    Parameters
+    ==========
+
+    check : bool, optional
+        A volatile flag to skip the sanity check.
+
+        If ``True``, it will check whether all the arguments are matrices,
+        and will fall back to ``Add`` if none of the argument is matrix.
+
+        If ``False``, it will skip the sanity check, and will accept whatever
+        argument under ``MatAdd``.
+
+        Default is ``True``.
+
+        Some examples are :
+
+        ``MatAdd`` falls back to ``Add`` if none of the arguments are
+        matrices
+        >>> MatAdd(1, 2, 3)
+        6
+
+        ``MatAdd`` will not attempt any fall back if ``check=False``
+        >>> x = MatAdd(1, 2, 3)
+        >>> x
+        1 + 2 + 3
+        >>> x.is_Matrix
+        True
+
+        .. Warning::
+            Setting this flag to ``False`` is dangerous. Only use when you
+            can guarantee that the arguments are in matrix context. The
+            assumption system can break as ``MatAdd`` uses hardcoded
+            assumptions.
+
     Examples
     ========
 
+    Symbolic matrix addition with matrix symbols:
     >>> from sympy import MatAdd, MatrixSymbol
     >>> A = MatrixSymbol('A', 5, 5)
     >>> B = MatrixSymbol('B', 5, 5)
@@ -41,7 +76,7 @@ class MatAdd(MatrixExpr, Add):
         # TypeErrors from GenericZeroMatrix().shape
         args = filter(lambda i: cls.identity != i, args)
         args = list(map(sympify, args))
-        check = kwargs.get('check', False)
+        check = kwargs.get('check', True)
 
         obj = Basic.__new__(cls, *args)
         if check:

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -73,7 +73,7 @@ class MatAdd(MatrixExpr, Add):
 
         obj = Basic.__new__(cls, *args)
         if check:
-            if any(not isinstance(i, MatrixExpr) for i in args):
+            if all(not isinstance(i, MatrixExpr) for i in args):
                 return Add.fromiter(args)
             validate(*args)
         return obj

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -33,20 +33,6 @@ class MatAdd(MatrixExpr, Add):
 
         Default is ``True``.
 
-        Some examples are :
-
-        ``MatAdd`` falls back to ``Add`` if none of the arguments are
-        matrices
-        >>> MatAdd(1, 2, 3)
-        6
-
-        ``MatAdd`` will not attempt any fall back if ``check=False``
-        >>> x = MatAdd(1, 2, 3)
-        >>> x
-        1 + 2 + 3
-        >>> x.is_Matrix
-        True
-
         .. Warning::
             Setting this flag to ``False`` is dangerous. Only use when you
             can guarantee that the arguments are in matrix context. The
@@ -57,12 +43,19 @@ class MatAdd(MatrixExpr, Add):
     ========
 
     Symbolic matrix addition with matrix symbols:
+
     >>> from sympy import MatAdd, MatrixSymbol
     >>> A = MatrixSymbol('A', 5, 5)
     >>> B = MatrixSymbol('B', 5, 5)
     >>> C = MatrixSymbol('C', 5, 5)
     >>> MatAdd(A, B, C)
     A + B + C
+
+    ``MatAdd`` falls back to ``Add`` if none of the arguments are
+    matrices
+
+    >>> MatAdd(1, 2, 3)
+    6
     """
     is_MatAdd = True
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -615,7 +615,9 @@ def get_postprocessor(cls):
                 # manipulate them like non-commutative scalars.
                 return cls._from_args(nonmatrices + [mat_class(*matrices).doit(deep=False)])
 
-        return mat_class(*matrices).doit(deep=False)
+        if cls == Add:
+            return mat_class(*matrices).doit(deep=False)
+        return mat_class(cls._from_args(nonmatrices), *matrices).doit(deep=False)
     return _postprocessor
 
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -615,7 +615,7 @@ def get_postprocessor(cls):
                 # manipulate them like non-commutative scalars.
                 return cls._from_args(nonmatrices + [mat_class(*matrices).doit(deep=False)])
 
-        return mat_class(cls._from_args(nonmatrices), *matrices).doit(deep=False)
+        return mat_class(*matrices).doit(deep=False)
     return _postprocessor
 
 

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -30,3 +30,10 @@ def test_doit_args():
 def test_generic_identity():
     assert MatAdd.identity == GenericZeroMatrix()
     assert MatAdd.identity != S.Zero
+
+
+def test_scalar_add_issue():
+    assert MatAdd(1, 2) == 3
+    assert MatAdd(1, 2).is_Matrix == False
+    assert MatAdd(1, 2, check=False).__class__ == MatAdd
+    assert MatAdd(1, 2, check=False).is_Matrix == True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16821

#### Brief description of what is fixed or changed

Unlike `MatMul` or other matrix expressions, `MatAdd` does not check the argument as default, and it is causing some problems like `is_Matrix` getting `True` even if it contains purely scalar.

Such thing can cause some issues.
And volatile constructor can confuse users. 

#### Other comments

Doc render:
![image](https://user-images.githubusercontent.com/34944973/57787100-bc8dde00-776f-11e9-977d-e809a369cae6.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Changed the keyword argument `check` to `True` in `MatAdd`. 
<!-- END RELEASE NOTES -->
