### PR TITLE
Add as_relational for Complement and SymmetricDifference

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -21,7 +21,7 @@ from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import Singleton, S
 from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
 from sympy.core.sympify import _sympify, sympify, converter
-from sympy.logic.boolalg import And, Or, Not, true, false
+from sympy.logic.boolalg import And, Or, Not, Xor, true, false
 from sympy.sets.contains import Contains
 from sympy.utilities import subsets
 from sympy.utilities.iterables import sift
@@ -1877,10 +1877,8 @@ class SymmetricDifference(Set):
 
         A_rel = A.as_relational(symbol)
         B_rel = B.as_relational(symbol)
-        A_neg = Not(A_rel)
-        B_neg = Not(B_rel)
 
-        return Or(And(A_rel, B_neg), And(B_rel, A_neg))
+        return Xor(A_rel, B_rel)
 
 
 def imageset(*args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1516,6 +1516,16 @@ class Complement(Set, EvalfMixin):
         B = self.args[1]
         return And(A.contains(other), Not(B.contains(other)))
 
+    def as_relational(self, symbol):
+        """Rewrite a complement in terms of equalities and logic
+        operators"""
+        A, B = self.args
+
+        A_rel = A.as_relational(symbol)
+        B_rel = Not(B.as_relational(symbol))
+
+        return And(A_rel, B_rel)
+
 
 class EmptySet(with_metaclass(Singleton, Set)):
     """
@@ -1859,6 +1869,18 @@ class SymmetricDifference(Set):
             return result
         else:
             return SymmetricDifference(A, B, evaluate=False)
+
+    def as_relational(self, symbol):
+        """Rewrite a symmetric_difference in terms of equalities and
+        logic operators"""
+        A, B = self.args
+
+        A_rel = A.as_relational(symbol)
+        B_rel = B.as_relational(symbol)
+        A_neg = Not(A_rel)
+        B_neg = Not(B_rel)
+
+        return Or(And(A_rel, B_neg), And(B_rel, A_neg))
 
 
 def imageset(*args):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -10,7 +10,7 @@ from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
 from sympy.core.relational import \
     Eq, Ne, Ge, Le, Gt, Lt, GreaterThan, LessThan
-from sympy.logic import And, Or, Not
+from sympy.logic import And, Or, Not, Xor
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import x, y, z, m, n
@@ -724,8 +724,7 @@ def test_Complement_as_relational_fail():
 def test_SymmetricDifference_as_relational():
     x = Symbol('x')
     expr = SymmetricDifference(Interval(0, 1), FiniteSet(2), evaluate=False)
-    assert expr.as_relational(x) == \
-        Eq(x, 2) & Not(Le(0, x) & Le(x, 1)) | Le(0, x) & Le(x, 1) & Ne(x, 2)
+    assert expr.as_relational(x) == Xor(Eq(x, 2), Le(0, x) & Le(x, 1))
 
 
 def test_EmptySet():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
+    Max, Min, Float,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet, E,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Eq, Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
@@ -8,6 +8,9 @@ from mpmath import mpi
 
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
+from sympy.core.relational import \
+    Eq, Ne, Ge, Le, Gt, Lt, GreaterThan, LessThan
+from sympy.logic import And, Or, Not
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import x, y, z, m, n
@@ -699,6 +702,30 @@ def test_Intersection_as_relational():
     assert (Intersection(Interval(0, 1), FiniteSet(2),
             evaluate=False).as_relational(x)
             == And(And(Le(0, x), Le(x, 1)), Eq(x, 2)))
+
+
+def test_Complement_as_relational():
+    x = Symbol('x')
+    expr = Complement(Interval(0, 1), FiniteSet(2), evaluate=False)
+    assert expr.as_relational(x) == \
+        And(Le(0, x), Le(x, 1), Ne(x, 2))
+
+
+@XFAIL
+def test_Complement_as_relational_fail():
+    x = Symbol('x')
+    expr = Complement(Interval(0, 1), FiniteSet(2), evaluate=False)
+    # XXX This example fails because 0 <= x changes to x >= 0
+    # during the evaluation.
+    assert expr.as_relational(x) == \
+            (0 <= x) & (x <= 1) & Ne(x, 2)
+
+
+def test_SymmetricDifference_as_relational():
+    x = Symbol('x')
+    expr = SymmetricDifference(Interval(0, 1), FiniteSet(2), evaluate=False)
+    assert expr.as_relational(x) == \
+        Eq(x, 2) & Not(Le(0, x) & Le(x, 1)) | Le(0, x) & Le(x, 1) & Ne(x, 2)
 
 
 def test_EmptySet():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently, `Complement` and `SymmetricDifference` does not have `as_relational` and it gives errors for that.

#### Other comments

I think that there would be a more natural way to represent relationals from rewriting the symbolic `Contains` object like ![image](https://user-images.githubusercontent.com/34944973/64146504-339ecd80-ce58-11e9-903e-e6e7508c40df.png), and that way may even have more possibility to extend to multivariate cases.

And also, I see that relational operators like `x >= 0` and `0 <= x` is not treated equally, which I have marked as a failing test.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
  - Fixed `as_relational` giving error for `Complement` and `SymmetricDifference` 
<!-- END RELEASE NOTES -->
