### PR TITLE
Show examples of FunctionMatrix using a symbolic shape

### DIFF
--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -15,9 +15,9 @@ class FunctionMatrix(MatrixExpr):
     Parameters
     ==========
 
-    rows : nonnegative integer
+    rows : nonnegative integer. Can be symbolic.
 
-    cols : nonnegative integer
+    cols : nonnegative integer. Can be symbolic.
 
     lamda : Function, Lambda or str
         If it is a SymPy ``Function`` or ``Lambda`` instance,
@@ -34,13 +34,9 @@ class FunctionMatrix(MatrixExpr):
     Creating a ``FunctionMatrix`` from ``Lambda``:
 
     >>> from sympy import FunctionMatrix, symbols, Lambda, MatPow, Matrix
-    >>> i, j = symbols('i,j')
-    >>> X = FunctionMatrix(3, 3, Lambda((i, j), i + j))
-    >>> Matrix(X)
-    Matrix([
-    [0, 1, 2],
-    [1, 2, 3],
-    [2, 3, 4]])
+    >>> i, j, n, m = symbols('i,j,n,m')
+    >>> FunctionMatrix(n, m, Lambda((i, j), i + j))
+    FunctionMatrix(n, m, Lambda((i, j), i + j))
 
     Creating a ``FunctionMatrix`` from a sympy function:
 
@@ -65,8 +61,8 @@ class FunctionMatrix(MatrixExpr):
 
     Creating a ``FunctionMatrix`` from python ``lambda``:
 
-    >>> FunctionMatrix(3, 3, 'lambda i, j: i + j')
-    FunctionMatrix(3, 3, Lambda((i, j), i + j))
+    >>> FunctionMatrix(n, m, 'lambda i, j: i + j')
+    FunctionMatrix(n, m, Lambda((i, j), i + j))
 
     Example of lazy evaluation of matrix product:
 


### PR DESCRIPTION
It wasn't clear from the docstring that they were allowed.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Make it clear in the FunctionMatrix docstring that it works with symbolic shapes
<!-- END RELEASE NOTES -->
