### PR TITLE
polynomials: Add zero roots after translation of non-trivial roots

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1027,8 +1027,6 @@ def roots(f, *gens, **flags):
         for currentroot, k in _result.items():
             result[coeff*currentroot] = k
 
-    result.update(zeros)
-
     if filter not in [None, 'C']:
         handlers = {
             'Z': lambda r: r.is_Integer,
@@ -1060,6 +1058,9 @@ def roots(f, *gens, **flags):
         for k, v in result.items():
             result1[k + translate_x] = v
         result = result1
+
+    # adding zero roots after non-trivial roots have been translated
+    result.update(zeros)
 
     if not multiple:
         return result

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -134,9 +134,14 @@ def test_issue_14522():
 
 
 def test_issue_15076():
-    sol = roots_quartic(Poly(t**4 -  6*t**2 + t/x - 3, t))
+    sol = roots_quartic(Poly(t**4 - 6*t**2 + t/x - 3, t))
     assert sol[0].has(x)
 
+
+def test_issue_16589():
+    eq = Poly(x**4 - 8*sqrt(2)*x**3 + 4*x**3 - 64*sqrt(2)*x**2 + 1024*x, x)
+    roots_eq = roots(eq)
+    assert 0 in roots_eq
 
 def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #16589

#### Brief description of what is fixed or changed
I have followed the suggestion by @jksuom to make the required code changes. 

#### Other comments
I have also added a test to check if the zero root is listed amongst the roots for the polynomial mentioned in the issue.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * The zero roots are added after non-trivial roots have been translated
<!-- END RELEASE NOTES -->
