### PR TITLE
Fix latex printing of set operators

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1872,12 +1872,6 @@ class LatexPrinter(Printer):
             tex = r'\left(%s\right)^{%s}' % (tex, exp)
         return tex
 
-    def _print_ProductSet(self, p):
-        if len(p.sets) > 1 and not has_variety(p.sets):
-            return self._print(p.sets[0]) + "^{%d}" % len(p.sets)
-        else:
-            return r" \times ".join(self._print(set) for set in p.sets)
-
     def _print_RandomDomain(self, d):
         if hasattr(d, 'as_boolean'):
             return '\\text{Domain: }' + self._print(d.as_boolean())
@@ -2016,16 +2010,31 @@ class LatexPrinter(Printer):
                 (self._print(i.min), self._print(i.max))
 
     def _print_Union(self, u):
-        return r" \cup ".join([self._print(i) for i in u.args])
+        prec = precedence_traditional(u)
+        args_str = [self.parenthesize(i, prec) for i in u.args]
+        return r" \cup ".join(args_str)
 
     def _print_Complement(self, u):
-        return r" \setminus ".join([self._print(i) for i in u.args])
+        prec = precedence_traditional(u)
+        args_str = [self.parenthesize(i, prec) for i in u.args]
+        return r" \setminus ".join(args_str)
 
     def _print_Intersection(self, u):
-        return r" \cap ".join([self._print(i) for i in u.args])
+        prec = precedence_traditional(u)
+        args_str = [self.parenthesize(i, prec) for i in u.args]
+        return r" \cap ".join(args_str)
 
     def _print_SymmetricDifference(self, u):
-        return r" \triangle ".join([self._print(i) for i in u.args])
+        prec = precedence_traditional(u)
+        args_str = [self.parenthesize(i, prec) for i in u.args]
+        return r" \triangle ".join(args_str)
+
+    def _print_ProductSet(self, p):
+        prec = precedence_traditional(p)
+        if len(p.sets) > 1 and not has_variety(p.sets):
+            return self.parenthesize(p.sets[0], prec) + "^{%d}" % len(p.sets)
+        return r" \times ".join(
+            self.parenthesize(set, prec) for set in p.sets)
 
     def _print_EmptySet(self, e):
         return r"\emptyset"

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -136,6 +136,28 @@ def precedence(item):
     return PRECEDENCE["Atom"]
 
 
+PRECEDENCE_TRADITIONAL = PRECEDENCE.copy()
+PRECEDENCE_TRADITIONAL['Integral'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['Sum'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['Product'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['Limit'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['Derivative'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['TensorProduct'] = PRECEDENCE["Mul"]
+PRECEDENCE_TRADITIONAL['Transpose'] = PRECEDENCE["Pow"]
+PRECEDENCE_TRADITIONAL['Adjoint'] = PRECEDENCE["Pow"]
+PRECEDENCE_TRADITIONAL['Dot'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Cross'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Gradient'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Divergence'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Curl'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Laplacian'] = PRECEDENCE["Mul"] - 1
+PRECEDENCE_TRADITIONAL['Union'] = PRECEDENCE['Xor']
+PRECEDENCE_TRADITIONAL['Intersection'] = PRECEDENCE['Xor']
+PRECEDENCE_TRADITIONAL['Complement'] = PRECEDENCE['Xor']
+PRECEDENCE_TRADITIONAL['SymmetricDifference'] = PRECEDENCE['Xor']
+PRECEDENCE_TRADITIONAL['ProductSet'] = PRECEDENCE['Xor']
+
+
 def precedence_traditional(item):
     """Returns the precedence of a given object according to the
     traditional rules of mathematics.
@@ -148,14 +170,11 @@ def precedence_traditional(item):
     from sympy.core.expr import UnevaluatedExpr
     from sympy.tensor.functions import TensorProduct
 
-    if isinstance(item, (Integral, Sum, Product, Limit, Derivative, TensorProduct)):
-        return PRECEDENCE["Mul"]
-    elif isinstance(item, (Transpose, Adjoint)):
-        return PRECEDENCE["Pow"]
-    elif (item.__class__.__name__ in ("Dot", "Cross", "Gradient", "Divergence",
-                                    "Curl", "Laplacian")):
-        return PRECEDENCE["Mul"]-1
-    elif isinstance(item, UnevaluatedExpr):
+    if isinstance(item, UnevaluatedExpr):
         return precedence_traditional(item.args[0])
-    else:
-        return precedence(item)
+
+    n = item.__class__.__name__
+    if n in PRECEDENCE_TRADITIONAL:
+        return PRECEDENCE_TRADITIONAL[n]
+
+    return precedence(item)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -6,7 +6,7 @@ from sympy import (
     Lambda, LaplaceTransform, Limit, Matrix, Max, MellinTransform, Min, Mul,
     Order, Piecewise, Poly, ring, field, ZZ, Pow, Product, Range, Rational,
     RisingFactorial, rootof, RootSum, S, Shi, Si, SineTransform, Subs,
-    Sum, Symbol, ImageSet, Tuple, Union, Ynm, Znm, arg, asin, acsc, Mod,
+    Sum, Symbol, ImageSet, Tuple, Ynm, Znm, arg, asin, acsc, Mod,
     assoc_laguerre, assoc_legendre, beta, binomial, catalan, ceiling, Complement,
     chebyshevt, chebyshevu, conjugate, cot, coth, diff, dirichlet_eta, euler,
     exp, expint, factorial, factorial2, floor, gamma, gegenbauer, hermite,
@@ -14,11 +14,11 @@ from sympy import (
     meijerg, oo, polar_lift, polylog, re, root, sin, sqrt, symbols,
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
-    Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
+    Contains, divisor_sigma, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
     stieltjes, mathieuc, mathieus, mathieucprime, mathieusprime,
-    UnevaluatedExpr, Quaternion, I, KroneckerProduct, Intersection, LambertW)
+    UnevaluatedExpr, Quaternion, I, KroneckerProduct, LambertW)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -44,6 +44,8 @@ from sympy.combinatorics.permutations import Cycle, Permutation
 from sympy import MatrixSymbol, ln
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Laplacian
 from sympy.sets.setexpr import SetExpr
+from sympy.sets.sets import \
+    Union, Intersection, Complement, SymmetricDifference, ProductSet
 
 import sympy as sym
 
@@ -868,10 +870,6 @@ def test_latex_Complement():
         r"\mathbb{R} \setminus \mathbb{N}"
 
 
-def test_latex_Complexes():
-    assert latex(S.Complexes) == r"\mathbb{C}"
-
-
 def test_latex_productset():
     line = Interval(0, 1)
     bigline = Interval(0, 10)
@@ -880,6 +878,129 @@ def test_latex_productset():
     assert latex(line**10) == r"%s^{10}" % latex(line)
     assert latex(line * bigline * fset) == r"%s \times %s \times %s" % (
         latex(line), latex(bigline), latex(fset))
+
+
+def test_set_operators_parenthesis():
+    a, b, c, d = symbols('a:d')
+    A = FiniteSet(a)
+    B = FiniteSet(b)
+    C = FiniteSet(c)
+    D = FiniteSet(d)
+
+    U1 = Union(A, B, evaluate=False)
+    U2 = Union(C, D, evaluate=False)
+    I1 = Intersection(A, B, evaluate=False)
+    I2 = Intersection(C, D, evaluate=False)
+    C1 = Complement(A, B, evaluate=False)
+    C2 = Complement(C, D, evaluate=False)
+    D1 = SymmetricDifference(A, B, evaluate=False)
+    D2 = SymmetricDifference(C, D, evaluate=False)
+    # XXX ProductSet does not support evaluate keyword
+    P1 = ProductSet(A, B)
+    P2 = ProductSet(C, D)
+
+    assert latex(Intersection(A, U2, evaluate=False)) == \
+        '\\left\\{a\\right\\} \\cap ' \
+        '\\left(\\left\\{c\\right\\} \\cup \\left\\{d\\right\\}\\right)'
+    assert latex(Intersection(U1, U2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cup \\left\\{b\\right\\}\\right) ' \
+        '\\cap \\left(\\left\\{c\\right\\} \\cup \\left\\{d\\right\\}\\right)'
+    assert latex(Intersection(C1, C2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\setminus ' \
+        '\\left\\{b\\right\\}\\right) \\cap \\left(\\left\\{c\\right\\} ' \
+        '\\setminus \\left\\{d\\right\\}\\right)'
+    assert latex(Intersection(D1, D2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\triangle ' \
+        '\\left\\{b\\right\\}\\right) \\cap \\left(\\left\\{c\\right\\} ' \
+        '\\triangle \\left\\{d\\right\\}\\right)'
+    assert latex(Intersection(P1, P2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\times \\left\\{b\\right\\}\\right) ' \
+        '\\cap \\left(\\left\\{c\\right\\} \\times ' \
+        '\\left\\{d\\right\\}\\right)'
+
+    assert latex(Union(A, I2, evaluate=False)) == \
+        '\\left\\{a\\right\\} \\cup ' \
+        '\\left(\\left\\{c\\right\\} \\cap \\left\\{d\\right\\}\\right)'
+    assert latex(Union(I1, I2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cap ''\\left\\{b\\right\\}\\right) ' \
+        '\\cup \\left(\\left\\{c\\right\\} \\cap \\left\\{d\\right\\}\\right)'
+    assert latex(Union(C1, C2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\setminus ' \
+        '\\left\\{b\\right\\}\\right) \\cup \\left(\\left\\{c\\right\\} ' \
+        '\\setminus \\left\\{d\\right\\}\\right)'
+    assert latex(Union(D1, D2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\triangle ' \
+        '\\left\\{b\\right\\}\\right) \\cup \\left(\\left\\{c\\right\\} ' \
+        '\\triangle \\left\\{d\\right\\}\\right)'
+    assert latex(Union(P1, P2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\times \\left\\{b\\right\\}\\right) ' \
+        '\\cup \\left(\\left\\{c\\right\\} \\times ' \
+        '\\left\\{d\\right\\}\\right)'
+
+    assert latex(Complement(A, C2, evaluate=False)) == \
+        '\\left\\{a\\right\\} \\setminus \\left(\\left\\{c\\right\\} ' \
+        '\\setminus \\left\\{d\\right\\}\\right)'
+    assert latex(Complement(U1, U2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cup \\left\\{b\\right\\}\\right) ' \
+        '\\setminus \\left(\\left\\{c\\right\\} \\cup ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(Complement(I1, I2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cap \\left\\{b\\right\\}\\right) ' \
+        '\\setminus \\left(\\left\\{c\\right\\} \\cap ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(Complement(D1, D2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\triangle ' \
+        '\\left\\{b\\right\\}\\right) \\setminus ' \
+        '\\left(\\left\\{c\\right\\} \\triangle \\left\\{d\\right\\}\\right)'
+    assert latex(Complement(P1, P2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\times \\left\\{b\\right\\}\\right) '\
+        '\\setminus \\left(\\left\\{c\\right\\} \\times '\
+        '\\left\\{d\\right\\}\\right)'
+
+    assert latex(SymmetricDifference(A, D2, evaluate=False)) == \
+        '\\left\\{a\\right\\} \\triangle \\left(\\left\\{c\\right\\} ' \
+        '\\triangle \\left\\{d\\right\\}\\right)'
+    assert latex(SymmetricDifference(U1, U2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cup \\left\\{b\\right\\}\\right) ' \
+        '\\triangle \\left(\\left\\{c\\right\\} \\cup ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(SymmetricDifference(I1, I2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\cap \\left\\{b\\right\\}\\right) ' \
+        '\\triangle \\left(\\left\\{c\\right\\} \\cap ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(SymmetricDifference(C1, C2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\setminus ' \
+        '\\left\\{b\\right\\}\\right) \\triangle ' \
+        '\\left(\\left\\{c\\right\\} \\setminus \\left\\{d\\right\\}\\right)'
+    assert latex(SymmetricDifference(P1, P2, evaluate=False)) == \
+        '\\left(\\left\\{a\\right\\} \\times \\left\\{b\\right\\}\\right) ' \
+        '\\triangle \\left(\\left\\{c\\right\\} \\times ' \
+        '\\left\\{d\\right\\}\\right)'
+
+    # XXX This can be incorrect since cartesian product is not associative
+    assert latex(ProductSet(A, P2)) == \
+        '\\left\\{a\\right\\} \\times \\left\\{c\\right\\} \\times ' \
+        '\\left\\{d\\right\\}'
+    assert latex(ProductSet(U1, U2)) == \
+        '\\left(\\left\\{a\\right\\} \\cup \\left\\{b\\right\\}\\right) ' \
+        '\\times \\left(\\left\\{c\\right\\} \\cup ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(ProductSet(I1, I2)) == \
+        '\\left(\\left\\{a\\right\\} \\cap \\left\\{b\\right\\}\\right) ' \
+        '\\times \\left(\\left\\{c\\right\\} \\cap ' \
+        '\\left\\{d\\right\\}\\right)'
+    assert latex(ProductSet(C1, C2)) == \
+        '\\left(\\left\\{a\\right\\} \\setminus ' \
+        '\\left\\{b\\right\\}\\right) \\times \\left(\\left\\{c\\right\\} ' \
+        '\\setminus \\left\\{d\\right\\}\\right)'
+    assert latex(ProductSet(D1, D2)) == \
+        '\\left(\\left\\{a\\right\\} \\triangle ' \
+        '\\left\\{b\\right\\}\\right) \\times \\left(\\left\\{c\\right\\} ' \
+        '\\triangle \\left\\{d\\right\\}\\right)'
+
+
+def test_latex_Complexes():
+    assert latex(S.Complexes) == r"\mathbb{C}"
 
 
 def test_latex_Naturals():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


<details><summary>Test code</summary>
<p>

```python
from sympy import *
from sympy.abc import a, b, c, d, e, f, g, h
from sympy.printing.precedence import PRECEDENCE

from IPython.display import display

A = FiniteSet(a)
B = FiniteSet(b)
C = FiniteSet(c)
D = FiniteSet(d)

U1 = Union(A, B, evaluate=False)
U2 = Union(C, D, evaluate=False)
I1 = Intersection(A, B, evaluate=False)
I2 = Intersection(C, D, evaluate=False)
C1 = Complement(A, B, evaluate=False)
C2 = Complement(C, D, evaluate=False)
D1 = SymmetricDifference(A, B, evaluate=False)
D2 = SymmetricDifference(C, D, evaluate=False)
# XXX ProductSet does not support evaluate keyword
P1 = ProductSet(A, B)
P2 = ProductSet(C, D)

display(Intersection(A, U2, evaluate=False))
display(Intersection(U1, U2, evaluate=False))
display(Intersection(C1, C2, evaluate=False))
display(Intersection(D1, D2, evaluate=False))
display(Intersection(P1, P2, evaluate=False))

display(Union(A, I2, evaluate=False))
display(Union(I1, I2, evaluate=False))
display(Union(C1, C2, evaluate=False))
display(Union(D1, D2, evaluate=False))
display(Union(P1, P2, evaluate=False))

display(Complement(A, C2, evaluate=False))
display(Complement(U1, U2, evaluate=False))
display(Complement(I1, I2, evaluate=False))
display(Complement(D1, D2, evaluate=False))
display(Complement(P1, P2, evaluate=False))

display(SymmetricDifference(A, D2, evaluate=False))
display(SymmetricDifference(U1, U2, evaluate=False))
display(SymmetricDifference(I1, I2, evaluate=False))
display(SymmetricDifference(C1, C2, evaluate=False))
display(SymmetricDifference(P1, P2, evaluate=False))

display(ProductSet(A, P2))
display(ProductSet(U1, U2))
display(ProductSet(I1, I2))
display(ProductSet(C1, C2))
display(ProductSet(D1, D2))
```

</p>
</details>

The result was like
![image](https://user-images.githubusercontent.com/34944973/63901358-2db38180-ca3f-11e9-919a-aadb6e296abc.png)
But I don't think that different set operators are compatible such way
![image](https://user-images.githubusercontent.com/34944973/63901411-66535b00-ca3f-11e9-9333-c04b0b635490.png)

I've also switched the `precedence_traditional` to use dictionary mapping, which may hopefully clean up some code.

#### Other comments

I've not fixed mathml here yet, but if there are same problems, it should be fixed too.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed missing parenthesis for set operators `Union`, `Intersection`, `Complement`, `SymmetricDifference`, `ProductSet`
<!-- END RELEASE NOTES -->
