### PR TITLE
DOC:cliffhanger in special topics 'finite_diff_derivatives.rst'

### DIFF
--- a/doc/src/modules/calculus/index.rst
+++ b/doc/src/modules/calculus/index.rst
@@ -10,6 +10,8 @@ Calculus
 .. automodule:: sympy.calculus.singularities
     :members:
 
+.. _finite_diff:
+
 .. automodule:: sympy.calculus.finite_diff
     :members:
 

--- a/doc/src/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/special_topics/finite_diff_derivatives.rst
@@ -251,4 +251,4 @@ much more efficient approach originally due to Bengt Fornberg and now incorporat
 
 :ref:`calculus-finite-differences`
 
-:ref:`finite_diff`
+:ref:`Finite difference weights <finite_diff>`

--- a/doc/src/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/special_topics/finite_diff_derivatives.rst
@@ -249,6 +249,6 @@ given above.
 Next we show how to perform these and many other discritizations of derivatives,  but using a
 much more efficient approach originally due to Bengt Fornberg and now incorporated into SymPy.
 
-:doc:`src/tutorial/calculus`
+:doc:`/src/tutorial/calculus`
 
 :ref:`finite_diff`

--- a/doc/src/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/special_topics/finite_diff_derivatives.rst
@@ -249,6 +249,6 @@ given above.
 Next we show how to perform these and many other discritizations of derivatives,  but using a
 much more efficient approach originally due to Bengt Fornberg and now incorporated into SymPy.
 
-:doc:`/src/tutorial/calculus`
+:ref:`calculus-finite-differences`
 
 :ref:`finite_diff`

--- a/doc/src/special_topics/finite_diff_derivatives.rst
+++ b/doc/src/special_topics/finite_diff_derivatives.rst
@@ -249,5 +249,6 @@ given above.
 Next we show how to perform these and many other discritizations of derivatives,  but using a
 much more efficient approach originally due to Bengt Fornberg and now incorporated into SymPy.
 
+:doc:`src/tutorial/calculus`
 
-
+:ref:`finite_diff`

--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -322,6 +322,8 @@ The ``O`` notation supports arbitrary limit points (other than 0):
     -5 + ──────── + ──────── + ──────── + ──────── + x + O⎝(x - 6) ; x → 6⎠
             2          6          24        120
 
+.. _calculus-finite-differences:
+
 Finite differences
 ==================
 


### PR DESCRIPTION
add link to doc/src/tutorial/calculus.rst and sympy/calculus/finite_diff.py in finite_diff_derivatives.rst.

closes #16904

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->