### PR TITLE
Fix canonical relationals for set equality

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -219,21 +219,22 @@ class Relational(Boolean, Expr, EvalfMixin):
         LHS_CEMS = getattr(r.lhs, 'could_extract_minus_sign', None)
         RHS_CEMS = getattr(r.rhs, 'could_extract_minus_sign', None)
 
+        if isinstance(r.lhs, BooleanAtom) or isinstance(r.rhs, BooleanAtom):
+            return r
+
         # Check if first value has negative sign
-        if not isinstance(r.lhs, BooleanAtom) and LHS_CEMS:
-            if LHS_CEMS():
-                r = r.reversedsign
-        elif not isinstance(r.rhs, BooleanAtom) and RHS_CEMS and \
-            not r.rhs.is_number:
-            if RHS_CEMS():
-                # Right hand side has a minus, but not lhs.
-                # How does the expression with reversed signs behave?
-                # This is so that expressions of the type
-                # Eq(x, -y) and Eq(-x, y)
-                # have the same canonical representation
-                expr1, _ = ordered([r.lhs, -r.rhs])
-                if expr1 != r.lhs:
-                    r = r.reversed.reversedsign
+        if LHS_CEMS and LHS_CEMS():
+            return r.reversedsign
+        elif not r.rhs.is_number and RHS_CEMS and RHS_CEMS():
+            # Right hand side has a minus, but not lhs.
+            # How does the expression with reversed signs behave?
+            # This is so that expressions of the type
+            # Eq(x, -y) and Eq(-x, y)
+            # have the same canonical representation
+            expr1, _ = ordered([r.lhs, -r.rhs])
+            if expr1 != r.lhs:
+                return r.reversed.reversedsign
+
         return r
 
     def equals(self, other, failing_expression=False):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -960,6 +960,16 @@ def test_improved_canonical():
     assert (pi >= x).canonical == (x <= pi)
 
 
+def test_set_equality_canonical():
+    a, b, c = symbols('a b c')
+
+    A = Eq(FiniteSet(a, b, c), FiniteSet(1, 2, 3))
+    B = Eq(FiniteSet(a, b, c), FiniteSet(4, 5, 6))
+
+    assert A.canonical == A
+    assert B.canonical == B
+
+
 def test_trigsimp():
     # issue 16736
     s, c = sin(2*x), cos(2*x)
@@ -979,6 +989,7 @@ def test_polynomial_relation_simplification():
     assert Le(-(3*x*(x + 1) + 4), -3*x).simplify() in [Ge(x**2, -Rational(4,3)), Le(-x**2, Rational(4, 3))]
     assert ((x**2+3)*(x**2-1)+3*x >= 2*x**2).simplify() in [(x**4 + 3*x >= 3), (-x**4 - 3*x <= -3)]
 
+
 def test_multivariate_linear_function_simplification():
     assert Ge(x + y, x - y).simplify() == Ge(y, 0)
     assert Le(-x + y, -x - y).simplify() == Le(y, 0)
@@ -988,6 +999,7 @@ def test_multivariate_linear_function_simplification():
     assert (2*x + y < 2*x + y + 3).simplify() == True
     a, b, c, d, e, f, g = symbols('a b c d e f g')
     assert Lt(a + b + c + 2*d, 3*d - f + g). simplify() == Lt(a, -b - c + d - f + g)
+
 
 def test_nonpolymonial_relations():
     assert Eq(cos(x), 0).simplify() == Eq(cos(x), 0)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -964,7 +964,7 @@ def test_set_equality_canonical():
     a, b, c = symbols('a b c')
 
     A = Eq(FiniteSet(a, b, c), FiniteSet(1, 2, 3))
-    B = Eq(FiniteSet(a, b, c), FiniteSet(4, 5, 6))
+    B = Ne(FiniteSet(a, b, c), FiniteSet(4, 5, 6))
 
     assert A.canonical == A
     assert B.canonical == B

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -966,8 +966,8 @@ def test_set_equality_canonical():
     A = Eq(FiniteSet(a, b, c), FiniteSet(1, 2, 3))
     B = Ne(FiniteSet(a, b, c), FiniteSet(4, 5, 6))
 
-    assert A.canonical == A
-    assert B.canonical == B
+    assert A.canonical == A.reversed
+    assert B.canonical == B.reversed
 
 
 def test_trigsimp():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Not every object would have `could_extract_minus_sign` attribute.
For example, set equalities are giving errors when `canonical` is callred

It had caused some problems while building boolean operators, even if `A` and `B` are built without any problem.
```python
from sympy import *

a, b, c = symbols('a b c')

A = Eq(FiniteSet(a, b, c), FiniteSet(1, 2, 3))
B = Ne(FiniteSet(a, b, c), FiniteSet(4, 5, 6))

And(A, B)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed `Eq.canonical` and `Ne.canonical` giving error when there are sets.
<!-- END RELEASE NOTES -->
