### PR TITLE
namespace of joint_rv_types changed to sympy.stats 

### DIFF
--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -71,6 +71,15 @@ from . import drv_types
 from .drv_types import (Geometric, Logarithmic, NegativeBinomial, Poisson, YuleSimon, Zeta)
 __all__.extend(drv_types.__all__)
 
+from . import joint_rv_types
+from .joint_rv_types import (
+    JointRV,
+    Dirichlet, GeneralizedMultivariateLogGamma, GeneralizedMultivariateLogGammaOmega,
+    Multinomial, MultivariateBeta, MultivariateEwens, MultivariateT, NegativeMultinomial,
+    NormalGamma
+)
+__all__.extend(joint_rv_types.__all__)
+
 from . import symbolic_probability
 from .symbolic_probability import Probability, Expectation, Variance, Covariance
 __all__.extend(symbolic_probability.__all__)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -8,11 +8,17 @@ from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
 from sympy.stats.rv import _value_check, random_symbols
 
-# __all__ = ['MultivariateNormal',
-# 'MultivariateLaplace',
-# 'MultivariateT',
-# 'NormalGamma'
-# ]
+__all__ = ['JointRV',
+'Dirichlet',
+'GeneralizedMultivariateLogGamma',
+'GeneralizedMultivariateLogGammaOmega',
+'Multinomial',
+'MultivariateBeta',
+'MultivariateEwens',
+'MultivariateT',
+'NegativeMultinomial',
+'NormalGamma'
+]
 
 def multivariate_rv(cls, sym, *args):
     args = list(map(sympify, args))
@@ -63,343 +69,6 @@ def JointRV(symbol, pdf, _set=None):
         dist = MarginalDistribution(dist, (jrv,))
         return JointPSpace(symbol, dist).value
     return jrv
-
-#-------------------------------------------------------------------------------
-# Multivariate Normal distribution ---------------------------------------------------------
-
-class MultivariateNormalDistribution(JointDistribution):
-    _argnames = ['mu', 'sigma']
-
-    is_Continuous=True
-
-    @property
-    def set(self):
-        k = len(self.mu)
-        return S.Reals**k
-
-    @staticmethod
-    def check(mu, sigma):
-        _value_check(len(mu) == len(sigma.col(0)),
-            "Size of the mean vector and covariance matrix are incorrect.")
-        #check if covariance matrix is positive definite or not.
-        _value_check((i > 0 for i in sigma.eigenvals().keys()),
-            "The covariance matrix must be positive definite. ")
-
-    def pdf(self, *args):
-        mu, sigma = self.mu, self.sigma
-        k = len(mu)
-        args = ImmutableMatrix(args)
-        x = args - mu
-        return  S(1)/sqrt((2*pi)**(k)*det(sigma))*exp(
-            -S(1)/2*x.transpose()*(sigma.inv()*\
-                x))[0]
-
-    def marginal_distribution(self, indices, sym):
-        sym = ImmutableMatrix([Indexed(sym, i) for i in indices])
-        _mu, _sigma = self.mu, self.sigma
-        k = len(self.mu)
-        for i in range(k):
-            if i not in indices:
-                _mu = _mu.row_del(i)
-                _sigma = _sigma.col_del(i)
-                _sigma = _sigma.row_del(i)
-        return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
-            -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
-                (_mu - sym)))[0])
-
-#-------------------------------------------------------------------------------
-# Multivariate Laplace distribution ---------------------------------------------------------
-
-class MultivariateLaplaceDistribution(JointDistribution):
-    _argnames = ['mu', 'sigma']
-    is_Continuous=True
-
-    @property
-    def set(self):
-        k = len(self.mu)
-        return S.Reals**k
-
-    @staticmethod
-    def check(mu, sigma):
-        _value_check(len(mu) == len(sigma.col(0)),
-            "Size of the mean vector and covariance matrix are incorrect.")
-        #check if covariance matrix is positive definite or not.
-        _value_check((i > 0 for i in sigma.eigenvals().keys()),
-            "The covariance matrix must be positive definite. ")
-
-    def pdf(self, *args):
-        mu, sigma = self.mu, self.sigma
-        mu_T = mu.transpose()
-        k = S(len(mu))
-        sigma_inv = sigma.inv()
-        args = ImmutableMatrix(args)
-        args_T = args.transpose()
-        x = (mu_T*sigma_inv*mu)[0]
-        y = (args_T*sigma_inv*args)[0]
-        v = 1 - k/2
-        return S(2)/((2*pi)**(S(k)/2)*sqrt(det(sigma)))\
-        *(y/(2 + x))**(S(v)/2)*besselk(v, sqrt((2 + x)*(y)))\
-        *exp((args_T*sigma_inv*mu)[0])
-
-
-#-------------------------------------------------------------------------------
-# Multivariate StudentT distribution ---------------------------------------------------------
-
-class MultivariateTDistribution(JointDistribution):
-    _argnames = ['mu', 'shape_mat', 'dof']
-    is_Continuous=True
-
-    @property
-    def set(self):
-        k = len(self.mu)
-        return S.Reals**k
-
-    @staticmethod
-    def check(mu, sigma, v):
-        _value_check(len(mu) == len(sigma.col(0)),
-            "Size of the location vector and shape matrix are incorrect.")
-        #check if covariance matrix is positive definite or not.
-        _value_check((i > 0 for i in sigma.eigenvals().keys()),
-            "The shape matrix must be positive definite. ")
-
-    def pdf(self, *args):
-        mu, sigma = self.mu, self.shape_mat
-        v = S(self.dof)
-        k = S(len(mu))
-        sigma_inv = sigma.inv()
-        args = ImmutableMatrix(args)
-        x = args - mu
-        return gamma((k + v)/2)/(gamma(v/2)*(v*pi)**(k/2)*sqrt(det(sigma)))\
-        *(1 + 1/v*(x.transpose()*sigma_inv*x)[0])**((-v - k)/2)
-
-def MultivariateT(syms, mu, sigma, v):
-    """
-    Creates a joint random variable with multivariate T-distribution.
-
-    Parameters
-    ==========
-
-    syms: list/tuple/set of symbols for identifying each component
-    mu: A list/tuple/set consisting of k means,represents a k
-        dimensional location vector
-    sigma: The shape matrix for the distribution
-
-    Returns
-    =======
-
-    A random symbol
-    """
-    return multivariate_rv(MultivariateTDistribution, syms, mu, sigma, v)
-
-
-#-------------------------------------------------------------------------------
-# Multivariate Normal Gamma distribution ---------------------------------------------------------
-
-class NormalGammaDistribution(JointDistribution):
-
-    _argnames = ['mu', 'lamda', 'alpha', 'beta']
-    is_Continuous=True
-
-    @staticmethod
-    def check(mu, lamda, alpha, beta):
-        _value_check(mu.is_real, "Location must be real.")
-        _value_check(lamda > 0, "Lambda must be positive")
-        _value_check(alpha > 0, "alpha must be positive")
-        _value_check(beta > 0, "beta must be positive")
-
-    @property
-    def set(self):
-        return S.Reals*Interval(0, S.Infinity)
-
-    def pdf(self, x, tau):
-        beta, alpha, lamda = self.beta, self.alpha, self.lamda
-        mu = self.mu
-
-        return beta**alpha*sqrt(lamda)/(gamma(alpha)*sqrt(2*pi))*\
-        tau**(alpha - S(1)/2)*exp(-1*beta*tau)*\
-        exp(-1*(lamda*tau*(x - mu)**2)/S(2))
-
-    def marginal_distribution(self, indices, *sym):
-        if len(indices) == 2:
-            return self.pdf(*sym)
-        if indices[0] == 0:
-            #For marginal over `x`, return non-standardized Student-T's
-            #distribution
-            x = sym[0]
-            v, mu, sigma = self.alpha - S(1)/2, self.mu, \
-                S(self.beta)/(self.lamda * self.alpha)
-            return Lambda(sym, gamma((v + 1)/2)/(gamma(v/2)*sqrt(pi*v)*sigma)*\
-                (1 + 1/v*((x - mu)/sigma)**2)**((-v -1)/2))
-        #For marginal over `tau`, return Gamma distribution as per construction
-        from sympy.stats.crv_types import GammaDistribution
-        return Lambda(sym, GammaDistribution(self.alpha, self.beta)(sym[0]))
-
-def NormalGamma(syms, mu, lamda, alpha, beta):
-    """
-    Creates a bivariate joint random variable with multivariate Normal gamma
-    distribution.
-
-    Parameters
-    ==========
-
-    syms: list/tuple/set of two symbols for identifying each component
-    mu: A real number, as the mean of the normal distribution
-    alpha: a positive integer
-    beta: a positive integer
-    lamda: a positive integer
-
-    Returns
-    =======
-
-    A random symbol
-    """
-    return multivariate_rv(NormalGammaDistribution, syms, mu, lamda, alpha, beta)
-
-#-------------------------------------------------------------------------------
-# Multivariate Beta/Dirichlet distribution ---------------------------------------------------------
-
-class MultivariateBetaDistribution(JointDistribution):
-
-    _argnames = ['alpha']
-    is_Continuous = True
-
-    @staticmethod
-    def check(alpha):
-        _value_check(len(alpha) >= 2, "At least two categories should be passed.")
-        for a_k in alpha:
-            _value_check((a_k > 0) != False, "Each concentration parameter"
-                                            " should be positive.")
-
-    @property
-    def set(self):
-        k = len(self.alpha)
-        return Interval(0, 1)**k
-
-    def pdf(self, *syms):
-        alpha = self.alpha
-        B = Mul.fromiter(map(gamma, alpha))/gamma(Add(*alpha))
-        return Mul.fromiter([sym**(a_k - 1) for a_k, sym in zip(alpha, syms)])/B
-
-def MultivariateBeta(syms, *alpha):
-    """
-    Creates a continuous random variable with Dirichlet/Multivariate Beta
-    Distribution.
-
-    The density of the dirichlet distribution can be found at [1].
-
-    Parameters
-    ==========
-
-    alpha: positive real numbers signifying concentration numbers.
-
-    Returns
-    =======
-
-    A RandomSymbol.
-
-    Examples
-    ========
-
-    >>> from sympy.stats import density
-    >>> from sympy.stats.joint_rv import marginal_distribution
-    >>> from sympy.stats.joint_rv_types import MultivariateBeta
-    >>> from sympy import Symbol
-    >>> a1 = Symbol('a1', positive=True)
-    >>> a2 = Symbol('a2', positive=True)
-    >>> B = MultivariateBeta('B', [a1, a2])
-    >>> C = MultivariateBeta('C', a1, a2)
-    >>> x = Symbol('x')
-    >>> y = Symbol('y')
-    >>> density(B)(x, y)
-    x**(a1 - 1)*y**(a2 - 1)*gamma(a1 + a2)/(gamma(a1)*gamma(a2))
-    >>> marginal_distribution(C, C[0])(x)
-    x**(a1 - 1)*gamma(a1 + a2)/(a2*gamma(a1)*gamma(a2))
-
-    References
-    ==========
-
-    .. [1] https://en.wikipedia.org/wiki/Dirichlet_distribution
-    .. [2] http://mathworld.wolfram.com/DirichletDistribution.html
-
-    """
-    if not isinstance(alpha[0], list):
-        alpha = (list(alpha),)
-    return multivariate_rv(MultivariateBetaDistribution, syms, alpha[0])
-
-Dirichlet = MultivariateBeta
-
-#-------------------------------------------------------------------------------
-# Multivariate Ewens distribution ---------------------------------------------------------
-
-class MultivariateEwensDistribution(JointDistribution):
-
-    _argnames = ['n', 'theta']
-    is_Discrete = True
-    is_Continuous = False
-
-    @staticmethod
-    def check(n, theta):
-        _value_check(isinstance(n, Integer) and (n > 0) == True,
-                        "sample size should be positive integer.")
-        _value_check(theta.is_positive, "mutation rate should be positive.")
-
-    @property
-    def set(self):
-        prod_set = Range(0, self.n//1 + 1)
-        for i in range(2, self.n + 1):
-            prod_set *= Range(0, self.n//i + 1)
-        return prod_set
-
-    def pdf(self, *syms):
-        n, theta = self.n, self.theta
-        term_1 = factorial(n)/rf(theta, n)
-        term_2 = Mul.fromiter([theta**syms[j]/((j+1)**syms[j]*factorial(syms[j]))
-                            for j in range(n)])
-        cond = Eq(sum([(k+1)*syms[k] for k in range(n)]), n)
-        return Piecewise((term_1 * term_2, cond), (0, True))
-
-def MultivariateEwens(syms, n, theta):
-    """
-    Creates a discrete random variable with Multivariate Ewens
-    Distribution.
-
-    The density of the said distribution can be found at [1].
-
-    Parameters
-    ==========
-
-    n: positive integer of class Integer,
-            size of the sample or the integer whose partitions are considered
-    theta: mutation rate, must be positive real number.
-
-    Returns
-    =======
-
-    A RandomSymbol.
-
-    Examples
-    ========
-
-    >>> from sympy.stats import density
-    >>> from sympy.stats.joint_rv import marginal_distribution
-    >>> from sympy.stats.joint_rv_types import MultivariateEwens
-    >>> from sympy import Symbol
-    >>> a1 = Symbol('a1', positive=True)
-    >>> a2 = Symbol('a2', positive=True)
-    >>> ed = MultivariateEwens('E', 2, 1)
-    >>> density(ed)(a1, a2)
-    Piecewise((2**(-a2)/(factorial(a1)*factorial(a2)), Eq(a1 + 2*a2, 2)), (0, True))
-    >>> marginal_distribution(ed, ed[0])(a1)
-    Piecewise((1/factorial(a1), Eq(a1, 2)), (0, True))
-
-    References
-    ==========
-
-    .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
-    .. [2] http://www.stat.rutgers.edu/home/hcrane/Papers/STS529.pdf
-
-    """
-    return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)
 
 #-------------------------------------------------------------------------------
 # Generalized Multivariate Log Gamma distribution ---------------------------------------------------------
@@ -555,7 +224,6 @@ def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     delta = Pow(Rational(omega.det()), Rational(1, len(lamda) - 1))
     return GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu)
 
-
 #-------------------------------------------------------------------------------
 # Multinomial distribution ---------------------------------------------------------
 
@@ -565,8 +233,7 @@ class MultinomialDistribution(JointDistribution):
     is_Continuous=False
     is_Discrete = True
 
-    @staticmethod
-    def check(n, p):
+    def check(self, n, p):
         _value_check(n > 0,
                         "number of trials must be a positve integer")
         for p_k in p:
@@ -626,6 +293,273 @@ def Multinomial(syms, n, *p):
     return multivariate_rv(MultinomialDistribution, syms, n, p[0])
 
 #-------------------------------------------------------------------------------
+# Multivariate Beta/Dirichlet distribution ---------------------------------------------------------
+
+class MultivariateBetaDistribution(JointDistribution):
+
+    _argnames = ['alpha']
+    is_Continuous = True
+
+    def check(self, alpha):
+        _value_check(len(alpha) >= 2, "At least two categories should be passed.")
+        for a_k in alpha:
+            _value_check((a_k > 0) != False, "Each concentration parameter"
+                                            " should be positive.")
+
+    @property
+    def set(self):
+        k = len(self.alpha)
+        return Interval(0, 1)**k
+
+    def pdf(self, *syms):
+        alpha = self.alpha
+        B = Mul.fromiter(map(gamma, alpha))/gamma(Add(*alpha))
+        return Mul.fromiter([sym**(a_k - 1) for a_k, sym in zip(alpha, syms)])/B
+
+def MultivariateBeta(syms, *alpha):
+    """
+    Creates a continuous random variable with Dirichlet/Multivariate Beta
+    Distribution.
+
+    The density of the dirichlet distribution can be found at [1].
+
+    Parameters
+    ==========
+
+    alpha: positive real numbers signifying concentration numbers.
+
+    Returns
+    =======
+
+    A RandomSymbol.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import density
+    >>> from sympy.stats.joint_rv import marginal_distribution
+    >>> from sympy.stats.joint_rv_types import MultivariateBeta
+    >>> from sympy import Symbol
+    >>> a1 = Symbol('a1', positive=True)
+    >>> a2 = Symbol('a2', positive=True)
+    >>> B = MultivariateBeta('B', [a1, a2])
+    >>> C = MultivariateBeta('C', a1, a2)
+    >>> x = Symbol('x')
+    >>> y = Symbol('y')
+    >>> density(B)(x, y)
+    x**(a1 - 1)*y**(a2 - 1)*gamma(a1 + a2)/(gamma(a1)*gamma(a2))
+    >>> marginal_distribution(C, C[0])(x)
+    x**(a1 - 1)*gamma(a1 + a2)/(a2*gamma(a1)*gamma(a2))
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Dirichlet_distribution
+    .. [2] http://mathworld.wolfram.com/DirichletDistribution.html
+
+    """
+    if not isinstance(alpha[0], list):
+        alpha = (list(alpha),)
+    return multivariate_rv(MultivariateBetaDistribution, syms, alpha[0])
+
+Dirichlet = MultivariateBeta
+
+#-------------------------------------------------------------------------------
+# Multivariate Ewens distribution ---------------------------------------------------------
+
+class MultivariateEwensDistribution(JointDistribution):
+
+    _argnames = ['n', 'theta']
+    is_Discrete = True
+    is_Continuous = False
+
+    def check(self, n, theta):
+        _value_check(isinstance(n, Integer) and (n > 0) == True,
+                        "sample size should be positive integer.")
+        _value_check(theta.is_positive, "mutation rate should be positive.")
+
+    @property
+    def set(self):
+        prod_set = Range(0, self.n//1 + 1)
+        for i in range(2, self.n + 1):
+            prod_set *= Range(0, self.n//i + 1)
+        return prod_set
+
+    def pdf(self, *syms):
+        n, theta = self.n, self.theta
+        term_1 = factorial(n)/rf(theta, n)
+        term_2 = Mul.fromiter([theta**syms[j]/((j+1)**syms[j]*factorial(syms[j]))
+                            for j in range(n)])
+        cond = Eq(sum([(k+1)*syms[k] for k in range(n)]), n)
+        return Piecewise((term_1 * term_2, cond), (0, True))
+
+def MultivariateEwens(syms, n, theta):
+    """
+    Creates a discrete random variable with Multivariate Ewens
+    Distribution.
+
+    The density of the said distribution can be found at [1].
+
+    Parameters
+    ==========
+
+    n: positive integer of class Integer,
+            size of the sample or the integer whose partitions are considered
+    theta: mutation rate, must be positive real number.
+
+    Returns
+    =======
+
+    A RandomSymbol.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import density
+    >>> from sympy.stats.joint_rv import marginal_distribution
+    >>> from sympy.stats.joint_rv_types import MultivariateEwens
+    >>> from sympy import Symbol
+    >>> a1 = Symbol('a1', positive=True)
+    >>> a2 = Symbol('a2', positive=True)
+    >>> ed = MultivariateEwens('E', 2, 1)
+    >>> density(ed)(a1, a2)
+    Piecewise((2**(-a2)/(factorial(a1)*factorial(a2)), Eq(a1 + 2*a2, 2)), (0, True))
+    >>> marginal_distribution(ed, ed[0])(a1)
+    Piecewise((1/factorial(a1), Eq(a1, 2)), (0, True))
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Ewens%27s_sampling_formula
+    .. [2] http://www.stat.rutgers.edu/home/hcrane/Papers/STS529.pdf
+
+    """
+    return multivariate_rv(MultivariateEwensDistribution, syms, n, theta)
+
+#-------------------------------------------------------------------------------
+# Multivariate Laplace distribution ---------------------------------------------------------
+
+class MultivariateLaplaceDistribution(JointDistribution):
+    _argnames = ['mu', 'sigma']
+    is_Continuous=True
+
+    @property
+    def set(self):
+        k = len(self.mu)
+        return S.Reals**k
+
+    def check(self, mu, sigma):
+        _value_check(len(mu) == len(sigma.col(0)),
+            "Size of the mean vector and covariance matrix are incorrect.")
+        #check if covariance matrix is positive definite or not.
+        _value_check((i > 0 for i in sigma.eigenvals().keys()),
+            "The covariance matrix must be positive definite. ")
+
+    def pdf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        mu_T = mu.transpose()
+        k = S(len(mu))
+        sigma_inv = sigma.inv()
+        args = ImmutableMatrix(args)
+        args_T = args.transpose()
+        x = (mu_T*sigma_inv*mu)[0]
+        y = (args_T*sigma_inv*args)[0]
+        v = 1 - k/2
+        return S(2)/((2*pi)**(S(k)/2)*sqrt(det(sigma)))\
+        *(y/(2 + x))**(S(v)/2)*besselk(v, sqrt((2 + x)*(y)))\
+        *exp((args_T*sigma_inv*mu)[0])
+
+#-------------------------------------------------------------------------------
+# Multivariate Normal distribution ---------------------------------------------------------
+
+class MultivariateNormalDistribution(JointDistribution):
+    _argnames = ['mu', 'sigma']
+
+    is_Continuous=True
+
+    @property
+    def set(self):
+        k = len(self.mu)
+        return S.Reals**k
+
+    def check(self, mu, sigma):
+        _value_check(len(mu) == len(sigma.col(0)),
+            "Size of the mean vector and covariance matrix are incorrect.")
+        #check if covariance matrix is positive definite or not.
+        _value_check((i > 0 for i in sigma.eigenvals().keys()),
+            "The covariance matrix must be positive definite. ")
+
+    def pdf(self, *args):
+        mu, sigma = self.mu, self.sigma
+        k = len(mu)
+        args = ImmutableMatrix(args)
+        x = args - mu
+        return  S(1)/sqrt((2*pi)**(k)*det(sigma))*exp(
+            -S(1)/2*x.transpose()*(sigma.inv()*\
+                x))[0]
+
+    def marginal_distribution(self, indices, sym):
+        sym = ImmutableMatrix([Indexed(sym, i) for i in indices])
+        _mu, _sigma = self.mu, self.sigma
+        k = len(self.mu)
+        for i in range(k):
+            if i not in indices:
+                _mu = _mu.row_del(i)
+                _sigma = _sigma.col_del(i)
+                _sigma = _sigma.row_del(i)
+        return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
+            -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
+                (_mu - sym)))[0])
+
+#-------------------------------------------------------------------------------
+# Multivariate StudentT distribution ---------------------------------------------------------
+
+class MultivariateTDistribution(JointDistribution):
+    _argnames = ['mu', 'shape_mat', 'dof']
+    is_Continuous=True
+
+    @property
+    def set(self):
+        k = len(self.mu)
+        return S.Reals**k
+
+    def check(self, mu, sigma, v):
+        _value_check(len(mu) == len(sigma.col(0)),
+            "Size of the location vector and shape matrix are incorrect.")
+        #check if covariance matrix is positive definite or not.
+        _value_check((i > 0 for i in sigma.eigenvals().keys()),
+            "The shape matrix must be positive definite. ")
+
+    def pdf(self, *args):
+        mu, sigma = self.mu, self.shape_mat
+        v = S(self.dof)
+        k = S(len(mu))
+        sigma_inv = sigma.inv()
+        args = ImmutableMatrix(args)
+        x = args - mu
+        return gamma((k + v)/2)/(gamma(v/2)*(v*pi)**(k/2)*sqrt(det(sigma)))\
+        *(1 + 1/v*(x.transpose()*sigma_inv*x)[0])**((-v - k)/2)
+
+def MultivariateT(syms, mu, sigma, v):
+    """
+    Creates a joint random variable with multivariate T-distribution.
+
+    Parameters
+    ==========
+
+    syms: list/tuple/set of symbols for identifying each component
+    mu: A list/tuple/set consisting of k means,represents a k
+        dimensional location vector
+    sigma: The shape matrix for the distribution
+
+    Returns
+    =======
+
+    A random symbol
+    """
+    return multivariate_rv(MultivariateTDistribution, syms, mu, sigma, v)
+
+#-------------------------------------------------------------------------------
 # Negative Multinomial Distribution ---------------------------------------------------------
 
 class NegativeMultinomialDistribution(JointDistribution):
@@ -634,8 +568,7 @@ class NegativeMultinomialDistribution(JointDistribution):
     is_Continuous=False
     is_Discrete = True
 
-    @staticmethod
-    def check(k0, p):
+    def check(self, k0, p):
         _value_check(k0 > 0,
                         "number of failures must be a positve integer")
         for p_k in p:
@@ -695,3 +628,65 @@ def NegativeMultinomial(syms, k0, *p):
     if not isinstance(p[0], list):
         p = (list(p), )
     return multivariate_rv(NegativeMultinomialDistribution, syms, k0, p[0])
+
+#-------------------------------------------------------------------------------
+# Multivariate Normal Gamma distribution ---------------------------------------------------------
+
+class NormalGammaDistribution(JointDistribution):
+
+    _argnames = ['mu', 'lamda', 'alpha', 'beta']
+    is_Continuous=True
+
+    def check(self, mu, lamda, alpha, beta):
+        _value_check(mu.is_real, "Location must be real.")
+        _value_check(lamda > 0, "Lambda must be positive")
+        _value_check(alpha > 0, "alpha must be positive")
+        _value_check(beta > 0, "beta must be positive")
+
+    @property
+    def set(self):
+        return S.Reals*Interval(0, S.Infinity)
+
+    def pdf(self, x, tau):
+        beta, alpha, lamda = self.beta, self.alpha, self.lamda
+        mu = self.mu
+
+        return beta**alpha*sqrt(lamda)/(gamma(alpha)*sqrt(2*pi))*\
+        tau**(alpha - S(1)/2)*exp(-1*beta*tau)*\
+        exp(-1*(lamda*tau*(x - mu)**2)/S(2))
+
+    def marginal_distribution(self, indices, *sym):
+        if len(indices) == 2:
+            return self.pdf(*sym)
+        if indices[0] == 0:
+            #For marginal over `x`, return non-standardized Student-T's
+            #distribution
+            x = sym[0]
+            v, mu, sigma = self.alpha - S(1)/2, self.mu, \
+                S(self.beta)/(self.lamda * self.alpha)
+            return Lambda(sym, gamma((v + 1)/2)/(gamma(v/2)*sqrt(pi*v)*sigma)*\
+                (1 + 1/v*((x - mu)/sigma)**2)**((-v -1)/2))
+        #For marginal over `tau`, return Gamma distribution as per construction
+        from sympy.stats.crv_types import GammaDistribution
+        return Lambda(sym, GammaDistribution(self.alpha, self.beta)(sym[0]))
+
+def NormalGamma(syms, mu, lamda, alpha, beta):
+    """
+    Creates a bivariate joint random variable with multivariate Normal gamma
+    distribution.
+
+    Parameters
+    ==========
+
+    syms: list/tuple/set of two symbols for identifying each component
+    mu: A real number, as the mean of the normal distribution
+    alpha: a positive integer
+    beta: a positive integer
+    lamda: a positive integer
+
+    Returns
+    =======
+
+    A random symbol
+    """
+    return multivariate_rv(NormalGammaDistribution, syms, mu, lamda, alpha, beta)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
[1] Discussion at https://gitter.im/sympy/stats

#### Brief description of what is fixed or changed
The distributions in joint_rv_types can now be imported directly via, `from sympy.stats import *` and similar import statements.
**Before**
```
Python 3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sympy.stats import GeneralizedMultivariateLogGamma
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'GeneralizedMultivariateLogGamma'
```
**After**
```
Python 3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sympy.stats import GeneralizedMultivariateLogGamma
```
The definitions of classes and functions have been reordered in alphabetical manner in accordance with `sympy.stats.crv_types`, `sympy.stats.drv_types` and `sympy.stats.frv_types`. 
#### Other comment
N/A

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
