### PR TITLE
Fix sqrtdenest raising IndexError

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -920,7 +920,7 @@ def radsimp(expr, symbolic=True, max_terms=4):
 def rad_rationalize(num, den):
     """
     Rationalize num/den by removing square roots in the denominator;
-    num and den are sum of terms whose squares are rationals
+    num and den are sum of terms whose squares are positive rationals.
 
     Examples
     ========
@@ -1061,9 +1061,9 @@ expand_fraction = fraction_expand
 
 def split_surds(expr):
     """
-    split an expression with terms whose squares are rationals
+    Split an expression with terms whose squares are positive rationals
     into a sum of terms whose surds squared have gcd equal to g
-    and a sum of terms with surds squared prime with g
+    and a sum of terms with surds squared prime with g.
 
     Examples
     ========

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -156,7 +156,8 @@ def _sqrt_match(p):
         res = (p, S.Zero, S.Zero)
     elif p.is_Add:
         pargs = sorted(p.args, key=default_sort_key)
-        if all((x**2).is_Rational for x in pargs):
+        sqargs = [x**2 for x in pargs]
+        if all(sq.is_Rational and sq.is_positive for sq in sqargs):
             r, b, a = split_surds(p)
             res = a, b, r
             return list(res)

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,5 +1,7 @@
 from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _subsets as subsets
+from sympy.simplify.sqrtdenest import _sqrt_match
+from sympy.core.expr import unchanged
 from sympy.utilities.pytest import slow
 
 r2, r3, r5, r6, r7, r10, r15, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 10,
@@ -180,6 +182,12 @@ def test_issue_5653():
     assert sqrtdenest(
         sqrt(2 + sqrt(2 + sqrt(2)))) == sqrt(2 + sqrt(2 + sqrt(2)))
 
+def test_issue_12420():
+    I = S.ImaginaryUnit
+    assert _sqrt_match(4 + I) == []
+    assert sqrtdenest((3 - sqrt(2)*sqrt(4 + 3*I) + 3*I)/2) == I
+    e = 3 - sqrt(2)*sqrt(4 + I) + 3*I
+    assert sqrtdenest(e) == e
 
 def test_sqrt_ratcomb():
     assert sqrtdenest(sqrt(1 + r3) + sqrt(3 + 3*r3) - sqrt(10 + 6*r3)) == 0


### PR DESCRIPTION

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #12420
Closes #12431

#### Brief description of what is fixed or changed

Add a check in `_sqrt_match` before calling `_split_surds`:
https://github.com/sympy/sympy/issues/12420#issuecomment-507412210


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
