### PR TITLE
Fix mathml presentation printer for set operations

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -8,7 +8,8 @@ from sympy import sympify, S, Mul
 from sympy.core.compatibility import range, string_types, default_sort_key
 from sympy.core.function import _coeff_isneg
 from sympy.printing.conventions import split_super_sub, requires_partial
-from sympy.printing.precedence import precedence_traditional, PRECEDENCE
+from sympy.printing.precedence import \
+    precedence_traditional, PRECEDENCE, PRECEDENCE_TRADITIONAL
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
 
@@ -1272,28 +1273,36 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             mrow.appendChild(self._print(arg))
         return mrow
 
-    def _print_SetOp(self, expr, symbol):
+    def _print_SetOp(self, expr, symbol, prec):
         mrow = self.dom.createElement('mrow')
-        mrow.appendChild(self._print(expr.args[0]))
+        mrow.appendChild(self.parenthesize(expr.args[0], prec))
         for arg in expr.args[1:]:
             x = self.dom.createElement('mo')
             x.appendChild(self.dom.createTextNode(symbol))
-            y = self._print(arg)
+            y = self.parenthesize(arg, prec)
             mrow.appendChild(x)
             mrow.appendChild(y)
         return mrow
 
     def _print_Union(self, expr):
-        return self._print_SetOp(expr, '&#x222A;')
+        prec = PRECEDENCE_TRADITIONAL['Union']
+        return self._print_SetOp(expr, '&#x222A;', prec)
 
     def _print_Intersection(self, expr):
-        return self._print_SetOp(expr, '&#x2229;')
+        prec = PRECEDENCE_TRADITIONAL['Intersection']
+        return self._print_SetOp(expr, '&#x2229;', prec)
 
     def _print_Complement(self, expr):
-        return self._print_SetOp(expr, '&#x2216;')
+        prec = PRECEDENCE_TRADITIONAL['Complement']
+        return self._print_SetOp(expr, '&#x2216;', prec)
 
     def _print_SymmetricDifference(self, expr):
-        return self._print_SetOp(expr, '&#x2206;')
+        prec = PRECEDENCE_TRADITIONAL['SymmetricDifference']
+        return self._print_SetOp(expr, '&#x2206;', prec)
+
+    def _print_ProductSet(self, expr):
+        prec = PRECEDENCE_TRADITIONAL['ProductSet']
+        return self._print_SetOp(expr, '&#x00d7;', prec)
 
     def _print_FiniteSet(self, s):
         return self._print_set(s.args)

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1250,55 +1250,41 @@ def test_print_SetOp():
     '<mn>4</mn><mi>y</mi></mfenced></mrow>'
 
     A = FiniteSet(a)
-    B = FiniteSet(b)
     C = FiniteSet(c)
     D = FiniteSet(d)
 
-    U1 = Union(A, B, evaluate=False)
-    U2 = Union(C, D, evaluate=False)
-    I1 = Intersection(A, B, evaluate=False)
-    I2 = Intersection(C, D, evaluate=False)
-    C1 = Complement(A, B, evaluate=False)
-    C2 = Complement(C, D, evaluate=False)
-    D1 = SymmetricDifference(A, B, evaluate=False)
-    D2 = SymmetricDifference(C, D, evaluate=False)
+    U1 = Union(C, D, evaluate=False)
+    I1 = Intersection(C, D, evaluate=False)
+    C1 = Complement(C, D, evaluate=False)
+    D1 = SymmetricDifference(C, D, evaluate=False)
     # XXX ProductSet does not support evaluate keyword
-    P1 = ProductSet(A, B)
-    P2 = ProductSet(C, D)
+    P1 = ProductSet(C, D)
 
-    assert prntr(Intersection(A, U2, evaluate=False)) == \
+    assert prntr(Union(A, I1, evaluate=False)) == \
+        '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
+        '<mo>&#x222A;</mo><mfenced><mrow><mfenced close="}" open="{">' \
+        '<mi>c</mi></mfenced><mo>&#x2229;</mo><mfenced close="}" open="{">' \
+        '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
+    assert prntr(Intersection(A, C1, evaluate=False)) == \
         '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
         '<mo>&#x2229;</mo><mfenced><mrow><mfenced close="}" open="{">' \
+        '<mi>c</mi></mfenced><mo>&#x2216;</mo><mfenced close="}" open="{">' \
+        '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
+    assert prntr(Complement(A, D1, evaluate=False)) == \
+        '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
+        '<mo>&#x2216;</mo><mfenced><mrow><mfenced close="}" open="{">' \
+        '<mi>c</mi></mfenced><mo>&#x2206;</mo><mfenced close="}" open="{">' \
+        '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
+    assert prntr(SymmetricDifference(A, P1, evaluate=False)) == \
+        '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
+        '<mo>&#x2206;</mo><mfenced><mrow><mfenced close="}" open="{">' \
+        '<mi>c</mi></mfenced><mo>&#x00d7;</mo><mfenced close="}" open="{">' \
+        '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
+    assert prntr(ProductSet(A, U1)) == \
+        '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
+        '<mo>&#x00d7;</mo><mfenced><mrow><mfenced close="}" open="{">' \
         '<mi>c</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{">' \
         '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
-    assert prntr(Intersection(U1, U2, evaluate=False)) == \
-        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
-        '</mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mi>b</mi>' \
-        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
-        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x222A;</mo>' \
-        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
-        '</mrow>'
-    assert prntr(Intersection(C1, C2, evaluate=False)) == \
-        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
-        '</mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mi>b</mi>' \
-        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
-        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x2216;</mo>' \
-        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
-        '</mrow>'
-    assert prntr(Intersection(D1, D2, evaluate=False)) == \
-        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
-        '</mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mi>b</mi>' \
-        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
-        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x2206;</mo>' \
-        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
-        '</mrow>'
-    assert prntr(Intersection(P1, P2, evaluate=False)) == \
-        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
-        '</mfenced><mo>&#x00d7;</mo><mfenced close="}" open="{"><mi>b</mi>' \
-        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
-        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x00d7;</mo>' \
-        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
-        '</mrow>'
 
 
 def test_print_logic():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -28,7 +28,7 @@ from sympy.physics.quantum import ComplexSpace, HilbertSpace, FockSpace, hbar, D
 from sympy.printing.mathml import mathml, MathMLContentPrinter, \
     MathMLPresentationPrinter, MathMLPrinter
 from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
-    SymmetricDifference, Interval, EmptySet
+    SymmetricDifference, Interval, EmptySet, ProductSet
 from sympy.stats.rv import RandomSymbol
 from sympy.utilities.pytest import raises
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Laplacian
@@ -1230,22 +1230,75 @@ def test_print_SetOp():
     f1 = FiniteSet(x, 1, 3)
     f2 = FiniteSet(y, 2, 4)
 
-    assert mpp.doprint(Union(f1, f2, evaluate=False)) == \
+    prntr = lambda x: mathml(x, printer='presentation')
+
+    assert prntr(Union(f1, f2, evaluate=False)) == \
     '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi>'\
     '</mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mn>2</mn>'\
     '<mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Intersection(f1, f2, evaluate=False)) == \
+    assert prntr(Intersection(f1, f2, evaluate=False)) == \
     '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi>'\
     '</mfenced><mo>&#x2229;</mo><mfenced close="}" open="{"><mn>2</mn>'\
     '<mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(Complement(f1, f2, evaluate=False)) == \
+    assert prntr(Complement(f1, f2, evaluate=False)) == \
     '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi>'\
     '</mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mn>2</mn>'\
     '<mn>4</mn><mi>y</mi></mfenced></mrow>'
-    assert mpp.doprint(SymmetricDifference(f1, f2, evaluate=False)) == \
+    assert prntr(SymmetricDifference(f1, f2, evaluate=False)) == \
     '<mrow><mfenced close="}" open="{"><mn>1</mn><mn>3</mn><mi>x</mi>'\
     '</mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mn>2</mn>'\
     '<mn>4</mn><mi>y</mi></mfenced></mrow>'
+
+    A = FiniteSet(a)
+    B = FiniteSet(b)
+    C = FiniteSet(c)
+    D = FiniteSet(d)
+
+    U1 = Union(A, B, evaluate=False)
+    U2 = Union(C, D, evaluate=False)
+    I1 = Intersection(A, B, evaluate=False)
+    I2 = Intersection(C, D, evaluate=False)
+    C1 = Complement(A, B, evaluate=False)
+    C2 = Complement(C, D, evaluate=False)
+    D1 = SymmetricDifference(A, B, evaluate=False)
+    D2 = SymmetricDifference(C, D, evaluate=False)
+    # XXX ProductSet does not support evaluate keyword
+    P1 = ProductSet(A, B)
+    P2 = ProductSet(C, D)
+
+    assert prntr(Intersection(A, U2, evaluate=False)) == \
+        '<mrow><mfenced close="}" open="{"><mi>a</mi></mfenced>' \
+        '<mo>&#x2229;</mo><mfenced><mrow><mfenced close="}" open="{">' \
+        '<mi>c</mi></mfenced><mo>&#x222A;</mo><mfenced close="}" open="{">' \
+        '<mi>d</mi></mfenced></mrow></mfenced></mrow>'
+    assert prntr(Intersection(U1, U2, evaluate=False)) == \
+        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
+        '</mfenced><mo>&#x222A;</mo><mfenced close="}" open="{"><mi>b</mi>' \
+        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
+        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x222A;</mo>' \
+        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
+        '</mrow>'
+    assert prntr(Intersection(C1, C2, evaluate=False)) == \
+        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
+        '</mfenced><mo>&#x2216;</mo><mfenced close="}" open="{"><mi>b</mi>' \
+        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
+        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x2216;</mo>' \
+        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
+        '</mrow>'
+    assert prntr(Intersection(D1, D2, evaluate=False)) == \
+        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
+        '</mfenced><mo>&#x2206;</mo><mfenced close="}" open="{"><mi>b</mi>' \
+        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
+        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x2206;</mo>' \
+        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
+        '</mrow>'
+    assert prntr(Intersection(P1, P2, evaluate=False)) == \
+        '<mrow><mfenced><mrow><mfenced close="}" open="{"><mi>a</mi>' \
+        '</mfenced><mo>&#x00d7;</mo><mfenced close="}" open="{"><mi>b</mi>' \
+        '</mfenced></mrow></mfenced><mo>&#x2229;</mo><mfenced><mrow>' \
+        '<mfenced close="}" open="{"><mi>c</mi></mfenced><mo>&#x00d7;</mo>' \
+        '<mfenced close="}" open="{"><mi>d</mi></mfenced></mrow></mfenced>' \
+        '</mrow>'
 
 
 def test_print_logic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Same as #17538

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added support for printing `ProductSet` in mathml presentation printer.
  - Fixed parenthesis for set operators `Union`, `Intersection`, `SymmetricDifference`, `Complement`, and `ProductSet` for mathml presentation printer.
<!-- END RELEASE NOTES -->
