### PR TITLE
Add rewriting method for permutation group to finite set

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -426,7 +426,18 @@ class PermutationGroup(Basic):
             parent = parents[temp]
         return rep
 
-    def _eval_rewrite_as_FiniteSet(self, *args, **kwargs):
+    def as_finite_set(self):
+        """Rewrite a group as a finite set object containing all its
+        members.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.named_groups import AlternatingGroup
+        >>> g = AlternatingGroup(3)
+        >>> g.as_finite_set()
+        {(0 1 2), (0 2 1), (2)}
+        """
         from sympy.sets.sets import FiniteSet
         return FiniteSet(*self.generate())
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -16,6 +16,7 @@ from sympy.core import Basic
 from sympy.core.compatibility import range
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.ntheory import sieve
+from sympy.sets.underlyingsets import UnderlyingSetOf
 from sympy.utilities.iterables import has_variety, is_sequence, uniq
 from sympy.utilities.randtest import _randrange
 from itertools import islice
@@ -178,6 +179,35 @@ class PermutationGroup(Basic):
         # finite presentation of the group as an instance of `FpGroup`
         obj._fp_presentation = None
         return obj
+
+    def underlying_set(self):
+        """Returns the underlying set of the permutation group.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.named_groups import CyclicGroup
+        >>> from sympy.combinatorics.permutations import Permutation
+
+        Getting the symbolic underlying set of a cyclic group:
+
+        >>> g = CyclicGroup(3).underlying_set()
+        >>> g
+        UnderlyingSetOf(PermutationGroup([
+            (0 1 2)]))
+
+        The notation retains some behaviors of sets (Not every behavior):
+
+        >>> g.contains(Permutation(0, 1, 2))
+        True
+
+        Rewriting to a finite set:
+
+        >>> from sympy.sets.sets import FiniteSet
+        >>> g.rewrite(FiniteSet)
+        {(0 1 2), (0 2 1), (2)}
+        """
+        return UnderlyingSetOf(self)
 
     def __getitem__(self, i):
         return self._generators[i]
@@ -425,21 +455,6 @@ class PermutationGroup(Basic):
             temp = parent
             parent = parents[temp]
         return rep
-
-    def as_finite_set(self):
-        """Rewrite a group as a finite set object containing all its
-        members.
-
-        Examples
-        ========
-
-        >>> from sympy.combinatorics.named_groups import AlternatingGroup
-        >>> g = AlternatingGroup(3)
-        >>> g.as_finite_set()
-        {(0 1 2), (0 2 1), (2)}
-        """
-        from sympy.sets.sets import FiniteSet
-        return FiniteSet(*self.generate())
 
     @property
     def base(self):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -426,6 +426,10 @@ class PermutationGroup(Basic):
             parent = parents[temp]
         return rep
 
+    def _eval_rewrite_as_FiniteSet(self, *args, **kwargs):
+        from sympy.sets.sets import FiniteSet
+        return FiniteSet(*self.generate())
+
     @property
     def base(self):
         """Return a base from the Schreier-Sims algorithm.

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -9,6 +9,7 @@ from sympy.combinatorics.generators import rubik_cube_generators
 from sympy.combinatorics.polyhedron import tetrahedron as Tetra, cube
 from sympy.combinatorics.testutil import _verify_bsgs, _verify_centralizer,\
     _verify_normal_closure
+from sympy.sets.sets import FiniteSet
 from sympy.utilities.pytest import raises, slow
 from sympy.combinatorics.homomorphisms import is_isomorphic
 
@@ -55,6 +56,23 @@ def test_generate():
     b = Permutation([2, 1, 3, 4, 5, 0])
     g = PermutationGroup([a, b]).generate(af=True)
     assert len(list(g)) == 360
+
+
+def test_rewrite_FiniteSet():
+    a = Permutation([2, 0, 1])
+    b = Permutation([2, 1, 0])
+    G = PermutationGroup([a, b])
+    g = G.rewrite(FiniteSet)
+
+    expected_members = [
+        Permutation([0, 1, 2]),
+        Permutation([0, 2, 1]),
+        Permutation([1, 0, 2]),
+        Permutation([1, 2, 0]),
+        Permutation([2, 0, 1]),
+        Permutation([2, 1, 0]),
+    ]
+    assert g == FiniteSet(*expected_members)
 
 
 def test_order():

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -62,7 +62,7 @@ def test_rewrite_FiniteSet():
     a = Permutation([2, 0, 1])
     b = Permutation([2, 1, 0])
     G = PermutationGroup([a, b])
-    g = G.rewrite(FiniteSet)
+    g = G.as_finite_set()
 
     expected_members = [
         Permutation([0, 1, 2]),

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -58,23 +58,6 @@ def test_generate():
     assert len(list(g)) == 360
 
 
-def test_rewrite_FiniteSet():
-    a = Permutation([2, 0, 1])
-    b = Permutation([2, 1, 0])
-    G = PermutationGroup([a, b])
-    g = G.as_finite_set()
-
-    expected_members = [
-        Permutation([0, 1, 2]),
-        Permutation([0, 2, 1]),
-        Permutation([1, 0, 2]),
-        Permutation([1, 2, 0]),
-        Permutation([2, 0, 1]),
-        Permutation([2, 1, 0]),
-    ]
-    assert g == FiniteSet(*expected_members)
-
-
 def test_order():
     a = Permutation([2, 0, 1, 3, 4, 5, 6, 7, 8, 9])
     b = Permutation([2, 1, 3, 4, 5, 6, 7, 8, 9, 0])

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -963,6 +963,13 @@ def test_sympy__sets__contains__Contains():
     assert _test_args(Contains(x, Range(0, 10, 2)))
 
 
+def test_sympy__sets__underlyingsets__UnderlyingSetOf():
+    from sympy.combinatorics.named_groups import AlternatingGroup
+    from sympy.sets.underlyingsets import UnderlyingSetOf
+    G = AlternatingGroup(3)
+    assert _test_args(UnderlyingSetOf(G))
+
+
 # STATS
 
 

--- a/sympy/sets/tests/test_underlyingsets.py
+++ b/sympy/sets/tests/test_underlyingsets.py
@@ -1,0 +1,24 @@
+from sympy.combinatorics.perm_groups import PermutationGroup
+from sympy.combinatorics.permutations import Permutation
+from sympy.sets.sets import FiniteSet
+from sympy.sets.underlyingsets import UnderlyingSetOf
+
+
+def test_PermutationGroup():
+    a = Permutation([2, 0, 1])
+    b = Permutation([2, 1, 0])
+    G = PermutationGroup([a, b])
+
+    g = G.underlying_set()
+    assert g == UnderlyingSetOf(G)
+
+    g = g.rewrite(FiniteSet)
+    expected_members = [
+        Permutation([0, 1, 2]),
+        Permutation([0, 2, 1]),
+        Permutation([1, 0, 2]),
+        Permutation([1, 2, 0]),
+        Permutation([2, 0, 1]),
+        Permutation([2, 1, 0]),
+    ]
+    assert g == FiniteSet(*expected_members)

--- a/sympy/sets/tests/test_underlyingsets.py
+++ b/sympy/sets/tests/test_underlyingsets.py
@@ -12,6 +12,10 @@ def test_PermutationGroup():
     g = G.underlying_set()
     assert g == UnderlyingSetOf(G)
 
+    assert a in g
+    assert b in g
+    assert a*b in g
+
     g = g.rewrite(FiniteSet)
     expected_members = [
         Permutation([0, 1, 2]),

--- a/sympy/sets/underlyingsets.py
+++ b/sympy/sets/underlyingsets.py
@@ -37,3 +37,4 @@ class UnderlyingSetOf(Set):
 
         if isinstance(parent, PermutationGroup):
             return parent.contains(other, **kwargs)
+        raise NotImplementedError()

--- a/sympy/sets/underlyingsets.py
+++ b/sympy/sets/underlyingsets.py
@@ -1,0 +1,39 @@
+from __future__ import print_function, division
+
+from sympy.core.sympify import _sympify
+
+from .sets import Set, FiniteSet
+
+
+class UnderlyingSetOf(Set):
+    """A symbolic notation for the underlying set of an algebraic
+    structure.
+
+    Parameters
+    ==========
+
+    parent : Group
+        A symbolic group object referring to
+    """
+    def __new__(cls, parent):
+        parent = _sympify(parent)
+        obj = super(UnderlyingSetOf, cls).__new__(cls, parent)
+        return obj
+
+    @property
+    def parent(self):
+        return self.args[0]
+
+    def _eval_rewrite_as_FiniteSet(self, *args, **kwargs):
+        from sympy.combinatorics.perm_groups import PermutationGroup
+        parent = self.parent
+
+        if isinstance(parent, PermutationGroup):
+            return FiniteSet(*self.parent.generate())
+
+    def _contains(self, other, **kwargs):
+        from sympy.combinatorics.perm_groups import PermutationGroup
+        parent = self.parent
+
+        if isinstance(parent, PermutationGroup):
+            return parent.contains(other, **kwargs)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that it is sometimes useful to rewrite `PermutationGroup` to show all its members.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Added rewriting method for `PermutationGroup` to `FiniteSet`
<!-- END RELEASE NOTES -->
