### PR TITLE
Fix identity of MatAdd and MatMul

### DIFF
--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -31,13 +31,15 @@ class MatAdd(MatrixExpr, Add):
     """
     is_MatAdd = True
 
+    identity = GenericZeroMatrix()
+
     def __new__(cls, *args, **kwargs):
         if not args:
-            return GenericZeroMatrix()
+            return cls.identity
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
-        args = filter(lambda i: GenericZeroMatrix() != i, args)
+        args = filter(lambda i: i != cls.identity, args)
         args = list(map(sympify, args))
         check = kwargs.get('check', False)
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
-        args = filter(lambda i: isinstance(i, cls.identity), args)
+        args = filter(lambda i: isinstance(i, cls.identity.__class__), args)
         args = list(map(sympify, args))
         check = kwargs.get('check', False)
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
-        args = filter(lambda i: i != cls.identity, args)
+        args = filter(lambda i: isinstance(i, cls.identity), args)
         args = list(map(sympify, args))
         check = kwargs.get('check', False)
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
-        args = filter(lambda i: isinstance(i, cls.identity.__class__), args)
+        args = filter(lambda i: cls.identity != i, args)
         args = list(map(sympify, args))
         check = kwargs.get('check', False)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -39,7 +39,7 @@ class MatMul(MatrixExpr, Mul):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
-        args = filter(lambda i: isinstance(i, cls.identity.__class__), args)
+        args = filter(lambda i: cls.identity != i, args)
         args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -39,7 +39,7 @@ class MatMul(MatrixExpr, Mul):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
-        args = filter(lambda i: isinstance(i, cls.identity), args)
+        args = filter(lambda i: isinstance(i, cls.identity.__class__), args)
         args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -29,15 +29,17 @@ class MatMul(MatrixExpr, Mul):
     """
     is_MatMul = True
 
+    identity = GenericIdentity()
+
     def __new__(cls, *args, **kwargs):
         check = kwargs.get('check', True)
 
         if not args:
-            return GenericIdentity()
+            return cls.identity
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
-        args = filter(lambda i: GenericIdentity() != i, args)
+        args = filter(lambda i: i != cls.identity, args)
         args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -39,7 +39,7 @@ class MatMul(MatrixExpr, Mul):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
-        args = filter(lambda i: i != cls.identity, args)
+        args = filter(lambda i: isinstance(i, cls.identity), args)
         args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,6 +1,7 @@
 from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
+from sympy.matrices.expressions.matexpr import GenericZeroMatrix
 from sympy.matrices import eye, ImmutableMatrix
-from sympy import Basic
+from sympy.core import Basic, S
 
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 2)
@@ -24,3 +25,8 @@ def test_doit_args():
     assert MatAdd(A, MatMul(A, B)).doit() == A + A*B
     assert (MatAdd(A, X, MatMul(A, B), Y, MatAdd(2*A, B)).doit() ==
             MatAdd(3*A + A*B + B, X, Y))
+
+
+def test_generic_identity():
+    assert MatAdd.identity == GenericZeroMatrix()
+    assert MatAdd.identity != S.Zero

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -1,8 +1,9 @@
-from sympy.core import I, symbols, Basic, Mul
+from sympy.core import I, symbols, Basic, Mul, S
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
 from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
+from sympy.matrices.expressions.matexpr import GenericIdentity
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
@@ -149,3 +150,7 @@ def test_issue_12950():
 def test_construction_with_Mul():
     assert Mul(C, D) == MatMul(C, D)
     assert Mul(D, C) == MatMul(D, C)
+
+def test_generic_identity():
+    assert MatMul.identity == GenericIdentity()
+    assert MatMul.identity != S.One


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Some lower level operations from `AssocOp` is using `identity` property, and I think `MatAdd` and `MatMul` inherits the identity from `Add` and `Mul` without any changes.

```python
>>> from sympy import *
>>> MatAdd.identity == S.Zero
True
>>> MatMul.identity == S.One
True
```

I've changed them to `GenericZeroMatrix`, and `GenericIdentityMatrix`

Though the old identity `S.One` for `MatMul` have less problem than `S.Zero` for `MatAdd`

#### Other comments

I think the matrix dimensions would have to be defined first, before any matrix operator is defined, for the fundamental concerns.
https://proofwiki.org/wiki/Definition:Matrix_Entrywise_Addition
https://proofwiki.org/wiki/Definition:Matrix_Product_(Conventional)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `MatAdd` and `MatMul` will use `GenericZeroMatrix` and `GenericIdentity` for `identity`
<!-- END RELEASE NOTES -->
