### PR TITLE
Range accepts symbolic arguments

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -4,11 +4,11 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
+from sympy.core.numbers import oo, Integer
 from sympy.core.logic import fuzzy_or
-from sympy.core.numbers import oo
 from sympy.core.relational import Eq
 from sympy.core.singleton import Singleton, S
-from sympy.core.symbol import Dummy, symbols
+from sympy.core.symbol import Dummy, symbols, Symbol
 from sympy.core.sympify import _sympify, sympify, converter
 from sympy.logic.boolalg import And
 from sympy.sets.sets import (Set, Interval, Union, FiniteSet,
@@ -509,6 +509,26 @@ class Range(Set):
         >>> Range(3).intersect(Range(4, oo))
         EmptySet()
 
+    Range will accept symbolic arguments but has very limited support
+    for doing anything other than displaying the Range:
+
+        >>> from sympy import Symbol, pprint
+        >>> from sympy.abc import i, j, k
+        >>> Range(i, j, k).start
+        i
+        >>> Range(i, j, k).inf
+        Traceback (most recent call last):
+        ...
+        ValueError: invalid method for symbolic range
+
+    Better success will be had when using integer symbols:
+
+        >>> n = Symbol('n', integer=True)
+        >>> r = Range(n, n + 20, 3)
+        >>> r.inf
+        n
+        >>> pprint(r)
+        {n, n + 3, ..., n + 17}
     """
 
     is_iterable = True
@@ -517,7 +537,8 @@ class Range(Set):
         from sympy.functions.elementary.integers import ceiling
         if len(args) == 1:
             if isinstance(args[0], range if PY3 else xrange):
-                args = args[0].__reduce__()[1]  # use pickle method
+                raise TypeError(
+                    'use sympify(%s) to convert range to Range' % args[0])
 
         # expand range
         slc = slice(*args)
@@ -527,42 +548,53 @@ class Range(Set):
 
         start, stop, step = slc.start or 0, slc.stop, slc.step or 1
         try:
-            start, stop, step = [
-                w if w in [S.NegativeInfinity, S.Infinity]
-                else sympify(as_int(w))
-                for w in (start, stop, step)]
+            ok = []
+            for w in (start, stop, step):
+                w = sympify(w)
+                if w in [S.NegativeInfinity, S.Infinity] or (
+                        w.has(Symbol) and w.is_integer != False):
+                    ok.append(w)
+                elif not w.is_Integer:
+                    raise ValueError
+                else:
+                    ok.append(w)
         except ValueError:
             raise ValueError(filldedent('''
     Finite arguments to Range must be integers; `imageset` can define
     other cases, e.g. use `imageset(i, i/10, Range(3))` to give
     [0, 1/10, 1/5].'''))
+        start, stop, step = ok
 
-        if not step.is_Integer:
-            raise ValueError(filldedent('''
-    Ranges must have a literal integer step.'''))
-
-        if all(i.is_infinite for i in  (start, stop)):
+        null = False
+        if any(i.has(Symbol) for i in (start, stop, step)):
             if start == stop:
-                # canonical null handled below
-                start = stop = S.One
-            else:
-                raise ValueError(filldedent('''
-    Either the start or end value of the Range must be finite.'''))
-
-        if start.is_infinite:
-            if step*(stop - start) < 0:
-                start = stop = S.One
+                null = True
             else:
                 end = stop
-        if not start.is_infinite:
-            ref = start if start.is_finite else stop
-            n = ceiling((stop - ref)/step)
-            if n <= 0:
-                # null Range
-                start = end = S.Zero
-                step = S.One
+        elif start.is_infinite:
+            span = step*(stop - start)
+            if span is S.NaN or span <= 0:
+                null = True
+            elif step.is_Integer and stop.is_infinite and abs(step) != 1:
+                raise ValueError(filldedent('''
+                    Step size must be %s in this case.''' % (1 if step > 0 else -1)))
             else:
-                end = ref + n*step
+                end = stop
+        else:
+            oostep = step.is_infinite
+            if oostep:
+                step = S.One if step > 0 else S.NegativeOne
+            n = ceiling((stop - start)/step)
+            if n <= 0:
+                null = True
+            elif oostep:
+                end = start + 1
+                step = S.One  # make it a canonical single step
+            else:
+                end = start + n*step
+        if null:
+            start = end = S.Zero
+            step = S.One
         return Basic.__new__(cls, start, end, step)
 
     start = property(lambda self: self.args[0])
@@ -580,6 +612,8 @@ class Range(Set):
         >>> Range(10).reversed
         Range(9, -1, -1)
         """
+        if self.has(Symbol):
+            _ = self.size  # validate
         if not self:
             return self
         return self.func(
@@ -592,12 +626,19 @@ class Range(Set):
             return S.false
         if not other.is_integer:
             return other.is_integer
+        if self.has(Symbol):
+            try:
+                _ = self.size  # validate
+            except ValueError:
+                return  # XXX is this what _contains should return?
         ref = self.start if self.start.is_finite else self.stop
         if (ref - other) % self.step:  # off sequence
             return S.false
         return _sympify(other >= self.inf and other <= self.sup)
 
     def __iter__(self):
+        if self.has(Symbol):
+            _ = self.size  # validate
         if self.start in [S.NegativeInfinity, S.Infinity]:
             raise ValueError("Cannot iterate over Range with infinite start")
         elif self:
@@ -612,20 +653,23 @@ class Range(Set):
                 i += step
 
     def __len__(self):
-        if not self:
-            return 0
-        dif = self.stop - self.start
-        if dif.is_infinite:
-            raise ValueError(
-                "Use .size to get the length of an infinite Range")
-        return abs(dif//self.step)
+        rv = self.size
+        if rv is S.Infinity:
+            raise ValueError('Use .size to get the length of an infinite Range')
+        return rv
 
     @property
     def size(self):
-        try:
-            return _sympify(len(self))
-        except ValueError:
+        if not self:
+            return S.Zero
+        dif = self.stop - self.start
+        if self.has(Symbol):
+            if dif.has(Symbol) or self.step.has(Symbol) or (
+                    not self.start.is_integer and not self.stop.is_integer):
+                raise ValueError('invalid method for symbolic range')
+        if dif.is_infinite:
             return S.Infinity
+        return Integer(abs(dif//self.step))
 
     def __nonzero__(self):
         return self.start != self.stop
@@ -642,7 +686,7 @@ class Range(Set):
         ambiguous = "cannot unambiguously re-stride from the end " + \
             "with an infinite value"
         if isinstance(i, slice):
-            if self.size.is_finite:
+            if self.size.is_finite:  # validates, too
                 start, stop, step = i.indices(self.size)
                 n = ceiling((stop - start)/step)
                 if n <= 0:
@@ -740,9 +784,24 @@ class Range(Set):
             if not self:
                 raise IndexError('Range index out of range')
             if i == 0:
+                if self.start.is_infinite:
+                    raise ValueError(ooslice)
+                if self.has(Symbol):
+                    if (self.stop > self.start) == self.step.is_positive and self.step.is_positive is not None:
+                        pass
+                    else:
+                        _ = self.size  # validate
                 return self.start
-            if i == -1 or i is S.Infinity:
-                return self.stop - self.step
+            if i == -1:
+                if self.stop.is_infinite:
+                    raise ValueError(ooslice)
+                n = self.stop - self.step
+                if n.is_Integer or (
+                        n.is_integer and (
+                            (n - self.start).is_nonnegative ==
+                            self.step.is_positive)):
+                    return n
+            _ = self.size  # validate
             rv = (self.stop if i < 0 else self.start) + i*self.step
             if rv.is_infinite:
                 raise ValueError(ooslice)
@@ -754,6 +813,12 @@ class Range(Set):
     def _inf(self):
         if not self:
             raise NotImplementedError
+        if self.has(Symbol):
+            if self.step.is_positive:
+                return self[0]
+            elif self.step.is_negative:
+                return self[-1]
+            _ = self.size  # validate
         if self.step > 0:
             return self.start
         else:
@@ -763,6 +828,12 @@ class Range(Set):
     def _sup(self):
         if not self:
             raise NotImplementedError
+        if self.has(Symbol):
+            if self.step.is_positive:
+                return self[-1]
+            elif self.step.is_negative:
+                return self[0]
+            _ = self.size  # validate
         if self.step > 0:
             return self.stop - self.step
         else:
@@ -775,17 +846,17 @@ class Range(Set):
     def as_relational(self, x):
         """Rewrite a Range in terms of equalities and logic operators. """
         from sympy.functions.elementary.integers import floor
-        i = (x - (self.inf if self.inf.is_finite else self.sup))/self.step
         return And(
-            Eq(i, floor(i)),
+            Eq(x, floor(x)),
             x >= self.inf if self.inf in self else x > self.inf,
             x <= self.sup if self.sup in self else x < self.sup)
 
 
 if PY3:
-    converter[range] = Range
+    converter[range] = lambda r: Range(r.start, r.stop, r.step)
 else:
-    converter[xrange] = Range
+    converter[xrange] = lambda r: Range(*r.__reduce__()[1])
+
 
 def normalize_theta_set(theta):
     """

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -630,7 +630,7 @@ class Range(Set):
             try:
                 _ = self.size  # validate
             except ValueError:
-                return  # XXX is this what _contains should return?
+                return
         ref = self.start if self.start.is_finite else self.stop
         if (ref - other) % self.step:  # off sequence
             return S.false
@@ -656,7 +656,7 @@ class Range(Set):
         rv = self.size
         if rv is S.Infinity:
             raise ValueError('Use .size to get the length of an infinite Range')
-        return rv
+        return int(rv)
 
     @property
     def size(self):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -189,12 +189,14 @@ def test_Range_set():
     assert Range(-oo, 1, -1) == empty
     assert Range(1, oo, -1) == empty
     assert Range(1, -oo, 1) == empty
-    raises(ValueError, lambda: Range(1, 4, oo))
-    raises(ValueError, lambda: Range(-oo, oo))
-    raises(ValueError, lambda: Range(oo, -oo, -1))
+    assert Range(1, -4, oo) == empty
+    assert Range(1, -4, -oo) == Range(1, 2)
+    assert Range(1, 4, oo) == Range(1, 2)
+    assert Range(-oo, oo).size == oo
+    assert Range(oo, -oo, -1).size == oo
     raises(ValueError, lambda: Range(-oo, oo, 2))
-    raises(ValueError, lambda: Range(0, pi, 1))
-    raises(ValueError, lambda: Range(1, 10, 0))
+    raises(ValueError, lambda: Range(x, pi, y))
+    raises(ValueError, lambda: Range(x, y, 0))
 
     assert 5 in Range(0, oo, 5)
     assert -5 in Range(-oo, 0, 5)
@@ -204,13 +206,11 @@ def test_Range_set():
     u = symbols('u', integer=None)
     assert Range(oo).contains(u) is not False
     inf = symbols('inf', infinite=True)
-    assert inf not in Range(oo)
-    inf = symbols('inf', infinite=True)
-    assert inf not in Range(oo)
-    assert Range(0, oo, 2)[-1] == oo
+    assert inf not in Range(-oo, oo)
+    raises(ValueError, lambda: Range(0, oo, 2)[-1])
+    raises(ValueError, lambda: Range(0, -oo, -2)[-1])
     assert Range(-oo, 1, 1)[-1] is S.Zero
     assert Range(oo, 1, -1)[-1] == 2
-    assert Range(0, -oo, -2)[-1] == -oo
     assert Range(1, 10, 1)[-1] == 9
     assert all(i.is_Integer for i in Range(0, -1, 1))
 
@@ -221,7 +221,6 @@ def test_Range_set():
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals) == Range(1, 10, 1)
     assert Range(-1, 10, 1).intersect(S.Naturals0) == Range(0, 10, 1)
-
 
     # test slicing
     assert Range(1, 10, 1)[5] == 6
@@ -262,6 +261,7 @@ def test_Range_set():
     raises(ValueError, lambda: Range(oo, 0, -2)[:1:-1])
 
     # test empty Range
+    assert Range(x, x, y) == empty
     assert empty.reversed == empty
     assert 0 not in empty
     assert list(empty) == []
@@ -305,16 +305,67 @@ def test_Range_set():
     else:
         builtin_range = xrange
 
-    assert Range(builtin_range(10)) == Range(10)
-    assert Range(builtin_range(1, 10)) == Range(1, 10)
-    assert Range(builtin_range(1, 10, 2)) == Range(1, 10, 2)
+    raises(TypeError, lambda: Range(builtin_range(1)))
+    assert S(builtin_range(10)) == Range(10)
     if PY3:
-        assert Range(builtin_range(1000000000000)) == \
+        assert S(builtin_range(1000000000000)) == \
             Range(1000000000000)
 
     # test Range.as_relational
-    assert Range(1, 4).as_relational(x) == (x >= 1) & (x <= 3) & Eq(x - 1, floor(x) - 1)
-    assert Range(oo, 1, -2).as_relational(x) == (x >= 3) & (x < oo) & Eq((3 - x)/2, floor((3 - x)/2))
+    assert Range(1, 4).as_relational(x) == (x >= 1) & (x <= 3) & Eq(x, floor(x))
+    assert Range(oo, 1, -2).as_relational(x) == (x >= 3) & (x < oo) & Eq(x, floor(x))
+
+    # symbolic Range
+    sr = Range(x, y, t)
+    i = Symbol('i', integer=True)
+    ip = Symbol('i', integer=True, positive=True)
+    ir = Range(i, i + 20, 2)
+    # args
+    assert sr.args == (x, y, t)
+    assert ir.args == (i, i + 20, 2)
+    # reversed
+    raises(ValueError, lambda: sr.reversed)
+    assert ir.reversed == Range(i + 18, i - 2, -2)
+    # contains
+    assert inf not in sr
+    assert inf not in ir
+    assert .1 not in sr
+    assert .1 not in ir
+    assert i + 1 not in ir
+    assert i + 2 in ir
+    raises(TypeError, lambda: 1 in sr)  # XXX is this what contains is supposed to do?
+    # iter
+    raises(ValueError, lambda: next(iter(sr)))
+    assert next(iter(ir)) == i
+    assert sr.intersect(S.Integers) == sr
+    assert sr.intersect(FiniteSet(x)) == Intersection({x}, sr)
+    raises(ValueError, lambda: sr[:2])
+    raises(ValueError, lambda: sr[0])
+    raises(ValueError, lambda: sr.as_relational(x))
+    # len
+    assert len(ir) == ir.size == 10
+    raises(ValueError, lambda: len(sr))
+    raises(ValueError, lambda: sr.size)
+    # bool
+    assert bool(ir) == bool(sr) == True
+    # getitem
+    raises(ValueError, lambda: sr[0])
+    raises(ValueError, lambda: sr[-1])
+    raises(ValueError, lambda: sr[:2])
+    assert ir[:2] == Range(i, i + 4, 2)
+    assert ir[0] == i
+    assert ir[-2] == i + 16
+    assert ir[-1] == i + 18
+    raises(ValueError, lambda: Range(i)[-1])
+    assert Range(ip)[-1] == ip - 1
+    assert ir.inf == i
+    assert ir.sup == i + 18
+    assert Range(ip).inf == 0
+    assert Range(ip).sup == ip - 1
+    raises(ValueError, lambda: Range(i).inf)
+    raises(ValueError, lambda: sr.as_relational(x))
+    assert ir.as_relational(x) == (
+        x >= i) & Eq(x, floor(x)) & (x <= i + 18)
 
 
 def test_range_range_intersection():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #17146 as alternate
closes #16833
closes #17366

#### Brief description of what is fixed or changed

`Range` now accepts symbolic entries but raises ValueError if a unconditional result cannot be returned. e.g. `Range(x)[0]` is not 0 unless x is known to be a positive integer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * Range accepts symbolic arguments
    * an infinite step is allowed for Range
    * all integers can be represented with `Range(-oo, oo)`; for this Range, the step must be 1
    * `Range(range(3))` should now be written `sympify(range(3))`
<!-- END RELEASE NOTES -->
