### PR TITLE
WIP: Fix pretty printing of roots that are not rational

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1791,10 +1791,14 @@ class PrettyPrinter(Printer):
                 a.append( self._print(S.One) )
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
-    # A helper function for _print_Pow to print x**(1/expt)
     def _print_nth_root(self, base, exp):
+        """A helper function to print ``x**(1/exp)`` as a root.
+
+        Here ``exp`` should be a ``prettyForm``, a string, or something
+        convertible by ``str``.  It should be a single line.
+        """
         bpretty = self._print(base)
-        exp = pretty(exp)
+        exp = str(exp)
         if exp == '2':  # careful, don't want 2.0 here
             istwo = True
             exp = ''
@@ -1845,8 +1849,9 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
             if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
-                # TODO: assumes d prints on single line: does Atom imply that?
-                return self._print_nth_root(b, d)
+                dp = self._print(d)
+                if dp.height() == 1:
+                    return self._print_nth_root(b, dp)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1791,13 +1791,19 @@ class PrettyPrinter(Printer):
                 a.append( self._print(S.One) )
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
-    # A helper function for _print_Pow to print x**(1/n)
-    def _print_nth_root(self, base, expt):
+    # A helper function for _print_Pow to print x**(1/expt)
+    def _print_nth_root(self, base, exp):
         bpretty = self._print(base)
+        exp = pretty(exp)
+        if exp == '2':  # careful, don't want 2.0 here
+            istwo = True
+            exp = ''
+        else:
+            istwo = False
 
         # In very simple cases, use a single-char root sign
         if (self._settings['use_unicode_sqrt_char'] and self._use_unicode
-            and expt is S.Half and bpretty.height() == 1
+            and istwo and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
             return prettyForm(*bpretty.left(u'\N{SQUARE ROOT}'))
@@ -1805,13 +1811,7 @@ class PrettyPrinter(Printer):
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ
-        # Make exponent number to put above it
-        if isinstance(expt, Rational):
-            exp = str(expt.q)
-            if exp == '2':
-                exp = ''
-        else:
-            exp = str(expt.args[0])
+        # Make exponent to put above it
         exp = exp.ljust(2)
         if len(exp) > 2:
             rootsign = ' '*(len(exp) - 2) + rootsign
@@ -1845,7 +1845,8 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
             if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
-                return self._print_nth_root(b, e)
+                # TODO: assumes d prints on single line: does Atom imply that?
+                return self._print_nth_root(b, d)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1798,7 +1798,9 @@ class PrettyPrinter(Printer):
         convertible by ``str``.  It should be a single line.
         """
         bpretty = self._print(base)
-        exp = str(exp)
+        #exp = str(exp)  # doesn't work on Python 2
+        from sympy.core.compatibility import unicode
+        exp = unicode(exp)
         if exp == '2':  # careful, don't want 2.0 here
             istwo = True
             exp = ''

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6897,7 +6897,7 @@ n = -∞  \
 def test_issue_17616():
     assert pretty(pi**(exp(-1))) == \
     'E ____\n'\
-    '\/ pi '
+    '\\/ pi '
 
     assert upretty(pi**(exp(-1))) == \
 u("""\
@@ -6907,7 +6907,7 @@ u("""\
 
     assert pretty(pi**(1/pi)) == \
     'pi____\n'\
-    '\/ pi '
+    '\\/ pi '
 
     assert upretty(pi**(1/pi)) == \
 u("""\

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6892,3 +6892,31 @@ u("""\
  ‾‾‾    \n\
 n = -∞  \
 """)
+
+
+def test_issue_17616():
+    assert pretty(pi**(exp(-1))) == \
+    'E ____\n'\
+    '\/ pi '
+
+    assert upretty(pi**(exp(-1))) == \
+u("""\
+ℯ ___\n\
+╲╱ π \
+""")
+
+    assert pretty(pi**(1/pi)) == \
+    'pi____\n'\
+    '\/ pi '
+
+    assert upretty(pi**(1/pi)) == \
+u("""\
+π ___\n\
+╲╱ π \
+""")
+
+    assert upretty(pi**(1/EulerGamma)) == \
+u("""\
+γ ___\n\
+╲╱ π \
+""")


### PR DESCRIPTION
`pi**exp(-1)` was printing wrong.  Fix that.  Use pretty printer
instead of `str` for the exponent.  Add tests.  Fixes #17616.

This code assumes the exponent is an Atom and it always prints on
one line.  Not sure the former necessarily implies the latter so
leave a todo note.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
