### PR TITLE
Rewrite Abs as conjugate

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -628,6 +628,9 @@ class Abs(Function):
     def _eval_rewrite_as_sign(self, arg, **kwargs):
         return arg/sign(arg)
 
+    def _eval_rewrite_as_conjugate(self, arg, **kwargs):
+        return (arg*conjugate(arg))**(S.Half)
+
 
 class arg(Function):
     """

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -478,6 +478,14 @@ def test_Abs_rewrite():
     assert abs(i).rewrite(Piecewise) == Piecewise((I*i, I*i >= 0), (-I*i, True))
 
 
+    assert Abs(y).rewrite(conjugate) == sqrt(y*conjugate(y))
+    assert Abs(i).rewrite(conjugate) == sqrt(-i**2) #  == -I*i
+
+    y = Symbol('y', extended_real=True)
+    assert  (Abs(exp(-I*x)-exp(-I*y))**2).rewrite(conjugate) == \
+        -exp(I*x)*exp(-I*y) + 2 - exp(-I*x)*exp(I*y)
+
+
 def test_Abs_real():
     # test some properties of abs that only apply
     # to real numbers


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Abs can now be rewritten as conjugate. Motivating example is:

```
(Abs(exp(-I*x)-exp(-I*y))**2).rewrite(conjugate)
```
which gives
```
-exp(I*x)*exp(-I*y) + 2 - exp(-I*x)*exp(I*y)
```
(with x and y real).

Useful for signal processing applications if nothing else.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * `Abs` can be rewritten as `conjugate`.
<!-- END RELEASE NOTES -->
