### PR TITLE
 Add scaling to LaTeX output

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -306,12 +306,12 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         rendering in IPython notebook or text rendering in LaTeX documents
     wrap_line: boolean
         If True, lines will wrap at the end; if False, they will not wrap
-        but continue as one line. This is only relevant if `pretty_print` is
+        but continue as one line. This is only relevant if ``pretty_print`` is
         True.
     num_columns: int or None
         If int, number of columns before wrapping is set to num_columns; if
         None, number of columns before wrapping is set to terminal width.
-        This is only relevant if `pretty_print` is True.
+        This is only relevant if ``pretty_print`` is True.
     no_global: boolean
         If True, the settings become system wide;
         if False, use just for this console/session.
@@ -342,7 +342,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     latex_printer: function, optional, default=None
         A custom LaTeX printer. This should mimic sympy.printing.latex().
     scaling: float, optional, default=1.0
-        Scale the LaTeX output. Useful for high dpi screens.
+        Scale the LaTeX output when using the ``png`` backend. Useful for high
+        dpi screens.
 
     Examples
     ========

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -35,7 +35,7 @@ def _init_python_printing(stringify_func, **settings):
 
 def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                            backcolor, fontsize, latex_mode, print_builtin,
-                           latex_printer, scaling, **settings):
+                           latex_printer, scale, **settings):
     """Setup printing in IPython interactive session. """
     try:
         from IPython.lib.latextools import latex_to_png
@@ -52,7 +52,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     imagesize = 'tight'
     offset = "0cm,0cm"
-    resolution = round(150*scaling)
+    resolution = round(150*scale)
     dvi = r"-T %s -D %d -bg %s -fg %s -O %s" % (
         imagesize, resolution, backcolor, forecolor, offset)
     dvioptions = dvi.split()
@@ -274,7 +274,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
-                  latex_printer=None, scaling=1.0, **settings):
+                  latex_printer=None, scale=1.0, **settings):
     r"""
     Initializes pretty-printer depending on the environment.
 
@@ -341,7 +341,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         A custom pretty printer. This should mimic sympy.printing.pretty().
     latex_printer: function, optional, default=None
         A custom LaTeX printer. This should mimic sympy.printing.latex().
-    scaling: float, optional, default=1.0
+    scale: float, optional, default=1.0
         Scale the LaTeX output when using the ``png`` backend. Useful for high
         dpi screens.
 
@@ -454,7 +454,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   "of IPython printing")
         _init_ipython_printing(ip, stringify_func, use_latex, euler,
                                forecolor, backcolor, fontsize, latex_mode,
-                               print_builtin, latex_printer, scaling,
+                               print_builtin, latex_printer, scale,
                                **settings)
     else:
         _init_python_printing(stringify_func, **settings)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -35,7 +35,7 @@ def _init_python_printing(stringify_func, **settings):
 
 def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                            backcolor, fontsize, latex_mode, print_builtin,
-                           latex_printer, **settings):
+                           latex_printer, scaling, **settings):
     """Setup printing in IPython interactive session. """
     try:
         from IPython.lib.latextools import latex_to_png
@@ -52,7 +52,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     imagesize = 'tight'
     offset = "0cm,0cm"
-    resolution = 150
+    resolution = round(150*scaling)
     dvi = r"-T %s -D %d -bg %s -fg %s -O %s" % (
         imagesize, resolution, backcolor, forecolor, offset)
     dvioptions = dvi.split()
@@ -274,7 +274,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='plain', print_builtin=True,
                   str_printer=None, pretty_printer=None,
-                  latex_printer=None, **settings):
+                  latex_printer=None, scaling=1.0, **settings):
     r"""
     Initializes pretty-printer depending on the environment.
 
@@ -341,6 +341,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         A custom pretty printer. This should mimic sympy.printing.pretty().
     latex_printer: function, optional, default=None
         A custom LaTeX printer. This should mimic sympy.printing.latex().
+    scaling: float, optional, default=1.0
+        Scale the LaTeX output. Useful for high dpi screens.
 
     Examples
     ========
@@ -451,6 +453,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   "of IPython printing")
         _init_ipython_printing(ip, stringify_func, use_latex, euler,
                                forecolor, backcolor, fontsize, latex_mode,
-                               print_builtin, latex_printer, **settings)
+                               print_builtin, latex_printer, scaling,
+                               **settings)
     else:
         _init_python_printing(stringify_func, **settings)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
As discussed in #17244, adding scaling to the LaTeX output is also useful.
![image](https://user-images.githubusercontent.com/8114497/61993004-ffb8d700-b065-11e9-8caa-a4b7ad5f0de5.png)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* interactive
    * The LaTeX output can be scaled by using `scale` in `init_printing`.
<!-- END RELEASE NOTES -->
