### PR TITLE
Core: Fixes Pow._eval_is_ error

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2613,7 +2613,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
     def _eval_power(self, expt):
         if expt.is_positive:
             return self
-        if expt.is_negative:
+        if expt.is_extended_negative:        
             return S.ComplexInfinity
         if expt.is_extended_real is False:
             return S.NaN

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2613,7 +2613,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
     def _eval_power(self, expt):
         if expt.is_positive:
             return self
-        if expt.is_extended_negative:        
+        if expt.is_extended_negative:
             return S.ComplexInfinity
         if expt.is_extended_real is False:
             return S.NaN

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -555,12 +555,12 @@ class Pow(Expr):
                 if self.exp.is_extended_nonnegative:
                     return True
             else:
-                if self.exp.is_integer:
+                if self.exp.is_integer and self.base.is_zero is not None:
                     return True
                 elif self.base.is_extended_negative:
                     if self.exp.is_Rational:
                         return False
-        if real_e and self.exp.is_extended_negative:
+        if real_e and self.exp.is_extended_negative and self.base.is_zero is not None:
             return Pow(self.base, -self.exp).is_extended_real
         im_b = self.base.is_imaginary
         im_e = self.exp.is_imaginary
@@ -621,7 +621,7 @@ class Pow(Expr):
                 rat = self.exp.is_rational
                 if not rat:
                     return rat
-                if self.exp.is_integer:
+                if self.exp.is_integer and self.base.is_zero is not None:
                     return False
                 else:
                     half = (2*self.exp).is_integer
@@ -1247,7 +1247,8 @@ class Pow(Expr):
         elif self.exp.is_rational:
             if self.base.is_algebraic is False:
                 return self.exp.is_zero
-            return self.base.is_algebraic
+            if self.exp.is_extended_negative and self.base.is_zero is False:
+                return self.base.is_algebraic
         elif self.base.is_algebraic and self.exp.is_algebraic:
             if ((fuzzy_not(self.base.is_zero)
                 and fuzzy_not(_is_one(self.base)))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1067,7 +1067,7 @@ def test_powers_Integer():
     assert S(-1)** S.Infinity == S.NaN
     assert S(2) ** S.Infinity == S.Infinity
     assert S(-2)** S.Infinity == S.Infinity + S.Infinity * S.ImaginaryUnit
-    assert S(0) ** S.Infinity == 0
+    assert S(0) ** S.NegativeInfinity is S.ComplexInfinity
 
     # check Nan
     assert S(1) ** S.NaN == S.NaN


### PR DESCRIPTION
Fixes#17453

**Earlier:**
>>> i = Dummy(integer=True)
>>> (1/(i-1)).is_finite
True <-- should be None

**Now:**
>>> i = Dummy(integer=True)
>>> (1/(i-1)).is_finite
None

**Testcase has also been added.**

<!-- BEGIN RELEASE NOTES -->
* core
     * Fixes `Pow._eval_is_` error which was printing a wrong result 

<!-- END RELEASE NOTES -->
