### PR TITLE
Reorder allow_unknown_functions handling

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -386,12 +386,12 @@ class CodePrinter(StrPrinter):
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))
-        elif expr.is_Function and self._settings.get('allow_unknown_functions', False):
-            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         elif (expr.func.__name__ in self._rewriteable_functions and
               self._rewriteable_functions[expr.func.__name__] in self.known_functions):
             # Simple rewrite to supported function possible
             return self._print(expr.rewrite(self._rewriteable_functions[expr.func.__name__]))
+        elif expr.is_Function and self._settings.get('allow_unknown_functions', False):
+            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:
             return self._print_not_supported(expr)
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -219,5 +219,8 @@ def test_beta():
     prntr = PythonCodePrinter()
     assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
 
+    prntr = PythonCodePrinter({'allow_unknown_functions': True})
+    assert prntr.doprint(expr) == 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
+
     prntr = MpmathPrinter()
     assert prntr.doprint(expr) ==  'mpmath.beta(x, y)'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1225,11 +1225,7 @@ def test_beta_scipy():
     assert abs(beta(1.3, 2.3) - F(1.3, 2.3)) <= 1e-10
 
 
-@XFAIL
 def test_beta_math():
-    # Not clear why it is not working since pycode(beta(x, y))
-    # gives 'math.gamma(x)*math.gamma(y)/math.gamma(x + y)'
-
     f = beta(x, y)
     F = lambdify((x, y), f, modules='math')
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#17394

#### Brief description of what is fixed or changed

It fixes the failing `test_beta_math` test in #17394.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Setting `allow_unknown_functions=True` will not attempt to print in the unsupported form if the rewriting scheme exists.
  - Fixed `pycode(beta(x, y), allow_unknown_functions=True)` printing unsupported function in python `math` module even if the rewriting scheme exists.
- utilities
  - Fixed `beta` function error in `lambdify` with the option `module='math'`
<!-- END RELEASE NOTES -->
