### PR TITLE
Standardised __new__ evaluation in Basic applied to Sets

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1814,6 +1814,22 @@ class Basic(with_metaclass(ManagedProperties)):
         2*Integral(x, x)
 
         """
+        if self._basic_version == 2:
+            args = self.args
+
+            # Evaluate args:
+            if hints.get('deep', True):
+                args = tuple(a.doit(**hints) for a in args)
+
+            # Evaluate self:
+            hints.pop('deep', None)
+            newobj = self._eval_doit(*args, **hints)
+            if newobj is not None:
+                return newobj
+
+            return self.func(*args)
+
+        # This is Basic.doit when _basic_version=1
         if hints.get('deep', True):
             terms = [term.doit(**hints) if isinstance(term, Basic) else term
                                          for term in self.args]

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1831,8 +1831,7 @@ class Basic(with_metaclass(ManagedProperties)):
 
         # This is Basic.doit when _basic_version=1
         if hints.get('deep', True):
-            terms = [term.doit(**hints) if isinstance(term, Basic) else term
-                                         for term in self.args]
+            terms = [term.doit(**hints) for term in self.args]
             return self.func(*terms)
         else:
             return self

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -130,6 +130,32 @@ class Basic(with_metaclass(ManagedProperties)):
         obj._args = args  # all items in args must be Basic objects
         return obj
 
+    @classmethod
+    def _eval_validate(cls, *args, **kwargs):
+        '''Basic._eval_validate raises if the args are invalid.
+
+        This method should be overridden by subclasses to validate args.
+        Invalid args should raise. When using _basic_version=2 this method
+        will be called by Basic.__new__ even if evaluate=False. It shoul
+        perform cheap validation of the arguments (e.g. checking types, number
+        of arguments). It should raise if anything is incorrect but otherwise
+        does not return anything.
+        '''
+        pass
+
+    @classmethod
+    def _eval_new(cls, *args, **kwargs):
+        '''Basic._eval_new
+
+        This method should be overridden by subclasses to "evaluate" the
+        instance. Any automatic evaluation to create a different object with
+        different args or of a different type should happen here and should be
+        returned from this method. If this method returns None then the
+        instance will be initialised normally and its args stored in
+        Basic.__new__ afterwards.
+        '''
+        pass
+
     def copy(self):
         return self.func(*self.args)
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -139,7 +139,9 @@ class Basic(with_metaclass(ManagedProperties)):
             # can optimise to avoid double sympification by returning None
             # from _eval_args where possible.
             if newargs is not None:
-                args = tuple(map(S, newargs))
+                if cls._basic_sympifyargs:
+                    newargs = tuple(map(S, newargs))
+                args = newargs
 
             # Now evaluate to something else
             if evaluate is None:

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -172,8 +172,8 @@ class ConditionSet(Set):
             if not isinstance(condition, Set):
                 raise TypeError('Tuple of syms means a set of conditions ZZZ...')
         if not isinstance(condition, (Boolean, Set)):
-            raise TypeError('Boolean exoected...')
-        if not isinstance(sym, (Symbol, Tuple)):
+            raise TypeError('Boolean expected...')
+        if not isinstance(sym, (Symbol, Tuple)) and condition not in (S.true, S.false):
             s = Dummy('lambda')
             if s not in condition.xreplace({sym: s}).free_symbols:
                 raise ValueError(

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -234,8 +234,12 @@ class Reals(with_metaclass(Singleton, Interval)):
 
     ComplexRegion
     """
+    start = _inf = left = S.NegativeInfinity
+    end = _sup = right = S.Infinity
+    left_open = right_open = True
+
     def __new__(cls):
-        return Interval.__new__(cls, -S.Infinity, S.Infinity)
+        return Basic.__new__(cls)
 
     def __eq__(self, other):
         return other == Interval(-S.Infinity, S.Infinity)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -329,14 +329,20 @@ class ImageSet(Set):
 
     @classmethod
     def _eval_doit(cls, flambda, *sets):
+
+        # FIXME: Much of what should be here is in the imageset function. It
+        # should be moved here so that imageset is equivalent to
+        # ImageSet().doit()
+
         if flambda is S.IdentityFunction:
             return sets[0]
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
             return FiniteSet(flambda.expr)
 
-        from sympy.sets.setexpr import SetExpr
-        return SetExpr(*sets)._eval_func(flambda).set
+        if len(sets) == 1:
+            from sympy.sets.setexpr import SetExpr
+            return SetExpr(sets[0])._eval_func(flambda).set
 
     lamda = property(lambda self: self.args[0])
     base_set = property(lambda self: ProductSet(*self.args[1:]))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -314,6 +314,7 @@ class ImageSet(Set):
     sympy.sets.sets.imageset
     """
     _basic_version = 2
+    _basic_autodoit = False
 
     @classmethod
     def _eval_args(cls, flambda, *sets):
@@ -333,6 +334,9 @@ class ImageSet(Set):
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
             return FiniteSet(flambda.expr)
+
+        from sympy.sets.setexpr import SetExpr
+        return SetExpr(*sets)._eval_func(flambda).set
 
     lamda = property(lambda self: self.args[0])
     base_set = property(lambda self: ProductSet(*self.args[1:]))
@@ -453,12 +457,6 @@ class ImageSet(Set):
     @property
     def is_iterable(self):
         return self.base_set.is_iterable
-
-    def doit(self, **kwargs):
-        from sympy.sets.setexpr import SetExpr
-        f = self.lamda
-        base_set = self.base_set
-        return SetExpr(base_set)._eval_func(f).set
 
 
 class Range(Set):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -335,7 +335,7 @@ class ImageSet(Set):
             return FiniteSet(flambda.expr)
 
     lamda = property(lambda self: self.args[0])
-    base_set = property(lambda self: ProductSet(self.args[1:]))
+    base_set = property(lambda self: ProductSet(*self.args[1:]))
 
     def __iter__(self):
         already_seen = set()

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -514,14 +514,12 @@ class Range(Set):
 
     _basic_version = 2
 
-    def __new__(cls, *args):
-        if len(args) == 1:
-            if isinstance(args[0], Range):
-                return args[0]
-            if isinstance(args[0], range):
-                return S(args[0])
-        return Basic.__new__(cls, *args)
-
+    # XXX: The code below shows a good example of why we should probably allow
+    # _eval_validate to return changed args. There isn't any other sensible
+    # way of handling the default arguments for Range which are quite
+    # complicated. Also in the _basic_version=2 scheme this is the natural
+    # place to specify argument defaults. Otherwise evaluate=False here will
+    # lead to a Range that has invalid args.
     @classmethod
     def _eval_validate(cls, *args):
         from sympy.functions.elementary.integers import ceiling
@@ -559,9 +557,6 @@ class Range(Set):
     @classmethod
     def _eval_new(cls, *args):
         from sympy.functions.elementary.integers import ceiling
-        if len(args) == 1:
-            if isinstance(args[0], range):
-                args = args[0].__reduce__()[1]  # use pickle method
 
         # expand range
         slc = slice(*args)
@@ -813,10 +808,9 @@ class Range(Set):
             x <= self.sup if self.sup in self else x < self.sup)
 
 
-if PY3:
-    converter[range] = lambda r: Range(*r.__reduce__()[1])
-else:
-    converter[xrange] = lambda r: Range(*r.__reduce__()[1])
+# Sympify range -> Range
+converter[range] = lambda r: Range(*r.__reduce__()[1])
+
 
 def normalize_theta_set(theta):
     """

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -238,8 +238,16 @@ class Reals(with_metaclass(Singleton, Interval)):
     end = _sup = right = S.Infinity
     left_open = right_open = True
 
-    def __new__(cls):
-        return Basic.__new__(cls)
+    # Override Interval._eval_args and _eval_doit since we don't take the same
+    # args here.
+
+    @classmethod
+    def _eval_args(cls):
+        pass
+
+    @classmethod
+    def _eval_doit(cls):
+        pass
 
     def __eq__(self, other):
         return other == Interval(-S.Infinity, S.Infinity)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -514,12 +514,17 @@ class Range(Set):
 
     _basic_version = 2
 
+    def __new__(cls, *args):
+        if len(args) == 1:
+            if isinstance(args[0], Range):
+                return args[0]
+            if isinstance(args[0], range):
+                return S(args[0])
+        return Basic.__new__(cls, *args)
+
     @classmethod
     def _eval_validate(cls, *args):
         from sympy.functions.elementary.integers import ceiling
-        if len(args) == 1:
-            if isinstance(args[0], range):
-                args = args[0].__reduce__()[1]  # use pickle method
 
         # expand range
         slc = slice(*args)
@@ -809,9 +814,9 @@ class Range(Set):
 
 
 if PY3:
-    converter[range] = Range
+    converter[range] = lambda r: Range(*r.__reduce__()[1])
 else:
-    converter[xrange] = Range
+    converter[xrange] = lambda r: Range(*r.__reduce__()[1])
 
 def normalize_theta_set(theta):
     """

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -351,8 +351,7 @@ def intersection_sets(self, other):
 def intersection_sets(a, b):
     if len(b.args) != len(a.args):
         return S.EmptySet
-    return ProductSet(i.intersect(j)
-            for i, j in zip(a.sets, b.sets))
+    return ProductSet(*(i.intersect(j) for i, j in zip(a.sets, b.sets)))
 
 @dispatch(Interval, Interval)
 def intersection_sets(a, b):

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -44,11 +44,11 @@ def union_sets(a, b):
     if len(b.args) != len(a.args):
         return None
     if a.args[0] == b.args[0]:
-        return a.args[0] * Union(ProductSet(a.args[1:]),
-                                    ProductSet(b.args[1:]))
+        return a.args[0] * Union(ProductSet(*a.args[1:]),
+                                    ProductSet(*b.args[1:]))
     if a.args[-1] == b.args[-1]:
-        return Union(ProductSet(a.args[:-1]),
-                     ProductSet(b.args[:-1])) * a.args[-1]
+        return Union(ProductSet(*a.args[:-1]),
+                     ProductSet(*b.args[:-1])) * a.args[-1]
     return None
 
 @dispatch(ProductSet, Set)

--- a/sympy/sets/ordinals.py
+++ b/sympy/sets/ordinals.py
@@ -7,16 +7,18 @@ class OmegaPower(Basic):
     building blocks of the Ordinal class.
     In OmegaPower(a, b) a represents exponent and b represents multiplicity.
     """
-    def __new__(cls, a, b):
-        if isinstance(b, int):
-            b = Integer(b)
-        if not isinstance(b, Integer) or b <= 0:
+
+    _basic_version = 2
+
+    @classmethod
+    def _eval_args(cls, a, b):
+        if not (b.is_Integer and b > 0):
             raise TypeError("multiplicity must be a positive integer")
 
         if not isinstance(a, Ordinal):
             a = Ordinal.convert(a)
 
-        return Basic.__new__(cls, a, b)
+        return a, b
 
     @property
     def exp(self):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1841,6 +1841,10 @@ def imageset(*args):
     from sympy.sets.fancysets import ImageSet
     from sympy.sets.setexpr import set_function
 
+    # FIXME: This whole function should just be a wrapper for
+    # ImageSet().doit(). The non-trivial processing below does not belong
+    # here.
+
     if len(args) < 2:
         raise ValueError('imageset expects at least 2 args, got: %s' % len(args))
 
@@ -1913,9 +1917,9 @@ def imageset(*args):
                     set.base_set)
 
         if r is not None:
-            return r
+            return r.doit()
 
-    return ImageSet(f, *set_list)
+    return ImageSet(f, *set_list).doit()
 
 
 def is_function_invertible_in_set(func, setv):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1430,11 +1430,11 @@ class Complement(Set, EvalfMixin):
 
     is_Complement = True
 
-    def __new__(cls, a, b, evaluate=True):
-        if evaluate:
-            return Complement.reduce(a, b)
+    _basic_version = 2
 
-        return Basic.__new__(cls, a, b)
+    @classmethod
+    def _eval_doit(cls, a, b):
+        return Complement.reduce(a, b)
 
     @staticmethod
     def reduce(A, B):
@@ -1597,19 +1597,16 @@ class FiniteSet(Set, EvalfMixin):
     is_FiniteSet = True
     is_iterable = True
 
-    def __new__(cls, *args, **kwargs):
-        evaluate = kwargs.get('evaluate', global_evaluate[0])
-        if evaluate:
-            args = list(map(sympify, args))
+    _basic_version = 2
 
-            if len(args) == 0:
-                return EmptySet()
-        else:
-            args = list(map(sympify, args))
+    @classmethod
+    def _eval_args(cls, *args, **kwargs):
+        return tuple(ordered(set(args), Set._infimum_key))
 
-        args = list(ordered(set(args), Set._infimum_key))
-        obj = Basic.__new__(cls, *args)
-        return obj
+    @classmethod
+    def _eval_doit(cls, *args, **kwargs):
+        if len(args) == 0:
+            return EmptySet()
 
     def _eval_Eq(self, other):
         if not isinstance(other, FiniteSet):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1775,14 +1775,14 @@ class SymmetricDifference(Set):
 
     is_SymmetricDifference = True
 
-    def __new__(cls, a, b, evaluate=True):
-        if evaluate:
-            return SymmetricDifference.reduce(a, b)
+    _basic_version = 2
 
-        return Basic.__new__(cls, a, b)
+    @classmethod
+    def _eval_doit(cls, a, b):
+        return SymmetricDifference.reduce(a, b)
 
-    @staticmethod
-    def reduce(A, B):
+    @classmethod
+    def reduce(cls, A, B):
         result = B._symmetric_difference(A)
         if result is not None:
             return result

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -302,11 +302,11 @@ def test_Range_set():
     else:
         builtin_range = xrange
 
-    assert Range(builtin_range(10)) == Range(10)
-    assert Range(builtin_range(1, 10)) == Range(1, 10)
-    assert Range(builtin_range(1, 10, 2)) == Range(1, 10, 2)
+    assert S(builtin_range(10)) == Range(10)
+    assert S(builtin_range(1, 10)) == Range(1, 10)
+    assert S(builtin_range(1, 10, 2)) == Range(1, 10, 2)
     if PY3:
-        assert Range(builtin_range(1000000000000)) == \
+        assert S(builtin_range(1000000000000)) == \
             Range(1000000000000)
 
     # test Range.as_relational

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -76,9 +76,9 @@ def test_integers():
 
 def test_ImageSet():
     raises(ValueError, lambda: ImageSet(x, S.Integers))
-    assert ImageSet(Lambda(x, 1), S.Integers) == FiniteSet(1)
+    assert ImageSet(Lambda(x, 1), S.Integers).doit() == FiniteSet(1)
     assert ImageSet(Lambda(x, y), S.Integers
-        ) == {y}
+        ).doit() == {y}
     squares = ImageSet(Lambda(x, x**2), S.Naturals)
     assert 4 in squares
     assert 5 not in squares
@@ -827,7 +827,7 @@ def test_issue_9543():
 
 
 def test_issue_16871():
-    assert ImageSet(Lambda(x, x), FiniteSet(1)) == {1}
+    assert ImageSet(Lambda(x, x), FiniteSet(1)).doit() == {1}
     assert ImageSet(Lambda(x, x - 3), S.Integers
         ).intersection(S.Integers) is S.Integers
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -103,17 +103,17 @@ def test_ImageSet():
 
     assert ImageSet(Lambda(x, x**2), Interval(0, 2)).doit() == Interval(0, 4)
 
-    c = ComplexRegion(Interval(1, 3)*Interval(1, 3))
-    assert Tuple(2, 6) in ImageSet(Lambda((x, y), (x, 2*y)), c)
-    assert Tuple(2, S.Half) in ImageSet(Lambda((x, y), (x, 1/y)), c)
-    assert Tuple(2, -2) not in ImageSet(Lambda((x, y), (x, y**2)), c)
-    assert Tuple(2, -2) in ImageSet(Lambda((x, y), (x, -2)), c)
-    c3 = Interval(3, 7)*Interval(8, 11)*Interval(5, 9)
-    assert Tuple(8, 3, 9) in ImageSet(Lambda((t, y, x), (y, t, x)), c3)
-    assert Tuple(S(1)/8, 3, 9) in ImageSet(Lambda((t, y, x), (1/y, t, x)), c3)
-    assert 2/pi not in ImageSet(Lambda((x, y), 2/x), c)
-    assert 2/S(100) not in ImageSet(Lambda((x, y), 2/x), c)
-    assert 2/S(3) in ImageSet(Lambda((x, y), 2/x), c)
+    c = (Interval(1, 3), Interval(1, 3))
+    assert Tuple(2, 6) in ImageSet(Lambda((x, y), (x, 2*y)), *c)
+    assert Tuple(2, S.Half) in ImageSet(Lambda((x, y), (x, 1/y)), *c)
+    assert Tuple(2, -2) not in ImageSet(Lambda((x, y), (x, y**2)), *c)
+    assert Tuple(2, -2) in ImageSet(Lambda((x, y), (x, -2)), *c)
+    c3 = (Interval(3, 7), Interval(8, 11), Interval(5, 9))
+    assert Tuple(8, 3, 9) in ImageSet(Lambda((t, y, x), (y, t, x)), *c3)
+    assert Tuple(S(1)/8, 3, 9) in ImageSet(Lambda((t, y, x), (1/y, t, x)), *c3)
+    assert 2/pi not in ImageSet(Lambda((x, y), 2/x), *c)
+    assert 2/S(100) not in ImageSet(Lambda((x, y), 2/x), *c)
+    assert 2/S(3) in ImageSet(Lambda((x, y), 2/x), *c)
 
     assert imageset(lambda x, y: x + y, S.Integers, S.Naturals
         ).base_set == ProductSet(S.Integers, S.Naturals)
@@ -129,7 +129,7 @@ def test_halfcircle():
     # I believe the code within fancysets is correct
     r, th = symbols('r, theta', real=True)
     L = Lambda((r, th), (r*cos(th), r*sin(th)))
-    halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
+    halfcircle = ImageSet(L, Interval(0, 1), Interval(0, pi))
 
     assert (r, 0) in halfcircle
     assert (1, 0) in halfcircle

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -38,7 +38,7 @@ def test_imageset():
     assert imageset(f, ints) == ImageSet(Lambda(x, cos(x)), ints)
     assert imageset(x, 1, ints) == FiniteSet(1)
     assert imageset(x, y, ints) == {y}
-    assert imageset((x, y), (1, z), ints*S.Reals) == {(1, z)}
+    assert imageset((x, y), (1, z), ints, S.Reals) == {(1, z)}
     clash = Symbol('x', integer=true)
     assert (str(imageset(lambda x: x + clash, Interval(-2, 1)).lamda.expr)
         in ('_x + x', 'x + _x'))

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -506,7 +506,7 @@ class ProductDomain(RandomDomain):
 
     @property
     def set(self):
-        return ProductSet(domain.set for domain in self.domains)
+        return ProductSet(*(domain.set for domain in self.domains))
 
     def __contains__(self, other):
         # Split event into each subdomain

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -199,15 +199,7 @@ if not USE_PYTEST:
 else:
     XFAIL = py.test.mark.xfail
     slow = py.test.mark.slow
-
-    def SKIP(reason):
-        def skipping(func):
-            @functools.wraps(func)
-            def inner(*args, **kwargs):
-                skip(reason)
-            return inner
-
-        return skipping
+    SKIP = py.test.mark.skip
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

First stab at #17280 

See also #17360 #17366 #17370 

#### Brief description of what is fixed or changed

This is a first draft of changes to `Basic.__new__` so standardise evaluation for evaluate=False/True. This creates a new Basic class attribute `_basic_version=1`. Subclasses can override this and set `_basic_version=2` to change the behaviour of `Basic.__new__`. These changes are then applied to most subclasses in the sets package to see how they look. I went through a couple of iterations on the basic outline of this so the implemented methods are not exactly as described in #17280. Further changes are planned such as defining doit on Basic (which will call `_eval_doit`).

Subclass using Basic version 2 should not define `__new__`. Instead `Basic.__new__` calls two class methods `_eval_args` and `_eval_doit`. The `_eval_args` method is responsible for handling any kwargs and default arguments and for validating the arguments and raising when they do not create a coherent object. The `args` tuple returned from `_eval_args` will be used directly as the object's Basic args if `evaluate=False`. If `evaluate=True` then the args tuple will be passed to `_eval_doit` which can return None if no evaluation is needed or possible or otherwise returns a different object that will ultimately be returned by `Basic.__new__`.

Sympification of all args and kwargs is also handled in `Basic.__new__` so that subclasses do not need to worry about it. If you look at `Basic.__new__` I have left many comments discussing how exactly to approach this since there is the possibility that some args will end up being sympified twice - once before `_eval_args` and once after.

#### Other comments

I picked sets here because I expected it to be small but also have a range of types of classes and class relationships. Indeed there are some strange things going on in the class hierarchy here. I was not immediately able to apply these changes to `ComplexRegion/Complexes` (#17370). Some changes to args were needed in `Reals` (#17360). I have also changed `Range` so that `Range(range(10))` is disallowed (#17366).

I should probably open a new issue about this but `ProductSet` here has auto-sympification disabled because it currently accepts unsimpifiable generators as arguments. I think that should just be disallowed - I don't see any good reason for accepting generators and the principle that args should be simpifiable is important IMO.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
