### PR TITLE
simplify tests Expr.is_zero before _eval_simplify

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -515,6 +515,10 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     kwargs = dict(ratio=ratio, measure=measure,
         rational=rational, inverse=inverse)
 
+    # no routine for Expr needs to check for is_zero
+    if isinstance(expr, Expr) and expr.is_zero and expr*0 is S.Zero:
+        return S.Zero
+
     _eval_simplify = getattr(expr, '_eval_simplify', None)
     if _eval_simplify is not None:
         return _eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -806,3 +806,9 @@ def test_issue_15965():
     assert simplify(A + B) == anew + bnew
     assert simplify(A) == anew
     assert simplify(B) == bnew
+
+
+def test_issue_7971():
+    z = Integral(x, (x, 1, 1))
+    assert z != 0
+    assert simplify(z) is S.Zero


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #7971 by adding a test for `is_zero` in the simplification routine
closes #17088

This only returns 0 for an object that is zero which,
when multiplied by zero, gives 0 (not an object like
Matrix.zeros(2).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
    - simplify tests for Expr.is_zero
<!-- END RELEASE NOTES -->
