### PR TITLE
Added cases for sparse arrays in __mul__ and __rmul__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -281,6 +281,9 @@ install:
   - pip install mpmath
   # -We:invalid makes invalid escape sequences error in Python 3.6. See
   # -#12028.
+  # SyntaxWarning flag for catching errors in Python3.8
+  # Issue -  #16973. -We:invalid can be dropped from 3.8 onwards, but
+  # it needs to be there for earlier versions.
   - |
     if [[ "${TEST_SETUP}" == "true" ]]; then
       # The install cycle below is to test installation on systems without
@@ -290,7 +293,7 @@ install:
       ~/.venv-no-setuptools/bin/pip uninstall -y setuptools;
       ~/.venv-no-setuptools/bin/python -We:invalid setup.py -q install;
     fi
-    python -We:invalid -m compileall -f -q sympy/;
+    python -We:invalid -We::SyntaxWarning -m compileall -f -q sympy/;
     python -We:invalid setup.py -q install;
     pip list --format=columns;
 

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -332,13 +332,13 @@ def _check_homomorphism(domain, codomain, images):
             # both indices
             while i < len(r):
                 power = r_arr[j][1]
-                if isinstance(domain, PermutationGroup):
+                if isinstance(domain, PermutationGroup) and r[i] in gens:
                     s = domain.generators[gens.index(r[i])]
                 else:
                     s = r[i]
                 if s in images:
                     w = w*images[s]**power
-                else:
+                elif s**-1 in images:
                     w = w*images[s**-1]**power
                 i += abs(power)
                 j += 1

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -4,6 +4,7 @@ from sympy.combinatorics.homomorphisms import homomorphism, group_isomorphism, i
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.fp_groups import FpGroup
 from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup, CyclicGroup
+from sympy.utilities.pytest import raises
 
 def test_homomorphism():
     # FpGroup -> PermutationGroup
@@ -99,3 +100,10 @@ def test_isomorphisms():
     H = CyclicGroup(5)
     assert G.order() == H.order()
     assert is_isomorphic(G, H)
+
+
+def test_check_homomorphism():
+    a = Permutation(1,2,3,4)
+    b = Permutation(1,3)
+    G = PermutationGroup([a, b])
+    raises(ValueError, lambda: homomorphism(G, G, [a], [a]))

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -52,7 +52,7 @@ def test_Tuple_concatenation():
 
 
 def test_Tuple_equality():
-    assert Tuple(1, 2) is not (1, 2)
+    assert not isinstance(Tuple(1, 2), tuple)
     assert (Tuple(1, 2) == (1, 2)) is True
     assert (Tuple(1, 2) != (1, 2)) is False
     assert (Tuple(1, 2) == (1, 3)) is False

--- a/sympy/core/tests/test_multidimensional.py
+++ b/sympy/core/tests/test_multidimensional.py
@@ -1,0 +1,22 @@
+from sympy import diff, sin, symbols, Function, Derivative
+from sympy.core.multidimensional import vectorize
+x, y, z = symbols('x y z')
+f, g, h = list(map(Function, 'fgh'))
+
+
+def test_vectorize():
+    @vectorize(0)
+    def vsin(x):
+        return sin(x)
+
+    assert vsin([1, x, y]) == [sin(1), sin(x), sin(y)]
+
+    @vectorize(0, 1)
+    def vdiff(f, y):
+        return diff(f, y)
+
+    assert vdiff([f(x, y, z), g(x, y, z), h(x, y, z)], [x, y, z]) == \
+         [[Derivative(f(x, y, z), x), Derivative(f(x, y, z), y),
+           Derivative(f(x, y, z), z)], [Derivative(g(x, y, z), x),
+                     Derivative(g(x, y, z), y), Derivative(g(x, y, z), z)],
+         [Derivative(h(x, y, z), x), Derivative(h(x, y, z), y), Derivative(h(x, y, z), z)]]

--- a/sympy/discrete/tests/test_convolutions.py
+++ b/sympy/discrete/tests/test_convolutions.py
@@ -142,6 +142,8 @@ def test_cyclic_convolution():
              p*x + q*w + r*v + s*u,
              p*y + t*u]
 
+    raises(ValueError, lambda: convolution([1, 2, 3], [4, 5, 6], cycle=-1))
+
 
 def test_convolution_fft():
     assert all(convolution_fft([], x, dps=y) == [] for x in ([], [1]) for y in (None, 3))

--- a/sympy/discrete/tests/test_recurrences.py
+++ b/sympy/discrete/tests/test_recurrences.py
@@ -55,3 +55,4 @@ def test_linrec():
         58516436*x + 56372788*y
     assert linrec(coeffs=[0]*50 + [1, 2, 3], init=[x, y, z], n=1000) == \
         11477135884896*x + 25999077948732*y + 41975630244216*z
+    assert linrec(coeffs=[], init=[1, 1], n=20) == 0

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -550,8 +550,6 @@ class log(Function):
             elif arg.is_Rational and arg.p == 1:
                 return -cls(arg.q)
 
-        if arg is S.ComplexInfinity:
-                return S.ComplexInfinity
         if isinstance(arg, exp) and arg.args[0].is_extended_real:
             return arg.args[0]
         elif isinstance(arg, exp_polar):

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -4,8 +4,9 @@ from sympy import (
     sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
     Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
     ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda, Derivative)
-from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.expr import unchanged
+from sympy.core.function import ArgumentIndexError
+from sympy.utilities.pytest import XFAIL, raises
 
 
 def N_equals(a, b):
@@ -436,7 +437,8 @@ def test_Abs():
     assert re(a).is_algebraic
     assert re(x).is_algebraic is None
     assert re(t).is_algebraic is False
-
+    assert Abs(x).fdiff() == sign(x)
+    raises(ArgumentIndexError, lambda: Abs(x).fdiff(2))
 
 def test_Abs_rewrite():
     x = Symbol('x', real=True)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -4,6 +4,8 @@ from sympy import (
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
     AccumBounds, MatrixSymbol, Pow)
 from sympy.abc import x, y, z
+from sympy.core.function import ArgumentIndexError
+from sympy.utilities.pytest import raises
 
 
 def test_exp_values():
@@ -40,6 +42,9 @@ def test_exp_values():
 
     assert exp(3*log(x) + oo*x) == exp(oo*x) * x**3
     assert exp(4*log(x)*log(y) + 3*log(x)) == x**3 * exp(4*log(x)*log(y))
+
+    assert exp(-oo, evaluate=False).is_finite is True
+    assert exp(oo, evaluate=False).is_finite is False
 
 
 def test_exp_log():
@@ -138,11 +143,17 @@ def test_exp_taylor_term():
     assert exp(x).taylor_term(1, x) == x
     assert exp(x).taylor_term(3, x) == x**3/6
     assert exp(x).taylor_term(4, x) == x**4/24
+    assert exp(x).taylor_term(-1, x) == S.Zero
 
 
 def test_exp_MatrixSymbol():
     A = MatrixSymbol("A", 2, 2)
     assert exp(A).has(exp)
+
+
+def test_exp_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: exp(x).fdiff(2))
 
 
 def test_log_values():
@@ -409,6 +420,19 @@ def test_issue_5673():
     assert e.is_positive is not True
     e3 = -2 + exp(exp(LambertW(log(2)))*LambertW(log(2)))
     assert e3.is_nonzero is not True
+
+
+def test_log_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: log(x).fdiff(2))
+
+
+def test_log_taylor_term():
+    x = symbols('x')
+    assert log(x).taylor_term(0, x) == x
+    assert log(x).taylor_term(1, x) == -x**2/2
+    assert log(x).taylor_term(4, x) == x**5/5
+    assert log(x).taylor_term(-1, x) == S.Zero
 
 
 def test_exp_expand_NC():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1,8 +1,9 @@
 from sympy import (symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log,
     sqrt, coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth,
     Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul,
-    AccumBounds)
+    AccumBounds, im, re)
 
+from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises
 
 
@@ -68,11 +69,24 @@ def test_sinh():
 
     assert sinh(k*pi*I/2) == sin(k*pi/2)*I
 
+    assert sinh(x).as_real_imag(deep=False) == (cos(im(x))*sinh(re(x)),
+                sin(im(x))*cosh(re(x)))
+    x = Symbol('x', extended_real=True)
+    assert sinh(x).as_real_imag(deep=False) == (sinh(x), 0)
+
+    x = Symbol('x', real=True)
+    assert sinh(I*x).is_finite is True
+
 
 def test_sinh_series():
     x = Symbol('x')
     assert sinh(x).series(x, 0, 10) == \
         x + x**3/6 + x**5/120 + x**7/5040 + x**9/362880 + O(x**10)
+
+
+def test_sinh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: sinh(x).fdiff(2))
 
 
 def test_cosh():
@@ -135,11 +149,24 @@ def test_cosh():
 
     assert cosh(k*pi) == cosh(k*pi)
 
+    assert cosh(x).as_real_imag(deep=False) == (cos(im(x))*cosh(re(x)),
+                sin(im(x))*sinh(re(x)))
+    x = Symbol('x', extended_real=True)
+    assert cosh(x).as_real_imag(deep=False) == (cosh(x), 0)
+
+    x = Symbol('x', real=True)
+    assert cosh(I*x).is_finite is True
+
 
 def test_cosh_series():
     x = Symbol('x')
     assert cosh(x).series(x, 0, 10) == \
         1 + x**2/2 + x**4/24 + x**6/720 + x**8/40320 + O(x**10)
+
+
+def test_cosh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: cosh(x).fdiff(2))
 
 
 def test_tanh():
@@ -204,11 +231,22 @@ def test_tanh():
 
     assert tanh(k*pi*I/2) == tan(k*pi/2)*I
 
+    assert tanh(x).as_real_imag(deep=False) == (sinh(re(x))*cosh(re(x))/(cos(im(x))**2
+                                + sinh(re(x))**2),
+                                sin(im(x))*cos(im(x))/(cos(im(x))**2 + sinh(re(x))**2))
+    x = Symbol('x', extended_real=True)
+    assert tanh(x).as_real_imag(deep=False) == (tanh(x), 0)
+
 
 def test_tanh_series():
     x = Symbol('x')
     assert tanh(x).series(x, 0, 10) == \
         x - x**3/3 + 2*x**5/15 - 17*x**7/315 + 62*x**9/2835 + O(x**10)
+
+
+def test_tanh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: tanh(x).fdiff(2))
 
 
 def test_coth():
@@ -276,10 +314,22 @@ def test_coth():
     assert coth(log(tan(2))) == coth(log(-tan(2)))
     assert coth(1 + I*pi/2) == tanh(1)
 
+    assert coth(x).as_real_imag(deep=False) == (sinh(re(x))*cosh(re(x))/(sin(im(x))**2
+                                + sinh(re(x))**2),
+                                -sin(im(x))*cos(im(x))/(sin(im(x))**2 + sinh(re(x))**2))
+    x = Symbol('x', extended_real=True)
+    assert coth(x).as_real_imag(deep=False) == (coth(x), 0)
+
+
 def test_coth_series():
     x = Symbol('x')
     assert coth(x).series(x, 0, 8) == \
         1/x + x/3 - x**3/45 + 2*x**5/945 - x**7/4725 + O(x**8)
+
+
+def test_coth_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: coth(x).fdiff(2))
 
 
 def test_csch():
@@ -348,6 +398,11 @@ def test_csch_series():
           - 73*x**9/3421440 + O(x**10)
 
 
+def test_csch_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: csch(x).fdiff(2))
+
+
 def test_sech():
     x, y = symbols('x, y')
 
@@ -410,6 +465,11 @@ def test_sech_series():
         1 - x**2/2 + 5*x**4/24 - 61*x**6/720 + 277*x**8/8064 + O(x**10)
 
 
+def test_sech_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: sech(x).fdiff(2))
+
+
 def test_asinh():
     x, y = symbols('x,y')
     assert asinh(x) == asinh(x)
@@ -445,6 +505,9 @@ def test_asinh():
     assert asinh(I*(sqrt(5) + 1)/4) == 3*pi*I/10
     assert asinh(-I*(sqrt(5) + 1)/4) == -3*pi*I/10
 
+    # Symmetry
+    assert asinh(-S.Half) == -asinh(S.Half)
+
 
 def test_asinh_rewrite():
     x = Symbol('x')
@@ -460,6 +523,11 @@ def test_asinh_series():
     assert asinh(x).taylor_term(7, x, t5, 0) == -5*x**7/112
 
 
+def test_asinh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: asinh(x).fdiff(2))
+
+
 def test_acosh():
     x = Symbol('x')
 
@@ -471,6 +539,7 @@ def test_acosh():
     assert acosh(0) == I*pi/2
     assert acosh(Rational(1, 2)) == I*pi/3
     assert acosh(Rational(-1, 2)) == 2*pi*I/3
+    assert acosh(nan) == nan
 
     # at infinites
     assert acosh(oo) == oo
@@ -516,6 +585,11 @@ def test_acosh_series():
     assert acosh(x).taylor_term(7, x, t5, 0) == - 5*I*x**7/112
 
 
+def test_acosh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: acosh(x).fdiff(2))
+
+
 def test_asech():
     x = Symbol('x')
 
@@ -527,6 +601,7 @@ def test_asech():
     assert asech(0) == oo
     assert asech(2) == I*pi/3
     assert asech(-2) == 2*I*pi / 3
+    assert asech(nan) == nan
 
     # at infinites
     assert asech(oo) == I*pi/2
@@ -585,6 +660,11 @@ def test_asech_rewrite():
     assert asech(x).rewrite(log) == log(1/x + sqrt(1/x - 1) * sqrt(1/x + 1))
 
 
+def test_asech_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: asech(x).fdiff(2))
+
+
 def test_acsch():
     x = Symbol('x')
 
@@ -622,6 +702,7 @@ def test_acsch():
     assert acsch(I*sqrt(2 - 2/sqrt(5))) == -2*I*pi / 5
     assert acsch(-I*(sqrt(6) - sqrt(2))) == 5*I*pi / 12
     assert acsch(I*(sqrt(6) - sqrt(2))) == -5*I*pi / 12
+    assert acsch(nan) == nan
 
     # properties
     # acsch(x) == asinh(1/x)
@@ -654,6 +735,11 @@ def test_acsch_rewrite():
     assert acsch(x).rewrite(log) == log(1/x + sqrt(1/x**2 + 1))
 
 
+def test_acsch_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: acsch(x).fdiff(2))
+
+
 def test_atanh():
     x = Symbol('x')
 
@@ -663,6 +749,7 @@ def test_atanh():
     assert atanh(-I) == -I*pi/4
     assert atanh(1) == oo
     assert atanh(-1) == -oo
+    assert atanh(nan) == nan
 
     # at infinites
     assert atanh(oo) == -I*pi/2
@@ -690,6 +777,8 @@ def test_atanh():
     assert atanh(I*(sqrt(3) - 2)) == -pi*I/12
     assert atanh(oo) == -I*pi/2
 
+    # Symmetry
+    assert atanh(-S.Half) == -atanh(S.Half)
 
 def test_atanh_rewrite():
     x = Symbol('x')
@@ -702,6 +791,11 @@ def test_atanh_series():
         x + x**3/3 + x**5/5 + x**7/7 + x**9/9 + O(x**10)
 
 
+def test_atanh_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: atanh(x).fdiff(2))
+
+
 def test_acoth():
     x = Symbol('x')
 
@@ -711,6 +805,7 @@ def test_acoth():
     assert acoth(-I) == I*pi/4
     assert acoth(1) == oo
     assert acoth(-1) == -oo
+    assert acoth(nan) == nan
 
     # at infinites
     assert acoth(oo) == 0
@@ -737,6 +832,9 @@ def test_acoth():
     assert acoth(I*(2 - sqrt(3))) == -5*pi*I/12
     assert acoth(I*(sqrt(3) - 2)) == 5*pi*I/12
 
+    # Symmetry
+    assert acoth(-S.Half) == -acoth(S.Half)
+
 
 def test_acoth_rewrite():
     x = Symbol('x')
@@ -747,6 +845,11 @@ def test_acoth_series():
     x = Symbol('x')
     assert acoth(x).series(x, 0, 10) == \
         I*pi/2 + x + x**3/3 + x**5/5 + x**7/7 + x**9/9 + O(x**10)
+
+
+def test_acoth_fdiff():
+    x = Symbol('x')
+    raises(ArgumentIndexError, lambda: acoth(x).fdiff(2))
 
 
 def test_inverses():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -3,11 +3,14 @@ from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, pi, atan,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
         Float, Pow, gcd, sec, csc, cot, diff, simplify, Heaviside, arg,
         conjugate, series, FiniteSet, asec, acsc, Mul, sinc, jn, Product,
-        AccumBounds)
+        AccumBounds, Interval, ImageSet, Lambda)
 from sympy.core.compatibility import range
-from sympy.utilities.pytest import XFAIL, slow, raises
+from sympy.core.function import ArgumentIndexError
 from sympy.core.relational import Ne, Eq
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy.sets.setexpr import SetExpr
+from sympy.utilities.pytest import XFAIL, slow, raises
+
 
 x, y, z = symbols('x y z')
 r = Symbol('r', real=True)
@@ -134,6 +137,9 @@ def test_sin():
     assert isinstance(sin( re(x) - im(y)), sin) is True
     assert isinstance(sin(-re(x) + im(y)), sin) is False
 
+    assert sin(SetExpr(Interval(0, 1))) == SetExpr(ImageSet(Lambda(x, sin(x)),
+                       Interval(0, 1)))
+
     for d in list(range(1, 22)) + [60, 85]:
         for n in range(0, d*2 + 1):
             x = n*pi/d
@@ -180,6 +186,7 @@ def test_sin_rewrite():
     assert sin(x).rewrite(csc) == 1/csc(x)
     assert sin(x).rewrite(cos) == cos(x - pi / 2, evaluate=False)
     assert sin(x).rewrite(sec) == 1 / sec(x - pi / 2, evaluate=False)
+    assert sin(cos(x)).rewrite(Pow) == sin(cos(x))
 
 
 def test_sin_expansion():
@@ -204,6 +211,11 @@ def test_sin_AccumBounds():
     assert sin(AccumBounds(3*S.Pi/4, 7*S.Pi/4)) == AccumBounds(-1, sin(3*S.Pi/4))
     assert sin(AccumBounds(S.Pi/4, S.Pi/3)) == AccumBounds(sin(S.Pi/4), sin(S.Pi/3))
     assert sin(AccumBounds(3*S.Pi/4, 5*S.Pi/6)) == AccumBounds(sin(5*S.Pi/6), sin(3*S.Pi/4))
+
+
+def test_sin_fdiff():
+    assert sin(x).fdiff() == cos(x)
+    raises(ArgumentIndexError, lambda: sin(x).fdiff(2))
 
 
 def test_trig_symmetry():
@@ -381,6 +393,7 @@ def test_cos_rewrite():
     assert cos(x).rewrite(sec) == 1/sec(x)
     assert cos(x).rewrite(sin) == sin(x + pi/2, evaluate=False)
     assert cos(x).rewrite(csc) == 1/csc(-x + pi/2, evaluate=False)
+    assert cos(sin(x)).rewrite(Pow) == cos(sin(x))
 
 
 def test_cos_expansion():
@@ -403,6 +416,11 @@ def test_cos_AccumBounds():
     assert cos(AccumBounds(3*S.Pi/4, 5*S.Pi/4)) == AccumBounds(-1, cos(3*S.Pi/4))
     assert cos(AccumBounds(5*S.Pi/4, 4*S.Pi/3)) == AccumBounds(cos(5*S.Pi/4), cos(4*S.Pi/3))
     assert cos(AccumBounds(S.Pi/4, S.Pi/3)) == AccumBounds(cos(S.Pi/3), cos(S.Pi/4))
+
+
+def test_cos_fdiff():
+    assert cos(x).fdiff() == -sin(x)
+    raises(ArgumentIndexError, lambda: cos(x).fdiff(2))
 
 
 def test_tan():
@@ -493,6 +511,9 @@ def test_tan():
     assert tan(15*pi/14) == tan(pi/14)
     assert tan(-15*pi/14) == -tan(pi/14)
 
+    assert tan(r).is_finite is None
+    assert tan(I*r).is_finite is True
+
 
 def test_tan_series():
     assert tan(x).series(x, 0, 9) == \
@@ -528,6 +549,9 @@ def test_tan_rewrite():
     assert tan(8*pi/19).rewrite(sqrt) == tan(8*pi/19)
     assert tan(x).rewrite(sec) == sec(x)/sec(x - pi/2, evaluate=False)
     assert tan(x).rewrite(csc) == csc(-x + pi/2, evaluate=False)/csc(x)
+    assert tan(sin(x)).rewrite(Pow) == tan(sin(x))
+    assert tan(2*pi/5, evaluate=False).rewrite(sqrt) == sqrt(sqrt(5)/8 +
+               S(5)/8)/(-S(1)/4 + sqrt(5)/4)
 
 
 def test_tan_subs():
@@ -552,6 +576,11 @@ def test_tan_AccumBounds():
     assert tan(AccumBounds(-oo, oo)) == AccumBounds(-oo, oo)
     assert tan(AccumBounds(S.Pi/3, 2*S.Pi/3)) == AccumBounds(-oo, oo)
     assert tan(AccumBounds(S.Pi/6, S.Pi/3)) == AccumBounds(tan(S.Pi/6), tan(S.Pi/3))
+
+
+def test_tan_fdiff():
+    assert tan(x).fdiff() == tan(x)**2 + 1
+    raises(ArgumentIndexError, lambda: tan(x).fdiff(2))
 
 
 def test_cot():
@@ -649,6 +678,10 @@ def test_cot_series():
     # issue 6210
     assert cot(x**4 + x**5).series(x, 0, 1) == \
         x**(-4) - 1/x**3 + x**(-2) - 1/x + 1 + O(x)
+    assert cot(pi*(1-x)).series(x, 0, 3) == -1/(pi*x) + pi*x/3 + O(x**3)
+    assert cot(x).taylor_term(0, x) == 1/x
+    assert cot(x).taylor_term(2, x) == S.Zero
+    assert cot(x).taylor_term(3, x) == -x**3/45
 
 
 def test_cot_rewrite():
@@ -676,6 +709,9 @@ def test_cot_rewrite():
     assert cot(pi/19).rewrite(sqrt) == cot(pi/19)
     assert cot(x).rewrite(sec) == sec(x - pi / 2, evaluate=False) / sec(x)
     assert cot(x).rewrite(csc) == csc(x) / csc(- x + pi / 2, evaluate=False)
+    assert cot(sin(x)).rewrite(Pow) == cot(sin(x))
+    assert cot(2*pi/5, evaluate=False).rewrite(sqrt) == (-S(1)/4 + sqrt(5)/4)/\
+                                                        sqrt(sqrt(5)/8 + S(5)/8)
 
 
 def test_cot_subs():
@@ -701,6 +737,11 @@ def test_cot_AccumBounds():
     assert cot(AccumBounds(-oo, oo)) == AccumBounds(-oo, oo)
     assert cot(AccumBounds(-S.Pi/3, S.Pi/3)) == AccumBounds(-oo, oo)
     assert cot(AccumBounds(S.Pi/6, S.Pi/3)) == AccumBounds(cot(S.Pi/3), cot(S.Pi/6))
+
+
+def test_cot_fdiff():
+    assert cot(x).fdiff() == -cot(x)**2 - 1
+    raises(ArgumentIndexError, lambda: cot(x).fdiff(2))
 
 
 def test_sinc():
@@ -769,6 +810,9 @@ def test_asin():
     assert asin(Rational(1, 7), evaluate=False).is_positive is True
     assert asin(Rational(-1, 7), evaluate=False).is_positive is False
     assert asin(p).is_positive is None
+    assert asin(sin(S(7)/2)) == -S(7)/2 + pi
+    assert asin(sin(-S(7)/4)) == S(7)/4 - pi
+    assert asin(cos(x)) == asin(cos(x))
 
 
 def test_asin_series():
@@ -786,6 +830,11 @@ def test_asin_rewrite():
     assert asin(x).rewrite(acot) == 2*acot((sqrt(-x**2 + 1) + 1)/x)
     assert asin(x).rewrite(asec) == -asec(1/x) + pi/2
     assert asin(x).rewrite(acsc) == acsc(1/x)
+
+
+def test_asin_fdiff():
+    assert asin(x).fdiff() == 1/sqrt(1 - x**2)
+    raises(ArgumentIndexError, lambda: asin(x).fdiff(2))
 
 
 def test_acos():
@@ -831,6 +880,8 @@ def test_acos_series():
     t5 = acos(x).taylor_term(5, x)
     assert t5 == -3*x**5/40
     assert acos(x).taylor_term(7, x, t5, 0) == -5*x**7/112
+    assert acos(x).taylor_term(0, x) == pi/2
+    assert acos(x).taylor_term(2, x) == S.Zero
 
 
 def test_acos_rewrite():
@@ -843,6 +894,11 @@ def test_acos_rewrite():
     assert acos(x).rewrite(acot) == -2*acot((sqrt(-x**2 + 1) + 1)/x) + pi/2
     assert acos(x).rewrite(asec) == asec(1/x)
     assert acos(x).rewrite(acsc) == -acsc(1/x) + pi/2
+
+
+def test_acos_fdiff():
+    assert acos(x).fdiff() == -1/sqrt(1 - x**2)
+    raises(ArgumentIndexError, lambda: acos(x).fdiff(2))
 
 
 def test_atan():
@@ -862,6 +918,9 @@ def test_atan():
     assert atan(r).is_real is True
 
     assert atan(-2*I) == -I*atanh(2)
+    assert atan(cot(x)) == atan(cot(x))
+    assert atan(cot(S(1)/4)) == -S(1)/4 + pi/2
+    assert acot(S(1)/4).is_rational is False
 
     for s in (x, p, n, np, nn, nz, ep, en, enp, enn, enz):
         if s.is_real or s.is_extended_real is None:
@@ -893,6 +952,11 @@ def test_atan_rewrite():
 
     assert atan(-5*I).evalf() == atan(x).rewrite(log).evalf(subs={x:-5*I})
     assert atan(5*I).evalf() == atan(x).rewrite(log).evalf(subs={x:5*I})
+
+
+def test_atan_fdiff():
+    assert atan(x).fdiff() == 1/(x**2 + 1)
+    raises(ArgumentIndexError, lambda: atan(x).fdiff(2))
 
 
 def test_atan2():
@@ -955,6 +1019,9 @@ def test_atan2():
     assert simplify(diff(atan2(y, x).rewrite(log), x)) == -y/(x**2 + y**2)
     assert simplify(diff(atan2(y, x).rewrite(log), y)) ==  x/(x**2 + y**2)
 
+    assert str(atan2(1, 2).evalf(5)) == '0.46365'
+    raises(ArgumentIndexError, lambda: atan2(x, y).fdiff(3))
+
 
 def test_acot():
     assert acot(nan) == nan
@@ -978,6 +1045,11 @@ def test_acot():
     assert acot(n).is_positive is False
     assert acot(p).is_positive is True
     assert acot(I).is_positive is False
+    assert acot(S(1)/4).is_rational is False
+    assert acot(cot(x)) == acot(cot(x))
+    assert acot(tan(x)) == acot(tan(x))
+    assert acot(cot(S(1)/4)) == S(1)/4
+    assert acot(tan(-S(1)/4)) == S(1)/4 - pi/2
 
 
 def test_acot_rewrite():
@@ -990,6 +1062,11 @@ def test_acot_rewrite():
 
     assert acot(-I/5).evalf() == acot(x).rewrite(log).evalf(subs={x:-I/5})
     assert acot(I/5).evalf() == acot(x).rewrite(log).evalf(subs={x:I/5})
+
+
+def test_acot_fdiff():
+    assert acot(x).fdiff() == -1/(x**2 + 1)
+    raises(ArgumentIndexError, lambda: acot(x).fdiff(2))
 
 
 def test_attributes():
@@ -1412,6 +1489,11 @@ def test_sec_rewrite():
     assert sec(x).rewrite(csc) == csc(-x + pi/2, evaluate=False)
 
 
+def test_sec_fdiff():
+    assert sec(x).fdiff() == tan(x)*sec(x)
+    raises(ArgumentIndexError, lambda: sec(x).fdiff(2))
+
+
 def test_csc():
     x = symbols('x', real=True)
     z = symbols('z')
@@ -1474,6 +1556,7 @@ def test_csc():
     assert csc(x).taylor_term(2, x) == 0
     assert csc(x).taylor_term(3, x) == 7*x**3/360
     assert csc(x).taylor_term(5, x) == 31*x**5/15120
+    raises(ArgumentIndexError, lambda: csc(x).fdiff(2))
 
 
 def test_asec():
@@ -1495,6 +1578,7 @@ def test_asec():
     assert asec(x).rewrite(atan) == (2*atan(x + sqrt(x**2 - 1)) - pi/2)*sqrt(x**2)/x
     assert asec(x).rewrite(acot) == (2*acot(x - sqrt(x**2 - 1)) - pi/2)*sqrt(x**2)/x
     assert asec(x).rewrite(acsc) == -acsc(x) + pi/2
+    raises(ArgumentIndexError, lambda: asec(x).fdiff(2))
 
 
 def test_asec_is_real():
@@ -1515,6 +1599,12 @@ def test_acsc():
     assert acsc(-oo) == 0
     assert acsc(zoo) == 0
 
+    assert acsc(csc(3)) == -3 + pi
+    assert acsc(csc(4)) == -4 + pi
+    assert acsc(csc(6)) == 6 - 2*pi
+    assert acsc(csc(x)) == acsc(csc(x))
+    assert acsc(sec(x)) == acsc(sec(x))
+
     assert acsc(x).diff(x) == -1/(x**2*sqrt(1 - 1/x**2))
     assert acsc(x).as_leading_term(x) == log(x)
 
@@ -1524,6 +1614,7 @@ def test_acsc():
     assert acsc(x).rewrite(atan) == (-atan(sqrt(x**2 - 1)) + pi/2)*sqrt(x**2)/x
     assert acsc(x).rewrite(acot) == (-acot(1/sqrt(x**2 - 1)) + pi/2)*sqrt(x**2)/x
     assert acsc(x).rewrite(asec) == -asec(x) + pi/2
+    raises(ArgumentIndexError, lambda: acsc(x).fdiff(2))
 
 
 def test_csc_rewrite():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -304,9 +304,9 @@ class sin(TrigonometricFunction):
                 return S.Zero
 
             if (2*pi_coeff).is_integer:
-                if pi_coeff.is_even:
-                    return S.Zero
-                elif pi_coeff.is_even is False:
+                # is_even-case handled above as then pi_coeff.is_integer,
+                # so check if known to be not even
+                if pi_coeff.is_even is False:
                     return S.NegativeOne**(pi_coeff - S.Half)
 
             if not pi_coeff.is_Rational:
@@ -564,9 +564,9 @@ class cos(TrigonometricFunction):
                 return (S.NegativeOne)**pi_coeff
 
             if (2*pi_coeff).is_integer:
-                if pi_coeff.is_even:
-                    return (S.NegativeOne)**(pi_coeff/2)
-                elif pi_coeff.is_even is False:
+                # is_even-case handled above as then pi_coeff.is_integer,
+                # so check if known to be not even
+                if pi_coeff.is_even is False:
                     return S.Zero
 
             if not pi_coeff.is_Rational:
@@ -1487,8 +1487,6 @@ class cot(TrigonometricFunction):
             return True
 
     def _eval_subs(self, old, new):
-        if self == old:
-            return new
         arg = self.args[0]
         argnew = arg.subs(old, new)
         if arg != argnew and (argnew/S.Pi).is_integer:

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -196,7 +196,7 @@ def test_plane():
     assert pl8.intersection(Plane(p1, normal_vector=(-1, -1, -11)))[0].equals(
         Line3D(p1, direction_ratio=(1, -1, 0)))
     assert pl3.random_point() in pl3
-    assert len(pl8.intersection(Ray3D(Point3D(0, 2, 3), Point3D(1, 0, 3)))) is 0
+    assert len(pl8.intersection(Ray3D(Point3D(0, 2, 3), Point3D(1, 0, 3)))) == 0
     # check if two plane are equals
     assert pl6.intersection(pl6)[0].equals(pl6)
     assert pl8.equals(Plane(p1, normal_vector=(0, 12, 0))) is False

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,5 +1,7 @@
 from sympy.core.numbers import Integer, Rational
 from sympy.core.compatibility import as_int
+from sympy.core.singleton import S
+from sympy.core.sympify import _sympify
 from sympy.utilities.misc import filldedent
 
 
@@ -20,13 +22,6 @@ def continued_fraction(a):
     ========
     continued_fraction_periodic, continued_fraction_reduce, continued_fraction_convergents
     """
-    from sympy.core.singleton import S
-    from sympy.core.symbol import Dummy
-    from sympy.core.sympify import _sympify
-    from sympy.core.power import Pow
-    from sympy.polys.polytools import primitive
-    from sympy.polys.polyerrors import ComputationFailed
-
     e = _sympify(a)
     if all(i.is_Rational for i in e.atoms()):
         if e.is_Integer:

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -150,7 +150,7 @@ class VectorLatexPrinter(LatexPrinter):
             base = r"\ddddot{%s}" % base
         else: # Fallback to standard printing
             return LatexPrinter().doprint(der_expr)
-        if len(base_split) is not 1:
+        if len(base_split) != 1:
             base += '_' + base_split[1]
         return base
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -642,7 +642,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 # at both ends. If there is a real value in between, then
                 # sample those points further.
                 elif p[1] is None and q[1] is None:
-                    if self.xscale is 'log':
+                    if self.xscale == 'log':
                         xarray = np.logspace(p[0], q[0], 10)
                     else:
                         xarray = np.linspace(p[0], q[0], 10)
@@ -671,14 +671,14 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
     def get_points(self):
         np = import_module('numpy')
         if self.only_integers is True:
-            if self.xscale is 'log':
+            if self.xscale == 'log':
                 list_x = np.logspace(int(self.start), int(self.end),
                         num=int(self.end) - int(self.start) + 1)
             else:
                 list_x = np.linspace(int(self.start), int(self.end),
                     num=int(self.end) - int(self.start) + 1)
         else:
-            if self.xscale is 'log':
+            if self.xscale == 'log':
                 list_x = np.logspace(self.start, self.end, num=self.nb_of_points)
             else:
                 list_x = np.linspace(self.start, self.end, num=self.nb_of_points)

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -26,7 +26,7 @@ from sympy.polys.agca.ideals import Ideal
 from sympy.polys.domains.field import Field
 from sympy.polys.orderings import ProductOrder, monomial_key
 from sympy.polys.polyerrors import CoercionFailed
-
+from sympy.core.basic import _aresame
 
 # TODO
 # - module saturation
@@ -357,7 +357,7 @@ class FreeModule(Module):
             if len(tpl) != self.rank:
                 raise CoercionFailed
             return FreeModuleElement(self, tpl)
-        elif elem is 0:
+        elif _aresame(elem, 0):
             return FreeModuleElement(self, (self.ring.convert(0),)*self.rank)
         else:
             raise CoercionFailed

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -603,8 +603,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
                 mrow.appendChild(x)
                 mrow.appendChild(y)
             for term in terms:
-                x = self._print(term)
-                mrow.appendChild(x)
+                mrow.appendChild(self.parenthesize(term, PRECEDENCE['Mul']))
                 if not term == terms[-1]:
                     y = self.dom.createElement('mo')
                     y.appendChild(self.dom.createTextNode(self.mathml_tag(expr)))

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1472,11 +1472,11 @@ def test_print_Vector():
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow>'
     assert mathml(x*Cross(ACS.i, ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xD7;</mo><msub><mover>'\
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
-        '<mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+        '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(Cross(x*ACS.i, ACS.j), printer='presentation') == \
         '<mrow><mo>-</mo><mrow><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub>'\
@@ -1499,13 +1499,13 @@ def test_print_Vector():
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Curl(3*ACS.x*ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<mo>&#xD7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn>'\
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced>'\
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'\
-        '</mfenced></mrow></mrow>'
+        '</mfenced></mrow></mfenced></mrow>'
     assert mathml(Curl(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mo>&#xD7;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
@@ -1522,13 +1522,13 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Divergence(3*ACS.x*ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<mo>&#xB7;</mo><mfenced><mrow><mfenced><mrow><mn>3</mn>'\
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced>'\
         '<mo>&InvisibleTimes;</mo><msub><mover><mi mathvariant="bold">j</mi>'\
         '<mo>^</mo></mover><mi mathvariant="bold">A</mi></msub></mrow>'\
-        '</mfenced></mrow></mrow>'
+        '</mfenced></mrow></mfenced></mrow>'
     assert mathml(Divergence(3*x*ACS.x*ACS.j + ACS.i), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mo>&#xB7;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
@@ -1560,11 +1560,11 @@ def test_print_Vector():
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(x*Dot(ACS.i, ACS.j), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><msub><mover>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><msub><mover>'\
         '<mi mathvariant="bold">i</mi><mo>^</mo></mover>'\
         '<mi mathvariant="bold">A</mi></msub><mo>&#xB7;</mo><msub><mover>'\
         '<mi mathvariant="bold">j</mi><mo>^</mo></mover>'\
-        '<mi mathvariant="bold">A</mi></msub></mrow></mrow>'
+        '<mi mathvariant="bold">A</mi></msub></mrow></mfenced></mrow>'
     assert mathml(Gradient(ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><msub><mi mathvariant="bold">x</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow>'
@@ -1574,9 +1574,9 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">y</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mrow></mfenced></mrow>'
     assert mathml(x*Gradient(ACS.x), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2207;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2207;</mo>'\
         '<msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi>'\
-        '</msub></mrow></mrow>'
+        '</msub></mrow></mfenced></mrow>'
     assert mathml(Gradient(x*ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2207;</mo><mfenced><mrow><msub><mi mathvariant="bold">'\
         'x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo>'\
@@ -1596,9 +1596,9 @@ def test_print_Vector():
         '<mo>&InvisibleTimes;</mo><msub><mi mathvariant="bold">y</mi>'\
         '<mi mathvariant="bold">A</mi></msub></mrow></mrow></mfenced></mrow>'
     assert mathml(x*Laplacian(ACS.x), printer='presentation') == \
-        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mrow><mo>&#x2206;</mo>'\
+        '<mrow><mi>x</mi><mo>&InvisibleTimes;</mo><mfenced><mrow><mo>&#x2206;</mo>'\
         '<msub><mi mathvariant="bold">x</mi><mi mathvariant="bold">A</mi>'\
-        '</msub></mrow></mrow>'
+        '</msub></mrow></mfenced></mrow>'
     assert mathml(Laplacian(x*ACS.x), printer='presentation') == \
         '<mrow><mo>&#x2206;</mo><mfenced><mrow><msub><mi mathvariant="bold">'\
         'x</mi><mi mathvariant="bold">A</mi></msub><mo>&InvisibleTimes;</mo>'\

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -19,10 +19,6 @@ def intersection_sets(a, b):
 def intersection_sets(a, b):
     return a
 
-@dispatch(Integers, Naturals)
-def intersection_sets(a, b):
-    return b
-
 @dispatch(Naturals, Naturals)
 def intersection_sets(a, b):
     return a if a is S.Naturals else b
@@ -105,11 +101,7 @@ def intersection_sets(a, b):
 
 @dispatch(Range, Naturals)
 def intersection_sets(a, b):
-    return intersection_sets(a, Interval(1, S.Infinity))
-
-@dispatch(Naturals, Range)
-def intersection_sets(a, b):
-    return intersection_sets(b, a)
+    return intersection_sets(a, Interval(b.inf, S.Infinity))
 
 @dispatch(Range, Range)
 def intersection_sets(a, b):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -211,6 +211,7 @@ def test_Range_set():
     assert empty.intersect(S.Integers) == empty
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals) == Range(1, 10, 1)
+    assert Range(-1, 10, 1).intersect(S.Naturals0) == Range(0, 10, 1)
 
 
     # test slicing

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -3182,7 +3182,7 @@ def power_representation(n, p, k, zeros=False):
             '''Todd G. Will, "When Is n^2 a Sum of k Squares?", [online].
                 Available: https://www.maa.org/sites/default/files/Will-MMz-201037918.pdf'''
             return
-        if feasible is 1:  # it's prime and k == 2
+        if feasible is not True:  # it's prime and k == 2
             yield prime_as_sum_of_two_squares(n)
             return
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -11,13 +11,15 @@ from __future__ import print_function, division
 
 from itertools import product
 
-from sympy import (Basic, Symbol, symbols, cacheit, sympify, Mul,
-        And, Or, Tuple, Piecewise, Eq, Lambda, exp, I, Dummy, nan)
+from sympy import (Basic, Symbol, symbols, cacheit, sympify, Mul, Add,
+        And, Or, Tuple, Piecewise, Eq, Lambda, exp, I, Dummy, nan, Rational)
 from sympy.sets.sets import FiniteSet
+from sympy.core.relational import Relational
 from sympy.stats.rv import (RandomDomain, ProductDomain, ConditionalDomain,
         PSpace, IndependentProductPSpace, SinglePSpace, random_symbols,
         sumsets, rv_subs, NamedArgsMixin)
 from sympy.core.containers import Dict
+from sympy.core.logic import Logic
 import random
 
 class FiniteDensity(dict):
@@ -142,14 +144,6 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
         if condition is True:
             return domain
         cond = rv_subs(condition)
-        # Check that we aren't passed a condition like die1 == z
-        # where 'z' is a symbol that we don't know about
-        # We will never be able to test this equality through iteration
-        if not cond.free_symbols.issubset(domain.free_symbols):
-            raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
-                condition, tuple(cond.free_symbols - domain.free_symbols)) +
-                "Will be unable to iterate using this condition")
-
         return Basic.__new__(cls, domain, cond)
 
 
@@ -165,7 +159,7 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
             return val
         elif val.is_Equality:
             return val.lhs == val.rhs
-        raise ValueError("Undeciable if %s" % str(val))
+        raise ValueError("Undecidable if %s" % str(val))
 
     def __contains__(self, other):
         return other in self.fulldomain and self._test(other)
@@ -308,8 +302,15 @@ class FinitePSpace(PSpace):
     def compute_expectation(self, expr, rvs=None, **kwargs):
         rvs = rvs or self.values
         expr = expr.xreplace(dict((rs, rs.symbol) for rs in rvs))
-        return sum([expr.xreplace(dict(elem)) * self.prob_of(elem)
-                for elem in self.domain])
+        probs = [self.prob_of(elem) for elem in self.domain]
+        if isinstance(expr, (Logic, Relational)):
+            parse_domain = [tuple(elem)[0][1] for elem in self.domain]
+            bools = [expr.xreplace(dict(elem)) for elem in self.domain]
+        else:
+            parse_domain = [expr.xreplace(dict(elem)) for elem in self.domain]
+            bools = [True for elem in self.domain]
+        return sum([Piecewise((prob * elem, blv), (0, True))
+                for prob, elem, blv in zip(probs, parse_domain, bools)])
 
     def compute_quantile(self, expr):
         cdf = self.compute_cdf(expr)
@@ -321,7 +322,16 @@ class FinitePSpace(PSpace):
 
     def probability(self, condition):
         cond_symbols = frozenset(rs.symbol for rs in random_symbols(condition))
-        assert cond_symbols.issubset(self.symbols)
+        cond = rv_subs(condition)
+        if not cond_symbols.issubset(self.symbols):
+            raise ValueError("Cannot compare foriegn random symbols, %s"
+                             %(str(cond_symbols - self.symbols)))
+        if isinstance(condition, Relational) and \
+            (not cond.free_symbols.issubset(self.domain.free_symbols)):
+            rv = condition.lhs if isinstance(condition.rhs, Symbol) else condition.rhs
+            return sum(Piecewise(
+                       (self.prob_of(elem), condition.subs(rv, list(elem)[0][1])),
+                       (0, True)) for elem in self.domain)
         return sum(self.prob_of(elem) for elem in self.where(condition))
 
     def conditional_space(self, condition):

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -140,7 +140,7 @@ class DieDistribution(SingleFiniteDistribution):
     @cacheit
     def dict(self):
         as_int(self.sides) # Check that self.sides can be converted to an integer
-        return super(DieDistribution, self).dict
+        return dict((k, Rational(1, self.sides)) for k in self.set)
 
     @property
     def set(self):

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -356,3 +356,16 @@ def test_FinitePSpace():
     X = Die('X', 6)
     space = pspace(X)
     assert space.density == DieDistribution(6)
+
+def test_symbolic_conditions():
+    B = Bernoulli('B', S(1)/4)
+    D = Die('D', 4)
+    b, n = symbols('b, n')
+    Y = P(Eq(B, b))
+    Z = E(D > n)
+    assert Y == \
+    Piecewise((S(1)/4, Eq(b, 1)), (0, True)) + \
+    Piecewise((S(3)/4, Eq(b, 0)), (0, True))
+    assert Z == \
+    Piecewise((S(1)/4, n < 1), (0, True)) + Piecewise((S(1)/2, n < 2), (0, True)) + \
+    Piecewise((S(3)/4, n < 3), (0, True)) + Piecewise((S(1), n < 4), (0, True))

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -165,8 +165,6 @@ def test_dependence():
     XX, YY = given(Tuple(X, Y), Eq(X + Y, 3))
     assert dependent(XX, YY)
 
-
-@XFAIL
 def test_dependent_finite():
     X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -188,6 +188,7 @@ def derive_by_array(expr, dx):
 
     """
     from sympy.matrices import MatrixBase
+    from sympy.tensor import SparseNDimArray
     array_types = (Iterable, MatrixBase, NDimArray)
 
     if isinstance(dx, array_types):
@@ -197,9 +198,19 @@ def derive_by_array(expr, dx):
                 raise ValueError("cannot derive by this array")
 
     if isinstance(expr, array_types):
-        expr = ImmutableDenseNDimArray(expr)
+        if isinstance(expr, NDimArray):
+            expr = expr.as_immutable()
+        else:
+            expr = ImmutableDenseNDimArray(expr)
+
         if isinstance(dx, array_types):
-            new_array = [[y.diff(x) for y in expr] for x in dx]
+            if isinstance(expr, SparseNDimArray):
+                lp = len(expr)
+                new_array = {k + i*lp: v
+                             for i, x in enumerate(dx)
+                             for k, v in expr.diff(x)._sparse_array.items()}
+            else:
+                new_array = [[y.diff(x) for y in expr] for x in dx]
             return type(expr)(new_array, dx.shape + expr.shape)
         else:
             return expr.diff(dx)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -367,19 +367,29 @@ class NDimArray(object):
 
     def __mul__(self, other):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
 
         if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
+
         other = sympify(other)
+        if isinstance(self, SparseNDimArray):
+            return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [i*other for i in self]
         return type(self)(result_list, self.shape)
 
     def __rmul__(self, other):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
 
         if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
+
         other = sympify(other)
+        if isinstance(self, SparseNDimArray):
+            return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [other*i for i in self]
         return type(self)(result_list, self.shape)
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Basic
+from sympy import S
 from sympy.core.expr import Expr
 from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify
@@ -129,33 +130,35 @@ class NDimArray(object):
     @classmethod
     def _handle_ndarray_creation_inputs(cls, iterable=None, shape=None, **kwargs):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
+        from sympy import Dict
 
-        if shape is None and iterable is None:
-            shape = ()
-            iterable = ()
-        # Construction from another `NDimArray`:
-        elif shape is None and isinstance(iterable, NDimArray):
-            shape = iterable.shape
-            iterable = list(iterable)
-        # Construct N-dim array from an iterable (numpy arrays included):
-        elif shape is None and isinstance(iterable, Iterable):
-            iterable, shape = cls._scan_iterable_shape(iterable)
+        if shape is None:
+            if iterable is None:
+                shape = ()
+                iterable = ()
+            # Construction of a sparse array from a sparse array
+            elif isinstance(iterable, SparseNDimArray):
+                return iterable._shape, iterable._sparse_array
+            # Construction from another `NDimArray`:
+            elif isinstance(iterable, NDimArray):
+                shape = iterable.shape
+                iterable = list(iterable)
+            # Construct N-dim array from an iterable (numpy arrays included):
+            elif isinstance(iterable, Iterable):
+                iterable, shape = cls._scan_iterable_shape(iterable)
 
-        # Construct N-dim array from a Matrix:
-        elif shape is None and isinstance(iterable, MatrixBase):
-            shape = iterable.shape
+            # Construct N-dim array from a Matrix:
+            elif isinstance(iterable, MatrixBase):
+                shape = iterable.shape
 
-        # Construct N-dim array from another N-dim array:
-        elif shape is None and isinstance(iterable, NDimArray):
-            shape = iterable.shape
+            # Construct N-dim array from another N-dim array:
+            elif isinstance(iterable, NDimArray):
+                shape = iterable.shape
 
-        # Construct NDimArray(iterable, shape)
-        elif shape is not None:
-            pass
-
-        else:
-            shape = ()
-            iterable = (iterable,)
+            else:
+                shape = ()
+                iterable = (iterable,)
 
         if isinstance(shape, (SYMPY_INTS, Integer)):
             shape = (shape,)
@@ -251,7 +254,9 @@ class NDimArray(object):
     def _eval_derivative_array(self, arg):
         from sympy import derive_by_array
         from sympy import Tuple
+        from sympy import SparseNDimArray
         from sympy.matrices.common import MatrixCommon
+
         if isinstance(arg, (Iterable, Tuple, MatrixCommon, NDimArray)):
             return derive_by_array(self, arg)
         else:
@@ -270,6 +275,11 @@ class NDimArray(object):
         >>> m.applyfunc(lambda i: 2*i)
         [[0, 2], [4, 6]]
         """
+        from sympy.tensor.array import SparseNDimArray
+
+        if isinstance(self, SparseNDimArray) and f(S.Zero) == 0:
+            return type(self)({k: f(v) for k, v in self._sparse_array.items() if f(v) != 0}, self.shape)
+
         return type(self)(map(f, self), self.shape)
 
     def __str__(self):
@@ -430,9 +440,17 @@ class NDimArray(object):
         >>> a == b
         False
         """
+        from sympy.tensor.array import SparseNDimArray
         if not isinstance(other, NDimArray):
             return False
-        return (self.shape == other.shape) and (list(self) == list(other))
+
+        if not self.shape == other.shape:
+            return False
+
+        if isinstance(self, SparseNDimArray) and isinstance(other, SparseNDimArray):
+            return dict(self._sparse_array) == dict(other._sparse_array)
+
+        return list(self) == list(other)
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -111,7 +111,6 @@ class SparseNDimArray(NDimArray):
 
         return type(self)(*(newshape + (self._array,)))
 
-
 class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):
 
     def __new__(cls, iterable=None, shape=None, **kwargs):

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -6,7 +6,7 @@ from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
-from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff
+from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff, Dict
 from sympy.tensor.array import Array, NDimArray
 
 from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
@@ -57,6 +57,7 @@ def test_tensorcontraction():
 
 def test_derivative_by_array():
     from sympy.abc import a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
+    from sympy.tensor.array import MutableSparseNDimArray, ImmutableSparseNDimArray
 
     bexpr = x*y**2*exp(z)*log(t)
     sexpr = sin(bexpr)
@@ -83,6 +84,13 @@ def test_derivative_by_array():
     assert diff(Array([[x, y], [z, t]]), Array([x, y])) == Array([[[1, 0], [0, 0]], [[0, 1], [0, 0]]])
     assert diff(Array([[x, y], [z, t]]), Array([[x, y], [z, t]])) == Array([[[[1, 0], [0, 0]], [[0, 1], [0, 0]]],
                                                                          [[[0, 0], [1, 0]], [[0, 0], [0, 1]]]])
+
+    # test for large scale sparse array
+    b = MutableSparseNDimArray.zeros(10000, 20000)
+    b[0, 0] = i
+    b[0, 1] = j
+    assert derive_by_array(b, i) == ImmutableSparseNDimArray({0: 1}, (10000, 20000))
+    assert derive_by_array(b, (i, j)) == ImmutableSparseNDimArray({0: 1, 200000001: 1}, (2, 10000, 20000))
 
 
 def test_issue_emerged_while_discussing_10972():

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -339,6 +339,10 @@ def test_diff_and_applyfunc():
     assert sdn == ImmutableSparseNDimArray([[x/2, y/2], [x*z/2, x*y*z/2]])
     assert sd != sdn
 
+    sdp = sd.applyfunc(lambda x: x+1)
+    assert sdp == ImmutableSparseNDimArray([[x + 1, y + 1], [x*z + 1, x*y*z + 1]])
+    assert sd != sdp
+
 
 def test_op_priority():
     from sympy.abc import x, y, z

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -136,6 +136,12 @@ def test_sparse():
     assert len(sparse_array._sparse_array) == 1
     assert sparse_array[0, 0] == 0
 
+    # test for large scale sparse array
+    # tests for __mul__ and __rmul__
+    a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
+    assert a * 3 == ImmutableDenseNDimArray({1:6, 3:12}, (10000, 20000))
+    assert 3 * a == ImmutableDenseNDimArray({1:6, 3:12}, (10000, 20000))
+
 
 def test_calculation():
 

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -139,8 +139,8 @@ def test_sparse():
     # test for large scale sparse array
     # tests for __mul__ and __rmul__
     a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
-    assert a * 3 == ImmutableDenseNDimArray({1:6, 3:12}, (10000, 20000))
-    assert 3 * a == ImmutableDenseNDimArray({1:6, 3:12}, (10000, 20000))
+    assert a * 3 == ImmutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
+    assert 3 * a == ImmutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
 
 
 def test_calculation():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -131,11 +131,13 @@ def test_sparse():
     assert len(sparse_array._sparse_array) == 0
     assert sparse_array[0, 0] == 0
 
-    # tests for large scale sparse arrays
-    # tests for __mul__ and __rmul__
-    a = MutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
-    assert a * 3 == MutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
-    assert 3 * a == MutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
+    # test for large scale sparse array
+    a = MutableSparseNDimArray.zeros(100000, 200000)
+    b = MutableSparseNDimArray.zeros(100000, 200000)
+    assert a == b
+    a[1, 1] = 1
+    b[1, 1] = 2
+    assert a != b
 
 
 def test_calculation():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -131,6 +131,12 @@ def test_sparse():
     assert len(sparse_array._sparse_array) == 0
     assert sparse_array[0, 0] == 0
 
+    # tests for large scale sparse arrays
+    # tests for __mul__ and __rmul__
+    a = MutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
+    assert a * 3 == MutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
+    assert 3 * a == MutableSparseNDimArray({1:6, 3:12}, (10000, 20000))
+
 
 def test_calculation():
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -106,9 +106,11 @@ See the appropriate docstrings for a detailed explanation of the output.
 
 from __future__ import print_function, division
 
+from sympy.core.assumptions import StdFactKB, _assume_defined
 from sympy.core import Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import (is_sequence, string_types, NotIterable,
                                       Iterable)
+from sympy.core.logic import fuzzy_bool
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 
@@ -125,10 +127,13 @@ class Indexed(Expr):
     >>> Indexed('A', i, j)
     A[i, j]
 
-    It is recommended that ``Indexed`` objects be created via ``IndexedBase``:
+    It is recommended that ``Indexed`` objects be created by indexing ``IndexedBase``:
+    ``IndexedBase('A')[i, j]`` instead of ``Indexed(IndexedBase('A'), i, j)``.
 
     >>> A = IndexedBase('A')
-    >>> Indexed('A', i, j) == A[i, j]
+    >>> a_ij = A[i, j]           # Prefer this,
+    >>> b_ij = Indexed(A, i, j)  # over this.
+    >>> a_ij == b_ij
     True
 
     """
@@ -136,6 +141,7 @@ class Indexed(Expr):
     is_Indexed = True
     is_symbol = True
     is_Atom = True
+
 
     def __new__(cls, base, *args, **kw_args):
         from sympy.utilities.misc import filldedent
@@ -159,7 +165,16 @@ class Indexed(Expr):
             else:
                 return base[args]
 
-        return Expr.__new__(cls, base, *args, **kw_args)
+        obj = Expr.__new__(cls, base, *args, **kw_args)
+
+        try:
+            IndexedBase._set_assumptions(obj, base.assumptions0)
+        except AttributeError:
+            IndexedBase._set_assumptions(obj, {})
+        return obj
+
+    def _hashable_content(self):
+        return super(Indexed, self)._hashable_content() + tuple(sorted(self.assumptions0.items()))
 
     @property
     def name(self):
@@ -189,6 +204,10 @@ class Indexed(Expr):
             if Tuple(self.indices).has(wrt):
                 return S.NaN
             return S.Zero
+
+    @property
+    def assumptions0(self):
+        return {k: v for k, v in self._assumptions.items() if v is not None}
 
     @property
     def base(self):
@@ -384,10 +403,35 @@ class IndexedBase(Expr, NotIterable):
     >>> B[i, j].shape
     (o, p)
 
+    Assumptions can be specified with keyword arguments the same way as for Symbol:
+
+    >>> A_real = IndexedBase('A', real=True)
+    >>> A_real.is_real
+    True
+    >>> A != A_real
+    True
     """
     is_commutative = True
     is_symbol = True
     is_Atom = True
+
+    @staticmethod
+    def _filter_assumptions(kw_args):
+        """Split the given dict into two parts: assumptions and not assumptions.
+           Keys are taken as assumptions if they correspond to an entry in ``_assume_defined``."""
+        assumptions = {k: v for k, v in kw_args.items() if k in _assume_defined}
+        Symbol._sanitize(assumptions)
+        # return assumptions, not assumptions
+        return assumptions, {k: v for k, v in kw_args.items() if k not in assumptions}
+
+    @staticmethod
+    def _set_assumptions(obj, assumptions):
+        """Set assumptions on obj, making sure to apply consistent values."""
+        tmp_asm_copy = assumptions.copy()
+        is_commutative = fuzzy_bool(assumptions.get('commutative', True))
+        assumptions['commutative'] = is_commutative
+        obj._assumptions = StdFactKB(assumptions)
+        obj._assumptions._generator = tmp_asm_copy  # Issue #8873
 
     def __new__(cls, label, shape=None, **kw_args):
         from sympy import MatrixBase, NDimArray
@@ -419,11 +463,20 @@ class IndexedBase(Expr, NotIterable):
         obj._offset = offset
         obj._strides = strides
         obj._name = str(label)
+        assumptions, _ = IndexedBase._filter_assumptions(kw_args)
+        IndexedBase._set_assumptions(obj, assumptions)
         return obj
 
     @property
     def name(self):
         return self._name
+
+    def _hashable_content(self):
+        return super(IndexedBase, self)._hashable_content() + tuple(sorted(self.assumptions0.items()))
+
+    @property
+    def assumptions0(self):
+        return {k: v for k, v in self._assumptions.items() if v is not None}
 
     def __getitem__(self, indices, **kw_args):
         if is_sequence(indices):

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -4,7 +4,7 @@ from sympy.tensor.indexed import IndexException
 from sympy.utilities.pytest import raises, XFAIL
 
 # import test:
-from sympy import IndexedBase, Idx, Indexed, S, sin, cos, Sum, Piecewise, And, Order, LessThan, StrictGreaterThan, \
+from sympy import IndexedBase, Idx, Indexed, S, sin, cos, exp, log, Sum, Piecewise, And, Order, LessThan, StrictGreaterThan, \
     GreaterThan, StrictLessThan, Range, Array, Subs, Function, KroneckerDelta, Derivative
 
 
@@ -202,6 +202,24 @@ def test_IndexedBase_shape():
     assert F.shape == Tuple(m)
     assert F[i].subs(i, j) == F[j]
     raises(IndexException, lambda: F[i, j])
+
+
+def test_IndexedBase_assumptions():
+    i = Symbol('i', integer=True)
+    a = Symbol('a')
+    A = IndexedBase(a, positive=True)
+    for c in (A, A[i]):
+        assert c.is_real
+        assert c.is_complex
+        assert not c.is_imaginary
+        assert c.is_nonnegative
+        assert c.is_nonzero
+        assert c.is_commutative
+        assert log(exp(c)) == c
+
+    assert A != IndexedBase(a)
+    assert A == IndexedBase(a, positive=True, real=True)
+    assert A[i] != Indexed(a, i)
 
 
 def test_Indexed_constructor():

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -274,9 +274,9 @@ def get_default_datatype(expr, complex_allowed=None):
         #check all entries
         dt = "int"
         for element in expr:
-            if dt is "int" and not element.is_integer:
+            if dt == "int" and not element.is_integer:
                 dt = "float"
-            if dt is "float" and not element.is_real:
+            if dt == "float" and not element.is_real:
                 return default_datatypes[final_dtype]
         return default_datatypes[dt]
     else:

--- a/sympy/utilities/tests/test_travis.py
+++ b/sympy/utilities/tests/test_travis.py
@@ -1,0 +1,6 @@
+def test_travis_issue_16986():
+    # If this causes the travis build to fail with Python3.8,
+    # then the changes made in PR #16986 are working as
+    # intended, and this file can be deleted.
+
+    assert int(1) is 1

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -167,9 +167,9 @@ class CoordSys3D(Basic):
             if isinstance(transformation, Lambda):
                 variable_names = ["x1", "x2", "x3"]
             elif isinstance(transformation, Symbol):
-                if transformation.name is 'spherical':
+                if transformation.name == 'spherical':
                     variable_names = ["r", "theta", "phi"]
-                elif transformation.name is 'cylindrical':
+                elif transformation.name == 'cylindrical':
                     variable_names = ["r", "theta", "z"]
                 else:
                     variable_names = ["x", "y", "z"]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16941

#### Brief description of what is fixed or changed
The multiplcation is cast to a list while calculating each term, which is unnecessary for the zero value in sparse array. Thanks to the lazy-evaluation of iterator in NDimArray, this issue will not cause a MemoryError, but the operation is slow.
Before:
```
>>> a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
>>> b = 3*a
#Operation takes a lot of time
```
Now
```
>>> a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
>>> b = 3*a
>>> b._sparse_array
{1:6, 3:12}
```
Since only the no-zero values in the dictionary are changed, this execution time is much ameliorated.
Some tests are added.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added specific case for sparse array in __mul__, __rmul__ and tests

<!-- END RELEASE NOTES -->
