### PR TITLE
Add Abs(imaginary).rewrite(Piecewise) and use in solve

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -622,6 +622,8 @@ class Abs(Function):
     def _eval_rewrite_as_Piecewise(self, arg, **kwargs):
         if arg.is_extended_real:
             return Piecewise((arg, arg >= 0), (-arg, True))
+        elif arg.is_imaginary:
+            return Piecewise((I*arg, I*arg >= 0), (-I*arg, True))
 
     def _eval_rewrite_as_sign(self, arg, **kwargs):
         return arg/sign(arg)

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -474,6 +474,9 @@ def test_Abs_rewrite():
     assert Abs(y).rewrite(Piecewise) == Abs(y)
     assert Abs(y).rewrite(sign) == y/sign(y)
 
+    i = Symbol('i', imaginary=True)
+    assert abs(i).rewrite(Piecewise) == Piecewise((I*i, I*i >= 0), (-I*i, True))
+
 
 def test_Abs_real():
     # test some properties of abs that only apply

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -112,7 +112,10 @@ def _separatevars(expr, force):
         arg = expr.args[0]
         if arg.is_Mul and not arg.is_number:
             s = separatevars(arg, dict=True, force=force)
-            return Mul(*map(expr.func, s.values()))
+            if s is not None:
+                return Mul(*map(expr.func, s.values()))
+            else:
+                return expr
 
     if len(expr.free_symbols) < 2:
         return expr

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -306,6 +306,10 @@ def test_separatevars():
     s = separatevars(abs(x*y*z))
     assert s == abs(x)*abs(y)*abs(z)
 
+    # abs(x+y)/abs(z) would be better but we test this here to
+    # see that it doesn't raise
+    assert separatevars(abs((x+y)/z)) == abs((x+y)/z)
+
 
 def test_separatevars_advanced_factor():
     x, y, z = symbols('x,y,z')

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1020,22 +1020,10 @@ def solve(f, *symbols, **flags):
     piece = Lambda(w, Piecewise((w, Ge(w, 0)), (-w, True)))
     for i, fi in enumerate(f):
         # Abs
-        reps = []
-        _abs = fi.atoms(Abs)
-        while _abs:
-            a = _abs.pop()
-            if not a.has(*symbols):
-                continue
-            newa = separatevars(a)
-            if not isinstance(newa, Abs):
-                _abs.update(newa.atoms(Abs))
-                continue
-            if a.args[0].is_extended_real is None:
-                raise NotImplementedError('solving %s when the argument '
-                    'is not real or imaginary.' % a)
-            reps.append((a, piece(a.args[0]) if a.args[0].is_extended_real else \
-                piece(a.args[0]*S.ImaginaryUnit)))
-        fi = fi.subs(reps)
+        fi = fi.rewrite(Abs, Piecewise)
+        if fi.has(Abs):
+            raise NotImplementedError('solving %s when the argument '
+                'is not real or imaginary.' % fi)
 
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1020,10 +1020,15 @@ def solve(f, *symbols, **flags):
     piece = Lambda(w, Piecewise((w, Ge(w, 0)), (-w, True)))
     for i, fi in enumerate(f):
         # Abs
-        fi = fi.rewrite(Abs, Piecewise)
-        if fi.has(Abs):
-            raise NotImplementedError('solving %s when the argument '
-                'is not real or imaginary.' % fi)
+        fi = fi.replace(Abs, lambda arg:
+            separatevars(Abs(arg)) if arg.has(*symbols) else Abs(arg))
+        fi = fi.replace(Abs, lambda arg:
+            Abs(arg).rewrite(Piecewise) if arg.has(*symbols) else Abs(arg))
+
+        for e in fi.find(Abs):
+            if e.has(*symbols):
+                raise NotImplementedError('solving %s when the argument '
+                    'is not real or imaginary.' % fi)
 
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1028,7 +1028,7 @@ def solve(f, *symbols, **flags):
         for e in fi.find(Abs):
             if e.has(*symbols):
                 raise NotImplementedError('solving %s when the argument '
-                    'is not real or imaginary.' % fi)
+                    'is not real or imaginary.' % e)
 
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2068,7 +2068,6 @@ def test_issue_10933():
     assert solve(I*x**4 + x**3 + x**2 + 1.)  # doesn't fail
 
 
-@XFAIL
 def test_Abs_handling():
     x = symbols('x', real=True)
     assert solve(abs(x/y), x) == [0]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2068,6 +2068,7 @@ def test_issue_10933():
     assert solve(I*x**4 + x**3 + x**2 + 1.)  # doesn't fail
 
 
+@XFAIL
 def test_Abs_handling():
     x = symbols('x', real=True)
     assert solve(abs(x/y), x) == [0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/17418#issuecomment-522130190

#### Brief description of what is fixed or changed

Adds the ability to rewrite Abs with an imaginary argument as Piecewise:
```julia
In [1]: i = Symbol('i', imaginary=True)                                                                                           

In [2]: abs(i).rewrite(Piecewise)                                                                                                 
Out[2]: 
⎧ⅈ⋅i   for ⅈ⋅i ≥ 0
⎨                 
⎩-ⅈ⋅i   otherwise 
```

This makes it possible to use rewrite(Piecewise) in solve, removing the custom rewrite code that was there.

#### Other comments

Thanks to @smichr for the separatevars tip!

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
     * Abs(x) for imaginary x can now rewrite as Piecewise.
<!-- END RELEASE NOTES -->
