### PR TITLE
Update RisingFactorial eval for k noninteger, x negative integer

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -577,10 +577,10 @@ class RisingFactorial(CombinatorialFunction):
                             return 1/reduce(lambda r, i:
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
-        else:
-            if k.is_integer == False:
-                if x.is_integer and x.is_negative:
-                    return S.Zero
+
+        if k.is_integer == False:
+            if x.is_integer and x.is_negative:
+                return S.Zero
 
     def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -577,6 +577,9 @@ class RisingFactorial(CombinatorialFunction):
                             return 1/reduce(lambda r, i:
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
+        else:
+            if x.is_integer and x.is_negative:
+                return S.Zero
 
     def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -578,8 +578,9 @@ class RisingFactorial(CombinatorialFunction):
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
         else:
-            if x.is_integer and x.is_negative:
-                return S.Zero
+            if k.is_number:
+                if x.is_integer and x.is_negative:
+                    return S.Zero
 
     def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -578,7 +578,7 @@ class RisingFactorial(CombinatorialFunction):
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
         else:
-            if k.is_number:
+            if k.is_integer == False:
                 if x.is_integer and x.is_negative:
                     return S.Zero
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -32,6 +32,7 @@ def test_rf_eval_apply():
 
     assert rf(-1, pi) == 0
     assert rf(-5, 1 + I) == 0
+    assert unchanged(rf, -3, x)
 
     assert rf(x, 0) == 1
     assert rf(x, 1) == x

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -32,7 +32,11 @@ def test_rf_eval_apply():
 
     assert rf(-1, pi) == 0
     assert rf(-5, 1 + I) == 0
-    assert unchanged(rf, -3, x)
+
+    assert unchanged(rf, -3, k)
+    assert unchanged(rf, x, Symbol('k', integer=False))
+    assert rf(-3, Symbol('k', integer=False)) == 0
+    assert rf(Symbol('x', negative=True, integer=True), Symbol('k', integer=False)) == 0
 
     assert rf(x, 0) == 1
     assert rf(x, 1) == x

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,7 +1,7 @@
 from sympy import (S, Symbol, symbols, factorial, factorial2, Float, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise,
-                   Mod, Eq, sqrt, Poly, Dummy)
+                   Mod, Eq, sqrt, Poly, Dummy, I)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.functions.combinatorial.factorials import subfactorial
@@ -29,6 +29,9 @@ def test_rf_eval_apply():
 
     assert rf(oo, -6) == oo
     assert rf(-oo, -7) == oo
+
+    assert rf(-1, pi) == 0
+    assert rf(-5, 1 + I) == 0
 
     assert rf(x, 0) == 1
     assert rf(x, 1) == x


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #17166.

#### Brief description of what is fixed or changed
`RisingFactorial(x, k)` where `k` is noninteger, `x` is negative integer returns `0`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * RisingFactorial(x, k) where k is a noninteger, x is a negative integer automatically evaluates to 0.
<!-- END RELEASE NOTES -->
