### PR TITLE
Don't call get_sympy_dir() at import time

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1088,7 +1088,7 @@ class SymPyTests(object):
         self._post_mortem = post_mortem
         self._kw = kw
         self._count = 0
-        self._root_dir = sympy_dir
+        self._root_dir = get_sympy_dir()
         self._reporter = reporter
         self._reporter.root_dir(self._root_dir)
         self._testfiles = []
@@ -1339,7 +1339,7 @@ class SymPyDocTests(object):
 
     def __init__(self, reporter, normal):
         self._count = 0
-        self._root_dir = sympy_dir
+        self._root_dir = get_sympy_dir()
         self._reporter = reporter
         self._reporter.root_dir(self._root_dir)
         self._normal = normal
@@ -2347,5 +2347,3 @@ class PyTestReporter(Reporter):
         self.write(" ")
         self.write("[FAIL]", "Red", align="right")
         self.write("\n")
-
-sympy_dir = get_sympy_dir()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This was causing issues with pyoxidizer because of the use of `__file__`, but this shouldn't be done at import time anyway. 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * remove `sympy_dir` variable from `sympy.utilities.runtests`. Use `get_sympy_dir()` instead (note that this is not really public API).
<!-- END RELEASE NOTES -->
