### PR TITLE
Fixes gh-17368: sympyrepr for Token was incorrect

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1511,7 +1511,7 @@ class Pointer(Variable):
     >>> i = Symbol('i', integer=True)
     >>> p = Pointer('x')
     >>> p[i+1]
-    Element(x, indices=((i + 1,),))
+    Element(x, indices=(i + 1,))
 
     """
 

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -266,7 +266,7 @@ class Token(Basic):
             if isinstance(arg, Token):
                 return printer._print(arg, *args, joiner=self._joiner(k, il), **kwargs)
             else:
-                return printer._print(v, *args, **kwargs)
+                return printer._print(arg, *args, **kwargs)
 
         if isinstance(v, Tuple):
             joined = self._joiner(k, il).join([_print(arg) for arg in v.args])

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -619,12 +619,22 @@ def test_FunctionCall():
     fc = FunctionCall('power', (x, 3))
     assert fc.function_args[0] == x
     assert fc.function_args[1] == 3
+    assert len(fc.function_args) == 2
     assert isinstance(fc.function_args[1], Integer)
     assert fc == FunctionCall('power', (x, 3))
     assert fc != FunctionCall('power', (3, x))
     assert fc != FunctionCall('Power', (x, 3))
     assert fc.func(*fc.args) == fc
 
+    fc2 = FunctionCall('fma', [2, 3, 4])
+    assert len(fc2.function_args) == 3
+    assert fc2.function_args[0] == 2
+    assert fc2.function_args[1] == 3
+    assert fc2.function_args[2] == 4
+    assert str(fc2) in ( # not sure if QuotedString is a better default...
+        'FunctionCall(fma, function_args=(2, 3, 4))',
+        'FunctionCall("fma", function_args=(2, 3, 4))',
+    )
 
 def test_ast_replace():
     x = Variable('x', real)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes gh-17368

#### Brief description of what is fixed or changed
sympyrepr for Token was incorrect (iterables were printed several times)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
