### PR TITLE
Abs(1/x) is now evaluated to 1/Abs(x)

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3119,17 +3119,21 @@ class Expr(Basic, EvalfMixin):
         as_leading_term is only allowed for results of .series()
         This is a wrapper to compute a series first.
         """
-        from sympy import Dummy, log
+        from sympy import Dummy, log, Piecewise, piecewise_fold
         from sympy.series.gruntz import calculate_series
 
+        if self.has(Piecewise):
+            expr = piecewise_fold(self)
+        else:
+            expr = self
         if self.removeO() == 0:
             return self
 
         if logx is None:
             d = Dummy('logx')
-            s = calculate_series(self, x, d).subs(d, log(x))
+            s = calculate_series(expr, x, d).subs(d, log(x))
         else:
-            s = calculate_series(self, x, logx)
+            s = calculate_series(expr, x, logx)
 
         return s.as_leading_term(x)
 
@@ -3208,7 +3212,7 @@ class Expr(Basic, EvalfMixin):
             from sympy.utilities.misc import filldedent
             raise ValueError(filldedent("""
                 cannot compute leadterm(%s, %s). The coefficient
-                should have been free of x but got %s""" % (self, x, c)))
+                should have been free of %s but got %s""" % (self, x, x, c)))
         c = c.subs(d, log(x))
         return c, e
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -508,7 +508,8 @@ class Abs(Function):
                 a, b = log(base).as_real_imag()
                 z = a + I*b
                 return exp(re(exponent*z))
-
+            elif exponent is S.NegativeOne:
+                return Abs(base)**S.NegativeOne
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))
         if isinstance(arg, AppliedUndef):

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -508,8 +508,8 @@ class Abs(Function):
                 a, b = log(base).as_real_imag()
                 z = a + I*b
                 return exp(re(exponent*z))
-            elif exponent is S.NegativeOne:
-                return Abs(base)**S.NegativeOne
+            elif exponent.is_integer and exponent.is_negative:
+                return Abs(base**(-exponent))**S.NegativeOne
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))
         if isinstance(arg, AppliedUndef):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Earlier `Abs(2/x)` became `2*Abs(1/x)`, now it becomes `2/Abs(x)`. Similarly `Abs(x/y)` becomes `Abs(x)/Abs(y)`.

I was conservative and only changed it for reciprocals, so higher negative powers stays as is. Not sure what the best setting is here.

The potential drawback with this is the series convergence testing. As far as I can tell, the matching expects `1/expression`, not `1/Abs(expression)`, but I cannot really tell the impact of it or possible changes. Adding a `piecewise_fold` got the tests back to before (I have only run the "relevant" ones, so anything may happen). I will not spend much time on it, if it doesn't work, but this behavior should be preferred in general.

Also improved the printing of an error message slightly.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `Abs(1/x)` is evaluated to `1/Abs(x)`.
 
<!-- END RELEASE NOTES -->
