### PR TITLE
Travis test failing after numpy 1.17

### DIFF
--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -4,6 +4,7 @@
 # Always write regular SymPy tests for anything, that can be tested in pure
 # Python (without numpy). Here we test everything, that a user may need when
 # using SymPy with NumPy
+from distutils.version import LooseVersion
 
 from sympy.external import import_module
 
@@ -231,8 +232,15 @@ def test_lambdify():
     f = lambdify(x, sin(x), "numpy")
     prec = 1e-15
     assert -prec < f(0.2) - sin02 < prec
-    with raises(AttributeError):
-        f(x)  # if this succeeds, it can't be a numpy function
+
+    # if this succeeds, it can't be a numpy function
+
+    if LooseVersion(numpy.__version__) >= LooseVersion('1.17'):
+        with raises(TypeError):
+            f(x)
+    else:
+        with raises(AttributeError):
+            f(x)
 
 
 def test_lambdify_matrix():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -485,10 +485,15 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
     But if we try to pass in a SymPy expression, it fails
 
-    >>> g(x + 1)
+    >>> try:
+    ...     g(x + 1)
+    ... # NumPy release after 1.17 raises TypeError instead of
+    ... # AttributeError
+    ... except (AttributeError, TypeError):
+    ...     raise AttributeError() # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
-    AttributeError: 'Add' object has no attribute 'sin'
+    AttributeError:
 
     Now, let's look at what happened. The reason this fails is that ``g``
     calls ``numpy.sin`` on the input expression, and ``numpy.sin`` does not


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17323

#### Brief description of what is fixed or changed

NumPy had changed the exception format
```
Exception raised:
    AttributeError: 'Add' object has no attribute 'sin'

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "/home/sylee957/miniconda3/envs/tensorflow/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest sympy.utilities.lambdify.lambdify[48]>", line 1, in <module>
        g(x + 1) #doctest: +IGNORE_EXCEPTION_DETAIL
      File "<lambdifygenerated-9>", line 2, in _lambdifygenerated
        return (x + sin(x))
    TypeError: loop of ufunc does not support argument 0 of type Add which has no callable sin method
```
It was not failing in python 2.7 because numpy had not been updated for the version yet.

I've just thought of changes like this, as the tutorial is all about some gotchas, and doctest does not have any good option for some version-aware tag.
Would there be any better idea?

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
