### PR TITLE
Add smith_normal_decomp

### DIFF
--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -5,6 +5,7 @@ from sympy.polys.polytools import Poly
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.normalforms import (
         smith_normal_form as _snf,
+        smith_normal_decomp as _snd,
         invariant_factors as _invf,
         hermite_normal_form as _hnf,
     )
@@ -41,6 +42,25 @@ def smith_normal_form(m, domain=None):
     '''
     dM = _to_domain(m, domain)
     return _snf(dM).to_Matrix()
+
+
+def smith_normal_decomp(m, domain=None):
+    '''
+    Return the Smith Normal Decomposition of a matrix `m` over the ring
+    `domain`. This will only work if the ring is a principal ideal domain.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix, ZZ
+    >>> from sympy.matrices.normalforms import smith_normal_form
+    >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
+    >>> a, s, t = smith_normal_form(m, domain=ZZ)
+    >>> assert a == m * s * t
+    '''
+    dM = _to_domain(m, domain)
+    a, s, t = _snd(dM)
+    return a.to_Matrix(), s.to_Matrix(), t.to_Matrix()
 
 
 def invariant_factors(m, domain=None):

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -56,7 +56,7 @@ def smith_normal_decomp(m, domain=None):
     >>> from sympy.matrices.normalforms import smith_normal_decomp
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
     >>> a, s, t = smith_normal_decomp(m, domain=ZZ)
-    >>> assert a == m * s * t
+    >>> assert a == s * m * t
     '''
     dM = _to_domain(m, domain)
     a, s, t = _snd(dM)

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -55,7 +55,7 @@ def smith_normal_decomp(m, domain=None):
     >>> from sympy import Matrix, ZZ
     >>> from sympy.matrices.normalforms import smith_normal_form
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
-    >>> a, s, t = smith_normal_form(m, domain=ZZ)
+    >>> a, s, t = smith_normal_decomp(m, domain=ZZ)
     >>> assert a == m * s * t
     '''
     dM = _to_domain(m, domain)

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -38,7 +38,7 @@ def smith_normal_form(m, domain=None):
     >>> from sympy.matrices.normalforms import smith_normal_form
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
     >>> print(smith_normal_form(m, domain=ZZ))
-    Matrix([[1, 0, 0], [0, 10, 0], [0, 0, -30]])
+    Matrix([[1, 0, 0], [0, 10, 0], [0, 0, 30]])
 
     '''
     dM = _to_domain(m, domain)

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -53,7 +53,7 @@ def smith_normal_decomp(m, domain=None):
     ========
 
     >>> from sympy import Matrix, ZZ
-    >>> from sympy.matrices.normalforms import smith_normal_form
+    >>> from sympy.matrices.normalforms import smith_normal_decomp
     >>> m = Matrix([[12, 6, 4], [3, 9, 6], [2, 16, 14]])
     >>> a, s, t = smith_normal_decomp(m, domain=ZZ)
     >>> assert a == m * s * t

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -5,6 +5,7 @@ from sympy.polys.polytools import Poly
 from sympy.polys.matrices import DomainMatrix
 from sympy.polys.matrices.normalforms import (
         smith_normal_form as _snf,
+        is_smith_normal_form as _is_snf,
         smith_normal_decomp as _snd,
         invariant_factors as _invf,
         hermite_normal_form as _hnf,
@@ -42,6 +43,14 @@ def smith_normal_form(m, domain=None):
     '''
     dM = _to_domain(m, domain)
     return _snf(dM).to_Matrix()
+
+
+def is_smith_normal_form(m, domain=None):
+    '''
+    Checks that the matrix is in Smith Normal Form
+    '''
+    dM = _to_domain(m, domain)
+    return _is_snf(dM)
 
 
 def smith_normal_decomp(m, domain=None):

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -18,7 +18,7 @@ import random
 
 def test_smith_normal():
     m = Matrix([[12,6,4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
-    smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
+    smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, 30, 0], [0, 0, 0, 0]])
     assert smith_normal_form(m) == smf
 
     a, s, t = smith_normal_decomp(m)
@@ -53,7 +53,7 @@ def test_smith_normal_deprecated():
         m = Matrix([[12, 6, 4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
     setattr(m, 'ring', ZZ)
     with warns_deprecated_sympy():
-        smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
+        smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, 30, 0], [0, 0, 0, 0]])
     assert smith_normal_form(m) == smf
 
     x = Symbol('x')

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -44,6 +44,8 @@ def test_smith_normal():
                 a, s, t = smith_normal_decomp(m)
                 assert a == s * m * t
                 assert is_smith_normal_form(a)
+                s.inv().to_DM(ZZ)
+                t.inv().to_DM(ZZ)
 
 
 def test_smith_normal_deprecated():

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -2,7 +2,7 @@ from sympy.testing.pytest import warns_deprecated_sympy
 
 from sympy.core.symbol import Symbol
 from sympy.polys.polytools import Poly
-from sympy.matrices import Matrix
+from sympy.matrices import Matrix, randMatrix
 from sympy.matrices.normalforms import (
     invariant_factors,
     smith_normal_form,
@@ -11,6 +11,8 @@ from sympy.matrices.normalforms import (
 )
 from sympy.polys.domains import ZZ, QQ
 from sympy.core.numbers import Integer
+
+import random
 
 
 def test_smith_normal():
@@ -32,6 +34,14 @@ def test_smith_normal():
     m = Matrix([[2, 4]])
     smf = Matrix([[2, 0]])
     assert smith_normal_form(m) == smf
+
+    prng = random.Random(0)
+    for i in range(6):
+        for j in range(6):
+            for _ in range(10 if i*j else 1):
+                m = randMatrix(i, j, max=5, percent=50, prng=prng)
+                a, s, t = smith_normal_decomp(m)
+                assert a == s * m * t
 
 
 def test_smith_normal_deprecated():

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -6,6 +6,7 @@ from sympy.matrices import Matrix
 from sympy.matrices.normalforms import (
     invariant_factors,
     smith_normal_form,
+    smith_normal_decomp,
     hermite_normal_form,
 )
 from sympy.polys.domains import ZZ, QQ
@@ -16,6 +17,9 @@ def test_smith_normal():
     m = Matrix([[12,6,4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
     smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]])
     assert smith_normal_form(m) == smf
+
+    a, s, t = smith_normal_decomp(m)
+    assert a == s * m * t
 
     x = Symbol('x')
     with warns_deprecated_sympy():

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -8,6 +8,7 @@ from sympy.matrices.normalforms import (
     smith_normal_form,
     smith_normal_decomp,
     hermite_normal_form,
+    is_smith_normal_form,
 )
 from sympy.polys.domains import ZZ, QQ
 from sympy.core.numbers import Integer
@@ -42,6 +43,7 @@ def test_smith_normal():
                 m = randMatrix(i, j, max=5, percent=50, prng=prng)
                 a, s, t = smith_normal_decomp(m)
                 assert a == s * m * t
+                assert is_smith_normal_form(a)
 
 
 def test_smith_normal_deprecated():

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -188,7 +188,7 @@ class DDM(list):
         to_list_flat
         sympy.polys.matrices.domainmatrix.DomainMatrix.to_list
         """
-        return list(self)
+        return [row[:] for row in self]
 
     def to_list_flat(self):
         """

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -44,7 +44,7 @@ def is_smith_normal_form(m):
     domain = m.domain
     shape = m.shape
     zero = domain.zero
-    m = list(m.to_dense().rep.to_ddm())
+    m = m.to_list()
 
     for i in range(shape[0]):
         for j in range(shape[1]):
@@ -89,7 +89,7 @@ def invariant_factors(m):
     '''
     domain = m.domain
     shape = m.shape
-    m = list(m.to_dense().rep.to_ddm())
+    m = m.to_list()
     return _smith_normal_decomp(m, domain, shape=shape, full=False)
 
 
@@ -111,7 +111,7 @@ def smith_normal_decomp(m):
     '''
     domain = m.domain
     rows, cols = shape = m.shape
-    m = list(m.to_dense().rep.to_ddm())
+    m = m.to_list()
 
     invs, s, t = _smith_normal_decomp(m, domain, shape=shape, full=True)
     smf = DomainMatrix.diag(invs, domain, shape).to_dense()
@@ -232,8 +232,8 @@ def _smith_normal_decomp(m, domain, shape, full):
             s, s2, t, t2 = list(map(to_domain_matrix, [s, s2, t, t2]))
             s = s2 * s
             t = t * t2
-            s = list(s.to_dense().rep.to_ddm())
-            t = list(t.to_dense().rep.to_ddm())
+            s = s.to_list()
+            t = t.to_list()
         else:
             invs = ret
 
@@ -330,7 +330,7 @@ def _hermite_normal_form(A):
     # We work one row at a time, starting from the bottom row, and working our
     # way up.
     m, n = A.shape
-    A = A.to_dense().rep.to_ddm().copy()
+    A = A.to_ddm().copy()
     # Our goal is to put pivot entries in the rightmost columns.
     # Invariant: Before processing each row, k should be the index of the
     # leftmost column in which we have so far put a pivot.
@@ -437,7 +437,7 @@ def _hermite_normal_form_modulo_D(A, D):
     m, n = A.shape
     if n < m:
         raise DMShapeError('Matrix must have at least as many columns as rows.')
-    A = A.to_dense().rep.to_ddm().copy()
+    A = A.to_list()
     k = n
     R = D
     for i in range(m - 1, -1, -1):

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -37,6 +37,35 @@ def smith_normal_form(m):
     return smf
 
 
+def is_smith_normal_form(m):
+    '''
+    Checks that the matrix is in Smith Normal Form
+    '''
+    domain = m.domain
+    shape = m.shape
+    zero = domain.zero
+    m = list(m.to_dense().rep.to_ddm())
+
+    for i in range(shape[0]):
+        for j in range(shape[1]):
+            if i == j:
+                continue
+            if not m[i][j] == zero:
+                return False
+
+    upper = min(shape[0], shape[1])
+    for i in range(1, upper):
+        if m[i-1][i-1] == zero:
+            if m[i][i] != zero:
+                return False
+        else:
+            r = domain.div(m[i][i], m[i-1][i-1])[1]
+            if r != zero:
+                return False
+
+    return True
+
+
 def add_columns(m, i, j, a, b, c, d):
     # replace m[:, i] by a*m[:, i] + b*m[:, j]
     # and m[:, j] by c*m[:, i] + d*m[:, j]
@@ -214,7 +243,7 @@ def _smith_normal_decomp(m, domain, shape, full):
         # in case m[0] doesn't divide the invariants of the rest of the matrix
         for i in range(len(result)-1):
             a, b = result[i], result[i+1]
-            if b and domain.div(a, b)[1] != 0:
+            if b and domain.div(b, a)[1] != 0:
                 if full:
                     x, y, d = domain.gcdex(a, b)
                 else:

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -150,8 +150,6 @@ def _smith_normal_decomp(m, domain, shape, full):
 
     def clear_row():
         # make m[0, 1:] zero by row and column operations
-        if m[0][0] == 0:
-            return  # pragma: nocover
         pivot = m[0][0]
         for j in range(1, cols):
             if m[0][j] == 0:
@@ -184,7 +182,6 @@ def _smith_normal_decomp(m, domain, shape, full):
             if full:
                 for row in t:
                     row[0], row[ind[0]] = row[ind[0]], row[0]
-
 
     # make the first row and column except m[0,0] zero
     while (any(m[0][i] != 0 for i in range(1,cols)) or

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -29,7 +29,7 @@ def smith_normal_form(m):
     ...                   [ZZ(3), ZZ(9), ZZ(6)],
     ...                   [ZZ(2), ZZ(16), ZZ(14)]], (3, 3), ZZ)
     >>> print(smith_normal_form(m).to_Matrix())
-    Matrix([[1, 0, 0], [0, 10, 0], [0, 0, -30]])
+    Matrix([[1, 0, 0], [0, 10, 0], [0, 0, 30]])
 
     '''
     invs = invariant_factors(m)
@@ -218,6 +218,13 @@ def _smith_normal_decomp(m, domain, shape, full):
 
     def to_domain_matrix(m):
         return DomainMatrix(m, shape=(len(m), len(m[0])), domain=domain)
+
+    if m[0][0] != 0:
+        c = domain.canonical_unit(m[0][0])
+        if c != domain.one:
+            m[0][0] *= c
+            if full:
+                s[0] = [elem * c for elem in s[0]]
 
     if 1 in shape:
         invs = ()

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -128,8 +128,6 @@ def _smith_normal_decomp(m, domain, shape, full):
 
     def clear_column():
         # make m[1:, 0] zero by row and column operations
-        if m[0][0] == 0:
-            return  # pragma: nocover
         pivot = m[0][0]
         for j in range(1, rows):
             if m[j][0] == 0:
@@ -141,8 +139,8 @@ def _smith_normal_decomp(m, domain, shape, full):
                     add_rows(s, 0, j, 1, 0, -d, 1)
             else:
                 a, b, g = domain.gcdex(pivot, m[j][0])
-                d_0 = domain.div(m[j][0], g)[0]
-                d_j = domain.div(pivot, g)[0]
+                d_0 = domain.exquo(m[j][0], g)
+                d_j = domain.exquo(pivot, g)
                 add_rows(m, 0, j, a, b, d_0, -d_j)
                 if full:
                     add_rows(s, 0, j, a, b, d_0, -d_j)
@@ -161,8 +159,8 @@ def _smith_normal_decomp(m, domain, shape, full):
                     add_columns(t, 0, j, 1, 0, -d, 1)
             else:
                 a, b, g = domain.gcdex(pivot, m[0][j])
-                d_0 = domain.div(m[0][j], g)[0]
-                d_j = domain.div(pivot, g)[0]
+                d_0 = domain.exquo(m[0][j], g)
+                d_j = domain.exquo(pivot, g)
                 add_columns(m, 0, j, a, b, d_0, -d_j)
                 if full:
                     add_columns(t, 0, j, a, b, d_0, -d_j)

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -58,6 +58,41 @@ def invariant_factors(m):
     [2] https://web.archive.org/web/20200331143852/https://sierra.nmsu.edu/morandi/notes/SmithNormalForm.pdf
 
     '''
+    return _smith_normal_decomp(m, full=False)
+
+
+def smith_normal_decomp(m):
+    '''
+    Return the Smith-Normal form decomposition of matrix `m`.
+
+    Examples
+    ========
+
+    >>> from sympy import ZZ
+    >>> from sympy.polys.matrices import DomainMatrix
+    >>> from sympy.polys.matrices.normalforms import smith_normal_decomp
+    >>> m = DomainMatrix([[ZZ(12), ZZ(6), ZZ(4)],
+    ...                   [ZZ(3), ZZ(9), ZZ(6)],
+    ...                   [ZZ(2), ZZ(16), ZZ(14)]], (3, 3), ZZ)
+    >>> a, s, t = smith_normal_decomp(m)
+    >>> assert a == s * m * t
+    '''
+    invs, s, t = _smith_normal_decomp(m, full=True)
+    smf = DomainMatrix.diag(invs, m.domain, m.shape).to_dense()
+
+    rows, cols = m.shape
+    s = DomainMatrix(s, domain=m.domain, shape=(rows, rows))
+    t = DomainMatrix(t, domain=m.domain, shape=(cols, cols))
+    return smf, s, t
+
+
+def _smith_normal_decomp(m, full):
+    '''
+    Return the tuple of abelian invariants for a matrix `m`
+    (as in the Smith-Normal form). If `full=True` then invertible matrices
+    ``s, t`` such that the product ``s, m, t`` is the Smith Normal Form
+    are also returned.
+    '''
     domain = m.domain
     if not domain.is_PID:
         msg = "The matrix entries must be over a principal ideal domain"
@@ -69,18 +104,25 @@ def invariant_factors(m):
     rows, cols = shape = m.shape
     m = list(m.to_dense().rep.to_ddm())
 
+    def eye(n):
+        return [[domain.one if i == j else domain.zero for i in range(n)] for j in range(n)]
+
+    if full:
+        s = eye(rows)
+        t = eye(cols)
+
     def add_rows(m, i, j, a, b, c, d):
         # replace m[i, :] by a*m[i, :] + b*m[j, :]
         # and m[j, :] by c*m[i, :] + d*m[j, :]
-        for k in range(cols):
+        for k in range(len(m[0])):
             e = m[i][k]
             m[i][k] = a*e + b*m[j][k]
             m[j][k] = c*e + d*m[j][k]
 
-    def clear_column(m):
+    def clear_column():
         # make m[1:, 0] zero by row and column operations
         if m[0][0] == 0:
-            return m  # pragma: nocover
+            return  # pragma: nocover
         pivot = m[0][0]
         for j in range(1, rows):
             if m[j][0] == 0:
@@ -88,18 +130,21 @@ def invariant_factors(m):
             d, r = domain.div(m[j][0], pivot)
             if r == 0:
                 add_rows(m, 0, j, 1, 0, -d, 1)
+                if full:
+                    add_rows(s, 0, j, 1, 0, -d, 1)
             else:
                 a, b, g = domain.gcdex(pivot, m[j][0])
                 d_0 = domain.div(m[j][0], g)[0]
                 d_j = domain.div(pivot, g)[0]
                 add_rows(m, 0, j, a, b, d_0, -d_j)
+                if full:
+                    add_rows(s, 0, j, a, b, d_0, -d_j)
                 pivot = g
-        return m
 
-    def clear_row(m):
+    def clear_row():
         # make m[0, 1:] zero by row and column operations
         if m[0][0] == 0:
-            return m  # pragma: nocover
+            return  # pragma: nocover
         pivot = m[0][0]
         for j in range(1, cols):
             if m[0][j] == 0:
@@ -107,35 +152,60 @@ def invariant_factors(m):
             d, r = domain.div(m[0][j], pivot)
             if r == 0:
                 add_columns(m, 0, j, 1, 0, -d, 1)
+                if full:
+                    add_columns(t, 0, j, 1, 0, -d, 1)
             else:
                 a, b, g = domain.gcdex(pivot, m[0][j])
                 d_0 = domain.div(m[0][j], g)[0]
                 d_j = domain.div(pivot, g)[0]
                 add_columns(m, 0, j, a, b, d_0, -d_j)
+                if full:
+                    add_columns(t, 0, j, a, b, d_0, -d_j)
                 pivot = g
-        return m
 
     # permute the rows and columns until m[0,0] is non-zero if possible
     ind = [i for i in range(rows) if m[i][0] != 0]
     if ind and ind[0] != 0:
         m[0], m[ind[0]] = m[ind[0]], m[0]
+        if full:
+            s[0], s[ind[0]] = s[ind[0]], s[0]
     else:
         ind = [j for j in range(cols) if m[0][j] != 0]
         if ind and ind[0] != 0:
             for row in m:
                 row[0], row[ind[0]] = row[ind[0]], row[0]
+            if full:
+                for row in t:
+                    row[0], row[ind[0]] = row[ind[0]], row[0]
+
 
     # make the first row and column except m[0,0] zero
     while (any(m[0][i] != 0 for i in range(1,cols)) or
            any(m[i][0] != 0 for i in range(1,rows))):
-        m = clear_column(m)
-        m = clear_row(m)
+        clear_column()
+        clear_row()
+
+    def to_domain_matrix(m):
+        return DomainMatrix(m, shape=(len(m), len(m[0])), domain=domain)
 
     if 1 in shape:
         invs = ()
     else:
-        lower_right = DomainMatrix([r[1:] for r in m[1:]], (rows-1, cols-1), domain)
-        invs = invariant_factors(lower_right)
+        if full:
+            invs, s_small, t_small = _smith_normal_decomp(
+                    to_domain_matrix([r[1:] for r in m[1:]]),
+                    full=True)
+
+            s2 = [[1] + [0]*(rows-1)] + [[0] + row for row in s_small]
+            t2 = [[1] + [0]*(cols-1)] + [[0] + row for row in t_small]
+            s, s2, t, t2 = list(map(to_domain_matrix, [s, s2, t, t2]))
+            s = s2 * s
+            t = t * t2
+            s = list(s.to_dense().rep.to_ddm())
+            t = list(t.to_dense().rep.to_ddm())
+        else:
+            lower_right = to_domain_matrix([r[1:] for r in m[1:]])
+            invs = _smith_normal_decomp(lower_right, full=False)
 
     if m[0][0]:
         result = [m[0][0]]
@@ -144,13 +214,27 @@ def invariant_factors(m):
         for i in range(len(result)-1):
             if result[i] and domain.div(result[i+1], result[i])[1] != 0:
                 g = domain.gcd(result[i+1], result[i])
-                result[i+1] = domain.div(result[i], g)[0]*result[i+1]
+                p = domain.div(result[i], g)[0]
+                if full:
+                    for j in rows:
+                        s[i+1][j] *= p
+                        s[i][j] *= g/result[i]
+                result[i+1] = p*result[i+1]
                 result[i] = g
             else:
                 break
     else:
+        if full:
+            if rows > 1:
+                s = s[1:] + [s[0]]
+            if cols > 1:
+                t = [row[1:] + [row[0]] for row in t]
         result = invs + (m[0][0],)
-    return tuple(result)
+
+    if full:
+        return tuple(result), s, t
+    else:
+        return tuple(result)
 
 
 def _gcdex(a, b):

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -220,9 +220,9 @@ def _smith_normal_decomp(m, domain, full):
                 g = domain.gcd(result[i+1], result[i])
                 p = domain.div(result[i], g)[0]
                 if full:
-                    for j in rows:
+                    for j in range(rows):
                         s[i+1][j] *= p
-                        s[i][j] *= g/result[i]
+                        s[i][j] *= result[i]/g
                 result[i+1] = p*result[i+1]
                 result[i] = g
             else:

--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -197,12 +197,10 @@ def _smith_normal_decomp(m, domain, full):
     if 1 in shape:
         invs = ()
     else:
+        lower_right = [r[1:] for r in m[1:]]
+        ret = _smith_normal_decomp(lower_right, domain, full=full)
         if full:
-            invs, s_small, t_small = _smith_normal_decomp(
-                    [r[1:] for r in m[1:]],
-                    domain,
-                    full=True)
-
+            invs, s_small, t_small = ret
             s2 = [[1] + [0]*(rows-1)] + [[0] + row for row in s_small]
             t2 = [[1] + [0]*(cols-1)] + [[0] + row for row in t_small]
             s, s2, t, t2 = list(map(to_domain_matrix, [s, s2, t, t2]))
@@ -211,8 +209,7 @@ def _smith_normal_decomp(m, domain, full):
             s = list(s.to_dense().rep.to_ddm())
             t = list(t.to_dense().rep.to_ddm())
         else:
-            lower_right = [r[1:] for r in m[1:]]
-            invs = _smith_normal_decomp(lower_right, domain, full=False)
+            invs = ret
 
     if m[0][0]:
         result = [m[0][0]]

--- a/sympy/polys/matrices/tests/test_normalforms.py
+++ b/sympy/polys/matrices/tests/test_normalforms.py
@@ -2,18 +2,86 @@ from sympy.testing.pytest import raises
 
 from sympy.core.symbol import Symbol
 from sympy.polys.matrices.normalforms import (
-    invariant_factors, smith_normal_form,
-    hermite_normal_form, _hermite_normal_form, _hermite_normal_form_modulo_D)
+    invariant_factors,
+    smith_normal_form,
+    smith_normal_decomp,
+    is_smith_normal_form,
+    hermite_normal_form,
+    _hermite_normal_form,
+    _hermite_normal_form_modulo_D
+)
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.matrices import DomainMatrix, DM
 from sympy.polys.matrices.exceptions import DMDomainError, DMShapeError
 
 
+def test_is_smith_normal_form():
+
+    snf_examples = [
+        DM([[0, 0], [0, 0]], ZZ),
+        DM([[1, 0], [0, 0]], ZZ),
+        DM([[1, 0], [0, 1]], ZZ),
+        DM([[1, 0], [0, 2]], ZZ),
+    ]
+
+    non_snf_examples = [
+        DM([[0, 1], [0, 0]], ZZ),
+        DM([[0, 0], [0, 1]], ZZ),
+        DM([[2, 0], [0, 3]], ZZ),
+    ]
+
+    for m in snf_examples:
+        assert is_smith_normal_form(m) is True
+
+    for m in non_snf_examples:
+        assert is_smith_normal_form(m) is False
+
+
 def test_smith_normal():
 
-    m = DM([[12, 6, 4, 8], [3, 9, 6, 12], [2, 16, 14, 28], [20, 10, 10, 20]], ZZ)
-    smf = DM([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, 30, 0], [0, 0, 0, 0]], ZZ)
+    m = DM([
+        [12, 6, 4, 8],
+        [3, 9, 6, 12],
+        [2, 16, 14, 28],
+        [20, 10, 10, 20]], ZZ)
+
+    smf = DM([
+        [1, 0, 0, 0],
+        [0, 10, 0, 0],
+        [0, 0, 30, 0],
+        [0, 0, 0, 0]], ZZ)
+
+    s = DM([
+        [0, 1, -1, 0],
+        [1, -4, 0, 0],
+        [0, -2, 3, 0],
+        [-2, 2, -1, 1]], ZZ)
+
+    t = DM([
+        [1, 1, 10, 0],
+        [0, -1, -2, 0],
+        [0, 1, 3, -2],
+        [0, 0, 0, 1]], ZZ)
+
     assert smith_normal_form(m).to_dense() == smf
+    assert smith_normal_decomp(m) == (smf, s, t)
+    assert is_smith_normal_form(smf)
+    assert smf == s * m * t
+
+    m00 = DomainMatrix.zeros((0, 0), ZZ).to_dense()
+    m01 = DomainMatrix.zeros((0, 1), ZZ).to_dense()
+    m10 = DomainMatrix.zeros((1, 0), ZZ).to_dense()
+    i11 = DM([[1]], ZZ)
+
+    assert smith_normal_form(m00) == m00.to_sparse()
+    assert smith_normal_form(m01) == m01.to_sparse()
+    assert smith_normal_form(m10) == m10.to_sparse()
+    assert smith_normal_form(i11) == i11.to_sparse()
+
+    assert smith_normal_decomp(m00) == (m00, m00, m00)
+    assert smith_normal_decomp(m01) == (m01, m00, i11)
+    assert smith_normal_decomp(m10) == (m10, i11, m00)
+    assert smith_normal_decomp(i11) == (i11, i11, i11)
 
     x = Symbol('x')
     m = DM([[x-1,  1, -1],
@@ -31,9 +99,22 @@ def test_smith_normal():
     assert smith_normal_form(DM([[0, -2]], ZZ)).to_dense() == DM([[2, 0]], ZZ)
     assert smith_normal_form(DM([[0], [-2]], ZZ)).to_dense() == DM([[2], [0]], ZZ)
 
+    assert smith_normal_decomp(DM([[0, -2]], ZZ)) == (
+        DM([[2, 0]], ZZ), DM([[-1]], ZZ), DM([[0, 1], [1, 0]], ZZ)
+    )
+    assert smith_normal_decomp(DM([[0], [-2]], ZZ)) == (
+        DM([[2], [0]], ZZ), DM([[0, -1], [1, 0]], ZZ), DM([[1]], ZZ)
+    )
+
     m =   DM([[3, 0, 0, 0], [0, 0, 0, 0], [0, 0, 2, 0]], ZZ)
     snf = DM([[1, 0, 0, 0], [0, 6, 0, 0], [0, 0, 0, 0]], ZZ)
+    s = DM([[1, 0, 1], [2, 0, 3], [0, 1, 0]], ZZ)
+    t = DM([[1, -2, 0, 0], [0, 0, 0, 1], [-1, 3, 0, 0], [0, 0, 1, 0]], ZZ)
+
     assert smith_normal_form(m).to_dense() == snf
+    assert smith_normal_decomp(m) == (snf, s, t)
+    assert is_smith_normal_form(snf)
+    assert snf == s * m * t
 
     raises(ValueError, lambda: smith_normal_form(DM([[1]], ZZ[x])))
 

--- a/sympy/polys/matrices/tests/test_normalforms.py
+++ b/sympy/polys/matrices/tests/test_normalforms.py
@@ -12,7 +12,7 @@ from sympy.polys.matrices.exceptions import DMDomainError, DMShapeError
 def test_smith_normal():
 
     m = DM([[12, 6, 4, 8], [3, 9, 6, 12], [2, 16, 14, 28], [20, 10, 10, 20]], ZZ)
-    smf = DM([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, -30, 0], [0, 0, 0, 0]], ZZ)
+    smf = DM([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, 30, 0], [0, 0, 0, 0]], ZZ)
     assert smith_normal_form(m).to_dense() == smf
 
     x = Symbol('x')
@@ -28,8 +28,8 @@ def test_smith_normal():
     assert smith_normal_form(zc).to_dense() == zc
 
     assert smith_normal_form(DM([[2, 4]], ZZ)).to_dense() == DM([[2, 0]], ZZ)
-    assert smith_normal_form(DM([[0, -2]], ZZ)).to_dense() == DM([[-2, 0]], ZZ)
-    assert smith_normal_form(DM([[0], [-2]], ZZ)).to_dense() == DM([[-2], [0]], ZZ)
+    assert smith_normal_form(DM([[0, -2]], ZZ)).to_dense() == DM([[2, 0]], ZZ)
+    assert smith_normal_form(DM([[0], [-2]], ZZ)).to_dense() == DM([[2], [0]], ZZ)
 
     m =   DM([[3, 0, 0, 0], [0, 0, 0, 0], [0, 0, 2, 0]], ZZ)
     snf = DM([[1, 0, 0, 0], [0, 6, 0, 0], [0, 0, 0, 0]], ZZ)


### PR DESCRIPTION
This returns `s,t` such that the product `s * m * t` is the
smith_normal_form where `m` is the original matrix
This commit changes the return output type from Matrix to the same
type as of input `m`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * Add `smith_normal_decomp` that returns the smith normal form and the matrices
     that decomposes the matrix into the smith normal form.
<!-- END RELEASE NOTES -->
