### PR TITLE
 _finger detects diff btwn 3-arg Xor/~Xor

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2385,7 +2385,7 @@ def _finger(eq):
     ========
 
     >>> from sympy.logic.boolalg import _finger as finger
-    >>> from sympy import And, Or, Not, to_cnf, symbols
+    >>> from sympy import And, Or, Not, Xor, to_cnf, symbols
     >>> from sympy.abc import a, b, x, y
     >>> eq = Or(And(Not(y), a), And(Not(y), b), And(x, y))
     >>> dict(finger(eq))

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2433,7 +2433,7 @@ def _finger(eq):
                     raise NotImplementedError('unexpected level of nesting')
     inv = defaultdict(list)
     for k, v in ordered(iter(d.items())):
-        v[-1] = tuple(sorted([k + (va,) for k, va in v[-1].items()]))
+        v[-1] = tuple(sorted([i + (j,) for i, j in v[-1].items()]))
         inv[tuple(v)].append(k)
     return inv
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2371,13 +2371,13 @@ def _finger(eq):
     """
     Assign a 5-item fingerprint to each symbol in the equation:
     [
-    # of times it appeared as a Symbol,
-    # of times it appeared as a Not(symbol),
-    # of times it appeared as a Symbol in an And or Or,
-    # of times it appeared as a Not(Symbol) in an And or Or,
-    sum of the number of arguments with which it appeared
-    as a Symbol, counting Symbol as 1 and Not(Symbol) as 2
-    and counting self as 1
+    # of times it appeared as a Symbol;
+    # of times it appeared as a Not(symbol);
+    # of times it appeared as a Symbol in an And or Or;
+    # of times it appeared as a Not(Symbol) in an And or Or;
+    a sorted list of tuples (i, j) where i is the number of arguments
+    in an And or Or with which it appeared as a Symbol, and j is
+    the number of arguments that were Not(Symbol)
     ]
 
     Examples
@@ -2388,14 +2388,16 @@ def _finger(eq):
     >>> from sympy.abc import a, b, x, y
     >>> eq = Or(And(Not(y), a), And(Not(y), b), And(x, y))
     >>> dict(finger(eq))
-    {(0, 0, 1, 0, 2): [x], (0, 0, 1, 0, 3): [a, b], (0, 0, 1, 2, 2): [y]}
+    {(0, 0, 1, 0, ((2, 0),)): [x],
+    (0, 0, 1, 0, ((2, 1),)): [a, b],
+    (0, 0, 1, 2, ((2, 0),)): [y]}
     >>> dict(finger(x & ~y))
-    {(0, 1, 0, 0, 0): [y], (1, 0, 0, 0, 0): [x]}
+    {(0, 1, 0, 0, ()): [y], (1, 0, 0, 0, ()): [x]}
 
     The equation must not have more than one level of nesting:
 
     >>> dict(finger(And(Or(x, y), y)))
-    {(0, 0, 1, 0, 2): [x], (1, 0, 1, 0, 2): [y]}
+    {(0, 0, 1, 0, ((2, 0),)): [x], (1, 0, 1, 0, ((2, 0),)): [y]}
     >>> dict(finger(And(Or(x, And(a, x)), y)))
     Traceback (most recent call last):
     ...
@@ -2404,24 +2406,25 @@ def _finger(eq):
     So y and x have unique fingerprints, but a and b do not.
     """
     f = eq.free_symbols
-    d = dict(list(zip(f, [[0] * 5 for fi in f])))
+    d = dict(list(zip(f, [[0]*4 + [[]] for fi in f])))
     for a in eq.args:
         if a.is_Symbol:
             d[a][0] += 1
         elif a.is_Not:
             d[a.args[0]][1] += 1
         else:
-            o = len(a.args) + sum(isinstance(ai, Not) for ai in a.args)
+            o = len(a.args), sum(isinstance(ai, Not) for ai in a.args)
             for ai in a.args:
                 if ai.is_Symbol:
                     d[ai][2] += 1
-                    d[ai][-1] += o
+                    d[ai][-1].append(o)
                 elif ai.is_Not:
                     d[ai.args[0]][3] += 1
                 else:
                     raise NotImplementedError('unexpected level of nesting')
     inv = defaultdict(list)
     for k, v in ordered(iter(d.items())):
+        v[-1] = tuple(sorted(v[-1]))
         inv[tuple(v)].append(k)
     return inv
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2375,29 +2375,38 @@ def _finger(eq):
     # of times it appeared as a Not(symbol);
     # of times it appeared as a Symbol in an And or Or;
     # of times it appeared as a Not(Symbol) in an And or Or;
-    a sorted list of tuples (i, j) where i is the number of arguments
+    a sorted tuple of tuples, (i, j, k), where i is the number of arguments
     in an And or Or with which it appeared as a Symbol, and j is
-    the number of arguments that were Not(Symbol)
+    the number of arguments that were Not(Symbol); k is the number
+    of times that (i, j) was seen.
     ]
 
     Examples
     ========
 
     >>> from sympy.logic.boolalg import _finger as finger
-    >>> from sympy import And, Or, Not
+    >>> from sympy import And, Or, Not, to_cnf, symbols
     >>> from sympy.abc import a, b, x, y
     >>> eq = Or(And(Not(y), a), And(Not(y), b), And(x, y))
     >>> dict(finger(eq))
-    {(0, 0, 1, 0, ((2, 0),)): [x],
-    (0, 0, 1, 0, ((2, 1),)): [a, b],
-    (0, 0, 1, 2, ((2, 0),)): [y]}
+    {(0, 0, 1, 0, ((2, 0, 1),)): [x],
+    (0, 0, 1, 0, ((2, 1, 1),)): [a, b],
+    (0, 0, 1, 2, ((2, 0, 1),)): [y]}
     >>> dict(finger(x & ~y))
     {(0, 1, 0, 0, ()): [y], (1, 0, 0, 0, ()): [x]}
+
+    In the following, the (5, 2, 6) means that there were 6 Or
+    functions in which a symbol appeared as itself amongst 5 arguments in
+    which there were also 2 negated symbols, e.g. ``(a0 | a1 | a2 | ~a3 | ~a4)``
+    is counted once for a0, a1 and a2.
+
+    >>> dict(finger(to_cnf(Xor(*symbols('a:5')))))
+    {(0, 0, 8, 8, ((5, 0, 1), (5, 2, 6), (5, 4, 1))): [a0, a1, a2, a3, a4]}
 
     The equation must not have more than one level of nesting:
 
     >>> dict(finger(And(Or(x, y), y)))
-    {(0, 0, 1, 0, ((2, 0),)): [x], (1, 0, 1, 0, ((2, 0),)): [y]}
+    {(0, 0, 1, 0, ((2, 0, 1),)): [x], (1, 0, 1, 0, ((2, 0, 1),)): [y]}
     >>> dict(finger(And(Or(x, And(a, x)), y)))
     Traceback (most recent call last):
     ...
@@ -2406,7 +2415,7 @@ def _finger(eq):
     So y and x have unique fingerprints, but a and b do not.
     """
     f = eq.free_symbols
-    d = dict(list(zip(f, [[0]*4 + [[]] for fi in f])))
+    d = dict(list(zip(f, [[0]*4 + [defaultdict(int)] for fi in f])))
     for a in eq.args:
         if a.is_Symbol:
             d[a][0] += 1
@@ -2417,14 +2426,14 @@ def _finger(eq):
             for ai in a.args:
                 if ai.is_Symbol:
                     d[ai][2] += 1
-                    d[ai][-1].append(o)
+                    d[ai][-1][o] += 1
                 elif ai.is_Not:
                     d[ai.args[0]][3] += 1
                 else:
                     raise NotImplementedError('unexpected level of nesting')
     inv = defaultdict(list)
     for k, v in ordered(iter(d.items())):
-        v[-1] = tuple(sorted(v[-1]))
+        v[-1] = tuple(sorted([k + (va,) for k, va in v[-1].items()]))
         inv[tuple(v)].append(k)
     return inv
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -365,7 +365,7 @@ def test_bool_map():
     assert bool_map(Xor(x, y, z), ~Xor(x, y, z)) == False
     assert bool_map(Xor(a, x, y, z), ~Xor(a, x, y, z)) == False
 
-    
+
 def test_bool_symbol():
     """Test that mixing symbols with boolean values
     works as expected"""

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -361,7 +361,11 @@ def test_bool_map():
     assert bool_map(Xor(x, y), ~Xor(x, y)) == False
     assert bool_map(And(x, y), Or(x, y)) is None
     assert bool_map(And(x, y), And(x, y, z)) is None
+    # issue 16179
+    assert bool_map(Xor(x, y, z), ~Xor(x, y, z)) == False
+    assert bool_map(Xor(a, x, y, z), ~Xor(a, x, y, z)) == False
 
+    
 def test_bool_symbol():
     """Test that mixing symbols with boolean values
     works as expected"""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #17169

#### Brief description of what is fixed or changed

```python
>>> f1 = Xor(*var('b:3'))
>>> f2 = ~Xor(*var('b:3'))
>>> bool_map(f1, f2)
False  <-- instead of True
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- logic
    - `bool_map` detects different between `Xor(*a)` and `~Xor(*a)` when `len(a) > 2`
<!-- END RELEASE NOTES -->
