### PR TITLE
Extend quadratic_denom_rule in manual integration

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -733,7 +733,7 @@ def quadratic_denom_rule(integral):
     a = sympy.Wild('a', exclude=[symbol])
     b = sympy.Wild('b', exclude=[symbol])
     c = sympy.Wild('c', exclude=[symbol])
-    
+
     match = integrand.match(a / (b * symbol ** 2 + c))
 
     if match:
@@ -745,7 +745,7 @@ def quadratic_denom_rule(integral):
             ], integrand, symbol)
         else:
             return ArctanRule(a, b, c, integrand, symbol)
-    
+
     d = sympy.Wild('d', exclude=[symbol])
     match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))
     if match2:
@@ -765,25 +765,25 @@ def quadratic_denom_rule(integral):
         numer1 =  (2*c*symbol+d)
         numer2 = - const*d + b
         u = sympy.Dummy('u')
-        step1 = URule(u, 
-                      denominator, 
-                      const, 
-                      integral_steps(u**(-1), u), 
-                      integrand, 
+        step1 = URule(u,
+                      denominator,
+                      const,
+                      integral_steps(u**(-1), u),
+                      integrand,
                       symbol)
         if const != 1:
-            step1 = ConstantTimesRule(const, 
-                                      numer1/denominator, 
-                                      step1, 
-                                      const*numer1/denominator, 
-                                      symbol)  
+            step1 = ConstantTimesRule(const,
+                                      numer1/denominator,
+                                      step1,
+                                      const*numer1/denominator,
+                                      symbol)
         if numer2.is_zero:
             return step1
         step2 = integral_steps(numer2/denominator, symbol)
         substeps = AddRule([step1, step2], integrand, symbol)
         rewriten = const*numer1/denominator+numer2/denominator
         return RewriteRule(rewriten, substeps, integrand, symbol)
-    
+
     return
 
 def root_mul_rule(integral):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -750,6 +750,8 @@ def quadratic_denom_rule(integral):
     match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))
     if match2:
         b, c =  match2[b], match2[c]
+        if b.is_zero:
+            return
         u = sympy.Dummy('u')
         u_func = symbol + c/(2*b)
         integrand2 = integrand.subs(symbol, u - c / (2*b))
@@ -760,6 +762,8 @@ def quadratic_denom_rule(integral):
     match3 = integrand.match((a* symbol + b) / (c * symbol ** 2 + d * symbol + e))
     if match3:
         a, b, c, d, e = match3[a], match3[b], match3[c], match3[d], match3[e]
+        if c.is_zero:
+            return
         denominator = c * symbol**2 + d * symbol + e
         const =  a/(2*c)
         numer1 =  (2*c*symbol+d)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -758,6 +758,8 @@ def quadratic_denom_rule(integral):
         next_step = integral_steps(integrand2, u)
         if next_step:
             return URule(u, u_func, None, next_step, integrand2, symbol)
+        else:
+            return
     e = sympy.Wild('e', exclude=[symbol])
     match3 = integrand.match((a* symbol + b) / (c * symbol ** 2 + d * symbol + e))
     if match3:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -509,4 +509,3 @@ def test_quadratic_denom():
     assert manualintegrate(f, x) == 5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - S(1)/3)/23)/69
     g = 3/(2*x**2 + 3*x + 1)
     assert manualintegrate(g, x) == 3*log(4*x + 2) - 3*log(4*x + 4)
-

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -503,3 +503,10 @@ def test_issue_15471():
     f = log(x)*cos(log(x))/x**(S(3)/4)
     F = -128*x**(S(1)/4)*sin(log(x))/289 + 240*x**(S(1)/4)*cos(log(x))/289 + (16*x**(S(1)/4)*sin(log(x))/17 + 4*x**(S(1)/4)*cos(log(x))/17)*log(x)
     assert manualintegrate(f, x) == F and F.diff(x).equals(f)
+
+def test_quadratic_denom():
+    f = (5*x + 2)/(3*x**2 - 2*x + 8)
+    assert manualintegrate(f, x) == 5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - S(1)/3)/23)/69
+    g = 3/(2*x**2 + 3*x + 1)
+    assert manualintegrate(g, x) == 3*log(4*x + 2) - 3*log(4*x + 4)
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently there are no rules that can handle integrals of the form (a*x+b)/(c*x**2+d*x+e).This PR adds the usual rewriting and change of variable used to integrate these cases:

```
>>> from sympy import *
>>> x = S('x')
>>> f = (5*x + 2)/(3*x**2 - 2*x + 8)
>>> manualintegrate.manualintegrate(f, x)
5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - 1/3)/23)/69
>>> manualintegrate.integral_steps(f, x)
RewriteRule(rewritten=(5*x - 5/3)/(3*x**2 - 2*x + 8) + 11/(3*(3*x**2 - 2*x + 8)), substep=AddRule(substeps=[ConstantTimesRule(constant=5/6, other=(6*x - 2)/(3*x**2 - 2*x + 8), substep=URule(u_var=_u, u_func=3*x**2 - 2*x + 8, constant=5/6, substep=ReciprocalRule(func=_u, context=1/_u, symbol=_u), context=(5*x + 2)/(3*x**2 - 2*x + 8), symbol=x), context=(5*x - 5/3)/(3*x**2 - 2*x + 8), symbol=x), ConstantTimesRule(constant=11/3, other=1/(3*x**2 - 2*x + 8), substep=URule(u_var=_u, u_func=x - 1/3, constant=None, substep=AlternativeRule(alternatives=[RewriteRule(rewritten=3/(9*_u**2 + 23), substep=ConstantTimesRule(constant=3, other=1/(9*_u**2 + 23), substep=PiecewiseRule(subfunctions=[(ArctanRule(a=1, b=9, c=23, context=1/(9*_u**2 + 23), symbol=_u), True), (ArccothRule(a=1, b=9, c=23, context=1/(9*_u**2 + 23), symbol=_u), False), (ArctanhRule(a=1, b=9, c=23, context=1/(9*_u**2 + 23), symbol=_u), False)], context=1/(9*_u**2 + 23), symbol=_u), context=3/(9*_u**2 + 23), symbol=_u), context=1/(-2*_u + 3*(_u + 1/3)**2 + 22/3), symbol=_u), RewriteRule(rewritten=1/(3*_u**2 + 23/3), substep=PiecewiseRule(subfunctions=[(ArctanRule(a=1, b=3, c=23/3, context=1/(3*_u**2 + 23/3), symbol=_u), True), (ArccothRule(a=1, b=3, c=23/3, context=1/(3*_u**2 + 23/3), symbol=_u), False), (ArctanhRule(a=1, b=3, c=23/3, context=1/(3*_u**2 + 23/3), symbol=_u), False)], context=1/(3*_u**2 + 23/3), symbol=_u), context=1/(-2*_u + 3*(_u + 1/3)**2 + 22/3), symbol=_u)], context=1/(-2*_u + 3*(_u + 1/3)**2 + 22/3), symbol=_u), context=1/(-2*_u + 3*(_u + 1/3)**2 + 22/3), symbol=x), context=11/(3*(3*x**2 - 2*x + 8)), symbol=x)], context=(5*x + 2)/(3*x**2 - 2*x + 8), symbol=x), context=(5*x + 2)/(3*x**2 - 2*x + 8), symbol=x)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * added rules in manualintegrate to cover all cases of rational functions with quadratic denominator
<!-- END RELEASE NOTES -->
