### PR TITLE
[GSoC] Bernoulli distribution for single random variable in given_condition

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -730,7 +730,11 @@ def probability(condition, given_condition=None, numsamples=None,
     given_condition = sympify(given_condition)
 
     if isinstance(given_condition, RandomSymbol):
-        if any([dependent(rv, given_condition) for rv in random_symbols(condition)]):
+        condrv = random_symbols(condition)
+        if len(condrv) == 1 and condrv[0] == given_condition:
+            from sympy.stats.frv_types import BernoulliDistribution
+            return BernoulliDistribution(probability(condition), 0, 1)
+        if any([dependent(rv, given_condition) for rv in condrv]):
             from sympy.stats.symbolic_probability import Probability
             return Probability(condition, given_condition)
         else:

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -6,6 +6,7 @@ from sympy.core.numbers import comp
 from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance, covariance,
         skewness, density, given, independent, dependent, where, pspace,
         random_symbols, sample, Geometric)
+from sympy.stats.frv_types import BernoulliDistribution
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, PSpace)
 from sympy.utilities.pytest import raises, XFAIL
@@ -244,5 +245,7 @@ def test_issue_12237():
     Y = Normal('Y', 0, 1)
     U = P(X > 0, X)
     V = P(Y < 0, X)
-    assert U == Probability(X > 0, X)
+    W = P(X + Y > 0, X)
+    assert W == Probability(X + Y > 0, X)
+    assert U == BernoulliDistribution(1/2, 0, 1)
     assert str(V) == '1/2'

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -247,5 +247,5 @@ def test_issue_12237():
     V = P(Y < 0, X)
     W = P(X + Y > 0, X)
     assert W == Probability(X + Y > 0, X)
-    assert U == BernoulliDistribution(1/2, 0, 1)
+    assert U == BernoulliDistribution(S(1)/2, S(0), S(1))
     assert str(V) == '1/2'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
[1] https://github.com/sympy/sympy/pull/15836#issuecomment-476190440

#### Brief description of what is fixed or changed
As the issue https://github.com/sympy/sympy/issues/12237 was being fixed via, https://github.com/sympy/sympy/pull/15836 a lot of discussion happened with @Upabjojr as can be seen in the thread. One of the tasks was to return `BernoulliDistribution` for queries of type, `P(f(X), X)` where `f(X)` denotes events like, `X > 0`, `X > a`, etc. Detailed reasoning can be seen in the comment referenced above.

#### Other comments
I have added this to GSoC because this was the part of discussion prior to the acceptance. 
In the coming PRs I will try to point `P` to `Probability` via deprecation procedure.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
