### PR TITLE
Fixed bug of index with slicing in Array

### DIFF
--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -52,15 +52,7 @@ class DenseNDimArray(NDimArray):
         if syindex is not None:
             return syindex
 
-        if isinstance(index, (SYMPY_INTS, Integer, slice)):
-            index = (index, )
-
-        if len(index) < self.rank():
-            index = tuple([i for i in index] + \
-                          [slice(None) for i in range(len(index), self.rank())])
-
-        if len(index) > self.rank():
-            raise ValueError('Dimension of index greater than rank of array')
+        index = self._check_index_for_getitem(index)
 
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
             sl_factors, eindices = self._get_slice_data_for_array_access(index)

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -59,6 +59,9 @@ class DenseNDimArray(NDimArray):
             index = tuple([i for i in index] + \
                           [slice(None) for i in range(len(index), self.rank())])
 
+        if len(index) > self.rank():
+            raise ValueError('Dimension of index greater than rank of array')
+
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
             sl_factors, eindices = self._get_slice_data_for_array_access(index)
             array = [self._array[self._parse_index(i)] for i in eindices]

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -547,6 +547,19 @@ class NDimArray(object):
         if shape == (0,) and len(flat_list) > 0:
             raise ValueError("if array shape is (0,) there cannot be elements")
 
+    def _check_index_for_getitem(self, index):
+        if isinstance(index, (SYMPY_INTS, Integer, slice)):
+            index = (index, )
+
+        if len(index) < self.rank():
+            index = tuple([i for i in index] + \
+                          [slice(None) for i in range(len(index), self.rank())])
+
+        if len(index) > self.rank():
+            raise ValueError('Dimension of index greater than rank of array')
+
+        return index
+
 
 class ImmutableNDimArray(NDimArray, Basic):
     _op_priority = 11.0

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -50,15 +50,7 @@ class SparseNDimArray(NDimArray):
         if syindex is not None:
             return syindex
 
-        if isinstance(index, (SYMPY_INTS, Integer, slice)):
-            index = (index, )
-
-        if len(index) < self.rank():
-            index = tuple([i for i in index] + \
-                          [slice(None) for i in range(len(index), self.rank())])
-
-        if len(index) > self.rank():
-            raise ValueError('Dimension of index greater than rank of array')
+        index = self._check_index_for_getitem(index)
 
         # `index` is a tuple with one or more slices:
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -57,6 +57,9 @@ class SparseNDimArray(NDimArray):
             index = tuple([i for i in index] + \
                           [slice(None) for i in range(len(index), self.rank())])
 
+        if len(index) > self.rank():
+            raise ValueError('Dimension of index greater than rank of array')
+
         # `index` is a tuple with one or more slices:
         if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
             sl_factors, eindices = self._get_slice_data_for_array_access(index)

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -119,6 +119,7 @@ def test_getitem():
 
     raises(ValueError, lambda: array[3, 4, 5])
     raises(ValueError, lambda: array[3, 4, 5, 6])
+    raises(ValueError, lambda: array[3, 4, 5, 3:4])
 
 
 def test_iterator():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -129,6 +129,7 @@ def test_getitem():
 
     raises(ValueError, lambda: array[3, 4, 5])
     raises(ValueError, lambda: array[3, 4, 5, 6])
+    raises(ValueError, lambda: array[3, 4, 5, 3:4])
 
 
 def test_sparse():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
If the index has a slice, the dimension of index is not verified. So it would return a value even if the dimension of index is greater than the rank of array.
before
```python
>>> from sympy import Array
>>> a = Array(range(24)).reshape(2 ,3, 4)
>>> a[1, 2, 3, 4]
ValueError: Wrong number of array axes
>>> a[1, 2, 3, 5:6]
23
>>> a[1, 2, 3, 4, 5:6]
23
```
So a test of length of index is added.
Now:
```python
>>> from sympy import Array
>>> a = Array(range(24)).reshape(2 ,3, 4)
>>> a[1, 2, 3, 4]
ValueError: Wrong number of array axes
>>> a[1, 2, 3, 5:6]
ValueError: Dimension of index greater than rank of array
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * FIxed bug of index with slicing
<!-- END RELEASE NOTES -->
