### PR TITLE
Preparing sympy for tensorflow release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
       # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
+        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
         - TEST_SAGE="true"
       addons:
         apt:
@@ -296,9 +296,6 @@ before_install:
             # Use a separate environment because sage downgrades matplotlib
             conda create -c conda-forge/label/cf201901 -n sage sagelib mpmath "ipython>=5.5.0,<6";
             conda clean --all;
-        fi
-        if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-            conda install matchpy;
         fi
     elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
         pip list | grep "numpy" && pip uninstall -y numpy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,12 @@ matrix:
             - gfortran
             - python-scipy
 
+    # Tensorflow 1 support
+    - python: 3.7
+      env:
+        - TEST_ASCII="true"
+        - TEST_OPT_DEPENDENCY="tensorflow<2"
+
     - python: 3.8
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
             - python-scipy
 
     # Tensorflow 1 support
-    - python: 3.7
+    - python: 3.6
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="tensorflow<2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_EXAMPLES="true"
   global:
     - secure: "YIEZal9EBTL+fg2YmoZoS8Bvt3eAVUOZjb38CtqpzR2CCSXWoUk35KG23m2NknlY1iKfYJyt7XWBszT/VKOQEbWQq7PIakV4vIByrWacgBxy1x3WC+rZoW7TX+JJiL+y942qIYbMoNMMB8xFpE5RDLSjSecMpFhJJXoafVTvju8="
+    - TF_XLA_FLAGS=--tf_xla_cpu_global_jit
 dist: trusty
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_EXAMPLES="true"
   global:
     - secure: "YIEZal9EBTL+fg2YmoZoS8Bvt3eAVUOZjb38CtqpzR2CCSXWoUk35KG23m2NknlY1iKfYJyt7XWBszT/VKOQEbWQq7PIakV4vIByrWacgBxy1x3WC+rZoW7TX+JJiL+y942qIYbMoNMMB8xFpE5RDLSjSecMpFhJJXoafVTvju8="
-    - TF_XLA_FLAGS=--tf_xla_cpu_global_jit
 dist: trusty
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet pycosat python-clang"
+        - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:
         apt:
           packages:
@@ -80,6 +81,7 @@ matrix:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
         - TEST_SAGE="true"
+        - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:
         apt:
           packages:
@@ -290,7 +292,6 @@ before_install:
         export CPATH=$CONDA_PREFIX/include;
         export LIBRARY_PATH=$CONDA_PREFIX/lib;
         export LD_LIBRARY_PATH=$CONDA_PREFIX/lib;
-        export SYMPY_STRICT_COMPILER_CHECKS=1;
         conda clean --all;
         if [[ "$TEST_SAGE" == "true" ]]; then
             # Use a separate environment because sage downgrades matplotlib

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -119,21 +119,21 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
     def _print_Piecewise(self, expr):
         tensorflow = import_module('tensorflow')
         if tensorflow and V(tensorflow.__version__) < '1.0':
-            tensorflow_piecewise = "select"
+            tensorflow_piecewise = "tensorflow.select"
         else:
-            tensorflow_piecewise = "where"
+            tensorflow_piecewise = "tensorflow.where"
 
         from sympy import Piecewise
         e, cond = expr.args[0].args
         if len(expr.args) == 1:
             return '{0}({1}, {2}, {3})'.format(
-                tensorflow_piecewise,
+                self._module_format(tensorflow_piecewise),
                 self._print(cond),
                 self._print(e),
                 0)
 
         return '{0}({1}, {2}, {3})'.format(
-            tensorflow_piecewise,
+            self._module_format(tensorflow_piecewise),
             self._print(cond),
             self._print(e),
             self._print(Piecewise(*expr.args[1:])))

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -200,7 +200,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         letters = self._get_letter_generator_for_einsum()
         contraction_string = ",".join(["".join([next(letters) for j in range(i)]) for i in expr.subranks])
         return '%s("%s", %s)' % (
-                self._module_format('tensorflow.einsum'),
+                self._module_format('tensorflow.linalg.einsum'),
                 contraction_string,
                 ", ".join([self._print(arg) for arg in expr.args])
         )
@@ -216,7 +216,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         if isinstance(base, CodegenArrayTensorProduct):
             elems = ["%s" % (self._print(arg)) for arg in base.args]
             return "%s(\"%s\", %s)" % (
-                self._module_format("tensorflow.einsum"),
+                self._module_format("tensorflow.linalg.einsum"),
                 contraction_string,
                 ", ".join(elems)
             )
@@ -242,7 +242,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         diagonal_string, letters_free, letters_dum = self._get_einsum_string(subranks, diagonal_indices)
         elems = [self._print(i) for i in elems]
         return '%s("%s", %s)' % (
-            self._module_format("tensorflow.einsum"),
+            self._module_format("tensorflow.linalg.einsum"),
             "{0}->{1}{2}".format(diagonal_string, "".join(letters_free), "".join(letters_dum)),
             ", ".join(elems)
         )

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,6 +1,7 @@
 from distutils.version import LooseVersion as V
 
-from sympy import Mul
+from sympy import Mul, S
+from sympy.codegen.cfunctions import Sqrt
 from sympy.core.compatibility import Iterable
 from sympy.external import import_module
 from sympy.printing.precedence import PRECEDENCE
@@ -16,50 +17,59 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
     printmethod = "_tensorflowcode"
 
     mapping = {
-        sympy.Abs: "tensorflow.abs",
-        sympy.sign: "tensorflow.sign",
-        sympy.ceiling: "tensorflow.ceil",
-        sympy.floor: "tensorflow.floor",
-        sympy.log: "tensorflow.log",
-        sympy.exp: "tensorflow.exp",
-        sympy.sqrt: "tensorflow.sqrt",
-        sympy.cos: "tensorflow.cos",
-        sympy.acos: "tensorflow.acos",
-        sympy.sin: "tensorflow.sin",
-        sympy.asin: "tensorflow.asin",
-        sympy.tan: "tensorflow.tan",
-        sympy.atan: "tensorflow.atan",
-        sympy.atan2: "tensorflow.atan2",
-        sympy.cosh: "tensorflow.cosh",
-        sympy.acosh: "tensorflow.acosh",
-        sympy.sinh: "tensorflow.sinh",
-        sympy.asinh: "tensorflow.asinh",
-        sympy.tanh: "tensorflow.tanh",
-        sympy.atanh: "tensorflow.atanh",
-        sympy.re: "tensorflow.real",
-        sympy.im: "tensorflow.imag",
-        sympy.arg: "tensorflow.angle",
-        sympy.erf: "tensorflow.erf",
-        sympy.loggamma: "tensorflow.gammaln",
-        sympy.Pow: "tensorflow.pow",
-        sympy.Eq: "tensorflow.equal",
-        sympy.Ne: "tensorflow.not_equal",
-        sympy.StrictGreaterThan: "tensorflow.greater",
-        sympy.StrictLessThan: "tensorflow.less",
-        sympy.LessThan: "tensorflow.less_equal",
-        sympy.GreaterThan: "tensorflow.greater_equal",
-        sympy.And: "tensorflow.logical_and",
-        sympy.Or: "tensorflow.logical_or",
-        sympy.Not: "tensorflow.logical_not",
-        sympy.Max: "tensorflow.maximum",
-        sympy.Min: "tensorflow.minimum",
+        sympy.Abs: "tensorflow.math.abs",
+        sympy.sign: "tensorflow.math.sign",
+
+        # XXX May raise error for ints.
+        sympy.ceiling: "tensorflow.math.ceil",
+        sympy.floor: "tensorflow.math.floor",
+        sympy.log: "tensorflow.math.log",
+        sympy.exp: "tensorflow.math.exp",
+        Sqrt: "tensorflow.math.sqrt",
+        sympy.cos: "tensorflow.math.cos",
+        sympy.acos: "tensorflow.math.acos",
+        sympy.sin: "tensorflow.math.sin",
+        sympy.asin: "tensorflow.math.asin",
+        sympy.tan: "tensorflow.math.tan",
+        sympy.atan: "tensorflow.math.atan",
+        sympy.atan2: "tensorflow.math.atan2",
+        # XXX Also may give NaN for complex results.
+        sympy.cosh: "tensorflow.math.cosh",
+        sympy.acosh: "tensorflow.math.acosh",
+        sympy.sinh: "tensorflow.math.sinh",
+        sympy.asinh: "tensorflow.math.asinh",
+        sympy.tanh: "tensorflow.math.tanh",
+        sympy.atanh: "tensorflow.math.atanh",
+
+        sympy.re: "tensorflow.math.real",
+        sympy.im: "tensorflow.math.imag",
+        sympy.arg: "tensorflow.math.angle",
+
+        # XXX May raise error for ints and complexes
+        sympy.erf: "tensorflow.math.erf",
+        sympy.loggamma: "tensorflow.math.lgamma",
+
+        sympy.Eq: "tensorflow.math.equal",
+        sympy.Ne: "tensorflow.math.not_equal",
+        sympy.StrictGreaterThan: "tensorflow.math.greater",
+        sympy.StrictLessThan: "tensorflow.math.less",
+        sympy.LessThan: "tensorflow.math.less_equal",
+        sympy.GreaterThan: "tensorflow.math.greater_equal",
+
+        sympy.And: "tensorflow.math.logical_and",
+        sympy.Or: "tensorflow.math.logical_or",
+        sympy.Not: "tensorflow.math.logical_not",
+        sympy.Max: "tensorflow.math.maximum",
+        sympy.Min: "tensorflow.math.minimum",
+
         # Matrices
-        sympy.MatAdd: "tensorflow.add",
-        sympy.HadamardProduct: "tensorflow.multiply",
-        sympy.Trace: "tensorflow.trace",
-        sympy.Determinant : "tensorflow.matrix_determinant",
-        sympy.Inverse: "tensorflow.matrix_inverse",
-        sympy.Transpose: "tensorflow.matrix_transpose",
+        sympy.MatAdd: "tensorflow.math.add",
+        sympy.HadamardProduct: "tensorflow.math.multiply",
+        sympy.Trace: "tensorflow.linalg.trace",
+        sympy.Transpose: "tensorflow.linalg.matrix_transpose",
+
+        # XXX May raise error for integer matrices.
+        sympy.Determinant : "tensorflow.linalg.det",
     }
 
     def _print_Function(self, expr):
@@ -79,11 +89,18 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
     _print_Application = _print_Function
     _print_MatrixExpr = _print_Function
     # TODO: a better class structure would avoid this mess:
+    _print_Relational = _print_Function
     _print_Not = _print_Function
     _print_And = _print_Function
     _print_Or = _print_Function
     _print_Transpose = _print_Function
+    _print_HadamardProduct = _print_Function
     _print_Trace = _print_Function
+    _print_Determinant = _print_Function
+
+    def _print_Inverse(self, expr):
+        op = self._module_format('tensorflow.linalg.inv')
+        return "{}({})".format(op, self._print(expr.arg))
 
     def _print_Derivative(self, expr):
         variables = expr.variables
@@ -121,6 +138,17 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
             self._print(e),
             self._print(Piecewise(*expr.args[1:])))
 
+    def _print_Pow(self, expr):
+        # XXX May raise error for
+        # int**float or int**complex or float**complex
+        base, exp = expr.args
+        if expr.exp == S.Half:
+            return "{}({})".format(
+                self._module_format("tensorflow.math.sqrt"), self._print(base))
+        return "{}({}, {})".format(
+            self._module_format("tensorflow.math.pow"),
+            self._print(base), self._print(exp))
+
     def _print_MatrixBase(self, expr):
         tensorflow_f = "tensorflow.Variable" if expr.free_symbols else "tensorflow.constant"
         data = "["+", ".join(["["+", ".join([self._print(j) for j in i])+"]" for i in expr.tolist()])+"]"
@@ -136,13 +164,16 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         if args:
             return "%s*%s" % (
                 self.parenthesize(Mul.fromiter(args), PRECEDENCE["Mul"]),
-                self._expand_fold_binary_op("tensorflow.matmul", mat_args)
+                self._expand_fold_binary_op(
+                    "tensorflow.linalg.matmul", mat_args)
             )
         else:
-            return self._expand_fold_binary_op("tensorflow.matmul", mat_args)
+            return self._expand_fold_binary_op(
+                "tensorflow.linalg.matmul", mat_args)
 
     def _print_MatPow(self, expr):
-        return self._expand_fold_binary_op("tensorflow.matmul", [expr.base]*expr.exp)
+        return self._expand_fold_binary_op(
+            "tensorflow.linalg.matmul", [expr.base]*expr.exp)
 
     def _print_Assignment(self, expr):
         # TODO: is this necessary?
@@ -224,7 +255,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         )
 
     def _print_CodegenArrayElementwiseAdd(self, expr):
-        return self._expand_fold_binary_op('tensorflow.add', expr.args)
+        return self._expand_fold_binary_op('tensorflow.math.add', expr.args)
 
 
 def tensorflow_code(expr):

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -60,7 +60,7 @@ def _compare_tensorflow_matrix(variables, expr, use_float=False):
         r = [i for row in r for i in row]
         e = [i for row in e for i in row]
         assert all(
-            abs(a-b) < 10**-(5-int(log(abs(a), 10))) for a, b in zip(r, e))
+            abs(a-b) < 10**-(4-int(log(abs(a), 10))) for a, b in zip(r, e))
 
 
 def _compare_tensorflow_matrix_scalar(variables, expr):

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -83,7 +83,7 @@ def test_codegen_einsum():
     if not tf:
         skip("TensorFlow not installed")
 
-    session = tf.Session()
+    session = tf.compat.v1.Session()
 
     M = MatrixSymbol("M", 2, 2)
     N = MatrixSymbol("N", 2, 2)
@@ -102,7 +102,7 @@ def test_codegen_extra():
     if not tf:
         skip("TensorFlow not installed")
 
-    session = tf.Session()
+    session = tf.compat.v1.Session()
 
     M = MatrixSymbol("M", 2, 2)
     N = MatrixSymbol("N", 2, 2)

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -20,6 +20,12 @@ from sympy.utilities.pytest import skip
 
 tf = tensorflow = import_module("tensorflow")
 
+if tensorflow:
+    # Hide Tensorflow warnings
+    import os
+    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
+
 M = MatrixSymbol("M", 3, 3)
 N = MatrixSymbol("N", 3, 3)
 P = MatrixSymbol("P", 3, 3)
@@ -208,21 +214,6 @@ def test_tensorflow_math():
     _compare_tensorflow_scalar(
         (x,), expr, rng=lambda: random.uniform(-.5, .5))
 
-    expr = re(x)
-    assert tensorflow_code(expr) == "tensorflow.math.real(x)"
-    _compare_tensorflow_scalar(
-        (x,), expr, rng=lambda: random.random() + random.random()*1j)
-
-    expr = im(x)
-    assert tensorflow_code(expr) == "tensorflow.math.imag(x)"
-    _compare_tensorflow_scalar(
-        (x,), expr, rng=lambda: random.random() + random.random()*1j)
-
-    expr = arg(x)
-    assert tensorflow_code(expr) == "tensorflow.math.angle(x)"
-    _compare_tensorflow_scalar(
-        (x,), expr, rng=lambda: random.random() + random.random()*1j)
-
     expr = erf(x)
     assert tensorflow_code(expr) == "tensorflow.math.erf(x)"
     _compare_tensorflow_scalar(
@@ -232,6 +223,12 @@ def test_tensorflow_math():
     assert tensorflow_code(expr) == "tensorflow.math.lgamma(x)"
     _compare_tensorflow_scalar(
         (x,), expr, rng=lambda: random.random())
+
+
+def test_tensorflow_complexes():
+    assert tensorflow_code(re(x)) == "tensorflow.math.real(x)"
+    assert tensorflow_code(im(x)) == "tensorflow.math.imag(x)"
+    assert tensorflow_code(arg(x)) == "tensorflow.math.angle(x)"
 
 
 def test_tensorflow_relational():

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -25,7 +25,7 @@ if tf is not None:
     llo = [[j for j in range(i, i+3)] for i in range(0, 9, 3)]
     m3x3 = tf.constant(llo)
     m3x3sympy = Matrix(llo)
-    session = tf.Session()
+    session = tf.compat.v1.Session()
 
 
 def _compare_tensorflow_matrix(variables, expr):

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -304,8 +304,6 @@ def test_tensorflow_matrices():
     assert tensorflow_code(expr) == "tensorflow.linalg.inv(M)"
     _compare_tensorflow_matrix((M,), expr, use_float=True)
 
-
-def test_transpose():
     expr = M.T
     assert tensorflow_code(expr, tensorflow_version='1.14') == \
         "tensorflow.linalg.matrix_transpose(M)"

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -105,7 +105,6 @@ def _compare_tensorflow_relational(
     with graph.as_default():
         tf_rvs = [eval(tensorflow_code(i)) for i in rvs]
         session = tf.compat.v1.Session(graph=graph)
-        print(f(*tf_rvs))
         r = session.run(f(*tf_rvs))
 
     e = expr.subs({k: v for k, v in zip(variables, rvs)}).doit()

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -9,7 +9,7 @@ from sympy.external import import_module
 from sympy.functions import \
     Abs, Max, Min, ceiling, exp, floor, sign, sin, asin, sqrt, cos, \
     acos, tan, atan, atan2, cosh, acosh, sinh, asinh, tanh, atanh, \
-    re, im, arg, erf, loggamma
+    re, im, arg, erf, loggamma, log
 from sympy.matrices import Matrix, MatrixBase, eye, randMatrix
 from sympy.matrices.expressions import \
     Determinant, HadamardProduct, Inverse, MatrixSymbol, Trace
@@ -59,7 +59,8 @@ def _compare_tensorflow_matrix(variables, expr, use_float=False):
     else:
         r = [i for row in r for i in row]
         e = [i for row in e for i in row]
-        assert all(abs(a-b) < 10**-6 for a, b in zip(r, e))
+        assert all(
+            abs(a-b) < 10**-(5-int(log(abs(a), 10))) for a, b in zip(r, e))
 
 
 def _compare_tensorflow_matrix_scalar(variables, expr):

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -292,10 +292,6 @@ def test_tensorflow_matrices():
         "tensorflow.linalg.matmul(tensorflow.linalg.matmul(M, M), M)"
     _compare_tensorflow_matrix((M,), expr)
 
-    expr = M.T
-    assert tensorflow_code(expr) == "tensorflow.linalg.matrix_transpose(M)"
-    _compare_tensorflow_matrix((M,), expr)
-
     expr = Trace(M)
     assert tensorflow_code(expr) == "tensorflow.linalg.trace(M)"
     _compare_tensorflow_matrix((M,), expr)
@@ -307,6 +303,16 @@ def test_tensorflow_matrices():
     expr = Inverse(M)
     assert tensorflow_code(expr) == "tensorflow.linalg.inv(M)"
     _compare_tensorflow_matrix((M,), expr, use_float=True)
+
+
+def test_transpose():
+    expr = M.T
+    assert tensorflow_code(expr, tensorflow_version='1.14') == \
+        "tensorflow.linalg.matrix_transpose(M)"
+    assert tensorflow_code(expr, tensorflow_version='1.13') == \
+        "tensorflow.matrix_transpose(M)"
+
+    _compare_tensorflow_matrix((M,), expr)
 
 
 def test_codegen_einsum():

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -1,16 +1,22 @@
 import random
 
-from sympy.printing.tensorflow import TensorflowPrinter
-from sympy.printing.tensorflow import tensorflow_code
-from sympy import (eye, symbols, MatrixSymbol, Symbol, Matrix, symbols, sin,
-        exp, Function, Derivative, Trace)
+from sympy import symbols, Symbol, Function, Derivative
 from sympy.codegen.array_utils import (CodegenArrayContraction,
         CodegenArrayTensorProduct, CodegenArrayElementwiseAdd,
         CodegenArrayPermuteDims, CodegenArrayDiagonal)
-from sympy.utilities.lambdify import lambdify
-
-from sympy.utilities.pytest import skip
+from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
 from sympy.external import import_module
+from sympy.functions import \
+    Abs, Max, Min, ceiling, exp, floor, sign, sin, asin, sqrt, cos, \
+    acos, tan, atan, atan2, cosh, acosh, sinh, asinh, tanh, atanh, \
+    re, im, arg, erf, loggamma
+from sympy.matrices import Matrix, MatrixBase, eye, randMatrix
+from sympy.matrices.expressions import \
+    Determinant, HadamardProduct, Inverse, MatrixSymbol, Trace
+from sympy.printing.tensorflow import TensorflowPrinter, tensorflow_code
+from sympy.utilities.lambdify import lambdify
+from sympy.utilities.pytest import skip
+
 
 tf = tensorflow = import_module("tensorflow")
 
@@ -25,142 +31,373 @@ if tf is not None:
     llo = [[j for j in range(i, i+3)] for i in range(0, 9, 3)]
     m3x3 = tf.constant(llo)
     m3x3sympy = Matrix(llo)
-    session = tf.compat.v1.Session()
 
 
-def _compare_tensorflow_matrix(variables, expr):
+def _compare_tensorflow_matrix(variables, expr, use_float=False):
     f = lambdify(variables, expr, 'tensorflow')
-    random_matrices = [Matrix([[random.randint(0, 10) for k in
-        range(i.shape[1])] for j in range(i.shape[0])]) for i in variables]
-    random_variables = [eval(tensorflow_code(i)) for i in
-            random_matrices]
-    r = session.run(f(*random_variables))
-    e = expr.subs({k: v for k, v in zip(variables, random_matrices)}).doit()
+    if not use_float:
+        random_matrices = [randMatrix(v.rows, v.cols) for v in variables]
+    else:
+        random_matrices = [randMatrix(v.rows, v.cols)/100. for v in variables]
+
+    graph = tf.Graph()
+    r = None
+    with graph.as_default():
+        random_variables = [eval(tensorflow_code(i)) for i in random_matrices]
+        session = tf.compat.v1.Session(graph=graph)
+        r = session.run(f(*random_variables))
+
+    e = expr.subs({k: v for k, v in zip(variables, random_matrices)})
+    e = e.doit()
     if e.is_Matrix:
+        if not isinstance(e, MatrixBase):
+            e = e.as_explicit()
         e = e.tolist()
-    assert (r == e).all()
+
+    if not use_float:
+        assert (r == e).all()
+    else:
+        r = [i for row in r for i in row]
+        e = [i for row in e for i in row]
+        assert all(abs(a-b) < 10**-6 for a, b in zip(r, e))
 
 
-def test_tensorflow_matrix():
+def _compare_tensorflow_matrix_scalar(variables, expr):
+    f = lambdify(variables, expr, 'tensorflow')
+    random_matrices = [
+        randMatrix(v.rows, v.cols).evalf() / 100 for v in variables]
+
+    graph = tf.Graph()
+    r = None
+    with graph.as_default():
+        random_variables = [eval(tensorflow_code(i)) for i in random_matrices]
+        session = tf.compat.v1.Session(graph=graph)
+        r = session.run(f(*random_variables))
+
+    e = expr.subs({k: v for k, v in zip(variables, random_matrices)})
+    e = e.doit()
+    assert abs(r-e) < 10**-6
+
+
+def _compare_tensorflow_scalar(
+    variables, expr, rng=lambda: random.randint(0, 10)):
+    f = lambdify(variables, expr, 'tensorflow')
+    rvs = [rng() for v in variables]
+
+    graph = tf.Graph()
+    r = None
+    with graph.as_default():
+        tf_rvs = [eval(tensorflow_code(i)) for i in rvs]
+        session = tf.compat.v1.Session(graph=graph)
+        r = session.run(f(*tf_rvs))
+
+    e = expr.subs({k: v for k, v in zip(variables, rvs)}).evalf().doit()
+    assert abs(r-e) < 10**-6
+
+
+def _compare_tensorflow_relational(
+    variables, expr, rng=lambda: random.randint(0, 10)):
+    f = lambdify(variables, expr, 'tensorflow')
+    rvs = [rng() for v in variables]
+
+    graph = tf.Graph()
+    r = None
+    with graph.as_default():
+        tf_rvs = [eval(tensorflow_code(i)) for i in rvs]
+        session = tf.compat.v1.Session(graph=graph)
+        print(f(*tf_rvs))
+        r = session.run(f(*tf_rvs))
+
+    e = expr.subs({k: v for k, v in zip(variables, rvs)}).doit()
+    assert r == e
+
+
+def test_tensorflow_printing():
+    assert tensorflow_code(eye(3)) == \
+        "tensorflow.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])"
+
+    expr = Matrix([[x, sin(y)], [exp(z), -t]])
+    assert tensorflow_code(expr) == \
+        "tensorflow.Variable(" \
+            "[[x, tensorflow.math.sin(y)]," \
+            " [tensorflow.math.exp(z), -t]])"
+
+
+def test_tensorflow_math():
     if not tf:
         skip("TensorFlow not installed")
 
-    assert tensorflow_code(eye(3)) == "tensorflow.constant([[1, 0, 0], [0, 1, 0], [0, 0, 1]])"
+    expr = Abs(x)
+    assert tensorflow_code(expr) == "tensorflow.math.abs(x)"
+    _compare_tensorflow_scalar((x,), expr)
 
-    expr = Matrix([[x, sin(y)], [exp(z), -t]])
-    assert tensorflow_code(expr) == "tensorflow.Variable([[x, tensorflow.sin(y)], [tensorflow.exp(z), -t]])"
+    expr = sign(x)
+    assert tensorflow_code(expr) == "tensorflow.math.sign(x)"
+    _compare_tensorflow_scalar((x,), expr)
+
+    expr = ceiling(x)
+    assert tensorflow_code(expr) == "tensorflow.math.ceil(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = floor(x)
+    assert tensorflow_code(expr) == "tensorflow.math.floor(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = exp(x)
+    assert tensorflow_code(expr) == "tensorflow.math.exp(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = sqrt(x)
+    assert tensorflow_code(expr) == "tensorflow.math.sqrt(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = x ** 4
+    assert tensorflow_code(expr) == "tensorflow.math.pow(x, 4)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = cos(x)
+    assert tensorflow_code(expr) == "tensorflow.math.cos(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = acos(x)
+    assert tensorflow_code(expr) == "tensorflow.math.acos(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = sin(x)
+    assert tensorflow_code(expr) == "tensorflow.math.sin(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = asin(x)
+    assert tensorflow_code(expr) == "tensorflow.math.asin(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = tan(x)
+    assert tensorflow_code(expr) == "tensorflow.math.tan(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = atan(x)
+    assert tensorflow_code(expr) == "tensorflow.math.atan(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = atan2(y, x)
+    assert tensorflow_code(expr) == "tensorflow.math.atan2(y, x)"
+    _compare_tensorflow_scalar((y, x), expr, rng=lambda: random.random())
+
+    expr = cosh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.cosh(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.random())
+
+    expr = acosh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.acosh(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.uniform(1, 2))
+
+    expr = sinh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.sinh(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.uniform(1, 2))
+
+    expr = asinh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.asinh(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.uniform(1, 2))
+
+    expr = tanh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.tanh(x)"
+    _compare_tensorflow_scalar((x,), expr, rng=lambda: random.uniform(1, 2))
+
+    expr = atanh(x)
+    assert tensorflow_code(expr) == "tensorflow.math.atanh(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.uniform(-.5, .5))
+
+    expr = re(x)
+    assert tensorflow_code(expr) == "tensorflow.math.real(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.random() + random.random()*1j)
+
+    expr = im(x)
+    assert tensorflow_code(expr) == "tensorflow.math.imag(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.random() + random.random()*1j)
+
+    expr = arg(x)
+    assert tensorflow_code(expr) == "tensorflow.math.angle(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.random() + random.random()*1j)
+
+    expr = erf(x)
+    assert tensorflow_code(expr) == "tensorflow.math.erf(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.random())
+
+    expr = loggamma(x)
+    assert tensorflow_code(expr) == "tensorflow.math.lgamma(x)"
+    _compare_tensorflow_scalar(
+        (x,), expr, rng=lambda: random.random())
+
+
+def test_tensorflow_relational():
+    expr = Eq(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.equal(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+    expr = Ne(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.not_equal(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+    expr = Ge(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.greater_equal(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+    expr = Gt(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.greater(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+    expr = Le(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.less_equal(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+    expr = Lt(x, y)
+    assert tensorflow_code(expr) == "tensorflow.math.less(x, y)"
+    _compare_tensorflow_relational((x, y), expr)
+
+
+def test_tensorflow_matrices():
+    if not tf:
+        skip("TensorFlow not installed")
 
     expr = M
     assert tensorflow_code(expr) == "M"
     _compare_tensorflow_matrix((M,), expr)
 
     expr = M + N
-    assert tensorflow_code(expr) == "tensorflow.add(M, N)"
+    assert tensorflow_code(expr) == "tensorflow.math.add(M, N)"
     _compare_tensorflow_matrix((M, N), expr)
 
-    expr = M*N
-    assert tensorflow_code(expr) == "tensorflow.matmul(M, N)"
+    expr = M * N
+    assert tensorflow_code(expr) == "tensorflow.linalg.matmul(M, N)"
+    _compare_tensorflow_matrix((M, N), expr)
+
+    expr = HadamardProduct(M, N)
+    assert tensorflow_code(expr) == "tensorflow.math.multiply(M, N)"
     _compare_tensorflow_matrix((M, N), expr)
 
     expr = M*N*P*Q
-    assert tensorflow_code(expr) == "tensorflow.matmul(tensorflow.matmul(tensorflow.matmul(M, N), P), Q)"
+    assert tensorflow_code(expr) == \
+        "tensorflow.linalg.matmul(" \
+            "tensorflow.linalg.matmul(" \
+                "tensorflow.linalg.matmul(M, N), P), Q)"
     _compare_tensorflow_matrix((M, N, P, Q), expr)
 
     expr = M**3
-    assert tensorflow_code(expr) == "tensorflow.matmul(tensorflow.matmul(M, M), M)"
+    assert tensorflow_code(expr) == \
+        "tensorflow.linalg.matmul(tensorflow.linalg.matmul(M, M), M)"
     _compare_tensorflow_matrix((M,), expr)
 
     expr = M.T
-    assert tensorflow_code(expr) == "tensorflow.matrix_transpose(M)"
+    assert tensorflow_code(expr) == "tensorflow.linalg.matrix_transpose(M)"
     _compare_tensorflow_matrix((M,), expr)
 
     expr = Trace(M)
-    assert tensorflow_code(expr) == "tensorflow.trace(M)"
+    assert tensorflow_code(expr) == "tensorflow.linalg.trace(M)"
     _compare_tensorflow_matrix((M,), expr)
+
+    expr = Determinant(M)
+    assert tensorflow_code(expr) == "tensorflow.linalg.det(M)"
+    _compare_tensorflow_matrix_scalar((M,), expr)
+
+    expr = Inverse(M)
+    assert tensorflow_code(expr) == "tensorflow.linalg.inv(M)"
+    _compare_tensorflow_matrix((M,), expr, use_float=True)
 
 
 def test_codegen_einsum():
     if not tf:
         skip("TensorFlow not installed")
 
-    session = tf.compat.v1.Session()
+    graph = tf.Graph()
+    with graph.as_default():
+        session = tf.compat.v1.Session(graph=graph)
 
-    M = MatrixSymbol("M", 2, 2)
-    N = MatrixSymbol("N", 2, 2)
+        M = MatrixSymbol("M", 2, 2)
+        N = MatrixSymbol("N", 2, 2)
 
-    cg = CodegenArrayContraction.from_MatMul(M*N)
-    f = lambdify((M, N), cg, 'tensorflow')
+        cg = CodegenArrayContraction.from_MatMul(M*N)
+        f = lambdify((M, N), cg, 'tensorflow')
 
-    ma = tf.constant([[1, 2], [3, 4]])
-    mb = tf.constant([[1,-2], [-1, 3]])
-    y = session.run(f(ma, mb))
-    c = session.run(tf.matmul(ma, mb))
-    assert (y == c).all()
+        ma = tf.constant([[1, 2], [3, 4]])
+        mb = tf.constant([[1,-2], [-1, 3]])
+        y = session.run(f(ma, mb))
+        c = session.run(tf.matmul(ma, mb))
+        assert (y == c).all()
 
 
 def test_codegen_extra():
     if not tf:
         skip("TensorFlow not installed")
 
-    session = tf.compat.v1.Session()
+    graph = tf.Graph()
+    with graph.as_default():
+        session = tf.compat.v1.Session()
 
-    M = MatrixSymbol("M", 2, 2)
-    N = MatrixSymbol("N", 2, 2)
-    P = MatrixSymbol("P", 2, 2)
-    Q = MatrixSymbol("Q", 2, 2)
-    ma = tf.constant([[1, 2], [3, 4]])
-    mb = tf.constant([[1,-2], [-1, 3]])
-    mc = tf.constant([[2, 0], [1, 2]])
-    md = tf.constant([[1,-1], [4, 7]])
+        M = MatrixSymbol("M", 2, 2)
+        N = MatrixSymbol("N", 2, 2)
+        P = MatrixSymbol("P", 2, 2)
+        Q = MatrixSymbol("Q", 2, 2)
+        ma = tf.constant([[1, 2], [3, 4]])
+        mb = tf.constant([[1,-2], [-1, 3]])
+        mc = tf.constant([[2, 0], [1, 2]])
+        md = tf.constant([[1,-1], [4, 7]])
 
-    cg = CodegenArrayTensorProduct(M, N)
-    assert tensorflow_code(cg) == 'tensorflow.einsum("ab,cd", M, N)'
-    f = lambdify((M, N), cg, 'tensorflow')
-    y = session.run(f(ma, mb))
-    c = session.run(tf.einsum("ij,kl", ma, mb))
-    assert (y == c).all()
+        cg = CodegenArrayTensorProduct(M, N)
+        assert tensorflow_code(cg) == 'tensorflow.einsum("ab,cd", M, N)'
+        f = lambdify((M, N), cg, 'tensorflow')
+        y = session.run(f(ma, mb))
+        c = session.run(tf.einsum("ij,kl", ma, mb))
+        assert (y == c).all()
 
-    cg = CodegenArrayElementwiseAdd(M, N)
-    assert tensorflow_code(cg) == 'tensorflow.add(M, N)'
-    f = lambdify((M, N), cg, 'tensorflow')
-    y = session.run(f(ma, mb))
-    c = session.run(ma + mb)
-    assert (y == c).all()
+        cg = CodegenArrayElementwiseAdd(M, N)
+        assert tensorflow_code(cg) == 'tensorflow.math.add(M, N)'
+        f = lambdify((M, N), cg, 'tensorflow')
+        y = session.run(f(ma, mb))
+        c = session.run(ma + mb)
+        assert (y == c).all()
 
-    cg = CodegenArrayElementwiseAdd(M, N, P)
-    assert tensorflow_code(cg) == 'tensorflow.add(tensorflow.add(M, N), P)'
-    f = lambdify((M, N, P), cg, 'tensorflow')
-    y = session.run(f(ma, mb, mc))
-    c = session.run(ma + mb + mc)
-    assert (y == c).all()
+        cg = CodegenArrayElementwiseAdd(M, N, P)
+        assert tensorflow_code(cg) == \
+            'tensorflow.math.add(tensorflow.math.add(M, N), P)'
+        f = lambdify((M, N, P), cg, 'tensorflow')
+        y = session.run(f(ma, mb, mc))
+        c = session.run(ma + mb + mc)
+        assert (y == c).all()
 
-    cg = CodegenArrayElementwiseAdd(M, N, P, Q)
-    assert tensorflow_code(cg) == 'tensorflow.add(tensorflow.add(tensorflow.add(M, N), P), Q)'
-    f = lambdify((M, N, P, Q), cg, 'tensorflow')
-    y = session.run(f(ma, mb, mc, md))
-    c = session.run(ma + mb + mc + md)
-    assert (y == c).all()
+        cg = CodegenArrayElementwiseAdd(M, N, P, Q)
+        assert tensorflow_code(cg) == \
+            'tensorflow.math.add(' \
+                'tensorflow.math.add(tensorflow.math.add(M, N), P), Q)'
+        f = lambdify((M, N, P, Q), cg, 'tensorflow')
+        y = session.run(f(ma, mb, mc, md))
+        c = session.run(ma + mb + mc + md)
+        assert (y == c).all()
 
-    cg = CodegenArrayPermuteDims(M, [1, 0])
-    assert tensorflow_code(cg) == 'tensorflow.transpose(M, [1, 0])'
-    f = lambdify((M,), cg, 'tensorflow')
-    y = session.run(f(ma))
-    c = session.run(tf.transpose(ma))
-    assert (y == c).all()
+        cg = CodegenArrayPermuteDims(M, [1, 0])
+        assert tensorflow_code(cg) == 'tensorflow.transpose(M, [1, 0])'
+        f = lambdify((M,), cg, 'tensorflow')
+        y = session.run(f(ma))
+        c = session.run(tf.transpose(ma))
+        assert (y == c).all()
 
-    cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [1, 2, 3, 0])
-    assert tensorflow_code(cg) == 'tensorflow.transpose(tensorflow.einsum("ab,cd", M, N), [1, 2, 3, 0])'
-    f = lambdify((M, N), cg, 'tensorflow')
-    y = session.run(f(ma, mb))
-    c = session.run(tf.transpose(tf.einsum("ab,cd", ma, mb), [1, 2, 3, 0]))
-    assert (y == c).all()
+        cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [1, 2, 3, 0])
+        assert tensorflow_code(cg) == 'tensorflow.transpose(tensorflow.einsum("ab,cd", M, N), [1, 2, 3, 0])'
+        f = lambdify((M, N), cg, 'tensorflow')
+        y = session.run(f(ma, mb))
+        c = session.run(tf.transpose(tf.einsum("ab,cd", ma, mb), [1, 2, 3, 0]))
+        assert (y == c).all()
 
-    cg = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N), (1, 2))
-    assert tensorflow_code(cg) == 'tensorflow.einsum("ab,bc->acb", M, N)'
-    f = lambdify((M, N), cg, 'tensorflow')
-    y = session.run(f(ma, mb))
-    c = session.run(tf.einsum("ab,bc->acb", ma, mb))
-    assert (y == c).all()
+        cg = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N), (1, 2))
+        assert tensorflow_code(cg) == 'tensorflow.einsum("ab,bc->acb", M, N)'
+        f = lambdify((M, N), cg, 'tensorflow')
+        y = session.run(f(ma, mb))
+        c = session.run(tf.einsum("ab,bc->acb", ma, mb))
+        assert (y == c).all()
 
 
 def test_MatrixElement_printing():
@@ -172,11 +409,10 @@ def test_MatrixElement_printing():
     assert tensorflow_code(3 * A[0, 0]) == "3*A[0, 0]"
 
     F = C[0, 0].subs(C, A - B)
-    assert tensorflow_code(F) == "(tensorflow.add((-1)*B, A))[0, 0]"
+    assert tensorflow_code(F) == "(tensorflow.math.add((-1)*B, A))[0, 0]"
 
 
 def test_tensorflow_Derivative():
-    f = Function("f")
-
     expr = Derivative(sin(x), x)
-    assert tensorflow_code(expr) == "tensorflow.gradients(tensorflow.sin(x), x)[0]"
+    assert tensorflow_code(expr) == \
+        "tensorflow.gradients(tensorflow.math.sin(x), x)[0]"

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -84,79 +84,9 @@ MPMATH_TRANSLATIONS = {
 NUMPY_TRANSLATIONS = {}
 SCIPY_TRANSLATIONS = {}
 
-TENSORFLOW_TRANSLATIONS = {
-    "Abs": "abs",
-    "ceiling": "ceil",
-    "im": "imag",
-    "ln": "log",
-    "Mod": "mod",
-    "conjugate": "conj",
-    "re": "real",
-}
+TENSORFLOW_TRANSLATIONS = {}
 
 NUMEXPR_TRANSLATIONS = {}
-
-
-def _import_tensorflow(namespace):
-    """Import hack for tensorflow."""
-    exec_("import tensorflow", {}, namespace)
-    exec_("abs = tensorflow.math.abs", {}, namespace)
-    exec_("sign = tensorflow.math.sign", {}, namespace)
-    exec_("ceil = tensorflow.math.ceil", {}, namespace)
-    exec_("floor = tensorflow.math.floor", {}, namespace)
-    exec_("log = tensorflow.math.log", {}, namespace)
-    exec_("exp = tensorflow.math.exp", {}, namespace)
-    exec_("sqrt = tensorflow.math.sqrt", {}, namespace)
-    exec_("cos = tensorflow.math.cos", {}, namespace)
-    exec_("acos = tensorflow.math.acos", {}, namespace)
-    exec_("sin = tensorflow.math.sin", {}, namespace)
-    exec_("asin = tensorflow.math.asin", {}, namespace)
-    exec_("tan = tensorflow.math.tan", {}, namespace)
-    exec_("atan = tensorflow.math.atan", {}, namespace)
-    exec_("atan2 = tensorflow.math.atan2", {}, namespace)
-    exec_("cosh = tensorflow.math.cosh", {}, namespace)
-    exec_("acosh = tensorflow.math.acosh", {}, namespace)
-    exec_("sinh = tensorflow.math.sinh", {}, namespace)
-    exec_("asinh = tensorflow.math.asinh", {}, namespace)
-    exec_("tanh = tensorflow.math.tanh", {}, namespace)
-    exec_("atanh = tensorflow.math.atanh", {}, namespace)
-
-    exec_("real = tensorflow.math.real", {}, namespace)
-    exec_("imag = tensorflow.math.imag", {}, namespace)
-    exec_("angle = tensorflow.math.angle", {}, namespace)
-
-    exec_("erf = tensorflow.math.erf", {}, namespace)
-    exec_("lgamma = tensorflow.math.lgamma", {}, namespace)
-
-    exec_("equal = tensorflow.math.equal", {}, namespace)
-    exec_("not_equal = tensorflow.math.not_equal", {}, namespace)
-    exec_("less = tensorflow.math.less", {}, namespace)
-    exec_("less_equal = tensorflow.math.less_equal", {}, namespace)
-    exec_("greater = tensorflow.math.greater", {}, namespace)
-    exec_("greater_equal = tensorflow.math.greater_equal", {}, namespace)
-
-    exec_("logical_and = tensorflow.math.logical_and", {}, namespace)
-    exec_("logical_or = tensorflow.math.logical_or", {}, namespace)
-    exec_("logical_not = tensorflow.math.logical_not", {}, namespace)
-    exec_("maximum = tensorflow.math.maximum", {}, namespace)
-    exec_("minimum = tensorflow.math.minimum", {}, namespace)
-
-    exec_("matrix_transpose = tensorflow.linalg.matrix_transpose",
-          {}, namespace)
-    exec_("matmul = tensorflow.linalg.matmul", {}, namespace)
-    exec_("inv = tensorflow.linalg.inv", {}, namespace)
-    exec_("det = tensorflow.linalg.det", {}, namespace)
-    exec_("trace = tensorflow.linalg.trace", {}, namespace)
-    exec_("einsum = tensorflow.linalg.einsum", {}, namespace)
-
-    exec_("add = tensorflow.math.add", {}, namespace)
-    exec_("multiply = tensorflow.math.multiply", {}, namespace)
-    exec_("pow = tensorflow.math.pow", {}, namespace)
-    exec_("mod = tensorflow.math.mod", {}, namespace)
-    exec_("conj = tensorflow.math.conj", {}, namespace)
-
-    exec_("where = tensorflow.where", {}, namespace)
-
 
 # Available modules:
 MODULES = {
@@ -164,7 +94,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
-    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, (_import_tensorflow,)),
+    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
         "from sympy.matrices import *",
@@ -202,10 +132,6 @@ def _import(module, reload=False):
             return
 
     for import_command in import_commands:
-        if isinstance(import_command, FunctionType):
-            import_command(namespace)
-            continue
-
         if import_command.startswith('import_module'):
             module = eval(import_command)
 
@@ -831,9 +757,16 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():
         for k in keys:
             if k not in namespace:
-                imp_mod_lines.append("from %s import %s" % (mod, k))
-    for ln in imp_mod_lines:
-        exec_(ln, {}, namespace)
+                ln = "from %s import %s" % (mod, k)
+                try:
+                    exec_(ln, {}, namespace)
+                except ModuleNotFoundError:
+                    # Tensorflow 2.0 has issues with importing a specific
+                    # function from its submodule.
+                    # https://github.com/tensorflow/tensorflow/issues/33022
+                    ln = "%s = %s.%s" % (k, mod, k)
+                    exec_(ln, {}, namespace)
+                imp_mod_lines.append(ln)
 
     # Provide lambda expression with builtins, and compatible implementation of range
     namespace.update({'builtins':builtins, 'range':range})

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -137,10 +137,15 @@ def _import_tensorflow(namespace):
 
     exec_("matrix_transpose = tensorflow.linalg.matrix_transpose",
           {}, namespace)
+    exec_("matmul = tensorflow.linalg.matmul", {}, namespace)
     exec_("inv = tensorflow.linalg.inv", {}, namespace)
     exec_("det = tensorflow.linalg.det", {}, namespace)
     exec_("trace = tensorflow.linalg.trace", {}, namespace)
+    exec_("einsum = tensorflow.linalg.einsum", {}, namespace)
 
+    exec_("add = tensorflow.math.add", {}, namespace)
+    exec_("multiply = tensorflow.math.multiply", {}, namespace)
+    exec_("pow = tensorflow.math.pow", {}, namespace)
     exec_("mod = tensorflow.math.mod", {}, namespace)
     exec_("conj = tensorflow.math.conj", {}, namespace)
 
@@ -152,7 +157,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
-    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("from tensorflow import *", _import_tensorflow,)),
+    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, (_import_tensorflow,)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
         "from sympy.matrices import *",

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -583,16 +583,43 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
     >>> import tensorflow as tf
     >>> from sympy import Max, sin
+
     >>> f = Max(x, sin(x))
     >>> func = lambdify(x, f, 'tensorflow')
+
+    After tensorflow v2, eager execution is enabled by default.
+    This line is for compatibility.
+
+    >>> tf.compat.v1.enable_eager_execution()
+
+    A tf.EagerTensor representing the result of the calculation
+
     >>> result = func(tf.constant(1.0))
-    >>> print(result) # a tf.Tensor representing the result of the calculation
+    >>> print(result)
+    tf.Tensor(1.0, shape=(), dtype=float32)
+    >>> print(result.__class__)
+    <class 'tensorflow.python.framework.ops.EagerTensor'>
+
+    >>> result.numpy()
+    1.0
+
+    If you disable eager execution
+
+    >>> tf.compat.v1.disable_eager_execution()
+
+    A tf.Tensor representing the result of the calculation
+
+    >>> result = func(tf.constant(1.0))
+    >>> print(result)
     Tensor("Maximum:0", shape=(), dtype=float32)
+    >>> print(result.__class__)
+    <class 'tensorflow.python.framework.ops.Tensor'>
+
     >>> sess = tf.compat.v1.Session()
     >>> sess.run(result) # compute result
     1.0
     >>> var = tf.Variable(1.0)
-    >>> sess.run(tf.global_variables_initializer())
+    >>> sess.run(tf.compat.v1.global_variables_initializer())
     >>> sess.run(func(var)) # also works for tf.Variable and tf.Placeholder
     1.0
     >>> tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]]) # works with any shape tensor

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -11,6 +11,8 @@ import re
 import textwrap
 import linecache
 
+from types import FunctionType
+
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, string_types, range, builtins, PY3)
 from sympy.utilities.misc import filldedent
@@ -94,13 +96,63 @@ TENSORFLOW_TRANSLATIONS = {
 
 NUMEXPR_TRANSLATIONS = {}
 
+
+def _import_tensorflow(namespace):
+    """Import hack for tensorflow."""
+    exec_("import tensorflow", {}, namespace)
+    exec_("abs = tensorflow.math.abs", {}, namespace)
+    exec_("sign = tensorflow.math.sign", {}, namespace)
+    exec_("ceil = tensorflow.math.ceil", {}, namespace)
+    exec_("floor = tensorflow.math.floor", {}, namespace)
+    exec_("log = tensorflow.math.log", {}, namespace)
+    exec_("exp = tensorflow.math.exp", {}, namespace)
+    exec_("sqrt = tensorflow.math.sqrt", {}, namespace)
+    exec_("cos = tensorflow.math.cos", {}, namespace)
+    exec_("acos = tensorflow.math.acos", {}, namespace)
+    exec_("sin = tensorflow.math.sin", {}, namespace)
+    exec_("asin = tensorflow.math.asin", {}, namespace)
+    exec_("tan = tensorflow.math.tan", {}, namespace)
+    exec_("atan = tensorflow.math.atan", {}, namespace)
+    exec_("atan2 = tensorflow.math.atan2", {}, namespace)
+    exec_("cosh = tensorflow.math.cosh", {}, namespace)
+    exec_("acosh = tensorflow.math.acosh", {}, namespace)
+    exec_("sinh = tensorflow.math.sinh", {}, namespace)
+    exec_("asinh = tensorflow.math.asinh", {}, namespace)
+    exec_("tanh = tensorflow.math.tanh", {}, namespace)
+    exec_("atanh = tensorflow.math.atanh", {}, namespace)
+
+    exec_("real = tensorflow.math.real", {}, namespace)
+    exec_("imag = tensorflow.math.imag", {}, namespace)
+    exec_("angle = tensorflow.math.angle", {}, namespace)
+
+    exec_("erf = tensorflow.math.erf", {}, namespace)
+    exec_("lgamma = tensorflow.math.lgamma", {}, namespace)
+
+    exec_("equal = tensorflow.math.equal", {}, namespace)
+    exec_("not_equal = tensorflow.math.not_equal", {}, namespace)
+    exec_("less = tensorflow.math.less", {}, namespace)
+    exec_("less_equal = tensorflow.math.less_equal", {}, namespace)
+    exec_("greater = tensorflow.math.greater", {}, namespace)
+    exec_("greater_equal = tensorflow.math.greater_equal", {}, namespace)
+
+    exec_("matrix_transpose = tensorflow.linalg.matrix_transpose",
+          {}, namespace)
+    exec_("inv = tensorflow.linalg.inv", {}, namespace)
+    exec_("det = tensorflow.linalg.det", {}, namespace)
+    exec_("trace = tensorflow.linalg.trace", {}, namespace)
+
+    exec_("mod = tensorflow.math.mod", {}, namespace)
+    exec_("conj = tensorflow.math.conj", {}, namespace)
+
+
+
 # Available modules:
 MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
-    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("from tensorflow import *",)),
+    "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("from tensorflow import *", _import_tensorflow,)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
         "from sympy.matrices import *",
@@ -138,6 +190,10 @@ def _import(module, reload=False):
             return
 
     for import_command in import_commands:
+        if isinstance(import_command, FunctionType):
+            import_command(namespace)
+            continue
+
         if import_command.startswith('import_module'):
             module = eval(import_command)
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -135,6 +135,12 @@ def _import_tensorflow(namespace):
     exec_("greater = tensorflow.math.greater", {}, namespace)
     exec_("greater_equal = tensorflow.math.greater_equal", {}, namespace)
 
+    exec_("logical_and = tensorflow.math.logical_and", {}, namespace)
+    exec_("logical_or = tensorflow.math.logical_or", {}, namespace)
+    exec_("logical_not = tensorflow.math.logical_not", {}, namespace)
+    exec_("maximum = tensorflow.math.maximum", {}, namespace)
+    exec_("minimum = tensorflow.math.minimum", {}, namespace)
+
     exec_("matrix_transpose = tensorflow.linalg.matrix_transpose",
           {}, namespace)
     exec_("matmul = tensorflow.linalg.matmul", {}, namespace)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -787,7 +787,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                 ln = "from %s import %s" % (mod, k)
                 try:
                     exec_(ln, {}, namespace)
-                except ModuleNotFoundError:
+                except ImportError:
                     # Tensorflow 2.0 has issues with importing a specific
                     # function from its submodule.
                     # https://github.com/tensorflow/tensorflow/issues/33022

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -582,17 +582,23 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     Usage with Tensorflow:
 
     >>> import tensorflow as tf
-    >>> from sympy import Max, sin
+    >>> from sympy import Max, sin, lambdify
+    >>> from sympy.abc import x
 
     >>> f = Max(x, sin(x))
     >>> func = lambdify(x, f, 'tensorflow')
 
     After tensorflow v2, eager execution is enabled by default.
-    This line is for compatibility.
+    If you want to get the compatible result across tensorflow v1 and v2
+    as same as this tutorial, run this line.
 
     >>> tf.compat.v1.enable_eager_execution()
 
-    A tf.EagerTensor representing the result of the calculation
+    If you have eager execution enabled, you can get the result out
+    immediately as you can use numpy.
+
+    If you pass tensorflow objects, you may get an ``EagerTensor``
+    object instead of value.
 
     >>> result = func(tf.constant(1.0))
     >>> print(result)
@@ -600,30 +606,21 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> print(result.__class__)
     <class 'tensorflow.python.framework.ops.EagerTensor'>
 
+    You can use ``.numpy()`` to get the numpy value of the tensor.
+
     >>> result.numpy()
     1.0
 
-    If you disable eager execution
+    >>> var = tf.Variable(2.0)
+    >>> result = func(var) # also works for tf.Variable and tf.Placeholder
+    >>> result.numpy()
+    2.0
 
-    >>> tf.compat.v1.disable_eager_execution()
+    And it works with any shape array.
 
-    A tf.Tensor representing the result of the calculation
-
-    >>> result = func(tf.constant(1.0))
-    >>> print(result)
-    Tensor("Maximum:0", shape=(), dtype=float32)
-    >>> print(result.__class__)
-    <class 'tensorflow.python.framework.ops.Tensor'>
-
-    >>> sess = tf.compat.v1.Session()
-    >>> sess.run(result) # compute result
-    1.0
-    >>> var = tf.Variable(1.0)
-    >>> sess.run(tf.compat.v1.global_variables_initializer())
-    >>> sess.run(func(var)) # also works for tf.Variable and tf.Placeholder
-    1.0
-    >>> tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]]) # works with any shape tensor
-    >>> sess.run(func(tensor))
+    >>> tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+    >>> result = func(tensor)
+    >>> result.numpy()
     [[1. 2.]
      [3. 4.]]
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -594,7 +594,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> result = func(tf.constant(1.0))
     >>> print(result) # a tf.Tensor representing the result of the calculation
     Tensor("Maximum:0", shape=(), dtype=float32)
-    >>> sess = tf.Session()
+    >>> sess = tf.compat.v1.Session()
     >>> sess.run(result) # compute result
     1.0
     >>> var = tf.Variable(1.0)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -155,6 +155,7 @@ def _import_tensorflow(namespace):
     exec_("mod = tensorflow.math.mod", {}, namespace)
     exec_("conj = tensorflow.math.conj", {}, namespace)
 
+    exec_("where = tensorflow.where", {}, namespace)
 
 
 # Available modules:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -572,7 +572,7 @@ def test_tensorflow_basic_math():
     expr = Max(sin(x), Abs(1/(x+2)))
     func = lambdify(x, expr, modules="tensorflow")
     a = tensorflow.constant(0, dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s) == 0.5
 
 
@@ -581,8 +581,8 @@ def test_tensorflow_placeholders():
         skip("tensorflow not installed.")
     expr = Max(sin(x), Abs(1/(x+2)))
     func = lambdify(x, expr, modules="tensorflow")
-    a = tensorflow.placeholder(dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    a = tensorflow.compat.v1.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s, feed_dict={a: 0}) == 0.5
 
 
@@ -592,11 +592,11 @@ def test_tensorflow_variables():
     expr = Max(sin(x), Abs(1/(x+2)))
     func = lambdify(x, expr, modules="tensorflow")
     a = tensorflow.Variable(0, dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    s = tensorflow.compat.v1.Session()
     if V(tensorflow.__version__) < '1.0':
         s.run(tensorflow.initialize_all_variables())
     else:
-        s.run(tensorflow.global_variables_initializer())
+        s.run(tensorflow.compat.v1.global_variables_initializer())
     assert func(a).eval(session=s) == 0.5
 
 
@@ -607,7 +607,7 @@ def test_tensorflow_logical_operations():
     func = lambdify([x, y], expr, modules="tensorflow")
     a = tensorflow.constant(False)
     b = tensorflow.constant(True)
-    s = tensorflow.Session()
+    s = tensorflow.compat.v1.Session()
     assert func(a, b).eval(session=s) == 0
 
 
@@ -616,8 +616,8 @@ def test_tensorflow_piecewise():
         skip("tensorflow not installed.")
     expr = Piecewise((0, Eq(x,0)), (-1, x < 0), (1, x > 0))
     func = lambdify(x, expr, modules="tensorflow")
-    a = tensorflow.placeholder(dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    a = tensorflow.compat.v1.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s, feed_dict={a: -1}) == -1
     assert func(a).eval(session=s, feed_dict={a: 0}) == 0
     assert func(a).eval(session=s, feed_dict={a: 1}) == 1
@@ -628,8 +628,8 @@ def test_tensorflow_multi_max():
         skip("tensorflow not installed.")
     expr = Max(x, -x, x**2)
     func = lambdify(x, expr, modules="tensorflow")
-    a = tensorflow.placeholder(dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    a = tensorflow.compat.v1.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s, feed_dict={a: -2}) == 4
 
 
@@ -638,8 +638,8 @@ def test_tensorflow_multi_min():
         skip("tensorflow not installed.")
     expr = Min(x, -x, x**2)
     func = lambdify(x, expr, modules="tensorflow")
-    a = tensorflow.placeholder(dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    a = tensorflow.compat.v1.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s, feed_dict={a: -2}) == -2
 
 
@@ -648,8 +648,8 @@ def test_tensorflow_relational():
         skip("tensorflow not installed.")
     expr = x >= 0
     func = lambdify(x, expr, modules="tensorflow")
-    a = tensorflow.placeholder(dtype=tensorflow.float32)
-    s = tensorflow.Session()
+    a = tensorflow.compat.v1.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.compat.v1.Session()
     assert func(a).eval(session=s, feed_dict={a: 1})
 
 
@@ -978,7 +978,7 @@ def test_tensorflow_array_arg():
 
     fcall = f(tensorflow.constant([2.0, 1.0]))
 
-    s = tensorflow.Session()
+    s = tensorflow.compat.v1.Session()
     assert s.run(fcall) == 5
 
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -204,17 +204,6 @@ def test_scipy_transl():
         assert scip in scipy.__dict__ or scip in scipy.special.__dict__
 
 
-def test_tensorflow_transl():
-    if not tensorflow:
-        skip("tensorflow not installed")
-
-    from sympy.utilities.lambdify import TENSORFLOW_TRANSLATIONS
-    for sym, tens in TENSORFLOW_TRANSLATIONS.items():
-        assert sym in sympy.__dict__
-        # XXX __dict__ is not supported after tensorflow 1.14.0
-        assert tens in tensorflow.__all__
-
-
 def test_numpy_translation_abs():
     if not numpy:
         skip("numpy not installed.")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17105 

#### Brief description of what is fixed or changed
I noticed that the master build is failing due to the following exception,
```
W tensorflow/compiler/jit/mark_for_compilation_pass.cc:1412] (One-time warning): Not using XLA:CPU for cluster because envvar TF_XLA_FLAGS=--tf_xla_cpu_global_jit was not set.  If you want XLA:CPU, either set that envvar, or use experimental_jit_scope to enable XLA:CPU.  To confirm that XLA is active, pass --vmodule=xla_compilation_cache=1 (as a proper command-line flag, not via TF_XLA_FLAGS) or set the envvar XLA_FLAGS=--xla_hlo_profile.
```
I have set the environment variable as said in the error message. Feel free to close this PR if you think you have a found a solution. This is just an attempt.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added `tensorflow_version` option for tensorflow code printers.
  - Fixed lambdify for tensorflow version >= 2.

<!-- END RELEASE NOTES -->
