### PR TITLE
New constructors for TensorSymmetry

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -35,6 +35,7 @@ from collections import defaultdict
 import operator
 import itertools
 from sympy import Rational, prod, Integer
+from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
@@ -1331,6 +1332,40 @@ class TensorSymmetry(Basic):
         obj = Basic.__new__(cls, base, generators, **kw_args)
         return obj
 
+    @classmethod
+    def from_direct_product(cls, *args):
+        """
+        Returns a TensorSymmetry object that is being a direct product of
+        fully (anti-)symmetric index permutation groups
+
+        Examples
+        ========
+
+        (*args) = (1): vector
+        (*args) = (2):  tensor with 2 symmetric indices
+        (*args) = (-2):  tensor with 2 antisymmetric indices
+        (*args) = (2, -2): tensor with the first 2 indices commuting and the last 2 anticommuting
+        (*args) = (1, 1, 1): tensor with 3 indices without any symmetry
+        """
+        base, sgs = [], [Permutation(1)]
+        for arg in args:
+            if arg > 0:
+                bsgs2 = get_symmetric_group_sgs(arg, False)
+            elif arg < 0:
+                bsgs2 = get_symmetric_group_sgs(-arg, True)
+            else:
+                continue
+            base, sgs = bsgs_direct_product(base, sgs, *bsgs2)
+
+        return TensorSymmetry(base, sgs)
+
+    @classmethod
+    def riemann(cls, *args):
+        """
+        Returns a monotorem symmetry of the Riemann tensor
+        """
+        return TensorSymmetry(riemann_bsgs)
+
     @property
     def base(self):
         return self.args[0]
@@ -1345,6 +1380,7 @@ class TensorSymmetry(Basic):
 
 
 def tensorsymmetry(*args):
+    # This method is obsolete, use TensorSymmetry.from_direct_product() instead
     """
     Return a ``TensorSymmetry`` object.
 


### PR DESCRIPTION
Adds from_direct_product and riemann TensorSymmetry class constructors.
These should be used instead of the static tensorsymmetry() method, because the latter:
1. Does not have any extra functionality 
2. Involves obscure Young tableau
3. Is not a member of TensorSymmetry class

tensorsymmetry() is left unchanged for compatibility, but should be considered obsolete and will be removed from documentation.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- tensor
  - Added two new TensorSymmetry constructors.
  - tensorsymmetry() method is obsolete.

<!-- END RELEASE NOTES -->
