### PR TITLE
[WIP]Added cases for sparse arrays in tensorproduct

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -42,7 +42,7 @@ def tensorproduct(*args):
     >>> p
     [[[[x, y], [z, t]], [[0, 0], [0, 0]], [[0, 0], [0, 0]]], [[[0, 0], [0, 0]], [[x, y], [z, t]], [[0, 0], [0, 0]]], [[[0, 0], [0, 0]], [[0, 0], [0, 0]], [[x, y], [z, t]]]]
     """
-    from sympy.tensor.array import SparseNDimArray
+    from sympy.tensor.array import SparseNDimArray, ImmutableSparseNDimArray
 
     if len(args) == 0:
         return S.One
@@ -57,13 +57,10 @@ def tensorproduct(*args):
     if not isinstance(a, NDimArray) or not isinstance(b, NDimArray):
         return a*b
 
-    if isinstance(a, SparseNDimArray) and not isinstance(b, NDimArray):
-        return type(a)({k: b*v for (k, v) in a._sparse_array}, a.shape)
-
-    if isinstance(b, SparseNDimArray) and not isinstance(a, NDimArray):
-        return type(b)({k: a*v for (k, v) in b._sparse_array}, b.shape)
-
-    # TODO: product for two sparse arrays
+    if isinstance(a, SparseNDimArray) and isinstance(b, SparseNDimArray):
+        lp = len(b)
+        new_array = {k1*lp + k2: v1*v2 for k1, v1 in a._sparse_array.items() for k2, v2 in b._sparse_array.items()}
+        return ImmutableSparseNDimArray(new_array, a.shape + b.shape)
 
     al = list(a)
     bl = list(b)

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -42,6 +42,8 @@ def tensorproduct(*args):
     >>> p
     [[[[x, y], [z, t]], [[0, 0], [0, 0]], [[0, 0], [0, 0]]], [[[0, 0], [0, 0]], [[x, y], [z, t]], [[0, 0], [0, 0]]], [[[0, 0], [0, 0]], [[0, 0], [0, 0]], [[x, y], [z, t]]]]
     """
+    from sympy.tensor.array import SparseNDimArray
+
     if len(args) == 0:
         return S.One
     if len(args) == 1:
@@ -54,6 +56,14 @@ def tensorproduct(*args):
 
     if not isinstance(a, NDimArray) or not isinstance(b, NDimArray):
         return a*b
+
+    if isinstance(a, SparseNDimArray) and not isinstance(b, NDimArray):
+        return type(a)({k: b*v for (k, v) in a._sparse_array}, a.shape)
+
+    if isinstance(b, SparseNDimArray) and not isinstance(a, NDimArray):
+        return type(b)({k: a*v for (k, v) in b._sparse_array}, b.shape)
+
+    # TODO: product for two sparse arrays
 
     al = list(a)
     bl = list(b)

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -7,7 +7,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff
-from sympy.tensor.array import Array, NDimArray
+from sympy.tensor.array import Array, NDimArray, MutableSparseNDimArray
 
 from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
@@ -42,6 +42,11 @@ def test_tensorproduct():
     assert tensorproduct(a, A, B) == Array([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
     assert tensorproduct(A, B, a) == Array([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
     assert tensorproduct(B, a, A) == Array([[a*x, a*y], [2*a*x, 2*a*y], [3*a*x, 3*a*y]])
+
+    # tests for large scale sparse array
+    a = MutableSparseNDimArray.zeros(10000, 20000)
+    assert tensorproduct(a, x) == MutableSparseNDimArray.zeros(10000, 20000)
+    assert tensorproduct(x, a) == MutableSparseNDimArray.zeros(10000, 20000)
 
 
 def test_tensorcontraction():

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -7,7 +7,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff
-from sympy.tensor.array import Array, NDimArray, MutableSparseNDimArray
+from sympy.tensor.array import Array, NDimArray, ImmutableSparseNDimArray
 
 from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
@@ -44,9 +44,10 @@ def test_tensorproduct():
     assert tensorproduct(B, a, A) == Array([[a*x, a*y], [2*a*x, 2*a*y], [3*a*x, 3*a*y]])
 
     # tests for large scale sparse array
-    a = MutableSparseNDimArray.zeros(10000, 20000)
-    assert tensorproduct(a, x) == MutableSparseNDimArray.zeros(10000, 20000)
-    assert tensorproduct(x, a) == MutableSparseNDimArray.zeros(10000, 20000)
+    a = ImmutableSparseNDimArray({1:2, 3:4},(1000, 2000))
+    b = ImmutableSparseNDimArray({1:2, 3:4},(1000, 2000))
+    assert tensorproduct(a, b) == ImmutableSparseNDimArray({2000001: 4, 2000003: 8, 6000001: 8, 6000003: 16}, (1000, 2000, 1000, 2000))
+
 
 
 def test_tensorcontraction():

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -7,7 +7,7 @@ from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate, diff
-from sympy.tensor.array import Array, NDimArray, ImmutableSparseNDimArray
+from sympy.tensor.array import Array, NDimArray, ImmutableDenseNDimArray, ImmutableSparseNDimArray, MutableSparseNDimArray
 
 from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
@@ -26,28 +26,29 @@ def test_tensorproduct():
     assert tensorproduct(x, y, z) == x*y*z
     assert tensorproduct(x, y, z, t) == x*y*z*t
 
-    A = Array([x, y])
-    B = Array([1, 2, 3])
-    C = Array([a, b, c, d])
+    for ArrayType in [ImmutableDenseNDimArray, ImmutableSparseNDimArray]:
+        A = ArrayType([x, y])
+        B = ArrayType([1, 2, 3])
+        C = ArrayType([a, b, c, d])
 
-    assert tensorproduct(A, B, C) == Array([[[a*x, b*x, c*x, d*x], [2*a*x, 2*b*x, 2*c*x, 2*d*x], [3*a*x, 3*b*x, 3*c*x, 3*d*x]],
-                                            [[a*y, b*y, c*y, d*y], [2*a*y, 2*b*y, 2*c*y, 2*d*y], [3*a*y, 3*b*y, 3*c*y, 3*d*y]]])
+        assert tensorproduct(A, B, C) == ArrayType([[[a*x, b*x, c*x, d*x], [2*a*x, 2*b*x, 2*c*x, 2*d*x], [3*a*x, 3*b*x, 3*c*x, 3*d*x]],
+                                                    [[a*y, b*y, c*y, d*y], [2*a*y, 2*b*y, 2*c*y, 2*d*y], [3*a*y, 3*b*y, 3*c*y, 3*d*y]]])
 
-    assert tensorproduct([x, y], [1, 2, 3]) == tensorproduct(A, B)
+        assert tensorproduct([x, y], [1, 2, 3]) == tensorproduct(A, B)
 
-    assert tensorproduct(A, 2) == Array([2*x, 2*y])
-    assert tensorproduct(A, [2]) == Array([[2*x], [2*y]])
-    assert tensorproduct([2], A) == Array([[2*x, 2*y]])
-    assert tensorproduct(a, A) == Array([a*x, a*y])
-    assert tensorproduct(a, A, B) == Array([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
-    assert tensorproduct(A, B, a) == Array([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
-    assert tensorproduct(B, a, A) == Array([[a*x, a*y], [2*a*x, 2*a*y], [3*a*x, 3*a*y]])
+        assert tensorproduct(A, 2) == ArrayType([2*x, 2*y])
+        assert tensorproduct(A, [2]) == ArrayType([[2*x], [2*y]])
+        assert tensorproduct([2], A) == ArrayType([[2*x, 2*y]])
+        assert tensorproduct(a, A) == ArrayType([a*x, a*y])
+        assert tensorproduct(a, A, B) == ArrayType([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
+        assert tensorproduct(A, B, a) == ArrayType([[a*x, 2*a*x, 3*a*x], [a*y, 2*a*y, 3*a*y]])
+        assert tensorproduct(B, a, A) == ArrayType([[a*x, a*y], [2*a*x, 2*a*y], [3*a*x, 3*a*y]])
 
     # tests for large scale sparse array
-    a = ImmutableSparseNDimArray({1:2, 3:4},(1000, 2000))
-    b = ImmutableSparseNDimArray({1:2, 3:4},(1000, 2000))
-    assert tensorproduct(a, b) == ImmutableSparseNDimArray({2000001: 4, 2000003: 8, 6000001: 8, 6000003: 16}, (1000, 2000, 1000, 2000))
-
+    for SparseArrayType in [ImmutableSparseNDimArray, MutableSparseNDimArray]:
+        a = SparseArrayType({1:2, 3:4},(1000, 2000))
+        b = SparseArrayType({1:2, 3:4},(1000, 2000))
+        assert tensorproduct(a, b) == ImmutableSparseNDimArray({2000001: 4, 2000003: 8, 6000001: 8, 6000003: 16}, (1000, 2000, 1000, 2000))
 
 
 def test_tensorcontraction():
@@ -63,7 +64,6 @@ def test_tensorcontraction():
 
 def test_derivative_by_array():
     from sympy.abc import a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
-    from sympy.tensor.array import MutableSparseNDimArray, ImmutableSparseNDimArray
 
     bexpr = x*y**2*exp(z)*log(t)
     sexpr = sin(bexpr)
@@ -92,11 +92,10 @@ def test_derivative_by_array():
                                                                          [[[0, 0], [1, 0]], [[0, 0], [0, 1]]]])
 
     # test for large scale sparse array
-    b = MutableSparseNDimArray.zeros(10000, 20000)
-    b[0, 0] = i
-    b[0, 1] = j
-    assert derive_by_array(b, i) == ImmutableSparseNDimArray({0: 1}, (10000, 20000))
-    assert derive_by_array(b, (i, j)) == ImmutableSparseNDimArray({0: 1, 200000001: 1}, (2, 10000, 20000))
+    for SparseArrayType in [ImmutableSparseNDimArray, MutableSparseNDimArray]:
+        b = MutableSparseNDimArray({0:i, 1:j}, (10000, 20000))
+        assert derive_by_array(b, i) == ImmutableSparseNDimArray({0: 1}, (10000, 20000))
+        assert derive_by_array(b, (i, j)) == ImmutableSparseNDimArray({0: 1, 200000001: 1}, (2, 10000, 20000))
 
 
 def test_issue_emerged_while_discussing_10972():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16941

#### Brief description of what is fixed or changed
Sparse array are cast into list while performing tensorproduct. Brief overview in #16941
**Before:**
```python
>>> a = MutableSparseNDimArray.zeros(10000, 20000)
>>> res = tensorproduct(a, 3)
Too slow
```
Thanks to the lazy-evaluation, it would not cause a MemoryError immediately. But as the evaluation continues, it is supposed to go beyond the limit of memory. So it should be fixed.
**Now:**

```python
>>> a = MutableSparseNDimArray({1:1}, (3, ))
>>> b = MutableSparseNDimArray({2:1}, (3, ))

>>> tensorproduct(a, b) == ImmutableSparseNDimArray({5: 1}, (3, 3))
True
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added specific cases for sparse array in tensorproduct and tests

<!-- END RELEASE NOTES -->
