### PR TITLE
MNT:Add path to git sympy in PYTHONPATH environment variable

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -225,6 +225,9 @@ def run_in_subprocess_with_hash_randomization(
 
     function_kwargs = function_kwargs or {}
 
+    # Add path to the git sympy directory to PYTHONPATH envirnoment variable
+    # before importing sympy
+    sys.path.insert(0, "../../.")
     # Now run the command
     commandstring = ("import sys; from %s import %s;sys.exit(%s(*%s, **%s))" %
                      (module, function, function, repr(function_args),


### PR DESCRIPTION
add the relative path to the git Sympy with `sys.path.insert` to PYTHONPATH

closes #17369

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
