### PR TITLE
Solvers: Fixed Attribute Error in NonLinSolve

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2902,7 +2902,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             base = value_res.base_set
                             imgset_yes = (dummy_n, base)
                 # update eq with everything that is known so far
-                eq2 = eq.subs(res)
+                eq2 = eq.subs(res).expand()
                 unsolved_syms = _unsolved_syms(eq2, sort=True)
                 if not unsolved_syms:
                     if res:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -178,6 +178,18 @@ def test_issue_11536():
     assert solveset(0**x - 1, x, S.Reals) == FiniteSet(0)
 
 
+def test_issue_17479():
+    import sympy as sb
+    from sympy.solvers.solveset import nonlinsolve
+    x, y, z = sb.symbols("x, y, z")
+    f = (x**2 + y**2)**2 + (x**2 + z**2)**2 - 2*(2*x**2 + y**2 + z**2)
+    fx = sb.diff(f, x)
+    fy = sb.diff(f, y)
+    fz = sb.diff(f, z)
+    sol = nonlinsolve([fx, fy, fz], [x, y, z])
+    assert len(sol) == 18
+
+
 def test_is_function_class_equation():
     from sympy.abc import x, a
     assert _is_function_class_equation(TrigonometricFunction,


### PR DESCRIPTION
Fixes#17479

#### When we try to solve this:

f = (x^2 + y^2)^2 + (x^2 + z^2)^2 - 2*(2*x^2 + y^2 + z^2)
fx = sb.diff(f, x)
fy = sb.diff(f, y)
fz = sb.diff(f, z)
sol = nonlinsolve([fx, fy, fz], [x, y, z])

### nonlinsolve fails with:
### AttributeError: 'ComplexRegion' object has no attribute 'as_coeff_Mul'

#### Thus, updated eq with everything that is known so far:
                - eq2 = eq.subs(res)
                + eq2 = eq.subs(res).expand()



<!-- BEGIN RELEASE NOTES -->
* solvers
    * Fixes nonlinsolve bug which raised an AttributeError
<!-- END RELEASE NOTES -->
