### PR TITLE
removed bug and added corresponding test cases

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3036,7 +3036,9 @@ def _ode_factorable_match(eq, func, x0):
     eqns = []
     r = None
     if isinstance(eqs, Pow):
-        eq, _ = _preprocess(eqs, func)
+        # if f(x)**p=0 then f(x)=0 (p>0)
+        if (expr.exp).is_positive:
+            eq = expr.base
         if isinstance(eq, Pow):
             return None
         else:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3577,13 +3577,27 @@ def test_factorable():
     assert set(sol) == set(dsolve(eq, f(x), hint='factorable'))
     assert checkodesol(eq, sol) == 4*[(True, 0)]
 
+    eq = Derivative(f(x), x)**4 - 2*Derivative(f(x), x)**2 + 1
+    sol = [Eq(f(x), C1 - x), Eq(f(x), C1 + x)]
+    assert set(sol) == set(dsolve(eq, f(x), hint='factorable'))
+    assert checkodesol(eq, sol) == 2*[(True, 0)]
+
+    eq = f(x)**2*Derivative(f(x), x)**6 - 2*f(x)**2*Derivative(f(x),
+         x)**4 + f(x)**2*Derivative(f(x), x)**2 - 2*f(x)*Derivative(f(x),
+         x)**5 + 4*f(x)*Derivative(f(x), x)**3 - 2*f(x)*Derivative(f(x),
+         x) + Derivative(f(x), x)**4 - 2*Derivative(f(x), x)**2 + 1
+    sol = [Eq(f(x), C1 - x), Eq(f(x), -sqrt(C1 + 2*x)),
+           Eq(f(x), sqrt(C1 + 2*x)), Eq(f(x), C1 + x)]
+    assert set(sol) == set(dsolve(eq, f(x), hint='factorable'))
+    assert checkodesol(eq, sol) == 4*[(True, 0)]
+
     eq = (f(x).diff(x, 2)-exp(f(x)))*(f(x).diff(x, 2)+exp(f(x)))
     raises(NotImplementedError, lambda: dsolve(eq, hint = 'factorable'))
 
 
 @slow
 def test_factorable_series():
-    # checkodesol doesn't work with series solution.
+
     eq = x**4*f(x)**2 + 2*x**4*f(x)*Derivative(f(x), (x, 2)) + x**4*Derivative(f(x),
          (x, 2))**2  + 2*x**3*f(x)*Derivative(f(x), x) + 2*x**3*Derivative(f(x),
          x)*Derivative(f(x), (x, 2)) - 7*x**2*f(x)**2 - 7*x**2*f(x)*Derivative(f(x),
@@ -3596,16 +3610,8 @@ def test_factorable_series():
           *(2 - sqrt(3)))*(-sqrt(3) + 1 + (3 - sqrt(3))*(4 - sqrt(3)))) - x**2/(-sqrt(3) - 1
           + (1 - sqrt(3))*(2 - sqrt(3))) + 1) + O(x**6))]
     assert set(sol) == set(dsolve(eq, f(x), hint='factorable'))
+    # checkodesol doesn't work with series solution.
     # FIXME: assert checkodesol(eq, sols) == 2*[(True, 0)]
-
-    eq = x**2*f(x)**2 - 2*x*f(x)*Derivative(f(x), (x, 2)) + Derivative(f(x), (x, 2))**2
-    sol = Eq(f(x), C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
-    assert sol == dsolve(eq, f(x), hint='factorable')
-    # FIXME: assert checkodesol(eq, sol) == (True, 0)
-    sol = Eq(f(x), C2*((x - 2)**4/6 + (x - 2)**3/6 + (x - 2)**2 + 1)
-          + C1*(x + (x - 2)**4/12 + (x - 2)**3/3 - 2) + O(x**6))
-    assert sol == dsolve(eq, f(x), hint='factorable', x0=2)
-    # FIXME: assert checkodesol(eq, sol) == (True, 0)
 
 
 def test_issue_17322():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3583,6 +3583,7 @@ def test_factorable():
 
 @slow
 def test_factorable_series():
+    # checkodesol doesn't work with series solution.
     eq = x**4*f(x)**2 + 2*x**4*f(x)*Derivative(f(x), (x, 2)) + x**4*Derivative(f(x),
          (x, 2))**2  + 2*x**3*f(x)*Derivative(f(x), x) + 2*x**3*Derivative(f(x),
          x)*Derivative(f(x), (x, 2)) - 7*x**2*f(x)**2 - 7*x**2*f(x)*Derivative(f(x),
@@ -3595,8 +3596,16 @@ def test_factorable_series():
           *(2 - sqrt(3)))*(-sqrt(3) + 1 + (3 - sqrt(3))*(4 - sqrt(3)))) - x**2/(-sqrt(3) - 1
           + (1 - sqrt(3))*(2 - sqrt(3))) + 1) + O(x**6))]
     assert set(sol) == set(dsolve(eq, f(x), hint='factorable'))
-    # checkodesol doesn't work with series solution.
     # FIXME: assert checkodesol(eq, sols) == 2*[(True, 0)]
+
+    eq = x**2*f(x)**2 - 2*x*f(x)*Derivative(f(x), (x, 2)) + Derivative(f(x), (x, 2))**2
+    sol = Eq(f(x), C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
+    assert sol == dsolve(eq, f(x), hint='factorable')
+    # FIXME: assert checkodesol(eq, sol) == (True, 0)
+    sol = Eq(f(x), C2*((x - 2)**4/6 + (x - 2)**3/6 + (x - 2)**2 + 1)
+          + C1*(x + (x - 2)**4/12 + (x - 2)**3/3 - 2) + O(x**6))
+    assert sol == dsolve(eq, f(x), hint='factorable', x0=2)
+    # FIXME: assert checkodesol(eq, sol) == (True, 0)
 
 
 def test_issue_17322():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

related to #16581 
#### Brief description of what is fixed or changed
during the implementation of the factorable method, I forgot a case when we would pass an equation
of type `eqs = expand(eq*eq) `(eq is some solvable ode) then factorable will not able to classify it.

Another bug is when the given equation is solvable by series. Then the solution depends upon x0
so I have to take care of it in the factorable method. (This is related to #16581)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - removed bug from factorable
<!-- END RELEASE NOTES -->