### PR TITLE
Pyglet plot fixes

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -89,6 +89,7 @@ if PY3:
     from functools import reduce
     from io import StringIO
     cStringIO = StringIO
+    from time import perf_counter as clock
 
     exec_ = getattr(builtins, "exec")
 
@@ -130,6 +131,7 @@ else:
     reduce = reduce
     from StringIO import StringIO
     from cStringIO import StringIO as cStringIO
+    from time import clock
 
     def exec_(_code_, _globs_=None, _locs_=None):
         """Execute code in a namespace."""
@@ -954,8 +956,3 @@ try:
 except ImportError:  # Python 2.7
     def filterfalse(pred, itr):
         return filter(lambda x: not pred(x), itr)
-
-try:
-    from time import clock
-except ImportError: # Python 3.8+
-    from time import perf_counter as clock

--- a/sympy/plotting/pygletplot/managed_window.py
+++ b/sympy/plotting/pygletplot/managed_window.py
@@ -14,7 +14,6 @@ class ManagedWindow(Window):
     in a separate thread. Behavior is added by creating a subclass
     which overrides setup, update, and/or draw.
     """
-    fps_limit = 30
     default_win_args = dict(width=600,
                             height=500,
                             vsync=False,
@@ -53,7 +52,6 @@ class ManagedWindow(Window):
             gl_lock.release()
 
         clock = Clock()
-        clock.set_fps_limit(self.fps_limit)
         while not self.has_exit:
             dt = clock.tick()
             gl_lock.acquire()

--- a/sympy/plotting/pygletplot/plot_axes.py
+++ b/sympy/plotting/pygletplot/plot_axes.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 import pyglet.gl as pgl
-from pyglet import font
+from pyglet import font, text
 
 from sympy.core import S
 from sympy.core.compatibility import is_sequence
@@ -139,19 +139,19 @@ class PlotAxesBase(PlotObject):
     def draw_axis(self, axis, color):
         raise NotImplementedError()
 
-    def draw_text(self, text, position, color, scale=1.0):
+    def draw_text(self, txt, position, color, scale=1.0):
         if len(color) == 3:
-            color = (color[0], color[1], color[2], 1.0)
+            color = (round(255*color[0]), round(255*color[1]), round(color[2]), 255)
 
         if self._p.label_font is None:
             self._p.label_font = font.load(self._p.font_face,
                                            self._p.font_size,
                                            bold=True, italic=False)
 
-        label = font.Text(self._p.label_font, text,
-                          color=color,
-                          valign=font.Text.BASELINE,
-                          halign=font.Text.CENTER)
+        label = text.Label(txt, font_name=self._p.font_face,
+                          color=color, bold=True, italic=False,
+                          x=round(position[0]), y=round(position[1]),
+                          anchor_x='center', anchor_y='center')
 
         pgl.glPushMatrix()
         pgl.glTranslatef(*position)
@@ -235,7 +235,7 @@ class PlotAxesOrdinate(PlotAxesBase):
         tick_label_vector[axis] = tick
         tick_label_vector[{0: 1, 1: 0, 2: 1}[axis]] = [-1, 1, 1][
             axis] * radius * 3.5
-        self.draw_text(str(tick), tick_label_vector, color, scale=0.5)
+        self.draw_text('{:g}'.format(float(tick)), tick_label_vector, color, scale=0.5)
 
 
 class PlotAxesFrame(PlotAxesBase):

--- a/sympy/plotting/pygletplot/plot_curve.py
+++ b/sympy/plotting/pygletplot/plot_curve.py
@@ -28,10 +28,15 @@ class PlotCurve(PlotModeBase):
                 _e = evaluate(t)    # calculate vertex
             except (NameError, ZeroDivisionError):
                 _e = None
-            if _e is not None:      # update bounding box
-                for axis in range(3):
-                    b[axis][0] = min([b[axis][0], _e[axis]])
-                    b[axis][1] = max([b[axis][1], _e[axis]])
+            _e = S(_e)
+            if _e is not None:
+                if S.NaN in _e:
+                    _e = None
+                else:
+                    # update bounding box
+                    for axis in range(3):
+                        b[axis][0] = min([b[axis][0], _e[axis]])
+                        b[axis][1] = max([b[axis][1], _e[axis]])
             self.verts.append(_e)
             self._calculating_verts_pos += 1.0
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/16537#issuecomment-487540560 

The example now works in `PygletPlot`.

#### Brief description of what is fixed or changed


#### Other comments
I upgraded pyglet to 1.4 (see https://github.com/pyglet/pyglet/issues/36) and realized that a method that was used is now removed (shouldn't be crucial for earlier version either).

I also found some other issues running the tests manually.

Fixed the deprecation warning:
```
/nobackup/data/sympy/sympy/plotting/pygletplot/plot_window.py:132: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
  self.last_caption_update = clock()
```
Enabled text rendering which didn't work because of an API change in (at least) 1.3. It is not perfect, but no errors and one can see the scale of the axes.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Supporting Pyglet 1.3 and minor bug fixes.
<!-- END RELEASE NOTES -->
