### PR TITLE
make perfect_power strict when candidates are given

### DIFF
--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -31,7 +31,7 @@ class Ynm(Function):
     Examples
     ========
 
-    >>> from sympy import Ynm, Symbol
+    >>> from sympy import Ynm, Symbol, simplify
     >>> from sympy.abc import n,m
     >>> theta = Symbol("theta")
     >>> phi = Symbol("phi")
@@ -41,20 +41,10 @@ class Ynm(Function):
 
     Several symmetries are known, for the order
 
-    >>> from sympy import Ynm, Symbol
-    >>> from sympy.abc import n,m
-    >>> theta = Symbol("theta")
-    >>> phi = Symbol("phi")
-
     >>> Ynm(n, -m, theta, phi)
     (-1)**m*exp(-2*I*m*phi)*Ynm(n, m, theta, phi)
 
     as well as for the angles
-
-    >>> from sympy import Ynm, Symbol, simplify
-    >>> from sympy.abc import n,m
-    >>> theta = Symbol("theta")
-    >>> phi = Symbol("phi")
 
     >>> Ynm(n, m, -theta, phi)
     Ynm(n, m, theta, phi)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -293,14 +293,15 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     collected so the largest possible ``e`` is sought. If ``big=False``
     then the smallest possible ``e`` (thus prime) will be chosen.
 
-    If ``candidates`` for exponents are given, they are assumed to be
-    sorted and the first one that is larger than the computed maximum
-    will signal failure for the routine.
-
-    If ``factor=True`` then simultaneous factorization of n is
+    If ``factor=True`` then simultaneous factorization of ``n`` is
     attempted since finding a factor indicates the only possible root
-    for n. This is True by default since only a few small factors will
+    for ``n``. This is True by default since only a few small factors will
     be tested in the course of searching for the perfect power.
+
+    The use of ``candidates`` is primarily for internal use; if provided,
+    False will be returned if ``n`` cannot be written as a power with one
+    of the candidates as an exponent and factoring (beyond testing for
+    a factor of 2) will not be attempted.
 
     Examples
     ========
@@ -319,7 +320,24 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     >>> is2pow = lambda n: bool(n and not n & (n - 1))
     >>> [(i, is2pow(i)) for i in range(5)]
     [(0, False), (1, True), (2, True), (3, False), (4, True)]
+
+    It is not necessary to provide ``candidates``. When provided
+    it will be assumed that they are sorted integers and the first
+    one that is larger than the computed maximum exponent possible
+    will signal failure for the routine.
+
+    >>> perfect_power(3**8, [9])
+    False
+    >>> perfect_power(3**8, [2, 4, 8])
+    (3, 8)
+    >>> perfect_power(3**8, [4, 8], big=False)
+    (9, 4)
+
+    See Also
+    ========
+    sympy.core.power.integer_nthroot
     """
+    from sympy.core.power import integer_nthroot
     n = as_int(n)
     if n < 3:
         if n < 1:
@@ -328,17 +346,25 @@ def perfect_power(n, candidates=None, big=True, factor=True):
     logn = math.log(n, 2)
     max_possible = int(logn) + 2  # only check values less than this
     not_square = n % 10 in [2, 3, 7, 8]  # squares cannot end in 2, 3, 7, 8
+    min_possible = 2 + not_square
     if not candidates:
-        candidates = primerange(2 + not_square, max_possible)
+        candidates = primerange(min_possible, max_possible)
+    else:
+        candidates = [i for i in candidates if min_possible <= i < max_possible]
+        if n%2 == 0:
+            e = trailing(n)
+            candidates = [i for i in candidates if e%i == 0]
+        if big:
+            candidates = reversed(candidates)
+        for e in candidates:
+            r, ok = integer_nthroot(n, e)
+            if ok:
+                return (r, e)
+        return False
+
 
     afactor = 2 + n % 2
     for e in candidates:
-        if e < 3:
-            if e == 1 or e == 2 and not_square:
-                continue
-        if e > max_possible:
-            return False
-
         # see if there is a factor present
         if factor:
             if n % afactor == 0:
@@ -351,31 +377,25 @@ def perfect_power(n, candidates=None, big=True, factor=True):
                 if e == 1:
                     return False
 
-                # maybe the bth root of n is exact
+                # maybe the e-th root of n is exact
                 r, exact = integer_nthroot(n, e)
                 if not exact:
-                    # then remove this factor and check to see if
-                    # any of e's factors are a common exponent; if
-                    # not then it's not a perfect power
-                    n //= afactor**e
-                    m = perfect_power(n, candidates=primefactors(e), big=big)
-                    if m is False:
+                    # Having a factor, we know that e is the maximal
+                    # possible value for a root of n.
+                    # If n = afactor**e*m can be written as a perfect
+                    # power then see if m can be written as r**E where
+                    # gcd(e, E) != 1 so n = (afactor**(e//E)*r)**E
+                    m = n//afactor**e
+                    rE = perfect_power(m, candidates=divisors(e), big=big)
+                    if not rE:
                         return False
                     else:
-                        r, m = m
-                        # adjust the two exponents so the bases can
-                        # be combined
-                        g = igcd(m, e)
-                        if g == 1:
-                            return False
-                        m //= g
-                        e //= g
-                        r, e = r**m*afactor**e, g
+                        r, E = rE
+                        return afactor**(e//E)*r, E
                 if not big:
                     e0 = primefactors(e)
-                    if len(e0) > 1 or e0[0] != e:
-                        e0 = e0[0]
-                        r, e = r**(e//e0), e0
+                    if e0[0] != e:
+                        r, e = r**(e//e0[0]), e0[0]
                 return r, e
             else:
                 # get the next factor ready for the next pass through the loop
@@ -392,7 +412,7 @@ def perfect_power(n, candidates=None, big=True, factor=True):
         if exact:
             if big:
                 m = perfect_power(r, big=big, factor=factor)
-                if m is not False:
+                if m:
                     r, e = m[0], e*m[1]
             return int(r), e
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -91,10 +91,8 @@ def is_square(n, prep=True):
     if not ((m*0x8bc40d7d) & (m*0xa1e2f5d1) & 0x14020a):
         m = n % 63
         if not ((m*0x3d491df7) & (m*0xc824a9f9) & 0x10f14008):
-            from sympy.ntheory import perfect_power
-            pp = perfect_power(n, [2], big=False)
-            if pp:
-                return pp[1] == 2
+            from sympy.core.power import integer_nthroot
+            return integer_nthroot(n, 2)[1]
     return False
 
 

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -146,6 +146,12 @@ def test_perfect_power():
     assert perfect_power(2**3*5**5) is False
     assert perfect_power(2*13**4) is False
     assert perfect_power(2**5*3**3) is False
+    t = 2**24
+    for d in divisors(24):
+        m = perfect_power(t*3**d)
+        assert m and m[1] == d or d == 1
+        m = perfect_power(t*3**d, big=False)
+        assert m and m[1] == 2 or d == 1 or d == 3, (d, m)
 
 
 def test_factorint():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #17048 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- ntheory
    - clarify `perfect_power` behavior in docstring and make it strict when candidates are given: return False if exponent of power not in candidates
<!-- END RELEASE NOTES -->
