### PR TITLE
Fix dagger implementation for matrices of operators and constants.

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1657,7 +1657,11 @@ class MatrixOperations(MatrixRequired):
     operations.  Should not be instantiated directly."""
 
     def _eval_adjoint(self):
-        return self.transpose().conjugate()
+        # in cases where the elements of the matrix are not simple
+        # scalars (e.g. an operator or another matrix), the correct
+        # definition of the adjoint is the transpose of the adjoint
+        # of each element.
+        return self.applyfunc(lambda x: x.adjoint()).transpose()
 
     def _eval_applyfunc(self, f):
         out = self._new(self.rows, self.cols, [f(x) for x in self])
@@ -1805,7 +1809,7 @@ class MatrixOperations(MatrixRequired):
         conjugate: By-element conjugation
         D: Dirac conjugation
         """
-        return self.T.C
+        return self.adjoint()
 
     def permute(self, perm, orientation='rows', direction='forward'):
         """Permute the rows or columns of a matrix by the given list of swaps.

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -481,6 +481,12 @@ def test_adjoint():
     assert ans.adjoint() == Matrix(dat)
 
 
+def test_adjoint_with_matrix_elements():
+    submat = Matrix([[0, I], [1, 0]])
+    mat = Matrix([[0, submat], [1, 0]])
+    assert mat.adjoint() == Matrix([[0, 1], [submat.adjoint(), 0]])
+
+
 def test_as_real_imag():
     m1 = OperationsOnlyMatrix(2, 2, [1, 2, 3, 4])
     m3 = OperationsOnlyMatrix(2, 2,
@@ -508,6 +514,12 @@ def test_conjugate():
     assert M.H == Matrix([[ 0, 1],
                           [-I, 2],
                           [ 5, 0]])
+
+
+def test_hermitian_conjugate_with_matrix_elements():
+    submat = Matrix([[0, I], [1, 0]])
+    mat = Matrix([[0, submat], [1, 0]])
+    assert mat.H == mat.adjoint()
 
 
 def test_doit():

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -78,12 +78,7 @@ class Dagger(adjoint):
 
     def __new__(cls, arg):
         if hasattr(arg, 'adjoint'):
-            obj = arg.adjoint()
-        elif hasattr(arg, 'conjugate') and hasattr(arg, 'transpose'):
-            obj = arg.conjugate().transpose()
-        if obj is not None:
-            return obj
-        return Expr.__new__(cls, arg)
-
-adjoint.__name__ = "Dagger"
-adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])
+            return arg.adjoint()
+        if hasattr(arg, 'conjugate') and hasattr(arg, 'transpose'):
+            return arg.conjugate().transpose()
+        return adjoint.__new__(cls, arg)

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -1,8 +1,15 @@
 from sympy import I, Matrix, symbols, conjugate, Expr, Integer
 
 from sympy.physics.quantum.dagger import adjoint, Dagger
+from sympy.physics.quantum.operator import Operator
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
+
+
+def test_constants():
+    assert Dagger(0) == 0
+    assert Dagger(1) == 1
+    assert Dagger(1 + 1j) == 1 - 1j
 
 
 def test_scalars():
@@ -27,6 +34,12 @@ def test_matrix():
     x = symbols('x')
     m = Matrix([[I, x*I], [2, 4]])
     assert Dagger(m) == m.H
+
+
+def test_matrix_of_operators():
+    A, B = symbols('A, B', cls=Operator)
+    mat = Matrix([[0, A*B], [0, 0]])
+    assert Dagger(mat) == Matrix([[0, 0], [Dagger(B)*Dagger(A), 0]])
 
 
 class Foo(Expr):

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -9,7 +9,7 @@ from sympy.utilities.pytest import skip
 def test_constants():
     assert Dagger(0) == 0
     assert Dagger(1) == 1
-    assert Dagger(1 + 1 * I) == 1 - 1 * I
+    assert Dagger(1 + I) == 1 - I
 
 
 def test_scalars():

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -9,7 +9,7 @@ from sympy.utilities.pytest import skip
 def test_constants():
     assert Dagger(0) == 0
     assert Dagger(1) == 1
-    assert Dagger(1 + 1j) == 1 - 1j
+    assert Dagger(1 + 1 * I) == 1 - 1 * I
 
 
 def test_scalars():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #16959

#### Brief description of what is fixed or changed

The implementation of adjoint for matrices did not take into account the case where elements might be non-scalars. This PR corrects the implementation to take the *adjoint* of each element rather than the *conjugate* of each element.

The dagger operator failed for constant scalar values (e.g. `5`, `1 + 1j`).

The dagger module monkeypatched the class name of the adjoint operator and its repr. These were removed for sanity.

#### Other comments

Tests were added for applying the Dagger operator to constants and matrices of operators.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Matrix .adjoint() and .H now return the correct result when the elements of the matrix are not scalars (before it was assumed that the adjoint of each element was always its conjugate, which is not true for matrices of matrices or matrices of operators).

* physics.quantum
  * Dagger(x) now returns conjugate(x) when x is a constant (before it raised an error).
  * Dagger(x) now returns the correct result when x is a matrix of operators (before it returned the conjugate of the contained operators instead of the adjoint).
  * Importing the quantum module no longer changes the name of the adjoint class to Dagger.
<!-- END RELEASE NOTES -->