### PR TITLE
matrices: fixed MatPow.doit() so now == mat**x

### DIFF
--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -71,7 +71,7 @@ class MatPow(MatrixExpr):
             raise ValueError("Matrix determinant is 0, not invertible.")
         elif isinstance(base, (Identity, ZeroMatrix)):
             return base
-        elif isinstance(base, MatrixBase) and exp.is_number:
+        elif isinstance(base, MatrixBase) and (exp.is_number or exp.is_negative is not None or base.det() != 0):
             if exp is S.One:
                 return base
             return base**exp
@@ -81,10 +81,6 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
-        elif exp.is_Number or exp.is_negative is not None or (isinstance(base, MatrixBase) and base.det() != 0):
-            jordan_pow = getattr(base, '_matrix_pow_by_jordan_blocks', None)
-            if jordan_pow is not None:
-                return jordan_pow (exp)
         return MatPow(base, exp)
 
     def _eval_transpose(self):

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -81,6 +81,10 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
+        elif exp.is_Number or exp.is_negative is not None or (isinstance(base, MatrixBase) and base.det() != 0):
+            jordan_pow = getattr(base, '_matrix_pow_by_jordan_blocks', None)
+            if jordan_pow is not None:
+                return jordan_pow (exp)
         return MatPow(base, exp)
 
     def _eval_transpose(self):


### PR DESCRIPTION
MatPow.doit() did not use _matrix_pow_by_jordan_blocks() where it could
and sometimes did not arrive at the same result as mat**x for matrices
where this was possible. Added the appropriate check an usage.

Example:
```python
Matrix ([[1,0],[0,1]])**x
Matrix([
[1, 0],
[0, 1]])

MatPow (Matrix ([[1,0],[0,1]]), x).doit ()
Matrix([
[1, 0],
[0, 1]])**x
```
Now:
```python
MatPow (Matrix ([[1,0],[0,1]]), x).doit ()
Matrix([
[1, 0],
[0, 1]])
```
#### References to other Issues or PRs
Fixes 17175


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added usage of `_matrix_pow_by_jordan_blocks()` in `MatPow.doit()` where aplicable.
<!-- END RELEASE NOTES -->