### PR TITLE
Dot product multiplied with matrix is giving an error

### DIFF
--- a/sympy/matrices/expressions/dotproduct.py
+++ b/sympy/matrices/expressions/dotproduct.py
@@ -1,12 +1,11 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic
+from sympy.core import Basic, Expr
 from sympy.core.sympify import _sympify
 from sympy.matrices.expressions.transpose import transpose
-from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
-class DotProduct(MatrixExpr):
+class DotProduct(Expr):
     """
     Dot product of vector matrices
 

--- a/sympy/matrices/expressions/tests/test_dotproduct.py
+++ b/sympy/matrices/expressions/tests/test_dotproduct.py
@@ -1,5 +1,7 @@
 from sympy.core.expr import unchanged
+from sympy.core.mul import Mul
 from sympy.matrices import Matrix
+from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.dotproduct import DotProduct
 from sympy.utilities.pytest import raises
 
@@ -27,6 +29,7 @@ def test_dotproduct_symbolic():
     B = MatrixSymbol('B', 3, 1)
 
     dot = DotProduct(A, B)
-    assert unchanged(Mul, dot, 2)
+    assert dot.is_scalar == True
+    assert unchanged(Mul, 2, dot)
     # XXX Fix forced evaluation for arithmetics with matrix expressions
     assert dot * A == (A[0, 0]*B[0, 0] + A[1, 0]*B[1, 0] + A[2, 0]*B[2, 0])*A

--- a/sympy/matrices/expressions/tests/test_dotproduct.py
+++ b/sympy/matrices/expressions/tests/test_dotproduct.py
@@ -1,6 +1,8 @@
+from sympy.core.expr import unchanged
 from sympy.matrices import Matrix
 from sympy.matrices.expressions.dotproduct import DotProduct
 from sympy.utilities.pytest import raises
+
 
 A = Matrix(3, 1, [1, 2, 3])
 B = Matrix(3, 1, [1, 3, 5])
@@ -19,3 +21,12 @@ def test_docproduct():
     raises(TypeError, lambda: DotProduct(D, A))
 
     raises(TypeError, lambda: DotProduct(B, C).doit())
+
+def test_dotproduct_symbolic():
+    A = MatrixSymbol('A', 3, 1)
+    B = MatrixSymbol('B', 3, 1)
+
+    dot = DotProduct(A, B)
+    assert unchanged(Mul, dot, 2)
+    # XXX Fix forced evaluation for arithmetics with matrix expressions
+    assert dot * A == (A[0, 0]*B[0, 0] + A[1, 0]*B[1, 0] + A[2, 0]*B[2, 0])*A


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Unevaluated `DotProduct` is acting like a matrix with no shape, so there can be lots of issues like
```
A = MatrixSymbol('A', 3, 1)
B = MatrixSymbol('B', 3, 1)

DotProduct(A, B) * A
```
throwing an error.
 
It may better subclass from `Expr`, like `Determinant`

#### Other comments

Also, every arithmetics with matrix expressions are invoking `.doit()`,
which makes things like summation or integrals evaluate.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Fixed symbolic `DotProduct` multiplied with matrices giving error.
  - `DotProduct` is properly considered a scalar.

<!-- END RELEASE NOTES -->
