### PR TITLE
Add matrix logarithm

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3286,9 +3286,7 @@ class MatrixBase(MatrixDeprecated,
 
         Examples for non positive-definite matrices:
 
-        >>> m = Matrix(
-        ...     [[S(3)/4, S(5)/4],
-        ...      [S(5)/4, S(3)/4]])
+        >>> m = Matrix([[S(3)/4, S(5)/4], [S(5)/4, S(3)/4]])
         >>> m.log()
         Matrix([
         [         I*pi/2, log(2) - I*pi/2],

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3235,7 +3235,20 @@ class MatrixBase(MatrixDeprecated,
         return self.__class__(banded(size, bands))
 
     def log(self):
-        """Return the logarithm of a square matrix"""
+        """Return the logarithm of a square matrix
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[1, 1], [0, 1]])
+        >>> m.log()
+        Matrix([[0, 1], [0, 0]])
+
+        >>> m = Matrix([[S(5)/4, S(3)/4], [S(3)/4, S(5)/4]])
+        >>> m.log()
+        Matrix([[0, log(2)], [log(2), 0]])
+        """
         if not self.is_square:
             raise NonSquareMatrixError(
                 "Logarithm is valid only for square matrices")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3227,6 +3227,11 @@ class MatrixBase(MatrixDeprecated,
         size = self.rows
         l = self[0, 0]
 
+        if l.is_zero:
+            raise MatrixError(
+                'Could not take logarithm or reciprocal for the given '
+                'eigenvalue {}'.format(l))
+
         bands = {0: log(l)}
         for i in range(1, size):
             bands[i] = -((-l) ** -i) / i

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3245,14 +3245,51 @@ class MatrixBase(MatrixDeprecated,
         Examples
         ========
 
-        >>> from sympy import Matrix
+        >>> from sympy import S, Matrix
+
+        Examples for positive-definite matrices:
+
         >>> m = Matrix([[1, 1], [0, 1]])
+        >>> m.is_positive_definite
+        True
         >>> m.log()
-        Matrix([[0, 1], [0, 0]])
+        Matrix([
+        [0, 1],
+        [0, 0]])
 
         >>> m = Matrix([[S(5)/4, S(3)/4], [S(3)/4, S(5)/4]])
+        >>> m.is_positive_definite
+        True
         >>> m.log()
-        Matrix([[0, log(2)], [log(2), 0]])
+        Matrix([
+        [     0, log(2)],
+        [log(2),      0]])
+
+        Examples for non positive-definite matrices:
+
+        >>> m = Matrix(
+        ...     [[S(3)/4, S(5)/4],
+        ...      [S(5)/4, S(3)/4]])
+        >>> m.is_positive_definite
+        False
+        >>> m.log()
+        Matrix([
+        [         I*pi/2, log(2) - I*pi/2],
+        [log(2) - I*pi/2,          I*pi/2]])
+
+        >>> m = Matrix(
+        ...     [[0, 0, 0, 1],
+        ...      [0, 0, 1, 0],
+        ...      [0, 1, 0, 0],
+        ...      [1, 0, 0, 0]])
+        >>> m.is_positive_definite
+        False
+        >>> m.log()
+        Matrix([
+        [ I*pi/2,       0,       0, -I*pi/2],
+        [      0,  I*pi/2, -I*pi/2,       0],
+        [      0, -I*pi/2,  I*pi/2,       0],
+        [-I*pi/2,       0,       0,  I*pi/2]])
         """
         if not self.is_square:
             raise NonSquareMatrixError(

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3200,7 +3200,7 @@ class MatrixBase(MatrixDeprecated,
         else:
             return type(self)(ret)
 
-    def _eval_matrix_log_jblock(self, principal=True):
+    def _eval_matrix_log_jblock(self):
         """Helper function to compute logarithm of a jordan block.
 
         Examples
@@ -3232,12 +3232,6 @@ class MatrixBase(MatrixDeprecated,
                 'Could not take logarithm or reciprocal for the given '
                 'eigenvalue {}'.format(l))
 
-        if l.is_negative and principal:
-            raise NonPositiveDefiniteMatrixError(
-                "A negative eigenvalue {} is found. Only positive "
-                "definite matrices have principal logarithm. Set "
-                "'principal=False' if you want non-principal result.")
-
         bands = {0: log(l)}
         for i in range(1, size):
             bands[i] = -((-l) ** -i) / i
@@ -3245,7 +3239,7 @@ class MatrixBase(MatrixDeprecated,
         from .sparsetools import banded
         return self.__class__(banded(size, bands))
 
-    def log(self, principal=True):
+    def log(self):
         """Return the logarithm of a square matrix
 
         Examples
@@ -3278,7 +3272,7 @@ class MatrixBase(MatrixDeprecated,
         ...      [S(5)/4, S(3)/4]])
         >>> m.is_positive_definite
         False
-        >>> m.log(principal=False)
+        >>> m.log()
         Matrix([
         [         I*pi/2, log(2) - I*pi/2],
         [log(2) - I*pi/2,          I*pi/2]])
@@ -3290,7 +3284,7 @@ class MatrixBase(MatrixDeprecated,
         ...      [1, 0, 0, 0]])
         >>> m.is_positive_definite
         False
-        >>> m.log(principal=False)
+        >>> m.log()
         Matrix([
         [ I*pi/2,       0,       0, -I*pi/2],
         [      0,  I*pi/2, -I*pi/2,       0],
@@ -3309,7 +3303,7 @@ class MatrixBase(MatrixDeprecated,
                 "the Jordan normal form can be computed")
 
         blocks = [
-            cell._eval_matrix_log_jblock(principal=principal)
+            cell._eval_matrix_log_jblock()
             for cell in cells]
         from sympy.matrices import diag
         eJ = diag(*blocks)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3273,16 +3273,12 @@ class MatrixBase(MatrixDeprecated,
         Examples for positive-definite matrices:
 
         >>> m = Matrix([[1, 1], [0, 1]])
-        >>> m.is_positive_definite
-        True
         >>> m.log()
         Matrix([
         [0, 1],
         [0, 0]])
 
         >>> m = Matrix([[S(5)/4, S(3)/4], [S(3)/4, S(5)/4]])
-        >>> m.is_positive_definite
-        True
         >>> m.log()
         Matrix([
         [     0, log(2)],
@@ -3293,8 +3289,6 @@ class MatrixBase(MatrixDeprecated,
         >>> m = Matrix(
         ...     [[S(3)/4, S(5)/4],
         ...      [S(5)/4, S(3)/4]])
-        >>> m.is_positive_definite
-        False
         >>> m.log()
         Matrix([
         [         I*pi/2, log(2) - I*pi/2],
@@ -3305,8 +3299,6 @@ class MatrixBase(MatrixDeprecated,
         ...      [0, 0, 1, 0],
         ...      [0, 1, 0, 0],
         ...      [1, 0, 0, 0]])
-        >>> m.is_positive_definite
-        False
         >>> m.log()
         Matrix([
         [ I*pi/2,       0,       0, -I*pi/2],

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3178,7 +3178,20 @@ class MatrixBase(MatrixDeprecated,
         return self.__class__(banded(size, bands))
 
     def exp(self):
-        """Return the exponentiation of a square matrix."""
+        """Return the exponential of a square matrix
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, Matrix
+
+        >>> t = Symbol('t')
+        >>> m = Matrix([[0, 1], [-1, 0]]) * t
+        >>> m.exp()
+        Matrix([
+        [    exp(I*t)/2 + exp(-I*t)/2, -I*exp(I*t)/2 + I*exp(-I*t)/2],
+        [I*exp(I*t)/2 - I*exp(-I*t)/2,      exp(I*t)/2 + exp(-I*t)/2]])
+        """
         if not self.is_square:
             raise NonSquareMatrixError(
                 "Exponentiation is valid only for square matrices")

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2,8 +2,8 @@ import random
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
-    S, Symbol, cos, exp, expand_mul, oo, pi, signsimp, simplify, sin, sqrt, symbols,
-    sympify, trigsimp, tan, sstr, diff, Function)
+    S, Symbol, cos, exp, log, expand_mul, oo, pi, signsimp, simplify, sin,
+    sqrt, symbols, sympify, trigsimp, tan, sstr, diff, Function)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     NonSquareMatrixError, DeferredVector, _find_reasonable_pivot_naive,
     _simplify)
@@ -2079,6 +2079,22 @@ def test_exp():
 
 
 def test_log():
+    l = Symbol('lamda')
+
+    m = Matrix.jordan_block(1, l)
+    assert m._eval_matrix_log_jblock() == Matrix([[log(l)]])
+
+    m = Matrix.jordan_block(4, l)
+    assert m._eval_matrix_log_jblock() == \
+        Matrix(
+            [
+                [log(l), 1/l, -1/(2*l**2), 1/(3*l**3)],
+                [0, log(l), 1/l, -1/(2*l**2)],
+                [0, 0, log(l), 1/l],
+                [0, 0, 0, log(l)]
+            ]
+        )
+
     m = Matrix(
         [[0, 0, 1],
         [0, 0, 0],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2078,6 +2078,15 @@ def test_exp():
     assert m.exp() == Matrix([[E*cos(1), -E*sin(1)], [E*sin(1), E*cos(1)]])
 
 
+def test_log():
+    m = Matrix(
+        [[0, 0, 1],
+        [0, 0, 0],
+        [-1, 0, 0]]
+    )
+    raises(MatrixError, lambda: m.log())
+
+
 def test_has():
     A = Matrix(((x, y), (2, 3)))
     assert A.has(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is the first step of implementing matrix logarithm using jordan decomposition method.

But the thing most confusing to me, is that the imaginary values of the principal logarithms for scalars should lie in the interval (−π, π] 
https://en.wikipedia.org/wiki/Complex_logarithm#Definition_of_principal_value
but the imaginary values of the eigenvalues of the principal logarithm for matrices should lie in the interval (−π, π)
https://en.wikipedia.org/wiki/Logarithm_of_a_matrix#Existence

And since sympy sets the `log(-1)` as `I*pi`, should setting the `principal=False` be considered consistent with the sympy's implementation of scalar log?

I don't know if those two wikipedia definitions are consistent each other, regarding a simple case like how `Matrix([[-1]]).log()` should be considered.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added `Matrix.log` for computing matrix logarithm.
<!-- END RELEASE NOTES -->
