### PR TITLE
Move the code in clashing() in abc.py to the module level

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -27,6 +27,28 @@ you still need to use ``Symbol('foo')`` or ``symbols('foo')``.
 You can freely mix usage of ``sympy.abc`` and ``Symbol``/``symbols``, though
 sticking with one and only one way to get the symbols does tend to make the code
 more readable.
+
+The module also defines some special names to help detect which names clash
+with the default SymPy namespace.
+
+``_clash1`` defines all the single letter variables that clash with
+SymPy objects; ``_clash2`` defines the multi-letter clashing symbols;
+and ``_clash`` is the union of both. These can be passed for ``locals``
+during sympification if one desires Symbols rather than the non-Symbol
+objects for those names.
+
+Examples
+========
+
+>>> from sympy import S
+>>> from sympy.abc import _clash1, _clash2, _clash
+>>> S("Q & C", locals=_clash1)
+C & Q
+>>> S('pi(x)', locals=_clash2)
+pi(x)
+>>> S('pi(C, Q)', locals=_clash)
+pi(C, Q)
+
 """
 
 from __future__ import print_function, division
@@ -70,50 +92,20 @@ _greek = list(greeks) # make a copy, so we can mutate it
 _greek.remove("lambda")
 _greek.append("lamda")
 
-def clashing():
-    """Return the clashing-symbols dictionaries.
+ns = {}
+exec_('from sympy import *', ns)
+_clash1 = {}
+_clash2 = {}
+while ns:
+    k, _ = ns.popitem()
+    if k in _greek:
+        _clash2[k] = Symbol(k)
+        _greek.remove(k)
+    elif k in _latin:
+        _clash1[k] = Symbol(k)
+        _latin.remove(k)
+_clash = {}
+_clash.update(_clash1)
+_clash.update(_clash2)
 
-    ``clash1`` defines all the single letter variables that clash with
-    SymPy objects; ``clash2`` defines the multi-letter clashing symbols;
-    and ``clash`` is the union of both. These can be passed for ``locals``
-    during sympification if one desires Symbols rather than the non-Symbol
-    objects for those names.
-
-    Examples
-    ========
-
-    >>> from sympy import S
-    >>> from sympy.abc import _clash1, _clash2, _clash
-    >>> S("Q & C", locals=_clash1)
-    And(C, Q)
-    >>> S('pi(x)', locals=_clash2)
-    pi(x)
-    >>> S('pi(C, Q)', locals=_clash)
-    pi(C, Q)
-
-    Note: if changes are made to the docstring examples they can only
-    be tested after removing "clashing" from the list of deleted items
-    at the bottom of this file which removes this function from the
-    namespace.
-    """
-
-    ns = {}
-    exec_('from sympy import *', ns)
-    clash1 = {}
-    clash2 = {}
-    while ns:
-        k, _ = ns.popitem()
-        if k in _greek:
-            clash2[k] = Symbol(k)
-            _greek.remove(k)
-        elif k in _latin:
-            clash1[k] = Symbol(k)
-            _latin.remove(k)
-    clash = {}
-    clash.update(clash1)
-    clash.update(clash2)
-    return clash1, clash2, clash
-
-_clash1, _clash2, _clash = clashing()
-
-del _latin, _greek, clashing, Symbol
+del _latin, _greek, Symbol

--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -97,15 +97,15 @@ exec_('from sympy import *', ns)
 _clash1 = {}
 _clash2 = {}
 while ns:
-    k, _ = ns.popitem()
-    if k in _greek:
-        _clash2[k] = Symbol(k)
-        _greek.remove(k)
-    elif k in _latin:
-        _clash1[k] = Symbol(k)
-        _latin.remove(k)
+    _k, _ = ns.popitem()
+    if _k in _greek:
+        _clash2[_k] = Symbol(_k)
+        _greek.remove(_k)
+    elif _k in _latin:
+        _clash1[_k] = Symbol(_k)
+        _latin.remove(_k)
 _clash = {}
 _clash.update(_clash1)
 _clash.update(_clash2)
 
-del _latin, _greek, Symbol
+del _latin, _greek, Symbol, _k


### PR DESCRIPTION
This makes linters such as pyflakes not complain about undefined names in the
function. This way is preferable regardless because the doctests for the
function, which have been moved to the module docstring, can actually be run.
Previously, clashing was deleted at the end of the module, so it was
impossible for the doctester to run it.

See https://github.com/sympy/sympy/pull/17544#issuecomment-526373164.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

 
#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* abc
  * document the `_clash` variables in the sympy.abc docstring
<!-- END RELEASE NOTES -->
