### PR TITLE
Added case in derive_by_array for sparse array

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -206,10 +206,9 @@ def derive_by_array(expr, dx):
         if isinstance(dx, array_types):
             if isinstance(expr, SparseNDimArray):
                 lp = len(expr)
-                new_array = {k + i*lp: expr.diff(x)._sparse_array[k]
-                             for k in expr._sparse_array
+                new_array = {k + i*lp: v
                              for i, x in enumerate(dx)
-                             if k in expr.diff(x)._sparse_array.keys()}
+                             for k, v in expr.diff(x)._sparse_array.items()}
             else:
                 new_array = [[y.diff(x) for y in expr] for x in dx]
             return type(expr)(new_array, dx.shape + expr.shape)
@@ -220,6 +219,7 @@ def derive_by_array(expr, dx):
             return ImmutableDenseNDimArray([expr.diff(i) for i in dx], dx.shape)
         else:
             return diff(expr, dx)
+
 
 def permutedims(expr, perm):
     """

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -188,9 +188,7 @@ def derive_by_array(expr, dx):
 
     """
     from sympy.matrices import MatrixBase
-    from sympy.tensor.array import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
-
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)
         for i in dx:
@@ -198,7 +196,9 @@ def derive_by_array(expr, dx):
                 raise ValueError("cannot derive by this array")
 
     if isinstance(expr, array_types):
-        if not isinstance(expr, SparseNDimArray):
+        if isinstance(expr, NDimArray):
+            expr = expr.as_immutable()
+        else:
             expr = ImmutableDenseNDimArray(expr)
         if isinstance(dx, array_types):
             new_array = [[y.diff(x) for y in expr] for x in dx]

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -190,6 +190,7 @@ def derive_by_array(expr, dx):
     from sympy.matrices import MatrixBase
     from sympy.tensor import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
+
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)
         for i in dx:
@@ -209,11 +210,7 @@ def derive_by_array(expr, dx):
                 new_array = [[y.diff(x) for y in expr] for x in dx]
             return type(expr)(new_array, dx.shape + expr.shape)
         else:
-            if isinstance(expr, SparseNDimArray):
-                new_array = {k: v.diff(dx) for (k, v) in expr._sparse_array.items() if v.diff(dx)!= 0}
-                return type(expr)(new_array, expr.shape)
-            else:
-                return expr.diff(dx)
+            return expr.diff(dx)
     else:
         if isinstance(dx, array_types):
             return ImmutableDenseNDimArray([expr.diff(i) for i in dx], dx.shape)
@@ -227,7 +224,7 @@ def _sparse_array_derive_by_array(expr, dx):
     sparse_array = {}
     loop_size = len(expr)
     for i, x in enumerate(dx):
-        sparse_diff = derive_by_array(expr, x)._sparse_array
+        sparse_diff = expr.diff(x)._sparse_array
         for k in sparse_diff:
             sparse_array[k + i*loop_size] = sparse_diff[k]
     return sparse_array

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -188,6 +188,7 @@ def derive_by_array(expr, dx):
 
     """
     from sympy.matrices import MatrixBase
+    from sympy.tensor.array import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
 
     if isinstance(dx, array_types):
@@ -197,7 +198,8 @@ def derive_by_array(expr, dx):
                 raise ValueError("cannot derive by this array")
 
     if isinstance(expr, array_types):
-        expr = ImmutableDenseNDimArray(expr)
+        if not isinstance(expr, SparseNDimArray):
+            expr = ImmutableDenseNDimArray(expr)
         if isinstance(dx, array_types):
             new_array = [[y.diff(x) for y in expr] for x in dx]
             return type(expr)(new_array, dx.shape + expr.shape)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -132,38 +132,36 @@ class NDimArray(object):
         from sympy.tensor.array import SparseNDimArray
         from sympy import Dict
 
-        if shape is None and iterable is None:
-            shape = ()
-            iterable = ()
-        # Construction of a sparse array from a disctionary
-        elif shape is not None and isinstance(iterable, (dict, Dict)):
-            return shape, iterable
-        # Construction of a sparse array from a sparse array
-        elif shape is None and isinstance(iterable, SparseNDimArray):
-            return iterable._shape, iterable._sparse_array
-        # Construction from another `NDimArray`:
-        elif shape is None and isinstance(iterable, NDimArray):
-            shape = iterable.shape
-            iterable = list(iterable)
-        # Construct N-dim array from an iterable (numpy arrays included):
-        elif shape is None and isinstance(iterable, Iterable):
-            iterable, shape = cls._scan_iterable_shape(iterable)
+        if shape is None:
+            if iterable is None:
+                shape = ()
+                iterable = ()
+            # Construction of a sparse array from a sparse array
+            elif isinstance(iterable, SparseNDimArray):
+                return iterable._shape, iterable._sparse_array
+            # Construction from another `NDimArray`:
+            elif isinstance(iterable, NDimArray):
+                shape = iterable.shape
+                iterable = list(iterable)
+            # Construct N-dim array from an iterable (numpy arrays included):
+            elif isinstance(iterable, Iterable):
+                iterable, shape = cls._scan_iterable_shape(iterable)
 
-        # Construct N-dim array from a Matrix:
-        elif shape is None and isinstance(iterable, MatrixBase):
-            shape = iterable.shape
+            # Construct N-dim array from a Matrix:
+            elif isinstance(iterable, MatrixBase):
+                shape = iterable.shape
 
-        # Construct N-dim array from another N-dim array:
-        elif shape is None and isinstance(iterable, NDimArray):
-            shape = iterable.shape
+            # Construct N-dim array from another N-dim array:
+            elif isinstance(iterable, NDimArray):
+                shape = iterable.shape
+
+            else:
+                shape = ()
+                iterable = (iterable,)
 
         # Construct NDimArray(iterable, shape)
         elif shape is not None:
             pass
-
-        else:
-            shape = ()
-            iterable = (iterable,)
 
         if isinstance(shape, (SYMPY_INTS, Integer)):
             shape = (shape,)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -159,10 +159,6 @@ class NDimArray(object):
                 shape = ()
                 iterable = (iterable,)
 
-        # Construct NDimArray(iterable, shape)
-        elif shape is not None:
-            pass
-
         if isinstance(shape, (SYMPY_INTS, Integer)):
             shape = (shape,)
 
@@ -257,10 +253,15 @@ class NDimArray(object):
     def _eval_derivative_array(self, arg):
         from sympy import derive_by_array
         from sympy import Tuple
+        from sympy import SparseNDimArray
         from sympy.matrices.common import MatrixCommon
+
         if isinstance(arg, (Iterable, Tuple, MatrixCommon, NDimArray)):
             return derive_by_array(self, arg)
         else:
+            if isinstance(self, SparseNDimArray):
+                new_array = {k: v.diff(arg) for (k, v) in self._sparse_array.items() if v.diff(arg)!= 0}
+                return type(self)(new_array, self.shape)
             return self.applyfunc(lambda x: x.diff(arg))
 
     def applyfunc(self, f):

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -426,9 +426,19 @@ class NDimArray(object):
         >>> a == b
         False
         """
+        from sympy.tensor.array import SparseNDimArray
         if not isinstance(other, NDimArray):
             return False
-        return (self.shape == other.shape) and (list(self) == list(other))
+
+        if not self.shape == other.shape:
+            return False
+
+        if isinstance(self, SparseNDimArray) and isinstance(other, SparseNDimArray):
+            return self._sparse_array.keys() == other._sparse_array.keys() and \
+                   all(v == other._sparse_array[k] for (k, v) in self._sparse_array.items()
+                       if k in other._sparse_array)
+
+        return list(self) == list(other)
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Basic
+from sympy import S
 from sympy.core.expr import Expr
 from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify
@@ -276,7 +277,7 @@ class NDimArray(object):
         """
         from sympy.tensor.array import SparseNDimArray
 
-        if isinstance(self, SparseNDimArray) and f(sympify(0)) == 0:
+        if isinstance(self, SparseNDimArray) and f(S.Zero) == 0:
             return type(self)({k: f(v) for k, v in self._sparse_array.items() if f(v) != 0}, self.shape)
 
         return type(self)(map(f, self), self.shape)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -129,10 +129,18 @@ class NDimArray(object):
     @classmethod
     def _handle_ndarray_creation_inputs(cls, iterable=None, shape=None, **kwargs):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
+        from sympy import Dict
 
         if shape is None and iterable is None:
             shape = ()
             iterable = ()
+        # Construction of a sparse array from a disctionary
+        elif shape is not None and isinstance(iterable, (dict, Dict)):
+            return shape, iterable
+        # Construction of a sparse array from a sparse array
+        elif shape is None and isinstance(iterable, SparseNDimArray):
+            return iterable._shape, iterable._sparse_array
         # Construction from another `NDimArray`:
         elif shape is None and isinstance(iterable, NDimArray):
             shape = iterable.shape

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -109,7 +109,24 @@ class SparseNDimArray(NDimArray):
         if new_total_size != self._loop_size:
             raise ValueError("Invalid reshape parameters " + newshape)
 
-        return type(self)(*(newshape + (self._array,)))
+        return type(self)(*(newshape + (self._sparse_array,)))
+    
+    def _eval_derivative_n_times(self, s, n):
+        from sympy import Integer, Derivative
+        if isinstance(n, (int, Integer)):
+            s_a = self._sparse_array
+            for i in range(n):
+                s_a2 = {}
+                for key in s_a:
+                    value = _sympify(s_a[key])
+                    s_a2[key] = Derivative(value, s, **{'evaluate':True})
+                if s_a == s_a2 or s_a2 is None:
+                    break
+                s_a = s_a2
+            return type(self)(s_a, self._shape)
+        else:
+            return None
+                
 
 
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -109,7 +109,7 @@ class SparseNDimArray(NDimArray):
         if new_total_size != self._loop_size:
             raise ValueError("Invalid reshape parameters " + newshape)
 
-        return type(self)(*(newshape + (self._sparse_array,)))
+        return type(self)(*(newshape + (self._array,)))
 
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):
 

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -110,7 +110,7 @@ class SparseNDimArray(NDimArray):
             raise ValueError("Invalid reshape parameters " + newshape)
 
         return type(self)(*(newshape + (self._sparse_array,)))
-    
+
     def _eval_derivative_n_times(self, s, n):
         from sympy import Integer, Derivative
         if isinstance(n, (int, Integer)):
@@ -124,10 +124,6 @@ class SparseNDimArray(NDimArray):
                     break
                 s_a = s_a2
             return type(self)(s_a, self._shape)
-        else:
-            return None
-                
-
 
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):
 

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -111,42 +111,6 @@ class SparseNDimArray(NDimArray):
 
         return type(self)(*(newshape + (self._sparse_array,)))
 
-    def _eval_derivative_array(self, arg):
-        from sympy.core.compatibility import Iterable
-        from sympy.matrices.common import MatrixCommon
-        from sympy import Derivative
-        from sympy import Dict
-        from sympy import derive_by_array
-        if isinstance(arg, (Iterable, Tuple, MatrixCommon, NDimArray)):
-            return derive_by_array(self, arg)
-        else:
-            s_a = self._sparse_array
-            s_a2 = {}
-            for key in s_a:
-                value = _sympify(s_a[key])
-                deri = Derivative(value, arg, **{'evaluate':True})
-                if deri != 0:
-                    s_a2[key] = deri
-            return type(self)(Dict(s_a2), self._shape)
-
-    def __eq__(self, other):
-        if not isinstance(other, NDimArray):
-            return False
-
-        if self.shape != other.shape:
-            return False
-
-        if isinstance(other, SparseNDimArray):
-            from sympy import Dict
-            dict_self = Dict(self._sparse_array)
-            dict_other = Dict(other._sparse_array)
-            return dict_self == dict_other
-
-        return list(self) == list(other)
-
-    def __hash__(self):
-        return super(SparseNDimArray, self).__hash__()
-
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):
 
     def __new__(cls, iterable=None, shape=None, **kwargs):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -116,8 +116,9 @@ class SparseNDimArray(NDimArray):
         from sympy.matrices.common import MatrixCommon
         from sympy import Derivative
         from sympy import Dict
+        from sympy import derive_by_array
         if isinstance(arg, (Iterable, Tuple, MatrixCommon, NDimArray)):
-            return type(self)([self.diff(x) for x in arg])
+            return derive_by_array(self, arg)
         else:
             s_a = self._sparse_array
             s_a2 = {}

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -57,7 +57,7 @@ def test_tensorcontraction():
 
 def test_derivative_by_array():
     from sympy.abc import a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
-    from sympy.tensor.array import MutableSparseNDimArray
+    from sympy.tensor.array import MutableSparseNDimArray, ImmutableSparseNDimArray
 
     bexpr = x*y**2*exp(z)*log(t)
     sexpr = sin(bexpr)
@@ -89,8 +89,8 @@ def test_derivative_by_array():
     b = MutableSparseNDimArray.zeros(10000, 20000)
     b[0, 0] = i
     b[0, 1] = j
-    assert derive_by_array(b, i)._sparse_array == Dict({0: 1})
-    assert derive_by_array(b, (i, j))._sparse_array == Dict({0: 1, 200000001: 1})
+    assert derive_by_array(b, i) == ImmutableSparseNDimArray({0: 1}, (10000, 20000))
+    assert derive_by_array(b, (i, j)) == ImmutableSparseNDimArray({0: 1, 200000001: 1}, (2, 10000, 20000))
 
 
 def test_issue_emerged_while_discussing_10972():

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -6,7 +6,7 @@ from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
-from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff
+from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff, Dict
 from sympy.tensor.array import Array, NDimArray
 
 from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
@@ -57,6 +57,7 @@ def test_tensorcontraction():
 
 def test_derivative_by_array():
     from sympy.abc import a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+    from sympy.tensor.array import MutableSparseNDimArray
 
     bexpr = x*y**2*exp(z)*log(t)
     sexpr = sin(bexpr)
@@ -83,6 +84,13 @@ def test_derivative_by_array():
     assert diff(Array([[x, y], [z, t]]), Array([x, y])) == Array([[[1, 0], [0, 0]], [[0, 1], [0, 0]]])
     assert diff(Array([[x, y], [z, t]]), Array([[x, y], [z, t]])) == Array([[[[1, 0], [0, 0]], [[0, 1], [0, 0]]],
                                                                          [[[0, 0], [1, 0]], [[0, 0], [0, 1]]]])
+
+    # test for large scale sparse array
+    b = MutableSparseNDimArray.zeros(10000, 20000)
+    b[0, 0] = i
+    b[0, 1] = j
+    assert derive_by_array(b, i)._sparse_array == Dict({0: 1})
+    assert derive_by_array(b, (i, j))._sparse_array == Dict({0: 1, 200000001: 1})
 
 
 def test_issue_emerged_while_discussing_10972():

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -333,6 +333,10 @@ def test_diff_and_applyfunc():
     assert sdn == ImmutableSparseNDimArray([[x/2, y/2], [x*z/2, x*y*z/2]])
     assert sd != sdn
 
+    sdp = sd.applyfunc(lambda x: x+1)
+    assert sdp == ImmutableSparseNDimArray([[x + 1, y + 1], [x*z + 1, x*y*z + 1]])
+    assert sd != sdp
+
 
 def test_op_priority():
     from sympy.abc import x, y, z

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -131,6 +131,14 @@ def test_sparse():
     assert len(sparse_array._sparse_array) == 0
     assert sparse_array[0, 0] == 0
 
+    # test for large scale sparse array
+    a = MutableSparseNDimArray.zeros(100000, 200000)
+    b = MutableSparseNDimArray.zeros(100000, 200000)
+    assert a == b
+    a[1, 1] = 1
+    b[1, 1] = 2
+    assert a != b
+
 
 def test_calculation():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16941

#### Brief description of what is fixed or changed
The sparse array is cast to dense array while performing a derivation. Using directly sparse array will bring an improvement when it comes to a great dimension array whose value are mostly zeros. 
The sparse was cast to dense array for derivative by both **array** and **scalar**. 
Before:
```python
>>> a = MutableSparseNDimArray.zeros(10000, 20000)
>>> a[1, 1] = i
>>> a[1, 2] = j
>>> d = derive_by_array(a, i)
MemoryError
>>> d = derive_by_array(a, (i, j))
MemoryError
```
Now：
```python
>>> a = MutableSparseNDimArray.zeros(10000, 20000)
>>> a[1, 1] = i
>>> derive_by_array(a, i) = ImmutableSparseNDimArray({20001:1},(10000, 20000))
True
>>> a[1, 2] = j
>>> derive_by_array(a, (i, j)) == ImmutableSparseNDimArray({20001: 1, 200020002: 1},(2, 10000, 20000))
True
```

#### Other comments 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added specific case for sparse array in derive_by_array 
<!-- END RELEASE NOTES -->
