### PR TITLE
acsc(0) -> zoo

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1600,6 +1600,7 @@ def test_acsc():
     assert acsc(oo) == 0
     assert acsc(-oo) == 0
     assert acsc(zoo) == 0
+    assert acsc(0) == zoo
 
     assert acsc(csc(3)) == -3 + pi
     assert acsc(csc(4)) == -4 + pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2727,6 +2727,8 @@ class acsc(InverseTrigonometricFunction):
 
     @classmethod
     def eval(cls, arg):
+        if arg.is_zero:
+            return S.ComplexInfinity
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN


### PR DESCRIPTION
Fixes #17143. `acsc(0)` returns `S.ComplexInfinity`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * acsc(0) is automatically evaluated
<!-- END RELEASE NOTES -->
