### PR TITLE
S(dict) -> Dict

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -42,7 +42,7 @@ Moved modules:
     * `reduce()`
     * `StringIO()`
     * `cStringIO()` (same as `StingIO()` in Python 3)
-    * Python 2 `__builtins__`, access with Python 3 name, `builtins`
+    * Python 2 `__builtin__`, access with Python 3 name, `builtins`
 
 Iterator/list changes:
     * `xrange` renamed as `range` in Python 3, import `range` for Python 2/3

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function, division
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range, MutableSet
@@ -268,6 +268,9 @@ class Dict(Basic):
         from sympy.utilities import default_sort_key
         return tuple(sorted(self.args, key=default_sort_key))
 
+
+# this handles dict, defaultdict, OrderedDict
+converter[dict] = lambda d: Dict(*d.items())
 
 class OrderedSet(MutableSet):
     def __init__(self, iterable=None):

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1536,4 +1536,6 @@ def N(x, n=15, **options):
     1.291
 
     """
-    return sympify(x).evalf(n, **options)
+    # by using rational=True, any evaluation of a string
+    # will be done using exact values for the Floats
+    return sympify(x, rational=True).evalf(n, **options)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3010,7 +3010,7 @@ def count_ops(expr, visual=False):
             if not a.is_Symbol:
                 args.extend(a.args)
 
-    elif type(expr) is dict:
+    elif isinstance(expr, Dict):
         ops = [count_ops(k, visual=visual) +
                count_ops(v, visual=visual) for k, v in expr.items()]
     elif iterable(expr):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -298,7 +298,7 @@ class AssocOp(Basic):
         was a number with no functions it would have been evaluated, but
         it wasn't so we must judiciously extract the numbers and reconstruct
         the object. This is *not* simply replacing numbers with evaluated
-        numbers. Nunmbers should be handled in the largest pure-number
+        numbers. Numbers should be handled in the largest pure-number
         expression as possible. So the code below separates ``self`` into
         number and non-number parts and evaluates the number parts and
         walks the args of the non-number part recursively (doing the same

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -89,7 +89,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
        - standard numeric python types: int, long, float, Decimal
        - strings (like "0.09" or "2e-19")
        - booleans, including ``None`` (will leave ``None`` unchanged)
-       - lists, sets or tuples containing any of the above
+       - dict, lists, sets or tuples containing any of the above
 
     .. warning::
         Note that this function uses ``eval``, and thus shouldn't be used on
@@ -241,6 +241,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     Notes
     =====
+
+    The keywords ``rational`` and ``convert_xor`` are only used
+    when the input is a string.
 
     Sometimes autosimplification during sympification results in expressions
     that are very different in structure than what was entered. Until such

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -259,11 +259,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     -2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x))) - 1
 
     """
-    if evaluate is None:
-        if global_evaluate[0] is False:
-            evaluate = global_evaluate[0]
-        else:
-            evaluate = True
     try:
         if a in sympy_classes:
             return a
@@ -274,20 +269,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         cls = type(a) # Probably an old-style class
     if cls in sympy_classes:
         return a
-    if cls is type(None):
-        if strict:
-            raise SympifyError(a)
-        else:
-            return a
 
-    # Support for basic numpy datatypes
-    # Note that this check exists to avoid importing NumPy when not necessary
-    if type(a).__module__ == 'numpy':
-        import numpy as np
-        if np.isscalar(a):
-            return _convert_numpy_types(a, locals=locals,
-                convert_xor=convert_xor, strict=strict, rational=rational,
-                evaluate=evaluate)
+    if isinstance(a, CantSympify):
+        raise SympifyError(a)
 
     try:
         return converter[cls](a)
@@ -298,8 +282,26 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             except KeyError:
                 continue
 
-    if isinstance(a, CantSympify):
-        raise SympifyError(a)
+    if cls is type(None):
+        if strict:
+            raise SympifyError(a)
+        else:
+            return a
+
+    if evaluate is None:
+        if global_evaluate[0] is False:
+            evaluate = global_evaluate[0]
+        else:
+            evaluate = True
+
+    # Support for basic numpy datatypes
+    # Note that this check exists to avoid importing NumPy when not necessary
+    if type(a).__module__ == 'numpy':
+        import numpy as np
+        if np.isscalar(a):
+            return _convert_numpy_types(a, locals=locals,
+                convert_xor=convert_xor, strict=strict, rational=rational,
+                evaluate=evaluate)
 
     _sympy_ = getattr(a, "_sympy_", None)
     if _sympy_ is not None:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -53,7 +53,7 @@ class CantSympify(object):
 
 def _convert_numpy_types(a, **sympify_args):
     """
-    Converts a numpy datatype input to an appropriate sympy type.
+    Converts a numpy datatype input to an appropriate SymPy type.
     """
     import numpy as np
     if not isinstance(a, np.floating):
@@ -85,7 +85,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     with SAGE.
 
     It currently accepts as arguments:
-       - any object defined in sympy
+       - any object defined in SymPy
        - standard numeric python types: int, long, float, Decimal
        - strings (like "0.09" or "2e-19")
        - booleans, including ``None`` (will leave ``None`` unchanged)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -561,3 +561,9 @@ def test_issue_11151():
     expr1 = Sum(0, (x, 1, 2))
     expr2 = expr1/expr0
     assert simplify(factor(expr2) - expr2) == 0
+
+
+def test_issue_13425():
+    assert N('2**.5', 30) == N('sqrt(2)', 30)
+    assert N('x - x', 30) == 0
+    assert abs((N('pi*.1', 22)*10 - pi).n()) < 1e-22

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -176,10 +176,7 @@ def test_issue_16772():
     assert sympify(tuple(['.3', '.2']), rational=True) == Tuple(*ans)
 
 
-@XFAIL
 def test_issue_16859():
-    # because there is a converter for float, the
-    # CantSympify class designation is ignored
     class no(float, CantSympify):
         pass
     raises(SympifyError, lambda: sympify(no(1.2)))

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -17,6 +17,7 @@ from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 from sympy.external import import_module
 
 import mpmath
+from collections import defaultdict, OrderedDict
 from mpmath.rational import mpq
 
 
@@ -679,3 +680,18 @@ def test_issue_5939():
      a = Symbol('a')
      b = Symbol('b')
      assert sympify('''a+\nb''') == a + b
+
+
+def test_issue_16759():
+    d = sympify({.5: 1})
+    assert S.Half not in d
+    assert Float(.5) in d
+    assert d[.5] is S.One
+    d = sympify(OrderedDict({.5: 1}))
+    assert S.Half not in d
+    assert Float(.5) in d
+    assert d[.5] is S.One
+    d = sympify(defaultdict(int, {.5: 1}))
+    assert S.Half not in d
+    assert Float(.5) in d
+    assert d[.5] is S.One

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -8,6 +8,7 @@ import math
 
 from sympy.core import sympify
 from sympy.core.compatibility import as_int, SYMPY_INTS, range, string_types
+from sympy.core.containers import Dict
 from sympy.core.evalf import bitcount
 from sympy.core.expr import Expr
 from sympy.core.function import Function
@@ -985,6 +986,8 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     smoothness, smoothness_p, divisors
 
     """
+    if isinstance(n, Dict):
+        n = dict(n)
     if multiple:
         fac = factorint(n, limit=limit, use_trial=use_trial,
                            use_rho=use_rho, use_pm1=use_pm1,

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -1,5 +1,5 @@
 from sympy import (Sieve, binomial_coefficients, binomial_coefficients_list,
-    Mul, S, Pow, sieve, Symbol, summation, Dummy,
+    Mul, S, Pow, sieve, Symbol, summation, Dummy, Dict,
     factorial as fac)
 from sympy.core.evalf import bitcount
 from sympy.core.numbers import Integer, Rational
@@ -263,6 +263,11 @@ def test_factorint():
     assert factorint((p1*p2**2)**3) == {p1: 3, p2: 6}
     # Test for non integer input
     raises(ValueError, lambda: factorint(4.5))
+    # test dict/Dict input
+    sans = '2**10*3**3'
+    n = {4: 2, 12: 3}
+    assert str(factorint(n)) == sans
+    assert str(factorint(Dict(n))) == sans
 
 
 def test_divisors_and_divisor_count():

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -148,7 +148,10 @@ class Indexed(Expr):
             base = IndexedBase(base)
         elif not hasattr(base, '__getitem__') and not isinstance(base, IndexedBase):
             raise TypeError(filldedent("""
-                Indexed expects string, Symbol, or IndexedBase as base."""))
+                The base can only be replaced with a string, Symbol,
+                IndexedBase or an object with a method for getting
+                items (i.e. an object with a `__getitem__` method).
+                """))
         args = list(map(sympify, args))
         if isinstance(base, (NDimArray, Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
             if len(args) == 1:

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -176,14 +176,15 @@ def test_IndexedBase_sugar():
     assert A1 == A2[Tuple(i, j)]
     assert all(a.is_Integer for a in A2[1, 0].args[1:])
 
+
 def test_IndexedBase_subs():
-    i, j, k = symbols('i j k', integer=True)
-    a, b, c = symbols('a b c')
+    i = symbols('i', integer=True)
+    a, b = symbols('a b')
     A = IndexedBase(a)
     B = IndexedBase(b)
-    C = IndexedBase(c)
     assert A[i] == B[i].subs(b, a)
-    assert isinstance(C[1].subs(C, {1: 2}), type(A[1]))
+    C = {1: 2}
+    assert C[1] == A[1].subs(A, C)
 
 
 def test_IndexedBase_shape():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #16769
fixes #13425

#### Brief description of what is fixed or changed

- dict can now be sympified
- evaluation of *strings* converts numbers in the string to rational before evaluation (#13425)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `sympify` will now convert all dict-types input to Dict
    - `N` now uses `rational=True` which gives the desired precision when evaluating string expressions, treating floats as exact
<!-- END RELEASE NOTES -->
