### PR TITLE
added new hypergeometric method to solve 2nd order ode

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1693,11 +1693,9 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
     eqs = []
     # We are comparing the coeff of powers of different x, for finding the values of
     # parameters of standerd equation.
-    for key, val in dict_I.items():
-        eqs.append(Eq(val, dict_I0[key]))
-    # I am trying to solve the equations for a, b, c.
-    # this is not a efficient way to solve and it is slowing the process
-    # also it is not giving solution always.
+    for key in [x**2, x, 1]:
+        eqs.append(Eq(dict_I[key], dict_I0[key]))
+
     _c = solve(eqs[2], c)[0]
     t = solve(eqs[0].subs(a-b, t), t)[0]
     _a = t+b

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1644,6 +1644,7 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
     a = Wild("a")
     b = Wild("b")
     c = Wild("c")
+    t = Wild("t")
     alpha = Wild("alpha")
     beta = Wild("beta")
     gamma = Wild("gamma")
@@ -1655,7 +1656,7 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
     if sing_point != [0, 1]:
         # If singular point is [0, 1] then we have standerd equation.
         eqs = []
-        sing_eqs = [-delta/gamma, -beta/alpha, (delta-beta)/(alpha-gamma)]
+        sing_eqs = [-beta/alpha, -delta/gamma, (delta-beta)/(alpha-gamma)]
         # making equations for the finding the mobius transformation
         for i in range(3):
             if i<len(sing_point):
@@ -1663,8 +1664,8 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
             else:
                 eqs.append(Eq(1/sing_eqs[i], 0))
         # solving above equations for the mobius transformation
-        _delta = solve(eqs[0], delta)[0]
-        _beta = solve(eqs[1], beta)[0]
+        _beta = solve(eqs[0], beta)[0]
+        _delta = solve(eqs[1], delta)[0]
         _gamma = solve(((eqs[2]).subs(beta, _beta)).subs(delta, _delta), gamma)[0]
         subs = (alpha*x + beta)/(gamma*x + delta)
         subs = subs.subs(beta, _beta)
@@ -1673,14 +1674,16 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
         subs = cancel(subs)
     else:
         subs = x
-    # applying mobius transformation in I0.
-    I0 = I0.subs(x, subs)
-    I0 = I0*(subs.diff(x))**2
-    I0 = factor(I0)
+    t = (solve(Eq(subs, t), x)[0]).subs(t, x)
+    # applying mobius transformation in I to make it into I0.
+    I = I.subs(x, t)
+    I = I*(t.diff(x))**2
+    I = factor(I)
+
     dict_I = {x**2:0, x:0, 1:0}
     I0_num, I0_dem = I0.as_numer_denom()
     # collecting coeff of (x**2, x), of the standerd equation.
-    dict_I0 = collect(expand(I0_num), [x**2, x], evaluate=False)
+    dict_I0 = {x**2:(a-b)**2 - 1, x:2*((1-a-b)*c + 2*a*b), 1:c*(c-2)}
     # collecting coeff of (x**2, x) from I0 of the given equation.
     dict_I.update(collect(expand(cancel(I*I0_dem)), [x**2, x], evaluate=False))
     eqs = []
@@ -1692,7 +1695,11 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
     # this is not a efficient way to solve and it is slowing the process
     # also it is not giving solution always.
 
-    _a, _b, _c = solve(eqs, [a, b, c])[0]
+    _c = solve(eqs[2], c)[0]
+    t = solve(eqs[0].subs(a-b, t), t)[0]
+    _a = t+b
+    _b = solve((eqs[1].subs(c, _c)).subs(a, _a), b)[0]
+    _a = t + _b
 
     rn = {'a':simplify(_a), 'b':simplify(_b), 'c':simplify(_c), 'k':k, 'r':r, 'mobius':subs, 'type':"2F1"}
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1613,15 +1613,17 @@ def ode_2nd_hypergeometirc(eq, func, order, match):
             y2 = Integral(exp(Integral((-(a+b+1)*x + c)/(x**2-x), x))/hyperexpand(hyper([a, b], [c], x)**2), x)*hyper([a, b], [c], x)
             sol = C0*hyper([a, b], [c], x) + C1*y2
         # applying transformation in the solution
-        e = logcombine(Integral(((a + b + 1)*x - c)/(2*(x**2 - x)), x), force=True)
+        e = logcombine(Integral(((a + b + 1)*x - c)/(2*(x**2 - x)), x).doit(), force=True)
         sol = (sol).subs(x, match['mobius'])
         sol = sol.subs(x, x**match['k'])
         e = (e.subs(x, match['mobius'])).subs(x, x**match['k'])
+
         if B:
-            e1 = Integral(A/2, x)
-            e1 = logcombine(e, force=True)
+            e1 = Integral(A/2, x).doit()
+            e1 = logcombine(e1, force=True)
             e = simplify(e - e1)
-        sol = exp(e)*(sol*x**((-match['k']+1)/2))
+
+        sol = cancel(exp(e))*(sol)*x**((-match['k']+1)/2)
         sol = Eq(func, sol)
 
     # if sol is None then we can try for series solution
@@ -1690,10 +1692,7 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func, r):
     # this is not a efficient way to solve and it is slowing the process
     # also it is not giving solution always.
 
-    _c = simplify(solve(eqs[2], c)[0])
-    _a, _b = solve([eqs[0].subs(c, _c), eqs[1].subs(c, _c)], [a, b])[0]
-    _c = _c.subs(a, _a)
-    _c = _c.subs(b, _b)
+    _a, _b, _c = solve(eqs, [a, b, c])[0]
 
     rn = {'a':simplify(_a), 'b':simplify(_b), 'c':simplify(_c), 'k':k, 'r':r, 'mobius':subs, 'type':"2F1"}
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1692,12 +1692,12 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     for key in [x**2, x, 1]:
         eqs.append(Eq(dict_I[key], dict_I0[key]))
 
-    _c = list(roots(eqs[2], c))[0]
+    _c = list(ordered(roots(eqs[2], c)))[0]
     if not _c.has(Symbol):
         _c = min(list(roots(eqs[2], c)))
-    s = list(roots(eqs[0].subs(a-b, s), s))[-1]
+    s = list(ordered(roots(eqs[0].subs(a-b, s), s)))[-1]
     _a = s+b
-    _b = list(roots((eqs[1].subs(c, _c)).subs(a, _a), b))[0]
+    _b = list(ordered(roots((eqs[1].subs(c, _c)).subs(a, _a), b)))[0]
     _a = s + _b
     rn = {'a':simplify(_a), 'b':simplify(_b), 'c':simplify(_c), 'k':k, 'mobius':mob, 'type':"2F1"}
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1634,10 +1634,6 @@ def ode_2nd_hypergeometric(eq, func, order, match):
         sol = cancel((e)*x**((-match['k']+1)/2))*sol
         sol = Eq(func, sol)
 
-    if sol is None:
-        raise NotImplementedError("The given ODE " + str(eq) + " cannot be solved by"
-            + " the hypergeometric method")
-
     return sol
 
 def match_2nd_2F1_hypergeometric(I, k, sing_point, func):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1627,12 +1627,8 @@ def ode_2nd_hypergeometric(eq, func, order, match):
 
     # if sol is None then we can try for series solution
     if sol is None:
-        try:
-            sol = dsolve(eq, func, hint = "2nd_power_series_regular", x0=x0)
-        except ValueError:
-            pass
-    if sol is None:
-        raise NotImplementedError("....")
+        raise NotImplementedError("The given ODE " + str(eq) + " cannot be solved by"
+            + " the hypergeometric method")
 
     return sol
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1692,6 +1692,10 @@ def match_2nd_2F1_hypergeometric(I, k, sing_point, func):
     for key in [x**2, x, 1]:
         eqs.append(Eq(dict_I[key], dict_I0[key]))
 
+    # We can have many possible roots for the equation.
+    # I am selecting the root on the basis that when we have
+    # standard equation eq = x*(x-1)*f(x).diff(x, 2) + ((a+b+1)*x-c)*f(x).diff(x) + a*b*f(x)
+    # then root should be a, b, c.
     _c = list(ordered(roots(eqs[2], c)))[0]
     if not _c.has(Symbol):
         _c = min(list(roots(eqs[2], c)))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1,7 +1,7 @@
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff,
     Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, sin, sqrt, Subs, Symbol, tan, asin, sinh,
-    Piecewise, symbols, Poly, sec, Ei, re, im, atan2, collect)
+    Piecewise, symbols, Poly, sec, Ei, re, im, atan2, collect, hyper)
 from sympy.solvers.ode import (_undetermined_coefficients_match,
     checkodesol, classify_ode, classify_sysode, constant_renumber,
     constantsimp, homogeneous_order, infinitesimals, checkinfsol,
@@ -3705,3 +3705,29 @@ def test_issue_17322():
     sol = [Eq(f(x), C1), Eq(f(x), C1*exp(-x))]
     assert set(sol) == set(dsolve(eq, hint='lie_group'))
     assert checkodesol(eq, sol) == 2*[(True, 0)]
+
+def test_2nd_2F1_hypergeometric():
+
+    a, b, c = symbols("a b c")
+
+    eq = x*(x-1)*f(x).diff(x, 2) + ((a+b+1)*x-c)*f(x).diff(x) + a*b*f(x)
+    sol = Eq(f(x), C1*x**(1 - c)*hyper((b - c + 1, a - c + 1), (2 - c,), x) + C2*hyper((b, a), (c,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    # assert checkodesol(eq, sol) == (True, 0) Hanging
+
+    eq = x*(x-1)*f(x).diff(x, 2) + (S(3)/2 -2*x)*f(x).diff(x) + 2*f(x)
+    sol = Eq(f(x), C1*x**(S(5)/2)*hyper((S(1)/2, S(3)/2), (S(7)/2,), x) + C2*hyper((-2, -1), (-S(3)/2,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq=x*(x-1)*f(x).diff(x, 2) + (S(3) -2*x)*f(x).diff(x) + 2*f(x)
+    sol = Eq(f(x), C1*x**4*hyper((2, 3), (5,), x) + C2*hyper((-2, -1), (-3,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = -x**(S(5)/7)*(-416*x**(S(9)/7)/9 - 2385*x**(S(5)/7)/49 + S(298)*x/3)*f(x)/(196*(-x**(S(6)/7) +
+         x)**2*(x**(S(6)/7) + x)**2) + Derivative(f(x), (x, 2))
+    sol = Eq(f(x), x**(S(45)/98)*(C1*x**(S(4)/49)*hyper((S(-1)/2, S(1)/3), (S(9)/7,), x**(S(2)/7)) +
+          C2*hyper((S(-11)/14, S(1)/21), (S(5)/7,), x**(S(2)/7)))/(x**(S(2)/7) - 1)**(S(19)/84))
+    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    # assert checkodesol(eq, sol) == (True, 0) Hanging

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3727,7 +3727,7 @@ def test_2nd_2F1_hypergeometric():
 
     eq = -x**(S(5)/7)*(-416*x**(S(9)/7)/9 - 2385*x**(S(5)/7)/49 + S(298)*x/3)*f(x)/(196*(-x**(S(6)/7) +
          x)**2*(x**(S(6)/7) + x)**2) + Derivative(f(x), (x, 2))
-    sol = Eq(f(x), x**(S(45)/98)*(x**(S(2)/7) - 1)**(S(103)/84)*(C1*x**(S(4)/49)*hyper((S(25)/14,
-          S(20)/21), (S(9)/7,), x**(S(2)/7)) + C2*hyper((S(3)/2, S(2)/3), (S(5)/7,), x**(S(2)/7))))
+    sol = Eq(f(x), x**(S(45)/98)*(C1*x**(S(4)/49)*hyper((S(1)/3, -S(1)/2), (S(9)/7,), x**(S(2)/7)) +
+          C2*hyper((S(1)/21, -S(11)/14), (S(5)/7,), x**(S(2)/7)))/(x**(S(2)/7) - 1)**(S(19)/84))
     assert sol == dsolve(eq, hint='2nd_hypergeometric')
     # assert checkodesol(eq, sol) == (True, 0) #issue-https://github.com/sympy/sympy/issues/17702

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3711,23 +3711,23 @@ def test_2nd_2F1_hypergeometric():
     a, b, c = symbols("a b c")
 
     eq = x*(x-1)*f(x).diff(x, 2) + ((a+b+1)*x-c)*f(x).diff(x) + a*b*f(x)
-    sol = Eq(f(x), C1*x**(1 - c)*hyper((b - c + 1, a - c + 1), (2 - c,), x) + C2*hyper((b, a), (c,), x))
-    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    sol = Eq(f(x), C1*x**(1 - c)*hyper((a - c + 1, b - c + 1), (2 - c,), x) + C2*hyper((a, b), (c,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
     # assert checkodesol(eq, sol) == (True, 0) Hanging
 
     eq = x*(x-1)*f(x).diff(x, 2) + (S(3)/2 -2*x)*f(x).diff(x) + 2*f(x)
-    sol = Eq(f(x), C1*x**(S(5)/2)*hyper((S(1)/2, S(3)/2), (S(7)/2,), x) + C2*hyper((-2, -1), (-S(3)/2,), x))
-    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    sol = Eq(f(x), C1*x**(S(5)/2)*hyper((S(3)/2, S(1)/2), (S(7)/2,), x) + C2*hyper((-1, -2), (-S(3)/2,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
     assert checkodesol(eq, sol) == (True, 0)
 
     eq=x*(x-1)*f(x).diff(x, 2) + (S(3) -2*x)*f(x).diff(x) + 2*f(x)
-    sol = Eq(f(x), C1*x**4*hyper((2, 3), (5,), x) + C2*hyper((-2, -1), (-3,), x))
-    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
+    sol = Eq(f(x), C1*x**4*hyper((3, 2), (5,), x) + C2*hyper((-1, -2), (-3,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
     assert checkodesol(eq, sol) == (True, 0)
 
     eq = -x**(S(5)/7)*(-416*x**(S(9)/7)/9 - 2385*x**(S(5)/7)/49 + S(298)*x/3)*f(x)/(196*(-x**(S(6)/7) +
          x)**2*(x**(S(6)/7) + x)**2) + Derivative(f(x), (x, 2))
-    sol = Eq(f(x), x**(S(45)/98)*(C1*x**(S(4)/49)*hyper((S(-1)/2, S(1)/3), (S(9)/7,), x**(S(2)/7)) +
-          C2*hyper((S(-11)/14, S(1)/21), (S(5)/7,), x**(S(2)/7)))/(x**(S(2)/7) - 1)**(S(19)/84))
-    assert sol == dsolve(eq, hint='2nd_hypergeometirc')
-    # assert checkodesol(eq, sol) == (True, 0) Hanging
+    sol = Eq(f(x), x**(S(45)/98)*(x**(S(2)/7) - 1)**(S(103)/84)*(C1*x**(S(4)/49)*hyper((S(25)/14,
+          S(20)/21), (S(9)/7,), x**(S(2)/7)) + C2*hyper((S(3)/2, S(2)/3), (S(5)/7,), x**(S(2)/7))))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
+    # assert checkodesol(eq, sol) == (True, 0) #issue-https://github.com/sympy/sympy/issues/17702

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3708,16 +3708,28 @@ def test_issue_17322():
 
 def test_2nd_2F1_hypergeometric():
 
-    a, b, c = symbols("a b c", integer=False)
-
-    eq = x*(x-1)*f(x).diff(x, 2) + ((a+b+1)*x-c)*f(x).diff(x) + a*b*f(x)
-    sol = Eq(f(x), C1*x**(1 - c)*hyper((a - c + 1, b - c + 1), (2 - c,), x) + C2*hyper((a, b), (c,), x))
-    assert sol == dsolve(eq, hint='2nd_hypergeometric')
-    # assert checkodesol(eq, sol) == (True, 0) Hanging
-
     eq = x*(x-1)*f(x).diff(x, 2) + (S(3)/2 -2*x)*f(x).diff(x) + 2*f(x)
     sol = Eq(f(x), C1*x**(S(5)/2)*hyper((S(3)/2, S(1)/2), (S(7)/2,), x) + C2*hyper((-1, -2), (-S(3)/2,), x))
     assert sol == dsolve(eq, hint='2nd_hypergeometric')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = x*(x-1)*f(x).diff(x, 2) + (S(7)/2*x)*f(x).diff(x) + f(x)
+    sol = Eq(f(x), (C1*(1 - x)**(S(5)/2)*hyper((S(1)/2, 2), (S(7)/2,), 1 - x) +
+          C2*hyper((-S(1)/2, -2), (-S(3)/2,), 1 - x))/(x - 1)**(S(5)/2))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = x*(x-1)*f(x).diff(x, 2) + (S(3)+ S(7)/2*x)*f(x).diff(x) + f(x)
+    sol = Eq(f(x), (C1*(1 - x)**(S(11)/2)*hyper((S(1)/2, 2), (S(13)/2,), 1 - x) +
+          C2*hyper((-S(7)/2, -5), (-S(9)/2,), 1 - x))/(x - 1)**(S(11)/2))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = x*(x-1)*f(x).diff(x, 2) + (-1+ S(7)/2*x)*f(x).diff(x) + f(x)
+    sol = Eq(f(x), (C1 + C2*Integral(exp(Integral((1 - x/2)/(x*(x - 1)), x))/(1 -
+          x/2)**2, x))*exp(Integral(1/(x - 1), x)/4)*exp(-Integral(7/(x -
+          1), x)/4)*hyper((S(1)/2, -1), (1,), x))
+    assert sol == dsolve(eq, hint='2nd_hypergeometric_Integral')
     assert checkodesol(eq, sol) == (True, 0)
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3708,7 +3708,7 @@ def test_issue_17322():
 
 def test_2nd_2F1_hypergeometric():
 
-    a, b, c = symbols("a b c")
+    a, b, c = symbols("a b c", integer=False)
 
     eq = x*(x-1)*f(x).diff(x, 2) + ((a+b+1)*x-c)*f(x).diff(x) + a*b*f(x)
     sol = Eq(f(x), C1*x**(1 - c)*hyper((a - c + 1, b - c + 1), (2 - c,), x) + C2*hyper((a, b), (c,), x))
@@ -3720,10 +3720,6 @@ def test_2nd_2F1_hypergeometric():
     assert sol == dsolve(eq, hint='2nd_hypergeometric')
     assert checkodesol(eq, sol) == (True, 0)
 
-    eq=x*(x-1)*f(x).diff(x, 2) + (S(3) -2*x)*f(x).diff(x) + 2*f(x)
-    sol = Eq(f(x), C1*x**4*hyper((3, 2), (5,), x) + C2*hyper((-1, -2), (-3,), x))
-    assert sol == dsolve(eq, hint='2nd_hypergeometric')
-    assert checkodesol(eq, sol) == (True, 0)
 
     eq = -x**(S(5)/7)*(-416*x**(S(9)/7)/9 - 2385*x**(S(5)/7)/49 + S(298)*x/3)*f(x)/(196*(-x**(S(6)/7) +
          x)**2*(x**(S(6)/7) + x)**2) + Derivative(f(x), (x, 2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
By implementing this method, any differential equation that can be transform into `eq = x*(1-x)*f(x).diff(x, 2) + (c-(a+b+1)*x)*f(x).diff(x) -a*b*f(x)` by applying the following transformations 
```
1- x --> x**k
2- x --> (a*x + b)/(c*x+d)
3- y --> P(x)*y
```
then the given equation can be solve.

It will cover a class of ode- 
```
In [14]: eq = x*(1-x)*f(x).diff(x, 2) + (c-(a+b+1)*x)*f(x).diff(x) -a*b*f(x)

In [15]: eq
Out[15]: 
                        2                                     
                       d                              d       
-a⋅b⋅f(x) + x⋅(1 - x)⋅───(f(x)) + (c - x⋅(a + b + 1))⋅──(f(x))
                        2                             dx      
                      dx                                      


```
Which is solvable in series solution.

By adding this method we will get the following type of solution-

```
In [17]: eq=x*(x-1)*f(x).diff(x, 2) + (S(3)/2 -2*x)*f(x).diff(x) + 2*f(x)

In [18]: dsolve(eq, f(x))
Out[18]: 
           5/2  ┌─  ⎛1/2, 3/2 │  ⎞       ┌─  ⎛-2, -1 │  ⎞
f(x) = C₁⋅x   ⋅ ├─  ⎜         │ x⎟ + C₂⋅ ├─  ⎜       │ x⎟
               2╵ 1 ⎝  7/2    │  ⎠      2╵ 1 ⎝ -3/2  │  ⎠

In [19]: checkodesol(eq,dsolve(eq, f(x)))
Out[19]: (True, 0)
```

#### Other comments

sources-
https://en.wikipedia.org/wiki/Frobenius_solution_to_the_hypergeometric_equation
https://drive.google.com/file/d/1wcJlEd6DMTRHAprH2N2oXaCHpa8PLDwp/view
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - added method in dsolve to solve 2nd order ode in 2F1 hyper function
<!-- END RELEASE NOTES -->
