### PR TITLE
[WIP] Add matrix wildcards

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2820,6 +2820,12 @@ def test_sympy__matrices__expressions__matexpr__GenericIdentity():
     from sympy.matrices.expressions.matexpr import GenericIdentity
     assert _test_args(GenericIdentity())
 
+
+def test_sympy__matrices__expressions__matexpr__MatrixWild():
+    from sympy.matrices.expressions.matexpr import MatrixWild
+    assert _test_args(MatrixWild('W', x, y))
+
+
 @SKIP("abstract class")
 def test_sympy__matrices__expressions__matexpr__MatrixExpr():
     pass

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1027,6 +1027,31 @@ class OneMatrix(MatrixExpr):
 
 
 class MatrixWild(MatrixSymbol, Wild):
+    """A wildcard for matrix expressions based on ``Wild``.
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol
+    >>> from sympy.matrices.expressions.matexpr import MatrixWild
+    >>> A, B = MatrixSymbol('A', 3, 3), MatrixSymbol('B', 3, 3)
+    >>> W = MatrixWild('W', 3, 3)
+    >>> (A*B).match(W)
+    {W_: A*B}
+    >>> (A*B).match(A*W)
+    {W_: B}
+    >>> (A**2).match(A*W)
+    {W_: A}
+
+    Note that ``W`` matched with ``A*B`` only because the expression had the
+    same shape as the matrix wildcard ``W``. If more flexibility is required, a
+    dimension of the matrix wildcard may itself be a wildcard.
+
+    >>> x = Wild('x')
+    >>> W = MatrixWild('W', x, 3)
+    >>> (A*B).match(W)
+    {x_: 3, W_: A*B}
+    """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):
         obj = MatrixSymbol.__new__(cls, name, n, m)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1048,9 +1048,9 @@ class MatrixWild(MatrixSymbol, Wild):
     dimension of the matrix wildcard may itself be a wildcard.
 
     >>> x = Wild('x')
-    >>> W = MatrixWild('W', x, 3)
-    >>> (A*B).match(W)
-    {x_: 3, W_: A*B}
+    >>> Y = MatrixWild('Y', x, 3)
+    >>> (A*B).match(Y)
+    {x_: 3, Y_: A*B}
     """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -767,6 +767,9 @@ class StrPrinter(Printer):
     def _print_OneMatrix(self, expr):
         return "1"
 
+    def _print_MatrixWild(self, expr):
+        return expr.name + '_'
+
     def _print_Predicate(self, expr):
         return "Q.%s" % expr.name
 


### PR DESCRIPTION
#### References to other Issues or PRs

Related to #17028

#### Brief description of what is fixed or changed

Adds a `MatrixWild` class that matches matrix expressions.

#### Other comments

This PR implements the same functionality as #17177, but uses new functionality internal to the `Mul` class.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Add wildcard for matrix expressions
<!-- END RELEASE NOTES -->