### PR TITLE
Wrong results for as_leading_term()

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -266,6 +266,25 @@ class factorial(CombinatorialFunction):
         if x.is_nonnegative or x.is_noninteger:
             return True
 
+    def _eval_as_leading_term(self, x):
+        from sympy import Order
+        arg = self.args[0]
+        arg_1 = arg.as_leading_term(x)
+        if Order(x, x).contains(arg_1):
+            return S.One
+        if Order(1, x).contains(arg_1):
+            return self.func(arg_1)
+        ####################################################
+        # The correct result here should be 'None'.        #
+        # Indeed arg in not bounded as x tends to 0.       #
+        # Consequently the series expansion does not admit #
+        # the leading term.                                #
+        # For compatibility reasons, the return value here #
+        # is the original function, i.e. factorial(arg),   #
+        # instead of None.                                 #
+        ####################################################
+        return self.func(arg)
+
 class MultiFactorial(CombinatorialFunction):
     pass
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -203,7 +203,7 @@ class gamma(Function):
         arg = self.args[0]
         arg_1 = arg.as_leading_term(x)
         if Order(x, x).contains(arg_1):
-            return None
+            return S(1) / arg_1
         if Order(1, x).contains(arg_1):
             return self.func(arg_1)
         ####################################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -198,6 +198,25 @@ class gamma(Function):
         import sage.all as sage
         return sage.gamma(self.args[0]._sage_())
 
+    def _eval_as_leading_term(self, x):
+        from sympy import Order
+        arg = self.args[0]
+        arg_1 = arg.as_leading_term(x)
+        if Order(x, x).contains(arg_1):
+            return None
+        if Order(1, x).contains(arg_1):
+            return self.func(arg_1)
+        ####################################################
+        # The correct result here should be 'None'.        #
+        # Indeed arg in not bounded as x tends to 0.       #
+        # Consequently the series expansion does not admit #
+        # the leading term.                                #
+        # For compatibility reasons, the return value here #
+        # is the original function, i.e. gamma(arg),       #
+        # instead of None.                                 #
+        ####################################################
+        return self.func(arg)
+
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -530,3 +530,9 @@ def test_multigamma():
     assert multigamma(-1.0, 3, evaluate=False).is_real == False
     assert multigamma(0.7, 3, evaluate=False).is_real == True
     assert multigamma(3, 3, evaluate=False).is_real == True
+
+def test_gamma_as_leading_term():
+    assert gamma(x).as_leading_term(x) == 1/x
+    assert gamma(2 + x).as_leading_term(x) == S(1)
+    assert gamma(cos(x)).as_leading_term(x) == S(1)
+    assert gamma(sin(x)).as_leading_term(x) == 1/x

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -5,7 +5,7 @@ from sympy import (
     atan, gamma, Symbol, S, pi, Integral, Rational, I,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
-    acos, erfi, LambertW)
+    acos, erfi, LambertW, factorial)
 
 from sympy.calculus.util import AccumBounds
 from sympy.core.add import Add
@@ -579,3 +579,10 @@ def test_issue_12571():
 
 def test_issue_14590():
     assert limit((x**3*((x + 1)/x)**x)/((x + 1)*(x + 2)*(x + 3)), x, oo) == exp(1)
+
+def test_issue_17431():
+    assert limit(((n + 1) + 1) / (((n + 1) + 2) * factorial(n + 1)) *
+                 (n + 2) * factorial(n) / (n + 1), n, oo) == 0
+    assert limit((n + 2)**2*factorial(n)/((n + 1)*(n + 3)*factorial(n + 1))
+                 , n, oo) == 0
+    assert limit((n + 1) * factorial(n) / (n * factorial(n + 1)), n, oo) == 0


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17431 

Refers to Issue #17463 

#### Brief description of what is fixed or changed

The `as_leading_term()` for both factorial and gamma functions return wrong results whenever the arguments tend to infinity.
Indeed `gamma(2 + 1/n).as_leading_term()` and `factorial(2 + 1/n).as_leading_term()` return respectively `gamma(1/n)` and `factorial(1/n)`, which are wrong results (see issue #17463 ).

In this pull request, `_eval_as_leading_term()` functions are implemented for both `gamma` and `factorial` functions.
This is in the direction of issue #17463 .
Now the return values, when the arguments tend to infinity, are the original functions. Probably the correct return value should be `None`, but for compatibility conditions it is for the moment better the former one.

Incidentally, this PR corrects also the wrong results of issue #17431 .


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - remove a bug for as_leading_term() for the gamma and factorial functions.

<!-- END RELEASE NOTES -->
