### PR TITLE
Fix issue with is_square

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -92,7 +92,7 @@ def is_square(n, prep=True):
         m = n % 63
         if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
             from sympy.ntheory import perfect_power
-            pp = perfect_power(n)
+            pp = perfect_power(n, [2])
             if pp:
                 return pp[1] % 2 == 0
     return False

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -92,8 +92,9 @@ def is_square(n, prep=True):
         m = n % 63
         if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
             from sympy.ntheory import perfect_power
-            if perfect_power(n, [2]):
-                return True
+            pp = perfect_power(n)
+            if pp:
+                return pp[1] % 2 == 0
     return False
 
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -92,9 +92,9 @@ def is_square(n, prep=True):
         m = n % 63
         if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
             from sympy.ntheory import perfect_power
-            pp = perfect_power(n, [2])
+            pp = perfect_power(n, [2], big=False)
             if pp:
-                return pp[1] % 2 == 0
+                return pp[1] == 2
     return False
 
 

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -137,3 +137,9 @@ def test_isprime():
 
 def test_is_square():
     assert [i for i in range(25) if is_square(i)] == [0, 1, 4, 9, 16]
+
+    # issue #17044
+    assert not is_square(216000)
+    assert not is_square(592704)
+    assert not is_square(1157625)
+    assert not is_square(1728000)

--- a/sympy/ntheory/tests/test_primetest.py
+++ b/sympy/ntheory/tests/test_primetest.py
@@ -139,7 +139,8 @@ def test_is_square():
     assert [i for i in range(25) if is_square(i)] == [0, 1, 4, 9, 16]
 
     # issue #17044
-    assert not is_square(216000)
-    assert not is_square(592704)
-    assert not is_square(1157625)
-    assert not is_square(1728000)
+    assert not is_square(60 ** 3)
+    assert not is_square(60 ** 5)
+    assert not is_square(84 ** 7)
+    assert not is_square(105 ** 9)
+    assert not is_square(120 ** 3)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17044.

#### Brief description of what is fixed or changed
If we call `perfect_power(216000, [2])` in the old `is_square` code we get `(60, 3)`. So we need to test the second argument of the result. The behavior of the `candidates` parameter in `perfect_power` is not explained well in the documentation- could be a separate issue.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
