### PR TITLE
Fancy

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -319,6 +319,9 @@ class ImageSet(Set):
                             else:
                                 raise NotImplementedError
                         else:
+                            # if there is more than 1 symbol from
+                            # variables in expr than this is a
+                            # coupled system
                             raise NotImplementedError
                     solns = cartes(*[solns[s] for s in variables])
                 except NotImplementedError:

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -470,8 +470,11 @@ class Range(Set):
     Either the start or end value of the Range must be finite.'''))
 
         if start.is_infinite:
-            end = stop
-        else:
+            if step*(stop - start) < 0:
+                start = stop = S.One
+            else:
+                end = stop
+        if not start.is_infinite:
             ref = start if start.is_finite else stop
             n = ceiling((stop - ref)/step)
             if n <= 0:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -159,6 +159,10 @@ def test_Range_set():
 
     assert Range(0, 0, 5) == empty
     assert Range(oo, oo, 1) == empty
+    assert Range(oo, 1, 1) == empty
+    assert Range(-oo, 1, -1) == empty
+    assert Range(1, oo, -1) == empty
+    assert Range(1, -oo, 1) == empty
     raises(ValueError, lambda: Range(1, 4, oo))
     raises(ValueError, lambda: Range(-oo, oo))
     raises(ValueError, lambda: Range(oo, -oo, -1))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -109,8 +109,10 @@ def test_halfcircle():
     L = Lambda((r, th), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
+    assert (r, 0) in halfcircle
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
+    assert (r, 2*pi) not in halfcircle
     assert (0, 0) in halfcircle
 
     assert not halfcircle.is_iterable

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -101,7 +101,6 @@ def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)
 
 
-@XFAIL
 def test_halfcircle():
     # This test sometimes works and sometimes doesn't.
     # It may be an issue with solve? Maybe with using Lambdas/dummys?


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #10287

There are also some Ranges that should be recognized as null Ranges -- see added tests.

#### Brief description of what is fixed or changed

When solving to see whether `(a, b)` can be substituted into `Lambda((x, y), (f(x,y), g(x,y)))` to give a value that is in the base set, the equations `(f(x,y) - a, g(x,y) - b)` are solved for x and y and x and y are then checked for inclusion in the base set.  The current code only handles the case for `Lambda((x, y), (f(x), g(y)))` or the linear case `Lambda((x,y),(M*x+N*y + C, P*x + Q*y + D))`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
    - fancyset Range recognizes null ranges when start or stop is infinite and step is wrong sign
    - bug fix in ImageSet contains method makes it more robust for multivariate cases
<!-- END RELEASE NOTES -->
