### PR TITLE
[GSoC] Implemented convolution operation of two formal power series

### DIFF
--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1221,7 +1221,7 @@ class FormalPowerSeries(SeriesBase):
 
         k = self.xk.variables[0]
         xk_seq = sequence(self.xk.formula, (k, 0, n-1))
-        terms = SeqMul(xk_seq * conv_seq, evaluate=False)[:]
+        terms = xk_seq * conv_seq
 
         return Add(*terms) + Order(self.xk.coeff(n), (self.x, self.x0))
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1160,7 +1160,7 @@ class FormalPowerSeries(SeriesBase):
             Set dyadic to identify the convolution type as dyadic (*bitwise-XOR*)
             convolution, which is performed using **FWHT**.
             Set subset to identify the convolution type as subset convolution.
-            Else, set None to interpret it as simple linear convolution. If 
+            Else, set None to interpret it as simple linear convolution. If
             cycle is non-zero, then it will be interpreted as cyclic convolution.
 
         Examples

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1145,7 +1145,8 @@ class FormalPowerSeries(SeriesBase):
         return self.func(f, self.x, self.x0, self.dir, (ak, self.xk, ind))
 
     def convolve(self, other, x=None, n=6, cycle=0, method=None):
-        """ Convolute two Formal Power Series and return the truncated terms upto specified order.
+        """Convolute two Formal Power Series and return the truncated terms
+        upto specified order.
 
         Parameters
         ==========
@@ -1156,11 +1157,11 @@ class FormalPowerSeries(SeriesBase):
         cycle : Integer
             Specifies the length for doing cyclic convolution.
         method : 'dyadic', 'subset' or None
-            dyadic : Identifies the convolution type as dyadic (*bitwise-XOR*)
-                    convolution, which is performed using **FWHT**.
-            subset : Identifies the convolution type as subset convolution.
-            None : Simple linear convolution. If cycle is non-zero, then it will be
-                    interpreted as cyclic convolution.
+            Set dyadic to identify the convolution type as dyadic (*bitwise-XOR*)
+            convolution, which is performed using **FWHT**.
+            Set subset to identify the convolution type as subset convolution.
+            Else, set None to interpret it as simple linear convolution. If 
+            cycle is non-zero, then it will be interpreted as cyclic convolution.
 
         Examples
         ========

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -508,9 +508,26 @@ def test_fps__operations():
     assert fi.function == sin(x)
     assert fi.truncate() == x - x**3/6 + x**5/120 + O(x**6)
 
-def test_fps__convolutions():
+def test_fps__convolution():
     f1, f2, f3 = fps(sin(x)), fps(exp(x)), fps(cos(x))
 
-    assert f1.convolve(f2, x, 6) == x + x**2 + x**3/3 - x**5/12 + O(x**6)
-    assert f1.convolve(f2, x, 7) == x + x**2 + x**3/3 - x**5/12 - x**6/36 + O(x**7)
-    assert f1.convolve(f3, x, 7) == x - 2*x**3/3 + x**5/12 + O(x**7)
+    raises(ValueError, lambda: f1.convolve(exp(x), x))
+    raises(ValueError, lambda: f1.convolve(fps(exp(x), dir=-1), x, 4))
+    raises(ValueError, lambda: f1.convolve(fps(exp(x), x0=1), x, 4))
+    raises(ValueError, lambda: f1.convolve(fps(exp(y)), x, 4))
+
+    assert f1.convolve(f2, x, 3) == x + x**2 + O(x**3)
+    assert f1.convolve(f2, x, 4) == x + x**2 + x**3/3 + O(x**4)
+    assert f1.convolve(f3, x, 4) == x - 2*x**3/3 + O(x**4)
+
+    assert f1.convolve(f2, x, 4, cycle=4) == 11*x/12 + 35*x**2/36 + x**3/3 + O(x**4)
+    assert f1.convolve(f3, x, 4, cycle=3) == -S(2)/3 + x + x**2/12 - 2*x**3/3 + O(x**4)
+    raises(ValueError, lambda: f1.convolve(f2, x, 4, cycle=6))
+
+    assert f1.convolve(f2, x, 6, dyadic=True) == \
+        S(4667)/4800 + 2641*x/2880 + x**3/3 + x**4/60 + x**5/20 + O(x**6)
+    assert f1.convolve(f3, x, 5, cycle=4, dyadic=True) == 9*x/8 - 97*x**3/144 + O(x**5)
+
+    assert f1.convolve(f2, x, 6, subset=True) == x + x**3/3 + x**5/20 + O(x**6)
+    assert f1.convolve(f3, x, 5, cycle=5, subset=True) == \
+        S(1)/24 + x - x**2/144 - 2*x**3/3 + O(x**5)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -524,10 +524,12 @@ def test_fps__convolution():
     assert f1.convolve(f3, x, 4, cycle=3) == -S(2)/3 + x + x**2/12 - 2*x**3/3 + O(x**4)
     raises(ValueError, lambda: f1.convolve(f2, x, 4, cycle=6))
 
-    assert f1.convolve(f2, x, 6, dyadic=True) == \
+    assert f1.convolve(f2, x, 6, method='dyadic') == \
         S(4667)/4800 + 2641*x/2880 + x**3/3 + x**4/60 + x**5/20 + O(x**6)
-    assert f1.convolve(f3, x, 5, cycle=4, dyadic=True) == 9*x/8 - 97*x**3/144 + O(x**5)
+    assert f1.convolve(f3, x, 5, cycle=4, method='dyadic') == 9*x/8 - 97*x**3/144 + O(x**5)
 
-    assert f1.convolve(f2, x, 6, subset=True) == x + x**3/3 + x**5/20 + O(x**6)
-    assert f1.convolve(f3, x, 5, cycle=5, subset=True) == \
+    raises(ValueError, lambda: f1.convolve(f2, x, 6, method='linear'))
+
+    assert f1.convolve(f2, x, 6, method='subset') == x + x**3/3 + x**5/20 + O(x**6)
+    assert f1.convolve(f3, x, 5, cycle=5, method='subset') == \
         S(1)/24 + x - x**2/144 - 2*x**3/3 + O(x**5)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -511,25 +511,11 @@ def test_fps__operations():
 def test_fps__convolution():
     f1, f2, f3 = fps(sin(x)), fps(exp(x)), fps(cos(x))
 
-    raises(ValueError, lambda: f1.convolve(exp(x), x))
-    raises(ValueError, lambda: f1.convolve(fps(exp(x), dir=-1), x, 4))
-    raises(ValueError, lambda: f1.convolve(fps(exp(x), x0=1), x, 4))
-    raises(ValueError, lambda: f1.convolve(fps(exp(y)), x, 4))
+    raises(ValueError, lambda: f1.product(exp(x), x))
+    raises(ValueError, lambda: f1.product(fps(exp(x), dir=-1), x, 4))
+    raises(ValueError, lambda: f1.product(fps(exp(x), x0=1), x, 4))
+    raises(ValueError, lambda: f1.product(fps(exp(y)), x, 4))
 
-    assert f1.convolve(f2, x, 3) == x + x**2 + O(x**3)
-    assert f1.convolve(f2, x, 4) == x + x**2 + x**3/3 + O(x**4)
-    assert f1.convolve(f3, x, 4) == x - 2*x**3/3 + O(x**4)
-
-    assert f1.convolve(f2, x, 4, cycle=4) == 11*x/12 + 35*x**2/36 + x**3/3 + O(x**4)
-    assert f1.convolve(f3, x, 4, cycle=3) == -S(2)/3 + x + x**2/12 - 2*x**3/3 + O(x**4)
-    raises(ValueError, lambda: f1.convolve(f2, x, 4, cycle=6))
-
-    assert f1.convolve(f2, x, 6, method='dyadic') == \
-        S(4667)/4800 + 2641*x/2880 + x**3/3 + x**4/60 + x**5/20 + O(x**6)
-    assert f1.convolve(f3, x, 5, cycle=4, method='dyadic') == 9*x/8 - 97*x**3/144 + O(x**5)
-
-    raises(ValueError, lambda: f1.convolve(f2, x, 6, method='linear'))
-
-    assert f1.convolve(f2, x, 6, method='subset') == x + x**3/3 + x**5/20 + O(x**6)
-    assert f1.convolve(f3, x, 5, cycle=5, method='subset') == \
-        S(1)/24 + x - x**2/144 - 2*x**3/3 + O(x**5)
+    assert f1.product(f2, x, 3) == x + x**2 + O(x**3)
+    assert f1.product(f2, x, 4) == x + x**2 + x**3/3 + O(x**4)
+    assert f1.product(f3, x, 4) == x - 2*x**3/3 + O(x**4)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -507,3 +507,10 @@ def test_fps__operations():
     fi = f2.integrate(x)
     assert fi.function == sin(x)
     assert fi.truncate() == x - x**3/6 + x**5/120 + O(x**6)
+
+def test_fps__convolutions():
+    f1, f2, f3 = fps(sin(x)), fps(exp(x)), fps(cos(x))
+
+    assert f1.convolve(f2, x, 6) == x + x**2 + x**3/3 - x**5/12 + O(x**6)
+    assert f1.convolve(f2, x, 7) == x + x**2 + x**3/3 - x**5/12 - x**6/36 + O(x**7)
+    assert f1.convolve(f3, x, 7) == x - 2*x**3/3 + x**5/12 + O(x**7)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Convolution of two `FormalPowerSeries` objects have been implemented. Presently, it takes in a `order` term, and prints all the terms in the convoluted resultant `fps` upto `order`. No `FormalPowerSeries` object is being returned as of now.

For example --
```
>>> f1, f2 = fps(sin(x)), fps(exp(x))
>>> f1.convolute(f2, x, order=6)
x + x**2 + x**3/3 - x**5/12 + O(x**6)
```
I have only implemented `linear convolution` as of now. Whether other forms of convolution is required has to be discussed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
   * Implemented convolution operation of two formal power series in `sympy.series.formal`
<!-- END RELEASE NOTES -->
