### PR TITLE
Add matrix wildcards

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2820,6 +2820,12 @@ def test_sympy__matrices__expressions__matexpr__GenericIdentity():
     from sympy.matrices.expressions.matexpr import GenericIdentity
     assert _test_args(GenericIdentity())
 
+
+def test_sympy__matrices__expressions__matexpr__MatrixWild():
+    from sympy.matrices.expressions.matexpr import MatrixWild
+    assert _test_args(MatrixWild('W', x, y))
+
+
 @SKIP("abstract class")
 def test_sympy__matrices__expressions__matexpr__MatrixExpr():
     pass

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1060,6 +1060,8 @@ class MatrixWild(MatrixSymbol, Wild):
         return obj
 
     def matches(self, expr, repl_dict={}, old=False):
+        if not isinstance(expr, MatrixExpr):
+            return None
         if any(expr.has(x) for x in self.exclude):
             return None
         if any(not f(expr) for f in self.properties):
@@ -1071,6 +1073,10 @@ class MatrixWild(MatrixSymbol, Wild):
             matches = selfdim.matches(exprdim)
             if matches is not None:
                 for match in matches:
+                    # Make sure already existing matches are equal
+                    if (match in repl_dict and
+                            repl_dict[match] != matches[match]):
+                        return None
                     repl_dict[match] = matches[match]
             elif selfdim != exprdim:
                 return None

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1027,6 +1027,31 @@ class OneMatrix(MatrixExpr):
 
 
 class MatrixWild(MatrixSymbol, Wild):
+    """A wildcard for matrix expressions based on ``Wild``.
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol
+    >>> from sympy.matrices.expressions.matexpr import MatrixWild
+    >>> A, B = MatrixSymbol('A', 3, 3), MatrixSymbol('B', 3, 3)
+    >>> W = MatrixWild('W', 3, 3)
+    >>> (A*B).match(W)
+    {W_: A*B}
+    >>> (A*B).match(A*W)
+    {W_: B}
+    >>> (A**2).match(A*W)
+    {W_: A}
+
+    Note that ``W`` matched with ``A*B`` only because the expression had the
+    same shape as the matrix wildcard ``W``. If more flexibility is required, a
+    dimension of the matrix wildcard may itself be a wildcard.
+
+    >>> x = Wild('x')
+    >>> W = MatrixWild('W', x, 3)
+    >>> (A*B).match(W)
+    {x_: 3, W_: A*B}
+    """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):
         obj = MatrixSymbol.__new__(cls, name, n, m)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1051,7 +1051,7 @@ class MatrixWild(MatrixSymbol, Wild):
     >>> x = Wild('x')
     >>> Y = MatrixWild('Y', x, 3)
     >>> (A*B).match(Y)
-    {x_: 3, Y_: A*B}
+    {Y_: A*B, x_: 3}
     """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1048,9 +1048,9 @@ class MatrixWild(MatrixSymbol, Wild):
     dimension of the matrix wildcard may itself be a wildcard.
 
     >>> x = Wild('x')
-    >>> W = MatrixWild('W', x, 3)
-    >>> (A*B).match(W)
-    {x_: 3, W_: A*B}
+    >>> Y = MatrixWild('Y', x, 3)
+    >>> (A*B).match(Y)
+    {x_: 3, Y_: A*B}
     """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1047,6 +1047,7 @@ class MatrixWild(MatrixSymbol, Wild):
     same shape as the matrix wildcard ``W``. If more flexibility is required, a
     dimension of the matrix wildcard may itself be a wildcard.
 
+    >>> from sympy.core.symbol import Wild
     >>> x = Wild('x')
     >>> Y = MatrixWild('Y', x, 3)
     >>> (A*B).match(Y)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1060,14 +1060,14 @@ class MatrixWild(MatrixSymbol, Wild):
         obj.properties = tuple(properties)
         return obj
 
-    def matches(self, expr, repl_dict={}, old=False):
+    def matches(self, expr, repl_dict=None, old=False):
         if not isinstance(expr, MatrixExpr):
             return None
         if any(expr.has(x) for x in self.exclude):
             return None
         if any(not f(expr) for f in self.properties):
             return None
-        repl_dict = repl_dict.copy()
+        repl_dict = repl_dict.copy() if repl_dict else {}
 
         # Make sure dimensions match
         for selfdim, exprdim in zip(self.shape, expr.shape):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1042,6 +1042,8 @@ class MatrixWild(MatrixSymbol, Wild):
     {W_: B}
     >>> (A**2).match(A*W)
     {W_: A}
+    >>> print(A.match(A*W))
+    None
 
     Note that ``W`` matched with ``A*B`` only because the expression had the
     same shape as the matrix wildcard ``W``. If more flexibility is required, a
@@ -1052,6 +1054,20 @@ class MatrixWild(MatrixSymbol, Wild):
     >>> Y = MatrixWild('Y', x, 3)
     >>> (A*B).match(Y)
     {Y_: A*B, x_: 3}
+
+    The ``properties`` and ``exclude`` parameters inherited from :class:`Wild`
+    are also supported.
+
+    >>> W = MatrixWild('W', 3, 3, properties=[lambda x: x.is_MatMul])
+    >>> (A*B).match(W)
+    {W_: A*B}
+    >>> print(A.match(W))
+    None
+    >>> Y = MatrixWild('Y', 3, 3, exclude=[A])
+    >>> print(A.match(Y))
+    None
+    >>> B.match(Y)
+    {Y_: B}
     """
 
     def __new__(cls, name, n, m, exclude=(), properties=()):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -175,27 +175,6 @@ class MatMul(MatrixExpr, Mul):
         coeff_nc = [x for x in self.args if not x.is_commutative]
         return [coeff_c, coeff_nc]
 
-    # XXX: This is needed because MatPow doesn't inherit from Pow so powers
-    # aren't expanded to multiplications during matching. Maybe there's a
-    # better way to do this?
-    def matches(self, expr, repl_dict={}, old=False):
-        from sympy.core.basic import preorder_traversal
-
-        def flip_matpow_isPower(expr):
-            for e in preorder_traversal(expr):
-                if isinstance(e, MatPow):
-                    e.is_Pow = not e.is_Pow
-
-        flip_matpow_isPower(self)
-        flip_matpow_isPower(expr)
-
-        result = super(MatMul, self).matches(expr)
-
-        flip_matpow_isPower(self)
-        flip_matpow_isPower(expr)
-
-        return result
-
     def _eval_derivative_matrix_lines(self, x):
         from .transpose import Transpose
         with_x_ind = [i for i, arg in enumerate(self.args) if arg.has(x)]

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -2,12 +2,13 @@ from __future__ import print_function, division
 
 from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
 from sympy.core import S
+from sympy.core.power import Pow
 from sympy.core.compatibility import range
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
 
 
-class MatPow(MatrixExpr):
+class MatPow(MatrixExpr, Pow):
 
     def __new__(cls, base, exp):
         base = _sympify(base)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -1,14 +1,14 @@
 from sympy import (KroneckerDelta, diff, Piecewise, Sum, Dummy, factor,
                    expand, zeros, gcd_terms, Eq, Symbol)
 
-from sympy.core import S, symbols, Add, Mul, SympifyError
+from sympy.core import S, symbols, Add, Mul, SympifyError, Wild
 from sympy.core.compatibility import long
 from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint)
-from sympy.matrices.expressions.matexpr import (MatrixElement,
+from sympy.matrices.expressions.matexpr import (MatrixElement, MatrixWild,
                                                 GenericZeroMatrix, GenericIdentity, OneMatrix)
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -74,6 +74,27 @@ def test_ZeroMatrix_doit():
     assert isinstance(Znn.rows, Add)
     assert Znn.doit() == ZeroMatrix(2*n, n)
     assert isinstance(Znn.doit().rows, Mul)
+
+
+def test_MatrixWild():
+    w1, w2 = symbols('w1, w2', cls=Wild, integer=True)
+
+    W = MatrixWild('W', n, m)
+    X = MatrixWild('X', n, n)
+    Y = MatrixWild('Y', w1, w1)
+    Z = MatrixWild('Z', w1, w2)
+
+    assert A.match(W) == {W: A}
+    assert A.match(X) is None
+    assert D.match(W) is None
+    assert D.match(X) == {X: D}
+
+    assert D.match(Y) == {Y: D, w1: n}
+    assert A.match(Y) is None  # Wildcard dim specifies square, but A is n by m
+    assert A.match(Z) == {Z: A, w1: n, w2: m}
+
+    # Different types
+    assert Z.matches(n) is None
 
 
 def test_OneMatrix():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -96,6 +96,15 @@ def test_MatrixWild():
     # Different types
     assert Z.matches(n) is None
 
+    # Test for exclusion
+    W = MatrixWild('W', n, n, exclude=[C])
+    assert (C*D).match(W) is None
+    assert D.match(W) == {W: D}
+
+    # Test for properties
+    W = MatrixWild('W', n, n, properties=[lambda x: x.is_MatMul])
+    assert (C*D).match(W) == {W: C*D}
+    assert C.match(W) is None
 
 def test_OneMatrix():
     A = MatrixSymbol('A', n, m)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -767,6 +767,9 @@ class StrPrinter(Printer):
     def _print_OneMatrix(self, expr):
         return "1"
 
+    def _print_MatrixWild(self, expr):
+        return expr.name + '_'
+
     def _print_Predicate(self, expr):
         return "Q.%s" % expr.name
 


### PR DESCRIPTION
#### References to other Issues or PRs

Related to #17028

#### Brief description of what is fixed or changed

Adds a `MatrixWild` class that matches matrix expressions.

#### Other comments

This PR implements the same functionality as #17177, but uses new functionality internal to the `Mul` class.

This pull request is the same as #17347, which was closed because it was not synchronizing with its corresponding remote branch.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Add wildcard for matrix expressions
<!-- END RELEASE NOTES -->