### PR TITLE
Fix iteration for symbolic set objects

### DIFF
--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -98,20 +98,23 @@ ComplexRegion
 Iteration over sets
 ^^^^^^^^^^^^^^^^^^^
 
-For set unions, `\{a, b\} \cup \{x, y\}` may have no problem to be
-comprehended like `\{a, b, x, y\}` regardless of the distinctiveness of
+For set unions, `\{a, b\} \cup \{x, y\}` can be treated as
+ `\{a, b, x, y\}` for iteration regardless of the distinctiveness of
 the elements, however, for set intersections, assuming that
 `\{a, b\} \cap \{x, y\}` is `\varnothing` or `\{a, b \}` would not
-always be valid.
+always be valid, since some of `a`, `b`, `x` or `y` may or may not be
+the elements of the intersection.
 
-So, we have designed ``__iter__`` method for composite sets to sample an
-element from a enumeratible set and testing its membership for an
-another set, until an undecidable `\in` appears, which would raise a
-``TypeError``.
+Iterating over the elements of a set involving intersection, complement,
+or symmetric difference yields (possibly duplicate) elements of the set
+provided that all elements are known to be the elements of the set.
+If any element cannot be determined to be a member of a set then the
+iteration gives ``TypeError``.
+This happens in the same cases where ``x in y`` would give an error.
 
 There are some reasons to implement like this, even if it breaks the
 consistency with how the python set iterator works.
 We keep in mind that sympy set comprehension like ``FiniteSet(*s)`` from
-a existing sympy sets could be a common usage, and at least try to give
-a consistent result with ``s`` simplified in a symbolic way,
-than giving a mathematically wrong iteration.
+a existing sympy sets could be a common usage.
+And this approach would make ``FiniteSet(*s)`` to be consistent with any
+symbolic set processing methods like ``FiniteSet(*simplify(s))``.

--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -99,7 +99,7 @@ Iteration over sets
 ^^^^^^^^^^^^^^^^^^^
 
 For set unions, `\{a, b\} \cup \{x, y\}` can be treated as
- `\{a, b, x, y\}` for iteration regardless of the distinctiveness of
+`\{a, b, x, y\}` for iteration regardless of the distinctiveness of
 the elements, however, for set intersections, assuming that
 `\{a, b\} \cap \{x, y\}` is `\varnothing` or `\{a, b \}` would not
 always be valid, since some of `a`, `b`, `x` or `y` may or may not be

--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -94,3 +94,24 @@ ComplexRegion
    :members:
 
 .. autofunction:: normalize_theta_set
+
+Iteration over sets
+^^^^^^^^^^^^^^^^^^^
+
+For set unions, `\{a, b\} \cup \{x, y\}` may have no problem to be
+comprehended like `\{a, b, x, y\}` regardless of the distinctiveness of
+the elements, however, for set intersections, assuming that
+`\{a, b\} \cap \{x, y\}` is `\varnothing` or `\{a, b \}` would not
+always be valid.
+
+So, we have designed ``__iter__`` method for composite sets to sample an
+element from a enumeratible set and testing its membership for an
+another set, until an undecidable `\in` appears, which would raise a
+``TypeError``.
+
+There are some reasons to implement like this, even if it breaks the
+consistency with how the python set iterator works.
+We keep in mind that sympy set comprehension like ``FiniteSet(*s)`` from
+a existing sympy sets could be a common usage, and at least try to give
+a consistent result with ``s`` simplified in a symbolic way,
+than giving a mathematically wrong iteration.

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -652,7 +652,7 @@ class Range(Set):
         if self.has(Symbol):
             _ = self.size  # validate
         if self.start in [S.NegativeInfinity, S.Infinity]:
-            raise ValueError("Cannot iterate over Range with infinite start")
+            raise TypeError("Cannot iterate over Range with infinite start")
         elif self:
             i = self.start
             step = self.step

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -496,7 +496,7 @@ class Range(Set):
         >>> next(iter(r))
         Traceback (most recent call last):
         ...
-        ValueError: Cannot iterate over Range with infinite start
+        TypeError: Cannot iterate over Range with infinite start
         >>> next(iter(r.reversed))
         0
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1339,7 +1339,19 @@ class Intersection(Set, LatticeOp):
         completed = False
         candidates = sets_sift[True] + sets_sift[None]
 
-        for s in candidates:
+        finite_candidates, others = [], []
+        for candidate in candidates:
+            length = None
+            try:
+                length = len(candidate)
+            except:
+                others.append(candidate)
+
+            if length is not None:
+                finite_candidates.append(candidate)
+        finite_candidates.sort(key=len)
+
+        for s in finite_candidates + others:
             other_sets = set(self.args) - set((s,))
             other = Intersection(*other_sets, evaluate=False)
             completed = True

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -785,10 +785,7 @@ class ProductSet(Set):
         If self.is_iterable returns True (both constituent sets are iterable),
         then return the Cartesian Product. Otherwise, raise TypeError.
         """
-        if self.is_iterable:
-            return product(*self.sets)
-        else:
-            raise TypeError("Not all constituent sets are iterable")
+        return product(*self.sets)
 
     @property
     def is_empty(self):
@@ -1260,9 +1257,7 @@ class Union(Set, LatticeOp, EvalfMixin):
                    sys.exc_info()[2])
 
     def __iter__(self):
-        if self.is_iterable:
-            return roundrobin(*(iter(arg) for arg in self.args))
-        raise TypeError("Not all constituent sets are iterable")
+        return roundrobin(*(iter(arg) for arg in self.args))
 
 
 class Intersection(Set, LatticeOp):
@@ -1341,7 +1336,7 @@ class Intersection(Set, LatticeOp):
     def __iter__(self):
         no_iter = True
         for s in self.args:
-            if s.is_iterable:
+            if not s.is_iterable is False:
                 no_iter = False
                 other_sets = set(self.args) - set((s,))
                 other = Intersection(*other_sets, evaluate=False)
@@ -1534,8 +1529,6 @@ class Complement(Set, EvalfMixin):
             return True
 
     def __iter__(self):
-        if not self.is_iterable:
-            raise TypeError("{} is not iterable".format(self))
         A, B = self.args
         for a in A:
             if a not in B:
@@ -1903,8 +1896,6 @@ class SymmetricDifference(Set):
             return True
 
     def __iter__(self):
-        if not self.is_iterable:
-            raise TypeError("{} is not iterable".format(self))
 
         args = self.args
         union = roundrobin(*(iter(arg) for arg in args))

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1350,7 +1350,7 @@ class Intersection(Set, LatticeOp):
                 except TypeError:
                     completed = False
             if completed:
-                raise StopIteration()
+                return
 
         if not completed:
             if not candidates:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -799,11 +799,7 @@ class ProductSet(Set):
         return measure
 
     def __len__(self):
-<<<<<<< HEAD
-        return Mul(*[len(s) for s in self.sets])
-=======
         return reduce(lambda a, b: a*b, (len(s) for s in self.args))
->>>>>>> 8f2abd4276... Add __iter__ for symbolic set objects
 
     def __bool__(self):
         return all([bool(s) for s in self.sets])

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1354,8 +1354,8 @@ class Intersection(Set, LatticeOp):
 
         if not completed:
             if not candidates:
-                raise ValueError("None of the constituent sets are iterable")
-            raise ValueError(
+                raise TypeError("None of the constituent sets are iterable")
+            raise TypeError(
                 "The computation had not completed because of the "
                 "undecidable set membership is found in every candidates.")
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1349,6 +1349,8 @@ class Intersection(Set, LatticeOp):
                         yield x
                 except TypeError:
                     completed = False
+            if completed:
+                raise StopIteration()
 
         if not completed:
             if not candidates:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -220,7 +220,7 @@ def test_Range_set():
     assert all(i.is_Integer for i in Range(0, -1, 1))
 
     it = iter(Range(-oo, 0, 2))
-    raises(ValueError, lambda: next(it))
+    raises(TypeError, lambda: next(it))
 
     assert empty.intersect(S.Integers) == empty
     assert Range(-1, 10, 1).intersect(S.Integers) == Range(-1, 10, 1)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -417,7 +417,7 @@ def test_intersection():
     i = Intersection(line**2, line**3, evaluate=False)
     assert (2, 2) not in i
     assert (2, 2, 2) not in i
-    raises(ValueError, lambda: list(i))
+    raises(TypeError, lambda: list(i))
 
     a = Intersection(Intersection(S.Integers, S.Naturals, evaluate=False), S.Reals, evaluate=False)
     assert a._argset == frozenset([Intersection(S.Naturals, S.Integers, evaluate=False), S.Reals])
@@ -1255,7 +1255,7 @@ def test_issue_10113():
 
 def test_issue_10248():
     raises(
-        ValueError, lambda: list(Intersection(S.Reals, FiniteSet(x)))
+        TypeError, lambda: list(Intersection(S.Reals, FiniteSet(x)))
     )
     A = Symbol('A', real=True)
     assert list(Intersection(S.Reals, FiniteSet(A))) == [A]

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1254,8 +1254,11 @@ def test_issue_10113():
 
 
 def test_issue_10248():
-    assert list(Intersection(S.Reals, FiniteSet(x))) == [
-        (-oo < x) & (x < oo)]
+    raises(
+        ValueError, lambda: list(Intersection(S.Reals, FiniteSet(x)))
+    )
+    A = Symbol('A', real=True)
+    assert list(Intersection(S.Reals, FiniteSet(A))) == [A]
 
 
 def test_issue_9447():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -245,9 +245,9 @@ def test_Complement():
     assert Complement(A, C, evaluate=False).is_iterable is True
     assert Complement(C, D, evaluate=False).is_iterable is None
 
-    assert [*Complement(A, B, evaluate=False)] == [1]
-    assert [*Complement(A, C, evaluate=False)] == [4]
-    raises(TypeError, lambda: [*Complement(C, A, evaluate=False)])
+    assert FiniteSet(*Complement(A, B, evaluate=False)) == FiniteSet(1)
+    assert FiniteSet(*Complement(A, C, evaluate=False)) == FiniteSet(4)
+    raises(TypeError, lambda: FiniteSet(*Complement(C, A, evaluate=False)))
 
     assert Complement(Interval(1, 3), Interval(1, 2)) == Interval(2, 3, True)
     assert Complement(FiniteSet(1, 3, 4), FiniteSet(3, 4)) == FiniteSet(1)
@@ -1175,7 +1175,8 @@ def test_SymmetricDifference():
     assert SymmetricDifference(A, C, evaluate=False).is_iterable is None
     assert FiniteSet(*SymmetricDifference(A, B, evaluate=False)) == \
         FiniteSet(0, 1, 3, 5, 6, 8, 10)
-    raises(TypeError, lambda: [*SymmetricDifference(A, C, evaluate=False)])
+    raises(TypeError,
+        lambda: FiniteSet(*SymmetricDifference(A, C, evaluate=False)))
 
     assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \
             FiniteSet(2, 4, 6, 8, 10)) == FiniteSet(0, 1, 3, 5, 6, 8, 10)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -236,6 +236,19 @@ def test_difference():
 
 
 def test_Complement():
+    A = FiniteSet(1, 3, 4)
+    B = FiniteSet(3, 4)
+    C = Interval(1, 3)
+    D = Interval(1, 2)
+
+    assert Complement(A, B, evaluate=False).is_iterable is True
+    assert Complement(A, C, evaluate=False).is_iterable is True
+    assert Complement(C, D, evaluate=False).is_iterable is None
+
+    assert [*Complement(A, B, evaluate=False)] == [1]
+    assert [*Complement(A, C, evaluate=False)] == [4]
+    raises(TypeError, lambda: [*Complement(C, A, evaluate=False)])
+
     assert Complement(Interval(1, 3), Interval(1, 2)) == Interval(2, 3, True)
     assert Complement(FiniteSet(1, 3, 4), FiniteSet(3, 4)) == FiniteSet(1)
     assert Complement(Union(Interval(0, 2), FiniteSet(2, 3, 4)),
@@ -432,6 +445,15 @@ def test_issue_9623():
 def test_is_disjoint():
     assert Interval(0, 2).is_disjoint(Interval(1, 2)) == False
     assert Interval(0, 2).is_disjoint(Interval(3, 4)) == True
+
+
+def test_ProductSet__len__():
+    A = FiniteSet(1, 2)
+    B = FiniteSet(1, 2, 3)
+    assert ProductSet(A).__len__() == 2
+    assert ProductSet(A).__len__() is not S(2)
+    assert ProductSet(A, B).__len__() == 6
+    assert ProductSet(A, B).__len__() is not S(6)
 
 
 def test_ProductSet():
@@ -1145,16 +1167,26 @@ def test_Eq():
 
 
 def test_SymmetricDifference():
-   assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \
-          FiniteSet(2, 4, 6, 8, 10)) == FiniteSet(0, 1, 3, 5, 6, 8, 10)
-   assert SymmetricDifference(FiniteSet(2, 3, 4), FiniteSet(2, 3 ,4 ,5 )) \
-          == FiniteSet(5)
-   assert FiniteSet(1, 2, 3, 4, 5) ^ FiniteSet(1, 2, 5, 6) == \
-          FiniteSet(3, 4, 6)
-   assert Set(1, 2 ,3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
-          Set(2, 3, 4) - Set(1, 2, 3))
-   assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
-          Interval(2, 5), Interval(2, 5) - Interval(0, 4))
+    A = FiniteSet(0, 1, 2, 3, 4, 5)
+    B = FiniteSet(2, 4, 6, 8, 10)
+    C = Interval(8, 10)
+
+    assert SymmetricDifference(A, B, evaluate=False).is_iterable is True
+    assert SymmetricDifference(A, C, evaluate=False).is_iterable is None
+    assert FiniteSet(*SymmetricDifference(A, B, evaluate=False)) == \
+        FiniteSet(0, 1, 3, 5, 6, 8, 10)
+    raises(TypeError, lambda: [*SymmetricDifference(A, C, evaluate=False)])
+
+    assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \
+            FiniteSet(2, 4, 6, 8, 10)) == FiniteSet(0, 1, 3, 5, 6, 8, 10)
+    assert SymmetricDifference(FiniteSet(2, 3, 4), FiniteSet(2, 3 ,4 ,5 )) \
+            == FiniteSet(5)
+    assert FiniteSet(1, 2, 3, 4, 5) ^ FiniteSet(1, 2, 5, 6) == \
+            FiniteSet(3, 4, 6)
+    assert Set(1, 2 ,3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
+            Set(2, 3, 4) - Set(1, 2, 3))
+    assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
+            Interval(2, 5), Interval(2, 5) - Interval(0, 4))
 
 
 def test_issue_9536():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -12,7 +12,8 @@ from sympy.core import Basic
 
 # this is the logical location of these functions
 from sympy.core.compatibility import (
-    as_int, default_sort_key, is_sequence, iterable, ordered, range, string_types
+    as_int, default_sort_key, is_sequence, iterable, ordered, range,
+    string_types, PY3
 )
 
 from sympy.utilities.enumerative import (
@@ -2578,3 +2579,28 @@ def rotations(s, dir=1):
     for i in range(len(seq)):
         yield seq
         seq = rotate_left(seq, dir)
+
+
+def roundrobin(*iterables):
+    """roundrobin recipe taken from itertools documentation:
+    https://docs.python.org/2/library/itertools.html#recipes
+
+    roundrobin('ABC', 'D', 'EF') --> A D E B F C
+
+    Recipe credited to George Sakkis
+    """
+    import itertools
+
+    if PY3:
+        nexts = itertools.cycle(iter(it).__next__ for it in iterables)
+    else:
+        nexts = itertools.cycle(iter(it).next for it in iterables)
+
+    pending = len(iterables)
+    while pending:
+        try:
+            for next in nexts:
+                yield next()
+        except StopIteration:
+            pending -= 1
+            nexts = itertools.cycle(itertools.islice(nexts, pending))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16362

#### Brief description of what is fixed or changed

Unevaluated `Complement`, `SymmetricDifference` sets hadn't implemented any iteration method, and it gives error for
```python
FiniteSet(
    *Complement(
        FiniteSet(1, 2, 3), 
        FiniteSet(0, 1),
        evaluate=False)
)
```
But I think that some cases can easily be determined to be finite or iterable, and it would be possible to add another way to access elements via sampling.

#### Other comments

I've also moved `roundrobin` to utilities.

The only remaining case would be `ConditionSet`, but I have not done the work here because I think that the class needs some redesigns to handle the `evaluate` keyword to properly test iterations over unevaluated ConditionSet.

I've added a doc about the set iteration implemented
![image](https://user-images.githubusercontent.com/34944973/64492524-960c2980-d2af-11e9-95d9-2093a2af53d6.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
  - Implemented iteration methods for `Complement`, `SymmetricDifference`.
  - Fixed `is_iterable` for `Complement` and `SymmetricDifference` to give `True` if the predicate can easily be determined.
<!-- END RELEASE NOTES -->
