### PR TITLE
use assumptions for integration variables

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -459,7 +459,12 @@ class Integral(AddWithLimits):
                 reps[x] = d
         if reps:
             undo = dict([(v, k) for k, v in reps.items()])
-            return self.xreplace(reps).doit(**hints).xreplace(undo)
+            did = self.xreplace(reps).doit(**hints)
+            if type(did) is tuple:  # when separate=True
+                did = tuple([i.xreplace(undo) for i in did])
+            else:
+                did = did.xreplace(undo)
+            return did
 
         # continue with existing assumptions
         undone_limits = []

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -451,7 +451,7 @@ class Integral(AddWithLimits):
                 d = Dummy(positive=True)
             elif all(i.is_nonpositive for i in l) and not x.is_nonpositive:
                 d = Dummy(negative=True)
-            elif not x.is_real:  # l were sorted so they must be real
+            elif all(i.is_real for i in l) and not x.is_real:
                 d = Dummy(real=True)
             else:
                 d = None

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1128,8 +1128,7 @@ def test_atom_bug():
 def test_limit_bug():
     z = Symbol('z', zero=False)
     assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
-        (log(z**2) + 2*EulerGamma + 2*log(pi))/(2*z) - \
-        (-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z + log(pi)/z
+        (log(z) + EulerGamma + log(pi))/z - Ci(pi**2*z)/z + log(pi)/z
 
 
 def test_issue_4703():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1207,9 +1207,10 @@ def test_issue_4326():
     R, b, h = symbols('R b h')
     # It doesn't matter if we can do the integral.  Just make sure the result
     # doesn't contain nan.  This is really a test against _eval_interval.
-    assert not integrate(((h*(x - R + b))/b)*sqrt(R**2 - x**2), (x, R - b, R)).has(nan)
+    e = integrate(((h*(x - R + b))/b)*sqrt(R**2 - x**2), (x, R - b, R))
+    assert not e.has(nan)
     # See that it evaluates
-    assert not integrate(((h*(x - R + b))/b)*sqrt(R**2 - x**2), (x, R - b, R)).has(Integral)
+    assert not e.has(Integral)
 
 
 def test_powers():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -813,10 +813,8 @@ def test_Subs_printing():
 
 
 def test_issue_15716():
-    x = Symbol('x')
-    e = -3**x*exp(-3)*log(3**x*exp(-3)/factorial(x))/factorial(x)
-    assert str(Integral(e, (x, -oo, oo)).doit()) ==  '-(Integral(-3*3**x/factorial(x), (x, -oo, oo))' \
-    ' + Integral(3**x*log(3**x/factorial(x))/factorial(x), (x, -oo, oo)))*exp(-3)'
+    e = Integral(factorial(x), (x, -oo, oo))
+    assert e.as_terms() == ([(e, ((1.0, 0.0), (1,), ()))], [e])
 
 
 def test_str_special_matrices():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2546,8 +2546,6 @@ def test_W23():
 
 def test_W23b():
     # like W23 but limits are reversed
-    x = symbols('x', real=True, positive=True)
-    y = symbols('y', real=True)
     a, b = symbols('a b', real=True, positive=True)
     r2 = integrate(integrate(x/(x**2 + y**2), (y, -oo, oo)), (x, a, b))
     assert r2.collect(pi) == pi*(-a + b)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #7334

#### Brief description of what is fixed or changed

definite integration limits are used to assign assumptions for the integration variables when they differ from the integration variable.

#### Other comments

The more strict assumption (e.g. positive when limits are nonnegative) is used since whether 0 is contained at a limit or not will not matter. (see @asmeurer comment on linked issue) Since `positive` and not `extended_positive` is used, this will also imply that the variable is finite and, again, the result of the integral should not depend on the inclusion of +/-oo.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
    - assumptions based upon definite integration limits are automatically applied to integration variables
<!-- END RELEASE NOTES -->
