### PR TITLE
Fix sqrt for pycode printer

### DIFF
--- a/sympy/codegen/pyutils.py
+++ b/sympy/codegen/pyutils.py
@@ -3,9 +3,17 @@ from sympy.printing.pycode import PythonCodePrinter
 """ This module collects utilities for rendering Python code. """
 
 
-def render_as_module(content):
-    """ Renders python code as a module (with the required imports) """
-    printer = PythonCodePrinter()
+def render_as_module(content, standard='python3'):
+    """Renders python code as a module (with the required imports)
+
+    Parameters
+    ==========
+
+    standard
+        See the parameter ``standard`` in
+        :meth:`sympy.printing.pycode.pycode`
+    """
+    printer = PythonCodePrinter(standard=standard)
     pystr = printer.doprint(content)
     if printer._settings['fully_qualified_modules']:
         module_imports_str = '\n'.join('import %s' % k for k in printer.module_imports)

--- a/sympy/codegen/pyutils.py
+++ b/sympy/codegen/pyutils.py
@@ -13,7 +13,7 @@ def render_as_module(content, standard='python3'):
         See the parameter ``standard`` in
         :meth:`sympy.printing.pycode.pycode`
     """
-    printer = PythonCodePrinter(standard=standard)
+    printer = PythonCodePrinter({'standard':standard})
     pystr = printer.doprint(content)
     if printer._settings['fully_qualified_modules']:
         module_imports_str = '\n'.join('import %s' % k for k in printer.module_imports)

--- a/sympy/codegen/pyutils.py
+++ b/sympy/codegen/pyutils.py
@@ -13,6 +13,7 @@ def render_as_module(content, standard='python3'):
         See the parameter ``standard`` in
         :meth:`sympy.printing.pycode.pycode`
     """
+    # XXX Remove the keyword 'standard' after dropping python 2 support.
     printer = PythonCodePrinter({'standard':standard})
     pystr = printer.doprint(content)
     if printer._settings['fully_qualified_modules']:

--- a/sympy/codegen/tests/test_pyutils.py
+++ b/sympy/codegen/tests/test_pyutils.py
@@ -1,0 +1,9 @@
+from sympy.codegen.ast import Print
+from sympy.codegen.pyutils import render_as_module
+
+def test_standard():
+    ast = Print('x y'.split(), "coordinate: %12.5g %12.5g")
+    assert render_as_module(ast, standard='python3') == \
+        '\n\nprint("coordinate: %12.5g %12.5g" % (x, y))'
+    assert render_as_module(ast, standard='python3') == \
+        '\n\nprint "coordinate: %12.5g %12.5g" % (x, y)'

--- a/sympy/codegen/tests/test_pyutils.py
+++ b/sympy/codegen/tests/test_pyutils.py
@@ -5,5 +5,5 @@ def test_standard():
     ast = Print('x y'.split(), "coordinate: %12.5g %12.5g")
     assert render_as_module(ast, standard='python3') == \
         '\n\nprint("coordinate: %12.5g %12.5g" % (x, y))'
-    assert render_as_module(ast, standard='python3') == \
+    assert render_as_module(ast, standard='python2') == \
         '\n\nprint "coordinate: %12.5g %12.5g" % (x, y)'

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -31,7 +31,7 @@ from sympy.polys.rings import ring
 from sympy.polys.rootoftools import CRootOf
 from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.printing.lambdarepr import LambdaPrinter
-from sympy.printing.pycode import PythonCodePrinter
+from sympy.printing.pycode import PythonCodePrinter, MpmathPrinter
 from sympy.simplify.radsimp import _split_gcd
 from sympy.simplify.simplify import _is_sum_surds
 from sympy.utilities import (
@@ -1069,19 +1069,20 @@ def to_number_field(extension, theta=None, **args):
                 "%s is not in a subfield of %s" % (root, theta.root))
 
 
-class IntervalPrinter(LambdaPrinter):
+class IntervalPrinter(MpmathPrinter, LambdaPrinter):
     """Use ``lambda`` printer but print numbers as ``mpi`` intervals. """
 
     def _print_Integer(self, expr):
-        return "mpi('%s')" % super(IntervalPrinter, self)._print_Integer(expr)
+        return "mpi('%s')" % super(PythonCodePrinter, self)._print_Integer(expr)
 
     def _print_Rational(self, expr):
-        return "mpi('%s')" % super(IntervalPrinter, self)._print_Rational(expr)
+        return "mpi('%s')" % super(PythonCodePrinter, self)._print_Rational(expr)
+
+    def _print_Half(self, expr):
+        return "mpi('%s')" % super(PythonCodePrinter, self)._print_Rational(expr)
 
     def _print_Pow(self, expr):
-        # XXX Isolate the math printer with python code printer.
-        return super(PythonCodePrinter, self)._print_Pow(expr, rational=True)
-
+        return super(MpmathPrinter, self)._print_Pow(expr, rational=True)
 
 @public
 def isolate(alg, eps=None, fast=False):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -31,6 +31,7 @@ from sympy.polys.rings import ring
 from sympy.polys.rootoftools import CRootOf
 from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.printing.lambdarepr import LambdaPrinter
+from sympy.printing.pycode import PythonCodePrinter
 from sympy.simplify.radsimp import _split_gcd
 from sympy.simplify.simplify import _is_sum_surds
 from sympy.utilities import (
@@ -1078,7 +1079,8 @@ class IntervalPrinter(LambdaPrinter):
         return "mpi('%s')" % super(IntervalPrinter, self)._print_Rational(expr)
 
     def _print_Pow(self, expr):
-        return super(IntervalPrinter, self)._print_Pow(expr, rational=True)
+        # XXX Isolate the math printer with python code printer.
+        return super(PythonCodePrinter, self)._print_Pow(expr, rational=True)
 
 
 @public

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -54,6 +54,11 @@ class LambdaPrinter(PythonCodePrinter):
     def _print_NumberSymbol(self, expr):
         return str(expr)
 
+    def _print_Pow(self, expr, **kwargs):
+        # XXX Temporary workaround. Should python math printer be
+        # isolated from PythonCodePrinter?
+        return super(PythonCodePrinter, self)._print_Pow(expr, **kwargs)
+
 
 # numexpr works by altering the string passed to numexpr.evaluate
 # rather than by populating a namespace.  Thus a special printer...

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -100,6 +100,7 @@ class AbstractPythonCodePrinter(CodePrinter):
     def __init__(self, settings=None):
         super(AbstractPythonCodePrinter, self).__init__(settings)
 
+        # XXX Remove after dropping python 2 support.
         # Python standard handler
         std = self._settings['standard']
         if std is None:
@@ -346,6 +347,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         if prnt.file != None: # Must be '!= None', cannot be 'is not None'
             print_args += ', file=%s' % self._print(prnt.file)
 
+        # XXX Remove after dropping python 2 support.
         if self.standard == 'python2':
             return 'print %s' % print_args
         return 'print(%s)' % print_args
@@ -439,6 +441,7 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         return self._hprint_Pow(expr, rational=rational)
 
     def _print_Rational(self, expr):
+        # XXX Remove after dropping python 2 support.
         if self.standard == 'python2':
             return '{}./{}.'.format(expr.p, expr.q)
         return '{}/{}'.format(expr.p, expr.q)
@@ -469,6 +472,8 @@ def pycode(expr, **settings):
         If 'python2', Python 2 sematics will be used.
         If 'python3', Python 3 sematics will be used.
         If None, the standard will be automatically detected.
+        Default is 'python3'. And this parameter may be removed in the
+        future.
 
     Examples
     ========

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -94,7 +94,7 @@ class AbstractPythonCodePrinter(CodePrinter):
         inline=True,
         fully_qualified_modules=True,
         contract=False,
-        standard=None
+        standard='python3'
     )
 
     def __init__(self, settings=None):
@@ -346,8 +346,8 @@ class AbstractPythonCodePrinter(CodePrinter):
         if prnt.file != None: # Must be '!= None', cannot be 'is not None'
             print_args += ', file=%s' % self._print(prnt.file)
 
-        # if self.standard == 'python2':
-        #     return 'print %s' % print_args
+        if self.standard == 'python2':
+            return 'print %s' % print_args
         return 'print(%s)' % print_args
 
     def _print_Stream(self, strm):
@@ -465,9 +465,10 @@ def pycode(expr, **settings):
     fully_qualified_modules : bool
         Whether or not to write out full module names of functions
         (``math.sin`` vs. ``sin``). default: ``True``.
-    standard : str, optional
+    standard : str or None, optional
         If 'python2', Python 2 sematics will be used.
         If 'python3', Python 3 sematics will be used.
+        If None, the standard will be automatically detected.
 
     Examples
     ========

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -346,8 +346,8 @@ class AbstractPythonCodePrinter(CodePrinter):
         if prnt.file != None: # Must be '!= None', cannot be 'is not None'
             print_args += ', file=%s' % self._print(prnt.file)
 
-        if self.standard == 'python2':
-            return 'print %s' % print_args
+        # if self.standard == 'python2':
+        #     return 'print %s' % print_args
         return 'print(%s)' % print_args
 
     def _print_Stream(self, strm):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -394,13 +394,13 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
 
         Python code printer automatically looks up ``math.sqrt``.
 
-        >>> printer = PythonCodePrinter()
+        >>> printer = PythonCodePrinter({'standard':'python3'})
         >>> printer._hprint_Pow(sqrt(x), rational=True)
-        'x**(1./2.)'
+        'x**(1/2)'
         >>> printer._hprint_Pow(sqrt(x), rational=False)
         'math.sqrt(x)'
         >>> printer._hprint_Pow(1/sqrt(x), rational=True)
-        'x**(-1./2.)'
+        'x**(-1/2)'
         >>> printer._hprint_Pow(1/sqrt(x), rational=False)
         '1/math.sqrt(x)'
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -531,6 +531,44 @@ class StrPrinter(Printer):
             return self._print(expr.as_expr())
 
     def _print_Pow(self, expr, rational=False):
+        """Printing helper function for ``Pow``
+
+        Parameters
+        ==========
+
+        rational : bool, optional
+            If ``True``, it will not attempt printing ``sqrt(x)`` or
+            ``x**S.Half`` as ``sqrt``, and will use ``x**(1/2)``
+            instead.
+
+            See examples for additional details
+
+        Examples
+        ========
+
+        >>> from sympy.functions import sqrt
+        >>> from sympy.printing.str import StrPrinter
+        >>> from sympy.abc import x
+
+        How ``rational`` keyword works with ``sqrt``:
+
+        >>> printer = StrPrinter()
+        >>> printer._print_Pow(sqrt(x), rational=True)
+        'x**(1/2)'
+        >>> printer._print_Pow(sqrt(x), rational=False)
+        'sqrt(x)'
+        >>> printer._print_Pow(1/sqrt(x), rational=True)
+        'x**(-1/2)'
+        >>> printer._print_Pow(1/sqrt(x), rational=False)
+        '1/sqrt(x)'
+
+        Notes
+        =====
+
+        ``sqrt(x)`` is canonicalized as ``Pow(x, S.Half)`` in SymPy,
+        so there is no need of defining a separate printer for ``sqrt``.
+        Instead, it should be handled here as well.
+        """
         PREC = precedence(expr)
 
         if expr.exp is S.Half and not rational:

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,4 +1,5 @@
-from sympy import symbols, sin, Matrix, Interval, Piecewise, Sum, lambdify,Expr
+from sympy import symbols, sin, Matrix, Interval, Piecewise, Sum, lambdify, \
+                  Expr, sqrt
 from sympy.utilities.pytest import raises
 
 from sympy.printing.tensorflow import TensorflowPrinter
@@ -188,6 +189,12 @@ def test_multiple_sums():
     f_ref = s.subs(zip(args, vals)).doit()
     f_res = f(*vals)
     assert f_res == f_ref
+
+
+def test_sqrt():
+    prntr = LambdaPrinter()
+    assert prntr._print_Pow(sqrt(x), rational=False) == 'sqrt(x)'
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
 
 def test_settings():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -192,9 +192,11 @@ def test_multiple_sums():
 
 
 def test_sqrt():
-    prntr = LambdaPrinter()
+    prntr = LambdaPrinter({'standard' : 'python2'})
     assert prntr._print_Pow(sqrt(x), rational=False) == 'sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
+    prntr = LambdaPrinter({'standard' : 'python3'})
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
 
 def test_settings():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -194,7 +194,7 @@ def test_multiple_sums():
 def test_sqrt():
     prntr = LambdaPrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'sqrt(x)'
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
 
 
 def test_settings():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -88,25 +88,31 @@ def test_sqrt():
     prntr = PythonCodePrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'math.sqrt(x)'
     assert prntr._print_Pow(1/sqrt(x), rational=False) == '1/math.sqrt(x)'
+
+    prntr = PythonCodePrinter({'standard' : 'python2'})
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
     assert prntr._print_Pow(1/sqrt(x), rational=True) == 'x**(-1./2.)'
+
+    prntr = PythonCodePrinter({'standard' : 'python3'})
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
+    assert prntr._print_Pow(1/sqrt(x), rational=True) == 'x**(-1/2)'
 
     prntr = MpmathPrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'mpmath.sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == \
         "x**(mpmath.mpf(1)/mpmath.mpf(2))"
 
-    prntr = NumPyPrinter()
+    prntr = NumPyPrinter({'standard' : 'python3'})
     assert prntr._print_Pow(sqrt(x), rational=False) == 'numpy.sqrt(x)'
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
-    prntr = SciPyPrinter()
+    prntr = SciPyPrinter({'standard' : 'python3'})
     assert prntr._print_Pow(sqrt(x), rational=False) == 'numpy.sqrt(x)'
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
-    prntr = SymPyPrinter()
+    prntr = SymPyPrinter({'standard' : 'python3'})
     assert prntr._print_Pow(sqrt(x), rational=False) == 'sympy.sqrt(x)'
-    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1./2.)'
+    assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
 
 class CustomPrintedObject(Expr):

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -48,6 +48,17 @@ def test_PythonCodePrinter():
     assert prntr.doprint(p[0, 1]) == 'p[0, 1]'
 
 
+def test_PythonCodePrinter_standard():
+    import sys
+    prntr = PythonCodePrinter()
+
+    python_version = sys.version_info.major
+    if python_version == 2:
+        assert prntr.standard == 'python2'
+    if python_version == 3:
+        assert prntr.standard == 'python3'
+
+
 def test_MpmathPrinter():
     p = MpmathPrinter()
     assert p.doprint(sign(x)) == 'mpmath.sign(x)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -51,7 +51,7 @@ def test_PythonCodePrinter():
 def test_MpmathPrinter():
     p = MpmathPrinter()
     assert p.doprint(sign(x)) == 'mpmath.sign(x)'
-    assert p.doprint(Rational(1, 2)) == "mpmath.mpf(1)/mpmath.mpf(2)"
+    assert p.doprint(Rational(1, 2)) == 'mpmath.mpf(1)/mpmath.mpf(2)'
 
 def test_NumPyPrinter():
     p = NumPyPrinter()

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -58,6 +58,7 @@ def test_PythonCodePrinter_standard():
     if python_version == 3:
         assert prntr.standard == 'python3'
 
+    raises(ValueError, lambda: PythonCodePrinter({'standard':'python4'}))
 
 def test_MpmathPrinter():
     p = MpmathPrinter()

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -50,7 +50,7 @@ def test_PythonCodePrinter():
 
 def test_PythonCodePrinter_standard():
     import sys
-    prntr = PythonCodePrinter()
+    prntr = PythonCodePrinter({'standard':None})
 
     python_version = sys.version_info.major
     if python_version == 2:
@@ -113,15 +113,15 @@ def test_sqrt():
     assert prntr._print_Pow(sqrt(x), rational=True) == \
         "x**(mpmath.mpf(1)/mpmath.mpf(2))"
 
-    prntr = NumPyPrinter({'standard' : 'python3'})
+    prntr = NumPyPrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'numpy.sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
-    prntr = SciPyPrinter({'standard' : 'python3'})
+    prntr = SciPyPrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'numpy.sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
-    prntr = SymPyPrinter({'standard' : 'python3'})
+    prntr = SymPyPrinter()
     assert prntr._print_Pow(sqrt(x), rational=False) == 'sympy.sqrt(x)'
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -835,14 +835,7 @@ def test_lambdify_docstring():
 
 
 def test_special_printers():
-    class IntervalPrinter(LambdaPrinter):
-        """Use ``lambda`` printer but print numbers as ``mpi`` intervals. """
-
-        def _print_Integer(self, expr):
-            return "mpi('%s')" % super(IntervalPrinter, self)._print_Integer(expr)
-
-        def _print_Rational(self, expr):
-            return "mpi('%s')" % super(IntervalPrinter, self)._print_Rational(expr)
+    from sympy.polys.numberfields import IntervalPrinter
 
     def intervalrepr(expr):
         return IntervalPrinter().doprint(expr)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16900

#### Brief description of what is fixed or changed

`sqrt` is canonicalized as power, so in reality it does not look up anything in https://github.com/sympy/sympy/blob/fb7bdbc7842623f3ed5dbead9e751b9468836dff/sympy/printing/pycode.py#L26
and I think that the false positive comes from the `_print_Pow` from the `StrPrinter`.

P.S. I think that there is another `Sqrt` defined for codegen specially designed for the purpose.

#### Other comments

I think that `rational` keyword is used in some places to print `sqrt(x)` as `x ** (1/2)`  instead of square root. And it seems like python do actually support square root computation by using power, even without the math library.

Also, I have added some developers reference docs.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added an option `standard` for python code printers to print rational numbers or print statement with python2 semantics. (May be removed after dropping python 2 compatibility)
  - `MpmathPrinter` will print rational numbers like `mpf(1)/mpf(2)`
  - python code printer will print `sqrt` as `math.sqrt`
  - `NumPyPrinter` will print negative integer powers as negative floating point powers, like `x**(-1.0)` which had caused `ValueError`. And may also resolve some relevant issues in `lambdify`

<!-- END RELEASE NOTES -->
