### PR TITLE
Allow symbolic parameters in joint_rv_types

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -58,7 +58,7 @@ from sympy import (log, sqrt, pi, S, Dummy, Interval, sympify, gamma, sign,
                    Lambda, Basic, lowergamma, erf, erfc, erfi, erfinv, I,
                    hyper, uppergamma, sinh, Ne, expint)
 from sympy.external import import_module
-from sympy.matrices import MatrixBase
+from sympy.matrices import MatrixBase, MatrixSymbol
 from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistribution,
                              ContinuousDistributionHandmade)
 from sympy.stats.joint_rv import JointPSpace, CompoundDistribution
@@ -2651,8 +2651,8 @@ def Normal(name, mean, std):
 
     """
 
-    if isinstance(mean, (list, MatrixBase)) and\
-        isinstance(std, (list, MatrixBase)):
+    if isinstance(mean, (list, MatrixBase, MatrixSymbol)) and\
+        isinstance(std, (list, MatrixBase, MatrixSymbol)):
         from sympy.stats.joint_rv_types import MultivariateNormalDistribution
         return multivariate_rv(
             MultivariateNormalDistribution, name, mean, std)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -58,7 +58,7 @@ from sympy import (log, sqrt, pi, S, Dummy, Interval, sympify, gamma, sign,
                    Lambda, Basic, lowergamma, erf, erfc, erfi, erfinv, I,
                    hyper, uppergamma, sinh, Ne, expint)
 from sympy.external import import_module
-from sympy.matrices import MatrixBase, MatrixSymbol
+from sympy.matrices import MatrixBase, MatrixExpr
 from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistribution,
                              ContinuousDistributionHandmade)
 from sympy.stats.joint_rv import JointPSpace, CompoundDistribution
@@ -2651,8 +2651,8 @@ def Normal(name, mean, std):
 
     """
 
-    if isinstance(mean, (list, MatrixBase, MatrixSymbol)) and\
-        isinstance(std, (list, MatrixBase, MatrixSymbol)):
+    if isinstance(mean, (list, MatrixBase, MatrixExpr)) and\
+        isinstance(std, (list, MatrixBase, MatrixExpr)):
         from sympy.stats.joint_rv_types import MultivariateNormalDistribution
         return multivariate_rv(
             MultivariateNormalDistribution, name, mean, std)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -105,8 +105,6 @@ class MultivariateNormalDistribution(JointDistribution):
         sym = ImmutableMatrix([Indexed(sym, i) for i in indices])
         _mu, _sigma = self.mu, self.sigma
         k = self.mu.shape[0]
-        if not isinstance(k, int):
-            raise ValueError('k must be of type int.')
         for i in range(k):
             if i not in indices:
                 _mu = _mu.row_del(i)

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -105,7 +105,7 @@ class MultivariateNormalDistribution(JointDistribution):
         sym = ImmutableMatrix([Indexed(sym, i) for i in indices])
         _mu, _sigma = self.mu, self.sigma
         k = self.mu.shape[0]
-        if not k.is_Integer:
+        if not isinstance(k, int):
             raise ValueError('k must be of type int.')
         for i in range(k):
             if i not in indices:

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -3,11 +3,11 @@ from sympy import (symbols, pi, oo, S, exp, sqrt, besselk, Indexed, Sum, simplif
                    IndexedBase, RisingFactorial)
 from sympy.core.numbers import comp
 from sympy.integrals.integrals import integrate
-from sympy.matrices import Matrix
+from sympy.matrices import Matrix, MatrixSymbol
 from sympy.stats import density
 from sympy.stats.crv_types import Normal
 from sympy.stats.joint_rv import marginal_distribution
-from sympy.stats.joint_rv_types import JointRV
+from sympy.stats.joint_rv_types import JointRV, MultivariateNormalDistribution
 from sympy.utilities.pytest import raises, XFAIL
 
 x, y, z, a, b = symbols('x y z a b')
@@ -27,6 +27,15 @@ def test_Normal():
     assert density(N)(0, 0) == exp(-2/y - 1/(2*x))/(2*pi*sqrt(x*y))
 
     raises (ValueError, lambda: Normal('M', [1, 2], [[1, 1], [1, -1]]))
+    # symbolic
+    n = symbols('n', natural=True)
+    mu = MatrixSymbol('mu', n, 1)
+    sigma = MatrixSymbol('sigma', n, n)
+    X = Normal('X', mu, sigma)
+    assert density(X) == MultivariateNormalDistribution(mu, sigma)
+    # Below tests should work after issue #17267 is resolved
+    # assert E(X) == mu
+    # assert variance(X) == sigma
 
 def test_MultivariateTDist():
     from sympy.stats.joint_rv_types import MultivariateT

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -50,8 +50,8 @@ def test_MultivariateTDist():
 def test_multivariate_laplace():
     from sympy.stats.crv_types import Laplace
     raises(ValueError, lambda: Laplace('T', [1, 2], [[1, 2], [2, 1]]))
-    L = Laplace('L', [1, 0], [[1, 2], [0, 1]])
-    assert density(L)(2, 3) == exp(2)*besselk(0, sqrt(3))/pi
+    L = Laplace('L', [1, 0], [[1, 0], [0, 1]])
+    assert density(L)(2, 3) == exp(2)*besselk(0, sqrt(39))/pi
     L1 = Laplace('L1', [1, 2], [[x, 0], [0, y]])
     assert density(L1)(0, 1) == \
         exp(2/y)*besselk(0, sqrt((2 + 4/y + 1/x)/y))/(pi*sqrt(x*y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
At present RVs in `joint_rv_types` does not allow symbolic parameters.
```python3
>>> from sympy.stats import *
>>> from sympy import symbols, MatrixSymbol
>>> n = symbols('n')
>>> mu = MatrixSymbol('mu', n, 1)
>>> sigma = MatrixSymbol('sigma', n, n)
>>> X = Normal('X', mu, sigma)
>>> X.pspace
SingleContinuousPSpace(X, NormalDistribution(mu, sigma))
```
This PR allows `joint_rv_types` to have symbolic parameters.
```python3
>>> from sympy.stats import *
>>> from sympy import symbols, MatrixSymbol
>>> n = symbols('n')
>>> mu = MatrixSymbol('mu', n, 1)
>>> sigma = MatrixSymbol('sigma', n, n)
>>> X = Normal('X', mu, sigma)
>>> X.pspace
JointPSpace(X, MultivariateNormalDistribution(mu, sigma))
```
#### Other comments
Ping @Upabjojr @sidhantnagpal 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- stats
    - Allow symbolic parameters in `sympy/stats/joint_rv_types`
<!-- END RELEASE NOTES -->
