### PR TITLE
Plotting Piecewise with Eq or Ne now works

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -289,6 +289,7 @@ class Lambdifier(object):
         from sympy import sqrt
         namespace.update({'sqrt': sqrt})
         namespace.update({'Eq': lambda x, y: x == y})
+        namespace.update({'Ne': lambda x, y: x != y})
         # End workaround.
         if use_python_math:
             namespace.update({'math': __import__('math')})
@@ -592,6 +593,9 @@ class Lambdifier(object):
             new_name = self.dict_fun[func_name]
             argstr = self.tree2str_translate(argtree)
             return new_name + '(' + argstr
+        elif func_name in ['Eq', 'Ne']:
+            op = {'Eq': '==', 'Ne': '!='}
+            return "(lambda x, y: x {} y)({}".format(op[func_name], self.tree2str_translate(argtree))
         else:
             template = '(%s(%s)).evalf(' if self.use_evalf else '%s(%s'
             if self.float_wrap_evalf:

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1,4 +1,4 @@
-from sympy import (pi, sin, cos, Symbol, Integral, Sum, sqrt, log,
+from sympy import (pi, sin, cos, Symbol, Integral, Sum, sqrt, log, exp, Ne,
                    oo, LambertW, I, meijerg, exp_polar, Max, Piecewise, And)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
@@ -547,3 +547,25 @@ def test_logplot_PR_16796():
     assert len(p[0].get_segments()) >= 30
     assert p[0].end == 100.0
     assert p[0].start == .001
+
+
+def test_issue_16572():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    x = Symbol('x')
+    p = plot(LambertW(x), show=False)
+    # Random number of segments, probably more than 50, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    assert len(p[0].get_segments()) >= 30
+
+
+def test_issue_11865():
+    k = Symbol('k', integer=True)
+    f = Piecewise((-I*exp(I*pi*k)/k + I*exp(-I*pi*k)/k, Ne(k, 0)), (2*pi, True))
+    p = plot(f, show=False)
+    # Random number of segments, probably more than 100, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    # and that there are no exceptions.
+    assert len(p[0].get_segments()) >= 30
+

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1,5 +1,6 @@
 from sympy import (pi, sin, cos, Symbol, Integral, Sum, sqrt, log, exp, Ne,
-                   oo, LambertW, I, meijerg, exp_polar, Max, Piecewise, And)
+                   oo, LambertW, I, meijerg, exp_polar, Max, Piecewise, And,
+                   real_root)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
 from sympy.plotting.plot import unset_show, plot_contour, PlotGrid
@@ -561,6 +562,9 @@ def test_issue_16572():
 
 
 def test_issue_11865():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
     k = Symbol('k', integer=True)
     f = Piecewise((-I*exp(I*pi*k)/k + I*exp(-I*pi*k)/k, Ne(k, 0)), (2*pi, True))
     p = plot(f, show=False)
@@ -569,3 +573,14 @@ def test_issue_11865():
     # and that there are no exceptions.
     assert len(p[0].get_segments()) >= 30
 
+
+def test_issue_11461():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    x = Symbol('x')
+    p = plot(real_root((log(x/(x-2))), 3), show=False)
+    # Random number of segments, probably more than 100, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    # and that there are no exceptions.
+    assert len(p[0].get_segments()) >= 30


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #11461
Fixes #11865
Closes #16572 (issue fixed in #17409 , but test added here).

#### Brief description of what is fixed or changed
Experimental lambdify didn't know about `Ne` (#11865) and even if it knew about `Eq`, the generated code lead to errors (#11461). 

#### Other comments
Not sure why I need to add the handling it twice. It seems like the `namespace` should possibly handle it, but it doesn't.

Added test for #16572, which I found while browsing, although the issue was fixed earlier.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
   * Plotting of `Piecewise` with `Eq` or `Ne` works.
<!-- END RELEASE NOTES -->
