### PR TITLE
Make checkodesol work for series solutions

### DIFF
--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2950,19 +2950,24 @@ def test_kamke():
 
 
 def test_series():
-    # FIXME: Maybe there should be a way to check series solutions
-    # checkodesol doesn't work with them.
     C1 = Symbol("C1")
     eq = f(x).diff(x) - f(x)
-    assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C1 + C1*x + C1*x**2/2 + C1*x**3/6 + C1*x**4/24 +
-        C1*x**5/120 + O(x**6))
+    sol = Eq(f(x), C1 + C1*x + C1*x**2/2 + C1*x**3/6 + C1*x**4/24 +
+            C1*x**5/120 + O(x**6))
+    assert dsolve(eq, hint='1st_power_series') == sol
+    assert checkodesol(eq, sol, order=1)[0]
+
     eq = f(x).diff(x) - x*f(x)
-    assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C1*x**4/8 + C1*x**2/2 + C1 + O(x**6))
+    sol = Eq(f(x), C1*x**4/8 + C1*x**2/2 + C1 + O(x**6))
+    assert dsolve(eq, hint='1st_power_series') == sol
+    assert checkodesol(eq, sol, order=1)[0]
+
     eq = f(x).diff(x) - sin(x*f(x))
     sol = Eq(f(x), (x - 2)**2*(1+ sin(4))*cos(4) + (x - 2)*sin(4) + 2 + O(x**3))
     assert dsolve(eq, hint='1st_power_series', ics={f(2): 2}, n=3) == sol
+    # FIXME: The solution here should be O((x-2)**3) so is incorrect
+    #assert checkodesol(eq, sol, order=1)[0]
+
 
 
 @XFAIL
@@ -3086,38 +3091,52 @@ def test_issue_7081():
 
 @slow
 def test_2nd_power_series_ordinary():
-    # FIXME: Maybe there should be a way to check series solutions
-    # checkodesol doesn't work with them.
     C1, C2 = symbols("C1 C2")
+
     eq = f(x).diff(x, 2) - x*f(x)
     assert classify_ode(eq) == ('2nd_linear_airy', '2nd_power_series_ordinary')
-    assert dsolve(eq, hint='2nd_power_series_ordinary') == Eq(f(x),
-        C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
-    assert dsolve(eq, x0=-2, hint='2nd_power_series_ordinary') == Eq(f(x),
-        C2*((x + 2)**4/6 + (x + 2)**3/6 - (x + 2)**2 + 1)
+    assert classify_ode(eq) == ('2nd_power_series_ordinary',)
+    sol = Eq(f(x), C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
+    assert dsolve(eq, hint='2nd_power_series_ordinary') == sol
+    assert checkodesol(eq, sol) == (True, 0)
+
+    sol = Eq(f(x), C2*((x + 2)**4/6 + (x + 2)**3/6 - (x + 2)**2 + 1)
         + C1*(x + (x + 2)**4/12 - (x + 2)**3/3 + S(2))
         + O(x**6))
-    assert dsolve(eq, n=2, hint='2nd_power_series_ordinary') == Eq(f(x), C2*x + C1 + O(x**2))
+    assert dsolve(eq, hint='2nd_power_series_ordinary', x0=-2) == sol
+    # FIXME: Solution should be O((x+2)**6)
+    # assert checkodesol(eq, sol) == (True, 0)
+
+    sol = Eq(f(x), C2*x + C1 + O(x**2))
+    assert dsolve(eq, hint='2nd_power_series_ordinary', n=2) == sol
+    assert checkodesol(eq, sol) == (True, 0)
+
     eq = (1 + x**2)*(f(x).diff(x, 2)) + 2*x*(f(x).diff(x)) -2*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C2*(-x**4/3 + x**2 + 1) + C1*x
-        + O(x**6))
+    sol = Eq(f(x), C2*(-x**4/3 + x**2 + 1) + C1*x + O(x**6))
+    assert dsolve(eq) == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
     eq = f(x).diff(x, 2) + x*(f(x).diff(x)) + f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C2*(
-        x**4/8 - x**2/2 + 1) + C1*x*(-x**2/3 + 1) + O(x**6))
+    sol = Eq(f(x), C2*(x**4/8 - x**2/2 + 1) + C1*x*(-x**2/3 + 1) + O(x**6))
+    assert dsolve(eq) == sol
+    # FIXME: checkodesol fails for this solution...
+    # assert checkodesol(eq, sol) == (True, 0)
 
     eq = f(x).diff(x, 2) + f(x).diff(x) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C2*(
-        -x**4/24 + x**3/6 + 1) + C1*x*(x**3/24 + x**2/6 - x/2
-        + 1) + O(x**6))
+    sol = Eq(f(x), C2*(-x**4/24 + x**3/6 + 1)
+            + C1*x*(x**3/24 + x**2/6 - x/2 + 1) + O(x**6))
+    assert dsolve(eq) == sol
+    # FIXME: checkodesol fails for this solution...
+    # assert checkodesol(eq, sol) == (True, 0)
 
     eq = f(x).diff(x, 2) + x*f(x)
     assert classify_ode(eq) == ('2nd_linear_airy', '2nd_power_series_ordinary')
-    assert dsolve(eq, n=7, hint='2nd_power_series_ordinary') == Eq(f(x), C2*(
-        x**6/180 - x**3/6 + 1) + C1*x*(-x**3/12 + 1) + O(x**7))
+    sol = Eq(f(x), C2*(x**6/180 - x**3/6 + 1) + C1*x*(-x**3/12 + 1) + O(x**7))
+    assert dsolve(eq, hint='2nd_power_series_ordinary', n=7) == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
 def test_Airy_equation():
     eq = f(x).diff(x, 2) - x*f(x)
@@ -3137,25 +3156,30 @@ def test_Airy_equation():
     assert dsolve(eq, f(x), hint='2nd_linear_airy') in (sol, sols)
 
 def test_2nd_power_series_regular():
-    # FIXME: Maybe there should be a way to check series solutions
-    # checkodesol doesn't work with them.
+    C1, C2 = symbols("C1 C2")
     eq = x**2*(f(x).diff(x, 2)) - 3*x*(f(x).diff(x)) + (4*x + 4)*f(x)
-    assert dsolve(eq, hint='2nd_power_series_regular') == Eq(f(x), C1*x**2*(-16*x**3/9 +
-        4*x**2 - 4*x + 1) + O(x**6))
+    sol = Eq(f(x), C1*x**2*(-16*x**3/9 + 4*x**2 - 4*x + 1) + O(x**6))
+    assert dsolve(eq, hint='2nd_power_series_regular') == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
     eq = 4*x**2*(f(x).diff(x, 2)) -8*x**2*(f(x).diff(x)) + (4*x**2 +
         1)*f(x)
-    assert dsolve(eq, hint='2nd_power_series_regular') == Eq(f(x), C1*sqrt(x)*(
-        x**4/24 + x**3/6 + x**2/2 + x + 1) + O(x**6))
+    sol = Eq(f(x), C1*sqrt(x)*(x**4/24 + x**3/6 + x**2/2 + x + 1) + O(x**6))
+    assert dsolve(eq, hint='2nd_power_series_regular') == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
     eq = x**2*(f(x).diff(x, 2)) - x**2*(f(x).diff(x)) + (
         x**2 - 2)*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*(-x**6/720 - 3*x**5/80 - x**4/8 +
-        x**2/2 + x/2 + 1)/x + C2*x**2*(-x**3/60 + x**2/20 + x/2 + 1)
-        + O(x**6))
+    sol = Eq(f(x), C1*(-x**6/720 - 3*x**5/80 - x**4/8 + x**2/2 + x/2 + 1)/x +
+            C2*x**2*(-x**3/60 + x**2/20 + x/2 + 1) + O(x**6))
+    assert dsolve(eq) == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
     eq = x**2*(f(x).diff(x, 2)) + x*(f(x).diff(x)) + (x**2 - Rational(1, 4))*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*besselj(S.Half, x) + C2*bessely(S.Half, x))
+    sol = Eq(f(x), C1*(x**4/24 - x**2/2 + 1)/sqrt(x) +
+        C2*sqrt(x)*(x**4/120 - x**2/6 + 1) + O(x**6))
+    assert dsolve(eq, hint='2nd_power_series_regular') == sol
+    assert checkodesol(eq, sol) == (True, 0)
 
 def test_2nd_linear_bessel_equation():
     eq = x**2*(f(x).diff(x, 2)) + x*(f(x).diff(x)) + (x**2 - 4)*f(x)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3095,7 +3095,6 @@ def test_2nd_power_series_ordinary():
 
     eq = f(x).diff(x, 2) - x*f(x)
     assert classify_ode(eq) == ('2nd_linear_airy', '2nd_power_series_ordinary')
-    assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     sol = Eq(f(x), C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
     assert dsolve(eq, hint='2nd_power_series_ordinary') == sol
     assert checkodesol(eq, sol) == (True, 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #16000 

#### Brief description of what is fixed or changed

Makes checkodesol work for series solutions of ODEs as returned by dsolve. I'm not sure this works for series solutions around non-zero points because dsolve doesn't yet return correct series solution around nonzero points.

#### Other comments

I'm still working on this...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * checkodesol now works for series solutions of ODEs.
<!-- END RELEASE NOTES -->
