### PR TITLE
Allowed Dict and dict in ArrayComprehension

### DIFF
--- a/sympy/tensor/array/array_comprehension.py
+++ b/sympy/tensor/array/array_comprehension.py
@@ -5,7 +5,7 @@ from sympy.core.expr import Expr
 from sympy.core import Basic
 from sympy.core.compatibility import Iterable
 from sympy.tensor.array import MutableDenseNDimArray, ImmutableDenseNDimArray
-from sympy import Symbol
+from sympy import Symbol, Dict
 from sympy.core.sympify import sympify
 from sympy.core.numbers import Integer
 
@@ -257,6 +257,12 @@ class ArrayComprehension(Basic):
         list_gen = self._function
         for var, inf, sup in reversed(self._limits):
             list_expr = list_gen
+            if isinstance(list_expr, Dict) or isinstance(list_expr, dict):
+                list_expr = Dict(list_expr)
+                list_gen = dict()
+                for val in range(inf, sup+1):
+                    list_gen.update(list_expr.subs(var, val))
+                return Dict(list_gen)
             list_gen = []
             for val in range(inf, sup+1):
                 if not isinstance(list_expr, Iterable):

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -1,8 +1,9 @@
 from sympy.tensor.array.array_comprehension import ArrayComprehension
 from sympy.tensor.array import ImmutableDenseNDimArray
-from sympy.abc import i, j, k, l, n
+from sympy import symbols, Dict
 from sympy.utilities.pytest import raises
 
+i, j, k, l, n = symbols('i j k l n')
 
 def test_array_comprehension():
     a = ArrayComprehension(i*j, (i, 1, 3), (j, 2, 4))
@@ -10,6 +11,8 @@ def test_array_comprehension():
     c = ArrayComprehension(i+j+k+l, (i, 1, 2), (j, 1, 3), (k, 1, 4), (l, 1, 5))
     d = ArrayComprehension(k, (i, 1, 5))
     e = ArrayComprehension(i, (j, k+1, k+5))
+    f = ArrayComprehension(Dict((k, k**2)), (k, i, j))
+    g = ArrayComprehension({k: k**2}, (k, i, j))
     assert a.doit().tolist() == [[2, 3, 4], [4, 6, 8], [6, 9, 12]]
     assert a.shape == (3, 3)
     assert a.is_numeric == True
@@ -35,6 +38,10 @@ def test_array_comprehension():
     assert c.bound_symbols == [i, j, k, l]
     assert d.doit().tolist() == [k, k, k, k, k]
     assert len(e) == 5
+    assert isinstance(f.subs(i, 0), ArrayComprehension)
+    assert str(f.subs(i, 0).subs(j, 5).doit()) == '{0: 0, 1: 1, 2: 4, 3: 9, 4: 16, 5: 25}'
+    assert isinstance(g.subs(i, 0), ArrayComprehension)
+    assert str(g.subs(i, 0).subs(j, 5).doit()) == '{0: 0, 1: 1, 2: 4, 3: 9, 4: 16, 5: 25}'
     raises(TypeError, lambda: ArrayComprehension(i*j, (i, 1, 3), (j, 2, [1, 3, 2])))
     raises(ValueError, lambda: ArrayComprehension(i*j, (i, 1, 3), (j, 2, 1)))
     raises(ValueError, lambda: ArrayComprehension(i*j, (i, 1, 3), (j, 2, j+1)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16944 
Related to https://github.com/sympy/sympy/pull/16815#issuecomment-498044725

#### Brief description of what is fixed or changed
At present unevaluated dictionary is not allowed in SymPy.
With this PR following are possible:
```python
>>> a = ArrayComprehension(Dict((k, k**2)), (k, 0, i))
>>> a.subs(i, 5).doit()
{0: 0, 1: 1, 2: 4, 3: 9, 4: 16, 5: 25}

>>> # Multiple symbols in dictionary and multiple variables in range
>>> a = ArrayComprehension(Dict((k + k**i, k**2)), (k, i, j))
>>> a.subs(i, 0).subs(j, 5).doit()
{1: 0, 2: 1, 3: 4, 4: 9, 5: 16, 6: 25}

>>> # dict is also allowed
>>> a = ArrayComprehension({k: k**2}, (k, 0, i)}
>>> a.subs(i, 5).doit()
{0: 0, 1: 1, 2: 4, 3: 9, 4: 16, 5: 25}
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- tensor
    - `Dict` and `dict` can be passed to `ArrayComprehension` in `sympy/tensor/array/array_comprehension.py`
<!-- END RELEASE NOTES -->
