### PR TITLE
Add sinc.rewrite(exp); update tsolve exp rewriting to avoid recursion errors

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -787,6 +787,10 @@ def test_sinc():
 
     assert sinc(x).rewrite(jn) == jn(0, x)
     assert sinc(x).rewrite(sin) == Piecewise((sin(x)/x, Ne(x, 0)), (1, True))
+    assert sinc(x).rewrite(exp) == Piecewise((-I*(exp(I*x) - exp(-I*x))/(2*x),
+                                              Ne(x, 0)), (1, True))
+    assert sinc(x**2).rewrite(exp) == Piecewise((-I*(exp(I*x**2) - exp(-I*x**2))/(2*x**2),
+                                                 Ne(x**2, 0)), (1, True))
 
 
 def test_asin():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -5,7 +5,7 @@ from sympy.core.basic import sympify, cacheit
 from sympy.core.compatibility import range
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_not, fuzzy_or
-from sympy.core.numbers import igcdex, Rational, pi
+from sympy.core.numbers import igcdex, Rational, pi, I
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
@@ -1886,6 +1886,11 @@ class sinc(Function):
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
         return Piecewise((sin(arg)/arg, Ne(arg, 0)), (1, True))
+
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
+        a = arg.doit()
+        return Piecewise((-I*(exp(I*a) - exp(-I*a))/(2*a),
+                                              Ne(a, 0)), (1, True))
 
 
 ###############################################################################

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2765,7 +2765,7 @@ def _tsolve(eq, sym, **flags):
             elif lhs.func == LambertW:
                 return _solve(lhs.args[0] - rhs*exp(rhs), sym, **flags)
 
-        rewrite = lhs.rewrite(exp)
+        rewrite = lhs.rewrite(exp).doit()
         if rewrite != lhs:
             return _solve(rewrite - rhs, sym, **flags)
     except NotImplementedError:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -5,7 +5,7 @@ from sympy import (
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
-    E, cbrt, denom, Add, Piecewise)
+    E, cbrt, denom, Add, Piecewise, sinc, zeta)
 
 from sympy.core.compatibility import range
 from sympy.core.function import nfloat
@@ -2111,3 +2111,23 @@ def test_issue_17452():
     assert solve((7**x)**x + pi, x) == [-sqrt(log(pi) + I*pi)/sqrt(log(7)),
                                         sqrt(log(pi) + I*pi)/sqrt(log(7))]
     assert solve(x**(x/11) + pi/11, x) == [exp(LambertW(-11*log(11) + 11*log(pi) + 11*I*pi))]
+
+
+def test_issue_17521():
+    assert solve(sinc(x), x) == [pi]
+    assert solve(sinc(x**2), x) == [-sqrt(pi), sqrt(pi)]
+    assert solve(sinc(x**3), x) == [pi**(S(1)/3),
+                                    pi**(S(1)/3)*(-1 + sqrt(3)*I)/2,
+                                    -pi**(S(1)/3)*(1 + sqrt(3)*I)/2]
+    assert solve(sinc(acos(x**E)), x) == [(-1)**exp(-1)]
+
+    raises(NotImplementedError, lambda: solve(zeta(x), x))
+    raises(NotImplementedError, lambda: solve(zeta(x**2), x))
+
+    xp = Symbol('xp', positive=True)
+    assert solve(sinc(xp), xp) == [pi]
+    assert solve(sinc(xp**2), xp) == [sqrt(pi)]
+    assert solve(sinc(xp**3), xp) == [pi**(S(1)/3)]
+
+    raises(NotImplementedError, lambda: solve(zeta(xp), xp))
+    raises(NotImplementedError, lambda: solve(zeta(xp ** 2), xp))


### PR DESCRIPTION
Closes #17521.

#### Brief description of what is fixed or changed
Add `sinc` rewriting method to `exp`. Previously `solve(sinc(x**2), x)` would be a recursion error. Add tests for rewriting and for solving this equation.

Call `.doit()` after rewriting to `exp` in `tsolve` to avoid recursion errors after variables have been through `posify`.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * sinc can be rewritten to exp
<!-- END RELEASE NOTES -->
