### PR TITLE
Fix LambertW printing for LaTeX and Mathematica

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2269,7 +2269,10 @@ class LatexPrinter(Printer):
         return self._print(Symbol(object.name))
 
     def _print_LambertW(self, expr):
-        return r"W\left(%s\right)" % self._print(expr.args[0])
+        if len(expr.args) == 1:
+            return r"W\left(%s\right)" % self._print(expr.args[0])
+        return r"W_{%s}\left(%s\right)" % \
+            (self._print(expr.args[1]), self._print(expr.args[0]))
 
     def _print_Morphism(self, morphism):
         domain = self._print(morphism.domain)

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -107,7 +107,6 @@ known_functions = {
     "DiracDelta": [(lambda x: True, "DiracDelta")],
     "Heaviside": [(lambda x: True, "HeavisideTheta")],
     "KroneckerDelta": [(lambda *x: True, "KroneckerDelta")],
-    "LambertW": [(lambda x: True, "ProductLog")],
 }
 
 
@@ -304,6 +303,12 @@ class MCodePrinter(CodePrinter):
         return expr.func.__name__ + "[%s]" % self.stringify(expr.args, ", ")
 
     _print_MinMaxBase = _print_Function
+
+    def _print_LambertW(self, expr):
+        if len(expr.args) == 1:
+            return "ProductLog[{}]".format(self._print(expr.args[0]))
+        return "ProductLog[{}, {}]".format(
+            self._print(expr.args[1]), self._print(expr.args[0]))
 
     def _print_Integral(self, expr):
         if len(expr.variables) == 1 and not expr.limits[0][1:]:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -525,6 +525,8 @@ def test_latex_functions():
         r'\left(\Omega\left(n\right)\right)^{2}'
 
     assert latex(LambertW(n)) == r'W\left(n\right)'
+    assert latex(LambertW(n, -1)) == r'W_{-1}\left(n\right)'
+    assert latex(LambertW(n, k)) == r'W_{k}\left(n\right)'
 
     assert latex(Mod(x, 7)) == r'x\bmod{7}'
     assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -79,6 +79,8 @@ def test_Function():
     assert mcode(harmonic(x, y)) == "HarmonicNumber[x, y]"
     assert mcode(Li(x)) == "LogIntegral[x] - LogIntegral[2]"
     assert mcode(LambertW(x)) == "ProductLog[x]"
+    assert mcode(LambertW(x, -1)) == "ProductLog[-1, x]"
+    assert mcode(LambertW(x, y)) == "ProductLog[y, x]"
 
 
 def test_special_polynomials():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

SymPy LambertW has extended notation to use second argument to give different solution in the complex plane.
however, it is ignored in LaTeX printer.
```
>>> latex(LambertW(x, k))
'W\\left(x\\right)'
```
And mathematica printer gives error when printing LambertW with two args.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed LaTeX printer not printing the second argument of `LambertW`.
  - Fixed Mathematica printer giving error when printing `LambertW` with 2 arguments.
<!-- END RELEASE NOTES -->
