### PR TITLE
Added a few methods for MathML content printing

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -15,6 +15,7 @@ from sympy.printing.printer import Printer
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
 
+
 class MathMLPrinterBase(Printer):
     """Contains common code required for MathMLContentPrinter and
     MathMLPresentationPrinter.
@@ -138,6 +139,14 @@ class MathMLContentPrinter(MathMLPrinterBase):
             'Number': 'cn',
             'int': 'cn',
             'Pow': 'power',
+            'Max': 'max',
+            'Min': 'min',
+            'Abs': 'abs',
+            'And': 'and',
+            'Or': 'or',
+            'Xor': 'xor',
+            'Not': 'not',
+            'Implies': 'implies',
             'Symbol': 'ci',
             'MatrixSymbol': 'ci',
             'RandomSymbol': 'ci',
@@ -147,14 +156,27 @@ class MathMLContentPrinter(MathMLPrinterBase):
             'cos': 'cos',
             'tan': 'tan',
             'cot': 'cot',
+            'csc': 'csc',
+            'sec': 'sec',
+            'sinh': 'sinh',
+            'cosh': 'cosh',
+            'tanh': 'tanh',
+            'coth': 'coth',
+            'csch': 'csch',
+            'sech': 'sech',
             'asin': 'arcsin',
             'asinh': 'arcsinh',
             'acos': 'arccos',
             'acosh': 'arccosh',
             'atan': 'arctan',
             'atanh': 'arctanh',
-            'acot': 'arccot',
             'atan2': 'arctan',
+            'acot': 'arccot',
+            'acoth': 'arccoth',
+            'asec': 'arcsec',
+            'asech': 'arcsech',
+            'acsc': 'arccsc',
+            'acsch': 'arccsch',
             'log': 'ln',
             'Equality': 'eq',
             'Unequality': 'neq',
@@ -297,6 +319,18 @@ class MathMLContentPrinter(MathMLPrinterBase):
 
     def _print_Infinity(self, e):
         return self.dom.createElement('infinity')
+
+    def _print_NaN(self, e):
+        return self.dom.createElement('notanumber')
+
+    def _print_EmptySet(self, e):
+        return self.dom.createElement('emptyset')
+
+    def _print_BooleanTrue(self, e):
+        return self.dom.createElement('true')
+
+    def _print_BooleanFalse(self, e):
+        return self.dom.createElement('false')
 
     def _print_NegativeInfinity(self, e):
         x = self.dom.createElement('apply')
@@ -484,6 +518,10 @@ class MathMLContentPrinter(MathMLPrinterBase):
         dom_element = self.dom.createElement(self.mathml_tag(p))
         dom_element.appendChild(self.dom.createTextNode(str(p)))
         return dom_element
+
+    _print_Implies = _print_AssocOp
+    _print_Not = _print_AssocOp
+    _print_Xor = _print_AssocOp
 
 
 class MathMLPresentationPrinter(MathMLPrinterBase):

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -5,7 +5,8 @@ from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     Lambda, IndexedBase, symbols, zoo, elliptic_f, elliptic_e, elliptic_pi, Ei, \
     expint, jacobi, gegenbauer, chebyshevt, chebyshevu, legendre, assoc_legendre, \
     laguerre, assoc_laguerre, hermite, TribonacciConstant, Contains, \
-    LambertW
+    LambertW, cot, coth, acot, acoth, csc, acsc, csch, acsch, sec, asec, sech, \
+    asech
 
 from sympy import elliptic_k, totient, reduced_totient, primenu, primeomega, \
     fresnelc, fresnels, Heaviside
@@ -218,6 +219,18 @@ def test_content_mathml_constants():
     mml = mathml(EulerGamma)
     assert mml == '<eulergamma/>'
 
+    mml = mathml(EmptySet())
+    assert mml == '<emptyset/>'
+
+    mml = mathml(S.true)
+    assert mml == '<true/>'
+
+    mml = mathml(S.false)
+    assert mml == '<false/>'
+
+    mml = mathml(S.NaN)
+    assert mml == '<notanumber/>'
+
 
 def test_content_mathml_trig():
     mml = mp._print(sin(x))
@@ -229,6 +242,15 @@ def test_content_mathml_trig():
     mml = mp._print(tan(x))
     assert mml.childNodes[0].nodeName == 'tan'
 
+    mml = mp._print(cot(x))
+    assert mml.childNodes[0].nodeName == 'cot'
+
+    mml = mp._print(csc(x))
+    assert mml.childNodes[0].nodeName == 'csc'
+
+    mml = mp._print(sec(x))
+    assert mml.childNodes[0].nodeName == 'sec'
+
     mml = mp._print(asin(x))
     assert mml.childNodes[0].nodeName == 'arcsin'
 
@@ -237,6 +259,15 @@ def test_content_mathml_trig():
 
     mml = mp._print(atan(x))
     assert mml.childNodes[0].nodeName == 'arctan'
+
+    mml = mp._print(acot(x))
+    assert mml.childNodes[0].nodeName == 'arccot'
+
+    mml = mp._print(acsc(x))
+    assert mml.childNodes[0].nodeName == 'arccsc'
+
+    mml = mp._print(asec(x))
+    assert mml.childNodes[0].nodeName == 'arcsec'
 
     mml = mp._print(sinh(x))
     assert mml.childNodes[0].nodeName == 'sinh'
@@ -247,6 +278,15 @@ def test_content_mathml_trig():
     mml = mp._print(tanh(x))
     assert mml.childNodes[0].nodeName == 'tanh'
 
+    mml = mp._print(coth(x))
+    assert mml.childNodes[0].nodeName == 'coth'
+
+    mml = mp._print(csch(x))
+    assert mml.childNodes[0].nodeName == 'csch'
+
+    mml = mp._print(sech(x))
+    assert mml.childNodes[0].nodeName == 'sech'
+
     mml = mp._print(asinh(x))
     assert mml.childNodes[0].nodeName == 'arcsinh'
 
@@ -255,6 +295,15 @@ def test_content_mathml_trig():
 
     mml = mp._print(acosh(x))
     assert mml.childNodes[0].nodeName == 'arccosh'
+
+    mml = mp._print(acoth(x))
+    assert mml.childNodes[0].nodeName == 'arccoth'
+
+    mml = mp._print(acsch(x))
+    assert mml.childNodes[0].nodeName == 'arccsch'
+
+    mml = mp._print(asech(x))
+    assert mml.childNodes[0].nodeName == 'arcsech'
 
 
 def test_content_mathml_relational():
@@ -483,6 +532,14 @@ def test_content_mathml_order():
 
 def test_content_settings():
     raises(TypeError, lambda: mathml(x, method="garbage"))
+
+
+def test_content_mathml_logic():
+    assert mathml(And(x, y)) == '<apply><and/><ci>x</ci><ci>y</ci></apply>'
+    assert mathml(Or(x, y)) == '<apply><or/><ci>x</ci><ci>y</ci></apply>'
+    assert mathml(Xor(x, y)) == '<apply><xor/><ci>x</ci><ci>y</ci></apply>'
+    assert mathml(Implies(x, y)) == '<apply><implies/><ci>x</ci><ci>y</ci></apply>'
+    assert mathml(Not(x)) == '<apply><not/><ci>x</ci></apply>'
 
 
 def test_presentation_printmethod():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17184

#### Brief description of what is fixed or changed
Add MathML content printing for (a)cot(h), (a)csc(h), (a)sec(h), a few constants and logic operations.

#### Other comments
Some of these worked earlier, but adding them to the mathml_tag dictionary makes it more clear that they are supported.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Added support for a number of functions and constants to the MathML content printer.
<!-- END RELEASE NOTES -->
