### PR TITLE
NumPy print support for identity matrices

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -608,6 +608,13 @@ class NumPyPrinter(PythonCodePrinter):
             func = self._module_format('numpy.array')
         return "%s(%s)" % (func, self._print(expr.tolist()))
 
+    def _print_Identity(self, expr):
+        shape = expr.shape
+        if all([dim.is_Integer for dim in shape]):
+            return "%s(%s)" % (self._module_format('numpy.eye'), self._print(expr.shape[0]))
+        else:
+            raise NotImplementedError
+
     def _print_BlockMatrix(self, expr):
         return '{0}({1})'.format(self._module_format('numpy.block'),
                                  self._print(expr.args[0].tolist()))

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -613,7 +613,7 @@ class NumPyPrinter(PythonCodePrinter):
         if all([dim.is_Integer for dim in shape]):
             return "%s(%s)" % (self._module_format('numpy.eye'), self._print(expr.shape[0]))
         else:
-            raise NotImplementedError("Symbolic matrix dimensions are not supported")
+            raise NotImplementedError("Symbolic matrix dimensions are not yet supported for identity matrices")
 
     def _print_BlockMatrix(self, expr):
         return '{0}({1})'.format(self._module_format('numpy.block'),

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -613,7 +613,7 @@ class NumPyPrinter(PythonCodePrinter):
         if all([dim.is_Integer for dim in shape]):
             return "%s(%s)" % (self._module_format('numpy.eye'), self._print(expr.shape[0]))
         else:
-            raise NotImplementedError
+            raise NotImplementedError("Non-symbolic matrix dimensions are not supported")
 
     def _print_BlockMatrix(self, expr):
         return '{0}({1})'.format(self._module_format('numpy.block'),

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -613,7 +613,7 @@ class NumPyPrinter(PythonCodePrinter):
         if all([dim.is_Integer for dim in shape]):
             return "%s(%s)" % (self._module_format('numpy.eye'), self._print(expr.shape[0]))
         else:
-            raise NotImplementedError("Non-symbolic matrix dimensions are not supported")
+            raise NotImplementedError("Symbolic matrix dimensions are not supported")
 
     def _print_BlockMatrix(self, expr):
         return '{0}({1})'.format(self._module_format('numpy.block'),

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -1,6 +1,6 @@
 from sympy import (
     Piecewise, lambdify, Equality, Unequality, Sum, Mod, cbrt, sqrt,
-    MatrixSymbol, BlockMatrix
+    MatrixSymbol, BlockMatrix, Identity
 )
 from sympy import eye
 from sympy.abc import x, i, j, a, b, c, d
@@ -252,3 +252,16 @@ def test_16857():
 
     printer = NumPyPrinter()
     assert printer.doprint(A) == 'numpy.block([[a_1, a_2], [a_3, a_4]])'
+
+
+def test_issue_17006():
+    if not np:
+        skip("NumPy not installed")
+
+    M = MatrixSymbol("M", 2, 2)
+
+    f = lambdify(M, M + Identity(2))
+    ma = np.matrix([[1, 2], [3, 4]])
+    mr = np.matrix([[2, 2], [3, 5]])
+
+    assert (f(ma) == mr).all()

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -269,4 +269,4 @@ def test_issue_17006():
     from sympy import symbols
     n = symbols('n', integer=True)
     N = MatrixSymbol("M", n, n)
-    raises(NotImplementedError, lambdify(N, N + Identity(n)))
+    raises(NotImplementedError, lambda: lambdify(N, N + Identity(n)))

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -11,7 +11,7 @@ from sympy.codegen.array_utils import (CodegenArrayContraction,
 from sympy.printing.lambdarepr import NumPyPrinter
 
 from sympy.utilities.pytest import warns_deprecated_sympy
-from sympy.utilities.pytest import skip
+from sympy.utilities.pytest import skip, raises
 from sympy.external import import_module
 
 np = import_module('numpy')
@@ -261,7 +261,12 @@ def test_issue_17006():
     M = MatrixSymbol("M", 2, 2)
 
     f = lambdify(M, M + Identity(2))
-    ma = np.matrix([[1, 2], [3, 4]])
-    mr = np.matrix([[2, 2], [3, 5]])
+    ma = np.array([[1, 2], [3, 4]])
+    mr = np.array([[2, 2], [3, 5]])
 
     assert (f(ma) == mr).all()
+
+    from sympy import symbols
+    n = symbols('n', integer=True)
+    N = MatrixSymbol("M", n, n)
+    raises(NotImplementedError, lambdify(N, N + Identity(n)))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -7,7 +7,7 @@ from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
 from sympy.core.numbers import pi
 from sympy.functions import acos, Piecewise, sign
 from sympy.logic import And, Or
-from sympy.matrices import SparseMatrix, MatrixSymbol
+from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
 from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
 )
@@ -49,6 +49,7 @@ def test_NumPyPrinter():
     A = MatrixSymbol("A", 2, 2)
     assert p.doprint(A**(-1)) == "numpy.linalg.inv(A)"
     assert p.doprint(A**5) == "numpy.linalg.matrix_power(A, 5)"
+    assert p.doprint(Identity(3)) == "numpy.eye(3)"
 
 
 def test_SciPyPrinter():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17006 

#### Brief description of what is fixed or changed

Adds support to the NumPy printing for printing identity matrices

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * NumPy printer now handles identity matrices
<!-- END RELEASE NOTES -->
