### PR TITLE
add missing 'return' keyword in atan2._eval_evalf. closes #17461

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1067,6 +1067,16 @@ def test_atan2():
     assert str(atan2(1, 2).evalf(5)) == '0.46365'
     raises(ArgumentIndexError, lambda: atan2(x, y).fdiff(3))
 
+def test_issue_17461():
+    class A(Symbol):
+        is_extended_real = True
+
+        def _eval_evalf(self, prec):
+            return Float(5.0)
+
+    x = A('X')
+    y = A('Y')
+    assert abs(atan2(x, y).evalf() - 0.785398163397448) <= 1e-10
 
 def test_acot():
     assert acot(nan) == nan

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3070,4 +3070,4 @@ class atan2(InverseTrigonometricFunction):
     def _eval_evalf(self, prec):
         y, x = self.args
         if x.is_extended_real and y.is_extended_real:
-            super(atan2, self)._eval_evalf(prec)
+            return super(atan2, self)._eval_evalf(prec)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17461


#### Brief description of what is fixed or changed

Add missing 'return' keyword in sympy.functions.atan2._eval_evalf

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added missing 'return' keyword in sympy.functions.atan2._eval_evalf
  * Added test for sympy.functions.atan2._eval_evalf

<!-- END RELEASE NOTES -->
