### PR TITLE
[WIP] LFortran code printing

### DIFF
--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -1,0 +1,83 @@
+import lfortran.asr.asr as asr
+import lfortran.asr.builder as builder
+
+
+class ASRConverter():
+
+    def __init__(self):
+
+        # The translation unit that will be modified during the conversion
+        # process. Since this object is stateful, the intention is that each
+        # instance of this class is used only once.
+        self.translation_unit = builder.make_translation_unit()
+        self.type_integer = builder.make_type_integer()
+
+        # Variables that will be used in the body of a function declaration.
+        self.variables = []
+
+    def _convert(self, expr, **kwargs):
+        convertmethod = '_convert_' + type(expr).__name__
+        if hasattr(self, convertmethod):
+            return getattr(self, convertmethod)(expr, **kwargs)
+        else:
+            raise NotImplementedError("Conversion method %s not implemented." %
+                                      convertmethod)
+
+    def _convert_arith(self, expr, op):
+        "A generalized converter for binary arithmetic expressions."
+        terms = list(expr.args)
+
+        first_left = self._convert(terms[0])
+        first_right = self._convert(terms[1])
+
+        lf_node = builder.make_binop(first_left, op, first_right)
+
+        for term in terms[2:]:
+            converted_term = self._convert(term)
+            lf_node = builder.make_binop(lf_node, op, converted_term)
+
+        return lf_node
+
+    # Only works with Add and Mul so far
+    def _convert_Add(self, expr):
+        return self._convert_arith(expr, asr.Add())
+
+    def _convert_Mul(self, expr):
+        return self._convert_arith(expr, asr.Mul())
+
+    def _convert_Integer(self, expr):
+        return asr.Num(expr.p, type=self.type_integer)
+
+    _convert_One = _convert_Integer
+    _convert_Zero = _convert_Integer
+
+    def _convert_Symbol(self, expr):
+        sym_name = expr.name
+
+        # TODO: Symbols can also be assignments, in which case the intent
+        # should not be "in"
+        var = asr.Variable(name=sym_name, intent="in", type=self.type_integer)
+        self.variables.append(var)
+        return var
+
+    def wrap_function_definition(self, expr):
+        """Convert a sympy expression, wrapping it in a function definition."""
+
+        converted_expr = self._convert(expr)
+        f = builder.scope_add_function(self.translation_unit.global_scope, "f",
+                                       return_var="ret")
+        f.args = self.variables
+        ret = f.return_var
+
+        f.body.extend([asr.Assignment(ret, converted_expr)])
+        return self.translation_unit
+
+
+def sympy_to_asr(expr):
+    """Convert a Sympy expression to an Lfortran expression, either standalone or
+       wrapped in a function definition
+
+    """
+
+    converter = ASRConverter()
+    return converter.wrap_function_definition(expr)

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -11,6 +11,8 @@ class ASRConverter(CodePrinter):
 
     def __init__(self):
 
+        super(ASRConverter, self).__init__()
+
         # The translation unit that will be modified during the conversion
         # process. Since this object is stateful, the intention is that each
         # instance of this class is used only once.
@@ -63,7 +65,7 @@ class ASRConverter(CodePrinter):
         # Floating point numbers in LFortran are represented as strings.
         # LFortran supports the _dp suffix, so we default to double precision
         # for everything
-        printed = CodePrinter._print_Float(self, expr)
+        printed = super(CodePrinter, self)._print_Float(expr)
         return asr.Num("%s_dp" % printed, type=self.type_real)
 
     def _print_Rational(self, expr):

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -92,7 +92,7 @@ class ASRConverter(CodePrinter):
 
         # TODO: Symbols can also be assignments, in which case the intent
         # should not be "in"
-        var = asr.Variable(name=sym_name, intent="in", type=self.type_integer)
+        var = asr.Variable(name=sym_name, intent="in", type=self.type_real)
         self.variables.append(var)
         return var
 

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -1,4 +1,5 @@
 from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.str import StrPrinter
 
 from sympy.external import import_module
 
@@ -33,9 +34,9 @@ class ASRConverter(CodePrinter):
             raise NotImplementedError("Conversion method %s not implemented." %
                                       convertmethod)
 
-    def _print_arith(self, expr, op):
+    def _print_arith(self, expr, op, order=None):
         "A generalized converter for binary arithmetic expressions."
-        terms = list(expr.args)
+        terms = super(StrPrinter, self)._as_ordered_terms(expr, order)
 
         first_left = self._print(terms[0])
         first_right = self._print(terms[1])

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -34,9 +34,13 @@ class ASRConverter(CodePrinter):
             raise NotImplementedError("Conversion method %s not implemented." %
                                       convertmethod)
 
-    def _print_arith(self, expr, op, order=None):
+    def _print_arith(self, expr, op, ordered):
         "A generalized converter for binary arithmetic expressions."
-        terms = super(StrPrinter, self)._as_ordered_terms(expr, order)
+
+        if ordered:
+            terms = super(StrPrinter, self)._as_ordered_terms(expr, None)
+        else:
+            terms = list(expr.args)
 
         first_left = self._print(terms[0])
         first_right = self._print(terms[1])
@@ -51,10 +55,10 @@ class ASRConverter(CodePrinter):
 
     # Only works with Add and Mul so far
     def _print_Add(self, expr):
-        return self._print_arith(expr, asr.Add())
+        return self._print_arith(expr, asr.Add(), ordered=True)
 
     def _print_Mul(self, expr):
-        return self._print_arith(expr, asr.Mul())
+        return self._print_arith(expr, asr.Mul(), ordered=False)
 
     def _print_Integer(self, expr):
         return asr.Num(expr.p, type=self.type_integer)

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -1,8 +1,10 @@
+from sympy.printing.codeprinter import CodePrinter
+
 import lfortran.asr.asr as asr
 import lfortran.asr.builder as builder
 
 
-class ASRConverter():
+class ASRConverter(CodePrinter):
 
     def __init__(self):
 
@@ -15,43 +17,43 @@ class ASRConverter():
         # Variables that will be used in the body of a function declaration.
         self.variables = []
 
-    def _convert(self, expr, **kwargs):
-        convertmethod = '_convert_' + type(expr).__name__
+    def _print(self, expr, **kwargs):
+        convertmethod = '_print_' + type(expr).__name__
         if hasattr(self, convertmethod):
             return getattr(self, convertmethod)(expr, **kwargs)
         else:
             raise NotImplementedError("Conversion method %s not implemented." %
                                       convertmethod)
 
-    def _convert_arith(self, expr, op):
+    def _print_arith(self, expr, op):
         "A generalized converter for binary arithmetic expressions."
         terms = list(expr.args)
 
-        first_left = self._convert(terms[0])
-        first_right = self._convert(terms[1])
+        first_left = self._print(terms[0])
+        first_right = self._print(terms[1])
 
         lf_node = builder.make_binop(first_left, op, first_right)
 
         for term in terms[2:]:
-            converted_term = self._convert(term)
+            converted_term = self._print(term)
             lf_node = builder.make_binop(lf_node, op, converted_term)
 
         return lf_node
 
     # Only works with Add and Mul so far
-    def _convert_Add(self, expr):
-        return self._convert_arith(expr, asr.Add())
+    def _print_Add(self, expr):
+        return self._print_arith(expr, asr.Add())
 
-    def _convert_Mul(self, expr):
-        return self._convert_arith(expr, asr.Mul())
+    def _print_Mul(self, expr):
+        return self._print_arith(expr, asr.Mul())
 
-    def _convert_Integer(self, expr):
+    def _print_Integer(self, expr):
         return asr.Num(expr.p, type=self.type_integer)
 
-    _convert_One = _convert_Integer
-    _convert_Zero = _convert_Integer
+    _print_One = _print_Integer
+    _print_Zero = _print_Integer
 
-    def _convert_Symbol(self, expr):
+    def _print_Symbol(self, expr):
         sym_name = expr.name
 
         # TODO: Symbols can also be assignments, in which case the intent
@@ -63,7 +65,7 @@ class ASRConverter():
     def wrap_function_definition(self, expr):
         """Convert a sympy expression, wrapping it in a function definition."""
 
-        converted_expr = self._convert(expr)
+        converted_expr = self._print(expr)
         f = builder.scope_add_function(self.translation_unit.global_scope, "f",
                                        return_var="ret")
         f.args = self.variables

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -26,14 +26,6 @@ class ASRConverter(CodePrinter):
         # Variables that will be used in the body of a function declaration.
         self.variables = []
 
-    def _print(self, expr, **kwargs):
-        convertmethod = '_print_' + type(expr).__name__
-        if hasattr(self, convertmethod):
-            return getattr(self, convertmethod)(expr, **kwargs)
-        else:
-            raise NotImplementedError("Conversion method %s not implemented." %
-                                      convertmethod)
-
     def _print_arith(self, expr, op, ordered):
         "A generalized converter for binary arithmetic expressions."
 

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -1,7 +1,10 @@
 from sympy.printing.codeprinter import CodePrinter
 
-import lfortran.asr.asr as asr
-import lfortran.asr.builder as builder
+from sympy.external import import_module
+
+lfortran = import_module("lfortran")
+asr = lfortran.asr.asr
+builder = lfortran.asr.builder
 
 
 class ASRConverter(CodePrinter):

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -78,11 +78,15 @@ class ASRConverter(CodePrinter):
         return self.translation_unit
 
 
-def sympy_to_asr(expr):
-    """Convert a Sympy expression to an Lfortran expression, either standalone or
-       wrapped in a function definition
 
-    """
+def sympy_to_lfortran(expr):
+    """Convert a SymPy expression to an LFortran ASR expression."""
+    converter = ASRConverter()
+    return converter._print(expr)
 
+
+def sympy_to_lfortran_wrapped(expr):
+    """Convert a Sympy expression to an Lfortran expression, wrapping it in a
+       function definition."""
     converter = ASRConverter()
     return converter.wrap_function_definition(expr)

--- a/sympy/codegen/lfort.py
+++ b/sympy/codegen/lfort.py
@@ -61,6 +61,10 @@ class ASRConverter(CodePrinter):
     _print_One = _print_Integer
     _print_Zero = _print_Integer
 
+    def _print_NegativeOne(self, expr):
+        return asr.UnaryOp(asr.USub(), asr.Num(1, type=self.type_integer),
+                           self.type_integer)
+
     def _print_Float(self, expr):
         # Floating point numbers in LFortran are represented as strings.
         # LFortran supports the _dp suffix, so we default to double precision

--- a/sympy/codegen/tests/test_lfort.py
+++ b/sympy/codegen/tests/test_lfort.py
@@ -48,10 +48,11 @@ def ast_to_tuple(ast, expr_type):
     return to_tuple(ast)
 
 
-def asr_to_tuple(asr, expr_type):
-    return ast_to_tuple(lfortran.asr_to_ast(asr), expr_type)
+def lfort_tup(expr, expr_type):
+    out_asr = sympy_to_lfortran(expr)
+    return ast_to_tuple(lfortran.asr_to_ast(out_asr), expr_type)
 
 
-def src_to_tuple(src, expr_type):
-    return ast_to_tuple(lfortran.src_to_ast(src, translation_unit=False),
-                        expr_type)
+def fcode_tup(expr, expr_type):
+    return ast_to_tuple(lfortran.src_to_ast(fcode(expr),
+                                            translation_unit=False), expr_type)

--- a/sympy/codegen/tests/test_lfort.py
+++ b/sympy/codegen/tests/test_lfort.py
@@ -1,0 +1,57 @@
+from sympy.codegen.lfort import sympy_to_lfortran
+from sympy.external import import_module
+from sympy.printing.fcode import fcode
+lfortran = import_module("lfortran")
+
+
+class ModifiedVisitor(lfortran.semantic.analyze.ExprVisitor):
+
+    types = {
+        'real': lfortran.semantic.analyze.Real(),
+        'integer': lfortran.semantic.analyze.Integer()
+    }
+
+    def __init__(self, global_scope, expr_type):
+        self.curr_type = self.types[expr_type]
+        super().__init__(global_scope)
+
+    # NOTE: We need to override this method because the analyzer currently
+    # checks to see if a variable is bound within a scope. We'll be testing
+    # against single expressions (such as "x + 1"), so that definitely won't be
+    # the case
+    def visit_Name(self, node):
+        node._type = self.curr_type
+
+
+# Adapted from LFortran's test_parser.py
+def to_tuple(t):
+    if t is None or isinstance(t, (str, int, complex, float)):
+        return t
+    elif isinstance(t, list):
+        return [to_tuple(e) for e in t]
+    result = [t.__class__.__name__]
+    if t._fields is None:
+        return tuple(result)
+    elif isinstance(t, lfortran.ast.ast.Num):
+        result.append(to_tuple(t.o))
+    else:
+        for f in t._fields:
+            result.append(to_tuple(getattr(t, f)))
+    return tuple(result)
+
+
+def ast_to_tuple(ast, expr_type):
+    """Parse a Fortran expression, producing a tuple from the annotated AST."""
+    symbol_table = lfortran.semantic.analyze.create_symbol_table(ast)
+    visitor = ModifiedVisitor(symbol_table, expr_type)
+    visitor.visit(ast)
+    return to_tuple(ast)
+
+
+def asr_to_tuple(asr, expr_type):
+    return ast_to_tuple(lfortran.asr_to_ast(asr), expr_type)
+
+
+def src_to_tuple(src, expr_type):
+    return ast_to_tuple(lfortran.src_to_ast(src, translation_unit=False),
+                        expr_type)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This pull request adds functionality to convert a SymPy expression to an [LFortran](https://lfortran.org/) abstract syntax tree node. Fortran code may then be generated utilizing the LFortran library.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * add support for code generation through LFortran project
<!-- END RELEASE NOTES -->
