### PR TITLE
Simplification of relations with min/max

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -129,7 +129,8 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         chebyshevu, chebyshevu_root, chebyshevt_root, laguerre,
         assoc_laguerre, gegenbauer, jacobi, jacobi_normalized, Ynm, Ynm_c,
         Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, beta, mathieus,
-        mathieuc, mathieusprime, mathieucprime, riemann_xi, betainc, betainc_regularized)
+        mathieuc, mathieusprime, mathieucprime, riemann_xi, betainc,
+        betainc_regularized, expand_minmax)
 
 from .ntheory import (nextprime, prevprime, prime, primepi, primerange,
         randprime, Sieve, sieve, primorial, cycle_length, composite,
@@ -349,7 +350,7 @@ __all__ = [
     'gegenbauer', 'jacobi', 'jacobi_normalized', 'Ynm', 'Ynm_c', 'Znm',
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi','betainc',
-    'betainc_regularized',
+    'betainc_regularized', 'expand_minmax',
 
     # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -639,32 +639,39 @@ class Equality(Relational):
             elif isinstance(e.lhs, (Min, Max)) and not e.rhs.has(Min, Max):
                 minmax, constant = e.lhs, e.rhs
             if minmax:
+                # There is a Min or Max for one of the arguments
                 from sympy.utilities.iterables import sift
                 enew = None
                 if constant.is_number:
+                    # The other side is a number, get rid of any numbers in Min/Max
                     numberpart, remaining = sift(minmax.args, lambda x: x.is_number, binary=True)
                     if numberpart:
-                        f = minmax.func
-                        if minmax.func == Min:
+                        if isinstance(minmax, Min):
                             if Min(*numberpart) < constant:
+                                # Smallest number in Min is smaller than other side
                                 enew = S.false
                             elif constant in numberpart:
+                                # Constant is in the Min, rewrite
                                 enew = Le(constant, Min(*remaining))
                             else:
+                                # Remove all numbers
                                 enew = Eq(constant, Min(*remaining))
                         else:
                             if Max(*numberpart) > constant:
+                                # Largest number in Max is larger than other side
                                 enew = S.false
                             elif constant in numberpart:
+                                # Constant in the Max, rewrite
                                 enew = Ge(constant, Max(*remaining))
                             else:
+                                # Remove all numbers
                                 enew = Eq(constant, Max(*remaining))
                 else:
                     from sympy.utilities.iterables import sift
                     constantpart, remaining = sift(minmax.args, lambda x: x == constant, binary=True)
                     if constantpart:
-                        f = minmax.func
-                        if minmax.func == Min:
+                        # Constant in the Min/Max, rewrite
+                        if isinstance(minmax, Min):
                             enew = Le(constant, Min(*remaining))
                             # enew = Le(constant, minmax._new_rawargs(*remaining))
                         else:
@@ -1116,7 +1123,7 @@ class GreaterThan(_Greater):
                 if e.rhs.is_number:
                     numberpart, remaining = sift(e.lhs.args, lambda x: x.is_number, binary=True)
                     if numberpart:
-                        if e.lhs.func == Max:
+                        if isinstance(e.lhs, Max):
                             if Max(*numberpart) >= e.rhs:
                                 enew = S.true
                             else:
@@ -1129,7 +1136,7 @@ class GreaterThan(_Greater):
                 else:
                     constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
                     if constantpart:
-                        if e.lhs.func == Max:
+                        if isinstance(e.lhs, Max):
                             enew = S.true
                         else:
                             enew = GreaterThan(Min(*remaining), e.rhs)
@@ -1204,9 +1211,10 @@ class StrictGreaterThan(_Greater):
                 enew = e
             if enew is not None:
                 if e.rhs.is_number:
+                    # Other side is number, evaluate cases
                     numberpart, remaining = sift(e.lhs.args, lambda x: x.is_number, binary=True)
                     if numberpart:
-                        if e.lhs.func == Max:
+                        if isinstance(e.lhs, Max):
                             if Max(*numberpart) > e.rhs:
                                 enew = S.true
                             else:
@@ -1214,9 +1222,10 @@ class StrictGreaterThan(_Greater):
                         else:
                             enew = S.false
                 else:
+                    # Other part is Symbol/expression, evaluate cases
                     constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
                     if constantpart:
-                        if e.lhs.func == Max:
+                        if isinstance(e.lhs, Max):
                             enew = StrictGreaterThan(Max(*remaining), e.rhs)
                         else:
                             enew = S.false

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1677,26 +1677,3 @@ def is_eq(lhs, rhs, assumptions=None):
             rv = False
         if rv is not None:
             return rv
-
-
-def expand_minmax(expr):
-    from sympy.functions.elementary.miscellaneous import Min, Max
-    from sympy.logic.boolalg import And, Or, BooleanFunction
-    if not expr.has(Min, Max) or not expr.has(Relational):
-        return expr
-    if expr.has(Eq, Ne):
-        expr = expr.simplify()
-    if isinstance(expr, (BooleanFunction)):
-        return expr.func(*[expand_minmax(e) for e in expr.args])
-    elif isinstance(expr, (Le, Lt, Ge, Gt)):
-        if isinstance(expr, (Le, Lt)):
-            expr = expr.reversed
-        if isinstance(expr.lhs, Min):
-            return expand_minmax(And(*[expr.func(a, expr.rhs) for a in expr.lhs.args]))
-        elif isinstance(expr.lhs, Max):
-            return expand_minmax(Or(*[expr.func(a, expr.rhs) for a in expr.lhs.args]))
-        elif isinstance(expr.rhs, Min):
-            return expand_minmax(Or(*[expr.func(expr.lhs, a) for a in expr.rhs.args]))
-        elif isinstance(expr.rhs, Max):
-            return expand_minmax(And(*[expr.func(expr.lhs, a) for a in expr.rhs.args]))
-    return expr

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -639,14 +639,38 @@ class Equality(Relational):
             elif isinstance(e.lhs, (Min, Max)) and not e.rhs.has(Min, Max):
                 minmax, constant = e.lhs, e.rhs
             if minmax:
-                constantpart, remaining = sift(minmax.args, lambda x: x == constant, binary=True)
-                if constantpart:
-                    if minmax.func == Min:
-                        enew = Le(constant, Min(*remaining))
-                        # enew = Le(constant, minmax._new_rawargs(*remaining))
-                    else:
-                        enew = Ge(constant, Max(*remaining))
-                        # enew = Ge(constant, minmax._new_rawargs(*remaining))
+                from sympy.utilities.iterables import sift
+                enew = None
+                if constant.is_number:
+                    numberpart, remaining = sift(minmax.args, lambda x: x.is_number, binary=True)
+                    if numberpart:
+                        f = minmax.func
+                        if minmax.func == Min:
+                            if Min(*numberpart) < constant:
+                                enew = S.false
+                            elif constant in numberpart:
+                                enew = Le(constant, Min(*remaining))
+                            else:
+                                enew = Eq(constant, Min(*remaining))
+                        else:
+                            if Max(*numberpart) > constant:
+                                enew = S.false
+                            elif constant in numberpart:
+                                enew = Ge(constant, Max(*remaining))
+                            else:
+                                enew = Eq(constant, Max(*remaining))
+                else:
+                    from sympy.utilities.iterables import sift
+                    constantpart, remaining = sift(minmax.args, lambda x: x == constant, binary=True)
+                    if constantpart:
+                        f = minmax.func
+                        if minmax.func == Min:
+                            enew = Le(constant, Min(*remaining))
+                            # enew = Le(constant, minmax._new_rawargs(*remaining))
+                        else:
+                            enew = Ge(constant, Max(*remaining))
+                            # enew = Ge(constant, minmax._new_rawargs(*remaining))
+                if enew is not None:
                     measure = kwargs['measure']
                     if measure(enew) <= kwargs['ratio']*measure(e):
                         e = enew.canonical
@@ -1083,24 +1107,33 @@ class GreaterThan(_Greater):
         if self.has(Min, Max):
             enew = None
             if isinstance(e.rhs, (Min, Max)) and not e.lhs.has(Min, Max):
-                # c >= Min/Max
-                constantpart, remaining = sift(e.rhs.args, lambda x: x == e.lhs, binary=True)
-                if constantpart:
-                    if e.rhs.func == Min:
-                        enew = S.true
-                    else:
-                        enew = GreaterThan(e.lhs, Max(*remaining))
-                        # e = GreaterThan(e.lhs, e.rhs._new_rawargs(*remaining)).canonical
+                # c >= Min/Max, reverse
+                enew = e.reversed
             elif isinstance(e.lhs, (Min, Max)) and not e.rhs.has(Min, Max):
                 # Min/Max >= c
-                constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
-                if constantpart:
-                    if e.lhs.func == Max:
-                        enew = S.true
-                    else:
-                        enew = GreaterThan(Min(*remaining), e.rhs)
-                        # e = GreaterThan(e.lhs._new_rawargs(*remaining), e.rhs).canonical
+                enew = e
             if enew is not None:
+                if e.rhs.is_number:
+                    numberpart, remaining = sift(e.lhs.args, lambda x: x.is_number, binary=True)
+                    if numberpart:
+                        if e.lhs.func == Max:
+                            if Max(*numberpart) >= e.rhs:
+                                enew = S.true
+                            else:
+                                enew = GreaterThan(Max(*remaining), e.rhs)
+                        else:
+                            if Min(*numberpart) < e.rhs:
+                                enew = S.false
+                            else:
+                                enew = GreaterThan(Min(*remaining), e.rhs)
+                else:
+                    constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
+                    if constantpart:
+                        if e.lhs.func == Max:
+                            enew = S.true
+                        else:
+                            enew = GreaterThan(Min(*remaining), e.rhs)
+                            # e = GreaterThan(e.lhs._new_rawargs(*remaining), e.rhs).canonical
                 measure = kwargs['measure']
                 if measure(enew) <= kwargs['ratio']*measure(eundo):
                     eundo = enew.canonical
@@ -1164,23 +1197,33 @@ class StrictGreaterThan(_Greater):
         if self.has(Min, Max):
             enew = None
             if isinstance(e.rhs, (Min, Max)) and not e.lhs.has(Min, Max):
-                # c > Min/Max
-                constantpart, remaining = sift(e.rhs.args, lambda x: x == e.lhs, binary=True)
-                if constantpart:
-                    if e.rhs.func == Max:
-                        enew = S.false
-                    else:
-                        enew = StrictGreaterThan(e.lhs, Min(*remaining))
-                        # e = StrictGreaterThan(e.lhs, e.rhs._new_rawargs(*remaining)).canonical
+                # c > Min/Max, reverse
+                enew = e.reversed
             elif isinstance(e.lhs, (Min, Max)) and not e.rhs.has(Min, Max):
                 # Min/Max > c
-                constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
-                if constantpart:
-                    if e.lhs.func == Max:
-                        enew = StrictGreaterThan(Min(*remaining), e.rhs)
-                    else:
-                        enew = S.false
+                enew = e
             if enew is not None:
+                if e.rhs.is_number:
+                    numberpart, remaining = sift(e.lhs.args, lambda x: x.is_number, binary=True)
+                    if numberpart:
+                        if e.lhs.func == Max:
+                            if Max(*numberpart) > e.rhs:
+                                enew = S.true
+                            else:
+                                enew = StrictGreaterThan(Max(*remaining), e.rhs)
+                        else:
+                            if Min(*numberpart) <= e.rhs:
+                                enew = S.false
+                            else:
+                                enew = StrictGreaterThan(Min(*remaining), e.rhs)
+                else:
+                    constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
+                    if constantpart:
+                        if e.lhs.func == Max:
+                            enew = S.true
+                        else:
+                            enew = GreaterThan(Min(*remaining), e.rhs)
+                            # e = GreaterThan(e.lhs._new_rawargs(*remaining), e.rhs).canonical
                 measure = kwargs['measure']
                 if measure(enew) <= kwargs['ratio']*measure(eundo):
                     eundo = enew.canonical

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1212,18 +1212,14 @@ class StrictGreaterThan(_Greater):
                             else:
                                 enew = StrictGreaterThan(Max(*remaining), e.rhs)
                         else:
-                            if Min(*numberpart) <= e.rhs:
-                                enew = S.false
-                            else:
-                                enew = StrictGreaterThan(Min(*remaining), e.rhs)
+                            enew = S.false
                 else:
                     constantpart, remaining = sift(e.lhs.args, lambda x: x == e.rhs, binary=True)
                     if constantpart:
                         if e.lhs.func == Max:
-                            enew = S.true
+                            enew = StrictGreaterThan(Max(*remaining), e.rhs)
                         else:
-                            enew = GreaterThan(Min(*remaining), e.rhs)
-                            # e = GreaterThan(e.lhs._new_rawargs(*remaining), e.rhs).canonical
+                            enew = S.false
                 measure = kwargs['measure']
                 if measure(enew) <= kwargs['ratio']*measure(eundo):
                     eundo = enew.canonical

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -667,7 +667,6 @@ class Equality(Relational):
                                 # Remove all numbers
                                 enew = Eq(constant, Max(*remaining))
                 else:
-                    from sympy.utilities.iterables import sift
                     constantpart, remaining = sift(minmax.args, lambda x: x == constant, binary=True)
                     if constantpart:
                         # Constant in the Min/Max, rewrite

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1566,7 +1566,7 @@ def is_eq(lhs, rhs, assumptions=None):
 
 def _simplify_inequality_with_minmax(e, fn, cmp1, cmp2):
     """ Simplify inequalities, i.e., ``>``, ``<``, ``>=``, ``<=``, that
-    contains a :class:`~.Min` and/or :class:`~.Max` functins.
+    contains a :class:`~.Min` and/or :class:`~.Max` functions.
 
     Written so that only ``>`` and ``>=``are supported, but it is possible to
     ``<`` and ``<=`` expressions by using ``.negated`` before and after simplifying.
@@ -1615,7 +1615,7 @@ def _simplify_inequality_with_minmax(e, fn, cmp1, cmp2):
 
 def _simplify_equality_with_minmax(e):
     """ Simplify :class:`~.Equality` that
-    contains a :class:`~.Min` and/or :class:`~.Max` functins.
+    contains a :class:`~.Min` and/or :class:`~.Max` functions.
     """
     from sympy.functions.elementary.miscellaneous import Min, Max
     if e.has(Min, Max):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1279,3 +1279,8 @@ def test_minmax_simplification_slow():
                     if isinstance(f2, Relational):
                         f2 = f2.subs([(x, v1), (y, v2)])
                     assert f2 == f.subs([(x, v1), (y, v2)])
+
+
+def test_issue_13605():
+    a = Symbol('a', positive=True)
+    assert simplify(1 > Max(0, 1 - a)) == S.true

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1254,11 +1254,15 @@ def test_weak_strict():
 
 
 def test_minmax_simplification():
-    x, y, z = symbols('x y z')
+    x, y, z = symbols('x y z', real=True)
     assert (Min(x, y, z) >= z).simplify() == (z <= Min(x, y))
     assert (Max(x, y, z) >= z).simplify() is S.true
     assert (Eq(Min(x, y, z), z)).simplify() == (z <= Min(x, y))
     assert (Ne(Max(x, y, z), z)).simplify() == (z < Max(x, y))
+    assert (Max(x, y, 2) >= 1).simplify() is S.true
+    assert (Max(x, y, 0) >= 1).simplify() == (Max(x, y) >= 1)
+    assert (Min(x, y, 0) >= 1).simplify() is S.false
+    assert (Min(x, y, 2) >= 1).simplify() == (Min(x, y) >= 1)
 
 
 def test_minmax_simplification_systematic_numerically():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1271,10 +1271,10 @@ def test_minmax_simplification_systematic_numerically():
     var = [x, y]
     valuelist = list(set(list(combinations(list(range(-2, 3))*3, 2))))
     # Skip combinations of +/-2 and 0, except for all 0
-    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
+    valuelist = [v for v in valuelist if any(w % 2 for w in v) or not any(v)]
     err = "{} and {} did not evalute to the same value for {}."
-    for rel in [Eq, Ne, Ge, Gt, Le, Lt]:
-        for minmax in [Min, Max]:
+    for rel in (Eq, Ne, Ge, Gt, Le, Lt):
+        for minmax in (Min, Max):
             f = rel(minmax(x, y), x)
             fs = f.simplify()
             for val in valuelist:
@@ -1301,10 +1301,10 @@ def test_minmax_simplification_systematic_numerically_slow():
     valuelist = list(set(list(combinations(list(range(-2, 3))*3, 2))))
     err = "{} and {} did not evalute to the same value for {}."
     # Skip combinations of +/-2 and 0, except for all 0
-    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
-    for const in [-2, -1, 0, 1, 2]:
-        for rel in [Eq, Ne, Ge, Gt, Le, Lt]:
-            for minmax in [Min, Max]:
+    valuelist = [v for v in valuelist if any(w % 2 for w in v) or not any(v)]
+    for const in (-2, -1, 0, 1, 2):
+        for rel in (Eq, Ne, Ge, Gt, Le, Lt):
+            for minmax in (Min, Max):
                 f = rel(minmax(x, y, const), x)
                 fs = f.simplify()
                 for val in valuelist:

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -10,7 +10,7 @@ from sympy.functions.combinatorial.factorials import (factorial, factorial2,
 from sympy.functions.combinatorial.numbers import (carmichael, fibonacci, lucas, tribonacci,
         harmonic, bernoulli, bell, euler, catalan, genocchi, partition, motzkin)
 from sympy.functions.elementary.miscellaneous import (sqrt, root, Min, Max,
-        Id, real_root, cbrt)
+        Id, real_root, cbrt, expand_minmax)
 from sympy.functions.elementary.complexes import (re, im, sign, Abs,
         conjugate, arg, polar_lift, periodic_argument, unbranched_argument,
         principal_branch, transpose, adjoint, polarify, unpolarify)
@@ -55,7 +55,7 @@ __all__ = [
     'carmichael', 'fibonacci', 'lucas', 'motzkin', 'tribonacci', 'harmonic',
     'bernoulli', 'bell', 'euler', 'catalan', 'genocchi', 'partition',
 
-    'sqrt', 'root', 'Min', 'Max', 'Id', 'real_root', 'cbrt',
+    'sqrt', 'root', 'Min', 'Max', 'Id', 'real_root', 'cbrt', 'expand_minmax',
 
     're', 'im', 'sign', 'Abs', 'conjugate', 'arg', 'polar_lift',
     'periodic_argument', 'unbranched_argument', 'principal_branch',

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -11,14 +11,14 @@ from sympy.core.mod import Mod
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
-from sympy.core.relational import Eq, Relational
+from sympy.core.relational import Eq, Ne, Le, Lt, Ge, Gt, Relational
 from sympy.core.singleton import Singleton
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy
 from sympy.core.rules import Transform
 from sympy.core.logic import fuzzy_and, fuzzy_or, _torf
 from sympy.core.traversal import walk
-from sympy.logic.boolalg import And, Or
+from sympy.logic.boolalg import And, Or, BooleanFunction
 
 
 def _minmax_as_Piecewise(op, *args):
@@ -869,8 +869,8 @@ class Min(MinMaxBase, Application):
 
 def expand_minmax(expr):
     """
-    Function to rewrite expressions with Min and Max in relations, to try to
-    remove the Min and Max functions.
+    Function to rewrite expressions with :class:`~.Min` and :class;`~.Max` in
+    relations, to try to remove the :class:`~.Min` and :class:`~.Min` functions.
 
     Examples
     ========
@@ -884,8 +884,6 @@ def expand_minmax(expr):
     (y >= x) | (z >= x)
 
     """
-    from sympy.core.relational import Eq, Ne, Le, Lt, Ge, Gt, Relational
-    from sympy.logic.boolalg import And, Or, BooleanFunction
     if not expr.has(Min, Max) or not expr.has(Relational):
         return expr
     if expr.has(Eq, Ne):

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -4,13 +4,14 @@ from sympy.core.expr import unchanged
 from sympy.core.function import Function
 from sympy.core.numbers import I, oo, Rational
 from sympy.core.power import Pow
+from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.external import import_module
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.miscellaneous import (sqrt, cbrt, root, Min,
-                                                      Max, real_root)
+                                        Max, real_root, expand_minmax)
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.delta_functions import Heaviside
 
@@ -448,6 +449,14 @@ def test_rewrite_as_Abs():
     test(Max(x, y))
     test(Min(x, y, z))
     test(Min(Max(w, x), Max(y, z)))
+
+
+def test_expand_minmax():
+    from sympy.abc import x, y, z, w
+    assert expand_minmax(Eq(x, Min(x, y, z))) == (y >= x) & (z >= x)
+    assert expand_minmax(x <= Max(y, z)) == (y >= x) | (z >= x)
+    assert expand_minmax(Max(x, y) <= Min(z, w)) == (w >= x) & (w >= y) & (z >= x) & (z >= y)
+
 
 def test_issue_14000():
     assert isinstance(sqrt(4, evaluate=False), Pow) == True

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -246,6 +246,9 @@ class BooleanAtom(Boolean):
     __ge__ = __lt__
     # \\\
 
+    def _eval_simplify(self, **kwargs):
+        return self
+
 
 class BooleanTrue(BooleanAtom, metaclass=Singleton):
     """
@@ -3094,12 +3097,12 @@ def simplify_patterns_and():
                      (And(Le(a, b), Ne(a, b)), Lt(a, b)),
                      (And(Lt(a, b), Ne(a, b)), Lt(a, b)),
                      # Min/max
-                     (And(Ge(a, b), Ge(a, c)), Ge(a, Max(b, c))),
-                     (And(Ge(a, b), Gt(a, c)), ITE(b > c, Ge(a, b), Gt(a, c))),
-                     (And(Gt(a, b), Gt(a, c)), Gt(a, Max(b, c))),
-                     (And(Le(a, b), Le(a, c)), Le(a, Min(b, c))),
-                     (And(Le(a, b), Lt(a, c)), ITE(b < c, Le(a, b), Lt(a, c))),
-                     (And(Lt(a, b), Lt(a, c)), Lt(a, Min(b, c))),
+                     #(And(Ge(a, b), Ge(a, c)), Ge(a, Max(b, c))),
+                     #(And(Ge(a, b), Gt(a, c)), ITE(b > c, Ge(a, b), Gt(a, c))),
+                     #(And(Gt(a, b), Gt(a, c)), Gt(a, Max(b, c))),
+                     #(And(Le(a, b), Le(a, c)), Le(a, Min(b, c))),
+                     #(And(Le(a, b), Lt(a, c)), ITE(b < c, Le(a, b), Lt(a, c))),
+                     #(And(Lt(a, b), Lt(a, c)), Lt(a, Min(b, c))),
                      # Sign
                      (And(Eq(a, b), Eq(a, -b)), And(Eq(a, S.Zero), Eq(b, S.Zero))),
                      )
@@ -3128,12 +3131,12 @@ def simplify_patterns_or():
                     (Or(Le(a, b), Ne(a, b)), S.true),
                     (Or(Lt(a, b), Ne(a, b)), Ne(a, b)),
                     # Min/max
-                    (Or(Ge(a, b), Ge(a, c)), Ge(a, Min(b, c))),
-                    (Or(Ge(a, b), Gt(a, c)), ITE(b > c, Gt(a, c), Ge(a, b))),
-                    (Or(Gt(a, b), Gt(a, c)), Gt(a, Min(b, c))),
-                    (Or(Le(a, b), Le(a, c)), Le(a, Max(b, c))),
-                    (Or(Le(a, b), Lt(a, c)), ITE(b >= c, Le(a, b), Lt(a, c))),
-                    (Or(Lt(a, b), Lt(a, c)), Lt(a, Max(b, c))),
+                    #(Or(Ge(a, b), Ge(a, c)), Ge(a, Min(b, c))),
+                    #(Or(Ge(a, b), Gt(a, c)), ITE(b > c, Gt(a, c), Ge(a, b))),
+                    #(Or(Gt(a, b), Gt(a, c)), Gt(a, Min(b, c))),
+                    #(Or(Le(a, b), Le(a, c)), Le(a, Max(b, c))),
+                    #(Or(Le(a, b), Lt(a, c)), ITE(b >= c, Le(a, b), Lt(a, c))),
+                    #(Or(Lt(a, b), Lt(a, c)), Lt(a, Max(b, c))),
                     )
     return _matchers_or
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3234,7 +3234,7 @@ def simplify_patterns_and():
                      (Tuple(Eq(a, b), Ge(a, b)), Eq(a, b)),
                      (Tuple(Eq(a, b), Le(a, b)), Eq(a, b)),
                      (Tuple(Ge(a, b), Gt(a, b)), Gt(a, b)),
-                     (Tuple(Ge(a, b), Le(a, b)), Eq(a, b)),
+                     # (Tuple(Ge(a, b), Le(a, b)), Eq(a, b)),
                      (Tuple(Ge(a, b), Ne(a, b)), Gt(a, b)),
                      (Tuple(Gt(a, b), Ne(a, b)), Gt(a, b)),
                      (Tuple(Le(a, b), Lt(a, b)), Lt(a, b)),
@@ -3249,6 +3249,10 @@ def simplify_patterns_and():
                      (Tuple(Le(a, b), Le(a, c)), Le(a, Min(b, c))),
                      (Tuple(Le(a, b), Lt(a, c)), ITE(b < c, Le(a, b), Lt(a, c))),
                      (Tuple(Lt(a, b), Lt(a, c)), Lt(a, Min(b, c))),
+                     (Tuple(Le(a, b), Ge(a, c)), ITE(Eq(b, c), Eq(a, b), ITE(b < c, S.false, And(Le(a, b), Ge(a, c))))),
+                     (Tuple(Lt(a, b), Gt(a, c)), ITE(b < c, S.false, And(Lt(a, b), Gt(a, c)))),
+                     (Tuple(Le(a, b), Gt(a, c)), ITE(b <= c, S.false, And(Le(a, b), Gt(a, c)))),
+                     (Tuple(Lt(a, b), Ge(a, c)), ITE(b <= c, S.false, And(Lt(a, b), Ge(a, c)))),
                      )
     return _matchers_and
 
@@ -3321,6 +3325,10 @@ def simplify_patterns_or():
                     (Tuple(Le(a, b), Lt(a, c)), ITE(b >= c, Le(a, b), Lt(a, c))),
                     (Tuple(Lt(a, b), Lt(a, c)), Lt(a, Max(b, c))),
 #                    (Tuple(Lt(b, a), Lt(c, a)), Lt(Max(b, c), a)),
+                    (Tuple(Le(a, b), Ge(a, c)), ITE(b >= c, S.true, Or(Le(a, b), Ge(a, c)))),
+                    (Tuple(Lt(a, b), Gt(a, c)), ITE(b > c, S.true, Or(Lt(a, b), Gt(a, c)))),
+                    (Tuple(Le(a, b), Gt(a, c)), ITE(b >= c, S.true, Or(Le(a, b), Gt(a, c)))),
+                    (Tuple(Lt(a, b), Ge(a, c)), ITE(b >= c, S.true, Or(Lt(a, b), Ge(a, c)))),
                     )
     return _matchers_or
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3139,7 +3139,7 @@ def _apply_patternbased_threeterm_simplification(Rel, patterns, func,
                 if res:
                     for tmpres, oldexpr in res:
                         # we have a matching, compute replacement
-                        np = simp.subs(tmpres)
+                        np = simp.xreplace(tmpres)
                         if np == dominatingvalue:
                             # if dominatingvalue, the whole expression
                             # will be replacementvalue

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -7,7 +7,6 @@ from itertools import chain, combinations, product, permutations
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import ordered, as_int
 from sympy.core.containers import Tuple
 from sympy.core.decorators import sympify_method_args, sympify_return
 from sympy.core.function import Application, Derivative

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3253,6 +3253,7 @@ def simplify_patterns_and():
                      (Tuple(Lt(a, b), Gt(a, c)), ITE(b < c, S.false, And(Lt(a, b), Gt(a, c)))),
                      (Tuple(Le(a, b), Gt(a, c)), ITE(b <= c, S.false, And(Le(a, b), Gt(a, c)))),
                      (Tuple(Lt(a, b), Ge(a, c)), ITE(b <= c, S.false, And(Lt(a, b), Ge(a, c)))),
+                     (Tuple(Eq(a, b), Eq(a, c)), ITE(Eq(b, c), Eq(a, b), S.false)),
                      )
     return _matchers_and
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -3045,6 +3045,7 @@ def _apply_patternbased_twoterm_simplification(Rel, patterns, func,
                                                dominatingvalue,
                                                replacementvalue,
                                                measure):
+    """ Apply pattern-based two-term simplification."""
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.core.relational import Ge, Gt, _Inequality
     changed = True
@@ -3112,6 +3113,7 @@ def _apply_patternbased_threeterm_simplification(Rel, patterns, func,
                                                  dominatingvalue,
                                                  replacementvalue,
                                                  measure):
+    """ Apply pattern-based three-term simplification."""
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.core.relational import Le, Lt, _Inequality
     changed = True
@@ -3176,6 +3178,8 @@ def _apply_patternbased_threeterm_simplification(Rel, patterns, func,
 
 
 def _simplify_patterns_and():
+    """ Two-term patterns for And."""
+
     from sympy.core import Wild
     from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
     from sympy.functions.elementary.complexes import Abs
@@ -3183,6 +3187,9 @@ def _simplify_patterns_and():
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
+    # Relationals patterns should be in alphabetical order
+    # (pattern1, pattern2, simplified)
+    # Do not use Ge, Gt
     _matchers_and = ((Tuple(Eq(a, b), Lt(a, b)), S.false),
                      # (Tuple(Eq(a, b), Lt(b, a)), S.false),
                      (Tuple(Le(b, a), Lt(a, b)), S.false),
@@ -3220,12 +3227,17 @@ def _simplify_patterns_and():
 
 
 def _simplify_patterns_and3():
+    """ Three-term patterns for And."""
+
     from sympy.core import Wild
     from sympy.core.relational import Eq, Ge, Gt
 
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
+    # Relationals patterns should be in alphabetical order
+    # (pattern1, pattern2, pattern3, simplified)
+    # Do not use Le, Lt
     _matchers_and = ((Tuple(Ge(a, b), Ge(b, c), Gt(c, a)), S.false),
                      (Tuple(Ge(a, b), Gt(b, c), Gt(c, a)), S.false),
                      (Tuple(Gt(a, b), Gt(b, c), Gt(c, a)), S.false),
@@ -3257,6 +3269,8 @@ def _simplify_patterns_and3():
 
 
 def _simplify_patterns_or():
+    """ Two-term patterns for Or."""
+
     from sympy.core import Wild
     from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
     from sympy.functions.elementary.complexes import Abs
@@ -3264,6 +3278,9 @@ def _simplify_patterns_or():
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
+    # Relationals patterns should be in alphabetical order
+    # (pattern1, pattern2, simplified)
+    # Do not use Ge, Gt
     _matchers_or = ((Tuple(Le(b, a), Le(a, b)), S.true),
                     (Tuple(Le(b, a), Lt(a, b)), S.true),
                     (Tuple(Le(b, a), Ne(a, b)), S.true),
@@ -3301,12 +3318,17 @@ def _simplify_patterns_or():
     return _matchers_or
 
 def _simplify_patterns_xor():
+    """ Two-term patterns for Xor."""
+
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.core import Wild
     from sympy.core.relational import Eq, Ne, Ge, Gt, Le, Lt
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
+    # Relationals patterns should be in alphabetical order
+    # (pattern1, pattern2, simplified)
+    # Do not use Ge, Gt
     _matchers_xor = ((Tuple(Le(b, a), Lt(a, b)), S.true),
                      # (Tuple(Lt(b, a), Le(a, b)), S.true),
                      # (Tuple(Eq(a, b), Le(b, a)), Gt(a, b)),

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1117,6 +1117,11 @@ def test_issue_8373():
     assert Or(x <= 1, x >= 1).simplify() == S.true
 
 
+def test_issue_7950():
+    x = symbols('x', real=True)
+    assert And(Eq(x, 1), Eq(x, 2)).simplify() == S.false
+
+
 @slow
 def test_relational_simplification_numerically():
     def test_simplification_numerically_function(original, simplified):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1107,6 +1107,9 @@ def test_relational_simplification():
         (Eq(x, y) & Eq(d, e) & (d >= e))
     assert And(Eq(x, y), Eq(x, -y)).simplify() == And(Eq(x, 0), Eq(y, 0))
     assert Xor(x >= y, x <= y).simplify() == Ne(x, y)
+    assert And(x > 1, x < -1, Eq(x, y)).simplify() == S.false
+    # From #16690
+    assert And(x >= y, Eq(y, 0)).simplify() == And(x >= 0, Eq(y, 0))
 
 
 def test_issue_8373():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1097,10 +1097,10 @@ def test_relational_simplification():
         (x >= y) | (y > z) | (w < y)
     assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify() == \
         Eq(x, y) & (y > z) & (w < y)
-    assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify(relational_minmax=True) == \
-       And(Eq(x, y), y > Max(w, z))
-    assert Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify(relational_minmax=True) == \
-       (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
+    # assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify(relational_minmax=True) == \
+    #    And(Eq(x, y), y > Max(w, z))
+    # assert Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify(relational_minmax=True) == \
+    #    (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
     assert And(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify() == \
         (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
     assert (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)).simplify() == \

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1093,6 +1093,16 @@ def test_relational_simplification():
     assert And(x >= y, Eq(y, x)).simplify() == Eq(x, y)
     assert And(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify() == \
         (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
+    assert Or(Eq(x, y), x >= y, w < y, z < y).simplify() == \
+        (x >= y) | (y > z) | (w < y)
+    assert Or(Eq(x, y), x >= y, w < y, z < y).simplify(relational_minmax=True) == \
+        Or(x >= y, y > Min(w, z))
+    assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify() == \
+        Eq(x, y) & (y > z) & (w < y)
+    assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify(relational_minmax=True) == \
+       And(Eq(x, y), y > Max(w, z))
+    assert Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify(relational_minmax=True) == \
+       (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
     assert (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)).simplify() == \
         (Eq(x, y) & Eq(d, e) & (d >= e))
     assert And(Eq(x, y), Eq(x, -y)).simplify() == And(Eq(x, 0), Eq(y, 0))
@@ -1138,20 +1148,23 @@ def test_relational_simplification_patterns_numerically():
     b = Wild('b')
     c = Wild('c')
     symb = [a, b, c]
-    patternlists = [simplify_patterns_and(), simplify_patterns_or(),
-                    simplify_patterns_xor()]
-    for patternlist in patternlists:
+    patternlists = [[And, simplify_patterns_and()],
+                    [Or, simplify_patterns_or()],
+                    [Xor, simplify_patterns_xor()]]
+    valuelist = list(set(list(combinations(list(range(-2, 3))*3, 3))))
+    # Skip combinations of +/-2 and 0, except for all 0
+    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
+    for func, patternlist in patternlists:
         for pattern in patternlist:
-            original = pattern[0]
+            original = func(*pattern[0].args)
             simplified = pattern[1]
-            valuelist = list(set(list(combinations(list(range(-2, 2))*3, 3))))
             for values in valuelist:
                 sublist = dict(zip(symb, values))
-                originalvalue = original.subs(sublist)
-                simplifiedvalue = simplified.subs(sublist)
+                originalvalue = original.xreplace(sublist)
+                simplifiedvalue = simplified.xreplace(sublist)
                 assert originalvalue == simplifiedvalue, "Original: {}\nand"\
                     " simplified: {}\ndo not evaluate to the same value for"\
-                    "{}".format(original, simplified, sublist)
+                    "{}".format(pattern[0], simplified, sublist)
 
 
 def test_issue_16803():
@@ -1270,3 +1283,27 @@ def test_refine():
     assert refine(Q.positive(x), Q.positive(x)) is S.true
     assert refine(Q.positive(x), Q.negative(x)) is S.false
     assert refine(Q.positive(x), Q.real(x)) == Q.positive(x)
+
+
+def test_relational_threeterm_simplification_patterns_numerically():
+    from sympy.core import Wild
+    from sympy.logic.boolalg import simplify_patterns_and3
+    a = Wild('a')
+    b = Wild('b')
+    c = Wild('c')
+    symb = [a, b, c]
+    patternlists = [[And, simplify_patterns_and3()]]
+    valuelist = list(set(list(combinations(list(range(-2, 3))*3, 3))))
+    # Skip combinations of +/-2 and 0, except for all 0
+    valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
+    for func, patternlist in patternlists:
+        for pattern in patternlist:
+            original = func(*pattern[0].args)
+            simplified = pattern[1]
+            for values in valuelist:
+                sublist = dict(zip(symb, values))
+                originalvalue = original.xreplace(sublist)
+                simplifiedvalue = simplified.xreplace(sublist)
+                assert originalvalue == simplifiedvalue, "Original: {}\nand"\
+                    " simplified: {}\ndo not evaluate to the same value for"\
+                    "{}".format(pattern[0], simplified, sublist)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1095,18 +1095,26 @@ def test_relational_simplification():
         (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
     assert Or(Eq(x, y), x >= y, w < y, z < y).simplify() == \
         (x >= y) | (y > z) | (w < y)
-    assert Or(Eq(x, y), x >= y, w < y, z < y).simplify(relational_minmax=True) == \
-        Or(x >= y, y > Min(w, z))
     assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify() == \
         Eq(x, y) & (y > z) & (w < y)
     assert And(Eq(x, y), x >= y, w < y, y >= z, z < y).simplify(relational_minmax=True) == \
        And(Eq(x, y), y > Max(w, z))
     assert Or(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify(relational_minmax=True) == \
        (Eq(x, y) | (x >= 1) | (y > Min(2, z)))
+    assert And(Eq(x, y), x >= 1, 2 < y, y >= 5, z < y).simplify() == \
+        (Eq(x, y) & (x >= 1) & (y >= 5) & (y > z))
     assert (Eq(x, y) & Eq(d, e) & (x >= y) & (d >= e)).simplify() == \
         (Eq(x, y) & Eq(d, e) & (d >= e))
     assert And(Eq(x, y), Eq(x, -y)).simplify() == And(Eq(x, 0), Eq(y, 0))
     assert Xor(x >= y, x <= y).simplify() == Ne(x, y)
+
+
+def test_issue_8373():
+    x = symbols('x', real=True)
+    assert Or(x < 1, x > -1).simplify() == S.true
+    assert Or(x < 1, x >= 1).simplify() == S.true
+    assert And(x < 1, x >= 1).simplify() == S.false
+    assert Or(x <= 1, x >= 1).simplify() == S.true
 
 
 @slow

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1155,15 +1155,15 @@ def test_relational_simplification_numerically():
 
 def test_relational_simplification_patterns_numerically():
     from sympy.core import Wild
-    from sympy.logic.boolalg import simplify_patterns_and, \
-        simplify_patterns_or, simplify_patterns_xor
+    from sympy.logic.boolalg import _simplify_patterns_and, \
+        _simplify_patterns_or, _simplify_patterns_xor
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
     symb = [a, b, c]
-    patternlists = [[And, simplify_patterns_and()],
-                    [Or, simplify_patterns_or()],
-                    [Xor, simplify_patterns_xor()]]
+    patternlists = [[And, _simplify_patterns_and()],
+                    [Or, _simplify_patterns_or()],
+                    [Xor, _simplify_patterns_xor()]]
     valuelist = list(set(list(combinations(list(range(-2, 3))*3, 3))))
     # Skip combinations of +/-2 and 0, except for all 0
     valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]
@@ -1300,12 +1300,12 @@ def test_refine():
 
 def test_relational_threeterm_simplification_patterns_numerically():
     from sympy.core import Wild
-    from sympy.logic.boolalg import simplify_patterns_and3
+    from sympy.logic.boolalg import _simplify_patterns_and3
     a = Wild('a')
     b = Wild('b')
     c = Wild('c')
     symb = [a, b, c]
-    patternlists = [[And, simplify_patterns_and3()]]
+    patternlists = [[And, _simplify_patterns_and3()]]
     valuelist = list(set(list(combinations(list(range(-2, 3))*3, 3))))
     # Skip combinations of +/-2 and 0, except for all 0
     valuelist = [v for v in valuelist if any([w % 2 for w in v]) or not any(v)]

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -586,11 +586,11 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
     expr = sympify(expr, rational=rational)
     kwargs = dict(
-        ratio=kwargs.pop('ratio', ratio),
-        measure=kwargs.pop('measure', measure),
-        rational=kwargs.pop('rational', rational),
-        inverse=kwargs.pop('inverse', inverse),
-        doit=kwargs.pop('doit', doit))
+        ratio=kwargs.get('ratio', ratio),
+        measure=kwargs.get('measure', measure),
+        rational=kwargs.get('rational', rational),
+        inverse=kwargs.get('inverse', inverse),
+        doit=kwargs.get('doit', doit))
     # no routine for Expr needs to check for is_zero
     if isinstance(expr, Expr) and expr.is_zero:
         return S.Zero

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -586,11 +586,12 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
     expr = sympify(expr, rational=rational)
     kwargs = dict(
-        ratio=kwargs.get('ratio', ratio),
-        measure=kwargs.get('measure', measure),
-        rational=kwargs.get('rational', rational),
-        inverse=kwargs.get('inverse', inverse),
-        doit=kwargs.get('doit', doit))
+        ratio=kwargs.pop('ratio', ratio),
+        measure=kwargs.pop('measure', measure),
+        rational=kwargs.pop('rational', rational),
+        inverse=kwargs.pop('inverse', inverse),
+        doit=kwargs.pop('doit', doit),
+        **kwargs)
     # no routine for Expr needs to check for is_zero
     if isinstance(expr, Expr) and expr.is_zero:
         return S.Zero

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -590,8 +590,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         measure=kwargs.pop('measure', measure),
         rational=kwargs.pop('rational', rational),
         inverse=kwargs.pop('inverse', inverse),
-        doit=kwargs.pop('doit', doit),
-        **kwargs)
+        doit=kwargs.pop('doit', doit))
     # no routine for Expr needs to check for is_zero
     if isinstance(expr, Expr) and expr.is_zero:
         return S.Zero


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #13605

#### Brief description of what is fixed or changed
This PR introduces simplification of relations with `Min` or `Max` in them. For example, it can do:
```
(Min(x, y, z) >= z).simplify() => (z <= Min(x, y))
(Max(x, y, z) >= z).simplify() => S.true
(Eq(Min(x, y, z), z)).simplify() => (z <= Min(x, y))
 (Ne(Max(x, y, z), z)).simplify() => (z < Max(x, y))
```

I realized the lack of simplification when seeing:
```
a = Symbol('a', positive=True)
integrate(sqrt(1/(1 - x**2)), (x, 0, a))
```
which returns
```
⎧asin(Min(1, a))  for a ≤ Min(1, a)
⎨                                  
⎩      nan            otherwise    
```

Now, instead we get (after simplify):
```
⎧asin(Min(1, a))  for a ≤ 1
⎨                          
⎩      nan        otherwise
```

(Of course, the expression can also be simplified, but that is more the role of Piecewise simplification than Relational simplification.)

#### Other comments

The commented out code is related to #17331. If/when that gets sorted out, it should be possible to (more or less) just uncomment those rows.

One can think about querying for extended_real here. At least when returning `S.true` or `S.false`. Not sure if it is worth it or not. Using `Min` and `Max` (and `Relational`) more or less only makes sense for real values.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `expand_minmax` introduced to remove `Min/Max` from relations.
* logic
   * Faster `simplify_logic` when used with relations.
* simplify
    * Improved simplification of relations.
<!-- END RELEASE NOTES -->
