### PR TITLE
Fixed bug of __getitem__ for single item array 

### DIFF
--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -67,8 +67,6 @@ class DenseNDimArray(NDimArray):
             if isinstance(index, slice):
                 return self._array[index]
             else:
-                if self.shape == ():
-                    index = ()
                 index = self._parse_index(index)
                 return self._array[index]
 

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -84,12 +84,13 @@ def test_ndim_array_initiation():
     raises(ValueError, lambda: vector_with_long_shape[long(5)])
 
     from sympy.abc import x
-    rank_zero_array = ImmutableDenseNDimArray(x)
-    assert len(rank_zero_array) == 1
-    assert rank_zero_array.shape == ()
-    assert rank_zero_array.rank() == 0
-    assert rank_zero_array[()] == x
-    assert rank_zero_array[0] == x
+    for ArrayType in [ImmutableDenseNDimArray, ImmutableSparseNDimArray]:
+        rank_zero_array = ArrayType(x)
+        assert len(rank_zero_array) == 1
+        assert rank_zero_array.shape == ()
+        assert rank_zero_array.rank() == 0
+        assert rank_zero_array[()] == x
+        raises(ValueError, lambda: rank_zero_array[0])
 
 
 def test_reshape():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -74,6 +74,14 @@ def test_ndim_array_initiation():
     assert vector_with_long_shape.rank() == 1
     raises(ValueError, lambda: vector_with_long_shape[long(5)])
 
+    from sympy.abc import x
+    for ArrayType in [MutableDenseNDimArray, MutableSparseNDimArray]:
+        rank_zero_array = ArrayType(x)
+        assert len(rank_zero_array) == 1
+        assert rank_zero_array.shape == ()
+        assert rank_zero_array.rank() == 0
+        assert rank_zero_array[()] == x
+        raises(ValueError, lambda: rank_zero_array[0])
 
 def test_sympify():
     from sympy.abc import x, y, z, t


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Fixed a bug of `__getitem__` in single item array. Following examples of NumPy.
Before:
```python
>>> a = Array(1)
>>> a
1
>>> a[()]
1
>>> a[0]
1
```
Now:
```python
>>> a = Array(1)
>>> a
1
>>> a[()]
1
>>> a[0]
ValueError: Wrong number of array axes
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Bugfix of `__getitem__` for single item array 

<!-- END RELEASE NOTES -->
