### PR TITLE
Fix diffx for cached solutions in nth_algebraic

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4092,9 +4092,12 @@ def ode_nth_order_reducible(eq, func, order, match):
 # This needs to produce an invertible function but the inverse depends
 # which variable we are integrating with respect to. Since the class can
 # be stored in cached results we need to ensure that we always get the
-# same class back for each particular integration variable.
-def _nth_algebraic_diffx(var, _stored={}):
-    cls = _stored.get(var, None)
+# same class back for each particular integration variable so we store these
+# classes in a global dict:
+_nth_algebraic_diffx_stored = {}
+
+def _nth_algebraic_diffx(var):
+    cls = _nth_algebraic_diffx_stored.get(var, None)
 
     if cls is None:
         # A class that behaves like Derivative wrt var but is "invertible".
@@ -4105,7 +4108,7 @@ def _nth_algebraic_diffx(var, _stored={}):
                 # is at work.
                 return lambda expr: Integral(expr, var) + Dummy('C')
 
-        _stored[var] = cls = diffx
+        cls = _nth_algebraic_diffx_stored.setdefault(var, diffx)
 
     return cls
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4089,6 +4089,25 @@ def ode_nth_order_reducible(eq, func, order, match):
 
     return fsol
 
+# This needs to produce an invertible function but the inverse depends
+# which variable we are integrating with respect to. Since the class can
+# be stored in cached results we need to ensure that we always get the
+# same class back for each particular integration variable.
+def _nth_algebraic_diffx(var, _stored={}):
+    cls = _stored.get(var, None)
+
+    if cls is None:
+        # A class that behaves like Derivative wrt var but is "invertible".
+        class diffx(Function):
+            def inverse(self):
+                # don't use integrate here because fx has been replaced by _t
+                # in the equation; integrals will not be correct while solve
+                # is at work.
+                return lambda expr: Integral(expr, var) + Dummy('C')
+
+        _stored[var] = cls = diffx
+
+    return cls
 
 def _nth_algebraic_match(eq, func):
     r"""
@@ -4099,18 +4118,11 @@ def _nth_algebraic_match(eq, func):
     solution (apart from evaluating the integrals).
     """
 
-    # Each integration should generate a different constant
-    constants = iter_numbered_constants(eq)
-    constant = lambda: next(constants, None)
+    # The independent variable
+    var = func.args[0]
 
-    # A class that behaves like Derivative but is "invertible"
-    class diffx(Function):
-        isadiffx = True  # apparently not needed for PY3
-        def inverse(self):
-            # don't use integrate here because fx has been replaced by _t
-            # in the equation; integrals will not be correct while solve
-            # is at work.
-            return lambda expr: Integral(expr, var) + constant()
+    # Derivative that solve can handle:
+    diffx = _nth_algebraic_diffx(var)
 
     # Replace derivatives wrt the independent variable with diffx
     def replace(eq, var):
@@ -4127,18 +4139,9 @@ def _nth_algebraic_match(eq, func):
         return eq.replace(Derivative, expand_diffx)
 
     # Restore derivatives in solution afterwards
-    from sympy.core.compatibility import PY3
     def unreplace(eq, var):
-        if PY3:
-            return eq.replace(diffx, lambda e: Derivative(e, var))
-        else:
-            from sympy.core.rules import Transform
-            return eq.xreplace(Transform(
-                lambda dx: Derivative(dx.args[0], var),
-                lambda dx: getattr(dx, 'isadiffx', None)))
+        return eq.replace(diffx, lambda e: Derivative(e, var))
 
-    # The independent variable
-    var = func.args[0]
     subs_eqn = replace(eq, var)
     try:
         # turn off simplification to protect Integrals that have


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/pull/16924#discussion_r289663106

#### Brief description of what is fixed or changed

Move the diffx class into a function that always returns the same class for the same integration variable. This should mean that it plays nicely with the cache.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
