### PR TITLE
Added check for LogNormal distribution

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2078,6 +2078,10 @@ class LogNormalDistribution(SingleContinuousDistribution):
 
     set = Interval(0, oo)
 
+    @staticmethod
+    def check(mean, std):
+        _value_check(std > 0, "Parameter std must be positive.")
+
     def pdf(self, x):
         mean, std = self.mean, self.std
         return exp(-(log(x) - mean)**2 / (2*std**2)) / (x*sqrt(2*pi)*std)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -707,8 +707,8 @@ def test_lognormal():
     # Right now, only density function and sampling works
     # Test sampling: Only e^mean in sample std of 0
     for i in range(3):
-        X = LogNormal('x', i, 0)
-        assert S(sample(X)) == N(exp(i))
+        X = LogNormal('x', i, 1)
+        assert sample(X) in X.pspace.domain.set
     # The sympy integrator can't do this too well
     #assert E(X) ==
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -705,7 +705,6 @@ def test_lognormal():
     #assert variance(X) == (exp(std**2)-1) * exp(2*mean + std**2)
 
     # Right now, only density function and sampling works
-    # Test sampling: Only e^mean in sample std of 0
     for i in range(3):
         X = LogNormal('x', i, 1)
         assert sample(X) in X.pspace.domain.set


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
From https://github.com/sympy/sympy/pull/17057: When using `scipy` for sampling from `LogNormal` distribution, it is giving domain error since one of the tests is using `std = 0`. But `std > 0`.

#### Brief description of what is fixed or changed
Added check condition for positive `std`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- stats
    - added check condition for `LogNormal` distribution.
<!-- END RELEASE NOTES -->
