### PR TITLE
Fortran Parser using Codegen AST 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet lfortran"
       addons:
         apt:
           packages:
@@ -78,7 +78,7 @@ matrix:
       # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet lfortran"
         - TEST_SAGE="true"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet lfortran"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet"
       addons:
         apt:
           packages:

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -179,9 +179,8 @@ doctest_list = [
     # ipython
     '*ipython*',
 
-    # antlr
-    'sympy/parsing/autolev',
-    'sympy/parsing/latex',
+    # antlr, lfortran
+    'sympy/parsing/',
 
     # matchpy
     '*rubi*',

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -138,7 +138,7 @@ test_list = [
     '*ipython*',
 
     # antlr, lfortran
-    'sympy/parsing/'',
+    'sympy/parsing/',
 
     # matchpy
     '*rubi*',

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -137,9 +137,8 @@ test_list = [
     # ipython
     '*ipython*',
 
-    # antlr
-    'sympy/parsing/tests/test_autolev',
-    'sympy/parsing/tests/test_latex',
+    # antlr, lfortran
+    'sympy/parsing/'',
 
     # matchpy
     '*rubi*',

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -90,6 +90,20 @@ change between releases, and become stricter, more relaxed, or some mix.
 
 .. autoclass:: sympy.parsing.latex.LaTeXParsingError
 
+`Fortran` Parsing Refrence
+---------------------------------
+
+.. module:: sympy.parsing.fortran.fortran_parser
+
+.. autoclass:: ASR2PyVisitor
+  :members:
+
+.. autofunction:: call_visitor_func
+
+.. autofunction:: call_visitor
+
+.. autofunction:: src_to_sympy
+
 Runtime Installation
 --------------------
 

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -90,15 +90,20 @@ change between releases, and become stricter, more relaxed, or some mix.
 
 .. autoclass:: sympy.parsing.latex.LaTeXParsingError
 
-`Fortran` Parsing Refrence
+
+SymPy Expression Reference
+--------------------------
+
+.. autoclass:: SymPyExpression
+  :members:
+
+`Fortran` Parsing Reference
 ---------------------------------
 
 .. module:: sympy.parsing.fortran.fortran_parser
 
 .. autoclass:: ASR2PyVisitor
   :members:
-
-.. autofunction:: call_visitor_func
 
 .. autofunction:: call_visitor
 

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -94,6 +94,8 @@ change between releases, and become stricter, more relaxed, or some mix.
 SymPy Expression Reference
 --------------------------
 
+.. module:: sympy.parsing.sym_expr
+
 .. autoclass:: SymPyExpression
   :members:
 

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ modules = [
     'sympy.parsing.autolev._antlr',
     'sympy.parsing.autolev.test-examples',
     'sympy.parsing.autolev.test-examples.pydy-example-repo',
+    'sympy.parsing.fortran',
     'sympy.parsing.latex',
     'sympy.parsing.latex._antlr',
     'sympy.physics',

--- a/sympy/parsing/fortran/__init__.py
+++ b/sympy/parsing/fortran/__init__.py
@@ -1,0 +1,2 @@
+
+"""Used for translating Fortran source code into a SymPy expression. """

--- a/sympy/parsing/fortran/fortran_parser.py
+++ b/sympy/parsing/fortran/fortran_parser.py
@@ -1,0 +1,458 @@
+from ast import (
+    Module, Assign, Name, Add, Sub, Div, Mult, BinOp, Call,
+    fix_missing_locations, arg, Store, Load, FunctionDef, arguments,
+    ImportFrom, alias, Str, keyword, NameConstant, Return
+)
+#External Dependecies
+#TODO: Find alternatives to remove astor
+from lfortran.asr import asr
+from lfortran.semantic.ast_to_asr import ast_to_asr
+from lfortran.ast import src_to_ast
+import astor
+
+"""
+This module contains all the necessary Classes and Function used to Parse Fortran
+code into SymPy expression
+
+The module and its API are currently under development and experimental.
+It is also dependent on LFortran for the ASR that is converted to SymPy syntax
+which is also under development.
+The module only supports the features currently supported by the LFortran ASR
+which will be updated as the development of LFortran and this module progresses.
+
+You might find unexpected bugs and exceptions while using the module, feel free
+to report them to the SymPy Issue Tracker
+
+The API for the module might also change while in development if better and more
+effective ways are discovered for the process
+
+Features Supported
+==================
+
+- Variable Declarations (integers and reals)
+- Assignment (only symbolic assignment, Arithmetic assignment not supported yet)
+- Function Definitions
+- Binary operations (including Addition, Substraction, Multiplication, Division)
+
+
+Notes
+=====
+
+The module currently depends on two external dependencies
+
+LFortran : Required to parse Fortran source code into ASR
+
+astor: Required to compile the python AST back to source code
+        Alternatives using SymPy's codegen module are being worked on to remove
+        the dependency
+
+Refrences
+=========
+
+.. [1] https://github.com/sympy/sympy/issues
+.. [2] https://gitlab.com/lfortran/lfortran
+.. [3] https://docs.lfortran.org/
+"""
+
+class ASR2PyVisitor(asr.ASTVisitor):
+    """
+    Visitor Class for LFortran ASR
+
+    It is a Visitor class derived from asr.ASRVisitor which visits all the nodes
+    of the LFortran ASR and createds correspondiong Python AST node for each
+    ASR node
+    """
+    def __init__(self):
+        """Initialize the Python AST with an empty Module"""
+        self.py_ast = Module(body = [])
+        fix_missing_locations(self.py_ast)
+
+    def visit_TranslationUnit(self, node):
+        """
+        Function to visit all the elements of the Translation Unit
+        created by LFortran ASR
+        """
+        for s in node.global_scope.symbols:
+            sym = node.global_scope.symbols[s]
+            self.visit(sym)
+        for item in node.items:
+            self.visit(item)
+
+    def visit_Assignment(self, node):
+        """Visitor Function for Assignment
+
+        Visits each Assignment is the LFortran ASR and creates corresponding
+        assignment for SymPy.
+
+        Notes
+        =====
+
+        The function currently only supports variable assignment and binary
+        operation assignments of varying multitudes
+
+        Raises
+        ======
+
+        NotImplementedError() when called for Numeric assignments or Arrays
+        """
+        #TODO: Arithmatic Assignment
+        if isinstance(node.target, asr.Variable):
+            target = node.target
+            value = node.value
+            if isinstance(value, asr.Variable):
+                new_node = Assign(
+                    targets = [
+                        Name(
+                            id = target.name,
+                            ctx = Store()
+                        )
+                    ],
+                    value = Name(
+                        id = value.name,
+                        ctx = Store()
+                    )
+                )
+            elif (type(value) == asr.BinOp):
+                exp_ast = call_visitor_func(value)
+                for expr in exp_ast.body:
+                    new_node = Assign(
+                        targets = [
+                            Name(
+                                id = target.name,
+                                ctx = Store()
+                            )
+                        ], value = expr
+                    )
+            else:
+                raise NotImplementedError("Numeric assignments not supported")
+        else:
+            raise NotImplementedError("Arrays not supported")
+        self.py_ast.body.append(new_node)
+        fix_missing_locations(self.py_ast)
+
+    def visit_BinOp(self, node):
+        """Visitor Function for Binary Operations
+
+        Visits each binary operation present in the LFortran ASR like addition,
+        substraction, multiplication,division and creates the operation node in
+        the Python AST
+
+        In case of more than one binary operations, the function calls the
+        call_visitor_func() function on the child nodes pertaining to the
+        binary operations recursively until all the operations have been included
+
+        Notes
+        =====
+
+        The function currently only supports binary operations with Variables or
+        other binary operation as nodes
+
+        Raises
+        ======
+
+        NotImplementedError() when called for Numeric assignments
+        """
+        #TODO: Integer Binary Operations
+        op = node.op
+        lhs = node.left
+        rhs = node.right
+
+        if isinstance(op, asr.Add):
+            bin_op = Add()
+        elif isinstance(op, asr.Sub):
+            bin_op = Sub()
+        elif isinstance(op, asr.Div):
+            bin_op = Div()
+        elif isinstance(op, asr.Mul):
+            bin_op = Mult()
+
+        if (type(lhs) == asr.Variable):
+            left_value = Name(
+                id = lhs.name,
+                ctx = Load()
+            )
+            if (type(rhs) == asr.Variable):
+                new_node = BinOp(
+                    left = left_value,
+                    op = bin_op,
+                    right = Name(
+                        id = rhs.name,
+                        ctx = Load()
+                    )
+                )
+            elif (type(rhs) == asr.BinOp):
+                r_exp_ast = call_visitor_func(rhs)
+                for expr in r_exp_ast.body:
+                    new_node = BinOp(
+                        left = left_value,
+                        op = bin_op,
+                        right = expr
+                    )
+            else:
+                raise NotImplementedError("Numeric Assignments not supported")
+        else:
+            l_exp_ast = call_visitor_func(lhs)
+            for exp in l_exp_ast.body:
+                left_value = exp
+            if (type(rhs) == asr.Variable):
+                new_node = BinOp(
+                    left = left_value,
+                    op = bin_op,
+                    right = Name(
+                        id = rhs.name,
+                        ctx = Load()
+                    )
+                )
+            elif(type(rhs) == asr.BinOp):
+                r_exp_ast = call_visitor_func(rhs)
+                for expr in r_exp_ast.body:
+                    new_node = BinOp(
+                        left = left_value,
+                        op = bin_op,
+                        right = expr
+                    )
+            else:
+                raise NotImplementedError("Numeric Assignments not supported")
+        self.py_ast.body.append(new_node)
+        fix_missing_locations(self.py_ast)
+
+    def visit_Variable(self, node):
+        """Visitor Function for Variable Declaration
+
+        Visits each variable declaration present in the ASR and creates a
+        Symbol declaration for each variable
+
+        Notes
+        =====
+        The functions currently only supports the declaration of integer and
+        real variables. Other data types are still under development.
+
+        Raises
+        ======
+
+        NotImplementedError() when called for unsupported data types
+        """
+        if isinstance(node.type, asr.Integer):
+            var_type = 'integer'
+        elif isinstance(node.type, asr.Real):
+            var_type = 'real'
+        else:
+            raise NotImplementedError("Data type not supported")
+
+        new_node = Assign(
+            targets = [
+                Name(
+                    id = node.name,
+                    ctx = Store()
+                )
+            ],
+            value = Call(
+                func = Name(
+                    id = 'Symbol',
+                    ctx = Load()
+                ),
+                args = [
+                    Str(node.name)
+                ],
+                keywords = [
+                    keyword(
+                        arg = var_type,
+                        value = NameConstant(value = True)
+                    )
+                ]
+            )
+        )
+        self.py_ast.body.append(new_node)
+        fix_missing_locations(self.py_ast)
+
+    def visit_Sequence(self, seq):
+        """Visitor Function for code sequence
+
+        Visits a code sequence/ block and calls the visitor function on all the
+        children of the code block to create corresponding code in python
+        """
+        py_seq = []
+        if seq is not None:
+            for node in seq:
+                expr = call_visitor_func(node)
+                for elem in expr.body:
+                    self.py_ast.append(elem)
+                    fix_missing_locations(self.py_ast)
+
+
+    def visit_Num(self, node):
+        """Visitor Function for Numbers in ASR
+
+        This function is currently under development and will be updated
+        with improvements in the LFortran ASR
+        """
+        #TODO:Numbers when the LFortran ASR is updated
+        #py_ast.append(Num(n=node.n))
+        #fix_missing_locations(self.py_ast)
+        pass
+
+    def visit_Function(self, node):
+        """Visitor Function for function Definitions
+
+        Visits each function definition present in the ASR and creates a
+        function definition node in the Python AST with all the elements of the
+        given function
+
+        The functions declares all the variables required as SymPy symbols in
+        the function before the function definition
+
+        This function also the call_visior_function to parse the contents of
+        the function body
+        """
+        # TODO: Return statement, variable declaration
+        fn_args =[]
+        fn_body = []
+        fn_name = node.name
+        for arg_iter in node.args:
+            fn_args.append(
+                arg(
+                    arg = arg_iter.name,
+                    annotation=None
+                )
+            )
+        for i in node.body:
+            fn_ast = call_visitor_func(i)
+        fn_body_expr = fn_ast.body
+        for sym in node.symtab.symbols:
+            decl = call_visitor_func(node.symtab.symbols[sym])
+            for symbols in decl.body:
+                self.py_ast.body.append(symbols)
+                fix_missing_locations(self.py_ast)
+        for elem in fn_body_expr:
+            fn_body.append(elem)
+        fn_return = Name(
+            id = node.return_var.name,
+            ctx = Load()
+        )
+        fn_body.append(
+            Return(
+                value = Name(
+                    id = fn_return,
+                    ctx = Store()
+                )
+            )
+        )
+        new_node = FunctionDef(
+            name = fn_name,
+            args = arguments(
+                args = fn_args,
+                vararg = None,
+                kwarg =None,
+                defaults = [],
+                kw_defaults = []
+            ),
+            decorator_list = [],
+            body = fn_body
+        )
+        self.py_ast.body.append(new_node)
+        fix_missing_locations(self.py_ast)
+
+    def ret_ast(self):
+        """Returns the AST"""
+        return self.py_ast
+
+def call_visitor(fort_node):
+    """Calls the AST Visitor on the Module
+
+    Thsi function is used to call the AST visitor for a program or module
+    It imports all the required modules and calls the visit() function
+    on the given node
+
+    Parameters
+    ==========
+
+    fort_node : <lfortran.asr.asr.Assignment object> or <lfortran.asr.asr.BinOp object>
+        The node for operation that the AST visitor is to be called upon
+
+
+    Examples
+    ========
+
+    >>> from sympy.parsing.fortran_parser import src_to_sympy
+    >>> src = "integer :: a"
+    >>> print(src_to_sympy(src))
+    from sympy import Symbol
+    a = Symbol('a', integer=True)
+    >>> src2 = '''\
+    ... real :: a, b, c
+    ... c = a + b
+    ... '''
+    >>> print(src_to_sympy(src2))
+    from sympy import Symbol
+    a = Symbol('a', real=True)
+    b = Symbol('b', real=True)
+    c = Symbol('c', real=True)
+    c = a + b
+
+    Returns
+    =======
+
+    res_ast : <_ast.Module object>
+        The root node the Python AST for the provided ASR node
+    """
+    v = ASR2PyVisitor()
+    v.py_ast.body.append(
+        ImportFrom(
+            module = 'sympy',
+            names = [
+                alias(
+                    name = 'Symbol',
+                    asname = None
+                )
+            ],
+            level = 0
+        )
+    )
+    v.visit(fort_node)
+    res_ast = v.ret_ast()
+    fix_missing_locations(res_ast)
+    return res_ast
+
+def call_visitor_func(fort_node):
+    """Calls the AST Visitor on an ASR Node
+
+    This function is used to call the AST Visitor on a node in the module
+    for dealing with multiple binary operations or parsing function body
+
+
+    Parameters
+    ==========
+
+    fort_node : <class 'lfortran.asr.asr.TranslationUnit'>
+        The translation Unit node for the Fortran ASR which acts as the root node
+
+    Returns
+    =======
+
+    res_ast : <_ast.Module object>
+        The root node the Python AST for the provided ASR node
+    """
+    v = ASR2PyVisitor()
+    v.visit(fort_node)
+    res_ast = v.ret_ast()
+    return res_ast
+
+def src_to_sympy(src):
+    """Wrapper function to convert the given Fortran source code to SymPy Expressions
+
+    Parameters
+    ==========
+
+    src : string
+        A string with the Fortran source code
+
+    Returns
+    =======
+
+    py_src : string
+        A string with the python source code compatible with SymPy
+    """
+    a_ast = src_to_ast(src,translation_unit=False)
+    a = ast_to_asr(a_ast)
+    py_src = astor.to_source(call_visitor(a))
+    return py_src

--- a/sympy/parsing/fortran/fortran_parser.py
+++ b/sympy/parsing/fortran/fortran_parser.py
@@ -1,50 +1,50 @@
-from ast import (
-    Module, Assign, Name, Add, Sub, Div, Mult, BinOp, Call,
-    fix_missing_locations, arg, Store, Load, FunctionDef, arguments,
-    ImportFrom, alias, Str, keyword, NameConstant, Return
+from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
+                               Return, FunctionDefinition, Assignment)
+from sympy.core import Add, Mul, Integer, Float
+from sympy import Symbol
+from sympy.external import import_module
+
+lfortran = import_module(
+    'lfortran',
+    warn_not_installed=True
 )
-#External Dependecies
-#TODO: Find alternatives to remove astor
-from lfortran.asr import asr
-from lfortran.semantic.ast_to_asr import ast_to_asr
-from lfortran.ast import src_to_ast
-import astor
+
+asr_mod = lfortran.asr
+asr = lfortran.asr.asr
+src_to_ast = lfortran.ast.src_to_ast
+ast_to_asr = lfortran.semantic.ast_to_asr.ast_to_asr
 
 """
-This module contains all the necessary Classes and Function used to Parse Fortran
-code into SymPy expression
+This module contains all the necessary Classes and Function used to Parse
+Fortran code into SymPy expression
 
 The module and its API are currently under development and experimental.
 It is also dependent on LFortran for the ASR that is converted to SymPy syntax
 which is also under development.
 The module only supports the features currently supported by the LFortran ASR
-which will be updated as the development of LFortran and this module progresses.
+which will be updated as the development of LFortran and this module progresses
 
 You might find unexpected bugs and exceptions while using the module, feel free
 to report them to the SymPy Issue Tracker
 
-The API for the module might also change while in development if better and more
-effective ways are discovered for the process
+The API for the module might also change while in development if better and
+more effective ways are discovered for the process
 
 Features Supported
 ==================
 
 - Variable Declarations (integers and reals)
-- Assignment (only symbolic assignment, Arithmetic assignment not supported yet)
 - Function Definitions
-- Binary operations (including Addition, Substraction, Multiplication, Division)
+- Assignments and Basic Binary Operations
 
 
 Notes
 =====
 
-The module currently depends on two external dependencies
+The module depends on an external dependency
 
 LFortran : Required to parse Fortran source code into ASR
 
-astor: Required to compile the python AST back to source code
-        Alternatives using SymPy's codegen module are being worked on to remove
-        the dependency
 
 Refrences
 =========
@@ -52,20 +52,23 @@ Refrences
 .. [1] https://github.com/sympy/sympy/issues
 .. [2] https://gitlab.com/lfortran/lfortran
 .. [3] https://docs.lfortran.org/
+
 """
+
 
 class ASR2PyVisitor(asr.ASTVisitor):
     """
     Visitor Class for LFortran ASR
 
-    It is a Visitor class derived from asr.ASRVisitor which visits all the nodes
-    of the LFortran ASR and createds correspondiong Python AST node for each
+    It is a Visitor class derived from asr.ASRVisitor which visits all the
+    nodes of the LFortran ASR and creates corresponding AST node for each
     ASR node
+
     """
+
     def __init__(self):
-        """Initialize the Python AST with an empty Module"""
-        self.py_ast = Module(body = [])
-        fix_missing_locations(self.py_ast)
+        """Initialize the Parser"""
+        self._py_ast = []
 
     def visit_TranslationUnit(self, node):
         """
@@ -88,133 +91,97 @@ class ASR2PyVisitor(asr.ASTVisitor):
         =====
 
         The function currently only supports variable assignment and binary
-        operation assignments of varying multitudes
+        operation assignments of varying multitudes. Any type of numberS or
+        array is not supported.
 
         Raises
         ======
 
         NotImplementedError() when called for Numeric assignments or Arrays
+
         """
-        #TODO: Arithmatic Assignment
+        # TODO: Arithmatic Assignment
         if isinstance(node.target, asr.Variable):
             target = node.target
             value = node.value
             if isinstance(value, asr.Variable):
-                new_node = Assign(
-                    targets = [
-                        Name(
-                            id = target.name,
-                            ctx = Store()
-                        )
-                    ],
-                    value = Name(
-                        id = value.name,
-                        ctx = Store()
-                    )
-                )
-            elif (type(value) == asr.BinOp):
-                exp_ast = call_visitor_func(value)
-                for expr in exp_ast.body:
-                    new_node = Assign(
-                        targets = [
-                            Name(
-                                id = target.name,
-                                ctx = Store()
+                new_node = Assignment(
+                        Variable(
+                                target.name
+                            ),
+                        Variable(
+                                value.name
                             )
-                        ], value = expr
                     )
+            elif (type(value) == asr.BinOp):
+                exp_ast = call_visitor(value)
+                for expr in exp_ast:
+                    new_node = Assignment(
+                            Variable(target.name),
+                            expr
+                        )
             else:
                 raise NotImplementedError("Numeric assignments not supported")
         else:
             raise NotImplementedError("Arrays not supported")
-        self.py_ast.body.append(new_node)
-        fix_missing_locations(self.py_ast)
+        self._py_ast.append(new_node)
 
     def visit_BinOp(self, node):
         """Visitor Function for Binary Operations
 
         Visits each binary operation present in the LFortran ASR like addition,
-        substraction, multiplication,division and creates the operation node in
-        the Python AST
+        subtraction, multiplication, division and creates the corresponding
+        operation node in SymPy's AST
 
         In case of more than one binary operations, the function calls the
-        call_visitor_func() function on the child nodes pertaining to the
-        binary operations recursively until all the operations have been included
+        call_visitor() function on the child nodes of the binary operations
+        recursively until all the operations have been processed.
 
         Notes
         =====
 
-        The function currently only supports binary operations with Variables or
-        other binary operation as nodes
+        The function currently only supports binary operations with Variables
+        or other binary operations. Numerics are not supported as of yet.
 
         Raises
         ======
 
         NotImplementedError() when called for Numeric assignments
+
         """
-        #TODO: Integer Binary Operations
+        # TODO: Integer Binary Operations
         op = node.op
         lhs = node.left
         rhs = node.right
 
-        if isinstance(op, asr.Add):
-            bin_op = Add()
-        elif isinstance(op, asr.Sub):
-            bin_op = Sub()
-        elif isinstance(op, asr.Div):
-            bin_op = Div()
-        elif isinstance(op, asr.Mul):
-            bin_op = Mult()
-
         if (type(lhs) == asr.Variable):
-            left_value = Name(
-                id = lhs.name,
-                ctx = Load()
-            )
-            if (type(rhs) == asr.Variable):
-                new_node = BinOp(
-                    left = left_value,
-                    op = bin_op,
-                    right = Name(
-                        id = rhs.name,
-                        ctx = Load()
-                    )
-                )
-            elif (type(rhs) == asr.BinOp):
-                r_exp_ast = call_visitor_func(rhs)
-                for expr in r_exp_ast.body:
-                    new_node = BinOp(
-                        left = left_value,
-                        op = bin_op,
-                        right = expr
-                    )
-            else:
-                raise NotImplementedError("Numeric Assignments not supported")
-        else:
-            l_exp_ast = call_visitor_func(lhs)
-            for exp in l_exp_ast.body:
+            left_value = Symbol(lhs.name)
+        elif(type(lhs) == asr.BinOp):
+            l_exp_ast = call_visitor(lhs)
+            for exp in l_exp_ast:
                 left_value = exp
-            if (type(rhs) == asr.Variable):
-                new_node = BinOp(
-                    left = left_value,
-                    op = bin_op,
-                    right = Name(
-                        id = rhs.name,
-                        ctx = Load()
-                    )
-                )
-            elif(type(rhs) == asr.BinOp):
-                r_exp_ast = call_visitor_func(rhs)
-                for expr in r_exp_ast.body:
-                    new_node = BinOp(
-                        left = left_value,
-                        op = bin_op,
-                        right = expr
-                    )
-            else:
-                raise NotImplementedError("Numeric Assignments not supported")
-        self.py_ast.body.append(new_node)
-        fix_missing_locations(self.py_ast)
+        else:
+            raise NotImplementedError("Numbers Currently not supported")
+
+        if (type(rhs) == asr.Variable):
+            right_value = Symbol(rhs.name)
+        elif(type(rhs) == asr.BinOp):
+            r_exp_ast = call_visitor(rhs)
+            for exp in r_exp_ast:
+                right_value = exp
+        else:
+            raise NotImplementedError("Numbers Currently not supported")
+
+        if isinstance(op, asr.Add):
+            new_node = Add(left_value, right_value)
+        elif isinstance(op, asr.Sub):
+            new_node = Add(left_value, -right_value)
+        elif isinstance(op, asr.Div):
+            new_node = Mul(left_value, 1/right_value)
+        elif isinstance(op, asr.Mul):
+            new_node = Mul(left_value, right_value)
+
+        self._py_ast.append(new_node)
 
     def visit_Variable(self, node):
         """Visitor Function for Variable Declaration
@@ -224,71 +191,54 @@ class ASR2PyVisitor(asr.ASTVisitor):
 
         Notes
         =====
-        The functions currently only supports the declaration of integer and
+
+        The functions currently only support declaration of integer and
         real variables. Other data types are still under development.
 
         Raises
         ======
 
         NotImplementedError() when called for unsupported data types
+
         """
         if isinstance(node.type, asr.Integer):
-            var_type = 'integer'
+            var_type = IntBaseType(String('integer'))
+            value = Integer(0)
         elif isinstance(node.type, asr.Real):
-            var_type = 'real'
+            var_type = FloatBaseType(String('real'))
+            value = Float(0.0)
         else:
             raise NotImplementedError("Data type not supported")
 
-        new_node = Assign(
-            targets = [
-                Name(
-                    id = node.name,
-                    ctx = Store()
-                )
-            ],
-            value = Call(
-                func = Name(
-                    id = 'Symbol',
-                    ctx = Load()
-                ),
-                args = [
-                    Str(node.name)
-                ],
-                keywords = [
-                    keyword(
-                        arg = var_type,
-                        value = NameConstant(value = True)
-                    )
-                ]
+        if not (node.intent == 'in'):
+            new_node = Variable(
+                node.name
+            ).as_Declaration(
+                type = var_type,
+                value = value
             )
-        )
-        self.py_ast.body.append(new_node)
-        fix_missing_locations(self.py_ast)
+            self._py_ast.append(new_node)
 
     def visit_Sequence(self, seq):
         """Visitor Function for code sequence
 
         Visits a code sequence/ block and calls the visitor function on all the
         children of the code block to create corresponding code in python
+
         """
-        py_seq = []
         if seq is not None:
             for node in seq:
-                expr = call_visitor_func(node)
-                for elem in expr.body:
-                    self.py_ast.append(elem)
-                    fix_missing_locations(self.py_ast)
-
+                self._py_ast.append(call_visitor(node))
 
     def visit_Num(self, node):
         """Visitor Function for Numbers in ASR
 
         This function is currently under development and will be updated
         with improvements in the LFortran ASR
+
         """
-        #TODO:Numbers when the LFortran ASR is updated
-        #py_ast.append(Num(n=node.n))
-        #fix_missing_locations(self.py_ast)
+        # TODO:Numbers when the LFortran ASR is updated
+        # self._py_ast.append(Integer(node.n))
         pass
 
     def visit_Function(self, node):
@@ -298,11 +248,12 @@ class ASR2PyVisitor(asr.ASTVisitor):
         function definition node in the Python AST with all the elements of the
         given function
 
-        The functions declares all the variables required as SymPy symbols in
+        The functions declare all the variables required as SymPy symbols in
         the function before the function definition
 
         This function also the call_visior_function to parse the contents of
         the function body
+
         """
         # TODO: Return statement, variable declaration
         fn_args =[]
@@ -310,132 +261,73 @@ class ASR2PyVisitor(asr.ASTVisitor):
         fn_name = node.name
         for arg_iter in node.args:
             fn_args.append(
-                arg(
-                    arg = arg_iter.name,
-                    annotation=None
+                Variable(
+                    arg_iter.name
                 )
             )
         for i in node.body:
-            fn_ast = call_visitor_func(i)
-        fn_body_expr = fn_ast.body
+            fn_ast = call_visitor(i)
+        try:
+            fn_body_expr = fn_ast
+        except UnboundLocalError:
+            fn_body_expr = []
         for sym in node.symtab.symbols:
-            decl = call_visitor_func(node.symtab.symbols[sym])
-            for symbols in decl.body:
-                self.py_ast.body.append(symbols)
-                fix_missing_locations(self.py_ast)
+            decl = call_visitor(node.symtab.symbols[sym])
+            for symbols in decl:
+                fn_body.append(symbols)
         for elem in fn_body_expr:
             fn_body.append(elem)
-        fn_return = Name(
-            id = node.return_var.name,
-            ctx = Load()
-        )
         fn_body.append(
             Return(
-                value = Name(
-                    id = fn_return,
-                    ctx = Store()
+                Variable(
+                    node.return_var.name
                 )
             )
         )
-        new_node = FunctionDef(
-            name = fn_name,
-            args = arguments(
-                args = fn_args,
-                vararg = None,
-                kwarg =None,
-                defaults = [],
-                kw_defaults = []
-            ),
-            decorator_list = [],
-            body = fn_body
-        )
-        self.py_ast.body.append(new_node)
-        fix_missing_locations(self.py_ast)
+        if isinstance(node.return_var.type, asr.Integer):
+            ret_type = IntBaseType(String('integer'))
+        elif isinstance(node.return_var.type, asr.Real):
+            ret_type = FloatBaseType(String('real'))
+        else:
+            raise NotImplementedError("Data type not supported")
+        new_node = FunctionDefinition(
+                    return_type = ret_type,
+                    name = fn_name,
+                    parameters = fn_args,
+                    body = fn_body
+                )
+        self._py_ast.append(new_node)
 
     def ret_ast(self):
-        """Returns the AST"""
-        return self.py_ast
+        """Returns the AST nodes"""
+        return self._py_ast
+
 
 def call_visitor(fort_node):
     """Calls the AST Visitor on the Module
 
-    Thsi function is used to call the AST visitor for a program or module
+    This function is used to call the AST visitor for a program or module
     It imports all the required modules and calls the visit() function
     on the given node
 
     Parameters
     ==========
 
-    fort_node : <lfortran.asr.asr.Assignment object> or <lfortran.asr.asr.BinOp object>
-        The node for operation that the AST visitor is to be called upon
-
-
-    Examples
-    ========
-
-    >>> from sympy.parsing.fortran_parser import src_to_sympy
-    >>> src = "integer :: a"
-    >>> print(src_to_sympy(src))
-    from sympy import Symbol
-    a = Symbol('a', integer=True)
-    >>> src2 = '''\
-    ... real :: a, b, c
-    ... c = a + b
-    ... '''
-    >>> print(src_to_sympy(src2))
-    from sympy import Symbol
-    a = Symbol('a', real=True)
-    b = Symbol('b', real=True)
-    c = Symbol('c', real=True)
-    c = a + b
+    fort_node : LFortran ASR object
+        Node for the operation for which the NodeVisitor is called
 
     Returns
     =======
 
-    res_ast : <_ast.Module object>
-        The root node the Python AST for the provided ASR node
-    """
-    v = ASR2PyVisitor()
-    v.py_ast.body.append(
-        ImportFrom(
-            module = 'sympy',
-            names = [
-                alias(
-                    name = 'Symbol',
-                    asname = None
-                )
-            ],
-            level = 0
-        )
-    )
-    v.visit(fort_node)
-    res_ast = v.ret_ast()
-    fix_missing_locations(res_ast)
-    return res_ast
+    res_ast : list
+        list of sympy AST Nodes
 
-def call_visitor_func(fort_node):
-    """Calls the AST Visitor on an ASR Node
-
-    This function is used to call the AST Visitor on a node in the module
-    for dealing with multiple binary operations or parsing function body
-
-
-    Parameters
-    ==========
-
-    fort_node : <class 'lfortran.asr.asr.TranslationUnit'>
-        The translation Unit node for the Fortran ASR which acts as the root node
-
-    Returns
-    =======
-
-    res_ast : <_ast.Module object>
-        The root node the Python AST for the provided ASR node
     """
     v = ASR2PyVisitor()
     v.visit(fort_node)
     res_ast = v.ret_ast()
     return res_ast
+
 
 def src_to_sympy(src):
     """Wrapper function to convert the given Fortran source code to SymPy Expressions
@@ -451,8 +343,9 @@ def src_to_sympy(src):
 
     py_src : string
         A string with the python source code compatible with SymPy
+
     """
     a_ast = src_to_ast(src,translation_unit=False)
     a = ast_to_asr(a_ast)
-    py_src = astor.to_source(call_visitor(a))
+    py_src = call_visitor(a)
     return py_src

--- a/sympy/parsing/fortran/fortran_parser.py
+++ b/sympy/parsing/fortran/fortran_parser.py
@@ -3,305 +3,305 @@ from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
 from sympy.core import Add, Mul, Integer, Float
 from sympy import Symbol
 from sympy.external import import_module
+lfortran = import_module('lfortran')
 
-lfortran = import_module(
-    'lfortran',
-    warn_not_installed=True
-)
+if lfortran:
+    asr_mod = lfortran.asr
+    asr = lfortran.asr.asr
+    src_to_ast = lfortran.ast.src_to_ast
+    ast_to_asr = lfortran.semantic.ast_to_asr.ast_to_asr
 
-asr_mod = lfortran.asr
-asr = lfortran.asr.asr
-src_to_ast = lfortran.ast.src_to_ast
-ast_to_asr = lfortran.semantic.ast_to_asr.ast_to_asr
-
-"""
-This module contains all the necessary Classes and Function used to Parse
-Fortran code into SymPy expression
-
-The module and its API are currently under development and experimental.
-It is also dependent on LFortran for the ASR that is converted to SymPy syntax
-which is also under development.
-The module only supports the features currently supported by the LFortran ASR
-which will be updated as the development of LFortran and this module progresses
-
-You might find unexpected bugs and exceptions while using the module, feel free
-to report them to the SymPy Issue Tracker
-
-The API for the module might also change while in development if better and
-more effective ways are discovered for the process
-
-Features Supported
-==================
-
-- Variable Declarations (integers and reals)
-- Function Definitions
-- Assignments and Basic Binary Operations
-
-
-Notes
-=====
-
-The module depends on an external dependency
-
-LFortran : Required to parse Fortran source code into ASR
-
-
-Refrences
-=========
-
-.. [1] https://github.com/sympy/sympy/issues
-.. [2] https://gitlab.com/lfortran/lfortran
-.. [3] https://docs.lfortran.org/
-
-"""
-
-
-class ASR2PyVisitor(asr.ASTVisitor):
     """
-    Visitor Class for LFortran ASR
+    This module contains all the necessary Classes and Function used to Parse
+    Fortran code into SymPy expression
 
-    It is a Visitor class derived from asr.ASRVisitor which visits all the
-    nodes of the LFortran ASR and creates corresponding AST node for each
-    ASR node
+    The module and its API are currently under development and experimental.
+    It is also dependent on LFortran for the ASR that is converted to SymPy syntax
+    which is also under development.
+    The module only supports the features currently supported by the LFortran ASR
+    which will be updated as the development of LFortran and this module progresses
+
+    You might find unexpected bugs and exceptions while using the module, feel free
+    to report them to the SymPy Issue Tracker
+
+    The API for the module might also change while in development if better and
+    more effective ways are discovered for the process
+
+    Features Supported
+    ==================
+
+    - Variable Declarations (integers and reals)
+    - Function Definitions
+    - Assignments and Basic Binary Operations
+
+
+    Notes
+    =====
+
+    The module depends on an external dependency
+
+    LFortran : Required to parse Fortran source code into ASR
+
+
+    Refrences
+    =========
+
+    .. [1] https://github.com/sympy/sympy/issues
+    .. [2] https://gitlab.com/lfortran/lfortran
+    .. [3] https://docs.lfortran.org/
 
     """
 
-    def __init__(self):
-        """Initialize the Parser"""
-        self._py_ast = []
 
-    def visit_TranslationUnit(self, node):
+    class ASR2PyVisitor(asr.ASTVisitor):
         """
-        Function to visit all the elements of the Translation Unit
-        created by LFortran ASR
-        """
-        for s in node.global_scope.symbols:
-            sym = node.global_scope.symbols[s]
-            self.visit(sym)
-        for item in node.items:
-            self.visit(item)
+        Visitor Class for LFortran ASR
 
-    def visit_Assignment(self, node):
-        """Visitor Function for Assignment
-
-        Visits each Assignment is the LFortran ASR and creates corresponding
-        assignment for SymPy.
-
-        Notes
-        =====
-
-        The function currently only supports variable assignment and binary
-        operation assignments of varying multitudes. Any type of numberS or
-        array is not supported.
-
-        Raises
-        ======
-
-        NotImplementedError() when called for Numeric assignments or Arrays
+        It is a Visitor class derived from asr.ASRVisitor which visits all the
+        nodes of the LFortran ASR and creates corresponding AST node for each
+        ASR node
 
         """
-        # TODO: Arithmatic Assignment
-        if isinstance(node.target, asr.Variable):
-            target = node.target
-            value = node.value
-            if isinstance(value, asr.Variable):
-                new_node = Assignment(
-                        Variable(
-                                target.name
-                            ),
-                        Variable(
-                                value.name
-                            )
-                    )
-            elif (type(value) == asr.BinOp):
-                exp_ast = call_visitor(value)
-                for expr in exp_ast:
+
+        def __init__(self):
+            """Initialize the Parser"""
+            self._py_ast = []
+
+        def visit_TranslationUnit(self, node):
+            """
+            Function to visit all the elements of the Translation Unit
+            created by LFortran ASR
+            """
+            for s in node.global_scope.symbols:
+                sym = node.global_scope.symbols[s]
+                self.visit(sym)
+            for item in node.items:
+                self.visit(item)
+
+        def visit_Assignment(self, node):
+            """Visitor Function for Assignment
+
+            Visits each Assignment is the LFortran ASR and creates corresponding
+            assignment for SymPy.
+
+            Notes
+            =====
+
+            The function currently only supports variable assignment and binary
+            operation assignments of varying multitudes. Any type of numberS or
+            array is not supported.
+
+            Raises
+            ======
+
+            NotImplementedError() when called for Numeric assignments or Arrays
+
+            """
+            # TODO: Arithmatic Assignment
+            if isinstance(node.target, asr.Variable):
+                target = node.target
+                value = node.value
+                if isinstance(value, asr.Variable):
                     new_node = Assignment(
-                            Variable(target.name),
-                            expr
+                            Variable(
+                                    target.name
+                                ),
+                            Variable(
+                                    value.name
+                                )
                         )
+                elif (type(value) == asr.BinOp):
+                    exp_ast = call_visitor(value)
+                    for expr in exp_ast:
+                        new_node = Assignment(
+                                Variable(target.name),
+                                expr
+                            )
+                else:
+                    raise NotImplementedError("Numeric assignments not supported")
             else:
-                raise NotImplementedError("Numeric assignments not supported")
-        else:
-            raise NotImplementedError("Arrays not supported")
-        self._py_ast.append(new_node)
-
-    def visit_BinOp(self, node):
-        """Visitor Function for Binary Operations
-
-        Visits each binary operation present in the LFortran ASR like addition,
-        subtraction, multiplication, division and creates the corresponding
-        operation node in SymPy's AST
-
-        In case of more than one binary operations, the function calls the
-        call_visitor() function on the child nodes of the binary operations
-        recursively until all the operations have been processed.
-
-        Notes
-        =====
-
-        The function currently only supports binary operations with Variables
-        or other binary operations. Numerics are not supported as of yet.
-
-        Raises
-        ======
-
-        NotImplementedError() when called for Numeric assignments
-
-        """
-        # TODO: Integer Binary Operations
-        op = node.op
-        lhs = node.left
-        rhs = node.right
-
-        if (type(lhs) == asr.Variable):
-            left_value = Symbol(lhs.name)
-        elif(type(lhs) == asr.BinOp):
-            l_exp_ast = call_visitor(lhs)
-            for exp in l_exp_ast:
-                left_value = exp
-        else:
-            raise NotImplementedError("Numbers Currently not supported")
-
-        if (type(rhs) == asr.Variable):
-            right_value = Symbol(rhs.name)
-        elif(type(rhs) == asr.BinOp):
-            r_exp_ast = call_visitor(rhs)
-            for exp in r_exp_ast:
-                right_value = exp
-        else:
-            raise NotImplementedError("Numbers Currently not supported")
-
-        if isinstance(op, asr.Add):
-            new_node = Add(left_value, right_value)
-        elif isinstance(op, asr.Sub):
-            new_node = Add(left_value, -right_value)
-        elif isinstance(op, asr.Div):
-            new_node = Mul(left_value, 1/right_value)
-        elif isinstance(op, asr.Mul):
-            new_node = Mul(left_value, right_value)
-
-        self._py_ast.append(new_node)
-
-    def visit_Variable(self, node):
-        """Visitor Function for Variable Declaration
-
-        Visits each variable declaration present in the ASR and creates a
-        Symbol declaration for each variable
-
-        Notes
-        =====
-
-        The functions currently only support declaration of integer and
-        real variables. Other data types are still under development.
-
-        Raises
-        ======
-
-        NotImplementedError() when called for unsupported data types
-
-        """
-        if isinstance(node.type, asr.Integer):
-            var_type = IntBaseType(String('integer'))
-            value = Integer(0)
-        elif isinstance(node.type, asr.Real):
-            var_type = FloatBaseType(String('real'))
-            value = Float(0.0)
-        else:
-            raise NotImplementedError("Data type not supported")
-
-        if not (node.intent == 'in'):
-            new_node = Variable(
-                node.name
-            ).as_Declaration(
-                type = var_type,
-                value = value
-            )
+                raise NotImplementedError("Arrays not supported")
             self._py_ast.append(new_node)
 
-    def visit_Sequence(self, seq):
-        """Visitor Function for code sequence
+        def visit_BinOp(self, node):
+            """Visitor Function for Binary Operations
 
-        Visits a code sequence/ block and calls the visitor function on all the
-        children of the code block to create corresponding code in python
+            Visits each binary operation present in the LFortran ASR like addition,
+            subtraction, multiplication, division and creates the corresponding
+            operation node in SymPy's AST
 
-        """
-        if seq is not None:
-            for node in seq:
-                self._py_ast.append(call_visitor(node))
+            In case of more than one binary operations, the function calls the
+            call_visitor() function on the child nodes of the binary operations
+            recursively until all the operations have been processed.
 
-    def visit_Num(self, node):
-        """Visitor Function for Numbers in ASR
+            Notes
+            =====
 
-        This function is currently under development and will be updated
-        with improvements in the LFortran ASR
+            The function currently only supports binary operations with Variables
+            or other binary operations. Numerics are not supported as of yet.
 
-        """
-        # TODO:Numbers when the LFortran ASR is updated
-        # self._py_ast.append(Integer(node.n))
-        pass
+            Raises
+            ======
 
-    def visit_Function(self, node):
-        """Visitor Function for function Definitions
+            NotImplementedError() when called for Numeric assignments
 
-        Visits each function definition present in the ASR and creates a
-        function definition node in the Python AST with all the elements of the
-        given function
+            """
+            # TODO: Integer Binary Operations
+            op = node.op
+            lhs = node.left
+            rhs = node.right
 
-        The functions declare all the variables required as SymPy symbols in
-        the function before the function definition
+            if (type(lhs) == asr.Variable):
+                left_value = Symbol(lhs.name)
+            elif(type(lhs) == asr.BinOp):
+                l_exp_ast = call_visitor(lhs)
+                for exp in l_exp_ast:
+                    left_value = exp
+            else:
+                raise NotImplementedError("Numbers Currently not supported")
 
-        This function also the call_visior_function to parse the contents of
-        the function body
+            if (type(rhs) == asr.Variable):
+                right_value = Symbol(rhs.name)
+            elif(type(rhs) == asr.BinOp):
+                r_exp_ast = call_visitor(rhs)
+                for exp in r_exp_ast:
+                    right_value = exp
+            else:
+                raise NotImplementedError("Numbers Currently not supported")
 
-        """
-        # TODO: Return statement, variable declaration
-        fn_args =[]
-        fn_body = []
-        fn_name = node.name
-        for arg_iter in node.args:
-            fn_args.append(
-                Variable(
-                    arg_iter.name
+            if isinstance(op, asr.Add):
+                new_node = Add(left_value, right_value)
+            elif isinstance(op, asr.Sub):
+                new_node = Add(left_value, -right_value)
+            elif isinstance(op, asr.Div):
+                new_node = Mul(left_value, 1/right_value)
+            elif isinstance(op, asr.Mul):
+                new_node = Mul(left_value, right_value)
+
+            self._py_ast.append(new_node)
+
+        def visit_Variable(self, node):
+            """Visitor Function for Variable Declaration
+
+            Visits each variable declaration present in the ASR and creates a
+            Symbol declaration for each variable
+
+            Notes
+            =====
+
+            The functions currently only support declaration of integer and
+            real variables. Other data types are still under development.
+
+            Raises
+            ======
+
+            NotImplementedError() when called for unsupported data types
+
+            """
+            if isinstance(node.type, asr.Integer):
+                var_type = IntBaseType(String('integer'))
+                value = Integer(0)
+            elif isinstance(node.type, asr.Real):
+                var_type = FloatBaseType(String('real'))
+                value = Float(0.0)
+            else:
+                raise NotImplementedError("Data type not supported")
+
+            if not (node.intent == 'in'):
+                new_node = Variable(
+                    node.name
+                ).as_Declaration(
+                    type = var_type,
+                    value = value
+                )
+                self._py_ast.append(new_node)
+
+        def visit_Sequence(self, seq):
+            """Visitor Function for code sequence
+
+            Visits a code sequence/ block and calls the visitor function on all the
+            children of the code block to create corresponding code in python
+
+            """
+            if seq is not None:
+                for node in seq:
+                    self._py_ast.append(call_visitor(node))
+
+        def visit_Num(self, node):
+            """Visitor Function for Numbers in ASR
+
+            This function is currently under development and will be updated
+            with improvements in the LFortran ASR
+
+            """
+            # TODO:Numbers when the LFortran ASR is updated
+            # self._py_ast.append(Integer(node.n))
+            pass
+
+        def visit_Function(self, node):
+            """Visitor Function for function Definitions
+
+            Visits each function definition present in the ASR and creates a
+            function definition node in the Python AST with all the elements of the
+            given function
+
+            The functions declare all the variables required as SymPy symbols in
+            the function before the function definition
+
+            This function also the call_visior_function to parse the contents of
+            the function body
+
+            """
+            # TODO: Return statement, variable declaration
+            fn_args =[]
+            fn_body = []
+            fn_name = node.name
+            for arg_iter in node.args:
+                fn_args.append(
+                    Variable(
+                        arg_iter.name
+                    )
+                )
+            for i in node.body:
+                fn_ast = call_visitor(i)
+            try:
+                fn_body_expr = fn_ast
+            except UnboundLocalError:
+                fn_body_expr = []
+            for sym in node.symtab.symbols:
+                decl = call_visitor(node.symtab.symbols[sym])
+                for symbols in decl:
+                    fn_body.append(symbols)
+            for elem in fn_body_expr:
+                fn_body.append(elem)
+            fn_body.append(
+                Return(
+                    Variable(
+                        node.return_var.name
+                    )
                 )
             )
-        for i in node.body:
-            fn_ast = call_visitor(i)
-        try:
-            fn_body_expr = fn_ast
-        except UnboundLocalError:
-            fn_body_expr = []
-        for sym in node.symtab.symbols:
-            decl = call_visitor(node.symtab.symbols[sym])
-            for symbols in decl:
-                fn_body.append(symbols)
-        for elem in fn_body_expr:
-            fn_body.append(elem)
-        fn_body.append(
-            Return(
-                Variable(
-                    node.return_var.name
-                )
-            )
-        )
-        if isinstance(node.return_var.type, asr.Integer):
-            ret_type = IntBaseType(String('integer'))
-        elif isinstance(node.return_var.type, asr.Real):
-            ret_type = FloatBaseType(String('real'))
-        else:
-            raise NotImplementedError("Data type not supported")
-        new_node = FunctionDefinition(
-                    return_type = ret_type,
-                    name = fn_name,
-                    parameters = fn_args,
-                    body = fn_body
-                )
-        self._py_ast.append(new_node)
+            if isinstance(node.return_var.type, asr.Integer):
+                ret_type = IntBaseType(String('integer'))
+            elif isinstance(node.return_var.type, asr.Real):
+                ret_type = FloatBaseType(String('real'))
+            else:
+                raise NotImplementedError("Data type not supported")
+            new_node = FunctionDefinition(
+                        return_type = ret_type,
+                        name = fn_name,
+                        parameters = fn_args,
+                        body = fn_body
+                    )
+            self._py_ast.append(new_node)
 
-    def ret_ast(self):
-        """Returns the AST nodes"""
-        return self._py_ast
-
+        def ret_ast(self):
+            """Returns the AST nodes"""
+            return self._py_ast
+else:
+    class ASR2PyVisitor():
+        def __init__(self, *args, **kwargs):
+            raise ImportError('lfortran not available')
 
 def call_visitor(fort_node):
     """Calls the AST Visitor on the Module

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -1,0 +1,247 @@
+from sympy.parsing.fortran.fortran_parser import src_to_sympy
+from sympy.printing import pycode, ccode, fcode
+
+
+class SymPyExpression(object):
+    """Class to store and handle SymPy expressions
+
+    This class will hold SymPy Expressions and handle the API for the
+    conversion to and from different languages.
+
+    It works with the C and the Fortran Parser to generate SymPy expressions
+    which are stored here and which can be converted to multiple language's
+    source code.
+
+    Notes
+    =====
+
+    -The module and its API are currently under development and experimental
+    and can be changed during development.
+
+    It currently only supports conversion from Fortran. The support for other
+    languages is under development. The Fortran parser does not support numeric
+    assignments, so all the variables have been Initialized to zero.
+
+    The module also depends on an external dependeny, LFortran which is
+    required to use the Fortran parser
+
+    Examples
+    ========
+
+    An example of variable definiton:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src2 = '''\
+    ... integer :: a, b, c, d
+    ... real :: p, q, r, s
+    ... '''
+    >>> p = SymPyExpression()
+    >>> p.convert_to_expr(src2, 'f')
+    >>> p.convert_to_c()
+    ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0']
+
+    An example of Assignment:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src3 = '''\
+    ... integer :: a, b, c, d, e
+    ... d = a + b - c
+    ... e = b * d + c * e / a
+    ... '''
+    >>> p = SymPyExpression(src3, 'f')
+    >>> p.convert_to_python()
+    ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'e = 0', 'd = a + b - c', 'e = b*d + c*e/a']
+
+    An example of function definition:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src = '''\
+    ... integer function f(a,b)
+    ... integer, intent(in) :: a, b
+    ... integer :: r
+    ... end function
+    ... '''
+    >>> a = SymPyExpression(src, 'f')
+    >>> a.convert_to_python()
+    ['def f(a, b):\\n   f = 0\\n    r = 0\\n    return f']
+
+    """
+
+    def __init__(self, source_code = None, mode = None):
+        """Constructor for SymPyExpression class"""
+        super(SymPyExpression, self).__init__()
+        if not(mode or source_code):
+            self._expr = []
+        elif mode:
+            if source_code:
+                if mode.lower() == 'f':
+                    self._expr = src_to_sympy(source_code)
+                #elif mode.lower() == 'c':
+                #    self._expr = src_to_c(source_code)
+                else:
+                    raise NotImplementedError(
+                        'Parser for specified language is not implemented'
+                    )
+            else:
+                raise ValueError('Source code not present')
+        else:
+            raise ValueError('Please specify a mode for conversion')
+
+    def convert_to_expr(self, src_code, mode):
+        """Converts the given source code to sympy Expressions
+
+        Attributes
+        ==========
+
+        src_code : String
+            the source code or filename of the source code that is to be
+            converted
+
+        mode: String
+            the mode to determine which parser is to be used according to the
+            language of the source code
+            f or F for Fortran
+            c or C for C/C++
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src3 = '''\
+        ... integer function f(a,b) result(r)
+        ... integer, intent(in) :: a, b
+        ... integer :: x
+        ... r = a + b -x
+        ... end function
+        ... '''
+        >>> p = SymPyExpression()
+        >>> p.convert_to_expr(src3, 'f')
+        >>> p.return_expr()
+        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+        Declaration(Variable(r, type=integer, value=0)),
+        Declaration(Variable(x, type=integer, value=0)),
+        Assignment(Variable(r), a + b - x),
+        Return(Variable(r))
+        ))]
+
+
+
+
+        """
+        if src_code:
+            if mode.lower() == 'f':
+                self._expr = src_to_sympy(src_code)
+            #elif mode.lower() == 'c':
+            #    self._expr = src_to_c(src_code)
+            else:
+                raise NotImplementedError(
+                    "Parser for specified language has not been implemented"
+                )
+        else:
+            raise ValueError('Source code not present')
+
+    def convert_to_python(self):
+        """Returns a list with python code for the sympy expressions
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src2 = '''\
+        ... integer :: a, b, c, d
+        ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
+        ... '''
+        >>> p = SymPyExpression(src2, 'f')
+        >>> p.convert_to_python()
+        ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'p = 0.0', 'q = 0.0', 'r = 0.0', 's = 0.0', 'c = a/b', 'd = c/a', 's = p/q', 'r = q/p']
+
+        """
+        self._pycode = []
+        for iter in self._expr:
+            self._pycode.append(pycode(iter))
+        return self._pycode
+
+    def convert_to_c(self):
+        """Returns a list with the c source code for the sympy expressions
+
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src2 = '''\
+        ... integer :: a, b, c, d
+        ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
+        ... '''
+        >>> p = SymPyExpression()
+        >>> p.convert_to_expr(src2, 'f')
+        >>> p.convert_to_c()
+        ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0', 'c = a/b;', 'd = c/a;', 's = p/q;', 'r = q/p;']
+
+        """
+        self._ccode = []
+        for iter in self._expr:
+            self._ccode.append(ccode(iter))
+        return self._ccode
+
+    def convert_to_fortran(self):
+        """Returns a list with the fortran source code for the sympy expressions
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src2 = '''\
+        ... integer :: a, b, c, d
+        ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
+        ... '''
+        >>> p = SymPyExpression(src2, 'f')
+        >>> p.convert_to_fortran()
+        ['      integer*4 a', '      integer*4 b', '      integer*4 c', '      integer*4 d', '      real*8 p', '      real*8 q', '      real*8 r', '      real*8 s', '      c = a/b', '      d = c/a', '      s = p/q', '      r = q/p']
+
+        """
+        self._fcode = []
+        for iter in self._expr:
+            self._fcode.append(fcode(iter))
+        return self._fcode
+
+    def return_expr(self):
+        """Returns the expression list
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src3 = '''\
+        ... integer function f(a,b)
+        ... integer, intent(in) :: a, b
+        ... integer :: r
+        ... r = a+b
+        ... f = r
+        ... end function
+        ... '''
+        >>> p = SymPyExpression()
+        >>> p.convert_to_expr(src3, 'f')
+        >>> p.return_expr()
+        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+        Declaration(Variable(f, type=integer, value=0)),
+        Declaration(Variable(r, type=integer, value=0)),
+        Assignment(Variable(f), Variable(r)),
+        Return(Variable(f))
+        ))]
+
+
+        """
+        return self._expr

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -1,247 +1,260 @@
-from sympy.parsing.fortran.fortran_parser import src_to_sympy
 from sympy.printing import pycode, ccode, fcode
+from sympy.external import import_module
+from sympy.utilities.decorator import doctest_depends_on
 
+lfortran = import_module('lfortran')
 
-class SymPyExpression(object):
-    """Class to store and handle SymPy expressions
+if lfortran:
+    from sympy.parsing.fortran.fortran_parser import src_to_sympy
 
-    This class will hold SymPy Expressions and handle the API for the
-    conversion to and from different languages.
+    @doctest_depends_on(modules=('lfortran',))
+    class SymPyExpression(object):
+        """Class to store and handle SymPy expressions
 
-    It works with the C and the Fortran Parser to generate SymPy expressions
-    which are stored here and which can be converted to multiple language's
-    source code.
+        This class will hold SymPy Expressions and handle the API for the
+        conversion to and from different languages.
 
-    Notes
-    =====
+        It works with the C and the Fortran Parser to generate SymPy expressions
+        which are stored here and which can be converted to multiple language's
+        source code.
 
-    -The module and its API are currently under development and experimental
-    and can be changed during development.
+        Notes
+        =====
 
-    It currently only supports conversion from Fortran. The support for other
-    languages is under development. The Fortran parser does not support numeric
-    assignments, so all the variables have been Initialized to zero.
+        The module and its API are currently under development and experimental
+        and can be changed during development.
 
-    The module also depends on an external dependeny, LFortran which is
-    required to use the Fortran parser
+        It currently only supports conversion from Fortran. The support for other
+        languages is under development. The Fortran parser does not support numeric
+        assignments, so all the variables have been Initialized to zero.
 
-    Examples
-    ========
-
-    An example of variable definiton:
-
-    >>> from sympy.parsing.sym_expr import SymPyExpression
-    >>> src2 = '''\
-    ... integer :: a, b, c, d
-    ... real :: p, q, r, s
-    ... '''
-    >>> p = SymPyExpression()
-    >>> p.convert_to_expr(src2, 'f')
-    >>> p.convert_to_c()
-    ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0']
-
-    An example of Assignment:
-
-    >>> from sympy.parsing.sym_expr import SymPyExpression
-    >>> src3 = '''\
-    ... integer :: a, b, c, d, e
-    ... d = a + b - c
-    ... e = b * d + c * e / a
-    ... '''
-    >>> p = SymPyExpression(src3, 'f')
-    >>> p.convert_to_python()
-    ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'e = 0', 'd = a + b - c', 'e = b*d + c*e/a']
-
-    An example of function definition:
-
-    >>> from sympy.parsing.sym_expr import SymPyExpression
-    >>> src = '''\
-    ... integer function f(a,b)
-    ... integer, intent(in) :: a, b
-    ... integer :: r
-    ... end function
-    ... '''
-    >>> a = SymPyExpression(src, 'f')
-    >>> a.convert_to_python()
-    ['def f(a, b):\\n   f = 0\\n    r = 0\\n    return f']
-
-    """
-
-    def __init__(self, source_code = None, mode = None):
-        """Constructor for SymPyExpression class"""
-        super(SymPyExpression, self).__init__()
-        if not(mode or source_code):
-            self._expr = []
-        elif mode:
-            if source_code:
-                if mode.lower() == 'f':
-                    self._expr = src_to_sympy(source_code)
-                #elif mode.lower() == 'c':
-                #    self._expr = src_to_c(source_code)
-                else:
-                    raise NotImplementedError(
-                        'Parser for specified language is not implemented'
-                    )
-            else:
-                raise ValueError('Source code not present')
-        else:
-            raise ValueError('Please specify a mode for conversion')
-
-    def convert_to_expr(self, src_code, mode):
-        """Converts the given source code to sympy Expressions
-
-        Attributes
-        ==========
-
-        src_code : String
-            the source code or filename of the source code that is to be
-            converted
-
-        mode: String
-            the mode to determine which parser is to be used according to the
-            language of the source code
-            f or F for Fortran
-            c or C for C/C++
+        The module also depends on an external dependeny, LFortran which is
+        required to use the Fortran parser
 
         Examples
         ========
 
-        >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src3 = '''\
-        ... integer function f(a,b) result(r)
-        ... integer, intent(in) :: a, b
-        ... integer :: x
-        ... r = a + b -x
-        ... end function
-        ... '''
-        >>> p = SymPyExpression()
-        >>> p.convert_to_expr(src3, 'f')
-        >>> p.return_expr()
-        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
-        Declaration(Variable(r, type=integer, value=0)),
-        Declaration(Variable(x, type=integer, value=0)),
-        Assignment(Variable(r), a + b - x),
-        Return(Variable(r))
-        ))]
-
-
-
-
-        """
-        if src_code:
-            if mode.lower() == 'f':
-                self._expr = src_to_sympy(src_code)
-            #elif mode.lower() == 'c':
-            #    self._expr = src_to_c(src_code)
-            else:
-                raise NotImplementedError(
-                    "Parser for specified language has not been implemented"
-                )
-        else:
-            raise ValueError('Source code not present')
-
-    def convert_to_python(self):
-        """Returns a list with python code for the sympy expressions
-
-        Examples
-        ========
+        An example of variable definiton:
 
         >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src2 = '''\
+        >>> src2 = '''
         ... integer :: a, b, c, d
         ... real :: p, q, r, s
-        ... c = a/b
-        ... d = c/a
-        ... s = p/q
-        ... r = q/p
-        ... '''
-        >>> p = SymPyExpression(src2, 'f')
-        >>> p.convert_to_python()
-        ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'p = 0.0', 'q = 0.0', 'r = 0.0', 's = 0.0', 'c = a/b', 'd = c/a', 's = p/q', 'r = q/p']
-
-        """
-        self._pycode = []
-        for iter in self._expr:
-            self._pycode.append(pycode(iter))
-        return self._pycode
-
-    def convert_to_c(self):
-        """Returns a list with the c source code for the sympy expressions
-
-
-        Examples
-        ========
-
-        >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src2 = '''\
-        ... integer :: a, b, c, d
-        ... real :: p, q, r, s
-        ... c = a/b
-        ... d = c/a
-        ... s = p/q
-        ... r = q/p
         ... '''
         >>> p = SymPyExpression()
         >>> p.convert_to_expr(src2, 'f')
         >>> p.convert_to_c()
-        ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0', 'c = a/b;', 'd = c/a;', 's = p/q;', 'r = q/p;']
+        ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0']
 
-        """
-        self._ccode = []
-        for iter in self._expr:
-            self._ccode.append(ccode(iter))
-        return self._ccode
-
-    def convert_to_fortran(self):
-        """Returns a list with the fortran source code for the sympy expressions
-
-        Examples
-        ========
+        An example of Assignment:
 
         >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src2 = '''\
-        ... integer :: a, b, c, d
-        ... real :: p, q, r, s
-        ... c = a/b
-        ... d = c/a
-        ... s = p/q
-        ... r = q/p
+        >>> src3 = '''
+        ... integer :: a, b, c, d, e
+        ... d = a + b - c
+        ... e = b * d + c * e / a
         ... '''
-        >>> p = SymPyExpression(src2, 'f')
-        >>> p.convert_to_fortran()
-        ['      integer*4 a', '      integer*4 b', '      integer*4 c', '      integer*4 d', '      real*8 p', '      real*8 q', '      real*8 r', '      real*8 s', '      c = a/b', '      d = c/a', '      s = p/q', '      r = q/p']
+        >>> p = SymPyExpression(src3, 'f')
+        >>> p.convert_to_python()
+        ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'e = 0', 'd = a + b - c', 'e = b*d + c*e/a']
 
-        """
-        self._fcode = []
-        for iter in self._expr:
-            self._fcode.append(fcode(iter))
-        return self._fcode
-
-    def return_expr(self):
-        """Returns the expression list
-
-        Examples
-        ========
+        An example of function definition:
 
         >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src3 = '''\
+        >>> src = '''
         ... integer function f(a,b)
         ... integer, intent(in) :: a, b
         ... integer :: r
-        ... r = a+b
-        ... f = r
         ... end function
         ... '''
-        >>> p = SymPyExpression()
-        >>> p.convert_to_expr(src3, 'f')
-        >>> p.return_expr()
-        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
-        Declaration(Variable(f, type=integer, value=0)),
-        Declaration(Variable(r, type=integer, value=0)),
-        Assignment(Variable(f), Variable(r)),
-        Return(Variable(f))
-        ))]
-
+        >>> a = SymPyExpression(src, 'f')
+        >>> a.convert_to_python()
+        ['def f(a, b):\\n   f = 0\\n    r = 0\\n    return f']
 
         """
-        return self._expr
+
+        def __init__(self, source_code = None, mode = None):
+            """Constructor for SymPyExpression class"""
+            super(SymPyExpression, self).__init__()
+            if not(mode or source_code):
+                self._expr = []
+            elif mode:
+                if source_code:
+                    if mode.lower() == 'f':
+                        self._expr = src_to_sympy(source_code)
+                    #elif mode.lower() == 'c':
+                    #    self._expr = src_to_c(source_code)
+                    else:
+                        raise NotImplementedError(
+                            'Parser for specified language is not implemented'
+                        )
+                else:
+                    raise ValueError('Source code not present')
+            else:
+                raise ValueError('Please specify a mode for conversion')
+
+        def convert_to_expr(self, src_code, mode):
+            """Converts the given source code to sympy Expressions
+
+            Attributes
+            ==========
+
+            src_code : String
+                the source code or filename of the source code that is to be
+                converted
+
+            mode: String
+                the mode to determine which parser is to be used according to the
+                language of the source code
+                f or F for Fortran
+                c or C for C/C++
+
+            Examples
+            ========
+
+            >>> from sympy.parsing.sym_expr import SymPyExpression
+            >>> src3 = '''
+            ... integer function f(a,b) result(r)
+            ... integer, intent(in) :: a, b
+            ... integer :: x
+            ... r = a + b -x
+            ... end function
+            ... '''
+            >>> p = SymPyExpression()
+            >>> p.convert_to_expr(src3, 'f')
+            >>> p.return_expr()
+            [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+            Declaration(Variable(r, type=integer, value=0)),
+            Declaration(Variable(x, type=integer, value=0)),
+            Assignment(Variable(r), a + b - x),
+            Return(Variable(r))
+            ))]
+
+
+
+
+            """
+            if src_code:
+                if mode.lower() == 'f':
+                    self._expr = src_to_sympy(src_code)
+                #elif mode.lower() == 'c':
+                #    self._expr = src_to_c(src_code)
+                else:
+                    raise NotImplementedError(
+                        "Parser for specified language has not been implemented"
+                    )
+            else:
+                raise ValueError('Source code not present')
+
+        def convert_to_python(self):
+            """Returns a list with python code for the sympy expressions
+
+            Examples
+            ========
+
+            >>> from sympy.parsing.sym_expr import SymPyExpression
+            >>> src2 = '''
+            ... integer :: a, b, c, d
+            ... real :: p, q, r, s
+            ... c = a/b
+            ... d = c/a
+            ... s = p/q
+            ... r = q/p
+            ... '''
+            >>> p = SymPyExpression(src2, 'f')
+            >>> p.convert_to_python()
+            ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'p = 0.0', 'q = 0.0', 'r = 0.0', 's = 0.0', 'c = a/b', 'd = c/a', 's = p/q', 'r = q/p']
+
+            """
+            self._pycode = []
+            for iter in self._expr:
+                self._pycode.append(pycode(iter))
+            return self._pycode
+
+        def convert_to_c(self):
+            """Returns a list with the c source code for the sympy expressions
+
+
+            Examples
+            ========
+
+            >>> from sympy.parsing.sym_expr import SymPyExpression
+            >>> src2 = '''
+            ... integer :: a, b, c, d
+            ... real :: p, q, r, s
+            ... c = a/b
+            ... d = c/a
+            ... s = p/q
+            ... r = q/p
+            ... '''
+            >>> p = SymPyExpression()
+            >>> p.convert_to_expr(src2, 'f')
+            >>> p.convert_to_c()
+            ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0', 'c = a/b;', 'd = c/a;', 's = p/q;', 'r = q/p;']
+
+            """
+            self._ccode = []
+            for iter in self._expr:
+                self._ccode.append(ccode(iter))
+            return self._ccode
+
+        def convert_to_fortran(self):
+            """Returns a list with the fortran source code for the sympy expressions
+
+            Examples
+            ========
+
+            >>> from sympy.parsing.sym_expr import SymPyExpression
+            >>> src2 = '''
+            ... integer :: a, b, c, d
+            ... real :: p, q, r, s
+            ... c = a/b
+            ... d = c/a
+            ... s = p/q
+            ... r = q/p
+            ... '''
+            >>> p = SymPyExpression(src2, 'f')
+            >>> p.convert_to_fortran()
+            ['      integer*4 a', '      integer*4 b', '      integer*4 c', '      integer*4 d', '      real*8 p', '      real*8 q', '      real*8 r', '      real*8 s', '      c = a/b', '      d = c/a', '      s = p/q', '      r = q/p']
+
+            """
+            self._fcode = []
+            for iter in self._expr:
+                self._fcode.append(fcode(iter))
+            return self._fcode
+
+        def return_expr(self):
+            """Returns the expression list
+
+            Examples
+            ========
+
+            >>> from sympy.parsing.sym_expr import SymPyExpression
+            >>> src3 = '''
+            ... integer function f(a,b)
+            ... integer, intent(in) :: a, b
+            ... integer :: r
+            ... r = a+b
+            ... f = r
+            ... end function
+            ... '''
+            >>> p = SymPyExpression()
+            >>> p.convert_to_expr(src3, 'f')
+            >>> p.return_expr()
+            [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+            Declaration(Variable(f, type=integer, value=0)),
+            Declaration(Variable(r, type=integer, value=0)),
+            Assignment(Variable(f), Variable(r)),
+            Return(Variable(f))
+            ))]
+
+
+            """
+            return self._expr
+else:
+    class SymPyExpression(object):
+        def __init__(self, *args, **kwargs):
+            raise ImportError('lfortran not available.')
+
+        def convert_to_expr(self, *args, **kwargs):
+            raise ImportError('lfortran not available')

--- a/sympy/parsing/tests/test_fortran_parser.py
+++ b/sympy/parsing/tests/test_fortran_parser.py
@@ -1,17 +1,28 @@
-from sympy.parsing.sym_expr import SymPyExpression
+import re
+
 from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
                                Return, FunctionDefinition, Assignment,
                                Declaration, CodeBlock)
 from sympy.core import Integer, Float, Add
 from sympy import Symbol
-import re
 
-expr1 = SymPyExpression()
-expr2 = SymPyExpression()
-src = """\
-integer :: a, b, c, d
-real :: p, q, r, s
-"""
+
+from sympy.external import import_module
+lfortran = import_module('lfortran')
+if lfortran:
+    from sympy.parsing.sym_expr import SymPyExpression
+
+    expr1 = SymPyExpression()
+    expr2 = SymPyExpression()
+    src = """\
+    integer :: a, b, c, d
+    real :: p, q, r, s
+    """
+else:
+    #bin/test will not execute any tests now
+    disabled = True
+
+
 
 
 def test_sym_expr():
@@ -103,14 +114,10 @@ def test_assignment():
     expr1.convert_to_expr(src1, 'f')
     ls1 = expr1.return_expr()
     for iter in range(0, 12):
-        if (iter < 8):
+        if iter < 8:
             assert isinstance(ls1[iter], Declaration)
         else:
             assert isinstance(ls1[iter], Assignment)
-            assert re.match(
-                r'Assignment\((?P<var>Variable)\(\w+\),\s(?P=var)\(\w+\)\)',
-                str(ls1[iter])
-            )
     assert ls1[8] == Assignment(
         Variable(Symbol('a')),
         Variable(Symbol('b'))

--- a/sympy/parsing/tests/test_fortran_parser.py
+++ b/sympy/parsing/tests/test_fortran_parser.py
@@ -1,183 +1,470 @@
-from sympy.parsing.fortran.fortran_parser import src_to_sympy
+from sympy.parsing.sym_expr import SymPyExpression
+from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
+                               Return, FunctionDefinition, Assignment,
+                               Declaration, CodeBlock)
+from sympy.core import Integer, Float, Add
+from sympy import Symbol
+import re
+
+expr1 = SymPyExpression()
+expr2 = SymPyExpression()
+src = """\
+integer :: a, b, c, d
+real :: p, q, r, s
+"""
 
 
-imp_stmt = "from sympy import Symbol"
-
-def test_declaration():
-    src1 = "integer :: a,b"
-    src2 = "real :: p,q"
-    src3 = """\
-    integer :: x
-    real :: p
-    integer :: y
-    real :: q
-    """
-    res1 = src_to_sympy(src1)
-    res2 = src_to_sympy(src2)
-    res3 = src_to_sympy(src3)
-    cmp1 = (
-        imp_stmt + "\n" +
-        "a = Symbol('a', integer=True)" + "\n" +
-        "b = Symbol('b', integer=True)"
+def test_sym_expr():
+    src1 = (
+        src +
+        """\
+        d = a + b -c
+        """
     )
-    cmp2 = (
-        imp_stmt + "\n" +
-        "p = Symbol('p', real=True)" + "\n" +
-        "q = Symbol('q', real=True)"
+    expr3 = SymPyExpression(src,'f')
+    expr4 = SymPyExpression(src1,'f')
+    ls1 = expr3.return_expr()
+    ls2 = expr4.return_expr()
+    for i in range(0, 7):
+        assert isinstance(ls1[i], Declaration)
+        assert isinstance(ls2[i], Declaration)
+    assert isinstance(ls2[8], Assignment)
+    assert ls1[0] == Declaration(
+        Variable(
+            Symbol('a'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
     )
-    cmp3 = (
-        imp_stmt + "\n" +
-        "x = Symbol('x', integer=True)" + "\n" +
-        "p = Symbol('p', real=True)" + "\n" +
-        "y = Symbol('y', integer=True)" + "\n" +
-        "q = Symbol('q', real=True)"
+    assert ls1[1] == Declaration(
+        Variable(
+            Symbol('b'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
     )
-    assert res1.strip() == cmp1
-    assert res2.strip() == cmp2
-    assert res3.strip() == cmp3
-
+    assert ls1[2] == Declaration(
+        Variable(
+            Symbol('c'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
+    )
+    assert ls1[3] == Declaration(
+        Variable(
+            Symbol('d'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
+    )
+    assert ls1[4] == Declaration(
+        Variable(
+            Symbol('p'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls1[5] == Declaration(
+        Variable(
+            Symbol('q'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls1[6] == Declaration(
+        Variable(
+            Symbol('r'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls1[7] == Declaration(
+        Variable(
+            Symbol('s'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls2[8] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') + Symbol('b') - Symbol('c')
+    )
 
 def test_assignment():
-    #TODO: Arithmetic Assignments
-    src = """\
-    integer :: a, b
-    a = b
-    """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "a = Symbol('a', integer=True)" + "\n" +
-        "b = Symbol('b', integer=True)" + "\n" +
-        "a = b"
+    src1 = (
+        src +
+        """\
+        a = b
+        c = d
+        p = q
+        r = s
+        """
     )
-    assert res.strip() == cmp
-
-def test_assignment_add():
-    src = """\
-    real :: c, d, e
-    e = c + d
-    """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "e = c + d"
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(0, 12):
+        if (iter < 8):
+            assert isinstance(ls1[iter], Declaration)
+        else:
+            assert isinstance(ls1[iter], Assignment)
+            assert re.match(
+                r'Assignment\((?P<var>Variable)\(\w+\),\s(?P=var)\(\w+\)\)',
+                str(ls1[iter])
+            )
+    assert ls1[8] == Assignment(
+        Variable(Symbol('a')),
+        Variable(Symbol('b'))
     )
-    assert res.strip() == cmp
-
-def test_assignment_sub():
-    src = """\
-    real :: c, d, e
-    e = c - d
-    """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "e = c - d"
+    assert ls1[9] == Assignment(
+        Variable(Symbol('c')),
+        Variable(Symbol('d'))
     )
-    assert res.strip() == cmp
-
-def test_assignment_mul():
-    src = """\
-    real :: c, d, e
-    e = c * d
-    """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "e = c * d"
+    assert ls1[10] == Assignment(
+        Variable(Symbol('p')),
+        Variable(Symbol('q'))
     )
-    assert res.strip() == cmp
-
-def test_assignment_div():
-    src = """\
-    real :: c, d, e
-    e = c / d
-    """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "e = c / d"
+    assert ls1[11] == Assignment(
+        Variable(Symbol('r')),
+        Variable(Symbol('s'))
     )
-    assert res.strip() == cmp
-
-def test_binop():
-    src1 = """\
-    real :: c, d, e, f, g
-    g = c + d - e * f
-    """
-    src2 = """\
-    real :: c, d, e, f, g
-    g = c - d + (e * f)
-    """
-    src3 = """\
-    real :: c, d, e, f, g
-    g = (c + e * (f / d)) - (f + (e * c))
-    """
-    res1 = src_to_sympy(src1)
-    res2 = src_to_sympy(src2)
-    res3 = src_to_sympy(src3)
-    cmp1 = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "f = Symbol('f', real=True)" + "\n" +
-        "g = Symbol('g', real=True)" + "\n" +
-        "g = c + d - e * f"
-    )
-    cmp2 = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "f = Symbol('f', real=True)" + "\n" +
-        "g = Symbol('g', real=True)" + "\n" +
-        "g = c - d + e * f"
-    )
-    cmp3 = (
-        imp_stmt + "\n" +
-        "c = Symbol('c', real=True)" + "\n" +
-        "d = Symbol('d', real=True)" + "\n" +
-        "e = Symbol('e', real=True)" + "\n" +
-        "f = Symbol('f', real=True)" + "\n" +
-        "g = Symbol('g', real=True)" + "\n" +
-        "g = c + e * (f / d) - (f + e * c)"
-    )
-    assert res1.strip() == cmp1
-    assert res2.strip() == cmp2
-    assert res3.strip() == cmp3
 
 
+def test_binop_add():
+    src1 = (
+        src +
+        """\
+        c = a + b
+        d = a + c
+        s = p + q + r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(8, 11):
+        assert isinstance(ls1[iter], Assignment)
+    assert ls1[8] == Assignment(
+        Variable(Symbol('c')),
+        Symbol('a') + Symbol('b')
+    )
+    assert ls1[9] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') + Symbol('c')
+    )
+    assert ls1[10] == Assignment(
+        Variable(Symbol('s')),
+        Symbol('p') + Symbol('q') + Symbol('r')
+    )
+
+
+def test_binop_sub():
+    src1 = (
+        src +
+        """\
+        c = a - b
+        d = a - c
+        s = p - q - r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(8, 11):
+        assert isinstance(ls1[iter], Assignment)
+    assert ls1[8] == Assignment(
+        Variable(Symbol('c')),
+        Symbol('a') - Symbol('b')
+    )
+    assert ls1[9] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') - Symbol('c')
+    )
+    assert ls1[10] == Assignment(
+        Variable(Symbol('s')),
+        Symbol('p') - Symbol('q') - Symbol('r')
+    )
+
+
+def test_binop_mul():
+    src1 = (
+        src +
+        """\
+        c = a * b
+        d = a * c
+        s = p * q * r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(8, 11):
+        assert isinstance(ls1[iter], Assignment)
+    assert ls1[8] == Assignment(
+        Variable(Symbol('c')),
+        Symbol('a') * Symbol('b')
+    )
+    assert ls1[9] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') * Symbol('c')
+    )
+    assert ls1[10] == Assignment(
+        Variable(Symbol('s')),
+        Symbol('p') * Symbol('q') * Symbol('r')
+    )
+
+
+def test_binop_div():
+    src1 = (
+        src +
+        """\
+        c = a / b
+        d = a / c
+        s = p / q
+        r = q / p
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(8, 12):
+        assert isinstance(ls1[iter], Assignment)
+    assert ls1[8] == Assignment(
+        Variable(Symbol('c')),
+        Symbol('a') / Symbol('b')
+    )
+    assert ls1[9] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') / Symbol('c')
+    )
+    assert ls1[10] == Assignment(
+        Variable(Symbol('s')),
+        Symbol('p') / Symbol('q')
+    )
+    assert ls1[11] == Assignment(
+        Variable(Symbol('r')),
+        Symbol('q') / Symbol('p')
+    )
+
+def test_mul_binop():
+    src1 = (
+        src +
+        """\
+        d = a + b - c
+        c = a * b + d
+        s = p * q / r
+        r = p * s + q / p
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    ls1 = expr1.return_expr()
+    for iter in range(8, 12):
+        assert isinstance(ls1[iter], Assignment)
+    assert ls1[8] == Assignment(
+        Variable(Symbol('d')),
+        Symbol('a') + Symbol('b') - Symbol('c')
+    )
+    assert ls1[9] == Assignment(
+        Variable(Symbol('c')),
+        Symbol('a') * Symbol('b') + Symbol('d')
+    )
+    assert ls1[10] == Assignment(
+        Variable(Symbol('s')),
+        Symbol('p') * Symbol('q') / Symbol('r')
+    )
+    assert ls1[11] == Assignment(
+        Variable(Symbol('r')),
+        Symbol('p') * Symbol('s') + Symbol('q') / Symbol('p')
+    )
 
 
 def test_function():
-    src = """\
-    function abc(a ,b) result(r)
-    integer, intent(in) :: a,b
-    r = a * b
+    src1 = """\
+    integer function f(a,b)
+    integer :: x, y
+    f = x + y
     end function
     """
-    res = src_to_sympy(src)
-    cmp = (
-        imp_stmt + "\n" +
-        "a = Symbol('a', integer=True)" + "\n" +
-        "b = Symbol('b', integer=True)" + "\n" +
-        "r = Symbol('r', integer=True)" + "\n" +
-        "\n" + "\n" +
-        "def abc(a, b):" + "\n" +
-        "    " + "r = a * b" + "\n" +
-        "    " + "return r"
+    expr1.convert_to_expr(src1, 'f')
+    for iter in expr1.return_expr():
+        assert isinstance(iter, FunctionDefinition)
+        assert iter == FunctionDefinition(
+            IntBaseType(String('integer')),
+            name=String('f'),
+            parameters=(
+                Variable(Symbol('a')),
+                Variable(Symbol('b'))
+            ),
+            body=CodeBlock(
+                Declaration(
+                    Variable(
+                        Symbol('a'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(0)
+                    )
+                ),
+                Declaration(
+                    Variable(
+                        Symbol('b'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(0)
+                    )
+                ),
+                Declaration(
+                    Variable(
+                        Symbol('f'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(0)
+                    )
+                ),
+                Declaration(
+                    Variable(
+                        Symbol('x'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(0)
+                    )
+                ),
+                Declaration(
+                    Variable(
+                        Symbol('y'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(0)
+                    )
+                ),
+                Assignment(
+                    Variable(Symbol('f')),
+                    Add(Symbol('x'), Symbol('y'))
+                ),
+                Return(Variable(Symbol('f')))
+            )
+        )
+
+
+def test_var():
+    expr1.convert_to_expr(src, 'f')
+    ls = expr1.return_expr()
+    for iter in expr1.return_expr():
+        assert isinstance(iter, Declaration)
+    assert ls[0] == Declaration(
+        Variable(
+            Symbol('a'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
     )
-    assert res.strip() == cmp
+    assert ls[1] == Declaration(
+        Variable(
+            Symbol('b'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
+    )
+    assert ls[2] == Declaration(
+        Variable(
+            Symbol('c'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
+    )
+    assert ls[3] == Declaration(
+        Variable(
+            Symbol('d'),
+            type = IntBaseType(String('integer')),
+            value = Integer(0)
+        )
+    )
+    assert ls[4] == Declaration(
+        Variable(
+            Symbol('p'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls[5] == Declaration(
+        Variable(
+            Symbol('q'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls[6] == Declaration(
+        Variable(
+            Symbol('r'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+    assert ls[7] == Declaration(
+        Variable(
+            Symbol('s'),
+            type = FloatBaseType(String('real')),
+            value = Float(0.0)
+        )
+    )
+
+
+def test_convert_py():
+    src1 = (
+        src +
+        """\
+        a = b + c
+        s = p * q / r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    exp_py = expr1.convert_to_python()
+    assert exp_py == [
+        'a = 0',
+        'b = 0',
+        'c = 0',
+        'd = 0',
+        'p = 0.0',
+        'q = 0.0',
+        'r = 0.0',
+        's = 0.0',
+        'a = b + c',
+        's = p*q/r'
+    ]
+
+
+def test_convert_fort():
+    src1 = (
+        src +
+        """\
+        a = b + c
+        s = p * q / r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    exp_fort = expr1.convert_to_fortran()
+    assert exp_fort == [
+        '      integer*4 a',
+        '      integer*4 b',
+        '      integer*4 c',
+        '      integer*4 d',
+        '      real*8 p',
+        '      real*8 q',
+        '      real*8 r',
+        '      real*8 s',
+        '      a = b + c',
+        '      s = p*q/r'
+    ]
+
+
+def test_convert_c():
+    src1 = (
+        src +
+        """\
+        a = b + c
+        s = p * q / r
+        """
+    )
+    expr1.convert_to_expr(src1, 'f')
+    exp_c = expr1.convert_to_c()
+    assert exp_c == [
+        'int a = 0',
+        'int b = 0',
+        'int c = 0',
+        'int d = 0',
+        'double p = 0.0',
+        'double q = 0.0',
+        'double r = 0.0',
+        'double s = 0.0',
+        'a = b + c;',
+        's = p*q/r;'
+    ]

--- a/sympy/parsing/tests/test_fortran_parser.py
+++ b/sympy/parsing/tests/test_fortran_parser.py
@@ -1,0 +1,183 @@
+from sympy.parsing.fortran.fortran_parser import src_to_sympy
+
+
+imp_stmt = "from sympy import Symbol"
+
+def test_declaration():
+    src1 = "integer :: a,b"
+    src2 = "real :: p,q"
+    src3 = """\
+    integer :: x
+    real :: p
+    integer :: y
+    real :: q
+    """
+    res1 = src_to_sympy(src1)
+    res2 = src_to_sympy(src2)
+    res3 = src_to_sympy(src3)
+    cmp1 = (
+        imp_stmt + "\n" +
+        "a = Symbol('a', integer=True)" + "\n" +
+        "b = Symbol('b', integer=True)"
+    )
+    cmp2 = (
+        imp_stmt + "\n" +
+        "p = Symbol('p', real=True)" + "\n" +
+        "q = Symbol('q', real=True)"
+    )
+    cmp3 = (
+        imp_stmt + "\n" +
+        "x = Symbol('x', integer=True)" + "\n" +
+        "p = Symbol('p', real=True)" + "\n" +
+        "y = Symbol('y', integer=True)" + "\n" +
+        "q = Symbol('q', real=True)"
+    )
+    assert res1.strip() == cmp1
+    assert res2.strip() == cmp2
+    assert res3.strip() == cmp3
+
+
+def test_assignment():
+    #TODO: Arithmetic Assignments
+    src = """\
+    integer :: a, b
+    a = b
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "a = Symbol('a', integer=True)" + "\n" +
+        "b = Symbol('b', integer=True)" + "\n" +
+        "a = b"
+    )
+    assert res.strip() == cmp
+
+def test_assignment_add():
+    src = """\
+    real :: c, d, e
+    e = c + d
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "e = c + d"
+    )
+    assert res.strip() == cmp
+
+def test_assignment_sub():
+    src = """\
+    real :: c, d, e
+    e = c - d
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "e = c - d"
+    )
+    assert res.strip() == cmp
+
+def test_assignment_mul():
+    src = """\
+    real :: c, d, e
+    e = c * d
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "e = c * d"
+    )
+    assert res.strip() == cmp
+
+def test_assignment_div():
+    src = """\
+    real :: c, d, e
+    e = c / d
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "e = c / d"
+    )
+    assert res.strip() == cmp
+
+def test_binop():
+    src1 = """\
+    real :: c, d, e, f, g
+    g = c + d - e * f
+    """
+    src2 = """\
+    real :: c, d, e, f, g
+    g = c - d + (e * f)
+    """
+    src3 = """\
+    real :: c, d, e, f, g
+    g = (c + e * (f / d)) - (f + (e * c))
+    """
+    res1 = src_to_sympy(src1)
+    res2 = src_to_sympy(src2)
+    res3 = src_to_sympy(src3)
+    cmp1 = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "f = Symbol('f', real=True)" + "\n" +
+        "g = Symbol('g', real=True)" + "\n" +
+        "g = c + d - e * f"
+    )
+    cmp2 = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "f = Symbol('f', real=True)" + "\n" +
+        "g = Symbol('g', real=True)" + "\n" +
+        "g = c - d + e * f"
+    )
+    cmp3 = (
+        imp_stmt + "\n" +
+        "c = Symbol('c', real=True)" + "\n" +
+        "d = Symbol('d', real=True)" + "\n" +
+        "e = Symbol('e', real=True)" + "\n" +
+        "f = Symbol('f', real=True)" + "\n" +
+        "g = Symbol('g', real=True)" + "\n" +
+        "g = c + e * (f / d) - (f + e * c)"
+    )
+    assert res1.strip() == cmp1
+    assert res2.strip() == cmp2
+    assert res3.strip() == cmp3
+
+
+
+
+def test_function():
+    src = """\
+    function abc(a ,b) result(r)
+    integer, intent(in) :: a,b
+    r = a * b
+    end function
+    """
+    res = src_to_sympy(src)
+    cmp = (
+        imp_stmt + "\n" +
+        "a = Symbol('a', integer=True)" + "\n" +
+        "b = Symbol('b', integer=True)" + "\n" +
+        "r = Symbol('r', integer=True)" + "\n" +
+        "\n" + "\n" +
+        "def abc(a, b):" + "\n" +
+        "    " + "r = a * b" + "\n" +
+        "    " + "return r"
+    )
+    assert res.strip() == cmp


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Related Issue: #16563
Rebased version of #17171 

#### Brief description of what is fixed or changed

Fortran parser for sympy using the codegen AST nodes
The parser can currently only parse variable and function definitions, assignments and basic binary operations for now due to the limitations in the lfortran ASR and codegen AST.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added a new Parser for parsing Fortran source code
  * Added SymPyExpression to handle parsed SymPy expressions
<!-- END RELEASE NOTES -->
