### PR TITLE
Matrix summation improvements

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -423,12 +423,13 @@ class AddWithLimits(ExprWithLimits):
         return self
 
     def _eval_expand_basic(self, **hints):
+        from sympy.matrices.matrices import MatrixBase
+
         summand = self.function.expand(**hints)
         if summand.is_Add and summand.is_commutative:
             return Add(*[self.func(i, *self.limits) for i in summand.args])
-        elif summand.is_Matrix:
-            return Matrix._new(summand.rows, summand.cols,
-                [self.func(i, *self.limits) for i in summand._mat])
+        elif isinstance(summand, MatrixBase):
+            return summand.applyfunc(lambda x: self.func(x, *self.limits))
         elif summand != self.function:
             return self.func(summand, *self.limits)
         return self

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -181,7 +181,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             f = self.function
 
         if self.function.is_Matrix:
-            return self.expand().doit()
+            expanded = self.expand()
+            if self != expanded:
+                return expanded.doit()
+            return self
 
         for n, limit in enumerate(self.limits):
             i, a, b = limit

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -921,6 +921,15 @@ def test_matrix_sum():
     assert result.__class__ == ImmutableSparseMatrix
 
 
+@XFAIL
+def test_failing_matrix_sum():
+    n = Symbol('n', nonnegative=True)
+    # TODO Implement matrix geometric series summation.
+    A = Matrix([[0, 1, 0], [-1, 0, 0], [0, 0, 0]])
+    assert Sum(A ** n, (n, 1, 4)).doit() == \
+        Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+
 def test_indexed_idx_sum():
     i = symbols('i', cls=Idx)
     r = Indexed('r', i)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -8,7 +8,8 @@ from sympy.abc import a, b, c, d, k, m, x, y, z
 from sympy.concrete.summations import telescopic
 from sympy.concrete.expr_with_intlimits import ReorderError
 from sympy.utilities.pytest import XFAIL, raises, slow
-from sympy.matrices import Matrix
+from sympy.matrices import \
+    Matrix, SparseMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
 from sympy.core.mod import Mod
 from sympy.core.compatibility import range
 
@@ -908,8 +909,16 @@ def test_issue_4668():
 
 
 def test_matrix_sum():
-    A = Matrix([[0,1],[n,0]])
-    assert Sum(A,(n,0,3)).doit() == Matrix([[0, 4], [6, 0]])
+    A = Matrix([[0, 1], [n, 0]])
+
+    result = Sum(A, (n, 0, 3)).doit()
+    assert result == Matrix([[0, 4], [6, 0]])
+    assert result.__class__ == ImmutableDenseMatrix
+
+    A = SparseMatrix([[0, 1], [n, 0]])
+
+    result = Sum(A, (n, 0, 3)).doit()
+    assert result.__class__ == ImmutableSparseMatrix
 
 
 def test_indexed_idx_sum():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There are some issues with `sum` involving matrices, which are fixed here.

1. Matrix was casted into MutableDenseMatrix after summation, but now, it will be casted into `ImmutableDenseMatrix` and `ImmutableSparseMatrix` respecting the original matrix class.
I made the behavior not to retain the mutability though, because `sympify` would already cast mutable matrix into a immutable one.

2. There was inefficient casting of sparse matrices into dense matrices in the original code.
```python
from sympy import *

x = Dummy('x', integer=True)
m = SparseMatrix(200, 200, {(0, 0): 1}) * x

from pyinstrument import Profiler

profiler = Profiler()
profiler.start()

Sum(m, (x, 1, 100)).doit()

profiler.stop()

print(profiler.output_text(unicode=True, color=True))
```
And the speed had improved as
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 18:56:58  Samples:  3315
 /_//_/// /_\ / //_// / //_'/ //     Duration: 3.343     CPU time: 3.344
/   _/                      v3.0.3
```
```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 18:56:23  Samples:  284
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.284     CPU time: 0.266
/   _/                      v3.0.3
```

3. Matrix expressions were throwing errors in summation because they don't have `_mat` attribute
```python
from sympy import *

x = Symbol('x')
Sum(Identity(3), (x, 0, 3)).doit()
```
`AttributeError: 'Identity' object has no attribute '_mat'`
But after now, it may not be computed because of lack of some formulas, but at least it will return unevaluated.
I've also changed the check like
```
            if self != expanded:
                return expanded.doit()
            return self
```
because of the recursion error, if it does not succeed rewriting.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- concrete
  - Fixed `Sum` casting dense matrix into sparse matrix.
  - `Sum` will cast mutable matrices into immutable variant after computation

<!-- END RELEASE NOTES -->
