### PR TITLE
optimize __neg__ routines

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -5,6 +5,7 @@ from functools import cmp_to_key
 
 from .basic import Basic
 from .compatibility import reduce, is_sequence, range
+from .evaluate import global_distribute
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
 from .operations import AssocOp
@@ -1073,6 +1074,12 @@ class Add(Expr, AssocOp):
             raise AttributeError("Cannot convert Add to mpc. Must be of the form Number + Number*I")
 
         return (Float(re_part)._mpf_, Float(im_part)._mpf_)
+
+    def __neg__(self):
+        if not global_distribute[0]:
+            return super(Add, self).__neg__()
+        return Add(*[-i for i in self.args])
+
 
 from .mul import Mul, _keep_coeff, prod
 from sympy.core.numbers import Rational

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -891,9 +891,6 @@ class Add(Expr, AssocOp):
     def _eval_transpose(self):
         return self.func(*[t.transpose() for t in self.args])
 
-    def __neg__(self):
-        return self*(-1)
-
     def _sage_(self):
         s = 0
         for x in self.args:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2179,6 +2179,7 @@ class Expr(Basic, EvalfMixin):
            x/6
 
         """
+        from .add import _unevaluated_Add
         c = sympify(c)
         if self is S.NaN:
             return None
@@ -2260,9 +2261,10 @@ class Expr(Basic, EvalfMixin):
                 if newarg is None:
                     return  # all or nothing
                 newargs.append(newarg)
-            # args should be in same order so use unevaluated return
             if cs is not S.One:
-                return Add._from_args([cs*t for t in newargs])
+                args = [cs*t for t in newargs]
+                # args may be in different order
+                return _unevaluated_Add(*args)
             else:
                 return Add._from_args(newargs)
         elif self.is_Mul:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -163,9 +163,6 @@ class Expr(Basic, EvalfMixin):
         # Mul has its own __neg__ routine, so we just
         # create a 2-args Mul with the -1 in the canonical
         # slot 0.
-        from sympy.core.evaluate import global_distribute
-        if self.is_Add and global_distribute[0]:
-            return Add(*[-i for i in self.args])
         c = self.is_commutative
         return Mul._from_args((S.NegativeOne, self), c)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -160,7 +160,14 @@ class Expr(Basic, EvalfMixin):
         return self
 
     def __neg__(self):
-        return Mul(S.NegativeOne, self)
+        # Mul has its own __neg__ routine, so we just
+        # create a 2-args Mul with the -1 in the canonical
+        # slot 0.
+        from sympy.core.evaluate import global_distribute
+        if self.is_Add and global_distribute[0]:
+            return Add(*[-i for i in self.args])
+        c = self.is_commutative
+        return Mul._from_args((S.NegativeOne, self), c)
 
     def __abs__(self):
         from sympy import Abs

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -94,6 +94,14 @@ class Mul(Expr, AssocOp):
 
     is_Mul = True
 
+    def __neg__(self):
+        c, a = self.as_coeff_Mul()
+        c = -c
+        if c is S.One:
+            return a
+        args = (c,) + self.make_args(a)
+        return self._from_args(args, self.is_commutative)
+
     @classmethod
     def flatten(cls, seq):
         """Return commutative, noncommutative and order arguments by

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -95,11 +95,17 @@ class Mul(Expr, AssocOp):
     is_Mul = True
 
     def __neg__(self):
-        c, a = self.as_coeff_Mul()
+        c, args = self.as_coeff_mul()
         c = -c
-        if c is S.One:
-            return a
-        args = (c,) + self.make_args(a)
+        if c is not S.One:
+            if args[0].is_Number:
+                args = list(args)
+                if c is S.NegativeOne:
+                    args[0] = -args[0]
+                else:
+                    args[0] *= c
+            else:
+                args = (c,) + args
         return self._from_args(args, self.is_commutative)
 
     @classmethod

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3255,6 +3255,9 @@ class NaN(with_metaclass(Singleton, Number)):
     def _latex(self, printer):
         return r"\text{NaN}"
 
+    def __neg__(self):
+        return self
+
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
         return self

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -55,7 +55,10 @@ class AssocOp(Basic):
 
     @classmethod
     def _from_args(cls, args, is_commutative=None):
-        """Create new instance with already-processed args"""
+        """Create new instance with already-processed args.
+        If the args are not in canonical order, then a non-canonical
+        result will be returned, so use with caution. The order of
+        args may change if the sign of the args is changed."""
         if len(args) == 0:
             return cls.identity
         elif len(args) == 1:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -4,6 +4,7 @@ from sympy import (Basic, Symbol, sin, cos, atan, exp, sqrt, Rational,
         floor
 )
 from sympy.core.compatibility import long, range
+from sympy.core.evaluate import distribute
 from sympy.core.expr import unchanged
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
@@ -2035,3 +2036,15 @@ def test_divmod():
     assert divmod(x, y) == (x//y, x % y)
     assert divmod(x, 3) == (x//3, x % 3)
     assert divmod(3, x) == (3//x, 3 % x)
+
+
+def test__neg__():
+    assert -(x*y) == -x*y
+    assert -(-x*y) == x*y
+    assert -(1.*x) == -1.*x
+    assert -(-1.*x) == 1.*x
+    assert -(2.*x) == -2.*x
+    assert -(-2.*x) == 2.*x
+    with distribute(False):
+        eq = -(x + y)
+        assert eq.is_Mul and eq.args == (-1, x + y)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1115,6 +1115,9 @@ def test_extractions():
            ((-x - y)/(y - x)).could_extract_minus_sign() is False
     assert (x - y).could_extract_minus_sign() is False
     assert (-x + y).could_extract_minus_sign() is True
+    # check that result is canonical
+    eq = (3*x + 15*y).extract_multiplicatively(3)
+    assert eq.args == eq.func(*eq.args).args
 
 
 def test_nan_extractions():

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -693,17 +693,18 @@ class log(Function):
 
         """
         from sympy import Abs, arg
+        sarg = self.args[0]
         if deep:
-            abs = Abs(self.args[0].expand(deep, **hints))
-            arg = arg(self.args[0].expand(deep, **hints))
-        else:
-            abs = Abs(self.args[0])
-            arg = arg(self.args[0])
+            sarg = self.args[0].expand(deep, **hints)
+        abs = Abs(sarg)
+        if abs == sarg:
+            return self, S.Zero
+        arg = arg(sarg)
         if hints.get('log', False):  # Expand the log
             hints['complex'] = False
             return (log(abs).expand(deep, **hints), arg)
         else:
-            return (log(abs), arg)
+            return log(abs), arg
 
     def _eval_is_rational(self):
         s = self.func(*self.args)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,9 +1,10 @@
 from sympy import (
-    Abs, adjoint, arg, atan, atan2, conjugate, cos, DiracDelta, E, exp, expand,
-    Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
-    sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
-    Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
-    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda, Derivative)
+    Abs, acos, adjoint, arg, atan, atan2, conjugate, cos, DiracDelta,
+    E, exp, expand, Expr, Function, Heaviside, I, im, log, nan, oo,
+    pi, Rational, re, S, sign, sin, sqrt, Symbol, symbols, transpose,
+    zoo, exp_polar, Piecewise, Interval, comp, Integral, Matrix,
+    ImmutableMatrix, SparseMatrix, ImmutableSparseMatrix, MatrixSymbol,
+    FunctionMatrix, Lambda, Derivative)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import XFAIL, raises
@@ -440,6 +441,11 @@ def test_Abs():
     assert re(t).is_algebraic is False
     assert Abs(x).fdiff() == sign(x)
     raises(ArgumentIndexError, lambda: Abs(x).fdiff(2))
+
+    # doesn't have recursion error
+    arg = sqrt(acos(1 - I)*acos(1 + I))
+    assert abs(arg) == arg
+
 
 def test_Abs_rewrite():
     x = Symbol('x', real=True)

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -470,4 +470,7 @@ class Order(Expr):
         #XXX: SAGE doesn't have Order yet. Let's return 0 instead.
         return Rational(0)._sage_()
 
+    def __neg__(self):
+        return self
+
 O = Order

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -829,11 +829,11 @@ def test_issue_17141():
     assert simplify(acos(-I)**2*acos(I)**2) == \
            log(1 + sqrt(2))**4 + pi**2*log(1 + sqrt(2))**2/2 + pi**4/16
     assert simplify(2**acos(I)**2) == 2**((pi - 2*I*log(1 + sqrt(2)))**2/4)
+    p = 2**acos(I+1)**2
+    assert simplify(p) == p
 
     # However, for a complex number it still happens
     if PY3:
-        raises(RecursionError, lambda: simplify(2**acos(I+1)**2))
         raises(RecursionError, lambda: simplify((2**acos(I+1)**2).rewrite('log')))
     else:
-        raises(RuntimeError, lambda: simplify(2**acos(I+1)**2))
         raises(RuntimeError, lambda: simplify((2**acos(I+1)**2).rewrite('log')))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
#### other issues

#13645 is not fixed

#### Brief description of what is fixed or changed

From #17242 I found the test runtimes decreased significantly when `__neg__` terms were rewritten. I am pushing this change alone to confirm this.

While working on this, a recursion error was encountered during the test run. So, serendipitously, that issue also got fixed. Running `as_real_imag` tests has reduced from about 12 seconds to 8 seconds.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * recusion error involving as_real_imag was removed
    * negation of expressions has been optimized
    * `extract_multiplicatively` returns a canonical expression
<!-- END RELEASE NOTES -->
