### PR TITLE
16987: remove dups in Intersection at instantiation

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -23,7 +23,7 @@ from sympy.core.sympify import _sympify, sympify, converter
 from sympy.logic.boolalg import And, Or, Not, true, false
 from sympy.sets.contains import Contains
 from sympy.utilities import subsets
-from sympy.utilities.iterables import sift
+from sympy.utilities.iterables import sift, uniq
 from sympy.utilities.misc import func_name, filldedent
 
 from mpmath import mpi, mpf
@@ -1260,7 +1260,7 @@ class Intersection(Set, LatticeOp):
         evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
-        args = _sympify(args)
+        args = list(ordered(uniq(_sympify(args))))
 
         # Reduce sets using known rules
         if evaluate:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -23,7 +23,7 @@ from sympy.core.sympify import _sympify, sympify, converter
 from sympy.logic.boolalg import And, Or, Not, true, false
 from sympy.sets.contains import Contains
 from sympy.utilities import subsets
-from sympy.utilities.iterables import sift, uniq
+from sympy.utilities.iterables import sift
 from sympy.utilities.misc import func_name, filldedent
 
 from mpmath import mpi, mpf
@@ -1260,7 +1260,7 @@ class Intersection(Set, LatticeOp):
         evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
-        args = list(ordered(uniq(_sympify(args))))
+        args = list(ordered(set(_sympify(args))))
 
         # Reduce sets using known rules
         if evaluate:

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -21,7 +21,7 @@ def test_imageset():
     assert imageset(x, abs(x), S.Integers) is S.Naturals0
     # issue 16878a
     r = symbols('r', real=True)
-    assert (1, r) not in imageset(x, (x, x), S.Reals)
+    assert (1, r) in imageset(x, (x, x), S.Reals) != False
     assert (r, r) in imageset(x, (x, x), S.Reals)
     assert 1 + I in imageset(x, x + I, S.Reals)
     assert {1} not in imageset(x, (x,), S.Reals)
@@ -341,6 +341,9 @@ def test_intersection():
 
     # issue 12178
     assert Intersection() == S.UniversalSet
+
+    # issue 16987
+    assert Intersection({1}, {1}, {x}) == Intersection({1}, {x})
 
 
 def test_issue_9623():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16987 without fully addressing the fact that a different wrong value is being returned from `Intersection({1}, {x})`. The value of `{1}` is being returned by `simplify_intersection`. (But this is only true if `x` is also `1`.)

#### Brief description of what is fixed or changed

Intersection simplification depends on the presence of duplicates as shown in the issue. In addition, there is some indeterminancy in the processing because the arguments are not sorted.

This PR fixes both those issue.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
    - processing of arguments of an intersection is more canonical
<!-- END RELEASE NOTES -->
