### PR TITLE
Improved handling of intersections involving FiniteSet

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -84,7 +84,9 @@ def test_not_empty_in():
     assert not_empty_in(FiniteSet((x**2 - 3*x + 2)/(x - 1)).intersect(S.Reals), x) == \
         Complement(S.Reals, FiniteSet(1))
     assert not_empty_in(FiniteSet(3, 4, x/(x - 1)).intersect(Interval(2, 3)), x) == \
-        Union(Interval(S(3)/2, 2), FiniteSet(3))
+        Interval(-oo, oo)
+    assert not_empty_in(FiniteSet(4, x/(x - 1)).intersect(Interval(2, 3)), x) == \
+        Interval(S(3)/2, 2)
     assert not_empty_in(FiniteSet(x/(x**2 - 1)).intersect(S.Reals), x) == \
         Complement(S.Reals, FiniteSet(-1, 1))
     assert not_empty_in(FiniteSet(x, x**2).intersect(Union(Interval(1, 3, True, True),

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -4,8 +4,8 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
+from sympy.core.logic import fuzzy_not, fuzzy_or
 from sympy.core.numbers import oo, Integer
-from sympy.core.logic import fuzzy_or
 from sympy.core.relational import Eq
 from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Dummy, symbols, Symbol
@@ -428,7 +428,7 @@ class ImageSet(Set):
                     if not dom:
                         # there is no solution in common
                         return False
-                return not isinstance(dom, Intersection)
+                return fuzzy_not(dom.is_empty)
         for soln in solns:
             try:
                 if soln in self.base_set:

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -425,7 +425,7 @@ class ImageSet(Set):
                     msgset = dom
                     other = e - o
                     dom = dom.intersection(solveset(e - o, x, domain=dom))
-                    if not dom:
+                    if dom.is_empty:
                         # there is no solution in common
                         return False
                 return fuzzy_not(dom.is_empty)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -370,9 +370,12 @@ class Set(Basic):
             s_o = self.intersect(other)
             if s_o == self:
                 return True
-            elif not isinstance(other, Intersection):
+            # This assumes that an unevaluated Intersection will always come
+            # back as an Intersection...
+            elif isinstance(s_o, Intersection):
+                return None
+            else:
                 return False
-            return s_o
         else:
             raise ValueError("Unknown argument '%s'" % other)
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -6,7 +6,7 @@ import inspect
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import (iterable, with_metaclass,
-    ordered, range, PY3, is_sequence)
+    ordered, range, PY3, is_sequence, reduce)
 from sympy.core.cache import cacheit
 from sympy.core.decorators import deprecated
 from sympy.core.evalf import EvalfMixin
@@ -1361,63 +1361,78 @@ class Intersection(Set, LatticeOp):
             binary=True)
         if not fs_args:
             return
-        fs_args.sort(key=len)
-        s = fs_args[0]
-        fs_args = fs_args[1:]
 
-        res = []
-        unk = []
-        for x in s:
-            c = fuzzy_and(fuzzy_bool(o.contains(x))
-                for o in fs_args + other)
-            if c:
-                res.append(x)
-            elif c is None:
-                unk.append(x)
+        # Convert to Python sets and build the set of all elements
+        fs_sets = [set(fs) for fs in fs_args]
+        all_elements = reduce(lambda a, b: a | b, fs_sets, set())
+
+        # Extract elements that are definitely in or definitely not in the
+        # intersection
+        definite = set()
+        for e in all_elements:
+            inall = fuzzy_and(s.contains(e) for s in args)
+            if inall is True:
+                definite.add(e)
+            if inall is not None:
+                for s in fs_sets:
+                    s.discard(e)
+
+        # At this point all elements in all of fs_sets are possibly in the
+        # intersection. In some cases this is because they are definitely in
+        # the intersection of the finite sets but it's not clear if they are
+        # members of other. We might have {m, n}, {m}, and Reals where we
+        # don't know if m or n is real. We want to remove n here but it is
+        # possibly in because it might be equal to m. So what we do now is
+        # extract the elements that are definitely in the remaining finite
+        # sets iteratively until none remain.
+        fs_elements = reduce(lambda a, b: a | b, fs_sets, set())
+        all_elements = fs_elements | definite # Used below
+        while fs_elements:
+            for e in fs_elements:
+                infs = fuzzy_and(FiniteSet(*s).contains(e) for s in fs_sets)
+                if infs is True:
+                    definite.add(e)
+                if infs is not None:
+                    for s in fs_sets:
+                        s.discard(e)
+                    fs_elements.remove(e)
+                    break
+            # If we completed the for loop without removing anything we are
+            # done so quit the outer while loop
             else:
-                pass  # drop arg
+                break
 
-        res = FiniteSet(
-            *res, evaluate=False) if res else S.EmptySet
-        if unk:
-            symbolic_s_list = [x for x in s if x.has(Symbol)]
-            non_symbolic_s = s - FiniteSet(
-                *symbolic_s_list, evaluate=False)
-            while fs_args:
-                v = fs_args.pop()
-                if all(i == j for i, j in zip_longest(
-                        symbolic_s_list,
-                        (x for x in v if x.has(Symbol)))):
-                    # all the symbolic elements of `v` are the same
-                    # as in `s` so remove the non-symbol containing
-                    # expressions from `unk`, since they cannot be
-                    # contained
-                    for x in non_symbolic_s:
-                        if x in unk:
-                            unk.remove(x)
-                else:
-                    # if only a subset of elements in `s` are
-                    # contained in `v` then remove them from `v`
-                    # and add this as a new arg
-                    contained = [x for x in symbolic_s_list
-                        if sympify(v.contains(x)) is S.true]
-                    if contained != symbolic_s_list:
-                        other.append(
-                            v - FiniteSet(
-                            *contained, evaluate=False))
-                    else:
-                        pass  # for coverage
+        # If any of the sets of remainder elements is empty then we discard
+        # all of them for the intersection.
+        if not all(fs_sets):
+            fs_sets = [set()]
 
-            other_sets = Intersection(*other)
-            if not other_sets:
-                return S.EmptySet  # b/c we use evaluate=False below
-            elif other_sets == S.UniversalSet:
-                res += FiniteSet(*unk)
+        if definite:
+            fs_sets = [fs | definite for fs in fs_sets]
+
+        if fs_sets == [set()]:
+            return S.EmptySet
+
+        sets = [FiniteSet(*s) for s in fs_sets]
+
+        # If all elements in the FiniteSets are in other then other isn't
+        # needed
+        allin = fuzzy_and(o.contains(e) for o in other for e in all_elements)
+        if allin is not True:
+            other = Intersection(*other)
+            if other is S.EmptySet:
+                return S.EmptySet
+            if other.is_Intersection:
+                sets.extend(other.args)
             else:
-                res += Intersection(
-                    FiniteSet(*unk),
-                    other_sets, evaluate=False)
-        return res
+                sets.append(other)
+
+        if len(sets) == 1:
+            return sets[0]
+        else:
+            return Intersection(*sets, evaluate=False)
+
+        return result
 
     def as_relational(self, symbol):
         """Rewrite an Intersection in terms of equalities and logic operators"""

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1432,8 +1432,6 @@ class Intersection(Set, LatticeOp):
         else:
             return Intersection(*sets, evaluate=False)
 
-        return result
-
     def as_relational(self, symbol):
         """Rewrite an Intersection in terms of equalities and logic operators"""
         return And(*[set.as_relational(symbol) for set in self.args])

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -346,6 +346,11 @@ def test_intersect1():
         Intersection(FiniteSet(2, 3, 4, 5, 6), Union(FiniteSet('ham'), Interval(0, 5)))
     assert Intersection(FiniteSet(1, 2, 3), Interval(2, x), Interval(3, y)) == \
         Intersection(FiniteSet(3), Interval(2, x), Interval(3, y), evaluate=False)
+    # XXX: Is the real=True necessary here?
+    # https://github.com/sympy/sympy/issues/17532
+    m, n = symbols('m, n', real=True)
+    assert Intersection(FiniteSet(m), FiniteSet(m, n), Interval(m, m+1)) == \
+        FiniteSet(m)
 
     # issue 8217
     assert Intersection(FiniteSet(x), FiniteSet(y)) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -346,6 +346,10 @@ def test_intersect1():
         Intersection(FiniteSet(2, 3, 4, 5, 6), Union(FiniteSet('ham'), Interval(0, 5)))
     assert Intersection(FiniteSet(1, 2, 3), Interval(2, x), Interval(3, y)) == \
         Intersection(FiniteSet(3), Interval(2, x), Interval(3, y), evaluate=False)
+    assert Intersection(FiniteSet(1, 2), Interval(0, 3), Interval(x, y)) == \
+        Intersection({1, 2}, Interval(x, y), evaluate=False)
+    assert Intersection(FiniteSet(1, 2, 4), Interval(0, 3), Interval(x, y)) == \
+        Intersection({1, 2}, Interval(x, y), evaluate=False)
     # XXX: Is the real=True necessary here?
     # https://github.com/sympy/sympy/issues/17532
     m, n = symbols('m, n', real=True)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -500,6 +500,10 @@ def test_is_subset():
     assert S.Naturals.is_subset(S.Integers)
     assert S.Naturals0.is_subset(S.Integers)
 
+    assert FiniteSet(x).is_subset(FiniteSet(y)) is None
+    assert FiniteSet(x).is_subset(FiniteSet(y).subs(y, x)) is True
+    assert FiniteSet(x).is_subset(FiniteSet(y).subs(y, x+1)) is False
+
 
 def test_is_proper_subset():
     assert Interval(0, 1).is_proper_subset(Interval(0, 2)) is True

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1025,7 +1025,6 @@ def test_issue_9637():
     assert Complement(a, Interval(1, 3)) == Complement(a, Interval(1, 3), evaluate=False)
 
 
-@XFAIL
 def test_issue_9808():
     # See https://github.com/sympy/sympy/issues/16342
     assert Complement(FiniteSet(y), FiniteSet(1)) == Complement(FiniteSet(y), FiniteSet(1), evaluate=False)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -22,6 +22,7 @@ def test_imageset():
     # issue 16878a
     r = symbols('r', real=True)
     assert imageset(x, (x, x), S.Reals)._contains((1, r)) == None
+    assert imageset(x, (x, x), S.Reals)._contains((1, 2)) == False
     assert (r, r) in imageset(x, (x, x), S.Reals)
     assert 1 + I in imageset(x, x + I, S.Reals)
     assert {1} not in imageset(x, (x,), S.Reals)
@@ -343,6 +344,8 @@ def test_intersect1():
         S.EmptySet
     assert Union(Interval(0, 5), FiniteSet('ham')).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
         Intersection(FiniteSet(2, 3, 4, 5, 6), Union(FiniteSet('ham'), Interval(0, 5)))
+    assert Intersection(FiniteSet(1, 2, 3), Interval(2, x), Interval(3, y)) == \
+        Intersection(FiniteSet(3), Interval(2, x), Interval(3, y), evaluate=False)
 
     # issue 8217
     assert Intersection(FiniteSet(x), FiniteSet(y)) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -21,7 +21,7 @@ def test_imageset():
     assert imageset(x, abs(x), S.Integers) is S.Naturals0
     # issue 16878a
     r = symbols('r', real=True)
-    assert (1, r) in imageset(x, (x, x), S.Reals) != False
+    assert imageset(x, (x, x), S.Reals)._contains((1, r)) == None
     assert (r, r) in imageset(x, (x, x), S.Reals)
     assert 1 + I in imageset(x, x + I, S.Reals)
     assert {1} not in imageset(x, (x,), S.Reals)
@@ -342,7 +342,7 @@ def test_intersect1():
     assert Union(Interval(0, 1), Interval(2, 3)).intersect(S.EmptySet) == \
         S.EmptySet
     assert Union(Interval(0, 5), FiniteSet('ham')).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
-        Union(FiniteSet(2, 3, 4, 5), Intersection(FiniteSet(6), Union(Interval(0, 5), FiniteSet('ham'))))
+        Intersection(FiniteSet(2, 3, 4, 5, 6), Union(FiniteSet('ham'), Interval(0, 5)))
 
     # issue 8217
     assert Intersection(FiniteSet(x), FiniteSet(y)) == \
@@ -1044,11 +1044,11 @@ def test_issue_Symbol_inter():
     assert Intersection(FiniteSet(1, m, n), FiniteSet(m, n, 2), i) == \
         Intersection(i, FiniteSet(m, n))
     assert Intersection(FiniteSet(m, n, x), FiniteSet(m, z), r) == \
-        Intersection(r, FiniteSet(m, z), FiniteSet(n, x))
+        Intersection(Intersection({m, z}, {m, n, x}), r)
     assert Intersection(FiniteSet(m, n, 3), FiniteSet(m, n, x), r) == \
-        Intersection(r, FiniteSet(3, m, n), evaluate=False)
+        Intersection(FiniteSet(3, m, n), FiniteSet(m, n, x), r, evaluate=False)
     assert Intersection(FiniteSet(m, n, 3), FiniteSet(m, n, 2, 3), r) == \
-        Union(FiniteSet(3), Intersection(r, FiniteSet(m, n)))
+        Intersection(FiniteSet(3, m, n), r)
     assert Intersection(r, FiniteSet(mat, 2, n), FiniteSet(0, mat, n)) == \
         Intersection(r, FiniteSet(n))
     assert Intersection(FiniteSet(sin(x), cos(x)), FiniteSet(sin(x), cos(x), 1), r) == \
@@ -1164,7 +1164,14 @@ def test_finite_set_intersection():
     assert Intersection._handle_finite_sets([FiniteSet(2, 3, x, y), FiniteSet(1, 2, x)]) == \
         Intersection._handle_finite_sets([FiniteSet(1, 2, x), FiniteSet(2, 3, x, y)]) == \
         Intersection(FiniteSet(1, 2, x), FiniteSet(2, 3, x, y)) == \
-        FiniteSet(1, 2, x)
+        Intersection(FiniteSet(1, 2, x), FiniteSet(2, x, y))
+
+    assert FiniteSet(1+x-y) & FiniteSet(1) == \
+        FiniteSet(1) & FiniteSet(1+x-y) == \
+        Intersection(FiniteSet(1+x-y), FiniteSet(1), evaluate=False)
+
+    assert FiniteSet(1) & FiniteSet(x) == FiniteSet(x) & FiniteSet(1) == \
+        Intersection(FiniteSet(1), FiniteSet(x), evaluate=False)
 
 
 def test_union_intersection_constructor():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -187,7 +187,15 @@ def test_issue_17479():
     fy = sb.diff(f, y)
     fz = sb.diff(f, z)
     sol = nonlinsolve([fx, fy, fz], [x, y, z])
-    assert len(sol) == 18
+    # FIXME: This previously gave 18 solutions and now gives 20 due to fixes
+    # in the handling of intersection of FiniteSets or possibly a small change
+    # to ImageSet._contains. However Using expand I can turn this into 16
+    # solutions either way:
+    #
+    #    >>> len(FiniteSet(*(Tuple(*(expand(w) for w in s)) for s in sol)))
+    #    16
+    #
+    assert len(sol) == 20
 
 
 def test_is_function_class_equation():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -74,13 +74,13 @@ def test_B1():
 
 
 def test_B2():
-    a, b, c = FiniteSet(j), FiniteSet(m), FiniteSet(j, k)
-    d, e = FiniteSet(i), FiniteSet(j, k, l)
-
     assert (FiniteSet(i, j, j, k, k, k) & FiniteSet(l, k, j) &
-            FiniteSet(j, m, j)) == Union(a, Intersection(b, Union(c, Intersection(d, FiniteSet(l)))))
-    # {j} U Intersection({m}, {j, k} U Intersection({i}, {l}))
-
+            FiniteSet(j, m, j)) == Intersection({j, m}, {i, j, k}, {j, k, l})
+    # Previous output below. Not sure why that should be the expected output.
+    # There should probably be a way to rewrite Intersections that way but I
+    # don't see why an Intersection should evaluate like that:
+    #
+    # == Union({j}, Intersection({m}, Union({j, k}, Intersection({i}, {l}))))
 
 
 def test_B3():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16953
Fixes #16342

#### Brief description of what is fixed or changed

New algorithm for calculating intersections involving FiniteSets. The previous algorithm wasn't reliable at handling elements with unknown set membership (e.g. symbols) and also changed the form of the output more than necessary in some cases.

Before:
```julia
In [1]: FiniteSet(1) & FiniteSet(x)
Out[1]: {1}
```
With this PR:
```julia
In [1]: FiniteSet(1) & FiniteSet(x)
Out[1]: {1} ∩ {x}

In [2]: s = FiniteSet(1) & FiniteSet(x)

In [3]: s.subs(x, 1)
Out[3]: {1}

In [4]: s.subs(x, 2)
Out[4]: ∅
```

Other changes can be seen from the tests e.g. on master:
```julia
In [2]: from sympy.abc import m,n,x,z

In [3]: Intersection(FiniteSet(m, n, x), FiniteSet(m, z), S.Reals)
Out[3]: {m, z} ∩ ℝ ∩ {n, x}

In [4]: _.subs(z, m+1).subs(n, m+2).subs(x, m+3)
Out[4]: ∅
```
Whereas with the PR:
```julia
In [1]: from sympy.abc import m,n,x,z

In [2]: Intersection(FiniteSet(m, n, x), FiniteSet(m, z), S.Reals)
Out[2]: ℝ ∩ {m, z} ∩ {m, n, x}

In [3]: _.subs(z, m+1).subs(n, m+2).subs(x, m+3)
Out[3]: ℝ ∩ {m}
```

#### Other comments

There is a recently added test in test_solveset.py that is changed under this PR. I don't think that either the previous or the current answer tested is entirely correct (comments in the code).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * Improved handling of intersections involving FiniteSets. Evaluation will only occur when it is generally valid and the result will always return as an Intersection when not fully evaluated.
    * Set.is_subset now returns True, False or None (previously an Intersection was returned instead of None).
    * FiniteSet._eval_Eq is fixed so that it doesn't evaluate when not possible due to arbitrary symbols in the elements (e.g. Eq(FiniteSet(x, y), FiniteSet(x))).
<!-- END RELEASE NOTES -->
