### PR TITLE
Quaternion: Fix bug where operations are left unevaluated

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -194,6 +194,16 @@ class Quaternion(Expr):
     def __neg__(self):
         return Quaternion(-self._a, -self._b, -self._c, -self.d)
 
+    def __truediv__(self, other):
+        return self * sympify(other)**-1
+
+    __div__ = __truediv__
+
+    def __rtruediv__(self, other):
+        return sympify(other) * self**-1
+
+    __rdiv__ = __rtruediv__
+
     def _eval_Integral(self, *args):
         return self.integrate(*args)
 
@@ -244,14 +254,13 @@ class Quaternion(Expr):
 
         # If q2 is a number or a sympy expression instead of a quaternion
         if not isinstance(q2, Quaternion):
-            if q1.real_field:
-                if q2.is_complex:
+            if q1.real_field and q2.is_complex:
                     return Quaternion(re(q2) + q1.a, im(q2) + q1.b, q1.c, q1.d)
-                else:
-                    # q2 is something strange, do not evaluate:
-                    return Add(q1, q2)
-            else:
+            elif q2.is_commutative:
                 return Quaternion(q1.a + q2, q1.b, q1.c, q1.d)
+            else:
+                # q2 is something strange, do not evaluate:
+                return Add(q1, q2)
 
         return Quaternion(q1.a + q2.a, q1.b + q2.b, q1.c + q2.c, q1.d
                           + q2.d)
@@ -347,24 +356,21 @@ class Quaternion(Expr):
 
         # If q1 is a number or a sympy expression instead of a quaternion
         if not isinstance(q1, Quaternion):
-            if q2.real_field:
-                if q1.is_complex:
+            if q2.real_field and q1.is_complex:
                     return Quaternion(re(q1), im(q1), 0, 0) * q2
-                else:
-                    return Mul(q1, q2)
-            else:
+            elif q1.is_commutative:
                 return Quaternion(q1 * q2.a, q1 * q2.b, q1 * q2.c, q1 * q2.d)
-
+            else:
+                return Mul(q1, q2)
 
         # If q2 is a number or a sympy expression instead of a quaternion
         if not isinstance(q2, Quaternion):
-            if q1.real_field:
-                if q2.is_complex:
+            if q1.real_field and q2.is_complex:
                     return q1 * Quaternion(re(q2), im(q2), 0, 0)
-                else:
-                    return Mul(q1, q2)
-            else:
+            elif q2.is_commutative:
                 return Quaternion(q2 * q1.a, q2 * q1.b, q2 * q1.c, q2 * q1.d)
+            else:
+                return Mul(q1, q2)
 
         return Quaternion(-q1.b*q2.b - q1.c*q2.c - q1.d*q2.d + q1.a*q2.a,
                           q1.b*q2.a + q1.c*q2.d - q1.d*q2.c + q1.a*q2.b,

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -259,8 +259,7 @@ class Quaternion(Expr):
             elif q2.is_commutative:
                 return Quaternion(q1.a + q2, q1.b, q1.c, q1.d)
             else:
-                # q2 is something strange, do not evaluate:
-                return Add(q1, q2)
+                raise ValueError("Only commutative expressions can be added with a Quaternion.")
 
         return Quaternion(q1.a + q2.a, q1.b + q2.b, q1.c + q2.c, q1.d
                           + q2.d)
@@ -361,7 +360,7 @@ class Quaternion(Expr):
             elif q1.is_commutative:
                 return Quaternion(q1 * q2.a, q1 * q2.b, q1 * q2.c, q1 * q2.d)
             else:
-                return Mul(q1, q2)
+                raise ValueError("Only commutative expressions can be multiplied with a Quaternion.")
 
         # If q2 is a number or a sympy expression instead of a quaternion
         if not isinstance(q2, Quaternion):
@@ -370,7 +369,7 @@ class Quaternion(Expr):
             elif q2.is_commutative:
                 return Quaternion(q2 * q1.a, q2 * q1.b, q2 * q1.c, q2 * q1.d)
             else:
-                return Mul(q1, q2)
+                raise ValueError("Only commutative expressions can be multiplied with a Quaternion.")
 
         return Quaternion(-q1.b*q2.b - q1.c*q2.c - q1.d*q2.d + q1.a*q2.a,
                           q1.b*q2.a + q1.c*q2.d - q1.d*q2.c + q1.a*q2.b,

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -25,12 +25,17 @@ def test_quaternion_construction():
 def test_quaternion_complex_real_addition():
     a = symbols("a", complex=True)
     b = symbols("b", real=True)
+    # This symbol is not complex:
+    c = symbols("c", commutative=False)
 
     q = Quaternion(x, y, z, w)
     assert a + q == Quaternion(x + re(a), y + im(a), z, w)
     assert 1 + q == Quaternion(1 + x, y, z, w)
     assert I + q == Quaternion(x, 1 + y, z, w)
     assert b + q == Quaternion(x + b, y, z, w)
+    raises(ValueError, lambda: c + q)
+    raises(ValueError, lambda: q * c)
+    raises(ValueError, lambda: c * q)
 
     assert -q == Quaternion(-x, -y, -z, -w)
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -25,17 +25,12 @@ def test_quaternion_construction():
 def test_quaternion_complex_real_addition():
     a = symbols("a", complex=True)
     b = symbols("b", real=True)
-    # This symbol is not complex:
-    c = symbols("c", commutative=False)
 
     q = Quaternion(x, y, z, w)
     assert a + q == Quaternion(x + re(a), y + im(a), z, w)
     assert 1 + q == Quaternion(1 + x, y, z, w)
     assert I + q == Quaternion(x, 1 + y, z, w)
     assert b + q == Quaternion(x + b, y, z, w)
-    assert c + q == Add(c, Quaternion(x, y, z, w), evaluate=False)
-    assert q * c == Mul(Quaternion(x, y, z, w), c, evaluate=False)
-    assert c * q == Mul(c, Quaternion(x, y, z, w), evaluate=False)
 
     assert -q == Quaternion(-x, -y, -z, -w)
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed 

There are several operations on quaternions which are left unevaluated
in some common situations. One of the most obviously problematic one
is the following, which is actually part of the tests on this module.

```python
>>> from sympy import Quaternion, symbols
>>> x, y, z, w = symbols('x y z w')
>>> q = Quaternion(x, y, z, w)
>>> q.normalize()
x + y*i + z*j + w*k/sqrt(w**2 + x**2 + y**2 + z**2)
>>> type(q.normalize())
<class 'sympy.core.mul.Mul'>
```

Here, `q.normalize()`, instead of returning a quaternion, returns an
unevaluated `Mul` object. The expected output would have been an
instance of `Quaternion` whose arguments are `x/sqrt(w**2 + x**2 +
y**2 + z**2)`, `y/sqrt(w**2 + x**2 + y**2 + z**2)`, etc.

The test for this is `assert q.normalize() == Quaternion(x, y, z, w) /
sqrt(w**2 + x**2 + y**2 + z**2)`. It passes, but both sides of the
equation are not quaternions, which is not what we would expect.

There are two reasons for this bug:

1. Division for quaternions is not implemented. For instance, `q / 2`
is left unevaluated.

2. Operations between a quaternion and an expression which is neither
a quaternion nor a complex number is left unevaluated. For example, `q*q.norm()**-1` is left unevaluated since `(q.norm()**-1).is_complex`
is `None`.

Both problems have been corrected.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* algebras
   * Implement division for quaternions and more flexible operations with other expressions.
<!-- END RELEASE NOTES -->
