### PR TITLE
Implement digamma and trigamma functions as Function subclasses

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2290,11 +2290,11 @@ def test_sympy__functions__special__gamma_functions__polygamma():
 
 def test_sympy__functions__special__gamma_functions__digamma():
     from sympy.functions.special.gamma_functions import digamma
-    assert _test_args(digamma(x, 1))
+    assert _test_args(digamma(x))
 
 def test_sympy__functions__special__gamma_functions__trigamma():
     from sympy.functions.special.gamma_functions import trigamma
-    assert _test_args(trigamma(x, 1))
+    assert _test_args(trigamma(x))
 
 def test_sympy__functions__special__gamma_functions__uppergamma():
     from sympy.functions.special.gamma_functions import uppergamma

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2288,6 +2288,13 @@ def test_sympy__functions__special__gamma_functions__polygamma():
     from sympy.functions.special.gamma_functions import polygamma
     assert _test_args(polygamma(x, 2))
 
+def test_sympy__functions__special__gamma_functions__digamma():
+    from sympy.functions.special.gamma_functions import digamma
+    assert _test_args(digamma(x, 1))
+
+def test_sympy__functions__special__gamma_functions__trigamma():
+    from sympy.functions.special.gamma_functions import trigamma
+    assert _test_args(trigamma(x, 1))
 
 def test_sympy__functions__special__gamma_functions__uppergamma():
     from sympy.functions.special.gamma_functions import uppergamma

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -47,12 +47,12 @@ class beta(Function):
     >>> from sympy import beta
     >>> from sympy import diff
     >>> diff(beta(x,y), x)
-    (polygamma(0, x) - polygamma(0, x + y))*beta(x, y)
+    (digamma(x) - digamma(x + y))*beta(x, y)
 
     >>> from sympy import beta
     >>> from sympy import diff
     >>> diff(beta(x,y), y)
-    (polygamma(0, y) - polygamma(0, x + y))*beta(x, y)
+    (digamma(y) - digamma(x + y))*beta(x, y)
 
     We can numerically evaluate the gamma function to arbitrary precision
     on the whole complex plane:

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -47,7 +47,7 @@ class beta(Function):
     >>> from sympy import beta
     >>> from sympy import diff
     >>> diff(beta(x,y), x)
-    (polygamma(x) - polygamma(x + y))*beta(x, y)
+    (polygamma(0, x) - polygamma(0, x + y))*beta(x, y)
 
     >>> from sympy import beta
     >>> from sympy import diff

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -52,7 +52,7 @@ class beta(Function):
     >>> from sympy import beta
     >>> from sympy import diff
     >>> diff(beta(x,y), y)
-    (digamma(y) - digamma(x + y))*beta(x, y)
+    (polygamma(0, y) - polygamma(0, x + y))*beta(x, y)
 
     We can numerically evaluate the gamma function to arbitrary precision
     on the whole complex plane:

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -47,7 +47,7 @@ class beta(Function):
     >>> from sympy import beta
     >>> from sympy import diff
     >>> diff(beta(x,y), x)
-    (digamma(x) - digamma(x + y))*beta(x, y)
+    (polygamma(x) - polygamma(x + y))*beta(x, y)
 
     >>> from sympy import beta
     >>> from sympy import diff

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -992,7 +992,7 @@ class loggamma(Function):
         return sage.log_gamma(self.args[0]._sage_())
 
 
-def digamma(x):
+class digamma(Function):
     r"""
     The digamma function is the first derivative of the loggamma function i.e,
 
@@ -1020,10 +1020,136 @@ def digamma(x):
     .. [2] http://mathworld.wolfram.com/DigammaFunction.html
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
-    return polygamma(0, x)
+    def _eval_evalf(self, prec):
+        n = sympify(0)
+        # the mpmath polygamma implementation valid only for nonnegative integers
+        if n.is_number and n.is_real:
+            if (n.is_integer or n == int(n)) and n.is_nonnegative:
+                return super(polygamma, self)._eval_evalf(prec)
+
+    def fdiff(self, argindex=1):
+        if argindex == 1:
+            x = self.args[0]
+            return trigamma(x)
+        else:
+            raise ArgumentIndexError(self, argindex)
+
+    def _eval_is_real(self):
+        if self.args[0].is_positive:
+            return True
+
+    def _eval_is_positive(self):
+        if self.args[0].is_positive:
+            return False
+
+    def _eval_is_negative(self):
+        if self.args[0].is_positive:
+            return True
+
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy import Order
+        if args0[1] != oo or not \
+                (self.args[0].is_Integer and self.args[0].is_nonnegative):
+            return super(polygamma, self)._eval_aseries(n, args0, x, logx)
+        z = self.args[1]
+        N = self.args[0]
+
+        if N == 0:
+            # digamma function series
+            # Abramowitz & Stegun, p. 259, 6.3.18
+            r = log(z) - 1/(2*z)
+            o = None
+            if n < 2:
+                o = Order(1/z, x)
+            else:
+                m = ceiling((n + 1)//2)
+                l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
+                r -= Add(*l)
+                o = Order(1/z**(2*m), x)
+            return r._eval_nseries(x, n, logx) + o
+        else:
+            # proper polygamma function
+            # Abramowitz & Stegun, p. 260, 6.4.10
+            # We return terms to order higher than O(x**n) on purpose
+            # -- otherwise we would not be able to return any terms for
+            #    quite a long time!
+            fac = gamma(N)
+            e0 = fac + N*fac/(2*z)
+            m = ceiling((n + 1)//2)
+            for k in range(1, m):
+                fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
+                e0 += bernoulli(2*k)*fac/z**(2*k)
+            o = Order(1/z**(2*m), x)
+            if n == 0:
+                o = Order(1/z, x)
+            elif n == 1:
+                o = Order(1/z**2, x)
+            r = e0._eval_nseries(z, n, logx) + o
+            return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
+
+    @classmethod
+    def eval(cls, z):
+        n, z = map(sympify, (0, z))
+        from sympy import unpolarify
+
+        if n == 0:
+            if z is S.NaN:
+                return S.NaN
+            elif z.is_Rational:
+
+                p, q = z.as_numer_denom()
+
+                # only expand for small denominators to avoid creating long expressions
+                if q <= 5:
+                    return expand_func(polygamma(n, z, evaluate=False))
+
+            elif z in (S.Infinity, S.NegativeInfinity):
+                return S.Infinity
+            else:
+                t = z.extract_multiplicatively(S.ImaginaryUnit)
+                if t in (S.Infinity, S.NegativeInfinity):
+                    return S.Infinity
+
+        # TODO n == 1 also can do some rational z
+
+    def _eval_expand_func(self, **hints):
+        n = sympify(0)
+        z = self.args[0]
+
+        if n == 0 and z.is_Rational:
+            p, q = z.as_numer_denom()
+
+            # Reference:
+            #   Values of the polygamma functions at rational arguments, J. Choi, 2007
+            part_1 = -S.EulerGamma - pi * cot(p * pi / q) / 2 - log(q) + Add(
+                *[cos(2 * k * pi * p / q) * log(2 * sin(k * pi / q)) for k in range(1, q)])
+
+            if z > 0:
+                n = floor(z)
+                z0 = z - n
+                return part_1 + Add(*[1 / (z0 + k) for k in range(n)])
+            elif z < 0:
+                n = floor(1 - z)
+                z0 = z + n
+                return part_1 - Add(*[1 / (z0 - 1 - k) for k in range(n)])
+
+        return polygamma(n, z)
+
+    def _eval_rewrite_as_harmonic(self, z, **kwargs):
+        return harmonic(z - 1) - S.EulerGamma
+
+    def _eval_as_leading_term(self, x):
+        from sympy import Order
+        n = sympify(0)
+        z = self.args[0].as_leading_term(x)
+        o = Order(z, x)
+        if n == 0 and o.contains(1/x):
+            return o.getn() * log(x)
+        else:
+            return self.func(n, z)
 
 
-def trigamma(x):
+class trigamma(Function):
     r"""
     The trigamma function is the second derivative of the loggamma function i.e,
 
@@ -1050,7 +1176,129 @@ def trigamma(x):
     .. [2] http://mathworld.wolfram.com/TrigammaFunction.html
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
-    return polygamma(1, x)
+        def _eval_evalf(self, prec):
+            n = sympify(1)
+            # the mpmath polygamma implementation valid only for nonnegative integers
+            if n.is_number and n.is_real:
+                if (n.is_integer or n == int(n)) and n.is_nonnegative:
+                    return super(polygamma, self)._eval_evalf(prec)
+
+        def fdiff(self, argindex=1):
+            if argindex == 1:
+                n = sympify(1)
+                z = self.args[0]
+                return polygamma(n + 1, z)
+            else:
+                raise ArgumentIndexError(self, argindex)
+
+        def _eval_is_real(self):
+            if self.args[0].is_positive:
+                return True
+
+        def _eval_is_positive(self):
+            if self.args[0].is_positive:
+                return True
+
+        def _eval_is_negative(self):
+            if self.args[0].is_positive:
+                return False
+
+        def _eval_aseries(self, n, args0, x, logx):
+            from sympy import Order
+            if args0[1] != oo or not \
+                    (self.args[0].is_Integer and self.args[0].is_nonnegative):
+                return super(polygamma, self)._eval_aseries(n, args0, x, logx)
+            z = self.args[1]
+            N = self.args[0]
+
+            if N == 0:
+                # digamma function series
+                # Abramowitz & Stegun, p. 259, 6.3.18
+                r = log(z) - 1/(2*z)
+                o = None
+                if n < 2:
+                    o = Order(1/z, x)
+                else:
+                    m = ceiling((n + 1)//2)
+                    l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
+                    r -= Add(*l)
+                    o = Order(1/z**(2*m), x)
+                return r._eval_nseries(x, n, logx) + o
+            else:
+                # proper polygamma function
+                # Abramowitz & Stegun, p. 260, 6.4.10
+                # We return terms to order higher than O(x**n) on purpose
+                # -- otherwise we would not be able to return any terms for
+                #    quite a long time!
+                fac = gamma(N)
+                e0 = fac + N*fac/(2*z)
+                m = ceiling((n + 1)//2)
+                for k in range(1, m):
+                    fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
+                    e0 += bernoulli(2*k)*fac/z**(2*k)
+                o = Order(1/z**(2*m), x)
+                if n == 0:
+                    o = Order(1/z, x)
+                elif n == 1:
+                    o = Order(1/z**2, x)
+                r = e0._eval_nseries(z, n, logx) + o
+                return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
+
+        @classmethod
+        def eval(cls, z):
+            n, z = map(sympify, (1, z))
+            from sympy import unpolarify
+
+            if n.is_integer:
+                if n.is_nonnegative:
+                    nz = unpolarify(z)
+                    if z != nz:
+                        return polygamma(n, nz)
+
+            # TODO n == 1 also can do some rational z
+
+        def _eval_expand_func(self, **hints):
+            n = sympify(1)
+            z = self.args[0]
+
+            if n.is_Integer and n.is_nonnegative:
+                if z.is_Add:
+                    coeff = z.args[0]
+                    if coeff.is_Integer:
+                        e = -(n + 1)
+                        if coeff > 0:
+                            tail = Add(*[Pow(
+                                z - i, e) for i in range(1, int(coeff) + 1)])
+                        else:
+                            tail = -Add(*[Pow(
+                                z + i, e) for i in range(0, int(-coeff))])
+                        return polygamma(n, z - coeff) + (-1)**n*factorial(n)*tail
+
+                elif z.is_Mul:
+                    coeff, z = z.as_two_terms()
+                    if coeff.is_Integer and coeff.is_positive:
+                        tail = [ polygamma(n, z + Rational(
+                            i, coeff)) for i in range(0, int(coeff)) ]
+                        if n == 0:
+                            return Add(*tail)/coeff + log(coeff)
+                        else:
+                            return Add(*tail)/coeff**(n + 1)
+                    z *= coeff
+
+            return polygamma(n, z)
+
+        def _eval_rewrite_as_zeta(self, z, **kwargs):
+            return (-1)**(2)*factorial(2)*zeta(2, z)
+
+        def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
+            return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))
+
+        def _eval_as_leading_term(self, x):
+            from sympy import Order
+            n = sympify(1)
+            z = self.args[0].as_leading_term(x)
+            return self.func(n, z)
+
 
 ###############################################################################
 ##################### COMPLETE MULTIVARIATE GAMMA FUNCTION ####################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1048,11 +1048,10 @@ class digamma(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
-        if args0[1] != oo or not \
-                (self.args[0].is_Integer and self.args[0].is_nonnegative):
+        if args0[1] != oo:
             return super(polygamma, self)._eval_aseries(n, args0, x, logx)
-        z = self.args[1]
-        N = self.args[0]
+        z = self.args[0]
+        N = sympify(0)
 
         if N == 0:
             # digamma function series

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1048,43 +1048,9 @@ class digamma(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
-        if args0[1] != oo:
-            return super(polygamma, self)._eval_aseries(n, args0, x, logx)
-        z = self.args[0]
-        N = sympify(0)
-
-        if N == 0:
-            # digamma function series
-            # Abramowitz & Stegun, p. 259, 6.3.18
-            r = log(z) - 1/(2*z)
-            o = None
-            if n < 2:
-                o = Order(1/z, x)
-            else:
-                m = ceiling((n + 1)//2)
-                l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
-                r -= Add(*l)
-                o = Order(1/z**(2*m), x)
-            return r._eval_nseries(x, n, logx) + o
-        else:
-            # proper polygamma function
-            # Abramowitz & Stegun, p. 260, 6.4.10
-            # We return terms to order higher than O(x**n) on purpose
-            # -- otherwise we would not be able to return any terms for
-            #    quite a long time!
-            fac = gamma(N)
-            e0 = fac + N*fac/(2*z)
-            m = ceiling((n + 1)//2)
-            for k in range(1, m):
-                fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
-                e0 += bernoulli(2*k)*fac/z**(2*k)
-            o = Order(1/z**(2*m), x)
-            if n == 0:
-                o = Order(1/z, x)
-            elif n == 1:
-                o = Order(1/z**2, x)
-            r = e0._eval_nseries(z, n, logx) + o
-            return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
+        as_polygamma = self.rewrite(polygamma)
+        args0 = [S.Zero,] + args0
+        return as_polygamma._eval_aseries(n,args0,x,logx)
 
     @classmethod
     def eval(cls, z):
@@ -1256,43 +1222,9 @@ class trigamma(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
-        if args0[1] != oo:
-            return super(polygamma, self)._eval_aseries(n, args0, x, logx)
-        z = self.args[0]
-        N = sympify(0)
-
-        if N == 0:
-            # digamma function series
-            # Abramowitz & Stegun, p. 259, 6.3.18
-            r = log(z) - 1/(2*z)
-            o = None
-            if n < 2:
-                o = Order(1/z, x)
-            else:
-                m = ceiling((n + 1)//2)
-                l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
-                r -= Add(*l)
-                o = Order(1/z**(2*m), x)
-            return r._eval_nseries(x, n, logx) + o
-        else:
-            # proper polygamma function
-            # Abramowitz & Stegun, p. 260, 6.4.10
-            # We return terms to order higher than O(x**n) on purpose
-            # -- otherwise we would not be able to return any terms for
-            #    quite a long time!
-            fac = gamma(N)
-            e0 = fac + N*fac/(2*z)
-            m = ceiling((n + 1)//2)
-            for k in range(1, m):
-                fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
-                e0 += bernoulli(2*k)*fac/z**(2*k)
-            o = Order(1/z**(2*m), x)
-            if n == 0:
-                o = Order(1/z, x)
-            elif n == 1:
-                o = Order(1/z**2, x)
-            r = e0._eval_nseries(z, n, logx) + o
-            return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
+        as_polygamma = self.rewrite(polygamma)
+        args0 = [S.One,] + args0
+        return as_polygamma._eval_aseries(n,args0,x,logx)
 
     @classmethod
     def eval(cls, z):

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1331,6 +1331,9 @@ class trigamma(Function):
     def _eval_rewrite_as_zeta(self, z, **kwargs):
         return (-1)**(2)*factorial(1)*zeta(2, z)
 
+    def _eval_rewrite_as_polygamma(self, z, **kwargs):
+        return polygamma(0,z)
+
     def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
         return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1022,33 +1022,32 @@ class digamma(Function):
     """
     def _eval_evalf(self, prec):
         z = self.args[0]
-        return polygamma(0,z).evalf(prec)
+        return polygamma(0, z).evalf(prec)
 
     def fdiff(self, argindex=1):
         z = self.args[0]
-        return polygamma(0,z).fdiff()
+        return polygamma(0, z).fdiff()
 
     def _eval_is_real(self):
         z = self.args[0]
-        return polygamma(0,z).is_real
+        return polygamma(0, z).is_real
 
     def _eval_is_positive(self):
         z = self.args[0]
-        return polygamma(0,z).is_positive
+        return polygamma(0, z).is_positive
 
     def _eval_is_negative(self):
         z = self.args[0]
-        return polygamma(0,z).is_negative
+        return polygamma(0, z).is_negative
 
     def _eval_aseries(self, n, args0, x, logx):
-        from sympy import Order
         as_polygamma = self.rewrite(polygamma)
         args0 = [S.Zero,] + args0
-        return as_polygamma._eval_aseries(n,args0,x,logx)
+        return as_polygamma._eval_aseries(n, args0, x, logx)
 
     @classmethod
     def eval(cls, z):
-        return polygamma(0,z)
+        return polygamma(0, z)
 
     def _eval_expand_func(self, **hints):
         z = self.args[0]
@@ -1058,11 +1057,11 @@ class digamma(Function):
         return harmonic(z - 1) - S.EulerGamma
 
     def _eval_rewrite_as_polygamma(self, z, **kwargs):
-        return polygamma(0,z)
+        return polygamma(0, z)
 
     def _eval_as_leading_term(self, x):
         z = self.args[0]
-        return polygamma(0,z).as_leading_term(x)
+        return polygamma(0, z).as_leading_term(x)
 
 
 
@@ -1095,29 +1094,28 @@ class trigamma(Function):
     """
     def _eval_evalf(self, prec):
         z = self.args[0]
-        return polygamma(1,z).evalf(prec)
+        return polygamma(1, z).evalf(prec)
 
     def fdiff(self, argindex=1):
         z = self.args[0]
-        return polygamma(1,z).fdiff()
+        return polygamma(1, z).fdiff()
 
     def _eval_is_real(self):
         z = self.args[0]
-        return polygamma(1,z).is_real
+        return polygamma(1, z).is_real
 
     def _eval_is_positive(self):
         z = self.args[0]
-        return polygamma(1,z).is_positive
+        return polygamma(1, z).is_positive
 
     def _eval_is_negative(self):
         z = self.args[0]
-        return polygamma(1,z).is_negative
+        return polygamma(1, z).is_negative
 
     def _eval_aseries(self, n, args0, x, logx):
-        from sympy import Order
         as_polygamma = self.rewrite(polygamma)
         args0 = [S.One,] + args0
-        return as_polygamma._eval_aseries(n,args0,x,logx)
+        return as_polygamma._eval_aseries(n, args0, x, logx)
 
     @classmethod
     def eval(cls, z):
@@ -1131,14 +1129,14 @@ class trigamma(Function):
         return (-1)**(2)*factorial(1)*zeta(2, z)
 
     def _eval_rewrite_as_polygamma(self, z, **kwargs):
-        return polygamma(1,z)
+        return polygamma(1, z)
 
     def _eval_rewrite_as_harmonic(self, z, **kwargs):
         return -harmonic(z - 1, 2) + S.Pi**2 / 6
 
     def _eval_as_leading_term(self, x):
         z = self.args[0]
-        return polygamma(1,z).as_leading_term(x)
+        return polygamma(1, z).as_leading_term(x)
 
 
 ###############################################################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1133,8 +1133,8 @@ class trigamma(Function):
     def _eval_rewrite_as_polygamma(self, z, **kwargs):
         return polygamma(1,z)
 
-    def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
-        return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))
+    def _eval_rewrite_as_harmonic(self, z, **kwargs):
+        return -harmonic(z - 1, 2) + S.Pi**2 / 6
 
     def _eval_as_leading_term(self, x):
         z = self.args[0]

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1092,6 +1092,34 @@ class digamma(Function):
         n, z = map(sympify, (0, z))
         from sympy import unpolarify
 
+
+        if n.is_integer:
+            if n.is_nonnegative:
+                nz = unpolarify(z)
+                if z != nz:
+                    return polygamma(n, nz)
+
+            if n == -1:
+                return loggamma(z)
+            else:
+                if z.is_Number:
+                    if z is S.NaN:
+                        return S.NaN
+                    elif z is S.Infinity:
+                        if n.is_Number:
+                            if n is S.Zero:
+                                return S.Infinity
+                            else:
+                                return S.Zero
+                    elif z.is_Integer:
+                        if z.is_nonpositive:
+                            return S.ComplexInfinity
+                        else:
+                            if n is S.Zero:
+                                return -S.EulerGamma + harmonic(z - 1, 1)
+                            elif n.is_odd:
+                                return (-1)**(n + 1)*factorial(n)*zeta(n + 1, z)
+
         if n == 0:
             if z is S.NaN:
                 return S.NaN

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1021,30 +1021,24 @@ class digamma(Function):
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
     def _eval_evalf(self, prec):
-        n = sympify(0)
-        # the mpmath polygamma implementation valid only for nonnegative integers
-        if n.is_number and n.is_real:
-            if (n.is_integer or n == int(n)) and n.is_nonnegative:
-                return super(digamma, self)._eval_evalf(prec)
+        z = self.args[0]
+        return polygamma(0,z).evalf(prec)
 
     def fdiff(self, argindex=1):
-        if argindex == 1:
-            x = self.args[0]
-            return trigamma(x)
-        else:
-            raise ArgumentIndexError(self, argindex)
+        z = self.args[0]
+        return polygamma(0,z).fdiff(1)
 
     def _eval_is_real(self):
-        if self.args[0].is_positive:
-            return True
+        z = self.args[0]
+        return polygamma(0,z).is_real()
 
     def _eval_is_positive(self):
-        if self.args[0].is_positive:
-            return False
+        z = self.args[0]
+        return polygamma(0,z).is_positive()
 
     def _eval_is_negative(self):
-        if self.args[0].is_positive:
-            return True
+        z = self.args[0]
+        return polygamma(0,z).is_negative()
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
@@ -1054,103 +1048,11 @@ class digamma(Function):
 
     @classmethod
     def eval(cls, z):
-        n, z = map(sympify, (0, z))
-        from sympy import unpolarify
-
-
-        if n.is_integer:
-            if n.is_nonnegative:
-                nz = unpolarify(z)
-                if z != nz:
-                    return polygamma(n, nz)
-
-            if n == -1:
-                return loggamma(z)
-            else:
-                if z.is_Number:
-                    if z is S.NaN:
-                        return S.NaN
-                    elif z is S.Infinity:
-                        if n.is_Number:
-                            if n is S.Zero:
-                                return S.Infinity
-                            else:
-                                return S.Zero
-                    elif z.is_Integer:
-                        if z.is_nonpositive:
-                            return S.ComplexInfinity
-                        else:
-                            if n is S.Zero:
-                                return -S.EulerGamma + harmonic(z - 1, 1)
-                            elif n.is_odd:
-                                return (-1)**(n + 1)*factorial(n)*zeta(n + 1, z)
-
-        if n == 0:
-            if z is S.NaN:
-                return S.NaN
-            elif z.is_Rational:
-
-                p, q = z.as_numer_denom()
-
-                # only expand for small denominators to avoid creating long expressions
-                if q <= 5:
-                    return expand_func(polygamma(n, z, evaluate=False))
-
-            elif z in (S.Infinity, S.NegativeInfinity):
-                return S.Infinity
-            else:
-                t = z.extract_multiplicatively(S.ImaginaryUnit)
-                if t in (S.Infinity, S.NegativeInfinity):
-                    return S.Infinity
-
-        # TODO n == 1 also can do some rational z
+        return polygamma(0,z)
 
     def _eval_expand_func(self, **hints):
-        n = sympify(0)
         z = self.args[0]
-
-        if n.is_Integer and n.is_nonnegative:
-            if z.is_Add:
-                coeff = z.args[0]
-                if coeff.is_Integer:
-                    e = -(n + 1)
-                    if coeff > 0:
-                        tail = Add(*[Pow(
-                            z - i, e) for i in range(1, int(coeff) + 1)])
-                    else:
-                        tail = -Add(*[Pow(
-                            z + i, e) for i in range(0, int(-coeff))])
-                    return polygamma(n, z - coeff) + (-1)**n*factorial(n)*tail
-
-            elif z.is_Mul:
-                coeff, z = z.as_two_terms()
-                if coeff.is_Integer and coeff.is_positive:
-                    tail = [ polygamma(n, z + Rational(
-                        i, coeff)) for i in range(0, int(coeff)) ]
-                    if n == 0:
-                        return Add(*tail)/coeff + log(coeff)
-                    else:
-                        return Add(*tail)/coeff**(n + 1)
-                z *= coeff
-
-        if n == 0 and z.is_Rational:
-            p, q = z.as_numer_denom()
-
-            # Reference:
-            #   Values of the polygamma functions at rational arguments, J. Choi, 2007
-            part_1 = -S.EulerGamma - pi * cot(p * pi / q) / 2 - log(q) + Add(
-                *[cos(2 * k * pi * p / q) * log(2 * sin(k * pi / q)) for k in range(1, q)])
-
-            if z > 0:
-                n = floor(z)
-                z0 = z - n
-                return part_1 + Add(*[1 / (z0 + k) for k in range(n)])
-            elif z < 0:
-                n = floor(1 - z)
-                z0 = z + n
-                return part_1 - Add(*[1 / (z0 - 1 - k) for k in range(n)])
-
-        return polygamma(n, z)
+        return polygamma(0, z).expand_func()
 
     def _eval_rewrite_as_harmonic(self, z, **kwargs):
         return harmonic(z - 1) - S.EulerGamma
@@ -1159,14 +1061,9 @@ class digamma(Function):
         return polygamma(0,z)
 
     def _eval_as_leading_term(self, x):
-        from sympy import Order
-        n = sympify(0)
-        z = self.args[0].as_leading_term(x)
-        o = Order(z, x)
-        if n == 0 and o.contains(1/x):
-            return o.getn() * log(x)
-        else:
-            return self.func(n, z)
+        z = self.args[0]
+        return polygamma(0,z).as_leading_term(x)
+
 
 
 class trigamma(Function):

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1025,7 +1025,7 @@ class digamma(Function):
         # the mpmath polygamma implementation valid only for nonnegative integers
         if n.is_number and n.is_real:
             if (n.is_integer or n == int(n)) and n.is_nonnegative:
-                return super(polygamma, self)._eval_evalf(prec)
+                return super(digamma, self)._eval_evalf(prec)
 
     def fdiff(self, argindex=1):
         if argindex == 1:
@@ -1208,7 +1208,7 @@ class trigamma(Function):
         # the mpmath polygamma implementation valid only for nonnegative integers
         if n.is_number and n.is_real:
             if (n.is_integer or n == int(n)) and n.is_nonnegative:
-                return super(polygamma, self)._eval_evalf(prec)
+                return super(trigamma, self)._eval_evalf(prec)
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1176,128 +1176,128 @@ class trigamma(Function):
     .. [2] http://mathworld.wolfram.com/TrigammaFunction.html
     .. [3] http://functions.wolfram.com/GammaBetaErf/PolyGamma2/
     """
-        def _eval_evalf(self, prec):
-            n = sympify(1)
-            # the mpmath polygamma implementation valid only for nonnegative integers
-            if n.is_number and n.is_real:
-                if (n.is_integer or n == int(n)) and n.is_nonnegative:
-                    return super(polygamma, self)._eval_evalf(prec)
+    def _eval_evalf(self, prec):
+        n = sympify(1)
+        # the mpmath polygamma implementation valid only for nonnegative integers
+        if n.is_number and n.is_real:
+            if (n.is_integer or n == int(n)) and n.is_nonnegative:
+                return super(polygamma, self)._eval_evalf(prec)
 
         def fdiff(self, argindex=1):
-            if argindex == 1:
-                n = sympify(1)
-                z = self.args[0]
-                return polygamma(n + 1, z)
-            else:
-                raise ArgumentIndexError(self, argindex)
-
-        def _eval_is_real(self):
-            if self.args[0].is_positive:
-                return True
-
-        def _eval_is_positive(self):
-            if self.args[0].is_positive:
-                return True
-
-        def _eval_is_negative(self):
-            if self.args[0].is_positive:
-                return False
-
-        def _eval_aseries(self, n, args0, x, logx):
-            from sympy import Order
-            if args0[1] != oo or not \
-                    (self.args[0].is_Integer and self.args[0].is_nonnegative):
-                return super(polygamma, self)._eval_aseries(n, args0, x, logx)
-            z = self.args[1]
-            N = self.args[0]
-
-            if N == 0:
-                # digamma function series
-                # Abramowitz & Stegun, p. 259, 6.3.18
-                r = log(z) - 1/(2*z)
-                o = None
-                if n < 2:
-                    o = Order(1/z, x)
-                else:
-                    m = ceiling((n + 1)//2)
-                    l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
-                    r -= Add(*l)
-                    o = Order(1/z**(2*m), x)
-                return r._eval_nseries(x, n, logx) + o
-            else:
-                # proper polygamma function
-                # Abramowitz & Stegun, p. 260, 6.4.10
-                # We return terms to order higher than O(x**n) on purpose
-                # -- otherwise we would not be able to return any terms for
-                #    quite a long time!
-                fac = gamma(N)
-                e0 = fac + N*fac/(2*z)
-                m = ceiling((n + 1)//2)
-                for k in range(1, m):
-                    fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
-                    e0 += bernoulli(2*k)*fac/z**(2*k)
-                o = Order(1/z**(2*m), x)
-                if n == 0:
-                    o = Order(1/z, x)
-                elif n == 1:
-                    o = Order(1/z**2, x)
-                r = e0._eval_nseries(z, n, logx) + o
-                return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
-
-        @classmethod
-        def eval(cls, z):
-            n, z = map(sympify, (1, z))
-            from sympy import unpolarify
-
-            if n.is_integer:
-                if n.is_nonnegative:
-                    nz = unpolarify(z)
-                    if z != nz:
-                        return polygamma(n, nz)
-
-            # TODO n == 1 also can do some rational z
-
-        def _eval_expand_func(self, **hints):
+        if argindex == 1:
             n = sympify(1)
             z = self.args[0]
+            return polygamma(n + 1, z)
+        else:
+            raise ArgumentIndexError(self, argindex)
 
-            if n.is_Integer and n.is_nonnegative:
-                if z.is_Add:
-                    coeff = z.args[0]
-                    if coeff.is_Integer:
-                        e = -(n + 1)
-                        if coeff > 0:
-                            tail = Add(*[Pow(
-                                z - i, e) for i in range(1, int(coeff) + 1)])
-                        else:
-                            tail = -Add(*[Pow(
-                                z + i, e) for i in range(0, int(-coeff))])
-                        return polygamma(n, z - coeff) + (-1)**n*factorial(n)*tail
+    def _eval_is_real(self):
+        if self.args[0].is_positive:
+            return True
 
-                elif z.is_Mul:
-                    coeff, z = z.as_two_terms()
-                    if coeff.is_Integer and coeff.is_positive:
-                        tail = [ polygamma(n, z + Rational(
-                            i, coeff)) for i in range(0, int(coeff)) ]
-                        if n == 0:
-                            return Add(*tail)/coeff + log(coeff)
-                        else:
-                            return Add(*tail)/coeff**(n + 1)
-                    z *= coeff
+    def _eval_is_positive(self):
+        if self.args[0].is_positive:
+            return True
 
-            return polygamma(n, z)
+    def _eval_is_negative(self):
+        if self.args[0].is_positive:
+            return False
 
-        def _eval_rewrite_as_zeta(self, z, **kwargs):
-            return (-1)**(2)*factorial(2)*zeta(2, z)
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy import Order
+        if args0[1] != oo or not \
+                (self.args[0].is_Integer and self.args[0].is_nonnegative):
+            return super(polygamma, self)._eval_aseries(n, args0, x, logx)
+        z = self.args[1]
+        N = self.args[0]
 
-        def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
-            return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))
+        if N == 0:
+            # digamma function series
+            # Abramowitz & Stegun, p. 259, 6.3.18
+            r = log(z) - 1/(2*z)
+            o = None
+            if n < 2:
+                o = Order(1/z, x)
+            else:
+                m = ceiling((n + 1)//2)
+                l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
+                r -= Add(*l)
+                o = Order(1/z**(2*m), x)
+            return r._eval_nseries(x, n, logx) + o
+        else:
+            # proper polygamma function
+            # Abramowitz & Stegun, p. 260, 6.4.10
+            # We return terms to order higher than O(x**n) on purpose
+            # -- otherwise we would not be able to return any terms for
+            #    quite a long time!
+            fac = gamma(N)
+            e0 = fac + N*fac/(2*z)
+            m = ceiling((n + 1)//2)
+            for k in range(1, m):
+                fac = fac*(2*k + N - 1)*(2*k + N - 2) / ((2*k)*(2*k - 1))
+                e0 += bernoulli(2*k)*fac/z**(2*k)
+            o = Order(1/z**(2*m), x)
+            if n == 0:
+                o = Order(1/z, x)
+            elif n == 1:
+                o = Order(1/z**2, x)
+            r = e0._eval_nseries(z, n, logx) + o
+            return (-1 * (-1/z)**N * r)._eval_nseries(x, n, logx)
 
-        def _eval_as_leading_term(self, x):
-            from sympy import Order
-            n = sympify(1)
-            z = self.args[0].as_leading_term(x)
-            return self.func(n, z)
+    @classmethod
+    def eval(cls, z):
+        n, z = map(sympify, (1, z))
+        from sympy import unpolarify
+
+            if n.is_integer:
+            if n.is_nonnegative:
+                nz = unpolarify(z)
+                if z != nz:
+                    return polygamma(n, nz)
+
+        # TODO n == 1 also can do some rational z
+
+    def _eval_expand_func(self, **hints):
+        n = sympify(1)
+        z = self.args[0]
+
+        if n.is_Integer and n.is_nonnegative:
+            if z.is_Add:
+                coeff = z.args[0]
+                if coeff.is_Integer:
+                    e = -(n + 1)
+                    if coeff > 0:
+                        tail = Add(*[Pow(
+                            z - i, e) for i in range(1, int(coeff) + 1)])
+                    else:
+                        tail = -Add(*[Pow(
+                            z + i, e) for i in range(0, int(-coeff))])
+                    return polygamma(n, z - coeff) + (-1)**n*factorial(n)*tail
+
+            elif z.is_Mul:
+                coeff, z = z.as_two_terms()
+                if coeff.is_Integer and coeff.is_positive:
+                    tail = [ polygamma(n, z + Rational(
+                        i, coeff)) for i in range(0, int(coeff)) ]
+                    if n == 0:
+                        return Add(*tail)/coeff + log(coeff)
+                    else:
+                        return Add(*tail)/coeff**(n + 1)
+                z *= coeff
+
+        return polygamma(n, z)
+
+    def _eval_rewrite_as_zeta(self, z, **kwargs):
+        return (-1)**(2)*factorial(2)*zeta(2, z)
+
+    def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
+        return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))
+
+    def _eval_as_leading_term(self, x):
+        from sympy import Order
+        n = sympify(1)
+        z = self.args[0].as_leading_term(x)
+        return self.func(n, z)
 
 
 ###############################################################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1249,11 +1249,11 @@ class trigamma(Function):
         n, z = map(sympify, (1, z))
         from sympy import unpolarify
 
-            if n.is_integer:
-            if n.is_nonnegative:
-                nz = unpolarify(z)
-                if z != nz:
-                    return polygamma(n, nz)
+        if n.is_integer:
+        if n.is_nonnegative:
+            nz = unpolarify(z)
+            if z != nz:
+                return polygamma(n, nz)
 
         # TODO n == 1 also can do some rational z
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1049,7 +1049,7 @@ class digamma(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
         as_polygamma = self.rewrite(polygamma)
-        args0 = [S.Zero,] + args0
+        args0 = [sympify(0),] + args0
         return as_polygamma._eval_aseries(n,args0,x,logx)
 
     @classmethod

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1043,7 +1043,7 @@ class digamma(Function):
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
         as_polygamma = self.rewrite(polygamma)
-        args0 = [sympify(0),] + args0
+        args0 = [S.Zero,] + args0
         return as_polygamma._eval_aseries(n,args0,x,logx)
 
     @classmethod

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1126,7 +1126,7 @@ class trigamma(Function):
         return polygamma(1, z).expand(func=True)
 
     def _eval_rewrite_as_zeta(self, z, **kwargs):
-        return (-1)**(2)*factorial(1)*zeta(2, z)
+        return zeta(2, z)
 
     def _eval_rewrite_as_polygamma(self, z, **kwargs):
         return polygamma(1, z)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1103,15 +1103,15 @@ class trigamma(Function):
 
     def _eval_is_real(self):
         z = self.args[0]
-        return polygamma(0,z).is_real()
+        return polygamma(1,z).is_real()
 
     def _eval_is_positive(self):
         z = self.args[0]
-        return polygamma(0,z).is_positive()
+        return polygamma(1,z).is_positive()
 
     def _eval_is_negative(self):
         z = self.args[0]
-        return polygamma(0,z).is_negative()
+        return polygamma(1,z).is_negative()
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1355,7 +1355,7 @@ class trigamma(Function):
         return polygamma(n, z)
 
     def _eval_rewrite_as_zeta(self, z, **kwargs):
-        return (-1)**(2)*factorial(2)*zeta(2, z)
+        return (-1)**(2)*factorial(1)*zeta(2, z)
 
     def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
         return S.NegativeOne**(2) * factorial(1) * (zeta(2) - harmonic(0, 2))

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1232,11 +1232,10 @@ class trigamma(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
-        if args0[1] != oo or not \
-                (self.args[0].is_Integer and self.args[0].is_nonnegative):
+        if args0[1] != oo:
             return super(polygamma, self)._eval_aseries(n, args0, x, logx)
-        z = self.args[1]
-        N = self.args[0]
+        z = self.args[0]
+        N = sympify(0)
 
         if N == 0:
             # digamma function series

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1183,7 +1183,7 @@ class trigamma(Function):
             if (n.is_integer or n == int(n)) and n.is_nonnegative:
                 return super(polygamma, self)._eval_evalf(prec)
 
-        def fdiff(self, argindex=1):
+    def fdiff(self, argindex=1):
         if argindex == 1:
             n = sympify(1)
             z = self.args[0]

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1026,19 +1026,19 @@ class digamma(Function):
 
     def fdiff(self, argindex=1):
         z = self.args[0]
-        return polygamma(0,z).fdiff(1)
+        return polygamma(0,z).fdiff()
 
     def _eval_is_real(self):
         z = self.args[0]
-        return polygamma(0,z).is_real()
+        return polygamma(0,z).is_real
 
     def _eval_is_positive(self):
         z = self.args[0]
-        return polygamma(0,z).is_positive()
+        return polygamma(0,z).is_positive
 
     def _eval_is_negative(self):
         z = self.args[0]
-        return polygamma(0,z).is_negative()
+        return polygamma(0,z).is_negative
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order
@@ -1099,19 +1099,19 @@ class trigamma(Function):
 
     def fdiff(self, argindex=1):
         z = self.args[0]
-        return polygamma(1,z).fdiff(1)
+        return polygamma(1,z).fdiff()
 
     def _eval_is_real(self):
         z = self.args[0]
-        return polygamma(1,z).is_real()
+        return polygamma(1,z).is_real
 
     def _eval_is_positive(self):
         z = self.args[0]
-        return polygamma(1,z).is_positive()
+        return polygamma(1,z).is_positive
 
     def _eval_is_negative(self):
         z = self.args[0]
-        return polygamma(1,z).is_negative()
+        return polygamma(1,z).is_negative
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1280,8 +1280,47 @@ class trigamma(Function):
         if n.is_integer:
             if n.is_nonnegative:
                 nz = unpolarify(z)
-            if z != nz:
-                return polygamma(n, nz)
+                if z != nz:
+                    return polygamma(n, nz)
+
+            if n == -1:
+                return loggamma(z)
+            else:
+                if z.is_Number:
+                    if z is S.NaN:
+                        return S.NaN
+                    elif z is S.Infinity:
+                        if n.is_Number:
+                            if n is S.Zero:
+                                return S.Infinity
+                            else:
+                                return S.Zero
+                    elif z.is_Integer:
+                        if z.is_nonpositive:
+                            return S.ComplexInfinity
+                        else:
+                            if n is S.Zero:
+                                return -S.EulerGamma + harmonic(z - 1, 1)
+                            elif n.is_odd:
+                                return (-1)**(n + 1)*factorial(n)*zeta(n + 1, z)
+
+        if n == 0:
+            if z is S.NaN:
+                return S.NaN
+            elif z.is_Rational:
+
+                p, q = z.as_numer_denom()
+
+                # only expand for small denominators to avoid creating long expressions
+                if q <= 5:
+                    return expand_func(polygamma(n, z, evaluate=False))
+
+            elif z in (S.Infinity, S.NegativeInfinity):
+                return S.Infinity
+            else:
+                t = z.extract_multiplicatively(S.ImaginaryUnit)
+                if t in (S.Infinity, S.NegativeInfinity):
+                    return S.Infinity
 
         # TODO n == 1 also can do some rational z
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1250,8 +1250,8 @@ class trigamma(Function):
         from sympy import unpolarify
 
         if n.is_integer:
-        if n.is_nonnegative:
-            nz = unpolarify(z)
+            if n.is_nonnegative:
+                nz = unpolarify(z)
             if z != nz:
                 return polygamma(n, nz)
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1155,6 +1155,9 @@ class digamma(Function):
     def _eval_rewrite_as_harmonic(self, z, **kwargs):
         return harmonic(z - 1) - S.EulerGamma
 
+    def _eval_rewrite_as_polygamma(self, z, **kwargs):
+        return polygamma(0,z)
+
     def _eval_as_leading_term(self, x):
         from sympy import Order
         n = sympify(0)

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, gamma, expand_func, beta, digamma, diff, conjugate)
-from sympy.functions.special.gamma_functions import digamma
+from sympy.functions.special.gamma_functions import polygamma
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises
 

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -13,8 +13,8 @@ def test_beta():
     assert expand_func(beta(x, y) - beta(y, x)) == 0  # Symmetric
     assert expand_func(beta(x, y)) == expand_func(beta(x, y + 1) + beta(x + 1, y)).simplify()
 
-    assert diff(beta(x, y), x) == beta(x, y)*(digamma(x) - digamma(x + y))
-    assert diff(beta(x, y), y) == beta(x, y)*(digamma(y) - digamma(x + y))
+    assert diff(beta(x, y), x) == beta(x, y)*(polygamma(0, x) - polygamma(0, x + y))
+    assert diff(beta(x, y), y) == beta(x, y)*(polygamma(0, y) - polygamma(0, x + y))
 
     assert conjugate(beta(x, y)) == beta(conjugate(x), conjugate(y))
 

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -1,4 +1,5 @@
 from sympy import (Symbol, gamma, expand_func, beta, digamma, diff, conjugate)
+from sympy.functions.special.gamma_functions import digamma
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.pytest import raises
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -450,6 +450,8 @@ def test_trigamma():
     assert trigamma(3) == pi**2/6 - Rational(5, 4)
 
     assert trigamma(x).rewrite(zeta) == zeta(2, x)
+    assert trigamma(x, evaluate=False).rewrite(harmonic) == \
+        trigamma(x).rewrite(polygamma).rewrite(harmonic)
 
     assert trigamma(x,evaluate=False).fdiff() == polygamma(2, x)
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -114,7 +114,7 @@ def test_lowergamma():
     assert td(lowergamma(randcplx(), y), y)
     assert td(lowergamma(x, randcplx()), x)
     assert lowergamma(x, y).diff(x) == \
-        gamma(x)*polygamma(0, x) - uppergamma(x, y)*log(y) \
+        gamma(x)*digamma(x) - uppergamma(x, y)*log(y) \
         - meijerg([], [1, 1], [0, 0, x], [], y)
 
     assert lowergamma(S.Half, x) == sqrt(pi)*erf(sqrt(x))
@@ -430,7 +430,7 @@ def test_digamma_expand_func():
 def test_trigamma():
     from sympy import I
 
-    assert trigamma(n, nan) == nan
+    assert trigamma(nan) == nan
 
     assert trigamma(oo) == 0
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -418,6 +418,9 @@ def test_digamma():
 
     assert digamma(x,evaluate=False).is_negative is None
 
+    assert digamma(x,evaluate=False).rewrite(polygamma) == polygamma(0, x)
+
+
 def test_digamma_expand_func():
     assert digamma(x).expand(func=True) == polygamma(0, x)
     assert digamma(2*x).expand(func=True) == \
@@ -455,6 +458,8 @@ def test_trigamma():
     assert trigamma(x,evaluate=False).is_positive is None
 
     assert trigamma(x,evaluate=False).is_negative is None
+
+    assert trigamma(x,evaluate=False).rewrite(polygamma) == polygamma(1, x)
 
 def test_trigamma_expand_func():
     assert trigamma(2*x).expand(func=True) == \

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -367,7 +367,62 @@ def test_polygamma_expand_func():
     e = polygamma(3, x + y + S(3)/4)
     assert e.expand(func=True, basic=False) == e
 
+def test_digamma():
+    from sympy import I
 
+    assert digamma(nan) == nan
+
+    assert digamma(oo) == oo
+    assert digamma(-oo) == oo
+    assert digamma(I*oo) == oo
+    assert digamma(-I*oo) == oo
+
+    assert digamma(-9) == zoo
+
+    assert digamma(-9) == zoo
+    assert digamma(-1) == zoo
+
+    assert digamma(0) == zoo
+
+    assert digamma(1) == -EulerGamma
+    assert digamma(7) == Rational(49, 20) - EulerGamma
+
+    def t(m, n):
+        x = S(m)/n
+        r = digamma(x)
+        if r.has(digamma):
+            return False
+        return abs(digamma(x.n()).n() - r.n()).n() < 1e-10
+    assert t(1, 2)
+    assert t(3, 2)
+    assert t(-1, 2)
+    assert t(1, 4)
+    assert t(-3, 4)
+    assert t(1, 3)
+    assert t(4, 3)
+    assert t(3, 4)
+    assert t(2, 3)
+    assert t(123, 5)
+
+    assert digamma(x).rewrite(zeta) == digamma(x)
+
+    assert digamma(x).rewrite(harmonic) == harmonic(x - 1) - EulerGamma
+
+    assert digamma(I).is_real is None
+
+def test_trigamma():
+    from sympy import I
+
+    assert trigamma(n, nan) == nan
+
+    assert trigamma(oo) == 0
+
+    assert trigamma(1) == pi**2/6
+    assert trigamma(2) == pi**2/6 - 1
+    assert trigamma(3) == pi**2/6 - Rational(5, 4)
+
+    assert trigamma(x).rewrite(zeta) == zeta(2, x)
+    
 def test_loggamma():
     raises(TypeError, lambda: loggamma(2, 3))
     raises(ArgumentIndexError, lambda: loggamma(x).fdiff(2))

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -449,7 +449,7 @@ def test_trigamma():
     assert trigamma(2) == pi**2/6 - 1
     assert trigamma(3) == pi**2/6 - Rational(5, 4)
 
-    assert trigamma(x).rewrite(zeta) == zeta(2, x)
+    assert trigamma(x, evaluate=False).rewrite(zeta) == zeta(2, x)
     assert trigamma(x, evaluate=False).rewrite(harmonic) == \
         trigamma(x).rewrite(polygamma).rewrite(harmonic)
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -410,6 +410,14 @@ def test_digamma():
 
     assert digamma(I).is_real is None
 
+    assert digamma(x,evaluate=False).fdiff() == polygamma(1, x)
+
+    assert digamma(x,evaluate=False).is_real is None
+
+    assert digamma(x,evaluate=False).is_positive is None
+
+    assert digamma(x,evaluate=False).is_negative is None
+
 def test_digamma_expand_func():
     assert digamma(x).expand(func=True) == polygamma(0, x)
     assert digamma(2*x).expand(func=True) == \
@@ -439,6 +447,14 @@ def test_trigamma():
     assert trigamma(3) == pi**2/6 - Rational(5, 4)
 
     assert trigamma(x).rewrite(zeta) == zeta(2, x)
+
+    assert trigamma(x,evaluate=False).fdiff() == polygamma(2, x)
+
+    assert trigamma(x,evaluate=False).is_real is None
+
+    assert trigamma(x,evaluate=False).is_positive is None
+
+    assert trigamma(x,evaluate=False).is_negative is None
 
 def test_trigamma_expand_func():
     assert trigamma(2*x).expand(func=True) == \

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -1,6 +1,6 @@
 from sympy import (
     Symbol, Dummy, gamma, I, oo, nan, zoo, factorial, sqrt, Rational,
-    multigamma, log, polygamma, EulerGamma, pi, uppergamma, S, expand_func,
+    multigamma, log, polygamma, digamma, trigamma, EulerGamma, pi, uppergamma, S, expand_func,
     loggamma, sin, cos, O, lowergamma, exp, erf, erfc, exp_polar, harmonic,
     zeta, conjugate, Ei, im, re, tanh, Abs)
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -404,7 +404,7 @@ def test_digamma():
     assert t(2, 3)
     assert t(123, 5)
 
-    assert digamma(x).rewrite(zeta) == digamma(x)
+    assert digamma(x).rewrite(zeta) == polygamma(0, x)
 
     assert digamma(x).rewrite(harmonic) == harmonic(x - 1) - EulerGamma
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -410,6 +410,23 @@ def test_digamma():
 
     assert digamma(I).is_real is None
 
+def test_digamma_expand_func():
+    assert digamma(x).expand(func=True) == polygamma(0, x)
+    assert digamma(2*x).expand(func=True) == \
+        polygamma(0, x)/2 + polygamma(0, Rational(1, 2) + x)/2 + log(2)
+    assert digamma(-1 + x).expand(func=True) == \
+        polygamma(0, x) - 1/(x - 1)
+    assert digamma(1 + x).expand(func=True) == \
+        1/x + polygamma(0, x )
+    assert digamma(2 + x).expand(func=True) == \
+        1/x + 1/(1 + x) + polygamma(0, x)
+    assert digamma(3 + x).expand(func=True) == \
+        polygamma(0, x) + 1/x + 1/(1 + x) + 1/(2 + x)
+    assert digamma(4 + x).expand(func=True) == \
+        polygamma(0, x) + 1/x + 1/(1 + x) + 1/(2 + x) + 1/(3 + x)
+    assert digamma(x + y).expand(func=True) == \
+        polygamma(0, x + y)
+
 def test_trigamma():
     from sympy import I
 
@@ -422,7 +439,25 @@ def test_trigamma():
     assert trigamma(3) == pi**2/6 - Rational(5, 4)
 
     assert trigamma(x).rewrite(zeta) == zeta(2, x)
-    
+
+def test_trigamma_expand_func():
+    assert trigamma(2*x).expand(func=True) == \
+        polygamma(1, x)/4 + polygamma(1, Rational(1, 2) + x)/4
+    assert trigamma(1 + x).expand(func=True) == \
+        polygamma(1, x) - 1/x**2
+    assert trigamma(2 + x).expand(func=True, multinomial=False) == \
+        polygamma(1, x) - 1/x**2 - 1/(1 + x)**2
+    assert trigamma(3 + x).expand(func=True, multinomial=False) == \
+        polygamma(1, x) - 1/x**2 - 1/(1 + x)**2 - 1/(2 + x)**2
+    assert trigamma(4 + x).expand(func=True, multinomial=False) == \
+        polygamma(1, x) - 1/x**2 - 1/(1 + x)**2 - \
+        1/(2 + x)**2 - 1/(3 + x)**2
+    assert trigamma(x + y).expand(func=True) == \
+        polygamma(1, x + y)
+    assert trigamma(3 + 4*x + y).expand(func=True, multinomial=False) == \
+        polygamma(1, y + 4*x) - 1/(y + 4*x)**2 - \
+        1/(1 + y + 4*x)**2 - 1/(2 + y + 4*x)**2
+
 def test_loggamma():
     raises(TypeError, lambda: loggamma(2, 3))
     raises(ArgumentIndexError, lambda: loggamma(x).fdiff(2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17596 

#### Brief description of what is fixed or changed
The digamma and trigamma functions were Python functions. Now they are Function subclasses

#### Other comments
Added tests for digamma and trigamma

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
    * made digamma and trigamma into Function subclasses
<!-- END RELEASE NOTES -->
