### PR TITLE
Integrals: Fixed InvalidComparison Error from Integrate

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1681,7 +1681,7 @@ def _meijerint_indefinite_1(f, x):
         # The antiderivative is most often expected to be defined
         # in the neighborhood of  x = 0.
         place = 0
-        if b < 0 or f.subs(x, 0).has(nan, zoo):
+        if (b < 0) == True or f.subs(x, 0).has(nan, zoo):
             place = None
         r = hyperexpand(r.subs(t, a*x**b), place=place)
 


### PR DESCRIPTION
Fixes#17473

integral(sin(x**n),x)
TypeError: Cannot determine truth value of Relational
Whereas,  integrate() should always return unevaluated when it can't compute the integral. 


<!-- BEGIN RELEASE NOTES -->
* integrals
    * Fixed `integrate` bug which raised an error instead of returning an unevaluated Integral

<!-- END RELEASE NOTES -->
