### PR TITLE
Fixed #17405

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -658,7 +658,8 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
 
             f_start = f(self.start)
             f_end = f(self.end)
-            sample([self.start, f_start], [self.end, f_end], 0)
+            sample(np.array([self.start, f_start]),
+                   np.array([self.end, f_end]), 0)
 
             return list_segments
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -579,7 +579,6 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         self.depth = kwargs.get('depth', 12)
         self.line_color = kwargs.get('line_color', None)
         self.xscale = kwargs.get('xscale', 'linear')
-        self.flag = 0
 
     def __str__(self):
         return 'cartesian line: %s for %s over %s' % (
@@ -623,13 +622,8 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
                 ynew = f(xnew)
                 new_point = np.array([xnew, ynew])
 
-                if self.flag == 1:
-                    return
                 # Maximum depth
                 if depth > self.depth:
-                    if p[1] is None or q[1] is None:
-                        self.flag = 1
-                        return
                     list_segments.append([p, q])
 
                 # Sample irrespective of whether the line is flat till the

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -522,3 +522,28 @@ def test_empty_plot():
         skip("Matplotlib not the default backend")
     # No exception showing an empty plot
     plot()
+
+
+def test_issue_17405():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    x = Symbol('x')
+    f = x**0.3 - 10*x**3 + x**2
+    p = plot(f, (x, -10, 10), show=False)
+    # Random number of segments, probably more than 100, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    assert len(p[0].get_segments()) >= 30
+
+
+def test_logplot_PR_16796():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    x = Symbol('x')
+    p = plot(x, (x, .001, 100), xscale='log', show=False)
+    # Random number of segments, probably more than 100, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    assert len(p[0].get_segments()) >= 30
+    assert p[0].end == 100.0
+    assert p[0].start == .001


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17405 

#### Brief description of what is fixed or changed
Plotting works even if the start-point happens to be `None` (because it is a complex number(?)).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Plots with fractional exponents and negative base values works again.
<!-- END RELEASE NOTES -->
