### PR TITLE
Added powsimp in _combine_inverse

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1032,6 +1032,7 @@ class Mul(Expr, AssocOp):
         Returns lhs/rhs, but treats arguments like symbols, so things like
         oo/oo return 1, instead of a nan.
         """
+        from sympy.simplify.simplify import powsimp
         if lhs == rhs:
             return S.One
 
@@ -1056,7 +1057,7 @@ class Mul(Expr, AssocOp):
                 else:
                     b.append(x)
             return lhs.func(*a)/rhs.func(*b)
-        return lhs/rhs
+        return powsimp(lhs/rhs)
 
     def as_powers_dict(self):
         d = defaultdict(int)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1051,10 +1051,11 @@ class Mul(Expr, AssocOp):
             for bi in tuple(b.keys()):
                 if bi in a:
                     a[bi] -= b.pop(bi)
+                    if not a[bi]:
+                        a.pop(bi)
             if len(b) != blen:
-                # do not recompute powers if exponent is 0
-                lhs = Mul(*[b**e for b, e in a.items() if e])
-                rhs = Mul(*[b**e for b, e in b.items() if e])
+                lhs = Mul(*[k**v for k, v in a.items()])
+                rhs = Mul(*[k**v for k, v in b.items()])
         return lhs/rhs
 
     def as_powers_dict(self):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1052,8 +1052,9 @@ class Mul(Expr, AssocOp):
                 if bi in a:
                     a[bi] -= b.pop(bi)
             if len(b) != blen:
-                lhs = Mul(*[b**e for b, e in a.items()])
-                rhs = Mul(*[b**e for b, e in b.items()])
+                # do not recompute powers if exponent is 0
+                lhs = Mul(*[b**e for b, e in a.items() if e])
+                rhs = Mul(*[b**e for b, e in b.items() if e])
         return lhs/rhs
 
     def as_powers_dict(self):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1061,6 +1061,10 @@ class Mul(Expr, AssocOp):
     def as_powers_dict(self):
         d = defaultdict(int)
         for term in self.args:
+            if term is S.NegativeInfinity:
+                for b, e in term.as_powers_dict():
+                    d[b] += e
+                continue
             b, e = term.as_base_exp()
             d[b] += e
         return d

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1061,12 +1061,8 @@ class Mul(Expr, AssocOp):
     def as_powers_dict(self):
         d = defaultdict(int)
         for term in self.args:
-            if term is S.NegativeInfinity:
-                for b, e in term.as_powers_dict():
-                    d[b] += e
-                continue
-            b, e = term.as_base_exp()
-            d[b] += e
+            for b, e in term.as_powers_dict().items():
+                d[b] += e
         return d
 
     def as_numer_denom(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3179,6 +3179,9 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     def ceiling(self):
         return self
 
+    def as_powers_dict(self):
+        return {S.NegativeOne: 1, S.Infinity: 1}
+
 
 class NaN(with_metaclass(Singleton, Number)):
     """

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -399,10 +399,13 @@ def test_match_wild_wild():
 def test__combine_inverse():
     x, y = symbols("x y")
     assert Mul._combine_inverse(x*I*y, x*I) == y
-    assert Mul._combine_inverse(x*x**(1+y), x**(1+y)) == x
+    assert Mul._combine_inverse(x*x**(1 + y), x**(1 + y)) == x
     assert Mul._combine_inverse(x*I*y, y*I) == x
     assert Mul._combine_inverse(oo*I*y, y*I) == oo
     assert Mul._combine_inverse(oo*I*y, oo*I) == y
+    assert Mul._combine_inverse(oo*I*y, oo*I) == y
+    assert Mul._combine_inverse(oo*y, -oo) == -y
+    assert Mul._combine_inverse(-oo*y, oo) == -y
     assert Add._combine_inverse(oo, oo) == S(0)
     assert Add._combine_inverse(oo*I, oo*I) == S(0)
     assert Add._combine_inverse(x*oo, x*oo) == S(0)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -399,6 +399,7 @@ def test_match_wild_wild():
 def test__combine_inverse():
     x, y = symbols("x y")
     assert Mul._combine_inverse(x*I*y, x*I) == y
+    assert Mul._combine_inverse(x*x**(1+y), x**(1+y)) == x
     assert Mul._combine_inverse(x*I*y, y*I) == x
     assert Mul._combine_inverse(oo*I*y, y*I) == oo
     assert Mul._combine_inverse(oo*I*y, oo*I) == y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Please refer to discussion on PR  https://github.com/sympy/sympy/pull/16848#issuecomment-494740582

#### Brief description of what is fixed or changed
Before
```
>>> x, a = symbols('x a')
>>> Mul._combine_inverse(x*x**a, x**a)
x
>>> Mul._combine_inverse(x*x**(a+1), x**(a+1))
x*x**(-a - 1)*x**(a + 1)
```
After
```
>>> x, a = symbols('x a')
>>> Mul._combine_inverse(x*x**a, x**a)
x
>>> Mul._combine_inverse(x*x**(a+1), x**(a+1))
x
>>> Mul._combine_inverse(x*x**(y+1), x**(y+1))
x
```
Modified `sympy/core/mul.py` and added test to `sympy/core/tests/test_match.py`
Changes suggested by @jksuom 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - Corrected `_combine_inverse` under `sympy/core/test_match.py`
<!-- END RELEASE NOTES -->
