### PR TITLE
Add automatic evaluation for compositions of inverse hyperbolic functions

### DIFF
--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
     integrate, log, Mul, N, oo, pi, Pow, product, Product,
-    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
+    Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath, evalf)
@@ -567,3 +567,7 @@ def test_issue_13425():
     assert N('2**.5', 30) == N('sqrt(2)', 30)
     assert N('x - x', 30) == 0
     assert abs((N('pi*.1', 22)*10 - pi).n()) < 1e-22
+
+
+def test_issue_17421():
+    assert N(acos(-I + acosh(cosh(cosh(1) + I)))) == 1.0*I

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -491,11 +491,11 @@ class exp(ExpBase):
                 return Pow(logs[0].args[0], arg.coeff(logs[0]))
 
 
-def _match_real_imag(expr):
+def match_real_imag(expr):
     """
     Try to match expr with a + b*I for real a and b.
 
-    ``_match_real_imag`` returns a tuple containing the real and imaginary
+    ``match_real_imag`` returns a tuple containing the real and imaginary
     parts of expr or (None, None) if direct matching is not possible. Contrary
     to ``re()``, ``im()``, ``as_real_imag()``, this helper won't force things
     by returning expressions themselves containing ``re()`` or ``im()`` and it
@@ -607,7 +607,7 @@ class log(Function):
         if isinstance(arg, exp) and arg.args[0].is_extended_real:
             return arg.args[0]
         elif isinstance(arg, exp) and arg.args[0].is_number:
-            r_, i_ = _match_real_imag(arg.args[0])
+            r_, i_ = match_real_imag(arg.args[0])
             if i_ and i_.is_comparable:
                 i_ %= 2*S.Pi
                 if i_ > S.Pi:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -927,20 +927,19 @@ class asinh(InverseHyperbolicFunction):
                 if _coeff_isneg(arg):
                     return -cls(-arg)
 
-        if isinstance(arg, sinh):
-            x = arg.args[0]
-            if x.is_number:
-                if x.is_real:
-                    return x
-                r, i = match_real_imag(x)
-                if r is not None and i is not None:
-                    f = floor((i + pi/2)/pi)
-                    if f.is_number and f.is_integer:
-                        m = r + I*i - I*pi*f
-                        if f % 2 == 0:
-                            return m
-                        else:
-                            return -m
+        if isinstance(arg, sinh) and arg.args[0].is_number:
+            z = arg.args[0]
+            if z.is_real:
+                return z
+            r, i = match_real_imag(z)
+            if r is not None and i is not None:
+                f = floor((i + pi/2)/pi)
+                m = z - I*pi*f
+                even = f.is_even
+                if even is True:
+                    return m
+                elif even is False:
+                    return -m
 
     @staticmethod
     @cacheit
@@ -1049,28 +1048,27 @@ class acosh(InverseHyperbolicFunction):
         if arg == -S.ImaginaryUnit*S.Infinity:
             return S.Infinity - S.ImaginaryUnit*S.Pi/2
 
-        if isinstance(arg, cosh):
-            x = arg.args[0]
-            if x.is_number:
-                if x.is_real:
-                    from sympy.functions.elementary.complexes import Abs
-                    return Abs(x)
-                r, i = match_real_imag(x)
-                if r is not None and i is not None:
-                    f = floor(i/pi)
-                    if f.is_number and f.is_integer:
-                        m = r + I*i - I*pi*f
-                        if f % 2 == 0:
-                            if r.is_nonnegative:
-                                return m
-                            elif r.is_negative:
-                                return -m
-                        else:
-                            m -= I*pi
-                            if r.is_nonpositive:
-                                return -m
-                            elif r.is_positive:
-                                return m
+        if isinstance(arg, cosh) and arg.args[0].is_number:
+            z = arg.args[0]
+            if z.is_real:
+                from sympy.functions.elementary.complexes import Abs
+                return Abs(z)
+            r, i = match_real_imag(z)
+            if r is not None and i is not None:
+                f = floor(i/pi)
+                m = z - I*pi*f
+                even = f.is_even
+                if even is True:
+                    if r.is_nonnegative:
+                        return m
+                    elif r.is_negative:
+                        return -m
+                elif even is False:
+                    m -= I*pi
+                    if r.is_nonpositive:
+                        return -m
+                    elif r.is_positive:
+                        return m
 
     @staticmethod
     @cacheit
@@ -1160,19 +1158,19 @@ class atanh(InverseHyperbolicFunction):
                 if _coeff_isneg(arg):
                     return -cls(-arg)
 
-        if isinstance(arg, tanh):
-            x = arg.args[0]
-            if x.is_number:
-                if x.is_real:
-                    return x
-                r, i = match_real_imag(x)
-                if r is not None and i is not None:
-                    f = floor(2*i/pi)
-                    if f.is_number and f.is_integer:
-                        if f % 2 == 0:
-                            return r + I*i - I*f*pi/2
-                        else:
-                            return r + I*i - I*(f + 1)*pi/2
+        if isinstance(arg, tanh) and arg.args[0].is_number:
+            z = arg.args[0]
+            if z.is_real:
+                return z
+            r, i = match_real_imag(z)
+            if r is not None and i is not None:
+                f = floor(2*i/pi)
+                even = f.is_even
+                m = z - I*f*pi/2
+                if even is True:
+                    return m
+                elif even is False:
+                    return m - I*pi/2
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1,11 +1,12 @@
 from __future__ import print_function, division
 
-from sympy.core import S, sympify, cacheit
+from sympy.core import S, sympify, cacheit, pi, I
 from sympy.core.add import Add
 from sympy.core.function import Function, ArgumentIndexError, _coeff_isneg
 from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
-from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.integers import floor
 
 
 def _rewrite_hyperbolics_as_exp(expr):
@@ -926,6 +927,21 @@ class asinh(InverseHyperbolicFunction):
                 if _coeff_isneg(arg):
                     return -cls(-arg)
 
+        if isinstance(arg, sinh):
+            x = arg.args[0]
+            if x.is_number:
+                if x.is_real:
+                    return x
+                r, i = match_real_imag(x)
+                if r is not None and i is not None:
+                    f = floor((i + pi/2)/pi)
+                    if f.is_number and f.is_integer:
+                        m = r + I*i - I*pi*f
+                        if f % 2 == 0:
+                            return m
+                        else:
+                            return -m
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -1033,6 +1049,29 @@ class acosh(InverseHyperbolicFunction):
         if arg == -S.ImaginaryUnit*S.Infinity:
             return S.Infinity - S.ImaginaryUnit*S.Pi/2
 
+        if isinstance(arg, cosh):
+            x = arg.args[0]
+            if x.is_number:
+                if x.is_real:
+                    from sympy.functions.elementary.complexes import Abs
+                    return Abs(x)
+                r, i = match_real_imag(x)
+                if r is not None and i is not None:
+                    f = floor(i/pi)
+                    if f.is_number and f.is_integer:
+                        m = r + I*i - I*pi*f
+                        if f % 2 == 0:
+                            if r.is_nonnegative:
+                                return m
+                            elif r.is_negative:
+                                return -m
+                        else:
+                            m -= I*pi
+                            if r.is_nonpositive:
+                                return -m
+                            elif r.is_positive:
+                                return m
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -1120,6 +1159,20 @@ class atanh(InverseHyperbolicFunction):
             else:
                 if _coeff_isneg(arg):
                     return -cls(-arg)
+
+        if isinstance(arg, tanh):
+            x = arg.args[0]
+            if x.is_number:
+                if x.is_real:
+                    return x
+                r, i = match_real_imag(x)
+                if r is not None and i is not None:
+                    f = floor(2*i/pi)
+                    if f.is_number and f.is_integer:
+                        if f % 2 == 0:
+                            return r + I*i - I*f*pi/2
+                        else:
+                            return r + I*i - I*(f + 1)*pi/2
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -3,7 +3,7 @@ from sympy import (
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
     AccumBounds, MatrixSymbol, Pow, gcd)
-from sympy.functions.elementary.exponential import _match_real_imag
+from sympy.functions.elementary.exponential import match_real_imag
 from sympy.abc import x, y, z
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -221,16 +221,16 @@ def test_log_values():
 def test_match_real_imag():
     x, y = symbols('x,y', real=True)
     i = Symbol('i', imaginary=True)
-    assert _match_real_imag(S.One) == (1, 0)
-    assert _match_real_imag(I) == (0, 1)
-    assert _match_real_imag(3 - 5*I) == (3, -5)
-    assert _match_real_imag(-sqrt(3) + S.Half*I) == (-sqrt(3), S.Half)
-    assert _match_real_imag(x + y*I) == (x, y)
-    assert _match_real_imag(x*I + y*I) == (0, x + y)
-    assert _match_real_imag((x + y)*I) == (0, x + y)
-    assert _match_real_imag(-S(2)/3*i*I) == (None, None)
-    assert _match_real_imag(1 - 2*i) == (None, None)
-    assert _match_real_imag(sqrt(2)*(3 - 5*I)) == (None, None)
+    assert match_real_imag(S.One) == (1, 0)
+    assert match_real_imag(I) == (0, 1)
+    assert match_real_imag(3 - 5*I) == (3, -5)
+    assert match_real_imag(-sqrt(3) + S.Half*I) == (-sqrt(3), S.Half)
+    assert match_real_imag(x + y*I) == (x, y)
+    assert match_real_imag(x*I + y*I) == (0, x + y)
+    assert match_real_imag((x + y)*I) == (0, x + y)
+    assert match_real_imag(-S(2)/3*i*I) == (None, None)
+    assert match_real_imag(1 - 2*i) == (None, None)
+    assert match_real_imag(sqrt(2)*(3 - 5*I)) == (None, None)
 
 
 def test_log_exact():

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -2,7 +2,7 @@ from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
-    AccumBounds, MatrixSymbol, Pow, gcd)
+    AccumBounds, MatrixSymbol, Pow, gcd, Sum, Product)
 from sympy.functions.elementary.exponential import match_real_imag
 from sympy.abc import x, y, z
 from sympy.core.expr import unchanged

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log,
     sqrt, coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth,
     Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul,
-    AccumBounds, im, re)
+    AccumBounds, im, re, Abs)
 
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
@@ -508,6 +508,20 @@ def test_asinh():
     # Symmetry
     assert asinh(-S.Half) == -asinh(S.Half)
 
+    # inverse composition
+    assert unchanged(asinh, sinh(Symbol('v1')))
+
+    assert asinh(sinh(0, evaluate=False)) == 0
+    assert asinh(sinh(-3, evaluate=False)) == -3
+    assert asinh(sinh(2, evaluate=False)) == 2
+    assert asinh(sinh(I, evaluate=False)) == I
+    assert asinh(sinh(-I, evaluate=False)) == -I
+    assert asinh(sinh(5*I, evaluate=False)) == -2*I*pi + 5*I
+    assert asinh(sinh(15 + 11*I)) == 15 - 4*I*pi + 11*I
+    assert asinh(sinh(-73 + 97*I)) == 73 - 97*I + 31*I*pi
+    assert asinh(sinh(-7 - 23*I)) == 7 - 7*I*pi + 23*I
+    assert asinh(sinh(13 - 3*I)) == -13 - I*pi + 3*I
+
 
 def test_asinh_rewrite():
     x = Symbol('x')
@@ -569,6 +583,22 @@ def test_acosh():
 
     assert str(acosh(5*I).n(6)) == '2.31244 + 1.5708*I'
     assert str(acosh(-5*I).n(6)) == '2.31244 - 1.5708*I'
+
+    # inverse composition
+    assert unchanged(acosh, Symbol('v1'))
+
+    assert acosh(cosh(-3, evaluate=False)) == 3
+    assert acosh(cosh(3, evaluate=False)) == 3
+    assert acosh(cosh(0, evaluate=False)) == 0
+    assert acosh(cosh(I, evaluate=False)) == I
+    assert acosh(cosh(-I, evaluate=False)) == I
+    assert acosh(cosh(7*I, evaluate=False)) == -2*I*pi + 7*I
+    assert acosh(cosh(1 + I)) == 1 + I
+    assert acosh(cosh(3 - 3*I)) == 3 - 3*I
+    assert acosh(cosh(-3 + 2*I)) == 3 - 2*I
+    assert acosh(cosh(-5 - 17*I)) == 5 - 6*I*pi + 17*I
+    assert acosh(cosh(-21 + 11*I)) == 21 - 11*I + 4*I*pi
+    assert acosh(cosh(cosh(1) + I)) == cosh(1) + I
 
 
 def test_acosh_rewrite():
@@ -779,6 +809,24 @@ def test_atanh():
 
     # Symmetry
     assert atanh(-S.Half) == -atanh(S.Half)
+
+    # inverse composition
+    assert unchanged(atanh, tanh(Symbol('v1')))
+
+    assert atanh(tanh(-5, evaluate=False)) == -5
+    assert atanh(tanh(0, evaluate=False)) == 0
+    assert atanh(tanh(7, evaluate=False)) == 7
+    assert atanh(tanh(I, evaluate=False)) == I
+    assert atanh(tanh(-I, evaluate=False)) == -I
+    assert atanh(tanh(-11*I, evaluate=False)) == -11*I + 4*I*pi
+    assert atanh(tanh(3 + I)) == 3 + I
+    assert atanh(tanh(4 + 5*I)) == 4 - 2*I*pi + 5*I
+    assert atanh(tanh(pi/2)) == pi/2
+    assert atanh(tanh(pi)) == pi
+    assert atanh(tanh(-3 + 7*I)) == -3 - 2*I*pi + 7*I
+    assert atanh(tanh(9 - 2*I/3)) == 9 - 2*I/3
+    assert atanh(tanh(-32 - 123*I)) == -32 - 123*I + 39*I*pi
+
 
 def test_atanh_rewrite():
     x = Symbol('x')


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #17421. The more difficult issue with evaluation near branch cuts is not addressed, but there is another issue that covers that (#6137).

#### Brief description of what is fixed or changed
Add automatic evaluation of `atanh(tanh(x)), acosh(cosh(x)), asinh(sinh(x))` for suitable `x`.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * atanh(tanh(x)), acosh(cosh(x)) and asinh(sinh(x)) are automatically evaluated
<!-- END RELEASE NOTES -->
