### PR TITLE
clean up of 16888

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1032,6 +1032,7 @@ class Mul(Expr, AssocOp):
         Returns lhs/rhs, but treats arguments like symbols, so things like
         oo/oo return 1, instead of a nan.
         """
+        from sympy.simplify.simplify import powsimp
         if lhs == rhs:
             return S.One
 
@@ -1056,7 +1057,7 @@ class Mul(Expr, AssocOp):
                 else:
                     b.append(x)
             return lhs.func(*a)/rhs.func(*b)
-        return lhs/rhs
+        return powsimp(lhs/rhs)
 
     def as_powers_dict(self):
         d = defaultdict(int)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -14,10 +14,10 @@ from .compatibility import reduce, range
 from .expr import Expr
 from .evaluate import global_distribute
 
+
+
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
-
-
 class NC_Marker:
     is_Order = False
     is_Mul = False
@@ -1029,10 +1029,11 @@ class Mul(Expr, AssocOp):
     @staticmethod
     def _combine_inverse(lhs, rhs):
         """
-        Returns lhs/rhs, but treats arguments like symbols, so things like
-        oo/oo return 1, instead of a nan.
+        Returns lhs/rhs, but treats arguments like symbols, so things
+        like oo/oo return 1 (instead of a nan) and ``I`` behaves like
+        a symbol instead of sqrt(-1).
         """
-        from sympy.simplify.simplify import powsimp
+        from .symbol import Dummy
         if lhs == rhs:
             return S.One
 
@@ -1045,25 +1046,30 @@ class Mul(Expr, AssocOp):
             return False
         if check(lhs, rhs) or check(rhs, lhs):
             return S.One
-        if lhs.is_Mul and rhs.is_Mul:
-            a = list(lhs.args)
-            b = [1]
-            for x in rhs.args:
-                if x in a:
-                    a.remove(x)
-                elif -x in a:
-                    a.remove(-x)
-                    b.append(-1)
-                else:
-                    b.append(x)
-            return lhs.func(*a)/rhs.func(*b)
-        return powsimp(lhs/rhs)
+        if any(i.is_Pow or i.is_Mul for i in (lhs, rhs)):
+            # gruntz and limit wants a literal I to not combine
+            # with a power of -1
+            d = Dummy('I')
+            _i = {S.ImaginaryUnit: d}
+            i_ = {d: S.ImaginaryUnit}
+            a = lhs.xreplace(_i).as_powers_dict()
+            b = rhs.xreplace(_i).as_powers_dict()
+            blen = len(b)
+            for bi in tuple(b.keys()):
+                if bi in a:
+                    a[bi] -= b.pop(bi)
+                    if not a[bi]:
+                        a.pop(bi)
+            if len(b) != blen:
+                lhs = Mul(*[k**v for k, v in a.items()]).xreplace(i_)
+                rhs = Mul(*[k**v for k, v in b.items()]).xreplace(i_)
+        return lhs/rhs
 
     def as_powers_dict(self):
         d = defaultdict(int)
         for term in self.args:
-            b, e = term.as_base_exp()
-            d[b] += e
+            for b, e in term.as_powers_dict().items():
+                d[b] += e
         return d
 
     def as_numer_denom(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3179,6 +3179,9 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     def ceiling(self):
         return self
 
+    def as_powers_dict(self):
+        return {S.NegativeOne: 1, S.Infinity: 1}
+
 
 class NaN(with_metaclass(Singleton, Number)):
     """

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -399,10 +399,13 @@ def test_match_wild_wild():
 def test__combine_inverse():
     x, y = symbols("x y")
     assert Mul._combine_inverse(x*I*y, x*I) == y
-    assert Mul._combine_inverse(x*x**(1+y), x**(1+y)) == x
+    assert Mul._combine_inverse(x*x**(1 + y), x**(1 + y)) == x
     assert Mul._combine_inverse(x*I*y, y*I) == x
     assert Mul._combine_inverse(oo*I*y, y*I) == oo
     assert Mul._combine_inverse(oo*I*y, oo*I) == y
+    assert Mul._combine_inverse(oo*I*y, oo*I) == y
+    assert Mul._combine_inverse(oo*y, -oo) == -y
+    assert Mul._combine_inverse(-oo*y, oo) == -y
     assert Add._combine_inverse(oo, oo) == S(0)
     assert Add._combine_inverse(oo*I, oo*I) == S(0)
     assert Add._combine_inverse(x*oo, x*oo) == S(0)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -399,6 +399,7 @@ def test_match_wild_wild():
 def test__combine_inverse():
     x, y = symbols("x y")
     assert Mul._combine_inverse(x*I*y, x*I) == y
+    assert Mul._combine_inverse(x*x**(1+y), x**(1+y)) == x
     assert Mul._combine_inverse(x*I*y, y*I) == x
     assert Mul._combine_inverse(oo*I*y, y*I) == oo
     assert Mul._combine_inverse(oo*I*y, oo*I) == y

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -8,6 +8,8 @@ from sympy.solvers.ode import (_undetermined_coefficients_match,
     checksysodesol, solve_ics, dsolve, get_numbered_constants)
 from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
+from sympy.utilities.misc import filldedent
+
 
 C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C0:11')
 u, x, y, z = symbols('u,x:z', real=True)
@@ -256,14 +258,17 @@ def test_linear_2eq_order2():
     # FIXME: assert checksysodesol(eq7, sol7) == (True, [0, 0])
 
     eq8 = (Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t))))
-    sol8 = ("[Eq(x(t), -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
-    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
-    "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]")
-    assert str(dsolve(eq8)) == sol8
+    assert filldedent(dsolve(eq8)) == filldedent('''
+        [Eq(x(t), -sqrt(133)*(-(-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 -
+        t**3/6 + 1) + C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) +
+        (-sqrt(133) - 1)*(C2*(-t**3/6 + sqrt(133)*t**3/6 + 1) + C1*t*(-t**3/12
+        + sqrt(133)*t**3/12 + 1) + O(t**6)) + 4*C2*(-sqrt(133)*t**3/6 - t**3/6
+        + 1) - 4*C2*(-t**3/6 + sqrt(133)*t**3/6 + 1) +
+        4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) - 4*C1*t*(-t**3/12 +
+        sqrt(133)*t**3/12 + 1) + O(t**6))/3192), Eq(y(t),
+        -sqrt(133)*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C2*(-t**3/6 +
+        sqrt(133)*t**3/6 + 1) + C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) -
+        C1*t*(-t**3/12 + sqrt(133)*t**3/12 + 1) + O(t**6))/266)]''')
     # FIXME: assert checksysodesol(eq8, sol8) == (True, [0, 0])
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Please refer to discussion on PR  https://github.com/sympy/sympy/pull/16848#issuecomment-494740582

closes #16888 (from which most of this is derived)

#### Brief description of what is fixed or changed
Before
```
>>> x, a = symbols('x a')
>>> Mul._combine_inverse(x*x**a, x**a)
x
>>> Mul._combine_inverse(x*x**(a+1), x**(a+1))
x*x**(-a - 1)*x**(a + 1)
```
After
```
>>> x, a = symbols('x a')
>>> Mul._combine_inverse(x*x**a, x**a)
x
>>> Mul._combine_inverse(x*x**(a+1), x**(a+1))
x
>>> Mul._combine_inverse(x*x**(y+1), x**(y+1))
x
```
Modified `sympy/core/mul.py` and added test to `sympy/core/tests/test_match.py`
Changes suggested by @jksuom 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `Mul._combine_inverse` acts when either lhs or rhs are a Mul or Pow and will keep any I
      from combining with powers of -1
    - (-oo).as_powers_dict now returns {-1:1, oo:1}
<!-- END RELEASE NOTES -->
