### PR TITLE
ImageSet cleanup - make ImageSet have clearly defined base sets

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2055,6 +2055,7 @@ class LatexPrinter(Printer):
         return r"\mathbb{C}"
 
     def _print_ImageSet(self, s):
+        # FIXME: this might need changing after ImageSet has changed...
         sets = s.args[1:]
         varsets = [r"%s \in %s" % (self._print(var), self._print(setv))
                    for var, setv in zip(s.lamda.variables, sets)]

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2055,9 +2055,14 @@ class LatexPrinter(Printer):
         return r"\mathbb{C}"
 
     def _print_ImageSet(self, s):
-        sig = s.lamda.signature[0]
         expr = s.lamda.expr
-        xiny = r"%s \in %s" % (self._print(sig), self._print(s.base_set))
+        if len(s.lamda.signature) == 1:
+            sig = s.lamda.signature[0]
+            set = s.base_sets[0]
+        else:
+            sig = s.lamda.signature
+            set = s.base_pset
+        xiny = r"%s \in %s" % (self._print(sig), self._print(set))
         return r"\left\{%s\; |\; %s\right\}" % (self._print(expr), xiny)
 
     def _print_ConditionSet(self, s):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2055,13 +2055,10 @@ class LatexPrinter(Printer):
         return r"\mathbb{C}"
 
     def _print_ImageSet(self, s):
-        # FIXME: this might need changing after ImageSet has changed...
-        sets = s.args[1:]
-        varsets = [r"%s \in %s" % (self._print(var), self._print(setv))
-                   for var, setv in zip(s.lamda.variables, sets)]
-        return r"\left\{%s\; |\; %s\right\}" % (
-            self._print(s.lamda.expr),
-            ', '.join(varsets))
+        sig = s.lamda.signature[0]
+        expr = s.lamda.expr
+        xiny = r"%s \in %s" % (self._print(sig), self._print(s.base_set))
+        return r"\left\{%s\; |\; %s\right\}" % (self._print(expr), xiny)
 
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2056,14 +2056,10 @@ class LatexPrinter(Printer):
 
     def _print_ImageSet(self, s):
         expr = s.lamda.expr
-        if len(s.lamda.signature) == 1:
-            sig = s.lamda.signature[0]
-            set = s.base_sets[0]
-        else:
-            sig = s.lamda.signature
-            set = s.base_pset
-        xiny = r"%s \in %s" % (self._print(sig), self._print(set))
-        return r"\left\{%s\; |\; %s\right\}" % (self._print(expr), xiny)
+        sig = s.lamda.signature
+        xys = ((self._print(x), self._print(y)) for x, y in zip(sig, s.base_sets))
+        xinys = r" , ".join(r"%s \in %s" % xy for xy in xys)
+        return r"\left\{%s\; |\; %s\right\}" % (self._print(expr), xinys)
 
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1985,15 +1985,15 @@ class PrettyPrinter(Printer):
             inn = u"\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
-        variables = ts.lamda.variables
+        (variables,) = ts.lamda.signature
         expr = self._print(ts.lamda.expr)
         bar = self._print("|")
         sets = [self._print(i) for i in ts.args[1:]]
-        if len(sets) == 1:
-            return self._print_seq((expr, bar, variables[0], inn, sets[0]), "{", "}", ' ')
+        if variables.is_symbol:
+            pargs = variables
         else:
-            pargs = tuple(j for var, setv in zip(variables, sets) for j in (var, inn, setv, ","))
-            return self._print_seq((expr, bar) + pargs[:-1], "{", "}", ' ')
+            pargs = '(' + ', '.join(map(str, variables)) + ')'
+        return self._print_seq((expr, bar, pargs, inn, sets[0]), "{", "}", ' ')
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1981,19 +1981,23 @@ class PrettyPrinter(Printer):
                                or set.is_Union)
 
     def _print_ImageSet(self, ts):
+        from sympy.sets.sets import ProductSet
         if self._use_unicode:
             inn = u"\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
-        (variables,) = ts.lamda.signature
-        expr = self._print(ts.lamda.expr)
+        fun = ts.lamda
+        sets = ts.base_sets
+        signature = fun.signature
+        expr = self._print(fun.expr)
         bar = self._print("|")
-        sets = [self._print(i) for i in ts.args[1:]]
-        if variables.is_symbol:
-            pargs = variables
+        if len(signature) == 1:
+            pargs = self._print(signature[0])
+            psets = self._print(sets[0])
         else:
-            pargs = '(' + ', '.join(map(str, variables)) + ')'
-        return self._print_seq((expr, bar, pargs, inn, sets[0]), "{", "}", ' ')
+            pargs = self._print(signature)
+            psets = self._print(ProductSet(*sets)) # XXX: evaluate=False?
+        return self._print_seq((expr, bar, pargs, inn, psets), "{", "}", ' ')
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1507,9 +1507,8 @@ class PrettyPrinter(Printer):
         else:
             arrow = " -> "
         if len(sig) == 1 and sig[0].is_symbol:
-            var_form = self._print(sig[0])
-        else:
-            var_form = self._print(tuple(sig))
+            sig = sig[0]
+        var_form = self._print(sig)
 
         return prettyForm(*stringPict.next(var_form, arrow, self._print(expr)), binding=8)
 
@@ -1982,7 +1981,6 @@ class PrettyPrinter(Printer):
                                or set.is_Union)
 
     def _print_ImageSet(self, ts):
-        from sympy.sets.sets import ProductSet
         if self._use_unicode:
             inn = u"\N{SMALL ELEMENT OF}"
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1500,15 +1500,16 @@ class PrettyPrinter(Printer):
         return self._print_Function(e, func_name="W")
 
     def _print_Lambda(self, e):
-        vars, expr = e.args
+        expr = e.expr
+        sig = e.signature
         if self._use_unicode:
             arrow = u" \N{RIGHTWARDS ARROW FROM BAR} "
         else:
             arrow = " -> "
-        if len(vars) == 1:
-            var_form = self._print(vars[0])
+        if len(sig) == 1 and sig[0].is_symbol:
+            var_form = self._print(sig[0])
         else:
-            var_form = self._print(tuple(vars))
+            var_form = self._print(tuple(sig))
 
         return prettyForm(*stringPict.next(var_form, arrow, self._print(expr)), binding=8)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1992,12 +1992,10 @@ class PrettyPrinter(Printer):
         expr = self._print(fun.expr)
         bar = self._print("|")
         if len(signature) == 1:
-            pargs = self._print(signature[0])
-            psets = self._print(sets[0])
+            return self._print_seq((expr, bar, signature[0], inn, sets[0]), "{", "}", ' ')
         else:
-            pargs = self._print(signature)
-            psets = self._print(ProductSet(*sets)) # XXX: evaluate=False?
-        return self._print_seq((expr, bar, pargs, inn, psets), "{", "}", ' ')
+            pargs = tuple(j for var, setv in zip(signature, sets) for j in (var, inn, setv, ","))
+            return self._print_seq((expr, bar) + pargs[:-1], "{", "}", ' ')
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2258,7 +2258,7 @@ __________ __________      \n\
     assert upretty(expr) == unicode_str
 
 
-def test_pretty_lambda():
+def test_pretty_Lambda():
     # S.IdentityFunction is a special case
     expr = Lambda(y, y)
     assert pretty(expr) == "x -> x"
@@ -2314,6 +2314,20 @@ u("""\
 u("""\
           2\n\
 (x, y) ↦ x \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = Lambda(((x, y),), x**2)
+    ascii_str = \
+"""\
+              2\n\
+((x, y),) -> x \
+"""
+    ucode_str = \
+u("""\
+             2\n\
+((x, y),) ↦ x \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3800,6 +3800,12 @@ def test_pretty_SetExpr():
 
 
 def test_pretty_ImageSet():
+    imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
+    ascii_str = '{x + y | x in {1, 2, 3} , y in {3, 4}}'
+    ucode_str = u('{x + y | x ∊ {1, 2, 3} , y ∊ {3, 4}}')
+    assert pretty(imgset) == ascii_str
+    assert upretty(imgset) == ucode_str
+
     imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     ascii_str = '{x + y | (x, y) in {1, 2, 3} x {3, 4}}'
     ucode_str = u('{x + y | (x, y) ∊ {1, 2, 3} × {3, 4}}')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -33,7 +33,7 @@ from sympy.physics.units import joule, degree
 from sympy.printing.pretty import pprint, pretty as xpretty
 from sympy.printing.pretty.pretty_symbology import center_accent
 
-from sympy.sets import ImageSet
+from sympy.sets import ImageSet, ProductSet
 from sympy.sets.setexpr import SetExpr
 from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
                                 MutableDenseNDimArray, MutableSparseNDimArray, tensorproduct)
@@ -3800,9 +3800,9 @@ def test_pretty_SetExpr():
 
 
 def test_pretty_ImageSet():
-    imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
-    ascii_str = '{x + y | x in {1, 2, 3} , y in {3, 4}}'
-    ucode_str = u('{x + y | x ∊ {1, 2, 3} , y ∊ {3, 4}}')
+    imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
+    ascii_str = '{x + y | (x, y) in {1, 2, 3} x {3, 4}}'
+    ucode_str = u('{x + y | (x, y) ∊ {1, 2, 3} × {3, 4}}')
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -209,12 +209,11 @@ class StrPrinter(Printer):
         return "%s**(-1)" % self.parenthesize(I.arg, PRECEDENCE["Pow"])
 
     def _print_Lambda(self, obj):
-        args, expr = obj.args
-        if len(args) == 1:
-            return "Lambda(%s, %s)" % (self._print(args.args[0]), self._print(expr))
-        else:
-            arg_string = ", ".join(self._print(arg) for arg in args)
-            return "Lambda((%s), %s)" % (arg_string, self._print(expr))
+        expr = obj.expr
+        sig = obj.signature
+        if len(sig) == 1 and sig[0].is_symbol:
+            sig = sig[0]
+        return "Lambda(%s, %s)" % (self._print(sig), self._print(expr))
 
     def _print_LatticeOp(self, expr):
         args = sorted(expr.args, key=default_sort_key)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1020,6 +1020,11 @@ def test_latex_ImageSet():
     assert latex(ImageSet(Lambda(x, x**2), S.Naturals)) == \
         r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
     y = Symbol('y')
+
+    imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
+    assert latex(imgset) == \
+        r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\} , y \in \left\{3, 4\right\}\right\}"
+
     imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     assert latex(imgset) == \
         r"\left\{x + y\; |\; \left( x, \  y\right) \in \left\{1, 2, 3\right\} \times \left\{3, 4\right\}\right\}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1020,9 +1020,9 @@ def test_latex_ImageSet():
     assert latex(ImageSet(Lambda(x, x**2), S.Naturals)) == \
         r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
     y = Symbol('y')
-    imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
+    imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     assert latex(imgset) == \
-        r"\left\{x + y\; |\; x \in \left\{1, 2, 3\right\}, y \in \left\{3, 4\right\}\right\}"
+        r"\left\{x + y\; |\; \left( x, \  y\right) \in \left\{1, 2, 3\right\} \times \left\{3, 4\right\}\right\}"
 
 
 def test_latex_ConditionSet():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -177,6 +177,8 @@ def test_Lambda():
     # issue 2908
     assert str(Lambda((), 1)) == "Lambda((), 1)"
     assert str(Lambda((), x)) == "Lambda((), x)"
+    assert str(Lambda((x, y), x+y)) == "Lambda((x, y), x + y)"
+    assert str(Lambda(((x, y),), x+y)) == "Lambda(((x, y),), x + y)"
 
 
 def test_Limit():

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -390,6 +390,13 @@ class ImageSet(Set):
 
         other = _sympify(other)
         expr = self.lamda.expr
+        sig = self.lamda.signature
+        variables = self.lamda.variables
+
+        rep = {v: Dummy(v.name) for v in variables}
+        variables = [v.subs(rep) for v in variables]
+        sig = sig.subs(rep)
+        expr = expr.subs(rep)
 
         # Map the parts of other to those in the Lambda expr
         equations = []
@@ -421,12 +428,12 @@ class ImageSet(Set):
                 symsetmap[sig] = bs
                 return True
 
-        if not all(rmatch(sg, st) for sg, st in zip(self.lamda.signature, self.base_sets)):
+        if not all(rmatch(sg, st) for sg, st in zip(sig, self.base_sets)):
             return False
 
         # Which of the variables in the Lambda signature need to be solved for?
         symss = (eq.free_symbols for eq in equations)
-        variables = set(self.lamda.variables) & reduce(set.union, symss, set())
+        variables = set(variables) & reduce(set.union, symss, set())
 
         for e in equations:
             syms = e.free_symbols & variables

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -17,6 +17,7 @@ from sympy.logic.boolalg import And
 from sympy.sets.sets import (Set, Interval, Union, FiniteSet,
     ProductSet)
 from sympy.utilities.misc import filldedent
+from sympy.utilities.iterables import cartes
 
 
 class Rationals(with_metaclass(Singleton, Set)):
@@ -460,9 +461,12 @@ class ImageSet(Set):
     def doit(self, **kwargs):
         from sympy.sets.setexpr import SetExpr
         f = self.lamda
-        if len(self.base_sets) == 1:
+        sig = f.signature
+        if len(sig) == 1 and sig[0].is_symbol and isinstance(f.expr, Expr):
             base_set = self.base_sets[0]
             return SetExpr(base_set)._eval_func(f).set
+        if all(s.is_FiniteSet for s in self.base_sets):
+            return FiniteSet(*(f(*a) for a in cartes(*self.base_sets)))
         return self
 
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -373,8 +373,8 @@ class ImageSet(Set):
 
     def __iter__(self):
         already_seen = set()
-        for i in self.base_set:
-            val = self.lamda(i)
+        for i in self.base_pset:
+            val = self.lamda(*i)
             if val in already_seen:
                 continue
             else:
@@ -421,9 +421,8 @@ class ImageSet(Set):
                 symsetmap[sig] = bs
                 return True
 
-        if not rmatch(self.lamda.signature[0], self.base_set):
+        if not all(rmatch(sg, st) for sg, st in zip(self.lamda.signature, self.base_sets)):
             return False
-
 
         # Which of the variables in the Lambda signature need to be solved for?
         symss = (eq.free_symbols for eq in equations)
@@ -449,12 +448,12 @@ class ImageSet(Set):
 
     @property
     def is_iterable(self):
-        return self.base_set.is_iterable
+        return all(s.is_iterable for s in self.base_sets)
 
     def doit(self, **kwargs):
         from sympy.sets.setexpr import SetExpr
         f = self.lamda
-        base_set = self.base_set
+        base_set = self.base_sets[0] # XXX: What if there are more base sets?
         return SetExpr(base_set)._eval_func(f).set
 
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -444,13 +444,13 @@ class ImageSet(Set):
                 sol = solveset(e, sym)
                 symsetmap[sym] &= sol
             else:
-                # Give up on solveset
-                from sympy.solvers.solvers import solve
-                solns = solve(equations, variables, dict=True)
-                return fuzzy_or(
-                        fuzzy_and(symsetmap[sym]._contains(sol[sym]) for sym in sol)
-                        for sol in solns
-                        )
+                # Use internal multivariate solveset
+                from sympy.solvers.solveset import _solveset_multi
+                base_sets = [symsetmap[v] for v in variables]
+                solnset = _solveset_multi(equations, variables, base_sets)
+                if solnset is None:
+                    return None
+                return fuzzy_not(solnset.is_empty)
 
         return fuzzy_not(fuzzy_or(s.is_empty for s in symsetmap.values()))
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -453,8 +453,10 @@ class ImageSet(Set):
     def doit(self, **kwargs):
         from sympy.sets.setexpr import SetExpr
         f = self.lamda
-        base_set = self.base_sets[0] # XXX: What if there are more base sets?
-        return SetExpr(base_set)._eval_func(f).set
+        if len(self.base_sets) == 1:
+            base_set = self.base_sets[0] # XXX: What if there are more base sets?
+            return SetExpr(base_set)._eval_func(f).set
+        return self
 
 
 class Range(Set):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -318,16 +318,16 @@ class ImageSet(Set):
         sets = [_sympify(s) for s in sets]
 
         if not all(isinstance(s, Set) for s in sets):
-            raise TypeError("Set argument to ImageSet should of type Set")
+            raise TypeError("Set arguments to ImageSet should of type Set")
 
         if not all(cls._check_sig(sg, st) for sg, st in zip(signature, sets)):
-            raise ValueError("Signature %s does not match Set %s" % (signature, sets))
+            raise ValueError("Signature %s does not match sets %s" % (signature, sets))
 
         if flambda is S.IdentityFunction and len(sets) == 1:
             return sets[0]
 
         if not set(flambda.variables) & flambda.expr.free_symbols:
-            is_empty = ProductSet(*sets).is_empty
+            is_empty = fuzzy_or(s.is_empty for s in sets)
             if is_empty == True:
                 return S.EmptySet
             elif is_empty == False:
@@ -461,7 +461,7 @@ class ImageSet(Set):
         from sympy.sets.setexpr import SetExpr
         f = self.lamda
         if len(self.base_sets) == 1:
-            base_set = self.base_sets[0] # XXX: What if there are more base sets?
+            base_set = self.base_sets[0]
             return SetExpr(base_set)._eval_func(f).set
         return self
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -221,8 +221,9 @@ def intersection_sets(self, other):
     if (len(self.lamda.variables) > 1
             or self.lamda.signature != self.lamda.variables):
         return None
+    base_set = self.base_sets[0]
 
-    elif self.base_sets == (S.Integers,):
+    if base_set is S.Integers:
         g = None
         if isinstance(other, ImageSet) and other.base_sets == (S.Integers,):
             g = other.lamda.expr
@@ -262,7 +263,6 @@ def intersection_sets(self, other):
 
         f = self.lamda.expr
         n = self.lamda.variables[0]
-        base = self.base_sets[0]
 
         n_ = Dummy(n.name, real=True)
         f_ = f.subs(n, n_)
@@ -285,8 +285,8 @@ def intersection_sets(self, other):
             return None
         else:
             # univarite imaginary part in same variable
-            base = base.intersect(solveset_real(im, n))
-        return imageset(lam, base)
+            base_set = base_set.intersect(solveset_real(im, n))
+        return imageset(lam, base_set)
 
     elif isinstance(other, Interval):
         from sympy.solvers.solveset import (invert_real, invert_complex,
@@ -294,7 +294,6 @@ def intersection_sets(self, other):
 
         f = self.lamda.expr
         n = self.lamda.variables[0]
-        base_set = self.base_sets[0]
         new_inf, new_sup = None, None
         new_lopen, new_ropen = other.left_open, other.right_open
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -216,9 +216,15 @@ def intersection_sets(a, b):
 @dispatch(ImageSet, Set)
 def intersection_sets(self, other):
     from sympy.solvers.diophantine import diophantine
-    if self.base_set is S.Integers:
+
+    # Only handle the straight-forward univariate case
+    if (len(self.lamda.variables) > 1
+            or self.lamda.signature != self.lamda.variables):
+        return None
+
+    elif self.base_sets == (S.Integers,):
         g = None
-        if isinstance(other, ImageSet) and other.base_set is S.Integers:
+        if isinstance(other, ImageSet) and other.base_sets == (S.Integers,):
             g = other.lamda.expr
             m = other.lamda.variables[0]
         elif other is S.Integers:
@@ -253,11 +259,10 @@ def intersection_sets(self, other):
     if other == S.Reals:
         from sympy.solvers.solveset import solveset_real
         from sympy.core.function import expand_complex
-        if len(self.lamda.variables) > 1:
-            return None
 
         f = self.lamda.expr
         n = self.lamda.variables[0]
+        base = self.base_sets[0]
 
         n_ = Dummy(n.name, real=True)
         f_ = f.subs(n, n_)
@@ -269,7 +274,6 @@ def intersection_sets(self, other):
         im = im.subs(n_, n)
         ifree = im.free_symbols
         lam = Lambda(n, re)
-        base = self.base_set
         if not im:
             # allow re-evaluation
             # of self in this case to make
@@ -290,7 +294,7 @@ def intersection_sets(self, other):
 
         f = self.lamda.expr
         n = self.lamda.variables[0]
-        base_set = self.base_set
+        base_set = self.base_sets[0]
         new_inf, new_sup = None, None
         new_lopen, new_ropen = other.left_open, other.right_open
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -673,7 +673,7 @@ class ProductSet(Set):
     is_ProductSet = True
 
     def __new__(cls, *sets, **assumptions):
-        if len(sets) == 1 and not isinstance(sets[0], (Set, set)) and iterable(sets[0]):
+        if len(sets) == 1 and iterable(sets[0]) and not isinstance(sets[0], (Set, set)):
             SymPyDeprecationWarning(
                 feature="ProductSet(iterable)",
                 useinstead="ProductSet(*iterable)",
@@ -1976,11 +1976,7 @@ def imageset(*args):
         raise ValueError('imageset expects at least 2 args, got: %s' % len(args))
 
     if isinstance(args[0], (Symbol, tuple)) and len(args) > 2:
-        if isinstance(args[0], tuple):
-            sig = (args[0],)
-        else:
-            sig = args[0]
-        f = Lambda(sig, args[1])
+        f = Lambda(args[0], args[1])
         set_list = args[2:]
     else:
         f = args[0]
@@ -2010,11 +2006,7 @@ def imageset(*args):
                 s = inspect.getargspec(f).args
         dexpr = _sympify(f(*[Dummy() for i in s]))
         var = tuple(_uniquely_named_symbol(Symbol(i), dexpr) for i in s)
-        expr = f(*var)
-        if len(var) == 1:
-            f = Lambda(var[0], expr)
-        else:
-            f = Lambda((var,), expr)
+        f = Lambda(var, f(*var))
     else:
         raise TypeError(filldedent('''
             expecting lambda, Lambda, or FunctionClass,
@@ -2056,9 +2048,9 @@ def imageset(*args):
         if r is not None:
             return r
 
-    set_list = set_list[0] if len(set_list) == 1 else ProductSet(*set_list)
+    #set_list = set_list[0] if len(set_list) == 1 else ProductSet(*set_list)
 
-    return ImageSet(f, set_list)
+    return ImageSet(f, *set_list)
 
 
 def is_function_invertible_in_set(func, setv):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 
-from itertools import product
 from collections import defaultdict
 import inspect
 
@@ -25,7 +24,7 @@ from sympy.logic.boolalg import And, Or, Not, Xor, true, false
 from sympy.sets.contains import Contains
 from sympy.utilities import subsets
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.utilities.iterables import sift, roundrobin
+from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 
 from mpmath import mpi, mpf
@@ -785,7 +784,7 @@ class ProductSet(Set):
         If self.is_iterable returns True (both constituent sets are iterable),
         then return the Cartesian Product. Otherwise, raise TypeError.
         """
-        return product(*self.sets)
+        return iproduct(*self.sets)
 
     @property
     def is_empty(self):
@@ -2044,12 +2043,15 @@ def imageset(*args):
             return set
 
         if isinstance(set, ImageSet):
+            # XXX: Maybe this should just be:
+            # f2 = set.lambda
+            # fun = Lambda(f2.signature, f(*f2.expr))
+            # return imageset(fun, *set.base_sets)
             if len(set.lamda.variables) == 1 and len(f.variables) == 1:
                 x = set.lamda.variables[0]
                 y = f.variables[0]
                 return imageset(
-                    Lambda(x, f.expr.subs(y, set.lamda.expr)),
-                    set.base_set)
+                    Lambda(x, f.expr.subs(y, set.lamda.expr)), *set.base_sets)
 
         if r is not None:
             return r

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2048,8 +2048,6 @@ def imageset(*args):
         if r is not None:
             return r
 
-    #set_list = set_list[0] if len(set_list) == 1 else ProductSet(*set_list)
-
     return ImageSet(f, *set_list)
 
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2012,7 +2012,10 @@ def imageset(*args):
         dexpr = _sympify(f(*[Dummy() for i in s]))
         var = tuple(_uniquely_named_symbol(Symbol(i), dexpr) for i in s)
         expr = f(*var)
-        f = Lambda((var,), expr)
+        if len(var) == 1:
+            f = Lambda(var[0], expr)
+        else:
+            f = Lambda((var,), expr)
     else:
         raise TypeError(filldedent('''
             expecting lambda, Lambda, or FunctionClass,
@@ -2051,7 +2054,9 @@ def imageset(*args):
         if r is not None:
             return r
 
-    return ImageSet(f, *set_list)
+    set_list = set_list[0] if len(set_list) == 1 else ProductSet(*set_list)
+
+    return ImageSet(f, set_list)
 
 
 def is_function_invertible_in_set(func, setv):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1977,7 +1977,11 @@ def imageset(*args):
         raise ValueError('imageset expects at least 2 args, got: %s' % len(args))
 
     if isinstance(args[0], (Symbol, tuple)) and len(args) > 2:
-        f = Lambda(args[0], args[1])
+        if isinstance(args[0], tuple):
+            sig = (args[0],)
+        else:
+            sig = args[0]
+        f = Lambda(sig, args[1])
         set_list = args[2:]
     else:
         f = args[0]
@@ -2008,7 +2012,7 @@ def imageset(*args):
         dexpr = _sympify(f(*[Dummy() for i in s]))
         var = tuple(_uniquely_named_symbol(Symbol(i), dexpr) for i in s)
         expr = f(*var)
-        f = Lambda(var, expr)
+        f = Lambda((var,), expr)
     else:
         raise TypeError(filldedent('''
             expecting lambda, Lambda, or FunctionClass,

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -674,7 +674,7 @@ class ProductSet(Set):
     is_ProductSet = True
 
     def __new__(cls, *sets, **assumptions):
-        if len(sets) == 1 and iterable(sets[0]) and not isinstance(sets[0], (Set, set)):
+        if len(sets) == 1 and not isinstance(sets[0], (Set, set)) and iterable(sets[0]):
             SymPyDeprecationWarning(
                 feature="ProductSet(iterable)",
                 useinstead="ProductSet(*iterable)",

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -128,6 +128,12 @@ def test_ImageSet():
     # Passing a set instead of a FiniteSet shouldn't raise
     assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})
 
+    S2 = ImageSet(Lambda(((x, y),), x+y), {(1, 2), (3, 4)})
+    assert 3 in S2.doit()
+    # FIXME: This doesn't yet work:
+    #assert 3 in S2
+    assert S2._contains(3) is None
+
     raises(TypeError, lambda: ImageSet(Lambda(x, x**2), 1))
 
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -136,18 +136,16 @@ def test_image_is_ImageSet():
 
 
 def test_halfcircle():
-    # This test sometimes works and sometimes doesn't.
-    # It may be an issue with solve? Maybe with using Lambdas/dummys?
-    # I believe the code within fancysets is correct
     r, th = symbols('r, theta', real=True)
     L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
-    assert halfcircle._contains((r, 0)) is None
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
-    #assert (r, 2*pi) not in halfcircle
     assert (0, 0) in halfcircle
+    assert halfcircle._contains((r, 0)) is None
+    # This one doesn't work:
+    #assert (r, 2*pi) not in halfcircle
 
     assert not halfcircle.is_iterable
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -105,10 +105,9 @@ def test_ImageSet():
     assert imageset(x, -x, Interval(0, 1)) == Interval(-1, 0)
 
     assert ImageSet(Lambda(x, x**2), Interval(0, 2)).doit() == Interval(0, 4)
-    # This could evaluate in principle. This just tests that doit with two
-    # base sets doesn't raise:
-    s = ImageSet(Lambda((x, y), 2*x), {4}, {3})
-    assert s.doit() == s
+    assert ImageSet(Lambda((x, y), 2*x), {4}, {3}).doit() == FiniteSet(8)
+    assert (ImageSet(Lambda((x, y), x+y), {1, 2, 3}, {10, 20, 30}).doit() ==
+                FiniteSet(11, 12, 13, 21, 22, 23, 31, 32, 33))
 
     c = Interval(1, 3) * Interval(1, 3)
     assert Tuple(2, 6) in ImageSet(Lambda(((x, y),), (x, 2*y)), c)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -119,9 +119,8 @@ def test_ImageSet():
     assert Rational(2, 3) in ImageSet(Lambda(((x, y),), 2/x), c)
 
     S1 = imageset(lambda x, y: x + y, S.Integers, S.Naturals)
-    # FIXME: The sets must be flattened somewhere in imageset...
-    #assert S1.base_pset == ProductSet(S.Integers, S.Naturals)
-    #assert S1.base_sets == (S.Integers, S.Naturals)
+    assert S1.base_pset == ProductSet(S.Integers, S.Naturals)
+    assert S1.base_sets == (S.Integers, S.Naturals)
 
     # Passing a set instead of a FiniteSet shouldn't raise
     assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})
@@ -141,7 +140,7 @@ def test_halfcircle():
     L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
-    #assert (r, 0) in halfcircle
+    #assert halfcircle._contains((r, 0)) is None
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
     assert (r, 2*pi) not in halfcircle

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -111,7 +111,7 @@ def test_ImageSet():
     assert Tuple(2, S.Half) in ImageSet(Lambda(((x, y),), (x, 1/y)), c)
     assert Tuple(2, -2) not in ImageSet(Lambda(((x, y),), (x, y**2)), c)
     assert Tuple(2, -2) in ImageSet(Lambda(((x, y),), (x, -2)), c)
-    c3 = Interval(3, 7)*Interval(8, 11)*Interval(5, 9)
+    c3 = ProductSet(Interval(3, 7), Interval(8, 11), Interval(5, 9))
     assert Tuple(8, 3, 9) in ImageSet(Lambda(((t, y, x),), (y, t, x)), c3)
     assert Tuple(Rational(1, 8), 3, 9) in ImageSet(Lambda(((t, y, x),), (1/y, t, x)), c3)
     assert 2/pi not in ImageSet(Lambda(((x, y),), 2/x), c)
@@ -136,10 +136,10 @@ def test_halfcircle():
     # It may be an issue with solve? Maybe with using Lambdas/dummys?
     # I believe the code within fancysets is correct
     r, th = symbols('r, theta', real=True)
-    L = Lambda((r, th), (r*cos(th), r*sin(th)))
+    L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
-    assert (r, 0) in halfcircle
+    #assert (r, 0) in halfcircle
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
     assert (r, 2*pi) not in halfcircle

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -143,11 +143,9 @@ def test_halfcircle():
     L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
-    # See https://github.com/sympy/sympy/issues/17621
-    #assert halfcircle._contains((r, 0)) is None
+    assert halfcircle._contains((r, 0)) is None
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
-    # XXX; What's happening here??????
     #assert (r, 2*pi) not in halfcircle
     assert (0, 0) in halfcircle
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -105,6 +105,10 @@ def test_ImageSet():
     assert imageset(x, -x, Interval(0, 1)) == Interval(-1, 0)
 
     assert ImageSet(Lambda(x, x**2), Interval(0, 2)).doit() == Interval(0, 4)
+    # This could evaluate in principle. This just tests that doit with two
+    # base sets doesn't raise:
+    s = ImageSet(Lambda((x, y), 2*x), {4}, {3})
+    assert s.doit() == s
 
     c = Interval(1, 3) * Interval(1, 3)
     assert Tuple(2, 6) in ImageSet(Lambda(((x, y),), (x, 2*y)), c)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -147,7 +147,7 @@ def test_halfcircle():
     #assert halfcircle._contains((r, 0)) is None
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
-    assert (r, 2*pi) not in halfcircle
+    #assert (r, 2*pi) not in halfcircle
     assert (0, 0) in halfcircle
 
     assert not halfcircle.is_iterable

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -106,17 +106,17 @@ def test_ImageSet():
 
     assert ImageSet(Lambda(x, x**2), Interval(0, 2)).doit() == Interval(0, 4)
 
-    c = ComplexRegion(Interval(1, 3)*Interval(1, 3))
-    assert Tuple(2, 6) in ImageSet(Lambda((x, y), (x, 2*y)), c)
-    assert Tuple(2, S.Half) in ImageSet(Lambda((x, y), (x, 1/y)), c)
-    assert Tuple(2, -2) not in ImageSet(Lambda((x, y), (x, y**2)), c)
-    assert Tuple(2, -2) in ImageSet(Lambda((x, y), (x, -2)), c)
+    c = Interval(1, 3) * Interval(1, 3)
+    assert Tuple(2, 6) in ImageSet(Lambda(((x, y),), (x, 2*y)), c)
+    assert Tuple(2, S.Half) in ImageSet(Lambda(((x, y),), (x, 1/y)), c)
+    assert Tuple(2, -2) not in ImageSet(Lambda(((x, y),), (x, y**2)), c)
+    assert Tuple(2, -2) in ImageSet(Lambda(((x, y),), (x, -2)), c)
     c3 = Interval(3, 7)*Interval(8, 11)*Interval(5, 9)
-    assert Tuple(8, 3, 9) in ImageSet(Lambda((t, y, x), (y, t, x)), c3)
-    assert Tuple(Rational(1, 8), 3, 9) in ImageSet(Lambda((t, y, x), (1/y, t, x)), c3)
-    assert 2/pi not in ImageSet(Lambda((x, y), 2/x), c)
-    assert 2/S(100) not in ImageSet(Lambda((x, y), 2/x), c)
-    assert Rational(2, 3) in ImageSet(Lambda((x, y), 2/x), c)
+    assert Tuple(8, 3, 9) in ImageSet(Lambda(((t, y, x),), (y, t, x)), c3)
+    assert Tuple(Rational(1, 8), 3, 9) in ImageSet(Lambda(((t, y, x),), (1/y, t, x)), c3)
+    assert 2/pi not in ImageSet(Lambda(((x, y),), 2/x), c)
+    assert 2/S(100) not in ImageSet(Lambda(((x, y),), 2/x), c)
+    assert Rational(2, 3) in ImageSet(Lambda(((x, y),), 2/x), c)
 
     assert imageset(lambda x, y: x + y, S.Integers, S.Naturals
         ).base_set == ProductSet(S.Integers, S.Naturals)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -144,9 +144,11 @@ def test_halfcircle():
     L = Lambda(((r, th),), (r*cos(th), r*sin(th)))
     halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))
 
+    # See https://github.com/sympy/sympy/issues/17621
     #assert halfcircle._contains((r, 0)) is None
     assert (1, 0) in halfcircle
     assert (0, -1) not in halfcircle
+    # XXX; What's happening here??????
     #assert (r, 2*pi) not in halfcircle
     assert (0, 0) in halfcircle
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -118,8 +118,10 @@ def test_ImageSet():
     assert 2/S(100) not in ImageSet(Lambda(((x, y),), 2/x), c)
     assert Rational(2, 3) in ImageSet(Lambda(((x, y),), 2/x), c)
 
-    assert imageset(lambda x, y: x + y, S.Integers, S.Naturals
-        ).base_set == ProductSet(S.Integers, S.Naturals)
+    S1 = imageset(lambda x, y: x + y, S.Integers, S.Naturals)
+    # FIXME: The sets must be flattened somewhere in imageset...
+    #assert S1.base_pset == ProductSet(S.Integers, S.Naturals)
+    #assert S1.base_sets == (S.Integers, S.Naturals)
 
     # Passing a set instead of a FiniteSet shouldn't raise
     assert unchanged(ImageSet, Lambda(x, x**2), {1, 2, 3})

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -34,7 +34,7 @@ def test_imageset():
     raises(TypeError, lambda: imageset(x, ints))
     raises(ValueError, lambda: imageset(x, y, z, ints))
     raises(ValueError, lambda: imageset(Lambda(x, cos(x)), y))
-    raises(ValueError, lambda: imageset(Lambda(x, x), ints, ints))
+    assert (1, 2) in imageset(Lambda(x, x), ints, ints)
     assert imageset(cos, ints) == ImageSet(Lambda(x, cos(x)), ints)
     def f(x):
         return cos(x)
@@ -49,7 +49,7 @@ def test_imageset():
         in ('_x + x', 'x + _x'))
     x1, x2 = symbols("x1, x2")
     assert imageset(lambda x, y: Add(x, y), Interval(1, 2)*Interval(2, 3)) == \
-        ImageSet(Lambda((x1, x2), x1+x2), Interval(1, 2)*Interval(2, 3))
+        ImageSet(Lambda(((x1, x2),), x1+x2), Interval(1, 2)*Interval(2, 3))
 
 
 def test_is_empty():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -34,7 +34,8 @@ def test_imageset():
     raises(TypeError, lambda: imageset(x, ints))
     raises(ValueError, lambda: imageset(x, y, z, ints))
     raises(ValueError, lambda: imageset(Lambda(x, cos(x)), y))
-    assert (1, 2) in imageset(Lambda(x, x), ints, ints)
+    assert (1, 2) in imageset(Lambda((x, y), (x, y)), ints, ints)
+    raises(ValueError, lambda: imageset(Lambda(x, x), ints, ints))
     assert imageset(cos, ints) == ImageSet(Lambda(x, cos(x)), ints)
     def f(x):
         return cos(x)
@@ -43,13 +44,13 @@ def test_imageset():
     assert imageset(f, ints) == ImageSet(Lambda(x, cos(x)), ints)
     assert imageset(x, 1, ints) == FiniteSet(1)
     assert imageset(x, y, ints) == {y}
-    assert imageset((x, y), (1, z), ints*S.Reals) == {(1, z)}
+    assert imageset((x, y), (1, z), ints, S.Reals) == {(1, z)}
     clash = Symbol('x', integer=true)
     assert (str(imageset(lambda x: x + clash, Interval(-2, 1)).lamda.expr)
         in ('_x + x', 'x + _x'))
     x1, x2 = symbols("x1, x2")
-    assert imageset(lambda x, y: Add(x, y), Interval(1, 2)*Interval(2, 3)) == \
-        ImageSet(Lambda(((x1, x2),), x1+x2), Interval(1, 2)*Interval(2, 3))
+    assert imageset(lambda x, y: Add(x, y), Interval(1, 2), Interval(2, 3)) == \
+        ImageSet(Lambda((x1, x2), x1+x2), Interval(1, 2), Interval(2, 3))
 
 
 def test_is_empty():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -48,8 +48,8 @@ def test_imageset():
     assert (str(imageset(lambda x: x + clash, Interval(-2, 1)).lamda.expr)
         in ('_x + x', 'x + _x'))
     x1, x2 = symbols("x1, x2")
-    assert imageset(lambda x,y: Add(x,y), Interval(1,2), Interval(2, 3)) == \
-        ImageSet(Lambda((x1, x2), x1+x2), Interval(1,2), Interval(2,3))
+    assert imageset(lambda x, y: Add(x, y), Interval(1, 2)*Interval(2, 3)) == \
+        ImageSet(Lambda((x1, x2), x1+x2), Interval(1, 2)*Interval(2, 3))
 
 
 def test_is_empty():

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -851,7 +851,7 @@ def solve_decomposition(f, symbol, domain):
             for iset in iter_iset:
                 new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)
                 dummy_var = tuple(iset.lamda.expr.free_symbols)[0]
-                base_set = iset.base_sets[0]
+                (base_set,) = iset.base_sets
                 if isinstance(new_solutions, FiniteSet):
                     new_exprs = new_solutions
 
@@ -2898,7 +2898,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             res[key_res] = value_res.lamda.expr
                             original_imageset[key_res] = value_res
                             dummy_n = value_res.lamda.expr.atoms(Dummy).pop()
-                            base = value_res.base_sets[0]
+                            (base,) = value_res.base_sets
                             imgset_yes = (dummy_n, base)
                 # update eq with everything that is known so far
                 eq2 = eq.subs(res).expand()

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2045,13 +2045,13 @@ def _solveset_multi(eqs, syms, domains):
 
     eqs = sorted(eqs, key=lambda eq: len(eq.free_symbols & set(syms)))
 
-    for n, eq in enumerate(eqs):
+    for n in range(len(eqs)):
         sols = []
         all_handled = True
         for sym in syms:
-            if sym not in eq.free_symbols:
+            if sym not in eqs[n].free_symbols:
                 continue
-            sol = solveset(eq, sym, domains[syms.index(sym)])
+            sol = solveset(eqs[n], sym, domains[syms.index(sym)])
 
             if isinstance(sol, FiniteSet):
                 i = syms.index(sym)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -851,7 +851,7 @@ def solve_decomposition(f, symbol, domain):
             for iset in iter_iset:
                 new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)
                 dummy_var = tuple(iset.lamda.expr.free_symbols)[0]
-                base_set = iset.base_set
+                base_set = iset.base_sets[0]
                 if isinstance(new_solutions, FiniteSet):
                     new_exprs = new_solutions
 
@@ -1278,15 +1278,15 @@ def _solve_modular(f, symbol, domain):
     if isinstance(g_n, ImageSet):
         lamda_expr = g_n.lamda.expr
         lamda_vars = g_n.lamda.variables
-        base_set = g_n.base_set
+        base_sets = g_n.base_sets
         sol_set = _solveset(f_x - lamda_expr, symbol, S.Integers)
         if isinstance(sol_set, FiniteSet):
             tmp_sol = EmptySet()
             for sol in sol_set:
-                tmp_sol += ImageSet(Lambda(lamda_vars, sol), base_set)
+                tmp_sol += ImageSet(Lambda(lamda_vars, sol), *base_sets)
             sol_set = tmp_sol
         else:
-            sol_set =  ImageSet(Lambda(lamda_vars, sol_set), base_set)
+            sol_set =  ImageSet(Lambda(lamda_vars, sol_set), *base_sets)
         return domain.intersect(sol_set)
 
     return unsolved_result
@@ -2898,7 +2898,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             res[key_res] = value_res.lamda.expr
                             original_imageset[key_res] = value_res
                             dummy_n = value_res.lamda.expr.atoms(Dummy).pop()
-                            base = value_res.base_set
+                            base = value_res.base_sets[0]
                             imgset_yes = (dummy_n, base)
                 # update eq with everything that is known so far
                 eq2 = eq.subs(res).expand()

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -234,7 +234,7 @@ def iproduct(*iterables):
     Examples
     ========
 
-    >>> from sympy.utilities import iproduct
+    >>> from sympy.utilities.iterables import iproduct
     >>> sorted(iproduct([1,2], [3,4]))
     [(1, 3), (1, 4), (2, 3), 2, 4)]
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -196,6 +196,76 @@ def group(seq, multiple=True):
     return groups
 
 
+def _iproduct2(iterable1, iterable2):
+    '''Cartesian product of two possibly infinite iterables'''
+
+    it1 = iter(iterable1)
+    it2 = iter(iterable2)
+
+    elems1 = []
+    elems2 = []
+
+    sentinel = object()
+    def append(it, elems):
+        e = next(it, sentinel)
+        if e is not sentinel:
+            elems.append(e)
+
+    n = 0
+    append(it1, elems1)
+    append(it2, elems2)
+
+    while n <= len(elems1) + len(elems2):
+        for m in range(n-len(elems1)+1, len(elems2)):
+            yield (elems1[n-m], elems2[m])
+        n += 1
+        append(it1, elems1)
+        append(it2, elems2)
+
+
+def iproduct(*iterables):
+    '''
+    Cartesian product of iterables.
+
+    Generator of the cartesian product of iterables. This is analogous to
+    itertools.product except that it works with infinite iterables and will
+    yield any item from the infinite product eventually.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities import iproduct
+    >>> sorted(iproduct([1,2], [3,4]))
+    [(1, 3), (1, 4), (2, 3), 2, 4)]
+
+    With an infinite iterator:
+
+    >>> from sympy import S
+    >>> (3,) in iproduct(S.Integers)
+    True
+    >>> (3, 4) in iproduct(S.Integers, S.Integers)
+    True
+
+    See Also
+    ========
+
+    sympy.iterables.cartes (itertools.product)
+    '''
+    if len(iterables) == 0:
+        yield ()
+        return
+    elif len(iterables) == 1:
+        for e in iterables[0]:
+            yield (e,)
+    elif len(iterables) == 2:
+        for e12 in _iproduct2(*iterables):
+            yield e12
+    else:
+        first, others = iterables[0], iterables[1:]
+        for ef, eo in _iproduct2(first, iproduct(*others)):
+            yield (ef,) + eo
+
+
 def multiset(seq):
     """Return the hashable sequence in multiset form with values being the
     multiplicity of the item in the sequence.

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -236,7 +236,7 @@ def iproduct(*iterables):
 
     >>> from sympy.utilities.iterables import iproduct
     >>> sorted(iproduct([1,2], [3,4]))
-    [(1, 3), (1, 4), (2, 3), 2, 4)]
+    [(1, 3), (1, 4), (2, 3), (2, 4)]
 
     With an infinite iterator:
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -5,18 +5,18 @@ from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
     factorial, true)
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
-from sympy.core.compatibility import range
+from sympy.core.compatibility import iterable, range
 from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
     cartes, common_prefix, common_suffix, connected_components, dict_merge,
     filter_symbols, flatten, generate_bell, generate_derangements,
     generate_involutions, generate_oriented_forest, group, has_dups, ibin,
-    kbins, minlex, multiset, multiset_combinations, multiset_partitions,
-    multiset_permutations, necklaces, numbered_symbols, ordered, partitions,
-    permutations, postfixes, postorder_traversal, prefixes, reshape,
-    rotate_left, rotate_right, runs, sift, strongly_connected_components,
-    subsets, take, topological_sort, unflatten, uniq, variations,
-    ordered_partitions, rotations)
+    iproduct, kbins, minlex, multiset, multiset_combinations,
+    multiset_partitions, multiset_permutations, necklaces, numbered_symbols,
+    ordered, partitions, permutations, postfixes, postorder_traversal,
+    prefixes, reshape, rotate_left, rotate_right, runs, sift,
+    strongly_connected_components, subsets, take, topological_sort, unflatten,
+    uniq, variations, ordered_partitions, rotations)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -72,6 +72,20 @@ def test_flatten():
     assert flatten([MyOp(x, y), z], cls=MyOp) == [x, y, z]
 
     assert flatten({1, 11, 2}) == list({1, 11, 2})
+
+
+def test_iproduct():
+    assert list(iproduct()) == [()]
+    assert list(iproduct([])) == []
+    assert list(iproduct([1,2,3])) == [(1,),(2,),(3,)]
+    assert sorted(iproduct([1, 2], [3, 4, 5])) == [
+        (1,3),(1,4),(1,5),(2,3),(2,4),(2,5)]
+    assert sorted(iproduct([0,1],[0,1],[0,1])) == [
+        (0,0,0),(0,0,1),(0,1,0),(0,1,1),(1,0,0),(1,0,1),(1,1,0),(1,1,1)]
+    assert iterable(iproduct(S.Integers)) is True
+    assert iterable(iproduct(S.Integers, S.Integers)) is True
+    assert (3,) in iproduct(S.Integers)
+    assert (4, 5) in iproduct(S.Integers, S.Integers)
 
 
 def test_group():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+
 from textwrap import dedent
+from itertools import islice, product
 
 from sympy import (
-    symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
+    symbols, Integer, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
     factorial, true)
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
 from sympy.core.compatibility import iterable, range
@@ -86,6 +88,14 @@ def test_iproduct():
     assert iterable(iproduct(S.Integers, S.Integers)) is True
     assert (3,) in iproduct(S.Integers)
     assert (4, 5) in iproduct(S.Integers, S.Integers)
+    assert (1, 2, 3) in iproduct(S.Integers, S.Integers, S.Integers)
+    triples  = set(islice(iproduct(S.Integers, S.Integers, S.Integers), 1000))
+    for n1, n2, n3 in triples:
+        assert isinstance(n1, Integer)
+        assert isinstance(n2, Integer)
+        assert isinstance(n3, Integer)
+    for t in set(product(*([range(-2, 3)]*3))):
+        assert t in iproduct(S.Integers, S.Integers, S.Integers)
 
 
 def test_group():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17455 
Fixes #17157 
Based on #17557 

#### Brief description of what is fixed or changed

Makes ImageSet have ~~a single base set~~ clearly defined base sets. Arguments to ImageSet are not implicitly combined into a ProductSet.

Current behaviour on master:
```julia
In [1]: ImageSet(Lambda((x, y), (2*x, y)), Integers, Integers)                                                                    
Out[1]: {(2⋅x, y) | x ∊ ℤ , y ∊ ℤ}

In [2]: ImageSet(Lambda((x, y), (2*x, y)), Integers*Integers)                                                                     
Out[2]: 
⎧                2⎫
⎨(2⋅x, y) | x ∊ ℤ ⎬
⎩                 ⎭

In [3]: (2, 1) in ImageSet(Lambda((x, y), (2*x, y)), Integers, Integers)                                                          
Out[3]: True

In [4]: (2, 1) in ImageSet(Lambda((x, y), (2*x, y)), Integers*Integers)                                                           
Out[4]: True

In [5]: (2, 1) in ImageSet(Lambda(x, x), Integers*Integers)                                                                       
Out[5]: True
```
The results above (`In[4]` in particular) conflate different things and mean that `ImageSet` is not well defined if we need to distinguish between a set of tuples and a product set.

With this PR:
```julia
In [1]: ImageSet(Lambda((x, y), (2*x, y)), Integers, Integers)                                                                                                
Out[1]: {(2⋅x, y) | x ∊ ℤ , y ∊ ℤ}

In [2]: ImageSet(Lambda((x, y), (2*x, y)), Integers*Integers)                                                                                                 
...
ValueError: Incompatible signature

In [3]: (2, 1) in ImageSet(Lambda((x, y), (2*x, y)), Integers, Integers)                                                                                      
Out[3]: True

In [4]: (2, 1) in ImageSet(Lambda((x, y), (2*x, y)), Integers*Integers)                                                                                       
...
ValueError: Incompatible signature

In [5]: (2, 1) in ImageSet(Lambda(x, x), Integers*Integers)                                                                                                   
Out[5]: True
```

#### Other comments

Maybe the base_set attribute should give DeprecationWarning

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * ImageSet can now represent sets of nested tuples and can have base sets that are nested ProductSets without flattening.
* sets
    * The definition of ImageSet is now tightened so that in `ImageSet(lamda, S1, S2, ...)` the number of set arguments must match the number of arguments accepted by the lamda function. Also `ImageSet` no longer implicitly combines arguments into a flattened `ProductSet` so `ImageSet(lamda, S1*S2, S3)` is not equivalent to `ImageSet(lamda, S1, S2, S2)`. This means that `ImageSet` is well defined in all cases including when mixing sets of tuples and `ProductSet` as base sets: the set `ImageSet(lamda, S1, S2, ...)` always means that set of `lamda(x1, x2, ...)` where `x1` in `S1`, etc.
* sets
    * ImageSet now has attributes base_sets which returns a list of sets and base_pset which returns a ProductSet of the basesets. In the new tighter definition of `ImageSet` these are more useful than the `base_set` attribute.
* printing
    * Printing of multivariate ImageSets is fixed.
<!-- END RELEASE NOTES -->
