### PR TITLE
Update Pow._eval_is_extended_real

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -585,7 +585,10 @@ class Pow(Expr):
                 return True
             c = self.exp.coeff(S.ImaginaryUnit)
             if c:
-                ok = (c*log(self.base)/S.Pi).is_Integer
+                if self.base.is_rational and c.is_rational:
+                    if self.base.is_nonzero and (self.base - 1).is_nonzero and c.is_nonzero:
+                        return False
+                ok = (c*log(self.base)/S.Pi).is_integer
                 if ok is not None:
                     return ok
 

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -5,6 +5,7 @@ from sympy.core.tests.test_evalf import NS
 from sympy.core.function import expand_multinomial
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.special.error_functions import erf
 from sympy.functions.elementary.trigonometric import (
     sin, cos, tan, sec, csc, sinh, cosh, tanh, atan)
 from sympy.series.order import O
@@ -469,3 +470,11 @@ def test_issue_2993():
     eq = (2.3*x + 4)
     assert eq**2 == 16.0*(0.575*x + 1)**2
     assert (1/eq).args == (eq, -1)  # don't change trivial power
+
+
+def test_issue_17450():
+    assert (erf(cosh(1)**7)**I).is_real is None
+    assert (erf(cosh(1)**7)**I).is_imaginary is False
+    assert (Pow(exp(1+sqrt(2)), ((1-sqrt(2))*I*pi), evaluate=False)).is_real is None
+    assert ((-10)**(10*I*pi/3)).is_real is False
+    assert ((-5)**(4*I*pi)).is_real is False


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17450.

#### Brief description of what is fixed or changed
`(erf(cosh(1)**7)**I).is_real` now returns `None` instead of `False`, while expressions like `(2**I).is_real` continue to return `False.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
