### PR TITLE
Fixed issue with showing empty plot

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1159,7 +1159,7 @@ class MatplotlibBackend(BaseBackend):
             xlim = (float(i) for i in xlim)
             ax.set_xlim(xlim)
         else:
-            if all(isinstance(s, LineOver1DRangeSeries) for s in parent._series):
+            if parent._series and all(isinstance(s, LineOver1DRangeSeries) for s in parent._series):
                 starts = [s.start for s in parent._series]
                 ends = [s.end for s in parent._series]
                 ax.set_xlim(min(starts), max(ends))

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -2122,6 +2122,8 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
        >>> check_arguments([x, x**2], 1, 1)
            [(x, (x, -10, 10)), (x**2, (x, -10, 10))]
     """
+    if not args:
+        return []
     if expr_len > 1 and isinstance(args[0], Expr):
         # Multiple expressions same range.
         # The arguments are tuples when the expression length is

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -504,3 +504,21 @@ def test_issue_15265():
 
     raises(ValueError,
         lambda: plot(eqn, xlim=(-1, 1), ylim=(-1, S.Infinity)))
+
+
+def test_empty_Plot():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    from sympy.plotting.plot import Plot
+    p = Plot()
+    # No exception showing an empty plot
+    p.show()
+
+
+def test_empty_plot():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    # No exception showing an empty plot
+    plot()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
(This is for the Matplotlib backend, I believe, default on my system.)
**Before**:
```
In [1]: from sympy.plotting.plot import Plot
   ...: p = Plot()

In [2]: p.show()
Traceback (most recent call last):

  File "<ipython-input-2-02f33f5f7a8f>", line 1, in <module>
    p.show()

  File "/nobackup/data/sympy/sympy/plotting/plot.py", line 187, in show
    self._backend.show()

  File "/nobackup/data/sympy/sympy/plotting/plot.py", line 1229, in show
    self.process_series()

  File "/nobackup/data/sympy/sympy/plotting/plot.py", line 1226, in process_series
    self._process_series(series, ax, parent)

  File "/nobackup/data/sympy/sympy/plotting/plot.py", line 1165, in _process_series
    ax.set_xlim(min(starts), max(ends))

ValueError: min() arg is an empty sequence
```

**Now**:

No ValueError

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Fixed `ValueError` raising when using `Plot.show()` with Matplotlib backend.
   * Fixed error for `plot`, `plot3d`, `plot_parametric`, `plot3d_parametric_line`, `plot3d_parametric_surface` when showing empty plot using Matplotlib backend.
<!-- END RELEASE NOTES -->
