### PR TITLE
Fix more compatibility issues with Python3.8.

### DIFF
--- a/examples/advanced/pidigits.py
+++ b/examples/advanced/pidigits.py
@@ -9,7 +9,7 @@ computation of the digits of pi.
 from mpmath import libmp, pi
 
 import math
-from time import clock
+from sympy.core.compatibility import clock
 import sys
 
 

--- a/examples/advanced/pyglet_plotting.py
+++ b/examples/advanced/pyglet_plotting.py
@@ -8,10 +8,10 @@ Suggested Usage:    python -i pyglet_plotting.py
 
 
 from sympy import symbols, sin, cos, pi, sqrt
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, clock
 from sympy.plotting.pygletplot import PygletPlot
 
-from time import sleep, clock
+from time import sleep
 
 
 def main():

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -954,3 +954,8 @@ try:
 except ImportError:  # Python 2.7
     def filterfalse(pred, itr):
         return filter(lambda x: not pred(x), itr)
+
+try:
+    from time import clock
+except ImportError: # Python 3.8+
+    from time import perf_counter as clock

--- a/sympy/plotting/pygletplot/plot_window.py
+++ b/sympy/plotting/pygletplot/plot_window.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from time import clock
+from sympy.core.compatibility import clock
 
 import pyglet.gl as pgl
 

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -653,8 +653,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             return table
         brac = self.dom.createElement('mfenced')
         if self._settings["mat_delim"] == "[":
-            brac.setAttribute('open', '[')
             brac.setAttribute('close', ']')
+            brac.setAttribute('open', '[')
         brac.appendChild(table)
         return brac
 
@@ -960,8 +960,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_AccumulationBounds(self, i):
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('open', u'\u27e8')
         brac.setAttribute('close', u'\u27e9')
+        brac.setAttribute('open', u'\u27e8')
         brac.appendChild(self._print(i.min))
         brac.appendChild(self._print(i.max))
         return brac
@@ -1105,19 +1105,19 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         brac = self.dom.createElement('mfenced')
         if i.start == i.end:
             # Most often, this type of Interval is converted to a FiniteSet
-            brac.setAttribute('open', '{')
             brac.setAttribute('close', '}')
+            brac.setAttribute('open', '{')
             brac.appendChild(self._print(i.start))
         else:
-            if i.left_open:
-                brac.setAttribute('open', '(')
-            else:
-                brac.setAttribute('open', '[')
-
             if i.right_open:
                 brac.setAttribute('close', ')')
             else:
                 brac.setAttribute('close', ']')
+
+            if i.left_open:
+                brac.setAttribute('open', '(')
+            else:
+                brac.setAttribute('open', '[')
             brac.appendChild(self._print(i.start))
             brac.appendChild(self._print(i.end))
 
@@ -1127,8 +1127,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_Abs(self, expr, exp=None):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
-        x.setAttribute('open', '|')
         x.setAttribute('close', '|')
+        x.setAttribute('open', '|')
         x.appendChild(self._print(expr.args[0]))
         mrow.appendChild(x)
         return mrow
@@ -1190,8 +1190,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_set(self, s):
         items = sorted(s, key=default_sort_key)
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('open', '{')
         brac.setAttribute('close', '}')
+        brac.setAttribute('open', '{')
         for item in items:
             brac.appendChild(self._print(item))
         return brac
@@ -1308,8 +1308,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_Range(self, s):
         dots = u"\u2026"
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('open', '{')
         brac.setAttribute('close', '}')
+        brac.setAttribute('open', '{')
 
         if s.start.is_infinite:
             printset = dots, s[-1] - s.step, s[-1]
@@ -1506,8 +1506,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         power = expr.args[2]
         sup = self.dom.createElement('msup')
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('open', u'\u27e8')
         brac.setAttribute('close', u'\u27e9')
+        brac.setAttribute('open', u'\u27e8')
         brac.appendChild(self._print(shift))
         sup.appendChild(brac)
         sup.appendChild(self._print(power))
@@ -1696,8 +1696,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_floor(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
-        x.setAttribute('open', u'\u230A')
         x.setAttribute('close', u'\u230B')
+        x.setAttribute('open', u'\u230A')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow
@@ -1705,8 +1705,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_ceiling(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
-        x.setAttribute('open', u'\u2308')
         x.setAttribute('close', u'\u2309')
+        x.setAttribute('open', u'\u2308')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow
@@ -1749,8 +1749,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x = self.dom.createElement('msub')
         x.appendChild(self.parenthesize(e.parent, PRECEDENCE["Atom"], strict = True))
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute("open", "")
         brac.setAttribute("close", "")
+        brac.setAttribute("open", "")
         for i in e.indices:
             brac.appendChild(self._print(i))
         x.appendChild(brac)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16977


#### Brief description of what is fixed or changed

Python3.8b official removed the deprecated ``` time.clock() ``` function.  Modified this with importing
clock from ``` sympy.core.compatibility ``` which conditionally imports ``` time.clock() ``` or ``` time.perf_counter() ``` depending on an ``` ImportError ```.

``` Node.toxml() ``` from ``` xml.dom.minidom ``` now preserves attribute order which was causing test failures in ``` test_mathml.py ```. Fixed these by changing the order of attribute insertion in ``` mathml.py ```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
