### PR TITLE
Add power set notation

### DIFF
--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -2,6 +2,9 @@
 Sets
 ====
 
+Basic Sets
+----------
+
 .. automodule:: sympy.sets.sets
 
 Set
@@ -24,8 +27,20 @@ FiniteSet
 .. autoclass:: FiniteSet
    :members:
 
+ConditionSet
+^^^^^^^^^^^^
+.. module:: sympy.sets.conditionset
+    :noindex:
+
+.. autoclass:: ConditionSet
+    :members:
+
 Compound Sets
 -------------
+
+.. module:: sympy.sets.sets
+    :noindex:
+
 Union
 ^^^^^
 .. autoclass:: Union
@@ -44,6 +59,11 @@ ProductSet
 Complement
 ^^^^^^^^^^
 .. autoclass:: Complement
+   :members:
+
+SymmetricDifference
+^^^^^^^^^^^^^^^^^^^
+.. autoclass:: SymmetricDifference
    :members:
 
 Singleton Sets
@@ -94,6 +114,16 @@ ComplexRegion
    :members:
 
 .. autofunction:: normalize_theta_set
+
+Power sets
+----------
+
+.. automodule:: sympy.sets.powerset
+
+PowerSet
+^^^^^^^^
+.. autoclass:: PowerSet
+   :members:
 
 Iteration over sets
 ^^^^^^^^^^^^^^^^^^^

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -823,6 +823,13 @@ def test_sympy__sets__ordinals__OrdinalZero():
     from sympy.sets.ordinals import OrdinalZero
     assert _test_args(OrdinalZero())
 
+
+def test_sympy__sets__powerset__PowerSet():
+    from sympy.sets.powerset import PowerSet
+    from sympy.core.singleton import S
+    assert _test_args(PowerSet(S.EmptySet))
+
+
 def test_sympy__sets__sets__EmptySet():
     from sympy.sets.sets import EmptySet
     assert _test_args(EmptySet())

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -4,6 +4,7 @@ from .fancysets import ImageSet, Range, ComplexRegion, Reals
 from .contains import Contains
 from .conditionset import ConditionSet
 from .ordinals import Ordinal, OmegaPower, ord0
+from .powerset import PowerSet
 from ..core.singleton import S
 Reals = S.Reals
 Naturals = S.Naturals

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -10,6 +10,65 @@ from .sets import Set, tfn
 
 
 class PowerSet(Set):
+    r"""A symbolic object representing a power set.
+
+    Parameters
+    ==========
+
+    arg : Set
+        The set to take power of.
+
+    evaluate : bool
+        The flag to control evaluation.
+
+        If the evaluation is disabled for finite sets, it can take
+        advantage of using subset test as a membership test.
+
+    Notes
+    =====
+
+    Power set `\mathcal{P}(S)` is defined as a set containing all the
+    subsets of `S`.
+
+    If the set `S` is a finite set, its power set would have
+    `2^{\left| S \right|}` elements, where `\left| S \right|` denotes
+    the cardinality of `S`.
+
+    Examples
+    ========
+
+    >>> from sympy.sets.powerset import PowerSet
+    >>> from sympy import S, FiniteSet
+
+    A power set of a finite set:
+
+    >>> PowerSet(FiniteSet(1, 2, 3))
+    {EmptySet(), {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
+
+    A power set of an empty set:
+
+    >>> PowerSet(S.EmptySet)
+    {EmptySet()}
+    >>> PowerSet(PowerSet(S.EmptySet))
+    {EmptySet(), {EmptySet()}}
+
+    A power set of an infinite set:
+
+    >>> PowerSet(S.Reals)
+    PowerSet(Reals)
+
+    An unevaluated power set:
+
+    >>> PowerSet(FiniteSet(1, 2, 3), evaluate=False)
+    PowerSet({1, 2, 3})
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Power_set
+
+    .. [2] https://en.wikipedia.org/wiki/Axiom_of_power_set
+    """
     def __new__(cls, arg, evaluate=global_evaluate[0]):
         arg = _sympify(arg)
 

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -90,7 +90,7 @@ class PowerSet(Set):
     @_sympifyit('other', NotImplemented)
     def _contains(self, other):
         if not isinstance(other, Set):
-            raise ValueError('{} must be a set.'.format(other))
+            return None
 
         arg = self.arg
         ret = fuzzy_bool(arg.is_superset(other))

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -75,17 +75,17 @@ class PowerSet(Set):
         if not isinstance(arg, Set):
             raise ValueError('{} must be a set.'.format(arg))
 
-        if evaluate:
-            ret = arg._eval_powerset()
-
-            if ret is not None and not isinstance(arg, PowerSet):
-                return ret
-
         return super(PowerSet, cls).__new__(cls, arg)
 
     @property
     def arg(self):
         return self.args[0]
+
+    def _eval_rewrite_as_FiniteSet(self, *args, **kwargs):
+        arg = self.arg
+        if arg.is_FiniteSet:
+            return arg.powerset()
+        return None
 
     @_sympifyit('other', NotImplemented)
     def _contains(self, other):

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -1,0 +1,43 @@
+from __future__ import print_function, division
+
+from sympy.core.decorators import _sympifyit
+from sympy.core.evaluate import global_evaluate
+from sympy.core.logic import fuzzy_bool
+from sympy.core.singleton import S
+from sympy.core.sympify import _sympify
+
+from .sets import Set, tfn
+
+
+class PowerSet(Set):
+    def __new__(cls, arg, evaluate=global_evaluate[0]):
+        arg = _sympify(arg)
+
+        if not isinstance(arg, Set):
+            raise ValueError('{} must be a set.'.format(arg))
+
+        if evaluate:
+            ret = arg._eval_powerset()
+
+            if ret is not None and not isinstance(arg, PowerSet):
+                return ret
+
+        return super(PowerSet, cls).__new__(cls, arg)
+
+    @property
+    def arg(self):
+        return self.args[0]
+
+    @_sympifyit('other', NotImplemented)
+    def _contains(self, other):
+        if not isinstance(other, Set):
+            raise ValueError('{} must be a set.'.format(other))
+
+        arg = self.arg
+        ret = fuzzy_bool(arg.is_superset(other))
+        if ret is not None:
+            return ret
+        return None
+
+    def __len__(self):
+        return 2 ** len(self.arg)

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -98,5 +98,11 @@ class PowerSet(Set):
             return ret
         return None
 
+    def _eval_is_subset(self, other):
+        if isinstance(other, PowerSet):
+            ret = self.arg.is_subset(other.arg)
+            if ret is not None:
+                return ret
+
     def __len__(self):
         return 2 ** len(self.arg)

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -43,24 +43,24 @@ class PowerSet(Set):
     A power set of a finite set:
 
     >>> PowerSet(FiniteSet(1, 2, 3))
-    {EmptySet(), {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
+    PowerSet({1, 2, 3})
 
     A power set of an empty set:
 
     >>> PowerSet(S.EmptySet)
-    {EmptySet()}
+    PowerSet(EmptySet())
     >>> PowerSet(PowerSet(S.EmptySet))
-    {EmptySet(), {EmptySet()}}
+    PowerSet(PowerSet(EmptySet()))
 
     A power set of an infinite set:
 
     >>> PowerSet(S.Reals)
     PowerSet(Reals)
 
-    An unevaluated power set:
+    Evaluating the power set of a finite set to its explicit form:
 
-    >>> PowerSet(FiniteSet(1, 2, 3), evaluate=False)
-    PowerSet({1, 2, 3})
+    >>> PowerSet(FiniteSet(1, 2, 3)).rewrite(FiniteSet)
+    {EmptySet(), {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
 
     References
     ==========

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -106,3 +106,17 @@ class PowerSet(Set):
 
     def __len__(self):
         return 2 ** len(self.arg)
+
+    def __iter__(self):
+        from .sets import FiniteSet
+        found = [S.EmptySet]
+        yield S.EmptySet
+
+        for x in self.arg:
+            temp = []
+            x = FiniteSet(x)
+            for y in found:
+                new = x + y
+                yield new
+                temp.append(new)
+            found.extend(temp)

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -92,17 +92,11 @@ class PowerSet(Set):
         if not isinstance(other, Set):
             return None
 
-        arg = self.arg
-        ret = fuzzy_bool(arg.is_superset(other))
-        if ret is not None:
-            return ret
-        return None
+        return fuzzy_bool(self.arg.is_superset(other))
 
     def _eval_is_subset(self, other):
         if isinstance(other, PowerSet):
-            ret = self.arg.is_subset(other.arg)
-            if ret is not None:
-                return ret
+            return self.arg.is_subset(other.arg)
 
     def __len__(self):
         return 2 ** len(self.arg)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -366,6 +366,12 @@ class Set(Basic):
 
         """
         if isinstance(other, Set):
+            dispatch = getattr(self, '_eval_is_subset', None)
+            if dispatch is not None:
+                ret = dispatch(other)
+                if ret is not None:
+                    return ret
+
             s_o = self.intersect(other)
             if s_o == self:
                 return True

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1832,6 +1832,25 @@ class FiniteSet(Set, EvalfMixin):
     def _eval_powerset(self):
         return self.func(*[self.func(*s) for s in subsets(self.args)])
 
+    def _eval_rewrite_as_PowerSet(self, *args, **kwargs):
+        """Rewriting method for a finite set to a power set."""
+        from .powerset import PowerSet
+
+        is2pow = lambda n: bool(n and not n & (n - 1))
+        if not is2pow(len(self)):
+            return None
+
+        fs_test = lambda arg: isinstance(arg, Set) and arg.is_FiniteSet
+        if not all((fs_test(arg) for arg in args)):
+            return None
+
+        biggest = max(args, key=len)
+        for arg in subsets(biggest.args):
+            arg_set = FiniteSet(*arg)
+            if arg_set not in args:
+                return None
+        return PowerSet(biggest)
+
     def __ge__(self, other):
         if not isinstance(other, Set):
             raise TypeError("Invalid comparison of set with %s" % func_name(other))

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -448,7 +448,7 @@ class Set(Basic):
             raise ValueError("Unknown argument '%s'" % other)
 
     def _eval_powerset(self):
-        raise NotImplementedError('Power set not defined for: %s' % self.func)
+        return None
 
     def powerset(self):
         """

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -78,6 +78,24 @@ def test_powerset__len__():
     assert len(A) == 16
 
 
+def test_powerset__iter__():
+    a = PowerSet(FiniteSet(1, 2)).__iter__()
+    assert next(a) == S.EmptySet
+    assert next(a) == FiniteSet(1)
+    assert next(a) == FiniteSet(2)
+    assert next(a) == FiniteSet(1, 2)
+
+    a = PowerSet(S.Naturals).__iter__()
+    assert next(a) == S.EmptySet
+    assert next(a) == FiniteSet(1)
+    assert next(a) == FiniteSet(2)
+    assert next(a) == FiniteSet(1, 2)
+    assert next(a) == FiniteSet(3)
+    assert next(a) == FiniteSet(1, 3)
+    assert next(a) == FiniteSet(2, 3)
+    assert next(a) == FiniteSet(1, 2, 3)
+
+
 def test_powerset_contains():
     A = PowerSet(FiniteSet(1), evaluate=False)
     assert A.contains(2) == Contains(2, A)

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -30,28 +30,40 @@ def test_powerset__contains__():
         for j in range(l):
             try:
                 if i <= j:
-                    assert subset_series[i] in PowerSet(subset_series[j])
+                    assert subset_series[i] in \
+                        PowerSet(subset_series[j], evaluate=False)
                 else:
-                    assert subset_series[i] not in PowerSet(subset_series[j])
+                    assert subset_series[i] not in \
+                        PowerSet(subset_series[j], evaluate=False)
             except:
                 raise AssertionError(
                     'Powerset membership test failed between '
                     '{} and {}.'.format(subset_series[i], subset_series[j]))
 
 
-def test_powerset_contains():
-    subset_series = [
-        S.EmptySet,
-        FiniteSet(1, 2),
-        S.Naturals,
-        S.Naturals0,
-        S.Integers,
-        S.Rationals,
-        S.Reals,
-        S.Complexes]
+@XFAIL
+def test_failing_powerset__contains__():
+    assert FiniteSet(1, 2) not in PowerSet(S.EmptySet)
+    assert S.Naturals not in PowerSet(S.EmptySet)
+    assert S.Naturals not in PowerSet(FiniteSet(1, 2))
+    assert S.Naturals0 not in PowerSet(S.EmptySet)
+    assert S.Naturals0 not in PowerSet(FiniteSet(1, 2))
+    assert S.Integers not in PowerSet(S.EmptySet)
+    assert S.Integers not in PowerSet(FiniteSet(1, 2))
+    assert S.Rationals not in PowerSet(S.EmptySet)
+    assert S.Rationals not in PowerSet(FiniteSet(1, 2))
+    assert S.Reals not in PowerSet(S.EmptySet)
+    assert S.Reals not in PowerSet(FiniteSet(1, 2))
+    assert S.Complexes not in PowerSet(S.EmptySet)
+    assert S.Complexes not in PowerSet(FiniteSet(1, 2))
 
-    l = len(subset_series)
-    for i in range(l):
-        for j in range(l):
-            if i <= j:
-                subset_series[i] in PowerSet(subset_series[j])
+
+def test_powerset__len__():
+    A = PowerSet(S.EmptySet, evaluate=False)
+    assert len(A) == 1
+    A = PowerSet(A, evaluate=False)
+    assert len(A) == 2
+    A = PowerSet(A, evaluate=False)
+    assert len(A) == 4
+    A = PowerSet(A, evaluate=False)
+    assert len(A) == 16

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -1,5 +1,7 @@
 from sympy.core.expr import unchanged
 from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.sets.contains import Contains
 from sympy.sets.powerset import PowerSet
 from sympy.sets.sets import FiniteSet
 from sympy.utilities.pytest import raises, XFAIL
@@ -67,3 +69,13 @@ def test_powerset__len__():
     assert len(A) == 4
     A = PowerSet(A, evaluate=False)
     assert len(A) == 16
+
+
+def test_powerset_contains():
+    A = PowerSet(FiniteSet(1), evaluate=False)
+    assert A.contains(2) == Contains(2, A)
+
+    x = Symbol('x')
+
+    A = PowerSet(FiniteSet(x), evaluate=False)
+    assert A.contains(FiniteSet(1)) == Contains(A, FiniteSet(1))

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -19,6 +19,16 @@ def test_powerset_rewrite_FiniteSet():
     assert PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet) == \
         FiniteSet(S.EmptySet, FiniteSet(1), FiniteSet(2), FiniteSet(1, 2))
     assert PowerSet(S.EmptySet).rewrite(FiniteSet) == FiniteSet(S.EmptySet)
+    assert PowerSet(S.Naturals).rewrite(FiniteSet) == PowerSet(S.Naturals)
+
+
+def test_finiteset_rewrite_powerset():
+    assert FiniteSet(S.EmptySet).rewrite(PowerSet) == PowerSet(S.EmptySet)
+    assert FiniteSet(
+        S.EmptySet, FiniteSet(1),
+        FiniteSet(2), FiniteSet(1, 2)).rewrite(PowerSet) == \
+            PowerSet(FiniteSet(1, 2))
+    assert FiniteSet(1, 2, 3).rewrite(PowerSet) == FiniteSet(1, 2, 3)
 
 
 def test_powerset__contains__():

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -1,0 +1,57 @@
+from sympy.core.expr import unchanged
+from sympy.core.singleton import S
+from sympy.sets.powerset import PowerSet
+from sympy.sets.sets import FiniteSet
+from sympy.utilities.pytest import raises, XFAIL
+
+
+def test_powerset_creation():
+    assert PowerSet(FiniteSet(1, 2)) == \
+        FiniteSet(S.EmptySet, FiniteSet(1), FiniteSet(2), FiniteSet(1, 2))
+    assert PowerSet(S.EmptySet) == FiniteSet(S.EmptySet)
+    raises(ValueError, lambda: PowerSet(123))
+    assert unchanged(PowerSet, S.Reals)
+    assert unchanged(PowerSet, S.Integers)
+
+
+def test_powerset__contains__():
+    subset_series = [
+        S.EmptySet,
+        FiniteSet(1, 2),
+        S.Naturals,
+        S.Naturals0,
+        S.Integers,
+        S.Rationals,
+        S.Reals,
+        S.Complexes]
+
+    l = len(subset_series)
+    for i in range(l):
+        for j in range(l):
+            try:
+                if i <= j:
+                    assert subset_series[i] in PowerSet(subset_series[j])
+                else:
+                    assert subset_series[i] not in PowerSet(subset_series[j])
+            except:
+                raise AssertionError(
+                    'Powerset membership test failed between '
+                    '{} and {}.'.format(subset_series[i], subset_series[j]))
+
+
+def test_powerset_contains():
+    subset_series = [
+        S.EmptySet,
+        FiniteSet(1, 2),
+        S.Naturals,
+        S.Naturals0,
+        S.Integers,
+        S.Rationals,
+        S.Reals,
+        S.Complexes]
+
+    l = len(subset_series)
+    for i in range(l):
+        for j in range(l):
+            if i <= j:
+                subset_series[i] in PowerSet(subset_series[j])

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -8,12 +8,17 @@ from sympy.utilities.pytest import raises, XFAIL
 
 
 def test_powerset_creation():
-    assert PowerSet(FiniteSet(1, 2)) == \
-        FiniteSet(S.EmptySet, FiniteSet(1), FiniteSet(2), FiniteSet(1, 2))
-    assert PowerSet(S.EmptySet) == FiniteSet(S.EmptySet)
+    assert unchanged(PowerSet, FiniteSet(1, 2))
+    assert unchanged(PowerSet, S.EmptySet)
     raises(ValueError, lambda: PowerSet(123))
     assert unchanged(PowerSet, S.Reals)
     assert unchanged(PowerSet, S.Integers)
+
+
+def test_powerset_rewrite_FiniteSet():
+    assert PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet) == \
+        FiniteSet(S.EmptySet, FiniteSet(1), FiniteSet(2), FiniteSet(1, 2))
+    assert PowerSet(S.EmptySet).rewrite(FiniteSet) == FiniteSet(S.EmptySet)
 
 
 def test_powerset__contains__():
@@ -47,19 +52,19 @@ def test_powerset__contains__():
 def test_failing_powerset__contains__():
     # XXX These are failing when evaluate=True,
     # but using unevaluated PowerSet works fine.
-    assert FiniteSet(1, 2) not in PowerSet(S.EmptySet)
-    assert S.Naturals not in PowerSet(S.EmptySet)
-    assert S.Naturals not in PowerSet(FiniteSet(1, 2))
-    assert S.Naturals0 not in PowerSet(S.EmptySet)
-    assert S.Naturals0 not in PowerSet(FiniteSet(1, 2))
-    assert S.Integers not in PowerSet(S.EmptySet)
-    assert S.Integers not in PowerSet(FiniteSet(1, 2))
-    assert S.Rationals not in PowerSet(S.EmptySet)
-    assert S.Rationals not in PowerSet(FiniteSet(1, 2))
-    assert S.Reals not in PowerSet(S.EmptySet)
-    assert S.Reals not in PowerSet(FiniteSet(1, 2))
-    assert S.Complexes not in PowerSet(S.EmptySet)
-    assert S.Complexes not in PowerSet(FiniteSet(1, 2))
+    assert FiniteSet(1, 2) not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Naturals not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Naturals not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
+    assert S.Naturals0 not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Naturals0 not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
+    assert S.Integers not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Integers not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
+    assert S.Rationals not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Rationals not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
+    assert S.Reals not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Reals not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
+    assert S.Complexes not in PowerSet(S.EmptySet).rewrite(FiniteSet)
+    assert S.Complexes not in PowerSet(FiniteSet(1, 2)).rewrite(FiniteSet)
 
 
 def test_powerset__len__():
@@ -80,4 +85,4 @@ def test_powerset_contains():
     x = Symbol('x')
 
     A = PowerSet(FiniteSet(x), evaluate=False)
-    assert A.contains(FiniteSet(1)) == Contains(A, FiniteSet(1))
+    assert A.contains(FiniteSet(1)) == Contains(FiniteSet(1), A)

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -45,6 +45,8 @@ def test_powerset__contains__():
 
 @XFAIL
 def test_failing_powerset__contains__():
+    # XXX These are failing when evaluate=True,
+    # but using unevaluated PowerSet works fine.
     assert FiniteSet(1, 2) not in PowerSet(S.EmptySet)
     assert S.Naturals not in PowerSet(S.EmptySet)
     assert S.Naturals not in PowerSet(FiniteSet(1, 2))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -892,7 +892,6 @@ def test_powerset():
                              FiniteSet(2), A)
     # Not finite sets
     I = Interval(0, 1)
-    raises(NotImplementedError, I.powerset)
 
 
 def test_product_basic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The previous implementation in #7329 have some limitations that it can only be applicable for finite sets, and generally, computation can be slow even for a handful of elements.
I've added a full symbolic representation to resolve such issues.

I also think that using powerset can resolve failings like `FiniteSet(1, 2) not in FiniteSet(S.EmptySet)` because it can use subset testing for membership testing.

#### Other comments

I've also fixed the rst section ordering, added missing docs for some other set classes.

The doc for the PowerSet would look like
![image](https://user-images.githubusercontent.com/34944973/64371749-50a3ee00-d05c-11e9-93b5-1965085ba1d0.png)


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- sets
  - Added `PowerSet` for representing symbolic power set.
  - Fixed table-of-contents in the set documentation.
  - Added missing documentation about `SymmetricDifference`, `ConditionSet`.

<!-- END RELEASE NOTES -->
