### PR TITLE
fix intersect_parallel_ray_and_segment method

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -458,7 +458,7 @@ class LinearEntity(GeometrySet):
                 return [seg]
             elif st1 >= 0: # st2 < 0:
                 return [Segment(ray.p1, seg.p1)]
-            elif st2 > 0: # st1 <= 0
+            elif st2 >= 0: # st1 < 0:
                 return [Segment(ray.p1, seg.p2)]
 
         def intersect_parallel_segments(seg1, seg2):

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -506,6 +506,7 @@ def test_intersection_2d():
     assert Ray((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == [Point(1, 1)]
     assert Ray((0, 0), (10, 10)).contains(Segment((1, 1), (2, 2))) is True
     assert Segment((1, 1), (2, 2)) in Line((0, 0), (10, 10))
+    assert s1.intersection(Ray((1, 1), (4, 4))) == [Point(1, 1)]
 
     # 16628 - this should be fast
     p0 = Point2D(S(249)/5, S(497999)/10000)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Hello. I find one bug: intersection between Segment((0,0), (1,1)) and Ray((1,1), (4,4)) return nothing.
`
s = Segment((0,0), (1,1))
`
`
s.intersection(Ray((1,1), (4,4)))
`
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I fixed [one condition](https://github.com/sympy/sympy/blob/master/sympy/geometry/line.py#L461) in intersect_parallel_ray_and_segment method 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Fixed a bug with intersection segment and ray.
<!-- END RELEASE NOTES -->
