### PR TITLE
exp.as_leading_term() returns wrong results

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -456,12 +456,12 @@ class exp(ExpBase):
         arg = self.args[0]
         if arg.is_Add:
             return Mul(*[exp(f).as_leading_term(x) for f in arg.args])
+        arg = arg.as_leading_term(x)
+        if Order(x, x).contains(arg):
+            return S.One
         if Order(1, x).contains(arg):
-            arg = arg.as_leading_term(x)
-            if x in arg.free_symbols:
-                return S(1)
             return exp(arg)
-        return exp(arg)
+        return None
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
         from sympy import sin

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -456,9 +456,11 @@ class exp(ExpBase):
         arg = self.args[0]
         if arg.is_Add:
             return Mul(*[exp(f).as_leading_term(x) for f in arg.args])
-        arg = self.args[0].as_leading_term(x)
         if Order(1, x).contains(arg):
-            return S.One
+            arg = arg.as_leading_term(x)
+            if x in arg.free_symbols:
+                return S(1)
+            return exp(arg)
         return exp(arg)
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -456,12 +456,21 @@ class exp(ExpBase):
         arg = self.args[0]
         if arg.is_Add:
             return Mul(*[exp(f).as_leading_term(x) for f in arg.args])
-        arg = arg.as_leading_term(x)
-        if Order(x, x).contains(arg):
+        arg_1 = arg.as_leading_term(x)
+        if Order(x, x).contains(arg_1):
             return S.One
-        if Order(1, x).contains(arg):
-            return exp(arg)
-        return None
+        if Order(1, x).contains(arg_1):
+            return exp(arg_1)
+        ####################################################
+        # The correct result here should be 'None'.        #
+        # Indeed arg in not bounded as x tends to 0.       #
+        # Consequently the series expansion does not admit #
+        # the leading term.                                #
+        # For compatibility reasons, the return value here #
+        # is the original function, i.e. exp(arg),         #
+        # instead of None.                                 #
+        ####################################################
+        return exp(arg)
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
         from sympy import sin

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -158,6 +158,9 @@ def test_exp_leading_term():
     assert exp(x).as_leading_term(x) == 1
     assert exp(1/x).as_leading_term(x) == exp(1/x)
     assert exp(2 + x).as_leading_term(x) == exp(2)
+    # issue 4615
+    assert exp((x + 1) / x**2).as_leading_term(x) == exp((x + 1) / x**2)
+    assert exp((2*x + 3) / (x+1)).as_leading_term(x) == exp(3)
 
 def test_exp_taylor_term():
     x = symbols('x')

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -156,11 +156,11 @@ def test_exp_rewrite():
 
 def test_exp_leading_term():
     assert exp(x).as_leading_term(x) == 1
-    assert exp(1/x).as_leading_term(x) == exp(1/x)
     assert exp(2 + x).as_leading_term(x) == exp(2)
-    # issue 4615
-    assert exp((x + 1) / x**2).as_leading_term(x) == exp((x + 1) / x**2)
     assert exp((2*x + 3) / (x+1)).as_leading_term(x) == exp(3)
+    raises(NotImplementedError, lambda: exp(1/x).as_leading_term(x))
+    # issue 4615
+    raises(NotImplementedError, lambda: exp((x + 1) / x**2).as_leading_term(x))
 
 def test_exp_taylor_term():
     x = symbols('x')

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -158,9 +158,13 @@ def test_exp_leading_term():
     assert exp(x).as_leading_term(x) == 1
     assert exp(2 + x).as_leading_term(x) == exp(2)
     assert exp((2*x + 3) / (x+1)).as_leading_term(x) == exp(3)
-    raises(NotImplementedError, lambda: exp(1/x).as_leading_term(x))
-    # issue 4615
-    raises(NotImplementedError, lambda: exp((x + 1) / x**2).as_leading_term(x))
+    # The following tests are commented, since now SymPy returns the
+    # original function when the leading term in the series expansion does
+    # not exist.
+    # raises(NotImplementedError, lambda: exp(1/x).as_leading_term(x))
+    # raises(NotImplementedError, lambda: exp((x + 1) / x**2).as_leading_term(x))
+    # raises(NotImplementedError, lambda: exp(x + 1/x).as_leading_term(x))
+
 
 def test_exp_taylor_term():
     x = symbols('x')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #4615 

#### Brief description of what is fixed or changed

`as_leading_term` does not work properly on exponential functions.
As noted in the issue #4615 , `exp((x+1)/x**2).as_leading_term(x)`
returns `exp(x**(-2))`, which is not the correct result.
Indeed when the argument of `exp` tends to `oo`, then it is not
correct doing the leading term of the `arg` and then applying the exponential.

Also SymPy in the case
`exp((2*x + 3) / (x+1)).as_leading_term(x)`
returns `S(1)`, which is not correct here, since the argument is closed to `3`.

In `test_exponential.py` the following tests are added
```
    assert exp((x + 1) / x**2).as_leading_term(x) == exp((x + 1) / x**2)
    assert exp((2*x + 3) / (x+1)).as_leading_term(x) == exp(3)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- functions
   - remove a bug for `as_leading_term()` for exponential functions.

<!-- END RELEASE NOTES -->
