### PR TITLE
Add simplification for log(exp())

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -503,6 +503,8 @@ def _match_real_imag(expr):
 
     """
     r_, i_ = expr.as_independent(S.ImaginaryUnit, as_Add=True)
+    if i_ == 0 and r_.is_real:
+        return (r_, i_)
     i_ = i_.as_coefficient(S.ImaginaryUnit)
     if i_ and i_.is_real and r_.is_real:
         return (r_, i_)
@@ -599,7 +601,7 @@ class log(Function):
         I = S.ImaginaryUnit
         if isinstance(arg, exp) and arg.args[0].is_extended_real:
             return arg.args[0]
-        elif isinstance(arg, exp):
+        elif isinstance(arg, exp) and arg.args[0].is_number:
             r_, i_ = _match_real_imag(arg.args[0])
             if i_ and i_.is_comparable:
                 i_ %= 2*S.Pi

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -491,6 +491,25 @@ class exp(ExpBase):
                 return Pow(logs[0].args[0], arg.coeff(logs[0]))
 
 
+def _match_real_imag(expr):
+    """
+    Try to match expr with a + b*I for real a and b.
+
+    ``_match_real_imag`` returns a tuple containing the real and imaginary
+    parts of expr or (None, None) if direct matching is not possible. Contrary
+    to ``re()``, ``im()``, ``as_real_imag()``, this helper won't force things
+    by returning expressions themselves containing ``re()`` or ``im()`` and it
+    doesn't expand its argument either.
+
+    """
+    r_, i_ = expr.as_independent(S.ImaginaryUnit, as_Add=True)
+    i_ = i_.as_coefficient(S.ImaginaryUnit)
+    if i_ and i_.is_real and r_.is_real:
+        return (r_, i_)
+    else:
+        return (None, None) # simpler to check for than None
+
+
 class log(Function):
     r"""
     The natural logarithm function `\ln(x)` or `\log(x)`.
@@ -577,8 +596,16 @@ class log(Function):
             elif arg.is_Rational and arg.p == 1:
                 return -cls(arg.q)
 
+        I = S.ImaginaryUnit
         if isinstance(arg, exp) and arg.args[0].is_extended_real:
             return arg.args[0]
+        elif isinstance(arg, exp):
+            r_, i_ = _match_real_imag(arg.args[0])
+            if i_ and i_.is_comparable:
+                i_ %= 2*S.Pi
+                if i_ > S.Pi:
+                    i_ -= 2*S.Pi
+                return r_ + expand_mul(i_ * I, deep=False)
         elif isinstance(arg, exp_polar):
             return unpolarify(arg.exp)
         elif isinstance(arg, AccumBounds):
@@ -590,7 +617,6 @@ class log(Function):
             return arg._eval_func(cls)
 
         if arg.is_number:
-            I = S.ImaginaryUnit
             if arg.is_negative:
                 return S.Pi * I + cls(-arg)
             elif arg is S.ComplexInfinity:
@@ -600,7 +626,7 @@ class log(Function):
 
         # don't autoexpand Pow or Mul (see the issue 3351):
         if not arg.is_Add:
-            coeff = arg.as_coefficient(S.ImaginaryUnit)
+            coeff = arg.as_coefficient(I)
 
             if coeff is not None:
                 if coeff is S.Infinity:
@@ -609,12 +635,11 @@ class log(Function):
                     return S.Infinity
                 elif coeff.is_Rational:
                     if coeff.is_nonnegative:
-                        return S.Pi * S.ImaginaryUnit * S.Half + cls(coeff)
+                        return S.Pi * I * S.Half + cls(coeff)
                     else:
-                        return -S.Pi * S.ImaginaryUnit * S.Half + cls(-coeff)
+                        return -S.Pi * I * S.Half + cls(-coeff)
 
         if arg.is_number and arg.is_algebraic:
-            I = S.ImaginaryUnit
             # Match arg = coeff*(r_ + i_*I) with coeff>0, r_ and i_ real.
             coeff, arg_ = arg.as_independent(I, as_Add=False)
             if coeff.is_negative:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -520,6 +520,11 @@ class log(Function):
     a logarithm of a different base ``b``, use ``log(x, b)``,
     which is essentially short-hand for ``log(x)/log(b)``.
 
+    ``log`` represents the principal branch of the natural
+    logarithm. As such it has a branch cut along the negative
+    real axis and returns values having a complex argument in
+    `(-\pi, \pi]`.
+
     Examples
     ========
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -3,6 +3,7 @@ from sympy import (
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
     AccumBounds, MatrixSymbol, Pow, gcd)
+from sympy.functions.elementary.exponential import _match_real_imag
 from sympy.abc import x, y, z
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -217,6 +218,21 @@ def test_log_values():
     assert log(2*3**2).func is log
 
 
+def test_match_real_imag():
+    x, y = symbols('x,y', real=True)
+    i = Symbol('i', imaginary=True)
+    assert _match_real_imag(S.One) == (1, 0)
+    assert _match_real_imag(I) == (0, 1)
+    assert _match_real_imag(3 - 5*I) == (3, -5)
+    assert _match_real_imag(-sqrt(3) + S.Half*I) == (-sqrt(3), S.Half)
+    assert _match_real_imag(x + y*I) == (x, y)
+    assert _match_real_imag(x*I + y*I) == (0, x + y)
+    assert _match_real_imag((x + y)*I) == (0, x + y)
+    assert _match_real_imag(-S(2)/3*i*I) == (None, None)
+    assert _match_real_imag(1 - 2*i) == (None, None)
+    assert _match_real_imag(sqrt(2)*(3 - 5*I)) == (None, None)
+
+
 def test_log_exact():
     # check for pi/2, pi/3, pi/4, pi/6, pi/8, pi/12; pi/5, pi/10:
     for n in range(-23, 24):
@@ -321,13 +337,6 @@ def test_log_exp():
     assert log(exp(19*I*pi/4)) == 3*I*pi/4
     assert log(exp(25*I*pi/7)) == -3*I*pi/7
     assert log(exp(-5*I)) == -5*I + 2*I*pi
-    r = Symbol('r', real=True)
-    i = Symbol('i', imaginary=True)
-    assert log(exp(r - 8*I)) == r - 8*I + 2*I*pi
-    assert unchanged(log, exp(i))
-    assert unchanged(log, exp(r*I))
-    assert unchanged(log, exp(i + I*pi/5))
-    assert log(exp((r + 50*I*pi)/7 + 3*I)) == r/7 - 6*I*pi/7 + 3*I
 
 
 def test_exp_assumptions():

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -315,6 +315,21 @@ def test_log_symbolic():
     assert log(-p).func is log and log(-p).args[0] == -p
 
 
+def test_log_exp():
+    assert log(exp(4*I*pi)) == 0     # exp evaluates
+    assert log(exp(-5*I*pi)) == I*pi # exp evaluates
+    assert log(exp(19*I*pi/4)) == 3*I*pi/4
+    assert log(exp(25*I*pi/7)) == -3*I*pi/7
+    assert log(exp(-5*I)) == -5*I + 2*I*pi
+    r = Symbol('r', real=True)
+    i = Symbol('i', imaginary=True)
+    assert log(exp(r - 8*I)) == r - 8*I + 2*I*pi
+    assert unchanged(log, exp(i))
+    assert unchanged(log, exp(r*I))
+    assert unchanged(log, exp(i + I*pi/5))
+    assert log(exp((r + 50*I*pi)/7 + 3*I)) == r/7 - 6*I*pi/7 + 3*I
+
+
 def test_exp_assumptions():
     r = Symbol('r', real=True)
     i = Symbol('i', imaginary=True)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1856,14 +1856,13 @@ def test_issue_8828():
 @slow
 def test_issue_2840_8155():
     assert solve(sin(3*x) + sin(6*x)) == [
-        0, -5*pi/3, -4*pi/3, -pi, -2*pi/3, -pi/3, pi/3, 2*pi/3, pi, 4*pi/3,
-        14*pi/9, 5*pi/3, 16*pi/9, 2*pi, -2*I*log(-(-1)**(S(1)/9)),
-        -2*I*log(-(-1)**(S(2)/9)), -2*I*log(-sin(pi/18) - I*cos(pi/18)),
+        0, -5*pi/3, -4*pi/3, -pi, -2*pi/3, -4*pi/9, -pi/3, -2*pi/9, 2*pi/9,
+        pi/3, 4*pi/9, 2*pi/3, pi, 4*pi/3, 14*pi/9, 5*pi/3, 16*pi/9, 2*pi,
+        -2*I*log(-(-1)**(S(1)/9)), -2*I*log(-(-1)**(S(2)/9)),
+        -2*I*log(-sin(pi/18) - I*cos(pi/18)),
         -2*I*log(-sin(pi/18) + I*cos(pi/18)),
         -2*I*log(sin(pi/18) - I*cos(pi/18)),
-        -2*I*log(sin(pi/18) + I*cos(pi/18)),
-        -2*I*log(exp(-2*I*pi/9)), -2*I*log(exp(-I*pi/9)),
-        -2*I*log(exp(I*pi/9)), -2*I*log(exp(2*I*pi/9))]
+        -2*I*log(sin(pi/18) + I*cos(pi/18))]
     assert solve(2*sin(x) - 2*sin(2*x)) == [
         0, -5*pi/3, -pi, -pi/3, pi/3, pi, 5*pi/3]
 


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17208

#### Brief description of what is fixed or changed
Before:
```
>>> log(exp(19*I*pi/4))
log(exp(3*I*pi/4))
>>> x = Symbol('x', real=True)
>>> log(exp(x + 7*I))
log(exp(x + 7*I))
```

After:
```
>>> log(exp(19*I*pi/4))
3*I*pi/4
>>> x = Symbol('x', real=True)
>>> log(exp(x + 7*I))
x - 2*I*pi + 7*I
```
(Update: expressions with variables will no longer be simplified.)

#### Other comments

I've factored out some code as a new helper: `_match_real_imag`.
Some feedback about this would be appreciated.
Should I move it to elementary/complexes.py ?
(I do intend to add some tests for it.)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added automatic evaluation for `log(exp()`.
<!-- END RELEASE NOTES -->
