### PR TITLE
Rewrite of non-commutative multiplication matching

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1001,7 +1001,7 @@ class Mul(Expr, AssocOp):
             node = nodes[node_ind]
 
             if node.is_Wild:
-                Mul._matches_add_wildcard(wildcard_dict, state, node)
+                Mul._matches_add_wildcard(wildcard_dict, state)
 
             states_matches = Mul._matches_new_states(wildcard_dict, state,
                                                      nodes, targets)
@@ -1020,13 +1020,13 @@ class Mul(Expr, AssocOp):
         return repl_dict
 
     @staticmethod
-    def _matches_add_wildcard(dictionary, state, wildcard):
+    def _matches_add_wildcard(dictionary, state):
         node_ind, target_ind = state
-        if wildcard in dictionary:
-            begin, end = dictionary[wildcard]
-            dictionary[wildcard] = (begin, target_ind)
+        if node_ind in dictionary:
+            begin, end = dictionary[node_ind]
+            dictionary[node_ind] = (begin, target_ind)
         else:
-            dictionary[wildcard] = (target_ind, target_ind)
+            dictionary[node_ind] = (target_ind, target_ind)
 
     @staticmethod
     def _matches_new_states(dictionary, state, nodes, targets):
@@ -1039,8 +1039,8 @@ class Mul(Expr, AssocOp):
             return None
 
         if node.is_Wild:
-            match_attempt = Mul._matches_match_wilds(dictionary, node,
-                                                        targets)
+            match_attempt = Mul._matches_match_wilds(dictionary, node_ind,
+                                                     nodes, targets)
             if match_attempt:
                 # A wildcard node can match more than one target, so only the
                 # target index is advanced
@@ -1066,8 +1066,9 @@ class Mul(Expr, AssocOp):
                 return None
 
     @staticmethod
-    def _matches_match_wilds(dictionary, wildcard, targets):
-        begin, end = dictionary[wildcard]
+    def _matches_match_wilds(dictionary, wildcard_ind, nodes, targets):
+        wildcard = nodes[wildcard_ind]
+        begin, end = dictionary[wildcard_ind]
         terms = targets[begin:end + 1]
         # TODO: Should this be self.func?
         mul = Mul(*terms) if len(terms) > 1 else terms[0]

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -969,15 +969,15 @@ class Mul(Expr, AssocOp):
 
         # Now match the non-commutative arguments, expanding powers to
         # multiplications
-        nc1 = Mul._matches_expand_matpows(nc1)
-        nc2 = Mul._matches_expand_matpows(nc2)
+        nc1 = Mul._matches_expand_pows(nc1)
+        nc2 = Mul._matches_expand_pows(nc2)
 
         repl_dict = Mul._matches_noncomm(nc1, nc2, repl_dict)
 
         return repl_dict or None
 
     @staticmethod
-    def _matches_expand_matpows(arg_list):
+    def _matches_expand_pows(arg_list):
         new_args = []
         for arg in arg_list:
             if arg.is_Pow and arg.exp > 0:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -988,12 +988,18 @@ class Mul(Expr, AssocOp):
 
     @staticmethod
     def _matches_noncomm(nodes, targets, repl_dict={}):
+        """Non-commutative multiplication matcher.
+
+        `nodes` is a list of symbols within the matcher multiplication
+        expression, while `targets` is a list of arguments in the
+        multiplication expression being matched against.
+        """
         # List of possible future states to be considered
         agenda = []
         # The current matching state, storing index in nodes and targets
         state = (0, 0)
         node_ind, target_ind = state
-        # Mapping between wildcards and the index ranges they match
+        # Mapping between wildcard indices and the index ranges they match
         wildcard_dict = {}
         repl_dict = repl_dict.copy()
 
@@ -1083,6 +1089,7 @@ class Mul(Expr, AssocOp):
 
     @staticmethod
     def _matches_match_wilds(dictionary, wildcard_ind, nodes, targets):
+        """Determine matches of a wildcard with sub-expression in `target`."""
         wildcard = nodes[wildcard_ind]
         begin, end = dictionary[wildcard_ind]
         terms = targets[begin:end + 1]
@@ -1092,6 +1099,7 @@ class Mul(Expr, AssocOp):
 
     @staticmethod
     def _matches_get_other_nodes(dictionary, nodes, node_ind):
+        """Find other wildcards that may have already been matched."""
         other_node_inds = []
         for ind in dictionary:
             if nodes[ind] == nodes[node_ind]:

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -211,6 +211,17 @@ def test_mul_noncommutative():
     assert (u*v*A*B).matches(u*v*A*C) is None
 
 
+def test_mul_noncommutative_mismatch():
+    A, B, C = symbols('A B C', commutative=False)
+    w = symbols('w', cls=Wild, commutative=False)
+
+    assert (w*B*w).matches(A*B*A) == {w: A}
+    assert (w*B*w).matches(A*C*B*A*C) == {w: A*C}
+    assert (w*B*w).matches(A*C*B*A*B) is None
+    assert (w*B*w).matches(A*B*C) is None
+    assert (w*w*C).matches(A*B*C) is None
+
+
 def test_mul_noncommutative_pow():
     A, B, C = symbols('A B C', commutative=False)
     w = symbols('w', cls=Wild, commutative=False)
@@ -221,6 +232,10 @@ def test_mul_noncommutative_pow():
 
     assert (A*B*(w**(-1))).matches(A*B*(C**(-1))) == {w: C}
     assert (A*(B*w)**(-1)*C).matches(A*(B*C)**(-1)*C) == {w: C}
+
+    assert ((w**2)*B*C).matches((A**2)*B*C) == {w: A}
+    assert ((w**2)*B*(w**3)).matches((A**2)*B*(A**3)) == {w: A}
+    assert ((w**2)*B*(w**4)).matches((A**2)*B*(A**2)) is None
 
 def test_complex():
     a, b, c = map(Symbol, 'abc')

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -181,6 +181,9 @@ def test_mul_noncommutative():
     assert (w*z).matches(x*A*B) is None
     assert (w*z).matches(x*y*A*B) is None
 
+    assert (w*A).matches(A) is None
+    assert (A*w*B).matches(A*B) is None
+
     assert (u*w*z).matches(x) is None
     assert (u*w*z).matches(x*y) is None
     assert (u*w*z).matches(A) is None

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -139,9 +139,9 @@ def test_mul():
 
 def test_mul_noncommutative():
     x, y = symbols('x y')
-    A, B = symbols('A B', commutative=False)
+    A, B, C = symbols('A B C', commutative=False)
     u, v = symbols('u v', cls=Wild)
-    w = Wild('w', commutative=False)
+    w, z = symbols('w z', cls=Wild, commutative=False)
 
     assert (u*v).matches(x) in ({v: x, u: 1}, {u: x, v: 1})
     assert (u*v).matches(x*y) in ({v: y, u: x}, {u: y, v: x})
@@ -170,6 +170,54 @@ def test_mul_noncommutative():
     assert (v*w).matches(-x*A*B) == {w: A*B, v: -x}
     assert (v*w).matches(-x*y*A*B) == {w: A*B, v: -x*y}
 
+    assert (w*z).matches(x) is None
+    assert (w*z).matches(x*y) is None
+    assert (w*z).matches(A) is None
+    assert (w*z).matches(A*B) == {w: A, z: B}
+    assert (w*z).matches(B*A) == {w: B, z: A}
+    assert (w*z).matches(A*B*C) in [{w: A, z: B*C}, {w: A*B, z: C}]
+    assert (w*z).matches(x*A) is None
+    assert (w*z).matches(x*y*A) is None
+    assert (w*z).matches(x*A*B) is None
+    assert (w*z).matches(x*y*A*B) is None
+
+    assert (u*w*z).matches(x) is None
+    assert (u*w*z).matches(x*y) is None
+    assert (u*w*z).matches(A) is None
+    assert (u*w*z).matches(A*B) == {u: 1, w: A, z: B}
+    assert (u*w*z).matches(B*A) == {u: 1, w: B, z: A}
+    assert (u*w*z).matches(x*A) is None
+    assert (u*w*z).matches(x*y*A) is None
+    assert (u*w*z).matches(x*A*B) == {u: x, w: A, z: B}
+    assert (u*w*z).matches(x*B*A) == {u: x, w: B, z: A}
+    assert (u*w*z).matches(x*y*A*B) == {u: x*y, w: A, z: B}
+    assert (u*w*z).matches(x*y*B*A) == {u: x*y, w: B, z: A}
+
+    assert (u*A).matches(x*A) == {u: x}
+    assert (u*A).matches(x*A*B) is None
+    assert (u*B).matches(x*A) is None
+    assert (u*A*B).matches(x*A*B) == {u: x}
+    assert (u*A*B).matches(x*B*A) is None
+    assert (u*A*B).matches(x*A) is None
+
+    assert (u*w*A).matches(x*A*B) is None
+    assert (u*w*B).matches(x*A*B) == {u: x, w: A}
+
+    assert (u*v*A*B).matches(x*A*B) in [{u: x, v: 1}, {v: x, u: 1}]
+    assert (u*v*A*B).matches(x*B*A) is None
+    assert (u*v*A*B).matches(u*v*A*C) is None
+
+
+def test_mul_noncommutative_pow():
+    A, B, C = symbols('A B C', commutative=False)
+    w = symbols('w', cls=Wild, commutative=False)
+
+    assert (A*B*w).matches(A*B**2) == {w: B}
+    assert (A*(B**2)*w*(B**3)).matches(A*B**8) == {w: B**3}
+    assert (A*B*w*C).matches(A*(B**4)*C) == {w: B**3}
+
+    assert (A*B*(w**(-1))).matches(A*B*(C**(-1))) == {w: C}
+    assert (A*(B*w)**(-1)*C).matches(A*(B*C)**(-1)*C) == {w: C}
 
 def test_complex():
     a, b, c = map(Symbol, 'abc')


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #17172

#### Brief description of what is fixed or changed

Rewrites the matching code for non-commutative multiplication expressions that:

* Respects expression structure (`A*w`matches`A*B` but not`C*B`)
* Accounts for non-commutativity (`A*B*w` matches `A*B*C` but not `B*A*C`)
* Enables non-commutative wildcards to match any subsequence (`A*w*D` matches `A*B*C*D`)

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * improvements to non-commutative matching
<!-- END RELEASE NOTES -->
