### PR TITLE
Added support for lambda in ArrayComprehension

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4006,6 +4006,11 @@ def test_sympy__tensor__array__array_comprehension__ArrayComprehension():
     arrcom = ArrayComprehension(x, (x, 1, 5))
     assert _test_args(arrcom)
 
+def test_sympy__tensor__array__array_comprehension__ArrayComprehensionMap():
+    from sympy.tensor.array.array_comprehension import ArrayComprehensionMap
+    arrcomma = ArrayComprehensionMap(lambda: 0, (x, 1, 5))
+    assert _test_args(arrcomma)
+
 def test_sympy__tensor__array__arrayop__Flatten():
     from sympy.tensor.array.arrayop import Flatten
     from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray

--- a/sympy/tensor/array/__init__.py
+++ b/sympy/tensor/array/__init__.py
@@ -204,6 +204,6 @@ from .dense_ndim_array import MutableDenseNDimArray, ImmutableDenseNDimArray, De
 from .sparse_ndim_array import MutableSparseNDimArray, ImmutableSparseNDimArray, SparseNDimArray
 from .ndim_array import NDimArray
 from .arrayop import tensorproduct, tensorcontraction, derive_by_array, permutedims
-from .array_comprehension import ArrayComprehension
+from .array_comprehension import ArrayComprehension, ArrayComprehensionMap
 
 Array = ImmutableDenseNDimArray

--- a/sympy/tensor/array/array_comprehension.py
+++ b/sympy/tensor/array/array_comprehension.py
@@ -260,19 +260,15 @@ class ArrayComprehension(Basic):
         for values in itertools.product(*[range(inf, sup+1)
                                         for var, inf, sup
                                         in self._limits]):
-            if hasattr(self, '_lambda'):
-                temp = self._lambda
-                if self._lambda.__code__.co_argcount == 0:
-                    temp = temp()
-                elif self._lambda.__code__.co_argcount == 1:
-                    temp = temp(functools.reduce(lambda a, b: a*b, values))
-            else:
-                temp = self.function
-                for var, val in zip(self.variables, values):
-                    temp = temp.subs(var, val)
-            res.append(temp)
+            res.append(self._get_element(values))
 
         return ImmutableDenseNDimArray(res, self.shape)
+
+    def _get_element(self, values):
+        temp = self.function
+        for var, val in zip(self.variables, values):
+            temp = temp.subs(var, val)
+        return temp
 
     def tolist(self):
         """Transform the expanded array to a list
@@ -382,3 +378,11 @@ class ArrayComprehensionMap(ArrayComprehension):
             def __new__(cls, *args, **kwargs):
                 return ArrayComprehensionMap(self._lambda, *args, **kwargs)
         return _
+
+    def _get_element(self, values):
+        temp = self._lambda
+        if self._lambda.__code__.co_argcount == 0:
+            temp = temp()
+        elif self._lambda.__code__.co_argcount == 1:
+            temp = temp(functools.reduce(lambda a, b: a*b, values))
+        return temp

--- a/sympy/tensor/array/array_comprehension.py
+++ b/sympy/tensor/array/array_comprehension.py
@@ -342,7 +342,8 @@ class ArrayComprehensionMap(ArrayComprehension):
     =====
 
     Only the lambda function is considered.
-    At most one argument in lambda function is accepted in order to avoid ambiguity.
+    At most one argument in lambda function is accepted in order to avoid ambiguity
+    in value assignment.
 
     Examples
     ========
@@ -362,6 +363,9 @@ class ArrayComprehensionMap(ArrayComprehension):
         if any(len(l) != 3 or None for l in symbols):
             raise ValueError('ArrayComprehension requires values lower and upper bound'
                               ' for the expression')
+
+        if not isLambda(function):
+            raise ValueError('Data type not supported')
 
         arglist = cls._check_limits_validity(function, symbols)
         obj = Basic.__new__(cls, *arglist, **assumptions)

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -1,4 +1,4 @@
-from sympy.tensor.array.array_comprehension import ArrayComprehension
+from sympy.tensor.array.array_comprehension import ArrayComprehension, ArrayComprehensionMap
 from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.abc import i, j, k, l
 from sympy.utilities.pytest import raises
@@ -50,7 +50,17 @@ def test_array_comprehension():
     raises(ValueError, lambda: b.tomatrix())
     raises(ValueError, lambda: c.tomatrix())
 
+def test_arraycomprehensionmap():
+    a = ArrayComprehensionMap(lambda i: i+1, (i, 1, 5))
+    assert a.doit().tolist() == [2, 3, 4, 5, 6]
+    assert a.shape == (5,)
+    assert a.is_shape_numeric
+    assert a.tolist() == [2, 3, 4, 5, 6]
+    assert len(a) == 5
+    assert isinstance(a.doit(), ImmutableDenseNDimArray)
+
     # tests about lambda expression
-    assert ArrayComprehension(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
-    assert ArrayComprehension(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
-    raises(ValueError, lambda: ArrayComprehension(lambda i, j: i+j, (i, 1, 5)).doit())
+    assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
+    assert ArrayComprehensionMap(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
+    raises(ValueError, lambda: ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5)).doit())
+    raises(ValueError, lambda: ArrayComprehensionMap(lambda i: i+1, (i, 1, k)))

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -60,6 +60,7 @@ def test_arraycomprehensionmap():
     assert isinstance(a.doit(), ImmutableDenseNDimArray)
     expr = ArrayComprehensionMap(lambda i: i+1, (i, 1, k))
     assert expr.doit() == expr
+    assert expr.subs(k, 4) == ArrayComprehensionMap(lambda i: i+1, (i, 1, 4))
 
     # tests about lambda expression
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -61,6 +61,14 @@ def test_arraycomprehensionmap():
     expr = ArrayComprehensionMap(lambda i: i+1, (i, 1, k))
     assert expr.doit() == expr
     assert expr.subs(k, 4) == ArrayComprehensionMap(lambda i: i+1, (i, 1, 4))
+    assert expr.subs(k, 4).doit() == ImmutableDenseNDimArray([2, 3, 4, 5])
+    b = ArrayComprehensionMap(lambda i: i+1, (i, 1, 2), (i, 1, 3), (i, 1, 4), (i, 1, 5))
+    assert b.doit().tolist() == [[[[2, 3, 4, 5, 6], [3, 5, 7, 9, 11], [4, 7, 10, 13, 16], [5, 9, 13, 17, 21]],
+                                  [[3, 5, 7, 9, 11], [5, 9, 13, 17, 21], [7, 13, 19, 25, 31], [9, 17, 25, 33, 41]],
+                                  [[4, 7, 10, 13, 16], [7, 13, 19, 25, 31], [10, 19, 28, 37, 46], [13, 25, 37, 49, 61]]],
+                                 [[[3, 5, 7, 9, 11], [5, 9, 13, 17, 21], [7, 13, 19, 25, 31], [9, 17, 25, 33, 41]],
+                                  [[5, 9, 13, 17, 21], [9, 17, 25, 33, 41], [13, 25, 37, 49, 61], [17, 33, 49, 65, 81]],
+                                  [[7, 13, 19, 25, 31], [13, 25, 37, 49, 61], [19, 37, 55, 73, 91], [25, 49, 73, 97, 121]]]]
 
     # tests about lambda expression
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -49,3 +49,8 @@ def test_array_comprehension():
     raises(ValueError, lambda: b.tolist())
     raises(ValueError, lambda: b.tomatrix())
     raises(ValueError, lambda: c.tomatrix())
+
+    # tests about lambda expression
+    assert ArrayComprehension(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
+    assert ArrayComprehension(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
+    raises(ValueError, lambda: ArrayComprehension(lambda i, j: i+j, (i, 1, 5)).doit())

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -66,3 +66,4 @@ def test_arraycomprehensionmap():
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
     assert ArrayComprehensionMap(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
     raises(ValueError, lambda: ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5)).doit())
+    raises(ValueError, lambda: ArrayComprehensionMap(i*j, (i, 1, 3), (j, 2, 4)))

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -58,9 +58,10 @@ def test_arraycomprehensionmap():
     assert a.tolist() == [2, 3, 4, 5, 6]
     assert len(a) == 5
     assert isinstance(a.doit(), ImmutableDenseNDimArray)
+    expr = ArrayComprehensionMap(lambda i: i+1, (i, 1, k))
+    assert expr.doit() == expr
 
     # tests about lambda expression
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
     assert ArrayComprehensionMap(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
     raises(ValueError, lambda: ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5)).doit())
-    raises(ValueError, lambda: ArrayComprehensionMap(lambda i: i+1, (i, 1, k)))


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#17057


#### Brief description of what is fixed or changed
- Added support for lambda expression in ArrayComprehension
Thanks to this PR, ArrayComprehension can accept lambda expression as a function to be extended.
At most 1 element can be passed to the lambda expression in order to avoid ambiguous expression.
Now:
```python
>>> ArrayComprehension(lambda: 3, (i, 1, 5)).doit()
[3, 3, 3, 3, 3]
>>> ArrayComprehension(lambda i: i+1, (i, 1, 5)).doit()
[2, 3, 4, 5, 6]
```

- Added tests accordingly

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Enabled lamda expression in ArrayComprehension
<!-- END RELEASE NOTES -->
