### PR TITLE
Modified behavior of __getitem__ for arrays

### DIFF
--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -160,7 +160,8 @@ def tensorcontraction(array, *contraction_axes):
         index_base_position = sum(icontrib)
         isum = S.Zero
         for sum_to_index in itertools.product(*summed_deltas):
-            isum += array[index_base_position + sum(sum_to_index)]
+            idx = array._get_tuple_index(index_base_position + sum(sum_to_index))
+            isum += array[idx]
 
         contracted_array.append(isum)
 

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -179,7 +179,7 @@ class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
         self._shape = shape
         self._array = list(flat_list)
         self._rank = len(shape)
-        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else 0
+        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
         return self
 
     def __setitem__(self, index, value):

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -30,6 +30,11 @@ class DenseNDimArray(NDimArray):
         0
         >>> a[1, 1]
         3
+        >>> a[0]
+        [0, 1]
+        >>> a[1]
+        [2, 3]
+
 
         Symbolic index:
 
@@ -49,13 +54,9 @@ class DenseNDimArray(NDimArray):
 
         if isinstance(index, (SYMPY_INTS, Integer)):
             index = Tuple(index)
-        if not isinstance(index, (tuple, slice)):
-            index = tuple(index)
         if not isinstance(index, slice) and len(index) < self.rank():
-            index = [i for i in index]
-            for i in range(len(index), self.rank()):
-                index.append(slice(None))
-            index = tuple(index)
+            index = tuple([i for i in index] + \
+                          [slice(None) for i in range(len(index), self.rank())])
 
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
             sl_factors, eindices = self._get_slice_data_for_array_access(index)
@@ -101,7 +102,10 @@ class DenseNDimArray(NDimArray):
         return Matrix(self.shape[0], self.shape[1], self._array)
 
     def __iter__(self):
-        return self._array.__iter__()
+        def iterator():
+            for i in range(self._loop_size):
+                yield self[self._get_tuple_index(i)]
+        return iterator()
 
     def reshape(self, *newshape):
         """

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -53,7 +53,7 @@ class DenseNDimArray(NDimArray):
             return syindex
 
         if isinstance(index, (SYMPY_INTS, Integer)):
-            index = Tuple(index)
+            index = (index, )
         if not isinstance(index, slice) and len(index) < self.rank():
             index = tuple([i for i in index] + \
                           [slice(None) for i in range(len(index), self.rank())])

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -5,6 +5,9 @@ from sympy import Basic, Tuple, S
 from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
+from sympy.core.compatibility import SYMPY_INTS
+from sympy.core.numbers import Integer
+
 
 
 class DenseNDimArray(NDimArray):
@@ -44,6 +47,16 @@ class DenseNDimArray(NDimArray):
         if syindex is not None:
             return syindex
 
+        if isinstance(index, (SYMPY_INTS, Integer)):
+            index = Tuple(index)
+        if not isinstance(index, (tuple, slice)):
+            index = tuple(index)
+        if not isinstance(index, slice) and len(index) < self.rank():
+            index = [i for i in index]
+            for i in range(len(index), self.rank()):
+                index.append(slice(None))
+            index = tuple(index)
+
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
             sl_factors, eindices = self._get_slice_data_for_array_access(index)
             array = [self._array[self._parse_index(i)] for i in eindices]
@@ -53,6 +66,8 @@ class DenseNDimArray(NDimArray):
             if isinstance(index, slice):
                 return self._array[index]
             else:
+                if self.shape == ():
+                    index = ()
                 index = self._parse_index(index)
                 return self._array[index]
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -69,13 +69,11 @@ class NDimArray(object):
         return ImmutableDenseNDimArray(iterable, shape, **kwargs)
 
     def _parse_index(self, index):
+        if isinstance(index, (SYMPY_INTS, Integer)):
+            raise ValueError("Only a tuple index is accepted")
 
-#        if isinstance(index, (SYMPY_INTS, Integer)):
-#            if index >= self._loop_size:
-#                raise ValueError("index out of range")
-#            return index
         if self._loop_size == 0:
-            raise ValueError("index out of range")
+            raise ValueError("Index not valide with an empty array")
 
         if len(index) != self._rank:
             raise ValueError('Wrong number of array axes')

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -70,10 +70,12 @@ class NDimArray(object):
 
     def _parse_index(self, index):
 
-        if isinstance(index, (SYMPY_INTS, Integer)):
-            if index >= self._loop_size:
-                raise ValueError("index out of range")
-            return index
+#        if isinstance(index, (SYMPY_INTS, Integer)):
+#            if index >= self._loop_size:
+#                raise ValueError("index out of range")
+#            return index
+        if self._loop_size == 0:
+            raise ValueError("index out of range")
 
         if len(index) != self._rank:
             raise ValueError('Wrong number of array axes')
@@ -306,7 +308,7 @@ class NDimArray(object):
         """
         def f(sh, shape_left, i, j):
             if len(shape_left) == 1:
-                return "["+", ".join([str(self[e]) for e in range(i, j)])+"]"
+                return "["+", ".join([str(self[self._get_tuple_index(e)]) for e in range(i, j)])+"]"
 
             sh //= shape_left[0]
             return "[" + ", ".join([f(sh, shape_left[1:], i+e*sh, i+(e+1)*sh) for e in range(shape_left[0])]) + "]" # + "\n"*len(shape_left)
@@ -356,7 +358,7 @@ class NDimArray(object):
 
         def f(sh, shape_left, i, j):
             if len(shape_left) == 1:
-                return [self[e] for e in range(i, j)]
+                return [self[self._get_tuple_index(e)] for e in range(i, j)]
             result = []
             sh //= shape_left[0]
             for e in range(shape_left[0]):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -121,7 +121,7 @@ class ImmutableSparseNDimArray(SparseNDimArray, ImmutableNDimArray):
         shape, flat_list = cls._handle_ndarray_creation_inputs(iterable, shape, **kwargs)
         shape = Tuple(*map(_sympify, shape))
         cls._check_special_bounds(flat_list, shape)
-        loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else 0
+        loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
 
         # Sparse array:
         if isinstance(flat_list, (dict, Dict)):
@@ -158,7 +158,7 @@ class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
         self = object.__new__(cls)
         self._shape = shape
         self._rank = len(shape)
-        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else 0
+        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else len(flat_list)
 
         # Sparse array:
         if isinstance(flat_list, (dict, Dict)):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -4,6 +4,7 @@ from sympy import S, Dict, Basic, Tuple
 from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
+from sympy.core.numbers import Integer
 
 import functools
 
@@ -27,10 +28,6 @@ class SparseNDimArray(NDimArray):
         0
         >>> a[1, 1]
         3
-        >>> a[0]
-        0
-        >>> a[2]
-        2
 
         Symbolic indexing:
 
@@ -47,6 +44,11 @@ class SparseNDimArray(NDimArray):
         syindex = self._check_symbolic_index(index)
         if syindex is not None:
             return syindex
+
+        if isinstance(index, Integer):
+            index = Tuple(index)
+        if not isinstance(index, (tuple, slice)):
+            index = tuple(index)
 
         # `index` is a tuple with one or more slices:
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
@@ -101,7 +103,7 @@ class SparseNDimArray(NDimArray):
     def __iter__(self):
         def iterator():
             for i in range(self._loop_size):
-                yield self[i]
+                yield self[self._get_tuple_index(i)]
         return iterator()
 
     def reshape(self, *newshape):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -5,6 +5,7 @@ from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
 from sympy.core.numbers import Integer
+from sympy.core.compatibility import SYMPY_INTS
 
 import functools
 
@@ -28,6 +29,10 @@ class SparseNDimArray(NDimArray):
         0
         >>> a[1, 1]
         3
+        >>> a[0]
+        [0, 1]
+        >>> a[1]
+        [2, 3]
 
         Symbolic indexing:
 
@@ -45,10 +50,11 @@ class SparseNDimArray(NDimArray):
         if syindex is not None:
             return syindex
 
-        if isinstance(index, Integer):
+        if isinstance(index, (SYMPY_INTS, Integer)):
             index = Tuple(index)
-        if not isinstance(index, (tuple, slice)):
-            index = tuple(index)
+        if not isinstance(index, slice) and len(index) < self.rank():
+            index = tuple([i for i in index] + \
+                          [slice(None) for i in range(len(index), self.rank())])
 
         # `index` is a tuple with one or more slices:
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -51,7 +51,7 @@ class SparseNDimArray(NDimArray):
             return syindex
 
         if isinstance(index, (SYMPY_INTS, Integer)):
-            index = Tuple(index)
+            index = (index, )
         if not isinstance(index, slice) and len(index) < self.rank():
             index = tuple([i for i in index] + \
                           [slice(None) for i in range(len(index), self.rank())])

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -185,7 +185,7 @@ def test_ndim_array_converting():
     assert (isinstance(matrix, Matrix))
 
     for i in range(len(dense_array)):
-        assert dense_array[i] == matrix[i]
+        assert dense_array[dense_array._get_tuple_index(i)] == matrix[i]
     assert matrix.shape == dense_array.shape
 
     assert ImmutableDenseNDimArray(matrix) == dense_array
@@ -201,7 +201,7 @@ def test_ndim_array_converting():
     assert(isinstance(matrix, SparseMatrix))
 
     for i in range(len(sparse_array)):
-        assert sparse_array[i] == matrix[i]
+        assert sparse_array[sparse_array._get_tuple_index(i)] == matrix[i]
     assert matrix.shape == sparse_array.shape
 
     assert ImmutableSparseNDimArray(matrix) == sparse_array

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -108,16 +108,16 @@ def test_getitem():
         array = ArrayType(range(24)).reshape(2, 3, 4)
         assert array.tolist() == [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
         assert array[0] == ArrayType([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
-        assert array[0, 0].tolist() == [0, 1, 2, 3]
+        assert array[0, 0] == ArrayType([0, 1, 2, 3])
         value = 0
         for i in range(2):
             for j in range(3):
                 for k in range(4):
-                    assert array[i, j , k] == value
+                    assert array[i, j, k] == value
                     value += 1
 
-        raises(ValueError, lambda: array[3, 4, 5])
-        raises(ValueError, lambda: array[3, 4, 5, 6])
+    raises(ValueError, lambda: array[3, 4, 5])
+    raises(ValueError, lambda: array[3, 4, 5, 6])
 
 
 def test_iterator():

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -103,6 +103,23 @@ def test_reshape():
     assert len(array) == 50
 
 
+def test_getitem():
+    for ArrayType in [ImmutableDenseNDimArray, ImmutableSparseNDimArray]:
+        array = ArrayType(range(24)).reshape(2, 3, 4)
+        assert array.tolist() == [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
+        assert array[0] == ArrayType([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
+        assert array[0, 0].tolist() == [0, 1, 2, 3]
+        value = 0
+        for i in range(2):
+            for j in range(3):
+                for k in range(4):
+                    assert array[i, j , k] == value
+                    value += 1
+
+        raises(ValueError, lambda: array[3, 4, 5])
+        raises(ValueError, lambda: array[3, 4, 5, 6])
+
+
 def test_iterator():
     array = ImmutableDenseNDimArray(range(4), (2, 2))
     j = 0

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -184,7 +184,7 @@ def test_ndim_array_converting():
     assert (isinstance(matrix, Matrix))
 
     for i in range(len(dense_array)):
-        assert dense_array[i] == matrix[i]
+        assert dense_array[dense_array._get_tuple_index(i)] == matrix[i]
     assert matrix.shape == dense_array.shape
 
     assert MutableDenseNDimArray(matrix) == dense_array
@@ -200,7 +200,7 @@ def test_ndim_array_converting():
     assert(isinstance(matrix, SparseMatrix))
 
     for i in range(len(sparse_array)):
-        assert sparse_array[i] == matrix[i]
+        assert sparse_array[sparse_array._get_tuple_index(i)] == matrix[i]
     assert matrix.shape == sparse_array.shape
 
     assert MutableSparseNDimArray(matrix) == sparse_array

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -108,6 +108,23 @@ def test_iterator():
         j += 1
 
 
+def test_getitem():
+    for ArrayType in [MutableDenseNDimArray, MutableSparseNDimArray]:
+        array = ArrayType(range(24)).reshape(2, 3, 4)
+        assert array.tolist() == [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
+        assert array[0] == ArrayType([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
+        assert array[0, 0].tolist() == [0, 1, 2, 3]
+        value = 0
+        for i in range(2):
+            for j in range(3):
+                for k in range(4):
+                    assert array[i, j , k] == value
+                    value += 1
+
+        raises(ValueError, lambda: array[3, 4, 5])
+        raises(ValueError, lambda: array[3, 4, 5, 6])
+
+
 def test_sparse():
     sparse_array = MutableSparseNDimArray([0, 0, 0, 1], (2, 2))
     assert len(sparse_array) == 2 * 2

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -113,16 +113,16 @@ def test_getitem():
         array = ArrayType(range(24)).reshape(2, 3, 4)
         assert array.tolist() == [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
         assert array[0] == ArrayType([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
-        assert array[0, 0].tolist() == [0, 1, 2, 3]
+        assert array[0, 0] == ArrayType([0, 1, 2, 3])
         value = 0
         for i in range(2):
             for j in range(3):
                 for k in range(4):
-                    assert array[i, j , k] == value
+                    assert array[i, j, k] == value
                     value += 1
 
-        raises(ValueError, lambda: array[3, 4, 5])
-        raises(ValueError, lambda: array[3, 4, 5, 6])
+    raises(ValueError, lambda: array[3, 4, 5])
+    raises(ValueError, lambda: array[3, 4, 5, 6])
 
 
 def test_sparse():


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Changed the way with which the arrays access elements. Taking
examples from NumPy
- Modified tests to avoid: A[0], this kind of access to item
- Modified accordingly the functions in which __getitem__ is being used

Before:
```python
>>> from sympy import Array
>>> A = Array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
>>> A[0, 0]
1
>>> A[0]
1
```
Now:
```python
>>> from sympy import Array
>>> A = Array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
>>> A[0, 0]
1
>>> A[0]
[1, 2, 3]
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Modified the behavior of `__getitem__` on Array to better match NumPy  
<!-- END RELEASE NOTES -->
