### PR TITLE
Increase coverage of beta_functions, error_functions, zeta_functions, and special polynomials

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -128,6 +128,8 @@ class erf(Function):
         if isinstance(arg, erfcinv):
             return S.One - arg.args[0]
 
+        # Unlikely to happend since erf2inv(0, x) is evaluated to
+        # erfinv(x)
         if isinstance(arg, erf2inv) and arg.args[0] is S.Zero:
             return arg.args[1]
 
@@ -513,6 +515,8 @@ class erfi(Function):
                 return I*nz.args[0]
             if isinstance(nz, erfcinv):
                 return I*(S.One - nz.args[0])
+            # Unlikely to happend since erf2inv(0, x) is evaluated to
+            # erfinv(x)
             if isinstance(nz, erf2inv) and nz.args[0] is S.Zero:
                 return I*nz.args[1]
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -19,6 +19,23 @@ from sympy.functions.special.hyper import hyper, meijerg
 # TODO series expansions
 # TODO see the "Note:" in Ei
 
+# Helper function
+def real_to_real_as_real_imag(self, deep=True, **hints):
+    if self.args[0].is_extended_real:
+        if deep:
+            hints['complex'] = False
+            return (self.expand(deep, **hints), S.Zero)
+        else:
+            return (self, S.Zero)
+    if deep:
+        x, y = self.args[0].expand(deep, **hints).as_real_imag()
+    else:
+        x, y = self.args[0].as_real_imag()
+    re = (self.func(x + I*y) + self.func(x - I*y))/2
+    im = (self.func(x + I*y) - self.func(x - I*y))/(2*I)
+    return (re, im)
+
+
 ###############################################################################
 ################################ ERROR FUNCTION ###############################
 ###############################################################################
@@ -128,8 +145,7 @@ class erf(Function):
         if isinstance(arg, erfcinv):
             return S.One - arg.args[0]
 
-        # Unlikely to happend since erf2inv(0, x) is evaluated to
-        # erfinv(x)
+        # Only happens with unevaluated erf2inv
         if isinstance(arg, erf2inv) and arg.args[0] is S.Zero:
             return arg.args[1]
 
@@ -206,23 +222,7 @@ class erf(Function):
         else:
             return self.func(arg)
 
-    def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_extended_real:
-            if deep:
-                hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
-            else:
-                return (self, S.Zero)
-        if deep:
-            x, y = self.args[0].expand(deep, **hints).as_real_imag()
-        else:
-            x, y = self.args[0].as_real_imag()
-
-        sq = -y**2/x**2
-        re = S.Half*(self.func(x + x*sqrt(sq)) + self.func(x - x*sqrt(sq)))
-        im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
-                    self.func(x + x*sqrt(sq)))
-        return (re, im)
+    as_real_imag = real_to_real_as_real_imag
 
 
 class erfc(Function):
@@ -398,23 +398,8 @@ class erfc(Function):
         else:
             return self.func(arg)
 
-    def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_extended_real:
-            if deep:
-                hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
-            else:
-                return (self, S.Zero)
-        if deep:
-            x, y = self.args[0].expand(deep, **hints).as_real_imag()
-        else:
-            x, y = self.args[0].as_real_imag()
+    as_real_imag = real_to_real_as_real_imag
 
-        sq = -y**2/x**2
-        re = S.Half*(self.func(x + x*sqrt(sq)) + self.func(x - x*sqrt(sq)))
-        im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
-                    self.func(x + x*sqrt(sq)))
-        return (re, im)
 
 class erfi(Function):
     r"""
@@ -515,8 +500,7 @@ class erfi(Function):
                 return I*nz.args[0]
             if isinstance(nz, erfcinv):
                 return I*(S.One - nz.args[0])
-            # Unlikely to happend since erf2inv(0, x) is evaluated to
-            # erfinv(x)
+            # Only happens with unevaluated erf2inv
             if isinstance(nz, erf2inv) and nz.args[0] is S.Zero:
                 return I*nz.args[1]
 
@@ -572,23 +556,8 @@ class erfi(Function):
     def _eval_expand_func(self, **hints):
         return self.rewrite(erf)
 
-    def as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_extended_real:
-            if deep:
-                hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
-            else:
-                return (self, S.Zero)
-        if deep:
-            x, y = self.args[0].expand(deep, **hints).as_real_imag()
-        else:
-            x, y = self.args[0].as_real_imag()
+    as_real_imag = real_to_real_as_real_imag
 
-        sq = -y**2/x**2
-        re = S.Half*(self.func(x + x*sqrt(sq)) + self.func(x - x*sqrt(sq)))
-        im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
-                    self.func(x + x*sqrt(sq)))
-        return (re, im)
 
 class erf2(Function):
     r"""
@@ -1582,6 +1551,8 @@ class TrigonometricIntegral(Function):
         arg = unpolarify(self.args[0])
         if argindex == 1:
             return self._trigfunc(arg)/arg
+        else:
+            raise ArgumentIndexError(self, argindex)
 
     def _eval_rewrite_as_Ei(self, z, **kwargs):
         return self._eval_rewrite_as_expint(z).rewrite(Ei)
@@ -2035,8 +2006,6 @@ class FresnelIntegral(Function):
         # if any were extracted automatically
         if z is S.Infinity:
             return S.Half
-        elif z is I*S.Infinity:
-            return cls._sign*I*S.Half
 
     def fdiff(self, argindex=1):
         if argindex == 1:
@@ -2047,35 +2016,12 @@ class FresnelIntegral(Function):
     def _eval_is_extended_real(self):
         return self.args[0].is_extended_real
 
+    _eval_is_finite = _eval_is_extended_real
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_extended_real:
-            if deep:
-                hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
-            else:
-                return (self, S.Zero)
-        if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
-        else:
-            re, im = self.args[0].as_real_imag()
-        return (re, im)
-
-    def as_real_imag(self, deep=True, **hints):
-        # Fresnel S
-        # http://functions.wolfram.com/06.32.19.0003.01
-        # http://functions.wolfram.com/06.32.19.0006.01
-        # Fresnel C
-        # http://functions.wolfram.com/06.33.19.0003.01
-        # http://functions.wolfram.com/06.33.19.0006.01
-        x, y = self._as_real_imag(deep=deep, **hints)
-        sq = -y**2/x**2
-        re = S.Half*(self.func(x + x*sqrt(sq)) + self.func(x - x*sqrt(sq)))
-        im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
-                self.func(x + x*sqrt(sq)))
-        return (re, im)
+    as_real_imag = real_to_real_as_real_imag
 
 
 class fresnels(FresnelIntegral):

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -603,6 +603,7 @@ class chebyshevu(OrthogonalPolynomial):
             # U_{-n}(x)  --->  -U_{n-2}(x)
             if n.could_extract_minus_sign():
                 if n == S.NegativeOne:
+                    # n can not be -1 here
                     return S.Zero
                 else:
                     return -chebyshevu(-n - 2, x)

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -805,7 +805,19 @@ class legendre(OrthogonalPolynomial):
             raise ArgumentIndexError(self, argindex)
         elif argindex == 2:
             # Diff wrt x
-            # Find better formula, this is unsuitable for x = 1
+            # Find better formula, this is unsuitable for x = +/-1
+            # http://www.autodiff.org/ad16/Oral/Buecker_Legendre.pdf says
+            # at x = 1:
+            #    n*(n + 1)/2            , m = 0
+            #    oo                     , m = 1
+            #    -(n-1)*n*(n+1)*(n+2)/4 , m = 2
+            #    0                      , m = 3, 4, ..., n
+            #
+            # at x = -1
+            #    (-1)**(n+1)*n*(n + 1)/2       , m = 0
+            #    (-1)**n*oo                    , m = 1
+            #    (-1)**n*(n-1)*n*(n+1)*(n+2)/4 , m = 2
+            #    0                             , m = 3, 4, ..., n
             n, x = self.args
             return n/(x**2 - 1)*(x*legendre(n, x) - legendre(n - 1, x))
         else:

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -1238,7 +1238,7 @@ class assoc_laguerre(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
+    def _eval_rewrite_as_polynomial(self, n, alpha, x, **kwargs):
         from sympy import Sum
         # Make sure n \in N_0
         if n.is_negative or n.is_integer is False:

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -145,10 +145,6 @@ class jacobi(OrthogonalPolynomial):
         elif b == -a:
             # P^{a, -a}_n(x)
             return gamma(n + a + 1) / gamma(n + 1) * (1 + x)**(a/2) / (1 - x)**(a/2) * assoc_legendre(n, -a, x)
-        elif a == -b:
-            # Will not happen since b == -a is equivalent
-            # P^{-b, b}_n(x)
-            return gamma(n - b + 1) / gamma(n + 1) * (1 - x)**(b/2) / (1 + x)**(b/2) * assoc_legendre(n, b, x)
 
         if not n.is_Number:
             # Symbolic result P^{a,b}_n(x)

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -146,6 +146,7 @@ class jacobi(OrthogonalPolynomial):
             # P^{a, -a}_n(x)
             return gamma(n + a + 1) / gamma(n + 1) * (1 + x)**(a/2) / (1 - x)**(a/2) * assoc_legendre(n, -a, x)
         elif a == -b:
+            # Will not happen since b == -a is equivalent
             # P^{-b, b}_n(x)
             return gamma(n - b + 1) / gamma(n + 1) * (1 - x)**(b/2) / (1 + x)**(b/2) * assoc_legendre(n, b, x)
 

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.complexes import re
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import cos
+from sympy.functions.elementary.trigonometric import cos, sec
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper
 
@@ -362,10 +362,8 @@ class gegenbauer(OrthogonalPolynomial):
                 if (re(a) > S.Half) == True:
                     return S.ComplexInfinity
                 else:
-                    # No sec function available yet
-                    #return (cos(S.Pi*(a+n)) * sec(S.Pi*a) * gamma(2*a+n) /
-                    #            (gamma(2*a) * gamma(n+1)))
-                    return None
+                    return (cos(S.Pi*(a+n)) * sec(S.Pi*a) * gamma(2*a+n) /
+                                (gamma(2*a) * gamma(n+1)))
 
             # Symbolic result C^a_n(x)
             # C^a_n(-x)  --->  (-1)**n * C^a_n(x)

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -1,4 +1,6 @@
-from sympy import (Symbol, gamma, expand_func, beta, digamma, diff)
+from sympy import (Symbol, gamma, expand_func, beta, digamma, diff, conjugate)
+from sympy.core.function import ArgumentIndexError
+from sympy.utilities.pytest import raises
 
 
 def test_beta():
@@ -12,3 +14,7 @@ def test_beta():
 
     assert diff(beta(x, y), x) == beta(x, y)*(digamma(x) - digamma(x + y))
     assert diff(beta(x, y), y) == beta(x, y)*(digamma(y) - digamma(x + y))
+
+    assert conjugate(beta(x, y)) == beta(conjugate(x), conjugate(y))
+
+    raises(ArgumentIndexError, lambda: beta(x, y).fdiff(3))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -72,7 +72,19 @@ def test_erf():
          erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
          re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
 
+    assert erf(x).as_real_imag(deep=False) == \
+        ((erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
+         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
+         I*(erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
+         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
+         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+
+    xr = Symbol('x', extended_real=True)
+    assert erf(xr).as_real_imag() == (erf(xr), 0)
+    assert erf(xr).as_real_imag(deep=False) == (erf(xr), 0)
+
     raises(ArgumentIndexError, lambda: erf(x).fdiff(2))
+
 
 
 def test_erf_series():
@@ -112,6 +124,8 @@ def test_erfc():
     assert erfc(I).is_real is False
     assert erfc(0).is_real is True
 
+    assert erfc(erfinv(x)) == 1 - x
+
     assert conjugate(erfc(z)) == erfc(conjugate(z))
 
     assert erfc(x).as_leading_term(x) == S.One
@@ -127,6 +141,7 @@ def test_erfc():
     assert erfc(z).rewrite('meijerg') == 1 - z*meijerg([S.Half], [], [0], [-S.Half], z**2)/sqrt(pi)
     assert erfc(z).rewrite('uppergamma') == 1 - sqrt(z**2)*(1 - erfc(sqrt(z**2)))/z
     assert erfc(z).rewrite('expint') == S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
+    assert erfc(z).rewrite('tractable') == _erfs(z)*exp(-z**2)
     assert expand_func(erf(x) + erfc(x)) == S.One
 
     assert erfc(x).as_real_imag() == \
@@ -136,6 +151,16 @@ def test_erfc():
          erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
          re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
 
+    assert erfc(x).as_real_imag(deep=False) == \
+        ((erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
+         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
+         I*(erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
+         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
+         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+
+    xr = Symbol('x', extended_real=True)
+    assert erfc(xr).as_real_imag() == (erfc(xr), 0)
+    assert erfc(xr).as_real_imag(deep=False) == (erfc(xr), 0)
     raises(ArgumentIndexError, lambda: erfc(x).fdiff(2))
 
 
@@ -242,6 +267,7 @@ def test_erfinv():
     assert erfinv(0) == 0
     assert erfinv(1) == S.Infinity
     assert erfinv(nan) == S.NaN
+    assert erfinv(-1) == S.NegativeInfinity
 
     assert erfinv(erf(w)) == w
     assert erfinv(erf(-w)) == -w
@@ -270,7 +296,11 @@ def test_erf2inv():
     assert erf2inv(0, 1) == S.Infinity
     assert erf2inv(1, 0) == S.One
     assert erf2inv(0, y) == erfinv(y)
-    assert erf2inv(oo,y) == erfcinv(-y)
+    assert erf2inv(oo, y) == erfcinv(-y)
+    assert erf2inv(x, 0) == x
+    assert erf2inv(x, oo) == erfinv(x)
+    assert erf2inv(nan, 0) == nan
+    assert erf2inv(0, nan) == nan
 
     assert erf2inv(x, y).diff(x) == exp(-x**2 + erf2inv(x, y)**2)
     assert erf2inv(x, y).diff(y) == sqrt(pi)*exp(erf2inv(x, y)**2)/2

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -100,6 +100,7 @@ def test__erfs():
     assert expand(erf(z).rewrite('tractable').diff(z).rewrite('intractable')) \
         == erf(z).diff(z)
     assert _erfs(z).rewrite("intractable") == (-erf(z) + 1)*exp(z**2)
+    raises(ArgumentIndexError, lambda: _erfs(z).fdiff(2))
 
 
 def test_erfc():
@@ -458,6 +459,7 @@ def test__eis():
 
     assert _eis(z).series(z, n=3) == EulerGamma + log(z) + z*(-log(z) - \
         EulerGamma + 1) + z**2*(log(z)/2 - S(3)/4 + EulerGamma/2) + O(z**3*log(z))
+    raises(ArgumentIndexError, lambda: _eis(z).fdiff(2))
 
 
 def tn_arg(func):

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -38,6 +38,7 @@ def test_erf():
     assert erf(erfinv(x)) == x
     assert erf(erfcinv(x)) == 1 - x
     assert erf(erf2inv(0, x)) == x
+    assert erf(erf2inv(0, x, evaluate=False)) == x # To cover code in erf
     assert erf(erf2inv(0, erf(erfcinv(1 - erf(erfinv(x)))))) == x
 
     assert erf(I).is_real is False
@@ -66,22 +67,15 @@ def test_erf():
     assert limit(((1 - erf(x))*exp(x**2)*sqrt(pi)*x - 1)*2*x**2, x, oo) == -1
 
     assert erf(x).as_real_imag() == \
-        ((erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+        (erf(re(x) - I*im(x))/2 + erf(re(x) + I*im(x))/2,
+         -I*(-erf(re(x) - I*im(x)) + erf(re(x) + I*im(x)))/2)
 
     assert erf(x).as_real_imag(deep=False) == \
-        ((erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erf(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+        (erf(re(x) - I*im(x))/2 + erf(re(x) + I*im(x))/2,
+         -I*(-erf(re(x) - I*im(x)) + erf(re(x) + I*im(x)))/2)
 
-    xr = Symbol('x', extended_real=True)
-    assert erf(xr).as_real_imag() == (erf(xr), 0)
-    assert erf(xr).as_real_imag(deep=False) == (erf(xr), 0)
+    assert erf(w).as_real_imag() == (erf(w), 0)
+    assert erf(w).as_real_imag(deep=False) == (erf(w), 0)
 
     raises(ArgumentIndexError, lambda: erf(x).fdiff(2))
 
@@ -146,22 +140,15 @@ def test_erfc():
     assert expand_func(erf(x) + erfc(x)) == S.One
 
     assert erfc(x).as_real_imag() == \
-        ((erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+        (erfc(re(x) - I*im(x))/2 + erfc(re(x) + I*im(x))/2,
+         -I*(-erfc(re(x) - I*im(x)) + erfc(re(x) + I*im(x)))/2)
 
     assert erfc(x).as_real_imag(deep=False) == \
-        ((erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erfc(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+        (erfc(re(x) - I*im(x))/2 + erfc(re(x) + I*im(x))/2,
+         -I*(-erfc(re(x) - I*im(x)) + erfc(re(x) + I*im(x)))/2)
 
-    xr = Symbol('x', extended_real=True)
-    assert erfc(xr).as_real_imag() == (erfc(xr), 0)
-    assert erfc(xr).as_real_imag(deep=False) == (erfc(xr), 0)
+    assert erfc(w).as_real_imag() == (erfc(w), 0)
+    assert erfc(w).as_real_imag(deep=False) == (erfc(w), 0)
     raises(ArgumentIndexError, lambda: erfc(x).fdiff(2))
 
     assert erfc(x).inverse() == erfcinv
@@ -192,6 +179,7 @@ def test_erfi():
     assert erfi(I*erfinv(x)) == I*x
     assert erfi(I*erfcinv(x)) == I*(1 - x)
     assert erfi(I*erf2inv(0, x)) == I*x
+    assert erfi(I*erf2inv(0, x, evaluate=False)) == I*x # To cover code in erfi
 
     assert erfi(I).is_real is False
     assert erfi(0).is_real is True
@@ -213,22 +201,14 @@ def test_erfi():
     assert expand_func(erfi(I*z)) == I*erf(z)
 
     assert erfi(x).as_real_imag() == \
-        ((erfi(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erfi(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erfi(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erfi(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
-
+        (erfi(re(x) - I*im(x))/2 + erfi(re(x) + I*im(x))/2,
+         -I*(-erfi(re(x) - I*im(x)) + erfi(re(x) + I*im(x)))/2)
     assert erfi(x).as_real_imag(deep=False) == \
-        ((erfi(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
-         erfi(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))/2,
-         I*(erfi(re(x) - I*re(x)*Abs(im(x))/Abs(re(x))) -
-         erfi(re(x) + I*re(x)*Abs(im(x))/Abs(re(x)))) *
-         re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
+        (erfi(re(x) - I*im(x))/2 + erfi(re(x) + I*im(x))/2,
+         -I*(-erfi(re(x) - I*im(x)) + erfi(re(x) + I*im(x)))/2)
 
-    xr = Symbol('x', extended_real=True)
-    assert erfi(xr).as_real_imag() == (erfi(xr), 0)
-    assert erfi(xr).as_real_imag(deep=False) == (erfi(xr), 0)
+    assert erfi(w).as_real_imag() == (erfi(w), 0)
+    assert erfi(w).as_real_imag(deep=False) == (erfi(w), 0)
 
     raises(ArgumentIndexError, lambda: erfi(x).fdiff(2))
 
@@ -637,6 +617,7 @@ def test_ci():
                                         expint(1, x*exp_polar(I*pi/2))/2
     assert Ci(x).rewrite(expint) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
                                         expint(1, x*exp_polar(I*pi/2))/2
+    raises(ArgumentIndexError, lambda: Ci(x).fdiff(2))
 
 
 def test_fresnel():
@@ -664,18 +645,26 @@ def test_fresnel():
         pi*z**3/6 - pi**3*z**7/336 + pi**5*z**11/42240 + O(z**15)
 
     assert fresnels(w).is_extended_real is True
+    assert fresnels(w).is_finite is True
 
-    assert fresnels(z).as_real_imag() == \
-        ((fresnels(re(z) - I*re(z)*Abs(im(z))/Abs(re(z)))/2 +
-          fresnels(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))/2,
-          I*(fresnels(re(z) - I*re(z)*Abs(im(z))/Abs(re(z))) -
-          fresnels(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))) *
-          re(z)*Abs(im(z))/(2*im(z)*Abs(re(z)))))
+    assert fresnels(z).is_extended_real is None
+    assert fresnels(z).is_finite is None
+
+    assert fresnels(z).as_real_imag() == (fresnels(re(z) - I*im(z))/2 +
+                    fresnels(re(z) + I*im(z))/2,
+                    -I*(-fresnels(re(z) - I*im(z)) + fresnels(re(z) + I*im(z)))/2)
+
+    assert fresnels(z).as_real_imag(deep=False) == (fresnels(re(z) - I*im(z))/2 +
+                    fresnels(re(z) + I*im(z))/2,
+                    -I*(-fresnels(re(z) - I*im(z)) + fresnels(re(z) + I*im(z)))/2)
+
+    assert fresnels(w).as_real_imag() == (fresnels(w), 0)
+    assert fresnels(w).as_real_imag(deep=True) == (fresnels(w), 0)
 
     assert fresnels(2 + 3*I).as_real_imag() == (
-        fresnels(2 + 3*I)/2 + fresnels(2 - 3*I)/2,
-        I*(fresnels(2 - 3*I) - fresnels(2 + 3*I))/2
-    )
+            fresnels(2 + 3*I)/2 + fresnels(2 - 3*I)/2,
+            -I*(fresnels(2 + 3*I) - fresnels(2 - 3*I))/2
+            )
 
     assert expand_func(integrate(fresnels(z), z)) == \
         z*fresnels(z) + cos(pi*z**2/2)/pi
@@ -707,22 +696,16 @@ def test_fresnel():
     assert fresnelc(w).is_extended_real is True
 
     assert fresnelc(z).as_real_imag() == \
-        ((fresnelc(re(z) - I*re(z)*Abs(im(z))/Abs(re(z)))/2 +
-          fresnelc(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))/2,
-          I*(fresnelc(re(z) - I*re(z)*Abs(im(z))/Abs(re(z))) -
-          fresnelc(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))) *
-          re(z)*Abs(im(z))/(2*im(z)*Abs(re(z)))))
+        (fresnelc(re(z) - I*im(z))/2 + fresnelc(re(z) + I*im(z))/2,
+         -I*(-fresnelc(re(z) - I*im(z)) + fresnelc(re(z) + I*im(z)))/2)
 
     assert fresnelc(z).as_real_imag(deep=False) == \
-        ((fresnelc(re(z) - I*re(z)*Abs(im(z))/Abs(re(z)))/2 +
-          fresnelc(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))/2,
-          I*(fresnelc(re(z) - I*re(z)*Abs(im(z))/Abs(re(z))) -
-          fresnelc(re(z) + I*re(z)*Abs(im(z))/Abs(re(z)))) *
-          re(z)*Abs(im(z))/(2*im(z)*Abs(re(z)))))
+        (fresnelc(re(z) - I*im(z))/2 + fresnelc(re(z) + I*im(z))/2,
+         -I*(-fresnelc(re(z) - I*im(z)) + fresnelc(re(z) + I*im(z)))/2)
 
     assert fresnelc(2 + 3*I).as_real_imag() == (
         fresnelc(2 - 3*I)/2 + fresnelc(2 + 3*I)/2,
-        I*(fresnelc(2 - 3*I) - fresnelc(2 + 3*I))/2
+         -I*(fresnelc(2 + 3*I) - fresnelc(2 - 3*I))/2
     )
 
     assert expand_func(integrate(fresnelc(z), z)) == \

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -591,9 +591,12 @@ def test_ci():
     assert Chi(x).nseries(x, n=4) == \
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
+    assert Ci(x).rewrite(uppergamma) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
+                                        expint(1, x*exp_polar(I*pi/2))/2
+    assert Ci(x).rewrite(expint) == -expint(1, x*exp_polar(-I*pi/2))/2 -\
+                                        expint(1, x*exp_polar(I*pi/2))/2
 
 
-@slow
 def test_fresnel():
     assert fresnels(0) == 0
     assert fresnels(oo) == S.Half
@@ -657,23 +660,6 @@ def test_fresnel():
     assert fresnelc(z).rewrite(hyper) == \
         z * hyper([S.One/4], [S.One/2, S(5)/4], -pi**2*z**4/16)
 
-    assert fresnelc(z).series(z, n=15) == \
-        z - pi**2*z**5/40 + pi**4*z**9/3456 - pi**6*z**13/599040 + O(z**15)
-
-    # issues 6510, 10102
-    fs = (S.Half - sin(pi*z**2/2)/(pi**2*z**3)
-        + (-1/(pi*z) + 3/(pi**3*z**5))*cos(pi*z**2/2))
-    fc = (S.Half - cos(pi*z**2/2)/(pi**2*z**3)
-        + (1/(pi*z) - 3/(pi**3*z**5))*sin(pi*z**2/2))
-    assert fresnels(z).series(z, oo) == fs + O(z**(-6), (z, oo))
-    assert fresnelc(z).series(z, oo) == fc + O(z**(-6), (z, oo))
-    assert (fresnels(z).series(z, -oo) + fs.subs(z, -z)).expand().is_Order
-    assert (fresnelc(z).series(z, -oo) + fc.subs(z, -z)).expand().is_Order
-    assert (fresnels(1/z).series(z) - fs.subs(z, 1/z)).expand().is_Order
-    assert (fresnelc(1/z).series(z) - fc.subs(z, 1/z)).expand().is_Order
-    assert ((2*fresnels(3*z)).series(z, oo) - 2*fs.subs(z, 3*z)).expand().is_Order
-    assert ((3*fresnelc(2*z)).series(z, oo) - 3*fc.subs(z, 2*z)).expand().is_Order
-
     assert fresnelc(w).is_extended_real is True
 
     assert fresnelc(z).as_real_imag() == \
@@ -706,3 +692,23 @@ def test_fresnel():
     verify_numerically(im(fresnelc(z)), fresnelc(z).as_real_imag()[1], z)
     verify_numerically(fresnelc(z), fresnelc(z).rewrite(hyper), z)
     verify_numerically(fresnelc(z), fresnelc(z).rewrite(meijerg), z)
+
+
+@slow
+def test_fresnel_series():
+    assert fresnelc(z).series(z, n=15) == \
+        z - pi**2*z**5/40 + pi**4*z**9/3456 - pi**6*z**13/599040 + O(z**15)
+
+    # issues 6510, 10102
+    fs = (S.Half - sin(pi*z**2/2)/(pi**2*z**3)
+        + (-1/(pi*z) + 3/(pi**3*z**5))*cos(pi*z**2/2))
+    fc = (S.Half - cos(pi*z**2/2)/(pi**2*z**3)
+        + (1/(pi*z) - 3/(pi**3*z**5))*sin(pi*z**2/2))
+    assert fresnels(z).series(z, oo) == fs + O(z**(-6), (z, oo))
+    assert fresnelc(z).series(z, oo) == fc + O(z**(-6), (z, oo))
+    assert (fresnels(z).series(z, -oo) + fs.subs(z, -z)).expand().is_Order
+    assert (fresnelc(z).series(z, -oo) + fc.subs(z, -z)).expand().is_Order
+    assert (fresnels(1/z).series(z) - fs.subs(z, 1/z)).expand().is_Order
+    assert (fresnelc(1/z).series(z) - fc.subs(z, 1/z)).expand().is_Order
+    assert ((2*fresnels(3*z)).series(z, oo) - 2*fs.subs(z, 3*z)).expand().is_Order
+    assert ((3*fresnelc(2*z)).series(z, oo) - 3*fc.subs(z, 2*z)).expand().is_Order

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -8,7 +8,7 @@ from sympy import (
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises, XFAIL, skip
 
 x = Symbol('x')
 
@@ -342,8 +342,8 @@ def test_laguerre():
     raises(ArgumentIndexError, lambda: laguerre(n, x).fdiff(3))
 
 
-@XFAIL
 def test_legendre_fail():
+    skip("Infinite recursion kills Travis")
     n = Symbol("n")
     assert laguerre(-n, x) == exp(x)*laguerre(n-1, -x)
     assert laguerre(-3, x) == exp(x)*laguerre(2, -x)

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -93,6 +93,8 @@ def test_gegenbauer():
     assert gegenbauer(n, a, 1) == gamma(2*a + n)/(gamma(2*a)*gamma(n + 1))
 
     assert gegenbauer(n, Rational(3, 4), -1) == zoo
+    assert gegenbauer(n, Rational(1, 4), -1) == (sqrt(2)*cos(pi*(n + S(1)/4))*
+                      gamma(n + S(1)/2)/(sqrt(pi)*gamma(n + 1)))
 
     m = Symbol("m", positive=True)
     assert gegenbauer(m, a, oo) == oo*RisingFactorial(a, m)

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -1,8 +1,9 @@
 from sympy import (
     Symbol, Dummy, diff, Derivative, Rational, roots, S, sqrt, hyper,
     cos, gamma, conjugate, factorial, pi, oo, zoo, binomial, RisingFactorial,
-    legendre, assoc_legendre, chebyshevu, chebyshevt, chebyshevt_root, chebyshevu_root,
-    laguerre, assoc_laguerre, laguerre_poly, hermite, gegenbauer, jacobi, jacobi_normalized)
+    legendre, assoc_legendre, chebyshevu, chebyshevt, chebyshevt_root,
+    chebyshevu_root, laguerre, assoc_laguerre, laguerre_poly, hermite,
+    gegenbauer, jacobi, jacobi_normalized, Sum)
 
 from sympy.core.compatibility import range
 from sympy.utilities.pytest import raises, XFAIL
@@ -45,6 +46,14 @@ def test_jacobi():
         jacobi(m, conjugate(a), conjugate(b), conjugate(x))
 
     assert diff(jacobi(n, a, b, x), n) == Derivative(jacobi(n, a, b, x), n)
+    assert str(diff(jacobi(n, a, b, x), a)) == 'Sum((jacobi(n, a, b, x) + '\
+        '(2*_k + a + b + 1)*RisingFactorial(_k + b + 1, -_k + n)*jacobi(_k, a,'\
+        ' b, x)/((-_k + n)*RisingFactorial(_k + a + b + 1, -_k + n)))/(_k + a'\
+        ' + b + n + 1), (_k, 0, n - 1))'
+    assert str(diff(jacobi(n, a, b, x), b)) == 'Sum(((-1)**(-_k + n)*(2*_k + '\
+        'a + b + 1)*RisingFactorial(_k + a + 1, -_k + n)*jacobi(_k, a, b, x)/'\
+        '((-_k + n)*RisingFactorial(_k + a + b + 1, -_k + n)) + jacobi(n, a, '\
+        'b, x))/(_k + a + b + n + 1), (_k, 0, n - 1))'
     assert diff(jacobi(n, a, b, x), x) == \
         (a/2 + b/2 + n/2 + S(1)/2)*jacobi(n - 1, a + 1, b + 1, x)
 
@@ -54,6 +63,10 @@ def test_jacobi():
 
     raises(ValueError, lambda: jacobi(-2.1, a, b, x))
     raises(ValueError, lambda: jacobi(Dummy(positive=True, integer=True), 1, 2, oo))
+
+    assert str(jacobi(n, a, b, x).rewrite("polynomial")) == 'Sum((1/2 - x/2)'\
+        '**_k*RisingFactorial(-n, _k)*RisingFactorial(_k + a + 1, -_k + n)*'\
+        'RisingFactorial(a + b + n + 1, _k)/factorial(_k), (_k, 0, n))/factorial(n)'
 
 
 def test_gegenbauer():
@@ -87,7 +100,19 @@ def test_gegenbauer():
     assert conjugate(gegenbauer(n, a, x)) == gegenbauer(n, conjugate(a), conjugate(x))
 
     assert diff(gegenbauer(n, a, x), n) == Derivative(gegenbauer(n, a, x), n)
+    assert str(diff(gegenbauer(n, a, x), a)) == 'Sum((2*(-1)**(-_k + n) + 2)*'\
+        '(_k + a)*gegenbauer(_k, a, x)/((-_k + n)*(_k + 2*a + n)) + ((2*_k + '\
+        '2)/((_k + 2*a)*(2*_k + 2*a + 1)) + 2/(_k + 2*a + n))*gegenbauer(n, a'\
+        ', x), (_k, 0, n - 1))'
     assert diff(gegenbauer(n, a, x), x) == 2*a*gegenbauer(n - 1, a + 1, x)
+
+    assert str(diff(gegenbauer(n, a, x), a).rewrite('polynomial')) == \
+         'Sum((2*(-1)**(-_k + n) + 2)*(_k + a)*Sum((-1)**_k*(2*x)**(_k - 2*_k'\
+         ')*RisingFactorial(a, _k - _k)/(factorial(_k)*factorial(_k - 2*_k)),'\
+         ' (_k, 0, floor(_k/2)))/((-_k + n)*(_k + 2*a + n)) + ((2*_k + 2)/((_'\
+         'k + 2*a)*(2*_k + 2*a + 1)) + 2/(_k + 2*a + n))*Sum((-1)**_k*(2*x)**'\
+         '(-2*_k + n)*RisingFactorial(a, -_k + n)/(factorial(_k)*factorial(-2'\
+         '*_k + n)), (_k, 0, floor(n/2))), (_k, 0, n - 1))'
 
 
 def test_legendre():

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -269,13 +269,13 @@ def test_chebyshev():
 
     assert diff(chebyshevu(n, x), x) == \
         (-x*chebyshevu(n, x) + (n + 1)*chebyshevt(n + 1, x))/(x**2 - 1)
-    _k = Dummy('k')
 
-    assert str(chebyshevt(n, x).rewrite("polynomial")) == 'Sum(x**(-2*_k + n)'\
-                    '*(x**2 - 1)**_k*binomial(n, 2*_k), (_k, 0, floor(n/2)))'
-    assert str(chebyshevu(n, x).rewrite("polynomial")) == 'Sum((-1)**_k*(2*x)'\
-                    '**(-2*_k + n)*factorial(-_k + n)/(factorial(_k)*factoria'\
-                    'l(-2*_k + n)), (_k, 0, floor(n/2)))'
+    _k = Dummy('k')
+    assert chebyshevt(n, x).rewrite("polynomial").dummy_eq(Sum(x**(-2*_k + n)
+                    *(x**2 - 1)**_k*binomial(n, 2*_k), (_k, 0, floor(n/2))))
+    assert chebyshevu(n, x).rewrite("polynomial").dummy_eq(Sum((-1)**_k*(2*x)
+                    **(-2*_k + n)*factorial(-_k + n)/(factorial(_k)*
+                       factorial(-2*_k + n)), (_k, 0, floor(n/2))))
     raises(ArgumentIndexError, lambda: chebyshevt(n, x).fdiff(1))
     raises(ArgumentIndexError, lambda: chebyshevt(n, x).fdiff(3))
     raises(ArgumentIndexError, lambda: chebyshevu(n, x).fdiff(1))
@@ -300,9 +300,10 @@ def test_hermite():
 
     assert conjugate(hermite(n, x)) == hermite(n, conjugate(x))
 
-    assert  str(hermite(n, x).rewrite("polynomial")) == 'factorial(n)*Sum((-1'\
-        ')**_k*(2*x)**(-2*_k + n)/(factorial(_k)*factorial(-2*_k + n)), (_k, '\
-        '0, floor(n/2)))'
+    _k = Dummy('k')
+    assert  hermite(n, x).rewrite("polynomial").dummy_eq(factorial(n)*Sum((-1)
+        **_k*(2*x)**(-2*_k + n)/(factorial(_k)*factorial(-2*_k + n)), (_k,
+        0, floor(n/2))))
 
     assert diff(hermite(n, x), x) == 2*n*hermite(n - 1, x)
     assert diff(hermite(n, x), n) == Derivative(hermite(n, x), n)
@@ -332,8 +333,8 @@ def test_laguerre():
 
     _k = Dummy('k')
 
-    assert str(laguerre(n, x).rewrite("polynomial")) == \
-        'Sum(x**_k*RisingFactorial(-n, _k)/factorial(_k)**2, (_k, 0, n))'
+    assert laguerre(n, x).rewrite("polynomial").dummy_eq(
+        Sum(x**_k*RisingFactorial(-n, _k)/factorial(_k)**2, (_k, 0, n)))
 
     assert diff(laguerre(n, x), x) == -assoc_laguerre(n - 1, 1, x)
 

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,9 +1,11 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
-                   exp_polar, polar_lift, O, stieltjes, Abs, Sum)
+                   exp_polar, polar_lift, O, stieltjes, Abs, Sum, oo)
+from sympy.core.function import ArgumentIndexError
+from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
+from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically as tn)
-from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
 
 x = Symbol('x')
 a = Symbol('a')
@@ -39,6 +41,8 @@ def test_zeta_eval():
     assert zeta(2, -2) == pi**2/6 + Rational(5, 4)
     assert zeta(4, -3) == pi**4/90 + Rational(1393, 1296)
     assert zeta(6, -4) == pi**6/945 + Rational(3037465, 2985984)
+
+    assert zeta(oo) == 1
 
     assert zeta(-1) == -Rational(1, 12)
     assert zeta(-2) == 0
@@ -81,6 +85,7 @@ def test_dirichlet_eta_eval():
 def test_rewriting():
     assert dirichlet_eta(x).rewrite(zeta) == (1 - 2**(1 - x))*zeta(x)
     assert zeta(x).rewrite(dirichlet_eta) == dirichlet_eta(x)/(1 - 2**(1 - x))
+    assert zeta(x).rewrite(dirichlet_eta, a=2) == zeta(x)
     assert tn(dirichlet_eta(x), dirichlet_eta(x).rewrite(zeta), x)
     assert tn(zeta(x), zeta(x).rewrite(dirichlet_eta), x)
 
@@ -106,6 +111,10 @@ def test_derivatives():
     assert td(polylog(b, z), z)
     assert td(lerchphi(c, b, x), x)
     assert td(lerchphi(x, b, c), x)
+    raises(ArgumentIndexError, lambda: lerchphi(c, b, x).fdiff(2))
+    raises(ArgumentIndexError, lambda: lerchphi(c, b, x).fdiff(4))
+    raises(ArgumentIndexError, lambda: polylog(b, z).fdiff(1))
+    raises(ArgumentIndexError, lambda: polylog(b, z).fdiff(3))
 
 
 def myexpand(func, target):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
Checking how much of Fresnel integrals are tested now that not all tests are marked as slow...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Fixed issue with `as_real_imag()` for Fresnel integrals.
   * Added case for direct evaluation of Gegenbauer polynomials.
   * Associated Laguerre polynomials can now be rewritten as (explicit) polynomials.
<!-- END RELEASE NOTES -->
