### PR TITLE
Sparse matrix block_collapse fix

### DIFF
--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -3,7 +3,8 @@ from sympy.matrices.expressions.blockmatrix import (block_collapse, bc_matmul,
         bc_transpose, blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
         Inverse, trace, Transpose, det)
-from sympy.matrices import Matrix, ImmutableMatrix, SparseMatrix, ones
+from sympy.matrices import (
+    Matrix, ImmutableMatrix, ImmutableSparseMatrix, ones)
 from sympy.core import Tuple, symbols, Expr
 from sympy.core.compatibility import range
 from sympy.functions import transpose
@@ -99,7 +100,7 @@ def test_block_collapse_explicit_matrices():
     A = Matrix([[1, 2], [3, 4]])
     assert block_collapse(BlockMatrix([[A]])) == A
 
-    A = SparseMatrix([[1, 2], [3, 4]])
+    A = ImmutableSparseMatrix([[1, 2], [3, 4]])
     assert block_collapse(BlockMatrix([[A]])) == A
 
 def test_BlockMatrix_trace():

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -3,7 +3,7 @@ from sympy.matrices.expressions.blockmatrix import (block_collapse, bc_matmul,
         bc_transpose, blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
         Inverse, trace, Transpose, det)
-from sympy.matrices import Matrix, ImmutableMatrix, ones
+from sympy.matrices import Matrix, ImmutableMatrix, SparseMatrix, ones
 from sympy.core import Tuple, symbols, Expr
 from sympy.core.compatibility import range
 from sympy.functions import transpose
@@ -95,6 +95,12 @@ def test_BlockMatrix():
     Z = MatrixSymbol('Z', *A.shape)
     assert block_collapse(Ab + Z) == A + Z
 
+def test_block_collapse_explicit_matrices():
+    A = Matrix([[1, 2], [3, 4]])
+    assert block_collapse(BlockMatrix([[A]])) == A
+
+    A = SparseMatrix([[1, 2], [3, 4]])
+    assert block_collapse(BlockMatrix([[A]])) == A
 
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#17250

#### Brief description of what is fixed or changed

This only contains the fix for the `block_collapse` which fails with sparse matrices like
```
A = ImmutableSparseMatrix([[1]])
block_collapse(BlockMatrix([[A]]))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `block_collapse` giving `AttributeError` with sparse matrices.
<!-- END RELEASE NOTES -->
