### PR TITLE
Use warns rather than raises to test for warnings

### DIFF
--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1975,5 +1975,6 @@ def test_tensorhead():
 
 def test_TensorType():
     with warns_deprecated_sympy():
-        sym = TensorSymmetry.no_symmetry(1)
-        TensorType(sym, 2)
+        sym2 = TensorSymmetry.fully_symmetric(2)
+        Lorentz = TensorIndexType('Lorentz')
+        S2 = TensorType([Lorentz]*2, sym2)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -13,7 +13,7 @@ from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry,
     riemann_cyclic_replace, riemann_cyclic, TensMul, tensor_heads, \
     TensorManager, TensExpr, TensorHead, canon_bp, \
     tensorhead, tensorsymmetry, TensorType
-from sympy.utilities.pytest import raises, XFAIL, ignore_warnings
+from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy, ignore_warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.compatibility import range
 from sympy.matrices import diag
@@ -1966,14 +1966,14 @@ def test_rewrite_tensor_to_Indexed():
 
 
 def test_tensorsymmetry():
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         tensorsymmetry([1]*2)
 
 def test_tensorhead():
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         tensorhead('A', [])
 
 def test_TensorType():
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         sym = TensorSymmetry.no_symmetry(1)
         TensorType(sym, 2)


### PR DESCRIPTION
changed `raises(SymPyDeprecationWarning)` to `with warns_deprecated_sympy():`
in `sympy/tensor/tests/test_tensor.py`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17364 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
