### PR TITLE
use equals as fallback in solve

### DIFF
--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1573,9 +1573,9 @@ def test_lambert_multivariate():
     assert solve(eq) == [LambertW(3*exp(-LambertW(3)))]
     # coverage test
     raises(NotImplementedError, lambda: solve(x - sin(x)*log(y - x), x))
-    assert solve(x**3 - 3**x, x) == [3, -3*LambertW(-log(3)/3)/log(3)]
-    assert set(solve(3*log(x) - x*log(3))) == set(  # 2.478... and 3
-        [3, -3*LambertW(-log(3)/3)/log(3)])
+    ans = [3, -3*LambertW(-log(3)/3)/log(3)]  # 3 and 2.478...
+    assert solve(x**3 - 3**x, x) == ans
+    assert set(solve(3*log(x) - x*log(3))) == set(ans)
     assert solve(LambertW(2*x) - y, x) == [y*exp(y)/2]
 
 
@@ -1599,7 +1599,9 @@ def test_lambert_bivariate():
     assert solve((a/x + exp(x/2)).diff(x), x) == \
             [4*LambertW(-sqrt(2)*sqrt(a)/4), 4*LambertW(sqrt(2)*sqrt(a)/4)]
     assert solve((1/x + exp(x/2)).diff(x), x) == \
-    [4*LambertW(-sqrt(2)/4), 4*LambertW(sqrt(2)/4), 4*LambertW(-sqrt(2)/4, -1)]
+        [4*LambertW(-sqrt(2)/4),
+        4*LambertW(sqrt(2)/4),  # nsimplifies as 2*2**(141/299)*3**(206/299)*5**(205/299)*7**(37/299)/21
+        4*LambertW(-sqrt(2)/4, -1)]
     assert solve(x*log(x) + 3*x + 1, x) == \
             [exp(-3 + LambertW(-exp(3)))]
     assert solve(-x**2 + 2**x, x) == [2, 4, -2*LambertW(log(2)/2)/log(2)]
@@ -1658,6 +1660,9 @@ def test_lambert_bivariate():
                 6*LambertW(S(1)/6 + sqrt(3)*I/6), 6*LambertW(-S(1)/3, -1)]
     assert solve(x**2 - y**2/exp(x), x, y, dict=True) == \
                 [{x: 2*LambertW(-y/2)}, {x: 2*LambertW(y/2)}]
+    # this is slow but not exceedingly slow
+    assert solve((x**3)**(x/2) + pi/2, x) == [
+        exp(LambertW(-2*log(2)/3 + 2*log(pi)/3 + 2*I*pi/3))]
 
 
 def test_rewrite_trig():


### PR DESCRIPTION
`checksol` is used before `equals` is used in `solve`.

Verified `nsimplify` results are now part of the simplification step of `solve`.

closes #17465 
```python
this PR
>>> t=time();ok=solve((x**3)**(x/2) + pi/2, x);time()-t
5.641563892364502
master
>>> t=time();ok=solve((x**3)**(x/2) + pi/2, x);time()-t
299.0749046802521
```
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * `equals` is used less often making solution process faster in some cases
<!-- END RELEASE NOTES -->
