### PR TITLE
parsing/latex: cleanup module import check

### DIFF
--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -26,9 +26,7 @@ ErrorListener = import_module('antlr4.error.ErrorListener',
 
 
 
-if ErrorListener is None:
-    pass
-else:
+if ErrorListener:
     class MathErrorListener(ErrorListener.ErrorListener):
         def __init__(self, src):
             super(ErrorListener.ErrorListener, self).__init__()


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Cleanup the import module check for ErrorListener to avoid an empty branch.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->