### PR TITLE
[WIP] Float.is_rational, Float(.5).q = 2, Float(integer).is_integer

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -24,17 +24,13 @@ class AskPrimeHandler(CommonHandler):
     @staticmethod
     def _number(expr, assumptions):
         # helper method
-        exact = not expr.atoms(Float)
         try:
             i = int(expr.round())
             if (expr - i).equals(0) is False:
                 raise TypeError
         except TypeError:
             return False
-        if exact:
-            return isprime(i)
-        # when not exact, we won't give a True or False
-        # since the number represents an approximate value
+        return isprime(i)
 
     @staticmethod
     def Basic(expr, assumptions):
@@ -118,8 +114,6 @@ class AskEvenHandler(CommonHandler):
             if not (expr - i).equals(0):
                 raise TypeError
         except TypeError:
-            return False
-        if isinstance(expr, (float, Float)):
             return False
         return i % 2 == 0
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -83,16 +83,16 @@ def test_int_12():
 def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
-    assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.integer(z)) is True
+    assert ask(Q.rational(z)) is True
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is None
+    assert ask(Q.irrational(z)) is False
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
     assert ask(Q.even(z)) is False
-    assert ask(Q.odd(z)) is False
+    assert ask(Q.odd(z)) is True
     assert ask(Q.finite(z)) is True
     assert ask(Q.prime(z)) is False
     assert ask(Q.composite(z)) is False
@@ -102,10 +102,10 @@ def test_float_1():
     z = 7.2123
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is None
+    assert ask(Q.rational(z)) is True
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is None
+    assert ask(Q.irrational(z)) is False
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
@@ -118,7 +118,7 @@ def test_float_1():
     assert ask(Q.antihermitian(z)) is False
 
     # test for issue #12168
-    assert ask(Q.rational(math.pi)) is None
+    assert ask(Q.rational(math.pi)) is True
 
 
 def test_zero_0():
@@ -2240,11 +2240,12 @@ def test_check_old_assumption():
 
 
 def test_issue_9636():
-    assert ask(Q.integer(1.0)) is False
-    assert ask(Q.prime(3.0)) is False
-    assert ask(Q.composite(4.0)) is False
-    assert ask(Q.even(2.0)) is False
-    assert ask(Q.odd(3.0)) is False
+    assert ask(Q.prime(3.0)) is True
+    assert ask(Q.composite(4.0)) is True
+    assert ask(Q.even(2.0)) is True
+    assert ask(Q.even(3.0)) is False
+    assert ask(Q.odd(2.0)) is False
+    assert ask(Q.odd(3.0)) is True
 
 
 def test_autosimp_used_to_fail():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1017,12 +1017,9 @@ class Float(Number):
     >>> _.is_Float
     False
     """
-    __slots__ = ['_mpf_', '_prec']
+    __slots__ = ['_mpf_', '_prec', 'q']
 
-    # A Float represents many real numbers,
-    # both rational and irrational.
-    is_rational = None
-    is_irrational = None
+    is_rational = True
     is_number = True
 
     is_real = True
@@ -1205,6 +1202,7 @@ class Float(Number):
         obj = Expr.__new__(cls)
         obj._mpf_ = mpf_norm(_mpf_, _prec)
         obj._prec = _prec
+        obj.q = 0 if obj._mpf_[2] >= 0 else 2 if obj._mpf_[2] == -1 else None
         return obj
 
     # mpz can't be pickled
@@ -1255,7 +1253,7 @@ class Float(Number):
         return False
 
     def _eval_is_integer(self):
-        return self._mpf_ == fzero
+        return self.q == 0
 
     def _eval_is_negative(self):
         if self._mpf_ == _mpf_ninf or self._mpf_ == _mpf_inf:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -467,14 +467,16 @@ def test_Float():
     assert Float('0.0').is_infinite is False
     assert Float('0.0').is_zero is True
 
-    # rationality properties
-    # if the integer test fails then the use of intlike
-    # should be removed from gamma_functions.py
-    assert Float(1).is_integer is False
-    assert Float(1).is_rational is None
-    assert Float(1).is_irrational is None
-    assert sqrt(2).n(15).is_rational is None
-    assert sqrt(2).n(15).is_irrational is None
+    assert Float(1).is_Float
+    assert Float(1).is_integer is True
+    assert Float(1).is_rational is True
+    assert Float(1).is_irrational is False
+    assert Float(.1).is_rational is True
+    assert Float(.5).is_rational is True
+    assert Float(.5).is_integer is False
+    assert Float(1.5).is_rational is True
+    assert sqrt(2).n(15).is_rational is True
+    assert sqrt(2).n(15).is_irrational is False
 
     # do not automatically evalf
     def teq(a):

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -267,21 +267,15 @@ def test_pow_as_base_exp():
 def test_issue_6100_12942_4473():
     x = Symbol('x')
     y = Symbol('y')
-    assert x**1.0 != x
-    assert x != x**1.0
+    assert x**1.0 == x
+    assert x == x**1.0
     assert True != x**1.0
     assert x**1.0 is not True
     assert x is not True
-    assert x*y != (x*y)**1.0
-    # Pow != Symbol
-    assert (x**1.0)**1.0 != x
-    assert (x**1.0)**2.0 == x**2
+    assert x*y == (x*y)**1.0 == x**1.0*y**1.0
+    # Pow == Symbol
     b = Basic()
     assert Pow(b, 1.0, evaluate=False) != b
-    # if the following gets distributed as a Mul (x**1.0*y**1.0 then
-    # __eq__ methods could be added to Symbol and Pow to detect the
-    # power-of-1.0 case.
-    assert ((x*y)**1.0).func is Pow
 
 
 def test_issue_6208():

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -14,12 +14,7 @@ from sympy.functions.elementary.trigonometric import sin, cos, cot
 from sympy.functions.combinatorial.numbers import bernoulli, harmonic
 from sympy.functions.combinatorial.factorials import factorial, rf, RisingFactorial
 
-def intlike(n):
-    try:
-        as_int(n, strict=False)
-        return True
-    except ValueError:
-        return False
+
 
 ###############################################################################
 ############################ COMPLETE GAMMA FUNCTION ##########################
@@ -113,7 +108,7 @@ class gamma(Function):
                 return S.NaN
             elif arg is S.Infinity:
                 return S.Infinity
-            elif intlike(arg):
+            elif arg.is_integer:
                 if arg.is_positive:
                     return factorial(arg - 1)
                 else:

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -32,7 +32,7 @@ from sympy.sets.fancysets import Range
 # dictionary mapping sympy function to (argument_conditions, C_function).
 # Used in C89CodePrinter._print_Function(self)
 known_functions_C89 = {
-    "Abs": [(lambda x: not x.is_integer, "fabs"), (lambda x: x.is_integer, "abs")],
+    "Abs": [(lambda x: not x.is_integer or x.is_Float, "fabs"), (lambda x: x.is_integer and not x.is_Float, "abs")],
     "sin": "sin",
     "cos": "cos",
     "tan": "tan",

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -335,7 +335,7 @@ class RustCodePrinter(CodePrinter):
             return self._print_not_supported(expr)
 
     def _print_Pow(self, expr):
-        if expr.base.is_integer and not expr.exp.is_integer:
+        if expr.base.is_integer and not expr.base.is_Float and not expr.exp.is_integer:
             expr = type(expr)(Float(expr.base), expr.exp)
             return self._print(expr)
         return self._print_Function(expr)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -639,9 +639,12 @@ def test_C99CodePrinter__precision():
     f32_printer = C99CodePrinter(dict(type_aliases={real: float32}))
     f64_printer = C99CodePrinter(dict(type_aliases={real: float64}))
     f80_printer = C99CodePrinter(dict(type_aliases={real: float80}))
-    assert f32_printer.doprint(sin(x+2.1)) == 'sinf(x + 2.1F)'
-    assert f64_printer.doprint(sin(x+2.1)) == 'sin(x + 2.1000000000000001)'
-    assert f80_printer.doprint(sin(x+Float('2.0'))) == 'sinl(x + 2.0L)'
+    assert f32_printer.doprint(sin(x + 2.1)
+        ) == 'sinf(x + 2.1F)'
+    assert f64_printer.doprint(sin(x + 2.1)
+        ) == 'sin(x + 2.1000000000000001)'
+    assert f80_printer.doprint(sin(x + Float('2.0'))
+        ) == 'sinl(x + 2.0L)'
 
     for printer, suffix in zip([f32_printer, f64_printer, f80_printer], ['f', '', 'l']):
         def check(expr, ref):
@@ -686,8 +689,8 @@ def test_C99CodePrinter__precision():
         check(gamma(x), 'tgamma{s}(x)')
         check(loggamma(x), 'lgamma{s}(x)')
 
-        check(ceiling(x + 2.), "ceil{s}(x + 2.0{S})")
-        check(floor(x + 2.), "floor{s}(x + 2.0{S})")
+        check(ceiling(x + 2.), "ceil{s}(x) + 2.0{S}")
+        check(floor(x + 2.), "floor{s}(x) + 2.0{S}")
         check(fma(x, y, -z), 'fma{s}(x, y, -z)')
         check(Max(x, 8.0, x**4.0), 'fmax{s}(8.0{S}, fmax{s}(x, pow{s}(x, 4.0{S})))')
         check(Min(x, 2.0), 'fmin{s}(2.0{S}, x)')

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -463,7 +463,7 @@ class Range(Set):
         try:
             start, stop, step = [
                 w if w in [S.NegativeInfinity, S.Infinity]
-                else sympify(as_int(w))
+                else sympify(as_int(w, strict=False))
                 for w in (start, stop, step)]
         except ValueError:
             raise ValueError(filldedent('''

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -79,7 +79,7 @@ def test_ImageSet():
     harmonics = ImageSet(Lambda(x, 1/x), S.Naturals)
     assert Rational(1, 5) in harmonics
     assert Rational(.25) in harmonics
-    assert 0.25 not in harmonics
+    assert 0.25 in harmonics
     assert Rational(.3) not in harmonics
     assert (1, 2) not in harmonics
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -266,7 +266,7 @@ def get_default_datatype(expr, complex_allowed=None):
         final_dtype = "complex"
     else:
         final_dtype = "float"
-    if expr.is_integer:
+    if expr.is_integer and not expr.is_Float:
         return default_datatypes["int"]
     elif expr.is_real:
         return default_datatypes["float"]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

WIP

#### Brief description of what is fixed or changed

Floats are a subset of Rationals whose denominator is a power of 2 and whose action in expressions is to moderate the precision of the result:
```python
>>> Float(0.1,5)._prec
20
>>> (10**100*Float(0.1,5))._prec
20
```
This precision only comes to play when a *result* is computed. Mathematical properties, however, are not affected by whether a number is an integer or a Float (or whether a number is any other Rational with denominator that is a power of 2): `Float(integer)*x == integer*x` and `Float(Rational(a, 2**e))*x == a/2**e*x` so `(x*y)**1.0 == x**1.0*y**1.0` and `sqrt(x) == x**.5`.

Toward this end, Float is now defined with `is_rational=True` and `is_integer=True` when the denominator of the number being represented is 1. In addition, when `x.is_rational` is tested, often another test is `...and x.q == 2`. So for this case, `Float.q=2 and for the case when `x` is an integer, `Float.q=0` (though I am not sure this is necessary; I set it to 0 so it wouldn't be confused with Integers that never have a q of 0) and for all other cases it is None. (There were only two other places where q was checked and that was in `_minpoly_cos` of `numberfields` where a check for q of 7 and 9 is made.) 

#### Other comments

I am only seeking to represent the intents and rationale of this PR in what was said above. It is not meant to be a definitive answer. And what exactly we want Float to mean -- and what it should mean -- has been an ongoing discussion spread over many issues.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
