### PR TITLE
Faster immutable matrix element access

### DIFF
--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -3,7 +3,7 @@ from sympy.matrices.expressions.blockmatrix import (block_collapse, bc_matmul,
         bc_transpose, blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
         Inverse, trace, Transpose, det)
-from sympy.matrices import Matrix, ImmutableMatrix, ones
+from sympy.matrices import Matrix, ImmutableMatrix, SparseMatrix, ones
 from sympy.core import Tuple, symbols, Expr
 from sympy.core.compatibility import range
 from sympy.functions import transpose
@@ -95,6 +95,12 @@ def test_BlockMatrix():
     Z = MatrixSymbol('Z', *A.shape)
     assert block_collapse(Ab + Z) == A + Z
 
+def test_block_collapse_explicit_matrices():
+    A = Matrix([[1, 2], [3, 4]])
+    assert block_collapse(BlockMatrix([[A]])) == A
+
+    A = SparseMatrix([[1, 2], [3, 4]])
+    assert block_collapse(BlockMatrix([[A]])) == A
 
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -59,14 +59,11 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
         if not isinstance(flat_list, Tuple):
             flat_list = Tuple(*flat_list)
 
-        return Basic.__new__(cls, rows, cols, flat_list)
-
-    @property
-    def _mat(self):
-        # self.args[2] is a Tuple.  Access to the elements
-        # of a tuple are significantly faster than Tuple,
-        # so return the internal tuple.
-        return self.args[2].args
+        obj = Basic.__new__(cls, rows, cols, flat_list)
+        obj.rows = int(rows)
+        obj.cols = int(cols)
+        obj._mat = flat_list.args
+        return obj
 
     def _entry(self, i, j, **kwargs):
         return DenseMatrix.__getitem__(self, (i, j))
@@ -100,18 +97,6 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
         indices = (i * cols + j for i in rowsList for j in colsList)
         return self._new(len(rowsList), len(colsList),
                          Tuple(*(mat[i] for i in indices), sympify=False), copy=False)
-
-    @property
-    def cols(self):
-        return int(self.args[1])
-
-    @property
-    def rows(self):
-        return int(self.args[0])
-
-    @property
-    def shape(self):
-        return tuple(int(i) for i in self.args[:2])
 
     def is_diagonalizable(self, reals_only=False, **kwargs):
         return super(ImmutableDenseMatrix, self).is_diagonalizable(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #17249

#### Brief description of what is fixed or changed

There can be unnecessary slowdown for using property access.
This makes the speed of the immutable matrices as same as the mutable matrices.

Additionally, a bug that `block_collapse` giving attribute error for sparse matrix had been fixed, while discovering a way to fix the test failings for the main changes as well.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Improved speed of accessing `rows`, `cols` and matrix elements for `ImmutableDenseMatrix`
  - Fixed `block_collapse` giving AttributeError for sparse matrices. 
<!-- END RELEASE NOTES -->
