### PR TITLE
Better is_constant

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -445,10 +445,9 @@ class Expr(Basic, EvalfMixin):
         all derivatives are zero then self is constant with respect to the
         given symbols.
 
-        3) finding out zeros of denominator expression with free_symbols and
-        multiplicative inverse for this expression. It won't be constant
-        if there are zeros. It gives more negative answers for expression
-        that are not constant.
+        3) finding out zeros of denominator expression with free_symbols.
+        It won't be constant if there are zeros. It gives more negative
+        answers for expression that are not constant.
 
         If neither evaluation nor differentiation can prove the expression is
         constant, None is returned unless two numerical values happened to be

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -447,8 +447,8 @@ class Expr(Basic, EvalfMixin):
 
         3) finding out zeros of denominator expression with free_symbols and
         multiplicative inverse for this expression. It won't be constant
-        if there are zeros. It gives more negative answerts for non-constants
-        expression.
+        if there are zeros. It gives more negative answers for expression
+        that are not constant.
 
         If neither evaluation nor differentiation can prove the expression is
         constant, None is returned unless two numerical values happened to be
@@ -498,16 +498,14 @@ class Expr(Basic, EvalfMixin):
 
         def check_denominator_zeros(expression):
 
-            from ..sets.sets import EmptySet
             from ..solvers import solveset
+            from ..solvers.solvers import denoms
 
             free_symbols = expression.free_symbols
-            multiplicative_inverse = 1 / expression
 
             for symb in free_symbols:
-                for equation in multiplicative_inverse.as_ordered_factors():
-                    if solveset(equation, symb) != EmptySet():
-                        return True
+                if any(solveset(d, symb) is not S.EmptySet for d in denoms(expression)):
+                    return True
             return False
 
         simplify = flags.get('simplify', True)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -501,10 +501,10 @@ class Expr(Basic, EvalfMixin):
             from ..solvers import solveset
             from ..solvers.solvers import denoms
 
-            free_symbols = expression.free_symbols
-
-            for symb in free_symbols:
-                if any(solveset(d, symb) is not S.EmptySet for d in denoms(expression)):
+            for den in denoms(expression):
+                if (den.is_zero or
+                    any(solveset(den, symb) is not S.EmptySet
+                        for symb in den.free_symbols)):
                     return True
             return False
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -593,7 +593,7 @@ class Expr(Basic, EvalfMixin):
                         # dead line provided _random returns None in such cases
                         return None
                 return False
-        if check_denominator_zeros(self) or check_denominator_zeros(1/self):
+        if check_denominator_zeros(self):
             return False
         return True
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
-    sin, cos, tan, exp, log, nan, oo, sqrt, symbols, Integral, sympify,
+    sin, cos, tan, cot, exp, log, nan, oo, sqrt, symbols, Integral, sympify,
     WildFunction, Poly, Function, Derivative, Number, pi, NumberSymbol, zoo,
     Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
     simplify, together, collect, factorial, apart, combsimp, factor, refine,
@@ -1701,6 +1701,16 @@ def test_issue_7426():
     f1 = a % c
     f2 = x % z
     assert f1.equals(f2) == False
+
+
+def test_issue_10651():
+    x = Symbol('x', real=True)
+    e1 = (-1 + x)/(1 - x)
+    e2 = tan(x)*cot(x)
+    e3 = (4*x**2 - 4)/((1 - x)*(1 + x))
+    assert e1.is_constant() == False
+    assert e2.is_constant() == False
+    assert e3.is_constant() == False
 
 
 def test_issue_10161():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1706,11 +1706,9 @@ def test_issue_7426():
 def test_issue_10651():
     x = Symbol('x', real=True)
     e1 = (-1 + x)/(1 - x)
-    e2 = tan(x)*cot(x)
     e3 = (4*x**2 - 4)/((1 - x)*(1 + x))
     e4 = 1/(cos(x)**2) - (tan(x))**2
     assert e1.is_constant() == False
-    assert e2.is_constant() == False
     assert e3.is_constant() == False
     assert e4.is_constant() == False
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1708,9 +1708,11 @@ def test_issue_10651():
     e1 = (-1 + x)/(1 - x)
     e2 = tan(x)*cot(x)
     e3 = (4*x**2 - 4)/((1 - x)*(1 + x))
+    e4 = 1/(cos(x)**2) - (tan(x))**2
     assert e1.is_constant() == False
     assert e2.is_constant() == False
     assert e3.is_constant() == False
+    assert e4.is_constant() == False
 
 
 def test_issue_10161():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #10651
Closes #10690

#### Brief description of what is fixed or changed
Improved the output of `.is_constant`

#### Other comments
Revived the PR in #10690 and only used `.is_zero` to determine the zero property of the expression. Returns None in more cases now (have not been able to find a case where it actually returns False caused by this, but None is better than an incorrect True).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * `is_constant` (correctly) returns `None` for cases where it earlier (incorrectly) returned `True`.
<!-- END RELEASE NOTES -->
