### PR TITLE
Do not try heurisch if integral contains abs or sign

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -16,8 +16,9 @@ from sympy.functions import log, sinh, cosh, tanh, coth, asinh, acosh
 from sympy.functions import sqrt, erf, erfi, li, Ei
 from sympy.functions import besselj, bessely, besseli, besselk
 from sympy.functions import hankel1, hankel2, jn, yn
-from sympy.functions.elementary.complexes import Abs, re, im, sign
+from sympy.functions.elementary.complexes import Abs, re, im, sign, arg
 from sympy.functions.elementary.exponential import LambertW
+from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 
@@ -101,7 +102,7 @@ def _symbols(name, n):
 
 def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
                      degree_offset=0, unnecessary_permutations=None,
-                     always_try_heurisch=None):
+                     _try_heurisch=None):
     """
     A wrapper around the heurisch integration algorithm.
 
@@ -132,7 +133,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         return f*x
 
     res = heurisch(f, x, rewrite, hints, mappings, retries, degree_offset,
-                   unnecessary_permutations, always_try_heurisch)
+                   unnecessary_permutations, _try_heurisch)
     if not isinstance(res, Basic):
         return res
     # We consider each denominator in the expression, and try to find
@@ -167,7 +168,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     for sub_dict in slns:
         expr = heurisch(f.subs(sub_dict), x, rewrite, hints, mappings, retries,
                         degree_offset, unnecessary_permutations,
-                        always_try_heurisch)
+                        _try_heurisch)
         cond = And(*[Eq(key, value) for key, value in sub_dict.items()])
         generic = Or(*[Ne(key, value) for key, value in sub_dict.items()])
         pairs.append((expr, cond))
@@ -176,13 +177,13 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     if len(pairs) == 1:
         pairs = [(heurisch(f, x, rewrite, hints, mappings, retries,
                               degree_offset, unnecessary_permutations,
-                              always_try_heurisch),
+                              _try_heurisch),
                               generic),
                  (pairs[0][0], True)]
     else:
         pairs.append((heurisch(f, x, rewrite, hints, mappings, retries,
                               degree_offset, unnecessary_permutations,
-                              always_try_heurisch),
+                              _try_heurisch),
                               True))
     return Piecewise(*pairs)
 
@@ -275,7 +276,7 @@ class DiffCache(object):
 
 def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
              degree_offset=0, unnecessary_permutations=None,
-             always_try_heurisch=None):
+             _try_heurisch=None):
     """
     Compute indefinite integral using heuristic Risch algorithm.
 
@@ -354,9 +355,9 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
 
     # There are some functions that Heurisch cannot currently handle,
     # so do not even try.
-    # Set always_try_heurisch=True to skip this check
-    if always_try_heurisch is not True:
-        if f.has(Abs, re, im, sign, Heaviside, DiracDelta):
+    # Set _try_heurisch=True to skip this check
+    if _try_heurisch is not True:
+        if f.has(Abs, re, im, sign, Heaviside, DiracDelta, floor, ceiling, arg):
             return
 
     if x not in f.free_symbols:

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -16,8 +16,10 @@ from sympy.functions import log, sinh, cosh, tanh, coth, asinh, acosh
 from sympy.functions import sqrt, erf, erfi, li, Ei
 from sympy.functions import besselj, bessely, besseli, besselk
 from sympy.functions import hankel1, hankel2, jn, yn
+from sympy.functions.elementary.complexes import Abs, re, im, sign
 from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 
 from sympy.simplify.radsimp import collect
 
@@ -98,7 +100,8 @@ def _symbols(name, n):
 
 
 def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
-                     degree_offset=0, unnecessary_permutations=None):
+                     degree_offset=0, unnecessary_permutations=None,
+                     always_try_heurisch=None):
     """
     A wrapper around the heurisch integration algorithm.
 
@@ -129,7 +132,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         return f*x
 
     res = heurisch(f, x, rewrite, hints, mappings, retries, degree_offset,
-                   unnecessary_permutations)
+                   unnecessary_permutations, always_try_heurisch)
     if not isinstance(res, Basic):
         return res
     # We consider each denominator in the expression, and try to find
@@ -163,7 +166,8 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     pairs = []
     for sub_dict in slns:
         expr = heurisch(f.subs(sub_dict), x, rewrite, hints, mappings, retries,
-                        degree_offset, unnecessary_permutations)
+                        degree_offset, unnecessary_permutations,
+                        always_try_heurisch)
         cond = And(*[Eq(key, value) for key, value in sub_dict.items()])
         generic = Or(*[Ne(key, value) for key, value in sub_dict.items()])
         pairs.append((expr, cond))
@@ -171,12 +175,14 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     # doing so may lead to longer Piecewise formulas
     if len(pairs) == 1:
         pairs = [(heurisch(f, x, rewrite, hints, mappings, retries,
-                              degree_offset, unnecessary_permutations),
+                              degree_offset, unnecessary_permutations,
+                              always_try_heurisch),
                               generic),
                  (pairs[0][0], True)]
     else:
         pairs.append((heurisch(f, x, rewrite, hints, mappings, retries,
-                              degree_offset, unnecessary_permutations),
+                              degree_offset, unnecessary_permutations,
+                              always_try_heurisch),
                               True))
     return Piecewise(*pairs)
 
@@ -268,7 +274,8 @@ class DiffCache(object):
         return cache[f]
 
 def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
-             degree_offset=0, unnecessary_permutations=None):
+             degree_offset=0, unnecessary_permutations=None,
+             always_try_heurisch=None):
     """
     Compute indefinite integral using heuristic Risch algorithm.
 
@@ -344,6 +351,14 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     components
     """
     f = sympify(f)
+
+    # There are some functions that Heurisch cannot currently handle,
+    # so do not even try.
+    # Set always_try_heurisch=True to skip this check
+    if always_try_heurisch is not True:
+        if f.has(Abs, re, im, sign, Heaviside, DiracDelta):
+            return
+
     if x not in f.free_symbols:
         return f*x
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1026,19 +1026,16 @@ class Integral(AddWithLimits):
 
                 # fall back to heurisch
                 if heurisch is not False:
-                    if heurisch is True or not (g.has(Abs) or g.has(sign)):
-                        # heurisch cannot handle integrals with Abs or sign
-                        # anyway
-                        try:
-                            if conds == 'piecewise':
-                                h = heurisch_wrapper(g, x, hints=[])
-                            else:
-                                h = heurisch_(g, x, hints=[])
-                        except PolynomialError:
-                            # XXX: this exception means there is a bug in the
-                            # implementation of heuristic Risch integration
-                            # algorithm.
-                            h = None
+                    try:
+                        if conds == 'piecewise':
+                            h = heurisch_wrapper(g, x, hints=[])
+                        else:
+                            h = heurisch_(g, x, hints=[])
+                    except PolynomialError:
+                        # XXX: this exception means there is a bug in the
+                        # implementation of heuristic Risch integration
+                        # algorithm.
+                        h = None
             else:
                 h = None
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1026,16 +1026,19 @@ class Integral(AddWithLimits):
 
                 # fall back to heurisch
                 if heurisch is not False:
-                    try:
-                        if conds == 'piecewise':
-                            h = heurisch_wrapper(g, x, hints=[])
-                        else:
-                            h = heurisch_(g, x, hints=[])
-                    except PolynomialError:
-                        # XXX: this exception means there is a bug in the
-                        # implementation of heuristic Risch integration
-                        # algorithm.
-                        h = None
+                    if heurisch is True or not (g.has(Abs) or g.has(sign)):
+                        # heurisch cannot handle integrals with Abs or sign
+                        # anyway
+                        try:
+                            if conds == 'piecewise':
+                                h = heurisch_wrapper(g, x, hints=[])
+                            else:
+                                h = heurisch_(g, x, hints=[])
+                        except PolynomialError:
+                            # XXX: this exception means there is a bug in the
+                            # implementation of heuristic Risch integration
+                            # algorithm.
+                            h = None
             else:
                 h = None
 

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -256,6 +256,6 @@ def test_integrate_Piecewise_rational_over_reals():
 
 
 @XFAIL
-@slow
 def test_issue_4311_slow():
+    # Not slow when bypassing heurish
     assert not integrate(x*abs(9-x**2), x).has(Integral)

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -33,6 +33,8 @@ def test_heurisch_polynomials():
     assert heurisch(1, x) == x
     assert heurisch(x, x) == x**2/2
     assert heurisch(x**17, x) == x**18/18
+    # For coverage
+    assert heurisch_wrapper(y, x) == y*x
 
 
 def test_heurisch_fractions():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -5,7 +5,7 @@ from sympy import (
     integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
-    symbols, sympify, tan, trigsimp, Tuple, lerchphi, exp_polar
+    symbols, sympify, tan, trigsimp, Tuple, lerchphi, exp_polar, li
 )
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
@@ -1546,3 +1546,10 @@ def test_issue_14709b():
     h = Symbol('h', positive=True)
     i = integrate(x*acos(1 - 2*x/h), (x, 0, h))
     assert i == 5*h**2*pi/16
+
+
+def test_li_integral():
+    y = Symbol('y')
+    assert Integral(li(y*x**2), x).doit() == Piecewise(
+            (x*li(x**2*y) - x*Ei(3*log(x) + 3*log(y)/2)/(sqrt(y)*sqrt(x**2)), Ne(y, 0)),
+            (0, True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
According to @jksuom, see https://github.com/sympy/sympy/issues/16217#issuecomment-471257311, `heurisch` cannot handle integrals with Abs or sign in them, so I disabled that step in case the expression has Abs or sign. Still possible to override by using `heurisch=True`.

#### Other comments
`test_V14` went from a few minutes to a few seconds with the same output on my computer. (The integration part, simplifying takes a few seconds as well.)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Integrals with abs or sign will not use the `heurisch` step by default.
<!-- END RELEASE NOTES -->
