### PR TITLE
Added guessing of best LaTeX font color

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -53,6 +53,22 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     preamble = preamble % (fontsize, addpackages)
 
+    # Guess best font color if none was given based on the ip.colors string.
+    # From the IPython documentation:
+    #   It has four case-insensitive values: 'nocolor', 'neutral', 'linux',
+    #   'lightbg'. The default is neutral, which should be legible on either
+    #   dark or light terminal backgrounds. linux is optimised for dark
+    #   backgrounds and lightbg for light ones.
+    if forecolor.lower() == 'auto':
+        color = ip.colors.lower()
+        if color.lower() == 'lightbg':
+            forecolor = 'Black'
+        elif color.lower() == 'linux':
+            forecolor = 'White'
+        else:
+            # No idea, go with gray.
+            forecolor = 'Gray'
+
     imagesize = 'tight'
     offset = "0cm,0cm"
     resolution = round(150*scale)
@@ -319,7 +335,7 @@ NO_GLOBAL = False
 
 def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
-                  no_global=False, ip=None, euler=False, forecolor='Black',
+                  no_global=False, ip=None, euler=False, forecolor='Auto',
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
@@ -372,8 +388,10 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     euler: boolean, optional, default=False
         Loads the euler package in the LaTeX preamble for handwritten style
         fonts (http://www.ctan.org/pkg/euler).
-    forecolor: string, optional, default='Black'
-        DVI setting for foreground color.
+    forecolor: string, optional, default='Auto'
+        DVI setting for foreground color. 'Auto' means that either 'Black' or
+        'White' will be selected based on a guess of the IPython terminal color
+        setting.
     backcolor: string, optional, default='Transparent'
         DVI setting for background color.
     fontsize: string, optional, default='10pt'

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -42,6 +42,22 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     except ImportError:
         pass
 
+    # Guess best font color if none was given based on the ip.colors string.
+    # From the IPython documentation:
+    #   It has four case-insensitive values: 'nocolor', 'neutral', 'linux',
+    #   'lightbg'. The default is neutral, which should be legible on either
+    #   dark or light terminal backgrounds. linux is optimised for dark
+    #   backgrounds and lightbg for light ones.
+    if forecolor.lower() == 'auto':
+        color = ip.colors.lower()
+        if color == 'lightbg':
+            forecolor = 'Black'
+        elif color == 'linux':
+            forecolor = 'White'
+        else:
+            # No idea, go with gray.
+            forecolor = 'Gray'
+
     preamble = "\\documentclass[varwidth,%s]{standalone}\n" \
                "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
     if euler:
@@ -53,22 +69,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     preamble = preamble % (fontsize, addpackages)
 
-    # Guess best font color if none was given based on the ip.colors string.
-    # From the IPython documentation:
-    #   It has four case-insensitive values: 'nocolor', 'neutral', 'linux',
-    #   'lightbg'. The default is neutral, which should be legible on either
-    #   dark or light terminal backgrounds. linux is optimised for dark
-    #   backgrounds and lightbg for light ones.
-    if forecolor.lower() == 'auto':
-        color = ip.colors.lower()
-        if color.lower() == 'lightbg':
-            forecolor = 'Black'
-        elif color.lower() == 'linux':
-            forecolor = 'White'
-        else:
-            # No idea, go with gray.
-            forecolor = 'Gray'
-
     imagesize = 'tight'
     offset = "0cm,0cm"
     resolution = round(150*scale)
@@ -76,7 +76,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         imagesize, resolution, backcolor, forecolor, offset)
     dvioptions = dvi.split()
 
-    svg_scale = 2.1*scale
+    svg_scale = 150/72*scale
     dvioptions_svg = ["--no-fonts", "--scale={}".format(svg_scale)]
 
     debug("init_printing: DVIOPTIONS:", dvioptions)
@@ -346,73 +346,76 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     Parameters
     ==========
 
-    pretty_print: boolean
+    pretty_print : boolean
         If True, use pretty_print to stringify or the provided pretty
         printer; if False, use sstrrepr to stringify or the provided string
         printer.
-    order: string or None
+    order : string or None
         There are a few different settings for this parameter:
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
         old, which is used for compatibility reasons and for long expressions;
         None, which sets it to lex.
-    use_unicode: boolean or None
+    use_unicode : boolean or None
         If True, use unicode characters;
         if False, do not use unicode characters.
-    use_latex: string, boolean, or None
-        If True, use default latex rendering in GUI interfaces (png and
+    use_latex : string, boolean, or None
+        If True, use default LaTeX rendering in GUI interfaces (png and
         mathjax);
-        if False, do not use latex rendering;
+        if False, do not use LaTeX rendering;
         if 'png', enable latex rendering with an external latex compiler,
         falling back to matplotlib if external compilation fails;
-        if 'matplotlib', enable latex rendering with matplotlib;
-        if 'mathjax', enable latex text generation, for example MathJax
+        if 'matplotlib', enable LaTeX rendering with matplotlib;
+        if 'mathjax', enable LaTeX text generation, for example MathJax
         rendering in IPython notebook or text rendering in LaTeX documents;
-        if 'svg', enable latex rendering with an external latex compiler,
+        if 'svg', enable LaTeX rendering with an external latex compiler,
         no fallback
-    wrap_line: boolean
+    wrap_line : boolean
         If True, lines will wrap at the end; if False, they will not wrap
         but continue as one line. This is only relevant if ``pretty_print`` is
         True.
-    num_columns: int or None
+    num_columns : int or None
         If int, number of columns before wrapping is set to num_columns; if
         None, number of columns before wrapping is set to terminal width.
         This is only relevant if ``pretty_print`` is True.
-    no_global: boolean
+    no_global : boolean
         If True, the settings become system wide;
         if False, use just for this console/session.
-    ip: An interactive console
+    ip : An interactive console
         This can either be an instance of IPython,
         or a class that derives from code.InteractiveConsole.
-    euler: boolean, optional, default=False
+    euler : boolean, optional, default=False
         Loads the euler package in the LaTeX preamble for handwritten style
         fonts (http://www.ctan.org/pkg/euler).
-    forecolor: string, optional, default='Auto'
+    forecolor : string, optional, default='Auto'
         DVI setting for foreground color. 'Auto' means that either 'Black',
         'White', or 'Gray' will be selected based on a guess of the IPython
         terminal color setting. See notes.
-    backcolor: string, optional, default='Transparent'
+    backcolor : string, optional, default='Transparent'
         DVI setting for background color. See notes.
-    fontsize: string, optional, default='10pt'
+    fontsize : string, optional, default='10pt'
         A font size to pass to the LaTeX documentclass function in the
         preamble.
-    latex_mode: string, optional, default='plain'
+    latex_mode : string, optional, default='plain'
         The mode used in the LaTeX printer. Can be one of:
         {'inline'|'plain'|'equation'|'equation*'}.
-    print_builtin: boolean, optional, default=True
-        If true then floats and integers will be printed. If false the
+    print_builtin : boolean, optional, default=True
+        If true then floats and integers will be printed. If False the
         printer will only print SymPy types.
-    str_printer: function, optional, default=None
+    str_printer : function, optional, default=None
         A custom string printer function. This should mimic
         sympy.printing.sstrrepr().
-    pretty_printer: function, optional, default=None
+    pretty_printer : function, optional, default=None
         A custom pretty printer. This should mimic sympy.printing.pretty().
-    latex_printer: function, optional, default=None
+    latex_printer : function, optional, default=None
         A custom LaTeX printer. This should mimic sympy.printing.latex().
-    scale: float, optional, default=1.0
-        Scale the LaTeX output when using the ``png`` backend. Useful for high
-        dpi screens.
+    scale : float, optional, default=1.0
+        Scale the LaTeX output when using the ``png`` or ``svg`` backends.
+        Useful for high dpi screens.
+    settings :
+        Any additional settings for the ``latex`` and ``pretty`` commands can
+        be passed.
 
     Examples
     ========
@@ -453,9 +456,9 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     Notes
     =====
 
-    The foreground and background colors can be selected when using 'png' LaTeX
-    rendering. Note that before the ``init_printing`` command is executed, the
-    LaTeX rendering is handled by the IPython console and not SymPy.
+    The foreground and background colors can be selected when using 'png' or
+    'svg' LaTeX rendering. Note that before the ``init_printing`` command is
+    executed, the LaTeX rendering is handled by the IPython console and not SymPy.
 
     The colors can be selected among the 68 standard colors known to ``dvips``,
     for a list see _[dvicolornames]. In addition, the background color can be

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -127,7 +127,10 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         # render any LaTeX environments such as array or matrix. So here we
         # ensure that if mathtext fails to render, we return None.
         try:
-            return latex_to_png(o)
+            try:
+                return latex_to_png(o, color=forecolor, scale=scale)
+            except TypeError: #  Old IPython version without color and scale
+                return latex_to_png(o)
         except ValueError as e:
             debug('matplotlib exception caught:', repr(e))
             return None

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -48,7 +48,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     #   'lightbg'. The default is neutral, which should be legible on either
     #   dark or light terminal backgrounds. linux is optimised for dark
     #   backgrounds and lightbg for light ones.
-    if forecolor.lower() == 'auto':
+    if forecolor is None:
         color = ip.colors.lower()
         if color == 'lightbg':
             forecolor = 'Black'
@@ -57,6 +57,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         else:
             # No idea, go with gray.
             forecolor = 'Gray'
+        debug("init_printing: Automatic foreground color:", forecolor)
 
     preamble = "\\documentclass[varwidth,%s]{standalone}\n" \
                "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
@@ -338,7 +339,7 @@ NO_GLOBAL = False
 
 def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
-                  no_global=False, ip=None, euler=False, forecolor='Auto',
+                  no_global=False, ip=None, euler=False, forecolor=None,
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
@@ -393,8 +394,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     euler : boolean, optional, default=False
         Loads the euler package in the LaTeX preamble for handwritten style
         fonts (http://www.ctan.org/pkg/euler).
-    forecolor : string, optional, default='Auto'
-        DVI setting for foreground color. 'Auto' means that either 'Black',
+    forecolor : string or None, optional, default=None
+        DVI setting for foreground color. None means that either 'Black',
         'White', or 'Gray' will be selected based on a guess of the IPython
         terminal color setting. See notes.
     backcolor : string, optional, default='Transparent'

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -389,11 +389,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         Loads the euler package in the LaTeX preamble for handwritten style
         fonts (http://www.ctan.org/pkg/euler).
     forecolor: string, optional, default='Auto'
-        DVI setting for foreground color. 'Auto' means that either 'Black' or
-        'White' will be selected based on a guess of the IPython terminal color
-        setting.
+        DVI setting for foreground color. 'Auto' means that either 'Black',
+        'White', or 'Gray' will be selected based on a guess of the IPython
+        terminal color setting. See notes.
     backcolor: string, optional, default='Transparent'
-        DVI setting for background color.
+        DVI setting for background color. See notes.
     fontsize: string, optional, default='10pt'
         A font size to pass to the LaTeX documentclass function in the
         preamble.
@@ -449,6 +449,32 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> x**2 + x + y**2 + y # doctest: +SKIP
     x + y +
     x**2 + y**2
+
+    Notes
+    =====
+
+    The foreground and background colors can be selected when using 'png' LaTeX
+    rendering. Note that before the ``init_printing`` command is executed, the
+    LaTeX rendering is handled by the IPython console and not SymPy.
+
+    The colors can be selected among the 68 standard colors known to ``dvips``,
+    for a list see _[dvicolornames]. In addition, the background color can be
+    set to  'Transparent' (which is the default value).
+
+    When using the 'Auto' foreground color, the guess is based on the
+    ``colors`` variable in the IPython console, see _[ipythoncolors]. Hence, if
+    that variable is set correctly in your IPython console, there is a high
+    chance that the output will be readable, although manual settings may be
+    needed.
+
+
+    References
+    ==========
+
+    .. [dvicolornames] https://en.wikibooks.org/wiki/LaTeX/Colors#The_68_standard_colors_known_to_dvips
+
+    .. [ipythoncolors] https://ipython.readthedocs.io/en/stable/config/details.html#terminal-colors
+
     """
     import sys
     from sympy.printing.printer import Printer

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -346,24 +346,26 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     Parameters
     ==========
 
-    pretty_print : boolean
+    pretty_print : boolean, default=True
         If True, use pretty_print to stringify or the provided pretty
         printer; if False, use sstrrepr to stringify or the provided string
         printer.
-    order : string or None
+    order : string or None, default='lex'
         There are a few different settings for this parameter:
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
         old, which is used for compatibility reasons and for long expressions;
         None, which sets it to lex.
-    use_unicode : boolean or None
+    use_unicode : boolean or None, default=None
         If True, use unicode characters;
-        if False, do not use unicode characters.
-    use_latex : string, boolean, or None
+        if False, do not use unicode characters;
+        if None, make a guess based on the environment.
+    use_latex : string, boolean, or None, default=None
         If True, use default LaTeX rendering in GUI interfaces (png and
         mathjax);
         if False, do not use LaTeX rendering;
+        if None, make a guess based on the environment;
         if 'png', enable latex rendering with an external latex compiler,
         falling back to matplotlib if external compilation fails;
         if 'matplotlib', enable LaTeX rendering with matplotlib;
@@ -375,11 +377,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         If True, lines will wrap at the end; if False, they will not wrap
         but continue as one line. This is only relevant if ``pretty_print`` is
         True.
-    num_columns : int or None
+    num_columns : int or None, default=None
         If int, number of columns before wrapping is set to num_columns; if
         None, number of columns before wrapping is set to terminal width.
         This is only relevant if ``pretty_print`` is True.
-    no_global : boolean
+    no_global : boolean, default=False
         If True, the settings become system wide;
         if False, use just for this console/session.
     ip : An interactive console
@@ -396,12 +398,13 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         DVI setting for background color. See notes.
     fontsize : string, optional, default='10pt'
         A font size to pass to the LaTeX documentclass function in the
-        preamble.
+        preamble. Note that the options are limited by the documentclass.
+        Consider using scale instead.
     latex_mode : string, optional, default='plain'
         The mode used in the LaTeX printer. Can be one of:
         {'inline'|'plain'|'equation'|'equation*'}.
     print_builtin : boolean, optional, default=True
-        If true then floats and integers will be printed. If False the
+        If ``True`` then floats and integers will be printed. If ``False`` the
         printer will only print SymPy types.
     str_printer : function, optional, default=None
         A custom string printer function. This should mimic
@@ -415,7 +418,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         Useful for high dpi screens.
     settings :
         Any additional settings for the ``latex`` and ``pretty`` commands can
-        be passed.
+        be used to fine-tune the output.
 
     Examples
     ========
@@ -461,11 +464,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     executed, the LaTeX rendering is handled by the IPython console and not SymPy.
 
     The colors can be selected among the 68 standard colors known to ``dvips``,
-    for a list see _[dvicolornames]. In addition, the background color can be
+    for a list see [1]_. In addition, the background color can be
     set to  'Transparent' (which is the default value).
 
     When using the 'Auto' foreground color, the guess is based on the
-    ``colors`` variable in the IPython console, see _[ipythoncolors]. Hence, if
+    ``colors`` variable in the IPython console, see [2]_. Hence, if
     that variable is set correctly in your IPython console, there is a high
     chance that the output will be readable, although manual settings may be
     needed.
@@ -474,9 +477,15 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     References
     ==========
 
-    .. [dvicolornames] https://en.wikibooks.org/wiki/LaTeX/Colors#The_68_standard_colors_known_to_dvips
+    .. [1] https://en.wikibooks.org/wiki/LaTeX/Colors#The_68_standard_colors_known_to_dvips
 
-    .. [ipythoncolors] https://ipython.readthedocs.io/en/stable/config/details.html#terminal-colors
+    .. [2] https://ipython.readthedocs.io/en/stable/config/details.html#terminal-colors
+
+    See Also
+    ========
+
+    sympy.printing.latex
+    sympy.printing.pretty
 
     """
     import sys


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #10655

#### Brief description of what is fixed or changed
Changed the default value of `forecolor` in `init_printing` to `auto`, which leads to that the best background color is guessed based on the colors setting of IPython. Note that this is not based on the actual background color, but on 

"InteractiveShell.colors sets the colour of tracebacks and object info (the output from e.g. zip?). It may also affect other things if the option below is set to 'legacy'. It has four case-insensitive values: 'nocolor', 'neutral', 'linux', 'lightbg'. The default is neutral, which should be legible on either dark or light terminal backgrounds. linux is optimised for dark backgrounds and lightbg for light ones."

Unfortunately, it does not work directly when starting a new IPython shell (I have not figured out how the initialization magic works there), running `init_printing` (or `init_session`) it works. The screen shots are from Spyder.

![sympydark](https://user-images.githubusercontent.com/8114497/61720768-b287ed00-ad67-11e9-9421-dec28415906e.png)

![sympylight](https://user-images.githubusercontent.com/8114497/61720785-bae02800-ad67-11e9-953e-d6d30529c5bc.png)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* interactive
   * Guess the best foreground color for LaTeX rendering if  `None` (new default) is given in `init_printing`.


<!-- END RELEASE NOTES -->
