### PR TITLE
Updated gitignore to avoid tracking of vscode's settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Vim's swap files
 *.sw[op]
 
+# VSCode settings file
+.vscode/
+
 # Generated files from Jython
 *$py.class
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
N/A

#### Brief description of what is fixed or changed
N/A

#### Other comments
I recently installed VSCode on my system and observed that as soon as `.vscode` is created it is being shown in `Untracked Files`. I believe that such settings files and folders should be in `.gitignore` file otherwise it makes it to difficult to keep track of the files to commit. Moreover, `.vscode` can safely be ignored as it is of very little use to the dev community.
If I am wrong then please give a short explanation in the comments section.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
