### PR TITLE
matrices: Fix wrong result in Sum over matrix expression

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -449,7 +449,7 @@ class MatrixExpr(Expr):
             rule = bottom_up(lambda x: reduce(lambda a, b: a*b, x.args) if isinstance(x, (Mul, MatMul)) else x)
             return rule(expr)
 
-        def recurse_expr(expr, index_ranges={}):
+        def recurse_expr(expr, index_ranges={}, was_matmul=None):
             if expr.is_Mul:
                 nonmatargs = []
                 pos_arg = []
@@ -459,7 +459,7 @@ class MatrixExpr(Expr):
                 counter = 0
                 args_ind = []
                 for arg in expr.args:
-                    retvals = recurse_expr(arg, index_ranges)
+                    retvals = recurse_expr(arg, index_ranges, was_matmul=True)
                     assert isinstance(retvals, list)
                     if isinstance(retvals, list):
                         for i in retvals:
@@ -535,11 +535,12 @@ class MatrixExpr(Expr):
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
                 count = 1
-                for i_other in index_ranges:
-                    if i_other == i1 or i_other == i2:
-                        continue
-                    r1, r2 = index_ranges[i_other]
-                    count *= r2 - r1 + 1
+                if not was_matmul:
+                    for i_other in index_ranges:
+                        if i_other == i1 or i_other == i2:
+                            continue
+                        r1, r2 = index_ranges[i_other]
+                        count *= r2 - r1 + 1
                 if i1 in index_ranges and i2 in index_ranges:
                     r1, r2 = index_ranges[i1]
                     if r1 != 0 or matrix_symbol.shape[0] != r2+1:
@@ -551,8 +552,7 @@ class MatrixExpr(Expr):
                             (r1, r2), matrix_symbol.shape[1]))
                     if (i1 == i2) and (i1 in index_ranges):
                         return [(count * trace(matrix_symbol), None)]
-                # return [(count * MatrixElement(matrix_symbol, i1, i2), (i1, i2))]
-                return [(count * expr, None)]
+                return [(count * MatrixElement(matrix_symbol, i1, i2), (i1, i2))]                
             elif isinstance(expr, Sum):
                 return recurse_expr(
                     expr.args[0],

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -449,7 +449,7 @@ class MatrixExpr(Expr):
             rule = bottom_up(lambda x: reduce(lambda a, b: a*b, x.args) if isinstance(x, (Mul, MatMul)) else x)
             return rule(expr)
 
-        def recurse_expr(expr, index_ranges={}, was_matmul=None):
+        def recurse_expr(expr, index_ranges={}, was_MatMul=None):
             if expr.is_Mul:
                 nonmatargs = []
                 pos_arg = []
@@ -459,7 +459,7 @@ class MatrixExpr(Expr):
                 counter = 0
                 args_ind = []
                 for arg in expr.args:
-                    retvals = recurse_expr(arg, index_ranges, was_matmul=True)
+                    retvals = recurse_expr(arg, index_ranges, was_MatMul=True)
                     assert isinstance(retvals, list)
                     if isinstance(retvals, list):
                         for i in retvals:
@@ -535,7 +535,7 @@ class MatrixExpr(Expr):
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
                 count = 1
-                if not was_matmul:
+                if not was_MatMul:
                     for i_other in index_ranges:
                         if i_other == i1 or i_other == i2:
                             continue
@@ -552,7 +552,8 @@ class MatrixExpr(Expr):
                             (r1, r2), matrix_symbol.shape[1]))
                     if (i1 == i2) and (i1 in index_ranges):
                         return [(count * trace(matrix_symbol), None)]
-                return [(count * MatrixElement(matrix_symbol, i1, i2), (i1, i2))]                
+                return [(count * MatrixElement(matrix_symbol, i1, i2), (i1, i2))]
+                # return [(count * expr, None)]
             elif isinstance(expr, Sum):
                 return recurse_expr(
                     expr.args[0],

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -534,19 +534,25 @@ class MatrixExpr(Expr):
                 return [(MatrixElement(identity, i1, i2), (i1, i2))]
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
-                if i1 in index_ranges:
+                count = 1
+                for i_other in index_ranges:
+                    if i_other == i1 or i_other == i2:
+                        continue
+                    r1, r2 = index_ranges[i_other]
+                    count *= r2 - r1 + 1
+                if i1 in index_ranges and i2 in index_ranges:
                     r1, r2 = index_ranges[i1]
                     if r1 != 0 or matrix_symbol.shape[0] != r2+1:
                         raise ValueError("index range mismatch: {0} vs. (0, {1})".format(
                             (r1, r2), matrix_symbol.shape[0]))
-                if i2 in index_ranges:
                     r1, r2 = index_ranges[i2]
                     if r1 != 0 or matrix_symbol.shape[1] != r2+1:
                         raise ValueError("index range mismatch: {0} vs. (0, {1})".format(
                             (r1, r2), matrix_symbol.shape[1]))
-                if (i1 == i2) and (i1 in index_ranges):
-                    return [(trace(matrix_symbol), None)]
-                return [(MatrixElement(matrix_symbol, i1, i2), (i1, i2))]
+                    if (i1 == i2) and (i1 in index_ranges):
+                        return [(count * trace(matrix_symbol), None)]
+                # return [(count * MatrixElement(matrix_symbol, i1, i2), (i1, i2))]
+                return [(count * expr, None)]
             elif isinstance(expr, Sum):
                 return recurse_expr(
                     expr.args[0],

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -202,8 +202,10 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
 
 def test_issue_16860():
-    from sympy.abc import a,b
+    from sympy.abc import a,b, c, d, e
     A = MatrixSymbol("A", k, k)
+    B = MatrixSymbol("B", k, k)
+    C = MatrixSymbol("C", k, k)
 
     # Test Sum expression with independent indices
     expr = Sum(A[a, a], (a, 0, k-1))
@@ -214,3 +216,15 @@ def test_issue_16860():
 
     expr = Sum(A[a, a], (b, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, None) == k*A
+
+    expr = Sum(A[a,b]*B[b,c], (b, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr) == A*B
+
+    expr = Sum(A[a,b]*B[b,c], (b, 0, k-1), (d, 0 ,k-1))
+    assert MatrixExpr.from_index_summation(expr) == k*A*B
+
+    expr = Sum(A[a,b]*B[b,c], (b, 0, k-1), (d, 0 ,k-1), (e, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr) == k**2*A*B
+
+    expr = Sum(A[a, a]*B[b, c]*C[c, d], (a, 0, k-1), (c, 0, k-1), (e, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, b) == k*trace(A)*B*C

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -204,7 +204,6 @@ def test_matrix_expression_from_index_summation():
 def test_issue_16860():
     from sympy.abc import a,b
     A = MatrixSymbol("A", k, k)
-    B = MatrixSymbol("B", k, k)
 
     # Test Sum expression with independent indices
     expr = Sum(A[a, a], (a, 0, k-1))

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -200,3 +200,18 @@ def test_matrix_expression_from_index_summation():
 
     expr = Sum(A[i1, i2]*B[i2, 0], (i2, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
+
+def test_issue_16860():
+    from sympy.abc import a,b
+    A = MatrixSymbol("A", k, k)
+    B = MatrixSymbol("B", k, k)
+
+    # Test Sum expression with independent indices
+    expr = Sum(A[a, a], (a, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, None) == trace(A)
+
+    expr = Sum(A[a, a], (a, 0, k-1), (b, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, None) == k*trace(A)
+
+    expr = Sum(A[a, a], (b, 0, k-1))
+    assert MatrixExpr.from_index_summation(expr, None) == k*A


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16860 

#### Brief description of what is fixed or changed
On giving some index in Sum() which are independent to
Matrix Element indices, those indices were ignored and the
the result was corresponding to the summation without that
independent indices

Example:

Before:
```
>>> expr = Sum(A[a, a], (a, 0, k-1), (b, 0, k-1))
>>> expr = MatrixExpr.from_index_summation(expr)
>>> print(expr)
Trace(A)
```
After:
```
>>> expr = Sum(A[a, a], (a, 0, k-1), (b, 0, k-1))
>>> expr = MatrixExpr.from_index_summation(expr)
>>> print(expr)
k*Trace(A)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * fixed the wrong calculation for summation over a matrix expression
<!-- END RELEASE NOTES -->
