### PR TITLE
Added sample methods for finite RV

### DIFF
--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -24,6 +24,7 @@ from sympy import (S, sympify, Rational, binomial, cacheit, Integer,
 from sympy import beta as beta_fn
 from sympy.external import import_module
 from sympy.core.compatibility import range
+from sympy.tensor.array import ArrayComprehensionMap
 from sympy.stats.frv import (SingleFiniteDistribution,
                              SingleFinitePSpace)
 from sympy.stats.rv import _value_check, Density, RandomSymbol
@@ -110,7 +111,8 @@ class DiscreteUniformDistribution(SingleFiniteDistribution):
             return S.Zero
 
     def _sample_random(self, size):
-        return [self.args[random.randint(0, len(self.args)-1)] for _ in range(size)]
+        x = Symbol('x')
+        return ArrayComprehensionMap(lambda: self.args[random.randint(0, len(self.args)-1)], (x, 0, size)).doit()
 
 
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -12,7 +12,8 @@ from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial, BetaBi
 from sympy.stats.frv_types import DieDistribution, BinomialDistribution, \
     HypergeometricDistribution
 from sympy.stats.rv import Density
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, skip
+
 
 oo = S.Infinity
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -2,6 +2,7 @@ from sympy import (FiniteSet, S, Symbol, sqrt, nan, beta,
                    symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial,
                    cancel, exp, I, Piecewise, Sum, Dummy)
 from sympy.core.compatibility import range
+from sympy.external import import_module
 from sympy.matrices import Matrix
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial, BetaBinomial,
                          Hypergeometric, Rademacher, P, E, variance, covariance, skewness,
@@ -416,3 +417,33 @@ def test_symbolic_conditions():
     assert Z == \
     Piecewise((S(1)/4, n < 1), (0, True)) + Piecewise((S(1)/2, n < 2), (0, True)) + \
     Piecewise((S(3)/4, n < 3), (0, True)) + Piecewise((S(1), n < 4), (0, True))
+
+
+def test_sampling_methods():
+    distribs_random = [DiscreteUniform("D", list(range(5)))]
+    distribs_scipy = [Hypergeometric("H", 1, 1, 1)]
+    distribs_pymc3 = [BetaBinomial("B", 1, 1, 1)]
+
+    size = 5
+
+    for X in distribs_random:
+        sam = X.pspace.distribution._sample_random(size)
+        for i in range(size):
+            assert sam[i] in X.pspace.domain.set
+
+    scipy = import_module('scipy')
+    if not scipy:
+        skip('Scipy not installed. Abort tests for _sample_scipy.')
+    else:
+        for X in distribs_scipy:
+            sam = X.pspace.distribution._sample_scipy(size)
+            for i in range(size):
+                assert sam[i] in X.pspace.domain.set
+    pymc3 = import_module('pymc3')
+    if not pymc3:
+        skip('PyMC3 not installed. Abort tests for _sample_pymc3.')
+    else:
+        for X in distribs_pymc3:
+            sam = X.pspace.distribution._sample_pymc3(size)
+            for i in range(size):
+                assert sam[i] in X.pspace.domain.set


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added sample methods for discrete RVs under `frv_types.py`
Continues #17057 

#### Other comments
Ping @Upabjojr @sidhantnagpal 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- stats
    - Added sample methods for finite RVs under `frv_types.py`
<!-- END RELEASE NOTES -->
