### PR TITLE
Fixing that lambdify fails when a single occurence of `E` is present

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -816,7 +816,8 @@ _known_functions_scipy_special = {
 _known_constants_scipy_constants = {
     'GoldenRatio': 'golden_ratio',
     'Pi': 'pi',
-    'E': 'e'
+    'E': 'e',
+    'Exp1': 'e'
 }
 
 class SciPyPrinter(NumPyPrinter):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -7,7 +7,7 @@ import mpmath
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
-    Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
+    Float, Matrix, Lambda, Piecewise, exp, E, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk, S,
@@ -1159,3 +1159,7 @@ def test_issue_16930():
     f = lambda x:  S.GoldenRatio * x**2
     f_ = lambdify(x, f(x), modules='scipy')
     assert f_(1) == scipy.constants.golden_ratio
+
+def test_single_e():
+    f = lambdify(x, E)
+    assert f(23) == exp(1.0)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Before this fix the if one tried to lambdify an expression containing
`E` one got the following error:

```
>>> fun = lambdify(x, E)
Traceback (most recent call last):
 File "<console>", line 1, in <module>
 File "/home/user/github/sympy/sympy/utilities/lambdify.py", line 754, in lambdify
  funcstr = funcprinter.doprint(funcname, args, expr)
 File "/home/user/github/sympy/sympy/utilities/lambdify.py", line 996, in doprint
  funcbody.append('return ({})'.format(self._exprrepr(expr)))
 File "/home/user/github/sympy/sympy/printing/codeprinter.py", line 107, in doprint
  lines = self._print(expr).splitlines()
 File "/home/user/github/sympy/sympy/printing/printer.py", line 287, in _print
  return getattr(self, printmethod)(expr, **kwargs)
 File "/home/user/github/sympy/sympy/printing/pycode.py", line 74, in _print_known_const
  known = self.known_constants[expr.__class__.__name__]
KeyError: 'Exp1'
```

current commit fixes this error, and instead gives the expected output:

```
>>> fun = lambdify(x, E)
>>> fun(23) - exp(1.0)
0
```

The error was actually in a printer, but this is how I found the error, hence my example.

#### Other comments

I also added a test not to break `lambdify()` like this in the future, since it became broken at some point between ~v1.0 and now. My test passes.

Running all tests, I noticed that the tests for `lambdify()` is not passing, and it is because of a failing test that is in master. This is taken care of in PR #17310 .

#### Release notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed a bug that would crash lambdify if expression contained E with no power.
<!-- END RELEASE NOTES -->