### PR TITLE
Fix missing import of zeros

### DIFF
--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -1,7 +1,7 @@
 '''Functions returning normal forms of matrices'''
 from __future__ import division, print_function
 
-from sympy.matrices.dense import diag
+from sympy.matrices.dense import diag, zeros
 
 
 def smith_normal_form(m, domain = None):

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -21,4 +21,3 @@ def test_smith_normal():
     setattr(m, 'ring', ZZ)
     smf = Matrix([[2, 0]])
     assert smith_normal_form(m) == smf
-    

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -16,3 +16,9 @@ def test_smith_normal():
     setattr(m, 'ring', QQ[x])
     invs = (Poly(1, x), Poly(x - 1), Poly(x**2 - 1))
     assert invariant_factors(m) == invs
+
+    m = Matrix([[2, 4]])
+    setattr(m, 'ring', ZZ)
+    smf = Matrix([[2, 0]])
+    assert smith_normal_form(m) == smf
+    


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed a missing import when calculating smith normal form.
<!-- END RELEASE NOTES -->
