### PR TITLE
Fixed LaTeX printing of derivative symbol with superscript

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -206,6 +206,18 @@ class LatexPrinter(Printer):
         else:
             return self._print(item)
 
+    def parenthesize_super(self, s):
+        """ Parenthesize s if there is a superscript in s"""
+        if "^" in s:
+            return r"\left({}\right)".format(s)
+        return s
+
+    def embed_super(self, s):
+        """ Embed s in {} if there is a superscript in s"""
+        if "^" in s:
+            return "{{{}}}".format(s)
+        return s
+
     def doprint(self, expr):
         tex = Printer.doprint(self, expr)
 
@@ -671,7 +683,9 @@ class LatexPrinter(Printer):
             if num == 1:
                 tex += r"%s %s" % (diff_symbol, self._print(x))
             else:
-                tex += r"%s %s^{%s}" % (diff_symbol, self._print(x), num)
+                tex += r"%s %s^{%s}" % (diff_symbol,
+                                        self.parenthesize_super(self._print(x)),
+                                        num)
 
         if dim == 1:
             tex = r"\frac{%s}{%s}" % (diff_symbol, tex)
@@ -938,7 +952,7 @@ class LatexPrinter(Printer):
         if isinstance(e.args[0], Implies):
             return self._print_Implies(e.args[0], r"\not\Rightarrow")
         if (e.args[0].is_Boolean):
-            return r"\neg (%s)" % self._print(e.args[0])
+            return r"\neg \left(%s\right)" % self._print(e.args[0])
         else:
             return r"\neg %s" % self._print(e.args[0])
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,7 +1,7 @@
 from sympy import (
     Add, Abs, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
     FiniteSet, Float, FourierTransform, Function, Indexed, IndexedBase, Integral,
-    Interval, InverseCosineTransform, InverseFourierTransform,
+    Interval, InverseCosineTransform, InverseFourierTransform, Derivative,
     InverseLaplaceTransform, InverseMellinTransform, InverseSineTransform,
     Lambda, LaplaceTransform, Limit, Matrix, Max, MellinTransform, Min, Mul,
     Order, Piecewise, Poly, ring, field, ZZ, Pow, Product, Range, Rational,
@@ -137,6 +137,7 @@ def test_latex_basic():
     assert latex(~(x >> ~y)) == r"x \not\Rightarrow \neg y"
     assert latex(Implies(Or(x,y), z)) == r"\left(x \vee y\right) \Rightarrow z"
     assert latex(Implies(z, Or(x,y))) == r"z \Rightarrow \left(x \vee y\right)"
+    assert latex(~(x & y)) == r"\neg \left(x \wedge y\right)"
 
     assert latex(~x, symbol_names={x: "x_i"}) == r"\neg x_i"
     assert latex(x & y, symbol_names={x: "x_i", y: "y_i"}) == \
@@ -2290,6 +2291,12 @@ def test_unit_ptinting():
     assert latex(5*meter) == r'5 \text{m}'
     assert latex(3*gibibyte) == r'3 \text{gibibyte}'
     assert latex(4*microgram/second) == r'\frac{4 \mu\text{g}}{\text{s}}'
+
+
+def test_issue_17092():
+    x_star = Symbol('x^*')
+    assert latex(Derivative(x_star, x_star,2)) == r'\frac{d^{2}}{d \left(x^{*}\right)^{2}} x^{*}'
+
 
 def test_latex_decimal_separator():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17092 

#### Brief description of what is fixed or changed
Earlier it was not possible to print `Derivative` with a superscripted symbol. Now:
![image](https://user-images.githubusercontent.com/8114497/62005605-07e04780-b136-11e9-86ee-38b025fd3775.png)

Also added `\left(...\right)` to printing of `Not` which was missing earlier.

#### Other comments

Probably the same thing can happen for more functions. I added two functions `parenthesize_super` and `embed_super` which puts `\left( \right` and `{ }` around the expression if it contains a superscript, respectively.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * Fixed LaTeX printing of `Derivative`when the derivation variable has a superscript.
<!-- END RELEASE NOTES -->
