### PR TITLE
modified _nth_algebraic_redundant method for general dsolve

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4225,7 +4225,10 @@ def _is_special_case_of(soln1, soln2, eq, order, var):
         return False
     eqns = [eq for eq in eqns if not isinstance(eq, BooleanTrue)]
 
-    constant_solns = solve(eqns, constants2)
+    try:
+        constant_solns = solve(eqns, constants2)
+    except NotImplementedError:
+        return False
 
     # Sometimes returns a dict and sometimes a list of dicts
     if isinstance(constant_solns, dict):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -265,7 +265,7 @@ from sympy.simplify import collect, logcombine, powsimp, separatevars, \
     simplify, trigsimp, posify, cse
 from sympy.simplify.powsimp import powdenest
 from sympy.simplify.radsimp import collect_const
-from sympy.solvers import solve
+from sympy.solvers import checksol, solve
 from sympy.solvers.pde import pdsolve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift
@@ -4230,6 +4230,13 @@ def _is_special_case_of(soln1, soln2, eq, order, var):
     # Sometimes returns a dict and sometimes a list of dicts
     if isinstance(constant_solns, dict):
         constant_solns = [constant_solns]
+
+    # after solving the issue 17418, maybe we don't need the following checksol code.
+    for constant_soln in constant_solns:
+        for eq in eqns:
+            eq=eq.rhs-eq.lhs
+            if checksol(eq, constant_soln) is not True:
+                return False
 
     # If any solution gives all constants as expressions that don't depend on
     # x then there exists constants for soln2 that give soln1
@@ -8307,7 +8314,7 @@ def _nonlinear_2eq_order1_type3(x, y, t, eq):
     F = r1[f].subs(x(t), u).subs(y(t), v(u))
     G = r2[g].subs(x(t), u).subs(y(t), v(u))
     sol2r = dsolve(Eq(diff(v(u), u), G/F))
-    if not isinstance(sol2r, list):
+    if isinstance(sol2r, Expr):
         sol2r = [sol2r]
     for sol2s in sol2r:
         sol1 = solve(Integral(1/F.subs(v(u), sol2s.rhs), u).doit() - t - C2, u)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4212,8 +4212,8 @@ def _is_special_case_of(soln1, soln2, eq, order, var):
         soln1 = soln1.subs(c_old, c_new)
 
     # n equations for sol1 = sol2, sol1'=sol2', ...
-    lhs = (soln1.rhs-soln1.lhs).doit()
-    rhs = (soln2.rhs-soln2.lhs).doit()
+    lhs = (soln1.rhs-soln1.lhs)
+    rhs = (soln2.rhs-soln2.lhs)
     eqns = [Eq(lhs, rhs)]
     for n in range(1, order):
         lhs = lhs.diff(var)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4188,31 +4188,32 @@ def _is_special_case_of(soln1, soln2, eq, order, var):
     True if soln1 is found to be a special case of soln2 wrt some value of the
     constants that appear in soln2. False otherwise.
     """
-    # The solutions returned by dsolve should be given explicitly as in
-    # Eq(f(x), expr). We will equate the RHSs of the two solutions giving an
-    # equation f1(x) = f2(x).
+    # The solutions returned by dsolve may be given explicitly or implicitly.
+    # We will equate the sol1=(soln1.rhs - soln1.lhs), sol2=(soln2.rhs - soln2.lhs)
+    # of the two solutions.
     #
-    # Since this is supposed to hold for all x it also holds for derivatives
-    # f1'(x) and f2'(x). For an order n ode we should be able to differentiate
+    # Since this is supposed to hold for all x it also holds for derivatives.
+    # For an order n ode we should be able to differentiate
     # each solution n times to get n+1 equations.
     #
     # We then try to solve those n+1 equations for the integrations constants
-    # in f2(x). If we can find a solution that doesn't depend on x then it
-    # means that some value of the constants in f1(x) is a special case of
-    # f2(x) corresponding to a paritcular choice of the integration constants.
+    # in sol2. If we can find a solution that doesn't depend on x then it
+    # means that some value of the constants in sol1 is a special case of
+    # sol2 corresponding to a paritcular choice of the integration constants.
 
     constants1 = soln1.free_symbols.difference(eq.free_symbols)
     constants2 = soln2.free_symbols.difference(eq.free_symbols)
 
-    constants1_new = get_numbered_constants(soln1.rhs - soln2.rhs, len(constants1))
+    constants1_new = get_numbered_constants((soln1.rhs-soln1.lhs) - (soln2.rhs-soln2.lhs),
+                     len(constants1))
     if len(constants1) == 1:
         constants1_new = {constants1_new}
     for c_old, c_new in zip(constants1, constants1_new):
         soln1 = soln1.subs(c_old, c_new)
 
-    # n equations for f1(x)=f2(x), f1'(x)=f2'(x), ...
-    lhs = soln1.rhs.doit()
-    rhs = soln2.rhs.doit()
+    # n equations for sol1 = sol2, sol1'=sol2', ...
+    lhs = (soln1.rhs-soln1.lhs).doit()
+    rhs = (soln2.rhs-soln2.lhs).doit()
     eqns = [Eq(lhs, rhs)]
     for n in range(1, order):
         lhs = lhs.diff(var)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4160,7 +4160,7 @@ def _remove_redundant_solutions(eq, solns, order, var):
     that the second solution is a special case of the first and we don't
     want to return it.
 
-    This does not always happen. if we have
+    This does not always happen. If we have
 
         eq = Eq((f(x)**2-4)*(f(x).diff(x)-4), 0)
 
@@ -4199,7 +4199,7 @@ def _is_special_case_of(soln1, soln2, eq, order, var):
     # We then try to solve those n+1 equations for the integrations constants
     # in sol2. If we can find a solution that doesn't depend on x then it
     # means that some value of the constants in sol1 is a special case of
-    # sol2 corresponding to a paritcular choice of the integration constants.
+    # sol2 corresponding to a particular choice of the integration constants.
 
     constants1 = soln1.free_symbols.difference(eq.free_symbols)
     constants2 = soln2.free_symbols.difference(eq.free_symbols)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -440,8 +440,8 @@ def test_nonlinear_2eq_order1():
     eq3 = (Eq(diff(x(t),t), y(t)*x(t)), Eq(diff(y(t),t), x(t)**3))
     tt = S(2)/3
     sol3 = [
-        Eq(x(t), 6**tt/(6*(-sinh(sqrt(C1)*(C2 + t)/2)/sqrt(C1))**tt)),
-        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1)*(C2 + t)/2)**2)/3)]
+        Eq(x(t), 6**tt/(6*(sinh(sqrt(C1)*(C2 + t)/2)/sqrt(C1))**tt)),
+        Eq(y(t), -sqrt(C1 + C1/sinh(sqrt(C1)*(C2 + t)/2)**2)/3)]
     assert dsolve(eq3) == sol3
     # FIXME: assert checksysodesol(eq3, sol3) == (True, [0, 0])
 
@@ -1075,8 +1075,8 @@ def test_classify_sysode():
 
 def test_solve_ics():
     # Basic tests that things work from dsolve.
-    assert dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2}) == \
-        Eq(f(x), sqrt(2 * x + 2))
+    #assert dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2}) == \
+    #    Eq(f(x), sqrt(2 * x + 2))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(x).diff(x).subs(x, 0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x, x) + f(x), f(x), ics={f(0): 1,
@@ -1087,10 +1087,10 @@ def test_solve_ics():
 
     # Test cases where dsolve returns two solutions.
     eq = (x**2*f(x)**2 - x).diff(x)
-    assert dsolve(eq, f(x), ics={f(1): 0}) == [Eq(f(x),
-        -sqrt(x - 1)/x), Eq(f(x), sqrt(x - 1)/x)]
-    assert dsolve(eq, f(x), ics={f(x).diff(x).subs(x, 1): 0}) == [Eq(f(x),
-        -sqrt(x - S(1)/2)/x), Eq(f(x), sqrt(x - S(1)/2)/x)]
+    #assert dsolve(eq, f(x), ics={f(1): 0}) == [Eq(f(x),
+    #    -sqrt(x - 1)/x), Eq(f(x), sqrt(x - 1)/x)]
+    #assert dsolve(eq, f(x), ics={f(x).diff(x).subs(x, 1): 0}) == [Eq(f(x),
+    #    -sqrt(x - S(1)/2)/x), Eq(f(x), sqrt(x - S(1)/2)/x)]
 
     eq = cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x)
     assert dsolve(eq, f(x),
@@ -1553,7 +1553,7 @@ def test_1st_homogeneous_coeff_ode2():
     eq1 = f(x).diff(x) - f(x)/x + 1/sin(f(x)/x)
     eq2 = x**2 + f(x)**2 - 2*x*f(x)*f(x).diff(x)
     eq3 = x*exp(f(x)/x) + f(x) - x*f(x).diff(x)
-    sol1 = [Eq(f(x), x*(-acos(C1 + log(x)) + 2*pi)), Eq(f(x), x*acos(C1 + log(x)))]
+    sol1 = Eq(f(x), x*(-acos(C1 + log(x)) + 2*pi))
     sol2 = Eq(log(f(x)), log(C1) + log(x/f(x)) - log(x**2/f(x)**2 - 1))
     sol3 = Eq(f(x), log((1/(C1 - log(x)))**x))
     # specific hints are applied for speed reasons
@@ -2336,8 +2336,6 @@ def test_unexpanded_Liouville_ODE():
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
     sol2s = constant_renumber(sol2)
     assert dsolve(eq2) in (sol2, sol2s)
-    assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
-
 
 def test_issue_4785():
     from sympy.abc import A
@@ -2572,13 +2570,13 @@ def test_almost_linear():
     d = f(x).diff(x)
     eq = x**2*f(x)**2*d + f(x)**3 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol[0].rhs == (C1*exp(3/x) - 1)**(S(1)/3)
+    assert sol.rhs == (C1*exp(3/x) - 1)**(S(1)/3)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*f(x)*d + 2*x*f(x)**2 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol[0].rhs == -sqrt(C1 - 2*Ei(4*x))*exp(-2*x)
-    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
+    # assert sol[0].rhs == -sqrt(C1 - 2*Ei(4*x))*exp(-2*x)
+    # assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*d + x*f(x) + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
@@ -2603,20 +2601,19 @@ def test_exact_enhancement():
     df = Derivative(f, x)
     eq = f/x**2 + ((f*x - 1)/x)*df
     sol = [Eq(f, (i*sqrt(C1*x**2 + 1) + 1)/x) for i in (-1, 1)]
-    assert set(dsolve(eq, f)) == set(sol)
-    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
+    # assert set(dsolve(eq, f)) == set(sol)
+    # assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
 
     eq = (x*f - 1) + df*(x**2 - x*f)
     sol = [Eq(f, x - sqrt(C1 + x**2 - 2*log(x))),
            Eq(f, x + sqrt(C1 + x**2 - 2*log(x)))]
-    assert set(dsolve(eq, f)) == set(sol)
-    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
+    # assert set(dsolve(eq, f)) == set(sol)
+    # assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
 
     eq = (x + 2)*sin(f) + df*x*cos(f)
-    sol = [Eq(f, -asin(C1*exp(-x)/x**2) + pi),
-           Eq(f, asin(C1*exp(-x)/x**2))]
-    assert set(dsolve(eq, f)) == set(sol)
-    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
+    sol = Eq(f, -asin(C1*exp(-x)/x**2) + pi)
+    assert dsolve(eq, f) == sol
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == (True, 0)
 
 
 @slow
@@ -3310,42 +3307,17 @@ def test_nth_algebraic_redundant_solutions():
     assert set(sol) == set(dsolve(eqn, f(x), hint='nth_algebraic'))
     assert set(sol) == set(dsolve(eqn, f(x)))
 
-    # This one doesn't work with dsolve at the time of writing but the
-    # redundancy checking code should not remove the algebraic solution.
-    from sympy.solvers.ode import _nth_algebraic_remove_redundant_solutions
-    eqn = f(x) + f(x)*f(x).diff(x)
-    solns = [Eq(f(x), 0),
-             Eq(f(x), C1 - x)]
-    solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 1, x)
-    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
-    assert set(solns) == set(solns_final)
 
-    solns = [Eq(f(x), exp(x)),
-             Eq(f(x), C1*exp(C2*x))]
-    solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 2, x)
-    assert solns_final == [Eq(f(x), C1*exp(C2*x))]
+    eqn = f(x) + f(x)*f(x).diff(x)
+    solns = Eq(f(x), C1 - x)
+    assert checkodesol(eqn, solns) == (True, 0)
+    assert solns == dsolve(eqn)
 
     # This one needs a substitution f' = g.
     eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
     sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x))
-
-
-#
-# These tests can be combined with the above test if they get fixed
-# so that dsolve actually works in all these cases.
-#
-
-# Fails due to division by f(x) eliminating the solution before nth_algebraic
-# is called.
-@XFAIL
-def test_nth_algebraic_find_multiple1():
-    eqn = f(x) + f(x)*f(x).diff(x)
-    solns = [Eq(f(x), 0),
-             Eq(f(x), C1 - x)]
-    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
-    assert set(solns) == set(dsolve(eqn, f(x)))
 
 
 # prep = True breaks this

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -440,8 +440,8 @@ def test_nonlinear_2eq_order1():
     eq3 = (Eq(diff(x(t),t), y(t)*x(t)), Eq(diff(y(t),t), x(t)**3))
     tt = S(2)/3
     sol3 = [
-        Eq(x(t), 6**tt/(6*(sinh(sqrt(C1)*(C2 + t)/2)/sqrt(C1))**tt)),
-        Eq(y(t), -sqrt(C1 + C1/sinh(sqrt(C1)*(C2 + t)/2)**2)/3)]
+        Eq(x(t), 6**tt/(6*(-sinh(sqrt(C1)*(C2 + t)/2)/sqrt(C1))**tt)),
+        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1)*(C2 + t)/2)**2)/3)]
     assert dsolve(eq3) == sol3
     # FIXME: assert checksysodesol(eq3, sol3) == (True, [0, 0])
 
@@ -1075,8 +1075,8 @@ def test_classify_sysode():
 
 def test_solve_ics():
     # Basic tests that things work from dsolve.
-    #assert dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2}) == \
-    #    Eq(f(x), sqrt(2 * x + 2))
+    assert dsolve(f(x).diff(x) - 1/f(x), f(x), ics={f(1): 2}) == \
+        Eq(f(x), sqrt(2 * x + 2))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x) - f(x), f(x), ics={f(x).diff(x).subs(x, 0): 1}) == Eq(f(x), exp(x))
     assert dsolve(f(x).diff(x, x) + f(x), f(x), ics={f(0): 1,
@@ -1087,10 +1087,10 @@ def test_solve_ics():
 
     # Test cases where dsolve returns two solutions.
     eq = (x**2*f(x)**2 - x).diff(x)
-    #assert dsolve(eq, f(x), ics={f(1): 0}) == [Eq(f(x),
-    #    -sqrt(x - 1)/x), Eq(f(x), sqrt(x - 1)/x)]
-    #assert dsolve(eq, f(x), ics={f(x).diff(x).subs(x, 1): 0}) == [Eq(f(x),
-    #    -sqrt(x - S(1)/2)/x), Eq(f(x), sqrt(x - S(1)/2)/x)]
+    assert dsolve(eq, f(x), ics={f(1): 0}) == [Eq(f(x),
+        -sqrt(x - 1)/x), Eq(f(x), sqrt(x - 1)/x)]
+    assert dsolve(eq, f(x), ics={f(x).diff(x).subs(x, 1): 0}) == [Eq(f(x),
+        -sqrt(x - S(1)/2)/x), Eq(f(x), sqrt(x - S(1)/2)/x)]
 
     eq = cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x)
     assert dsolve(eq, f(x),
@@ -1553,7 +1553,7 @@ def test_1st_homogeneous_coeff_ode2():
     eq1 = f(x).diff(x) - f(x)/x + 1/sin(f(x)/x)
     eq2 = x**2 + f(x)**2 - 2*x*f(x)*f(x).diff(x)
     eq3 = x*exp(f(x)/x) + f(x) - x*f(x).diff(x)
-    sol1 = Eq(f(x), x*(-acos(C1 + log(x)) + 2*pi))
+    sol1 = [Eq(f(x), x*(-acos(C1 + log(x)) + 2*pi)), Eq(f(x), x*acos(C1 + log(x)))]
     sol2 = Eq(log(f(x)), log(C1) + log(x/f(x)) - log(x**2/f(x)**2 - 1))
     sol3 = Eq(f(x), log((1/(C1 - log(x)))**x))
     # specific hints are applied for speed reasons
@@ -2336,6 +2336,7 @@ def test_unexpanded_Liouville_ODE():
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
     sol2s = constant_renumber(sol2)
     assert dsolve(eq2) in (sol2, sol2s)
+    assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
 
 def test_issue_4785():
     from sympy.abc import A
@@ -2570,13 +2571,13 @@ def test_almost_linear():
     d = f(x).diff(x)
     eq = x**2*f(x)**2*d + f(x)**3 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol.rhs == (C1*exp(3/x) - 1)**(S(1)/3)
+    assert sol[0].rhs == (C1*exp(3/x) - 1)**(S(1)/3)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*f(x)*d + 2*x*f(x)**2 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    # assert sol[0].rhs == -sqrt(C1 - 2*Ei(4*x))*exp(-2*x)
-    # assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
+    assert sol[0].rhs == -sqrt((C1 - 2*Ei(4*x))*exp(-4*x))
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*d + x*f(x) + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
@@ -2601,19 +2602,20 @@ def test_exact_enhancement():
     df = Derivative(f, x)
     eq = f/x**2 + ((f*x - 1)/x)*df
     sol = [Eq(f, (i*sqrt(C1*x**2 + 1) + 1)/x) for i in (-1, 1)]
-    # assert set(dsolve(eq, f)) == set(sol)
-    # assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
+    assert set(dsolve(eq, f)) == set(sol)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
 
     eq = (x*f - 1) + df*(x**2 - x*f)
     sol = [Eq(f, x - sqrt(C1 + x**2 - 2*log(x))),
            Eq(f, x + sqrt(C1 + x**2 - 2*log(x)))]
-    # assert set(dsolve(eq, f)) == set(sol)
-    # assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
+    assert set(dsolve(eq, f)) == set(sol)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
 
     eq = (x + 2)*sin(f) + df*x*cos(f)
-    sol = Eq(f, -asin(C1*exp(-x)/x**2) + pi)
-    assert dsolve(eq, f) == sol
-    assert checkodesol(eq, sol, order=1, solve_for_func=False) == (True, 0)
+    sol = [Eq(f, -asin(C1*exp(-x)/x**2) + pi),
+           Eq(f, asin(C1*exp(-x)/x**2))]
+    assert set(dsolve(eq, f)) == set(sol)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False) == [(True, 0), (True, 0)]
 
 
 @slow
@@ -3307,17 +3309,41 @@ def test_nth_algebraic_redundant_solutions():
     assert set(sol) == set(dsolve(eqn, f(x), hint='nth_algebraic'))
     assert set(sol) == set(dsolve(eqn, f(x)))
 
-
+    # This one doesn't work with dsolve at the time of writing but the
+    # redundancy checking code should not remove the algebraic solution.
+    from sympy.solvers.ode import _remove_redundant_solutions
     eqn = f(x) + f(x)*f(x).diff(x)
-    solns = Eq(f(x), C1 - x)
-    assert checkodesol(eqn, solns) == (True, 0)
-    assert solns == dsolve(eqn)
+    solns = [Eq(f(x), 0),
+             Eq(f(x), C1 - x)]
+    solns_final =  _remove_redundant_solutions(eqn, solns, 1, x)
+    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
+    assert set(solns) == set(solns_final)
+
+    solns = [Eq(f(x), exp(x)),
+             Eq(f(x), C1*exp(C2*x))]
+    solns_final =  _remove_redundant_solutions(eqn, solns, 2, x)
+    assert solns_final == [Eq(f(x), C1*exp(C2*x))]
 
     # This one needs a substitution f' = g.
     eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
     sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
     assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x))
+
+#
+# These tests can be combined with the above test if they get fixed
+# so that dsolve actually works in all these cases.
+#
+
+# Fails due to division by f(x) eliminating the solution before nth_algebraic
+# is called.
+@XFAIL
+def test_nth_algebraic_find_multiple1():
+    eqn = f(x) + f(x)*f(x).diff(x)
+    solns = [Eq(f(x), 0),
+             Eq(f(x), C1 - x)]
+    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
+    assert set(solns) == set(dsolve(eqn, f(x)))
 
 
 # prep = True breaks this

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3415,3 +3415,17 @@ def test_issue_15913():
 def test_issue_16146():
     raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x), g(x), h(x)]))
     raises(ValueError, lambda: dsolve([f(x).diff(x), g(x).diff(x)], [f(x)]))
+
+def test_dsolve_remove_redundant_solutions():
+
+    eq = (f(x)-2)*f(x).diff(x)
+    sol = Eq(f(x), C1)
+    assert dsolve(eq) == sol
+
+    eq = (f(x)-sin(x))*(f(x).diff(x, 2))
+    sol = {Eq(f(x), C1 + C2*x), Eq(f(x), sin(x))}
+    assert set(dsolve(eq)) == sol
+
+    eq = (f(x)**2-2*f(x)+1)*f(x).diff(x, 3)
+    sol = Eq(f(x), C1 + C2*x + C3*x**2)
+    assert dsolve(eq) == sol

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2575,8 +2575,11 @@ def test_almost_linear():
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*f(x)*d + 2*x*f(x)**2 + 1
-    sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol[0].rhs == -sqrt((C1 - 2*Ei(4*x))*exp(-4*x))
+    sol = [
+        Eq(f(x), -sqrt((C1 - 2*Ei(4*x))*exp(-4*x))),
+        Eq(f(x), sqrt((C1 - 2*Ei(4*x))*exp(-4*x)))
+    ]
+    assert set(dsolve(eq, f(x), hint = 'almost_linear')) == set(sol)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*d + x*f(x) + 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests. Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #17338 

#### Brief description of what is fixed or changed
I am trying to implement 'factorable' method (in pr #17338 ) for dsolve and I am returning a list of solutions. But solutions may be redundant so I want to add the function (`_nth_algebraic_remove_redundant_solutions`) to dsolve so that I can remove the redundant solution.

 The function `_nth_algebraic_remove_redundant_solutions` is already implemented for `nth_algebraic` type of ode. I am just adding(and changing name) it into dsolve.


#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - added a method to dsolve for removing the redundant solution
<!-- END RELEASE NOTES -->
