### PR TITLE
Function and IndexedBase inherits assumptions from Symbol

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -372,10 +372,14 @@ class Function(Application, Expr):
     >>> g.diff(x)
     Derivative(g(x), x)
 
-    Assumptions can be passed to Function.
+    Assumptions can be passed to Function, and if function is initialized with a
+    symbol, the function inherits the associated assumptions:
 
     >>> f_real = Function('f', real=True)
     >>> f_real(x).is_real
+    True
+    >>> f_real_inherit = Function(Symbol('f', real=True))
+    >>> f_real_inherit(x).is_real
     True
 
     Note that assumptions on a function are unrelated to the assumptions on
@@ -863,6 +867,9 @@ class UndefinedFunction(FunctionClass):
     def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs):
         __dict__ = __dict__ or {}
         # Allow Function('f', real=True)
+        # and/or Function(Symbol('f', real=True))
+        if hasattr(name, "assumptions0"):
+            kwargs.update(name.assumptions0)
         __dict__.update({'is_' + arg: val for arg, val in kwargs.items() if arg in _assume_defined})
         # You can add other attributes, although they do have to be hashable
         # (but seriously, if you want to add anything other than assumptions,
@@ -871,7 +878,7 @@ class UndefinedFunction(FunctionClass):
         # Save these for __eq__
         __dict__.update({'_extra_kwargs': kwargs})
         __dict__['__module__'] = None # For pickling
-        ret = super(UndefinedFunction, mcl).__new__(mcl, name, bases, __dict__)
+        ret = super(UndefinedFunction, mcl).__new__(mcl, str(name), bases, __dict__)
         ret.name = name
         return ret
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -869,7 +869,13 @@ class UndefinedFunction(FunctionClass):
         # Allow Function('f', real=True)
         # and/or Function(Symbol('f', real=True))
         if hasattr(name, "assumptions0"):
-            kwargs.update(name.assumptions0)
+            for k, v in name.assumptions0.items():
+                if k in kwargs and v != kwargs[k]:
+                    raise ValueError(
+                        "clash between assumptions inherited from name and passed assumptions"
+                    )
+                else:
+                    kwargs[k] = v
         __dict__.update({'is_' + arg: val for arg, val in kwargs.items() if arg in _assume_defined})
         # You can add other attributes, although they do have to be hashable
         # (but seriously, if you want to add anything other than assumptions,

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -874,8 +874,7 @@ class UndefinedFunction(FunctionClass):
                     raise ValueError(
                         "clash between assumptions inherited from name and passed assumptions"
                     )
-                else:
-                    kwargs[k] = v
+                kwargs[k] = v
         __dict__.update({'is_' + arg: val for arg, val in kwargs.items() if arg in _assume_defined})
         # You can add other attributes, although they do have to be hashable
         # (but seriously, if you want to add anything other than assumptions,

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -884,7 +884,7 @@ class UndefinedFunction(FunctionClass):
         __dict__.update({'_extra_kwargs': kwargs})
         __dict__['__module__'] = None # For pickling
         ret = super(UndefinedFunction, mcl).__new__(mcl, str(name), bases, __dict__)
-        ret.name = name
+        ret.name = str(name)
         return ret
 
     def __instancecheck__(cls, instance):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -865,40 +865,49 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs):
-        __dict__ = __dict__ or {}
+        from .symbol import _filter_assumptions
         # Allow Function('f', real=True)
         # and/or Function(Symbol('f', real=True))
+        assumptions, kwargs = _filter_assumptions(kwargs)
         if isinstance(name, Symbol):
-            for k, v in name.assumptions0.items():
-                if k in kwargs and v != kwargs[k]:
-                    raise ValueError(
-                        "clash between assumptions inherited from name and passed assumptions"
-                    )
-                kwargs[k] = v
-        __dict__.update({'is_' + arg: val for arg, val in kwargs.items() if arg in _assume_defined})
+            assumptions = name._merge(assumptions)
+            name = name.name
+        elif not isinstance(name, string_types):
+            raise TypeError('expecting string or Symbol for name')
+        else:
+            commutative = assumptions.get('commutative', None)
+            assumptions = Symbol(name, **assumptions).assumptions0
+            if commutative is None:
+                assumptions.pop('commutative')
+        __dict__ = __dict__ or {}
+        # put the `is_*` for into __dict__
+        __dict__.update({'is_%s' % k: v for k, v in assumptions.items()})
         # You can add other attributes, although they do have to be hashable
         # (but seriously, if you want to add anything other than assumptions,
         # just subclass Function)
         __dict__.update(kwargs)
+        # add back the sanitized assumptions without the is_ prefix
+        kwargs.update(assumptions)
         # Save these for __eq__
-        __dict__.update({'_extra_kwargs': kwargs})
-        __dict__['__module__'] = None # For pickling
-        ret = super(UndefinedFunction, mcl).__new__(mcl, str(name), bases, __dict__)
-        ret.name = str(name)
-        return ret
+        __dict__.update({'_kwargs': kwargs})
+        # do this for pickling
+        __dict__['__module__'] = None
+        obj = super(UndefinedFunction, mcl).__new__(mcl, name, bases, __dict__)
+        obj.name = name
+        return obj
 
     def __instancecheck__(cls, instance):
         return cls in type(instance).__mro__
 
-    _extra_kwargs = {}
+    _kwargs = {}
 
     def __hash__(self):
-        return hash((self.class_key(), frozenset(self._extra_kwargs.items())))
+        return hash((self.class_key(), frozenset(self._kwargs.items())))
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and
             self.class_key() == other.class_key() and
-            self._extra_kwargs == other._extra_kwargs)
+            self._kwargs == other._kwargs)
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -373,7 +373,7 @@ class Function(Application, Expr):
     Derivative(g(x), x)
 
     Assumptions can be passed to Function, and if function is initialized with a
-    symbol, the function inherits the associated assumptions:
+    Symbol, the function inherits the name and assumptions associated with the Symbol:
 
     >>> f_real = Function('f', real=True)
     >>> f_real(x).is_real
@@ -868,7 +868,7 @@ class UndefinedFunction(FunctionClass):
         __dict__ = __dict__ or {}
         # Allow Function('f', real=True)
         # and/or Function(Symbol('f', real=True))
-        if hasattr(name, "assumptions0"):
+        if isinstance(name, Symbol):
             for k, v in name.assumptions0.items():
                 if k in kwargs and v != kwargs[k]:
                     raise ValueError(

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1100,12 +1100,14 @@ def test_function_assumptions():
     x = Symbol('x')
     f = Function('f')
     f_real = Function('f', real=True)
+    f_real_inherit = Function(Symbol('f', real=True))
 
     assert f != f_real
     assert f(x) != f_real(x)
 
     assert f(x).is_real is None
     assert f_real(x).is_real is True
+    assert f_real_inherit(x).is_real is True
 
     # Can also do it this way, but it won't be equal to f_real because of the
     # way UndefinedFunction.__new__ works.

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1107,7 +1107,7 @@ def test_function_assumptions():
 
     assert f(x).is_real is None
     assert f_real(x).is_real is True
-    assert f_real_inherit(x).is_real is True
+    assert f_real_inherit(x).is_real is True and f_real_inherit.name == 'f'
 
     # Can also do it this way, but it won't be equal to f_real because of the
     # way UndefinedFunction.__new__ works.

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1107,7 +1107,7 @@ def test_function_assumptions():
 
     assert f(x).is_real is None
     assert f_real(x).is_real is True
-    assert f_real_inherit(x).is_real is True and f_real_inherit.name == 'f'
+    assert f_real_inherit(x).is_real is True and str(f_real_inherit) == 'f'
 
     # Can also do it this way, but it won't be equal to f_real because of the
     # way UndefinedFunction.__new__ works.

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1107,7 +1107,7 @@ def test_function_assumptions():
 
     assert f(x).is_real is None
     assert f_real(x).is_real is True
-    assert f_real_inherit(x).is_real is True and str(f_real_inherit) == 'f'
+    assert f_real_inherit(x).is_real is True and f_real_inherit.name == 'f'
 
     # Can also do it this way, but it won't be equal to f_real because of the
     # way UndefinedFunction.__new__ works.

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1100,8 +1100,10 @@ def test_function_assumptions():
     x = Symbol('x')
     f = Function('f')
     f_real = Function('f', real=True)
+    f_real1 = Function('f', real=1)
     f_real_inherit = Function(Symbol('f', real=True))
 
+    assert f_real == f_real1  # assumptions are sanitized
     assert f != f_real
     assert f(x) != f_real(x)
 
@@ -1110,7 +1112,8 @@ def test_function_assumptions():
     assert f_real_inherit(x).is_real is True and f_real_inherit.name == 'f'
 
     # Can also do it this way, but it won't be equal to f_real because of the
-    # way UndefinedFunction.__new__ works.
+    # way UndefinedFunction.__new__ works. Any non-recognized assumptions
+    # are just added literally as something which is used in the hash
     f_real2 = Function('f', is_real=True)
     assert f_real2(x).is_real is True
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -410,6 +410,14 @@ class IndexedBase(Expr, NotIterable):
     True
     >>> A != A_real
     True
+
+    Assumptions can also be inherited from the symbol used to initialize the IndexedBase:
+
+    >>> I = symbols('I', integer=True)
+    >>> C_inherit = IndexedBase(I)
+    >>> C_explicit = IndexedBase('I', integer=True)
+    >>> C_inherit.assumptions0 == C_explicit.assumptions0
+    True
     """
     is_commutative = True
     is_symbol = True
@@ -463,7 +471,19 @@ class IndexedBase(Expr, NotIterable):
         obj._offset = offset
         obj._strides = strides
         obj._name = str(label)
-        assumptions, _ = IndexedBase._filter_assumptions(kw_args)
+
+        assumptions = label.assumptions0
+        passed_assumptions, _ = IndexedBase._filter_assumptions(kw_args)
+        for k, passed in passed_assumptions.items():
+            inherited = assumptions.get(k, None)
+            if inherited is None:
+                assumptions[k] = passed
+            elif passed !=  inherited:
+                raise ValueError(
+                    "clash between assumptions inherited from label and passed assumptions"
+                )
+            else:
+                pass  # passed == inherited
         IndexedBase._set_assumptions(obj, assumptions)
         return obj
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -411,7 +411,7 @@ class IndexedBase(Expr, NotIterable):
     >>> A != A_real
     True
 
-    Assumptions can also be inherited from the symbol used to initialize the IndexedBase:
+    Assumptions can also be inherited if a Symbol is used to initialize the IndexedBase:
 
     >>> I = symbols('I', integer=True)
     >>> C_inherit = IndexedBase(I)

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -474,16 +474,13 @@ class IndexedBase(Expr, NotIterable):
 
         assumptions = label.assumptions0
         passed_assumptions, _ = IndexedBase._filter_assumptions(kw_args)
-        for k, passed in passed_assumptions.items():
-            inherited = assumptions.get(k, None)
-            if inherited is None:
-                assumptions[k] = passed
-            elif passed !=  inherited:
+        for k, v in passed_assumptions.items():
+            if k in assumptions and v != assumptions[k]:
                 raise ValueError(
                     "clash between assumptions inherited from label and passed assumptions"
                 )
             else:
-                pass  # passed == inherited
+                assumptions[k] = v
         IndexedBase._set_assumptions(obj, assumptions)
         return obj
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -479,8 +479,7 @@ class IndexedBase(Expr, NotIterable):
                 raise ValueError(
                     "clash between assumptions inherited from label and passed assumptions"
                 )
-            else:
-                assumptions[k] = v
+            assumptions[k] = v
         IndexedBase._set_assumptions(obj, assumptions)
         return obj
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -416,7 +416,7 @@ class IndexedBase(Expr, NotIterable):
     >>> I = symbols('I', integer=True)
     >>> C_inherit = IndexedBase(I)
     >>> C_explicit = IndexedBase('I', integer=True)
-    >>> C_inherit.assumptions0 == C_explicit.assumptions0
+    >>> C_inherit == C_explicit
     True
     """
     is_commutative = True
@@ -463,6 +463,14 @@ class IndexedBase(Expr, NotIterable):
         offset = kw_args.pop('offset', S.Zero)
         strides = kw_args.pop('strides', None)
 
+        # If label is a symbol, ensure the stored label is a plain (no assumptions) symbol,
+        # and propagate any extra assumptions onto the new object.
+        if isinstance(label, Symbol):
+            assumptions = label.assumptions0
+            label = Symbol(str(label))
+        else:
+            assumptions = {}
+
         if shape is not None:
             obj = Expr.__new__(cls, label, shape)
         else:
@@ -472,7 +480,7 @@ class IndexedBase(Expr, NotIterable):
         obj._strides = strides
         obj._name = str(label)
 
-        assumptions = label.assumptions0
+        # Combine assumptions from kw_args and symbol.
         passed_assumptions, _ = IndexedBase._filter_assumptions(kw_args)
         for k, v in passed_assumptions.items():
             if k in assumptions and v != assumptions[k]:

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -229,8 +229,7 @@ def test_IndexedBase_assumptions_inheritance():
 
     assert I_inherit.is_integer
     assert I_explicit.is_integer
-    assert I_inherit.assumptions0 == I_explicit.assumptions0
-    assert I_inherit != I_explicit  # Because the underlying symbol is different.
+    assert I_inherit == I_explicit
 
 
 def test_Indexed_constructor():

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -222,6 +222,17 @@ def test_IndexedBase_assumptions():
     assert A[i] != Indexed(a, i)
 
 
+def test_IndexedBase_assumptions_inheritance():
+    I = Symbol('I', integer=True)
+    I_inherit = IndexedBase(I)
+    I_explicit = IndexedBase('I', integer=True)
+
+    assert I_inherit.is_integer
+    assert I_explicit.is_integer
+    assert I_inherit.assumptions0 == I_explicit.assumptions0
+    assert I_inherit != I_explicit  # Because the underlying symbol is different.
+
+
 def test_Indexed_constructor():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, j)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1022,6 +1022,7 @@ class _EvaluatorPrinter(object):
         from sympy import Dummy, Function, flatten, Derivative, ordered, Basic
         from sympy.matrices import DeferredVector
         from sympy.core.symbol import _uniquely_named_symbol
+        from sympy.core.expr import Expr
 
         # Args of type Dummy can cause name collisions with args
         # of type Symbol.  Force dummify of everything in this
@@ -1038,7 +1039,9 @@ class _EvaluatorPrinter(object):
             elif isinstance(arg, Basic) and arg.is_symbol:
                 s = self._argrepr(arg)
                 if dummify or not self._is_safe_ident(s):
-                    dummy = _uniquely_named_symbol(Dummy().name, expr)
+                    dummy = Dummy()
+                    if isinstance(expr, Expr):
+                        dummy = _uniquely_named_symbol(dummy.name, expr)
                     s = self._argrepr(dummy)
                     expr = self._subexpr(expr, {arg: dummy})
             elif dummify or isinstance(arg, (Function, Derivative)):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -13,6 +13,7 @@ import linecache
 
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, string_types, range, builtins, PY3)
+from sympy.utilities.misc import filldedent
 from sympy.utilities.decorator import doctest_depends_on
 
 __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
@@ -1226,15 +1227,17 @@ def implemented_function(symfunc, implementation):
     # Delayed import to avoid circular imports
     from sympy.core.function import UndefinedFunction
     # if name, create function to hold implementation
-    _extra_kwargs = {}
+    kwargs = {}
     if isinstance(symfunc, UndefinedFunction):
-        _extra_kwargs = symfunc._extra_kwargs
+        kwargs = symfunc._kwargs
         symfunc = symfunc.__name__
     if isinstance(symfunc, string_types):
         # Keyword arguments to UndefinedFunction are added as attributes to
         # the created class.
-        symfunc = UndefinedFunction(symfunc, _imp_=staticmethod(implementation), **_extra_kwargs)
+        symfunc = UndefinedFunction(
+            symfunc, _imp_=staticmethod(implementation), **kwargs)
     elif not isinstance(symfunc, UndefinedFunction):
-        raise ValueError('symfunc should be either a string or'
-                         ' an UndefinedFunction instance.')
+        raise ValueError(filldedent('''
+            symfunc should be either a string or
+            an UndefinedFunction instance.'''))
     return symfunc

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1021,6 +1021,7 @@ class _EvaluatorPrinter(object):
         """
         from sympy import Dummy, Function, flatten, Derivative, ordered, Basic
         from sympy.matrices import DeferredVector
+        from sympy.core.symbol import _uniquely_named_symbol
 
         # Args of type Dummy can cause name collisions with args
         # of type Symbol.  Force dummify of everything in this
@@ -1037,7 +1038,7 @@ class _EvaluatorPrinter(object):
             elif isinstance(arg, Basic) and arg.is_symbol:
                 s = self._argrepr(arg)
                 if dummify or not self._is_safe_ident(s):
-                    dummy = Dummy()
+                    dummy = _uniquely_named_symbol(Dummy().name, expr)
                     s = self._argrepr(dummy)
                     expr = self._subexpr(expr, {arg: dummy})
             elif dummify or isinstance(arg, (Function, Derivative)):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This PR is a continuation of PR #16085 resulting from a discussion with @smichr [there](https://github.com/sympy/sympy/pull/16085#discussion_r287332934).
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

If `Function` or `IndexedBase` is instantiated with a `Symbol` they will inherit the associated assumptions:

```python
from sympy import Symbol, Function, IndexedBase, log, exp, ask, Q
from sympy.abc import x

X = IndexedBase(Symbol("X", real=True))
f = Function(Symbol("f", real=True))

assert ask(Q.real(X))
assert log(exp(X)) == X
assert ask(Q.real(f(x)))
assert log(exp(f(x))) == f(x)
```  


#### Other comments

For `Function` this is currently only applied to `UndefinedFunction`, i.e. the result of `Function('f')`. This is because according to the docstring for the function module, this is the only type of function for which we do not have a function body that would otherwise define what assumptions are made. 

Further, the current implementation has the following (possibly confusing) properties:

```python
assert Function('x', real=True) != Function(Symbol('x', real=True))
assert IndexedBase('x', real=True) != IndexedBase(Symbol('x', real=True))
```

For `IndexedBase` the reason is that the symbol/label is part of the equality check, and the inequality is due to `Symbol('x') != Symbol('x', real=True)`. For `Function` it is less clear because only the symbol string is stored in both cases. In this case, it is because the assumptions are not logically expanded before they are stored (via `StdFactKB`). The following is therefore also true after this PR:

```python
x = Symbol('x', real=True)
assert Function('x', **x.assumptions0) == Function(x)
```
Because `Function` did not currently perform assumption expanding prior to this PR, I have not enforced this either (yet). 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * added support for inheriting assumptions from symbols to IndexedBase
* core
  * added support for inheriting assumptions from symbols to Function
<!-- END RELEASE NOTES -->
