### PR TITLE
add and use iwalk

### DIFF
--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -2,7 +2,7 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
         Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise, Indexed,
-        Matrix, Basic, Dict)
+        Matrix, Basic, Dict, Line)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.basic import _aresame
 from sympy.core.function import PoleError, _mexpand, arity
@@ -857,6 +857,13 @@ def test_nfloat():
     assert nfloat(Eq((3 - I)**2/2 + I, 0)) == S.false
     # pass along kwargs
     assert nfloat([{S.Half: x}], dkeys=True) == [{Float(0.5): x}]
+    # handle all objects
+    assert str(nfloat(1 + pi, 2)) == '4.1'
+    line = Line((123456, 1.1234), (pi + sqrt(2), Rational(3, 12345)))
+    assert str(nfloat(line, 2)) == \
+        'Line2D(Point2D(1.2e+5, 1.1), Point2D(4.6, 0.00024))'
+    assert str(nfloat(Line((1, sqrt(2) + pi),(3, 4)), 2)) == \
+        'Line2D(Point2D(1.0, 4.6), Point2D(3.0, 4.0))'
 
 
 def test_issue_7068():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2584,3 +2584,53 @@ def rotations(s, dir=1):
     for i in range(len(seq)):
         yield seq
         seq = rotate_left(seq, dir)
+
+
+def iwalk(a, do=None, sanitize=None, dkeys=True):
+    """Return input after applying `do` to items in Python builtin
+    containers. If ``sanitize`` is provided, apply that to a
+    container before applying ``do`` to its contents. If ``dkeys``
+    is True (default) then process dictionary values and keys.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import iwalk
+    >>> tup = lambda x: tuple(x) if type(x) is list else x
+    >>> add = lambda x: x + 1 if isinstance(x, int) else x
+    >>> input = [3, (.1, 2)]
+
+    The ``do`` action only happens to contents of iterables:
+
+    >>> iwalk(input, do=tup)
+    [3, (0.1, 2)]
+
+    The ``sanitize`` action happens to the iterables, in
+    this case the lists become tuples:
+
+    >>> iwalk(input, sanitize=tup)
+    (3, (0.1, 2))
+
+    >>> iwalk(input, do=add, sanitize=tup)
+    (4, (0.1, 3))
+    """
+    if isinstance(a, (list, set, tuple, frozenset)):
+        a = sanitize(a) if sanitize else a
+        new = []
+        for i in a:
+            new.append(iwalk(i, do, sanitize))
+        a = type(a)(new)
+    elif isinstance(a, dict):
+        a = sanitize(a) if sanitize else a
+        kv = [(
+            iwalk(k, do, sanitize) if dkeys else k,
+            iwalk(v, do, sanitize))
+            for k, v in a.items()]
+        if isinstance(a, defaultdict):
+            a.clear()
+            a.update(list(kv))
+        else:
+            a = dict(kv)
+    else:
+        a = do(a) if do else a
+    return a

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from textwrap import dedent
+from collections import defaultdict
 
 from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
@@ -806,3 +807,9 @@ def test_iwalk():
     assert iwalk(input, do=add, sanitize=tup) == (4, (0.1, 3))
     assert iwalk({(1, 2): (3, 4)}, do=lambda i: i*10,
         dkeys=False) == {(1, 2): (30, 40)}
+    input = defaultdict(int, {1: .5})
+    f = lambda x: x + 1 if isinstance(x, int) else x - 1
+    ok = iwalk(input, do=f)
+    assert len(ok) == 1
+    assert list(ok.items()) == [(2, -0.5)]
+    assert ok[1] == 0

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -16,7 +16,7 @@ from sympy.utilities.iterables import (
     permutations, postfixes, postorder_traversal, prefixes, reshape,
     rotate_left, rotate_right, runs, sift, strongly_connected_components,
     subsets, take, topological_sort, unflatten, uniq, variations,
-    ordered_partitions, rotations)
+    ordered_partitions, rotations, iwalk)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -783,3 +783,26 @@ def test_ibin():
     assert ibin(3, 3, str=True) == '011'
     assert list(ibin(2, 'all')) == [(0, 0), (0, 1), (1, 0), (1, 1)]
     assert list(ibin(2, 'all', str=True)) == ['00', '01', '10', '11']
+
+
+def test_iwalk():
+    tup = lambda x: tuple(x) if type(x) is list else x
+    add = lambda x: x + 1 if isinstance(x, int) else x
+    input = [3, [.1, 2]]
+    x = iwalk(input, do=tup)
+    saw = []
+    def who(i, saw=saw):
+        saw.append(type(i))
+        return i
+    ok = iwalk(x, do=who, sanitize=who)
+    assert saw == [list, int, list, float, int]
+    saw[:] = []
+    ok = iwalk(x, sanitize=who)
+    assert saw == [list, list]
+    saw[:] = []
+    ok = iwalk(x, do=who)
+    assert saw == [int, float, int]
+    assert iwalk(input, sanitize=tup) == (3, (0.1, 2))
+    assert iwalk(input, do=add, sanitize=tup) == (4, (0.1, 3))
+    assert iwalk({(1, 2): (3, 4)}, do=lambda i: i*10,
+        dkeys=False) == {(1, 2): (30, 40)}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

SymPy is written in Python but applying SymPy functions to SymPy objects in Python containers is no cakewalk. But with `iwalk` -- or pywalk? -- this is made a little easier.

If this is added, no routines would have to be 'list aware', like `simplify`, the user could just use `iwalk(alist, simplify)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `nfloat` can now be applied to arbitrary Python containers and SymPy objects
- utilities
    - `iwalk` added to `iterables` allows the application of a function to objects in arbitrary Python containers; an option to apply a function to the containers, too, is provided
<!-- END RELEASE NOTES -->
