### PR TITLE
Contains allowed in Piecewise

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -190,8 +190,7 @@ class Piecewise(Function):
                     _c = c
                     x = free.pop()
                     try:
-                        if not c.has(Contains):
-                            c = c.as_set().as_relational(x)
+                        c = c.as_set().as_relational(x)
                     except NotImplementedError:
                         pass
                     else:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -6,6 +6,7 @@ from sympy.core.compatibility import range
 from sympy.core.numbers import Rational, NumberSymbol
 from sympy.core.relational import (Equality, Unequality, Relational,
     _canonical)
+from sympy.sets.contains import Contains
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or,
     true, false, Or, ITE, simplify_logic)
@@ -189,7 +190,8 @@ class Piecewise(Function):
                     _c = c
                     x = free.pop()
                     try:
-                        c = c.as_set().as_relational(x)
+                        if not c.has(Contains):
+                            c = c.as_set().as_relational(x)
                     except NotImplementedError:
                         pass
                     else:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -6,7 +6,6 @@ from sympy.core.compatibility import range
 from sympy.core.numbers import Rational, NumberSymbol
 from sympy.core.relational import (Equality, Unequality, Relational,
     _canonical)
-from sympy.sets.contains import Contains
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or,
     true, false, Or, ITE, simplify_logic)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -3,7 +3,7 @@ from sympy import (
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
     cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
-    DiracDelta, Heaviside, Add, Mul, factorial, Ge)
+    DiracDelta, Heaviside, Add, Mul, factorial, Ge, Contains, Le)
 from sympy.core.expr import unchanged
 from sympy.functions.elementary.piecewise import Undefined, ExprCondPair
 from sympy.printing import srepr
@@ -51,6 +51,13 @@ def test_piecewise1():
 
     assert Piecewise((1, x > 0), (2, And(x <= 0, x > -1))
         ) == Piecewise((1, x > 0), (2, x > -1))
+
+    # test for supporting Contains in Piecewise
+    assert Piecewise(
+        (S(1), And(Le(x, 6), Ge(x, 1), S.Integers.contains(x))),
+        (S(0), True)) == Piecewise(
+                        (1, Contains(x, S.Integers) & (x >= 1) & (x <= 6)),
+                        (0, True))
 
     # Test subs
     p = Piecewise((-1, x < -1), (x**2, x < 0), (log(x), x >= 0))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -53,13 +53,12 @@ def test_piecewise1():
         ) == Piecewise((1, x > 0), (2, x > -1))
 
     # test for supporting Contains in Piecewise
-    pargs = ((S(1), And(Le(x, 6), Ge(x, 1), Contains(x, S.Integers))),
-        (S(0), True))
-    pwise = Piecewise(*pargs)
-    assert pwise # checks whether the object has been created successfully
-    assert pwise.subs(x, S(3)/2) == S(0)
-    assert pwise.subs(x, 2) == S(1)
-    assert pwise.subs(x, 7) == S(0)
+    pwise = Piecewise(
+        (1, And(x <= 6, x > 1, Contains(x, S.Integers))),
+        (0, True))
+    assert pwise.subs(x, pi) == 0
+    assert pwise.subs(x, 2) == 1
+    assert pwise.subs(x, 7) == 0
 
     # Test subs
     p = Piecewise((-1, x < -1), (x**2, x < 0), (log(x), x >= 0))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -53,11 +53,13 @@ def test_piecewise1():
         ) == Piecewise((1, x > 0), (2, x > -1))
 
     # test for supporting Contains in Piecewise
-    assert Piecewise(
-        (S(1), And(Le(x, 6), Ge(x, 1), S.Integers.contains(x))),
-        (S(0), True)) == Piecewise(
-                        (1, Contains(x, S.Integers) & (x >= 1) & (x <= 6)),
-                        (0, True))
+    pargs = ((S(1), And(Le(x, 6), Ge(x, 1), Contains(x, S.Integers))),
+        (S(0), True))
+    pwise = Piecewise(*pargs)
+    assert pwise # checks whether the object has been created successfully
+    assert pwise.subs(x, S(3)/2) == S(0)
+    assert pwise.subs(x, 2) == S(1)
+    assert pwise.subs(x, 7) == S(0)
 
     # Test subs
     p = Piecewise((-1, x < -1), (x**2, x < 0), (log(x), x >= 0))

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -48,4 +48,4 @@ class Contains(BooleanFunction):
             isinstance(i, (Eq, Ne))])
 
     def as_set(self):
-        return self
+        raise NotImplementedError()

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -36,5 +36,7 @@ def test_binary_symbols():
 def test_as_set():
     x = Symbol('x')
     y = Symbol('y')
-    assert Contains(x, FiniteSet(y)
-        ).as_set() == Contains(x, FiniteSet(y))
+    # Contains is a BooleanFunction whose value depends on an arg's
+    # containment in a Set -- rewriting as a Set is not yet implemented
+    raises(NotImplementedError, lambda:
+           Contains(x, FiniteSet(y)).as_set())


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17112 

#### Brief description of what is fixed or changed
I have made changes to allow `Contains` in `Piecewise`. The approach is to skip, `c = c.as_set().as_relational(x)` when `c.has(Contains)` is `True`.

#### Other comments
Take a look at the last few comments of https://github.com/sympy/sympy/pull/16962 for details.

ping @oscarbenjamin @smichr 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * `Contains` allowed in `Piecewise`
<!-- END RELEASE NOTES -->
