### PR TITLE
Add matrix attributes zero and one

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -669,7 +669,7 @@ class MatrixSpecial(MatrixRequired):
     @classmethod
     def _eval_eye(cls, rows, cols):
         def entry(i, j):
-            return S.One if i == j else S.Zero
+            return cls.one if i == j else cls.zero
         return cls._new(rows, cols, entry)
 
     @classmethod
@@ -679,27 +679,27 @@ class MatrixSpecial(MatrixRequired):
                 if i == j:
                     return eigenvalue
                 elif j + 1 == i:
-                    return S.One
-                return S.Zero
+                    return cls.one
+                return cls.zero
         else:
             def entry(i, j):
                 if i == j:
                     return eigenvalue
                 elif i + 1 == j:
-                    return S.One
-                return S.Zero
+                    return cls.one
+                return cls.zero
         return cls._new(rows, cols, entry)
 
     @classmethod
     def _eval_ones(cls, rows, cols):
         def entry(i, j):
-            return S.One
+            return cls.one
         return cls._new(rows, cols, entry)
 
     @classmethod
     def _eval_zeros(cls, rows, cols):
         def entry(i, j):
-            return S.Zero
+            return cls.zero
         return cls._new(rows, cols, entry)
 
     @classmethod
@@ -2145,7 +2145,7 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__rdiv__')
     def __div__(self, other):
-        return self * (S.One / other)
+        return self * (self.one / other)
 
     @call_highest_priority('__rmatmul__')
     def __matmul__(self, other):
@@ -2342,6 +2342,8 @@ class _MinimalMatrix(object):
     is_MatrixLike = True
     _sympify = staticmethod(sympify)
     _class_priority = 3
+    zero = S.Zero
+    one = S.One
 
     is_Matrix = True
     is_MatrixExpr = False

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -185,7 +185,7 @@ class DenseMatrix(MatrixBase):
         new_mat_cols = other.cols
 
         # preallocate the array
-        new_mat = [S.Zero]*new_mat_rows*new_mat_cols
+        new_mat = [self.zero]*new_mat_rows*new_mat_cols
 
         # if we multiply an n x 0 with a 0 x m, the
         # expected behavior is to produce an n x m matrix of zeros

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -83,7 +83,7 @@ class MatrixDeterminant(MatrixCommon):
 
         # the 0 x 0 case is trivial
         if self.rows == 0 and self.cols == 0:
-            return self._new(1,1, [S.One])
+            return self._new(1,1, [self.one])
 
         #
         # Partition self = [ a_11  R ]
@@ -111,11 +111,11 @@ class MatrixDeterminant(MatrixCommon):
         for i in range(self.rows - 2):
             diags.append(A * diags[i])
         diags = [(-R*d)[0, 0] for d in diags]
-        diags = [S.One, -a] + diags
+        diags = [self.one, -a] + diags
 
         def entry(i,j):
             if j > i:
-                return S.Zero
+                return self.zero
             return diags[i - j]
 
         toeplitz = self._new(self.cols + 1, self.rows, entry)
@@ -158,9 +158,9 @@ class MatrixDeterminant(MatrixCommon):
 
         # handle the trivial cases
         if self.rows == 0 and self.cols == 0:
-            return self._new(1, 1, [S.One])
+            return self._new(1, 1, [self.one])
         elif self.rows == 1 and self.cols == 1:
-            return self._new(2, 1, [S.One, -self[0,0]])
+            return self._new(2, 1, [self.one, -self[0,0]])
 
         submat, toeplitz = self._eval_berkowitz_toeplitz_matrix()
         return toeplitz * submat._eval_berkowitz_vector()
@@ -181,7 +181,7 @@ class MatrixDeterminant(MatrixCommon):
         # thesis http://www.math.usm.edu/perry/Research/Thesis_DRL.pdf
         def bareiss(mat, cumm=1):
             if mat.rows == 0:
-                return S.One
+                return mat.one
             elif mat.rows == 1:
                 return mat[0, 0]
 
@@ -192,7 +192,7 @@ class MatrixDeterminant(MatrixCommon):
             pivot_pos, pivot_val, _, _ = _find_reasonable_pivot(mat[:, 0],
                                          iszerofunc=iszerofunc)
             if pivot_pos is None:
-                return S.Zero
+                return mat.zero
 
             # if we have a valid pivot, we'll do a "row swap", so keep the
             # sign of the det
@@ -234,7 +234,7 @@ class MatrixDeterminant(MatrixCommon):
         instead of a copy."""
 
         if self.rows == 0:
-            return S.One
+            return self.one
             # sympy/matrices/tests/test_matrices.py contains a test that
             # suggests that the determinant of a 0 x 0 matrix is one, by
             # convention.
@@ -251,10 +251,10 @@ class MatrixDeterminant(MatrixCommon):
         # Bottom right entry of U is 0 => det(A) = 0.
         # It may be impossible to determine if this entry of U is zero when it is symbolic.
         if iszerofunc(lu[lu.rows-1, lu.rows-1]):
-            return S.Zero
+            return self.zero
 
         # Compute det(P)
-        det = -S.One if len(row_swaps)%2 else S.One
+        det = -self.one if len(row_swaps)%2 else self.one
 
         # Compute det(U) by calculating the product of U's diagonal entries.
         # The upper triangular portion of lu is the upper triangular portion of the
@@ -456,7 +456,7 @@ class MatrixDeterminant(MatrixCommon):
 
         n = self.rows
         if n == 0:
-            return S.One
+            return self.one
         elif n == 1:
             return self[0,0]
         elif n == 2:
@@ -726,11 +726,11 @@ class MatrixReductions(MatrixDeterminant):
             # before we zero the other rows
             if normalize_last is False:
                 i, j = piv_row, piv_col
-                mat[i*cols + j] = S.One
+                mat[i*cols + j] = self.one
                 for p in range(i*cols + j + 1, (i + 1)*cols):
                     mat[p] = mat[p] / pivot_val
                 # after normalizing, the pivot value is 1
-                pivot_val = S.One
+                pivot_val = self.one
 
             # zero above and below the pivot
             for row in range(rows):
@@ -752,7 +752,7 @@ class MatrixReductions(MatrixDeterminant):
         if normalize_last is True and normalize is True:
             for piv_i, piv_j in enumerate(pivot_cols):
                 pivot_val = mat[piv_i*cols + piv_j]
-                mat[piv_i*cols + piv_j] = S.One
+                mat[piv_i*cols + piv_j] = self.one
                 for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
                     mat[p] = mat[p] / pivot_val
 
@@ -1010,8 +1010,8 @@ class MatrixSubspaces(MatrixReductions):
         for free_var in free_vars:
             # for each free variable, we will set it to 1 and all others
             # to 0.  Then, we will use back substitution to solve the system
-            vec = [S.Zero]*self.cols
-            vec[free_var] = S.One
+            vec = [self.zero]*self.cols
+            vec[free_var] = self.one
             for piv_row, piv_col in enumerate(pivots):
                 vec[piv_col] -= reduced[piv_row, free_var]
             basis.append(vec)
@@ -1772,7 +1772,7 @@ class MatrixEigen(MatrixSubspaces):
         # Pad with zeros if singular values are computed in reverse way,
         # to give consistent format.
         if len(vals) < self.cols:
-            vals += [S.Zero] * (self.cols - len(vals))
+            vals += [self.zero] * (self.cols - len(vals))
 
         # sort them in descending order
         vals.sort(reverse=True, key=default_sort_key)
@@ -2005,7 +2005,7 @@ class MatrixDeprecated(MatrixCommon):
 
         berkowitz
         """
-        sign, minors = S.One, []
+        sign, minors = self.one, []
 
         for poly in self.berkowitz():
             minors.append(sign * poly[-1])
@@ -2039,14 +2039,14 @@ class MatrixDeprecated(MatrixCommon):
             for i, B in enumerate(items):
                 items[i] = (R * B)[0, 0]
 
-            items = [S.One, a] + items
+            items = [self.one, a] + items
 
             for i in range(n):
                 T[i:, i] = items[:n - i + 1]
 
             transforms[k - 1] = T
 
-        polys = [self._new([S.One, -A[0, 0]])]
+        polys = [self._new([self.one, -A[0, 0]])]
 
         for i, T in enumerate(transforms):
             polys.append(T * polys[i])
@@ -2132,6 +2132,8 @@ class MatrixBase(MatrixDeprecated,
     is_Matrix = True
     _class_priority = 3
     _sympify = staticmethod(sympify)
+    zero = S.Zero
+    one = S.One
 
     __hash__ = None  # Mutable
 
@@ -2362,7 +2364,7 @@ class MatrixBase(MatrixDeprecated,
                     return rows, cols, flat_list
                 elif len(arr.shape) == 1:
                     rows, cols = arr.shape[0], 1
-                    flat_list = [S.Zero] * rows
+                    flat_list = [cls.zero] * rows
                     for i in range(len(arr)):
                         flat_list[i] = cls._sympify(arr[i])
                     return rows, cols, flat_list
@@ -2699,7 +2701,7 @@ class MatrixBase(MatrixDeprecated,
         singular_values
         """
         if not self:
-            return S.Zero
+            return self.zero
         singularvalues = self.singular_values()
         return Max(*singularvalues) / Min(*singularvalues)
 
@@ -3606,17 +3608,17 @@ class MatrixBase(MatrixDeprecated,
         def entry_L(i, j):
             if i < j:
                 # Super diagonal entry
-                return S.Zero
+                return self.zero
             elif i == j:
-                return S.One
+                return self.one
             elif j < combined.cols:
                 return combined[i, j]
             # Subdiagonal entry of L with no corresponding
             # entry in combined
-            return S.Zero
+            return self.zero
 
         def entry_U(i, j):
-            return S.Zero if i > j else combined[i, j]
+            return self.zero if i > j else combined[i, j]
 
         L = self._new(combined.rows, combined.rows, entry_L)
         U = self._new(combined.rows, combined.cols, entry_U)
@@ -3811,7 +3813,7 @@ class MatrixBase(MatrixDeprecated,
                 # These entries are zero by construction, so don't bother
                 # computing them.
                 for row in range(pivot_row + 1, lu.rows):
-                    lu[row, pivot_col] = S.Zero
+                    lu[row, pivot_col] = self.zero
 
             pivot_col += 1
             if pivot_col == lu.cols:


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16883 and others

#### Brief description of what is fixed or changed
Matrix codebase currently makes use of the hardcoded constants
S.Zero and S.One. That is inconvenient when a non-Basic data
type is used to speed up computation (cf. #16883). This PR
replaces these constants with class attributes zero and one that
can be modified by subclassing.


#### Other comments
This is a step of work in progress.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Mutable attributes zero and one added to replace hardcoded S.Zero and S.One
<!-- END RELEASE NOTES -->
