### PR TITLE
Faster matrix exponential computation

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3142,16 +3142,13 @@ class MatrixBase(MatrixDeprecated,
 
         A trivial example of 1*1 Jordan block:
 
-        >>> m = Matrix([[l]])
+        >>> m = Matrix.jordan_block(1, l)
         >>> m._eval_matrix_exp_jblock()
         Matrix([[exp(lamda)]])
 
         An example of 3*3 Jordan block:
 
-        >>> m = Matrix(
-        ...     [[l, 1, 0],
-        ...     [0, l, 1],
-        ...     [0, 0, l]])
+        >>> m = Matrix.jordan_block(3, l)
         >>> m._eval_matrix_exp_jblock()
         Matrix([
         [exp(lamda), exp(lamda), exp(lamda)/2],

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3133,6 +3133,35 @@ class MatrixBase(MatrixDeprecated,
     def _eval_matrix_exp_jblock(self):
         """A helper function to compute an exponential of a Jordan block
         matrix
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, Matrix
+        >>> l = Symbol('lamda')
+
+        A trivial example of 1*1 Jordan block:
+
+        >>> m = Matrix([[l]])
+        >>> m._eval_matrix_exp_jblock()
+        Matrix([[exp(lamda)]])
+
+        An example of 3*3 Jordan block:
+
+        >>> m = Matrix(
+        ...     [[l, 1, 0],
+        ...     [0, l, 1],
+        ...     [0, 0, l]])
+        >>> m._eval_matrix_exp_jblock()
+        Matrix([
+        [exp(lamda), exp(lamda), exp(lamda)/2],
+        [         0, exp(lamda),   exp(lamda)],
+        [         0,          0,   exp(lamda)]])
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Matrix_function#Jordan_decomposition
         """
         size = self.rows
         l = self[0, 0]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3164,9 +3164,7 @@ class MatrixBase(MatrixDeprecated,
         l = self[0, 0]
         exp_l = exp(l)
 
-        bands = dict()
-        for i in range(size):
-            bands[i] = exp_l / factorial(i)
+        bands = {i: exp_l / factorial(i) for i in range(size)}
 
         from .sparsetools import banded
         return self.__class__(banded(size, bands))

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3164,8 +3164,8 @@ class MatrixBase(MatrixDeprecated,
         l = self[0, 0]
         exp_l = exp(l)
 
-        bands = {0: exp_l}
-        for i in range(1, size):
+        bands = dict()
+        for i in range(size):
             bands[i] = exp_l / factorial(i)
 
         from .sparsetools import banded

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2025,6 +2025,20 @@ def test_Matrix_berkowitz_charpoly():
     assert p.as_expr().subs(p.gen, x) == x**2 - 3*x
 
 
+def test_exp_jordan_block():
+    l = Symbol('lamda')
+
+    m = Matrix.jordan_block(1, l)
+    assert m._eval_matrix_exp_jblock() == Matrix([[exp(l)]])
+
+    m = Matrix.jordan_block(3, l)
+    assert m._eval_matrix_exp_jblock() == \
+        Matrix([
+            [exp(l), exp(l), exp(l)/2],
+            [0, exp(l), exp(l)],
+            [0, 0, exp(l)]])
+
+
 def test_exp():
     m = Matrix([[3, 4], [0, -2]])
     m_exp = Matrix([[exp(3), -4*exp(-2)/5 + 4*exp(3)/5], [0, exp(-2)]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The previous implementation uses naive matrix power computation for matrix function series expansion, so it can be obvious that it can be slow if a jordan block is large

```python
from sympy import *
from sympy.matrices.sparsetools import banded
from pyinstrument import Profiler

l = Symbol('lambda')
m = banded(30, {0: l, 1: 1})
m = Matrix(m)

profiler = Profiler()
profiler.start()

m.exp()

profiler.stop()

print(profiler.output_text(unicode=True, color=True))
```

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 23:53:52  Samples:  12604
 /_//_/// /_\ / //_// / //_'/ //     Duration: 12.633    CPU time: 12.594
/   _/                      v3.0.3
```
It improves to 
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 23:53:24  Samples:  7308
 /_//_/// /_\ / //_// / //_'/ //     Duration: 7.320     CPU time: 7.281
/   _/                      v3.0.3
```
after using more direct formula, and using new `banded` constructor.

However, I see the `Matrix.exp` already takes about 7 seconds for computing jordan decomposition itself, even given a jordan block.
Which may mask the obvious speed disadvantage of using naive matrix powers, and large jordan cells may not appear that frequently for most of the real situations. But improvement is an improvement.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
