### PR TITLE
Added induced pcgs and exponent-vector 

### DIFF
--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -514,9 +514,10 @@ class Collector(DefaultPrinting):
         >>> ipcgs = collector.induced_pcgs(gens)
         >>> [gen.order() for gen in ipcgs]
         [2, 2, 2]
-        >>> G = S.sylow_subgroup(2)
+        >>> G = S.sylow_subgroup(3)
         >>> PcGroup = G.polycyclic_group()
         >>> collector = PcGroup.collector
+        >>> gens = [G[0], G[1]]
         >>> ipcgs = collector.induced_pcgs(gens)
         >>> [gen.order() for gen in ipcgs]
         [3]

--- a/sympy/combinatorics/tests/test_pc_groups.py
+++ b/sympy/combinatorics/tests/test_pc_groups.py
@@ -70,3 +70,21 @@ def test_exponent_vector():
             for i in range(len(exp)):
                 g = g*pcgs[i]**exp[i] if exp[i] else g
             assert g == gen
+
+
+def test_induced_pcgs():
+    G = SymmetricGroup(9).sylow_subgroup(3)
+    PcGroup = G.polycyclic_group()
+    collector = PcGroup.collector
+    gens = [G[0], G[1]]
+    ipcgs = collector.induced_pcgs(gens)
+    order = [gen.order() for gen in ipcgs]
+    assert order == [3, 3]
+
+    G = SymmetricGroup(20).sylow_subgroup(2)
+    PcGroup = G.polycyclic_group()
+    collector = PcGroup.collector
+    gens = [G[0], G[1], G[2], G[3]]
+    ipcgs = collector.induced_pcgs(gens)
+    order = [gen.order() for gen in ipcgs]
+    assert order ==[2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
 Added induced pcgs and exponent-vector for polycyclic subgroup.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  combinatorics
   * added methods to compute induced-pcgs and exp vector for pc subgroup
<!-- END RELEASE NOTES -->
