### PR TITLE
Added cases in NDimArray operations for sparse array

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -384,6 +384,8 @@ class NDimArray(object):
 
         other = sympify(other)
         if isinstance(self, SparseNDimArray):
+            if(other == S.Zero):
+                return type(self)({}, self.shape)
             return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
 
         result_list = [i*other for i in self]
@@ -398,6 +400,8 @@ class NDimArray(object):
 
         other = sympify(other)
         if isinstance(self, SparseNDimArray):
+            if(other == S.Zero):
+                return type(self)({}, self.shape)
             return type(self)({k: other*v for (k, v) in self._sparse_array.items()}, self.shape)
 
         result_list = [other*i for i in self]
@@ -405,10 +409,15 @@ class NDimArray(object):
 
     def __div__(self, other):
         from sympy.matrices.matrices import MatrixBase
+        from sympy.tensor.array import SparseNDimArray
 
         if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected")
+
         other = sympify(other)
+        if isinstance(self, SparseNDimArray) and other != S.Zero:
+            return type(self)({k: v/other for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [i/other for i in self]
         return type(self)(result_list, self.shape)
 
@@ -416,6 +425,11 @@ class NDimArray(object):
         raise NotImplementedError('unsupported operation on NDimArray')
 
     def __neg__(self):
+        from sympy.tensor.array import SparseNDimArray
+
+        if isinstance(self, SparseNDimArray):
+            return type(self)({k: -v for (k, v) in self._sparse_array.items()}, self.shape)
+
         result_list = [-i for i in self]
         return type(self)(result_list, self.shape)
 

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
-from sympy import Symbol, Rational, SparseMatrix, Dict, diff, symbols, Indexed, IndexedBase
+from sympy import Symbol, Rational, SparseMatrix, Dict, diff, symbols, Indexed, IndexedBase, S
 from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import ImmutableSparseNDimArray
@@ -135,6 +135,24 @@ def test_sparse():
     raises(TypeError, sparse_assignment)
     assert len(sparse_array._sparse_array) == 1
     assert sparse_array[0, 0] == 0
+    assert sparse_array/0 == ImmutableSparseNDimArray([[S.NaN, S.NaN], [S.NaN, S.ComplexInfinity]], (2, 2))
+
+    # test for large scale sparse array
+    # equality test
+    assert ImmutableSparseNDimArray.zeros(100000, 200000) == ImmutableSparseNDimArray.zeros(100000, 200000)
+
+    # __mul__ and __rmul__
+    a = ImmutableSparseNDimArray({200001: 1}, (100000, 200000))
+    assert a * 3 == ImmutableSparseNDimArray({200001: 3}, (100000, 200000))
+    assert 3 * a == ImmutableSparseNDimArray({200001: 3}, (100000, 200000))
+    assert a * 0 == ImmutableSparseNDimArray({}, (100000, 200000))
+    assert 0 * a == ImmutableSparseNDimArray({}, (100000, 200000))
+
+    # __div__
+    assert a/3 == ImmutableSparseNDimArray({200001: S.One/3}, (100000, 200000))
+
+    # __neg__
+    assert -a == ImmutableSparseNDimArray({200001: -1}, (100000, 200000))
 
 
 def test_calculation():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
-from sympy import Symbol, Rational, SparseMatrix, diff, sympify
+from sympy import Symbol, Rational, SparseMatrix, diff, sympify, S
 from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
@@ -122,6 +122,7 @@ def test_sparse():
     sparse_array[0, 0] = 123
     assert len(sparse_array._sparse_array) == 2
     assert sparse_array[0, 0] == 123
+    assert sparse_array/0 == MutableSparseNDimArray([[S.ComplexInfinity, S.NaN], [S.NaN, S.ComplexInfinity]], (2, 2))
 
     # when element in sparse array become zero it will disappear from
     # dictionary
@@ -132,6 +133,7 @@ def test_sparse():
     assert sparse_array[0, 0] == 0
 
     # test for large scale sparse array
+    # equality test
     a = MutableSparseNDimArray.zeros(100000, 200000)
     b = MutableSparseNDimArray.zeros(100000, 200000)
     assert a == b
@@ -142,6 +144,14 @@ def test_sparse():
     # __mul__ and __rmul__
     assert a * 3 == MutableSparseNDimArray({200001: 3}, (100000, 200000))
     assert 3 * a == MutableSparseNDimArray({200001: 3}, (100000, 200000))
+    assert a * 0 == MutableSparseNDimArray({}, (100000, 200000))
+    assert 0 * a == MutableSparseNDimArray({}, (100000, 200000))
+
+    # __div__
+    assert a/3 == MutableSparseNDimArray({200001: S.One/3}, (100000, 200000))
+
+    # __neg__
+    assert -a == MutableSparseNDimArray({200001: -1}, (100000, 200000))
 
 
 def test_calculation():


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#16941 `__div__`  and `__neg__`

#### Brief description of what is fixed or changed
- Fixed issue about sparse arrays being cast to list while performing `__div__`  and `__neg__`
- Added cases in `__mul__` and `__rmul__` for sparse array if multiplying by 0
- Added test about dividing by 0
- Added other tests
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added specific case for sparse array in __div__, __neg__ and tests
<!-- END RELEASE NOTES -->
