### PR TITLE
Quaternion: Fixed the order of multiplication with a complex number

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -349,7 +349,7 @@ class Quaternion(Expr):
         if not isinstance(q1, Quaternion):
             if q2.real_field:
                 if q1.is_complex:
-                    return q2 * Quaternion(re(q1), im(q1), 0, 0)
+                    return Quaternion(re(q1), im(q1), 0, 0) * q2
                 else:
                     return Mul(q1, q2)
             else:

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -153,7 +153,7 @@ def test_quaternion_rotation_iss1593():
                 [0, sin(x), cos(x)]]))
 
 
-def test_quaternion_nultiplication():
+def test_quaternion_multiplication():
     q1 = Quaternion(3 + 4*I, 2 + 5*I, 0, 7 + 8*I, real_field = False)
     q2 = Quaternion(1, 2, 3, 5)
     q3 = Quaternion(1, 1, 1, y)
@@ -163,3 +163,10 @@ def test_quaternion_nultiplication():
     assert q2.mul(2) == Quaternion(2, 4, 6, 10)
     assert q2.mul(q3) == Quaternion(-5*y - 4, 3*y - 2, 9 - 2*y, y + 4)
     assert q2.mul(q3) == q2*q3
+
+    z = symbols('z', complex=True)
+    z_quat = Quaternion(re(z), im(z), 0, 0)
+    q = Quaternion(*symbols('q:4', real=True))
+
+    assert z * q == z_quat * q
+    assert q * z == q * z_quat


### PR DESCRIPTION
Fixed an issue that when a complex number on the left is multiplied by
a quaternion on the right, the multiplication is performed in the
reversed order.

Example before the fix:
```python
In [1]: from sympy import Quaternion, I

In [2]: J = Quaternion(0, 0, 1, 0)

In [3]: K = Quaternion(0, 0, 0, 1)

In [4]: I * J == K
Out[4]: False

In [5]: I * J == -K
Out[5]: True
```

I also added a test to make sure that multiplying a complex number by
a quaternion is performed in the correct order. (And I corrected a
typo.)

<!-- BEGIN RELEASE NOTES -->
* algebras
   * Fix a bug where multiplication of a complex number by a quaternion is performed in the wrong order.
<!-- END RELEASE NOTES -->