### PR TITLE
Added some attributes to Markov chain

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -375,6 +375,25 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
             raise ValueError("Fundamental matrix doesn't exists.")
         return ImmutableMatrix((I - Q).inv().tolist())
 
+    def absorbing_probabilites(self):
+        """
+        Computes the absorbing probabilities, i.e.,
+        the ij-th entry of the matrix denotes the
+        probability of Markov chain being absorbed
+        in state j starting from state i.
+        """
+        R = self._transient2absorbing()
+        N = self.fundamental_matrix()
+        if R == None or N == None:
+            return None
+        return N*R
+
+    def is_regular(self):
+        w = self.fixed_row_vector()
+        if w is None or isinstance(w, (Lambda)):
+            return None
+        return all((wi > 0) == True for wi in w.row(0))
+
     def is_absorbing_state(self, state):
         trans_probs = self.transition_probabilities
         if isinstance(trans_probs, ImmutableMatrix) and \

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -334,16 +334,9 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         if not isinstance(trans_probs, ImmutableMatrix):
             return None
 
-        m, trans_states, t2t = trans_probs.shape[0], [], []
-        for i in range(m):
-            if trans_probs[i, i] != 1:
-                trans_states.append(i)
-
-        for si in trans_states:
-            tij = []
-            for sj in trans_states:
-                tij.append(trans_probs[si, sj])
-            t2t.append(tij)
+        m = trans_probs.shape[0]
+        trans_states = [i for i in range(m) if trans_probs[i, i] != 1]
+        t2t = [[trans_probs[si, sj] for sj in trans_states] for si in trans_states]
 
         return ImmutableMatrix(t2t)
 
@@ -357,8 +350,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         if not isinstance(trans_probs, ImmutableMatrix):
             return None
 
-        m, trans_states, absorb_states, t2a = \
-            trans_probs.shape[0], [], [], []
+        m, trans_states, absorb_states = \
+            trans_probs.shape[0], [], []
         for i in range(m):
             if trans_probs[i, i] == 1:
                 absorb_states.append(i)
@@ -368,15 +361,11 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         if not absorb_states or not trans_states:
             return None
 
-        for si in trans_states:
-            tij = []
-            for sj in absorb_states:
-                tij.append(trans_probs[si, sj])
-            t2a.append(tij)
+        t2a = [[trans_probs[si, sj] for sj in absorb_states]
+                for si in trans_states]
 
         return ImmutableMatrix(t2a)
 
-    @property
     def fundamental_matrix(self):
         Q = self._transient2transient()
         if Q == None:
@@ -392,13 +381,11 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
             state < trans_probs.shape[0]:
             return S(trans_probs[state, state]) == S.One
 
-    @property
     def is_absorbing_chain(self):
         trans_probs = self.transition_probabilities
         return any(self.is_absorbing_state(state) == True
                     for state in range(trans_probs.shape[0]))
 
-    @property
     def fixed_row_vector(self):
         trans_probs = self.transition_probabilities
         if trans_probs == None:
@@ -420,7 +407,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         The fixed row vector is the limiting
         distribution of a discrete Markov chain.
         """
-        return self.fixed_row_vector
+        return self.fixed_row_vector()
 
     def probability(self, condition, given_condition=None, evaluate=True, **kwargs):
         """

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -384,7 +384,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         I = eye(Q.shape[0])
         if (I - Q).det() == 0:
             raise ValueError("Fundamental matrix doesn't exists.")
-        return (I - Q).inv()
+        return ImmutableMatrix((I - Q).inv().tolist())
 
     def is_absorbing_state(self, state):
         trans_probs = self.transition_probabilities

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -349,8 +349,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
         wm = Matrix([wi])
         eqs = (wm*trans_probs - wm).tolist()[0]
         eqs.append(sum(wi) - 1)
-        soln = linsolve(eqs, wi)
-        return ImmutableMatrix([*soln])
+        soln = list(linsolve(eqs, wi))[0]
+        return ImmutableMatrix([[sol for sol in soln]])
 
     def probability(self, condition, given_condition=None, evaluate=True, **kwargs):
         """

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -74,6 +74,7 @@ def test_DiscreteMarkovChain():
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
     w = ImmutableMatrix([[S(11)/39, S(16)/39, S(4)/13]])
     assert Y4.limiting_distribution == w
+    assert Y4.is_regular() == True
     TS1 = MatrixSymbol('T', 3, 3)
     Y5 = DiscreteMarkovChain('Y', trans_probs=TS1)
     assert Y5.limiting_distribution(w, TO4).doit() == True
@@ -82,3 +83,4 @@ def test_DiscreteMarkovChain():
     assert Y6._transient2absorbing() == ImmutableMatrix([[S(1)/2, 0], [0, 0], [0, S(1)/2]])
     assert Y6._transient2transient() == ImmutableMatrix([[0, S(1)/2, 0], [S(1)/2, 0, S(1)/2], [0, S(1)/2, 0]])
     assert Y6.fundamental_matrix() == ImmutableMatrix([[S(3)/2, S(1), S(1)/2], [S(1), S(2), S(1)], [S(1)/2, S(1), S(3)/2]])
+    assert Y6.absorbing_probabilites() == ImmutableMatrix([[S(3)/4, S(1)/4], [S(1)/2, S(1)/2], [S(1)/4, S(3)/4]])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -1,4 +1,5 @@
-from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And)
+from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And,
+                   ImmutableMatrix)
 from sympy.stats import DiscreteMarkovChain, P, TransitionMatrixOf, E
 from sympy.stats.rv import RandomIndexedSymbol
 from sympy.stats.symbolic_probability import Probability, Expectation
@@ -67,7 +68,7 @@ def test_DiscreteMarkovChain():
     assert Y3.is_absorbing_chain == False
     TO4 = Matrix([[S(1)/5, S(2)/5, S(2)/5], [S(1)/10, S(1)/2, S(2)/5], [S(3)/5, S(3)/10, S(1)/10]])
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
-    w = Matrix([[S(11)/39, S(16)/39, S(4)/13]])
+    w = ImmutableMatrix([[S(11)/39, S(16)/39, S(4)/13]])
     assert Y4.fixed_row_vector == w
     TS1 = MatrixSymbol('T', 3, 3)
     Y5 = DiscreteMarkovChain('Y', trans_probs=TS1)

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -32,6 +32,8 @@ def test_DiscreteMarkovChain():
     TS = MatrixSymbol('T', 3, 3)
     Y = DiscreteMarkovChain("Y", [0, 1, 2], T)
     YS = DiscreteMarkovChain("Y", [0, 1, 2], TS)
+    assert YS._transient2transient() == None
+    assert YS._transient2absorbing() == None
     assert Y.joint_distribution(1, Y[2], 3) == JointDistribution(Y[1], Y[2], Y[3])
     raises(ValueError, lambda: Y.joint_distribution(Y[1].symbol, Y[2].symbol))
     assert P(Eq(Y[3], 2), Eq(Y[1], 1)).round(2) == Float(0.36, 2)
@@ -64,12 +66,19 @@ def test_DiscreteMarkovChain():
     TO3 = Matrix([[S(1)/4, S(3)/4, 0],[S(1)/3, S(1)/3, S(1)/3],[0, S(1)/4, S(3)/4]])
     Y2 = DiscreteMarkovChain('Y', trans_probs=TO2)
     Y3 = DiscreteMarkovChain('Y', trans_probs=TO3)
+    assert Y3._transient2absorbing() == None
+    raises (ValueError, lambda: Y3.fundamental_matrix)
     assert Y2.is_absorbing_chain == True
     assert Y3.is_absorbing_chain == False
     TO4 = Matrix([[S(1)/5, S(2)/5, S(2)/5], [S(1)/10, S(1)/2, S(2)/5], [S(3)/5, S(3)/10, S(1)/10]])
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
     w = ImmutableMatrix([[S(11)/39, S(16)/39, S(4)/13]])
-    assert Y4.fixed_row_vector == w
+    assert Y4.limiting_distribution == w
     TS1 = MatrixSymbol('T', 3, 3)
     Y5 = DiscreteMarkovChain('Y', trans_probs=TS1)
-    assert Y5.fixed_row_vector(w, TO4).doit() == True
+    assert Y5.limiting_distribution(w, TO4).doit() == True
+    TO6 = Matrix([[S(1), 0, 0, 0, 0],[S(1)/2, 0, S(1)/2, 0, 0],[0, S(1)/2, 0, S(1)/2, 0], [0, 0, S(1)/2, 0, S(1)/2], [0, 0, 0, 0, 1]])
+    Y6 = DiscreteMarkovChain('Y', trans_probs=TO6)
+    assert Y6._transient2absorbing() == Matrix([[1/2, 0], [0, 0], [0, 1/2]])
+    assert Y6._transient2transient() == Matrix([[0, 1/2, 0], [1/2, 0, 1/2], [0, 1/2, 0]])
+    assert Y6.fundamental_matrix == Matrix([[3/2, 1, 1/2], [1, 2, 1], [1/2, 1, 3/2]])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -79,6 +79,6 @@ def test_DiscreteMarkovChain():
     assert Y5.limiting_distribution(w, TO4).doit() == True
     TO6 = Matrix([[S(1), 0, 0, 0, 0],[S(1)/2, 0, S(1)/2, 0, 0],[0, S(1)/2, 0, S(1)/2, 0], [0, 0, S(1)/2, 0, S(1)/2], [0, 0, 0, 0, 1]])
     Y6 = DiscreteMarkovChain('Y', trans_probs=TO6)
-    assert Y6._transient2absorbing() == Matrix([[1/2, 0], [0, 0], [0, 1/2]])
-    assert Y6._transient2transient() == Matrix([[0, 1/2, 0], [1/2, 0, 1/2], [0, 1/2, 0]])
-    assert Y6.fundamental_matrix == Matrix([[3/2, 1, 1/2], [1, 2, 1], [1/2, 1, 3/2]])
+    assert Y6._transient2absorbing() == ImmutableMatrix([[S(1)/2, 0], [0, 0], [0, S(1)/2]])
+    assert Y6._transient2transient() == ImmutableMatrix([[0, S(1)/2, 0], [S(1)/2, 0, S(1)/2], [0, S(1)/2, 0]])
+    assert Y6.fundamental_matrix == ImmutableMatrix([[S(3)/2, S(1), S(1)/2], [S(1), S(2), S(1)], [S(1)/2, S(1), S(3)/2]])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -67,9 +67,9 @@ def test_DiscreteMarkovChain():
     Y2 = DiscreteMarkovChain('Y', trans_probs=TO2)
     Y3 = DiscreteMarkovChain('Y', trans_probs=TO3)
     assert Y3._transient2absorbing() == None
-    raises (ValueError, lambda: Y3.fundamental_matrix)
-    assert Y2.is_absorbing_chain == True
-    assert Y3.is_absorbing_chain == False
+    raises (ValueError, lambda: Y3.fundamental_matrix())
+    assert Y2.is_absorbing_chain() == True
+    assert Y3.is_absorbing_chain() == False
     TO4 = Matrix([[S(1)/5, S(2)/5, S(2)/5], [S(1)/10, S(1)/2, S(2)/5], [S(3)/5, S(3)/10, S(1)/10]])
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
     w = ImmutableMatrix([[S(11)/39, S(16)/39, S(4)/13]])
@@ -81,4 +81,4 @@ def test_DiscreteMarkovChain():
     Y6 = DiscreteMarkovChain('Y', trans_probs=TO6)
     assert Y6._transient2absorbing() == ImmutableMatrix([[S(1)/2, 0], [0, 0], [0, S(1)/2]])
     assert Y6._transient2transient() == ImmutableMatrix([[0, S(1)/2, 0], [S(1)/2, 0, S(1)/2], [0, S(1)/2, 0]])
-    assert Y6.fundamental_matrix == ImmutableMatrix([[S(3)/2, S(1), S(1)/2], [S(1), S(2), S(1)], [S(1)/2, S(1), S(3)/2]])
+    assert Y6.fundamental_matrix() == ImmutableMatrix([[S(3)/2, S(1), S(1)/2], [S(1), S(2), S(1)], [S(1)/2, S(1), S(3)/2]])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -57,3 +57,18 @@ def test_DiscreteMarkovChain():
     assert P(And(Eq(Y[2], 1), Eq(Y[1], 1), Eq(Y[0], 0)), TransitionMatrixOf(Y, TO1)) == \
             Probability(Eq(Y[0], 0))/4
     raises (ValueError, lambda: str(P(And(Eq(Y[2], 1), Eq(Y[1], 1), Eq(Y[0], 0)), Eq(Y[1], 1))))
+
+    # testing properties of Markov chain
+    TO2 = Matrix([[S(1), 0, 0],[S(1)/3, S(1)/3, S(1)/3],[0, S(1)/4, S(3)/4]])
+    TO3 = Matrix([[S(1)/4, S(3)/4, 0],[S(1)/3, S(1)/3, S(1)/3],[0, S(1)/4, S(3)/4]])
+    Y2 = DiscreteMarkovChain('Y', trans_probs=TO2)
+    Y3 = DiscreteMarkovChain('Y', trans_probs=TO3)
+    assert Y2.is_absorbing_chain == True
+    assert Y3.is_absorbing_chain == False
+    TO4 = Matrix([[S(1)/5, S(2)/5, S(2)/5], [S(1)/10, S(1)/2, S(2)/5], [S(3)/5, S(3)/10, S(1)/10]])
+    Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
+    w = Matrix([[S(11)/39, S(16)/39, S(4)/13]])
+    assert Y4.fixed_row_vector == w
+    TS1 = MatrixSymbol('T', 3, 3)
+    Y5 = DiscreteMarkovChain('Y', trans_probs=TS1)
+    assert Y5.fixed_row_vector(w, TO4).doit() == True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Some attributes specific to `DiscreteMarkovChain` have been added. The names are,

- `is_absorbing_state`
- `is_absorbing_chain`
- `fixed_row_vector`

I will try to add more like, `equilibrium_distribution`, and some given [here](https://docs.google.com/document/d/1oIeaROiJyglpbris7X1uZPRE5ZeO0pD1ygCFhBIeATI/edit#heading=h.4kagr2anaga2).

#### Other comments
I haven't allowed overriding of information(transition matrix, state space) because these attributes are properties of Markov chain and should be determined by the state of the object and not by what is passed after creation of the object. Though that's my reasoning.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Attributes specific to `DiscreteMarkovChain` have been added like, `is_absorbing_chain`, `fixed_row_vector`, etc.
<!-- END RELEASE NOTES -->
