### PR TITLE
Fix gram schmidt for complex numbers

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1069,7 +1069,7 @@ class MatrixSubspaces(MatrixReductions):
         rankcheck = kwargs.get('rankcheck', False)
 
         def project(a, b):
-            return b * (a.dot(b) / b.dot(b))
+            return b * (a.dot(b, hermitian=True) / b.dot(b, hermitian=True))
 
         def perp_to_subspace(vec, basis):
             """projects vec onto the subspace given
@@ -4741,7 +4741,7 @@ class MatrixBase(MatrixDeprecated,
             tmp = mat[:, j]  # take original v
             for i in range(j):
                 # subtract the project of mat on new vector
-                R[i, j] = Q[:, i].dot(mat[:, j])
+                R[i, j] = Q[:, i].dot(mat[:, j], hermitian=True)
                 tmp -= Q[:, i] * R[i, j]
                 tmp.expand()
             # normalize it

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3803,3 +3803,12 @@ def test_issue_11948():
     A = MatrixSymbol('A', 3, 3)
     a = Wild('a')
     assert A.match(a) == {a: A}
+
+def test_gramschmidt_conjugate_dot():
+    vecs = [Matrix([1, I]), Matrix([1, -I])]
+    assert Matrix.orthogonalize(*vecs) == \
+        [Matrix([[1], [I]]), Matrix([[1], [-I]])]
+
+    mat = Matrix([[1, I], [1, -I]])
+    Q, R = mat.QRdecomposition()
+    assert Q * Q.H == Matrix.eye(2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`dot` does not conjugate for default, and it had wrong result for giving `nan` values for some complex vectors, and giving non-unitary `Q` in QR decomposition for matrices.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices 
  - Fixed `Matrix.orthogonalize` and `Matrix.QRdecomposition` giving wrong result for complex vectors because of using dot without conjugation.
<!-- END RELEASE NOTES -->
