### PR TITLE
higher level continued fraction

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -19,5 +19,5 @@ from .multinomial import binomial_coefficients, binomial_coefficients_list, \
     multinomial_coefficients
 from .continued_fraction import continued_fraction_periodic, \
     continued_fraction_iterator, continued_fraction_reduce, \
-    continued_fraction_convergents
+    continued_fraction_convergents, continued_fraction
 from .egyptian_fraction import egyptian_fraction

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,18 +1,92 @@
 from sympy.core.numbers import Integer, Rational
+from sympy.core.compatibility import as_int
+from sympy.utilities.misc import filldedent
 
 
 
-def continued_fraction_periodic(p, q, d=0):
+def continued_fraction(a):
+    """Return the continued fraction representation of a Rational or
+    quadratic irrational.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.continued_fraction import continued_fraction
+    >>> from sympy import sqrt
+    >>> continued_fraction((1 + 2*sqrt(3))/5)
+    [0, 1, [8, 3, 34, 3]]
+
+    See Also
+    ========
+    continued_fraction_periodic, continued_fraction_reduce, continued_fraction_convergents
+    """
+    from sympy.core.singleton import S
+    from sympy.core.symbol import Dummy
+    from sympy.core.sympify import _sympify
+    from sympy.core.power import Pow
+    from sympy.polys.polytools import primitive
+    from sympy.polys.polyerrors import ComputationFailed
+
+    e = _sympify(a)
+    if all(i.is_Rational for i in e.atoms()):
+        if e.is_Integer:
+            return continued_fraction_periodic(e, 1, 0)
+        elif e.is_Rational:
+            return continued_fraction_periodic(e.p, e.q, 0)
+        elif e.is_Pow and e.exp is S.Half and e.base.is_Integer:
+            return continued_fraction_periodic(0, 1, e.base)
+        elif e.is_Mul and len(e.args) == 2 and (
+                e.args[0].is_Rational and
+                e.args[1].is_Pow and
+                e.args[1].base.is_Integer and
+                e.args[1].exp is S.Half):
+            a, b = e.args
+            return continued_fraction_periodic(0, a.q, b.base, a.p)
+        else:
+            # this should not have to work very hard- no
+            # simplification, cancel, etc... which should be
+            # done by the user.  e.g. This is a fancy 1 but
+            # the user should simplify it first:
+            # sqrt(2)*(1 + sqrt(2))/(sqrt(2) + 2)
+            p, d = e.expand().as_numer_denom()
+            if d.is_Integer:
+                if p.is_Rational:
+                    return continued_fraction_periodic(p, d)
+                # look for a + b*c
+                # with c = sqrt(s)
+                if p.is_Add and len(p.args) == 2:
+                    a, bc = p.args
+                else:
+                    a = S.Zero
+                    bc = p
+                if a.is_Integer:
+                    b = S.NaN
+                    if bc.is_Mul and len(bc.args) == 2:
+                        b, c = bc.args
+                    elif bc.is_Pow:
+                        b = Integer(1)
+                        c = bc
+                    if b.is_Integer and (
+                            c.is_Pow and c.exp is S.Half and
+                            c.base.is_Integer):
+                        # (a + b*sqrt(c))/d
+                        c = c.base
+                        return continued_fraction_periodic(a, d, c, b)
+    raise ValueError(
+        'expecting a rational or quadratic irrational, not %s' % e)
+
+
+def continued_fraction_periodic(p, q, d=0, s=1):
     r"""
     Find the periodic continued fraction expansion of a quadratic irrational.
 
     Compute the continued fraction expansion of a rational or a
-    quadratic irrational number, i.e. `\frac{p + \sqrt{d}}{q}`, where
-    `p`, `q` and `d \ge 0` are integers.
+    quadratic irrational number, i.e. `\frac{p + s\sqrt{d}}{q}`, where
+    `p`, `q \ne 0` and `d \ge 0` are integers.
 
     Returns the continued fraction representation (canonical form) as
     a list of integers, optionally ending (for quadratic irrationals)
-    with repeating block as the last term of this list.
+    with list of integers representing the repeating digits.
 
     Parameters
     ==========
@@ -23,6 +97,8 @@ def continued_fraction_periodic(p, q, d=0):
         the denominator of the number
     d : int, optional
         the irrational part (discriminator) of the number's numerator
+    s : int, optional
+        the coefficient of the irrational part
 
     Examples
     ========
@@ -58,20 +134,39 @@ def continued_fraction_periodic(p, q, d=0):
 
     """
     from sympy.core.compatibility import as_int
-    from sympy.functions import sqrt
+    from sympy.functions import sqrt, floor
+    from sympy.ntheory.primetest import is_square
 
-    p, q, d = list(map(as_int, [p, q, d]))
-    sd = sqrt(d)
-
-    if q == 0:
-        raise ValueError("The denominator is zero.")
+    p, q, d, s = list(map(as_int, [p, q, d, s]))
 
     if d < 0:
-        raise ValueError("Delta supposed to be a non-negative "
-                         "integer, got %d" % d)
-    elif d == 0 or sd.is_integer:
-        # the number is a rational number
-        return list(continued_fraction_iterator(Rational(p + sd, q)))
+        raise ValueError("expected non-negative for `d` but got %s" % d)
+
+    if q == 0:
+        raise ValueError("The denominator cannot be 0.")
+
+    if not s:
+        d = 0
+
+    # check for rational case
+    sd = sqrt(d)
+    if sd.is_Integer:
+        return list(continued_fraction_iterator(Rational(p + s*sd, q)))
+
+    # irrational case with sd != Integer
+    if q < 0:
+        p, q, s = -p, -q, -s
+
+    n = (p + s*sd)/q
+    if n < 0:
+        w = floor(-n)
+        f = -n - w
+        one_f = continued_fraction(1 - f)  # 1-f < 1 so cf is [0 ... [...]]
+        one_f[0] -= w + 1
+        return one_f
+
+    d *= s**2
+    sd *= s
 
     if (d - p**2)%q:
         d *= q**2
@@ -84,9 +179,9 @@ def continued_fraction_periodic(p, q, d=0):
 
     while (p, q) not in pq:
         pq[(p, q)] = len(terms)
-        terms.append(int((p + sd)/q))
+        terms.append((p + sd)//q)
         p = terms[-1]*q - p
-        q = (d - p**2)/q
+        q = (d - p**2)//q
 
     i = pq[(p, q)]
     return terms[:i] + [terms[i:]]
@@ -124,7 +219,7 @@ def continued_fraction_reduce(cf):
     >>> continued_fraction_reduce([1, 4, 2, [3, 1]])
     (sqrt(21) + 287)/238
     >>> continued_fraction_reduce([[1]])
-    1/2 + sqrt(5)/2
+    (1 + sqrt(5))/2
     >>> from sympy.ntheory.continued_fraction import continued_fraction_periodic
     >>> continued_fraction_reduce(continued_fraction_periodic(8, 5, 13))
     (sqrt(13) + 8)/5
@@ -135,6 +230,7 @@ def continued_fraction_reduce(cf):
     continued_fraction_periodic
 
     """
+    from sympy.core.exprtools import factor_terms
     from sympy.core.symbol import Dummy
     from sympy.solvers import solve
 
@@ -158,9 +254,14 @@ def continued_fraction_reduce(cf):
         solns = solve(continued_fraction_reduce(period + [y]) - y, y)
         solns.sort()
         pure = solns[-1]
-        return a.subs(x, pure).radsimp()
+        rv = a.subs(x, pure).radsimp()
     else:
-        return a
+        rv = a
+    if rv.is_Add:
+        rv = factor_terms(rv)
+        if rv.is_Mul and rv.args[0] == -1:
+            rv = rv.func(*rv.args)
+    return rv
 
 
 def continued_fraction_iterator(x):

--- a/sympy/ntheory/tests/test_continued_fraction.py
+++ b/sympy/ntheory/tests/test_continued_fraction.py
@@ -3,11 +3,25 @@ from sympy.ntheory.continued_fraction import \
     (continued_fraction_periodic as cf_p,
      continued_fraction_iterator as cf_i,
      continued_fraction_convergents as cf_c,
-     continued_fraction_reduce as cf_r)
+     continued_fraction_reduce as cf_r,
+     continued_fraction as cf)
 from sympy.utilities.pytest import raises
 
 
 def test_continued_fraction():
+    assert cf_p(1, 1, 10, 0) == cf_p(1, 1, 0, 1)
+    assert cf_p(1, -1, 10, 1) == cf_p(-1, 1, 10, -1)
+    t = sqrt(2)
+    assert cf((1 + t)*(1 - t)) == cf(-1)
+    for n in [0, 2, S(2)/3, sqrt(2), 3*sqrt(2), 1 + 2*sqrt(3)/5,
+            (2 - 3*sqrt(5))/7, 1 + sqrt(2), (-5 + sqrt(17))/4]:
+        assert (cf_r(cf(n)) - n).expand() == 0
+        assert (cf_r(cf(-n)) + n).expand() == 0
+    raises(ValueError, lambda: cf(sqrt(2 + sqrt(3))))
+    raises(ValueError, lambda: cf(sqrt(2) + sqrt(3)))
+    raises(ValueError, lambda: cf(pi))
+    raises(ValueError, lambda: cf(.1))
+
     raises(ValueError, lambda: cf_p(1, 0, 0))
     raises(ValueError, lambda: cf_p(1, 1, -1))
     assert cf_p(4, 3, 0) == [1, 3]
@@ -53,3 +67,4 @@ def test_continued_fraction():
     assert (cf_r([0, 1, 1, 7, [24, 8]]) - (sqrt(3) + 2)/7).expand() == 0
     assert cf_r([1, 5, 9]) == S(55)/46
     assert (cf_r([[1]]) - (sqrt(5) + 1)/2).expand() == 0
+    assert cf_r([-3, 1, 1, [2]]) == -1 - sqrt(2)

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -1675,7 +1675,7 @@ def length(P, Q, D):
     >>> length(-2 , 4, 5) # (-2 + sqrt(5))/4
     3
     >>> length(-5, 4, 17) # (-5 + sqrt(17))/4
-    5
+    4
 
     See Also
     ========

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -273,11 +273,9 @@ def test_bf_pell():
 def test_length():
     assert length(2, 1, 0) == 1
     assert length(-2, 4, 5) == 3
-    assert length(-5, 4, 17) == 5
+    assert length(-5, 4, 17) == 4
     assert length(0, 4, 13) == 6
-    assert length(-31, 8, 613) == 69
     assert length(7, 13, 11) == 23
-    assert length(-40, 5, 23) == 4
     assert length(1, 6, 4) == 2
 
 

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -366,7 +366,7 @@ def test_G17():
 
 def test_G18():
     assert cf_p(1, 2, 5) == [[1]]
-    assert cf_r([[1]]) == S.Half + sqrt(5)/2
+    assert cf_r([[1]]).expand() == S.Half + sqrt(5)/2
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16922 
closes #16932

#### Brief description of what is fixed or changed

Provide a more user-friendly `continued_fraction` interface.

#### Other comments

This handles the details of computing the continued-fraction of expressions like `(2 + 3*sqrt(5))/7` and auto-detects Expr/list entry so the same function can be used to round-trip an expression.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- ntheory
    - `continued_fraction` now imports as a function instead of a module; the new function is a high-level interface to `continued_fraction_periodic` that allows the input of valid expressions like `(2 - 3*sqrt(5))/7 -> [-1, 3, [18, 2, 1, 1, 4, 10, 4, 1, 1, 2]]`
    - `continued_fraction_periodic` no longer returns continued fractions with more than negative number
<!-- END RELEASE NOTES -->
