### PR TITLE
Fix precedence control for tribonacci constant in mathematica code

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -205,7 +205,9 @@ class MCodePrinter(CodePrinter):
         return 'GoldenRatio'
 
     def _print_TribonacciConstant(self, expr):
-        return self.doprint(expr._eval_expand_func())
+        expanded = expr.expand(func=True)
+        PREC = precedence(expr)
+        return self.parenthesize(expanded, PREC)
 
     def _print_EulerGamma(self, expr):
         return 'EulerGamma'

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -127,8 +127,11 @@ def test_constants():
     assert mcode(pi) == "Pi"
     assert mcode(S.GoldenRatio) == "GoldenRatio"
     assert mcode(S.TribonacciConstant) == \
-        "1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + " \
-        "(1/3)*(3*33^(1/2) + 19)^(1/3)"
+        "(1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + " \
+        "(1/3)*(3*33^(1/2) + 19)^(1/3))"
+    assert mcode(2*S.TribonacciConstant) == \
+        "2*(1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + " \
+        "(1/3)*(3*33^(1/2) + 19)^(1/3))"
     assert mcode(S.EulerGamma) == "EulerGamma"
     assert mcode(S.Catalan) == "Catalan"
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I have found that I had done some flaw for printing `TribonacciConstant`in #16128
`mathematica_code(2*TribonacciConstant)`
It should not print like
`'2*1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + (1/3)*(3*33^(1/2) + 19)^(1/3)'`
but it should
'2*(1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + (1/3)*(3*33^(1/2) + 19)^(1/3))'

I think that precedence control gets messed up when trying to rewrite things while printing. At least this approach puts additional bracket, if the thing rewritten is not an atomic expr.

But still it may a limitation like always attempting to put the brackets, though
`mathematica_code(TribonaccoConstant)`
`'(1/3 + (1/3)*(19 - 3*33^(1/2))^(1/3) + (1/3)*(3*33^(1/2) + 19)^(1/3))'`

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Mathematica code printer will put an additional parenthesis to the printed result of `TribonacciConstant` to fix the precedence control.
<!-- END RELEASE NOTES -->
