### PR TITLE
removed bug from match and added test case

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -423,7 +423,7 @@ class Add(Expr, AssocOp):
         Returns lhs - rhs, but treats oo like a symbol so oo - oo
         returns 0, instead of a nan.
         """
-        from sympy.core.function import expand_mul
+        from sympy.simplify.simplify import signsimp
         from sympy.core.symbol import Dummy
         inf = (S.Infinity, S.NegativeInfinity)
         if lhs.has(*inf) or rhs.has(*inf):
@@ -432,14 +432,14 @@ class Add(Expr, AssocOp):
                 S.Infinity: oo,
                 S.NegativeInfinity: -oo}
             ireps = {v: k for k, v in reps.items()}
-            eq = expand_mul(lhs.xreplace(reps) - rhs.xreplace(reps))
+            eq = signsimp(lhs.xreplace(reps) - rhs.xreplace(reps))
             if eq.has(oo):
                 eq = eq.replace(
                     lambda x: x.is_Pow and x.base == oo,
                     lambda x: x.base)
             return eq.xreplace(ireps)
         else:
-            return expand_mul(lhs - rhs)
+            return signsimp(lhs - rhs)
 
     @cacheit
     def as_two_terms(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17397 

#### Brief description of what is fixed or changed
During the implementation of solving ode of Bessel/airy(#16581) type of differential equation, I found a bug in the match. And @oscarbenjamin  proposed a solution for the bug.

Now by doing this, I am able to match the differential equations.

eg- 

```julia
In [13]: a3 = Wild('a3', exclude=[f(x), f(x).diff(x), f(x).diff(x, 2)])
    ...: b3 = Wild('b3', exclude=[f(x), f(x).diff(x), f(x).diff(x, 2)])
    ...: c3 = Wild('c3', exclude=[f(x), f(x).diff(x), f(x).diff(x, 2)])
    ...: 

In [14]: deq = a3*(f(x).diff(x, 2)) + b3*f(x).diff(x) + c3*f(x)

In [15]: eq = (x-2)**2*(f(x).diff(x, 2)) + (x-2)*(f(x).diff(x)) + ((x-2)**2 - 4)*f
    ...: (x)

In [16]: r = collect(eq, [f(x).diff(x, 2), f(x).diff(x), f(x)]).match(deq)

In [17]: r
Out[17]: 
⎧           2                        2    ⎫
⎨a₃: (x - 2) , b₃: x - 2, c₃: (x - 2)  - 4⎬
⎩                                         ⎭

```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - removed match bug 
<!-- END RELEASE NOTES -->