### PR TITLE
Fixed code generation for beta, fresnelc, fresnels, lowergamma, and uppergamma

### DIFF
--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -109,3 +109,6 @@ class beta(Function):
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate(), self.args[1].conjugate())
+
+    def _eval_rewrite_as_gamma(self, x, y, **kwargs):
+        return self._eval_expand_func(**kwargs)

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -18,3 +18,5 @@ def test_beta():
     assert conjugate(beta(x, y)) == beta(conjugate(x), conjugate(y))
 
     raises(ArgumentIndexError, lambda: beta(x, y).fdiff(3))
+
+    assert beta(x, y).rewrite(gamma) == gamma(x)*gamma(y)/gamma(x + y)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -61,6 +61,7 @@ class CodePrinter(StrPrinter):
     _rewriteable_functions = {
             'erf2': 'erf',
             'Li': 'li',
+            'beta': 'gamma'
     }
 
     def __init__(self, settings=None):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -449,6 +449,9 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
     def _print_Half(self, expr):
         return self._print_Rational(expr)
 
+    _print_lowergamma = CodePrinter._print_not_supported
+    _print_uppergamma = CodePrinter._print_not_supported
+
 
 for k in PythonCodePrinter._kf:
     setattr(PythonCodePrinter, '_print_%s' % k, _print_known_func)
@@ -783,6 +786,9 @@ class NumPyPrinter(PythonCodePrinter):
     def _print_CodegenArrayElementwiseAdd(self, expr):
         return self._expand_fold_binary_op('numpy.add', expr.args)
 
+    _print_lowergamma = CodePrinter._print_not_supported
+    _print_uppergamma = CodePrinter._print_not_supported
+
 
 for k in NumPyPrinter._kf:
     setattr(NumPyPrinter, '_print_%s' % k, _print_known_func)
@@ -849,6 +855,20 @@ class SciPyPrinter(NumPyPrinter):
             self._print(expr.args[0]),
             self._print(expr.args[1]),
             self._print(expr.args[2]))
+
+    def _print_lowergamma(self, expr):
+        return "{0}({2})*{1}({2}, {3})".format(
+            self._module_format('scipy.special.gamma'),
+            self._module_format('scipy.special.gammainc'),
+            self._print(expr.args[0]),
+            self._print(expr.args[1]))
+
+    def _print_uppergamma(self, expr):
+        return "{0}({2})*{1}({2}, {3})".format(
+            self._module_format('scipy.special.gamma'),
+            self._module_format('scipy.special.gammaincc'),
+            self._print(expr.args[0]),
+            self._print(expr.args[1]))
 
 for k in SciPyPrinter._kf:
     setattr(SciPyPrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -511,6 +511,8 @@ class MpmathPrinter(PythonCodePrinter):
     """
     printmethod = "_mpmathcode"
 
+    language = "Python with mpmath"
+
     _kf = dict(chain(
         _known_functions.items(),
         [(k, 'mpmath.' + v) for k, v in _known_functions_mpmath.items()]
@@ -589,6 +591,7 @@ class NumPyPrinter(PythonCodePrinter):
     logical operators, etc.
     """
     printmethod = "_numpycode"
+    language = "Python with NumPy"
 
     _kf = dict(chain(
         PythonCodePrinter._kf.items(),
@@ -836,6 +839,8 @@ _known_constants_scipy_constants = {
 
 class SciPyPrinter(NumPyPrinter):
 
+    language = "Python with SciPy"
+
     _kf = dict(chain(
         NumPyPrinter._kf.items(),
         [(k, 'scipy.special.' + v) for k, v in _known_functions_scipy_special.items()]
@@ -897,6 +902,8 @@ for k in SciPyPrinter._kc:
 
 
 class SymPyPrinter(PythonCodePrinter):
+
+    language = "Python with SymPy"
 
     _kf = {k: 'sympy.' + v for k, v in chain(
         _known_functions.items(),

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -451,6 +451,8 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
 
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
+    _print_fresnelc = CodePrinter._print_not_supported
+    _print_fresnels = CodePrinter._print_not_supported
 
 
 for k in PythonCodePrinter._kf:
@@ -493,6 +495,9 @@ def pycode(expr, **settings):
 _not_in_mpmath = 'log1p log2'.split()
 _in_mpmath = [(k, v) for k, v in _known_functions_math.items() if k not in _not_in_mpmath]
 _known_functions_mpmath = dict(_in_mpmath, **{
+    'beta': 'beta',
+    'fresnelc': 'fresnelc',
+    'fresnels': 'fresnels',
     'sign': 'sign',
 })
 _known_constants_mpmath = {
@@ -788,6 +793,8 @@ class NumPyPrinter(PythonCodePrinter):
 
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
+    _print_fresnelc = CodePrinter._print_not_supported
+    _print_fresnels = CodePrinter._print_not_supported
 
 
 for k in NumPyPrinter._kf:
@@ -817,6 +824,7 @@ _known_functions_scipy_special = {
     'hermite': 'eval_hermite',
     'laguerre': 'eval_laguerre',
     'assoc_laguerre': 'eval_genlaguerre',
+    'beta': 'beta'
 }
 
 _known_constants_scipy_constants = {
@@ -869,6 +877,17 @@ class SciPyPrinter(NumPyPrinter):
             self._module_format('scipy.special.gammaincc'),
             self._print(expr.args[0]),
             self._print(expr.args[1]))
+
+    def _print_fresnels(self, expr):
+        return "{0}({1})[0]".format(
+                self._module_format("scipy.special.fresnel"),
+                self._print(expr.args[0]))
+
+    def _print_fresnelc(self, expr):
+        return "{0}({1})[1]".format(
+                self._module_format("scipy.special.fresnel"),
+                self._print(expr.args[0]))
+
 
 for k in SciPyPrinter._kf:
     setattr(SciPyPrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -161,3 +161,23 @@ def test_NumPyPrinter_print_seq():
     n = NumPyPrinter()
 
     assert n._print_seq(range(2)) == '(0, 1,)'
+
+
+def test_issue_16535_16536():
+    from sympy import lowergamma, uppergamma
+
+    a = symbols('a')
+    expr1 = lowergamma(a, x)
+    expr2 = uppergamma(a, x)
+
+    prntr = SciPyPrinter()
+    prntr.doprint(expr1) == 'scipy.special.gamma(a)*scipy.special.gammainc(a, x)'
+    prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
+
+    prntr = NumPyPrinter()
+    prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
+    prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
+
+    prntr = PythonCodePrinter()
+    prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
+    prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -5,7 +5,6 @@ from sympy.codegen import Assignment
 from sympy.codegen.ast import none
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
-from sympy.core.singleton import S
 from sympy.core.numbers import pi
 from sympy.functions import acos, Piecewise, sign, sqrt
 from sympy.logic import And, Or
@@ -171,13 +170,54 @@ def test_issue_16535_16536():
     expr2 = uppergamma(a, x)
 
     prntr = SciPyPrinter()
-    prntr.doprint(expr1) == 'scipy.special.gamma(a)*scipy.special.gammainc(a, x)'
-    prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
+    assert prntr.doprint(expr1) == 'scipy.special.gamma(a)*scipy.special.gammainc(a, x)'
+    assert prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
 
     prntr = NumPyPrinter()
-    prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
-    prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
+    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
 
     prntr = PythonCodePrinter()
-    prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
-    prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
+    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
+
+
+def test_fresnel_integrals():
+    from sympy import fresnelc, fresnels
+
+    expr1 = fresnelc(x)
+    expr2 = fresnels(x)
+
+    prntr = SciPyPrinter()
+    assert prntr.doprint(expr1) == 'scipy.special.fresnel(x)[1]'
+    assert prntr.doprint(expr2) == 'scipy.special.fresnel(x)[0]'
+
+    prntr = NumPyPrinter()
+    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # fresnelc\nfresnelc(x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # fresnels\nfresnels(x)'
+
+    prntr = PythonCodePrinter()
+    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # fresnelc\nfresnelc(x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # fresnels\nfresnels(x)'
+
+    prntr = MpmathPrinter()
+    assert prntr.doprint(expr1) == 'mpmath.fresnelc(x)'
+    assert prntr.doprint(expr2) == 'mpmath.fresnels(x)'
+
+
+def test_beta():
+    from sympy import beta
+
+    expr = beta(x, y)
+
+    prntr = SciPyPrinter()
+    assert prntr.doprint(expr) == 'scipy.special.beta(x, y)'
+
+    prntr = NumPyPrinter()
+    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+
+    prntr = PythonCodePrinter()
+    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+
+    prntr = MpmathPrinter()
+    assert prntr.doprint(expr) ==  'mpmath.beta(x, y)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -174,8 +174,8 @@ def test_issue_16535_16536():
     assert prntr.doprint(expr2) == 'scipy.special.gamma(a)*scipy.special.gammaincc(a, x)'
 
     prntr = NumPyPrinter()
-    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
-    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
+    assert prntr.doprint(expr1) == '  # Not supported in Python with NumPy:\n  # lowergamma\nlowergamma(a, x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python with NumPy:\n  # uppergamma\nuppergamma(a, x)'
 
     prntr = PythonCodePrinter()
     assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # lowergamma\nlowergamma(a, x)'
@@ -193,8 +193,8 @@ def test_fresnel_integrals():
     assert prntr.doprint(expr2) == 'scipy.special.fresnel(x)[0]'
 
     prntr = NumPyPrinter()
-    assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # fresnelc\nfresnelc(x)'
-    assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # fresnels\nfresnels(x)'
+    assert prntr.doprint(expr1) == '  # Not supported in Python with NumPy:\n  # fresnelc\nfresnelc(x)'
+    assert prntr.doprint(expr2) == '  # Not supported in Python with NumPy:\n  # fresnels\nfresnels(x)'
 
     prntr = PythonCodePrinter()
     assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # fresnelc\nfresnelc(x)'

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -484,7 +484,7 @@ def BetaNoncentral(name, alpha, beta, lamda):
 
     Compute cdf with specific 'x', 'alpha', 'beta' and 'lamda' values as follows :
     >>> cdf(BetaNoncentral("x", 1, 1, 1), evaluate=False)(2).doit()
-    exp(-1/2)*Integral(Sum(2**(-_k)*_x**_k/(beta(_k + 1, 1)*factorial(_k)), (_k, 0, oo)), (_x, 0, 2))
+    2*exp(1/2)
 
     The argument evaluate=False prevents an attempt at evaluation
     of the sum for general x, before the argument 2 is passed.

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -10,16 +10,16 @@ from sympy import (
     Float, Matrix, Lambda, Piecewise, exp, E, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
-    digamma, RisingFactorial, besselj, bessely, besseli, besselk, S,
+    digamma, RisingFactorial, besselj, bessely, besseli, besselk, S, beta,
     MatrixSymbol, chebyshevt, chebyshevu, legendre, hermite, laguerre,
-    gegenbauer, assoc_legendre, assoc_laguerre, jacobi)
+    gegenbauer, assoc_legendre, assoc_laguerre, jacobi, fresnelc, fresnels)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.printing.pycode import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function, lambdastr
 from sympy.utilities.pytest import skip
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.external import import_module
-from sympy.functions.special.gamma_functions import uppergamma,lowergamma
+from sympy.functions.special.gamma_functions import uppergamma, lowergamma
 
 import sympy
 
@@ -1195,8 +1195,42 @@ def test_issue_16536():
     a = symbols('a')
     f1 = lowergamma(a, x)
     F = lambdify((a, x), f1, modules='scipy')
-    assert (abs(lowergamma(1, 3) - F(1, 3))) <= 1e-8
+    assert abs(lowergamma(1, 3) - F(1, 3)) <= 1e-10
 
     f2 = uppergamma(a, x)
     F = lambdify((a, x), f2, modules='scipy')
-    assert (abs(uppergamma(1, 3) - F(1, 3))) <= 1e-8
+    assert abs(uppergamma(1, 3) - F(1, 3)) <= 1e-10
+
+
+def test_fresnel_integrals_scipy():
+    if not scipy:
+        skip("scipy not installed")
+
+    f1 = fresnelc(x)
+    f2 = fresnels(x)
+    F1 = lambdify(x, f1, modules='scipy')
+    F2 = lambdify(x, f2, modules='scipy')
+
+    assert abs(fresnelc(1.3) - F1(1.3)) <= 1e-10
+    assert abs(fresnels(1.3) - F2(1.3)) <= 1e-10
+
+
+def test_beta_scipy():
+    if not scipy:
+        skip("scipy not installed")
+
+    f = beta(x, y)
+    F = lambdify((x, y), f, modules='scipy')
+
+    assert abs(beta(1.3, 2.3) - F(1.3, 2.3)) <= 1e-10
+
+
+@XFAIL
+def test_beta_math():
+    # Not clear why it is not working since pycode(beta(x, y))
+    # gives 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+
+    f = beta(x, y)
+    F = lambdify((x, y), f, modules='math')
+
+    assert abs(beta(1.3, 2.3) - F(1.3, 2.3)) <= 1e-10

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1186,3 +1186,17 @@ def test_issue_16930():
 def test_single_e():
     f = lambdify(x, E)
     assert f(23) == exp(1.0)
+
+
+def test_issue_16536():
+    if not scipy:
+        skip("scipy not installed")
+
+    a = symbols('a')
+    f1 = lowergamma(a, x)
+    F = lambdify((a, x), f1, modules='scipy')
+    assert (abs(lowergamma(1, 3) - F(1, 3))) <= 1e-8
+
+    f2 = uppergamma(a, x)
+    F = lambdify((a, x), f2, modules='scipy')
+    assert (abs(uppergamma(1, 3) - F(1, 3))) <= 1e-8


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16535
Fixes #16536

#### Brief description of what is fixed or changed
Added support for `fresnelc`, `fresnels`, `lowergamma` and `uppergamma` for SciPy and not implemented warnings for Math and NumPy. 

Added support for `beta` code generation (possibly rewriting to `gamma`).

#### Other comments

I do not fully understand `lambdify`. See comment in the XFAIL-test. As far as I can tell, it should be using the `PythonCodePrinter` when `modules="math"`, but the result differs compared to printing directly. Also, it is not clear if actually specifying `scipy` always gives the `scipy` result (fortunately there are different function names).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `beta` can be rewritten as `gamma`.
* printing
   * Added SciPy `lambdify` support for `fresnelc`, `fresnels`, `lowergamma` and `uppergamma`.
   * Added Python code generation support for `beta` (with automatic rewrite to `gamma` if required).
<!-- END RELEASE NOTES -->
