### PR TITLE
Tensor substitute index implemented properly

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3980,26 +3980,10 @@ def perm2tensor(t, g, is_canon_bp=False):
     raise NotImplementedError()
 
 
-@deprecated(useinstead=".substitute_indices() instance method", issue=15276,
-            deprecated_since_version="1.5")
 def substitute_indices(t, *index_tuples):
     if not isinstance(t, TensExpr):
         return t
-    free = t.free
-    free1 = []
-    for j, ipos in free:
-        for i, v in index_tuples:
-            if i._name == j._name and i.tensor_index_type == j.tensor_index_type:
-                if i._is_up == j._is_up:
-                    free1.append((v, ipos))
-                else:
-                    free1.append((-v, ipos))
-                break
-        else:
-            free1.append((j, ipos))
-
-    t = TensMul.from_data(t.coeff, t.components, free1, t.dum)
-    return t
+    return t.substitute_indices(*index_tuples)
 
 
 def _expand(expr, **kwargs):

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -606,8 +606,6 @@ def test_add1():
     t2 = 1 + A(a, -a)
     assert t1 != t2
     assert t2 != TensMul.from_data(0, [], [], [])
-    t = p(i) + q(i)
-    raises(ValueError, lambda: t(i, j))
 
 
 def test_special_eq_ne():
@@ -701,7 +699,6 @@ def test_mul():
 
     t = A(-b, a)*B(-a, c)*A(-c, d)
     t1 = tensor_mul(*t.split())
-    assert t == t(-b, d)
     assert t == t1
     assert tensor_mul(*[]) == TensMul.from_data(S.One, [], [], [])
 
@@ -711,9 +708,8 @@ def test_mul():
     assert str(t) == '1'
     assert t == 1
     raises(ValueError, lambda: A(a, b)*A(a, c))
-    t = A(a, b)*A(-a, c)
-    raises(ValueError, lambda: t(a, b, c))
 
+@filter_warnings_decorator
 def test_substitute_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
@@ -1089,6 +1085,7 @@ def test_contract_delta1():
     t1 = t.contract_delta(delta)
     assert t1.equals(n**2 - 1)
 
+@filter_warnings_decorator
 def test_fun():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -1100,7 +1097,7 @@ def test_fun():
     assert t(a,b,c) == t
     assert canon_bp(t - t(b,a,c) - q(c)*p(a)*q(b) + q(c)*p(b)*q(a)) == 0
     assert t(b,c,d) == q(d)*p(b)*q(c) + g(b,c)*g(d,e)*q(-e)
-    t1 = t.fun_eval((a,b),(b,a))
+    t1 = t.substitute_indices((a,b),(b,a))
     assert canon_bp(t1 - q(c)*p(b)*q(a) - g(a,b)*g(c,d)*q(-d)) == 0
 
     # check that g_{a b; c} = 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17515 


#### Brief description of what is fixed or changed
Now `.substitute_indices()` is a single method for all tensor expressions for substituting indices. The `.fun_eval()` method is deprecated as having unclear name. The `__call__()` method for tensor expressions is also deprecated because it is dangerous.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- tensor
  - Extended `.substitute_indices()` method for all tensor expressions.
  - Deprecated `.fun_eval()` in favor of `.substitute_indices()`.
  - Deprecated `.__call__()` for all tensor expressions.

<!-- END RELEASE NOTES -->

#### Backwards compatibility breaks and deprecations
- tensor
  - Deprecated `.fun_eval()` in favor of `.substitute_indices()`.
  - Deprecated `.__call__()` for all tensor expressions.