### PR TITLE
Partition does not properly handle FiniteSet and python set

### DIFF
--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -66,7 +66,11 @@ class Partition(FiniteSet):
         args = []
         for arg in partition:
             if isinstance(arg, list):
-                args.append(set(arg))
+                as_set = set(arg)
+                if len(as_set) < len(arg):
+                    raise ValueError(
+                        "Partition contained duplicated elements.")
+                args.append(as_set)
             else:
                 args.append(arg)
 

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -37,6 +37,8 @@ class Partition(FiniteSet):
         Examples
         ========
 
+        Creating Partition from Python lists:
+
         >>> from sympy.combinatorics.partitions import Partition
         >>> a = Partition([1, 2], [3])
         >>> a
@@ -48,6 +50,18 @@ class Partition(FiniteSet):
         >>> a.members
         (1, 2, 3)
 
+        Creating Partition from Python sets:
+
+        >>> Partition({1, 2, 3}, {4, 5})
+        {{4, 5}, {1, 2, 3}}
+
+        Creating Partition from SymPy finite sets:
+
+        >>> from sympy.sets.sets import FiniteSet
+        >>> a = FiniteSet(1, 2, 3)
+        >>> b = FiniteSet(4, 5)
+        >>> Partition(a, b)
+        {{4, 5}, {1, 2, 3}}
         """
         args = []
         for arg in partition:

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -78,7 +78,8 @@ class Partition(FiniteSet):
 
         if not all(isinstance(part, FiniteSet) for part in args):
             raise ValueError(
-                "Each argument to Partition should be a list or a FiniteSet")
+                "Each argument to Partition should be " \
+                "a list, set, or a FiniteSet")
 
         # sort so we have a canonical reference for RGS
         U = Union(*args)

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -64,17 +64,15 @@ class Partition(FiniteSet):
         {{4, 5}, {1, 2, 3}}
         """
         args = []
+        dups = False
         for arg in partition:
             if isinstance(arg, list):
                 as_set = set(arg)
                 if len(as_set) < len(arg):
-                    raise ValueError(
-                        "Partition contained duplicated elements.")
-                args.append(as_set)
-            else:
-                args.append(arg)
-
-        args = [_sympify(arg) for arg in args]
+                    dups = True
+                    break  # error below
+                arg = as_set
+            args.append(_sympify(arg))
 
         if not all(isinstance(part, FiniteSet) for part in args):
             raise ValueError(
@@ -83,8 +81,8 @@ class Partition(FiniteSet):
 
         # sort so we have a canonical reference for RGS
         U = Union(*args)
-        if len(U) < sum(len(arg) for arg in args):
-            raise ValueError("Partition contained duplicated elements.")
+        if dups or len(U) < sum(len(arg) for arg in args):
+            raise ValueError("Partition contained duplicate elements.")
 
         obj = FiniteSet.__new__(cls, *args)
         obj.members = tuple(U)

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -4,14 +4,24 @@ from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             random_integer_partition)
 from sympy.utilities.pytest import raises
 from sympy.utilities.iterables import default_sort_key, partitions
-from sympy.sets.sets import Set
+from sympy.sets.sets import Set, FiniteSet
 
+
+def test_partition_constructor():
+    raises(ValueError, lambda: Partition(*list(range(3))))
+    raises(ValueError, lambda: Partition([1, 1, 2]))
+
+    assert Partition([1, 2, 3], [4, 5]) == Partition([4, 5], [1, 2, 3])
+    assert Partition({1, 2, 3}, {4, 5}) == Partition([1, 2, 3], [4, 5])
+
+    a = FiniteSet(1, 2, 3)
+    b = FiniteSet(4, 5)
+    assert Partition(a, b) == Partition([1, 2, 3], [4, 5])
+    assert Partition({a, b}) == Partition(FiniteSet(a, b))
+    assert Partition({a, b}) != Partition(a, b)
 
 def test_partition():
     from sympy.abc import x
-
-    raises(ValueError, lambda: Partition(*list(range(3))))
-    raises(ValueError, lambda: Partition([1, 1, 2]))
 
     a = Partition([1, 2, 3], [4])
     b = Partition([1, 2], [3, 4])

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -10,6 +10,7 @@ from sympy.sets.sets import Set, FiniteSet
 def test_partition_constructor():
     raises(ValueError, lambda: Partition(*list(range(3))))
     raises(ValueError, lambda: Partition([1, 1, 2]))
+    raises(ValueError, lambda: Partition(1, 2, 3))
 
     assert Partition([1, 2, 3], [4, 5]) == Partition([4, 5], [1, 2, 3])
     assert Partition({1, 2, 3}, {4, 5}) == Partition([1, 2, 3], [4, 5])

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -8,9 +8,10 @@ from sympy.sets.sets import Set, FiniteSet
 
 
 def test_partition_constructor():
-    raises(ValueError, lambda: Partition(*list(range(3))))
     raises(ValueError, lambda: Partition([1, 1, 2]))
+    raises(ValueError, lambda: Partition([1, 2, 3], [2, 3, 4]))
     raises(ValueError, lambda: Partition(1, 2, 3))
+    raises(ValueError, lambda: Partition(*list(range(3))))
 
     assert Partition([1, 2, 3], [4, 5]) == Partition([4, 5], [1, 2, 3])
     assert Partition({1, 2, 3}, {4, 5}) == Partition([1, 2, 3], [4, 5])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

https://github.com/sympy/sympy/blob/9721de77798ec38276958a4e63ceb1ae9acd49ff/sympy/combinatorics/partitions.py#L52-L54
It states that the argument can be FiniteSet, but it is not working because it attempts summation with list in here
https://github.com/sympy/sympy/blob/9721de77798ec38276958a4e63ceb1ae9acd49ff/sympy/combinatorics/partitions.py#L57 

So in reality, only list arguments were working

I have changed the sanitization scheme, so it gets converted to FiniteSet first, also with some special treatment for lists.

Now, it also works with python sets as arguments

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Fixed `Partition` raising error when `set`s or `FiniteSet`s are given as arguments.
<!-- END RELEASE NOTES -->
