### PR TITLE
Add numpy printing support for some matrix expressions

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -526,6 +526,51 @@ class NumPyPrinter(PythonCodePrinter):
                                self._print(arg1),
                                self._print(arg2))
 
+    def _print_ZeroMatrix(self, expr):
+        return '{}({})'.format(self._module_format('numpy.zeros'),
+            self._print(expr.shape))
+
+    def _print_OneMatrix(self, expr):
+        return '{}({})'.format(self._module_format('numpy.ones'),
+            self._print(expr.shape))
+
+    def _print_FunctionMatrix(self, expr):
+        from sympy.core.function import Lambda
+        from sympy.abc import i, j
+        lamda = expr.lamda
+        if not isinstance(lamda, Lambda):
+            lamda = Lambda((i, j), lamda(i, j))
+        return '{}(lambda {}: {}, {})'.format(self._module_format('numpy.fromfunction'),
+            ', '.join(self._print(arg) for arg in lamda.args[0]),
+            self._print(lamda.args[1]), self._print(expr.shape))
+
+    def _print_HadamardProduct(self, expr):
+        func = self._module_format('numpy.multiply')
+        return ''.join('{}({}, '.format(func, self._print(arg)) \
+            for arg in expr.args[:-1]) + "{}{}".format(self._print(expr.args[-1]),
+            ')' * (len(expr.args) - 1))
+
+    def _print_KroneckerProduct(self, expr):
+        func = self._module_format('numpy.kron')
+        return ''.join('{}({}, '.format(func, self._print(arg)) \
+            for arg in expr.args[:-1]) + "{}{}".format(self._print(expr.args[-1]),
+            ')' * (len(expr.args) - 1))
+
+    def _print_Adjoint(self, expr):
+        return '{}.getH()'.format(self._print(expr.arg))
+
+    def _print_DiagonalOf(self, expr):
+        return '{}({})'.format(self._module_format('numpy.diag'), self._print(expr.arg))
+
+    def _print_DiagonalizeVector(self, expr):
+        return '{}({})'.format(self._module_format('numpy.diagflat'),
+            self._print(expr.args[0]))
+
+    def _print_DiagonalMatrix(self, expr):
+        return '{}({}, {}({}, {}))'.format(self._module_format('numpy.multiply'),
+            self._print(expr.arg), self._module_format('numpy.eye'),
+            self._print(expr.shape[0]), self._print(expr.shape[1]))
+
     def _print_Piecewise(self, expr):
         "Piecewise function printer"
         exprs = '[{0}]'.format(','.join(self._print(arg.expr) for arg in expr.args))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -44,11 +44,28 @@ def test_MpmathPrinter():
     assert p.doprint(Rational(1, 2)) == 'mpmath.mpf(1)/mpmath.mpf(2)'
 
 def test_NumPyPrinter():
+    from sympy import (Lambda, ZeroMatrix, OneMatrix, FunctionMatrix,
+        HadamardProduct, KroneckerProduct, Adjoint, DiagonalOf,
+        DiagonalizeVector, DiagonalMatrix)
+    from sympy.abc import a, b
     p = NumPyPrinter()
     assert p.doprint(sign(x)) == 'numpy.sign(x)'
     A = MatrixSymbol("A", 2, 2)
+    B = MatrixSymbol("B", 2, 2)
+    C = MatrixSymbol("C", 1, 5)
+    D = MatrixSymbol("D", 3, 4)
     assert p.doprint(A**(-1)) == "numpy.linalg.inv(A)"
     assert p.doprint(A**5) == "numpy.linalg.matrix_power(A, 5)"
+    assert p.doprint(ZeroMatrix(2, 3)) == "numpy.zeros((2, 3))"
+    assert p.doprint(OneMatrix(2, 3)) == "numpy.ones((2, 3))"
+    assert p.doprint(FunctionMatrix(4, 5, Lambda((a, b), a + b))) == \
+        "numpy.fromfunction(lambda a, b: a + b, (4, 5))"
+    assert p.doprint(HadamardProduct(A, B)) == "numpy.multiply(A, B)"
+    assert p.doprint(KroneckerProduct(A, B)) == "numpy.kron(A, B)"
+    assert p.doprint(Adjoint(A)) == "A.getH()"
+    assert p.doprint(DiagonalOf(A)) == "numpy.diag(A)"
+    assert p.doprint(DiagonalizeVector(C)) == "numpy.diagflat(C)"
+    assert p.doprint(DiagonalMatrix(D)) == "numpy.multiply(D, numpy.eye(3, 4))"
 
 
 def test_SciPyPrinter():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes  #17013
Clashes with  #17027

#### Brief description of what is fixed or changed

` NumPyPrinter ` now supports printing the following matrix expressions 

* `ZeroMatrix` 
* `OneMatrix`
* `FunctionMatrix`
* `HadamardProduct`
* `KroneckerProduct`
* `Adjoint`
* `DiagonalOf`
* `DiagonalizeVector`
* `DiagonalMatrix`



#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added NumPy printing for several matrix expressions.
<!-- END RELEASE NOTES -->
