### PR TITLE
Reduce exp() argument modulo 2*I*pi

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -262,6 +262,12 @@ class exp(ExpBase):
                             return -S.ImaginaryUnit
                         elif ask(Q.odd(coeff + S.Half)):
                             return S.ImaginaryUnit
+                    elif coeff.is_Rational:
+                        ncoeff = coeff % 2 # restrict to [0, 2pi)
+                        if ncoeff > 1: # restrict to (-pi, pi]
+                            ncoeff -= 2
+                        if ncoeff != coeff:
+                            return cls(ncoeff*S.Pi*S.ImaginaryUnit)
 
             # Warning: code in risch.py will be very sensitive to changes
             # in this (see DifferentialExtension).
@@ -292,16 +298,21 @@ class exp(ExpBase):
         elif arg.is_Add:
             out = []
             add = []
+            argchanged = False
             for a in arg.args:
                 if a is S.One:
                     add.append(a)
                     continue
                 newa = cls(a)
                 if isinstance(newa, cls):
-                    add.append(a)
+                    if newa.args[0] != a:
+                        add.append(newa.args[0])
+                        argchanged = True
+                    else:
+                        add.append(a)
                 else:
                     out.append(newa)
-            if out:
+            if out or argchanged:
                 return Mul(*out)*cls(Add(*add), evaluate=False)
 
         elif isinstance(arg, MatrixBase):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -250,24 +250,23 @@ class exp(ExpBase):
         elif isinstance(arg, SetExpr):
             return arg._eval_func(cls)
         elif arg.is_Mul:
-            if arg.is_number or arg.is_Symbol:
-                coeff = arg.coeff(S.Pi*S.ImaginaryUnit)
-                if coeff:
-                    if ask(Q.integer(2*coeff)):
-                        if ask(Q.even(coeff)):
-                            return S.One
-                        elif ask(Q.odd(coeff)):
-                            return S.NegativeOne
-                        elif ask(Q.even(coeff + S.Half)):
-                            return -S.ImaginaryUnit
-                        elif ask(Q.odd(coeff + S.Half)):
-                            return S.ImaginaryUnit
-                    elif coeff.is_Rational:
-                        ncoeff = coeff % 2 # restrict to [0, 2pi)
-                        if ncoeff > 1: # restrict to (-pi, pi]
-                            ncoeff -= 2
-                        if ncoeff != coeff:
-                            return cls(ncoeff*S.Pi*S.ImaginaryUnit)
+            coeff = arg.as_coefficient(S.Pi*S.ImaginaryUnit)
+            if coeff:
+                if (2*coeff).is_integer:
+                    if coeff.is_even:
+                        return S.One
+                    elif coeff.is_odd:
+                        return S.NegativeOne
+                    elif (coeff + S.Half).is_even:
+                        return -S.ImaginaryUnit
+                    elif (coeff + S.Half).is_odd:
+                        return S.ImaginaryUnit
+                elif coeff.is_Rational:
+                    ncoeff = coeff % 2 # restrict to [0, 2pi)
+                    if ncoeff > 1: # restrict to (-pi, pi]
+                        ncoeff -= 2
+                    if ncoeff != coeff:
+                        return cls(ncoeff*S.Pi*S.ImaginaryUnit)
 
             # Warning: code in risch.py will be very sensitive to changes
             # in this (see DifferentialExtension).

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -59,6 +59,13 @@ def test_exp_period():
     assert exp(2 - 17*I*pi/5) == exp(2 + 3*I*pi/5)
     assert exp(log(3) + 29*I*pi/9) == 3 * exp(-7*I*pi/9)
 
+    n = Symbol('n', integer=True)
+    e = Symbol('e', even=True)
+    assert exp(e*I*pi) == 1
+    assert exp((e + 1)*I*pi) == -1
+    assert exp((1 + 4*n)*I*pi/2) == I
+    assert exp((-1 + 4*n)*I*pi/2) == -I
+
 
 def test_exp_log():
     x = Symbol("x", real=True)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -48,6 +48,18 @@ def test_exp_values():
     assert exp(oo, evaluate=False).is_finite is False
 
 
+def test_exp_period():
+    assert exp(9*I*pi/4) == exp(I*pi/4)
+    assert exp(46*I*pi/18) == exp(5*I*pi/9)
+    assert exp(25*I*pi/7) == exp(-3*I*pi/7)
+    assert exp(-19*I*pi/3) == exp(-I*pi/3)
+    assert exp(37*I*pi/8) - exp(-11*I*pi/8) == 0
+    assert exp(-5*I*pi/3) / exp(11*I*pi/5) * exp(148*I*pi/15) == 1
+
+    assert exp(2 - 17*I*pi/5) == exp(2 + 3*I*pi/5)
+    assert exp(log(3) + 29*I*pi/9) == 3 * exp(-7*I*pi/9)
+
+
 def test_exp_log():
     x = Symbol("x", real=True)
     assert log(exp(x)) == x

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -171,8 +171,8 @@ def mdft(n):
     >>> mdft(3)
     Matrix([
     [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],
-    [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3, sqrt(3)*exp(-4*I*pi/3)/3],
-    [sqrt(3)/3, sqrt(3)*exp(-4*I*pi/3)/3, sqrt(3)*exp(-8*I*pi/3)/3]])
+    [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3,  sqrt(3)*exp(2*I*pi/3)/3],
+    [sqrt(3)/3,  sqrt(3)*exp(2*I*pi/3)/3, sqrt(3)*exp(-2*I*pi/3)/3]])
     """
     mat = [[None for x in range(n)] for y in range(n)]
     base = exp(-2*pi*I/n)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17216

#### Brief description of what is fixed or changed
`exp()` arguments with an imaginary part that is a rational multiple of pi
will now be reduced mod `2*pi*I`. (In fact the principal value will be retained.)

Before:
```
In [8]: exp(9*I*pi/4) - exp(I*pi/4)
Out[8]: -exp(I*pi/4) + exp(9*I*pi/4)

In [9]: simplify(_)
Out[9]: -(-1)**(1/4) + exp(9*I*pi/4)
```

After:
```
In [4]: exp(9*I*pi/4) - exp(I*pi/4)
Out[4]: 0
```


#### Other comments


#### Release Notes


<!-- BEGIN RELEASE NOTES -->

* functions
  * `exp()` now reduces its argument mod `2*pi*I`.
<!-- END RELEASE NOTES -->
