### PR TITLE
Eq(a, b) is not True when a and b are unsigned infinite values

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -524,6 +524,19 @@ class Add(Expr, AssocOp):
     _eval_is_commutative = lambda self: _fuzzy_group(
         a.is_commutative for a in self.args)
 
+    def _eval_is_infinite(self):
+        sawinf = False
+        for a in self.args:
+            ainf = a.is_infinite
+            if ainf is None:
+                return None
+            elif ainf is True:
+                # infinite+infinite might not be infinite
+                if sawinf is True:
+                    return None
+                sawinf = True
+        return sawinf
+
     def _eval_is_imaginary(self):
         nz = []
         im_I = []

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -189,6 +189,27 @@ def fuzzy_or(args):
     return fuzzy_not(fuzzy_and(fuzzy_not(i) for i in args))
 
 
+def fuzzy_xor(args):
+    """Return None if any element of args is not True or False, else
+    True (if there are an odd number of True elements), else False."""
+    t = f = 0
+    for a in args:
+        ai = fuzzy_bool(a)
+        if ai:
+            t += 1
+        elif ai is False:
+            f += 1
+        else:
+            return
+    return t % 2 == 1
+
+
+def fuzzy_nand(args):
+    """Return False if all args are True, True if they are all False,
+    else None."""
+    return fuzzy_not(fuzzy_and(args))
+
+
 class Logic(object):
     """Logical expression"""
     # {} 'op' -> LogicClass

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1401,6 +1401,9 @@ class Mul(Expr, AssocOp):
                 saw_NON = True
             elif t.is_extended_nonnegative:
                 saw_NON = True
+            # FIXME: is_positive/is_negative is False doesn't take account of
+            # Symbol('x', infinite=True, extended_real=True) which has
+            # e.g. is_positive is False but has uncertain sign.
             elif t.is_positive is False:
                 sign = -sign
                 if saw_NOT:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1401,7 +1401,7 @@ class Mul(Expr, AssocOp):
                 saw_NON = True
             elif t.is_extended_nonnegative:
                 saw_NON = True
-            # FIXME: is_positive/is_negative is False doesn't take account of
+            # FIXME: is_positive/is_negative is False doesn't take account of
             # Symbol('x', infinite=True, extended_real=True) which has
             # e.g. is_positive is False but has uncertain sign.
             elif t.is_positive is False:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -456,7 +456,7 @@ class Equality(Relational):
     def __new__(cls, lhs, rhs=None, **options):
         from sympy.core.add import Add
         from sympy.core.containers import Tuple
-        from sympy.core.logic import fuzzy_bool, fuzzy_xor, fuzzy_and
+        from sympy.core.logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
         from sympy.core.expr import _n2
         from sympy.simplify.simplify import clear_coefficients
         from sympy.utilities.iterables import sift
@@ -495,43 +495,30 @@ class Equality(Relational):
                     isinstance(rhs, Boolean)):
                 return S.false  # only Booleans can equal Booleans
 
-            # if anything is infinite in an expression, the finite
-            # terms will not matter because the result will be
-            # nan or infinite
-            def isinf(e):
-                s = sift(Add.make_args(e), lambda x: x.is_infinite)
-                for i in s:
-                    s[i] = Add(*s[i])
-                return {i:s.get(i, S.Zero) for i in (True, False, None)}
-            L = isinf(lhs)
-            R = isinf(rhs)
-            if L[1] or R[1]:  # there is an infinite value
-                if not L[None] and not R[None]:  # nothing is unknown
-                    inf = L[1], R[1]
-                    if fuzzy_xor(map(bool, inf)):
-                        return S.false  # one side is not infinite
-                    if L[1] == -R[1]:
-                        return S.false  # inf != -inf
-                    if S.ComplexInfinity in inf:
-                        return S.false  # zoo only equals zoo
-                    xreal = [i.is_extended_real for i in inf]
-                    xor = fuzzy_xor(xreal)
-                    if xor:
-                        return S.false  # one is real and the other not
-                    if xor is not None:
-                        # extended_real for both is True or False
-                        if xreal[0] is False:
-                            xreal = [(S.ImaginaryUnit*i).is_extended_real for i in inf]
-                        if fuzzy_and(xreal):  # both infinite parts same wrt real
-                            xpos = [i.is_extended_positive for i in inf]
-                            xor = fuzzy_xor(xpos)
-                            if xor:
-                                return S.false
-                            if xor is not None:
-                                # infinite parts match
-                                real = Eq(L[0], R[0])
-                                if real is not None:
-                                    return real
+            if lhs.is_infinite or rhs.is_infinite:
+                if fuzzy_xor([lhs.is_infinite, rhs.is_infinite]):
+                    return S.false
+                if fuzzy_xor([lhs.is_extended_real, rhs.is_extended_real]):
+                    return S.false
+                if fuzzy_and([lhs.is_extended_real, rhs.is_extended_real]):
+                    r = fuzzy_xor([lhs.is_extended_positive, fuzzy_not(rhs.is_extended_positive)])
+                    return S(r)
+
+                # Try to split real/imaginary parts and equate them
+                def split_real_imag(expr):
+                    return sift(Add.make_args(expr), lambda a:a.is_extended_real)
+
+                lhs_ri = split_real_imag(lhs)
+                if not lhs_ri[None]:
+                    rhs_ri = split_real_imag(rhs)
+                    if not rhs_ri[None]:
+                        I = S.ImaginaryUnit
+                        eq_real = Eq(Add(*lhs_ri[True]), Add(*rhs_ri[True]))
+                        eq_imag = Eq(I*Add(*lhs_ri[False]), I*Add(*rhs_ri[False]))
+                        res = fuzzy_and(map(fuzzy_bool, [eq_real, eq_imag]))
+                        if res is not None:
+                            return S(res)
+
                 return Relational.__new__(cls, lhs, rhs, **options)
 
             if all(isinstance(i, Expr) for i in (lhs, rhs)):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -458,6 +458,7 @@ class Equality(Relational):
         from sympy.core.containers import Tuple
         from sympy.core.logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
         from sympy.core.expr import _n2
+        from sympy.functions.elementary.complexes import arg
         from sympy.simplify.simplify import clear_coefficients
         from sympy.utilities.iterables import sift
 
@@ -522,6 +523,15 @@ class Equality(Relational):
                         res = fuzzy_and(map(fuzzy_bool, [eq_real, eq_imag]))
                         if res is not None:
                             return S(res)
+
+                # Compare e.g. zoo with 1+I*oo by comparing args
+                arglhs = arg(lhs)
+                argrhs = arg(rhs)
+                # Guard against Eq(nan, nan) -> False
+                if not (arglhs == S.NaN and argrhs == S.NaN):
+                    res = fuzzy_bool(Eq(arglhs, argrhs))
+                    if res is not None:
+                        return S(res)
 
                 return Relational.__new__(cls, lhs, rhs, **options)
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -505,16 +505,20 @@ class Equality(Relational):
                     return S(r)
 
                 # Try to split real/imaginary parts and equate them
+                I = S.ImaginaryUnit
+
                 def split_real_imag(expr):
-                    return sift(Add.make_args(expr), lambda a:a.is_extended_real)
+                    real_imag = lambda t: (
+                            'real' if t.is_extended_real else
+                            'imag' if (I*t).is_extended_real else None)
+                    return sift(Add.make_args(expr), real_imag)
 
                 lhs_ri = split_real_imag(lhs)
                 if not lhs_ri[None]:
                     rhs_ri = split_real_imag(rhs)
                     if not rhs_ri[None]:
-                        I = S.ImaginaryUnit
-                        eq_real = Eq(Add(*lhs_ri[True]), Add(*rhs_ri[True]))
-                        eq_imag = Eq(I*Add(*lhs_ri[False]), I*Add(*rhs_ri[False]))
+                        eq_real = Eq(Add(*lhs_ri['real']), Add(*rhs_ri['real']))
+                        eq_imag = Eq(I*Add(*lhs_ri['imag']), I*Add(*rhs_ri['imag']))
                         res = fuzzy_and(map(fuzzy_bool, [eq_real, eq_imag]))
                         if res is not None:
                             return S(res)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -465,6 +465,12 @@ def test_symbol_falsepositive_mul():
     assert x.is_nonzero is None
 
 
+@XFAIL
+def test_symbol_infinitereal_mul():
+    ix = Symbol('ix', infinite=True, extended_real=True)
+    assert (-ix).is_extended_positive is None
+
+
 def test_neg_symbol_falsepositive():
     x = -Symbol('x', positive=False)
     assert x.is_positive is None

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -928,6 +928,37 @@ def test_Mul_is_infinite():
     assert Mul(0, i, evaluate=False).is_infinite is S.NaN.is_infinite
 
 
+def test_Add_is_infinite():
+    x = Symbol('x')
+    f = Symbol('f', finite=True)
+    i = Symbol('i', infinite=True)
+    i2 = Symbol('i2', infinite=True)
+    z = Dummy(zero=True)
+    nzf = Dummy(finite=True, zero=False)
+    from sympy import Add
+    assert (x+f).is_finite is None
+    assert (x+i).is_finite is None
+    assert (f+i).is_finite is False
+    assert (x+f+i).is_finite is None
+    assert (z+i).is_finite is False
+    assert (nzf+i).is_finite is False
+    assert (z+f).is_finite is True
+    assert (i+i2).is_finite is None
+    assert Add(0, f, evaluate=False).is_finite is True
+    assert Add(0, i, evaluate=False).is_finite is False
+
+    assert (x+f).is_infinite is None
+    assert (x+i).is_infinite is None
+    assert (f+i).is_infinite is True
+    assert (x+f+i).is_infinite is None
+    assert (z+i).is_infinite is True
+    assert (nzf+i).is_infinite is True
+    assert (z+f).is_infinite is False
+    assert (i+i2).is_infinite is None
+    assert Add(0, f, evaluate=False).is_infinite is False
+    assert Add(0, i, evaluate=False).is_infinite is True
+
+
 def test_special_is_rational():
     i = Symbol('i', integer=True)
     i2 = Symbol('i2', integer=True)

--- a/sympy/core/tests/test_logic.py
+++ b/sympy/core/tests/test_logic.py
@@ -197,4 +197,3 @@ def test_fuzzy_xor():
 def test_fuzzy_nand():
     for args in [(1, 0), (1, 1), (0, 0)]:
         assert fuzzy_nand(args) == fuzzy_not(fuzzy_and(args))
-

--- a/sympy/core/tests/test_logic.py
+++ b/sympy/core/tests/test_logic.py
@@ -1,6 +1,6 @@
 from sympy.core.compatibility import PY3
 from sympy.core.logic import (fuzzy_not, Logic, And, Or, Not, fuzzy_and,
-                              fuzzy_or, _fuzzy_group, _torf)
+    fuzzy_or, _fuzzy_group, _torf, fuzzy_nand, fuzzy_xor)
 from sympy.utilities.pytest import raises
 
 T = True
@@ -183,3 +183,18 @@ def test_formatting():
     raises(ValueError, lambda: S('a&b'))
     raises(ValueError, lambda: S('a|b'))
     raises(ValueError, lambda: S('! a'))
+
+
+def test_fuzzy_xor():
+    assert fuzzy_xor((None,)) is None
+    assert fuzzy_xor((None, True)) is None
+    assert fuzzy_xor((None, False)) is None
+    assert fuzzy_xor((True, False)) is True
+    assert fuzzy_xor((True, True)) is False
+    assert fuzzy_xor((True, True, False)) is False
+    assert fuzzy_xor((True, True, False, True)) is True
+
+def test_fuzzy_nand():
+    for args in [(1, 0), (1, 1), (0, 0)]:
+        assert fuzzy_nand(args) == fuzzy_not(fuzzy_and(args))
+

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -786,6 +786,11 @@ def test_issue_10401():
     fin = symbols('inf', finite=True)
     inf = symbols('inf', infinite=True)
     inf2 = symbols('inf2', infinite=True)
+    infx = symbols('infx', infinite=True, extended_real=True)
+    infnx = symbols('inf~x', infinite=True, extended_real=False)
+    infp = symbols('infp', infinite=True, extended_positive=True)
+    infp1 = symbols('infp1', infinite=True, extended_positive=True)
+    infn = symbols('infn', infinite=True, extended_negative=True)
     zero = symbols('z', zero=True)
     nonzero = symbols('nz', zero=False, finite=True)
 
@@ -795,7 +800,19 @@ def test_issue_10401():
 
     T, F = S.true, S.false
     assert Eq(fin, inf) is F
-    assert Eq(inf, inf2) is T and inf != inf2
+    assert Eq(inf, inf2) not in (T, F) and inf != inf2
+    assert Eq(1 + inf, 2 + inf2) not in (T, F) and inf != inf2
+    assert Eq(infp, infp1) is T
+    assert Eq(infp, infn) is F
+    assert Eq(1 + I*oo, 2 + I*oo) is F
+    assert Eq(1 + I*oo, 2 + I*infx) is F
+    assert Eq(1 + I*oo, 2 + infx) is F
+    assert Eq(zoo, sqrt(2) + I*oo) is F
+    r = Symbol('r', real=True)
+    i = Symbol('i', imaginary=True)
+    assert Eq(i*I, r) not in (T, F)
+    assert Eq(infx, infnx) is F
+    assert Eq(zoo, oo) is F
     assert Eq(inf/inf2, 0) is F
     assert Eq(inf/fin, 0) is F
     assert Eq(fin/inf, 0) is T

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -787,6 +787,7 @@ def test_issue_10401():
     inf = symbols('inf', infinite=True)
     inf2 = symbols('inf2', infinite=True)
     infx = symbols('infx', infinite=True, extended_real=True)
+    infx2 = symbols('infx2', infinite=True, extended_real=True)
     infnx = symbols('inf~x', infinite=True, extended_real=False)
     infp = symbols('infp', infinite=True, extended_positive=True)
     infp1 = symbols('infp1', infinite=True, extended_positive=True)
@@ -804,10 +805,19 @@ def test_issue_10401():
     assert Eq(1 + inf, 2 + inf2) not in (T, F) and inf != inf2
     assert Eq(infp, infp1) is T
     assert Eq(infp, infn) is F
+    assert Eq(1 + I*oo, I*oo) is F
+    assert Eq(I*oo, 1 + I*oo) is F
     assert Eq(1 + I*oo, 2 + I*oo) is F
     assert Eq(1 + I*oo, 2 + I*infx) is F
     assert Eq(1 + I*oo, 2 + infx) is F
-    assert Eq(zoo, sqrt(2) + I*oo) is F
+    # FIXME: The test below fails because (-infx).is_extended_positive is True
+    # (should be None)
+    #assert Eq(1 + I*infx, 1 + I*infx2) not in (T, F) and infx != infx2
+    #
+    # Maybe the test below should work but it isn't clear what the
+    # relationship should be between zoo and any other complex infinity.
+    #assert Eq(zoo, sqrt(2) + I*oo) is F
+    assert Eq(zoo, oo) is F
     r = Symbol('r', real=True)
     i = Symbol('i', imaginary=True)
     assert Eq(i*I, r) not in (T, F)
@@ -817,7 +827,9 @@ def test_issue_10401():
     assert Eq(inf/fin, 0) is F
     assert Eq(fin/inf, 0) is T
     assert Eq(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
-    assert Eq(inf, -inf) is F
+    # The commented out test below is incorrect because:
+    assert zoo == -zoo
+    #assert Eq(inf, -inf) is F
 
     assert Eq(fin/(fin + 1), 1) is S.false
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -789,6 +789,7 @@ def test_issue_10401():
     infx = symbols('infx', infinite=True, extended_real=True)
     infx2 = symbols('infx2', infinite=True, extended_real=True)
     infnx = symbols('inf~x', infinite=True, extended_real=False)
+    infnx2 = symbols('inf~x2', infinite=True, extended_real=False)
     infp = symbols('infp', infinite=True, extended_positive=True)
     infp1 = symbols('infp1', infinite=True, extended_positive=True)
     infn = symbols('infn', infinite=True, extended_negative=True)
@@ -822,6 +823,7 @@ def test_issue_10401():
     i = Symbol('i', imaginary=True)
     assert Eq(i*I, r) not in (T, F)
     assert Eq(infx, infnx) is F
+    assert Eq(infnx, infnx2) not in (T, F) and infnx != infnx2
     assert Eq(zoo, oo) is F
     assert Eq(inf/inf2, 0) is F
     assert Eq(inf/fin, 0) is F

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -815,9 +815,7 @@ def test_issue_10401():
     # (should be None)
     #assert Eq(1 + I*infx, 1 + I*infx2) not in (T, F) and infx != infx2
     #
-    # Maybe the test below should work but it isn't clear what the
-    # relationship should be between zoo and any other complex infinity.
-    #assert Eq(zoo, sqrt(2) + I*oo) is F
+    assert Eq(zoo, sqrt(2) + I*oo) is F
     assert Eq(zoo, oo) is F
     r = Symbol('r', real=True)
     i = Symbol('i', imaginary=True)
@@ -831,7 +829,9 @@ def test_issue_10401():
     assert Eq(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
     # The commented out test below is incorrect because:
     assert zoo == -zoo
-    #assert Eq(inf, -inf) is F
+    assert Eq(zoo, -zoo) is T
+    assert Eq(oo, -oo) is F
+    assert Eq(inf, -inf) not in (T, F)
 
     assert Eq(fin/(fin + 1), 1) is S.false
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

closes #17529 

#### Brief description of what is fixed or changed

`Eq(*symbols('a b', infinite=True))` no longer evaluates to True.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
