### PR TITLE
Fix HTML rendering of parameters and returns section

### DIFF
--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -337,3 +337,24 @@ code{
     border-radius: 3px;
     padding: 2px;
 }
+
+/*
+Temporary workaround for field list styles. Remove this after field list
+rendering problem is fixed in the upstream
+https://github.com/sphinx-doc/sphinx/issues/6604
+*/
+
+dl.field-list > dt {
+    width: 100px;
+    flex: inherit;
+    color: black;
+    padding: 1px 8px 1px 5px;
+    background-color: #EEDDEE;
+}
+
+dl.field-list > dd {
+    width: 600px;
+    margin: 1px 8px 1px 5px;
+    background-color: white;
+    padding: 0;
+}

--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -9,7 +9,7 @@
  *
  */
 
-@import url("basic.css");
+@import url("classic.css");
 @import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 /* -- page layout ----------------------------------------------------------- */
@@ -336,25 +336,4 @@ code{
     background-color: #ECF0F3;
     border-radius: 3px;
     padding: 2px;
-}
-
-/*
-Temporary workaround for field list styles. Remove this after field list
-rendering problem is fixed in the upstream
-https://github.com/sphinx-doc/sphinx/issues/6604
-*/
-
-dl.field-list > dt {
-    width: 100px;
-    flex: inherit;
-    color: black;
-    padding: 1px 8px 1px 5px;
-    background-color: #EEDDEE;
-}
-
-dl.field-list > dd {
-    width: 600px;
-    margin: 1px 8px 1px 5px;
-    background-color: white;
-    padding: 0;
 }

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -382,7 +382,7 @@ def encipher_affine(msg, key, symbols=None, _inverse=False):
     symbols
         String of characters (default = uppercase letters).
 
-        When no symbols are given, ``msg`` is convertedvto upper case
+        When no symbols are given, ``msg`` is converted to upper case
         letters and all other characters are ignored.
 
     Returns

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -116,16 +116,19 @@ def padded_key(key, symbols, filter=True):
 
 def check_and_join(phrase, symbols=None, filter=None):
     """
-    Joins characters of `phrase` and if ``symbols`` is given, raises
+    Joins characters of ``phrase`` and if ``symbols`` is given, raises
     an error if any character in ``phrase`` is not in ``symbols``.
 
     Parameters
     ==========
 
-    phrase :    string or list of strings to be returned as a string
+    phrase
+        String or list of strings to be returned as a string.
 
-    symbols :   iterable of characters allowed in ``phrase``;
-                if ``symbols`` is None, no checking is performed
+    symbols
+        Iterable of characters allowed in ``phrase``.
+
+        If ``symbols`` is ``None``, no checking is performed.
 
     Examples
     ========
@@ -198,25 +201,17 @@ def encipher_shift(msg, key, symbols=None):
     Parameters
     ==========
 
-            key : an integer (the secret key)
+    key : int
+        The secret key.
 
-            msg : plaintext of upper-case letters
+    msg : str
+        Plaintext of upper-case letters.
 
     Returns
     =======
 
-            ct : ciphertext of upper-case letters
-
-    ALGORITHM:
-
-        STEPS:
-            0. Number the letters of the alphabet from 0, ..., N
-            1. Compute from the string ``msg`` a list ``L1`` of
-               corresponding integers.
-            2. Compute from the list ``L1`` a new list ``L2``, given by
-               adding ``(k mod 26)`` to each element in ``L1``.
-            3. Compute from the list ``L2`` a string ``ct`` of
-               corresponding letters.
+    str
+        Ciphertext of upper-case letters.
 
     Examples
     ========
@@ -239,6 +234,17 @@ def encipher_shift(msg, key, symbols=None):
 
     Notes
     =====
+
+    ALGORITHM:
+
+        STEPS:
+            0. Number the letters of the alphabet from 0, ..., N
+            1. Compute from the string ``msg`` a list ``L1`` of
+               corresponding integers.
+            2. Compute from the list ``L1`` a new list ``L2``, given by
+               adding ``(k mod 26)`` to each element in ``L1``.
+            3. Compute from the list ``L2`` a string ``ct`` of
+               corresponding letters.
 
     The shift cipher is also called the Caesar cipher, after
     Julius Caesar, who, according to Suetonius, used it with a
@@ -367,19 +373,26 @@ def encipher_affine(msg, key, symbols=None, _inverse=False):
     Parameters
     ==========
 
-            msg : string of characters that appear in ``symbols``
+    msg : str
+        Characters that appear in ``symbols``.
 
-            a, b : a pair integers, with ``gcd(a, N) = 1``
-            (the secret key)
+    a, b : int, int
+        A pair integers, with ``gcd(a, N) = 1`` (the secret key).
 
-            symbols : string of characters (default = uppercase
-            letters). When no symbols are given, ``msg`` is converted
-            to upper case letters and all other characters are ignored.
+    symbols
+        String of characters (default = uppercase letters).
+
+        When no symbols are given, ``msg`` is convertedvto upper case
+        letters and all other characters are ignored.
 
     Returns
     =======
 
-            ct : string of characters (the ciphertext message)
+    ct
+        String of characters (the ciphertext message)
+
+    Notes
+    =====
 
     ALGORITHM:
 
@@ -392,9 +405,6 @@ def encipher_affine(msg, key, symbols=None, _inverse=False):
                ``x`` in ``L1``.
             3. Compute from the list ``L2`` a string ``ct`` of
                corresponding letters.
-
-    Notes
-    =====
 
     This is a straightforward generalization of the shift cipher with
     the added complexity of requiring 2 characters to be deciphered in
@@ -799,19 +809,25 @@ def encipher_hill(msg, key, symbols=None, pad="Q"):
     Parameters
     ==========
 
-            msg : plaintext message of `n` upper-case letters
+    msg
+        Plaintext message of `n` upper-case letters.
 
-            key : a `k x k` invertible matrix `K`, all of whose
-            entries are in `Z_{26}` (or whatever number of symbols
-            are being used).
+    key
+        A `k \times k` invertible matrix `K`, all of whose entries are
+        in `Z_{26}` (or whatever number of symbols are being used).
 
-            pad : character (default "Q") to use to make length
-            of text be a multiple of ``k``
+    pad
+        Character (default "Q") to use to make length of text be a
+        multiple of ``k``.
 
     Returns
     =======
 
-            ct : ciphertext of upper-case letters
+    ct
+        Ciphertext of upper-case letters.
+
+    Notes
+    =====
 
     ALGORITHM:
 
@@ -945,19 +961,25 @@ def encipher_bifid(msg, key, symbols=None):
     Parameters
     ==========
 
-            msg : plaintext string
+    msg
+        Plaintext string.
 
-            key : short string for key; duplicate characters are
-            ignored and then it is padded with the characters in
-            ``symbols`` that were not in the short key
+    key
+        Short string for key.
 
-            symbols : `n \times n` characters defining the alphabet
-            (default is string.printable)
+        Duplicate characters are ignored and then it is padded with the
+        characters in ``symbols`` that were not in the short key.
+
+    symbols
+        `n \times n` characters defining the alphabet.
+
+        (default is string.printable)
 
     Returns
     =======
 
-            ciphertext (using Bifid5 cipher without spaces)
+    ciphertext
+        Ciphertext using Bifid5 cipher without spaces.
 
     See Also
     ========
@@ -1001,19 +1023,25 @@ def decipher_bifid(msg, key, symbols=None):
     Parameters
     ==========
 
-            msg : ciphertext string
+    msg
+        Ciphertext string.
 
-            key : short string for key; duplicate characters are
-            ignored and then it is padded with the characters in
-            symbols that were not in the short key
+    key
+        Short string for key.
 
-            symbols : `n \times n` characters defining the alphabet
-            (default=string.printable, a `10 \times 10` matrix)
+        Duplicate characters are ignored and then it is padded with the
+        characters in symbols that were not in the short key.
+
+    symbols
+        `n \times n` characters defining the alphabet.
+
+        (default=string.printable, a `10 \times 10` matrix)
 
     Returns
     =======
 
-            deciphered text
+    deciphered
+        Deciphered text.
 
     Examples
     ========
@@ -1165,18 +1193,23 @@ def encipher_bifid5(msg, key):
     Parameters
     ==========
 
-            msg : plaintext string; converted to upper case and
-            filtered of anything but all letters except J.
+    msg : str
+        Plaintext string.
 
-            key : short string for key; non-alphabetic letters, J
-            and duplicated characters are ignored and then, if the
-            length is less than 25 characters, it is padded with other
-            letters of the alphabet (in alphabetical order).
+        Converted to upper case and filtered of anything but all letters
+        except J.
+
+    key
+        Short string for key; non-alphabetic letters, J and duplicated
+        characters are ignored and then, if the length is less than 25
+        characters, it is padded with other letters of the alphabet
+        (in alphabetical order).
 
     Returns
     =======
 
-            ct : ciphertext (all caps, no spaces)
+    ct
+        Ciphertext (all caps, no spaces).
 
     Examples
     ========
@@ -1235,17 +1268,20 @@ def decipher_bifid5(msg, key):
     Parameters
     ==========
 
-        msg : ciphertext string
+    msg
+        Ciphertext string.
 
-        key : short string for key; duplicated characters are
-        ignored and if the length is less then 25 characters, it
-        will be padded with other letters from the alphabet omitting
-        "J". Non-alphabetic characters are ignored.
+    key
+        Short string for key; duplicated characters are ignored and if
+        the length is less then 25 characters, it will be padded with
+        other letters from the alphabet omitting "J".
+        Non-alphabetic characters are ignored.
 
     Returns
     =======
 
-        plaintext from Bifid5 cipher (all caps, no spaces)
+    plaintext
+        Plaintext from Bifid5 cipher (all caps, no spaces).
 
     Examples
     ========
@@ -1303,16 +1339,20 @@ def encipher_bifid6(msg, key):
     Parameters
     ==========
 
-        msg : plaintext string (digits okay)
+    msg
+        Plaintext string (digits okay).
 
-        key : short string for key (digits okay). If ``key`` is
-        less than 36 characters long, the square will be filled with
-        letters A through Z and digits 0 through 9.
+    key
+        Short string for key (digits okay).
+
+        If ``key`` is less than 36 characters long, the square will be
+        filled with letters A through Z and digits 0 through 9.
 
     Returns
     =======
 
-        ciphertext from Bifid cipher (all caps, no spaces)
+    ciphertext
+        Ciphertext from Bifid cipher (all caps, no spaces).
 
     See Also
     ========
@@ -1336,17 +1376,21 @@ def decipher_bifid6(msg, key):
     Parameters
     ==========
 
-        msg : ciphertext string (digits okay); converted to upper case
+    msg
+        Ciphertext string (digits okay); converted to upper case
 
-        key : short string for key (digits okay). If ``key`` is
-        less than 36 characters long, the square will be filled with
-        letters A through Z and digits 0 through 9. All letters are
-        converted to uppercase.
+    key
+        Short string for key (digits okay).
+
+        If ``key`` is less than 36 characters long, the square will be
+        filled with letters A through Z and digits 0 through 9.
+        All letters are converted to uppercase.
 
     Returns
     =======
 
-        plaintext from Bifid cipher (all caps, no spaces)
+    plaintext
+        Plaintext from Bifid cipher (all caps, no spaces).
 
     Examples
     ========
@@ -2237,18 +2281,20 @@ def lfsr_sequence(key, fill, n):
     Parameters
     ==========
 
-        key : a list of finite field elements,
-            `[c_0, c_1, \ldots, c_k].`
+    key : list
+        A list of finite field elements, `[c_0, c_1, \ldots, c_k].`
 
-        fill : the list of the initial terms of the LFSR
-            sequence, `[x_0, x_1, \ldots, x_k].`
+    fill : list
+        The list of the initial terms of the LFSR sequence,
+        `[x_0, x_1, \ldots, x_k].`
 
-        n : number of terms of the sequence that the
-            function returns.
+    n
+        Number of terms of the sequence that the function returns.
 
     Returns
     =======
 
+    L
         The LFSR sequence defined by
         `x_{n+1} = c_k x_n + \ldots + c_0 x_{n-k}`, for
         `n \leq k`.
@@ -2338,17 +2384,21 @@ def lfsr_autocorrelation(L, P, k):
     Parameters
     ==========
 
-        L : is a periodic sequence of elements of `GF(2)`.
+    L
+        A periodic sequence of elements of `GF(2)`.
         L must have length larger than P.
 
-        P : the period of L
+    P
+        The period of L.
 
-        k : an integer (`0 < k < P`)
+    k : int
+        An integer `k` (`0 < k < P`).
 
     Returns
     =======
 
-        The k-th value of the autocorrelation of the LFSR L
+    autocorrelation
+        The k-th value of the autocorrelation of the LFSR L.
 
     Examples
     ========
@@ -2384,17 +2434,18 @@ def lfsr_connection_polynomial(s):
     Parameters
     ==========
 
-        s : a sequence of elements of even length, with entries in
-        a finite field
+    s
+        A sequence of elements of even length, with entries in a finite
+        field.
 
     Returns
     =======
 
-        C(x) : the connection polynomial of a minimal LFSR yielding
-        s.
+    C(x)
+        The connection polynomial of a minimal LFSR yielding s.
 
-    This implements the algorithm in section 3 of J. L. Massey's
-    article [M]_.
+        This implements the algorithm in section 3 of J. L. Massey's
+        article [M]_.
 
     Examples
     ========
@@ -2492,12 +2543,18 @@ def elgamal_private_key(digit=10, seed=None):
     Parameters
     ==========
 
-    digit : minimum number of binary digits for key
+    digit : int
+        Minimum number of binary digits for key.
 
     Returns
     =======
 
-    (p, r, d) : p = prime number, r = primitive root, d = random number
+    tuple : (p, r, d)
+        p = prime number.
+
+        r = primitive root.
+
+        d = random number.
 
     Notes
     =====
@@ -2523,18 +2580,22 @@ def elgamal_private_key(digit=10, seed=None):
 
 
 def elgamal_public_key(key):
-    """
+    r"""
     Return three number tuple as public key.
 
     Parameters
     ==========
 
-    key : Tuple (p, r, e)  generated by ``elgamal_private_key``
+    key : (p, r, e)
+        Tuple generated by ``elgamal_private_key``.
 
     Returns
     =======
 
-    (p, r, e = r**d mod p) : d is a random number in private key.
+    tuple : (p, r, e)
+        `e = r**d \bmod p`
+
+        `d` is a random number in private key.
 
     Examples
     ========
@@ -2565,13 +2626,17 @@ def encipher_elgamal(i, key, seed=None):
     Parameters
     ==========
 
-    msg : int of encoded message
-    key : public key
+    msg
+        int of encoded message.
+
+    key
+        Public key.
 
     Returns
     =======
 
-    (c1, c2) : Encipher into two number
+    tuple : (c1, c2)
+        Encipher into two number.
 
     Notes
     =====
@@ -2665,13 +2730,18 @@ def dh_private_key(digit=10, seed=None):
     Parameters
     ==========
 
-    digit: minimum number of binary digits required in key
+    digit
+        Minimum number of binary digits required in key.
 
     Returns
     =======
 
-    (p, g, a) : p = prime number, g = primitive root of p,
-                a = random number from 2 through p - 1
+    tuple : (p, g, a)
+        p = prime number.
+
+        g = primitive root of p.
+
+        a = random number from 2 through p - 1.
 
     Notes
     =====
@@ -2704,7 +2774,7 @@ def dh_private_key(digit=10, seed=None):
 
 
 def dh_public_key(key):
-    """
+    r"""
     Return three number tuple as public key.
 
     This is the tuple that Alice sends to Bob.
@@ -2712,12 +2782,15 @@ def dh_public_key(key):
     Parameters
     ==========
 
-    key : Tuple (p, g, a) generated by ``dh_private_key``
+    key : (p, g, a)
+        A tuple generated by ``dh_private_key``.
 
     Returns
     =======
 
-    (p, g, g^a mod p) : p, g and a as in Parameters
+    tuple : int, int, int
+        A tuple of `(p, g, g^a \mod p)` with `p`, `g` and `a` given as
+        parameters.s
 
     Examples
     ========
@@ -2745,14 +2818,18 @@ def dh_shared_key(key, b):
     Parameters
     ==========
 
-    key : Tuple (p, g, x) generated by ``dh_public_key``
-    b : Random number in the range of 2 to p - 1
-       (Chosen by second key exchange member (Bob))
+    key : (p, g, x)
+        Tuple `(p, g, x)` generated by ``dh_public_key``.
+
+    b
+        Random number in the range of `2` to `p - 1`
+        (Chosen by second key exchange member (Bob)).
 
     Returns
     =======
 
-    shared key (int)
+    int
+        A shared key.
 
     Examples
     ========
@@ -2790,13 +2867,17 @@ def _legendre(a, p):
     Parameters
     ==========
 
-    a : int the number to test
-    p : the prime to test a against
+    a : int
+        The number to test.
+
+    p : prime
+        The prime to test ``a`` against.
 
     Returns
     =======
 
-    legendre symbol (a / p) (int)
+    int
+        Legendre symbol (a / p).
 
     """
     sig = pow(a, (p - 1)//2, p)
@@ -2855,17 +2936,20 @@ def gm_private_key(p, q, a=None):
     Parameters
     ==========
 
-    p, q, a : initialization variables
+    p, q, a
+        Initialization variables.
 
     Returns
     =======
 
-    p, q : the input value p and q
+    tuple : (p, q)
+        The input value ``p`` and ``q``.
 
     Raises
     ======
 
-    ValueError : if p and q are not distinct odd primes
+    ValueError
+        If ``p`` and ``q`` are not distinct odd primes.
 
     """
     if p == q:
@@ -2889,16 +2973,17 @@ def gm_public_key(p, q, a=None, seed=None):
     Parameters
     ==========
 
-    p, q, a : (int) initialization variables
+    p, q, a : int, int, int
+        Initialization variables.
 
     Returns
     =======
 
-    (a, N) : tuple[int]
-        a is the input a if it is not None otherwise
-        some random integer coprime to p and q.
+    tuple : (a, N)
+        ``a`` is the input ``a`` if it is not ``None`` otherwise
+        some random integer coprime to ``p`` and ``q``.
 
-        N is the product of p and q
+        ``N`` is the product of ``p`` and ``q``.
 
     """
 
@@ -2925,13 +3010,17 @@ def encipher_gm(i, key, seed=None):
     Parameters
     ==========
 
-    i : (int) the message to encrypt
-    key : Tuple (a, N) the public key
+    i : int
+        The message to encrypt.
+
+    key : (a, N)
+        The public key.
 
     Returns
     =======
 
-    List[int] : the randomized encrypted message.
+    list : list of int
+        The randomized encrypted message.
 
     """
     if i < 0:
@@ -2958,13 +3047,17 @@ def decipher_gm(message, key):
     Parameters
     ==========
 
-    List[int] : the randomized encrypted message.
-    key : Tuple (p, q) the private key
+    message : list of int
+        The randomized encrypted message.
+
+    key : (p, q)
+        The private key.
 
     Returns
     =======
 
-    i : (int) the encrypted message
+    int
+        The encrypted message.
 
     """
     p, q = key
@@ -2993,17 +3086,20 @@ def bg_private_key(p, q):
     Parameters
     ==========
 
-    p, q : the keys to be checked
+    p, q
+        The keys to be checked.
 
     Returns
     =======
 
-    p, q : input values
+    p, q
+        Input values.
 
     Raises
     ======
 
-    ValueError : if p and q do not pass the above conditions
+    ValueError
+        If p and q do not pass the above conditions.
 
     """
 
@@ -3029,12 +3125,14 @@ def bg_public_key(p, q):
     Parameters
     ==========
 
-    p, q : the private keys
+    p, q
+        The private keys.
 
     Returns
     =======
 
-    N : the public key
+    N
+        The public key.
 
     """
     p, q = bg_private_key(p, q)
@@ -3058,18 +3156,23 @@ def encipher_bg(i, key, seed=None):
     Parameters
     ==========
 
-    i : message, a non-negative integer
-    key : the public key
+    i
+        Message, a non-negative integer
+
+    key
+        The public key
 
     Returns
     =======
 
-    (encrypted_message, x_L) : Tuple
+    Tuple
+        (encrypted_message, x_L)
 
     Raises
     ======
 
-    ValueError : if i is negative
+    ValueError
+        If i is negative.
 
     """
 
@@ -3115,13 +3218,17 @@ def decipher_bg(message, key):
     Parameters
     ==========
 
-    message : Tuple of encrypted message and a non-negative integer.
-    key : Tuple of private keys
+    message
+        Tuple of encrypted message and a non-negative integer.
+
+    key
+        Tuple of private keys.
 
     Returns
     =======
 
-    orig_msg : The original message
+    orig_msg
+        The original message
 
     """
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16585 

#### Brief description of what is fixed or changed

I've concluded that the sphinx field list rendering problem is an upstream problem.
https://github.com/sphinx-doc/sphinx/issues/6604
I also see that many projects are pinning down the sphinx version because of the issue https://github.com/numpy/numpydoc/issues/215

But somehow, I've tried out specifying the CSS theme like below with some basic trials and errors, and at least I can confirm that this works for almost every corners of sympy docs, without having any problem of overflowing or breaking other formats.

Also, I've fixed some bad formats in the cryptography module, so that I can also present how the changes look like.

<details><summary>check_and_join</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848568-373aab00-bd17-11e9-80f0-febb9f391329.png>
</p>
</details>

<details><summary>decipher_gm</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848593-50dbf280-bd17-11e9-88fe-f742288d932e.png>
</p>
</details>

<details><summary>dh_private_key</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848610-5f2a0e80-bd17-11e9-8e00-91fdc8d8c039.png>
</p>
</details>

<details><summary>dh_shared_key</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848627-7537cf00-bd17-11e9-9085-d5b5bbc57130.png>
</p>
</details>

<details><summary>elgamal_private_key</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848670-939dca80-bd17-11e9-8e3b-61033470ed07.png>
</p>
</details>

<details><summary>encipher_affine</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848696-a6b09a80-bd17-11e9-9f5e-47439cd9ec2e.png>
</p>
</details>

<details><summary>encipher_bifid</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848714-b7f9a700-bd17-11e9-882b-d9ebc8b12c57.png>
</p>
</details>

<details><summary>encipher_bifid5</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848730-c9db4a00-bd17-11e9-8391-4a911dfc957e.png>
</p>
</details>

<details><summary>encipher_bifid6</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848752-dbbced00-bd17-11e9-9334-adcba34a9417.png>
</p>
</details>

<details><summary>encipher_elgamal</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848761-eaa39f80-bd17-11e9-8349-eb6e1628efb2.png>
</p>
</details>

<details><summary>encipher_gm</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848792-027b2380-bd18-11e9-92a1-82b4d575d634.png>
</p>
</details>

<details><summary>encipher_hill</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848818-158df380-bd18-11e9-9812-22ff0858c04a.png>
</p>
</details>

<details><summary>encipher_shift</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848831-26d70000-bd18-11e9-924f-2ece83cb74b5.png>
</p>
</details>

<details><summary>gm_private_key</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848847-36eedf80-bd18-11e9-9c16-7cdc0b66853c.png>
</p>
</details>

<details><summary>gm_public_key</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848869-4c640980-bd18-11e9-9416-b6cb0a0f1879.png>
</p>
</details>

<details><summary>lfsr_autocorrelation</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848880-5b4abc00-bd18-11e9-80ab-2f397515ff4b.png>
</p>
</details>

<details><summary>lfsr_autocorrelation_polynomial</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848899-6d2c5f00-bd18-11e9-8b50-bfe5f7be7ccf.png>
</p>
</details>

<details><summary>lfsr_sequence</summary>
<p>
<img src=https://user-images.githubusercontent.com/34944973/62848919-846b4c80-bd18-11e9-8f6c-ab43746f51bf.png>
</p>
</details>

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
