### PR TITLE
Fixed printing of non-trivial derivative count

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -685,12 +685,12 @@ class LatexPrinter(Printer):
             else:
                 tex += r"%s %s^{%s}" % (diff_symbol,
                                         self.parenthesize_super(self._print(x)),
-                                        num)
+                                        self._print(num))
 
         if dim == 1:
             tex = r"\frac{%s}{%s}" % (diff_symbol, tex)
         else:
-            tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, dim, tex)
+            tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
 
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -656,6 +656,17 @@ def test_latex_derivatives():
     assert latex(diff(f(x), (x, n))) == \
         r"\frac{d^{n}}{d x^{n}} f{\left(x \right)}"
 
+    x1 = Symbol('x1')
+    x2 = Symbol('x2')
+    assert latex(diff(f(x1, x2), x1)) == r'\frac{\partial}{\partial x_{1}} f{\left(x_{1},x_{2} \right)}'
+
+    n1 = Symbol('n1')
+    assert latex(diff(f(x), (x, n1))) ==  r'\frac{d^{n_{1}}}{d x^{n_{1}}} f{\left(x \right)}'
+
+    n2 = Symbol('n2')
+    assert latex(diff(f(x), (x, Max(n1, n2)))) == \
+        r'\frac{d^{\max\left(n_{1}, n_{2}\right)}}{d x^{\max\left(n_{1}, n_{2}\right)}} f{\left(x \right)}'
+
 
 def test_latex_subs():
     assert latex(Subs(x*y, (


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Found a minor flaw when printing derivatives with non-trivial derivative counts.

Earlier:

![image](https://user-images.githubusercontent.com/8114497/62119948-f4adb300-b2c0-11e9-84f5-d44370e50022.png)

![image](https://user-images.githubusercontent.com/8114497/62119953-f8d9d080-b2c0-11e9-99f2-886fe8c35657.png)

Now:

![image](https://user-images.githubusercontent.com/8114497/62119975-042cfc00-b2c1-11e9-9b69-c3ae4ab23123.png)

![image](https://user-images.githubusercontent.com/8114497/62119988-098a4680-b2c1-11e9-8e68-3a79527429e2.png)


#### Other comments

It does happen in practice that one gets counts like that. For example, from a test
```
exprm2 = 2*y*x*sin(x)*cos(x)*log(x)*exp(x)
exprm2.diff((x, n))
```
![image](https://user-images.githubusercontent.com/8114497/62120131-4eae7880-b2c1-11e9-8f76-619dab12deaa.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * LaTeX printing of non-trivial derivative counts fixed.
<!-- END RELEASE NOTES -->
