### PR TITLE
Better comparison for frac, floor, and ceiling

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -157,7 +157,7 @@ class floor(RoundFunction):
     def __le__(self, other):
         if self.args[0] == other and other.is_real:
             return S.true
-        if other == S.Infinity and self.is_finite:
+        if other is S.Infinity and self.is_finite:
             return S.true
         return Le(self, other, evaluate=False)
 
@@ -248,7 +248,7 @@ class ceiling(RoundFunction):
     def __ge__(self, other):
         if self.args[0] == other and other.is_real:
             return S.true
-        if other == S.NegativeInfinity and self.is_real:
+        if other is S.NegativeInfinity and self.is_real:
             return S.true
         return Ge(self, other, evaluate=False)
 
@@ -380,7 +380,7 @@ class frac(Function):
             other = _sympify(other)
             # Check if other <= 0
             if other.is_extended_nonpositive:
-                    return S.true
+                return S.true
             # Check if other >= 1
             res = self._value_one_or_more(other)
             if res is not None:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -155,6 +155,8 @@ class floor(RoundFunction):
     def __le__(self, other):
         if self.args[0] == other and other.is_real:
             return S.true
+        if other == S.Infinity and self.is_finite:
+            return S.true
         return Le(self, other, evaluate=False)
 
     def __gt__(self, other):
@@ -243,6 +245,8 @@ class ceiling(RoundFunction):
 
     def __ge__(self, other):
         if self.args[0] == other and other.is_real:
+            return S.true
+        if other == S.NegativeInfinity and self.is_real:
             return S.true
         return Ge(self, other, evaluate=False)
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -350,7 +350,7 @@ class frac(Function):
                     (self.rewrite(ceiling) == other):
                 return S.true
             # Check if other < 0
-            if other.is_extended_real and other.is_extended_negative:
+            if other.is_extended_negative:
                 return S.false
             # Check if other >= 1
             res = self._value_one_or_more(other)
@@ -379,7 +379,7 @@ class frac(Function):
         if self.is_extended_real:
             other = _sympify(other)
             # Check if other <= 0
-            if other.is_extended_real and other.is_extended_nonpositive:
+            if other.is_extended_nonpositive:
                     return S.true
             # Check if other >= 1
             res = self._value_one_or_more(other)
@@ -395,7 +395,7 @@ class frac(Function):
             if res is not None:
                 return not(res)
             # Check if other >= 1
-            if other.is_extended_real and other.is_extended_negative:
+            if other.is_extended_negative:
                 return S.true
         return Gt(self, other, evaluate=False)
 
@@ -403,7 +403,7 @@ class frac(Function):
         if self.is_extended_real:
             other = _sympify(other)
             # Check if other < 0
-            if other.is_extended_real and other.is_extended_negative:
+            if other.is_extended_negative:
                 return S.false
             # Check if other >= 1
             res = self._value_one_or_more(other)
@@ -415,7 +415,7 @@ class frac(Function):
         if self.is_extended_real:
             other = _sympify(other)
             # Check if other <= 0
-            if other.is_extended_real and other.is_extended_nonpositive:
+            if other.is_extended_nonpositive:
                 return S.false
             # Check if other >= 1
             res = self._value_one_or_more(other)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -3,9 +3,11 @@ from __future__ import print_function, division
 from sympy.core import Add, S
 from sympy.core.evalf import get_integer_part, PrecisionExhausted
 from sympy.core.function import Function
+from sympy.core.logic import fuzzy_or
 from sympy.core.numbers import Integer
-from sympy.core.relational import Gt, Lt, Ge, Le
+from sympy.core.relational import Gt, Lt, Ge, Le, Relational
 from sympy.core.symbol import Symbol
+from sympy.core.sympify import _sympify
 
 
 ###############################################################################
@@ -313,7 +315,7 @@ class frac(Function):
                 if arg is S.NaN:
                     return S.NaN
                 elif arg is S.ComplexInfinity:
-                    return None
+                    return S.NaN
                 else:
                     return arg - floor(arg)
             return cls(arg, evaluate=False)
@@ -346,4 +348,86 @@ class frac(Function):
         if isinstance(self, frac):
             if (self.rewrite(floor) == other) or \
                     (self.rewrite(ceiling) == other):
+                return S.true
+            # Check if other < 0
+            if other.is_extended_real and other.is_extended_negative:
+                return S.false
+            # Check if other >= 1
+            res = self._value_one_or_more(other)
+            if res is not None:
+                return S.false
+
+    def _eval_is_finite(self):
+        return True
+
+    def _eval_is_real(self):
+        return self.args[0].is_extended_real
+
+    def _eval_is_imaginary(self):
+        return self.args[0].is_imaginary
+
+    def _eval_is_integer(self):
+        return self.args[0].is_integer
+
+    def _eval_is_zero(self):
+        return fuzzy_or([self.args[0].is_zero, self.args[0].is_integer])
+
+    def _eval_is_negative(self):
+        return False
+
+    def __ge__(self, other):
+        if self.is_extended_real:
+            other = _sympify(other)
+            # Check if other <= 0
+            if other.is_extended_real and other.is_extended_nonpositive:
+                    return S.true
+            # Check if other >= 1
+            res = self._value_one_or_more(other)
+            if res is not None:
+                return not(res)
+        return Ge(self, other, evaluate=False)
+
+    def __gt__(self, other):
+        if self.is_extended_real:
+            other = _sympify(other)
+            # Check if other < 0
+            res = self._value_one_or_more(other)
+            if res is not None:
+                return not(res)
+            # Check if other >= 1
+            if other.is_extended_real and other.is_extended_negative:
+                return S.true
+        return Gt(self, other, evaluate=False)
+
+    def __le__(self, other):
+        if self.is_extended_real:
+            other = _sympify(other)
+            # Check if other < 0
+            if other.is_extended_real and other.is_extended_negative:
+                return S.false
+            # Check if other >= 1
+            res = self._value_one_or_more(other)
+            if res is not None:
+                return res
+        return Le(self, other, evaluate=False)
+
+    def __lt__(self, other):
+        if self.is_extended_real:
+            other = _sympify(other)
+            # Check if other <= 0
+            if other.is_extended_real and other.is_extended_nonpositive:
+                return S.false
+            # Check if other >= 1
+            res = self._value_one_or_more(other)
+            if res is not None:
+                return res
+        return Lt(self, other, evaluate=False)
+
+    def _value_one_or_more(self, other):
+        if other.is_extended_real:
+            if other.is_number:
+                res = other >= 1
+                if res and not isinstance(res, Relational):
+                    return S.true
+            if other.is_integer and other.is_positive:
                 return S.true

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -113,6 +113,7 @@ def test_floor():
     assert (floor(x) > x).is_Relational
     assert (floor(x) <= y).is_Relational  # arg is not same as rhs
     assert (floor(x) > y).is_Relational
+    assert (floor(y) <= oo) == True
 
     assert floor(y).rewrite(frac) == y - frac(y)
     assert floor(y).rewrite(ceiling) == -ceiling(-y)
@@ -228,6 +229,7 @@ def test_ceiling():
     assert (ceiling(x) < x).is_Relational
     assert (ceiling(x) >= y).is_Relational  # arg is not same as rhs
     assert (ceiling(x) < y).is_Relational
+    assert (ceiling(y) >= -oo) == True
 
     assert ceiling(y).rewrite(floor) == -floor(-y)
     assert ceiling(y).rewrite(frac) == y + frac(-y)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,5 +1,6 @@
 from sympy import AccumBounds, Symbol, floor, nan, oo, zoo, E, symbols, \
-        ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac, Eq
+        ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac, Eq, \
+        Le, Ge, Gt, Lt, Ne, sqrt
 
 from sympy.core.expr import unchanged
 from sympy.utilities.pytest import XFAIL
@@ -246,6 +247,7 @@ def test_frac():
     assert isinstance(frac(x), frac)
     assert frac(oo) == AccumBounds(0, 1)
     assert frac(-oo) == AccumBounds(0, 1)
+    assert frac(zoo) == nan
 
     assert frac(n) == 0
     assert frac(nan) == nan
@@ -270,6 +272,121 @@ def test_frac():
 
     assert Eq(frac(y), y - floor(y))
     assert Eq(frac(y), y + ceiling(-y))
+
+    r = Symbol('r', real=True)
+    p_i = Symbol('p_i', integer=True, positive=True)
+    n_i = Symbol('p_i', integer=True, negative=True)
+    np_i = Symbol('np_i', integer=True, nonpositive=True)
+    nn_i = Symbol('nn_i', integer=True, nonnegative=True)
+    p_r = Symbol('p_r', real=True, positive=True)
+    n_r = Symbol('n_r', real=True, negative=True)
+    np_r = Symbol('np_r', real=True, nonpositive=True)
+    nn_r = Symbol('nn_r', real=True, nonnegative=True)
+
+    # Real frac argument, integer rhs
+    assert frac(r) <= p_i
+    assert not frac(r) <= n_i
+    assert (frac(r) <= np_i).has(Le)
+    assert (frac(r) <= nn_i).has(Le)
+    assert frac(r) < p_i
+    assert not frac(r) < n_i
+    assert not frac(r) < np_i
+    assert (frac(r) < nn_i).has(Lt)
+    assert not frac(r) >= p_i
+    assert frac(r) >= n_i
+    assert frac(r) >= np_i
+    assert (frac(r) >= nn_i).has(Ge)
+    assert not frac(r) > p_i
+    assert frac(r) > n_i
+    assert (frac(r) > np_i).has(Gt)
+    assert (frac(r) > nn_i).has(Gt)
+
+    assert not Eq(frac(r), p_i)
+    assert not Eq(frac(r), n_i)
+    assert Eq(frac(r), np_i).has(Eq)
+    assert Eq(frac(r), nn_i).has(Eq)
+
+    assert Ne(frac(r), p_i)
+    assert Ne(frac(r), n_i)
+    assert Ne(frac(r), np_i).has(Ne)
+    assert Ne(frac(r), nn_i).has(Ne)
+
+
+    # Real frac argument, real rhs
+    assert (frac(r) <= p_r).has(Le)
+    assert not frac(r) <= n_r
+    assert (frac(r) <= np_r).has(Le)
+    assert (frac(r) <= nn_r).has(Le)
+    assert (frac(r) < p_r).has(Lt)
+    assert not frac(r) < n_r
+    assert not frac(r) < np_r
+    assert (frac(r) < nn_r).has(Lt)
+    assert (frac(r) >= p_r).has(Ge)
+    assert frac(r) >= n_r
+    assert frac(r) >= np_r
+    assert (frac(r) >= nn_r).has(Ge)
+    assert (frac(r) > p_r).has(Gt)
+    assert frac(r) > n_r
+    assert (frac(r) > np_r).has(Gt)
+    assert (frac(r) > nn_r).has(Gt)
+
+    assert not Eq(frac(r), n_r)
+    assert Eq(frac(r), p_r).has(Eq)
+    assert Eq(frac(r), np_r).has(Eq)
+    assert Eq(frac(r), nn_r).has(Eq)
+
+    assert Ne(frac(r), p_r).has(Ne)
+    assert Ne(frac(r), n_r)
+    assert Ne(frac(r), np_r).has(Ne)
+    assert Ne(frac(r), nn_r).has(Ne)
+
+    # Real frac argument, +/- oo rhs
+    assert frac(r) < oo
+    assert frac(r) <= oo
+    assert not frac(r) > oo
+    assert not frac(r) >= oo
+
+    assert not frac(r) < -oo
+    assert not frac(r) <= -oo
+    assert frac(r) > -oo
+    assert frac(r) >= -oo
+
+    assert frac(r) < 1
+    assert frac(r) <= 1
+    assert not frac(r) > 1
+    assert not frac(r) >= 1
+
+    assert not frac(r) < 0
+    assert (frac(r) <= 0).has(Le)
+    assert (frac(r) > 0).has(Gt)
+    assert frac(r) >= 0
+
+    # Some test for numbers
+    assert frac(r) <= sqrt(2)
+    assert (frac(r) <= sqrt(3) - sqrt(2)).has(Le)
+    assert not frac(r) <= sqrt(2) - sqrt(3)
+    assert not frac(r) >= sqrt(2)
+    assert (frac(r) >= sqrt(3) - sqrt(2)).has(Ge)
+    assert frac(r) >= sqrt(2) - sqrt(3)
+
+    assert not Eq(frac(r), sqrt(2))
+    assert Eq(frac(r), sqrt(3) - sqrt(2)).has(Eq)
+    assert not Eq(frac(r), sqrt(2) - sqrt(3))
+    assert Ne(frac(r), sqrt(2))
+    assert Ne(frac(r), sqrt(3) - sqrt(2)).has(Ne)
+    assert Ne(frac(r), sqrt(2) - sqrt(3))
+
+    assert frac(p_i, evaluate=False).is_zero
+    assert frac(p_i, evaluate=False).is_finite
+    assert frac(p_i, evaluate=False).is_integer
+    assert frac(p_i, evaluate=False).is_real
+    assert frac(r).is_finite
+    assert frac(r).is_real
+    assert frac(r).is_zero is None
+    assert frac(r).is_integer is None
+
+    assert frac(oo).is_finite
+    assert frac(oo).is_real
 
 
 def test_series():

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -247,7 +247,7 @@ def test_frac():
     assert isinstance(frac(x), frac)
     assert frac(oo) == AccumBounds(0, 1)
     assert frac(-oo) == AccumBounds(0, 1)
-    assert frac(zoo) == nan
+    assert frac(zoo) is nan
 
     assert frac(n) == 0
     assert frac(nan) == nan

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1733,6 +1733,13 @@ class LatexPrinter(Printer):
     def _print_UniversalSet(self, expr):
         return r"\mathbb{U}"
 
+    def _print_frac(self, expr, exp=None):
+        if exp is None:
+            return r"\operatorname{frac}{\left(%s\right)}" % self._print(expr.args[0])
+        else:
+            return r"\operatorname{frac}{\left(%s\right)}^{%s}" % (
+                    self._print(expr.args[0]), self._print(exp))
+
     def _print_tuple(self, expr):
         if self._settings['decimal_separator'] =='comma':
             return r"\left( %s\right)" % \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -10,7 +10,7 @@ from sympy import (
     assoc_laguerre, assoc_legendre, beta, binomial, catalan, ceiling, Complement,
     chebyshevt, chebyshevu, conjugate, cot, coth, diff, dirichlet_eta, euler,
     exp, expint, factorial, factorial2, floor, gamma, gegenbauer, hermite,
-    hyper, im, jacobi, laguerre, legendre, lerchphi, log,
+    hyper, im, jacobi, laguerre, legendre, lerchphi, log, frac,
     meijerg, oo, polar_lift, polylog, re, root, sin, sqrt, symbols,
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
@@ -370,8 +370,11 @@ def test_latex_functions():
 
     assert latex(floor(x)) == r"\left\lfloor{x}\right\rfloor"
     assert latex(ceiling(x)) == r"\left\lceil{x}\right\rceil"
+    assert latex(frac(x)) == r"\operatorname{frac}{\left(x\right)}"
     assert latex(floor(x)**2) == r"\left\lfloor{x}\right\rfloor^{2}"
     assert latex(ceiling(x)**2) == r"\left\lceil{x}\right\rceil^{2}"
+    assert latex(frac(x)**2) == r"\operatorname{frac}{\left(x\right)}^{2}"
+
     assert latex(Min(x, 2, x**3)) == r"\min\left(2, x, x^{3}\right)"
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"
@@ -2286,7 +2289,7 @@ def test_DiffGeomMethods():
         r'\operatorname{d}\left(g{\left(\mathbf{x},\mathbf{y} \right)}\right)'
 
 
-def test_unit_ptinting():
+def test_unit_printing():
     assert latex(5*meter) == r'5 \text{m}'
     assert latex(3*gibibyte) == r'3 \text{gibibyte}'
     assert latex(4*microgram/second) == r'\frac{4 \mu\text{g}}{\text{s}}'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16992

#### Brief description of what is fixed or changed
Started out as wanting to automatically evaluate `floor(x) <= oo` and `ceiling(x) >= -oo` for real x, but since that was a quite small PR, I had a look at `frac` as well. Since the output of frac is limited, one can make quite some assumptions there.

It also turned out that there was not LaTeX printing for frac, so I added that. I selected a plain (operatorname) version: 
![image](https://user-images.githubusercontent.com/8114497/61957914-95019000-afc0-11e9-8ae4-43c650cdf662.png) 
The alternative, to use {} was turned down to avoid confusion with sets.



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * More cases of relations with `frac`, `ceiling`, and `floor` leads to automatic evaluation.
   * `frac(zoo)` no longer leads to an error.

* printing
   * Added LaTeX printing for `frac`.
<!-- END RELEASE NOTES -->
