### PR TITLE
[Prototype] Mpmath and NumPy matrix wrapper

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3940,6 +3940,12 @@ except ImportError:
     pass
 
 
+def sympify_mpmath_matrix(x):
+    from sympy.matrices.expressions.mpmath import WrappedMpmathMatrix
+    return WrappedMpmathMatrix(x)
+
+converter[mpmath.matrix] = sympify_mpmath_matrix
+
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3940,12 +3940,6 @@ except ImportError:
     pass
 
 
-def sympify_mpmath_matrix(x):
-    from sympy.matrices.expressions.mpmath import WrappedMpmathMatrix
-    return WrappedMpmathMatrix(x)
-
-converter[mpmath.matrix] = sympify_mpmath_matrix
-
 def sympify_mpmath(x):
     return Expr._from_mpmath(x, x.context.prec)
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -316,16 +316,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         except AttributeError:
             pass
 
-    if not strict:
-        # Put numpy array conversion _before_ float/int, see
-        # <https://github.com/sympy/sympy/issues/13924>.
-        flat = getattr(a, "flat", None)
-        if flat is not None:
-            shape = getattr(a, "shape", None)
-            if shape is not None:
-                from ..tensor.array import Array
-                return Array(a.flat, a.shape)  # works with e.g. NumPy arrays
-
     if not isinstance(a, string_types):
         for coerce in (float, int):
             try:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -73,6 +73,7 @@ class MatrixExpr(Expr):
 
     def __new__(cls, *args, **kwargs):
         args = map(_sympify, args)
+        kwargs.pop('copy', None)
         return Basic.__new__(cls, *args, **kwargs)
 
     # The following is adapted from the core Expr object

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -63,6 +63,11 @@ class MatPow(MatrixExpr):
             exp = exp*base.args[1]
             base = base.args[0]
 
+        # XXX Mpmath only supports integer matrix power
+        from .mpmath import MpmathMatrix
+        if isinstance(base, MpmathMatrix) and exp.is_Integer:
+            return base._eval_pow(exp)
+
         if exp.is_zero and base.is_square:
             if isinstance(base, MatrixBase):
                 return base.func(Identity(base.shape[0]))

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -68,6 +68,10 @@ class MatPow(MatrixExpr):
         if isinstance(base, MpmathMatrix) and exp.is_Integer:
             return base._eval_pow(exp)
 
+        from .numpy import NumPyMatrix
+        if isinstance(base, NumPyMatrix) and exp.is_Integer:
+            return base._eval_pow(exp)
+
         if exp.is_zero and base.is_square:
             if isinstance(base, MatrixBase):
                 return base.func(Identity(base.shape[0]))

--- a/sympy/matrices/expressions/mpmath.py
+++ b/sympy/matrices/expressions/mpmath.py
@@ -1,0 +1,8 @@
+import mpmath
+
+from .matexpr import MatrixExpr
+
+class MpmathMatrix(MatrixExpr):
+    def __new__(self, *args, **kwargs):
+        if not len(args) != 1:
+            raise ValueError("The argument should be of length 1")

--- a/sympy/matrices/expressions/mpmath.py
+++ b/sympy/matrices/expressions/mpmath.py
@@ -1,8 +1,79 @@
 import mpmath
 
-from .matexpr import MatrixExpr
+from sympy.core.basic import Basic
+from sympy.core.numbers import Integer
+
+from .matexpr import MatrixExpr, MatrixElement
+
+class WrappedMpmathMatrix(Basic):
+    """"""
+    is_Atom = True
+
+    def _hashable_content(self):
+        return tuple(self._mat._toliststr())
+
+    def __new__(cls, arg, copy=True):
+        if not isinstance(arg, mpmath.matrix):
+            raise ValueError('Only mpmath.matrix type is supported.')
+
+        if copy:
+            obj = Basic.__new__(cls, arg.copy())
+        else:
+            obj = Basic.__new__(cls, arg)
+        return obj
+
+    @property
+    def _mat(self):
+        return self.args[0]
 
 class MpmathMatrix(MatrixExpr):
-    def __new__(self, *args, **kwargs):
-        if not len(args) != 1:
-            raise ValueError("The argument should be of length 1")
+    is_Atom = True
+
+    def __new__(cls, arg, copy=True):
+        if not isinstance(arg, mpmath.matrix):
+            raise ValueError('Only mpmath.matrix type is supported.')
+
+        obj = MatrixExpr.__new__(cls, arg, copy=copy)
+        return obj
+
+    @property
+    def _wrapped(self):
+        return self.args[0]
+
+    def doit(self, **kwargs):
+        return self
+
+    def _entry(self, i, j, **kwargs):
+        return MatrixElement(self, i, j)
+
+    def as_explicit(self):
+        from sympy.matrices.immutable import ImmutableDenseMatrix
+        return ImmutableDenseMatrix(self._wrapped._mat.tolist())
+
+    @property
+    def rows(self):
+        return Integer(self._wrapped._mat.rows)
+
+    @property
+    def cols(self):
+        return Integer(self._wrapped._mat.cols)
+
+    @property
+    def shape(self):
+        return self.rows, self.cols
+
+    def _eval_pow(self, exp):
+        # XXX Mpmath only supports integer power
+        return MpmathMatrix(self._wrapped._mat ** int(exp), copy=False)
+
+    def _eval_inverse(self):
+        return MpmathMatrix(self._wrapped._mat ** -1, copy=False)
+
+    def _eval_transpose(self):
+        return MpmathMatrix(self._wrapped._mat.transpose(), copy=False)
+
+    def _eval_conjugate(self):
+        return MpmathMatrix(self._wrapped._mat.conjugate(), copy=False)
+
+    def _eval_adjoint(self):
+        return MpmathMatrix(self._wrapped._mat.transpose_conj(), copy=False)

--- a/sympy/matrices/expressions/mpmath.py
+++ b/sympy/matrices/expressions/mpmath.py
@@ -1,6 +1,7 @@
 import mpmath
 
 from sympy.core.basic import Basic
+from sympy.core.sympify import _sympify
 from sympy.core.numbers import Integer
 
 from .matexpr import MatrixExpr, MatrixElement
@@ -77,3 +78,6 @@ class MpmathMatrix(MatrixExpr):
 
     def _eval_adjoint(self):
         return MpmathMatrix(self._wrapped._mat.transpose_conj(), copy=False)
+
+    def _eval_determinant(self):
+        return _sympify(mpmath.det(self._wrapped._mat))

--- a/sympy/matrices/expressions/numpy.py
+++ b/sympy/matrices/expressions/numpy.py
@@ -1,27 +1,36 @@
-import mpmath
-
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify, converter
 from sympy.core.numbers import Integer
+from sympy.external import import_module
 
 from .matexpr import MatrixExpr, MatrixElement
 
-def sympify_mpmath_matrix(x):
-    from sympy.matrices.expressions.mpmath import WrappedMpmathMatrix
-    return WrappedMpmathMatrix(x)
+numpy = import_module('numpy')
 
-converter[mpmath.matrix] = sympify_mpmath_matrix
+def sympify_numpy_array(a):
+    from sympy.tensor.array import Array
 
-class WrappedMpmathMatrix(Basic):
+    if len(a.shape) == 2:
+        return WrappedNumPyMatrix(a)
+    else:
+        return Array(a.flat, a.shape)
+
+if numpy:
+    converter[numpy.ndarray] = sympify_numpy_array
+
+class WrappedNumPyMatrix(Basic):
     """"""
     is_Atom = True
 
     def _hashable_content(self):
-        return tuple(self._mat._toliststr())
+        return tuple(self._mat.tostring())
 
     def __new__(cls, arg, copy=True):
-        if not isinstance(arg, mpmath.matrix):
-            raise ValueError('Only mpmath.matrix type is supported.')
+        if not isinstance(arg, numpy.ndarray):
+            raise ValueError('Only Numpy array type is supported.')
+
+        if not len(arg.shape) == 2:
+            raise ValueError('Only 2-Dimensional array is supported')
 
         if copy:
             obj = Basic.__new__(cls, arg.copy())
@@ -33,12 +42,15 @@ class WrappedMpmathMatrix(Basic):
     def _mat(self):
         return self.args[0]
 
-class MpmathMatrix(MatrixExpr):
+class NumPyMatrix(MatrixExpr):
     is_Atom = True
 
     def __new__(cls, arg, copy=True):
-        if not isinstance(arg, mpmath.matrix):
-            raise ValueError('Only mpmath.matrix type is supported.')
+        if not isinstance(arg, numpy.ndarray):
+            raise ValueError('Only Numpy array type is supported.')
+
+        if not len(arg.shape) == 2:
+            raise ValueError('Only 2-Dimensional array is supported')
 
         obj = MatrixExpr.__new__(cls, arg, copy=copy)
         return obj
@@ -59,38 +71,44 @@ class MpmathMatrix(MatrixExpr):
 
     @property
     def rows(self):
-        return Integer(self._wrapped._mat.rows)
+        return Integer(self._wrapped._mat.shape[0])
 
     @property
     def cols(self):
-        return Integer(self._wrapped._mat.cols)
+        return Integer(self._wrapped._mat.shape[1])
 
     @property
     def shape(self):
         return self.rows, self.cols
 
     def _eval_pow(self, exp):
-        # XXX Mpmath only supports integer power
-        return MpmathMatrix(self._wrapped._mat ** int(exp), copy=False)
+        mat = self._wrapped._mat
+        return NumPyMatrix(
+            numpy.linalg.matrix_power(mat, int(exp)), copy=False)
 
     def _eval_inverse(self):
-        return MpmathMatrix(self._wrapped._mat ** -1, copy=False)
+        mat = self._wrapped._mat
+        return NumPyMatrix(numpy.linalg.inv(mat), copy=False)
 
     def _eval_transpose(self):
-        return MpmathMatrix(self._wrapped._mat.transpose(), copy=False)
+        mat = self._wrapped._mat
+        return NumPyMatrix(numpy.transpose(mat), copy=False)
 
     def _eval_conjugate(self):
-        return MpmathMatrix(self._wrapped._mat.conjugate(), copy=False)
+        mat = self._wrapped._mat
+        return NumPyMatrix(numpy.conj(mat), copy=False)
 
     def _eval_adjoint(self):
-        return MpmathMatrix(self._wrapped._mat.transpose_conj(), copy=False)
+        mat = self._wrapped._mat
+        return NumPyMatrix(numpy.conj(numpy.transpose(mat)), copy=False)
 
     def _eval_determinant(self):
-        return _sympify(mpmath.det(self._wrapped._mat))
+        mat = self._wrapped._mat
+        return _sympify(numpy.linalg.det(mat))
 
-    def _eval_rref(self, tol=10**-10):
+    def _eval_rref(self, tol=10**-8):
         # Experimental custom implementation
-        fabs = mpmath.fabs
+        fabs = numpy.absolute
         mat = self._wrapped._mat.copy()
 
         def is_zero(val):
@@ -106,8 +124,10 @@ class MpmathMatrix(MatrixExpr):
 
             return max_index
 
+        rows, cols = mat.shape
+
         row = 0
-        for col in range(mat.cols):
+        for col in range(cols):
             if is_zero(mat[row, col]):
                 pivot_pos = find_pivot(mat[row:, col])
                 if pivot_pos == None:
@@ -117,11 +137,11 @@ class MpmathMatrix(MatrixExpr):
 
             mat[row, col:] /= mat[row, col]
 
-            for i in range(mat.rows):
+            for i in range(rows):
                 if i == row:
                     continue
                 mat[i, col:] -=  mat[i, col] * mat[row, col:]
 
             row += 1
 
-        return MpmathMatrix(mat, copy=False)
+        return NumPyMatrix(mat, copy=False)

--- a/sympy/matrices/expressions/rref.py
+++ b/sympy/matrices/expressions/rref.py
@@ -1,0 +1,24 @@
+from .matexpr import MatrixExpr
+from sympy.matrices.matrices import MatrixBase
+
+class ReducedRowEchelonForm(MatrixExpr):
+
+    def __new__(cls, arg, **kwargs):
+        return MatrixExpr.__new__(cls, arg, **kwargs)
+
+    def doit(self, deep=True):
+        arg = self.args[0]
+        if deep == True:
+            arg = arg.doit()
+
+        if isinstance(arg, MatrixBase):
+            return arg.rref()
+        return arg._eval_rref()
+
+    @property
+    def rows(self):
+        return self.args[0].rows
+
+    @property
+    def cols(self):
+        return self.args[0].cols

--- a/sympy/matrices/expressions/rref.py
+++ b/sympy/matrices/expressions/rref.py
@@ -12,7 +12,7 @@ class ReducedRowEchelonForm(MatrixExpr):
             arg = arg.doit()
 
         if isinstance(arg, MatrixBase):
-            return arg.rref()
+            return arg.rref()[0]
         return arg._eval_rref()
 
     @property

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1611,6 +1611,9 @@ class LatexPrinter(Printer):
         return r"\mathbb{I}" if self._settings[
             'mat_symbol_style'] == 'plain' else r"\mathbf{I}"
 
+    def _print_MpmathMatrix(self, expr):
+        return self._print(expr.as_explicit())
+
     def _print_NDimArray(self, expr):
 
         if expr.rank() == 0:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1614,6 +1614,9 @@ class LatexPrinter(Printer):
     def _print_MpmathMatrix(self, expr):
         return self._print(expr.as_explicit())
 
+    def _print_NumPyMatrix(self, expr):
+        return self._print(expr.as_explicit())
+
     def _print_NDimArray(self, expr):
 
         if expr.rank() == 0:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

So from the comment https://github.com/sympy/sympy/pull/17250#issuecomment-514814547 there had been discussion of using wrapped numeric matrices dedicated for some purpose.

However, I think that things may be overly complicated from the MatrixBase, to integrate with other matrix types

Instead, I have an another idea of using the interface of matrix expressions instead, and it looks like it is actually more simpler from this perspective, only having to be careful about copying and mutating the original matrices.

Possible usage can be below. I've not implemented addition and multiplication yet

![image](https://user-images.githubusercontent.com/34944973/61890520-92f8ec00-af42-11e9-9f52-81c2465f5d95.png)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
