### PR TITLE
Fixed #17354

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -684,7 +684,9 @@ class Expr(Basic, EvalfMixin):
                     if b is S.NaN:
                         # evaluation may succeed when substitution fails
                         b = expr._random(None, 1, 0, 1, 0)
-                except ZeroDivisionError:
+                except (ZeroDivisionError, ValueError):
+                    # In case of (at least) a Relational, a division by zero
+                    # will show up here as a ValueError
                     b = None
                 if b is not None and b is not S.NaN and b.equals(a) is False:
                     return False

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -5,7 +5,7 @@ from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, 
                    simplify, together, collect, factorial, apart, combsimp, factor, refine,
                    cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
                    exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr,
-                   integrate, gammasimp, Gt)
+                   integrate, gammasimp, Gt, Min, euler, fresnelc)
 from sympy.core.expr import ExprBuilder, unchanged
 from sympy.core.function import AppliedUndef
 from sympy.core.compatibility import range, round, PY3
@@ -1893,3 +1893,8 @@ def test_ExprBuilder():
 def test_issue_17354():
     # Check that there is no exception
     assert Max(y/(x - 1), y/(x + 1)).equals(0) is False
+    assert Min(1/x, y).is_constant() in [None, False]
+    assert Integral(x, (x, 0, z/(y))).is_constant() in [None, False]
+    assert Integral(x, (x, 0, z/(y-1))).is_constant() in [None, False]
+    assert euler(y/z, x).is_constant() in [None, False]
+    assert fresnelc(x/y).is_constant() in [None, False]

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1888,3 +1888,8 @@ def test_ExprBuilder():
     eb = ExprBuilder(Mul)
     eb.args.extend([x, x])
     assert eb.build() == x**2
+
+
+def test_issue_17354():
+    # Check that there is no exception
+    assert Max(y/(x - 1), y/(x + 1)).equals(0) is False

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -7,7 +7,7 @@ from sympy import (
     Matrix, MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise, posify, rad,
     Rational, root, S, separatevars, signsimp, simplify, sign, sin,
     sinc, sinh, solve, sqrt, Sum, Symbol, symbols, sympify, tan, tanh,
-    zoo)
+    zoo, Max)
 from sympy.core.mul import _keep_coeff
 from sympy.core.expr import unchanged
 from sympy.simplify.simplify import nthroot, inversecombine
@@ -893,3 +893,9 @@ def test_issue_17292():
     assert simplify(abs(x)/abs(x**2)) == 1/abs(x)
     # this is bigger than the issue: check that deep processing works
     assert simplify(5*abs((x**2 - 1)/(x - 1))) == 5*Abs(x + 1)
+
+
+def test_issue_17354():
+    # Check that there is no exception
+    assert (Max(y/(x - 1), y/(x + 1)) >= 0).simplify() == \
+        (Max(y/(x - 1), y/(x + 1)) >= 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17354 

#### Brief description of what is fixed or changed
Division by zero exceptions are not propagated and since 1/0 is `zoo` since #16770, it may happen that `Min` and `Max` expressions now get `zoo` as an argument, which will throw a ValueError.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * `.is_constant` is more robust.
<!-- END RELEASE NOTES -->
