### PR TITLE
add plot_parametric to global namespace

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -80,7 +80,7 @@ from .algebras import *
 # from combinatorics import *
 # This module is slow to import:
 #from physics import units
-from .plotting import plot, textplot, plot_backends, plot_implicit
+from .plotting import plot, textplot, plot_backends, plot_implicit, plot_parametric
 from .printing import *
 from .interactive import init_session, init_printing
 


### PR DESCRIPTION
closes #17252
 
fixed import error for `plot_parametric`  when trying `from sympy import plot_parametric`.
After this change, it has similar behavior to `plot_implicit` and `plot_backend` which don't give error if tried importing using `from sympy import plot_implicit` or `from sympy import plot_backend`

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->