### PR TITLE
Fix parenthesis in LaTeX printer for Hadamard Power

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1616,7 +1616,10 @@ class LatexPrinter(Printer):
             map(lambda arg: parens(arg, prec, strict=True), args))
 
     def _print_HadamardPower(self, expr):
-        template = r"%s^{\circ {%s}}"
+        if precedence_traditional(expr.exp) < PRECEDENCE["Mul"]:
+            template = r"%s^{\circ \left({%s}\right)}"
+        else:
+            template = r"%s^{\circ {%s}}"
         return self._helper_print_standard_power(expr, template)
 
     def _print_KroneckerProduct(self, expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1653,16 +1653,19 @@ def test_Hadamard():
     assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \circ Y\right) Y'
 
     assert latex(HadamardPower(X, 2)) == r'X^{\circ {2}}'
-    assert latex(HadamardPower(X, -1)) == r'X^{\circ {-1}}'
+    assert latex(HadamardPower(X, -1)) == r'X^{\circ \left({-1}\right)}'
     assert latex(HadamardPower(MatAdd(X, Y), 2)) == \
         r'\left(X + Y\right)^{\circ {2}}'
     assert latex(HadamardPower(MatMul(X, Y), 2)) == \
         r'\left(X Y\right)^{\circ {2}}'
 
     assert latex(HadamardPower(MatPow(X, -1), -1)) == \
-        r'\left(X^{-1}\right)^{\circ {-1}}'
+        r'\left(X^{-1}\right)^{\circ \left({-1}\right)}'
     assert latex(MatPow(HadamardPower(X, -1), -1)) == \
-        r'\left(X^{\circ {-1}}\right)^{-1}'
+        r'\left(X^{\circ \left({-1}\right)}\right)^{-1}'
+
+    assert latex(HadamardPower(X, n+1)) == \
+        r'X^{\circ \left({n + 1}\right)}'
 
 
 def test_ElementwiseApplyFunction():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Add parenthesis before circ in LaTeX printer for Hadamard powers when the precedence of the exponent is lower than the precedence of multiplication.
<!-- END RELEASE NOTES -->
