### PR TITLE
Sets: Replace is_EmptySet by a new is_empty attribute

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -4,6 +4,7 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
+from sympy.core.logic import fuzzy_or
 from sympy.core.numbers import oo
 from sympy.core.relational import Eq
 from sympy.core.singleton import Singleton, S
@@ -312,9 +313,10 @@ class ImageSet(Set):
             return sets[0]
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
-            if any(s.is_empty for s in sets):
+            emptyprod = fuzzy_or(s.is_empty for s in sets)
+            if emptyprod == True:
                 return S.EmptySet
-            elif all(s.is_empty == False for s in sets):
+            elif emptyprod == False:
                 return FiniteSet(flambda.expr)
 
         return Basic.__new__(cls, flambda, *sets)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -312,7 +312,10 @@ class ImageSet(Set):
             return sets[0]
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
-            return FiniteSet(flambda.expr)
+            if all(s.is_empty for s in sets):
+                return S.EmptySet
+            elif any(s.is_empty == False for s in sets):
+                return FiniteSet(flambda.expr)
 
         return Basic.__new__(cls, flambda, *sets)
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -34,6 +34,7 @@ class Rationals(with_metaclass(Singleton, Set)):
     is_iterable = True
     _inf = S.NegativeInfinity
     _sup = S.Infinity
+    is_empty = False
 
     def _contains(self, other):
         if not isinstance(other, Expr):
@@ -94,6 +95,7 @@ class Naturals(with_metaclass(Singleton, Set)):
     is_iterable = True
     _inf = S.One
     _sup = S.Infinity
+    is_empty = False
 
     def _contains(self, other):
         if not isinstance(other, Expr):
@@ -129,6 +131,7 @@ class Naturals0(Naturals):
     Integers : also includes the negative integers
     """
     _inf = S.Zero
+    is_empty = False
 
     def _contains(self, other):
         if not isinstance(other, Expr):
@@ -171,6 +174,7 @@ class Integers(with_metaclass(Singleton, Set)):
     """
 
     is_iterable = True
+    is_empty = False
 
     def _contains(self, other):
         if not isinstance(other, Expr):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -312,9 +312,9 @@ class ImageSet(Set):
             return sets[0]
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
-            if all(s.is_empty for s in sets):
+            if any(s.is_empty for s in sets):
                 return S.EmptySet
-            elif any(s.is_empty == False for s in sets):
+            elif all(s.is_empty == False for s in sets):
                 return FiniteSet(flambda.expr)
 
         return Basic.__new__(cls, flambda, *sets)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -60,7 +60,21 @@ class Set(Basic):
     is_Complement = None
     is_ComplexRegion = False
 
-    is_empty = None
+    @property
+    def is_empty(self):
+        """
+        Property method to check whether a set is empty.
+        Returns ``True``, ``False`` or ``None`` (if unknown).
+
+        Examples
+        ========
+
+        >>> from sympy import Interval, var
+        >>> x = var('x', real=True)
+        >>> Interval(x, x + 1).is_empty
+        False
+        """
+        return None
 
     @property
     @deprecated(useinstead="is_empty", issue=16946, deprecated_since_version="1.5")
@@ -526,7 +540,7 @@ class Set(Basic):
     def is_closed(self):
         """
         A property method to check whether a set is closed. A set is closed
-        if it's complement is an open set.
+        if its complement is an open set.
 
         Examples
         ========
@@ -1411,7 +1425,7 @@ class Complement(Set, EvalfMixin):
     r"""Represents the set difference or relative complement of a set with
     another set.
 
-    `A - B = \{x \in A| x \\notin B\}`
+    `A - B = \{x \in A \mid x \notin B\}`
 
 
     Examples
@@ -1809,7 +1823,7 @@ def imageset(*args):
     unevaluated ImageSet object.
 
     .. math::
-        { f(x) | x \in self }
+        \{ f(x) \mid x \in \mathrm{self} \}
 
     Examples
     ========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -77,7 +77,8 @@ class Set(Basic):
         return None
 
     @property
-    @deprecated(useinstead="is_empty", issue=16946, deprecated_since_version="1.5")
+    @deprecated(useinstead="is S.EmptySet or is_empty",
+            issue=16946, deprecated_since_version="1.5")
     def is_EmptySet(self):
         return None
 
@@ -1507,7 +1508,8 @@ class EmptySet(with_metaclass(Singleton, Set)):
     is_FiniteSet = True
 
     @property
-    @deprecated(useinstead="is_empty", issue=16946, deprecated_since_version="1.5")
+    @deprecated(useinstead="is S.EmptySet or is_empty",
+            issue=16946, deprecated_since_version="1.5")
     def is_EmptySet(self):
         return True
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -8,6 +8,7 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import (iterable, with_metaclass,
     ordered, range, PY3, is_sequence)
 from sympy.core.cache import cacheit
+from sympy.core.decorators import deprecated
 from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
 from sympy.core.expr import Expr
@@ -60,6 +61,11 @@ class Set(Basic):
     is_ComplexRegion = False
 
     is_empty = None
+
+    @property
+    @deprecated(useinstead="is_empty", issue=16946, deprecated_since_version="1.5")
+    def is_EmptySet(self):
+        return None
 
     @staticmethod
     def _infimum_key(expr):
@@ -1492,6 +1498,11 @@ class EmptySet(with_metaclass(Singleton, Set)):
     """
     is_empty = True
     is_FiniteSet = True
+
+    @property
+    @deprecated(useinstead="is_empty", issue=16946, deprecated_since_version="1.5")
+    def is_EmptySet(self):
+        return True
 
     @property
     def _measure(self):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -944,7 +944,7 @@ class Interval(Set, EvalfMixin):
             return False
         elif (self.end - self.start).is_extended_positive:
             return False
-        elif self.left_open is False and self.right_open is False and \
+        elif self.left_open == False and self.right_open == False and \
                 self.start.is_finite and self.end.is_finite:
             # separate check for compact intervals (account for
             # [a, a] = FiniteSet(a) => not empty)
@@ -1550,6 +1550,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
     """
 
     is_UniversalSet = True
+    is_empty = False
 
     def _complement(self, other):
         return S.EmptySet

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -748,6 +748,11 @@ class ProductSet(Set):
             raise TypeError("Not all constituent sets are iterable")
 
     @property
+    def is_empty(self):
+        if all(s.is_empty == False for s in self.sets):
+            return False
+
+    @property
     def _measure(self):
         measure = 1
         for set in self.sets:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,4 +1,5 @@
 from sympy.core.compatibility import range, PY3
+from sympy.core.expr import unchanged
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
 from sympy.sets.sets import (FiniteSet, Interval, imageset, Union,
@@ -80,7 +81,7 @@ def test_ImageSet():
     assert ImageSet(Lambda(x, y), S.Integers) == {y}
     assert ImageSet(Lambda(x, 1), S.EmptySet) == S.EmptySet
     empty = Intersection(FiniteSet(log(2)/pi), S.Integers)
-    assert ImageSet(Lambda(x, 1), empty) != FiniteSet(1)  # issue #17471
+    assert unchanged(ImageSet, Lambda(x, 1), empty)  # issue #17471
     squares = ImageSet(Lambda(x, x**2), S.Naturals)
     assert 4 in squares
     assert 5 not in squares

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -77,8 +77,10 @@ def test_integers():
 def test_ImageSet():
     raises(ValueError, lambda: ImageSet(x, S.Integers))
     assert ImageSet(Lambda(x, 1), S.Integers) == FiniteSet(1)
-    assert ImageSet(Lambda(x, y), S.Integers
-        ) == {y}
+    assert ImageSet(Lambda(x, y), S.Integers) == {y}
+    assert ImageSet(Lambda(x, 1), S.EmptySet) == S.EmptySet
+    assert ImageSet(Lambda(x, 1), Intersection(FiniteSet(log(2)/pi),
+        S.Integers)) != FiniteSet(1)  # issue #17471
     squares = ImageSet(Lambda(x, x**2), S.Naturals)
     assert 4 in squares
     assert 5 not in squares

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -79,8 +79,8 @@ def test_ImageSet():
     assert ImageSet(Lambda(x, 1), S.Integers) == FiniteSet(1)
     assert ImageSet(Lambda(x, y), S.Integers) == {y}
     assert ImageSet(Lambda(x, 1), S.EmptySet) == S.EmptySet
-    assert ImageSet(Lambda(x, 1), Intersection(FiniteSet(log(2)/pi),
-        S.Integers)) != FiniteSet(1)  # issue #17471
+    empty = Intersection(FiniteSet(log(2)/pi), S.Integers)
+    assert ImageSet(Lambda(x, 1), empty) != FiniteSet(1)  # issue #17471
     squares = ImageSet(Lambda(x, x**2), S.Naturals)
     assert 4 in squares
     assert 5 not in squares

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -48,7 +48,8 @@ def test_imageset():
 
 
 def test_is_empty():
-    for s in [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals]:
+    for s in [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals,
+            S.UniversalSet]:
         assert s.is_empty == False
 
 
@@ -101,6 +102,7 @@ def test_interval_is_empty():
     assert Interval(1, 2).is_empty == False
     assert Interval(3, 3).is_empty == False  # FiniteSet
     assert Interval(r, r).is_empty == False  # FiniteSet
+    assert Interval(r, r + nn).is_empty == False  # tests compact case
     assert Interval(x, x).is_empty == False
     assert Interval(1, oo).is_empty == False
     assert Interval(-oo, oo).is_empty == False

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -412,10 +412,7 @@ def test_ProductSet_of_single_arg_is_arg():
 
 def test_ProductSet_is_empty():
     assert ProductSet(S.Integers, S.Reals).is_empty == False
-
-    assert unchanged(Intersection, S.Integers, FiniteSet(sin(2)/pi))
-    empty = Intersection(S.Integers, FiniteSet(sin(2)/pi))
-    assert ProductSet(empty, S.Reals).is_empty == None
+    assert ProductSet(Interval(x, 1), S.Reals).is_empty == None
 
 
 def test_interval_subs():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -107,14 +107,13 @@ def test_interval_is_empty():
     assert Interval(1, 2).is_empty == False
     assert Interval(3, 3).is_empty == False  # FiniteSet
     assert Interval(r, r).is_empty == False  # FiniteSet
-    assert Interval(r, r + nn).is_empty == False  # tests compact case
+    assert Interval(r, r + nn).is_empty == False
     assert Interval(x, x).is_empty == False
     assert Interval(1, oo).is_empty == False
     assert Interval(-oo, oo).is_empty == False
     assert Interval(-oo, 1).is_empty == False
     assert Interval(x, y).is_empty == None
     assert Interval(r, oo).is_empty == False  # real implies finite
-    assert Interval(x, oo).is_empty == False
     assert Interval(n, 0).is_empty == False
     assert Interval(n, 0, left_open=True).is_empty == False
     assert Interval(p, 0).is_empty == True  # EmptySet
@@ -412,8 +411,9 @@ def test_ProductSet_of_single_arg_is_arg():
 
 def test_ProductSet_is_empty():
     assert ProductSet(S.Integers, S.Reals).is_empty == False
-    assert ProductSet(Intersection(FiniteSet(sin(2)/pi), S.Integers),
-        S.Reals).is_empty == None
+    empty = Intersection(FiniteSet(sin(2)/pi), S.Integers)
+    assert empty is not S.EmptySet and \
+            ProductSet(empty, S.Reals).is_empty == None
 
 
 def test_interval_subs():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -7,6 +7,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
 from mpmath import mpi
 
 from sympy.core.compatibility import range
+from sympy.core.expr import unchanged
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import x, y, z, m, n
@@ -411,9 +412,10 @@ def test_ProductSet_of_single_arg_is_arg():
 
 def test_ProductSet_is_empty():
     assert ProductSet(S.Integers, S.Reals).is_empty == False
-    empty = Intersection(FiniteSet(sin(2)/pi), S.Integers)
-    assert empty is not S.EmptySet and \
-            ProductSet(empty, S.Reals).is_empty == None
+
+    assert unchanged(Intersection, S.Integers, FiniteSet(sin(2)/pi))
+    empty = Intersection(S.Integers, FiniteSet(sin(2)/pi))
+    assert ProductSet(empty, S.Reals).is_empty == None
 
 
 def test_interval_subs():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -7,7 +7,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
 from mpmath import mpi
 
 from sympy.core.compatibility import range
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import x, y, z, m, n
 
@@ -51,6 +51,11 @@ def test_is_empty():
     for s in [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals,
             S.UniversalSet]:
         assert s.is_empty == False
+
+
+def test_deprecated_is_EmptySet():
+    with warns_deprecated_sympy():
+        S.EmptySet.is_EmptySet
 
 
 def test_interval_arguments():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -403,6 +403,12 @@ def test_ProductSet_of_single_arg_is_arg():
     assert ProductSet(Interval(0, 1)) == Interval(0, 1)
 
 
+def test_ProductSet_is_empty():
+    assert ProductSet(S.Integers, S.Reals).is_empty == False
+    assert ProductSet(Intersection(FiniteSet(sin(2)/pi), S.Integers),
+        S.Reals).is_empty == None
+
+
 def test_interval_subs():
     a = Symbol('a', real=True)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -47,6 +47,11 @@ def test_imageset():
         ImageSet(Lambda((x1, x2), x1+x2), Interval(1,2), Interval(2,3))
 
 
+def test_is_empty():
+    for s in [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals]:
+        assert s.is_empty == False
+
+
 def test_interval_arguments():
     assert Interval(0, oo) == Interval(0, oo, False, True)
     assert Interval(0, oo).right_open is true
@@ -85,6 +90,33 @@ def test_interval_symbolic_end_points():
     assert Union(Interval(a, 0), Interval(-3, 0)).inf == Min(-3, a)
 
     assert Interval(0, a).contains(1) == LessThan(1, a)
+
+
+def test_interval_is_empty():
+    x, y = symbols('x, y')
+    r = Symbol('r', real=True)
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
+    nn = Symbol('nn', nonnegative=True)
+    assert Interval(1, 2).is_empty == False
+    assert Interval(3, 3).is_empty == False  # FiniteSet
+    assert Interval(r, r).is_empty == False  # FiniteSet
+    assert Interval(x, x).is_empty == False
+    assert Interval(1, oo).is_empty == False
+    assert Interval(-oo, oo).is_empty == False
+    assert Interval(-oo, 1).is_empty == False
+    assert Interval(x, y).is_empty == None
+    assert Interval(r, oo).is_empty == False  # real implies finite
+    assert Interval(x, oo).is_empty == False
+    assert Interval(n, 0).is_empty == False
+    assert Interval(n, 0, left_open=True).is_empty == False
+    assert Interval(p, 0).is_empty == True  # EmptySet
+    assert Interval(nn, 0).is_empty == None
+    assert Interval(n, p).is_empty == False
+    assert Interval(0, p, left_open=True).is_empty == False
+    assert Interval(0, p, right_open=True).is_empty == False
+    assert Interval(0, nn, left_open=True).is_empty == None
+    assert Interval(0, nn, right_open=True).is_empty == None
 
 
 def test_union():
@@ -161,6 +193,11 @@ def test_union_iter():
 
     # Round robin
     assert list(u) == [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4]
+
+
+def test_union_is_empty():
+    assert (Interval(x, y) + FiniteSet(1)).is_empty == False
+    assert (Interval(x, y) + Interval(-x, y)).is_empty == None
 
 
 def test_difference():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -7,7 +7,6 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
 from mpmath import mpi
 
 from sympy.core.compatibility import range
-from sympy.core.expr import unchanged
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import x, y, z, m, n

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -166,8 +166,10 @@ def test_core_undefinedfunctions_fail():
 
 
 def test_core_interval():
-    for c in (Interval, Interval(0, 2)):
-        check(c)
+    # Set.is_EmptySet is deprecated since 1.5
+    with ignore_warnings(SymPyDeprecationWarning):
+        for c in (Interval, Interval(0, 2)):
+            check(c)
 
 
 def test_core_multidimensional():

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -25,14 +25,18 @@ from sympy.core.multidimensional import vectorize
 
 from sympy.core.compatibility import HAS_GMPY
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.pytest import ignore_warnings
 
 from sympy import symbols, S
 
 from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
-excluded_attrs = set(['_assumptions', '_mhash', 'message'])
+excluded_attrs = set([
+    '_assumptions',  # This is a local cache that isn't automatically filled on creation
+    '_mhash',   # Cached after __hash__ is called but set to None after creation
+    'message',   # This is an exception attribute that is present but deprecated in Py2 (can be removed when Py2 support is dropped
+    'is_EmptySet',  # Deprecated from SymPy 1.5. This can be removed when is_EmptySet is removed.
+    ])
 
 
 def check(a, exclude=[], check_attr=True):
@@ -166,10 +170,8 @@ def test_core_undefinedfunctions_fail():
 
 
 def test_core_interval():
-    # Set.is_EmptySet is deprecated since 1.5
-    with ignore_warnings(SymPyDeprecationWarning):
-        for c in (Interval, Interval(0, 2)):
-            check(c)
+    for c in (Interval, Interval(0, 2)):
+        check(c)
 
 
 def test_core_multidimensional():


### PR DESCRIPTION
Rationale: Checking for is_EmptySet can be achieved via isinstance(),
but it can't properly handle the unknown case, generally resulting
in "None" in the assumptions system. Also, a set may well be empty
even though it's not recognized as such by SymPy.

is_empty correctly returns True, False or None.

Specific code, particularly for the "False" case, is added to
EmptySet, Naturals, Naturals0, Rationals, Reals, Interval, Union.

#### References to other Issues or PRs
Fixes #16946.
Fixes #17471.

#### Other comments

No test problems are expected, since `is_EmptySet` wasn't actually used anywhere.

At various places throughout the codebase, there are checks for `is S.EmptySet`. As of now I did not change these instances even though the only case where `True` is returned by `is_empty` is for `S.EmptySet` i.e. if SymPy is already capable of recognizing an empty set.

More interesting is the case of `is not S.EmptySet`, those instances could potentially be logic errors: `not S.EmptySet` does not imply that the set is indeed non-empty.
```
# git grep "not S.EmptySet"
calculus/util.py:            if critical_values is not S.EmptySet:
functions/elementary/trigonometric.py:                    is not S.EmptySet and \
functions/elementary/trigonometric.py:                        7*S.Pi/2)) is not S.EmptySet:
functions/elementary/trigonometric.py:                    is not S.EmptySet:
functions/elementary/trigonometric.py:                        is not S.EmptySet:
sets/tests/test_fancysets.py:    assert q is not S.EmptySet
solvers/inequalities.py:                    if interval is not S.EmptySet:
solvers/inequalities.py:                if global_interval is not S.EmptySet:
solvers/solveset.py:        elif rhs_s is not S.EmptySet:
solvers/solveset.py:                            if new_value is not S.EmptySet:
solvers/solveset.py:                            if new_value is not S.EmptySet:
solvers/solveset.py:                    if soln is not S.EmptySet:
```

In any case, those would be issues unrelated to this PR. Comments?

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* sets
  * Added `is_empty` which returns `True`, `False` or `None` and deprecated `is_EmptySet`.
<!-- END RELEASE NOTES -->
