### PR TITLE
Make pytest tests work under pytest with -Werror

### DIFF
--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -196,6 +196,9 @@ def test_ignore_does_not_raise_without_warning():
 
 def test_ignore_allows_other_warnings():
     with warnings.catch_warnings(record=True) as w:
+        # This is needed when pytest is run as -Werror
+        # the setting is reverted at the end of the catch_Warnings block.
+        warnings.simplefilter("always")
         with ignore_warnings(UserWarning):
             warnings.warn('this is the warning message', UserWarning)
             warnings.warn('this is the other message', RuntimeWarning)
@@ -216,6 +219,9 @@ def test_ignore_continues_after_warning():
 
 def test_ignore_many_warnings():
     with warnings.catch_warnings(record=True) as w:
+        # This is needed when pytest is run as -Werror
+        # the setting is reverted at the end of the catch_Warnings block.
+        warnings.simplefilter("always")
         with ignore_warnings(UserWarning):
             warnings.warn('this is the warning message', UserWarning)
             warnings.warn('this is the other message', RuntimeWarning)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes a couple of tests so that they work under pytest when -Werror is used. Previously:
```
$ pytest -Werror sympy/utilities/tests/test_pytest.py
========================================== test session starts ==========================================
platform linux -- Python 3.6.3, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/cosc/enojb/linux/current/sympy/sympy.git/.hypothesis/examples')
architecture: 64-bit
cache:        yes
ground types: gmpy 2.0.8

rootdir: /home/cosc/enojb/linux/current/sympy/sympy.git, inifile: pytest.ini
plugins: xdist-1.27.0, instafail-0.4.1, forked-1.0.2, doctestplus-0.3.0, cov-2.7.1, hypothesis-4.28.2
collected 24 items                                                                                      

sympy/utilities/tests/test_pytest.py .....................F.F                                     [100%]

=============================================== FAILURES ================================================
___________________________________ test_ignore_allows_other_warnings ___________________________________

    def test_ignore_allows_other_warnings():
        with warnings.catch_warnings(record=True) as w:
            with ignore_warnings(UserWarning):
                warnings.warn('this is the warning message', UserWarning)
>               warnings.warn('this is the other message', RuntimeWarning)
E               RuntimeWarning: this is the other message

sympy/utilities/tests/test_pytest.py:201: RuntimeWarning
_______________________________________ test_ignore_many_warnings _______________________________________

    def test_ignore_many_warnings():
        with warnings.catch_warnings(record=True) as w:
            with ignore_warnings(UserWarning):
                warnings.warn('this is the warning message', UserWarning)
>               warnings.warn('this is the other message', RuntimeWarning)
E               RuntimeWarning: this is the other message

sympy/utilities/tests/test_pytest.py:221: RuntimeWarning
                                            DO *NOT* COMMIT!                                            
================================== 2 failed, 22 passed in 0.22 seconds ==================================
```
With this PR the tests pass under `pytest`, `pytest -Werror` and `bin/test`. These are the only two tests I found that don't work under `pytest -Werror` so I think this makes it possible to run the whole test suite with -Werror.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
