### PR TITLE
Improve handling of exact trig values (rational multiples of pi)

### DIFF
--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -223,8 +223,7 @@ def test_harmonic_rational():
     Heee = harmonic(ne + pe/qe)
     Aeee = (-log(10) + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
-             + pi*(1/S(4) + sqrt(5)/4)/(2*sqrt(-sqrt(5)/8 + 5/S(8)))
-             + 13944145/S(4720968))
+             + pi*sqrt(2*sqrt(5)/5 + 1)/2 + 13944145/S(4720968))
 
     Heeo = harmonic(ne + pe/qo)
     Aeeo = (-log(26) + 2*log(sin(3*pi/13))*cos(4*pi/13) + 2*log(sin(2*pi/13))*cos(32*pi/13)
@@ -237,7 +236,7 @@ def test_harmonic_rational():
              + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
-             + 11818877030/S(4286604231) + pi*(sqrt(5)/8 + 5/S(8))/sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 11818877030/S(4286604231) + pi*sqrt(2*sqrt(5) + 5)/2)
 
     Heoo = harmonic(ne + po/qo)
     Aeoo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)
@@ -248,8 +247,7 @@ def test_harmonic_rational():
     Hoee = harmonic(no + pe/qe)
     Aoee = (-log(10) + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
-             + pi*(1/S(4) + sqrt(5)/4)/(2*sqrt(-sqrt(5)/8 + 5/S(8)))
-             + 779405/S(277704))
+             + pi*sqrt(2*sqrt(5)/5 + 1)/2 + 779405/S(277704))
 
     Hoeo = harmonic(no + pe/qo)
     Aoeo = (-log(26) + 2*log(sin(3*pi/13))*cos(4*pi/13) + 2*log(sin(2*pi/13))*cos(32*pi/13)
@@ -262,7 +260,7 @@ def test_harmonic_rational():
              + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
-             + 486853480/S(186374097) + pi*(sqrt(5)/8 + 5/S(8))/sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 486853480/S(186374097) + pi*sqrt(2*sqrt(5) + 5)/2)
 
     Hooo = harmonic(no + po/qo)
     Aooo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)
@@ -272,7 +270,6 @@ def test_harmonic_rational():
 
     H = [Heee, Heeo, Heoe, Heoo, Hoee, Hoeo, Hooe, Hooo]
     A = [Aeee, Aeeo, Aeoe, Aeoo, Aoee, Aoeo, Aooe, Aooo]
-
     for h, a in zip(H, A):
         e = expand_func(h).doit()
         assert cancel(e/a) == 1

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -816,6 +816,12 @@ def test_asin():
     assert asin((sqrt(3) - 1)/sqrt(2**3)) == pi/12
     assert asin(-(sqrt(3) - 1)/sqrt(2**3)) == -pi/12
 
+    # check round-trip for exact values:
+    for d in [5, 6, 8, 10, 12]:
+        for n in range(-(d//2), d//2 + 1):
+            if gcd(n, d) == 1:
+                assert asin(sin(n*pi/d)) == n*pi/d
+
     assert asin(x).diff(x) == 1/sqrt(1 - x**2)
 
     assert asin(0.2).is_real is True
@@ -870,6 +876,12 @@ def test_acos():
     assert acos(-1) == pi
     assert acos(sqrt(2)/2) == pi/4
     assert acos(-sqrt(2)/2) == (3*pi)/4
+
+    # check round-trip for exact values:
+    for d in [5, 6, 8, 10, 12]:
+        for num in range(d):
+            if gcd(num, d) == 1:
+                assert acos(cos(num*pi/d)) == num*pi/d
 
     assert acos(2*I) == pi/2 - asin(2*I)
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1615,6 +1615,15 @@ def test_asec():
     assert asec(-oo) == pi/2
     assert asec(zoo) == pi/2
 
+    assert asec(sec(13*pi/4)) == 3*pi/4
+    assert asec(1 + sqrt(5)) == 2*pi/5
+    assert asec(2/sqrt(3)) == pi/6
+    assert asec(sqrt(4 - 2*sqrt(2))) == pi/8
+    assert asec(-sqrt(4 + 2*sqrt(2))) == 5*pi/8
+    assert asec(sqrt(2 + 2*sqrt(5)/5)) == 3*pi/10
+    assert asec(-sqrt(2 + 2*sqrt(5)/5)) == 7*pi/10
+    assert asec(sqrt(2) - sqrt(6)) == 11*pi/12
+
     assert asec(x).diff(x) == 1/(x**2*sqrt(1 - 1/x**2))
     assert asec(x).as_leading_term(x) == log(x)
 
@@ -1651,6 +1660,16 @@ def test_acsc():
     assert acsc(csc(6)) == 6 - 2*pi
     assert unchanged(acsc, csc(x))
     assert unchanged(acsc, sec(x))
+
+    assert acsc(2/sqrt(3)) == pi/3
+    assert acsc(csc(13*pi/4)) == -pi/4
+    assert acsc(sqrt(2 + 2*sqrt(5)/5)) == pi/5
+    assert acsc(-sqrt(2 + 2*sqrt(5)/5)) == -pi/5
+    assert acsc(-2) == -pi/6
+    assert acsc(-sqrt(4 + 2*sqrt(2))) == -pi/8
+    assert acsc(sqrt(4 - 2*sqrt(2))) == 3*pi/8
+    assert acsc(1 + sqrt(5)) == pi/10
+    assert acsc(sqrt(2) - sqrt(6)) == -5*pi/12
 
     assert acsc(x).diff(x) == -1/(x**2*sqrt(1 - 1/x**2))
     assert acsc(x).as_leading_term(x) == log(x)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -465,6 +465,11 @@ def test_tan():
     assert tan(17*pi/4) == S.One
     assert tan(-3*pi/4) == S.One
 
+    assert tan(pi/5) == sqrt(5 - 2*sqrt(5))
+    assert tan(2*pi/5) == sqrt(5 + 2*sqrt(5))
+    assert tan(18*pi/5) == -sqrt(5 + 2*sqrt(5))
+    assert tan(-16*pi/5) == -sqrt(5 - 2*sqrt(5))
+
     assert tan(pi/6) == 1/sqrt(3)
     assert tan(-pi/6) == -1/sqrt(3)
     assert tan(7*pi/6) == 1/sqrt(3)
@@ -926,6 +931,20 @@ def test_atan():
     assert atan(0) == 0
     assert atan(1) == pi/4
     assert atan(sqrt(3)) == pi/3
+    assert atan(-(1 + sqrt(2))) == -3*pi/8
+    assert atan(sqrt((5 - 2 * sqrt(5)))) == pi/5
+    assert atan(-sqrt(1 - 2 * sqrt(5)/ 5)) == -pi/10
+    assert atan(sqrt(1 + 2 * sqrt(5) / 5)) == 3*pi/10
+    assert atan(-2 + sqrt(3)) == -pi/12
+    assert atan(2 + sqrt(3)) == 5*pi/12
+    assert atan(-2 - sqrt(3)) == -5*pi/12
+
+    # check round-trip for exact values:
+    for d in [5, 6, 8, 10, 12]:
+        for num in range(-(d//2), d//2 + 1):
+            if gcd(num, d) == 1:
+                assert atan(tan(num*pi/d)) == num*pi/d
+
     assert atan(oo) == pi/2
     assert atan(x).diff(x) == 1/(1 + x**2)
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -628,10 +628,10 @@ def test_cot():
     assert cot(7*pi/6) == sqrt(3)
     assert cot(-5*pi/6) == sqrt(3)
 
-    assert cot(pi/8).expand() == 1 + sqrt(2)
-    assert cot(3*pi/8).expand() == -1 + sqrt(2)
-    assert cot(5*pi/8).expand() == 1 - sqrt(2)
-    assert cot(7*pi/8).expand() == -1 - sqrt(2)
+    assert cot(pi/8) == 1 + sqrt(2)
+    assert cot(3*pi/8) == -1 + sqrt(2)
+    assert cot(5*pi/8) == 1 - sqrt(2)
+    assert cot(7*pi/8) == -1 - sqrt(2)
 
     assert cot(pi/12) == sqrt(3) + 2
     assert cot(5*pi/12) == -sqrt(3) + 2

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -470,10 +470,15 @@ def test_tan():
     assert tan(7*pi/6) == 1/sqrt(3)
     assert tan(-5*pi/6) == 1/sqrt(3)
 
-    assert tan(pi/8).expand() == -1 + sqrt(2)
-    assert tan(3*pi/8).expand() == 1 + sqrt(2)
-    assert tan(5*pi/8).expand() == -1 - sqrt(2)
-    assert tan(7*pi/8).expand() == 1 - sqrt(2)
+    assert tan(pi/8) == -1 + sqrt(2)
+    assert tan(3*pi/8) == 1 + sqrt(2)  # issue 15959
+    assert tan(5*pi/8) == -1 - sqrt(2)
+    assert tan(7*pi/8) == 1 - sqrt(2)
+
+    assert tan(pi/10) == sqrt(1 - 2*sqrt(5)/5)
+    assert tan(3*pi/10) == sqrt(1 + 2*sqrt(5)/5)
+    assert tan(17*pi/10) == -sqrt(1 + 2*sqrt(5)/5)
+    assert tan(-31*pi/10) == -sqrt(1 - 2*sqrt(5)/5)
 
     assert tan(pi/12) == -sqrt(3) + 2
     assert tan(5*pi/12) == sqrt(3) + 2
@@ -488,8 +493,6 @@ def test_tan():
     assert tan(17*pi/24).radsimp() == -2 + sqrt(3) + sqrt(2) - sqrt(6)
     assert tan(19*pi/24).radsimp() == 2 - sqrt(3) + sqrt(2) - sqrt(6)
     assert tan(23*pi/24).radsimp() == 2 + sqrt(3) - sqrt(2) - sqrt(6)
-
-    assert 1 == (tan(8*pi/15)*cos(8*pi/15)/sin(8*pi/15)).ratsimp()
 
     assert tan(x*I) == tanh(x)*I
 
@@ -647,8 +650,6 @@ def test_cot():
     assert cot(19*pi/24).radsimp() == sqrt(2) + sqrt(3) - 2 - sqrt(6)
     assert cot(23*pi/24).radsimp() == -sqrt(2) - sqrt(3) - 2 - sqrt(6)
 
-    assert 1 == (cot(4*pi/15)*sin(4*pi/15)/cos(4*pi/15)).ratsimp()
-
     assert cot(x*I) == -coth(x)*I
     assert cot(k*pi*I) == -coth(k*pi)*I
 
@@ -671,6 +672,16 @@ def test_cot():
     assert cot(i).is_finite is True
 
     assert cot(x).subs(x, 3*pi) == zoo
+
+
+def test_tan_cot_sin_cos_evalf():
+    assert abs((tan(8*pi/15)*cos(8*pi/15)/sin(8*pi/15) - 1).evalf()) < 1e-14
+    assert abs((cot(4*pi/15)*sin(4*pi/15)/cos(4*pi/15) - 1).evalf()) < 1e-14
+
+@XFAIL
+def test_tan_cot_sin_cos_ratsimp():
+    assert 1 == (tan(8*pi/15)*cos(8*pi/15)/sin(8*pi/15)).ratsimp()
+    assert 1 == (cot(4*pi/15)*sin(4*pi/15)/cos(4*pi/15)).ratsimp()
 
 
 def test_cot_series():
@@ -1735,6 +1746,3 @@ def test_issue_14543():
     assert sec(pi/2 + x) == -csc(x)
     assert sec(3*pi/2 + x) == csc(x)
     assert sec(3*pi/2 - x) == -csc(x)
-
-def test_issue_15959():
-    assert tan(3*pi/8) == 1 + sqrt(2)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1897,6 +1897,34 @@ class InverseTrigonometricFunction(Function):
     """Base class for inverse trigonometric functions."""
 
     @staticmethod
+    def _asin_table():
+        # Only keys with could_extract_minus_sign() == False
+        # are actually needed.
+        return {
+            sqrt(3)/2: S.Pi/3,
+            sqrt(2)/2: S.Pi/4,
+            1/sqrt(2): S.Pi/4,
+            sqrt((5 - sqrt(5))/8): S.Pi/5,
+            sqrt(2)*sqrt(5 - sqrt(5))/4: S.Pi/5,
+            sqrt((5 + sqrt(5))/8): 2*S.Pi/5,
+            sqrt(2)*sqrt(5 + sqrt(5))/4: 2*S.Pi/5,
+            S.Half: S.Pi/6,
+            sqrt(2 - sqrt(2))/2: S.Pi/8,
+            sqrt(S.Half - sqrt(2)/4): S.Pi/8,
+            sqrt(2 + sqrt(2))/2: 3*S.Pi/8,
+            sqrt(S.Half + sqrt(2)/4): 3*S.Pi/8,
+            (sqrt(5) - 1)/4: S.Pi/10,
+            (1 - sqrt(5))/4: -S.Pi/10,
+            (sqrt(5) + 1)/4: 3*S.Pi/10,
+            sqrt(6)/4 - sqrt(2)/4: S.Pi/12,
+            -sqrt(6)/4 + sqrt(2)/4: -S.Pi/12,
+            (sqrt(3) - 1)/sqrt(8): S.Pi/12,
+            (1 - sqrt(3))/sqrt(8): -S.Pi/12,
+            sqrt(6)/4 + sqrt(2)/4: 5*S.Pi/12,
+            (1 + sqrt(3))/sqrt(8): 5*S.Pi/12
+        }
+
+    @staticmethod
     def _atan_table():
         # Only keys with could_extract_minus_sign() == False
         # are actually needed.
@@ -1999,29 +2027,9 @@ class asin(InverseTrigonometricFunction):
             return -cls(-arg)
 
         if arg.is_number:
-            cst_table = {
-                sqrt(3)/2: 3,
-                -sqrt(3)/2: -3,
-                sqrt(2)/2: 4,
-                -sqrt(2)/2: -4,
-                1/sqrt(2): 4,
-                -1/sqrt(2): -4,
-                sqrt((5 - sqrt(5))/8): 5,
-                -sqrt((5 - sqrt(5))/8): -5,
-                S.Half: 6,
-                -S.Half: -6,
-                sqrt(2 - sqrt(2))/2: 8,
-                -sqrt(2 - sqrt(2))/2: -8,
-                (sqrt(5) - 1)/4: 10,
-                (1 - sqrt(5))/4: -10,
-                (sqrt(3) - 1)/sqrt(2**3): 12,
-                (1 - sqrt(3))/sqrt(2**3): -12,
-                (sqrt(5) + 1)/4: S(10)/3,
-                -(sqrt(5) + 1)/4: -S(10)/3
-            }
-
-            if arg in cst_table:
-                return S.Pi / cst_table[arg]
+            asin_table = cls._asin_table()
+            if arg in asin_table:
+                return asin_table[arg]
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
@@ -2179,19 +2187,11 @@ class acos(InverseTrigonometricFunction):
             return S.ComplexInfinity
 
         if arg.is_number:
-            cst_table = {
-                S.Half: S.Pi/3,
-                -S.Half: 2*S.Pi/3,
-                sqrt(2)/2: S.Pi/4,
-                -sqrt(2)/2: 3*S.Pi/4,
-                1/sqrt(2): S.Pi/4,
-                -1/sqrt(2): 3*S.Pi/4,
-                sqrt(3)/2: S.Pi/6,
-                -sqrt(3)/2: 5*S.Pi/6,
-            }
-
-            if arg in cst_table:
-                return cst_table[arg]
+            asin_table = cls._asin_table()
+            if arg in asin_table:
+                return pi/2 - asin_table[arg]
+            elif -arg in asin_table:
+                return pi/2 + asin_table[-arg]
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1310,6 +1310,8 @@ class cot(TrigonometricFunction):
                 return None
 
             if pi_coeff.is_Rational:
+                if pi_coeff.q == 5 or pi_coeff.q == 10:
+                    return tan(S.Pi/2 - arg)
                 if pi_coeff.q > 2 and not pi_coeff.q % 2:
                     narg = pi_coeff*S.Pi*2
                     cresult, sresult = cos(narg), cos(narg - S.Pi/2)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1315,7 +1315,7 @@ class cot(TrigonometricFunction):
                     cresult, sresult = cos(narg), cos(narg - S.Pi/2)
                     if not isinstance(cresult, cos) \
                             and not isinstance(sresult, cos):
-                        return (1 + cresult)/sresult
+                        return 1/sresult + cresult/sresult
                 table2 = {
                     12: (3, 4),
                     20: (4, 5),

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1896,7 +1896,25 @@ class sinc(Function):
 class InverseTrigonometricFunction(Function):
     """Base class for inverse trigonometric functions."""
 
-    pass
+    @staticmethod
+    def _atan_table():
+        # Only keys with could_extract_minus_sign() == False
+        # are actually needed.
+        return {
+            sqrt(3)/3: S.Pi/6,
+            1/sqrt(3): S.Pi/6,
+            sqrt(3): S.Pi/3,
+            sqrt(2) - 1: S.Pi/8,
+            1 - sqrt(2): -S.Pi/8,
+            1 + sqrt(2): 3*S.Pi/8,
+            sqrt(5 - 2*sqrt(5)): S.Pi/5,
+            sqrt(5 + 2*sqrt(5)): 2*S.Pi/5,
+            sqrt(1 - 2*sqrt(5)/5): S.Pi/10,
+            sqrt(1 + 2*sqrt(5)/5): 3*S.Pi/10,
+            2 - sqrt(3): S.Pi/12,
+            -2 + sqrt(3): -S.Pi/12,
+            2 + sqrt(3): 5*S.Pi/12
+        }
 
 
 class asin(InverseTrigonometricFunction):
@@ -2353,25 +2371,9 @@ class atan(InverseTrigonometricFunction):
             return -cls(-arg)
 
         if arg.is_number:
-            cst_table = {
-                sqrt(3)/3: 6,
-                -sqrt(3)/3: -6,
-                1/sqrt(3): 6,
-                -1/sqrt(3): -6,
-                sqrt(3): 3,
-                -sqrt(3): -3,
-                (1 + sqrt(2)): S(8)/3,
-                -(1 + sqrt(2)): S(8)/3,
-                (sqrt(2) - 1): 8,
-                (1 - sqrt(2)): -8,
-                sqrt((5 + 2*sqrt(5))): S(5)/2,
-                -sqrt((5 + 2*sqrt(5))): -S(5)/2,
-                (2 - sqrt(3)): 12,
-                -(2 - sqrt(3)): -12
-            }
-
-            if arg in cst_table:
-                return S.Pi / cst_table[arg]
+            atan_table = cls._atan_table()
+            if arg in atan_table:
+                return atan_table[arg]
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:
@@ -2447,10 +2449,33 @@ class atan(InverseTrigonometricFunction):
 
 
 class acot(InverseTrigonometricFunction):
-    """
+    r"""
     The inverse cotangent function.
 
     Returns the arc cotangent of x (measured in radians).
+
+    Notes
+    =====
+
+    ``acot(x)`` will evaluate automatically in the cases ``oo``, ``-oo``,
+    ``zoo``, ``0``, ``1``, ``-1`` and for some instances when the result is a
+    rational multiple of pi (see the eval class method).
+
+    A purely imaginary argument will lead to an ``acoth`` expression.
+
+    ``acot(x)`` has a branch cut along `(-i, i)`, hence it is discontinuous
+    at 0. Its range for real ``x`` is `(-\frac{\pi}{2}, \frac{\pi}{2}]`.
+
+    Examples
+    ========
+
+    >>> from sympy import acot, sqrt
+    >>> acot(0)
+    pi/2
+    >>> acot(1)
+    pi/4
+    >>> acot(sqrt(3) - 2)
+    -5*pi/12
 
     See Also
     ========
@@ -2461,9 +2486,8 @@ class acot(InverseTrigonometricFunction):
     References
     ==========
 
-    .. [1] https://en.wikipedia.org/wiki/Inverse_trigonometric_functions
-    .. [2] http://dlmf.nist.gov/4.23
-    .. [3] http://functions.wolfram.com/ElementaryFunctions/ArcCot
+    .. [1] http://dlmf.nist.gov/4.23
+    .. [2] http://functions.wolfram.com/ElementaryFunctions/ArcCot
 
     """
 
@@ -2513,27 +2537,12 @@ class acot(InverseTrigonometricFunction):
             return -cls(-arg)
 
         if arg.is_number:
-            cst_table = {
-                sqrt(3)/3: 3,
-                -sqrt(3)/3: -3,
-                1/sqrt(3): 3,
-                -1/sqrt(3): -3,
-                sqrt(3): 6,
-                -sqrt(3): -6,
-                (1 + sqrt(2)): 8,
-                -(1 + sqrt(2)): -8,
-                (1 - sqrt(2)): -S(8)/3,
-                (sqrt(2) - 1): S(8)/3,
-                sqrt(5 + 2*sqrt(5)): 10,
-                -sqrt(5 + 2*sqrt(5)): -10,
-                (2 + sqrt(3)): 12,
-                -(2 + sqrt(3)): -12,
-                (2 - sqrt(3)): S(12)/5,
-                -(2 - sqrt(3)): -S(12)/5,
-            }
-
-            if arg in cst_table:
-                return S.Pi / cst_table[arg]
+            atan_table = cls._atan_table()
+            if arg in atan_table:
+                ang = pi/2 - atan_table[arg]
+                if ang > pi/2: # restrict to (-pi/2,pi/2]
+                    ang -= pi
+                return ang
 
         i_coeff = arg.as_coefficient(S.ImaginaryUnit)
         if i_coeff is not None:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1003,6 +1003,22 @@ class tan(TrigonometricFunction):
                 return None
 
             if pi_coeff.is_Rational:
+                q = pi_coeff.q
+                p = pi_coeff.p % q
+                # ensure simplified results are returned for n*pi/5, n*pi/10
+                table10 = {
+                    1: sqrt(1 - 2*sqrt(5)/5),
+                    2: sqrt(5 - 2*sqrt(5)),
+                    3: sqrt(1 + 2*sqrt(5)/5),
+                    4: sqrt(5 + 2*sqrt(5))
+                    }
+                if q == 5 or q == 10:
+                    n = 10 * p / q
+                    if n > 5:
+                        n = 10 - n
+                        return -table10[n]
+                    else:
+                        return table10[n]
                 if not pi_coeff.q % 2:
                     narg = pi_coeff*S.Pi*2
                     cresult, sresult = cos(narg), cos(narg - S.Pi/2)
@@ -1021,8 +1037,6 @@ class tan(TrigonometricFunction):
                     60: (20, 30),
                     120: (40, 60)
                     }
-                q = pi_coeff.q
-                p = pi_coeff.p % q
                 if q in table2:
                     nvala, nvalb = cls(p*S.Pi/table2[q][0]), cls(p*S.Pi/table2[q][1])
                     if None == nvala or None == nvalb:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1944,6 +1944,30 @@ class InverseTrigonometricFunction(Function):
             2 + sqrt(3): 5*S.Pi/12
         }
 
+    @staticmethod
+    def _acsc_table():
+        # Keys for which could_extract_minus_sign()
+        # will obviously return True are omitted.
+        return {
+            2*sqrt(3)/3: S.Pi/3,
+            sqrt(2): S.Pi/4,
+            sqrt(2 + 2*sqrt(5)/5): S.Pi/5,
+            1/sqrt(S(5)/8 - sqrt(5)/8): S.Pi/5,
+            sqrt(2 - 2*sqrt(5)/5): 2*S.Pi/5,
+            1/sqrt(S(5)/8 + sqrt(5)/8): 2*S.Pi/5,
+            2: S.Pi/6,
+            sqrt(4 + 2*sqrt(2)): S.Pi/8,
+            2/sqrt(2 - sqrt(2)): S.Pi/8,
+            sqrt(4 - 2*sqrt(2)): 3*S.Pi/8,
+            2/sqrt(2 + sqrt(2)): 3*S.Pi/8,
+            1 + sqrt(5): S.Pi/10,
+            sqrt(5) - 1: 3*S.Pi/10,
+            -(sqrt(5) - 1): -3*S.Pi/10,
+            sqrt(6) + sqrt(2): S.Pi/12,
+            sqrt(6) - sqrt(2): 5*S.Pi/12,
+            -(sqrt(6) - sqrt(2)): -5*S.Pi/12
+        }
+
 
 class asin(InverseTrigonometricFunction):
     """
@@ -2628,8 +2652,9 @@ class asec(InverseTrigonometricFunction):
     Notes
     =====
 
-    ``asec(x)`` will evaluate automatically in the cases
-    ``oo``, ``-oo``, ``0``, ``1``, ``-1``.
+    ``asec(x)`` will evaluate automatically in the cases ``oo``, ``-oo``,
+    ``0``, ``1``, ``-1`` and for some instances when the result is a rational
+    multiple of pi (see the eval class method).
 
     ``asec(x)`` has branch cut in the interval [-1, 1]. For complex arguments,
     it can be defined [4]_ as
@@ -2687,6 +2712,13 @@ class asec(InverseTrigonometricFunction):
                 return S.Pi
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
             return S.Pi/2
+
+        if arg.is_number:
+            acsc_table = cls._acsc_table()
+            if arg in acsc_table:
+                return pi/2 - acsc_table[arg]
+            elif -arg in acsc_table:
+                return pi/2 + acsc_table[-arg]
 
         if isinstance(arg, sec):
             ang = arg.args[0]
@@ -2756,8 +2788,9 @@ class acsc(InverseTrigonometricFunction):
     Notes
     =====
 
-    ``acsc(x)`` will evaluate automatically in the cases
-    ``oo``, ``-oo``, ``0``, ``1``, ``-1``.
+    ``acsc(x)`` will evaluate automatically in the cases ``oo``, ``-oo``,
+    ``0``, ``1``, ``-1`` and for some instances when the result is a rational
+    multiple of pi (see the eval class method).
 
     Examples
     ========
@@ -2796,6 +2829,14 @@ class acsc(InverseTrigonometricFunction):
                 return -S.Pi/2
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
             return S.Zero
+
+        if arg.could_extract_minus_sign():
+            return -cls(-arg)
+
+        if arg.is_number:
+            acsc_table = cls._acsc_table()
+            if arg in acsc_table:
+                return acsc_table[arg]
 
         if isinstance(arg, csc):
             ang = arg.args[0]

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -593,7 +593,6 @@ def test_H33():
 
 # I. Trigonometry
 
-@XFAIL
 def test_I1():
     assert tan(7*pi/10) == -sqrt(1 + 2/sqrt(5))
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17106
Fixes #13679
Applies the tan() change from #15959 also to cot()
See also #6053, in particular [this comment](https://github.com/sympy/sympy/issues/6053#issuecomment-485394307)

#### Brief description of what is fixed or changed
- tan and cot give simplified results for some exact values (n * pi/5, n * pi/10, n * pi/8)
- some values are added to atan, acot constant table
- asin, acos now recognize all exact values for n * pi/5, n * pi/8, n * pi/10, n * pi/12
- asec, acsc now recognize exact values (new feature)
- for atan/acot, asin/acos, asec/acsc a single constants table is shared by two functions (reducing redundancy)

#### Other comments
I'm sorry if this changeset has become somewhat large. I tried to regroup the changes in meaningful separate commits (including some more details in the commit messages). If I should break this PR up into separate PRs, please do tell me.

While a previous `@XFAIL` is now working, there is an unfortunate regression concerning two tests where previously `ratsimp()` was able to simplify an expression of the form `tan*cos/sin` or `cot*sin/cos` to 1. Arguably these tests were more a test of `ratsimp` than of trig functions. So for now I've changed them to numeric evalf tests and kept the old versions as `@XFAIL`.

In acot's docstring I added a note explaining that the odd/discontinuous definition is used by SymPy. The reference to Wikipedia is removed since the Wikipedia article is based on the alternative definition.

Any review would be very welcome!

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Improve presentation of some tan, cot values for n * pi/5, n * pi/8, n * pi/10.
  * Make asec, acsc recognize exact values resulting in a rational multiple of pi.
  * Make asin, acos, atan, acot recognize some additional exact values.
<!-- END RELEASE NOTES -->
