### PR TITLE
diophantine: note re parametric soln; remove gcd

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -2178,32 +2178,40 @@ def parametrize_ternary_quadratic(eq):
     >>> from sympy import Tuple, ordered
     >>> from sympy.abc import x, y, z
     >>> from sympy.solvers.diophantine import parametrize_ternary_quadratic
-    >>> parametrize_ternary_quadratic(4*x**2 + 2*y**2 - 3*z**2)
-    (2*p**2 - 3*q**2, -4*p**2 + 12*p*q - 6*q**2, 4*p**2 - 8*p*q + 6*q**2)
 
-        More than one solution can be represented by a given ``p`` and
-        ``q``. If `p` and ``q`` are not coprime, this is trivially true
-        since the common factor will also be a common factor of the
-        solution values. But it may also be true when they are coprime:
-
-        >>> sol = Tuple(*_)
-        >>> p, q = ordered(sol.free_symbols)
-        >>> sol.subs([(p, 3), (q, 2)])
-        (6, 12, 12)
-        >>> sol.subs([(q, 1), (p, 1)])
-        (-1, 2, 2)
-        >>> sol.subs([(q, 0), (p, 1)])
-        (2, -4, 4)
-        >>> sol.subs([(q, 1), (p, 0)])
-        (-3, -6, 6)
-
-        Except for sign and a common factor, these are equivalent to
-        the solution of (1, 2, 2).
-
-    It is also possible that solution will contain 3 parameters:
+    The parametrized solution may be returned with three parameters:
 
     >>> parametrize_ternary_quadratic(2*x**2 + y**2 - 2*z**2)
     (p**2 - 2*q**2, -2*p**2 + 4*p*q - 4*p*r - 4*q**2, p**2 - 4*p*q + 2*q**2 - 4*q*r)
+
+    There might also be only two parameters:
+
+    >>> parametrize_ternary_quadratic(4*x**2 + 2*y**2 - 3*z**2)
+    (2*p**2 - 3*q**2, -4*p**2 + 12*p*q - 6*q**2, 4*p**2 - 8*p*q + 6*q**2)
+
+    Notes
+    =====
+
+    Consider ``p`` and ``q`` in the previous 2-parameter
+    solution and observe that more than one solution can be represented
+    by a given pair of parameters. If `p` and ``q`` are not coprime, this is
+    trivially true since the common factor will also be a common factor of the
+    solution values. But it may also be true even when ``p`` and
+    ``q`` are coprime:
+
+    >>> sol = Tuple(*_)
+    >>> p, q = ordered(sol.free_symbols)
+    >>> sol.subs([(p, 3), (q, 2)])
+    (6, 12, 12)
+    >>> sol.subs([(q, 1), (p, 1)])
+    (-1, 2, 2)
+    >>> sol.subs([(q, 0), (p, 1)])
+    (2, -4, 4)
+    >>> sol.subs([(q, 1), (p, 0)])
+    (-3, -6, 6)
+
+    Except for sign and a common factor, these are equivalent to
+    the solution of (1, 2, 2).
 
     References
     ==========

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -65,11 +65,16 @@ def _sorted_tuple(*i):
 def _remove_gcd(*x):
     try:
         g = igcd(*x)
-        return tuple([i//g for i in x])
     except ValueError:
-        return x
+        fx = list(filter(None, x))
+        if len(fx) < 2:
+            return x
+        g = igcd(*[i.as_content_primitive()[0] for i in fx])
     except TypeError:
         raise TypeError('_remove_gcd(a,b,c) or _remove_gcd(*container)')
+    if g == 1:
+        return x
+    return tuple([i//g for i in x])
 
 
 def _rational_pq(a, b):
@@ -1988,13 +1993,13 @@ def _diop_ternary_quadratic(_var, coeff):
                     s = r
                     min_sum = m
 
-            x_0, y_0, z_0 = s[0], -coeff[x*z], s[1]
+            x_0, y_0, z_0 = _remove_gcd(s[0], -coeff[x*z], s[1])
 
         else:
             var[0], var[1] = _var[1], _var[0]
             y_0, x_0, z_0 = _diop_ternary_quadratic(var, coeff)
 
-        return _remove_gcd(x_0, y_0, z_0)
+        return x_0, y_0, z_0
 
     if coeff[x**2] == 0:
         # If the coefficient of x is zero change the variables
@@ -2170,17 +2175,35 @@ def parametrize_ternary_quadratic(eq):
     Examples
     ========
 
+    >>> from sympy import Tuple, ordered
     >>> from sympy.abc import x, y, z
     >>> from sympy.solvers.diophantine import parametrize_ternary_quadratic
-    >>> parametrize_ternary_quadratic(x**2 + y**2 - z**2)
-    (2*p*q, p**2 - q**2, p**2 + q**2)
+    >>> parametrize_ternary_quadratic(4*x**2 + 2*y**2 - 3*z**2)
+    (2*p**2 - 3*q**2, -4*p**2 + 12*p*q - 6*q**2, 4*p**2 - 8*p*q + 6*q**2)
 
-    Here `p` and `q` are two co-prime integers.
+        More than one solution can be represented by a given ``p`` and
+        ``q``. If `p` and ``q`` are not coprime, this is trivially true
+        since the common factor will also be a common factor of the
+        solution values. But it may also be true when they are coprime:
 
-    >>> parametrize_ternary_quadratic(3*x**2 + 2*y**2 - z**2 - 2*x*y + 5*y*z - 7*y*z)
-    (2*p**2 - 2*p*q - q**2, 2*p**2 + 2*p*q - q**2, 2*p**2 - 2*p*q + 3*q**2)
-    >>> parametrize_ternary_quadratic(124*x**2 - 30*y**2 - 7729*z**2)
-    (-1410*p**2 - 363263*q**2, 2700*p**2 + 30916*p*q - 695610*q**2, -60*p**2 + 5400*p*q + 15458*q**2)
+        >>> sol = Tuple(*_)
+        >>> p, q = ordered(sol.free_symbols)
+        >>> sol.subs([(p, 3), (q, 2)])
+        (6, 12, 12)
+        >>> sol.subs([(q, 1), (p, 1)])
+        (-1, 2, 2)
+        >>> sol.subs([(q, 0), (p, 1)])
+        (2, -4, 4)
+        >>> sol.subs([(q, 1), (p, 0)])
+        (-3, -6, 6)
+
+        Except for sign and a common factor, these are equivalent to
+        the solution of (1, 2, 2).
+
+    It is also possible that solution will contain 3 parameters:
+
+    >>> parametrize_ternary_quadratic(2*x**2 + y**2 - 2*z**2)
+    (p**2 - 2*q**2, -2*p**2 + 4*p*q - 4*p*r - 4*q**2, p**2 - 4*p*q + 2*q**2 - 4*q*r)
 
     References
     ==========
@@ -2237,7 +2260,7 @@ def _parametrize_ternary_quadratic(solution, _var, coeff):
     y = (A*y_0 - _mexpand(B/r*p))
     z = (A*z_0 - _mexpand(B/r*q))
 
-    return x, y, z
+    return _remove_gcd(x, y, z)
 
 
 def diop_ternary_quadratic_normal(eq):

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -1,6 +1,6 @@
 from sympy import (Add, Matrix, Mul, S, symbols, Eq, pi, factorint, oo, powsimp)
 from sympy.core.function import _mexpand
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, ordered
 from sympy.functions.elementary.trigonometric import sin
 from sympy.solvers.diophantine import (descent, diop_bf_DN, diop_DN,
     diop_solve, diophantine, divisible, equivalent, find_DN, ldescent, length,
@@ -409,10 +409,10 @@ def test_diop_ternary_quadratic():
         (-2, 0, n1)
     eq = -5*x*y - 8*x*z - 3*y*z + 8*z**2
     assert parametrize_ternary_quadratic(eq) == \
-        (64*p**2 - 24*p*q, -64*p*q + 64*q**2, 40*p*q)
+        (8*p**2 - 3*p*q, -8*p*q + 8*q**2, 5*p*q)
     # this cannot be tested with diophantine because it will
     # factor into a product
-    assert diop_solve(x*y + 2*y*z) == (-4*p*q, -2*n1*p**2 + 2*p**2, 2*p*q)
+    assert diop_solve(x*y + 2*y*z) == (-2*p*q, -n1*p**2 + p**2, p*q)
 
 
 def test_square_factor():
@@ -906,3 +906,31 @@ def test_issue_9538():
     eq = x - 3*y + 2
     assert diophantine(eq, syms=[y,x]) == set([(t_0, 3*t_0 - 2)])
     raises(TypeError, lambda: diophantine(eq, syms=set([y,x])))
+
+
+def test_ternary_quadratic():
+    # solution with 3 parameters
+    s = diophantine(2*x**2 + y**2 - 2*z**2)
+    p, q, r = ordered(S(s).free_symbols)
+    assert s == {(
+        p**2 - 2*q**2,
+        -2*p**2 + 4*p*q - 4*p*r - 4*q**2,
+        p**2 - 4*p*q + 2*q**2 - 4*q*r)}
+    # solution with Mul in solution
+    s = diophantine(x**2 + 2*y**2 - 2*z**2)
+    assert s == {(4*p*q, p**2 - 2*q**2, p**2 + 2*q**2)}
+    # solution with no Mul in solution
+    s = diophantine(2*x**2 + 2*y**2 - z**2)
+    assert s == {(2*p**2 - q**2, -2*p**2 + 4*p*q - q**2,
+        4*p**2 - 4*p*q + 2*q**2)}
+    # reduced form when parametrized
+    s = diophantine(3*x**2 + 72*y**2 - 27*z**2)
+    assert s == {(24*p**2 - 9*q**2, 6*p*q, 8*p**2 + 3*q**2)}
+    assert parametrize_ternary_quadratic(
+        3*x**2 + 2*y**2 - z**2 - 2*x*y + 5*y*z - 7*y*z) == (
+        2*p**2 - 2*p*q - q**2, 2*p**2 + 2*p*q - q**2, 2*p**2 -
+        2*p*q + 3*q**2)
+    assert parametrize_ternary_quadratic(
+        124*x**2 - 30*y**2 - 7729*z**2) == (
+        -1410*p**2 - 363263*q**2, 2700*p**2 + 30916*p*q -
+        695610*q**2, -60*p**2 + 5400*p*q + 15458*q**2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #11697 

#### Brief description of what is fixed or changed

A docstring has been updated to indicate the relationship between the parameterized solution and the actual solution: the parameterized solution does not produce coprime results from coprime input.

I also noticed that symbolic gcd was not being handled so updated the routine that removes the gcd of parameterized solutions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * the gcd of parameterized ternary solutions is now removed
<!-- END RELEASE NOTES -->
