### PR TITLE
[GSoC] Changed namespace of joint_rv_types

### DIFF
--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -71,6 +71,15 @@ from . import drv_types
 from .drv_types import (Geometric, Logarithmic, NegativeBinomial, Poisson, YuleSimon, Zeta)
 __all__.extend(drv_types.__all__)
 
+from . import joint_rv_types
+from .joint_rv_types import (
+    JointRV,
+    Dirichlet, GeneralizedMultivariateLogGamma, GeneralizedMultivariateLogGammaOmega,
+    Multinomial, MultivariateBeta, MultivariateEwens, MultivariateT, NegativeMultinomial,
+    NormalGamma
+)
+__all__.extend(joint_rv_types.__all__)
+
 from . import symbolic_probability
 from .symbolic_probability import Probability, Expectation, Variance, Covariance
 __all__.extend(symbolic_probability.__all__)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -8,11 +8,17 @@ from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
     JointDistributionHandmade, MarginalDistribution)
 from sympy.stats.rv import _value_check, random_symbols
 
-# __all__ = ['MultivariateNormal',
-# 'MultivariateLaplace',
-# 'MultivariateT',
-# 'NormalGamma'
-# ]
+__all__ = ['JointRV',
+'Dirichlet',
+'GeneralizedMultivariateLogGamma',
+'GeneralizedMultivariateLogGammaOmega',
+'Multinomial',
+'MultivariateBeta',
+'MultivariateEwens',
+'MultivariateT',
+'NegativeMultinomial',
+'NormalGamma'
+]
 
 def multivariate_rv(cls, sym, *args):
     args = list(map(sympify, args))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
[1] https://github.com/sympy/sympy/pull/16893

#### Brief description of what is fixed or changed
#### Other comments
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * joint_rv_types can now be imported with `from sympy.stats import *`
<!-- END RELEASE NOTES -->
