### PR TITLE
Rewrote some a == a tests

### DIFF
--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -1,14 +1,14 @@
 from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re, Abs,
         exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi, symbols,
-        expand_complex)
-
+        expand_complex, Pow)
+from sympy.core.expr import unchanged
 
 def test_complex():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
     e = (a + I*b)*(a - I*b)
     assert e.expand() == a**2 + b**2
-    assert sqrt(I) == sqrt(I)
+    assert sqrt(I) == Pow(I, Rational(1, 2))
 
 
 def test_conjugate():
@@ -38,7 +38,7 @@ def test_conjugate():
 def test_abs1():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
-    assert abs(a) == abs(a)
+    assert abs(a) == Abs(a)
     assert abs(-a) == abs(a)
     assert abs(a + I*b) == sqrt(a**2 + b**2)
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -5,14 +5,15 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         Matrix, Basic, Dict)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.basic import _aresame
+from sympy.core.cache import clear_cache
+from sympy.core.compatibility import range
+from sympy.core.expr import unchanged
 from sympy.core.function import PoleError, _mexpand, arity
 from sympy.core.sympify import sympify
 from sympy.sets.sets import FiniteSet
 from sympy.solvers.solveset import solveset
-from sympy.utilities.iterables import subsets, variations
-from sympy.core.cache import clear_cache
-from sympy.core.compatibility import range
 from sympy.tensor.array import NDimArray
+from sympy.utilities.iterables import subsets, variations
 
 from sympy.abc import t, w, x, y, z
 f, g, h = symbols('f g h', cls=Function)
@@ -175,12 +176,12 @@ def test_Lambda():
     assert e(y) == y**2
 
     assert Lambda((), 42)() == 42
-    assert Lambda((), 42) == Lambda((), 42)
+    assert unchanged(Lambda, (), 42)
     assert Lambda((), 42) != Lambda((), 43)
     assert Lambda((), f(x))() == f(x)
     assert Lambda((), 42).nargs == FiniteSet(0)
 
-    assert Lambda(x, x**2) == Lambda(x, x**2)
+    assert unchanged(Lambda, (x,), x**2)
     assert Lambda(x, x**2) == Lambda(y, y**2)
     assert Lambda(x, x**2) != Lambda(y, y**2 + 1)
     assert Lambda((x, y), x**y) == Lambda((y, x), y**x)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -8,11 +8,11 @@ from sympy import (Rational, Symbol, Float, I, sqrt, cbrt, oo, nan, pi, E,
                    AlgebraicNumber, simplify, sin, fibonacci, RealField,
                    sympify, srepr)
 from sympy.core.compatibility import long
-from sympy.core.power import integer_nthroot, isqrt, integer_log
+from sympy.core.expr import unchanged
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
     igcd2, igcd_lehmer, mpf_norm, comp, mod_inverse)
-from sympy.core.mod import Mod
+from sympy.core.power import integer_nthroot, isqrt, integer_log
 from sympy.polys.domains.groundtypes import PythonRational
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.iterables import permutations
@@ -1261,7 +1261,7 @@ def test_no_len():
 
 
 def test_issue_3321():
-    assert sqrt(Rational(1, 5)) == sqrt(Rational(1, 5))
+    assert sqrt(Rational(1, 5)) == Rational(1, 5)**S.Half
     assert 5 * sqrt(Rational(1, 5)) == sqrt(5)
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -18,7 +18,7 @@ def test_rf_eval_apply():
     assert rf(nan, y) == nan
     assert rf(x, nan) == nan
 
-    assert rf(x, y) == rf(x, y)
+    assert unchanged(rf, x, y)
 
     assert rf(oo, 0) == 1
     assert rf(-oo, 0) == 1
@@ -82,7 +82,7 @@ def test_ff_eval_apply():
     assert ff(nan, y) == nan
     assert ff(x, nan) == nan
 
-    assert ff(x, y) == ff(x, y)
+    assert unchanged(ff, x, y)
 
     assert ff(oo, 0) == 1
     assert ff(-oo, 0) == 1

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -385,7 +385,7 @@ def test_catalan():
         assert catalan(n).rewrite(factorial).subs(n, i) == c
         assert catalan(n).rewrite(Product).subs(n, i).doit() == c
 
-    assert catalan(x) == catalan(x)
+    assert unchanged(catalan, x)
     assert catalan(2*x).rewrite(binomial) == binomial(4*x, 2*x)/(2*x + 1)
     assert catalan(Rational(1, 2)).rewrite(gamma) == 8/(3*pi)
     assert catalan(Rational(1, 2)).rewrite(factorial).rewrite(gamma) ==\

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -41,7 +41,7 @@ def test_re():
     assert re(i*I) == I * i
     assert re(i) == 0
 
-    assert re(x + y) == re(x + y)
+    assert re(x + y) == re(x) + re(y)
     assert re(x + r) == re(x) + r
 
     assert re(re(x)) == re(x)
@@ -137,7 +137,7 @@ def test_im():
     assert im(i*I) == 0
     assert im(i) == -I * i
 
-    assert im(x + y) == im(x + y)
+    assert im(x + y) == im(x) + im(y)
     assert im(x + r) == im(x)
     assert im(x + r*I) == im(x) + r
 
@@ -350,6 +350,7 @@ def test_as_real_imag():
 def test_sign_issue_3068():
     n = pi**1000
     i = int(n)
+    x = Symbol('x')
     assert (n - i).round() == 1  # doesn't hang
     assert sign(n - i) == 1
     # perhaps it's not possible to get the sign right when
@@ -806,7 +807,7 @@ def test_derivatives_issue_4757():
 
 
 def test_issue_11413():
-    from sympy import symbols, Matrix, simplify
+    from sympy import Matrix, simplify
     v0 = Symbol('v0')
     v1 = Symbol('v1')
     v2 = Symbol('v2')
@@ -853,6 +854,7 @@ def test_periodic_argument():
 @XFAIL
 def test_principal_branch_fail():
     # TODO XXX why does abs(x)._eval_evalf() not fall back to global evalf?
+    from sympy import principal_branch
     assert N_equals(principal_branch((1 + I)**2, pi/2), 0)
 
 
@@ -892,10 +894,12 @@ def test_issue_6167_6151():
     i = int(n)
     assert sign(n - i) == 1
     assert abs(n - i) == n - i
+    x = Symbol('x')
     eps = pi**-1500
     big = pi**1000
     one = cos(x)**2 + sin(x)**2
     e = big*one - big + eps
+    from sympy import simplify
     assert sign(simplify(e)) == 1
     for xi in (111, 11, 1, S(1)/10):
         assert sign(e.subs(x, xi)) == 1

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -3,6 +3,7 @@ from sympy import (symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log,
     Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul,
     AccumBounds, im, re)
 
+from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises
 
@@ -20,16 +21,16 @@ def test_sinh():
 
     assert sinh(0) == 0
 
-    assert sinh(1) == sinh(1)
+    assert unchanged(sinh, 1)
     assert sinh(-1) == -sinh(1)
 
-    assert sinh(x) == sinh(x)
+    assert unchanged(sinh, x)
     assert sinh(-x) == -sinh(x)
 
-    assert sinh(pi) == sinh(pi)
+    assert unchanged(sinh, pi)
     assert sinh(-pi) == -sinh(pi)
 
-    assert sinh(2**1024 * E) == sinh(2**1024 * E)
+    assert unchanged(sinh, 2**1024 * E)
     assert sinh(-2**1024 * E) == -sinh(2**1024 * E)
 
     assert sinh(pi*I) == 0
@@ -60,7 +61,7 @@ def test_sinh():
     assert sinh(pi*I/105) == sin(pi/105)*I
     assert sinh(-pi*I/105) == -sin(pi/105)*I
 
-    assert sinh(2 + 3*I) == sinh(2 + 3*I)
+    assert unchanged(sinh, 2 + 3*I)
 
     assert sinh(x*I) == sin(x)*I
 
@@ -102,16 +103,16 @@ def test_cosh():
 
     assert cosh(0) == 1
 
-    assert cosh(1) == cosh(1)
+    assert unchanged(cosh, 1)
     assert cosh(-1) == cosh(1)
 
-    assert cosh(x) == cosh(x)
+    assert unchanged(cosh, x)
     assert cosh(-x) == cosh(x)
 
     assert cosh(pi*I) == cos(pi)
     assert cosh(-pi*I) == cos(pi)
 
-    assert cosh(2**1024 * E) == cosh(2**1024 * E)
+    assert unchanged(cosh, 2**1024 * E)
     assert cosh(-2**1024 * E) == cosh(2**1024 * E)
 
     assert cosh(pi*I/2) == 0
@@ -140,14 +141,14 @@ def test_cosh():
     assert cosh(pi*I/105) == cos(pi/105)
     assert cosh(-pi*I/105) == cos(pi/105)
 
-    assert cosh(2 + 3*I) == cosh(2 + 3*I)
+    assert unchanged(cosh, 2 + 3*I)
 
     assert cosh(x*I) == cos(x)
 
     assert cosh(k*pi*I) == cos(k*pi)
     assert cosh(17*k*pi*I) == cos(17*k*pi)
 
-    assert cosh(k*pi) == cosh(k*pi)
+    assert unchanged(cosh, k*pi)
 
     assert cosh(x).as_real_imag(deep=False) == (cos(im(x))*cosh(re(x)),
                 sin(im(x))*sinh(re(x)))
@@ -182,16 +183,16 @@ def test_tanh():
 
     assert tanh(0) == 0
 
-    assert tanh(1) == tanh(1)
+    assert unchanged(tanh, 1)
     assert tanh(-1) == -tanh(1)
 
-    assert tanh(x) == tanh(x)
+    assert unchanged(tanh, x)
     assert tanh(-x) == -tanh(x)
 
-    assert tanh(pi) == tanh(pi)
+    assert unchanged(tanh, pi)
     assert tanh(-pi) == -tanh(pi)
 
-    assert tanh(2**1024 * E) == tanh(2**1024 * E)
+    assert unchanged(tanh, 2**1024 * E)
     assert tanh(-2**1024 * E) == -tanh(2**1024 * E)
 
     assert tanh(pi*I) == 0
@@ -201,10 +202,10 @@ def test_tanh():
     assert tanh(-3*10**73*pi*I) == 0
     assert tanh(7*10**103*pi*I) == 0
 
-    assert tanh(pi*I/2) == tanh(pi*I/2)
-    assert tanh(-pi*I/2) == -tanh(pi*I/2)
-    assert tanh(5*pi*I/2) == tanh(5*pi*I/2)
-    assert tanh(7*pi*I/2) == tanh(7*pi*I/2)
+    assert tanh(pi*I/2) == zoo
+    assert tanh(-pi*I/2) == zoo
+    assert tanh(5*pi*I/2) == zoo
+    assert tanh(7*pi*I/2) == zoo
 
     assert tanh(pi*I/3) == sqrt(3)*I
     assert tanh(-2*pi*I/3) == sqrt(3)*I
@@ -222,7 +223,7 @@ def test_tanh():
     assert tanh(pi*I/105) == tan(pi/105)*I
     assert tanh(-pi*I/105) == -tan(pi/105)*I
 
-    assert tanh(2 + 3*I) == tanh(2 + 3*I)
+    assert unchanged(tanh, 2 + 3*I)
 
     assert tanh(x*I) == tan(x)*I
 
@@ -260,18 +261,17 @@ def test_coth():
     assert coth(oo) == 1
     assert coth(-oo) == -1
 
-    assert coth(0) == coth(0)
     assert coth(0) == zoo
-    assert coth(1) == coth(1)
+    assert unchanged(coth, 1)
     assert coth(-1) == -coth(1)
 
-    assert coth(x) == coth(x)
+    assert unchanged(coth, x)
     assert coth(-x) == -coth(x)
 
     assert coth(pi*I) == -I*cot(pi)
     assert coth(-pi*I) == cot(pi)*I
 
-    assert coth(2**1024 * E) == coth(2**1024 * E)
+    assert unchanged(coth, 2**1024 * E)
     assert coth(-2**1024 * E) == -coth(2**1024 * E)
 
     assert coth(pi*I) == -I*cot(pi)
@@ -302,7 +302,7 @@ def test_coth():
     assert coth(pi*I/105) == -cot(pi/105)*I
     assert coth(-pi*I/105) == cot(pi/105)*I
 
-    assert coth(2 + 3*I) == coth(2 + 3*I)
+    assert unchanged(coth, 2 + 3*I)
 
     assert coth(x*I) == -cot(x)*I
 
@@ -472,7 +472,7 @@ def test_sech_fdiff():
 
 def test_asinh():
     x, y = symbols('x,y')
-    assert asinh(x) == asinh(x)
+    assert unchanged(asinh, x)
     assert asinh(-x) == -asinh(x)
 
     #at specific points
@@ -531,7 +531,7 @@ def test_asinh_fdiff():
 def test_acosh():
     x = Symbol('x')
 
-    assert acosh(-x) == acosh(-x)
+    assert unchanged(acosh, -x)
 
     #at specific points
     assert acosh(1) == 0
@@ -593,7 +593,7 @@ def test_acosh_fdiff():
 def test_asech():
     x = Symbol('x')
 
-    assert asech(-x) == asech(-x)
+    assert unchanged(asech, -x)
 
     # values at fixed points
     assert asech(1) == 0
@@ -668,8 +668,8 @@ def test_asech_fdiff():
 def test_acsch():
     x = Symbol('x')
 
-    assert acsch(-x) == acsch(-x)
-    assert acsch(x) == -acsch(-x)
+    assert unchanged(acsch, x)
+    assert acsch(-x) == -acsch(x)
 
     # values at fixed points
     assert acsch(1) == log(1 + sqrt(2))

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,6 +1,7 @@
 from sympy import AccumBounds, Symbol, floor, nan, oo, zoo, E, symbols, \
         ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac, Eq
 
+from sympy.core.expr import unchanged
 from sympy.utilities.pytest import XFAIL
 
 x = Symbol('x')
@@ -60,27 +61,27 @@ def test_floor():
     assert floor(E + 17) == 19
     assert floor(pi + 2) == 5
 
-    assert floor(E + pi) == floor(E + pi)
-    assert floor(I + pi) == floor(I + pi)
+    assert floor(E + pi) == 5
+    assert floor(I + pi) == 3 + I
 
     assert floor(floor(pi)) == 3
     assert floor(floor(y)) == floor(y)
     assert floor(floor(x)) == floor(floor(x))
 
-    assert floor(x) == floor(x)
-    assert floor(2*x) == floor(2*x)
-    assert floor(k*x) == floor(k*x)
+    assert unchanged(floor, x)
+    assert unchanged(floor, 2*x)
+    assert unchanged(floor, k*x)
 
     assert floor(k) == k
     assert floor(2*k) == 2*k
     assert floor(k*n) == k*n
 
-    assert floor(k/2) == floor(k/2)
+    assert unchanged(floor, k/2)
 
-    assert floor(x + y) == floor(x + y)
+    assert unchanged(floor, x + y)
 
-    assert floor(x + 3) == floor(x + 3)
-    assert floor(x + k) == floor(x + k)
+    assert floor(x + 3) == floor(x) + 3
+    assert floor(x + k) == floor(x) + k
 
     assert floor(y + 3) == floor(y) + 3
     assert floor(y + k) == floor(y) + k
@@ -89,7 +90,7 @@ def test_floor():
 
     assert floor(k + n) == k + n
 
-    assert floor(x*I) == floor(x*I)
+    assert unchanged(floor, x*I)
     assert floor(k*I) == k*I
 
     assert floor(Rational(23, 10) - E*I) == 2 - 3*I
@@ -175,8 +176,8 @@ def test_ceiling():
     assert ceiling(E + 17) == 20
     assert ceiling(pi + 2) == 6
 
-    assert ceiling(E + pi) == ceiling(E + pi)
-    assert ceiling(I + pi) == ceiling(I + pi)
+    assert ceiling(E + pi) == 6
+    assert ceiling(I + pi) == I + 4
 
     assert ceiling(ceiling(pi)) == 4
     assert ceiling(ceiling(y)) == ceiling(y)
@@ -190,12 +191,12 @@ def test_ceiling():
     assert ceiling(2*k) == 2*k
     assert ceiling(k*n) == k*n
 
-    assert ceiling(k/2) == ceiling(k/2)
+    assert unchanged(ceiling, k/2)
 
-    assert ceiling(x + y) == ceiling(x + y)
+    assert unchanged(ceiling, x + y)
 
-    assert ceiling(x + 3) == ceiling(x + 3)
-    assert ceiling(x + k) == ceiling(x + k)
+    assert ceiling(x + 3) == ceiling(x) + 3
+    assert ceiling(x + k) == ceiling(x) + k
 
     assert ceiling(y + 3) == ceiling(y) + 3
     assert ceiling(y + k) == ceiling(y) + k
@@ -204,7 +205,7 @@ def test_ceiling():
 
     assert ceiling(k + n) == k + n
 
-    assert ceiling(x*I) == ceiling(x*I)
+    assert unchanged(ceiling, x*I)
     assert ceiling(k*I) == k*I
 
     assert ceiling(Rational(23, 10) - E*I) == 3 - 2*I
@@ -254,7 +255,7 @@ def test_frac():
     assert frac(0.5 + I*r) == 0.5 + I*frac(r)
     assert frac(n + I*r) == I*frac(r)
     assert frac(n + I*k) == 0
-    assert frac(x + I*x) == frac(x + I*x)
+    assert unchanged(frac, x + I*x)
     assert frac(x + I*n) == frac(x)
 
     assert frac(x).rewrite(floor) == x - floor(x)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,20 +1,21 @@
 import itertools as it
 
+from sympy.core.expr import unchanged
 from sympy.core.function import Function
 from sympy.core.numbers import I, oo, Rational
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
+from sympy.external import import_module
+from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.miscellaneous import (sqrt, cbrt, root, Min,
                                                       Max, real_root)
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.functions.elementary.exponential import log
-from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
 
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.pytest import raises, skip, ignore_warnings
-from sympy.external import import_module
 
 def test_Min():
     from sympy.abc import x, y, z
@@ -43,8 +44,8 @@ def test_Min():
     assert Min(-oo, oo) == -oo
     assert Min(oo, -oo) == -oo
     assert Min(n, n) == n
-    assert Min(n, np) == Min(n, np)
-    assert Min(np, n) == Min(np, n)
+    assert unchanged(Min, n, np)
+    assert Min(np, n) == Min(n, np)
     assert Min(n, 0) == n
     assert Min(0, n) == n
     assert Min(n, nn) == n
@@ -70,8 +71,8 @@ def test_Min():
     assert Min(0, oo) == 0
     assert Min(oo, 0) == 0
     assert Min(nn, nn) == nn
-    assert Min(nn, p) == Min(nn, p)
-    assert Min(p, nn) == Min(p, nn)
+    assert unchanged(Min, nn, p)
+    assert Min(p, nn) == Min(nn, p)
     assert Min(nn, oo) == nn
     assert Min(oo, nn) == nn
     assert Min(p, p) == p
@@ -97,7 +98,8 @@ def test_Min():
     assert Min(2, x, p, n, oo, n_, p, 2, -2, -2) == Min(-2, x, n, n_)
     assert Min(0, x, 1, y) == Min(0, x, y)
     assert Min(1000, 100, -100, x, p, n) == Min(n, x, -100)
-    assert Min(cos(x), sin(x)) == Min(cos(x), sin(x))
+    assert unchanged(Min, sin(x), cos(x))
+    assert Min(sin(x), cos(x)) == Min(cos(x), sin(x))
     assert Min(cos(x), sin(x)).subs(x, 1) == cos(1)
     assert Min(cos(x), sin(x)).subs(x, S(1)/2) == sin(S(1)/2)
     raises(ValueError, lambda: Min(cos(x), sin(x)).subs(x, I))
@@ -146,11 +148,8 @@ def test_Max():
     n = Symbol('n', negative=True)
     n_ = Symbol('n_', negative=True)
     nn = Symbol('nn', nonnegative=True)
-    nn_ = Symbol('nn_', nonnegative=True)
     p = Symbol('p', positive=True)
     p_ = Symbol('p_', positive=True)
-    np = Symbol('np', nonpositive=True)
-    np_ = Symbol('np_', nonpositive=True)
     r = Symbol('r', real=True)
 
     assert Max(5, 4) == 5

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,6 +1,6 @@
 from sympy import (
     symbols, expand, expand_func, nan, oo, Float, conjugate, diff,
-    re, im, Abs, O, exp_polar, polar_lift, gruntz, limit,
+    re, im, O, exp_polar, polar_lift, gruntz, limit,
     Symbol, I, integrate, Integral, S,
     sqrt, sin, cos, sinc, sinh, cosh, exp, log, pi, EulerGamma,
     erf, erfc, erfi, erf2, erfinv, erfcinv, erf2inv,
@@ -9,10 +9,9 @@ from sympy import (
     fresnels, fresnelc,
     hyper, meijerg, E)
 
-from sympy.functions.special.error_functions import _erfs, _eis
-
+from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
-
+from sympy.functions.special.error_functions import _erfs, _eis
 from sympy.utilities.pytest import raises, slow
 
 x, y, z = symbols('x,y,z')
@@ -628,7 +627,7 @@ def test_fresnel():
     assert fresnels(-oo) == -S.Half
     assert fresnels(I*oo) == -I*S.Half
 
-    assert fresnels(z) == fresnels(z)
+    assert unchanged(fresnels, z)
     assert fresnels(-z) == -fresnels(z)
     assert fresnels(I*z) == -I*fresnels(z)
     assert fresnels(-I*z) == I*fresnels(z)
@@ -680,7 +679,7 @@ def test_fresnel():
     assert fresnelc(-oo) == -S.Half
     assert fresnelc(I*oo) == I*S.Half
 
-    assert fresnelc(z) == fresnelc(z)
+    assert unchanged(fresnelc, z)
     assert fresnelc(-z) == -fresnelc(z)
     assert fresnelc(I*z) == I*fresnelc(z)
     assert fresnelc(-I*z) == -I*fresnelc(z)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -2,11 +2,13 @@ from sympy import (
     Symbol, gamma, I, oo, nan, zoo, factorial, sqrt, Rational, log,
     polygamma, EulerGamma, pi, uppergamma, S, expand_func, loggamma, sin,
     cos, O, lowergamma, exp, erf, erfc, exp_polar, harmonic, zeta,conjugate)
+
+from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
+from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                                       random_complex_number as randcplx,
                                       verify_numerically as tn)
-from sympy.utilities.pytest import raises
 
 x = Symbol('x')
 y = Symbol('y')
@@ -125,8 +127,8 @@ def test_lowergamma():
         lowergamma(-2, x*exp_polar(I*pi)) + 2*pi*I
 
     assert conjugate(lowergamma(x, y)) == lowergamma(conjugate(x), conjugate(y))
-    assert conjugate(lowergamma(x, 0)) == conjugate(lowergamma(x, 0))
-    assert conjugate(lowergamma(x, -oo)) == conjugate(lowergamma(x, -oo))
+    assert conjugate(lowergamma(x, 0)) == 0
+    assert unchanged(conjugate, lowergamma(x, -oo))
 
     assert lowergamma(
         x, y).rewrite(expint) == -y**x*expint(-x + 1, y) + gamma(x)
@@ -160,6 +162,8 @@ def test_uppergamma():
     assert tn(uppergamma(S.Half - 3, x, evaluate=False),
               uppergamma(S.Half - 3, x), x)
 
+    assert unchanged(uppergamma, x, -oo)
+
     assert tn_branch(-3, uppergamma)
     assert tn_branch(-4, uppergamma)
     assert tn_branch(S(1)/3, uppergamma)
@@ -175,7 +179,7 @@ def test_uppergamma():
 
     assert conjugate(uppergamma(x, y)) == uppergamma(conjugate(x), conjugate(y))
     assert conjugate(uppergamma(x, 0)) == gamma(conjugate(x))
-    assert conjugate(uppergamma(x, -oo)) == conjugate(uppergamma(x, -oo))
+    assert unchanged(conjugate, uppergamma(x, -oo))
 
     assert uppergamma(x, y).rewrite(expint) == y**x*expint(-x + 1, y)
     assert uppergamma(x, y).rewrite(lowergamma) == gamma(x) - lowergamma(x, y)
@@ -183,6 +187,7 @@ def test_uppergamma():
     assert uppergamma(70, 6) == 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
     assert (uppergamma(S(77) / 2, 6) - uppergamma(S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
     assert (uppergamma(-S(77) / 2, 6) - uppergamma(-S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
+
 
 def test_polygamma():
     from sympy import I
@@ -375,9 +380,9 @@ def test_loggamma():
     assert s1 == loggamma(x).rewrite('intractable').series(x)
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
-    assert conjugate(loggamma(0)) == conjugate(loggamma(0))
+    assert conjugate(loggamma(0)) == oo
     assert conjugate(loggamma(1)) == loggamma(conjugate(1))
-    assert conjugate(loggamma(-oo)) == conjugate(loggamma(-oo))
+    assert conjugate(loggamma(-oo)) == conjugate(zoo)
     assert loggamma(x).is_real is None
     y, z = Symbol('y', real=True), Symbol('z', imaginary=True)
     assert loggamma(y).is_real

--- a/sympy/functions/special/tests/test_singularity_functions.py
+++ b/sympy/functions/special/tests/test_singularity_functions.py
@@ -1,10 +1,10 @@
 from sympy import (
-    adjoint, conjugate, nan, pi, symbols, transpose, DiracDelta, Symbol, diff,
+    nan, pi, symbols, DiracDelta, Symbol, diff,
     Piecewise, I, Eq, Derivative, oo, SingularityFunction, Heaviside,
-    Derivative, Float
+    Float
 )
 
-
+from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises
 
@@ -37,7 +37,7 @@ def test_fdiff():
 
 def test_eval():
     assert SingularityFunction(x, a, n).func == SingularityFunction
-    assert SingularityFunction(x, 5, n) == SingularityFunction(x, 5, n)
+    assert unchanged(SingularityFunction, x, 5, n)
     assert SingularityFunction(5, 3, 2) == 4
     assert SingularityFunction(3, 5, 1) == 0
     assert SingularityFunction(3, 3, 0) == 1

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -8,7 +8,7 @@ from sympy import (
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
-from sympy.utilities.pytest import raises, XFAIL, skip
+from sympy.utilities.pytest import raises, skip
 
 x = Symbol('x')
 
@@ -291,9 +291,9 @@ def test_hermite():
     assert hermite(6, x) == 64*x**6 - 480*x**4 + 720*x**2 - 120
 
     n = Symbol("n")
-    assert hermite(n, x) == hermite(n, x)
+    assert unchanged(hermite, n, x)
     assert hermite(n, -x) == (-1)**n*hermite(n, x)
-    assert hermite(-n, x) == hermite(-n, x)
+    assert unchanged(hermite, -n, x)
 
     assert hermite(n, 0) == 2**n*sqrt(pi)/gamma(S(1)/2 - n/2)
     assert hermite(n, oo) == oo


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #5136 and #16997

#### Brief description of what is fixed or changed
Replaced a number of "a == a"-tests, primarily with unchanged, but it is also clear that code development have lead to some of these not being unchanged (anymore?).

It is quite interesting to look at what is changed and the evolution of the code (or "bad" tests).

#### Other comments
I will keep an eye on the code coverage to make sure that no quick-exits of `__eq__` have lost coverage.

In the process I also enabled the theoretical possibility of some XFAIL-tests to pass. Most likely, the idea was not that the tests fail because of not declared variables or functions...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
