### PR TITLE
KroneckerDelta simplification and rewrite(Piecewise)

### DIFF
--- a/doc/src/modules/simplify/simplify.rst
+++ b/doc/src/modules/simplify/simplify.rst
@@ -15,6 +15,10 @@ nthroot
 -------
 .. autofunction:: nthroot
 
+kroneckersimp
+-------------
+.. autofunction:: kroneckersimp
+
 besselsimp
 ----------
 .. autofunction:: besselsimp

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1058,8 +1058,6 @@ class Piecewise(Function):
                     k *= rewrite_eq(c.args)
                 elif isinstance(c, Ne):
                     k *= 1 - rewrite_ne(c.args)
-                elif isinstance(c, And):
-                    k *= rewrite_and(c.args)
                 elif isinstance(c, Or):
                     k *= rewrite_or(c.args)
                 else:
@@ -1075,9 +1073,7 @@ class Piecewise(Function):
                 elif isinstance(c, Ne):
                     k *= rewrite_ne(c.args)
                 elif isinstance(c, And):
-                    k *= rewrite_and(c.args)
-                elif isinstance(c, Or):
-                    k *= rewrite_or(c.args)
+                    k *= 1 - rewrite_and(c.args)
                 else:
                     raise ValueError
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1029,6 +1029,32 @@ class Piecewise(Function):
             last = ITE(c, a, last)
         return _canonical(last)
 
+    def _eval_rewrite_as_KroneckerDelta(self, *args):
+        from sympy import Ne, Eq, KroneckerDelta
+
+        equalities = []
+        true_value = None
+        for i in args:
+            if isinstance(i[1], Eq) or isinstance(i[1], Ne):
+                equalities.append(i)
+            elif i[1] is S.true:
+                if true_value is None:
+                    true_value = i[0]
+            else:
+                return
+
+        if true_value is not None:
+            equals = equalities[::-1]
+            result = true_value
+
+            for i in equals:
+                k = KroneckerDelta(*i[1].args)
+                if isinstance(i[1], Eq):
+                    result = k * i[0] + (1 - k) * result
+                else:
+                    result = (1 - k) * i[0] + k * result
+            return result
+
 
 def piecewise_fold(expr):
     """

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1032,6 +1032,9 @@ class Piecewise(Function):
     def _eval_rewrite_as_KroneckerDelta(self, *args):
         from sympy import Ne, Eq, KroneckerDelta
 
+        class UnrecognizedCondition(Exception):
+            pass
+
         conditions = []
         true_value = None
         for i in args:
@@ -1061,7 +1064,7 @@ class Piecewise(Function):
                 elif isinstance(c, Or):
                     k *= rewrite_or(c.args)
                 else:
-                    raise ValueError
+                    raise UnrecognizedCondition
 
             return k
 
@@ -1075,7 +1078,7 @@ class Piecewise(Function):
                 elif isinstance(c, And):
                     k *= 1 - rewrite_and(c.args)
                 else:
-                    raise ValueError
+                    raise UnrecognizedCondition
 
             return 1 - k
 
@@ -1095,7 +1098,7 @@ class Piecewise(Function):
                         k = rewrite_or(i[1].args)
                     else:
                         return
-                except ValueError:
+                except UnrecognizedCondition:
                     return
 
                 result = k * i[0] + (1 - k) * result

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1052,7 +1052,7 @@ class Piecewise(Function):
             return KroneckerDelta(*args)
 
         def rewrite_ne(args):
-            return KroneckerDelta(*args)
+            return 1 - KroneckerDelta(*args)
 
         def rewrite_and(args):
             k = 1
@@ -1060,7 +1060,7 @@ class Piecewise(Function):
                 if isinstance(c, Eq):
                     k *= rewrite_eq(c.args)
                 elif isinstance(c, Ne):
-                    k *= 1 - rewrite_ne(c.args)
+                    k *= rewrite_ne(c.args)
                 elif isinstance(c, Or):
                     k *= rewrite_or(c.args)
                 else:
@@ -1074,7 +1074,7 @@ class Piecewise(Function):
                 if isinstance(c, Eq):
                     k *= 1 - rewrite_eq(c.args)
                 elif isinstance(c, Ne):
-                    k *= rewrite_ne(c.args)
+                    k *= 1 - rewrite_ne(c.args)
                 elif isinstance(c, And):
                     k *= 1 - rewrite_and(c.args)
                 else:
@@ -1091,7 +1091,7 @@ class Piecewise(Function):
                     if isinstance(i[1], Eq):
                         k = rewrite_eq(i[1].args)
                     elif isinstance(i[1], Ne):
-                        k = 1 - rewrite_ne(i[1].args)
+                        k = rewrite_ne(i[1].args)
                     elif isinstance(i[1], And):
                         k = rewrite_and(i[1].args)
                     elif isinstance(i[1], Or):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1299,3 +1299,6 @@ def test_eval_rewrite_as_KroneckerDelta():
 
     p21 = Piecewise((0, Or(x > 1, x < 0)), (1, True))
     assert f(p21) == p21
+
+    p22 = Piecewise((0, ~((Eq(y, -1) | Ne(x, 0)) & (Ne(x, 1) | Ne(y, -1)))), (1, True))
+    assert f(p22) == K(-1, y)*K(0, x) - K(-1, y)*K(1, x) - K(0, x) + 1

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1290,3 +1290,12 @@ def test_eval_rewrite_as_KroneckerDelta():
 
     p18 = Piecewise((-4, Eq(y, 1) | (Eq(x, -5) & Eq(x, z))), (4, True))
     assert f(p18) == 8*K(-5, x)*K(1, y)*K(x, z) - 8*K(-5, x)*K(x, z) - 8*K(1, y) + 4
+
+    p19 = Piecewise((0, x > 2), (1, True))
+    assert f(p19) == p19
+
+    p20 = Piecewise((0, And(x < 2, x > -5)), (1, True))
+    assert f(p20) == p20
+
+    p21 = Piecewise((0, Or(x > 1, x < 0)), (1, True))
+    assert f(p21) == p21

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1287,3 +1287,6 @@ def test_eval_rewrite_as_KroneckerDelta():
     p17 = Piecewise((0, Ne(t, x) & (Ne(m, n) | Ne(n, t) | Ne(n, x))),
                     (1, Ne(t, x)), (-1, Ne(m, n) | Ne(n, t) | Ne(n, x)), (0, True))
     assert f(p17) == K(m, n)*K(n, t)*K(n, x) - K(t, x)
+
+    p18 = Piecewise((-4, Eq(y, 1) | (Eq(x, -5) & Eq(x, z))), (4, True))
+    assert f(p18) == 8*K(-5, x)*K(1, y)*K(x, z) - 8*K(-5, x)*K(x, z) - 8*K(1, y) + 4

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1247,3 +1247,33 @@ def test_eval_rewrite_as_KroneckerDelta():
 
     p5 = Piecewise((3, Ne(x, 2)), (4, Eq(y, 2)), (5, True))
     assert f(p5) == (5 - K(2, y))*K(2, x) - 3*K(2, x) + 3
+
+    p6 = Piecewise((0, Ne(x, 1) & Ne(y, 4)), (1, True))
+    assert f(p6) == -(1 - K(1, x)) * (1 - K(4, y)) + 1
+
+    p7 = Piecewise((2, Eq(y, 3) & Ne(x, 2)), (1, True))
+    assert f(p7) == (1 - K(2, x)) * K(3, y) + 1
+
+    p8 = Piecewise((4, Eq(x, 3) & Ne(y, 2)), (1, True))
+    assert f(p8) == 3 * (1 - K(2, y)) * K(3, x) + 1
+
+    p9 = Piecewise((6, Eq(x, 4) & Eq(y, 1)), (1, True))
+    assert f(p9) == 5 * K(1, y) * K(4, x) + 1
+
+    p10 = Piecewise((4, Ne(x, -4) | Ne(y, 1)), (1, True))
+    assert f(p10) == -3 * K(-4, x) * K(1, y) + 4
+
+    p11 = Piecewise((1, Eq(y, 2) | Ne(x, -3)), (2, True))
+    assert f(p11) == (1 - K(2, y)) * K(-3, x) + 1
+
+    p12 = Piecewise((-1, Eq(x, 1) | Ne(y, 3)), (1, True))
+    assert f(p12) == 2 * (1 - K(1, x)) * K(3, y) - 1
+
+    p13 = Piecewise((3, Eq(x, 2) | Eq(y, 4)), (1, True))
+    assert f(p13) == -2 * (1 - K(2, x)) * (1 - K(4, y)) + 3
+
+    p14 = Piecewise((1, Ne(x, 0) | Ne(y, 1)), (3, True))
+    assert f(p14) == 2 * K(0, x) * K(1, y) + 1
+
+    p15 = Piecewise((2, Eq(x, 3) | Ne(y, 2)), (3, Eq(x, 4) & Eq(y, 5)), (1, True))
+    assert f(p15) == (1 - K(3, x)) * (2 * K(4, x) * K(5, y) + 1) * K(2, y) - 2 * (1 - K(3, x)) * K(2, y) + 2

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1234,46 +1234,46 @@ def test_eval_rewrite_as_KroneckerDelta():
     f = lambda p: p.rewrite(K)
 
     p1 = Piecewise((0, Eq(x, y)), (1, True))
-    assert f(p1) == 1 - K(x, y)
+    assert f(p1).equals(1 - K(x, y))
 
     p2 = Piecewise((x, Eq(y,0)), (z, Eq(t,0)), (n, True))
-    assert f(p2) == x*K(0, y) + (1 - K(0, y))*(n*(1 - K(0, t)) + z*K(0, t))
+    assert f(p2).equals(x*K(0, y) + (1 - K(0, y))*(n*(1 - K(0, t)) + z*K(0, t)))
 
     p3 = Piecewise((1, Ne(x, y)), (0, True))
-    assert f(p3) == 1 - K(x, y)
+    assert f(p3).equals(1 - K(x, y))
 
     p4 = Piecewise((1, Eq(x, 3)), (4, True), (5, True))
-    assert f(p4) == 4 - 3*K(3, x)
+    assert f(p4).equals(4 - 3*K(3, x))
 
     p5 = Piecewise((3, Ne(x, 2)), (4, Eq(y, 2)), (5, True))
-    assert f(p5) == (5 - K(2, y))*K(2, x) - 3*K(2, x) + 3
+    assert f(p5).equals((5 - K(2, y))*K(2, x) - 3*K(2, x) + 3)
 
     p6 = Piecewise((0, Ne(x, 1) & Ne(y, 4)), (1, True))
-    assert f(p6) == -(1 - K(1, x)) * (1 - K(4, y)) + 1
+    assert f(p6).equals(-(1 - K(1, x)) * (1 - K(4, y)) + 1)
 
     p7 = Piecewise((2, Eq(y, 3) & Ne(x, 2)), (1, True))
-    assert f(p7) == (1 - K(2, x)) * K(3, y) + 1
+    assert f(p7).equals((1 - K(2, x)) * K(3, y) + 1)
 
     p8 = Piecewise((4, Eq(x, 3) & Ne(y, 2)), (1, True))
-    assert f(p8) == 3 * (1 - K(2, y)) * K(3, x) + 1
+    assert f(p8).equals(3 * (1 - K(2, y)) * K(3, x) + 1)
 
     p9 = Piecewise((6, Eq(x, 4) & Eq(y, 1)), (1, True))
-    assert f(p9) == 5 * K(1, y) * K(4, x) + 1
+    assert f(p9).equals(5 * K(1, y) * K(4, x) + 1)
 
     p10 = Piecewise((4, Ne(x, -4) | Ne(y, 1)), (1, True))
-    assert f(p10) == -3 * K(-4, x) * K(1, y) + 4
+    assert f(p10).equals(-3 * K(-4, x) * K(1, y) + 4)
 
     p11 = Piecewise((1, Eq(y, 2) | Ne(x, -3)), (2, True))
-    assert f(p11) == (1 - K(2, y)) * K(-3, x) + 1
+    assert f(p11).equals((1 - K(2, y)) * K(-3, x) + 1)
 
     p12 = Piecewise((-1, Eq(x, 1) | Ne(y, 3)), (1, True))
-    assert f(p12) == 2 * (1 - K(1, x)) * K(3, y) - 1
+    assert f(p12).equals(2 * (1 - K(1, x)) * K(3, y) - 1)
 
     p13 = Piecewise((3, Eq(x, 2) | Eq(y, 4)), (1, True))
-    assert f(p13) == -2 * (1 - K(2, x)) * (1 - K(4, y)) + 3
+    assert f(p13).equals(-2 * (1 - K(2, x)) * (1 - K(4, y)) + 3)
 
     p14 = Piecewise((1, Ne(x, 0) | Ne(y, 1)), (3, True))
-    assert f(p14) == 2 * K(0, x) * K(1, y) + 1
+    assert f(p14).equals(2 * K(0, x) * K(1, y) + 1)
 
     p15 = Piecewise((2, Eq(x, 3) | Ne(y, 2)), (3, Eq(x, 4) & Eq(y, 5)), (1, True))
-    assert f(p15) == (1 - K(3, x)) * (2 * K(4, x) * K(5, y) + 1) * K(2, y) - 2 * (1 - K(3, x)) * K(2, y) + 2
+    assert f(p15).equals((1 - K(3, x)) * (2 * K(4, x) * K(5, y) + 1) * K(2, y) - 2 * (1 - K(3, x)) * K(2, y) + 2)

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -444,3 +444,9 @@ class KroneckerDelta(Function):
     def _sage_(self):
         import sage.all as sage
         return sage.kronecker_delta(self.args[0]._sage_(), self.args[1]._sage_())
+
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
+        from sympy.functions.elementary.piecewise import Piecewise
+        from sympy.core.relational import Ne
+        i, j = args
+        return Piecewise((0, Ne(i, j)), (1, True))

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -1,6 +1,6 @@
 from sympy import (
     adjoint, conjugate, Dummy, Eijk, KroneckerDelta, LeviCivita, Symbol,
-    symbols, transpose,
+    symbols, transpose, Piecewise, Ne
 )
 from sympy.core.compatibility import range, long
 from sympy.physics.secondquant import evaluate_deltas, F
@@ -60,6 +60,8 @@ def test_kronecker_delta():
     assert transpose(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
     # to test if canonical
     assert (KroneckerDelta(i, j) == KroneckerDelta(j, i)) == True
+
+    assert KroneckerDelta(i, j).rewrite(Piecewise) == Piecewise((0, Ne(i, j)), (1, True))
 
 def test_kronecker_delta_secondquant():
     """secondquant-specific methods"""

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -5,7 +5,7 @@ the expression E**(pi*I) will be converted into -1
 the expression (x+x)**2 will be converted into 4*x**2
 """
 from .simplify import (simplify, hypersimp, hypersimilar,
-    logcombine, separatevars, posify, besselsimp,
+    logcombine, separatevars, posify, besselsimp, kroneckersimp,
     signsimp, bottom_up, nsimplify)
 
 from .fu import FU, fu

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1146,14 +1146,14 @@ def kroneckersimp(expr):
     if not expr.has(KroneckerDelta):
         return expr
 
+    if expr.has(Piecewise):
+        expr = expr.rewrite(KroneckerDelta)
+
     newexpr = expr
     expr = None
+
     while newexpr != expr:
         expr = newexpr
-
-        if expr.has(Piecewise):
-            expr = expr.rewrite(KroneckerDelta)
-
         newexpr = expr.replace(is_mul_with_kronecker, cancel_kronecker_mul)
 
     return expr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1112,10 +1112,10 @@ def kroneckersimp(expr):
 
     The only simplification currently attempted is to identify multiplicative cancellation:
 
-    >>> from sympy import kroneckersimp
+    >>> from sympy import KroneckerDelta, kroneckersimp
     >>> from sympy.abc import i, j
-    >>> kroneckersimp(KroneckerDelta(0, j) * KroneckerDelta(1, j))
-    >>> 0
+    >>> kroneckersimp(1 + KroneckerDelta(0, j) * KroneckerDelta(1, j))
+    1
     """
     def args_cancel(a1, a2, a3, a4):
         return Eq(a1, a2) is S.true and Eq(a3, a4) is S.false

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1131,6 +1131,9 @@ def kroneckersimp(expr):
     def cancel_kronecker_mul(m):
         from sympy.utilities.iterables import subsets
 
+        if m.has(Piecewise):
+            m = m.rewrite(KroneckerDelta)
+
         args = m.args
         deltas = [a for a in args if isinstance(a, KroneckerDelta)]
         for delta1, delta2 in subsets(deltas, 2):
@@ -1141,7 +1144,7 @@ def kroneckersimp(expr):
         return m
 
     def is_mul_with_kronecker(e):
-        return isinstance(e, Mul) and e.has(KroneckerDelta)
+        return isinstance(e, Mul) and e.has(KroneckerDelta) or e.has(Piecewise)
 
     if not expr.has(KroneckerDelta):
         return expr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from sympy.core import (Basic, S, Add, Mul, Pow, Symbol, sympify, expand_mul,
                         expand_func, Function, Dummy, Expr, factor_terms,
-                        expand_power_exp)
+                        expand_power_exp, Eq)
 from sympy.core.compatibility import iterable, ordered, range, as_int
 from sympy.core.evaluate import global_evaluate
 from sympy.core.function import expand_log, count_ops, _mexpand, _coeff_isneg, nfloat
@@ -1113,7 +1113,7 @@ def kroneckersimp(expr):
     The only simplification attempted is to identify multiplicative cancellation.
     """
     def args_cancel(a1, a2, a3, a4):
-        return a1.equals(a2) and not a3.equals(a4)
+        return Eq(a1, a2) is S.true and Eq(a3, a4) is S.false
 
     def cancel_kronecker_mul(m):
         args = m.args

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1117,25 +1117,27 @@ def kroneckersimp(expr):
     >>> kroneckersimp(1 + KroneckerDelta(0, j) * KroneckerDelta(1, j))
     1
     """
-    def args_cancel(a1, a2, a3, a4):
-        return Eq(a1, a2) is S.true and Eq(a3, a4) is S.false
+    def args_cancel(args1, args2):
+        for i1 in range(2):
+            for i2 in range(2):
+                a1 = args1[i1]
+                a2 = args2[i2]
+                a3 = args1[(i1 + 1) % 2]
+                a4 = args2[(i2 + 1) % 2]
+                if Eq(a1, a2) is S.true and Eq(a3, a4) is S.false:
+                    return True
+        return False
 
     def cancel_kronecker_mul(m):
+        from sympy.utilities.iterables import subsets
+
         args = m.args
         deltas = [a for a in args if isinstance(a, KroneckerDelta)]
-
-        for i in range(len(deltas)):
-            args1 = deltas[i].args
-            for j in range(i+1, len(deltas)):
-                args2 = deltas[j].args
-                for i1 in range(2):
-                    for i2 in range(2):
-                        a1 = args1[i1]
-                        a2 = args2[i2]
-                        a3 = args1[(i1 + 1) % 2]
-                        a4 = args2[(i2 + 1) % 2]
-                        if args_cancel(a1, a2, a3, a4):
-                            return Mul(*((0,) + args))
+        for delta1, delta2 in subsets(deltas, 2):
+            args1 = delta1.args
+            args2 = delta2.args
+            if args_cancel(args1, args2):
+                return 0*m
         return m
 
     def is_mul_with_kronecker(e):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -17,6 +17,7 @@ from sympy.functions.elementary.complexes import unpolarify
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.integers import ceiling
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.special.bessel import besselj, besseli, besselk, jn, bessely
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -589,6 +590,9 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     # hyperexpand automatically only works on hypergeometric terms
     expr = hyperexpand(expr)
 
+    if expr.has(KroneckerDelta):
+        expr = expr.rewrite(Piecewise)
+
     expr = piecewise_fold(expr)
 
     if expr.has(BesselBase):
@@ -614,10 +618,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
     if expr.has(Product):
         expr = product_simplify(expr)
-
-    if expr.has(KroneckerDelta):
-        from sympy.functions.elementary.piecewise import Piecewise
-        expr = simplify(expr.rewrite(Piecewise))
 
     from sympy.physics.units import Quantity
     from sympy.physics.units.util import quantity_simplify

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1140,9 +1140,6 @@ def kroneckersimp(expr):
                 return 0*m
         return m
 
-    def is_mul_with_kronecker(e):
-        return isinstance(e, Mul) and e.has(KroneckerDelta)
-
     if not expr.has(KroneckerDelta):
         return expr
 
@@ -1154,7 +1151,7 @@ def kroneckersimp(expr):
 
     while newexpr != expr:
         expr = newexpr
-        newexpr = expr.replace(is_mul_with_kronecker, cancel_kronecker_mul)
+        newexpr = expr.replace(lambda e: isinstance(e, Mul), cancel_kronecker_mul)
 
     return expr
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1131,9 +1131,6 @@ def kroneckersimp(expr):
     def cancel_kronecker_mul(m):
         from sympy.utilities.iterables import subsets
 
-        if m.has(Piecewise):
-            m = m.rewrite(KroneckerDelta)
-
         args = m.args
         deltas = [a for a in args if isinstance(a, KroneckerDelta)]
         for delta1, delta2 in subsets(deltas, 2):
@@ -1144,7 +1141,7 @@ def kroneckersimp(expr):
         return m
 
     def is_mul_with_kronecker(e):
-        return isinstance(e, Mul) and e.has(KroneckerDelta) or e.has(Piecewise)
+        return isinstance(e, Mul) and e.has(KroneckerDelta)
 
     if not expr.has(KroneckerDelta):
         return expr
@@ -1153,6 +1150,10 @@ def kroneckersimp(expr):
     expr = None
     while newexpr != expr:
         expr = newexpr
+
+        if expr.has(Piecewise):
+            expr = expr.rewrite(KroneckerDelta)
+
         newexpr = expr.replace(is_mul_with_kronecker, cancel_kronecker_mul)
 
     return expr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -19,6 +19,7 @@ from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.special.bessel import besselj, besseli, besselk, jn, bessely
+from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.polys import together, cancel, factor
 from sympy.simplify.combsimp import combsimp
 from sympy.simplify.cse_opts import sub_pre, sub_post
@@ -613,6 +614,10 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
     if expr.has(Product):
         expr = product_simplify(expr)
+
+    if expr.has(KroneckerDelta):
+        from sympy.functions.elementary.piecewise import Piecewise
+        expr = simplify(expr.rewrite(Piecewise))
 
     from sympy.physics.units import Quantity
     from sympy.physics.units.util import quantity_simplify

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1110,7 +1110,12 @@ def kroneckersimp(expr):
     """
     Simplify expressions with KroneckerDelta.
 
-    The only simplification attempted is to identify multiplicative cancellation.
+    The only simplification currently attempted is to identify multiplicative cancellation:
+
+    >>> from sympy import kroneckersimp
+    >>> from sympy.abc import i, j
+    >>> kroneckersimp(KroneckerDelta(0, j) * KroneckerDelta(1, j))
+    >>> 0
     """
     def args_cancel(a1, a2, a3, a4):
         return Eq(a1, a2) is S.true and Eq(a3, a4) is S.false

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -851,12 +851,10 @@ def test_simplify_kroneckerdelta():
     assert simplify(K(1, i) + Piecewise((1, Eq(j, 2)), (0, True))) == K(1, i) + K(2, j)
 
     # issue 17214
-    e1 = K(0, j) * K(1, j)
-    assert simplify(e1) == 0
+    assert simplify(K(0, j) * K(1, j)) == 0
 
     n = Symbol('n', integer=True)
-    e2 = K(0, n) * K(1, n)
-    assert simplify(e2) == 0
+    assert simplify(K(0, n) * K(1, n)) == 0
 
     M = Matrix(4, 4, lambda i, j: K(j - i, n) if i <= j else 0)
     assert simplify(M**2) == Matrix([[K(0, n), 0, K(1, n), 0],

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -3,8 +3,8 @@ from sympy import (
     collect,cos, cosh, cot, coth, count_ops, csch, Derivative, diff, E,
     Eq, erf, exp, exp_polar, expand, expand_multinomial, factor,
     factorial, Float, fraction, Function, gamma, GoldenRatio, hyper,
-    hypersimp, I, Integral, integrate, log, logcombine, Lt, Matrix,
-    MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise, posify, rad,
+    hypersimp, I, Integral, integrate, KroneckerDelta, log, logcombine, Lt,
+    Matrix, MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise, posify, rad,
     Rational, root, S, separatevars, signsimp, simplify, sign, sin,
     sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan, tanh,
     zoo)
@@ -837,3 +837,19 @@ def test_issue_17141():
     else:
         raises(RuntimeError, lambda: simplify(2**acos(I+1)**2))
         raises(RuntimeError, lambda: simplify((2**acos(I+1)**2).rewrite('log')))
+
+
+def test_simplify_kroneckerdelta():
+    i, j = symbols("i j")
+
+    assert simplify(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
+    assert simplify(KroneckerDelta(0, j)) == KroneckerDelta(0, j)
+    assert simplify(KroneckerDelta(i, 0)) == KroneckerDelta(i, 0)
+
+    # issue 17214
+    e1 = KroneckerDelta(0, j) * KroneckerDelta(1, j)
+    assert simplify(e1) == 0
+
+    n = Symbol('n', integer=True)
+    e2 = KroneckerDelta(0, n) * KroneckerDelta(1, n)
+    assert simplify(e2) == 0

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -853,3 +853,9 @@ def test_simplify_kroneckerdelta():
     n = Symbol('n', integer=True)
     e2 = KroneckerDelta(0, n) * KroneckerDelta(1, n)
     assert simplify(e2) == 0
+
+    M = Matrix(4, 4, lambda i, j: KroneckerDelta(j - i, n) if i <= j else 0)
+    assert simplify(M**2) == Matrix([[KroneckerDelta(0, n), 0, KroneckerDelta(1, n), 0],
+                                     [0, KroneckerDelta(0, n), 0, KroneckerDelta(1, n)],
+                                     [0, 0, KroneckerDelta(0, n), 0],
+                                     [0, 0, 0, KroneckerDelta(0, n)]])

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -841,21 +841,25 @@ def test_issue_17141():
 
 def test_simplify_kroneckerdelta():
     i, j = symbols("i j")
+    K = KroneckerDelta
 
-    assert simplify(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
-    assert simplify(KroneckerDelta(0, j)) == KroneckerDelta(0, j)
-    assert simplify(KroneckerDelta(i, 0)) == KroneckerDelta(i, 0)
+    assert simplify(K(i, j)) == K(i, j)
+    assert simplify(K(0, j)) == K(0, j)
+    assert simplify(K(i, 0)) == K(i, 0)
+
+    assert simplify(K(0, j).rewrite(Piecewise) * K(1, j)) == 0
+    assert simplify(K(1, i) + Piecewise((1, Eq(j, 2)), (0, True))) == K(1, i) + K(2, j)
 
     # issue 17214
-    e1 = KroneckerDelta(0, j) * KroneckerDelta(1, j)
+    e1 = K(0, j) * K(1, j)
     assert simplify(e1) == 0
 
     n = Symbol('n', integer=True)
-    e2 = KroneckerDelta(0, n) * KroneckerDelta(1, n)
+    e2 = K(0, n) * K(1, n)
     assert simplify(e2) == 0
 
-    M = Matrix(4, 4, lambda i, j: KroneckerDelta(j - i, n) if i <= j else 0)
-    assert simplify(M**2) == Matrix([[KroneckerDelta(0, n), 0, KroneckerDelta(1, n), 0],
-                                     [0, KroneckerDelta(0, n), 0, KroneckerDelta(1, n)],
-                                     [0, 0, KroneckerDelta(0, n), 0],
-                                     [0, 0, 0, KroneckerDelta(0, n)]])
+    M = Matrix(4, 4, lambda i, j: K(j - i, n) if i <= j else 0)
+    assert simplify(M**2) == Matrix([[K(0, n), 0, K(1, n), 0],
+                                     [0, K(0, n), 0, K(1, n)],
+                                     [0, 0, K(0, n), 0],
+                                     [0, 0, 0, K(0, n)]])


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #17214.

#### Brief description of what is fixed or changed
Add `_eval_rewrite_as_Piecewise` to `KroneckerDelta`. Add `simplify` recognition of expressions containing `KroneckerDelta` and attempt to simplify via `Piecewise`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * KroneckerDelta can be rewritten as Piecewise.
  * Piecewise can be rewritten as KroneckerDelta
* simplify
  * simplify attempts to simplify expressions containing KroneckerDelta.
<!-- END RELEASE NOTES -->
