### PR TITLE
Sparse triangular and diagonal solve bug

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -158,12 +158,6 @@ class DenseMatrix(MatrixBase):
                     sum(L[i, k]**2 for k in range(i)))
         return self._new(L)
 
-    def _diagonal_solve(self, rhs):
-        """Helper function of function diagonal_solve,
-        without the error checks, to be used privately.
-        """
-        return self._new(rhs.rows, rhs.cols, lambda i, j: rhs[i, j] / self[i, i])
-
     def _eval_add(self, other):
         # we assume both arguments are dense matrices since
         # sparse matrices have a higher priority

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2357,6 +2357,13 @@ class MatrixBase(MatrixDeprecated,
     def __ne__(self, other):
         return not self == other
 
+    def _diagonal_solve(self, rhs):
+        """Helper function of function diagonal_solve, without the error
+        checks, to be used privately.
+        """
+        return self._new(
+            rhs.rows, rhs.cols, lambda i, j: rhs[i, j] / self[i, i])
+
     def _matrix_pow_by_jordan_blocks(self, num):
         from sympy.matrices import diag, MutableMatrix
         from sympy import binomial

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -587,11 +587,12 @@ class SparseMatrix(MatrixBase):
         for i, j, v in self.row_list():
             if i > j:
                 rows[i].append((j, v))
-        X = rhs.copy()
-        for i in range(self.rows):
-            for j, v in rows[i]:
-                X[i, 0] -= v*X[j, 0]
-            X[i, 0] /= self[i, i]
+        X = rhs.as_mutable().copy()
+        for j in range(rhs.cols):
+            for i in range(rhs.rows):
+                for u, v in rows[i]:
+                    X[i, j] -= v*X[u, j]
+                X[i, j] /= self[i, i]
         return self._new(X)
 
     @property
@@ -608,12 +609,12 @@ class SparseMatrix(MatrixBase):
         for i, j, v in self.row_list():
             if i < j:
                 rows[i].append((j, v))
-        X = rhs.copy()
-        for i in range(self.rows - 1, -1, -1):
-            rows[i].reverse()
-            for j, v in rows[i]:
-                X[i, 0] -= v*X[j, 0]
-            X[i, 0] /= self[i, i]
+        X = rhs.as_mutable().copy()
+        for j in range(rhs.cols):
+            for i in reversed(range(rhs.rows)):
+                for u, v in reversed(rows[i]):
+                    X[i, j] -= v*X[u, j]
+                X[i, j] /= self[i, i]
         return self._new(X)
 
 

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -315,10 +315,6 @@ class SparseMatrix(MatrixBase):
 
         return C
 
-    def _diagonal_solve(self, rhs):
-        "Diagonal solve."
-        return self._new(self.rows, 1, lambda i, j: rhs[i, 0] / self[i, i])
-
     def _eval_inverse(self, **kwargs):
         """Return the matrix inverse using Cholesky or LDL (default)
         decomposition as selected with the ``method`` keyword: 'CH' or 'LDL',

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2511,10 +2511,6 @@ def test_diagonal_solve():
     A = Matrix([[1, 0], [1, 2]])
     raises(TypeError, lambda: A.diagonal_solve(B))
 
-    A = SparseMatrix.diag([1, 2, 3])
-    B = Matrix([[1, 2], [3, 4], [5, 6]])
-    assert A.diagonal_solve(B) == Matrix([[1, 2], [S(3)/2, 2], [S(5)/3, 2]])
-
 
 def test_matrix_norm():
     # Vector Tests

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2511,6 +2511,10 @@ def test_diagonal_solve():
     A = Matrix([[1, 0], [1, 2]])
     raises(TypeError, lambda: A.diagonal_solve(B))
 
+    A = SparseMatrix.diag([1, 2, 3])
+    B = Matrix([[1, 2], [3, 4], [5, 6]])
+    assert A.diagonal_solve(B) == Matrix([[1, 2], [S(3)/2, 2], [S(5)/3, 2]])
+
 
 def test_matrix_norm():
     # Vector Tests

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -1,6 +1,7 @@
-from sympy import Abs, S, Symbol, I, Rational, PurePoly, Float
-from sympy.matrices import (Matrix, SparseMatrix, eye, ones, zeros,
-    ShapeError)
+from sympy import Abs, S, Symbol, symbols, I, Rational, PurePoly, Float
+from sympy.matrices import \
+    Matrix, MutableSparseMatrix, ImmutableSparseMatrix, SparseMatrix, eye, \
+    ones, zeros, ShapeError
 from sympy.utilities.pytest import raises
 
 def test_sparse_matrix():
@@ -604,6 +605,46 @@ def test_sparse_solve():
     assert A*s == A[:, 0]
     s = A.solve_least_squares(A[:, 0], 'LDL')
     assert A*s == A[:, 0]
+
+
+def test_lower_triangular_solve():
+    a, b, c, d = symbols('a:d')
+    u, v, w, x = symbols('u:x')
+
+    A = SparseMatrix([[a, 0], [c, d]])
+    B = MutableSparseMatrix([[u, v], [w, x]])
+    C = ImmutableSparseMatrix([[u, v], [w, x]])
+
+    sol = Matrix([[u/a, v/a], [(w - c*u/a)/d, (x - c*v/a)/d]])
+    assert A.lower_triangular_solve(B) == sol
+    assert A.lower_triangular_solve(C) == sol
+
+
+def test_upper_triangular_solve():
+    a, b, c, d = symbols('a:d')
+    u, v, w, x = symbols('u:x')
+
+    A = SparseMatrix([[a, b], [0, d]])
+    B = MutableSparseMatrix([[u, v], [w, x]])
+    C = ImmutableSparseMatrix([[u, v], [w, x]])
+
+    sol = Matrix([[(u - b*w/d)/a, (v - b*x/d)/a], [w/d, x/d]])
+    assert A.upper_triangular_solve(B) == sol
+    assert A.upper_triangular_solve(C) == sol
+
+
+def test_diagonal_solve():
+    a, d = symbols('a d')
+    u, v, w, x = symbols('u:x')
+
+    A = SparseMatrix([[a, 0], [0, d]])
+    B = MutableSparseMatrix([[u, v], [w, x]])
+    C = ImmutableSparseMatrix([[u, v], [w, x]])
+
+    sol = Matrix([[u/a, v/a], [w/d, x/d]])
+    assert A.diagonal_solve(B) == sol
+    assert A.diagonal_solve(C) == sol
+
 
 def test_hermitian():
     x = Symbol('x')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

```python
from sympy import *

m1 = SparseMatrix.diag([1, 2, 3])
m2 = Matrix([[1, 2], [3, 4], [5, 6]])
m1.diagonal_solve(m2)
```
Dense diagonal solve doesn't have this bug, but sparse diagonal solve is only solving the first column and giving the colunm vector.
Looks like sparse solver is using more inferiorly overridden version. 

I've also found same bug for upper and lower triangular solve

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `SparseMatrix.diagonal_solve` only solving the first column of the RHS matrix.
  - Fixed `SparseMatrix.upper_triangular_solve` and `SparseMatrix.lower_triangular_solve` only solving the first column of the RHS matrix.
  - Fixed `SparseMatrix.upper_triangular_solve` and `SparseMatrix.lower_triangular_solve`  not working if RHS is an immutable matrix.

<!-- END RELEASE NOTES -->
