### PR TITLE
[WIP] Wildcards for matrix expressions

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2752,6 +2752,11 @@ def test_sympy__matrices__expressions__matexpr__GenericIdentity():
     from sympy.matrices.expressions.matexpr import GenericIdentity
     assert _test_args(GenericIdentity())
 
+
+def test_sympy__matrices__expressions__matexpr__MatrixWild():
+    from sympy.matrices.expressions.matexpr import MatrixWild
+    assert _test_args(MatrixWild('W', x, y))
+
 @SKIP("abstract class")
 def test_sympy__matrices__expressions__matexpr__MatrixExpr():
     pass

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1032,10 +1032,16 @@ class MatrixWild(MatrixSymbol, Wild):
         repl_dict = repl_dict.copy()
         # Make sure dimensions match
         for selfdim, exprdim in zip(self.shape, expr.shape):
-            matches = selfdim.matches(exprdim)
+            matches = selfdim.matches(exprdim, repl_dict)
             if matches is not None:
                 for match in matches:
-                    repl_dict[match] = matches[match]
+                    if (match in repl_dict and repl_dict[match]
+                            != matches[match]):
+                        # The dimension was matched before, but this new match
+                        # isn't the same
+                        return None
+                    else:
+                        repl_dict[match] = matches[match]
             elif selfdim != exprdim:
                 return None
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from functools import wraps, reduce
 import collections
 
-from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Eq, Mul, Add
+from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Eq, Mul, Add, Wild
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import range, SYMPY_INTS, default_sort_key, string_types
 from sympy.core.sympify import SympifyError, _sympify
@@ -1025,6 +1025,22 @@ class OneMatrix(MatrixExpr):
     def _entry(self, i, j, **kwargs):
         return S.One
 
+
+class MatrixWild(MatrixSymbol, Wild):
+
+    def matches(self, expr, repl_dict={}, old=False):
+        repl_dict = repl_dict.copy()
+        # Make sure dimensions match
+        for selfdim, exprdim in zip(self.shape, expr.shape):
+            matches = selfdim.matches(exprdim)
+            if matches is not None:
+                for match in matches:
+                    repl_dict[match] = matches[match]
+            elif selfdim != exprdim:
+                return None
+
+        repl_dict[self] = expr
+        return repl_dict
 
 def matrix_symbols(expr):
     return [sym for sym in expr.free_symbols if sym.is_Matrix]

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1029,6 +1029,8 @@ class OneMatrix(MatrixExpr):
 class MatrixWild(MatrixSymbol, Wild):
 
     def matches(self, expr, repl_dict={}, old=False):
+        if not isinstance(expr, MatrixExpr):
+            return None
         repl_dict = repl_dict.copy()
         # Make sure dimensions match
         for selfdim, exprdim in zip(self.shape, expr.shape):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -160,7 +160,11 @@ class MatMul(MatrixExpr, Mul):
         if repl_dict is None and c1 != c2:
             return None
 
-        # Now match the non-commutative arguments
+        # Now match the non-commutative arguments, expanding powers to
+        # multiplications
+        nc1 = MatMul._matches_expand_matpows(nc1)
+        nc2 = MatMul._matches_expand_matpows(nc2)
+
         repl_dict = MatMul._matches_noncomm(nc1, nc2, repl_dict)
 
         return repl_dict
@@ -227,6 +231,16 @@ class MatMul(MatrixExpr, Mul):
         terms = targets[begin:end + 1]
         mul = MatMul(*terms)
         return wildcard.matches(mul)
+
+    @staticmethod
+    def _matches_expand_matpows(arg_list):
+        new_args = []
+        for arg in arg_list:
+            if isinstance(arg, MatPow) and arg.exp > 0:
+                new_args.extend([arg.base] * arg.exp)
+            else:
+                new_args.append(arg)
+        return new_args
 
     def _eval_determinant(self):
         from sympy.matrices.expressions.determinant import Determinant

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -161,7 +161,6 @@ class MatMul(MatrixExpr, Mul):
             return None
 
         # Now match the non-commutative arguments
-        # TODO: Need a type check here
         repl_dict = MatMul._matches_noncomm(nc1, nc2, repl_dict)
 
         return repl_dict

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -167,7 +167,7 @@ class MatMul(MatrixExpr, Mul):
 
         repl_dict = MatMul._matches_noncomm(nc1, nc2, repl_dict)
 
-        return repl_dict
+        return repl_dict or None
 
     @staticmethod
     def _matches_noncomm(nodes, targets, repl_dict={}):
@@ -229,7 +229,7 @@ class MatMul(MatrixExpr, Mul):
     def _matches_match_wilds(dictionary, wildcard, targets):
         begin, end = dictionary[wildcard]
         terms = targets[begin:end + 1]
-        mul = MatMul(*terms)
+        mul = MatMul(*terms) if len(terms) > 1 else terms[0]
         return wildcard.matches(mul)
 
     @staticmethod

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -151,8 +151,8 @@ class MatMul(MatrixExpr, Mul):
         c2, nc2 = expr.args_cnc()
         c1, c2 = [c or [1] for c in [c1, c2]]
 
-        comm_mul_self = self.func(*c1)
-        comm_mul_expr = expr.func(*c1)
+        comm_mul_self = Mul(*c1)
+        comm_mul_expr = Mul(*c2)
         repl_dict = comm_mul_expr.matches(comm_mul_self, repl_dict, old)
 
         # If the commutative arguments didn't match and aren't equal, then

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -177,7 +177,13 @@ class MatMul(MatrixExpr, Mul):
         wildcard_dict = {}
         repl_dict = repl_dict.copy()
 
-        while node_ind < len(nodes) and target_ind < len(targets):
+        while target_ind < len(targets):
+            # Skip to the next state if the node index has advanced too far but
+            # the end of the targets hasn't been reached
+            if node_ind >= len(nodes):
+                state = agenda.pop()
+                node_ind, target_ind = state
+                continue
             node, target = nodes[node_ind], targets[target_ind]
 
             if isinstance(node, Wild):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -226,10 +226,15 @@ class MatMul(MatrixExpr, Mul):
             if match_attempt:
                 return [(node_ind, target_ind + 1),
                         (node_ind + 1, target_ind + 1)], match_attempt
-        elif node == target:
-            return [(node_ind + 1, target_ind + 1)], None
         else:
-            return None
+            match_attempt = node.matches(target)
+
+            if match_attempt:
+                return [(node_ind + 1, target_ind + 1)], match_attempt
+            elif node == target:
+                return [(node_ind + 1, target_ind + 1)], None
+            else:
+                return None
 
     @staticmethod
     def _matches_match_wilds(dictionary, wildcard, targets):

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -1,15 +1,16 @@
 from sympy import (KroneckerDelta, diff, Piecewise, Sum, Dummy, factor,
                    expand, zeros, gcd_terms, Eq, Symbol)
 
-from sympy.core import S, symbols, Add, Mul, SympifyError
+from sympy.core import S, symbols, Add, Mul, SympifyError, Wild
 from sympy.core.compatibility import long
 from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint)
-from sympy.matrices.expressions.matexpr import (MatrixElement,
-                                                GenericZeroMatrix, GenericIdentity, OneMatrix)
+from sympy.matrices.expressions.matexpr import (MatrixElement, MatrixWild,
+                                                GenericZeroMatrix,
+                                                GenericIdentity, OneMatrix)
 from sympy.utilities.pytest import raises, XFAIL
 
 
@@ -130,6 +131,27 @@ def test_Identity_doit():
     assert isinstance(Inn.rows, Add)
     assert Inn.doit() == Identity(2*n)
     assert isinstance(Inn.doit().rows, Mul)
+
+
+def test_MatrixWild():
+    w1, w2 = symbols('w1, w2', cls=Wild, integer=True)
+
+    W = MatrixWild('W', n, m)
+    X = MatrixWild('X', n, n)
+    Y = MatrixWild('Y', w1, w1)
+    Z = MatrixWild('Z', w1, w2)
+
+    assert A.match(W) == {W: A}
+    assert A.match(X) is None
+    assert D.match(W) is None
+    assert D.match(X) == {X: D}
+
+    assert D.match(Y) == {Y: D, w1: n}
+    assert A.match(Y) is None  # Wildcard dim specifies square, but A is n by m
+    assert A.match(Z) == {Z: A, w1: n, w2: m}
+
+    # Different types
+    assert Z.matches(n) is None
 
 
 def test_addition():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -1,9 +1,9 @@
-from sympy.core import I, symbols, Basic, Mul, S
+from sympy.core import I, symbols, Basic, Mul, S, Wild
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
 from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
-from sympy.matrices.expressions.matexpr import GenericIdentity
+from sympy.matrices.expressions.matexpr import GenericIdentity, MatrixWild
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
@@ -113,6 +113,17 @@ def test_matmul_scalar_Matrix_doit():
 def test_matmul_sympify():
     assert isinstance(MatMul(eye(1), eye(1)).args[0], Basic)
 
+def test_matmul_matrix_wild():
+    W = MatrixWild('W', n, n)
+    X = MatrixWild('X', m, n)
+
+    assert (D * C).match(W) == {W: D * C}
+    assert (E * D * C).match(E * W) == {W: D * C}
+    assert (D * C * A).match(W * A) == {W: D * C}
+
+    assert ((D ** 2) * C * A).match(W * D * C * A) == {W: D}
+    assert (D * C * A).match(W * D * C * A) is None
+    assert (D**(-1)).match(W**(-1)) == {W: D}
 
 def test_collapse_MatrixBase():
     A = Matrix([[1, 1], [1, 1]])

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -116,14 +116,26 @@ def test_matmul_sympify():
 def test_matmul_matrix_wild():
     W = MatrixWild('W', n, n)
     X = MatrixWild('X', m, n)
+    M = MatrixSymbol('M', n, n)
+    N = MatrixSymbol('N', n, n)
 
     assert (D * C).match(W) == {W: D * C}
     assert (E * D * C).match(E * W) == {W: D * C}
     assert (D * C * A).match(W * A) == {W: D * C}
+    assert (M * D * C * N * D).match(M * W * D) == {W: D * C * N}
 
     assert ((D ** 2) * C * A).match(W * D * C * A) == {W: D}
+    assert ((D ** 3) * C * A).match(D * W * D * C * A) == {W: D}
+    assert (C * (D ** 4) * M).match(C * D**2 * W * M) == {W: MatMul(D, D)}
+
     assert (D * C * A).match(W * D * C * A) is None
+    assert (D * C * A).match(D * C * A * X) is None
+    assert (D * C * A).match(D * C * W * A) is None
+
+    assert (D * C * A).match(D * W) is None
+
     assert (D**(-1)).match(W**(-1)) == {W: D}
+    assert (D.T * C).match(W.T * C) == {W: D}
 
 def test_collapse_MatrixBase():
     A = Matrix([[1, 1], [1, 1]])

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -767,6 +767,9 @@ class StrPrinter(Printer):
     def _print_OneMatrix(self, expr):
         return "1"
 
+    def _print_MatrixWild(self, expr):
+        return expr.name + '_'
+
     def _print_Predicate(self, expr):
         return "Q.%s" % expr.name
 


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17172
Related to #17028


#### Brief description of what is fixed or changed

Adds a `MatrixWild` wildcard that matches any matrix expression with a similar shape. As a demonstration:

```python
>>> A = MatrixSymbol('A', N, N)
>>> B = MatrixSymbol('B', N, N)
>>> W = MatrixWild('W', N, N)
>>> (A * B).match(W)
{W_: A*B}
>>> w = Wild('w')
>>> X = MatrixWild('X', w, w)
>>> (A * B).match(X)
{w_: N, X_: A*B}
>>> (A * B * A).match(A * W * A)
{W_: B}
```
#### Other comments

To-do:
* [ ] Account for mismatches between wildcards
* [x] Expand powers in multiplication
* [ ] Support for ignoring certain expressions
* [ ] Related tests
* [ ] Documentation and comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Add wildcard for matrix expressions
<!-- END RELEASE NOTES -->
