### PR TITLE
Fix asec and acos docstrings

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2147,7 +2147,7 @@ class acos(InverseTrigonometricFunction):
     the result is a rational multiple of pi (see the eval class method).
 
     ``acos(zoo)`` evaluates to ``zoo``
-    (see note in :py:class`sympy.functions.elementary.trigonometric.asec`)
+    (see note in :class:`sympy.functions.elementary.trigonometric.asec`)
 
     A purely imaginary argument will be rewritten to asinh.
 
@@ -2671,7 +2671,7 @@ class asec(InverseTrigonometricFunction):
     simplifies to :math:`-i\log\left(z/2 + O\left(z^3\right)\right)` which
     ultimately evaluates to ``zoo``.
 
-    As ``asec(x)`` = ``asec(1/x)``, a similar argument can be given for
+    As ``acos(x)`` = ``asec(1/x)``, a similar argument can be given for
     ``acos(x)``.
 
     Examples


### PR DESCRIPTION


#### References to other Issues or PRs
See #9344 for original discussion of asec(0) and acos(zoo)


#### Brief description of what is fixed or changed
- `asec` docstring erroneously stated that `asec(1/x) = asec(x)`, while it should be `acos(1/x) = asec(x)`.
- A reference to the above docstring in acos docstring wasn't rendered correctly in the html docs due to wrong syntax. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
