### PR TITLE
Fix lambdify not catching up module imports

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -744,6 +744,15 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                 # Cannot infer name with certainty. arg_# will have to do.
                 names.append('arg_' + str(n))
 
+    # Create the function definition code and execute it
+    funcname = '_lambdifygenerated'
+    if _module_present('tensorflow', namespaces):
+        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify)
+    else:
+        funcprinter = _EvaluatorPrinter(printer, dummify)
+    funcstr = funcprinter.doprint(funcname, args, expr)
+
+    # Collect the module imports from the code printers.
     imp_mod_lines = []
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():
         for k in keys:
@@ -754,17 +763,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
     # Provide lambda expression with builtins, and compatible implementation of range
     namespace.update({'builtins':builtins, 'range':range})
-
-    # Create the function definition code and execute it
-
-    funcname = '_lambdifygenerated'
-
-    if _module_present('tensorflow', namespaces):
-        funcprinter = _TensorflowEvaluatorPrinter(printer, dummify)
-    else:
-        funcprinter = _EvaluatorPrinter(printer, dummify)
-
-    funcstr = funcprinter.doprint(funcname, args, expr)
 
     funclocals = {}
     global _lambdify_generated_counter

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -28,7 +28,6 @@ MutableDenseMatrix = Matrix
 
 numpy = import_module('numpy')
 scipy = import_module('scipy')
-scipy_special = import_module('scipy.special')
 numexpr = import_module('numexpr')
 tensorflow = import_module('tensorflow')
 
@@ -1129,6 +1128,7 @@ def test_issue_15654():
     scipy_value = f(nv, lv, rv, Zv)
     assert abs(sympy_value - scipy_value) < 1e-15
 
+
 def test_issue_15827():
     if not numpy:
         skip("numpy not installed")
@@ -1154,3 +1154,13 @@ def test_issue_15827():
     assert numpy.array_equal(i(numpy.array([[1, 2, 3], [1, 2, 3]]), numpy.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]), \
     numpy.array([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])), numpy.array([[ 120, 240, 360, 480, 600], \
     [ 120, 240, 360, 480, 600]]))
+
+
+def test_issue_16930():
+    if not scipy:
+        skip("scipy not installed")
+
+    x = symbols("x")
+    f = lambda x:  S.GoldenRatio * x**2
+    f_ = lambdify(x, f(x), modules='scipy')
+    assert f_(1) == scipy.constants.golden_ratio


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16930

#### Brief description of what is fixed or changed

I think that there was an handler, but was not properly organized.
It should move after the actual printing is done.

I also think that things are inefficiently organized in lambdify, such as importing all the functions in `numpy` or `scipy` namespace even if only some are used. And it may have been the reason why some things are working without reason, while some thing had not worked.
But I think it may be separately fixed after this issue is resolved.

#### Other comments

I've also removed `scipy_special = import_module('scipy.special')` in tests, because it is not used anywhere.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - `lambdify` will properly catch up the submodules used in external module import.
<!-- END RELEASE NOTES -->
