### PR TITLE
fix Integer floordiv for non-integer denominator; divmod with inf and nan

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -558,8 +558,6 @@ class Number(AtomicExpr):
             raise ZeroDivisionError('modulo by zero')
         if self.is_Integer and other.is_Integer:
             return Tuple(*divmod(self.p, other.p))
-        elif other.is_infinite or other is S.NaN:
-            return Tuple(S.NaN, S.NaN)
         else:
             if isinstance(other, Float):
                 rat = self/Rational(other)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2304,7 +2304,9 @@ class Integer(Rational):
         return self, S.One
 
     def __floordiv__(self, other):
-        return Integer(self.p // Integer(other).p)
+        if isinstance(other, Integer):
+            return Integer(self.p // other)
+        return Integer(divmod(self, other)[0])
 
     def __rfloordiv__(self, other):
         return Integer(Integer(other).p // self.p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -545,12 +545,12 @@ class Number(AtomicExpr):
 
     def __divmod__(self, other):
         from .containers import Tuple
+        from sympy.functions.elementary.complexes import sign
 
         try:
             other = Number(other)
-            if other.is_infinite or self.is_infinite or \
-                    S.NaN in (self, other):
-                raise TypeError
+            if self.is_infinite or S.NaN in (self, other):
+                return (S.NaN, S.NaN)
         except TypeError:
             msg = "unsupported operand type(s) for divmod(): '%s' and '%s'"
             raise TypeError(msg % (type(self).__name__, type(other).__name__))
@@ -558,13 +558,16 @@ class Number(AtomicExpr):
             raise ZeroDivisionError('modulo by zero')
         if self.is_Integer and other.is_Integer:
             return Tuple(*divmod(self.p, other.p))
+        elif isinstance(other, Float):
+            rat = self/Rational(other)
         else:
-            if isinstance(other, Float):
-                rat = self/Rational(other)
-            else:
-                rat = self/other
-        w = int(rat) if rat > 0 else int(rat) - 1
-        r = self - other*w
+            rat = self/other
+        if other.is_finite:
+            w = int(rat) if rat > 0 else int(rat) - 1
+            r = self - other*w
+        else:
+            w = 0 if not self or (sign(self) == sign(other)) else -1
+            r = other if w else self
         return Tuple(w, r)
 
     def __rdivmod__(self, other):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -555,8 +555,13 @@ class Number(AtomicExpr):
             raise ZeroDivisionError('modulo by zero')
         if self.is_Integer and other.is_Integer:
             return Tuple(*divmod(self.p, other.p))
+        elif other.is_infinite or other is S.NaN:
+            return Tuple(S.NaN, S.NaN)
         else:
-            rat = self/other
+            if isinstance(other, Float):
+                rat = self/Rational(other)
+            else:
+                rat = self/other
         w = int(rat) if rat > 0 else int(rat) - 1
         r = self - other*w
         return Tuple(w, r)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -548,6 +548,9 @@ class Number(AtomicExpr):
 
         try:
             other = Number(other)
+            if other.is_infinite or self.is_infinite or \
+                    S.NaN in (self, other):
+                raise TypeError
         except TypeError:
             msg = "unsupported operand type(s) for divmod(): '%s' and '%s'"
             raise TypeError(msg % (type(self).__name__, type(other).__name__))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -15,7 +15,7 @@ from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
 from sympy.core.mod import Mod
 from sympy.polys.domains.groundtypes import PythonRational
 from sympy.utilities.decorator import conserve_mpmath_dps
-from sympy.utilities.iterables import permutations, cartes
+from sympy.utilities.iterables import permutations
 from sympy.utilities.pytest import XFAIL, raises
 
 from mpmath import mpf
@@ -177,10 +177,18 @@ def test_divmod():
     assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
     assert divmod(S(-8), S(-2.5) ) == Tuple(3 , -0.5)
 
-    for i, j in cartes(*[[S.One, oo, -oo, S.NaN]]*2):
-        if i == j == 1:
-            continue
-        raises(TypeError, lambda: divmod(i, j))
+    assert divmod(oo, 1) == (S.NaN, S.NaN)
+    assert divmod(S.NaN, 1) == (S.NaN, S.NaN)
+    assert divmod(1, S.NaN) == (S.NaN, S.NaN)
+    ans = [(-1, oo), (-1, oo), (0, 0), (0, 1), (0, 2)]
+    OO = float('inf')
+    ANS = [tuple(map(float, i)) for i in ans]
+    assert [divmod(i, oo) for i in range(-2, 3)] == ans
+    assert [divmod(i, OO) for i in range(-2, 3)] ==  ANS
+    ans = [(0, -2), (0, -1), (0, 0), (-1, -oo), (-1, -oo)]
+    ANS = [tuple(map(float, i)) for i in ans]
+    assert [divmod(i, -oo) for i in range(-2, 3)] == ans
+    assert [divmod(i, -OO) for i in range(-2, 3)] == ANS
     assert divmod(S(3.5), S(-2)) == divmod(3.5, -2)
     assert divmod(-S(3.5), S(-2)) == divmod(-3.5, -2)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -122,7 +122,8 @@ def test_divmod():
     assert divmod(S("3.5"), S("2")) == Tuple(S("1"), S("1.5"))
     assert divmod(S("2"), S("1/3")) == Tuple(S("6"), S("0"))
     assert divmod(S("1/3"), S("2")) == Tuple(S("0"), S("1/3"))
-    assert divmod(S("2"), S("0.1")) == Tuple(S("20"), S("0"))
+    assert divmod(S("2"), S("1/10")) == Tuple(S("20"), S("0"))
+    assert divmod(S("2"), S(".1"))[0] == 19
     assert divmod(S("0.1"), S("2")) == Tuple(S("0"), S("0.1"))
     assert divmod(S("2"), 2) == Tuple(S("1"), S("0"))
     assert divmod(2, S("2")) == Tuple(S("1"), S("0"))
@@ -133,7 +134,7 @@ def test_divmod():
     assert divmod(S("3.5"), S("3/2")) == Tuple(S("2"), S("0.5"))
     assert divmod(S("3/2"), S("1/3")) == Tuple(S("4"), Float("1/6"))
     assert divmod(S("1/3"), S("3/2")) == Tuple(S("0"), S("1/3"))
-    assert divmod(S("3/2"), S("0.1")) == Tuple(S("15"), S("0"))
+    assert divmod(S("3/2"), S("0.1"))[0] == 14
     assert divmod(S("0.1"), S("3/2")) == Tuple(S("0"), S("0.1"))
     assert divmod(S("3/2"), 2) == Tuple(S("0"), S("3/2"))
     assert divmod(2, S("3/2")) == Tuple(S("1"), S("0.5"))
@@ -155,7 +156,7 @@ def test_divmod():
     assert divmod(S("1/3"), 1.5) == Tuple(S("0"), S("1/3"))
     assert divmod(0.3, S("1/3")) == Tuple(S("0"), S("0.3"))
     assert divmod(S("0.1"), 2) == Tuple(S("0"), S("0.1"))
-    assert divmod(2, S("0.1")) == Tuple(S("20"), S("0"))
+    assert divmod(2, S("0.1"))[0] == 19
     assert divmod(S("0.1"), 1.5) == Tuple(S("0"), S("0.1"))
     assert divmod(1.5, S("0.1")) == Tuple(S("15"), S("0"))
     assert divmod(S("0.1"), 0.3) == Tuple(S("0"), S("0.1"))
@@ -175,6 +176,14 @@ def test_divmod():
     assert divmod(S(4), S(-3.1)) == Tuple(-2, -2.2)
     assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
     assert divmod(S(-8), S(-2.5) ) == Tuple(3 , -0.5)
+
+    nana = (S.NaN, S.NaN)
+    assert divmod(S(1), oo) == nana
+    assert divmod(S(1), -oo) == nana
+    assert divmod(S(1), S.NaN) == nana
+    assert divmod(S(3.5), S(-2)) == divmod(3.5, -2)
+    assert divmod(-S(3.5), S(-2)) == divmod(-3.5, -2)
+
 
 def test_igcd():
     assert igcd(0, 0) == 0
@@ -1910,7 +1919,5 @@ def test_abc():
     z = numbers.Integer(3)
     assert(isinstance(z, nums.Number))
 
-
 def test_floordiv():
-    assert Float(3.5)//S.Half == 7
-    assert S('35/10')//S.Half == 7
+    assert S(2)//S.Half == 4

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -15,7 +15,7 @@ from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
 from sympy.core.mod import Mod
 from sympy.polys.domains.groundtypes import PythonRational
 from sympy.utilities.decorator import conserve_mpmath_dps
-from sympy.utilities.iterables import permutations
+from sympy.utilities.iterables import permutations, cartes
 from sympy.utilities.pytest import XFAIL, raises
 
 from mpmath import mpf
@@ -177,10 +177,10 @@ def test_divmod():
     assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
     assert divmod(S(-8), S(-2.5) ) == Tuple(3 , -0.5)
 
-    nana = (S.NaN, S.NaN)
-    assert divmod(S(1), oo) == nana
-    assert divmod(S(1), -oo) == nana
-    assert divmod(S(1), S.NaN) == nana
+    for i, j in cartes(*[[S.One, oo, -oo, S.NaN]]*2):
+        if i == j == 1:
+            continue
+        raises(TypeError, lambda: divmod(i, j))
     assert divmod(S(3.5), S(-2)) == divmod(3.5, -2)
     assert divmod(-S(3.5), S(-2)) == divmod(-3.5, -2)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1909,3 +1909,8 @@ def test_abc():
     assert(isinstance(y, nums.Rational))
     z = numbers.Integer(3)
     assert(isinstance(z, nums.Number))
+
+
+def test_floordiv():
+    assert Float(3.5)//S.Half == 7
+    assert S('35/10')//S.Half == 7


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #16844

#### Brief description of what is fixed or changed

Formerly
```python
S(3)//S.Half -> ZeroDivisionError
```
Now
```python
S(3)//S.Half -> 6 matches Python 3//.5 -> 6.0
```

Also correct `divmod` when other is Float to match Python behavior but do not match Python behavior when other is infinite:
```python
>>> divmod(1.,float('-inf'))
(-1.0, -inf)
>>> divmod(1.,float('inf'))
(0.0, 1.0)
>>> divmod(-1.,float('inf'))
(-1.0, inf)
>>> divmod(-1.,float('-inf'))
(0.0, -1.0)
```
In these cases, as with `other == S.NaN`, `(nan, nan)` is being returned.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - numbers: Integer//d corrected for case when d is not an integer
    - divmod(a, b) behavior matches Python's when arguments involve oo or nan
<!-- END RELEASE NOTES -->
