### PR TITLE
Symbolic conditions allowed in sympy.stats.frv

### DIFF
--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -167,7 +167,7 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
             return val
         elif val.is_Equality:
             return val.lhs == val.rhs
-        raise ValueError("Undeciable if %s" % str(val))
+        raise ValueError("Undecidable if %s" % str(val))
 
     def __contains__(self, other):
         return other in self.fulldomain and self._test(other)
@@ -323,9 +323,12 @@ class FinitePSpace(PSpace):
 
     def probability(self, condition):
         cond_symbols = frozenset(rs.symbol for rs in random_symbols(condition))
-        assert cond_symbols.issubset(self.symbols)
+        cond = rv_subs(condition)
+        if not cond_symbols.issubset(self.symbols):
+            raise ValueError("Cannot compare foriegn random symbols, %s"
+                             %(str(cond_symbols - self.symbols)))
         if isinstance(condition, Relational) and \
-            (not cond_symbols.issubset(self.domain.free_symbols)):
+            (not cond.free_symbols.issubset(self.domain.free_symbols)):
             rv = condition.lhs if isinstance(condition.rhs, Symbol) else condition.rhs
             return sum(Piecewise(
                        (self.prob_of(elem), condition.subs(rv, list(elem)[0][1])),

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -146,10 +146,10 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
         # Check that we aren't passed a condition like die1 == z
         # where 'z' is a symbol that we don't know about
         # We will never be able to test this equality through iteration
-        # if not cond.free_symbols.issubset(domain.free_symbols):
-        #     raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
-        #         condition, tuple(cond.free_symbols - domain.free_symbols)) +
-        #         "Will be unable to iterate using this condition")
+        if not cond.free_symbols.issubset(domain.free_symbols):
+            raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
+                condition, tuple(cond.free_symbols - domain.free_symbols)) +
+                "Will be unable to iterate using this condition")
 
         return Basic.__new__(cls, domain, cond)
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -146,10 +146,10 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
         # Check that we aren't passed a condition like die1 == z
         # where 'z' is a symbol that we don't know about
         # We will never be able to test this equality through iteration
-        if not cond.free_symbols.issubset(domain.free_symbols):
-            raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
-                condition, tuple(cond.free_symbols - domain.free_symbols)) +
-                "Will be unable to iterate using this condition")
+        # if not cond.free_symbols.issubset(domain.free_symbols):
+        #     raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
+        #         condition, tuple(cond.free_symbols - domain.free_symbols)) +
+        #         "Will be unable to iterate using this condition")
 
         return Basic.__new__(cls, domain, cond)
 

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -136,7 +136,7 @@ class DieDistribution(SingleFiniteDistribution):
     @property
     @cacheit
     def dict(self):
-        as_int(self.sides)
+        as_int(self.sides) # Check that self.sides can be converted to an integer
         return dict((k, Rational(1, self.sides)) for k in self.set)
 
     @property

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -136,8 +136,8 @@ class DieDistribution(SingleFiniteDistribution):
     @property
     @cacheit
     def dict(self):
-        as_int(self.sides) # Check that self.sides can be converted to an integer
-        return super(DieDistribution, self).dict
+        as_int(self.sides)
+        return dict((k, Rational(1, self.sides)) for k in self.set)
 
     @property
     def set(self):

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -122,7 +122,7 @@ def test_domains():
     Z = Die('x', 4)
 
     raises(ValueError, lambda: P(X > Z))  # Two domains with same internal symbol
-    raises(ValueError, lambda: P(X > y))  # Tests for foreign symbol
+    # raises(ValueError, lambda: P(X > y))  # Tests for foreign symbol
 
     assert pspace(X + Y).domain.set == FiniteSet(1, 2, 3, 4, 5, 6)**2
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -122,6 +122,7 @@ def test_domains():
     Z = Die('x', 4)
 
     raises(ValueError, lambda: P(X > Z))  # Two domains with same internal symbol
+    raises(ValueError, lambda: P(X > y))  # Tests for foreign symbol
 
     assert pspace(X + Y).domain.set == FiniteSet(1, 2, 3, 4, 5, 6)**2
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,6 +1,6 @@
 from sympy import (FiniteSet, S, Symbol, sqrt, nan,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial,
-        cancel, exp, I, Piecewise, Rational)
+        cancel, exp, I, Piecewise)
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -323,7 +323,7 @@ def test_FinitePSpace():
 
 def test_symbolic_conditions():
     B = Bernoulli('B', S(1)/4)
-    b = symbols('d, b')
+    b = symbols('b')
     Y = P(Eq(B, b))
     assert Y == \
     Piecewise((1/4, Eq(b, 1)), (0, True)) + Piecewise((3/4, Eq(b, 0)), (0, True))

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,6 +1,6 @@
 from sympy import (FiniteSet, S, Symbol, sqrt, nan,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial,
-        cancel, exp, I, Piecewise)
+        cancel, exp, I, Piecewise, Rational)
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
@@ -326,4 +326,5 @@ def test_symbolic_conditions():
     b = symbols('b')
     Y = P(Eq(B, b))
     assert Y == \
-    Piecewise((1/4, Eq(b, 1)), (0, True)) + Piecewise((3/4, Eq(b, 0)), (0, True))
+    Piecewise((Rational(1, 4), Eq(b, 1)), (0, True)) + \
+    Piecewise((Rational(3, 4), Eq(b, 0)), (0, True))

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -323,7 +323,7 @@ def test_FinitePSpace():
 
 def test_symbolic_conditions():
     B = Bernoulli('B', S(1)/4)
-    d, b = symbols('d, b')
+    b = symbols('d, b')
     Y = P(Eq(B, b))
     assert Y == \
     Piecewise((1/4, Eq(b, 1)), (0, True)) + Piecewise((3/4, Eq(b, 0)), (0, True))

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -320,3 +320,10 @@ def test_FinitePSpace():
     X = Die('X', 6)
     space = pspace(X)
     assert space.density == DieDistribution(6)
+
+def test_symbolic_conditions():
+    B = Bernoulli('B', S(1)/4)
+    d, b = symbols('d, b')
+    Y = P(Eq(B, b))
+    assert Y == \
+    Piecewise((1/4, Eq(b, 1)), (0, True)) + Piecewise((3/4, Eq(b, 0)), (0, True))

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -122,7 +122,6 @@ def test_domains():
     Z = Die('x', 4)
 
     raises(ValueError, lambda: P(X > Z))  # Two domains with same internal symbol
-    # raises(ValueError, lambda: P(X > y))  # Tests for foreign symbol
 
     assert pspace(X + Y).domain.set == FiniteSet(1, 2, 3, 4, 5, 6)**2
 
@@ -323,8 +322,13 @@ def test_FinitePSpace():
 
 def test_symbolic_conditions():
     B = Bernoulli('B', S(1)/4)
-    b = symbols('b')
+    D = Die('D', 4)
+    b, n = symbols('b, n')
     Y = P(Eq(B, b))
+    Z = E(D > n)
     assert Y == \
-    Piecewise((Rational(1, 4), Eq(b, 1)), (0, True)) + \
-    Piecewise((Rational(3, 4), Eq(b, 0)), (0, True))
+    Piecewise((S(1)/4, Eq(b, 1)), (0, True)) + \
+    Piecewise((S(3)/4, Eq(b, 0)), (0, True))
+    assert Z == \
+    Piecewise((S(1)/4, n < 1), (0, True)) + Piecewise((S(1)/2, n < 2), (0, True)) + \
+    Piecewise((S(3)/4, n < 3), (0, True)) + Piecewise((S(1), n < 4), (0, True))

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -167,7 +167,6 @@ def test_dependence():
     assert dependent(XX, YY)
 
 
-@XFAIL
 def test_dependent_finite():
     X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -166,7 +166,6 @@ def test_dependence():
     XX, YY = given(Tuple(X, Y), Eq(X + Y, 3))
     assert dependent(XX, YY)
 
-@XFAIL
 def test_dependent_finite():
     X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -166,7 +166,7 @@ def test_dependence():
     XX, YY = given(Tuple(X, Y), Eq(X + Y, 3))
     assert dependent(XX, YY)
 
-
+@XFAIL
 def test_dependent_finite():
     X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
N/A

#### Brief description of what is fixed or changed
The `@XFAIL` decorator has been removed from the function, `test_dependent_finite` in `sympy.stats.tests.test_rv`.

#### Other comments
I was just going through the tests in `sympy.stats.tests.test_rv` looking for some general improvements to be made in stats module and came across this `@XFAIL` test. As an attempt to solve this I just commented the part which didn't allow foreign symbols in `ConditionalFiniteDomain`. The notable point is that after removing the said part all the tests of `sympy.stats` are passing on my local system as shown below. 
My question is if no test is failing then why, foreign symbols are not allowed in `ConditionalFiniteDomain`. Either there should be test checking this fact or foreign symbols should be allowed. I have few more approaches in my mind if you are willing to discuss. :)
Please **DO NOT CLOSE** this PR, rather discuss and make suggestions. 

**Test Results**
```
Python 3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sympy
>>> sympy.test('/stats/')
============================================================================================= test process starts =============================================================================================
executable:         /usr/bin/python3  (3.6.7-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
numpy:              1.15.3
random seed:        54277752
hash randomization: on (PYTHONHASHSEED=1784891003)

sympy/stats/tests/test_continuous_rv.py[72] ...w..........................................f................ww.......                                                                                       [OK]
sympy/stats/tests/test_discrete_rv.py[15] .......w.......                                                                                                                                                  [OK]
sympy/stats/tests/test_error_prop.py[2] ..                                                                                                                                                                 [OK]
sympy/stats/tests/test_finite_rv.py[19] ...................                                                                                                                                                [OK]
sympy/stats/tests/test_joint_rv.py[13] ............f                                                                                                                                                       [OK]
sympy/stats/tests/test_mix.py[3] ...                                                                                                                                                                       [OK]
sympy/stats/tests/test_rv.py[24] ........................                                                                                                                                                  [OK]
sympy/stats/tests/test_symbolic_probability.py[2] ..                                                                                                                                                       [OK]

________________________________________________________________________________________________ slowest tests ________________________________________________________________________________________________
test_JointPSpace_marginal_distribution - Took 11.347 seconds
================================================================= tests finished: 144 passed, 4 skipped, 2 expected to fail, in 61.95 seconds =================================================================
True
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
