### PR TITLE
Test limit(acos(erfi(x)), x, 1) (issue 13575)

### DIFF
--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -75,6 +75,8 @@ def test_erf():
 
     assert erf(w).as_real_imag() == (erf(w), 0)
     assert erf(w).as_real_imag(deep=False) == (erf(w), 0)
+    # issue 13575
+    assert erf(I).as_real_imag() == (0, -I*erf(I))
 
     raises(ArgumentIndexError, lambda: erf(x).fdiff(2))
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -4,7 +4,8 @@ from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
     atan, gamma, Symbol, S, pi, Integral, Rational, I, EulerGamma,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
-    binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels)
+    binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
+    acos, erfi)
 
 from sympy.calculus.util import AccumBounds
 from sympy.core.add import Add
@@ -540,3 +541,7 @@ def test_issue_14377():
 
 def test_issue_15984():
     assert limit((-x + log(exp(x) + 1))/x, x, oo, dir='-').doit() == 0
+
+
+def test_issue_13575():
+    assert isinstance(limit(acos(erfi(x)), x, 1), Add)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -544,4 +544,10 @@ def test_issue_15984():
 
 
 def test_issue_13575():
-    assert isinstance(limit(acos(erfi(x)), x, 1), Add)
+    result = limit(acos(erfi(x)), x, 1)
+    assert isinstance(result, Add)
+
+    re, im = result.evalf().as_real_imag()
+
+    assert abs(re) < 1e-12
+    assert abs(im - 1.08633774961570) < 1e-12


### PR DESCRIPTION
Fixes #13575. Bisected to [72a94c5fe61445c260f7579438dd68ae4ee3577d](https://github.com/sympy/sympy/pull/14404/commits/72a94c5fe61445c260f7579438dd68ae4ee3577d).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
