### PR TITLE
Fix misc. typos

### DIFF
--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -11,7 +11,7 @@
 # heuristics to know where a multi-line expression is
 # broken. As a result you can't use more than one space
 # in a sequence. However you can and must indent your
-# expression using standard Pyhon rules.
+# expression using standard Python rules.
 #
 # You can retrieve the last output using '_' built-in
 # symbol. If the previous command did not generate

--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -127,7 +127,7 @@ For easier use, there is a syntactic sugar for expressions.
 For example, ``cos(x) + 1`` is equal to ``cos(x).__add__(1)`` is equal to
 ``Add(cos(x), Integer(1))``
 
-This works becauses Python allows you to override the behavior of built-in
+This works because Python allows you to override the behavior of built-in
 operations ``+, *, -, /`` etc., by defining methods with names ``__add__``,
 ``__mul__`` etc., so ``cos(x) + 1`` is evaluated as ``cos(x).__add__(1)``.
 

--- a/doc/src/modules/holonomic/about.rst
+++ b/doc/src/modules/holonomic/about.rst
@@ -36,7 +36,7 @@ Here `D` is the Differential Operator and `L` is called the annihilator
 of the function.
 
 A unique holonomic function can be defined from the annihilator and a set of
-initial conditons.
+initial conditions.
 For instance:
 
 .. math::

--- a/doc/src/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/modules/physics/mechanics/autolev_parser.rst
@@ -82,7 +82,7 @@ The parser can be used as follows::
     >>> sympy_code = parse_autolev(open('double_pendulum.al'), include_numeric=True)
 
     # The include_pydy flag is False by default. Setting it to True will
-    # enable PyDy simulation code to be outputed if applicable.
+    # enable PyDy simulation code to be outputted if applicable.
 
     >>> print(sympy_code)
     import sympy.physics.mechanics as me

--- a/doc/src/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/special_topics/finite_diff_derivatives.rst
@@ -101,7 +101,7 @@ Coefficients of `c_i` evaluated at `x_i + 2*h`:
 	>>> m32 = P(x0+2*h, x0, c, n).diff(c[1])
 	>>> m33 = P(x0+2*h, x0, c, n).diff(c[2])
 
-Matrix of the coeffcients is 3x3 in this case:
+Matrix of the coefficients is 3x3 in this case:
 
 	>>> M = Matrix([[m11, m12, m13], [m21, m22, m23], [m31, m32, m33]])
 
@@ -143,7 +143,7 @@ at `x_i` and thus using points at `x_{i-1}`,  `x_{i}`,  and `x_{i+1}`. So here i
 	>>> m31 = P(x0+h, x0, c, n).diff(c[0])
 	>>> m32 = P(x0+h, x0, c, n).diff(c[1])
 	>>> m33 = P(x0+h, x0, c, n).diff(c[2])
-	>>> # matrix of the coeffcients is 3x3 in this case
+	>>> # matrix of the coefficients is 3x3 in this case
 	>>> M = Matrix([[m11, m12, m13], [m21, m22, m23], [m31, m32, m33]])
 
 Now that we have the matrix of coefficients we next form the right-hand-side and solve by inverting `M`:
@@ -219,7 +219,7 @@ degree polynomial P coefficients of `c_i` evaluated at `x_i, x_{i-1},` and `x_{i
     >>> m32 = P(xN-2*h, xN, c, n).diff(c[1])
     >>> m33 = P(xN-2*h, xN, c, n).diff(c[2])
 
-Next we construct the `3 \times 3` matrix of the coeffcients:
+Next we construct the `3 \times 3` matrix of the coefficients:
 
     >>> M = Matrix([[m11, m12, m13], [m21, m22, m23], [m31, m32, m33]])
     >>> # matrix of the function values...actually a vector of right hand sides
@@ -247,7 +247,7 @@ Also,  we note that output of formats appropriate to Fortran,  C,  etc. may be d
 given above.
 
 Next we show how to perform these and many other discritizations of derivatives,  but using a
-much more efficient approach originally due to Bengt Fornberg and now incorported into SymPy.
+much more efficient approach originally due to Bengt Fornberg and now incorporated into SymPy.
 
 
 

--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -111,7 +111,7 @@ matrices, and much, much more, and do it all symbolically.  It includes
 modules for plotting, printing (like 2D pretty printed output of math
 formulas, or `\LaTeX`), code generation, physics, statistics, combinatorics,
 number theory, geometry, logic, and more. Here is a small sampling of the sort
-of symbolic power SymPy is capable of, to whet your appetite.
+of symbolic power SymPy is capable of, to wet your appetite.
 
  >>> from sympy import *
  >>> x, t, z, nu = symbols('x t z nu')

--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -111,7 +111,7 @@ matrices, and much, much more, and do it all symbolically.  It includes
 modules for plotting, printing (like 2D pretty printed output of math
 formulas, or `\LaTeX`), code generation, physics, statistics, combinatorics,
 number theory, geometry, logic, and more. Here is a small sampling of the sort
-of symbolic power SymPy is capable of, to wet your appetite.
+of symbolic power SymPy is capable of, to whet your appetite.
 
  >>> from sympy import *
  >>> x, t, z, nu = symbols('x t z nu')

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -427,7 +427,7 @@ guaranteed to be accurate in some limited domain of numerics and symbols,
 and any complicated expressions beyond its decidability are treated as ``None``,
 which behaves similarly to logical ``False``.
 
-The list of methods using zero testing procedures are as followings.
+The list of methods using zero testing procedures are as follows:
 
 ``echelon_form`` , ``is_echelon`` , ``rank`` , ``rref`` , ``nullspace`` ,
 ``eigenvects`` , ``inverse_ADJ`` , ``inverse_GE`` , ``inverse_LU`` ,

--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -230,7 +230,7 @@ format, which can be rendered with Graphviz.  See the
 :ref:`tutorial-manipulation` section for some examples of the output of this
 printer.
 
-Here is an example of the raw ouput of the ``dotprint()`` function
+Here is an example of the raw output of the ``dotprint()`` function
 
     >>> from sympy.printing.dot import dotprint
     >>> from sympy.abc import x

--- a/examples/intermediate/sample.py
+++ b/examples/intermediate/sample.py
@@ -21,7 +21,7 @@ def sample2d(f, x_args):
     try:
         f = sympify(f)
     except SympifyError:
-        raise ValueError("f could not be interpretted as a SymPy function")
+        raise ValueError("f could not be interpreted as a SymPy function")
     try:
         x, x_min, x_max, x_n = x_args
     except (TypeError, IndexError):

--- a/examples/notebooks/Macaulay_resultant.ipynb
+++ b/examples/notebooks/Macaulay_resultant.ipynb
@@ -44,7 +44,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are a number of steps needed to contruct matrix $A$. Let us consider an example from https://dl.acm.org/citation.cfm?id=550525 to \n",
+    "There are a number of steps needed to construct matrix $A$. Let us consider an example from https://dl.acm.org/citation.cfm?id=550525 to \n",
     "show the construction."
    ]
   },

--- a/examples/notebooks/Sylvester_resultant.ipynb
+++ b/examples/notebooks/Sylvester_resultant.ipynb
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the definition, it is clear that the resultant will equal zero if and only if $p$ and $q$ have at least one common root. Thus, the resultant becomes very usefull in identifying whether common roots exist. "
+    "From the definition, it is clear that the resultant will equal zero if and only if $p$ and $q$ have at least one common root. Thus, the resultant becomes very useful in identifying whether common roots exist. "
    ]
   },
   {

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -148,7 +148,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     derivative is wanted, weights for 0th, 1st and 2nd order are
     calculated "for free", so are formulae using subsets of ``x_list``.
     This is something one can take advantage of to save computational cost.
-    Be aware that one should define ``x_list`` from nearest to farest from
+    Be aware that one should define ``x_list`` from nearest to farthest from
     ``x0``. If not, subsets of ``x_list`` will yield poorer approximations,
     which might not grand an order of accuracy of ``len(x_list) - order``.
 

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -148,7 +148,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     derivative is wanted, weights for 0th, 1st and 2nd order are
     calculated "for free", so are formulae using subsets of ``x_list``.
     This is something one can take advantage of to save computational cost.
-    Be aware that one should define ``x_list`` from nearest to farthest from
+    Be aware that one should define ``x_list`` from nearest to furthest from
     ``x0``. If not, subsets of ``x_list`` will yield poorer approximations,
     which might not grand an order of accuracy of ``len(x_list) - order``.
 

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -231,7 +231,7 @@ class CodegenArrayContraction(_CodegenArrayAbstract):
     def _get_index_shifts(expr):
         """
         Get the mapping of indices at the positions before the contraction
-        occures.
+        occurs.
 
         Examples
         ========

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1582,7 +1582,7 @@ class While(Token):
     Parameters
     ==========
 
-    condition : expression convertable to Boolean
+    condition : expression convertible to Boolean
     body : CodeBlock or iterable
         When passed an iterable it is used to instantiate a CodeBlock.
 

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -1166,7 +1166,7 @@ def modified_coset_enumeration_r(fp_grp, Y, max_cosets=None, draft=None,
     r"""
     Introduce a new set of symbols y \in Y that correspond to the
     generators of the subgroup. Store the elements of Y as a
-    word P[\alpha, x] and compute the coset table simlar to that of
+    word P[\alpha, x] and compute the coset table similar to that of
     the regular coset enumeration methods.
 
     Examples

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -398,7 +398,7 @@ class RewritingSystem(object):
                     else:
                         self.reduction_automaton.states[state].add_transition(letter, current_state_name)
             elif current_state_type == 'a':
-                # Check if the transition to any new state in posible.
+                # Check if the transition to any new state in possible.
                 for letter in automaton_alphabet:
                     _next = current_state_name*letter
                     while len(_next) and _next not in self.reduction_automaton.states:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1079,7 +1079,7 @@ class Derivative(Expr):
     derivatives wrt AppliedUndef and Derivatives are allowed.
     For example, in the Euler-Lagrange method one may write
     F(t, u, v) where u = f(t) and v = f'(t). These variables can be
-    written explicity as functions of time::
+    written explicitly as functions of time::
 
         >>> from sympy.abc import t
         >>> F = Function('F')
@@ -2062,7 +2062,7 @@ class Subs(Expr):
         else:
             expr = sympify(expr)
 
-        # use symbols with names equal to the point value (with preppended _)
+        # use symbols with names equal to the point value (with prepended _)
         # to give a variable-independent expression
         pre = "_"
         pts = sorted(set(point), key=default_sort_key)
@@ -2077,7 +2077,7 @@ class Subs(Expr):
             s_pts = {p: Symbol(pre + mystr(p)) for p in pts}
             reps = [(v, s_pts[p])
                 for v, p in zip(variables, point)]
-            # if any underscore-preppended symbol is already a free symbol
+            # if any underscore-prepended symbol is already a free symbol
             # and is a variable with a different point value, then there
             # is a clash, e.g. _0 clashes in Subs(_0 + _1, (_0, _1), (1, 0))
             # because the new symbol that would be created is _1 but _1
@@ -2215,7 +2215,7 @@ class Subs(Expr):
                     i.has(new) for i in self.args):
                 # the substitution is neutral
                 return self.xreplace({old: new})
-            # any occurance of old before this point will get
+            # any occurrence of old before this point will get
             # handled by replacements from here on
             i = self.variables.index(old)
             for j in range(i, len(self.variables)):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3206,7 +3206,7 @@ class NaN(with_metaclass(Singleton, Number)):
     the examples below.
 
     NaN is not comparable so inequalities raise a TypeError.  This is in
-    constrast with floating point nan where all inequalities are false.
+    contrast with floating point nan where all inequalities are false.
 
     NaN is a singleton, and can be accessed by ``S.NaN``, or can be imported
     as ``nan``.

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -173,7 +173,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         This works more or less identical to ``~``/``Not``. The difference is
         that ``negated`` returns the relationship even if `evaluate=False`.
         Hence, this is useful in code when checking for e.g. negated relations
-        to exisiting ones as it will not be affected by the `evaluate` flag.
+        to existing ones as it will not be affected by the `evaluate` flag.
 
         """
         ops = {Eq: Ne, Ge: Lt, Gt: Le, Le: Gt, Lt: Ge, Ne: Eq}

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -113,7 +113,7 @@ def _uniquely_named_symbol(xname, exprs=(), compare=str, modify=None, **assumpti
             is printed, e.g. this includes underscores that appear on
             Dummy symbols)
         modify : a single arg function that changes its string argument
-            in some way (the default is to preppend underscores)
+            in some way (the default is to prepend underscores)
 
     Examples
     ========

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1923,7 +1923,7 @@ def test_mul_zero_detection():
     # zero value so args should be tested in both directions and
     # TO AVOID GETTING THE CACHED RESULT, Dummy MUST BE USED
 
-    # real is unknonwn
+    # real is unknown
     def test(z, b, e):
         if z.is_zero and b.is_finite:
             assert e.is_real and e.is_zero

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -360,7 +360,7 @@ def test_function_comparable_infinities():
 
 
 def test_deriv1():
-    # These all requre derivatives evaluated at a point (issue 4719) to work.
+    # These all require derivatives evaluated at a point (issue 4719) to work.
     # See issue 4624
     assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), x, 2*x)
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -361,7 +361,7 @@ def encipher_affine(msg, key, symbols=None, _inverse=False):
 
             symbols : string of characters (default = uppercase
             letters). When no symbols are given, ``msg`` is converted
-            to upper case letters and all other charactes are ignored.
+            to upper case letters and all other characters are ignored.
 
     Returns
     =======

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -581,7 +581,7 @@ class cos(TrigonometricFunction):
 
             # cosine formula #####################
             # https://github.com/sympy/sympy/issues/6048
-            # explicit calculations are preformed for
+            # explicit calculations are performed for
             # cos(k pi/n) for n = 8,10,12,15,20,24,30,40,60,120
             # Some other exact values like cos(k pi/240) can be
             # calculated using a partial-fraction decomposition

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -142,7 +142,7 @@ class GeometryEntity(Basic):
         return a.__mul__(self)
 
     def __rsub__(self, a):
-        """Implementation of reverse substraction method."""
+        """Implementation of reverse subtraction method."""
         return a.__sub__(self)
 
     def __str__(self):

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -103,7 +103,7 @@ def are_coplanar(*e):
                 pt3d.append(i)
             elif isinstance(i, LinearEntity3D):
                 pt3d.extend(i.args)
-            elif isinstance(i, GeometryEntity):  # XXX we should have a GeometryEntity3D class so we can tell the difference between 2D and 3D -- here we just want to deal with 2D objects; if new 3D objects are encountered that we didn't hanlde above, an error should be raised
+            elif isinstance(i, GeometryEntity):  # XXX we should have a GeometryEntity3D class so we can tell the difference between 2D and 3D -- here we just want to deal with 2D objects; if new 3D objects are encountered that we didn't handle above, an error should be raised
                 # all 2D objects have some Point that defines them; so convert those points to 3D pts by making z=0
                 for p in i.args:
                     if isinstance(p, Point):

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1994,7 +1994,7 @@ class HolonomicFunction(object):
         arg1 = roots(r.parent.base.to_sympy(a), recurrence.n)
         arg2 = roots(r.parent.base.to_sympy(b), recurrence.n)
 
-        # iterate thorugh the initial conditions to find
+        # iterate through the initial conditions to find
         # the hypergeometric representation of the given
         # function.
         # The answer will be a linear combination
@@ -2203,7 +2203,7 @@ def from_hyper(func, x0=0, evalf=False):
 
     if isinstance(simp, hyper):
         x0 = 1
-        # use evalf if the function can't be simpified
+        # use evalf if the function can't be simplified
         y0 = _find_conditions(simp, x, x0, sol.order, evalf)
         while not y0:
             x0 += 1

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -60,7 +60,7 @@ class Integral(AddWithLimits):
             (x, a, b) - definite integral
 
         The ``as_dummy`` method can be used to see which symbols cannot be
-        targeted by subs: those with a preppended underscore cannot be
+        targeted by subs: those with a prepended underscore cannot be
         changed with ``subs``. (Also, the integration variables themselves --
         the first element of a limit -- can never be changed by subs.)
 

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1900,7 +1900,7 @@ def _guess_expansion(f, x):
 
 def _meijerint_definite_2(f, x):
     """
-    Try to integrate f dx from zero to infinty.
+    Try to integrate f dx from zero to infinity.
 
     The body of this function computes various 'simplifications'
     f1, f2, ... of f (e.g. by calling expand_mul(), trigexpand()

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -796,7 +796,7 @@ def limited_integrate(fa, fd, G, DE):
     Solves the limited integration problem:  f = Dv + Sum(ci*wi, (i, 1, n))
     """
     fa, fd = fa*Poly(1/fd.LC(), DE.t), fd.monic()
-    # interpretting limited integration problem as a
+    # interpreting limited integration problem as a
     # parametric Risch DE problem
     Fa = Poly(0, DE.t)
     Fd = Poly(1, DE.t)

--- a/sympy/integrals/rubi/__init__.py
+++ b/sympy/integrals/rubi/__init__.py
@@ -38,7 +38,7 @@ As seen in the above example, a rule has 3 parts
 1. Pattern with constraints. Expression is matched against this pattern.
 2. Replacement function, which gives the resulting expression with which the original expression has to be replaced with.
    There is also `rubi.append(1)`. This (rubi) is a list which keeps track of rules applied to an expression.
-   This can be accesed by `rules_applied` in `rubi.py`
+   This can be accessed by `rules_applied` in `rubi.py`
 3. Rule, which combines pattern and replacement function.
 (For more details refer to matchpy documents)
 

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -824,7 +824,7 @@ def NumericQ(u):
 
 def Length(expr):
     """
-    Returns number of elements in the experssion just as sympy's len.
+    Returns number of elements in the expression just as sympy's len.
 
     Examples
     ========

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -162,7 +162,7 @@ def enable_automatic_int_sympification(shell):
 
 
 def enable_automatic_symbols(shell):
-    """Allow IPython to automatially create symbols (``isympy -a``). """
+    """Allow IPython to automatically create symbols (``isympy -a``). """
     # XXX: This should perhaps use tokenize, like int_to_Integer() above.
     # This would avoid re-executing the code, which can lead to subtle
     # issues.  For example:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1612,7 +1612,7 @@ def is_nnf(expr, simplified=True):
     Checks if expr is in Negation Normal Form.
     A logical expression is in Negation Normal Form (NNF) if it
     contains only And, Or and Not, and Not is applied only to literals.
-    If simpified is True, checks if result contains no redundant clauses.
+    If simplified is True, checks if result contains no redundant clauses.
 
     Examples
     ========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -310,7 +310,7 @@ class MatrixDeterminant(MatrixCommon):
         lambda**2 - lambda - 6
 
         And if ``x`` clashes with an existing symbol, underscores will
-        be preppended to the name to make it unique:
+        be prepended to the name to make it unique:
 
         >>> A = Matrix([[1, 2], [x, 0]])
         >>> A.charpoly(x).as_expr()
@@ -1273,7 +1273,7 @@ class MatrixEigen(MatrixSubspaces):
             else:
                 eigs = roots(mat.charpoly(x=Dummy('x')), **flags)
 
-        # make sure the algebraic multiplicty sums to the
+        # make sure the algebraic multiplicity sums to the
         # size of the matrix
         if error_when_incomplete and (sum(eigs.values()) if
             isinstance(eigs, dict) else len(eigs)) != self.cols:
@@ -1671,7 +1671,7 @@ class MatrixEigen(MatrixSubspaces):
         calc_transform : bool
             If ``False``, then only `J` is returned.
         chop : bool
-            All matrices are convered to exact types when computing
+            All matrices are converted to exact types when computing
             eigenvalues and eigenvectors.  As a result, there may be
             approximation errors.  If ``chop==True``, these errors
             will be truncated.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3460,7 +3460,7 @@ def test_opportunistic_simplification():
 
 def test_partial_pivoting():
     # example from https://en.wikipedia.org/wiki/Pivot_element
-    # partial pivoting with back subsitution gives a perfect result
+    # partial pivoting with back substitution gives a perfect result
     # naive pivoting give an error ~1e-13, so anything better than
     # 1e-15 is good
     mm=Matrix([[0.003 ,59.14, 59.17],[ 5.291, -6.13,46.78]])

--- a/sympy/ntheory/tests/test_bbp_pi.py
+++ b/sympy/ntheory/tests/test_bbp_pi.py
@@ -5,7 +5,7 @@ from sympy.utilities.pytest import raises
 
 
 # http://www.herongyang.com/Cryptography/Blowfish-First-8366-Hex-Digits-of-PI.html
-# There are actually 8336 listed there; with the preppended 3 there are 8337
+# There are actually 8336 listed there; with the prepended 3 there are 8337
 # below
 dig=''.join('''
 3243f6a8885a308d313198a2e03707344a4093822299f31d0082efa98ec4e6c89452821e638d013

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -93,7 +93,7 @@ def test_dynamics_online():
 
 
 def test_output_01():
-    """Autolev example calculates the position, velocity, and accleration of a
+    """Autolev example calculates the position, velocity, and acceleration of a
     point and expresses in a single reference frame::
 
           (1) FRAMES C,D,F

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -218,9 +218,9 @@ class Beam(object):
     def boundary_conditions(self):
         """
         Returns a dictionary of boundary conditions applied on the beam.
-        The dictionary has three kewwords namely moment, slope and deflection.
+        The dictionary has three keywords namely moment, slope and deflection.
         The value of each keyword is a list of tuple, where each tuple
-        contains loaction and value of a boundary condition in the format
+        contains location and value of a boundary condition in the format
         (location, value).
 
         Examples
@@ -1193,7 +1193,7 @@ class Beam(object):
 
     def max_deflection(self):
         """
-        Returns point of max deflection and its coresponding deflection value
+        Returns point of max deflection and its corresponding deflection value
         in a Beam object.
         """
         from sympy import solve, Piecewise
@@ -1662,7 +1662,7 @@ class Beam3D(Beam):
         Returns a dictionary of boundary conditions applied on the beam.
         The dictionary has two keywords namely slope and deflection.
         The value of each keyword is a list of tuple, where each tuple
-        contains loaction and value of a boundary condition in the format
+        contains location and value of a boundary condition in the format
         (location, value). Further each value is a list corresponding to
         slope or deflection(s) values along three axes at that location.
 

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -126,7 +126,7 @@ class KanesMethod(object):
             kd_eqs = [dynamicsymbols('dummy_kd')]
 
         if not isinstance(frame, ReferenceFrame):
-            raise TypeError('An intertial ReferenceFrame must be supplied')
+            raise TypeError('An inertial ReferenceFrame must be supplied')
         self._inertial = frame
 
         self._fr = None

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -365,7 +365,7 @@ class LagrangesMethod(object):
 
         The operating points may be also entered using the ``op_point`` kwarg.
         This takes a dictionary of {symbol: value}, or a an iterable of such
-        dictionaries. The values may be numberic or symbolic. The more values
+        dictionaries. The values may be numeric or symbolic. The more values
         you can specify beforehand, the faster this computation will run.
 
         For more documentation, please see the ``Linearizer`` class."""

--- a/sympy/physics/mechanics/tests/test_kane4.py
+++ b/sympy/physics/mechanics/tests/test_kane4.py
@@ -65,7 +65,7 @@ def test_replace_qdots_in_force():
     assert (KM2.mass_matrix.expand() == mass_matrix_expected.expand())
     assert (KM2.forcing.expand() == forcing_matrix_expected.expand())
 
-    # Check fr1 with reference fr_expected from [1] with u:s insted of qdots.
+    # Check fr1 with reference fr_expected from [1] with u:s instead of qdots.
     fr1_expected = Matrix([ 0, -(sig*q2 + delta * u2) ])
     assert fr1.expand() == fr1_expected.expand()
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2308,7 +2308,7 @@ def substitute_dummies(expr, new_indices=False, pretty_indices={}):
     the structure of the term.  For each term, we obtain a sequence of all
     dummy variables, where the order is determined by the index range, what
     factors the index belongs to and its position in each factor.  See
-    _get_ordered_dummies() for more inforation about the sorting of dummies.
+    _get_ordered_dummies() for more information about the sorting of dummies.
     The index sequence is then substituted consistently in each term.
 
     Examples

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -666,7 +666,7 @@ def test_dummy_order_inner_outer_lines_VT1T1T1T1():
         # dummy order.  That is because the proximity to external indices
         # has higher influence on the canonical dummy ordering than the
         # position of a dummy on the factors.  In fact, the terms here are
-        # similar in structure as the result of the dummy substitions above.
+        # similar in structure as the result of the dummy substitutions above.
         v(k, l, c, d)*t(c, ii)*t(d, jj)*t(aa, k)*t(bb, l),
         v(l, k, c, d)*t(c, ii)*t(d, jj)*t(aa, k)*t(bb, l),
         v(k, l, d, c)*t(c, ii)*t(d, jj)*t(aa, k)*t(bb, l),
@@ -828,7 +828,7 @@ def test_equivalent_internal_lines_VT2():
         #
         # This test show that the dummy order may not be sensitive to all
         # index permutations.  The following expressions have identical
-        # structure as the resulting terms from of the dummy subsitutions
+        # structure as the resulting terms from of the dummy substitutions
         # in the test above.  Here, all expressions have the same dummy
         # order, so they cannot be simplified by means of dummy
         # substitution.  In order to simplify further, it is necessary to

--- a/sympy/physics/vector/fieldfunctions.py
+++ b/sympy/physics/vector/fieldfunctions.py
@@ -233,7 +233,7 @@ def scalar_potential(field, frame):
     if field == Vector(0):
         return S(0)
     #Express the field exntirely in frame
-    #Subsitute coordinate variables also
+    #Substitute coordinate variables also
     _check_frame(frame)
     field = express(field, frame, variables=True)
     #Make a list of dimensions of the frame

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -123,7 +123,7 @@ def express(expr, frame, frame2=None, variables=False):
             #Given expr is a scalar field
             frame_set = set([])
             expr = sympify(expr)
-            #Subsitute all the coordinate variables
+            #Substitute all the coordinate variables
             for x in expr.free_symbols:
                 if isinstance(x, CoordinateSym)and x.frame != frame:
                     frame_set.add(x.frame)

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -385,7 +385,7 @@ class Vector(object):
         return outstr
 
     def __sub__(self, other):
-        """The subraction operator. """
+        """The subtraction operator. """
         return self.__add__(other * -1)
 
     def __xor__(self, other):

--- a/sympy/polys/domains/characteristiczero.py
+++ b/sympy/polys/domains/characteristiczero.py
@@ -1,4 +1,4 @@
-"""Implementaton of :class:`CharacteristicZero` class. """
+"""Implementation of :class:`CharacteristicZero` class. """
 
 from __future__ import print_function, division
 

--- a/sympy/polys/domains/gmpyintegerring.py
+++ b/sympy/polys/domains/gmpyintegerring.py
@@ -1,4 +1,4 @@
-"""Implementaton of :class:`GMPYIntegerRing` class. """
+"""Implementation of :class:`GMPYIntegerRing` class. """
 
 from __future__ import print_function, division
 

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -1,4 +1,4 @@
-"""Implementaton of :class:`GMPYRationalField` class. """
+"""Implementation of :class:`GMPYRationalField` class. """
 
 from __future__ import print_function, division
 

--- a/sympy/polys/domains/pythonintegerring.py
+++ b/sympy/polys/domains/pythonintegerring.py
@@ -1,4 +1,4 @@
-"""Implementaton of :class:`PythonIntegerRing` class. """
+"""Implementation of :class:`PythonIntegerRing` class. """
 
 from __future__ import print_function, division
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1192,7 +1192,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
             return self.square()
         elif n == 3:
             return self*self.square()
-        elif len(self) <= 5: # TODO: use an actuall density measure
+        elif len(self) <= 5: # TODO: use an actual density measure
             return self._pow_multinomial(n)
         else:
             return self._pow_generic(n)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1421,7 +1421,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
                 return x == coeff
             return False
 
-        # Find coefficient for higest derivative, multiply coefficients to
+        # Find coefficient for highest derivative, multiply coefficients to
         # bring the equation into Euler form if possible
         r_rescaled = None
         if r is not None:
@@ -2931,7 +2931,7 @@ def constant_renumber(expr, variables=None, newconstants=None):
         isconstant = lambda s: s.startswith('C') and s[1:].isdigit()
         constantsymbols = [sym for sym in expr.free_symbols if isconstant(sym.name)]
 
-    # Find new constants checking that they aren't alread in the ODE
+    # Find new constants checking that they aren't already in the ODE
     if newconstants is None:
         iter_constants = numbered_symbols(start=1, prefix='C', exclude=variables)
     else:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2710,7 +2710,7 @@ def _tsolve(eq, sym, **flags):
                     except NotImplementedError:
                         pass
 
-                # Collect possible solutions and check with subtitution later.
+                # Collect possible solutions and check with substitution later.
                 check = []
                 if rhs == 1:
                     # f(x) ** g(x) = 1 -- g(x)=0 or f(x)=+-1

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1247,7 +1247,7 @@ def test_trig_system():
 def test_trig_system_fail():
     # fails because solveset trig solver is not much smart.
     sys = [x + y - pi/2, sin(x) + sin(y) - 1]
-    # solveset returns conditonset for sin(x) + sin(y) - 1
+    # solveset returns conditionset for sin(x) + sin(y) - 1
     soln_1 = (ImageSet(Lambda(n, n*pi + pi/2), S.Integers),
         ImageSet(Lambda(n, n*pi)), S.Integers)
     soln_1 = FiniteSet(soln_1)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -272,7 +272,7 @@ def Benini(name, alpha, beta, sigma):
                 -\beta\log^2\left[{\frac{x}{\sigma}}\right]}
                 \left(\frac{\alpha}{x}+\frac{2\beta\log{\frac{x}{\sigma}}}{x}\right)
 
-    This is a heavy-tailed distrubtion and is also known as the log-Rayleigh
+    This is a heavy-tailed distribution and is also known as the log-Rayleigh
     distribution.
 
     Parameters
@@ -2491,7 +2491,7 @@ def Normal(name, mean, std):
     ==========
 
     mu : Real number or a list representing the mean or the mean vector
-    sigma : Real number or a positive definite sqaure matrix,
+    sigma : Real number or a positive definite square matrix,
          :math:`\sigma^2 > 0` the variance
 
     Returns

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -226,7 +226,7 @@ class ConditionalDiscreteDomain(DiscreteDomain, ConditionalDomain):
         rv = self.symbols
         if len(self.symbols) > 1:
             raise NotImplementedError(filldedent('''
-                Multivariate condtional domains are not yet implemented.'''))
+                Multivariate conditional domains are not yet implemented.'''))
         rv = list(rv)[0]
         return reduce_rational_inequalities_wrap(self.condition,
             rv).intersect(self.fulldomain.set)

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -198,11 +198,11 @@ class SingleFiniteDistribution(Basic, NamedArgsMixin):
             return Density(self)
         return dict((k, self.pmf(k)) for k in self.set)
 
-    def pmf(self, *args): # to be overrided by specific distribution
+    def pmf(self, *args): # to be overridden by specific distribution
         raise NotImplementedError()
 
     @property
-    def set(self): # to be overrided by specific distribution
+    def set(self): # to be overridden by specific distribution
         raise NotImplementedError()
 
     values = property(lambda self: self.dict.values)
@@ -321,7 +321,7 @@ class FinitePSpace(PSpace):
         cond_symbols = frozenset(rs.symbol for rs in random_symbols(condition))
         cond = rv_subs(condition)
         if not cond_symbols.issubset(self.symbols):
-            raise ValueError("Cannot compare foriegn random symbols, %s"
+            raise ValueError("Cannot compare foreign random symbols, %s"
                              %(str(cond_symbols - self.symbols)))
         if isinstance(condition, Relational) and \
             (not cond.free_symbols.issubset(self.domain.free_symbols)):

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -525,7 +525,7 @@ def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     syms: list/tuple/set of symbols for identifying each component
     omega: A square matrix
            Every element of square matrix must be absolute value of
-           sqaure root of correlation coefficient
+           square root of correlation coefficient
     v: positive real
     lamda: a list of positive reals
     mu: a list of positive reals
@@ -590,7 +590,7 @@ class MultinomialDistribution(JointDistribution):
     @staticmethod
     def check(n, p):
         _value_check(n > 0,
-                        "number of trials must be a positve integer")
+                        "number of trials must be a positive integer")
         for p_k in p:
             _value_check((p_k >= 0, p_k <= 1),
                         "probability must be in range [0, 1]")
@@ -659,7 +659,7 @@ class NegativeMultinomialDistribution(JointDistribution):
     @staticmethod
     def check(k0, p):
         _value_check(k0 > 0,
-                        "number of failures must be a positve integer")
+                        "number of failures must be a positive integer")
         for p_k in p:
             _value_check((p_k >= 0, p_k <= 1),
                         "probability must be in range [0, 1].")

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -90,7 +90,7 @@ def entropy(expr, condition=None, **kwargs):
     b: base of the logarithm, optional
        By default, it is taken as Euler's number
 
-    Retruns
+    Returns
     =======
 
     result : Entropy of the expression, a constant

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -50,7 +50,7 @@ def _set_converter(itr):
 
 def _matrix_checks(matrix):
     if not isinstance(matrix, (Matrix, MatrixSymbol, ImmutableMatrix)):
-        raise TypeError("Transition probabilities etiher should "
+        raise TypeError("Transition probabilities either should "
                             "be a Matrix or a MatrixSymbol.")
     if matrix.shape[0] != matrix.shape[1]:
         raise ValueError("%s is not a square matrix"%(matrix))
@@ -94,13 +94,13 @@ class StochasticProcess(Basic):
 
     def __call__(self, time):
         """
-        Overrided in ContinuousTimeStochasticProcess.
+        Overridden in ContinuousTimeStochasticProcess.
         """
         raise NotImplementedError("Use [] for indexing discrete time stochastic process.")
 
     def __getitem__(self, time):
         """
-        Overrided in DiscreteTimeStochasticProcess.
+        Overridden in DiscreteTimeStochasticProcess.
         """
         raise NotImplementedError("Use () for indexing continuous time stochastic process.")
 
@@ -481,7 +481,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
                 lhsg, rhsg = (rhsg, lhsg)
             keyc, statec, keyg, stateg = (lhsc.key, rhsc, lhsg.key, rhsg)
             if Lt(stateg, trans_probs.shape[0]) == False or Lt(statec, trans_probs.shape[1]) == False:
-                raise IndexError("No information is avaliable for (%s, %s) in "
+                raise IndexError("No information is available for (%s, %s) in "
                     "transition probabilities of shape, (%s, %s). "
                     "State space is zero indexed."
                     %(stateg, statec, trans_probs.shape[0], trans_probs.shape[1]))
@@ -577,7 +577,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess):
             Unevaluated object if computations cannot be done due to
             insufficient information.
         Expr
-            In all other cases when the computations are successfull.
+            In all other cases when the computations are successful.
 
         Note
         ====

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -318,7 +318,7 @@ def get_contraction_structure(expr):
        dicts for the non-trivial deeper contractions, omitting dicts with None
        as the one and only key.
 
-    .. Note:: The presence of expressions among the dictinary keys indicates
+    .. Note:: The presence of expressions among the dictionary keys indicates
        multiple levels of index contractions.  A nested dict displays nested
        contractions and may itself contain dicts from a deeper level.  In
        practical calculations the summation in the deepest nested level must be

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -595,7 +595,7 @@ class _TensorDataLazyEvaluator(CantSympify):
         # inverse, this is not the case for other tensors.
         self._substitutions_dict_tensmul[metric, True, True] = data
         inverse_transpose = self.inverse_transpose_matrix(data)
-        # in symmetric spaces, the traspose is the same as the original matrix,
+        # in symmetric spaces, the transpose is the same as the original matrix,
         # the full covariant metric tensor is the inverse transpose, so this
         # code will be able to handle non-symmetric metrics.
         self._substitutions_dict_tensmul[metric, False, False] = inverse_transpose

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -117,7 +117,7 @@ def copy(src, dst, only_update=False, copystat=True, cwd=None,
         raise FileNotFoundError("Source: `{}` does not exist".format(src))
 
     # We accept both (re)naming destination file _or_
-    # passing a (possible non-existant) destination directory
+    # passing a (possible non-existent) destination directory
     if dest_is_dir:
         if not dst[-1] == '/':
             dst = dst+'/'

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -252,7 +252,7 @@ default_datatypes = {
     "complex": DataType("double", "COMPLEX*16", "complex", "", "", "float") #FIXME:
        # complex is only supported in fortran, python, julia, and octave.
        # So to not break c or rust code generation, we stick with double or
-       # float, respecitvely (but actually should raise an exeption for
+       # float, respecitvely (but actually should raise an exception for
        # explicitly complex variables (x.is_complex==True))
 }
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -686,7 +686,7 @@ def sift(seq, keyfunc, binary=False):
 
     If you need to sort the sifted items it might be better to use
     ``ordered`` which can economically apply multiple sort keys
-    to a squence while sorting.
+    to a sequence while sorting.
 
     See Also
     ========

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -114,7 +114,7 @@ def express(expr, system, system2=None, variables=False):
             # Given expr is a scalar field
             system_set = set([])
             expr = sympify(expr)
-            # Subsitute all the coordinate variables
+            # Substitute all the coordinate variables
             for x in expr.atoms(BaseScalar):
                 if x.system != system:
                     system_set.add(x.system)
@@ -307,7 +307,7 @@ def scalar_potential(field, coord_sys):
     if field == Vector.zero:
         return S(0)
     # Express the field exntirely in coord_sys
-    # Subsitute coordinate variables also
+    # Substitute coordinate variables also
     if not isinstance(coord_sys, CoordSys3D):
         raise TypeError("coord_sys must be a CoordSys3D")
     field = express(field, coord_sys, variables=True)


### PR DESCRIPTION
Found via `codespell -q 3 -I ../sympy-whitelist.txt`where wiltelist contains:
```
ang
ans
cas
dum
german
iff
ith
lightyear
lightyears
nd
numer
numers
ot
sinc
```
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
