### PR TITLE
Fix amendments to check method in sympy.stats.crv_types

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1128,9 +1128,9 @@ class FDistributionDistribution(SingleContinuousDistribution):
 
     @staticmethod
     def check(d1, d2):
-        _value_check((d1 > 0, d1.is_integer), \
+        _value_check((d1 > 0, d1.is_integer),
             "Degrees of freedom d1 must be positive integer.")
-        _value_check((d2 > 0, d2.is_integer), \
+        _value_check((d2 > 0, d2.is_integer),
             "Degrees of freedom d2 must be positive integer.")
 
     def pdf(self, x):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1128,9 +1128,9 @@ class FDistributionDistribution(SingleContinuousDistribution):
 
     @staticmethod
     def check(d1, d2):
-        _value_check(d1 > 0 and d1.is_integer, \
+        _value_check((d1 > 0, d1.is_integer), \
             "Degrees of freedom d1 must be positive integer.")
-        _value_check(d2 > 0 and d2.is_integer, \
+        _value_check((d2 > 0, d2.is_integer), \
             "Degrees of freedom d2 must be positive integer.")
 
     def pdf(self, x):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16842 

#### Brief description of what is fixed or changed
Due to merging of #16765, the way the check method uses _value_check
is better to be changed in some cases as shown in the example below

#### Other comments
earlier :
```
_value_check(d1 > 0 and d1.is_integer, \
        "Degrees of freedom d1 must be positive integer.")
_value_check(d2 > 0 and d2.is_integer, \
        "Degrees of freedom d2 must be positive integer.")
```
as of now :
```
_value_check((d1 > 0, d1.is_integer), \
    "Degrees of freedom d1 must be positive integer.")
_value_check((d2 > 0, d2.is_integer), \
    "Degrees of freedom d2 must be positive integer.")
```
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
