### PR TITLE
Added some MathML presentation printing methods

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -741,6 +741,53 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         mrow.appendChild(x)
         return mrow
 
+    def _print_HBar(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x210F;'))
+        return x
+
+    def _print_EulerGamma(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x3B3;'))
+        return x
+
+    def _print_TribonacciConstant(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('TribonacciConstant'))
+        return x
+
+    def _print_Dagger(self, e):
+        msup = self.dom.createElement('msup')
+        msup.appendChild(self._print(e.args[0]))
+        msup.appendChild(self.dom.createTextNode('&#x2020;'))
+        return msup
+
+    def _print_Contains(self, e):
+        mrow = self.dom.createElement('mrow')
+        mrow.appendChild(self._print(e.args[0]))
+        mo = self.dom.createElement('mo')
+        mo.appendChild(self.dom.createTextNode('&#x2208;'))
+        mrow.appendChild(mo)
+        mrow.appendChild(self._print(e.args[1]))
+        return mrow
+
+    def _print_HilbertSpace(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x210B;'))
+        return x
+
+    def _print_ComplexSpace(self, e):
+        msup = self.dom.createElement('msup')
+        msup.appendChild(self.dom.createTextNode('&#x1D49E;'))
+        msup.appendChild(self._print(e.args[0]))
+        return msup
+
+    def _print_FockSpace(self, e):
+        x = self.dom.createElement('mi')
+        x.appendChild(self.dom.createTextNode('&#x2131;'))
+        return x
+
+
     def _print_Integral(self, expr):
         intsymbols = {1: "&#x222B;", 2: "&#x222C;", 3: "&#x222D;"}
 

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -4,7 +4,7 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
     Lambda, IndexedBase, symbols, zoo, elliptic_f, elliptic_e, elliptic_pi, Ei, \
     expint, jacobi, gegenbauer, chebyshevt, chebyshevu, legendre, assoc_legendre, \
-    laguerre, assoc_laguerre, hermite
+    laguerre, assoc_laguerre, hermite, TribonacciConstant, EulerGamma, Contains
 
 from sympy import elliptic_k, totient, reduced_totient, primenu, primeomega, \
     fresnelc, fresnels, Heaviside
@@ -22,6 +22,7 @@ from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.zeta_functions import polylog, lerchphi, zeta, dirichlet_eta
 from sympy.logic.boolalg import And, Or, Implies, Equivalent, Xor, Not
 from sympy.matrices.expressions.determinant import Determinant
+from sympy.physics.quantum import ComplexSpace, HilbertSpace, FockSpace, hbar, Dagger
 from sympy.printing.mathml import mathml, MathMLContentPrinter, \
     MathMLPresentationPrinter, MathMLPrinter
 from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
@@ -1139,6 +1140,27 @@ def test_print_EmptySet():
 
 def test_print_UniversalSet():
     assert mpp.doprint(S.UniversalSet) == '<mo>&#x1D54C;</mo>'
+
+
+def test_print_spaces():
+    assert mpp.doprint(HilbertSpace()) == '<mi>&#x210B;</mi>'
+    assert mpp.doprint(ComplexSpace(2)) == '<msup>&#x1D49E;<mn>2</mn></msup>'
+    assert mpp.doprint(FockSpace()) == '<mi>&#x2131;</mi>'
+
+
+def test_print_constants():
+    assert mpp.doprint(hbar) == '<mi>&#x210F;</mi>'
+    assert mpp.doprint(TribonacciConstant) == '<mi>TribonacciConstant</mi>'
+    assert mpp.doprint(EulerGamma) == '<mi>&#x3B3;</mi>'
+
+
+def test_print_Contains():
+    assert mpp.doprint(Contains(x, S.Naturals)) == \
+        '<mrow><mi>x</mi><mo>&#x2208;</mo><mi mathvariant="normal">&#x2115;</mi></mrow>'
+
+
+def test_print_Dagger():
+    assert mpp.doprint(Dagger(x)) == '<msup><mi>x</mi>&#x2020;</msup>'
 
 
 def test_print_SetOp():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #16036

#### Brief description of what is fixed or changed
Added printing of some constants, spaces, and functions.

Before:
<img width="578" alt="beforeconstants" src="https://user-images.githubusercontent.com/8114497/59976459-28603380-95c5-11e9-877c-61cf5cd40c7a.PNG">

After:
<img width="563" alt="afterconstants" src="https://user-images.githubusercontent.com/8114497/59976461-2f874180-95c5-11e9-813f-0b24d05d1c16.PNG">



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * Added MathML presentation printing of some constants and spaces.
    * Added MathML presentation printing of `Contains` and `Dagger`.
<!-- END RELEASE NOTES -->
