### PR TITLE
consider Naturals.inf for intersection with Range

### DIFF
--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -1,5 +1,7 @@
 from sympy.core.numbers import Integer, Rational
 from sympy.core.compatibility import as_int
+from sympy.core.singleton import S
+from sympy.core.sympify import _sympify
 from sympy.utilities.misc import filldedent
 
 
@@ -20,13 +22,6 @@ def continued_fraction(a):
     ========
     continued_fraction_periodic, continued_fraction_reduce, continued_fraction_convergents
     """
-    from sympy.core.singleton import S
-    from sympy.core.symbol import Dummy
-    from sympy.core.sympify import _sympify
-    from sympy.core.power import Pow
-    from sympy.polys.polytools import primitive
-    from sympy.polys.polyerrors import ComputationFailed
-
     e = _sympify(a)
     if all(i.is_Rational for i in e.atoms()):
         if e.is_Integer:

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -19,10 +19,6 @@ def intersection_sets(a, b):
 def intersection_sets(a, b):
     return a
 
-@dispatch(Integers, Naturals)
-def intersection_sets(a, b):
-    return b
-
 @dispatch(Naturals, Naturals)
 def intersection_sets(a, b):
     return a if a is S.Naturals else b
@@ -105,11 +101,7 @@ def intersection_sets(a, b):
 
 @dispatch(Range, Naturals)
 def intersection_sets(a, b):
-    return intersection_sets(a, Interval(1, S.Infinity))
-
-@dispatch(Naturals, Range)
-def intersection_sets(a, b):
-    return intersection_sets(b, a)
+    return intersection_sets(a, Interval(b.inf, S.Infinity))
 
 @dispatch(Range, Range)
 def intersection_sets(a, b):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -211,6 +211,7 @@ def test_Range_set():
     assert empty.intersect(S.Integers) == empty
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals) == Range(1, 10, 1)
+    assert Range(-1, 10, 1).intersect(S.Naturals0) == Range(0, 10, 1)
 
 
     # test slicing


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
```python
>>> Naturals0.intersect(Range(-2,3))
Range(1, 4, 1) --> should be Range(4)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
    - Naturals0.intersect(Range) is handled correctly now
<!-- END RELEASE NOTES -->
