### PR TITLE
small diophantine optimization

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -1976,11 +1976,12 @@ def _diop_ternary_quadratic(_var, coeff):
             min_sum = abs(s[0]) + abs(s[1])
 
             for r in sols:
-                if abs(r[0]) + abs(r[1]) < min_sum:
+                m = abs(r[0]) + abs(r[1])
+                if m < min_sum:
                     s = r
-                    min_sum = abs(s[0]) + abs(s[1])
+                    min_sum = m
 
-                x_0, y_0, z_0 = s[0], -coeff[x*z], s[1]
+            x_0, y_0, z_0 = s[0], -coeff[x*z], s[1]
 
         else:
             var[0], var[1] = _var[1], _var[0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Just avoid calculating sum twice per solution and `-coeff[x*z]` once per solution. If it were possible for there to be only one solution the dedenting of the `x_0, ...` would be necessary...but I am not sure this would ever be possible.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
