### PR TITLE
BlockMatrix is now printed to numpy with the correct output shape.

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -608,6 +608,10 @@ class NumPyPrinter(PythonCodePrinter):
             func = self._module_format('numpy.array')
         return "%s(%s)" % (func, self._print(expr.tolist()))
 
+    def _print_BlockMatrix(self, expr):
+        return '{0}({1})'.format(self._module_format('numpy.block'),
+                                 self._print(expr.args[0].tolist()))
+
     def _print_CodegenArrayTensorProduct(self, expr):
         array_list = [j for i, arg in enumerate(expr.args) for j in
                 (self._print(arg), "[%i, %i]" % (2*i, 2*i+1))]

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -1,5 +1,7 @@
-from sympy import (Piecewise, lambdify, Equality, Unequality, Sum, Mod, cbrt,
-        sqrt, MatrixSymbol)
+from sympy import (
+    Piecewise, lambdify, Equality, Unequality, Sum, Mod, cbrt, sqrt,
+    MatrixSymbol, BlockMatrix
+)
 from sympy import eye
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Cbrt, Sqrt
@@ -236,3 +238,17 @@ def test_issue_15601():
     with warns_deprecated_sympy():
         ans = f(eye(3), eye(3))
         assert np.array_equal(ans, np.array([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+
+def test_16857():
+    if not np:
+        skip("NumPy not installed")
+    # Make a BlockMatrix and test its shape after printing. Fixes #16857.
+    a_n = [MatrixSymbol('a_{}'.format(i), 10, 3) for i in range(2)]
+    A = BlockMatrix([[a_i, a_i] for a_i in a_n])
+    assert A.shape == (20, 6)
+
+    f = lambdify(a_n, A)
+    a_arrays = [np.ones(a_i.shape) for a_i in a_n]
+    ans = f(*a_arrays)
+    assert ans.shape == A.shape
+

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -243,15 +243,9 @@ def test_16857():
     if not np:
         skip("NumPy not installed")
 
-    # Make a BlockMatrix and test its shape after printing. Fixes #16857.
     a_n = [MatrixSymbol('a_{}'.format(i), 10, 3) for i in range(2)]
     A = BlockMatrix([[a_i, a_i] for a_i in a_n])
     assert A.shape == (20, 6)
 
-    f = lambdify(a_n, A)
-    a_arrays = [np.full(a_i.shape, i) for i, a_i in enumerate(a_n)]
-    sympy_ans = f(*a_arrays)
-    assert sympy_ans.shape == A.shape
-    # Compare to direct numpy implementation
-    np_ans = np.block([[a_i, a_i] for a_i in a_arrays])
-    assert np.array_equal(np_ans, sympy_ans)
+    printer = NumPyPrinter()
+    assert printer.doprint(A) == 'numpy.block([[a_0, a_0], [a_1, a_1]])'

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -255,4 +255,3 @@ def test_16857():
     # Compare to direct numpy implementation
     np_ans = np.block([[a_i, a_i] for a_i in a_arrays])
     assert np.array_equal(np_ans, sympy_ans)
-

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -242,13 +242,17 @@ def test_issue_15601():
 def test_16857():
     if not np:
         skip("NumPy not installed")
+
     # Make a BlockMatrix and test its shape after printing. Fixes #16857.
     a_n = [MatrixSymbol('a_{}'.format(i), 10, 3) for i in range(2)]
     A = BlockMatrix([[a_i, a_i] for a_i in a_n])
     assert A.shape == (20, 6)
 
     f = lambdify(a_n, A)
-    a_arrays = [np.ones(a_i.shape) for a_i in a_n]
-    ans = f(*a_arrays)
-    assert ans.shape == A.shape
+    a_arrays = [np.full(a_i.shape, i) for i, a_i in enumerate(a_n)]
+    sympy_ans = f(*a_arrays)
+    assert sympy_ans.shape == A.shape
+    # Compare to direct numpy implementation
+    np_ans = np.block([[a_i, a_i] for a_i in a_arrays])
+    assert np.array_equal(np_ans, sympy_ans)
 

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -243,9 +243,12 @@ def test_16857():
     if not np:
         skip("NumPy not installed")
 
-    a_n = [MatrixSymbol('a_{}'.format(i), 10, 3) for i in range(2)]
-    A = BlockMatrix([[a_i, a_i] for a_i in a_n])
+    a_1 = MatrixSymbol('a_1', 10, 3)
+    a_2 = MatrixSymbol('a_2', 10, 3)
+    a_3 = MatrixSymbol('a_3', 10, 3)
+    a_4 = MatrixSymbol('a_4', 10, 3)
+    A = BlockMatrix([[a_1, a_2], [a_3, a_4]])
     assert A.shape == (20, 6)
 
     printer = NumPyPrinter()
-    assert printer.doprint(A) == 'numpy.block([[a_0, a_0], [a_1, a_1]])'
+    assert printer.doprint(A) == 'numpy.block([[a_1, a_2], [a_3, a_4]])'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16857

#### Brief description of what is fixed or changed
`BlockMatrix` was not printed to `numpy` code correctly, the `numpy` result had a different shape from the original. This PR fixes that.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
