### PR TITLE
Don't flatten ProductSet args

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -10,6 +10,7 @@ from __future__ import print_function, division
 
 from collections import OrderedDict, defaultdict
 
+from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range, MutableSet
 from sympy.core.sympify import sympify, converter
@@ -142,6 +143,20 @@ class Tuple(Basic):
             return self.args.index(value, start)
         else:
             return self.args.index(value, start, stop)
+
+    def _eval_Eq(self, other):
+        from sympy.core.logic import fuzzy_and, fuzzy_bool
+        from sympy.core.relational import Eq
+
+        if not isinstance(other, Tuple) or len(self) != len(other):
+            return S.false
+
+        r = fuzzy_and(fuzzy_bool(Eq(s, o)) for s, o in zip(self, other))
+        if r is True:
+            return S.true
+        elif r is False:
+            return S.false
+
 
 converter[tuple] = lambda tup: Tuple(*tup)
 

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -145,10 +145,11 @@ class Tuple(Basic):
             return self.args.index(value, start, stop)
 
     def _eval_Eq(self, other):
+        from sympy.core.function import AppliedUndef
         from sympy.core.logic import fuzzy_and, fuzzy_bool
         from sympy.core.relational import Eq
 
-        if other.is_Symbol:
+        if other.is_Symbol or isinstance(other, AppliedUndef):
             return None
 
         if not isinstance(other, Tuple) or len(self) != len(other):

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -148,6 +148,9 @@ class Tuple(Basic):
         from sympy.core.logic import fuzzy_and, fuzzy_bool
         from sympy.core.relational import Eq
 
+        if other.is_Symbol:
+            return None
+
         if not isinstance(other, Tuple) or len(self) != len(other):
             return S.false
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -486,6 +486,10 @@ class Equality(Relational):
                     isinstance(lhs, Boolean) !=
                     isinstance(rhs, Boolean)):
                 return S.false  # only Booleans can equal Booleans
+            elif not (lhs.is_Symbol or rhs.is_Symbol) and (
+                    isinstance(lhs, Expr) !=
+                    isinstance(rhs, Expr)):
+                return S.false  # only Exprs can equal Exprs
 
             # check finiteness
             fin = L, R = [i.is_finite for i in (lhs, rhs)]

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -487,12 +487,6 @@ class Equality(Relational):
                     isinstance(lhs, Boolean) !=
                     isinstance(rhs, Boolean)):
                 return S.false  # only Booleans can equal Booleans
-            # FIXME: There should be a more generic test here than just if one
-            # object is a Tuple and the other is not.
-            elif not (lhs.is_Symbol or rhs.is_Symbol) and (
-                    isinstance(lhs, Tuple) !=
-                    isinstance(rhs, Tuple)):
-                return S.false  # only Tuples can equal Tuples
 
             # check finiteness
             fin = L, R = [i.is_finite for i in (lhs, rhs)]

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -449,6 +449,7 @@ class Equality(Relational):
 
     def __new__(cls, lhs, rhs=None, **options):
         from sympy.core.add import Add
+        from sympy.core.containers import Tuple
         from sympy.core.logic import fuzzy_bool
         from sympy.core.expr import _n2
         from sympy.simplify.simplify import clear_coefficients
@@ -486,10 +487,12 @@ class Equality(Relational):
                     isinstance(lhs, Boolean) !=
                     isinstance(rhs, Boolean)):
                 return S.false  # only Booleans can equal Booleans
+            # FIXME: There should be a more generic test here than just if one
+            # object is a Tuple and the other is not.
             elif not (lhs.is_Symbol or rhs.is_Symbol) and (
-                    isinstance(lhs, Expr) !=
-                    isinstance(rhs, Expr)):
-                return S.false  # only Exprs can equal Exprs
+                    isinstance(lhs, Tuple) !=
+                    isinstance(rhs, Tuple)):
+                return S.false  # only Tuples can equal Tuples
 
             # check finiteness
             fin = L, R = [i.is_finite for i in (lhs, rhs)]

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -4,6 +4,7 @@ from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, In
 from sympy.core.compatibility import is_sequence, iterable, range
 from sympy.core.containers import tuple_wrapper
 from sympy.core.expr import unchanged
+from sympy.core.function import Function
 from sympy.core.relational import Eq
 from sympy.utilities.pytest import raises
 
@@ -78,6 +79,9 @@ def test_Tuple_Eq():
     assert unchanged(Eq, Tuple(1, x), Tuple(1, 2))
     assert Eq(Tuple(1, x), Tuple(1, 2)).subs(x, 2) is S.true
     assert unchanged(Eq, Tuple(1, 2), x)
+    f = Function('f')
+    assert unchanged(Eq, Tuple(1), f(x))
+    assert Eq(Tuple(1), f(x)).subs(x, 1).subs(f, Lambda(y, (y,))) is S.true
 
 
 def test_Tuple_comparision():

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -77,6 +77,7 @@ def test_Tuple_Eq():
     assert Eq(Tuple(1, 2), Tuple(1, 2)) is S.true
     assert unchanged(Eq, Tuple(1, x), Tuple(1, 2))
     assert Eq(Tuple(1, x), Tuple(1, 2)).subs(x, 2) is S.true
+    assert unchanged(Eq, Tuple(1, 2), x)
 
 
 def test_Tuple_comparision():

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -4,11 +4,11 @@ from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, In
 from sympy.core.compatibility import is_sequence, iterable, range
 from sympy.core.containers import tuple_wrapper
 from sympy.core.expr import unchanged
-from sympy.core.function import Function
+from sympy.core.function import Function, Lambda
 from sympy.core.relational import Eq
 from sympy.utilities.pytest import raises
 
-from sympy.abc import x
+from sympy.abc import x, y
 
 
 def test_Tuple():

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,8 +1,13 @@
 from collections import defaultdict
+
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
-from sympy.core.containers import tuple_wrapper
-from sympy.utilities.pytest import raises
 from sympy.core.compatibility import is_sequence, iterable, range
+from sympy.core.containers import tuple_wrapper
+from sympy.core.expr import unchanged
+from sympy.core.relational import Eq
+from sympy.utilities.pytest import raises
+
+from sympy.abc import x
 
 
 def test_Tuple():
@@ -61,6 +66,17 @@ def test_Tuple_equality():
     assert (Tuple(1, 2) != Tuple(1, 2)) is False
     assert (Tuple(1, 2) == Tuple(1, 3)) is False
     assert (Tuple(1, 2) != Tuple(1, 3)) is True
+
+
+def test_Tuple_Eq():
+    assert Eq(Tuple(), Tuple()) is S.true
+    assert Eq(Tuple(1), 1) is S.false
+    assert Eq(Tuple(1, 2), Tuple(1)) is S.false
+    assert Eq(Tuple(1), Tuple(1)) is S.true
+    assert Eq(Tuple(1, 2), Tuple(1, 3)) is S.false
+    assert Eq(Tuple(1, 2), Tuple(1, 2)) is S.true
+    assert unchanged(Eq, Tuple(1, x), Tuple(1, 2))
+    assert Eq(Tuple(1, x), Tuple(1, 2)).subs(x, 2) is S.true
 
 
 def test_Tuple_comparision():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -129,6 +129,9 @@ def test_Eq():
     # issue 13348
     assert Eq(True, 1) is S.false
 
+    assert Eq((), 1) is S.false
+
+
 def test_rel_Infinity():
     # NOTE: All of these are actually handled by sympy.core.Number, and do
     # not create Relational objects.

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2031,7 +2031,7 @@ class LatexPrinter(Printer):
 
     def _print_ProductSet(self, p):
         prec = precedence_traditional(p)
-        if len(p.sets) > 1 and not has_variety(p.sets):
+        if len(p.sets) >= 1 and not has_variety(p.sets):
             return self.parenthesize(p.sets[0], prec) + "^{%d}" % len(p.sets)
         return r" \times ".join(
             self.parenthesize(set, prec) for set in p.sets)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1892,7 +1892,7 @@ class PrettyPrinter(Printer):
             return self.emptyPrinter(expr)
 
     def _print_ProductSet(self, p):
-        if len(p.sets) > 1 and not has_variety(p.sets):
+        if len(p.sets) >= 1 and not has_variety(p.sets):
             from sympy import Pow
             return self._print(Pow(p.sets[0], len(p.sets), evaluate=False))
         else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3858,7 +3858,13 @@ def test_pretty_Intersection_issue_10414():
     assert upretty(Intersection(a, b)) == ucode_str
     assert pretty(Intersection(a, b)) == ascii_str
 
-def test_ProductSet_paranthesis():
+def test_ProductSet_exponent():
+    ucode_str = '      1\n[0, 1] '
+    assert upretty(Interval(0, 1)**1) == ucode_str
+    ucode_str = '      2\n[0, 1] '
+    assert upretty(Interval(0, 1)**2) == ucode_str
+
+def test_ProductSet_parenthesis():
     ucode_str = u'([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])'
 
     a, b, c = Interval(2, 3), Interval(4, 7), Interval(1, 9)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -876,7 +876,7 @@ def test_latex_productset():
     fset = FiniteSet(1, 2, 3)
     assert latex(line**2) == r"%s^{2}" % latex(line)
     assert latex(line**10) == r"%s^{10}" % latex(line)
-    assert latex(line * bigline * fset) == r"%s \times %s \times %s" % (
+    assert latex((line * bigline * fset).flatten()) == r"%s \times %s \times %s" % (
         latex(line), latex(bigline), latex(fset))
 
 
@@ -978,7 +978,7 @@ def test_set_operators_parenthesis():
         '\\left\\{d\\right\\}\\right)'
 
     # XXX This can be incorrect since cartesian product is not associative
-    assert latex(ProductSet(A, P2)) == \
+    assert latex(ProductSet(A, P2).flatten()) == \
         '\\left\\{a\\right\\} \\times \\left\\{c\\right\\} \\times ' \
         '\\left\\{d\\right\\}'
     assert latex(ProductSet(U1, U2)) == \

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -305,13 +305,13 @@ class ImageSet(Set):
     """
     def __new__(cls, flambda, *sets):
         if not isinstance(flambda, Lambda):
-            raise ValueError('first argument must be a Lambda')
+            raise ValueError('First argument must be a Lambda')
 
         sets = [_sympify(s) for s in sets]
 
         if flambda is S.IdentityFunction:
             if len(sets) != 1:
-                raise ValueError('identity function requires a single set')
+                raise ValueError('Identity function requires a single set')
             return sets[0]
 
         if not all(isinstance(s, Set) for s in sets):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -307,13 +307,15 @@ class ImageSet(Set):
         if not isinstance(flambda, Lambda):
             raise ValueError('first argument must be a Lambda')
 
+        sets = [_sympify(s) for s in sets]
+
         if flambda is S.IdentityFunction:
             if len(sets) != 1:
-                raise ValueError('identify function requires a single set')
+                raise ValueError('identity function requires a single set')
             return sets[0]
 
         if not all(isinstance(s, Set) for s in sets):
-            raise TypeError("Set arguments to ProductSet should of type Set")
+            raise TypeError("Set arguments to ImageSet should of type Set")
 
         sets = [s.flatten() if s.is_ProductSet else s for s in sets]
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -336,7 +336,7 @@ class ImageSet(Set):
         if len(sets) == 1:
             return sets[0]
         else:
-            return ProductSet(self.args[1:]).flatten()
+            return ProductSet(*self.args[1:]).flatten()
 
     def __iter__(self):
         already_seen = set()

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -312,6 +312,11 @@ class ImageSet(Set):
                 raise ValueError('identify function requires a single set')
             return sets[0]
 
+        if not all(isinstance(s, Set) for s in sets):
+            raise TypeError("Set arguments to ProductSet should of type Set")
+
+        sets = [s.flatten() if s.is_ProductSet else s for s in sets]
+
         if not set(flambda.variables) & flambda.expr.free_symbols:
             emptyprod = fuzzy_or(s.is_empty for s in sets)
             if emptyprod == True:
@@ -322,7 +327,14 @@ class ImageSet(Set):
         return Basic.__new__(cls, flambda, *sets)
 
     lamda = property(lambda self: self.args[0])
-    base_set = property(lambda self: ProductSet(self.args[1:]))
+
+    @property
+    def base_set(self):
+        sets = self.args[1:]
+        if len(sets) == 1:
+            return sets[0]
+        else:
+            return ProductSet(self.args[1:]).flatten()
 
     def __iter__(self):
         already_seen = set()

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -351,8 +351,8 @@ def intersection_sets(self, other):
 def intersection_sets(a, b):
     if len(b.args) != len(a.args):
         return S.EmptySet
-    return ProductSet(i.intersect(j)
-            for i, j in zip(a.sets, b.sets))
+    return ProductSet(*(i.intersect(j) for i, j in zip(a.sets, b.sets)))
+
 
 @dispatch(Interval, Interval)
 def intersection_sets(a, b):

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -41,14 +41,15 @@ def union_sets(a, b):
 def union_sets(a, b):
     if b.is_subset(a):
         return a
-    if len(b.args) != len(a.args):
+    if len(b.sets) != len(a.sets):
         return None
-    if a.args[0] == b.args[0]:
-        return a.args[0] * Union(ProductSet(a.args[1:]),
-                                    ProductSet(b.args[1:]))
-    if a.args[-1] == b.args[-1]:
-        return Union(ProductSet(a.args[:-1]),
-                     ProductSet(b.args[:-1])) * a.args[-1]
+    if len(a.sets) == 2:
+        a1, a2 = a.sets
+        b1, b2 = b.sets
+        if a1 == b1:
+            return a1 * Union(a2, b2)
+        if a2 == b2:
+            return Union(a1, b1) * a2
     return None
 
 @dispatch(ProductSet, Set)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -739,6 +739,9 @@ class ProductSet(Set):
 
         Passes operation on to constituent sets
         """
+        if element.is_Symbol:
+            return None
+
         if not isinstance(element, Tuple) or len(element) != len(self.sets):
             return False
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -194,12 +194,12 @@ class Set(Basic):
     def _complement(self, other):
         # this behaves as other - self
         if isinstance(self, ProductSet) and isinstance(other, ProductSet):
+            # If self and other are disjoint then other - self == self
+            if len(self.sets) != len(other.sets):
+                return other
+
             # There can be other ways to represent this but this gives:
             # (A x B) - (C x D) = ((A - C) x B) U (A x (B - D))
-
-            if len(self.sets) != len(other.sets):
-                raise ValueError("A is not a subset of B")
-
             overlaps = []
             pairs = list(zip(self.sets, other.sets))
             for n in range(len(pairs)):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -656,12 +656,17 @@ class ProductSet(Set):
     >>> set(coin**2)
     {(H, H), (H, T), (T, H), (T, T)}
 
+    The Cartesian product is not commutative or associative e.g.:
+
+    >>> I*S == S*I
+    False
+    >>> (I*I)*I == I*(I*I)
+    False
 
     Notes
     =====
 
     - Passes most operations down to the argument sets
-    - Flattens Products of ProductSets
 
     References
     ==========
@@ -1759,7 +1764,7 @@ class FiniteSet(Set, EvalfMixin):
         """
         # evaluate=True is needed to override evaluate=False context;
         # we need Eq to do the evaluation
-        return fuzzy_or([tfn[Eq(e, other, evaluate=True)] for e in self.args])
+        return fuzzy_or(fuzzy_bool(Eq(e, other, evaluate=True)) for e in self.args)
 
     @property
     def _boundary(self):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -721,7 +721,8 @@ class ProductSet(Set):
         if len(self.sets) != len(other.sets):
             return false
 
-        return And(*(Eq(x, y) for x, y in zip(self.sets, other.sets)))
+        eqs = (Eq(x, y) for x, y in zip(self.sets, other.sets))
+        return tfn[fuzzy_and(map(fuzzy_bool, eqs))]
 
     def _contains(self, element):
         """

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -745,11 +745,12 @@ class ProductSet(Set):
         return fuzzy_and(s._contains(e) for s, e in zip(self.sets, element))
 
     def as_relational(self, *symbols):
+        symbols = [_sympify(s) for s in symbols]
         if len(symbols) != len(self.sets) or not all(
                 i.is_Symbol for i in symbols):
             raise ValueError(
                 'number of symbols must match the number of sets')
-        return And(*[s.contains(i) for s, i in zip(self.sets, symbols)])
+        return And(*[s.as_relational(i) for s, i in zip(self.sets, symbols)])
 
     @property
     def _boundary(self):
@@ -1710,7 +1711,7 @@ class FiniteSet(Set, EvalfMixin):
             yield fuzzy_and(self._contains(e) for e in o_set - s_set)
             yield fuzzy_and(other._contains(e) for e in s_set - o_set)
 
-        return fuzzy_and(all_in_both())
+        return tfn[fuzzy_and(all_in_both())]
 
     def __iter__(self):
         return iter(self.args)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -193,21 +193,19 @@ class Set(Basic):
 
     def _complement(self, other):
         # this behaves as other - self
-        if isinstance(other, ProductSet):
-            # For each set consider it or it's complement
-            # We need at least one of the sets to be complemented
-            # Consider all 2^n combinations.
-            # We can conveniently represent these options easily using a
-            # ProductSet
+        if isinstance(self, ProductSet) and isinstance(other, ProductSet):
+            # There can be other ways to represent this but this gives:
+            # (A x B) - (C x D) = ((A - C) x B) U (A x (B - D))
 
-            # XXX: this doesn't work if the dimensions of the sets isn't same.
-            # A - B is essentially same as A if B has a different
-            # dimensionality than A
-            switch_sets = ProductSet(*(FiniteSet(o, o - s) for s, o in
-                                     zip(self.sets, other.sets)))
-            product_sets = (ProductSet(*set) for set in switch_sets)
-            # Union of all combinations but this one
-            return Union(*(p for p in product_sets if p != other))
+            if len(self.sets) != len(other.sets):
+                raise ValueError("A is not a subset of B")
+
+            overlaps = []
+            pairs = list(zip(self.sets, other.sets))
+            for n in range(len(pairs)):
+                sets = (o if i != n else o-s for i, (s, o) in enumerate(pairs))
+                overlaps.append(ProductSet(*sets))
+            return Union(*overlaps)
 
         elif isinstance(other, Interval):
             if isinstance(self, Interval) or isinstance(self, FiniteSet):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -121,6 +121,9 @@ def test_ImageSet():
     assert imageset(lambda x, y: x + y, S.Integers, S.Naturals
         ).base_set == ProductSet(S.Integers, S.Naturals)
 
+    # Passing a set instead of a FiniteSet shouldn't raise
+    assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})
+
 
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -124,6 +124,8 @@ def test_ImageSet():
     # Passing a set instead of a FiniteSet shouldn't raise
     assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})
 
+    raises(TypeError, lambda: ImageSet(Lambda(x, x**2), None))
+
 
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -124,7 +124,7 @@ def test_ImageSet():
     # Passing a set instead of a FiniteSet shouldn't raise
     assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})
 
-    raises(TypeError, lambda: ImageSet(Lambda(x, x**2), None))
+    raises(TypeError, lambda: ImageSet(Lambda(x, x**2), 1))
 
 
 def test_image_is_ImageSet():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -470,6 +470,13 @@ def test_ProductSet():
     assert (x3, x3) in S3 * S3
     assert x3 + x3 not in S3 * S3
 
+    raises(ValueError, lambda: S.Reals**-1)
+    with warns_deprecated_sympy():
+        ProductSet(FiniteSet(s) for s in range(2))
+    raises(TypeError, lambda: ProductSet(None))
+
+    raises(ValueError, lambda: ProductSet(Interval(0, 1)).as_relational(x, y))
+
 
 def test_ProductSet_of_single_arg_is_not_arg():
     assert unchanged(ProductSet, Interval(0, 1))
@@ -1070,6 +1077,9 @@ def test_Eq():
     assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x) is True
     assert Eq(FiniteSet({x, y}).subs(y, x+1), FiniteSet({x})) is False
     assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x+1) is False
+
+    assert Eq(ProductSet({1}, {2}), Interval(1, 2)) not in (S.true, S.false)
+    assert Eq(ProductSet({1}), ProductSet({1}, {2})) is S.false
 
 
 def test_SymmetricDifference():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -262,7 +262,10 @@ def test_Complement():
     B = FiniteSet(*symbols('d:f'))
     assert unchanged(Complement, ProductSet(A, A), B)
 
-    raises(ValueError, lambda: Complement(ProductSet(A, A), ProductSet(B, B, B)))
+    A2 = ProductSet(A, A)
+    B3 = ProductSet(B, B, B)
+    assert A2 - B3 == A2
+    assert B3 - A2 == B3
 
 
 def test_complement():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -423,6 +423,7 @@ def test_is_disjoint():
 
 
 def test_ProductSet():
+    # ProductSet is always a set of Tuples
     assert ProductSet(S.Reals) == S.Reals ** 1
     assert ProductSet(S.Reals, S.Reals) == S.Reals ** 2
     assert ProductSet(S.Reals, S.Reals, S.Reals) == S.Reals ** 3
@@ -430,6 +431,7 @@ def test_ProductSet():
     assert ProductSet(S.Reals) != S.Reals
     assert ProductSet(S.Reals, S.Reals) == S.Reals * S.Reals
     assert ProductSet(S.Reals, S.Reals, S.Reals) != S.Reals * S.Reals * S.Reals
+    assert ProductSet(S.Reals, S.Reals, S.Reals) == (S.Reals * S.Reals * S.Reals).flatten()
 
     assert 1 not in ProductSet(S.Reals)
     assert (1,) in ProductSet(S.Reals)
@@ -448,7 +450,7 @@ def test_ProductSet():
     assert ProductSet() == FiniteSet(())
     assert ProductSet(S.Reals, S.EmptySet) == S.EmptySet
 
-    # See GH-174598
+    # See GH-17458
 
     for n in range(5):
         Rn = ProductSet(*(S.Reals,) * n)
@@ -475,8 +477,6 @@ def test_ProductSet():
         ProductSet(FiniteSet(s) for s in range(2))
     raises(TypeError, lambda: ProductSet(None))
 
-    raises(ValueError, lambda: ProductSet(Interval(0, 1)).as_relational(x, y))
-
     S1 = FiniteSet(1, 2)
     S2 = FiniteSet(3, 4)
     S3 = ProductSet(S1, S2)
@@ -485,6 +485,17 @@ def test_ProductSet():
             == And(Or(Eq(x, 1), Eq(x, 2)), Or(Eq(y, 3), Eq(y, 4))))
     raises(ValueError, lambda: S3.as_relational(x))
     raises(ValueError, lambda: S3.as_relational(x, 1))
+    raises(ValueError, lambda: ProductSet(Interval(0, 1)).as_relational(x, y))
+
+    Z2 = ProductSet(S.Integers, S.Integers)
+    assert Z2.contains((1, 2)) is S.true
+    assert Z2.contains((1,)) is S.false
+    assert Z2.contains(x) == Contains(x, Z2, evaluate=False)
+    assert Z2.contains(x).subs(x, 1) is S.false
+    assert Z2.contains((x, 1)).subs(x, 2) is S.true
+    assert Z2.contains((x, y)) == Contains((x, y), Z2, evaluate=False)
+    assert unchanged(Contains, (x, y), Z2)
+    assert Contains((1, 2), Z2) is S.true
 
 
 def test_ProductSet_of_single_arg_is_not_arg():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -422,8 +422,58 @@ def test_is_disjoint():
     assert Interval(0, 2).is_disjoint(Interval(3, 4)) == True
 
 
-def test_ProductSet_of_single_arg_is_arg():
+def test_ProductSet():
+    assert ProductSet(S.Reals) == S.Reals ** 1
+    assert ProductSet(S.Reals, S.Reals) == S.Reals ** 2
+    assert ProductSet(S.Reals, S.Reals, S.Reals) == S.Reals ** 3
+
+    assert ProductSet(S.Reals) != S.Reals
+    assert ProductSet(S.Reals, S.Reals) == S.Reals * S.Reals
+    assert ProductSet(S.Reals, S.Reals, S.Reals) != S.Reals * S.Reals * S.Reals
+
+    assert 1 not in ProductSet(S.Reals)
+    assert (1,) in ProductSet(S.Reals)
+
+    assert 1 not in ProductSet(S.Reals, S.Reals)
+    assert (1, 2) in ProductSet(S.Reals, S.Reals)
+    assert (1, I) not in ProductSet(S.Reals, S.Reals)
+
+    assert (1, 2, 3) in ProductSet(S.Reals, S.Reals, S.Reals)
+    assert (1, 2, 3) in S.Reals ** 3
+    assert (1, 2, 3) not in S.Reals * S.Reals * S.Reals
+    assert ((1, 2), 3) in S.Reals * S.Reals * S.Reals
+    assert (1, (2, 3)) not in S.Reals * S.Reals * S.Reals
+    assert (1, (2, 3)) in S.Reals * (S.Reals * S.Reals)
+
+    assert ProductSet() == FiniteSet(())
+    assert ProductSet(S.Reals, S.EmptySet) == S.EmptySet
+
+    # See GH-174598
+
+    for n in range(5):
+        Rn = ProductSet(*(S.Reals,) * n)
+        assert (1,) * n in Rn
+        assert 1 not in Rn
+
+    assert (S.Reals * S.Reals) * S.Reals != S.Reals * (S.Reals * S.Reals)
+
+    S1 = S.Reals
+    S2 = S.Integers
+    x1 = pi
+    x2 = 3
+    assert x1 in S1
+    assert x2 in S2
+    assert (x1, x2) in S1 * S2
+    S3 = S1 * S2
+    x3 = (x1, x2)
+    assert x3 in S3
+    assert (x3, x3) in S3 * S3
+    assert x3 + x3 not in S3 * S3
+
+
+def test_ProductSet_of_single_arg_is_not_arg():
     assert unchanged(ProductSet, Interval(0, 1))
+    assert ProductSet(Interval(0, 1)) != Interval(0, 1)
 
 
 def test_ProductSet_is_empty():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -258,6 +258,12 @@ def test_Complement():
     assert Complement(FiniteSet(x, y, 2), Interval(-10, 10)) == \
             Complement(FiniteSet(x, y), Interval(-10, 10))
 
+    A = FiniteSet(*symbols('a:c'))
+    B = FiniteSet(*symbols('d:f'))
+    assert unchanged(Complement, ProductSet(A, A), B)
+
+    raises(ValueError, lambda: Complement(ProductSet(A, A), ProductSet(B, B, B)))
+
 
 def test_complement():
     assert Interval(0, 1).complement(S.Reals) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1104,6 +1104,10 @@ def test_Eq():
     assert Eq(FiniteSet(()), FiniteSet(1)) is S.false
     assert Eq(ProductSet(), FiniteSet(1)) is S.false
 
+    i1 = Interval(0, 1)
+    i2 = Interval(x, y)
+    assert unchanged(Eq, ProductSet(i1, i1), ProductSet(i2, i2))
+
 
 def test_SymmetricDifference():
    assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -477,6 +477,15 @@ def test_ProductSet():
 
     raises(ValueError, lambda: ProductSet(Interval(0, 1)).as_relational(x, y))
 
+    S1 = FiniteSet(1, 2)
+    S2 = FiniteSet(3, 4)
+    S3 = ProductSet(S1, S2)
+    assert (S3.as_relational(x, y)
+            == And(S1.as_relational(x), S2.as_relational(y))
+            == And(Or(Eq(x, 1), Eq(x, 2)), Or(Eq(y, 3), Eq(y, 4))))
+    raises(ValueError, lambda: S3.as_relational(x))
+    raises(ValueError, lambda: S3.as_relational(x, 1))
+
 
 def test_ProductSet_of_single_arg_is_not_arg():
     assert unchanged(ProductSet, Interval(0, 1))
@@ -1073,13 +1082,16 @@ def test_Eq():
     assert Eq(s1*s2, s2*s1) == False
 
     assert unchanged(Eq, FiniteSet({x, y}), FiniteSet({x}))
-    assert Eq(FiniteSet({x, y}).subs(y, x), FiniteSet({x})) is True
-    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x) is True
-    assert Eq(FiniteSet({x, y}).subs(y, x+1), FiniteSet({x})) is False
-    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x+1) is False
+    assert Eq(FiniteSet({x, y}).subs(y, x), FiniteSet({x})) is S.true
+    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x) is S.true
+    assert Eq(FiniteSet({x, y}).subs(y, x+1), FiniteSet({x})) is S.false
+    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x+1) is S.false
 
     assert Eq(ProductSet({1}, {2}), Interval(1, 2)) not in (S.true, S.false)
     assert Eq(ProductSet({1}), ProductSet({1}, {2})) is S.false
+
+    assert Eq(FiniteSet(()), FiniteSet(1)) is S.false
+    assert Eq(ProductSet(), FiniteSet(1)) is S.false
 
 
 def test_SymmetricDifference():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -423,7 +423,7 @@ def test_is_disjoint():
 
 
 def test_ProductSet_of_single_arg_is_arg():
-    assert ProductSet(Interval(0, 1)) == Interval(0, 1)
+    assert unchanged(ProductSet, Interval(0, 1))
 
 
 def test_ProductSet_is_empty():
@@ -773,8 +773,10 @@ def test_product_basic():
     assert (0, 0) in square
     assert 0 not in square
     assert (H, T) in coin ** 2
-    assert (.5, .5, .5) in square * unit_line
-    assert (H, 3, 3) in coin * d6* d6
+    assert (.5, .5, .5) in (square * unit_line).flatten()
+    assert ((.5, .5), .5) in square * unit_line
+    assert (H, 3, 3) in (coin * d6 * d6).flatten()
+    assert ((H, 3), 3) in coin * d6 * d6
     HH, TT = sympify(H), sympify(T)
     assert set(coin**2) == set(((HH, HH), (HH, TT), (TT, HH), (TT, TT)))
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -361,7 +361,7 @@ class MultivariateEwensDistribution(JointDistribution):
         prod_set = Range(0, self.n + 1)
         for i in range(2, self.n + 1):
             prod_set *= Range(0, self.n//i + 1)
-        return prod_set
+        return prod_set.flatten()
 
     def pdf(self, *syms):
         n, theta = self.n, self.theta

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -510,7 +510,7 @@ class ProductDomain(RandomDomain):
 
     @property
     def set(self):
-        return ProductSet(domain.set for domain in self.domains)
+        return ProductSet(*(domain.set for domain in self.domains))
 
     def __contains__(self, other):
         # Split event into each subdomain

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -157,10 +157,10 @@ def test_MultivariateEwens():
                                             factorial(a[0])*factorial(a[1])*
                                             factorial(a[2])), Eq(a[0] + 2*a[1] +
                                             3*a[2], 3)), (0, True))
-    #assert marginal_distribution(ed, ed[1])(a[1]) == Piecewise((6*2**(-a[1])*
-    #                                                theta**a[1]/((theta + 1)*
-    #                                                (theta + 2)*factorial(a[1])),
-    #                                                Eq(2*a[1] + 1, 3)), (0, True))
+    assert marginal_distribution(ed, ed[1])(a[1]) == Piecewise((6*2**(-a[1])*
+                                                    theta**a[1]/((theta + 1)*
+                                                    (theta + 2)*factorial(a[1])),
+                                                    Eq(2*a[1] + 1, 3)), (0, True))
     raises(ValueError, lambda: MultivariateEwens('e1', 5, theta_f))
 
     # tests for symbolic dimensions

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -157,10 +157,10 @@ def test_MultivariateEwens():
                                             factorial(a[0])*factorial(a[1])*
                                             factorial(a[2])), Eq(a[0] + 2*a[1] +
                                             3*a[2], 3)), (0, True))
-    assert marginal_distribution(ed, ed[1])(a[1]) == Piecewise((6*2**(-a[1])*
-                                                    theta**a[1]/((theta + 1)*
-                                                    (theta + 2)*factorial(a[1])),
-                                                    Eq(2*a[1] + 1, 3)), (0, True))
+    #assert marginal_distribution(ed, ed[1])(a[1]) == Piecewise((6*2**(-a[1])*
+    #                                                theta**a[1]/((theta + 1)*
+    #                                                (theta + 2)*factorial(a[1])),
+    #                                                Eq(2*a[1] + 1, 3)), (0, True))
     raises(ValueError, lambda: MultivariateEwens('e1', 5, theta_f))
 
     # tests for symbolic dimensions


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17458 

#### Brief description of what is fixed or changed

This changes `ProductSet` so that it no longer automatically flattens other ProductSets in its arguments e.g.:
```julia
In [1]: S.Reals * S.Reals                                                                                                         
Out[1]: 
 2
ℝ 

In [2]: S.Reals * S.Reals * S.Reals                                                                                               
Out[2]: 
⎛ 2⎞    
⎝ℝ ⎠ × ℝ

In [3]: S.Reals**3                                                                                                                
Out[3]: 
 3
ℝ 

In [5]: (1, 2, 3) in S.Reals**3                                                                                                   
Out[5]: True

In [6]: (1, 2, 3) in S.Reals*S.Reals*S.Reals                                                                                      
Out[6]: False

In [7]: ((1, 2), 3) in S.Reals*S.Reals*S.Reals                                                                                    
Out[7]: True
```
The empty ProductSet is changed so that it returns the set consiting only of the empty tuple:
```julia
In [12]: ProductSet()                                                                                                             
Out[12]: {()}

In [13]: () in ProductSet()                                                                                                       
Out[13]: True
```
Passing an iterable argument to ProductSet is deprecated:
```julia
In [1]: ProductSet(S.Reals for n in range(2))                                                                                     
/Users/enojb/current/sympy/sympy/sympy/sets/sets.py:683: SymPyDeprecationWarning: 

ProductSet(iterable) has been deprecated since SymPy 1.5. Use
ProductSet(*iterable) instead. See
https://github.com/sympy/sympy/issues/17557 for more info.

  deprecated_since_version="1.5"
Out[1]: 
 2
ℝ
```
Iterable arguments should be unpacked instead:
```julia
In [2]: ProductSet(*(S.Reals for n in range(2)))                                                                                  
Out[2]: 
 2
ℝ
```
A flatten method is added to ProductSet to get something similar to the old behaviour:
```julia
In [3]: S.Reals * S.Reals * S.Reals                                                                                               
Out[3]: 
⎛ 2⎞    
⎝ℝ ⎠ × ℝ

In [4]: _.flatten()                                                                                                               
Out[4]: 
 3
ℝ 
```

#### Other comments

This follows on from #17474 and is the foundation for fixing ImageSet issues as described in #17455. For now there are no major changes to ImageSet. In this PR ImageSet uses flatten() to maintain the current ProductSet behaviour.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * ProductSet no longer automatically flattens its arguments but provides a flatten() method instead. This also means that the Cartesian product of sets is not associative.
    * The ProductSet of no sets is no longer the empty set. Instead is the set consisting of the empty tuple.
    * Passing an iterable argument to ProductSet is now deprecated. An iterable should be unpacked when passed to ProductSet.
    * Fixed printing of unary ProductSets
    * ProductSet.as_relational always returns relationals
    * Equalities involving Tuples can now evaluate and some bugs for equalities involving FiniteSets are fixed.
<!-- END RELEASE NOTES -->
