### PR TITLE
Renames `TensExpr/Add/Mul` to `TensorExpr/Add/Mul`

### DIFF
--- a/doc/src/modules/tensor/tensor.rst
+++ b/doc/src/modules/tensor/tensor.rst
@@ -14,13 +14,13 @@ Tensor
 .. autoclass:: TensorHead
    :members:
 
-.. autoclass:: TensExpr
+.. autoclass:: TensorExpr
    :members:
 
-.. autoclass:: TensAdd
+.. autoclass:: TensorAdd
    :members:
 
-.. autoclass:: TensMul
+.. autoclass:: TensorMul
    :members:
 
 .. autofunction:: canon_bp

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -96,7 +96,7 @@ class Add(Expr, AssocOp):
         """
         from sympy.calculus.util import AccumBounds
         from sympy.matrices.expressions import MatrixExpr
-        from sympy.tensor.tensor import TensExpr
+        from sympy.tensor.tensor import TensorExpr
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -155,7 +155,7 @@ class Add(Expr, AssocOp):
                 extra.append(o)
                 continue
 
-            elif isinstance(o, TensExpr):
+            elif isinstance(o, TensorExpr):
                 coeff = o.__add__(coeff) if coeff else o
                 continue
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4079,8 +4079,18 @@ def test_sympy__tensor__tensor__TensorIndex():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     assert _test_args(TensorIndex('i', Lorentz))
 
+
+@SKIP("deprecated class")
+def test_sympy__tensor__tensor__TensExpr():
+    pass
+
 @SKIP("abstract class")
 def test_sympy__tensor__tensor__TensorExpr():
+    pass
+
+
+@SKIP("deprecated class")
+def test_sympy__tensor__tensor__TensAdd():
     pass
 
 def test_sympy__tensor__tensor__TensorAdd():
@@ -4102,6 +4112,10 @@ def test_sympy__tensor__tensor__Tensor():
     p = TensorHead('p', [Lorentz], sym)
     assert _test_args(p(a))
 
+
+@SKIP("deprecated class")
+def test_sympy__tensor__tensor__TensMul():
+    pass
 
 def test_sympy__tensor__tensor__TensorMul():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, tensor_indices, tensor_heads

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4080,18 +4080,18 @@ def test_sympy__tensor__tensor__TensorIndex():
     assert _test_args(TensorIndex('i', Lorentz))
 
 @SKIP("abstract class")
-def test_sympy__tensor__tensor__TensExpr():
+def test_sympy__tensor__tensor__TensorExpr():
     pass
 
-def test_sympy__tensor__tensor__TensAdd():
-    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, tensor_indices, TensAdd, tensor_heads
+def test_sympy__tensor__tensor__TensorAdd():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, tensor_indices, TensorAdd, tensor_heads
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     p, q = tensor_heads('p,q', [Lorentz], sym)
     t1 = p(a)
     t2 = q(a)
-    assert _test_args(TensAdd(t1, t2))
+    assert _test_args(TensorAdd(t1, t2))
 
 
 def test_sympy__tensor__tensor__Tensor():
@@ -4103,7 +4103,7 @@ def test_sympy__tensor__tensor__Tensor():
     assert _test_args(p(a))
 
 
-def test_sympy__tensor__tensor__TensMul():
+def test_sympy__tensor__tensor__TensorMul():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, tensor_indices, tensor_heads
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -27,7 +27,7 @@
 """
 from sympy import S, Mul, eye, trace
 from sympy.tensor.tensor import TensorIndexType, TensorIndex,\
-    TensMul, TensAdd, tensor_mul, Tensor, TensorHead, TensorSymmetry
+    TensorMul, TensorAdd, tensor_mul, Tensor, TensorHead, TensorSymmetry
 from sympy.core.compatibility import range
 
 
@@ -43,7 +43,7 @@ GammaMatrix = TensorHead("GammaMatrix", [LorentzIndex],
 
 def extract_type_tens(expression, component):
     """
-    Extract from a ``TensExpr`` all tensors with `component`.
+    Extract from a ``TensorExpr`` all tensors with `component`.
 
     Returns two tensor expressions:
 
@@ -54,7 +54,7 @@ def extract_type_tens(expression, component):
     """
     if isinstance(expression, Tensor):
         sp = [expression]
-    elif isinstance(expression, TensMul):
+    elif isinstance(expression, TensorMul):
         sp = expression.args
     else:
         raise ValueError('wrong type')
@@ -187,8 +187,8 @@ def gamma_trace(t):
     0
 
     """
-    if isinstance(t, TensAdd):
-        res = TensAdd(*[_trace_single_line(x) for x in t.args])
+    if isinstance(t, TensorAdd):
+        res = TensorAdd(*[_trace_single_line(x) for x in t.args])
         return res
     t = _simplify_single_line(t)
     res = _trace_single_line(t)
@@ -220,7 +220,7 @@ def _simplify_single_line(expression):
 
 def _trace_single_line(t):
     """
-    Evaluate the trace of a single gamma matrix line inside a ``TensExpr``.
+    Evaluate the trace of a single gamma matrix line inside a ``TensorExpr``.
 
     Notes
     =====
@@ -265,7 +265,7 @@ def _trace_single_line(t):
             tcoeff = t.coeff
             return t.nocoeff if tcoeff else t
         if numG % 2 == 1:
-            return TensMul.from_data(S.Zero, [], [], [])
+            return TensorMul.from_data(S.Zero, [], [], [])
         elif numG > 4:
             # find the open matrix indices and connect them:
             a = t.split()
@@ -284,7 +284,7 @@ def _trace_single_line(t):
                 t2 = t2.contract_metric(g)
                 t2 = simplify_gpgp(t2, False)
                 args.append(t2)
-            t3 = TensAdd(*args)
+            t3 = TensorAdd(*args)
             t3 = _trace_single_line(t3)
             return t3
         else:
@@ -299,10 +299,10 @@ def _trace_single_line(t):
             return t3
 
     t = t.expand()
-    if isinstance(t, TensAdd):
+    if isinstance(t, TensorAdd):
         a = [_trace_single_line1(x)*x.coeff for x in t.args]
-        return TensAdd(*a)
-    elif isinstance(t, (Tensor, TensMul)):
+        return TensorAdd(*a)
+    elif isinstance(t, (Tensor, TensorMul)):
         r = t.coeff*_trace_single_line1(t)
         return r
     else:
@@ -316,7 +316,7 @@ def _gamma_trace1(*a):
         return gctr
     n = len(a)
     if n%2 == 1:
-        #return TensMul.from_data(S.Zero, [], [], [])
+        #return TensorMul.from_data(S.Zero, [], [], [])
         return S.Zero
     if n == 2:
         ind0 = a[0].get_indices()[0]
@@ -415,13 +415,13 @@ def kahane_simplify(expression):
 
     if isinstance(expression, Mul):
         return expression
-    if isinstance(expression, TensAdd):
-        return TensAdd(*[kahane_simplify(arg) for arg in expression.args])
+    if isinstance(expression, TensorAdd):
+        return TensorAdd(*[kahane_simplify(arg) for arg in expression.args])
 
     if isinstance(expression, Tensor):
         return expression
 
-    assert isinstance(expression, TensMul)
+    assert isinstance(expression, TensorMul)
 
     gammas = expression.args
 
@@ -706,9 +706,9 @@ def kahane_simplify(expression):
 
     t = resulting_coeff * resulting_expr
     t1 = None
-    if isinstance(t, TensAdd):
+    if isinstance(t, TensorAdd):
         t1 = t.args[0]
-    elif isinstance(t, TensMul):
+    elif isinstance(t, TensorMul):
         t1 = t
     if t1:
         pass

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -1,7 +1,7 @@
 from sympy import Matrix
 
 from sympy.tensor.tensor import tensor_indices, TensorHead, tensor_heads, \
-    TensExpr, canon_bp
+    TensorExpr, canon_bp
 from sympy import eye
 from sympy.physics.hep.gamma_matrices import GammaMatrix as G, LorentzIndex, \
     kahane_simplify, gamma_trace, _simplify_single_line, simplify_gamma_expression
@@ -10,9 +10,9 @@ from sympy.physics.hep.gamma_matrices import GammaMatrix as G, LorentzIndex, \
 def _is_tensor_eq(arg1, arg2):
     arg1 = canon_bp(arg1)
     arg2 = canon_bp(arg2)
-    if isinstance(arg1, TensExpr):
+    if isinstance(arg1, TensorExpr):
         return arg1.equals(arg2)
-    elif isinstance(arg2, TensExpr):
+    elif isinstance(arg2, TensorExpr):
         return arg2.equals(arg1)
     return arg1 == arg2
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1751,14 +1751,14 @@ class LatexPrinter(Printer):
         index_map = expr.index_map
         return self._printer_tensor_indices(name, indices, index_map)
 
-    def _print_TensMul(self, expr):
+    def _print_TensorMul(self, expr):
         # prints expressions like "A(a)", "3*A(a)", "(1+x)*A(a)"
         sign, args = expr._get_args_for_traditional_printer()
         return sign + "".join(
             [self.parenthesize(arg, precedence(expr)) for arg in args]
         )
 
-    def _print_TensAdd(self, expr):
+    def _print_TensorAdd(self, expr):
         a = []
         args = expr.args
         for x in args:

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -41,9 +41,9 @@ PRECEDENCE_VALUES = {
     "MatAdd": PRECEDENCE["Add"],
     "MatPow": PRECEDENCE["Pow"],
     "MatrixSolve": PRECEDENCE["Mul"],
-    "TensAdd": PRECEDENCE["Add"],
-    # As soon as `TensMul` is a subclass of `Mul`, remove this:
-    "TensMul": PRECEDENCE["Mul"],
+    "TensorAdd": PRECEDENCE["Add"],
+    # As soon as `TensorMul` is a subclass of `Mul`, remove this:
+    "TensorMul": PRECEDENCE["Mul"],
     "HadamardProduct": PRECEDENCE["Mul"],
     "HadamardPower": PRECEDENCE["Pow"],
     "KroneckerProduct": PRECEDENCE["Mul"],

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1105,7 +1105,7 @@ class PrettyPrinter(Printer):
         index_map = expr.index_map
         return self._printer_tensor_indices(name, indices, index_map)
 
-    def _print_TensMul(self, expr):
+    def _print_TensorMul(self, expr):
         sign, args = expr._get_args_for_traditional_printer()
         args = [
             prettyForm(*self._print(i).parens()) if
@@ -1118,7 +1118,7 @@ class PrettyPrinter(Printer):
         else:
             return pform
 
-    def _print_TensAdd(self, expr):
+    def _print_TensorAdd(self, expr):
         args = [
             prettyForm(*self._print(i).parens()) if
             precedence_traditional(i) < PRECEDENCE["Mul"] else self._print(i)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -400,14 +400,14 @@ class StrPrinter(Printer):
     def _print_Tensor(self, expr):
         return expr._print()
 
-    def _print_TensMul(self, expr):
+    def _print_TensorMul(self, expr):
         # prints expressions like "A(a)", "3*A(a)", "(1+x)*A(a)"
         sign, args = expr._get_args_for_traditional_printer()
         return sign + "*".join(
             [self.parenthesize(arg, precedence(expr)) for arg in args]
         )
 
-    def _print_TensAdd(self, expr):
+    def _print_TensorAdd(self, expr):
         return expr._print()
 
     def _print_PermutationGroup(self, expr):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1815,6 +1815,12 @@ def tensor_heads(s, index_types, symmetry=None, comm=0):
     return thlist
 
 
+class TensExpr(Expr):
+    @deprecated(useinstead="TensorExpr", issue=17509, deprecated_since_version="1.5")
+    def __new__(cls, *args, **kw_args):
+        return TensorExpr(*args, **kw_args)
+
+
 class TensorExpr(Expr):
     """
     Abstract base class for tensor expressions
@@ -2215,6 +2221,30 @@ class TensorExpr(Expr):
         return expr
 
 
+class TensAdd(TensorExpr, AssocOp):
+    @deprecated(useinstead="TensorAdd", issue=17509, deprecated_since_version="1.5")
+    def __new__(cls, *args, **kw_args):
+        return TensorAdd(*args, **kw_args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorAdd._flatten_terms()", issue=17509,
+                deprecated_since_version="1.5")
+    def _tensAdd_flatten(args):
+        return TensorAdd._flatten_terms(args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorAdd._check_indices()", issue=17509,
+                deprecated_since_version="1.5")
+    def _tensAdd_check(args):
+        return TensorAdd._check_indices(args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorAdd._collect_terms()", issue=17509,
+                deprecated_since_version="1.5")
+    def _tensAdd_collect_terms(args):
+        return TensorAdd._collect_terms(args)
+
+
 class TensorAdd(TensorExpr, AssocOp):
     """
     Sum of tensors
@@ -2262,7 +2292,7 @@ class TensorAdd(TensorExpr, AssocOp):
     def __new__(cls, *args, **kw_args):
         args = [_sympify(x) for x in args if x]
 
-        args = TensorAdd._tensAdd_flatten(args)
+        args = TensorAdd._flatten_terms(args)
 
         obj = Basic.__new__(cls, *args, **kw_args)
         return obj
@@ -2281,7 +2311,7 @@ class TensorAdd(TensorExpr, AssocOp):
             return args[0]
 
         # now check that all addends have the same indices:
-        TensorAdd._tensAdd_check(args)
+        TensorAdd._check_indices(args)
 
         # if TensorAdd has only 1 element in its `args`:
         if len(args) == 1:  # and isinstance(args[0], TensorMul):
@@ -2299,7 +2329,7 @@ class TensorAdd(TensorExpr, AssocOp):
             return args[0]
 
         # Collect terms appearing more than once, differing by their coefficients:
-        args = TensorAdd._tensAdd_collect_terms(args)
+        args = TensorAdd._collect_terms(args)
 
         # collect canonicalized terms
         def sort_key(t):
@@ -2319,7 +2349,7 @@ class TensorAdd(TensorExpr, AssocOp):
         return obj
 
     @staticmethod
-    def _tensAdd_flatten(args):
+    def _flatten_terms(args):
         # flatten TensorAdd, coerce terms which are not tensors to tensors
         a = []
         for x in args:
@@ -2331,7 +2361,7 @@ class TensorAdd(TensorExpr, AssocOp):
         return args
 
     @staticmethod
-    def _tensAdd_check(args):
+    def _check_indices(args):
         # check that all addends have the same free indices
         indices0 = set([x[0] for x in get_index_structure(args[0]).free])
         list_indices = [set([y[0] for y in get_index_structure(x).free]) for x in args[1:]]
@@ -2339,7 +2369,7 @@ class TensorAdd(TensorExpr, AssocOp):
             raise ValueError('all tensors must have the same indices')
 
     @staticmethod
-    def _tensAdd_collect_terms(args):
+    def _collect_terms(args):
         # collect TensorMul terms differing at most by their coefficient
         terms_dict = defaultdict(list)
         scalars = S.Zero
@@ -2643,7 +2673,7 @@ class Tensor(TensorExpr):
         return index_map
 
     def doit(self, **kwargs):
-        args, indices, free, dum = TensorMul._tensMul_contract_indices([self])
+        args, indices, free, dum = TensorMul._contract_indices([self])
         return args[0]
 
     @staticmethod
@@ -2962,6 +2992,53 @@ class Tensor(TensorExpr):
         return self._check_add_Sum(expr, index_symbols)
 
 
+class TensMul(TensorExpr, AssocOp):
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def __new__(cls, *args, **kw_args):
+        return TensorMul(*args, **kw_args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _indices_to_free_dum(args_indices):
+        return TensorMul._indices_to_free_dum(args_indices)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _dummy_data_to_dum(dummy_data):
+        return TensorMul._dummy_data_to_dum(dummy_data)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul._contract_indices()", issue=17509,
+                deprecated_since_version="1.5")
+    def _tensMul_contract_indices(args, replace_indices=True):
+        return TensorMul._contract_indices(args, replace_indices)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _get_components_from_args(args):
+        return TensorMul._get_components_from_args(args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _rebuild_tensors_list(args, index_structure):
+        return TensorMul._rebuild_tensors_list(args, index_structure)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def from_data(coeff, components, free, dum, **kw_args):
+        return TensorMul.from_data(coeff, components, free, dum, **kw_args)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _get_tensors_from_components_free_dum(components, free, dum):
+        return TensorMul._get_tensors_from_components_free_dum(components, free, dum)
+
+    @staticmethod
+    @deprecated(useinstead="TensorMul", issue=17509, deprecated_since_version="1.5")
+    def _index_replacement_for_contract_metric(args, free, dum):
+        return TensorMul._index_replacement_for_contract_metric(args, free, dum)
+
+
 class TensorMul(TensorExpr, AssocOp):
     """
     Product of tensors
@@ -3010,7 +3087,7 @@ class TensorMul(TensorExpr, AssocOp):
         # Flatten:
         args = [i for arg in args for i in (arg.args if isinstance(arg, (TensorMul, Mul)) else [arg])]
 
-        args, indices, free, dum = TensorMul._tensMul_contract_indices(args, replace_indices=False)
+        args, indices, free, dum = TensorMul._contract_indices(args, replace_indices=False)
 
         # Data for indices:
         index_types = [i.tensor_index_type for i in indices]
@@ -3077,7 +3154,7 @@ class TensorMul(TensorExpr, AssocOp):
         return [(p2a, p2b) for (i, p1a, p1b, p2a, p2b) in dummy_data]
 
     @staticmethod
-    def _tensMul_contract_indices(args, replace_indices=True):
+    def _contract_indices(args, replace_indices=True):
         replacements = [{} for _ in args]
 
         #_index_order = all([_has_index_order(arg) for arg in args])
@@ -3162,7 +3239,7 @@ class TensorMul(TensorExpr, AssocOp):
         if len(args) == 1:
             return args[0]
 
-        args, indices, free, dum = TensorMul._tensMul_contract_indices(args)
+        args, indices, free, dum = TensorMul._contract_indices(args)
 
         # Data for indices:
         index_types = [i.tensor_index_type for i in indices]

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -9,9 +9,9 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.printing.pretty.pretty import pretty
 from sympy.tensor.array import Array
 from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, \
-    get_symmetric_group_sgs, TensorIndex, tensor_mul, TensAdd, \
-    riemann_cyclic_replace, riemann_cyclic, TensMul, tensor_heads, \
-    TensorManager, TensExpr, TensorHead, canon_bp, \
+    get_symmetric_group_sgs, TensorIndex, tensor_mul, TensorAdd, \
+    riemann_cyclic_replace, riemann_cyclic, TensorMul, tensor_heads, \
+    TensorManager, TensorExpr, TensorHead, canon_bp, \
     tensorhead, tensorsymmetry, TensorType
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy, ignore_warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -27,9 +27,9 @@ def filter_warnings_decorator(f):
     return wrapper
 
 def _is_equal(arg1, arg2):
-    if isinstance(arg1, TensExpr):
+    if isinstance(arg1, TensorExpr):
         return arg1.equals(arg2)
-    elif isinstance(arg2, TensExpr):
+    elif isinstance(arg2, TensorExpr):
         return arg2.equals(arg1)
     return arg1 == arg2
 
@@ -490,7 +490,7 @@ def test_TensorSymmetry():
     assert sym.base == Tuple(0, 1)
     assert sym.generators == Tuple(Permutation(0, 1)(3, 4), Permutation(1, 2)(3, 4))
 
-def test_TensExpr():
+def test_TensorExpr():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     g = Lorentz.metric
@@ -501,13 +501,13 @@ def test_TensExpr():
     raises(ValueError, lambda: S.One/(A(c, d) + g(c, d)))
     raises(ValueError, lambda: A(a, b) + A(a, c))
     t = A(a, b) + B(a, b)
-    #raises(NotImplementedError, lambda: TensExpr.__mul__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__add__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__radd__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__sub__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__rsub__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__div__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__rdiv__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__mul__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__add__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__radd__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__sub__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__rsub__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__div__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensorExpr.__rdiv__(t, 'a'))
     with ignore_warnings(SymPyDeprecationWarning):
         # DO NOT REMOVE THIS AFTER DEPRECATION REMOVED:
         raises(ValueError, lambda: A(a, b)**2)
@@ -525,15 +525,15 @@ def test_TensorHead():
     assert A.comm == 0
 
 def test_add1():
-    assert TensAdd().args == ()
-    assert TensAdd().doit() == 0
+    assert TensorAdd().args == ()
+    assert TensorAdd().doit() == 0
     # simple example of algebraic expression
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
     # A, B symmetric
     A, B = tensor_heads('A,B', [Lorentz]*2, TensorSymmetry.fully_symmetric(2))
     t1 = A(b, -d0)*B(d0, a)
-    assert TensAdd(t1).equals(t1)
+    assert TensorAdd(t1).equals(t1)
     t2a = B(d0, a) + A(d0, a)
     t2 = A(b, -d0)*t2a
     assert str(t2) == 'A(b, -L_0)*(A(L_0, a) + B(L_0, a))'
@@ -605,7 +605,7 @@ def test_add1():
     assert (t + t1).expand().equals(2)
     t2 = 1 + A(a, -a)
     assert t1 != t2
-    assert t2 != TensMul.from_data(0, [], [], [])
+    assert t2 != TensorMul.from_data(0, [], [], [])
     t = p(i) + q(i)
     raises(ValueError, lambda: t(i, j))
 
@@ -678,7 +678,7 @@ def test_mul():
     from sympy.abc import x
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
-    t = TensMul.from_data(S.One, [], [], [])
+    t = TensorMul.from_data(S.One, [], [], [])
     assert str(t) == '1'
     A, B = tensor_heads('A B', [Lorentz]*2, TensorSymmetry.fully_symmetric(2))
     t = (1 + x)*A(a, b)
@@ -703,9 +703,9 @@ def test_mul():
     t1 = tensor_mul(*t.split())
     assert t == t(-b, d)
     assert t == t1
-    assert tensor_mul(*[]) == TensMul.from_data(S.One, [], [], [])
+    assert tensor_mul(*[]) == TensorMul.from_data(S.One, [], [], [])
 
-    t = TensMul.from_data(1, [], [], [])
+    t = TensorMul.from_data(1, [], [], [])
     C = TensorHead('C', [])
     assert str(C()) == 'C'
     assert str(t) == '1'
@@ -1283,13 +1283,13 @@ def test_valued_tensor_iter():
     assert list(ba_matrix) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, -1, -2, -3, -4, -5, -6]
     assert list(BA) == list_BA
 
-    # iteration on VTensMul
+    # iteration on VTensorMul
     assert list(A(i1)) == [E, px, py, pz]
     assert list(BA(i1, i2)) == list_BA
     assert list(3 * BA(i1, i2)) == [3 * i for i in list_BA]
     assert list(-5 * BA(i1, i2)) == [-5 * i for i in list_BA]
 
-    # iteration on VTensAdd
+    # iteration on VTensorAdd
     # A(i1) + A(i1)
     assert list(A(i1) + A(i1)) == [2*E, 2*px, 2*py, 2*pz]
     assert BA(i1, i2) - BA(i1, i2) == 0
@@ -1600,7 +1600,7 @@ def test_valued_components_with_wrong_symmetry():
 
 
 @filter_warnings_decorator
-def test_issue_10972_TensMul_data():
+def test_issue_10972_TensorMul_data():
     Lorentz = TensorIndexType('Lorentz', metric=False, dummy_fmt='i', dim=2)
     Lorentz.data = [-1, 1]
 
@@ -1624,7 +1624,7 @@ def test_issue_10972_TensMul_data():
 
 
 @filter_warnings_decorator
-def test_TensMul_data():
+def test_TensorMul_data():
     Lorentz = TensorIndexType('Lorentz', metric=False, dummy_fmt='L', dim=4)
     Lorentz.data = [-1, 1, 1, 1]
 
@@ -1681,7 +1681,7 @@ def test_TensMul_data():
 
 
 @filter_warnings_decorator
-def test_issue_11020_TensAdd_data():
+def test_issue_11020_TensorAdd_data():
     Lorentz = TensorIndexType('Lorentz', metric=False, dummy_fmt='i', dim=2)
     Lorentz.data = [-1, 1]
 
@@ -1770,8 +1770,8 @@ def test_tensor_expand():
 
     A, B, C, D = tensor_heads("A B C D", [L])
 
-    assert isinstance(Add(A(i), B(i)), TensAdd)
-    assert isinstance(expand(A(i)+B(i)), TensAdd)
+    assert isinstance(Add(A(i), B(i)), TensorAdd)
+    assert isinstance(expand(A(i)+B(i)), TensorAdd)
 
     expr = A(i)*(A(-i)+B(-i))
     assert expr.args == (A(L_0), A(-L_0) + B(-L_0))
@@ -1798,8 +1798,8 @@ def test_tensor_expand():
     assert str(expr) == "A(i)*(B(j)*C(k) + C(j)*(A(k) + D(k)))"
     assert str(expr.expand()) == "A(i)*B(j)*C(k) + A(i)*C(j)*A(k) + A(i)*C(j)*D(k)"
 
-    assert isinstance(TensMul(3), TensMul)
-    tm = TensMul(3).doit()
+    assert isinstance(TensorMul(3), TensorMul)
+    tm = TensorMul(3).doit()
     assert tm == 3
     assert isinstance(tm, Integer)
 
@@ -1890,7 +1890,7 @@ def test_tensor_replacement():
     repl = {A(i): [[1, 2], [3, 4]]}
     raises(ValueError, lambda: expr._extract_data(repl))
 
-    # TensAdd:
+    # TensorAdd:
     expr = A(k)*H(i, j) + B(k)*H(i, j)
     repl = {A(k): [1], B(k): [1], H(i, j): [[1, 2],[3,4]], L:diag(1,1)}
     assert expr._extract_data(repl) == ([k, i, j], Array([[[2, 4], [6, 8]]]))

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -1,7 +1,7 @@
-from sympy.tensor.tensor import (TensExpr, TensMul)
+from sympy.tensor.tensor import (TensorExpr, TensorMul)
 
 
-class PartialDerivative(TensExpr):
+class PartialDerivative(TensorExpr):
     """
     Partial derivative for tensor expressions.
 
@@ -39,10 +39,10 @@ class PartialDerivative(TensExpr):
 
         # TODO: check that all variables have rank 1.
 
-        args, indices, free, dum = TensMul._tensMul_contract_indices([expr] +
+        args, indices, free, dum = TensorMul._tensMul_contract_indices([expr] +
             list(variables), replace_indices=True)
 
-        obj = TensExpr.__new__(cls, *args)
+        obj = TensorExpr.__new__(cls, *args)
 
         obj._indices = indices
         obj._free = free
@@ -50,7 +50,7 @@ class PartialDerivative(TensExpr):
         return obj
 
     def doit(self):
-        args, indices, free, dum = TensMul._tensMul_contract_indices(self.args)
+        args, indices, free, dum = TensorMul._tensMul_contract_indices(self.args)
 
         obj = self.func(*args)
         obj._indices = indices

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -39,7 +39,7 @@ class PartialDerivative(TensorExpr):
 
         # TODO: check that all variables have rank 1.
 
-        args, indices, free, dum = TensorMul._tensMul_contract_indices([expr] +
+        args, indices, free, dum = TensorMul._contract_indices([expr] +
             list(variables), replace_indices=True)
 
         obj = TensorExpr.__new__(cls, *args)
@@ -50,7 +50,7 @@ class PartialDerivative(TensorExpr):
         return obj
 
     def doit(self):
-        args, indices, free, dum = TensorMul._tensMul_contract_indices(self.args)
+        args, indices, free, dum = TensorMul._contract_indices(self.args)
 
         obj = self.func(*args)
         obj._indices = indices


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17508 

#### Brief description of what is fixed or changed
Trivial change of names.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- tensor
  - `TensExpr/Add/Mul` classes renamed to `TensorExpr/Add/Mul`
<!-- END RELEASE NOTES -->

#### Backwards Compatibility Breaks and Deprecations
- tensor
  -  `TensExpr/Add/Mul` classes renamed to `TensorExpr/Add/Mul`