### PR TITLE
Fixed issue with identical conditions in Piecewise

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -281,10 +281,7 @@ class Piecewise(Function):
                     newargs[-1] = ExprCondPair(expr, orcond)
                     continue
                 elif newargs[-1].cond == cond:
-                    orexpr = Or(expr, newargs[-1].expr)
-                    if isinstance(orexpr, (And, Or)):
-                        orexpr = distribute_and_over_or(orexpr)
-                    newargs[-1] == ExprCondPair(orexpr, cond)
+                    newargs[-1] == ExprCondPair(expr, cond)
                     continue
 
             newargs.append(ExprCondPair(expr, cond))

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -281,7 +281,7 @@ class Piecewise(Function):
                     newargs[-1] = ExprCondPair(expr, orcond)
                     continue
                 elif newargs[-1].cond == cond:
-                    newargs[-1] == ExprCondPair(expr, cond)
+                    newargs[-1] = ExprCondPair(expr, cond)
                     continue
 
             newargs.append(ExprCondPair(expr, cond))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1302,3 +1302,13 @@ def test_eval_rewrite_as_KroneckerDelta():
 
     p22 = Piecewise((0, ~((Eq(y, -1) | Ne(x, 0)) & (Ne(x, 1) | Ne(y, -1)))), (1, True))
     assert f(p22) == K(-1, y)*K(0, x) - K(-1, y)*K(1, x) - K(0, x) + 1
+
+
+@slow
+def test_identical_conds_issue():
+    from sympy.stats import Uniform, density
+    u1 = Uniform('u1', 0, 1)
+    u2 = Uniform('u2', 0, 1)
+    # Result is quite big, so not really important here (and should ideally be
+    # simpler). Should not give an exception though.
+    density(u1 + u2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Noticed it when looking at #17321 

#### Brief description of what is fixed or changed
Earlier:
```
In [11]: density(u1+u2)
Traceback (most recent call last):

  File "<ipython-input-11-19168704ba21>", line 1, in <module>
    density(u1+u2)

  File "/nobackup/data/sympy/sympy/stats/rv.py", line 889, in density
    return Density(expr, condition).doit(evaluate=evaluate, **kwargs)

  File "/nobackup/data/sympy/sympy/stats/rv.py", line 842, in doit
    return result.doit()

  File "/nobackup/data/sympy/sympy/core/basic.py", line 1691, in doit
    for term in self.args]

  File "/nobackup/data/sympy/sympy/core/basic.py", line 1691, in <listcomp>
    for term in self.args]

  File "/nobackup/data/sympy/sympy/integrals/integrals.py", line 462, in doit
    did = self.xreplace(reps).doit(**hints)

  File "/nobackup/data/sympy/sympy/integrals/integrals.py", line 669, in doit
    evalued_pw = piecewise_fold(Add(*piecewises))._eval_interval(x, a, b)

  File "/nobackup/data/sympy/sympy/functions/elementary/piecewise.py", line 568, in _eval_interval
    irv = self._handle_irel(x, handler)

  File "/nobackup/data/sympy/sympy/functions/elementary/piecewise.py", line 457, in _handle_irel
    return Piecewise(*args)

  File "/nobackup/data/sympy/sympy/functions/elementary/piecewise.py", line 139, in __new__
    r = cls.eval(*newargs)

  File "/nobackup/data/sympy/sympy/functions/elementary/piecewise.py", line 284, in eval
    orexpr = Or(expr, newargs[-1].expr)

  File "/nobackup/data/sympy/sympy/core/operations.py", line 418, in __new__
    _args = frozenset(cls._new_args_filter(args))

  File "/nobackup/data/sympy/sympy/logic/boolalg.py", line 787, in _new_args_filter
    args = BooleanFunction.binary_check_and_simplify(*args)

  File "/nobackup/data/sympy/sympy/logic/boolalg.py", line 456, in binary_check_and_simplify
    args = [as_Boolean(i) for i in args]

  File "/nobackup/data/sympy/sympy/logic/boolalg.py", line 456, in <listcomp>
    args = [as_Boolean(i) for i in args]

  File "/nobackup/data/sympy/sympy/logic/boolalg.py", line 54, in as_Boolean
    raise TypeError('expecting bool or Boolean, not `%s`.' % e)

TypeError: expecting bool or Boolean, not `Integral(Piecewise((0, (_Dummy_2005 <= 1) & (_Dummy_2005/_z > -1) & ((_Dummy_2005 <= 1) | (_Dummy_2005/_z > -1)) & ((_Dummy_2005 <= 1) | (_Dummy_2005/(_z - 1) > -1)) & ((_Dummy_2005 <= 1) | (_Dummy_2005/(_z - 1) < 1)) & ((_Dummy_2005 <= 1) | (_Dummy_2005/Abs(_z - 1) < 1)) & ((_Dummy_2005/_z > -1) | (_Dummy_2005/(_z - 1) > -1)) & ((_Dummy_2005/_z > -1) | (_Dummy_2005/(_z - 1) < 1)) & ((_Dummy_2005/_z > -1) | (_Dummy_2005/Abs(_z - 1) < 1)) & ((_Dummy_2005/(_z - 1) > -1) | (_Dummy_2005/Abs(_z - 1) < 1)) & ((_Dummy_2005/(_z - 1) < 1) | (_Dummy_2005/Abs(_z - 1) < 1))), (_z*(1/(_z - 1) - _z/(_Dummy_2005*(_z - 1)) + 1/_Dummy_2005 + 1/(_Dummy_2005*(_z - 1))) - 1/(_z - 1) + _z/(_Dummy_2005*(_z - 1)) - 1/_Dummy_2005 - 1/(_Dummy_2005*(_z - 1)), (_Dummy_2005 <= 1) & (_Dummy_2005/_z > -1) & (Abs(_z - 1)/_Dummy_2005 < 1)), (_z*((meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 + meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005) - (meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005, (_Dummy_2005 <= 1) & (_Dummy_2005/_z > -1)), (0, (_Dummy_2005 <= 1) & (_Dummy_2005/Abs(_z) < 1) & (_Dummy_2005/(_z - 1) > -1) & (_Dummy_2005/(_z - 1) < 1)), (-1, (_Dummy_2005 <= 1) & (Abs(_z)/_Dummy_2005 < 1) & (_Dummy_2005/(_z - 1) > -1) & (_Dummy_2005/(_z - 1) < 1)), (_z*(-(meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z)/_Dummy_2005), (_Dummy_2005 <= 1) & (_Dummy_2005/(_z - 1) > -1) & (_Dummy_2005/(_z - 1) < 1)), (0, (_Dummy_2005 <= 1) & (_Dummy_2005/Abs(_z) < 1) & (_Dummy_2005/Abs(_z - 1) < 1)), (-1, (_Dummy_2005 <= 1) & (Abs(_z)/_Dummy_2005 < 1) & (_Dummy_2005/Abs(_z - 1) < 1)), (_z*(-(meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z)/_Dummy_2005), (_Dummy_2005 <= 1) & (_Dummy_2005/Abs(_z - 1) < 1)), (_z*(1/(_z - 1) - _z/(_Dummy_2005*(_z - 1)) + 1/_Dummy_2005 + 1/(_Dummy_2005*(_z - 1))) - 1/(_z - 1) + _z/(_Dummy_2005*(_z - 1)) - 1/_Dummy_2005 - 1/(_Dummy_2005*(_z - 1)), (_Dummy_2005 <= 1) & (_Dummy_2005/Abs(_z) < 1) & (Abs(_z - 1)/_Dummy_2005 < 1)), (_z*(1/(_z - 1) - _z/(_Dummy_2005*(_z - 1)) + 1/_Dummy_2005 + 1/(_Dummy_2005*(_z - 1))) - 1 - 1/(_z - 1) + _z/(_Dummy_2005*(_z - 1)) - 1/_Dummy_2005 - 1/(_Dummy_2005*(_z - 1)), (_Dummy_2005 <= 1) & (Abs(_z)/_Dummy_2005 < 1) & (Abs(_z - 1)/_Dummy_2005 < 1)), (_z*(-(meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z)/_Dummy_2005) + _z*(1/(_z - 1) - _z/(_Dummy_2005*(_z - 1)) + 1/_Dummy_2005 + 1/(_Dummy_2005*(_z - 1))) - 1/(_z - 1) + _z/(_Dummy_2005*(_z - 1)) - 1/_Dummy_2005 - 1/(_Dummy_2005*(_z - 1)), (_Dummy_2005 <= 1) & (Abs(_z - 1)/_Dummy_2005 < 1)), (_z*((meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 + meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005) - (meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005, (_Dummy_2005 <= 1) & (_Dummy_2005/Abs(_z) < 1)), (_z*((meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 + meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005) - 1 - (meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005, (_Dummy_2005 <= 1) & (Abs(_z)/_Dummy_2005 < 1)), (_z*(-(meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/_z)/_Dummy_2005) + _z*((meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 + meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005) - (meijerg(((1, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)) + meijerg(((2, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1)))/_Dummy_2005 - meijerg(((0, 1, 1), ()), ((), (1, 0, 0)), _Dummy_2005/polar_lift(_z - 1))/_Dummy_2005, _Dummy_2005 <= 1), (0, True)), (_Dummy_2005, 0, 1))`.
```

Now that doesn't happen.

#### Other comments
I couldn't really find a simpler example as this only seems to be triggered if the identical conditions are generated in the earlier stages of `Piecewise.eval`(?).

Also, while `(x + 2) or sin(y)` works in Python, SymPy's `Or(x + 2, sin(y)` doesn't (which is probably the source of this issue).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `Piecewise` with identical conditions bug fixed.
<!-- END RELEASE NOTES -->
