### PR TITLE
SciPy numeric test failing.

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1040,7 +1040,7 @@ def test_scipy_polys():
     for sympy_fn, num_params in polys:
         args = params[:num_params] + (x,)
         f = lambdify(args, sympy_fn(*args))
-        for i in range(100):
+        for i in range(10):
             tn = numpy.random.randint(3, 10)
             tparams = tuple(numpy.random.uniform(0, 5, size=num_params-1))
             tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
@@ -1055,7 +1055,7 @@ def test_scipy_polys():
             vals = (tn,) + tparams + (tv,)
             scipy_result = f(*vals)
             sympy_result = sympy_fn(*vals).evalf()
-            atol = 1e-13*(1 + abs(sympy_result))
+            atol = 1e-6*(1 + abs(sympy_result))
 
             try:
                 assert abs(scipy_result - sympy_result) < atol

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1067,6 +1067,7 @@ def test_scipy_polys():
                     "SciPy result {scipy_result} had failed to "
                     "converge within the tolerance {tol}"
                     .format(
+                        func=repr(sympy_fn),
                         args=repr(vals),
                         sympy_result=repr(sympy_result),
                         scipy_result=repr(scipy_result),

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1062,9 +1062,9 @@ def test_scipy_polys():
             except:
                 raise AssertionError(
                     "The random test with arguments {args} had failed "
-                    "because the SymPy result ({sympy_result}) and "
-                    "SciPy result ({scipy_result}) had failed to "
-                    "converge within the tolerance ({tol})"
+                    "because the SymPy result {sympy_result} and "
+                    "SciPy result {scipy_result} had failed to "
+                    "converge within the tolerance {tol}"
                     .format(
                         args=repr(vals),
                         sympy_result=repr(sympy_result),

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1061,7 +1061,8 @@ def test_scipy_polys():
                 assert abs(scipy_result - sympy_result) < atol
             except:
                 raise AssertionError(
-                    "The random test with arguments {args} had failed "
+                    "The random test of the function {func} with the "
+                    "arguments {args} had failed "
                     "because the SymPy result {sympy_result} and "
                     "SciPy result {scipy_result} had failed to "
                     "converge within the tolerance {tol}"

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1051,9 +1051,27 @@ def test_scipy_polys():
             if sympy_fn == assoc_legendre:
                 tv = numpy.random.uniform(-1, 1)
                 tparams = tuple(numpy.random.randint(1, tn, size=1))
+
             vals = (tn,) + tparams + (tv,)
+            scipy_result = f(*vals)
             sympy_result = sympy_fn(*vals).evalf()
-            assert abs(f(*vals) - sympy_result) < 1e-13*(1 + abs(sympy_result))
+            atol = 1e-13*(1 + abs(sympy_result))
+
+            try:
+                assert abs(scipy_result - sympy_result) < atol
+            except:
+                raise AssertionError(
+                    "The random test with arguments {args} had failed "
+                    "because the SymPy result ({sympy_result}) and "
+                    "SciPy result ({scipy_result}) had failed to "
+                    "converge within the tolerance ({tol})"
+                    .format(
+                        args=repr(vals),
+                        sympy_result=repr(sympy_result),
+                        scipy_result=repr(scipy_result),
+                        tol=atol)
+                    )
+
 
 
 def test_lambdify_inspect():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1037,10 +1037,17 @@ def test_scipy_polys():
         (jacobi, 3)
     ]
 
+    msg = \
+        "The random test of the function {func} with the arguments " \
+        "{args} had failed because the SymPy result {sympy_result} " \
+        "and SciPy result {scipy_result} had failed to converge " \
+        "within the tolerance {tol} " \
+        "(Actual absolute difference : {diff})"
+
     for sympy_fn, num_params in polys:
         args = params[:num_params] + (x,)
         f = lambdify(args, sympy_fn(*args))
-        for i in range(10):
+        for _ in range(10):
             tn = numpy.random.randint(3, 10)
             tparams = tuple(numpy.random.uniform(0, 5, size=num_params-1))
             tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
@@ -1055,22 +1062,18 @@ def test_scipy_polys():
             vals = (tn,) + tparams + (tv,)
             scipy_result = f(*vals)
             sympy_result = sympy_fn(*vals).evalf()
-            atol = 1e-6*(1 + abs(sympy_result))
-
+            atol = 1e-9*(1 + abs(sympy_result))
+            diff = abs(scipy_result - sympy_result)
             try:
-                assert abs(scipy_result - sympy_result) < atol
+                assert diff < atol
             except:
                 raise AssertionError(
-                    "The random test of the function {func} with the "
-                    "arguments {args} had failed "
-                    "because the SymPy result {sympy_result} and "
-                    "SciPy result {scipy_result} had failed to "
-                    "converge within the tolerance {tol}"
-                    .format(
+                    msg.format(
                         func=repr(sympy_fn),
                         args=repr(vals),
                         sympy_result=repr(sympy_result),
                         scipy_result=repr(scipy_result),
+                        diff=diff,
                         tol=atol)
                     )
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1040,7 +1040,7 @@ def test_scipy_polys():
     for sympy_fn, num_params in polys:
         args = params[:num_params] + (x,)
         f = lambdify(args, sympy_fn(*args))
-        for i in range(10):
+        for i in range(100):
             tn = numpy.random.randint(3, 10)
             tparams = tuple(numpy.random.uniform(0, 5, size=num_params-1))
             tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#15656

#### Brief description of what is fixed or changed

@johanbluecreek from [gitter](https://gitter.im/sympy/sympy) reported that the test is failing

> jksuom: OK, then I must be doing something wrong. I have now tried it in three fresh pulls. This is what I do: clone repo from github, step in to sympy folder, run `python isympy.py`, where I run `test("sympy/utilities/tests/test_lambdify.py", verbose=True)`, which fails at the test_scipy_polys test. Should I open an issue for this instead maybe?

In my experiment, I think this is sometimes failing because the result sometimes does not converge within the tolerance.

```python
from sympy import *
import numpy

x = symbols('x')
numpy.random.seed(0)

params = symbols('n k a b')
# list polynomials with the number of parameters
polys = [
    (chebyshevt, 1),
    (chebyshevu, 1),
    (legendre, 1),
    (hermite, 1),
    (laguerre, 1),
    (gegenbauer, 2),
    (assoc_legendre, 2),
    (assoc_laguerre, 2),
    (jacobi, 3)
]

for sympy_fn, num_params in polys:
    args = params[:num_params] + (x,)
    f = lambdify(args, sympy_fn(*args))
    for i in range(1000):
        tn = numpy.random.randint(3, 10)
        tparams = tuple(numpy.random.uniform(0, 5, size=num_params-1))
        tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
        # SciPy supports hermite for real arguments only
        if sympy_fn == hermite:
            tv = numpy.real(tv)
        # assoc_legendre needs x in (-1, 1) and integer param at most n
        if sympy_fn == assoc_legendre:
            tv = numpy.random.uniform(-1, 1)
            tparams = tuple(numpy.random.randint(1, tn, size=1))
        vals = (tn,) + tparams + (tv,)
        
        scipy_result = f(*vals)
        sympy_result = sympy_fn(*vals).evalf()
        atol = 1e-13*(1 + abs(sympy_result))
        try:
            assert abs(scipy_result - sympy_result) < atol
        except:
            print ("The random test of the function {func} with arguments {args} had failed "
                  "because the SymPy result ({sympy_result}) and "
                  "SciPy result ({scipy_result}) had failed to converge "
                  "within the tolerance ({tol})"
                  .format(
                      func=repr(sympy_fn),
                      args=repr(vals), 
                      sympy_result=repr(sympy_result), 
                      scipy_result=repr(scipy_result),
                      tol=atol
                )
            )
```
Here is the log for 100 runs, and it looks like the tolerance may have to larger.
I'm thinking of `1e-6`. ~~But just want to see if the original test can fail in travis occasionally.~~ And also confirmed that it fails on travis in https://travis-ci.org/sympy/sympy/jobs/566166122. (Though the random number across each test looks like same)

```
The random test of the function chebyshevu with arguments (9, (-0.43259385920023874-0.026086345013372814j)) had failed because the SymPy result (1.12068700158265 + 0.0930626563702013*I) and SciPy result ((1.1206870015598724+0.09306265636922717j)) had failed to converge within the tolerance (2.12454435818557E-13)
The random test of the function assoc_laguerre with arguments (9, 3.9451798627966674, (6.603931596701038+3.4293485930128202j)) had failed because the SymPy result (-203.369291107077 + 241.30621252449*I) and SciPy result ((-203.36929110706944+241.30621252445786j)) had failed to converge within the tolerance (3.16575279082994E-11)
The random test of the function assoc_laguerre with arguments (9, 0.5103586455957593, (5.138706502421096-1.6034897614746524j)) had failed because the SymPy result (9.06777041814552 - 9.03843239930053*I) and SciPy result ((9.067770418145223-9.03843239930197j)) had failed to converge within the tolerance (1.38030356007050E-12)
The random test of the function assoc_laguerre with arguments (9, 4.6622170847056745, (9.984160003760884-2.627919368181464j)) had failed because the SymPy result (203.534697698353 + 49.7159989336689*I) and SciPy result ((203.53469769838418+49.71599893357932j)) had failed to converge within the tolerance (2.10518623795434E-11)
The random test of the function assoc_laguerre with arguments (9, 1.6498044188459797, (7.958271029720553-0.08215964364423023j)) had failed because the SymPy result (-1.01771224965379 + 1.12811574383769*I) and SciPy result ((-1.0177122496749398+1.1281157438375942j)) had failed to converge within the tolerance (2.51933648497950E-13)
The random test of the function assoc_laguerre with arguments (7, 4.103671310482032, (8.477566050227225-0.1869303393011812j)) had failed because the SymPy result (-8.81413619942513 - 2.25735125268985*I) and SciPy result ((-8.814136199413701-2.2573512526899777j)) had failed to converge within the tolerance (1.00986060262019E-12)
The random test of the function assoc_laguerre with arguments (8, 1.7943078939639767, (8.177531024456105-2.0374272874909902j)) had failed because the SymPy result (43.6664210224823 + 6.84639975285573*I) and SciPy result ((43.66642102247563+6.846399752858656j)) had failed to converge within the tolerance (4.51998813854583E-12)
The random test of the function assoc_laguerre with arguments (8, 3.770451831243587, (4.381540471100591+0.5957053411978421j)) had failed because the SymPy result (9.81362560191277 - 6.48582024637755*I) and SciPy result ((9.813625601910987-6.485820246377247j)) had failed to converge within the tolerance (1.27632100943084E-12)
The random test of the function jacobi with arguments (8, 3.045754085237476, 2.815744353567689, (-0.12834380740692808+0.1105389961124601j)) had failed because the SymPy result (0.762865302890861 + 1.82614474681082*I) and SciPy result ((0.762865302890321+1.8261447468112866j)) had failed to converge within the tolerance (2.97908264270584E-13)
The random test of the function jacobi with arguments (9, 1.5901514458027732, 0.768332713863063, (-1.1101255328330666-0.049036728236266036j)) had failed because the SymPy result (-50.3956176102337 - 49.5072559089964*I) and SciPy result ((-50.39561761006158-49.50725590900967j)) had failed to converge within the tolerance (7.16447921785870E-12)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
