### PR TITLE
powsimp correctly handles sign extraction from signed base

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -213,44 +213,47 @@ class Order(Expr):
                 # expand()'ed expr (handled in "if expr.is_Add" branch below).
                 expr = expr.expand()
 
-            if expr.is_Add:
-                lst = expr.extract_leading_order(args)
-                expr = Add(*[f.expr for (e, f) in lst])
+            old_expr = None
+            while old_expr != expr:
+                old_expr = expr
+                if expr.is_Add:
+                    lst = expr.extract_leading_order(args)
+                    expr = Add(*[f.expr for (e, f) in lst])
 
-            elif expr:
-                expr = expr.as_leading_term(*args)
-                expr = expr.as_independent(*args, as_Add=False)[1]
+                elif expr:
+                    expr = expr.as_leading_term(*args)
+                    expr = expr.as_independent(*args, as_Add=False)[1]
 
-                expr = expand_power_base(expr)
-                expr = expand_log(expr)
+                    expr = expand_power_base(expr)
+                    expr = expand_log(expr)
 
-                if len(args) == 1:
-                    # The definition of O(f(x)) symbol explicitly stated that
-                    # the argument of f(x) is irrelevant.  That's why we can
-                    # combine some power exponents (only "on top" of the
-                    # expression tree for f(x)), e.g.:
-                    # x**p * (-x)**q -> x**(p+q) for real p, q.
-                    x = args[0]
-                    margs = list(Mul.make_args(
-                        expr.as_independent(x, as_Add=False)[1]))
+                    if len(args) == 1:
+                        # The definition of O(f(x)) symbol explicitly stated that
+                        # the argument of f(x) is irrelevant.  That's why we can
+                        # combine some power exponents (only "on top" of the
+                        # expression tree for f(x)), e.g.:
+                        # x**p * (-x)**q -> x**(p+q) for real p, q.
+                        x = args[0]
+                        margs = list(Mul.make_args(
+                            expr.as_independent(x, as_Add=False)[1]))
 
-                    for i, t in enumerate(margs):
-                        if t.is_Pow:
-                            b, q = t.args
-                            if b in (x, -x) and q.is_real and not q.has(x):
-                                margs[i] = x**q
-                            elif b.is_Pow and not b.exp.has(x):
-                                b, r = b.args
-                                if b in (x, -x) and r.is_real:
-                                    margs[i] = x**(r*q)
-                            elif b.is_Mul and b.args[0] is S.NegativeOne:
-                                b = -b
-                                if b.is_Pow and not b.exp.has(x):
+                        for i, t in enumerate(margs):
+                            if t.is_Pow:
+                                b, q = t.args
+                                if b in (x, -x) and q.is_real and not q.has(x):
+                                    margs[i] = x**q
+                                elif b.is_Pow and not b.exp.has(x):
                                     b, r = b.args
                                     if b in (x, -x) and r.is_real:
                                         margs[i] = x**(r*q)
+                                elif b.is_Mul and b.args[0] is S.NegativeOne:
+                                    b = -b
+                                    if b.is_Pow and not b.exp.has(x):
+                                        b, r = b.args
+                                        if b in (x, -x) and r.is_real:
+                                            margs[i] = x**(r*q)
 
-                    expr = Mul(*margs)
+                        expr = Mul(*margs)
 
             expr = expr.subs(rs)
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -88,7 +88,9 @@ def test_simple_8():
     assert O(x**2*sqrt(x)) == O(x**(S(5)/2))
     assert O(x**3*sqrt(-(-x)**3)) == O(x**(S(9)/2))
     assert O(x**(S(3)/2)*sqrt((-x)**3)) == O(x**3)
-    assert O(x*(-2*x)**(I/2)) == O(x*(-x)**(I/2))
+    # not sure why the first doesn't become the 3rd without
+    # iteration in the Order.__new__ routine.
+    assert O(x*(-2*x)**(I/2)) == O(x*(-x)**(I/2)) == O((-x)**(1 + I/2))
 
 
 def test_as_expr_variables():

--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -12,18 +12,19 @@ from sympy.utilities.iterables import default_sort_key
 def sub_pre(e):
     """ Replace y - x with -(x - y) if -1 can be extracted from y - x.
     """
-    reps = [a for a in e.atoms(Add) if a.could_extract_minus_sign()]
+    # replacing Add, A, from which -1 can be extracted with -1*-A
+    adds = [a for a in e.atoms(Add) if a.could_extract_minus_sign()]
+    reps = dict((a, Mul._from_args([S.NegativeOne, -a])) for a in adds)
+    e = e.xreplace(reps)
 
-    # make it canonical
-    reps.sort(key=default_sort_key)
-
-    e = e.xreplace(dict((a, Mul._from_args([S.NegativeOne, -a])) for a in reps))
     # repeat again for persisting Adds but mark these with a leading 1, -1
     # e.g. y - x -> 1*-1*(x - y)
     if isinstance(e, Basic):
         negs = {}
         for a in sorted(e.atoms(Add), key=default_sort_key):
-            if a in reps or a.could_extract_minus_sign():
+            if a in reps:
+                negs[a] = reps[a]
+            elif a.could_extract_minus_sign():
                 negs[a] = Mul._from_args([S.One, S.NegativeOne, -a])
         e = e.xreplace(negs)
     return e

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -202,7 +202,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         be = list(c_powers.items())
         _n = S.NegativeOne
         for b, e in be:
-            if (b.is_Symbol or b.is_Add) and -b in c_powers:
+            if (b.is_Symbol or b.is_Add) and -b in c_powers and b in c_powers:
                 if (b.is_positive is not None or e.is_integer):
                     if e.is_integer or b.is_negative:
                         c_powers[-b] += c_powers.pop(b)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -201,10 +201,14 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         # check for base and negated base pairs
         be = list(c_powers.items())
         _n = S.NegativeOne
-        for i, (b, e) in enumerate(be):
-            if ((-b).is_Symbol or b.is_Add) and -b in c_powers:
-                if (b.is_positive in (0, 1) or e.is_integer):
-                    c_powers[-b] += c_powers.pop(b)
+        for b, e in be:
+            if (b.is_Symbol or b.is_Add) and -b in c_powers:
+                if (b.is_positive is not None or e.is_integer):
+                    if e.is_integer or b.is_negative:
+                        c_powers[-b] += c_powers.pop(b)
+                    else:  # (-b).is_positive so use its e
+                        e = c_powers.pop(-b)
+                        c_powers[b] += e
                     if _n in c_powers:
                         c_powers[_n] += e
                     else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #17524 

#### Brief description of what is fixed or changed

During base combination in `powsimp` the exponent corresponding to the base being removed from `c_powers` is now being used. A base raised to an integer power can always add to `(-base)**x` as can a positive base raised to any power. In these cases base `b` and exponent `e` are used.

When a base is negative then the negated base (which is positive) and *its* exponent is used.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
