### PR TITLE
Fix incorrect results from isqrt fast path.

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -22,12 +22,15 @@ from math import sqrt as _sqrt
 
 def isqrt(n):
     """Return the largest integer less than or equal to sqrt(n)."""
+    if n < 0:
+        raise ValueError("n must be nonnegative")
+
     # Fast path: with IEEE 754 binary64 floats and a correctly-rounded
     # math.sqrt, int(math.sqrt(n)) works for any integer n satisfying 0 <= n <
     # 4503599761588224 = 2**52 + 2**27. But Python doesn't guarantee either
     # IEEE 754 format floats *or* correct rounding of math.sqrt, so check the
     # answer and fall back to the slow method if necessary.
-    if 0 <= n < 4503599761588224:
+    if n < 4503599761588224:
         s = int(_sqrt(int(n)))
         if 0 <= n - s*s <= 2*s:
             return s

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -24,6 +24,7 @@ def isqrt(n):
     """Return the largest integer less than or equal to sqrt(n)."""
     if n < 0:
         raise ValueError("n must be nonnegative")
+    n = int(n)
 
     # Fast path: with IEEE 754 binary64 floats and a correctly-rounded
     # math.sqrt, int(math.sqrt(n)) works for any integer n satisfying 0 <= n <
@@ -31,11 +32,11 @@ def isqrt(n):
     # IEEE 754 format floats *or* correct rounding of math.sqrt, so check the
     # answer and fall back to the slow method if necessary.
     if n < 4503599761588224:
-        s = int(_sqrt(int(n)))
+        s = int(_sqrt(n))
         if 0 <= n - s*s <= 2*s:
             return s
 
-    return integer_nthroot(int(n), 2)[0]
+    return integer_nthroot(n, 2)[0]
 
 
 def integer_nthroot(y, n):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -22,8 +22,16 @@ from math import sqrt as _sqrt
 
 def isqrt(n):
     """Return the largest integer less than or equal to sqrt(n)."""
-    if n < 17984395633462800708566937239552:
-        return int(_sqrt(n))
+    # Fast path: with IEEE 754 binary64 floats and a correctly-rounded
+    # math.sqrt, int(math.sqrt(n)) works for any integer n satisfying 0 <= n <
+    # 4503599761588224 = 2**52 + 2**27. But Python doesn't guarantee either
+    # IEEE 754 format floats *or* correct rounding of math.sqrt, so check the
+    # answer and fall back to the slow method if necessary.
+    if 0 <= n < 4503599761588224:
+        s = int(_sqrt(int(n)))
+        if 0 <= n - s*s <= 2*s:
+            return s
+
     return integer_nthroot(int(n), 2)[0]
 
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1026,12 +1026,31 @@ def test_integer_log():
 
 def test_isqrt():
     from math import sqrt as _sqrt
-    limit = 17984395633462800708566937239551
+    limit = 4503599761588223
     assert int(_sqrt(limit)) == integer_nthroot(limit, 2)[0]
     assert int(_sqrt(limit + 1)) != integer_nthroot(limit + 1, 2)[0]
     assert isqrt(limit + 1) == integer_nthroot(limit + 1, 2)[0]
-    assert isqrt(limit + 1 - S.Half) == integer_nthroot(limit + 1, 2)[0]
+    assert isqrt(limit + S.Half) == integer_nthroot(limit, 2)[0]
     assert isqrt(limit + 1 + S.Half) == integer_nthroot(limit + 1, 2)[0]
+    assert isqrt(limit + 2 + S.Half) == integer_nthroot(limit + 2, 2)[0]
+
+    # Regression tests for https://github.com/sympy/sympy/issues/17034
+    assert isqrt(4503599761588224) == 67108864
+    assert isqrt(9999999999999999) == 99999999
+
+    raises(ValueError, lambda: isqrt(-1))
+    raises(ValueError, lambda: isqrt(-10**1000))
+    raises(ValueError, lambda: -S.Half)
+
+    # Check that using an inaccurate math.sqrt doesn't affect the results.
+    from sympy.core import power
+    old_sqrt = power._sqrt
+    power._sqrt = lambda x: 2.999999999
+    try:
+        assert isqrt(9) == 3
+        assert isqrt(10000) == 100
+    finally:
+        power._sqrt = old_sqrt
 
 
 def test_powers_Integer():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1040,7 +1040,7 @@ def test_isqrt():
 
     raises(ValueError, lambda: isqrt(-1))
     raises(ValueError, lambda: isqrt(-10**1000))
-    raises(ValueError, lambda: -S.Half)
+    raises(ValueError, lambda: isqrt(-S.Half))
 
     # Check that using an inaccurate math.sqrt doesn't affect the results.
     from sympy.core import power

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1038,9 +1038,16 @@ def test_isqrt():
     assert isqrt(4503599761588224) == 67108864
     assert isqrt(9999999999999999) == 99999999
 
+    # Other corner cases, especially involving non-integers.
     raises(ValueError, lambda: isqrt(-1))
     raises(ValueError, lambda: isqrt(-10**1000))
     raises(ValueError, lambda: isqrt(-S.Half))
+
+    tiny = Rational(1, 10**1000)
+    raises(ValueError, lambda: isqrt(-tiny))
+    assert isqrt(1-tiny) == 0
+    assert isqrt(4503599761588224-tiny) == 67108864
+    assert isqrt(10**100 - tiny) == 10**50 - 1
 
     # Check that using an inaccurate math.sqrt doesn't affect the results.
     from sympy.core import power


### PR DESCRIPTION
Fixes #17034 

The fast path of `sympy.core.power.isqrt` returned incorrect results in some cases, and didn't allow for the possibility of an incorrectly-rounded `math.sqrt` function. This PR fixes these issues and adds suitable regression tests.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * Fixed a bug in the integer square root function for small inputs.

<!-- END RELEASE NOTES -->
