### PR TITLE
[GSoC] sympy.fps return a formal power series object for polynomial functions

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3824,6 +3824,10 @@ def test_sympy__series__formal__FormalPowerSeries():
     from sympy.series.formal import fps
     assert _test_args(fps(log(1 + x), x))
 
+def test_sympy__series__formal__Coeff():
+    from sympy.series.formal import fps
+    assert _test_args(fps(x**2 + x + 1, x))
+
 
 def test_sympy__simplify__hyperexpand__Hyper_Function():
     from sympy.simplify.hyperexpand import Hyper_Function

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -779,7 +779,11 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
                 result[2].subs(x, rep2 + rep2b))
 
     if f.is_polynomial(x):
-        return None
+        k= Dummy('k')
+        ak = sequence(Coeff(f, x, k), (k, 1, oo))
+        xk = sequence(x**k, (k, 0, oo))
+        ind = f.coeff(x, 0)
+        return ak, xk, ind
 
     #  Break instances of Add
     #  this allows application of different
@@ -899,6 +903,16 @@ def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
         dir = sympify(dir)
 
     return _compute_fps(f, x, x0, dir, hyper, order, rational, full)
+
+
+class Coeff(Function):
+    """
+    Coeff(p, x, n) represents the nth coefficient of the polynomial p in x
+    """
+    @classmethod
+    def eval(cls, p, x, n):
+        if p.is_polynomial(x) and n.is_integer:
+            return p.coeff(x, n)
 
 
 class FormalPowerSeries(SeriesBase):

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -779,7 +779,7 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
                 result[2].subs(x, rep2 + rep2b))
 
     if f.is_polynomial(x):
-        k= Dummy('k')
+        k = Dummy('k')
         ak = sequence(Coeff(f, x, k), (k, 1, oo))
         xk = sequence(x**k, (k, 0, oo))
         ind = f.coeff(x, 0)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -146,9 +146,16 @@ def test_fps():
     assert fps(2, x) == 2
     assert fps(2, x, dir='+') == 2
     assert fps(2, x, dir='-') == 2
-    assert fps(x**2 + x + 1) == x**2 + x + 1
     assert fps(1/x + 1/x**2) == 1/x + 1/x**2
     assert fps(log(1 + x), hyper=False, rational=False) == log(1 + x)
+
+    f = fps(x**2 + x + 1)
+    assert isinstance(f, FormalPowerSeries)
+    assert f.function == x**2 + x + 1
+    assert f[0] == 1
+    assert f[2] == x**2
+    assert f.truncate(4) == x**2 + x + 1 + O(x**4)
+    assert f.polynomial() == x**2 + x + 1
 
     f = fps(log(1 + x))
     assert isinstance(f, FormalPowerSeries)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #12310 (The issue which led to this PR)

Two former PR's --
Closes #13854
Closes #12324

#### Brief description of what is fixed or changed

**Formerly**, polynomial functions, when referenced through `fps`, did not return a `Formal Power Series` object, instead the function itself got returned.

```
>>> from sympy import Symbol, fps
>>> x = Symbol('x')
>>> p = fps(x ** 2)
>>> p
x**2
>>> type(p)
<class 'sympy.core.power.Pow'>
>>> p[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'Pow' object does not support indexing
```
I implemented the `Coeff` class according to the lines of Aaron's comment [here](https://github.com/sympy/sympy/issues/12310#issuecomment-286585230). Further integration of class methods and functions might be required into the class. Coefficient sequence of the formal power series of polynomial functions contains a `Coeff` object now.

**Now**, A `Formal Power Series` object gets returned.

```
>>> from sympy import Symbol, fps
>>> x = Symbol('x')
>>> p = fps(x ** 2)
>>> p
FormalPowerSeries(x**2 + x + 1, x, 0, 1, (SeqFormula(Coeff(x**2 + x + 1, x, _k), (_k, 1, oo)), SeqFormula(x**_k, (_k, 0, oo)), 1))
>>> p.truncate()
1 + x + x**2 + O(x**6)
>>> p[0]
1
```

#### Other comments


#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* series
    * sympy.fps returns a `Formal Power Series` object for `polynomial` functions.

<!-- END RELEASE NOTES -->
