### PR TITLE
Add refine handlers for re(), im().

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -240,6 +240,57 @@ def refine_Relational(expr, assumptions):
     return ask(Q.is_true(expr), assumptions)
 
 
+def refine_re(expr, assumptions):
+    """
+    Handler for real part.
+
+    >>> from sympy.assumptions.refine import refine_re
+    >>> from sympy import Q, re
+    >>> from sympy.abc import x
+    >>> refine_re(re(x), Q.real(x))
+    x
+    >>> refine_re(re(x), Q.imaginary(x))
+    0
+    """
+    arg = expr.args[0]
+    if ask(Q.real(arg), assumptions):
+        return arg
+    if ask(Q.imaginary(arg), assumptions):
+        return 0
+    return _refine_reim(expr, assumptions)
+
+
+def refine_im(expr, assumptions):
+    """
+    Handler for imaginary part.
+
+    >>> from sympy.assumptions.refine import refine_im
+    >>> from sympy import Q, im
+    >>> from sympy.abc import x
+    >>> refine_im(im(x), Q.real(x))
+    0
+    >>> refine_im(im(x), Q.imaginary(x))
+    -I*x
+    """
+    arg = expr.args[0]
+    if ask(Q.real(arg), assumptions):
+        return 0
+    if ask(Q.imaginary(arg), assumptions):
+        return - S.ImaginaryUnit * arg
+    return _refine_reim(expr, assumptions)
+
+
+def _refine_reim(expr, assumptions):
+    # Helper function for refine_re & refine_im
+    expanded = expr.expand(complex = True)
+    if expanded != expr:
+        refined = refine(expanded, assumptions)
+        if refined != expanded:
+            return refined
+    # Best to leave the expression as is
+    return None
+
+
 handlers_dict = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -249,5 +300,7 @@ handlers_dict = {
     'GreaterThan': refine_Relational,
     'LessThan': refine_Relational,
     'StrictGreaterThan': refine_Relational,
-    'StrictLessThan': refine_Relational
+    'StrictLessThan': refine_Relational,
+    're': refine_re,
+    'im': refine_im
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt,
-                   atan, atan2, nan, Symbol)
-from sympy.abc import x, y, z
+                   atan, atan2, nan, Symbol, re, im)
+from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.utilities.pytest import slow
@@ -143,6 +143,39 @@ def test_atan2():
     assert refine(atan2(y, x), Q.positive(y) & Q.zero(x)) == pi/2
     assert refine(atan2(y, x), Q.negative(y) & Q.zero(x)) == -pi/2
     assert refine(atan2(y, x), Q.zero(y) & Q.zero(x)) == nan
+
+
+def test_re():
+    assert refine(re(x), Q.real(x)) == x
+    assert refine(re(x), Q.imaginary(x)) == 0
+    assert refine(re(x+y), Q.real(x) & Q.real(y)) == x + y
+    assert refine(re(x+y), Q.real(x) & Q.imaginary(y)) == x
+    assert refine(re(x*y), Q.real(x) & Q.real(y)) == x * y
+    assert refine(re(x*y), Q.real(x) & Q.imaginary(y)) == 0
+    assert refine(re(x*y*z), Q.real(x) & Q.real(y) & Q.real(z)) == x * y * z
+
+
+def test_im():
+    assert refine(im(x), Q.imaginary(x)) == -I*x
+    assert refine(im(x), Q.real(x)) == 0
+    assert refine(im(x+y), Q.imaginary(x) & Q.imaginary(y)) == -I*x - I*y
+    assert refine(im(x+y), Q.real(x) & Q.imaginary(y)) == -I*y
+    assert refine(im(x*y), Q.imaginary(x) & Q.real(y)) == -I*x*y
+    assert refine(im(x*y), Q.imaginary(x) & Q.imaginary(y)) == 0
+    assert refine(im(1/x), Q.imaginary(x)) == -I/x
+    assert refine(im(x*y*z), Q.imaginary(x) & Q.imaginary(y)
+        & Q.imaginary(z)) == -I*x*y*z
+
+
+def test_complex():
+    assert refine(re(1/(x + I*y)), Q.real(x) & Q.real(y)) == \
+        x/(x**2 + y**2)
+    assert refine(im(1/(x + I*y)), Q.real(x) & Q.real(y)) == \
+        -y/(x**2 + y**2)
+    assert refine(re((w + I*x) * (y + I*z)), Q.real(w) & Q.real(x) & Q.real(y)
+        & Q.real(z)) == w*y - x*z
+    assert refine(im((w + I*x) * (y + I*z)), Q.real(w) & Q.real(x) & Q.real(y)
+        & Q.real(z)) == w*z + x*y
 
 
 def test_func_args():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Issue #17011 

#### Brief description of what is fixed or changed

Added two methods ``` refine_re() ``` & ``` refine_im() ```  in ``` sympy.assumptions.refine.py ``` 
along with tests.

#### Other comments

I wasn't sure how to handle cases where there wasn't enough information about the variables. With
the current changes, ``` refine(re(x*y)) ``` gives ``` re(x)*re(y) - im(x)*im(y) ``` which might actually be
less preferable than ``` re(x*y) ```.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  assumptions 
    *  add refine_re() ,  refine_im()

<!-- END RELEASE NOTES -->
