### PR TITLE
[WIP] Matrix derived to its matrix element and single-entry matrix

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2930,6 +2930,11 @@ def test_sympy__matrices__expressions__matexpr__OneMatrix():
     assert _test_args(OneMatrix(3, 5))
 
 
+def test_sympy__matrices__expressions__matexpr__SingleEntryMatrix():
+    from sympy.matrices.expressions.matexpr import SingleEntryMatrix
+    assert _test_args(SingleEntryMatrix(3, 4, 1, 2))
+
+
 def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
     from sympy.matrices.expressions.matexpr import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -28,7 +28,7 @@ from .expressions import (
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagMatrix, DiagonalMatrix, DiagonalOf, trace,
     DotProduct, kronecker_product, KroneckerProduct,
-    PermutationMatrix, MatrixPermute)
+    PermutationMatrix, MatrixPermute, SingleEntryMatrix)
 
 __all__ = [
     'ShapeError', 'NonSquareMatrixError',
@@ -60,4 +60,5 @@ __all__ = [
     'det', 'diagonalize_vector', 'DiagMatrix', 'DiagonalMatrix',
     'DiagonalOf', 'trace', 'DotProduct', 'kronecker_product',
     'KroneckerProduct', 'PermutationMatrix', 'MatrixPermute',
+    'SingleEntryMatrix',
 ]

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -28,7 +28,7 @@ from .expressions import (
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagMatrix, DiagonalMatrix, DiagonalOf, trace,
     DotProduct, kronecker_product, KroneckerProduct,
-    PermutationMatrix, MatrixPermute, SingleEntryMatrix)
+    PermutationMatrix, MatrixPermute)
 
 __all__ = [
     'ShapeError', 'NonSquareMatrixError',

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -7,7 +7,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
-                      SingleEntryMatrix, matrix_symbols)
+                      matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -7,7 +7,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
-                      matrix_symbols)
+                      SingleEntryMatrix, matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1121,15 +1121,26 @@ class SingleEntryMatrix(MatrixExpr):
     is 1.
     """
     def __new__(cls, m, n, i, j):
-        if m <= 0 or n <= 0:
+        m, n, i, j = _sympify(m), _sympify(n), _sympify(i), _sympify(j)
+
+        if not i.is_integer or not j.is_integer or \
+            not m.is_integer or not n.is_integer:
             raise ValueError(
-                "Matrix dimensions ({}, {}) should be positive "
-                "integers.".format(m, n)
+                "Matrix dimensions ({}, {}) and index specifications "
+                "({}, {}) should be integers or integer symbols."
+                .format(m, n, i, j)
             )
-        if i >= m or j >= n or i < 0 or j < 0:
+
+        if not m.is_positive or not n.is_positive:
             raise ValueError(
-                'The location ({}, {}) of the single entry is out of '
-                'the matrix dimensions ({}, {})'.format(i, j, m, n))
+                "Matrix dimensions ({}, {}) should be positives".format(m, n)
+            )
+
+        if (i >= m) == True or (j >= n) == True \
+            or i.is_negative or j.is_negative:
+            raise ValueError(
+                'The index ({}, {}) of the single entry is out of '
+                'the matrix bounds ({}, {})'.format(i, j, m, n))
 
         obj = super(SingleEntryMatrix, cls).__new__(cls, m, n, i, j)
         return obj

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1123,15 +1123,14 @@ class SingleEntryMatrix(MatrixExpr):
     def __new__(cls, m, n, i, j):
         m, n, i, j = _sympify(m), _sympify(n), _sympify(i), _sympify(j)
 
-        if not i.is_integer or not j.is_integer or \
-            not m.is_integer or not n.is_integer:
+        if False in (i.is_integer, j.is_integer, m.is_integer, n.is_integer):
             raise ValueError(
                 "Matrix dimensions ({}, {}) and index specifications "
                 "({}, {}) should be integers or integer symbols."
                 .format(m, n, i, j)
             )
 
-        if not m.is_positive or not n.is_positive:
+        if m.is_positive is False or n.is_positive is False:
             raise ValueError(
                 "Matrix dimensions ({}, {}) should be positives".format(m, n)
             )

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1121,6 +1121,11 @@ class SingleEntryMatrix(MatrixExpr):
     is 1.
     """
     def __new__(cls, m, n, i, j):
+        if m <= 0 or n <= 0:
+            raise ValueError(
+                "Matrix dimensions ({}, {}) should be positive "
+                "integers.".format(m, n)
+            )
         if i >= m or j >= n or i < 0 or j < 0:
             raise ValueError(
                 'The location ({}, {}) of the single entry is out of '

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -734,6 +734,8 @@ class MatrixElement(Expr):
             from sympy import MatrixBase
             if isinstance(self.parent, MatrixBase):
                 return self.parent.diff(v)[self.i, self.j]
+            elif self.parent == v:
+                return SingleEntryMatrix(v.rows, v.cols, self.i, self.j)
             return S.Zero
 
         M = self.args[0]
@@ -826,8 +828,11 @@ class MatrixSymbol(MatrixExpr):
         return self
 
     def _eval_derivative(self, x):
-        # x is a scalar:
-        return ZeroMatrix(self.shape[0], self.shape[1])
+        if isinstance(x, MatrixElement):
+            if self == x.parent:
+                return SingleEntryMatrix(self.rows, self.cols, x.i, x.j)
+
+        return super(MatrixSymbol, self)._eval_derivative(x)
 
     def _eval_derivative_matrix_lines(self, x):
         if self != x:
@@ -1109,6 +1114,28 @@ class OneMatrix(MatrixExpr):
 
     def _entry(self, i, j, **kwargs):
         return S.One
+
+
+class SingleEntryMatrix(MatrixExpr):
+    """A matrix which is zero everywhere except the entry (i, j) which
+    is 1.
+    """
+    def __new__(cls, m, n, i, j):
+        if i >= m or j >= n or i < 0 or j < 0:
+            raise ValueError(
+                'The location ({}, {}) of the single entry is out of '
+                'the matrix dimensions ({}, {})'.format(i, j, m, n))
+
+        obj = super(SingleEntryMatrix, cls).__new__(cls, m, n, i, j)
+        return obj
+
+    @property
+    def shape(self):
+        return self._args[:2]
+
+    def _entry(self, i, j, **kwargs):
+        _, _, ii, jj = self._args
+        return KroneckerDelta(i, ii) * KroneckerDelta(j, jj)
 
 
 def matrix_symbols(expr):

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -9,7 +9,7 @@ from sympy import (MatrixSymbol, Inverse, symbols, Determinant, Trace,
                    HadamardProduct, HadamardPower, KroneckerDelta, Sum,
                    Rational)
 from sympy import MatAdd, Identity, MatMul, ZeroMatrix
-from sympy.matrices.expressions import hadamard_power
+from sympy.matrices.expressions import hadamard_power, SingleEntryMatrix
 
 k = symbols("k")
 i, j = symbols("i j")
@@ -71,8 +71,6 @@ def test_matrix_derivative_by_scalar():
 
 
 def test_matrix_derivative_by_matrix_element():
-    from .matexpr import SingleEntryMatrix
-
     M = MatrixSymbol('M', 2, 2)
     assert M[1, 1].diff(M) == SingleEntryMatrix(2, 2, 1, 1)
     assert M.diff(M[0, 0]) == SingleEntryMatrix(2, 2, 0, 0)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -70,6 +70,14 @@ def test_matrix_derivative_by_scalar():
     assert expr.diff(x) == 2*mu*Identity(k)
 
 
+def test_matrix_derivative_by_matrix_element():
+    from .matexpr import SingleEntryMatrix
+
+    M = MatrixSymbol('M', 2, 2)
+    assert M[1, 1].diff(M) == SingleEntryMatrix(2, 2, 1, 1)
+    assert M.diff(M[0, 0]) == SingleEntryMatrix(2, 2, 0, 0)
+
+
 def test_matrix_derivative_non_matrix_result():
     # This is a 4-dimensional array:
     assert A.diff(A) == Derivative(A, A)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -8,8 +8,9 @@ from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint, NonSquareMatrixError)
-from sympy.matrices.expressions.matexpr import (MatrixElement,
-                                                GenericZeroMatrix, GenericIdentity, OneMatrix)
+from sympy.matrices.expressions.matexpr import (
+    MatrixElement, GenericZeroMatrix, GenericIdentity, OneMatrix,
+    SingleEntryMatrix)
 from sympy.testing.pytest import raises, XFAIL
 
 
@@ -238,6 +239,15 @@ def test_Identity_doit():
     assert Inn.doit() == Identity(2*n)
     assert isinstance(Inn.doit().rows, Mul)
 
+
+def test_SingleEntryMatrix():
+    assert SingleEntryMatrix(2, 2, 0, 0).as_explicit() == \
+        ImmutableMatrix([[1, 0], [0, 0]])
+    assert SingleEntryMatrix(2, 2, 1, 1).as_explicit() == \
+        ImmutableMatrix([[0, 0], [0, 1]])
+    raises(ValueError, lambda: SingleEntryMatrix(2, 2, 2, 2))
+    raises(ValueError, lambda: SingleEntryMatrix(2, 2, -1, -1))
+    raises(ValueError, lambda: SingleEntryMatrix(-1, -1, 0, 0))
 
 def test_addition():
     A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -249,6 +249,21 @@ def test_SingleEntryMatrix():
     raises(ValueError, lambda: SingleEntryMatrix(2, 2, -1, -1))
     raises(ValueError, lambda: SingleEntryMatrix(-1, -1, 0, 0))
 
+    n = Symbol('n', integer=False)
+    raises(ValueError, lambda: SingleEntryMatrix(n, n, 3, 3))
+    n = Symbol('n', integer=True, negative=True)
+    raises(ValueError, lambda: SingleEntryMatrix(n, n, 3, 3))
+    n = Symbol('n', integer=True, positive=True)
+    assert SingleEntryMatrix(n, n, 3, 3)
+
+    i, j = symbols('i j', integer=False)
+    raises(ValueError, lambda: SingleEntryMatrix(n, n, i, j))
+    i, j = symbols('i j', integer=True, nonnegative=False)
+    raises(ValueError, lambda: SingleEntryMatrix(n, n, i, j))
+    i, j = symbols('i j', integer=True, nonnegative=True)
+    assert SingleEntryMatrix(n, n, i, j)
+
+
 def test_addition():
     A = MatrixSymbol('A', n, m)
     B = MatrixSymbol('B', n, m)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1726,6 +1726,12 @@ class LatexPrinter(Printer):
         perm_str = self._print(P.args[0])
         return "P_{%s}" % perm_str
 
+    def _print_SingleEntryMatrix(self, expr):
+        _, _, i, j = expr.args
+        if self._settings['mat_symbol_style'] == 'plain':
+            return r"\mathbb{J}" + "^{%s, %s}" % (i, j)
+        return r"\mathbf{J}" + "^{%s, %s}" % (i, j)
+
     def _print_NDimArray(self, expr):
 
         if expr.rank() == 0:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17229

#### Brief description of what is fixed or changed

I've added a new matrix class to handle the derivative for a matrix element of a symbolic matrix with respect to its parent, and vice versa.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added a new matrix class `SingleEntryMatrix` to represent a m x n matrix with a single entry equal to 1 and 0 everywhere else.
  - Fixed a matrix symbol derived with respect to its element, or a matrix element of matrix symbol derived with respect to its parent matrix giving zero matrix.
<!-- END RELEASE NOTES -->
