### PR TITLE
modify Basic.__eq__ to detect dissimilar Numbers

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -806,9 +806,9 @@ def disambiguate(*iter):
     for k in mapping:
         # the first or only symbol doesn't get subscripted but make
         # sure that it's a Symbol, not a Dummy
-        k0 = Symbol("%s" % (k), **mapping[k][0].assumptions0)
-        if k != k0:
-            reps[mapping[k][0]] = k0
+        mapk0 = Symbol("%s" % (k), **mapping[k][0].assumptions0)
+        if mapping[k][0] != mapk0:
+            reps[mapping[k][0]] = mapk0
         # the others get subscripts (and are made into Symbols)
         skip = 0
         for i in range(1, len(mapping[k])):

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -5,7 +5,7 @@ import collections
 import sys
 
 from sympy.core.basic import (Basic, Atom, preorder_traversal, as_Basic,
-    _atomic)
+    _atomic, _aresame)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Symbol
 from sympy.core.function import Function, Lambda
@@ -20,6 +20,12 @@ b1 = Basic()
 b2 = Basic(b1)
 b3 = Basic(b2)
 b21 = Basic(b2, b1)
+
+
+def test__aresame():
+    assert not _aresame(Basic([]), Basic())
+    assert not _aresame(Basic([]), Basic(()))
+    assert not _aresame(Basic(2), Basic(2.))
 
 
 def test_structure():

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -94,7 +94,7 @@ def test_evalc():
 
 def test_pythoncomplex():
     x = Symbol("x")
-    assert 4j*x == 4*x*I
+    assert 4j*x != 4*x*I
     assert 4j*x == 4.0*x*I
     assert 4.1j*x != 4*x*I
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1687,10 +1687,13 @@ def test_Float_eq():
     assert Float(.75) == S(3)/4
     assert Float(5/18) == 5/18
     # 4473
-    assert t**2 == t**2.0
     assert Float(2.) != 3
     assert Float((0,1,-3)) == S(1)/8
     assert Float((0,1,-3)) != S(1)/9
+    # 16196
+    assert 2 == Float(2)  # as per Python
+    # but in a computation...
+    assert t**2 != t**2.0
 
 
 def test_int_NumberSymbols():

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -275,7 +275,7 @@ def test_issue_6100_12942_4473():
     assert x*y != (x*y)**1.0
     # Pow != Symbol
     assert (x**1.0)**1.0 != x
-    assert (x**1.0)**2.0 == x**2
+    assert (x**1.0)**2.0 != x**2
     b = Basic()
     assert Pow(b, 1.0, evaluate=False) != b
     # if the following gets distributed as a Mul (x**1.0*y**1.0 then

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -123,8 +123,8 @@ def test_sub():
 def test_pow():
     assert h**l == h**x == 1
     assert l**h == x**h == 2
-    assert x**l == 1/x
-    assert l**x == (-1)**x
+    assert (x**l).args == (1/x).args and (x**l).is_Pow
+    assert (l**x).args == ((-1)**x).args and (l**x).is_Pow
 
 
 def test_div():

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -433,8 +433,8 @@ def test_issue_8524():
     assert gamma(e - S.Half).is_positive is False
 
 def test_issue_14450():
-    assert uppergamma(S(3)/8, x).evalf() == uppergamma(0.375, x)
-    assert lowergamma(x, S(3)/8).evalf() == lowergamma(x, 0.375)
+    assert uppergamma(S(3)/8, x).evalf() == uppergamma(S(3)/8, x)
+    assert lowergamma(x, S(3)/8).evalf() == lowergamma(x, S(3)/8)
     # some values from Wolfram Alpha for comparison
     assert abs(uppergamma(S(3)/8, 2).evalf() - 0.07105675881) < 1e-9
     assert abs(lowergamma(S(3)/8, 2).evalf() - 2.2993794256) < 1e-9

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -294,7 +294,7 @@ def test_issue_3623():
 def test_issue_3664():
     n = Symbol('n', integer=True, nonzero=True)
     assert integrate(-1./2 * x * sin(n * pi * x/2), [x, -2, 0]) == \
-        2*cos(pi*n)/(pi*n)
+        2.0*cos(pi*n)/(pi*n)
     assert integrate(-Rational(1)/2 * x * sin(n * pi * x/2), [x, -2, 0]) == \
         2*cos(pi*n)/(pi*n)
 

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -163,8 +163,8 @@ def test_entropy():
 
     # test for density object
     ent = entropy(d)
-    assert entropy(d) == 0.5*log(2)
-    assert d.entropy() == 0.5*log(2)
+    assert entropy(d) == log(2)/2
+    assert d.entropy() == log(2)/2
 
     np = import_module('numpy', min_module_version='1.4.0')
     if np:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1537,9 +1537,8 @@ class FiniteSet(Set, EvalfMixin):
         else:
             args = list(map(sympify, args))
 
-        args = list(ordered(frozenset(tuple(args)), Set._infimum_key))
+        args = list(ordered(set(args), Set._infimum_key))
         obj = Basic.__new__(cls, *args)
-        obj._elements = frozenset(args)
         return obj
 
     def _eval_Eq(self, other):
@@ -1615,7 +1614,7 @@ class FiniteSet(Set, EvalfMixin):
 
         """
         r = false
-        for e in self._elements:
+        for e in self.args:
             # override global evaluation so we can use Eq to do
             # do the evaluation
             t = Eq(e, other, evaluate=True)
@@ -1657,12 +1656,9 @@ class FiniteSet(Set, EvalfMixin):
     def _eval_evalf(self, prec):
         return FiniteSet(*[elem._eval_evalf(prec) for elem in self])
 
-    def _hashable_content(self):
-        return (self._elements,)
-
     @property
     def _sorted_args(self):
-        return tuple(ordered(self.args, Set._infimum_key))
+        return self.args
 
     def _eval_powerset(self):
         return self.func(*[self.func(*s) for s in subsets(self.args)])

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -647,6 +647,8 @@ def test_finite_basic():
     assert A >= AandB and B >= AandB
     assert A > AandB and B > AandB
 
+    assert FiniteSet(1.0) == FiniteSet(1)
+
 
 def test_powerset():
     # EmptySet

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3256,7 +3256,7 @@ def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
     sol = Eq(f(x), C1 + g(x))
     assert checkodesol(eqn, sol, order=1, solve_for_func=False)[0]
-    assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x), hint='nth_algebraic'), dsolve(eqn, f(x), hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
     eqn = (diff(f(x)) - x)*(diff(f(x)) + x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16916 

#### Brief description of what is fixed or changed

`Float(2) == 2` but the use of Float in an Expr will test as unequal `x**2.0 != x**2`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - numbers still compare the same as they do in Python (`Float(1) == 1`) except when they appear in an Expression, e.g. `x**2.0 != x**2`
    - bugfix to `disambiguate` was made
- sets
    - `FiniteSet(1) == FiniteSet(1.0)`
<!-- END RELEASE NOTES -->
