### PR TITLE
Cartesian product is not associative

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -604,17 +604,6 @@ class ProductSet(Set):
     is_ProductSet = True
 
     def __new__(cls, *sets, **assumptions):
-        def flatten(arg):
-            if isinstance(arg, Set):
-                if arg.is_ProductSet:
-                    return sum(map(flatten, arg.args), [])
-                else:
-                    return [arg]
-            elif iterable(arg):
-                return sum(map(flatten, arg), [])
-            raise TypeError("Input must be Sets or iterables of Sets")
-        sets = flatten(list(sets))
-
         if EmptySet() in sets or len(sets) == 0:
             return EmptySet()
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -550,7 +550,8 @@ class Set(Basic):
     def __pow__(self, exp):
         if not sympify(exp).is_Integer and exp >= 0:
             raise ValueError("%s: Exponent must be a positive Integer" % exp)
-        return ProductSet([self]*exp)
+        sets = [self]*exp
+        return ProductSet(*sets)
 
     def __sub__(self, other):
         return Complement(self, other)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

From https://en.wikipedia.org/wiki/Cartesian_product#Non-commutativity_and_non-associativity, it states that the cartesian product is not associative.

> Strictly speaking, the Cartesian product is not associative (unless one of the involved sets is empty).

But sympy flattens the product
```python
>>> from sympy import *

>>> a = FiniteSet(1, 2)
>>> b = a * a
>>> c = b * a
>>> FiniteSet(*c)
{(1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 2), (2, 1, 1), (2, 1, 2), (2, 2, 1), (2, 2, 2)}
```
and I think that things can be ambiguous, and there would be no way to distinguish a set of tuples like `(1, (1, 1))`, `((1, 1), 1)`

There is a separate definition for n-ary cartesian product, which can make the set of n-tuples like `(1, 1, 1)`
https://en.wikipedia.org/wiki/Cartesian_product#Cartesian_products_of_several_sets

Also, I just wonder Cartesian product of a single set should be `{(1), (2)}` instead of `{1, 2}`, if there can be a tuple containing single element.

However, things can go down to how n-Tuple can be defined
https://en.wikipedia.org/wiki/Tuple
and there are some different definitions for tuple
https://en.wikipedia.org/wiki/Ordered_pair
which doesn't seem like compatible each other

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
  - Made `ProductSet` not associative
<!-- END RELEASE NOTES -->
