### PR TITLE
Core: Fixes _xreplace error while differentiating function of function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -828,6 +828,10 @@ class AppliedUndef(Function):
 
     def __new__(cls, *args, **options):
         args = list(map(sympify, args))
+        u = [a.name for a in args if isinstance(a, UndefinedFunction)]
+        if u:
+            raise ValueError('invalid argument%s: %s' % (
+                's'*(len(u) > 1), ', '.join(u)))
         obj = super(AppliedUndef, cls).__new__(cls, *args, **options)
         return obj
 
@@ -911,6 +915,10 @@ class UndefinedFunction(FunctionClass):
 
     def __ne__(self, other):
         return not self == other
+
+    @property
+    def _diff_wrt(self):
+        return False
 
 
 class WildFunction(Function, AtomicExpr):
@@ -1274,6 +1282,10 @@ class Derivative(Expr):
                         v, count = v
                     if count == 0:
                         continue
+                elif isinstance(v, UndefinedFunction):
+                    raise ValueError(
+                        "cannot differentiate wrt "
+                        "UndefinedFunction: %s" % v)
                 else:
                     count = 1
                 variable_count.append(Tuple(v, count))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1262,6 +1262,12 @@ def test_issue_15360():
     assert f.name == 'f'
 
 
+def test_issue_15947():
+    assert f._diff_wrt is False
+    raises(ValueError, lambda: f(f))
+    raises(ValueError, lambda: f(x).diff(f))
+
+
 def test_Derivative_free_symbols():
     f = Function('f')
     n = Symbol('n', integer=True, positive=True)


### PR DESCRIPTION
Fixes#15947

It's possible to call f(g) when f and g are both functions. The result was raising a TypeError when differentiating.

Now it is disallowed with a better error message, after being explicitly checked.
>>> f(f)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\function.py", line 811, in __new__
    's'*(len(u) > 1), ', '.join(u)))
**ValueError: invalid argument: f**

<!-- BEGIN RELEASE NOTES -->
* Core
   * Fixes TypeError: _xreplace error while differentiating function of function  


<!-- END RELEASE NOTES -->
