### PR TITLE
allow And/Or.subs to short-circuit

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -679,6 +679,25 @@ class And(LatticeOp, BooleanFunction):
             newargs.append(x)
         return LatticeOp._new_args_filter(newargs, And)
 
+    def _eval_subs(self, old, new):
+        args = []
+        bad = None
+        for i in self.args:
+            try:
+                i = i.subs(old, new)
+            except:  # store any problem
+                if bad is None:
+                    bad = i
+                continue
+            if i == False:
+                return S.false
+            elif i != True:
+                args.append(i)
+        if bad is not None:
+            # let it raise
+            bad.subs(old, new)
+        return self.func(*args)
+
     def _eval_simplify(self, **kwargs):
         from sympy.core.relational import Equality, Relational
         from sympy.solvers.solveset import linear_coeffs
@@ -796,6 +815,25 @@ class Or(LatticeOp, BooleanFunction):
                 rel.append(c)
             newargs.append(x)
         return LatticeOp._new_args_filter(newargs, Or)
+
+    def _eval_subs(self, old, new):
+        args = []
+        bad = None
+        for i in self.args:
+            try:
+                i = i.subs(old, new)
+            except:  # store any problem
+                if bad is None:
+                    bad = i
+                continue
+            if i == True:
+                return S.true
+            elif i != False:
+                args.append(i)
+        if bad is not None:
+            # let it raise
+            bad.subs(old, new)
+        return self.func(*args)
 
     def _eval_as_set(self):
         from sympy.sets.sets import Union

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -685,7 +685,8 @@ class And(LatticeOp, BooleanFunction):
         for i in self.args:
             try:
                 i = i.subs(old, new)
-            except:  # store any problem
+            except TypeError:
+                # store TypeError
                 if bad is None:
                     bad = i
                 continue
@@ -822,7 +823,8 @@ class Or(LatticeOp, BooleanFunction):
         for i in self.args:
             try:
                 i = i.subs(old, new)
-            except:  # store any problem
+            except TypeError:
+                # store TypeError
                 if bad is None:
                     bad = i
                 continue

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1079,3 +1079,12 @@ def test_issue_16803():
     # No simplification done, but should not raise an exception
     assert ((n > 3) | (n < 0) | ((n > 0) & (n < 3))).simplify() == \
         ((n > 3) | (n < 0) | ((n > 0) & (n < 3)))
+
+
+def test_issue_17530():
+    r = {x: oo, y: oo}
+    assert Or(x + y > 0, x - y < 0).subs(r)
+    assert not And(x + y < 0, x - y < 0).subs(r)
+    raises(TypeError, lambda: Or(x + y < 0, x - y < 0).subs(r))
+    raises(TypeError, lambda: And(x + y > 0, x - y < 0).subs(r))
+    raises(TypeError, lambda: And(x + y > 0, x - y < 0).subs(r))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #17530

#### Brief description of what is fixed or changed

When And or Or can evaluate during substitution they are allowed to do so and any args that would generate an error are ignored unless the substitution doesn't short-circuit -- then the error is raised.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
    * And/Or will supress errors if evaluation of other args during subs gives False/True
<!-- END RELEASE NOTES -->
