### PR TITLE
Added relational operator printer for various languages

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -390,7 +390,7 @@ class C89CodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_sinc(self, expr):
         from sympy.functions.elementary.trigonometric import sin

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -532,3 +532,4 @@ class CodePrinter(StrPrinter):
     _print_Unit = _print_not_supported
     _print_Wild = _print_not_supported
     _print_WildFunction = _print_not_supported
+    _print_Relational = _print_not_supported

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -369,6 +369,7 @@ class FCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
+        op = op if op not in self._relationals else self._relationals[op]
         return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Indexed(self, expr):
@@ -430,14 +431,6 @@ class FCodePrinter(CodePrinter):
                 '{body}\n'
                 'end do').format(target=target, start=start, stop=stop,
                         step=step, body=body)
-
-    def _print_Equality(self, expr):
-        lhs, rhs = expr.args
-        return ' == '.join(map(lambda arg: self._print(arg), (lhs, rhs)))
-
-    def _print_Unequality(self, expr):
-        lhs, rhs = expr.args
-        return ' /= '.join(map(lambda arg: self._print(arg), (lhs, rhs)))
 
     def _print_Type(self, type_):
         type_ = self.type_aliases.get(type_, type_)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -365,6 +365,12 @@ class FCodePrinter(CodePrinter):
             return "%sd%s" % (printed[:e], printed[e + 1:])
         return "%sd0" % printed
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
+
     def _print_Indexed(self, expr):
         inds = [ self._print(i) for i in expr.indices ]
         return "%s(%s)" % (self._print(expr.base.label), ", ".join(inds))

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -285,7 +285,7 @@ class GLSLPrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Add(self, expr, order=None):
         if self._settings['use_operators']:

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -281,6 +281,12 @@ class GLSLPrinter(CodePrinter):
     def _print_Rational(self, expr):
         return "%s.0/%s.0" % (expr.p, expr.q)
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+
     def _print_Add(self, expr, order=None):
         if self._settings['use_operators']:
             return CodePrinter._print_Add(self, expr, order=order)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -113,6 +113,12 @@ class JavascriptCodePrinter(CodePrinter):
         p, q = int(expr.p), int(expr.q)
         return '%d/%d' % (p, q)
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+
     def _print_Indexed(self, expr):
         # calculate index for 1d array
         dims = expr.shape

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -117,7 +117,7 @@ class JavascriptCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Indexed(self, expr):
         # calculate index for 1d array

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -194,7 +194,7 @@ class JuliaCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Pow(self, expr):
         powsymbol = '^' if all([x.is_number for x in expr.args]) else '.^'

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -190,6 +190,11 @@ class JuliaCodePrinter(CodePrinter):
             return (sign + multjoin(a, a_str) +
                     divsym + "(%s)" % multjoin(b, b_str))
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
 
     def _print_Pow(self, expr):
         powsymbol = '^' if all([x.is_number for x in expr.args]) else '.^'

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -157,6 +157,11 @@ class MCodePrinter(CodePrinter):
             res += '**'.join(self.parenthesize(a, PREC) for a in nc)
         return res
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
 
     # Primitive numbers
     def _print_Zero(self, expr):

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -161,7 +161,7 @@ class MCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     # Primitive numbers
     def _print_Zero(self, expr):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -209,6 +209,11 @@ class OctaveCodePrinter(CodePrinter):
             return (sign + multjoin(a, a_str) +
                     divsym + "(%s)" % multjoin(b, b_str))
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
 
     def _print_Pow(self, expr):
         powsymbol = '^' if all([x.is_number for x in expr.args]) else '.^'

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -213,7 +213,7 @@ class OctaveCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Pow(self, expr):
         powsymbol = '^' if all([x.is_number for x in expr.args]) else '.^'

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -246,7 +246,7 @@ class RCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_sinc(self, expr):
         from sympy.functions.elementary.trigonometric import sin

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -358,6 +358,12 @@ class RustCodePrinter(CodePrinter):
         p, q = int(expr.p), int(expr.q)
         return '%d_f64/%d.0' % (p, q)
 
+    def _print_Relational(self, expr):
+        lhs_code = self._print(expr.lhs)
+        rhs_code = self._print(expr.rhs)
+        op = expr.rel_op
+        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+
     def _print_Indexed(self, expr):
         # calculate index for 1d array
         dims = expr.shape

--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -362,7 +362,7 @@ class RustCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         rhs_code = self._print(expr.rhs)
         op = expr.rel_op
-        return ("{0} {1} {2}").format(lhs_code, op, rhs_code)
+        return "{0} {1} {2}".format(lhs_code, op, rhs_code)
 
     def _print_Indexed(self, expr):
         # calculate index for 1d array

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -1,4 +1,5 @@
-from sympy.core import pi, oo, symbols, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy
+from sympy.core import (pi, symbols, Rational, Integer, GoldenRatio, EulerGamma,
+                        Catalan, Lambda, Dummy, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
 from sympy.utilities.pytest import raises
 from sympy.printing.glsl import GLSLPrinter
@@ -35,6 +36,15 @@ def test_glsl_code_Pow():
     assert glsl_code(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
         "pow(3.5*2*x, -x + pow(y, x))/(pow(x, 2.0) + y)"
     assert glsl_code(x**-1.0) == '1.0/x'
+
+
+def test_glsl_code_Relational():
+    assert glsl_code(Eq(x, y)) == "x == y"
+    assert glsl_code(Ne(x, y)) == "x != y"
+    assert glsl_code(Le(x, y)) == "x <= y"
+    assert glsl_code(Lt(x, y)) == "x < y"
+    assert glsl_code(Gt(x, y)) == "x > y"
+    assert glsl_code(Ge(x, y)) == "x >= y"
 
 
 def test_glsl_code_constants_mathh():

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -1,5 +1,6 @@
 from sympy.core import (pi, oo, symbols, Rational, Integer, GoldenRatio,
-                        EulerGamma, Catalan, Lambda, Dummy, S)
+                        EulerGamma, Catalan, Lambda, Dummy, S, Eq, Ne, Le,
+                        Lt, Gt, Ge)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
                              sinh, cosh, tanh, asin, acos, acosh, Max, Min)
 from sympy.utilities.pytest import raises
@@ -52,6 +53,16 @@ def test_jscode_Rational():
     assert jscode(Rational(18, 9)) == "2"
     assert jscode(Rational(3, -7)) == "-3/7"
     assert jscode(Rational(-3, -7)) == "3/7"
+
+
+def test_Relational():
+    assert jscode(Eq(x, y)) == "x == y"
+    assert jscode(Ne(x, y)) == "x != y"
+    assert jscode(Le(x, y)) == "x <= y"
+    assert jscode(Lt(x, y)) == "x < y"
+    assert jscode(Gt(x, y)) == "x > y"
+    assert jscode(Ge(x, y)) == "x >= y"
+
 
 
 def test_jscode_Integer():

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -1,5 +1,5 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
-                        Tuple, Symbol)
+                        Tuple, Symbol, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
 from sympy.functions import Piecewise, sqrt, ceiling, exp, sin, cos
 from sympy.utilities.pytest import raises
@@ -10,7 +10,6 @@ from sympy.functions.special.bessel import (jn, yn, besselj, bessely, besseli,
                                             besselk, hankel1, hankel2, airyai,
                                             airybi, airyaiprime, airybiprime)
 from sympy.utilities.pytest import XFAIL
-from sympy.core.compatibility import range
 
 from sympy import julia_code
 
@@ -29,6 +28,15 @@ def test_Rational():
     assert julia_code(Rational(-3, -7)) == "3/7"
     assert julia_code(x + Rational(3, 7)) == "x + 3/7"
     assert julia_code(Rational(3, 7)*x) == "3*x/7"
+
+
+def test_Relational():
+    assert julia_code(Eq(x, y)) == "x == y"
+    assert julia_code(Ne(x, y)) == "x != y"
+    assert julia_code(Le(x, y)) == "x <= y"
+    assert julia_code(Lt(x, y)) == "x < y"
+    assert julia_code(Gt(x, y)) == "x > y"
+    assert julia_code(Ge(x, y)) == "x >= y"
 
 
 def test_Function():

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -1,5 +1,5 @@
-from sympy.core import (S, pi, oo, symbols, Function,
-                        Rational, Integer, Tuple, Derivative)
+from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer, Tuple,
+                        Derivative, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.integrals import Integral
 from sympy.concrete import Sum
 from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
@@ -30,6 +30,15 @@ def test_Rational():
     assert mcode(Rational(-3, -7)) == "3/7"
     assert mcode(x + Rational(3, 7)) == "x + 3/7"
     assert mcode(Rational(3, 7)*x) == "(3/7)*x"
+
+
+def test_Relational():
+    assert mcode(Eq(x, y)) == "x == y"
+    assert mcode(Ne(x, y)) == "x != y"
+    assert mcode(Le(x, y)) == "x <= y"
+    assert mcode(Lt(x, y)) == "x < y"
+    assert mcode(Gt(x, y)) == "x > y"
+    assert mcode(Ge(x, y)) == "x >= y"
 
 
 def test_Function():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -1,6 +1,6 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol, EulerGamma, GoldenRatio, Catalan,
-                        Lambda, Mul, Pow, Mod)
+                        Lambda, Mul, Pow, Mod, Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.functions import (arg, atan2, bernoulli, beta, ceiling, chebyshevu,
                              chebyshevt, conjugate, DiracDelta, exp, expint,
@@ -25,10 +25,6 @@ from sympy.functions.special.error_functions import (Chi, Ci, erf, erfc, erfi,
                                                      erfcinv, erfinv, fresnelc,
                                                      fresnels, li, Shi, Si, Li,
                                                      erf2)
-from sympy.polys.polytools import gcd, lcm
-from sympy.ntheory.primetest import isprime
-from sympy.core.compatibility import range
-
 from sympy import octave_code
 from sympy import octave_code as mcode
 
@@ -47,6 +43,15 @@ def test_Rational():
     assert mcode(Rational(-3, -7)) == "3/7"
     assert mcode(x + Rational(3, 7)) == "x + 3/7"
     assert mcode(Rational(3, 7)*x) == "3*x/7"
+
+
+def test_Relational():
+    assert mcode(Eq(x, y)) == "x == y"
+    assert mcode(Ne(x, y)) == "x != y"
+    assert mcode(Le(x, y)) == "x <= y"
+    assert mcode(Lt(x, y)) == "x < y"
+    assert mcode(Gt(x, y)) == "x > y"
+    assert mcode(Ge(x, y)) == "x >= y"
 
 
 def test_Function():

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -1,13 +1,12 @@
 from sympy.core import (S, pi, oo, symbols, Rational, Integer,
-                        GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq)
+                        GoldenRatio, EulerGamma, Catalan, Lambda, Dummy,
+                        Eq, Ne, Le, Lt, Gt, Ge)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
-                             gamma, sign)
+                             sign)
 from sympy.logic import ITE
 from sympy.utilities.pytest import raises
-from sympy.printing.rust import RustCodePrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.tensor import IndexedBase, Idx
-from sympy.matrices import Matrix, MatrixSymbol
 
 from sympy import rust_code
 
@@ -17,6 +16,15 @@ x, y, z = symbols('x,y,z')
 def test_Integer():
     assert rust_code(Integer(42)) == "42"
     assert rust_code(Integer(-56)) == "-56"
+
+
+def test_Relational():
+    assert rust_code(Eq(x, y)) == "x == y"
+    assert rust_code(Ne(x, y)) == "x != y"
+    assert rust_code(Le(x, y)) == "x <= y"
+    assert rust_code(Lt(x, y)) == "x < y"
+    assert rust_code(Gt(x, y)) == "x > y"
+    assert rust_code(Ge(x, y)) == "x >= y"
 
 
 def test_Rational():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17238 

#### Brief description of what is fixed or changed
Added relational operator printer for following languages:
1. glsl
2. js
3. julia
4. mathematica
5. octave
6. rust

I have also verified that they are correct. Added tests for same.
Ping @sylee957 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
    - added relational operator printing for various languages
<!-- END RELEASE NOTES -->
