### PR TITLE
Float.is_integer updated for removing disparity in gamma

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1254,7 +1254,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_[2] == fzero[2]
+        return self._mpf_[2] >= 0
 
     def _eval_is_negative(self):
         if self._mpf_ == _mpf_ninf:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1254,7 +1254,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_ == fzero
+        return self._mpf_[2] == fzero[2]
 
     def _eval_is_negative(self):
         if self._mpf_ == _mpf_ninf:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1254,7 +1254,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_[2] >= 0
+        return self._mpf_ == fzero
 
     def _eval_is_negative(self):
         if self._mpf_ == _mpf_ninf:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -468,6 +468,9 @@ def test_Float():
     assert Float('0.0').is_zero is True
 
     # rationality properties
+    # if the integer test fails then the use of intlike
+    # should be removed from gamma_functions.py
+    assert Float(1).is_integer is False
     assert Float(1).is_rational is None
     assert Float(1).is_irrational is None
     assert sqrt(2).n(15).is_rational is None

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -107,7 +107,7 @@ class gamma(Function):
                 return S.NaN
             elif arg is S.Infinity:
                 return S.Infinity
-            elif arg.is_Integer:
+            elif arg.is_integer:
                 if arg.is_positive:
                     return factorial(arg - 1)
                 else:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Add, S, sympify, oo, pi, Dummy, expand_func
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, as_int
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
@@ -14,6 +14,12 @@ from sympy.functions.elementary.trigonometric import sin, cos, cot
 from sympy.functions.combinatorial.numbers import bernoulli, harmonic
 from sympy.functions.combinatorial.factorials import factorial, rf, RisingFactorial
 
+def intlike(n):
+    try:
+        as_int(n, strict=False)
+        return True
+    except ValueError:
+        return False
 
 ###############################################################################
 ############################ COMPLETE GAMMA FUNCTION ##########################
@@ -107,7 +113,7 @@ class gamma(Function):
                 return S.NaN
             elif arg is S.Infinity:
                 return S.Infinity
-            elif arg.is_integer:
+            elif intlike(arg):
                 if arg.is_positive:
                     return factorial(arg - 1)
                 else:

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -19,6 +19,7 @@ def test_gamma():
 
     assert gamma(-100) == zoo
     assert gamma(0) == zoo
+    assert gamma(-100.0) == zoo
 
     assert gamma(1) == 1
     assert gamma(2) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
[1] Fixes https://github.com/sympy/sympy/issues/16847
[2] https://github.com/sympy/sympy/issues/16847#issuecomment-493653572

#### Brief description of what is fixed or changed
Float.is_integer now returns `True` for values like, `-1.0`,  which helps in removing disparity as mentioned in the issue referenced above. 

#### Other comments
ping @smichr @jksuom @ritesh99rakesh 

The following test is failing due to the changes,
```
__________ sympy/core/tests/test_power.py:test_issue_6100_12942_4473 ___________
Traceback (most recent call last):
  File "/home/gagandeep/sympy/sympy/core/tests/test_power.py", line 284, in test_issue_6100_12942_4473
    assert ((x*y)**1.0).func is Pow
AssertionError
```
`(x*y)**1.0` is converted to `x**1.0*y**1.0` returning `Mul` instead of `Pow` therefore failing the test.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
