### PR TITLE
[WIP]  Convert matrix expressions to Indexed

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -569,7 +569,7 @@ class MatrixExpr(Expr):
         else:
             return remove_matelement(retexpr, first_index, last_index)
 
-    def as_indexed(self):
+    def _eval_rewrite_as_Indexed(self, *args, **kwargs):
         from sympy import Idx, IndexedBase
 
         def nth_varname(n):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -622,7 +622,7 @@ class MatrixExpr(Expr):
                                                     col_idx)
                     result.append(arg_indexed)
 
-                return Mul(*args_c, *result)
+                return Mul.fromiter(args_c + result)
 
             elif isinstance(expr, MatAdd):
                 # TODO: DRY
@@ -638,7 +638,7 @@ class MatrixExpr(Expr):
                                                 col_idx)
                     result.append(indexed)
 
-                return Add(*result)
+                return Add.fromiter(result)
 
             else:
                 raise NotImplementedError

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -569,6 +569,84 @@ class MatrixExpr(Expr):
         else:
             return remove_matelement(retexpr, first_index, last_index)
 
+    def as_indexed(self):
+        from sympy import Idx, IndexedBase
+
+        def nth_varname(n):
+            start = ord('i')
+            step = ord('z') - ord('i') + 1
+            if n + start <= ord('z'):
+                return chr(n + start)
+            else:
+                total = []
+                while n > 0:
+                    total.insert(0, chr(n % step + start))
+                    n = n // step - 1
+                if len(total) <= 1:
+                    total.insert(0, 'i')
+                return ''.join(total)
+
+        def varname_generator(names):
+            counter = 0
+            while True:
+                varname = nth_varname(counter)
+                if varname not in names:
+                    yield varname
+                counter += 1
+
+        def as_indexed_helper(expr, generator, row_idx=None, col_idx=None):
+
+            if isinstance(expr, MatrixSymbol):
+                rows, cols = self.shape
+                if not row_idx:
+                    row_idx = Idx(next(generator), range=rows)
+                if not col_idx:
+                    col_idx = Idx(next(generator), range=cols)
+                base = IndexedBase(expr.name)
+                return base[row_idx, col_idx]
+
+            elif isinstance(expr, MatMul):
+                result = []
+                args_c, args_nc = expr.args_cnc()
+                first_nc = args_nc.pop(0)
+                first_indexed = as_indexed_helper(first_nc, generator)
+                row_idx, col_idx = first_indexed.indices
+
+                result.append(first_indexed)
+
+                for arg in args_nc:
+                    row_idx = col_idx
+                    cols = arg.shape[1]
+                    col_idx = Idx(next(generator), range=cols)
+                    arg_indexed = as_indexed_helper(arg, generator, row_idx,
+                                                    col_idx)
+                    result.append(arg_indexed)
+
+                return Mul(*args_c, *result)
+
+            elif isinstance(expr, MatAdd):
+                # TODO: DRY
+                rows, cols = self.shape
+                if not row_idx:
+                    row_idx = Idx(next(generator), range=rows)
+                if not col_idx:
+                    col_idx = Idx(next(generator), range=cols)
+
+                result = []
+                for arg in expr.args:
+                    indexed = as_indexed_helper(arg, generator, row_idx,
+                                                col_idx)
+                    result.append(indexed)
+
+                return Add(*result)
+
+            else:
+                raise NotImplementedError
+
+        names = [e.name for e in self.free_symbols]
+        generator = varname_generator(names)
+        return as_indexed_helper(self, generator)
+
     def applyfunc(self, func):
         from .applyfunc import ElementwiseApplyFunction
         return ElementwiseApplyFunction(func, self)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -597,7 +597,7 @@ class MatrixExpr(Expr):
         def as_indexed_helper(expr, generator, row_idx=None, col_idx=None):
 
             if isinstance(expr, MatrixSymbol):
-                rows, cols = self.shape
+                rows, cols = expr.shape
                 if not row_idx:
                     row_idx = Idx(next(generator), range=rows)
                 if not col_idx:
@@ -626,7 +626,7 @@ class MatrixExpr(Expr):
 
             elif isinstance(expr, MatAdd):
                 # TODO: DRY
-                rows, cols = self.shape
+                rows, cols = expr.shape
                 if not row_idx:
                     row_idx = Idx(next(generator), range=rows)
                 if not col_idx:

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -283,6 +283,34 @@ def test_MatrixSymbol_determinant():
         A[0, 3]*A[1, 2]*A[2, 1]*A[3, 0]
 
 
+def test_rewrite_as_indexed():
+    from sympy import Indexed, IndexedBase, Idx
+    Cb = IndexedBase('C')
+    Db = IndexedBase('D')
+
+    i = Idx('i', n)
+    j = Idx('j', n)
+    k = Idx('k', n)
+
+    assert C.rewrite(Indexed) == Cb[i, j]
+    assert (C + D).rewrite(Indexed) == Cb[i, j] + Db[i, j]
+    assert (C*D).rewrite(Indexed) == Cb[i, j] * Db[j, k]
+
+    Ab = IndexedBase('A')
+    ll = Idx('l', m)
+
+    assert (C*D*A).rewrite(Indexed) == Cb[i, j]*Db[j, k]*Ab[k, ll]
+
+    k = Idx('k', m)
+
+    assert ((C + D)*A).rewrite(Indexed) == (Cb[i, j] + Db[i, j])*Ab[j, k]
+
+    i = Idx('i', m)
+    k = Idx('k', n)
+    Eb = IndexedBase('E')
+    assert (E*(C + D)).rewrite(Indexed) == (Cb[j, k] + Db[j, k])*Eb[i, j]
+
+
 def test_MatrixElement_diff():
     assert (A[3, 0]*A[0, 0]).diff(A[0, 0]) == A[3, 0]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Adds an `as_indexed` method that converts a matrix expression to its corresponding contraction using represented by `Indexed` objects, functioning as an inverse of `from_index_summation`.

```python
>>> n, m = symbols('n m', integer=True)
>>> A = MatrixSymbol('A', n, m)
>>> B = MatrixSymbol('B', m, n)
>>> e = A*B
>>> e.as_indexed()
A[i, j]*B[j, k]
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * add `as_indexed` to convert matrix expressions to `Indexed`
<!-- END RELEASE NOTES -->
