### PR TITLE
Make permutation atom

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -541,7 +541,7 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
         from sympy.combinatorics import Permutation
         expr = _sympify(expr)
         permutation = Permutation(permutation)
-        plist = permutation.args[0]
+        plist = permutation.array_form
         if plist == sorted(plist):
             return expr
         obj = Basic.__new__(cls, expr, permutation)
@@ -1336,7 +1336,7 @@ def _recognize_matrix_expression(expr):
     elif isinstance(expr, (MatrixSymbol, IndexedBase)):
         return expr
     elif isinstance(expr, CodegenArrayPermuteDims):
-        if expr.permutation.args[0] == [1, 0]:
+        if expr.permutation.array_form == [1, 0]:
             return _RecognizeMatOp(Transpose, [_recognize_matrix_expression(expr.expr)])
         elif isinstance(expr.expr, CodegenArrayTensorProduct):
             ranks = expr.expr.subranks

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1344,7 +1344,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics import Permutation, PermutationGroup
         >>> p = PermutationGroup(Permutation(1, 3), Permutation(1, 2))
         >>> p.elements
-        {(3), (2 3), (3)(1 2), (1 2 3), (1 3 2), (1 3)}
+        {(1 2 3), (1 3 2), (1 3), (2 3), (3), (3)(1 2)}
 
         """
         return set(self._elements)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 import random
 from collections import defaultdict
 
-from sympy.core import Basic
+from sympy.core.basic import Basic, Atom
 from sympy.core.compatibility import is_sequence, reduce, range, as_int
 from sympy.matrices import zeros
 from sympy.polys.polytools import lcm
@@ -466,7 +466,7 @@ class Cycle(dict):
         return Cycle(self)
 
 
-class Permutation(Basic):
+class Permutation(Atom):
     """
     A permutation, alternatively known as an 'arrangement number' or 'ordering'
     is an arrangement of the elements of an ordered list into a one-to-one
@@ -968,7 +968,8 @@ class Permutation(Basic):
         Permutation([2, 1, 3, 0])
 
         """
-        p = Basic.__new__(cls, perm)
+        from sympy.core.containers import Tuple
+        p = super(Permutation, cls).__new__(cls)
         p._array_form = perm
         p._size = len(perm)
         return p

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -968,7 +968,6 @@ class Permutation(Atom):
         Permutation([2, 1, 3, 0])
 
         """
-        from sympy.core.containers import Tuple
         p = super(Permutation, cls).__new__(cls)
         p._array_form = perm
         p._size = len(perm)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -762,8 +762,12 @@ def test_make_perm():
 
 
 def test_elements():
+    from sympy.sets.sets import FiniteSet
+
     p = Permutation(2, 3)
     assert PermutationGroup(p).elements == {Permutation(3), Permutation(2, 3)}
+    assert FiniteSet(*PermutationGroup(p).elements) \
+        == FiniteSet(Permutation(2, 3), Permutation(3))
 
 
 def test_is_group():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -475,7 +475,6 @@ def test_sympy__combinatorics__subsets__Subset():
     assert _test_args(Subset(['c', 'd'], ['a', 'b', 'c', 'd']))
 
 
-@XFAIL
 def test_sympy__combinatorics__permutations__Permutation():
     from sympy.combinatorics.permutations import Permutation
     assert _test_args(Permutation([0, 1, 2, 3]))

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -777,7 +777,7 @@ class NumPyPrinter(PythonCodePrinter):
         return "%s(%s, %s)" % (
             self._module_format("numpy.transpose"),
             self._print(expr.expr),
-            self._print(expr.permutation.args[0]),
+            self._print(expr.array_form),
         )
 
     def _print_CodegenArrayElementwiseAdd(self, expr):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -777,7 +777,7 @@ class NumPyPrinter(PythonCodePrinter):
         return "%s(%s, %s)" % (
             self._module_format("numpy.transpose"),
             self._print(expr.expr),
-            self._print(expr.array_form),
+            self._print(expr.permutation.array_form),
         )
 
     def _print_CodegenArrayElementwiseAdd(self, expr):

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -222,7 +222,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         return "%s(%s, %s)" % (
             self._module_format("tensorflow.transpose"),
             self._print(expr.expr),
-            self._print(expr.array_form),
+            self._print(expr.permutation.array_form),
         )
 
     def _print_CodegenArrayElementwiseAdd(self, expr):

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -222,7 +222,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         return "%s(%s, %s)" % (
             self._module_format("tensorflow.transpose"),
             self._print(expr.expr),
-            self._print(expr.permutation.args[0]),
+            self._print(expr.array_form),
         )
 
     def _print_CodegenArrayElementwiseAdd(self, expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #7369

#### Brief description of what is fixed or changed

Using non-basic args for `Permutation` had some problems for
```
from sympy import *
from sympy.combinatorics import *

FiniteSet(*AlternatingGroup(4).generate())
```
giving the error `TypeError: unhashable type: 'list'`

Alternatively to the approach used in #7369, I'm thinking of making `Permutation` an `Atom`, because it seems like the class is taking too much advantage of using python native number types and operations.

It can also solve the slowdown problem noted in the original comment
```
def test1():
    S = SymmetricGroup(9)
    c = 0
    for element in S.generate_dimino(af=False):
        c += 1
    print('c=', c)

test1()
``` 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - `Permutation` will be an instance of `Atom` instead of `Basic`.
  - Fixed `Permutation` raising error when used as an element of `FiniteSet`.
<!-- END RELEASE NOTES -->
