### PR TITLE
Add InvalidComparison exception

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -12,6 +12,22 @@ from mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict
 
+
+class InvalidComparison(TypeError):
+    '''Raised by inequalities between uncomparable objects'''
+    pass
+
+
+class InvalidNanComparison(InvalidComparison):
+    '''Raised by inequalities with nans'''
+    pass
+
+
+class InvalidNonRealComparison(InvalidComparison):
+    '''Raised by inequalities between objects that are not real numbers'''
+    pass
+
+
 class Expr(Basic, EvalfMixin):
     """
     Base class for algebraic expressions.
@@ -337,9 +353,9 @@ class Expr(Basic, EvalfMixin):
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_extended_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
+                raise InvalidNonRealComparison("Invalid comparison of complex %s" % me)
             if me is S.NaN:
-                raise TypeError("Invalid NaN comparison")
+                raise InvalidNanComparison("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 >= 0)
@@ -360,9 +376,9 @@ class Expr(Basic, EvalfMixin):
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_extended_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
+                raise InvalidNonRealComparison("Invalid comparison of complex %s" % me)
             if me is S.NaN:
-                raise TypeError("Invalid NaN comparison")
+                raise InvalidNanComparison("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 <= 0)
@@ -383,9 +399,9 @@ class Expr(Basic, EvalfMixin):
             raise TypeError("Invalid comparison %s > %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_extended_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
+                raise InvalidNonRealComparison("Invalid comparison of complex %s" % me)
             if me is S.NaN:
-                raise TypeError("Invalid NaN comparison")
+                raise InvalidNanComparison("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 > 0)
@@ -407,9 +423,9 @@ class Expr(Basic, EvalfMixin):
             raise TypeError("Invalid comparison %s < %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_extended_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
+                raise InvalidNonRealComparison("Invalid comparison of complex %s" % me)
             if me is S.NaN:
-                raise TypeError("Invalid NaN comparison")
+                raise InvalidNanComparison("Invalid NaN comparison")
         n2 = _n2(self, other)
         if n2 is not None:
             return _sympify(n2 < 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Adds an exception class `InvalidComparison` that is raised when in inequality has invalid arguments as in `I < 0`. There are two subclass of InvalidComparison: `InvalidNanComparison` and `InvalidNonRealComparison`. These all subclass TypeError for backwards compatibility.

#### Other comments

The idea here is that code that currently catches TypeError can be made to catch the more specific InvalidComparison exception. This would make the code more informative and be less likely to mask bugs (normally a TypeError indicates a bug).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Now exceptions raised from inequalities involving NaNs or non-real numbers will raise InvalidComparison rather than TypeError. InvalidComparison is a subclass of TypeError so catching TypeError will still work but it is usually preferable to catch the more specific InvalidComparison exception instead.
<!-- END RELEASE NOTES -->
