### PR TITLE
Remove orphaned method _diagonalize_clear_subproducts

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1106,24 +1106,6 @@ class MatrixEigen(MatrixSubspaces):
     """Provides basic matrix eigenvalue/vector operations.
     Should not be instantiated directly."""
 
-    @property
-    def _cache_is_diagonalizable(self):
-        SymPyDeprecationWarning(
-            feature='_cache_is_diagonalizable',
-            deprecated_since_version="1.4",
-            issue=15887
-            ).warn()
-        return None
-
-    @property
-    def _cache_eigenvects(self):
-        SymPyDeprecationWarning(
-            feature='_cache_eigenvects',
-            deprecated_since_version="1.4",
-            issue=15887
-            ).warn()
-        return None
-
     def diagonalize(self, reals_only=False, sort=False, normalize=False):
         """
         Return (P, D), where D is diagonal and

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2408,11 +2408,6 @@ class MatrixBase(MatrixDeprecated,
             return 'Matrix(%s, %s, [])' % (self.rows, self.cols)
         return "Matrix(%s)" % str(self.tolist())
 
-    def _diagonalize_clear_subproducts(self):
-        del self._is_symbolic
-        del self._is_symmetric
-        del self._eigenvects
-
     def _format_str(self, printer=None):
         if not printer:
             from sympy.printing.str import StrPrinter

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1856,12 +1856,6 @@ def test_issue_15887():
 
     # Test deprecated cache and kwargs
     with warns_deprecated_sympy():
-        a._cache_eigenvects
-
-    with warns_deprecated_sympy():
-        a._cache_is_diagonalizable
-
-    with warns_deprecated_sympy():
         a.is_diagonalizable(clear_cache=True)
 
     with warns_deprecated_sympy():

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -32,9 +32,7 @@ from sympy import symbols, S
 from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
-excluded_attrs = set(
-    ['_assumptions', '_mhash', 'message']
-    )
+excluded_attrs = set(['_assumptions', '_mhash', 'message'])
 
 
 def check(a, exclude=[], check_attr=True):

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -33,9 +33,7 @@ from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
 excluded_attrs = set(
-    ['_assumptions', '_mhash', 'message',
-    # XXX Remove these after deprecation is done for issue #15887
-    '_cache_eigenvects', '_cache_is_diagonalizable']
+    ['_assumptions', '_mhash', 'message']
     )
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

`_diagonalize_clear_products` had became orphaned in #11954 because `_eigenvects` and other cache were renamed such as `_cache_eigenvects`. And since we had decided to remove the cache completely because of the problems in #15887, I think that it can also be removed completely.

Also, I have removed some private attributes in #16163 because it doesn't have to follow deprecation cycle strictly.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
