### PR TITLE
Piecewise recursively evaluates itself

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -311,7 +311,9 @@ class Piecewise(Function):
         for e, c in self.args:
             if hints.get('deep', True):
                 if isinstance(e, Basic):
-                    e = e.doit(**hints)
+                    newe = e.doit(**hints)
+                    if newe != self:
+                        e = newe
                 if isinstance(c, Basic):
                     c = c.doit(**hints)
             newargs.append((e, c))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,7 +2,7 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, ITE,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
-    cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
+    cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Sum, Tuple, zoo,
     DiracDelta, Heaviside, Add, Mul, factorial, Ge, Contains, Le)
 from sympy.core.expr import unchanged
 from sympy.functions.elementary.piecewise import Undefined, ExprCondPair
@@ -605,6 +605,9 @@ def test_doit():
     p2 = Piecewise((x, x < 1), (Integral(2 * x), -1 <= x), (x, 3 < x))
     assert p2.doit() == p1
     assert p2.doit(deep=False) == p2
+    # issue 17165
+    p1 = Sum(y**x, (x, -1, oo)).doit()
+    assert p1.doit() == p1
 
 
 def test_piecewise_interval():

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -71,7 +71,7 @@ class MatPow(MatrixExpr):
             raise ValueError("Matrix determinant is 0, not invertible.")
         elif isinstance(base, (Identity, ZeroMatrix)):
             return base
-        elif isinstance(base, MatrixBase) and exp.is_number:
+        elif isinstance(base, MatrixBase) and (exp.is_number or exp.is_negative is not None or base.det() != 0):
             if exp is S.One:
                 return base
             return base**exp
@@ -81,10 +81,6 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
-        elif exp.is_Number or exp.is_negative is not None or (isinstance(base, MatrixBase) and base.det() != 0):
-            jordan_pow = getattr(base, '_matrix_pow_by_jordan_blocks', None)
-            if jordan_pow is not None:
-                return jordan_pow (exp)
         return MatPow(base, exp)
 
     def _eval_transpose(self):

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -81,6 +81,10 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
+        elif exp.is_Number or exp.is_negative is not None or (isinstance(base, MatrixBase) and base.det() != 0):
+            jordan_pow = getattr(base, '_matrix_pow_by_jordan_blocks', None)
+            if jordan_pow is not None:
+                return jordan_pow (exp)
         return MatPow(base, exp)
 
     def _eval_transpose(self):

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -71,7 +71,7 @@ class MatPow(MatrixExpr):
             raise ValueError("Matrix determinant is 0, not invertible.")
         elif isinstance(base, (Identity, ZeroMatrix)):
             return base
-        elif isinstance(base, MatrixBase) and (exp.is_number or exp.is_negative is not None or base.det() != 0):
+        elif isinstance(base, MatrixBase) and exp.is_number:
             if exp is S.One:
                 return base
             return base**exp


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17165

#### Brief description of what is fixed or changed
Changed Piecewise.doit() to avoid recursively evaluating itself ad infinitium with each execution.

#### Other comments
This only partially addresses #17165, the other issue being whether the constructor should fold a piecewise expression upon instantiation to avoid a recursive nesting. In that case maybe it is best to leave it to the user to decide whether they want to fold or no? Or add a hint to request folding from the constructor?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Changed Piecewise.doit() to avoid recursively evaluating itself.
<!-- END RELEASE NOTES -->
