### PR TITLE
Modify comparisons to adhere to Python 3.8 guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -281,6 +281,9 @@ install:
   - pip install mpmath
   # -We:invalid makes invalid escape sequences error in Python 3.6. See
   # -#12028.
+  # SyntaxWarning flag for catching errors in Python3.8
+  # Issue -  #16973. -We:invalid can be dropped from 3.8 onwards, but
+  # it needs to be there for earlier versions.
   - |
     if [[ "${TEST_SETUP}" == "true" ]]; then
       # The install cycle below is to test installation on systems without
@@ -290,7 +293,7 @@ install:
       ~/.venv-no-setuptools/bin/pip uninstall -y setuptools;
       ~/.venv-no-setuptools/bin/python -We:invalid setup.py -q install;
     fi
-    python -We:invalid -m compileall -f -q sympy/;
+    python -We:invalid -We::SyntaxWarning -m compileall -f -q sympy/;
     python -We:invalid setup.py -q install;
     pip list --format=columns;
 

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -52,7 +52,7 @@ def test_Tuple_concatenation():
 
 
 def test_Tuple_equality():
-    assert Tuple(1, 2) is not (1, 2)
+    assert not isinstance(Tuple(1, 2), tuple)
     assert (Tuple(1, 2) == (1, 2)) is True
     assert (Tuple(1, 2) != (1, 2)) is False
     assert (Tuple(1, 2) == (1, 3)) is False

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -196,7 +196,7 @@ def test_plane():
     assert pl8.intersection(Plane(p1, normal_vector=(-1, -1, -11)))[0].equals(
         Line3D(p1, direction_ratio=(1, -1, 0)))
     assert pl3.random_point() in pl3
-    assert len(pl8.intersection(Ray3D(Point3D(0, 2, 3), Point3D(1, 0, 3)))) is 0
+    assert len(pl8.intersection(Ray3D(Point3D(0, 2, 3), Point3D(1, 0, 3)))) == 0
     # check if two plane are equals
     assert pl6.intersection(pl6)[0].equals(pl6)
     assert pl8.equals(Plane(p1, normal_vector=(0, 12, 0))) is False

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -150,7 +150,7 @@ class VectorLatexPrinter(LatexPrinter):
             base = r"\ddddot{%s}" % base
         else: # Fallback to standard printing
             return LatexPrinter().doprint(der_expr)
-        if len(base_split) is not 1:
+        if len(base_split) != 1:
             base += '_' + base_split[1]
         return base
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -642,7 +642,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 # at both ends. If there is a real value in between, then
                 # sample those points further.
                 elif p[1] is None and q[1] is None:
-                    if self.xscale is 'log':
+                    if self.xscale == 'log':
                         xarray = np.logspace(p[0], q[0], 10)
                     else:
                         xarray = np.linspace(p[0], q[0], 10)
@@ -671,14 +671,14 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
     def get_points(self):
         np = import_module('numpy')
         if self.only_integers is True:
-            if self.xscale is 'log':
+            if self.xscale == 'log':
                 list_x = np.logspace(int(self.start), int(self.end),
                         num=int(self.end) - int(self.start) + 1)
             else:
                 list_x = np.linspace(int(self.start), int(self.end),
                     num=int(self.end) - int(self.start) + 1)
         else:
-            if self.xscale is 'log':
+            if self.xscale == 'log':
                 list_x = np.logspace(self.start, self.end, num=self.nb_of_points)
             else:
                 list_x = np.linspace(self.start, self.end, num=self.nb_of_points)

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -26,7 +26,7 @@ from sympy.polys.agca.ideals import Ideal
 from sympy.polys.domains.field import Field
 from sympy.polys.orderings import ProductOrder, monomial_key
 from sympy.polys.polyerrors import CoercionFailed
-
+from sympy.core.basic import _aresame
 
 # TODO
 # - module saturation
@@ -357,7 +357,7 @@ class FreeModule(Module):
             if len(tpl) != self.rank:
                 raise CoercionFailed
             return FreeModuleElement(self, tpl)
-        elif elem is 0:
+        elif _aresame(elem, 0):
             return FreeModuleElement(self, (self.ring.convert(0),)*self.rank)
         else:
             raise CoercionFailed

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -3182,7 +3182,7 @@ def power_representation(n, p, k, zeros=False):
             '''Todd G. Will, "When Is n^2 a Sum of k Squares?", [online].
                 Available: https://www.maa.org/sites/default/files/Will-MMz-201037918.pdf'''
             return
-        if feasible is 1:  # it's prime and k == 2
+        if feasible is not True:  # it's prime and k == 2
             yield prime_as_sum_of_two_squares(n)
             return
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -274,9 +274,9 @@ def get_default_datatype(expr, complex_allowed=None):
         #check all entries
         dt = "int"
         for element in expr:
-            if dt is "int" and not element.is_integer:
+            if dt == "int" and not element.is_integer:
                 dt = "float"
-            if dt is "float" and not element.is_real:
+            if dt == "float" and not element.is_real:
                 return default_datatypes[final_dtype]
         return default_datatypes[dt]
     else:

--- a/sympy/utilities/tests/test_travis.py
+++ b/sympy/utilities/tests/test_travis.py
@@ -1,0 +1,6 @@
+def test_travis_issue_16986():
+    # If this causes the travis build to fail with Python3.8,
+    # then the changes made in PR #16986 are working as
+    # intended, and this file can be deleted.
+
+    assert int(1) is 1

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -167,9 +167,9 @@ class CoordSys3D(Basic):
             if isinstance(transformation, Lambda):
                 variable_names = ["x1", "x2", "x3"]
             elif isinstance(transformation, Symbol):
-                if transformation.name is 'spherical':
+                if transformation.name == 'spherical':
                     variable_names = ["r", "theta", "phi"]
-                elif transformation.name is 'cylindrical':
+                elif transformation.name == 'cylindrical':
                     variable_names = ["r", "theta", "z"]
                 else:
                     variable_names = ["x", "y", "z"]


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #16973 

#### Brief description of what is fixed or changed

Use comparison operators instead of ```is``` with string, int literals.
Modify the compilation command in .travis.yml to
 ``` python -We::SyntaxWarning -m compileall -f -q sympy/; ``` . 

#### Other comments

The ```::SyntaxWarning``` filter causes the compiler to flag any warnings as errors. The command was previously ``` python -We:invalid -m compileall -f -q sympy/; ``` in order for it to flag invalid escape sequences. According to the Python 3.8 changelog, invalid escape sequences now generate a SyntaxWarning as well, so this should work for those as well.

#### Release notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
