### PR TITLE
ElementwiseApplyFunction cannot be simplified

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -191,7 +191,7 @@ class MatrixExpr(Expr):
         if self.is_Atom:
             return self
         else:
-            return self.__class__(*[simplify(x, **kwargs) for x in self.args])
+            return self.func(*[simplify(x, **kwargs) for x in self.args])
 
     def _eval_adjoint(self):
         from sympy.matrices.expressions.adjoint import Adjoint

--- a/sympy/matrices/expressions/tests/test_applyfunc.py
+++ b/sympy/matrices/expressions/tests/test_applyfunc.py
@@ -1,5 +1,5 @@
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
-from sympy import (Matrix, Lambda, MatrixBase, MatrixSymbol, exp, symbols, MatMul, sin)
+from sympy import (Matrix, Lambda, MatrixBase, MatrixSymbol, exp, symbols, MatMul, sin, simplify)
 from sympy.utilities.pytest import raises
 from sympy.matrices.common import ShapeError
 
@@ -23,6 +23,7 @@ def test_applyfunc_matrix():
     assert expr.doit() == Xd.applyfunc(lambda x: x**2)
     assert expr.shape == (3, 3)
     assert expr.func(*expr.args) == expr
+    assert simplify(expr) == expr
     assert expr[0, 0] == double(Xd[0, 0])
 
     expr = ElementwiseApplyFunction(double, X)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixing bug preventing the simplification of ElementwiseApplyFunc.
<!-- END RELEASE NOTES -->
