### PR TITLE
Symbolic dimensions allowed in MultivariateEwens

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -258,6 +258,9 @@ class Basic(with_metaclass(ManagedProperties)):
         (0, 1, 2, 3, 4)
 
         """
+        from sympy.tensor.array import ArrayComprehension
+        if isinstance(args, ArrayComprehension):
+            return cls(args, **assumptions)
         return cls(*tuple(args), **assumptions)
 
     @classmethod

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -258,9 +258,6 @@ class Basic(with_metaclass(ManagedProperties)):
         (0, 1, 2, 3, 4)
 
         """
-        from sympy.tensor.array import ArrayComprehension
-        if isinstance(args, ArrayComprehension):
-            return cls(args, **assumptions)
         return cls(*tuple(args), **assumptions)
 
     @classmethod

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division
 from sympy import (Basic, Lambda, sympify, Indexed, Symbol, ProductSet, S,
  Dummy)
 from sympy.concrete.summations import Sum, summation
+from sympy.concrete.products import Product
 from sympy.core.compatibility import string_types
 from sympy.core.containers import Tuple
 from sympy.integrals.integrals import Integral, integrate
@@ -64,7 +65,11 @@ class JointPSpace(ProductPSpace):
     @property
     def component_count(self):
         _set = self.distribution.set
-        return len(_set.args) if isinstance(_set, ProductSet) else 1
+        if isinstance(_set, ProductSet):
+            return S(len(_set.args))
+        elif isinstance(_set, Product):
+            return _set.limits[0][-1]
+        return S(1)
 
     @property
     def pdf(self):
@@ -87,6 +92,9 @@ class JointPSpace(ProductPSpace):
 
     def marginal_distribution(self, *indices):
         count = self.component_count
+        if count.atoms(Symbol):
+            raise ValueError("Marginal distributions cannot be computed "
+                                "for symbolic dimensions. It is a work under progress.")
         orig = [Indexed(self.symbol, i) for i in range(count)]
         all_syms = [Symbol(str(i)) for i in orig]
         replace_dict = dict(zip(all_syms, orig))
@@ -182,7 +190,7 @@ class JointRandomSymbol(RandomSymbol):
     """
     def __getitem__(self, key):
         if isinstance(self.pspace, JointPSpace):
-            if self.pspace.component_count <= key:
+            if (self.pspace.component_count <= key) == True:
                 raise ValueError("Index keys for %s can only up to %s." %
                     (self.name, self.pspace.component_count - 1))
             return Indexed(self, key)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,13 +1,12 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt, IndexedBase,
                     besselk, gamma, Interval, Range, factorial, Mul, Integer,
                     Add, rf, Eq, Piecewise, ones, Symbol, Pow, Rational, Sum,
-                  imageset, Intersection, Matrix, symbols)
+                  imageset, Intersection, Matrix, symbols, Product, IndexedBase)
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
 from sympy.stats.rv import _value_check, random_symbols
-from sympy.tensor.array import ArrayComprehension
 
 # __all__ = ['MultivariateNormal',
 # 'MultivariateLaplace',
@@ -340,7 +339,7 @@ class MultivariateEwensDistribution(JointDistribution):
 
     @staticmethod
     def check(n, theta):
-        _value_check(isinstance(n, Integer) and (n > 0) == True,
+        _value_check((n > 0),
                         "sample size should be positive integer.")
         _value_check(theta.is_positive, "mutation rate should be positive.")
 
@@ -348,9 +347,8 @@ class MultivariateEwensDistribution(JointDistribution):
     def set(self):
         if not isinstance(self.n, Integer):
             i = Symbol('i', integer=True, positive=True)
-            s = ArrayComprehension(Intersection(S.Naturals0, Interval(0, self.n//i)),
+            return Product(Intersection(S.Naturals0, Interval(0, self.n//i)),
                                     (i, 1, self.n))
-            return Mul.fromiter(s.doit())
         prod_set = Range(0, self.n + 1)
         for i in range(2, self.n + 1):
             prod_set *= Range(0, self.n//i + 1)
@@ -359,19 +357,20 @@ class MultivariateEwensDistribution(JointDistribution):
     def pdf(self, *syms):
         n, theta = self.n, self.theta
         condi = isinstance(self.n, Integer)
-        if (not isinstance(syms, Indexed)) and not condi:
-            raise ValueError("Please use Indexed object for syms as "
+        if not (isinstance(syms[0], IndexedBase) or condi):
+            raise ValueError("Please use IndexedBase object for syms as "
                                 "the dimension is symbolic")
-
         term_1 = factorial(n)/rf(theta, n)
-        expri = lambda j: theta**syms[j]/((j+1)**syms[j]*factorial(syms[j]))
         if condi:
-            term_2 = Mul.fromiter([expri(j) for j in range(n)])
+            term_2 = Mul.fromiter([theta**syms[j]/((j+1)**syms[j]*factorial(syms[j]))
+                                    for j in range(n)])
             cond = Eq(sum([(k + 1)*syms[k] for k in range(n)]), n)
             return Piecewise((term_1 * term_2, cond), (0, True))
+        syms = syms[0]
         j, k = symbols('j, k', positive=True, integer=True)
-        term_2 = ArrayComprehension(expri(j), (j, 0, n - 1))
-        cond = ArrayComprehension((k + 1)*syms[k], (k, 0, n - 1))
+        term_2 = Product(theta**syms[j]/((j+1)**syms[j]*factorial(syms[j])),
+                            (j, 0, n - 1))
+        cond = Eq(Sum((k + 1)*syms[k], (k, 0, n - 1)), n)
         return Piecewise((term_1 * term_2, cond), (0, True))
 
 

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,5 +1,6 @@
 from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, Sum, simplify,
-                    Mul, Rational, Integral, factorial, gamma, Piecewise, Eq)
+                    Mul, Rational, Integral, factorial, gamma, Piecewise, Eq, Product,
+                    IndexedBase)
 from sympy.core.numbers import comp
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
@@ -66,7 +67,6 @@ def test_GeneralizedMultivariateLogGammaDistribution():
                      [h, h, h, 1]])
     v, l, mu = (4, [1, 2, 3, 4], [1, 2, 3, 4])
     y_1, y_2, y_3, y_4 = symbols('y_1:5', real=True)
-    n = symbols('n', negative=False, integer=True)
     delta = symbols('d', positive=True)
     G = GMVLGO('G', omega, v, l, mu)
     Gd = GMVLG('Gd', delta, v, l, mu)
@@ -135,7 +135,10 @@ def test_MultivariateBeta():
 
 def test_MultivariateEwens():
     from sympy.stats.joint_rv_types import MultivariateEwens
-    n, theta = symbols('n theta', positive=True)
+
+    n, theta, i = symbols('n theta i', positive=True)
+
+    # tests for integer dimensions
     theta_f = symbols('t_f', negative=True)
     a = symbols('a_1:4', positive = True, integer = True)
     ed = MultivariateEwens('E', 3, theta)
@@ -150,7 +153,14 @@ def test_MultivariateEwens():
                                                     (theta + 2)*factorial(a[1])),
                                                     Eq(2*a[1] + 1, 3)), (0, True))
     raises(ValueError, lambda: MultivariateEwens('e1', 5, theta_f))
-    raises(ValueError, lambda: MultivariateEwens('e1', n, theta))
+
+    # tests for symbolic dimensions
+    eds = MultivariateEwens('E', n, theta)
+    a = IndexedBase('a')
+    den = ("Piecewise((factorial(n)*Product(theta**a[j]*(j + 1)**(-a[j])/"
+           "factorial(a[j]), (j, 0, n - 1))/RisingFactorial(theta, n),"
+           " Eq(n, Sum((k + 1)*a[k], (k, 0, n - 1)))), (0, True))")
+    assert str(density(eds)(a)) == den
 
 def test_Multinomial():
     from sympy.stats.joint_rv_types import Multinomial

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, Sum, simplify,
                     Mul, Rational, Integral, factorial, gamma, Piecewise, Eq, Product,
-                    IndexedBase)
+                    IndexedBase, RisingFactorial)
 from sympy.core.numbers import comp
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
@@ -157,10 +157,11 @@ def test_MultivariateEwens():
     # tests for symbolic dimensions
     eds = MultivariateEwens('E', n, theta)
     a = IndexedBase('a')
-    den = ("Piecewise((factorial(n)*Product(theta**a[j]*(j + 1)**(-a[j])/"
-           "factorial(a[j]), (j, 0, n - 1))/RisingFactorial(theta, n),"
-           " Eq(n, Sum((k + 1)*a[k], (k, 0, n - 1)))), (0, True))")
-    assert str(density(eds)(a)) == den
+    j, k = symbols('j, k')
+    den = Piecewise((factorial(n)*Product(theta**a[j]*(j + 1)**(-a[j])/
+           factorial(a[j]), (j, 0, n - 1))/RisingFactorial(theta, n),
+            Eq(n, Sum((k + 1)*a[k], (k, 0, n - 1)))), (0, True))
+    assert density(eds)(a).dummy_eq(den)
 
 def test_Multinomial():
     from sympy.stats.joint_rv_types import Multinomial


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
[1] Extends https://github.com/sympy/sympy/pull/16576

#### Brief description of what is fixed or changed
Symbolic dimensions can now be passed to `MultivariateEwens` in `sympy.stats.joint_rv_types`.

#### Other comments
This is a work in progress task. There are some problems with `ArrayComprehension` which need to be handled, for instance, it is not possible to multiply the elements of `ArrayComprehension` and return an unevaluated `Mul` object. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
