### PR TITLE
15987 extended express for non cartesian frames

### DIFF
--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -5,7 +5,7 @@ from sympy.vector.dyadic import (Dyadic, DyadicAdd, DyadicMul,
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
 from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
-from sympy.vector.functions import (extended_express,express, matrix_to_vector,
+from sympy.vector.functions import (extended_express, express, matrix_to_vector,
                                     laplacian, is_conservative,
                                     is_solenoidal, scalar_potential,
                                     directional_derivative,

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -5,7 +5,7 @@ from sympy.vector.dyadic import (Dyadic, DyadicAdd, DyadicMul,
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
 from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
-from sympy.vector.functions import (express, matrix_to_vector,
+from sympy.vector.functions import (extended_express,express, matrix_to_vector,
                                     laplacian, is_conservative,
                                     is_solenoidal, scalar_potential,
                                     directional_derivative,

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -10,7 +10,48 @@ from math import isnan
 
 
 def extended_express(expr,coordsys):
-   "allow transformation between cartesian and non-cartesian frames"
+    """
+    express for vectors allowing transformation between cartesian and non-cartesian frames
+
+    Parameters
+    ==========
+
+    expr : Vector/Dyadic/scalar(sympyfiable)
+        The expression to re-express in CoordSys3D 'system'
+
+    system: CoordSys3D
+        The coordinate system the expr is to be expressed in
+    Examples
+    =========
+
+    >>> from sympy.vector import extended_express, CoordSys3D
+    >>> from sympy import pi
+    >>> N=CoordSys3D('N')
+    >>> C=N.create_new('C',transformation='cylindrical',base_vectors=('r','theta','z'))
+    >>> extended_express(5*N.i,C)
+    5*C.r
+    >>> extended_express(5*N.j,C)
+    5*C.r+pi/2*C.theta
+    >>> extended_express(10*N.k,C)
+    10*C.z
+    >>> extended_express(6*C.r,N)
+    6*N.i
+    >>> extended_express(6*C.r+pi/2*C.theta)
+    6*N.j
+
+    where a coordinate is undefined (eg theta with extended_express(N.k), it is mapped to zero
+    The non-cartesian frame must be defined as a child of the cartesian frame as above.
+
+    the output is expressed in terms of the base vectors of the derived coordinate systems
+    currently they default to i,j and k which are confusing for non-cartesian systems so it
+    is recommended to explicitly name them as above.
+ 
+    See Also  
+    ========
+
+    CoordSys3D.transformation_from_parent,CoordSys3D.transformation_to_parent
+
+"""
    assert isinstance(coordsys,CoordSys3D) # check we are expressing in a frame
 
    parts=expr.separate() # get different coordinate frames in vector, cry if more than one

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -52,7 +52,7 @@ def extended_express(expr,coordsys):
    vals=transform_function(*args)
 
    ans=Vector.zero
-
+ 
    for v,c in zip(vals,to_coeffs):
        if isnan(v):  # v is nan ie infinity from an arctan
            v=0 # use to solve for cylindrical coords where theta is undefined

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -4,7 +4,7 @@ from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
-from sympy.core import sympify,nan
+from sympy.core import sympify, nan
 from sympy.vector.dyadic import Dyadic
 
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -10,7 +10,7 @@ from sympy.vector.dyadic import Dyadic
 
 def extended_express(expr,coordsys):
     """
-    express for vectors allowing transformation between  
+    express for vectors allowing transformation between
     cartesian (x,y,z) and non-cartesian frames (eg cylindrical)
 
     Parameters
@@ -41,13 +41,13 @@ def extended_express(expr,coordsys):
     >>> extended_express(6*C.r + pi/2*C.theta,N)
     6*N.j
 
-    Where a coordinate is undefined (eg theta with 
+    Where a coordinate is undefined (eg theta with
     extended_express(N.k), it is mapped to zero.
-    The non-cartesian frame must be defined as a child of the 
+    The non-cartesian frame must be defined as a child of the
     cartesian frame as above.
 
-    The output is expressed in terms of the base vectors of the 
-    derived coordinate systems. Currently they default to i,j 
+    The output is expressed in terms of the base vectors of the
+    derived coordinate systems. Currently they default to i,j
     and k which are confusing for non-cartesian systems so it
     is recommended to explicitly name them as above.
 
@@ -59,14 +59,14 @@ def extended_express(expr,coordsys):
 
     """
     if not isinstance(coordsys, CoordSys3D):
-        raise TypeError("system should be a CoordSys3D instance") 
+        raise TypeError("system should be a CoordSys3D instance")
              # check we are expressing in a frame
 
-    parts=expr.separate() 
+    parts=expr.separate()
     # get different coordinate frames in vector, cry if more than one
 
     if isinstance(parts,dict):
-        if(len(parts) == 0): return Vector.zero 
+        if(len(parts) == 0): return Vector.zero
              # we have been given zero vector
         if(len(parts) > 1):  raise ValueError("Does not support \
             expressions containing multiple base coordinate frames")
@@ -77,7 +77,7 @@ def extended_express(expr,coordsys):
         foundframe = parts.system
         foundvector = parts
 
-    # we should now have found the only frame in the vector, 
+    # we should now have found the only frame in the vector,
     # and we now have to convert it to the given frame
 
     from_frame = foundframe
@@ -99,10 +99,10 @@ def extended_express(expr,coordsys):
 
     for i,j in zip(from_coeffs1,from_coeffs2):
            # could be expressed in either for inertial frame
-        coeff1 = foundvector.coeff(i)  
+        coeff1 = foundvector.coeff(i)
            # understand both N.i and N.x (or C.r and C.i)
         coeff2 = foundvector.coeff(j)
-        if coeff1 != 0 and coeff2 !=0 : 
+        if coeff1 != 0 and coeff2 !=0 :
             raise ValueError("Cannot express vector with both base \
                       vectors and base scalars - check your vector")
         args.append(coeff1 + coeff2) # only one can be non-zero
@@ -113,8 +113,8 @@ def extended_express(expr,coordsys):
 
     for v,c in zip(vals,to_coeffs):
         if v is nan:  # v is nan ie infinity from an arctan
-            v = 0 
-        # use to solve for cylindrical coords 
+            v = 0
+        # use to solve for cylindrical coords
         # where theta is undefined
         ans += v*c
     return ans

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -27,9 +27,9 @@ def extended_express(expr,coordsys):
 
     >>> from sympy.vector import extended_express, CoordSys3D
     >>> from sympy import pi
-    >>> N=CoordSys3D('N')
-    >>> C=N.create_new('C',transformation='cylindrical', \
-        vector_names=('r','theta','z'))
+    >>> N = CoordSys3D('N')
+    >>> C = N.create_new('C', transformation='cylindrical',
+        vector_names = ('r', 'theta', 'z'))
     >>> extended_express(5*N.i,C)
     5*C.r
     >>> extended_express(5*N.j,C)
@@ -38,7 +38,7 @@ def extended_express(expr,coordsys):
     10*C.z
     >>> extended_express(6*C.r,N)
     6*N.i
-    >>> extended_express(6*C.r+pi/2*C.theta,N)
+    >>> extended_express(6*C.r + pi/2*C.theta,N)
     6*N.j
 
     Where a coordinate is undefined (eg theta with 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -4,7 +4,7 @@ from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
-from sympy.core import sympify
+from sympy.core import sympify,nan
 from sympy.vector.dyadic import Dyadic
 
 
@@ -112,7 +112,7 @@ def extended_express(expr,coordsys):
     ans=Vector.zero
 
     for v,c in zip(vals,to_coeffs):
-        if v is sympy.nan:  # v is nan ie infinity from an arctan
+        if v is nan:  # v is nan ie infinity from an arctan
             v = 0 
         # use to solve for cylindrical coords 
         # where theta is undefined

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -16,11 +16,12 @@ def extended_express(expr,coordsys):
     Parameters
     ==========
 
-    expr : Vector/Dyadic/scalar(sympyfiable)
-        The expression to re-express in CoordSys3D 'system'
+    expr : Vector
+        The expression to re-express in CoordSys3D 'coordsys'
 
     system: CoordSys3D
         The coordinate system the expr is to be expressed in
+
     Examples
     =========
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -6,6 +6,8 @@ from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
+from math import isnan
+
 
 def extended_express(expr,coordsys):
    "allow transformation between cartesian and non-cartesian frames"

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -28,7 +28,7 @@ def extended_express(expr,coordsys):
     >>> from sympy.vector import extended_express, CoordSys3D
     >>> from sympy import pi
     >>> N = CoordSys3D('N')
-    >>> C = N.create_new('C', transformation='cylindrical',
+    >>> C = N.create_new('C', transformation='cylindrical', \
         vector_names = ('r', 'theta', 'z'))
     >>> extended_express(5*N.i,C)
     5*C.r

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -6,12 +6,12 @@ from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
-from math import isnan
 
 
 def extended_express(expr,coordsys):
     """
-    express for vectors allowing transformation between cartesian and non-cartesian frames
+    express for vectors allowing transformation between  
+    cartesian (x,y,z) and non-cartesian frames (eg cylindrical)
 
     Parameters
     ==========
@@ -28,7 +28,8 @@ def extended_express(expr,coordsys):
     >>> from sympy.vector import extended_express, CoordSys3D
     >>> from sympy import pi
     >>> N=CoordSys3D('N')
-    >>> C=N.create_new('C',transformation='cylindrical',vector_names=('r','theta','z'))
+    >>> C=N.create_new('C',transformation='cylindrical', \
+        vector_names=('r','theta','z'))
     >>> extended_express(5*N.i,C)
     5*C.r
     >>> extended_express(5*N.j,C)
@@ -40,66 +41,82 @@ def extended_express(expr,coordsys):
     >>> extended_express(6*C.r+pi/2*C.theta,N)
     6*N.j
 
-    where a coordinate is undefined (eg theta with extended_express(N.k), it is mapped to zero
-    The non-cartesian frame must be defined as a child of the cartesian frame as above.
+    Where a coordinate is undefined (eg theta with 
+    extended_express(N.k), it is mapped to zero.
+    The non-cartesian frame must be defined as a child of the 
+    cartesian frame as above.
 
-    the output is expressed in terms of the base vectors of the derived coordinate systems
-    currently they default to i,j and k which are confusing for non-cartesian systems so it
+    The output is expressed in terms of the base vectors of the 
+    derived coordinate systems. Currently they default to i,j 
+    and k which are confusing for non-cartesian systems so it
     is recommended to explicitly name them as above.
 
     See Also
     ========
 
-    CoordSys3D.transformation_from_parent,CoordSys3D.transformation_to_parent
+    CoordSys3D.transformation_from_parent,
+    CoordSys3D.transformation_to_parent
 
     """
     if not isinstance(coordsys, CoordSys3D):
-        raise TypeError("system should be a CoordSys3D instance") # check we are expressing in a frame
+        raise TypeError("system should be a CoordSys3D instance") 
+             # check we are expressing in a frame
 
-    parts=expr.separate() # get different coordinate frames in vector, cry if more than one
+    parts=expr.separate() 
+    # get different coordinate frames in vector, cry if more than one
 
     if isinstance(parts,dict):
-        if(len(parts)==0): return Vector.zero # we have been given zero vector
-        if(len(parts)>1):  raise ValueError("Does not support expressions containing multiple base coordinate frames")
+        if(len(parts) == 0): return Vector.zero 
+             # we have been given zero vector
+        if(len(parts) > 1):  raise ValueError("Does not support \
+            expressions containing multiple base coordinate frames")
 
-        foundframe=tuple(parts.keys())[0]
-        foundvector=tuple(parts.values())[0]
+        foundframe = tuple(parts.keys())[0]
+        foundvector = tuple(parts.values())[0]
     else:
-        foundframe=parts.system
-        foundvector=parts
+        foundframe = parts.system
+        foundvector = parts
 
-    # we should now have found the only frame in the vector, and we now have to convert it to the given frame
+    # we should now have found the only frame in the vector, 
+    # and we now have to convert it to the given frame
 
-    from_frame=foundframe
-    to_frame=coordsys
+    from_frame = foundframe
+    to_frame = coordsys
 
-    from_coeffs1=from_frame.base_vectors()
-    from_coeffs2=from_frame.base_scalars()
-    to_coeffs=to_frame.base_vectors()    # output with vectors
+    from_coeffs1 = from_frame.base_vectors()
+    from_coeffs2 = from_frame.base_scalars()
+    to_coeffs = to_frame.base_vectors()    # output with vectors
 
-    if from_frame._parent==to_frame:
-        transform_function=from_frame._transformation_lambda
+    if from_frame._parent == to_frame:
+        transform_function = from_frame._transformation_lambda
     else:
-        if to_frame._parent==from_frame:
-            transform_function=to_frame._transformation_from_parent_lambda
+        if to_frame._parent == from_frame:
+            transform_function =  \
+                to_frame._transformation_from_parent_lambda
         else:
             raise ValueError("Cannot link Coordinate frames")
     args=[]
 
-    for i,j in zip(from_coeffs1,from_coeffs2): # could be expressed in either for inertial frame
-        coeff1=foundvector.coeff(i)  # understand both N.i and N.x (or C.r and C.i)
-        coeff2=foundvector.coeff(j)
-        if coeff1!=0 and coeff2!=0: raise ValueError("Cannot express vector with both base vectors and base scalars - check your vector")
-        args.append(coeff1+coeff2) # only one can be non-zero
+    for i,j in zip(from_coeffs1,from_coeffs2):
+           # could be expressed in either for inertial frame
+        coeff1 = foundvector.coeff(i)  
+           # understand both N.i and N.x (or C.r and C.i)
+        coeff2 = foundvector.coeff(j)
+        if coeff1 != 0 and coeff2 !=0 : 
+            raise ValueError("Cannot express vector with both base \
+                      vectors and base scalars - check your vector")
+        args.append(coeff1 + coeff2) # only one can be non-zero
 
     vals=transform_function(*args)
 
     ans=Vector.zero
 
     for v,c in zip(vals,to_coeffs):
-        if isnan(v):  # v is nan ie infinity from an arctan
-            v=0 # use to solve for cylindrical coords where theta is undefined
-        ans=ans+v*c
+        if v is sympy.nan:  # v is nan ie infinity from an arctan
+            v = 0 
+        # use to solve for cylindrical coords 
+        # where theta is undefined
+        ans += v*c
     return ans
 
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -46,8 +46,8 @@ def extended_express(expr,coordsys):
     the output is expressed in terms of the base vectors of the derived coordinate systems
     currently they default to i,j and k which are confusing for non-cartesian systems so it
     is recommended to explicitly name them as above.
- 
-    See Also  
+
+    See Also
     ========
 
     CoordSys3D.transformation_from_parent,CoordSys3D.transformation_to_parent
@@ -60,7 +60,7 @@ def extended_express(expr,coordsys):
 
     if isinstance(parts,dict):
         if(len(parts)==0): return Vector.zero # we have been given zero vector
-        if(len(parts)>1):  raise(ValueError," Doesn't support expressions containing multiple base coordinate frames ")
+        if(len(parts)>1):  raise ValueError("Does not support expressions containing multiple base coordinate frames")
 
         foundframe=tuple(parts.keys())[0]
         foundvector=tuple(parts.values())[0]
@@ -75,27 +75,27 @@ def extended_express(expr,coordsys):
 
     from_coeffs1=from_frame.base_vectors()
     from_coeffs2=from_frame.base_scalars()
-    to_coeffs=to_frame.base_vectors()    # output with vectors      
+    to_coeffs=to_frame.base_vectors()    # output with vectors
 
-    if from_frame._parent==to_frame: 
+    if from_frame._parent==to_frame:
         transform_function=from_frame._transformation_lambda
-    else: 
-        if to_frame._parent==from_frame: 
+    else:
+        if to_frame._parent==from_frame:
             transform_function=to_frame._transformation_from_parent_lambda
-        else: 
-            raise(ValueError," Cannot link Coordinate frames")
+        else:
+            raise ValueError("Cannot link Coordinate frames")
     args=[]
 
     for i,j in zip(from_coeffs1,from_coeffs2): # could be expressed in either for inertial frame
         coeff1=foundvector.coeff(i)  # understand both N.i and N.x (or C.r and C.i)
         coeff2=foundvector.coeff(j)
-        if coeff1!=0 and coeff2!=0: raise(ValueError,"cannot express vector with both base vectors and base scalars - check your vector")
+        if coeff1!=0 and coeff2!=0: raise ValueError("Cannot express vector with both base vectors and base scalars - check your vector")
         args.append(coeff1+coeff2) # only one can be non-zero
 
     vals=transform_function(*args)
 
     ans=Vector.zero
- 
+
     for v,c in zip(vals,to_coeffs):
         if isnan(v):  # v is nan ie infinity from an arctan
             v=0 # use to solve for cylindrical coords where theta is undefined

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -1,6 +1,6 @@
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSys3D
-from sympy.vector.functions import extended_express,express, matrix_to_vector, orthogonalize
+from sympy.vector.functions import extended_express, express, matrix_to_vector, orthogonalize
 from sympy import symbols, S, sqrt, sin, cos, ImmutableMatrix as Matrix
 from sympy.utilities.pytest import raises
 

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -1,6 +1,6 @@
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSys3D
-from sympy.vector.functions import express, matrix_to_vector, orthogonalize
+from sympy.vector.functions import extended_express,express, matrix_to_vector, orthogonalize
 from sympy import symbols, S, sqrt, sin, cos, ImmutableMatrix as Matrix
 from sympy.utilities.pytest import raises
 
@@ -9,6 +9,23 @@ q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
 A = N.orient_new_axis('A', q1, N.k)
 B = A.orient_new_axis('B', q2, A.i)
 C = B.orient_new_axis('C', q3, B.j)
+
+from sympy import pi,atan2
+
+Sph=N.create_new('S',transformation='spherical')
+Cyl=N.create_new('C',transformation='cylindrical',vector_names=('r','t','z'),variable_names=('rho','theta','h'))
+
+def test_extended_express():
+    assert extended_express(N.i,Cyl)==Cyl.r
+    assert extended_express(N.j,Cyl)==Cyl.r+pi/2*Cyl.t
+    assert extended_express(N.k,Cyl)==Cyl.z
+    assert extended_express(4*N.i+3*N.j+100*N.k,Cyl)==5*Cyl.r+atan2(3,4)*Cyl.t+100*Cyl.z
+    assert extended_express(Cyl.r,N)==N.i
+    assert extended_express(Cyl.t,N)==Vector.zero
+    assert extended_express(Cyl.z,N)==N.k
+    assert extended_express(Cyl.r+pi/2*Cyl.t,N)==N.j
+    assert extended_express(5*Cyl.r+atan2(3,4)*Cyl.t+100*Cyl.z,N)== 4*N.i+3*N.j+100*N.k
+
 
 
 def test_express():


### PR DESCRIPTION
Adds a version of express that supports conversion with non-cartesian frames (eg cylindrical) 

#### References to other Issues or PRs

Fixes #15987 

enables conversion between cartesian frames (eg x,y,z) and non-cartesian frames (eg r,theta,z)

#### Other comments

This patch enables easy usage of the lambda functions hidden away in CoordSys3D for non-cartesian geometry. It raises errors if vectors with multiple frames are combined, it relies on the non-cartesian being the direct child of the cartesian, and expresses the result in the base_vectors of the target coordinate frame. These currently default to i,j,k, even for non-cartesian vectors which is confusing and would ideally be changed for these cases. It gets the arguments from the source expression and can understand in terms of base vector or base scalar, but will throw an error if both appear at once. The functionality for doing fancy stuff with the transformation equations is present in CoordSys3D, but for this first implementation the lambda functions created in CoordSys3D were accessed to provide support for cylindrical and spherical coordinate systems. Ideally this would be combined with express, and refactored together, but as I am not currently familiar with all the cases for express and how it works, I have initially provided this as a separate callable function. 

This supplies expected behaviour that is currently missing - CoordSys3D enables you to create cylindrical/spherical/custom coordinate systems, but currently you cannot convert to/from them with the standard build. This patch supplies a solution to this. 


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
      *  convert to/from non-cartesian coordinate frames
           added extended_express(expr,CoordSys) that can express to/from non-cartesian frames (eg cylindrical,spherical)
<!-- END RELEASE NOTES -->
