### PR TITLE
Many different printing fixes

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -196,11 +196,11 @@ definite integrals.  Here is a sampling of some of the power of ``integrate``.
     ⎮ sin⎝x ⎠ dx
     ⌡
     >>> integ.doit()
-                    ⎛√2⋅x⎞
-    3⋅√2⋅√π⋅fresnels⎜────⎟⋅Γ(3/4)
-                    ⎝ √π ⎠
-    ─────────────────────────────
-               8⋅Γ(7/4)
+             ⎛√2⋅x⎞
+    3⋅√2⋅√π⋅S⎜────⎟⋅Γ(3/4)
+             ⎝ √π ⎠
+    ──────────────────────
+           8⋅Γ(7/4)
 
     >>> integ = Integral(x**y*exp(-x), (x, 0, oo))
     >>> integ

--- a/doc/src/tutorial/solvers.rst
+++ b/doc/src/tutorial/solvers.rst
@@ -142,9 +142,9 @@ In the ``solveset`` module, the non linear system of equations is solved using
    ``solve`` can be used for such cases:
 
    >>> solve([x**2 - y**2/exp(x)], [x, y], dict=True)
-   ⎡⎧             ⎛y⎞⎫⎤
-   ⎢⎨x: 2⋅LambertW⎜─⎟⎬⎥
-   ⎣⎩             ⎝2⎠⎭⎦
+   ⎡⎧      ⎛y⎞⎫⎤
+   ⎢⎨x: 2⋅W⎜─⎟⎬⎥
+   ⎣⎩      ⎝2⎠⎭⎦
 
    3. Currently ``nonlinsolve`` is not properly capable of solving the system of equations
    having trigonometric functions.
@@ -179,7 +179,7 @@ multiplicity 1 and ``3`` is a root of multiplicity 2.
    ``solve`` can be used for such cases:
 
    >>> solve(x*exp(x) - 1, x )
-   [LambertW(1)]
+   [W(1)]
 
 
 .. _tutorial-dsolve:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -487,6 +487,22 @@ class CodePrinter(StrPrinter):
         else:
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
+    def _print_erf2(self, expr):
+        # Generic approach if erf is supported, but not erf2
+        if expr.func.__name__ in self.known_functions or not "erf" in self.known_functions:
+            return self._print_Function(expr)
+        else:
+            from sympy.functions.special.error_functions import erf
+            return self._print(erf(expr.args[1]) - erf(expr.args[0]))
+
+    def _print_Li(self, expr):
+        # Generic approach if li is supported, but not Li
+        if expr.func.__name__ in self.known_functions or not "li" in self.known_functions:
+            return self._print_Function(expr)
+        else:
+            from sympy.functions.special.error_functions import li
+            return self._print(li(expr.args[0]) - li(2))
+
     def _print_not_supported(self, expr):
         self._not_supported.add(expr)
         return self.emptyPrinter(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2196,6 +2196,9 @@ class LatexPrinter(Printer):
     def _print_Object(self, object):
         return self._print(Symbol(object.name))
 
+    def _print_LambertW(self, expr):
+        return r"W\left(%s\right)" % self._print(expr.args[0])
+
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)
         codomain = self._print(morphism.codomain)

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -290,7 +290,10 @@ class MCodePrinter(CodePrinter):
             for cond, mfunc in cond_mfunc:
                 if cond(*expr.args):
                     return "%s[%s]" % (mfunc, self.stringify(expr.args, ", "))
-        self._not_supported.add(expr)
+        elif (expr.func.__name__ in self._rewriteable_functions and
+              self._rewriteable_functions[expr.func.__name__] in self.known_functions):
+            # Simple rewrite to supported function possible
+            return self._print(expr.rewrite(self._rewriteable_functions[expr.func.__name__]))
         return expr.func.__name__ + "[%s]" % self.stringify(expr.args, ", ")
 
     _print_MinMaxBase = _print_Function

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -75,6 +75,39 @@ known_functions = {
     "chebyshevu": [(lambda *x: True, "ChebyshevU")],
     "legendre": [(lambda *x: True, "LegendreP")],
     "assoc_legendre": [(lambda *x: True, "LegendreP")],
+    "mathieuc": [(lambda *x: True, "MathieuC")],
+    "mathieus": [(lambda *x: True, "MathieuS")],
+    "mathieucprime": [(lambda *x: True, "MathieuCPrime")],
+    "mathieusprime": [(lambda *x: True, "MathieuSPrime")],
+    "stieltjes": [(lambda x: True, "StieltjesGamma")],
+    "elliptic_e": [(lambda *x: True, "EllipticE")],
+    "elliptic_f": [(lambda *x: True, "EllipticE")],
+    "elliptic_k": [(lambda x: True, "EllipticK")],
+    "elliptic_pi": [(lambda *x: True, "EllipticPi")],
+    "zeta": [(lambda *x: True, "Zeta")],
+    "besseli": [(lambda *x: True, "BesselI")],
+    "besselj": [(lambda *x: True, "BesselJ")],
+    "besselk": [(lambda *x: True, "BesselK")],
+    "bessely": [(lambda *x: True, "BesselY")],
+    "hankel1": [(lambda *x: True, "HankelH1")],
+    "hankel2": [(lambda *x: True, "HankelH2")],
+    "airyai": [(lambda x: True, "AiryAi")],
+    "airybi": [(lambda x: True, "AiryBi")],
+    "airyaiprime": [(lambda x: True, "AiryAiPrime")],
+    "airybiprime": [(lambda x: True, "AiryBiPrime")],
+    "polylog": [(lambda *x: True, "PolyLog")],
+    "lerchphi": [(lambda *x: True, "LerchPhi")],
+    "gcd": [(lambda *x: True, "GCD")],
+    "lcm": [(lambda *x: True, "LCM")],
+    "jn": [(lambda *x: True, "SphericalBesselJ")],
+    "yn": [(lambda *x: True, "SphericalBesselY")],
+    "hyper": [(lambda *x: True, "HypergeometricPFQ")],
+    "meijerg": [(lambda *x: True, "MeijerG")],
+    "appellf1": [(lambda *x: True, "AppellF1")],
+    "DiracDelta": [(lambda x: True, "DiracDelta")],
+    "Heaviside": [(lambda x: True, "HeavisideTheta")],
+    "KroneckerDelta": [(lambda *x: True, "KroneckerDelta")],
+    "LambertW": [(lambda x: True, "ProductLog")],
 }
 
 
@@ -257,6 +290,7 @@ class MCodePrinter(CodePrinter):
             for cond, mfunc in cond_mfunc:
                 if cond(*expr.args):
                     return "%s[%s]" % (mfunc, self.stringify(expr.args, ", "))
+        self._not_supported.add(expr)
         return expr.func.__name__ + "[%s]" % self.stringify(expr.args, ", ")
 
     _print_MinMaxBase = _print_Function

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -534,6 +534,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             'primeomega': '&#x3A9;',
             'fresnels': 'S',
             'fresnelc': 'C',
+            'LambertW': 'W',
             'Heaviside': '&#x398;',
             'BooleanTrue': 'True',
             'BooleanFalse': 'False',

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -29,8 +29,7 @@ known_fcns_src1 = ["sin", "cos", "tan", "cot", "sec", "csc",
                    "besseli", "besselj", "besselk", "bessely",
                    "bernoulli", "beta", "euler", "exp", "factorial", "floor",
                    "fresnelc", "fresnels", "gamma", "harmonic", "log",
-                   "polylog", "sign", "zeta", "legendre", "gcd", "lcm",
-                   "isprime"]
+                   "polylog", "sign", "zeta", "legendre"]
 
 # These functions have different names ("Sympy": "Octave"), more
 # generally a mapping to (argument_conditions, octave_function).

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -29,13 +29,15 @@ known_fcns_src1 = ["sin", "cos", "tan", "cot", "sec", "csc",
                    "besseli", "besselj", "besselk", "bessely",
                    "bernoulli", "beta", "euler", "exp", "factorial", "floor",
                    "fresnelc", "fresnels", "gamma", "harmonic", "log",
-                   "polylog", "sign", "zeta"]
+                   "polylog", "sign", "zeta", "legendre", "gcd", "lcm",
+                   "isprime"]
 
 # These functions have different names ("Sympy": "Octave"), more
 # generally a mapping to (argument_conditions, octave_function).
 known_fcns_src2 = {
     "Abs": "abs",
     "arg": "angle",  # arg/angle ok in Octave but only angle in Matlab
+    "binomial": "bincoeff",
     "ceiling": "ceil",
     "chebyshevu": "chebyshevU",
     "chebyshevt": "chebyshevT",
@@ -51,6 +53,7 @@ known_fcns_src2 = {
     "loggamma": "gammaln",
     "Max": "max",
     "Min": "min",
+    "Mod": "mod",
     "polygamma": "psi",
     "re": "real",
     "RisingFactorial": "pochhammer",

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1424,6 +1424,35 @@ class PrettyPrinter(Printer):
         func_name = greek_unicode['Phi'] if self._use_unicode else 'lerchphi'
         return self._print_Function(e, func_name=func_name)
 
+    def _print_dirichlet_eta(self, e):
+        func_name = greek_unicode['eta'] if self._use_unicode else 'dirichlet_eta'
+        return self._print_Function(e, func_name=func_name)
+
+    def _print_Heaviside(self, e):
+        func_name = greek_unicode['theta'] if self._use_unicode else 'Heaviside'
+        return self._print_Function(e, func_name=func_name)
+
+    def _print_fresnels(self, e):
+        return self._print_Function(e, func_name="S")
+
+    def _print_fresnelc(self, e):
+        return self._print_Function(e, func_name="C")
+
+    def _print_airyai(self, e):
+        return self._print_Function(e, func_name="Ai")
+
+    def _print_airybi(self, e):
+        return self._print_Function(e, func_name="Bi")
+
+    def _print_airyaiprime(self, e):
+        return self._print_Function(e, func_name="Ai'")
+
+    def _print_airybiprime(self, e):
+        return self._print_Function(e, func_name="Bi'")
+
+    def _print_LambertW(self, e):
+        return self._print_Function(e, func_name="W")
+
     def _print_Lambda(self, e):
         vars, expr = e.args
         if self._use_unicode:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6705,7 +6705,7 @@ def test_str_special_matrices():
     assert upretty(OneMatrix(2, 2)) == u'𝟙'
 
 
-def test_pretty_functions():
+def test_pretty_misc_functions():
     assert pretty(LambertW(x)) == 'W(x)'
     assert upretty(LambertW(x)) == u'W(x)'
     assert pretty(LambertW(x, y)) == 'W(x, y)'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7,7 +7,9 @@ from sympy import (
     Segment, Subs, Sum, Symbol, Tuple, Trace, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
     SeqPer, SeqFormula, SeqAdd, SeqMul, fourier_series, fps, ITE,
-    Complement, Interval, Intersection, Union, EulerGamma, GoldenRatio)
+    Complement, Interval, Intersection, Union, EulerGamma, GoldenRatio,
+    LambertW, airyai, airybi, airyaiprime, airybiprime, fresnelc, fresnels,
+    Heaviside, dirichlet_eta)
 
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
     SubAugmentedAssignment, MulAugmentedAssignment, DivAugmentedAssignment, ModAugmentedAssignment)
@@ -6701,3 +6703,28 @@ def test_str_special_matrices():
     assert upretty(ZeroMatrix(2, 2)) == u'𝟘'
     assert pretty(OneMatrix(2, 2)) == '1'
     assert upretty(OneMatrix(2, 2)) == u'𝟙'
+
+
+def test_pretty_functions():
+    assert pretty(LambertW(x)) == 'W(x)'
+    assert upretty(LambertW(x)) == u'W(x)'
+    assert pretty(LambertW(x, y)) == 'W(x, y)'
+    assert upretty(LambertW(x, y)) == u'W(x, y)'
+    assert pretty(airyai(x)) == 'Ai(x)'
+    assert upretty(airyai(x)) == u'Ai(x)'
+    assert pretty(airybi(x)) == 'Bi(x)'
+    assert upretty(airybi(x)) == u'Bi(x)'
+    assert pretty(airyaiprime(x)) == "Ai'(x)"
+    assert upretty(airyaiprime(x)) == u"Ai'(x)"
+    assert pretty(airybiprime(x)) == "Bi'(x)"
+    assert upretty(airybiprime(x)) == u"Bi'(x)"
+    assert pretty(fresnelc(x)) == 'C(x)'
+    assert upretty(fresnelc(x)) == u'C(x)'
+    assert pretty(fresnels(x)) == 'S(x)'
+    assert upretty(fresnels(x)) == u'S(x)'
+    assert pretty(Heaviside(x)) == 'Heaviside(x)'
+    assert upretty(Heaviside(x)) == u'θ(x)'
+    assert pretty(Heaviside(x, y)) == 'Heaviside(x, y)'
+    assert upretty(Heaviside(x, y)) == u'θ(x, y)'
+    assert pretty(dirichlet_eta(x)) == 'dirichlet_eta(x)'
+    assert upretty(dirichlet_eta(x)) == u'η(x)'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -17,7 +17,7 @@ from sympy import (
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
-    UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection)
+    UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection, LambertW)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -515,6 +515,8 @@ def test_latex_functions():
     assert latex(primeomega(n)) == r'\Omega\left(n\right)'
     assert latex(primeomega(n) ** 2) == \
         r'\left(\Omega\left(n\right)\right)^{2}'
+
+    assert latex(LambertW(n)) == r'W\left(n\right)'
 
     assert latex(Mod(x, 7)) == r'x\bmod{7}'
     assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -10,7 +10,7 @@ from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
                              FallingFactorial, harmonic, atan2, sec, acsc,
                              hermite, laguerre, assoc_laguerre, jacobi,
                              gegenbauer, chebyshevt, chebyshevu, legendre,
-                             assoc_legendre)
+                             assoc_legendre, Li, LambertW)
 
 from sympy import mathematica_code as mcode
 
@@ -68,6 +68,8 @@ def test_Function():
     assert mcode(catalan(x)) == "CatalanNumber[x]"
     assert mcode(harmonic(x)) == "HarmonicNumber[x]"
     assert mcode(harmonic(x, y)) == "HarmonicNumber[x, y]"
+    assert mcode(Li(x)) == "LogIntegral[x] - LogIntegral[2]"
+    assert mcode(LambertW(x)) == "ProductLog[x]"
 
 
 def test_special_polynomials():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -4,7 +4,8 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     S, MatrixSymbol, Function, Derivative, log, true, false, Range, Min, Max, \
     Lambda, IndexedBase, symbols, zoo, elliptic_f, elliptic_e, elliptic_pi, Ei, \
     expint, jacobi, gegenbauer, chebyshevt, chebyshevu, legendre, assoc_legendre, \
-    laguerre, assoc_laguerre, hermite, TribonacciConstant, EulerGamma, Contains
+    laguerre, assoc_laguerre, hermite, TribonacciConstant, Contains, \
+    LambertW
 
 from sympy import elliptic_k, totient, reduced_totient, primenu, primeomega, \
     fresnelc, fresnels, Heaviside
@@ -1132,6 +1133,11 @@ def test_print_FiniteSet():
     f1 = FiniteSet(x, 1, 3)
     assert mpp.doprint(f1) == \
         '<mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi></mfenced>'
+
+
+def test_print_LambertW():
+    assert mpp.doprint(LambertW(x)) == '<mrow><mi>W</mi><mfenced><mi>x</mi></mfenced></mrow>'
+    assert mpp.doprint(LambertW(x, y)) == '<mrow><mi>W</mi><mfenced><mi>x</mi><mi>y</mi></mfenced></mrow>'
 
 
 def test_print_EmptySet():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -1,16 +1,16 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
-                        Tuple, Symbol)
-from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
+                        Tuple, Symbol, EulerGamma, GoldenRatio, Catalan,
+                        Lambda, Mul, Pow, Mod)
 from sympy.functions import (arg, atan2, bernoulli, beta, ceiling, chebyshevu,
                              chebyshevt, conjugate, DiracDelta, exp, expint,
                              factorial, floor, harmonic, Heaviside, im,
                              laguerre, LambertW, log, Max, Min, Piecewise,
                              polylog, re, RisingFactorial, sign, sinc, sqrt,
-                             zeta)
+                             zeta, binomial, legendre)
 from sympy.functions import (sin, cos, tan, cot, sec, csc, asin, acos, acot,
                              atan, asec, acsc, sinh, cosh, tanh, coth, csch,
                              sech, asinh, acosh, atanh, acoth, asech, acsch)
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
                             HadamardProduct, SparseMatrix)
@@ -22,8 +22,10 @@ from sympy.functions.special.gamma_functions import (gamma, lowergamma,
                                                      polygamma)
 from sympy.functions.special.error_functions import (Chi, Ci, erf, erfc, erfi,
                                                      erfcinv, erfinv, fresnelc,
-                                                     fresnels, li, Shi, Si)
-from sympy.utilities.pytest import XFAIL
+                                                     fresnels, li, Shi, Si, Li,
+                                                     erf2)
+from sympy.polys.polytools import gcd, lcm
+from sympy.ntheory.primetest import isprime
 from sympy.core.compatibility import range
 
 from sympy import octave_code
@@ -59,6 +61,7 @@ def test_Function():
     assert mcode(harmonic(x)) == 'harmonic(x)'
     assert mcode(bernoulli(x)) == "bernoulli(x)"
     assert mcode(bernoulli(x, y)) == "bernoulli(x, y)"
+    assert mcode(legendre(x, y)) == "legendre(x, y)"
 
 
 def test_Function_change_name():
@@ -83,6 +86,8 @@ def test_Function_change_name():
     assert mcode(DiracDelta(x, 3)) == "dirac(3, x)"
     assert mcode(Heaviside(x)) == "heaviside(x)"
     assert mcode(Heaviside(x, y)) == "heaviside(x, y)"
+    assert mcode(binomial(x, y)) == "bincoeff(x, y)"
+    assert mcode(Mod(x, y)) == "mod(x, y)"
 
 
 def test_minmax():
@@ -488,3 +493,8 @@ def test_MatrixElement_printing():
 def test_zeta_printing_issue_14820():
     assert octave_code(zeta(x)) == 'zeta(x)'
     assert octave_code(zeta(x, y)) == '% Not supported in Octave:\n% zeta\nzeta(x, y)'
+
+
+def test_automatic_rewrite():
+    assert octave_code(Li(x)) == 'logint(x) - logint(2)'
+    assert octave_code(erf2(x, y)) == '-erf(x) + erf(y)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Unfortunately this is a mess of fixes, although all are related to printing. Probably the easiest is to check the release notes and the code to see what has changed. I will add some before and after tables in the comments.

No tests yet, but they will come.



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing 
   * `erf2` and `Li` are printed using `erf`and `li`, respectively, if the latter is supported, but not the former for all code printers.
   * Better `LambertW` printing for LaTeX, pretty, and MathML presentation.
   * Mathematica printing for many special functions added.
   * Some functions added to Octave printer.
   * Some functions added to pretty printer.

<!-- END RELEASE NOTES -->
