### PR TITLE
Improved code in Expr.__lt__ and similar functions in Expr

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -305,7 +305,7 @@ class Expr(Basic, EvalfMixin):
                     return S.true
             if (self.is_infinite and self.is_extended_nonnegative) \
                     or (other.is_infinite and other.is_extended_nonpositive):
-                return S.false
+                return S.true
             nneg = (self - other).is_extended_nonnegative
             if nneg is not None:
                 return sympify(nneg)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -362,7 +362,7 @@ class Expr(Basic, EvalfMixin):
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 < 0)
-        if self.is_extended_real or other.is_extended_real:
+        if self.is_extended_real and other.is_extended_real:
             dif = self - other
             if dif.is_extended_negative is not None and \
                     dif.is_extended_negative is not dif.is_extended_nonnegative:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -299,11 +299,16 @@ class Expr(Basic, EvalfMixin):
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 >= 0)
-        if self.is_extended_real or other.is_extended_real:
-            dif = self - other
-            if dif.is_extended_nonnegative is not None and \
-                    dif.is_extended_nonnegative is not dif.is_extended_negative:
-                return sympify(dif.is_extended_nonnegative)
+        if self.is_extended_real and other.is_extended_real:
+            if self.is_infinite and other.is_infinite:
+                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
+                    return S.true
+            if (self.is_infinite and self.is_extended_nonnegative) \
+                    or (other.is_infinite and other.is_extended_nonpositive):
+                return S.false
+            nneg = (self - other).is_extended_nonnegative
+            if nneg is not None:
+                return sympify(nneg)
         return GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
@@ -320,11 +325,16 @@ class Expr(Basic, EvalfMixin):
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 <= 0)
-        if self.is_extended_real or other.is_extended_real:
-            dif = self - other
-            if dif.is_extended_nonpositive is not None and \
-                    dif.is_extended_nonpositive is not dif.is_extended_positive:
-                return sympify(dif.is_extended_nonpositive)
+        if self.is_extended_real and other.is_extended_real:
+            if self.is_infinite and other.is_infinite:
+                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
+                    return S.true
+            if (self.is_infinite and self.is_extended_nonpositive) \
+                    or (other.is_infinite and other.is_extended_nonnegative):
+                return S.true
+            npos = (self - other).is_extended_nonpositive
+            if npos is not None:
+                return sympify(npos)
         return LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
@@ -341,11 +351,18 @@ class Expr(Basic, EvalfMixin):
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 > 0)
-        if self.is_extended_real or other.is_extended_real:
-            dif = self - other
-            if dif.is_extended_positive is not None and \
-                    dif.is_extended_positive is not dif.is_extended_nonpositive:
-                return sympify(dif.is_extended_positive)
+
+        if self.is_extended_real and other.is_extended_real:
+            if self.is_infinite and other.is_infinite:
+                if (self * other).is_extended_positive: # inf > inf & -inf > -inf
+                    return S.false
+
+            if (self.is_infinite and self.is_extended_nonpositive) \
+                    or (other.is_infinite and other.is_extended_nonnegative):
+                return S.false
+            pos = (self - other).is_extended_positive
+            if pos is not None:
+                return sympify(pos)
         return StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
@@ -363,10 +380,15 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 < 0)
         if self.is_extended_real and other.is_extended_real:
-            dif = self - other
-            if dif.is_extended_negative is not None and \
-                    dif.is_extended_negative is not dif.is_extended_nonnegative:
-                return sympify(dif.is_extended_negative)
+            if self.is_infinite and other.is_infinite:
+                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
+                    return S.false
+            if (self.is_infinite and self.is_extended_nonnegative) \
+                    or (other.is_infinite and other.is_extended_nonpositive):
+                return S.false
+            neg = (self - other).is_extended_negative
+            if neg is not None:
+                return sympify(neg)
         return StrictLessThan(self, other, evaluate=False)
 
     def __trunc__(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -300,8 +300,8 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 >= 0)
         if self.is_extended_real and other.is_extended_real:
-            if (self.is_infinite and self.is_extended_nonnegative) \
-                    or (other.is_infinite and other.is_extended_nonpositive):
+            if (self.is_infinite and self.is_extended_positive) \
+                    or (other.is_infinite and other.is_extended_negative):
                 return S.true
             nneg = (self - other).is_extended_nonnegative
             if nneg is not None:
@@ -323,8 +323,8 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 <= 0)
         if self.is_extended_real and other.is_extended_real:
-            if (self.is_infinite and self.is_extended_nonpositive) \
-                    or (other.is_infinite and other.is_extended_nonnegative):
+            if (self.is_infinite and self.is_extended_negative) \
+                    or (other.is_infinite and other.is_extended_positive):
                 return S.true
             npos = (self - other).is_extended_nonpositive
             if npos is not None:
@@ -347,8 +347,8 @@ class Expr(Basic, EvalfMixin):
             return _sympify(n2 > 0)
 
         if self.is_extended_real and other.is_extended_real:
-            if (self.is_infinite and self.is_extended_nonpositive) \
-                    or (other.is_infinite and other.is_extended_nonnegative):
+            if (self.is_infinite and self.is_extended_negative) \
+                    or (other.is_infinite and other.is_extended_positive):
                 return S.false
             pos = (self - other).is_extended_positive
             if pos is not None:
@@ -370,8 +370,8 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 < 0)
         if self.is_extended_real and other.is_extended_real:
-            if (self.is_infinite and self.is_extended_nonnegative) \
-                    or (other.is_infinite and other.is_extended_nonpositive):
+            if (self.is_infinite and self.is_extended_positive) \
+                    or (other.is_infinite and other.is_extended_negative):
                 return S.false
             neg = (self - other).is_extended_negative
             if neg is not None:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -300,9 +300,6 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 >= 0)
         if self.is_extended_real and other.is_extended_real:
-            if self.is_infinite and other.is_infinite:
-                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
-                    return S.true
             if (self.is_infinite and self.is_extended_nonnegative) \
                     or (other.is_infinite and other.is_extended_nonpositive):
                 return S.true
@@ -326,9 +323,6 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 <= 0)
         if self.is_extended_real and other.is_extended_real:
-            if self.is_infinite and other.is_infinite:
-                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
-                    return S.true
             if (self.is_infinite and self.is_extended_nonpositive) \
                     or (other.is_infinite and other.is_extended_nonnegative):
                 return S.true
@@ -353,10 +347,6 @@ class Expr(Basic, EvalfMixin):
             return _sympify(n2 > 0)
 
         if self.is_extended_real and other.is_extended_real:
-            if self.is_infinite and other.is_infinite:
-                if (self * other).is_extended_positive: # inf > inf & -inf > -inf
-                    return S.false
-
             if (self.is_infinite and self.is_extended_nonpositive) \
                     or (other.is_infinite and other.is_extended_nonnegative):
                 return S.false
@@ -380,9 +370,6 @@ class Expr(Basic, EvalfMixin):
         if n2 is not None:
             return _sympify(n2 < 0)
         if self.is_extended_real and other.is_extended_real:
-            if self.is_infinite and other.is_infinite:
-                if (self * other).is_extended_positive:  # inf < inf & -inf < -inf
-                    return S.false
             if (self.is_infinite and self.is_extended_nonnegative) \
                     or (other.is_infinite and other.is_extended_nonpositive):
                 return S.false

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1845,9 +1845,11 @@ def test_issue_7426():
     assert f1.equals(f2) is None
 
 
-def test_issue_1112():
-    # x = Symbol('x', extended_positive=False)
-    # assert (x > 0) is S.false
+def test_issue_11122():
+    x = Symbol('x', extended_positive=False)
+    assert (x > 0) is not S.false
+    # (x > 0) should remain unevaluated after PR #16956
+
     x = Symbol('x', positive=False, real=True)
     assert (x > 0) is S.false
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1846,8 +1846,8 @@ def test_issue_7426():
 
 
 def test_issue_1112():
-    x = Symbol('x', extended_positive=False)
-    assert (x > 0) is S.false
+    # x = Symbol('x', extended_positive=False)
+    # assert (x > 0) is S.false
     x = Symbol('x', positive=False, real=True)
     assert (x > 0) is S.false
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -5,8 +5,8 @@ from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, 
                    simplify, together, collect, factorial, apart, combsimp, factor, refine,
                    cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
                    exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr,
-                   integrate, gammasimp)
-from sympy.core.expr import ExprBuilder
+                   integrate, gammasimp, Gt)
+from sympy.core.expr import ExprBuilder, unchanged
 from sympy.core.function import AppliedUndef
 from sympy.core.compatibility import range, round, PY3
 from sympy.physics.secondquant import FockState
@@ -1847,7 +1847,7 @@ def test_issue_7426():
 
 def test_issue_11122():
     x = Symbol('x', extended_positive=False)
-    assert (x > 0) is not S.false
+    assert unchanged(Gt, x, 0)  # (x > 0)
     # (x > 0) should remain unevaluated after PR #16956
 
     x = Symbol('x', positive=False, real=True)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -849,10 +849,10 @@ def test_holes():
     # this also tests that the integrate method is used on non-Piecwise
     # arguments in _eval_integral
     A, B = symbols("A B")
-    a, b = symbols('a b', finite=True)
+    a, b = symbols('a b', real=True)
     assert Piecewise((A, And(x < 0, a < 1)), (B, Or(x < 1, a > 2))
         ).integrate(x) == Piecewise(
-        (B*x, a > 2),
+        (B*x, (a > 2)),
         (Piecewise((A*x, x < 0), (B*x, x < 1), (nan, True)), a < 1),
         (Piecewise((B*x, x < 1), (nan, True)), True))
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -776,7 +776,7 @@ def test_multivariate_bool_as_set():
 
 
 def test_all_or_nothing():
-    x = symbols('x', real=True)
+    x = symbols('x', extended_real=True)
     args = x >= -oo, x <= oo
     v = And(*args)
     if v.func is And:

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -2,7 +2,7 @@
 
 from sympy import (And, Eq, FiniteSet, Ge, Gt, Interval, Le, Lt, Ne, oo, I,
                    Or, S, sin, cos, tan, sqrt, Symbol, Union, Integral, Sum,
-                   Function, Poly, PurePoly, pi, root, log, exp, Dummy, Abs)
+                   Function, Poly, PurePoly, pi, root, log, exp, Dummy, Abs, Piecewise)
 from sympy.solvers.inequalities import (reduce_inequalities,
                                         solve_poly_inequality as psolve,
                                         reduce_rational_inequalities,
@@ -389,7 +389,7 @@ def test_issue_10198():
 def test_issue_10047():
     # this must remain an inequality, not True, since if x
     # is not real the inequality is invalid
-    assert solve(sin(x) < 2) == (x <= oo)
+    assert solve(sin(x) < 2) == True
 
 
 def test_issue_10268():

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -387,8 +387,11 @@ def test_issue_10198():
 
 
 def test_issue_10047():
-    # this must remain an inequality, not True, since if x
+    # issue 10047: this must remain an inequality, not True, since if x
     # is not real the inequality is invalid
+    # assert solve(sin(x) < 2) == (x <= oo)
+
+    # with PR 16956, (x <= oo) autoevaluates when x is extended_real
     assert solve(sin(x) < 2) == True
 
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -33,15 +33,15 @@ x, y, z = map(Symbol, 'xyz')
 
 
 def test_single_normal():
-    mu = Symbol('mu', extended_real=True)
-    sigma = Symbol('sigma', extended_positive=True)
+    mu = Symbol('mu', real=True)
+    sigma = Symbol('sigma', positive=True)
     X = Normal('x', 0, 1)
     Y = X*sigma + mu
 
     assert E(Y) == mu
     assert variance(Y) == sigma**2
     pdf = density(Y)
-    x = Symbol('x')
+    x = Symbol('x', real=True)
     assert (pdf(x) ==
             2**S.Half*exp(-(mu - x)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -33,8 +33,8 @@ x, y, z = map(Symbol, 'xyz')
 
 
 def test_single_normal():
-    mu = Symbol('mu', real=True)
-    sigma = Symbol('sigma', positive=True)
+    mu = Symbol('mu', extended_real=True)
+    sigma = Symbol('sigma', extended_positive=True)
     X = Normal('x', 0, 1)
     Y = X*sigma + mu
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16915 and #16582


#### Brief description of what is fixed or changed
With this, the Relational expressions evaluate in the certain conditions.
```py
>>> from sympy import *
>>> from sympy.abc import x,y,z
>>> a = symbols('a', extended_real =True)
>>> a > oo # since a can be real or oo both results in False
False
>>> a < oo
a < oo
>>> b = symbols('b', extended_positive=False)
>>> b > 0
b > 0
>>>
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * improved code in Expr.\__lt\__ and other functions. 
<!-- END RELEASE NOTES -->
