### PR TITLE
Make log() recognize some exact values

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -12,6 +12,7 @@ from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
 
 # NOTE IMPORTANT
@@ -568,12 +569,29 @@ class log(Function):
             return arg._eval_func(cls)
 
         if arg.is_number:
+            I = S.ImaginaryUnit
             if arg.is_negative:
-                return S.Pi * S.ImaginaryUnit + cls(-arg)
+                return S.Pi * I + cls(-arg)
             elif arg is S.ComplexInfinity:
                 return S.ComplexInfinity
             elif arg is S.Exp1:
                 return S.One
+            cst_table = {
+                sqrt(3)/2 + I*S.Half: S.Pi/6,
+                sqrt(3)/2 - I*S.Half: -S.Pi/6,
+                sqrt(2)/2 + I*sqrt(2)/2: S.Pi/4,
+                sqrt(2)/2 - I*sqrt(2)/2: -S.Pi/4,
+                S.Half + I*sqrt(3)/2: S.Pi/3,
+                S.Half - I*sqrt(3)/2: -S.Pi/3,
+                -S.Half + I*sqrt(3)/2: 2*S.Pi/3,
+                -S.Half - I*sqrt(3)/2: -2*S.Pi/3,
+                -sqrt(2)/2 + I*sqrt(2)/2: 3*S.Pi/4,
+                -sqrt(2)/2 - I*sqrt(2)/2: -3*S.Pi/4,
+                -sqrt(3)/2 + I*S.Half: 5*S.Pi/6,
+                -sqrt(3)/2 - I*S.Half: -5*S.Pi/6
+            }
+            if arg in cst_table:
+                return I * cst_table[arg]
 
         # don't autoexpand Pow or Mul (see the issue 3351):
         if not arg.is_Add:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -582,6 +582,7 @@ class log(Function):
             elif arg is S.Exp1:
                 return S.One
 
+        if arg.is_number and arg.is_algebraic:
             # Check for arguments involving rational
             # multiples of pi
             r_ = re(arg)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -478,6 +478,7 @@ class exp(ExpBase):
 class log(Function):
     r"""
     The natural logarithm function `\ln(x)` or `\log(x)`.
+
     Logarithms are taken with the natural base, `e`. To get
     a logarithm of a different base ``b``, use ``log(x, b)``,
     which is essentially short-hand for ``log(x)/log(b)``.
@@ -485,16 +486,19 @@ class log(Function):
     Examples
     ========
 
-    >>> from sympy import log, S
+    >>> from sympy import log, sqrt, S, I
     >>> log(8, 2)
     3
     >>> log(S(8)/3, 2)
     -log(3)/log(2) + 3
+    >>> log(-1 + I*sqrt(3))
+    log(2) + 2*I*pi/3
 
     See Also
     ========
 
     exp
+
     """
 
     def fdiff(self, argindex=1):

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -198,6 +198,16 @@ def test_log_values():
     assert log(-sqrt(2)/2 - I*sqrt(2)/2) == -I*3*pi/4
     assert log(-sqrt(3)/2 - I*S.Half) == -I*5*pi/6
 
+    assert log(-S(1)/4 + sqrt(5)/4 - I*sqrt(sqrt(5)/8 + S(5)/8)) == -I*2*pi/5
+    assert log(sqrt(S(5)/8 - sqrt(5)/8) + I*(S(1)/4 + sqrt(5)/4)) == I*3*pi/10
+    assert log(-sqrt(sqrt(2)/4 + S(1)/2) + I*sqrt(S(1)/2 - sqrt(2)/4)) == I*7*pi/8
+    assert log(-sqrt(6)/4 - sqrt(2)/4 + I*(-sqrt(6)/4 + sqrt(2)/4)) == -I*11*pi/12
+
+    assert log(-1 + I*sqrt(3)) == log(2) + I*2*pi/3
+    assert log(5 + 5*I) == log(5*sqrt(2)) + I*pi/4
+    assert log(5*(1 + I)/sqrt(2)) == log(5) + I*pi/4
+    assert log(-sqrt(6) + sqrt(2) - I*sqrt(6) - I*sqrt(2)) == log(4) - I*7*pi/12
+
     assert exp(-log(3))**(-1) == 3
 
     assert log(S.Half) == -log(2)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -239,9 +239,15 @@ def test_log_exact():
     assert log(5 + 5*I) == log(5*sqrt(2)) + I*pi/4
     assert log(sqrt(-12)) == log(2*sqrt(3)) + I*pi/2
     assert log(-sqrt(6) + sqrt(2) - I*sqrt(6) - I*sqrt(2)) == log(4) - I*7*pi/12
+    assert log(-sqrt(6-3*sqrt(2)) - I*sqrt(6+3*sqrt(2))) == log(2*sqrt(3)) - 5*I*pi/8
     assert log(1 + I*sqrt(2-sqrt(2))/sqrt(2+sqrt(2))) == log(2/sqrt(sqrt(2) + 2)) + I*pi/8
     assert log(cos(7*pi/12) + I*sin(7*pi/12)) == 7*I*pi/12
     assert log(cos(6*pi/5) + I*sin(6*pi/5)) == -4*I*pi/5
+
+    assert log(5*(1 + I)/sqrt(2)) == log(5) + I*pi/4
+    assert log(sqrt(2)*(-sqrt(3) + 1 - sqrt(3)*I - I)) == log(4) - I*7*pi/12
+    assert log(-sqrt(2)*(1 - I*sqrt(3))) == log(2*sqrt(2)) + 2*I*pi/3
+    assert log(sqrt(3)*I*(-sqrt(6 - 3*sqrt(2)) - I*sqrt(3*sqrt(2) + 6))) == log(6) - I*pi/8
 
     zero = (1 + sqrt(2))**2 - 3 - 2*sqrt(2)
     assert log(zero - I*sqrt(3)) == log(sqrt(3)) - I*pi/2
@@ -249,6 +255,8 @@ def test_log_exact():
 
     # bail quickly if no obvious simplification is possible:
     assert unchanged(log, (sqrt(2)-1/sqrt(sqrt(3)+I))**1000)
+    # beware of non-real coefficients
+    assert unchanged(log, sqrt(2-sqrt(5))*(1 + I))
 
 
 def test_log_base():

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -3,7 +3,7 @@ from sympy import (
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
     AccumBounds, MatrixSymbol, Pow, gcd)
-rom sympy.abc import x, y, z
+from sympy.abc import x, y, z
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises, XFAIL

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -191,6 +191,13 @@ def test_log_values():
     assert log(0, 2) == zoo
     assert log(0, 5) == zoo
 
+    assert log(sqrt(3)/2 + I*S.Half) == I*pi/6
+    assert log(S.Half - I*sqrt(3)/2) == -I*pi/3
+    assert log(sqrt(2)/2 + I*sqrt(2)/2) == I*pi/4
+    assert log(-S.Half + I*sqrt(3)/2) == I*2*pi/3
+    assert log(-sqrt(2)/2 - I*sqrt(2)/2) == -I*3*pi/4
+    assert log(-sqrt(3)/2 - I*S.Half) == -I*5*pi/6
+
     assert exp(-log(3))**(-1) == 3
 
     assert log(S.Half) == -log(2)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -2,7 +2,7 @@ from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
-    AccumBounds, MatrixSymbol, Pow)
+    AccumBounds, MatrixSymbol, Pow, gcd)
 from sympy.abc import x, y, z
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -191,9 +191,22 @@ def test_log_values():
     assert log(0, 2) == zoo
     assert log(0, 5) == zoo
 
-    assert log(sqrt(3)/2 + I*S.Half) == I*pi/6
+    assert exp(-log(3))**(-1) == 3
+
+    assert log(S.Half) == -log(2)
+    assert log(2*3).func is log
+    assert log(2*3**2).func is log
+
+
+def test_log_exact():
+    # check for pi/2, pi/3, pi/4, pi/6, pi/8, pi/12; pi/5, pi/10:
+    for n in range(-23, 24):
+        if gcd(n, 24) != 1:
+            assert log(exp(n*I*pi/24).rewrite(sqrt)) == n*I*pi/24
+        for n in range(-9, 10):
+            assert log(exp(n*I*pi/10).rewrite(sqrt)) == n*I*pi/10
+
     assert log(S.Half - I*sqrt(3)/2) == -I*pi/3
-    assert log(sqrt(2)/2 + I*sqrt(2)/2) == I*pi/4
     assert log(-S.Half + I*sqrt(3)/2) == I*2*pi/3
     assert log(-sqrt(2)/2 - I*sqrt(2)/2) == -I*3*pi/4
     assert log(-sqrt(3)/2 - I*S.Half) == -I*5*pi/6
@@ -205,14 +218,18 @@ def test_log_values():
 
     assert log(-1 + I*sqrt(3)) == log(2) + I*2*pi/3
     assert log(5 + 5*I) == log(5*sqrt(2)) + I*pi/4
-    assert log(5*(1 + I)/sqrt(2)) == log(5) + I*pi/4
+    assert log(sqrt(-12)) == log(2*sqrt(3)) + I*pi/2
     assert log(-sqrt(6) + sqrt(2) - I*sqrt(6) - I*sqrt(2)) == log(4) - I*7*pi/12
+    assert log(1 + I*sqrt(2-sqrt(2))/sqrt(2+sqrt(2))) == log(2/sqrt(sqrt(2) + 2)) + I*pi/8
+    assert log(cos(7*pi/12) + I*sin(7*pi/12)) == 7*I*pi/12
+    assert log(cos(6*pi/5) + I*sin(6*pi/5)) == -4*I*pi/5
 
-    assert exp(-log(3))**(-1) == 3
+    zero = (1 + sqrt(2))**2 - 3 - 2*sqrt(2)
+    assert log(zero - I*sqrt(3)) == log(sqrt(3)) - I*pi/2
+    assert unchanged(log, zero + I*zero) or log(zero + zero*I) == zoo
 
-    assert log(S.Half) == -log(2)
-    assert log(2*3).func is log
-    assert log(2*3**2).func is log
+    # bail quickly if no obvious simplification is possible:
+    assert unchanged(log, (sqrt(2)-1/sqrt(sqrt(3)+I))**1000)
 
 
 def test_log_base():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1346,16 +1346,10 @@ def test_failing_assumptions():
 
 def test_issue_6056():
     assert solve(tanh(x + 3)*tanh(x - 3) - 1) == []
-    assert set([simplify(w) for w in solve(tanh(x - 1)*tanh(x + 1) + 1)]) == set([
-        -log(2)/2 + log(1 - I),
-        -log(2)/2 + log(-1 - I),
-        -log(2)/2 + log(1 + I),
-        -log(2)/2 + log(-1 + I),])
-    assert set([simplify(w) for w in solve((tanh(x + 3)*tanh(x - 3) + 1)**2)]) == set([
-        -log(2)/2 + log(1 - I),
-        -log(2)/2 + log(-1 - I),
-        -log(2)/2 + log(1 + I),
-        -log(2)/2 + log(-1 + I),])
+    assert solve(tanh(x - 1)*tanh(x + 1) + 1) == \
+            [-3*I*pi/4, -I*pi/4, I*pi/4, 3*I*pi/4]
+    assert solve((tanh(x + 3)*tanh(x - 3) + 1)**2) == \
+            [-3*I*pi/4, -I*pi/4, I*pi/4, 3*I*pi/4]
 
 
 def test_issue_5673():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1837,19 +1837,16 @@ def test_issue_8828():
 @slow
 def test_issue_2840_8155():
     assert solve(sin(3*x) + sin(6*x)) == [
-        0, -pi, pi, 14*pi/9, 16*pi/9, 2*pi, 2*I*(log(2) - log(-1 - sqrt(3)*I)),
-        2*I*(log(2) - log(-1 + sqrt(3)*I)), 2*I*(log(2) - log(1 - sqrt(3)*I)),
-        2*I*(log(2) - log(1 + sqrt(3)*I)), 2*I*(log(2) - log(-sqrt(3) - I)),
-        2*I*(log(2) - log(-sqrt(3) + I)), 2*I*(log(2) - log(sqrt(3) - I)),
-        2*I*(log(2) - log(sqrt(3) + I)), -2*I*log(-(-1)**(S(1)/9)), -2*I*log(
-        -(-1)**(S(2)/9)), -2*I*log(-sin(pi/18) - I*cos(pi/18)), -2*I*log(-sin(
-        pi/18) + I*cos(pi/18)), -2*I*log(sin(pi/18) - I*cos(pi/18)), -2*I*log(
-        sin(pi/18) + I*cos(pi/18)), -2*I*log(exp(-2*I*pi/9)), -2*I*log(exp(
-        -I*pi/9)), -2*I*log(exp(I*pi/9)), -2*I*log(exp(2*I*pi/9))]
+        0, -5*pi/3, -4*pi/3, -pi, -2*pi/3, -pi/3, pi/3, 2*pi/3, pi, 4*pi/3,
+        14*pi/9, 5*pi/3, 16*pi/9, 2*pi, -2*I*log(-(-1)**(S(1)/9)),
+        -2*I*log(-(-1)**(S(2)/9)), -2*I*log(-sin(pi/18) - I*cos(pi/18)),
+        -2*I*log(-sin(pi/18) + I*cos(pi/18)),
+        -2*I*log(sin(pi/18) - I*cos(pi/18)),
+        -2*I*log(sin(pi/18) + I*cos(pi/18)),
+        -2*I*log(exp(-2*I*pi/9)), -2*I*log(exp(-I*pi/9)),
+        -2*I*log(exp(I*pi/9)), -2*I*log(exp(2*I*pi/9))]
     assert solve(2*sin(x) - 2*sin(2*x)) == [
-        0, -pi, pi, 2*I*(log(2) - log(-sqrt(3) - I)), 2*I*(log(2) -
-        log(-sqrt(3) + I)), 2*I*(log(2) - log(sqrt(3) - I)), 2*I*(log(2) -
-        log(sqrt(3) + I))]
+        0, -5*pi/3, -pi, -pi/3, pi/3, pi, 5*pi/3]
 
 
 def test_issue_9567():


### PR DESCRIPTION
With these changes, `log(a+b*I)` will automatically evaluate if its argument has a complex argument that is a rational multiple of pi (with a denominator in {3, 4, 5, 6, 8, 10, 12}.)

#### References to other Issues or PRs
Fixes #4612 

#### Brief description of what is fixed or changed
A constants table is added to log.eval() in order to detect some specific log arguments. This is similar to the approach used by the inverse trigonometric functions.
~~Only arguments leading to a purely imaginary result are evaluated automatically.~~

#### Other comments
~~I refrained from adding support for other angles (pi/5, pi/8, pi/10, pi/12) primarily because some form of pre-processing would be necessary: I could add `sqrt(2)/4 + sqrt(6)/4 - I*sqrt(2)/4 + I*sqrt(6)/4` to the table, but then `log(cos(pi/12) + I*sin(pi/12))` still wouldn't be recognized since it evaluates to `log(sqrt(2)/4 + sqrt(6)/4 + I*(-sqrt(2)/4 + sqrt(6)/4))` (with `I` factored out).
Obviously, potentially slow operation (simplify etc.) are to be avoided, since most of the time the log argument won't be listed in the table.
Is there some kind of pre-processing that would be acceptable? Maybe just `re()` and `im()` or `expand_mul(deep=False)` for each of the top-level terms of the Add?~~
Any review or advice is most welcome.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * log() now recognizes algebraic values having a complex argument of `I*n*pi/3`, `I*n*pi/4`, `I*n*pi/5`,  `I*n*pi/6`, `I*n*pi/8`, `I*n*pi/10` or `I*n*pi/12`
<!-- END RELEASE NOTES -->
