### PR TITLE
Add flag to control verbosity to print_tree

### DIFF
--- a/sympy/printing/tests/test_tree.py
+++ b/sympy/printing/tests/test_tree.py
@@ -157,3 +157,23 @@ def test_print_tree_MatAdd():
     ]
 
     assert tree(A + B) == "".join(test_str)
+
+
+def test_print_tree_MatAdd_noassumptions():
+    from sympy.matrices.expressions import MatrixSymbol, MatAdd
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 3, 3)
+
+    test_str = \
+"""MatAdd: A + B
++-MatrixSymbol: A
+| +-Symbol: A
+| +-Integer: 3
+| +-Integer: 3
++-MatrixSymbol: B
+  +-Symbol: B
+  +-Integer: 3
+  +-Integer: 3
+"""
+
+    assert tree(A + B, assumptions=False) == test_str

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -36,7 +36,7 @@ def pprint_nodes(subtrees):
     return f
 
 
-def print_node(node):
+def print_node(node, assumptions=True):
     """
     Returns information about the "node".
 
@@ -53,11 +53,23 @@ def print_node(node):
     return s
 
 
-def tree(node):
+def tree(node, assumptions=True):
     """
     Returns a tree representation of "node" as a string.
 
     It uses print_node() together with pprint_nodes() on node.args recursively.
+
+    Parameters
+    ==========
+
+    asssumptions : bool
+        The flag to decide whether to print out all the assumption data
+        (such as ``is_integer`, ``is_real``) associated with the
+        expression or not.
+
+        Enabling the flag makes the result verbose, and the printed
+        result may not be determinisitic because of the randomness used
+        in backtracing the assumptions.
 
     See Also
     ========
@@ -67,7 +79,7 @@ def tree(node):
     """
     subtrees = []
     for arg in node.args:
-        subtrees.append(tree(arg))
+        subtrees.append(tree(arg, assumptions=assumptions))
     s = print_node(node) + pprint_nodes(subtrees)
     return s
 

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -41,15 +41,27 @@ def print_node(node, assumptions=True):
     Returns information about the "node".
 
     This includes class name, string representation and assumptions.
+
+    Parameters
+    ==========
+
+    assumptions : bool, optional
+        See the ``assumptions`` keyword in ``tree``
     """
     s = "%s: %s\n" % (node.__class__.__name__, str(node))
-    d = node._assumptions
+
+    if assumptions:
+        d = node._assumptions
+    else:
+        d = None
+
     if d:
         for a in sorted(d):
             v = d[a]
             if v is None:
                 continue
             s += "%s: %s\n" % (a, v)
+
     return s
 
 
@@ -62,7 +74,7 @@ def tree(node, assumptions=True):
     Parameters
     ==========
 
-    asssumptions : bool
+    asssumptions : bool, optional
         The flag to decide whether to print out all the assumption data
         (such as ``is_integer`, ``is_real``) associated with the
         expression or not.
@@ -80,13 +92,25 @@ def tree(node, assumptions=True):
     subtrees = []
     for arg in node.args:
         subtrees.append(tree(arg, assumptions=assumptions))
-    s = print_node(node) + pprint_nodes(subtrees)
+    s = print_node(node, assumptions=assumptions) + pprint_nodes(subtrees)
     return s
 
 
-def print_tree(node):
+def print_tree(node, assumptions=True):
     """
     Prints a tree representation of "node".
+
+    Parameters
+    ==========
+
+    asssumptions : bool, optional
+        The flag to decide whether to print out all the assumption data
+        (such as ``is_integer`, ``is_real``) associated with the
+        expression or not.
+
+        Enabling the flag makes the result verbose, and the printed
+        result may not be determinisitic because of the randomness used
+        in backtracing the assumptions.
 
     Examples
     ========
@@ -95,6 +119,9 @@ def print_tree(node):
     >>> from sympy import Symbol
     >>> x = Symbol('x', odd=True)
     >>> y = Symbol('y', even=True)
+
+    Printing with full assumptions information:
+
     >>> print_tree(y**x)
     Pow: y**x
     +-Symbol: y
@@ -135,10 +162,17 @@ def print_tree(node):
       transcendental: False
       zero: False
 
+    Hiding the assumptions:
+
+    >>> print_tree(y**x, assumptions=False)
+    Pow: y**x
+    +-Symbol: y
+    +-Symbol: x
+
     See Also
     ========
 
     tree
 
     """
-    print(tree(node))
+    print(tree(node, assumptions=assumptions))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently sympy assumptions cache can be non-deterministic because of some randomization used, so it would not be possible to test out the `tree_print` as before, which I had found during #17314
Also, it had made the result too verbose.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added flag `assumptions` to control verbosity for `print_tree`
<!-- END RELEASE NOTES -->
