### PR TITLE
Edit parentheses bug in mathml

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -603,8 +603,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 mrow.appendChild(x)
                 mrow.appendChild(y)
             for term in terms:
-                x = self._print(term)
-                mrow.appendChild(x)
+                mrow.appendChild(self.parenthesize(term, PRECEDENCE['Mul']))
                 if not term == terms[-1]:
                     y = self.dom.createElement('mo')
                     y.appendChild(self.dom.createTextNode(self.mathml_tag(expr)))

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1472,11 +1472,11 @@ def test_print_Vector():
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow>'
     assert mathml(x*Cross(ACS.i, ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub><mover>'\
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
-        '<mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+        '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(Cross(x*ACS.i, ACS.j), printer='presentation') == \
         '<mrow><mo>-</mo><mrow><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub>'\
@@ -1499,13 +1499,13 @@ def test_print_Vector():
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Curl(3*ACS.x*ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn>'\
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced>'\
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'\
-        '</mfenced></mrow></mrow>'
+        '</mfenced></mrow></mfenced></mrow>'
     assert mathml(Curl(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
@@ -1522,13 +1522,13 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Divergence(3*ACS.x*ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<mo>&#xB7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn>'\
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced>'\
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'\
-        '</mfenced></mrow></mrow>'
+        '</mfenced></mrow></mfenced></mrow>'
     assert mathml(Divergence(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mo>&#xB7;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
@@ -1560,11 +1560,11 @@ def test_print_Vector():
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Dot(ACS.i, ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><msub><mover>'\
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
-        '<mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+        '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(Gradient(ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow>'
@@ -1574,9 +1574,9 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">y</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mrow></mfenced></mrow>'
     assert mathml(x*Gradient(ACS.x), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi>'\
-        '</msub></mrow></mrow>'
+        '</msub></mrow></mfenced></mrow>'
     assert mathml(Gradient(x*ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mfenced><mrow><msub><mi mathvariant="bold">'\
         'x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo>'\
@@ -1596,9 +1596,9 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">y</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mrow></mfenced></mrow>'
     assert mathml(x*Laplacian(ACS.x), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2206;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2206;</mo>'\
         '<msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi>'\
-        '</msub></mrow></mrow>'
+        '</msub></mrow></mfenced></mrow>'
     assert mathml(Laplacian(x*ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2206;</mo><mfenced><mrow><msub><mi mathvariant="bold">'\
         'x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo>'\


### PR DESCRIPTION
```
[Before]
print(mathml(sympify("(2*x + 3*y + 1)*(4*x**2 - 6*x*y - 2*x + 9*y**2 - 3*y + 1)"),printer='presentation'))
---Display in mathml
2*x + 3*y + 14*x**2 - 6*x*y - 2*x + 9*y**2 - 3*y + 1

[After]
print(mathml(sympify("(2*x + 3*y + 1)*(4*x**2 - 6*x*y - 2*x + 9*y**2 - 3*y + 1)"),printer='presentation'))
---Display in mathml
(2*x + 3*y + 1)(4*x**2 - 6*x*y - 2*x + 9*y**2 - 3*y + 1)
```
StackOverFlow(Japanese)
[https://ja.stackoverflow.com/q/55578/22541
](https://ja.stackoverflow.com/q/55578/22541
)
StackOverFlow(English)
[https://stackoverflow.com/q/56479585/7864698](https://stackoverflow.com/q/56479585/7864698)

<!-- BEGIN RELEASE NOTES -->
* printing
  * fixed bug of display of parentheses in `mathml`