### PR TITLE
Added cases for sparse arrays  in __mul__ and __rmul__

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -377,19 +377,29 @@ class NDimArray(object):
 
     def __mul__(self, other):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
 
         if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
+
         other = sympify(other)
+        if isinstance(self, SparseNDimArray):
+            return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [i*other for i in self]
         return type(self)(result_list, self.shape)
 
     def __rmul__(self, other):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
 
         if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
+
         other = sympify(other)
+        if isinstance(self, SparseNDimArray):
+            return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [other*i for i in self]
         return type(self)(result_list, self.shape)
 

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -139,6 +139,10 @@ def test_sparse():
     b[1, 1] = 2
     assert a != b
 
+    # __mul__ and __rmul__
+    assert a * 3 == MutableSparseNDimArray({200001: 3}, (100000, 200000))
+    assert 3 * a == MutableSparseNDimArray({200001: 3}, (100000, 200000))
+
 
 def test_calculation():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16941 `__mul__` and `__rmul__`

#### Brief description of what is fixed or changed
The multiplcation is cast to a list while calculating each term, which is unnecessary for the zero value in sparse array(since 0*x = 0). Thanks to the lazy-evaluation of iterator in NDimArray, this issue will not cause a MemoryError, but the operation is slow.
Before:
```
>>> a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
>>> b = 3*a
#Operation takes a lot of time
```
Now
```
>>> a = ImmutableSparseNDimArray({1:2, 3:4}, (10000, 20000))
>>> 3*a == ImmutableSparseNDimArray({1:6, 3:12}, (10000, 20000))

```
Since only the no-zero values in the dictionary are changed, this execution time is much ameliorated.
Tests are also added.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added specific case for sparse array in __mul__, __rmul__ and tests

<!-- END RELEASE NOTES -->
