### PR TITLE
Updated sinc derivative

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -781,7 +781,11 @@ def test_sinc():
 
     assert sinc(-x) == sinc(x)
 
-    assert sinc(x).diff() == (x*cos(x) - sin(x)) / x**2
+    assert sinc(x).diff() == Piecewise(((x*cos(x) - sin(x)) / x**2, Ne(x, 0)), (0, True))
+
+    assert sinc(x).diff(x).equals(sinc(x).rewrite(sin).diff(x))
+
+    assert sinc(x).diff().subs(x, 0) is S.Zero
 
     assert sinc(x).series() == 1 - x**2/6 + x**4/120 + O(x**6)
 
@@ -1040,7 +1044,6 @@ def test_atan2():
 
     assert atan2(y, x).rewrite(log) == -I*log((x + I*y)/sqrt(x**2 + y**2))
     assert atan2(0, 0) == S.NaN
-    w = Symbol('w')
 
     ex = atan2(y, x) - arg(x + I*y)
     assert ex.subs({x:2, y:3}).rewrite(arg) == 0

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1826,7 +1826,7 @@ class sinc(Function):
     * Differentiation
 
     >>> sinc(x).diff()
-    (x*cos(x) - sin(x))/x**2
+    Piecewise(((x*cos(x) - sin(x))/x**2, Ne(x, 0)), (0, True))
 
     * Series Expansion
 
@@ -1848,7 +1848,7 @@ class sinc(Function):
     def fdiff(self, argindex=1):
         x = self.args[0]
         if argindex == 1:
-            return (x*cos(x) - sin(x)) / x**2
+            return Piecewise(((x*cos(x) - sin(x))/x**2, Ne(x, S.Zero)), (S.Zero, S.true))
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -1885,7 +1885,7 @@ class sinc(Function):
         return jn(0, arg)
 
     def _eval_rewrite_as_sin(self, arg, **kwargs):
-        return Piecewise((sin(arg)/arg, Ne(arg, 0)), (1, True))
+        return Piecewise((sin(arg)/arg, Ne(arg, S.Zero)), (S.One, S.true))
 
 
 ###############################################################################


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Return a Piecewise for `sinc(x).diff()` to make it possible to evaluate at `x = 0`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * `sinc.diff()` now returns a `Piecewise` so it is possible to evaluate at `0`.
<!-- END RELEASE NOTES -->
