### PR TITLE
Integral transform with symbolic bounds does not cause errors

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -21,6 +21,7 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
+from sympy.logic.boolalg import true
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
 from sympy.series import limit
@@ -259,7 +260,10 @@ class Integral(AddWithLimits):
         u = sympify(u)
         if isinstance(u, Expr):
             ufree = u.free_symbols
-            if len(ufree) != 1:
+            if len(ufree) == 0:
+                raise ValueError(filldedent('''
+                f(u) cannot be a constant'''))
+            if len(ufree) > 1:
                 raise ValueError(filldedent('''
                 When f(u) has more than one free symbol, the one replacing x
                 must be identified: pass f(u) as (f(u), u)'''))
@@ -272,6 +276,7 @@ class Integral(AddWithLimits):
                 a free symbol in expr, but symbol is not in expr's free
                 symbols.'''))
             if not isinstance(uvar, Symbol):
+                # This probably never evaluates to True
                 raise ValueError(filldedent('''
                 Expecting a tuple (expr, symbol) but didn't get
                 a symbol; got %s''' % uvar))
@@ -342,7 +347,7 @@ class Integral(AddWithLimits):
                 if len(xab) == 3:
                     a, b = xab[1:]
                     a, b = _calc_limit(a, b), _calc_limit(b, a)
-                    if a - b > 0:
+                    if (a - b > 0) in (True, true):
                         a, b = b, a
                         newfunc = -newfunc
                     newlimits.append((uvar, a, b))

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -7,6 +7,7 @@ from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import diff
+from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
 from sympy.core.numbers import oo, pi
 from sympy.core.relational import Ne
@@ -21,7 +22,6 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
-from sympy.logic.boolalg import true
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
 from sympy.series import limit
@@ -347,7 +347,7 @@ class Integral(AddWithLimits):
                 if len(xab) == 3:
                     a, b = xab[1:]
                     a, b = _calc_limit(a, b), _calc_limit(b, a)
-                    if (a - b > 0) in (True, true):
+                    if fuzzy_bool(a - b > 0):
                         a, b = b, a
                         newfunc = -newfunc
                     newlimits.append((uvar, a, b))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2,7 +2,7 @@ from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
     tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfc, erfi,
     EulerGamma, Expr, factor, Function, gamma, gammasimp, I, Idx, im, IndexedBase,
-    Integral, integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
+    integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
     symbols, sympify, tan, trigsimp, Tuple
@@ -416,6 +416,26 @@ def test_transform():
     i = Integral(x + y, (x, 1, 2), (y, 1, 2))
     assert i.transform(x, (x + 2*y, x)).doit() == \
         i.transform(x, (x + 2*z, x)).doit() == 3
+
+    i = Integral(x, (x, a, b))
+    assert i.transform(x, 2*s) == Integral(4*s, (s, a/2, b/2))
+    raises(ValueError, lambda: i.transform(x, 1))
+    raises(ValueError, lambda: i.transform(x, s*t))
+    raises(ValueError, lambda: i.transform(x, -s))
+    raises(ValueError, lambda: i.transform(x, (s, t)))
+    raises(ValueError, lambda: i.transform(2*x, 2*s))
+
+    i = Integral(x**2, (x, 1, 2))
+    raises(ValueError, lambda: i.transform(x**2, s))
+
+    am = Symbol('a', negative=True)
+    bp = Symbol('b', positive=True)
+    i = Integral(x, (x, bp, am))
+    i.transform(x, 2*s)
+    assert i.transform(x, 2*s) == Integral(-4*s, (s, am/2, bp/2))
+
+    i = Integral(x, (x, a))
+    assert i.transform(x, 2*s) == Integral(4*s, (s, a/2))
 
 
 def test_issue_4052():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -9,10 +9,10 @@ from sympy.integrals.transforms import (mellin_transform,
     InverseSineTransform, InverseCosineTransform, IntegralTransformError)
 from sympy import (
     gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi, arg,
-    cos, S, Abs, And, Or, sin, sqrt, I, log, tan, hyperexpand, meijerg,
+    cos, S, Abs, And, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, erfc, besselj, bessely, besseli, besselk,
-    exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
-    gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2, Abs)
+    exp_polar, unpolarify, Function, expint, expand_mul,
+    gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2)
 from sympy.utilities.pytest import XFAIL, slow, skip, raises
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier it was not possible to apply a transformation when the bounds where symbolic (although it worked in some special cases):

```
In [3]: i = Integral(x, (x, a, b))

In [4]: str(i.transform(x, 2*s))
Traceback (most recent call last):

  File "<ipython-input-4-f25746ea1999>", line 1, in <module>
    str(i.transform(x, 2*s))

  File "/nobackup/data/sympy/sympy/integrals/integrals.py", line 345, in transform
    if a - b > 0:

  File "/nobackup/data/sympy/sympy/core/relational.py", line 310, in __nonzero__
    raise TypeError("cannot determine truth value of Relational")

TypeError: cannot determine truth value of Relational
```

This was caused by a comparison to determine which bound is upper and lower that could not evaluate and caused an error. However, as the integral will still be correct and evaluate to the correct value even if the bounds are changed, now, the bounds are swapped if it can be determined that they are in the wrong order but kept if not.

```
In [19]: i = Integral(x, (x, a, b))

In [20]: str(i.transform(x, 2*s))
Out[20]: 'Integral(4*s, (s, a/2, b/2))'
```


#### Other comments
Also improved the error text for one case, removed some imports from test_transforms.py and increased the test coverage a bit for integrals.py

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
   * Symbolic bounds do not cause errors when doing variable transformations.
<!-- END RELEASE NOTES -->
