### PR TITLE
use doit in simplify by default

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -316,9 +316,10 @@ class Product(ExprWithIntLimits):
             else:
                 return f
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.simplify import product_simplify
-        return product_simplify(self)
+        rv = product_simplify(self)
+        return rv.doit() if kwargs['doit'] else rv
 
     def _eval_transpose(self):
         if self.is_commutative:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -271,7 +271,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         return Sum(f, (k, upper + 1, new_upper)).doit()
 
-    def _eval_simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.simplify import factor_sum, sum_combine
         from sympy.core.function import expand
         from sympy.core.mul import Mul

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -260,22 +260,23 @@ def test_conjugate_transpose():
     assert p.transpose().doit() == p.doit().transpose()
 
 
-def test_simplify():
+def test_simplify_prod():
     y, t, b, c = symbols('y, t, b, c', integer = True)
 
-    assert simplify(Product(x*y, (x, n, m), (y, a, k)) * \
+    _simplify = lambda e: simplify(e, doit=False)
+    assert _simplify(Product(x*y, (x, n, m), (y, a, k)) * \
         Product(y, (x, n, m), (y, a, k))) == \
             Product(x*y**2, (x, n, m), (y, a, k))
-    assert simplify(3 * y* Product(x, (x, n, m)) * Product(x, (x, m + 1, a))) \
+    assert _simplify(3 * y* Product(x, (x, n, m)) * Product(x, (x, m + 1, a))) \
         == 3 * y * Product(x, (x, n, a))
-    assert simplify(Product(x, (x, k + 1, a)) * Product(x, (x, n, k))) == \
+    assert _simplify(Product(x, (x, k + 1, a)) * Product(x, (x, n, k))) == \
         Product(x, (x, n, a))
-    assert simplify(Product(x, (x, k + 1, a)) * Product(x + 1, (x, n, k))) == \
+    assert _simplify(Product(x, (x, k + 1, a)) * Product(x + 1, (x, n, k))) == \
         Product(x, (x, k + 1, a)) * Product(x + 1, (x, n, k))
-    assert simplify(Product(x, (t, a, b)) * Product(y, (t, a, b)) * \
+    assert _simplify(Product(x, (t, a, b)) * Product(y, (t, a, b)) * \
         Product(x, (t, b+1, c))) == Product(x*y, (t, a, b)) * \
             Product(x, (t, b+1, c))
-    assert simplify(Product(x, (t, a, b)) * Product(x, (t, b+1, c)) * \
+    assert _simplify(Product(x, (t, a, b)) * Product(x, (t, b+1, c)) * \
         Product(y, (t, a, b))) == Product(x*y, (t, a, b)) * \
             Product(x, (t, b+1, c))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -739,53 +739,54 @@ def test_issue_6274():
     assert NS(Sum(n, (n, 10, 5))) == '-30.0000000000000'
 
 
-def test_simplify():
+def test_simplify_sum():
     y, t, v = symbols('y, t, v')
 
-    assert simplify(Sum(x*y, (x, n, m), (y, a, k)) + \
+    _simplify = lambda e: simplify(e, doit=False)
+    assert _simplify(Sum(x*y, (x, n, m), (y, a, k)) + \
         Sum(y, (x, n, m), (y, a, k))) == Sum(y * (x + 1), (x, n, m), (y, a, k))
-    assert simplify(Sum(x, (x, n, m)) + Sum(x, (x, m + 1, a))) == \
+    assert _simplify(Sum(x, (x, n, m)) + Sum(x, (x, m + 1, a))) == \
         Sum(x, (x, n, a))
-    assert simplify(Sum(x, (x, k + 1, a)) + Sum(x, (x, n, k))) == \
+    assert _simplify(Sum(x, (x, k + 1, a)) + Sum(x, (x, n, k))) == \
         Sum(x, (x, n, a))
-    assert simplify(Sum(x, (x, k + 1, a)) + Sum(x + 1, (x, n, k))) == \
+    assert _simplify(Sum(x, (x, k + 1, a)) + Sum(x + 1, (x, n, k))) == \
         Sum(x, (x, n, a)) + Sum(1, (x, n, k))
-    assert simplify(Sum(x, (x, 0, 3)) * 3 + 3 * Sum(x, (x, 4, 6)) + \
+    assert _simplify(Sum(x, (x, 0, 3)) * 3 + 3 * Sum(x, (x, 4, 6)) + \
         4 * Sum(z, (z, 0, 1))) == 4*Sum(z, (z, 0, 1)) + 3*Sum(x, (x, 0, 6))
-    assert simplify(3*Sum(x**2, (x, a, b)) + Sum(x, (x, a, b))) == \
+    assert _simplify(3*Sum(x**2, (x, a, b)) + Sum(x, (x, a, b))) == \
         Sum(x*(3*x + 1), (x, a, b))
-    assert simplify(Sum(x**3, (x, n, k)) * 3 + 3 * Sum(x, (x, n, k)) + \
+    assert _simplify(Sum(x**3, (x, n, k)) * 3 + 3 * Sum(x, (x, n, k)) + \
         4 * y * Sum(z, (z, n, k))) + 1 == \
             4*y*Sum(z, (z, n, k)) + 3*Sum(x**3 + x, (x, n, k)) + 1
-    assert simplify(Sum(x, (x, a, b)) + 1 + Sum(x, (x, b + 1, c))) == \
+    assert _simplify(Sum(x, (x, a, b)) + 1 + Sum(x, (x, b + 1, c))) == \
         1 + Sum(x, (x, a, c))
-    assert simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + \
+    assert _simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + \
         Sum(x, (t, b+1, c))) == x * Sum(1, (t, a, c)) + y * Sum(1, (t, a, b))
-    assert simplify(Sum(x, (t, a, b)) + Sum(x, (t, b+1, c)) + \
+    assert _simplify(Sum(x, (t, a, b)) + Sum(x, (t, b+1, c)) + \
         Sum(y, (t, a, b))) == x * Sum(1, (t, a, c)) + y * Sum(1, (t, a, b))
-    assert simplify(Sum(x, (t, a, b)) + 2 * Sum(x, (t, b+1, c))) == \
-        simplify(Sum(x, (t, a, b)) + Sum(x, (t, b+1, c)) + Sum(x, (t, b+1, c)))
-    assert simplify(Sum(x, (x, a, b))*Sum(x**2, (x, a, b))) == \
+    assert _simplify(Sum(x, (t, a, b)) + 2 * Sum(x, (t, b+1, c))) == \
+        _simplify(Sum(x, (t, a, b)) + Sum(x, (t, b+1, c)) + Sum(x, (t, b+1, c)))
+    assert _simplify(Sum(x, (x, a, b))*Sum(x**2, (x, a, b))) == \
         Sum(x, (x, a, b)) * Sum(x**2, (x, a, b))
-    assert simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + Sum(z, (t, a, b))) \
+    assert _simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + Sum(z, (t, a, b))) \
         == (x + y + z) * Sum(1, (t, a, b))          # issue 8596
-    assert simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + Sum(z, (t, a, b)) + \
+    assert _simplify(Sum(x, (t, a, b)) + Sum(y, (t, a, b)) + Sum(z, (t, a, b)) + \
         Sum(v, (t, a, b))) == (x + y + z + v) * Sum(1, (t, a, b))  # issue 8596
-    assert simplify(Sum(x * y, (x, a, b)) / (3 * y)) == \
+    assert _simplify(Sum(x * y, (x, a, b)) / (3 * y)) == \
         (Sum(x, (x, a, b)) / 3)
-    assert simplify(Sum(Function('f')(x) * y * z, (x, a, b)) / (y * z)) \
+    assert _simplify(Sum(Function('f')(x) * y * z, (x, a, b)) / (y * z)) \
         == Sum(Function('f')(x), (x, a, b))
-    assert simplify(Sum(c * x, (x, a, b)) - c * Sum(x, (x, a, b))) == 0
-    assert simplify(c * (Sum(x, (x, a, b))  + y)) == c * (y + Sum(x, (x, a, b)))
-    assert simplify(c * (Sum(x, (x, a, b)) + y * Sum(x, (x, a, b)))) == \
+    assert _simplify(Sum(c * x, (x, a, b)) - c * Sum(x, (x, a, b))) == 0
+    assert _simplify(c * (Sum(x, (x, a, b))  + y)) == c * (y + Sum(x, (x, a, b)))
+    assert _simplify(c * (Sum(x, (x, a, b)) + y * Sum(x, (x, a, b)))) == \
         c * (y + 1) * Sum(x, (x, a, b))
-    assert simplify(Sum(Sum(c * x, (x, a, b)), (y, a, b))) == \
+    assert _simplify(Sum(Sum(c * x, (x, a, b)), (y, a, b))) == \
                 c * Sum(x, (x, a, b), (y, a, b))
-    assert simplify(Sum((3 + y) * Sum(c * x, (x, a, b)), (y, a, b))) == \
+    assert _simplify(Sum((3 + y) * Sum(c * x, (x, a, b)), (y, a, b))) == \
                 c * Sum((3 + y), (y, a, b)) * Sum(x, (x, a, b))
-    assert simplify(Sum((3 + t) * Sum(c * t, (x, a, b)), (y, a, b))) == \
+    assert _simplify(Sum((3 + t) * Sum(c * t, (x, a, b)), (y, a, b))) == \
                 c*t*(t + 3)*Sum(1, (x, a, b))*Sum(1, (y, a, b))
-    assert simplify(Sum(Sum(d * t, (x, a, b - 1)) + \
+    assert _simplify(Sum(Sum(d * t, (x, a, b - 1)) + \
                 Sum(d * t, (x, b, c)), (t, a, b))) == \
                     d * Sum(1, (x, a, c)) * Sum(t, (t, a, b))
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1866,7 +1866,7 @@ class Atom(Basic):
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         return self
 
     @property

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3384,12 +3384,10 @@ class Expr(Basic, EvalfMixin):
         from sympy.integrals import integrate
         return integrate(self, *args, **kwargs)
 
-    def simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
+    def simplify(self, **kwargs):
         """See the simplify function in sympy.simplify"""
         from sympy.simplify import simplify
-        from sympy.core.function import count_ops
-        measure = measure or count_ops
-        return simplify(self, ratio, measure)
+        return simplify(self, **kwargs)
 
     def nsimplify(self, constants=[], tolerance=None, full=False):
         """See the nsimplify function in sympy.simplify"""

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2542,9 +2542,9 @@ class AlgebraicNumber(Expr):
 
         return AlgebraicNumber((minpoly, root), self.coeffs())
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.polys import CRootOf, minpoly
-
+        measure, ratio = kwargs['measure'], kwargs['ratio']
         for r in [r for r in self.minpoly.all_roots() if r.func != CRootOf]:
             if minpoly(self.root - r).is_Symbol:
                 # use the matching root if it's simpler

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -279,11 +279,9 @@ class Relational(Boolean, Expr, EvalfMixin):
                     return right
                 return left
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         r = self
-        r = r.func(*[i.simplify(ratio=ratio, measure=measure,
-                                rational=rational, inverse=inverse)
-                     for i in r.args])
+        r = r.func(*[i.simplify(**kwargs) for i in r.args])
         if r.is_Relational:
             dif = r.lhs - r.rhs
             # replace dif with a valid Number that will
@@ -297,7 +295,8 @@ class Relational(Boolean, Expr, EvalfMixin):
                 r = r.func._eval_relation(v, S.Zero)
 
         r = r.canonical
-        if measure(r) < ratio*measure(self):
+        measure = kwargs['measure']
+        if measure(r) < kwargs['ratio']*measure(self):
             return r
         else:
             return self
@@ -525,11 +524,10 @@ class Equality(Relational):
                 return set([self.rhs])
         return set()
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.solvers.solveset import linear_coeffs
         # standard simplify
-        e = super(Equality, self)._eval_simplify(
-            ratio, measure, rational, inverse)
+        e = super(Equality, self)._eval_simplify(**kwargs)
         if not isinstance(e, Equality):
             return e
         free = self.free_symbols
@@ -542,7 +540,8 @@ class Equality(Relational):
                     enew = e.func(x, -b/m)
                 else:
                     enew = e.func(m*x, -b)
-                if measure(enew) <= ratio*measure(e):
+                measure = kwargs['measure']
+                if measure(enew) <= kwargs['ratio']*measure(e):
                     e = enew
             except ValueError:
                 pass
@@ -612,10 +611,9 @@ class Unequality(Relational):
                 return set([self.rhs])
         return set()
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         # simplify as an equality
-        eq = Equality(*self.args)._eval_simplify(
-            ratio, measure, rational, inverse)
+        eq = Equality(*self.args)._eval_simplify(**kwargs)
         if isinstance(eq, Equality):
             # send back Ne with the new args
             return self.func(*eq.args)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -16,12 +16,13 @@ from math import sqrt as _sqrt
 class CombinatorialFunction(Function):
     """Base class for combinatorial functions. """
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.combsimp import combsimp
         # combinatorial function with non-integer arguments is
         # automatically passed to gammasimp
         expr = combsimp(self)
-        if measure(expr) <= ratio*measure(self):
+        measure = kwargs['measure']
+        if measure(expr) <= kwargs['ratio']*measure(self):
             return expr
         return self
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -392,10 +392,10 @@ class sign(Function):
     def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         from sympy.functions.special.delta_functions import Heaviside
         if arg.is_extended_real:
-            return Heaviside(arg)*2-1
+            return Heaviside(arg)*2 - 1
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        return self.func(self.args[0].factor())
+    def _eval_simplify(self, **kwargs):
+        return self.func(self.args[0].factor())  # XXX include doit?
 
 
 class Abs(Function):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -661,17 +661,16 @@ class log(Function):
 
         return self.func(arg)
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.simplify import expand_log, simplify, inversecombine
-        if (len(self.args) == 2):
-            return simplify(self.func(*self.args), ratio=ratio, measure=measure,
-                            rational=rational, inverse=inverse)
-        expr = self.func(simplify(self.args[0], ratio=ratio, measure=measure,
-                         rational=rational, inverse=inverse))
-        if inverse:
+        if len(self.args) == 2:  # it's unevaluated
+            return simplify(self.func(*self.args), **kwargs)
+
+        expr = self.func(simplify(self.args[0], **kwargs))
+        if kwargs['inverse']:
             expr = inversecombine(expr)
         expr = expand_log(expr, deep=True)
-        return min([expr, self], key=measure)
+        return min([expr, self], key=kwargs['measure'])
 
     def as_real_imag(self, deep=True, **hints):
         """

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -57,12 +57,8 @@ class ExprCondPair(Tuple):
         yield self.expr
         yield self.cond
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        return self.func(*[a.simplify(
-            ratio=ratio,
-            measure=measure,
-            rational=rational,
-            inverse=inverse) for a in self.args])
+    def _eval_simplify(self, **kwargs):
+        return self.func(*[a.simplify(**kwargs) for a in self.args])
 
 class Piecewise(Function):
     """
@@ -321,9 +317,9 @@ class Piecewise(Function):
             newargs.append((e, c))
         return self.func(*newargs)
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        args = [a._eval_simplify(ratio, measure, rational, inverse)
-            for a in self.args]
+    def _eval_simplify(self, **kwargs):
+        from sympy.simplify.simplify import simplify
+        args = [simplify(a, **kwargs) for a in self.args]
         _blessed = lambda e: getattr(e.lhs, '_diff_wrt', False) and (
             getattr(e.rhs, '_diff_wrt', None) or
             isinstance(e.rhs, (Rational, NumberSymbol)))

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -486,7 +486,7 @@ def test_log_product():
     x, y = symbols('x,y', positive=True)
     from sympy.concrete import Product, Sum
     f, g = Function('f'), Function('g')
-    assert simplify(log(Product(x**i, (i, 1, n)))) == Sum(i*log(x), (i, 1, n))
+    assert simplify(log(Product(x**i, (i, 1, n)))) == log(Product(x**i, (i, 1, n)))
     assert simplify(log(Product(x**i*y**j, (i, 1, n), (j, 1, m)))) == \
             log(Product(x**i*y**j, (i, 1, n), (j, 1, m)))
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -79,7 +79,7 @@ class BesselBase(Function):
                         self._a*self._b*f(nu + 2, z)._eval_expand_func())
         return self
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.simplify import besselsimp
         return besselsimp(self)
 

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -211,7 +211,7 @@ class DiracDelta(Function):
                 return cls(-arg, k) if k else cls(-arg)
 
     @deprecated(useinstead="expand(diracdelta=True, wrt=x)", issue=12859, deprecated_since_version="1.1")
-    def simplify(self, x):
+    def simplify(self, x, **kwargs):
         return self.expand(diracdelta=True, wrt=x)
 
     def _eval_expand_diracdelta(self, **hints):

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -302,7 +302,7 @@ class hyper(TupleParametersBase):
         c3 = And(re(e) >= 1, abs(z) < 1)
         return Or(c1, c2, c3)
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
+    def _eval_simplify(self, **kwargs):
         from sympy.simplify.hyperexpand import hyperexpand
         return hyperexpand(self)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1133,12 +1133,11 @@ class Integral(AddWithLimits):
                 break
         return integrate(leading_term, *self.args[1:])
 
-    def _eval_simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
+    def _eval_simplify(self, **kwargs):
         from sympy.core.exprtools import factor_terms
         from sympy.simplify.simplify import simplify
 
         expr = factor_terms(self)
-        kwargs = dict(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
         if isinstance(expr, Integral):
             return expr.func(*[simplify(i, **kwargs) for i in expr.args])
         return expr.simplify(**kwargs)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1946,7 +1946,7 @@ class MatrixOperations(MatrixRequired):
         """
         return self.applyfunc(lambda x: x.replace(F, G, map))
 
-    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+    def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.
 
         Examples
@@ -1960,8 +1960,7 @@ class MatrixOperations(MatrixRequired):
         >>> _.simplify()
         Matrix([[x]])
         """
-        return self.applyfunc(lambda x: x.simplify(ratio=ratio, measure=measure,
-                                                   rational=rational, inverse=inverse))
+        return self.applyfunc(lambda x: x.simplify(**kwargs))
 
     def subs(self, *args, **kwargs):  # should mirror core.basic.subs
         """Return a new matrix with subs applied to each entry.

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -755,7 +755,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         for k in range(0, self.cols):
             self[i, k], self[j, k] = self[j, k], self[i, k]
 
-    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+    def simplify(self, **kwargs):
         """Applies simplify to the elements of a matrix in place.
 
         This is a shortcut for M.applyfunc(lambda x: simplify(x, ratio, measure))
@@ -766,8 +766,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         sympy.simplify.simplify.simplify
         """
         for i in range(len(self._mat)):
-            self._mat[i] = _simplify(self._mat[i], ratio=ratio, measure=measure,
-                                     rational=rational, inverse=inverse)
+            self._mat[i] = _simplify(self._mat[i], **kwargs)
 
     def zip_row_op(self, i, k, f):
         """In-place operation on row ``i`` using two-arg functor whose args are

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -222,13 +222,13 @@ def test_zero_matmul():
 def test_matadd_simplify():
     A = MatrixSymbol('A', 1, 1)
     assert simplify(MatAdd(A, ImmutableMatrix([[sin(x)**2 + cos(x)**2]]))) == \
-        MatAdd(A, ImmutableMatrix([[1]]))
+        MatAdd(A, Matrix([[1]]))
 
 
 def test_matmul_simplify():
     A = MatrixSymbol('A', 1, 1)
     assert simplify(MatMul(A, ImmutableMatrix([[sin(x)**2 + cos(x)**2]]))) == \
-        MatMul(A, ImmutableMatrix([[1]]))
+        MatMul(A, Matrix([[1]]))
 
 
 def test_invariants():

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -377,7 +377,7 @@ def signsimp(expr, evaluate=None):
     return e
 
 
-def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, doit=True):
     """Simplifies the given expression.
 
     Simplification is not a well defined term and the exact strategies
@@ -509,6 +509,10 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     For example, ``asin(sin(x))`` will yield ``x`` without checking whether
     x belongs to the set where this relation is true. The default is
     False.
+
+    Note that ``simplify()`` automatically calls ``doit()`` on the final
+    expression. You can avoid this behavior by passing ``doit=False`` as
+    an argument.
     """
 
     expr = sympify(expr)
@@ -521,7 +525,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
 
     _eval_simplify = getattr(expr, '_eval_simplify', None)
     if _eval_simplify is not None:
-        return _eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
+        return _eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse, doit=doit)
 
     original_expr = expr = signsimp(expr)
 
@@ -645,7 +649,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     if floats and rational is None:
         expr = nfloat(expr, exponent=False)
 
-    return expr
+    return expr if not doit else expr.doit()
 
 
 def sum_simplify(s, **kwargs):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -805,10 +805,11 @@ def test_issue_15965():
     A = Sum(z*x**y, (x, 1, a))
     anew = z*Sum(x**y, (x, 1, a))
     B = Integral(x*y, x)
-    bnew = y*Integral(x, x)
-    assert simplify(A + B) == anew + bnew
+    bdo = x**2*y/2
+    assert simplify(A + B) == anew + bdo
     assert simplify(A) == anew
-    assert simplify(B) == bnew
+    assert simplify(B) == bdo
+    assert simplify(B, doit=False) == y*Integral(x, x)
 
 
 def test_issue_17137():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -623,7 +623,7 @@ def test_Piecewise():
 def test_polymorphism():
     class A(Basic):
         def _eval_simplify(x, **kwargs):
-            return 1
+            return S.One
 
     a = A(5, 2)
     assert simplify(a) == 1

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -5550,7 +5550,6 @@ def _solve_variation_of_parameters(eq, func, order, match):
     if r.get('simplify', True):
         wr = simplify(wr)  # We need much better simplification for
                            # some ODEs. See issue 4662, for example.
-
         # To reduce commonly occurring sin(x)**2 + cos(x)**2 to 1
         wr = trigsimp(wr, deep=True, recursive=True)
     if not wr:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2285,10 +2285,15 @@ def test_nth_linear_constant_coeff_variation_of_parameters_simplify_False():
     sol_simp = dsolve(eq, f(x), hint=our_hint, simplify=True)
     sol_nsimp = dsolve(eq, f(x), hint=our_hint, simplify=False)
     assert sol_simp != sol_nsimp
+    # /----------
     # eq.subs(*sol_simp.args) doesn't simplify to zero without help
     zero = checkodesol(eq, sol_simp, order=5, solve_for_func=False)[1]
-    assert zero.rewrite(exp).simplify() == 0
+    # if this fails because zero.is_zero, replace this block with
+    # assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
+    assert not zero.is_zero and zero.rewrite(exp).simplify() == 0
+    # \-----------
     assert checkodesol(eq, sol_nsimp, order=5, solve_for_func=False)[0]
+
 
 def test_Liouville_ODE():
     hint = 'Liouville'

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2235,8 +2235,8 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     sol8 = Eq(f(x), C1*exp(x) + C2*exp(2*x) + (6*x + 5)*exp(-x)/36)
     sol9 = Eq(f(x), (C1 + C2*x + C3*x**2 + x**3/6)*exp(x))
     sol10 = Eq(f(x), (C1 + x*(C2 + log(x)))*exp(-x))
-    sol11 = Eq(f(x), cos(x)*(C2 - Integral(1/cos(x), x)) + sin(x)*(C1 +
-        Integral(1/sin(x), x)))
+    sol11 = Eq(f(x), (C1 + log(sin(x) - 1)/2 - log(sin(x) + 1)/2
+        )*cos(x) + (C2 + log(cos(x) - 1)/2 - log(cos(x) + 1)/2)*sin(x))
     sol12 = Eq(f(x), C1 + C2*x + x**3*(C3 + log(x)/6) + C4*x**2)
     sol1s = constant_renumber(sol1)
     sol2s = constant_renumber(sol2)
@@ -2285,7 +2285,9 @@ def test_nth_linear_constant_coeff_variation_of_parameters_simplify_False():
     sol_simp = dsolve(eq, f(x), hint=our_hint, simplify=True)
     sol_nsimp = dsolve(eq, f(x), hint=our_hint, simplify=False)
     assert sol_simp != sol_nsimp
-    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
+    # eq.subs(*sol_simp.args) doesn't simplify to zero without help
+    zero = checkodesol(eq, sol_simp, order=5, solve_for_func=False)[1]
+    assert zero.rewrite(exp).simplify() == 0
     assert checkodesol(eq, sol_nsimp, order=5, solve_for_func=False)[0]
 
 def test_Liouville_ODE():

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -72,7 +72,7 @@ class BasisDependent(Expr):
 
     n = evalf
 
-    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+    def simplify(self, **kwargs):
         """
         Implements the SymPy simplify routine for this quantity.
 
@@ -80,8 +80,7 @@ class BasisDependent(Expr):
         ========================
 
         """
-        simp_components = [simp(v, ratio=ratio, measure=measure,
-                           rational=rational, inverse=inverse) * k for
+        simp_components = [simp(v, **kwargs) * k for
                            k, v in self.components.items()]
         return self._add_func(*simp_components)
 
@@ -101,8 +100,8 @@ class BasisDependent(Expr):
 
     trigsimp.__doc__ += tsimp.__doc__
 
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        return self.simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
+    def _eval_simplify(self, **kwargs):
+        return self.simplify(**kwargs)
 
     def _eval_trigsimp(self, **opts):
         return self.trigsimp(**opts)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

modified to close #9329
Closes #6399
Closes #2936

#### Brief description of what is fixed or changed

`doit` is called automatically in `simplify` by default

#### Other comments

An audit of `simplify` methods has not been done but it was noticed that some routines call `_eval_simplify` from within `_eval_simplify` which is a bad idea unless one knows that all objects being simplified actually have that method. It is better to call `simplify(arg)`.

It might be better to drop the `_eval_simplify` methods and just use `simplify` for simplification routines for a given type of object. Or else give a `_eval_simplify` stub to all Basic that just returns self.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
    - `simplify` will now apply doit to an expression by default; this can be disabled by passing `doit=False`
<!-- END RELEASE NOTES -->
