### PR TITLE
Pretty print roots for small integers and short Symbols

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1791,10 +1791,14 @@ class PrettyPrinter(Printer):
                 a.append( self._print(S.One) )
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
-    # A helper function for _print_Pow to print x**(1/expt)
     def _print_nth_root(self, base, exp):
+        """A helper function to print ``x**(1/exp)`` as a root.
+
+        Here ``exp`` should be a ``prettyForm``, a string, or something
+        convertible by ``str``.  It should be a single line.
+        """
         bpretty = self._print(base)
-        exp = pretty(exp)
+        exp = str(exp)
         if exp == '2':  # careful, don't want 2.0 here
             istwo = True
             exp = ''
@@ -1845,8 +1849,9 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
             if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
-                # TODO: assumes d prints on single line: does Atom imply that?
-                return self._print_nth_root(b, d)
+                dp = self._print(d)
+                if dp.height() == 1:
+                    return self._print_nth_root(b, dp)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1791,13 +1791,19 @@ class PrettyPrinter(Printer):
                 a.append( self._print(S.One) )
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
-    # A helper function for _print_Pow to print x**(1/n)
-    def _print_nth_root(self, base, expt):
+    # A helper function for _print_Pow to print x**(1/expt)
+    def _print_nth_root(self, base, exp):
         bpretty = self._print(base)
+        exp = pretty(exp)
+        if exp == '2':  # careful, don't want 2.0 here
+            istwo = True
+            exp = ''
+        else:
+            istwo = False
 
         # In very simple cases, use a single-char root sign
         if (self._settings['use_unicode_sqrt_char'] and self._use_unicode
-            and expt is S.Half and bpretty.height() == 1
+            and istwo and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
             return prettyForm(*bpretty.left(u'\N{SQUARE ROOT}'))
@@ -1805,13 +1811,7 @@ class PrettyPrinter(Printer):
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ
-        # Make exponent number to put above it
-        if isinstance(expt, Rational):
-            exp = str(expt.q)
-            if exp == '2':
-                exp = ''
-        else:
-            exp = str(expt.args[0])
+        # Make exponent to put above it
         exp = exp.ljust(2)
         if len(exp) > 2:
             rootsign = ' '*(len(exp) - 2) + rootsign
@@ -1845,7 +1845,8 @@ class PrettyPrinter(Printer):
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
             if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
-                return self._print_nth_root(b, e)
+                # TODO: assumes d prints on single line: does Atom imply that?
+                return self._print_nth_root(b, d)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1798,7 +1798,9 @@ class PrettyPrinter(Printer):
         convertible by ``str``.  It should be a single line.
         """
         bpretty = self._print(base)
-        exp = str(exp)
+        #exp = str(exp)  # doesn't work on Python 2
+        from sympy.core.compatibility import unicode
+        exp = unicode(exp)
         if exp == '2':  # careful, don't want 2.0 here
             istwo = True
             exp = ''

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1849,9 +1849,9 @@ class PrettyPrinter(Printer):
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
             if self._settings['root_notation']:
-                # small Integer roots and short Symbols, not irrational roots
+                # small integer roots and short symbols
                 n, d = fraction(e)
-                if n == 1 and (d.is_Symbol or (d.is_Integer and d != 1)):
+                if n == 1 and d != 1 and d.is_Atom:
                     dp = self._print(d)
                     if dp.height() == 1 and dp.width() <= 3:
                         return self._print_nth_root(b, dp)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5665,6 +5665,7 @@ def test_PrettyPoly():
 
 def test_issue_6285():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
+    assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
 
 
 def test_issue_6359():
@@ -6904,40 +6905,37 @@ n = -∞  \
 
 def test_issue_17616():
     assert pretty(pi**(exp(-1))) == \
-    '  / -1\\\n'\
-    '  \\e  /\n'\
-    'pi     '
+    'E ____\n'\
+    '\\/ pi '
+
     assert upretty(pi**(exp(-1))) == \
 u("""\
- ⎛ -1⎞\n\
- ⎝ℯ  ⎠\n\
-π     \
+ℯ ___\n\
+╲╱ π \
 """)
 
+    assert pretty(pi**(1/pi)) == \
+    'pi____\n'\
+    '\\/ pi '
+
+    assert upretty(pi**(1/pi)) == \
+u("""\
+π ___\n\
+╲╱ π \
+""")
+
+
+def test_Pow_symbol_short_and_long():
     assert upretty(pi**(1/EulerGamma)) == \
 u("""\
- 1\n\
- ─\n\
- γ\n\
-π \
+γ ___\n\
+╲╱ π \
 """)
     assert pretty(pi**(1/EulerGamma)) == \
     '      1     \n'\
     '  ----------\n'\
     '  EulerGamma\n'\
     'pi          '
-
-
-def test_Pow_symbol_short_and_long():
-    z = Symbol("x_2")
-    assert upretty(7**(1/z)) == \
-u("""\
-x₂___\n\
-╲╱ 7 \
-""")
-    assert pretty(7**(1/z)) == \
-    'x_2___\n'\
-    ' \/ 7 '
 
     z = Symbol("x_17")
     assert upretty(7**(1/z)) == \
@@ -6950,12 +6948,3 @@ x₁₇___\n\
     ' ----\n'\
     ' x_17\n'\
     '7    '
-
-    z = Symbol("verylong")
-    assert upretty(7**(1/z)) == \
-u("""\
-    1    \n\
- ────────\n\
- verylong\n\
-7        \
-""")

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6897,7 +6897,7 @@ n = -∞  \
 def test_issue_17616():
     assert pretty(pi**(exp(-1))) == \
     'E ____\n'\
-    '\/ pi '
+    '\\/ pi '
 
     assert upretty(pi**(exp(-1))) == \
 u("""\
@@ -6907,7 +6907,7 @@ u("""\
 
     assert pretty(pi**(1/pi)) == \
     'pi____\n'\
-    '\/ pi '
+    '\\/ pi '
 
     assert upretty(pi**(1/pi)) == \
 u("""\

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2058,19 +2058,28 @@ u("""\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = 2**Rational(1, 1000)
+    expr = 2**Rational(1, 999)
     ascii_str = \
 """\
-1000___\n\
-  \\/ 2 \
+999___\n\
+ \\/ 2 \
 """
     ucode_str = \
 u("""\
-1000___\n\
-  ╲╱ 2 \
+999___\n\
+ ╲╱ 2 \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+    expr = 2**Rational(1, 1000)
+    ascii_str = \
+"""\
+ 1/1000\n\
+2      \
+"""
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ascii_str
 
     expr = sqrt(x**2 + 1)
     ascii_str = \
@@ -2132,11 +2141,11 @@ u("""\
     assert upretty(expr) == ucode_str
 
     expr = (2 + (
-        1 + x**2)/(2 + x))**Rational(1, 4) + (1 + x**Rational(1, 1000))/sqrt(3 + x**2)
+        1 + x**2)/(2 + x))**Rational(1, 4) + (1 + x**Rational(1, 100))/sqrt(3 + x**2)
     ascii_str = \
 """\
      ____________              \n\
-    /      2        1000___    \n\
+    /      2         100___    \n\
    /      x  + 1      \\/ x  + 1\n\
 4 /   2 + ------  + -----------\n\
 \\/        x + 2        ________\n\
@@ -2146,7 +2155,7 @@ u("""\
     ucode_str = \
 u("""\
      ____________              \n\
-    ╱      2        1000___    \n\
+    ╱      2         100___    \n\
    ╱      x  + 1      ╲╱ x  + 1\n\
 4 ╱   2 + ──────  + ───────────\n\
 ╲╱        x + 2        ________\n\
@@ -5656,7 +5665,6 @@ def test_PrettyPoly():
 
 def test_issue_6285():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
-    assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
 
 
 def test_issue_6359():
@@ -6896,27 +6904,58 @@ n = -∞  \
 
 def test_issue_17616():
     assert pretty(pi**(exp(-1))) == \
-    'E ____\n'\
-    '\\/ pi '
-
+    '  / -1\\\n'\
+    '  \\e  /\n'\
+    'pi     '
     assert upretty(pi**(exp(-1))) == \
 u("""\
-ℯ ___\n\
-╲╱ π \
-""")
-
-    assert pretty(pi**(1/pi)) == \
-    'pi____\n'\
-    '\\/ pi '
-
-    assert upretty(pi**(1/pi)) == \
-u("""\
-π ___\n\
-╲╱ π \
+ ⎛ -1⎞\n\
+ ⎝ℯ  ⎠\n\
+π     \
 """)
 
     assert upretty(pi**(1/EulerGamma)) == \
 u("""\
-γ ___\n\
-╲╱ π \
+ 1\n\
+ ─\n\
+ γ\n\
+π \
+""")
+    assert pretty(pi**(1/EulerGamma)) == \
+    '      1     \n'\
+    '  ----------\n'\
+    '  EulerGamma\n'\
+    'pi          '
+
+
+def test_Pow_symbol_short_and_long():
+    z = Symbol("x_2")
+    assert upretty(7**(1/z)) == \
+u("""\
+x₂___\n\
+╲╱ 7 \
+""")
+    assert pretty(7**(1/z)) == \
+    'x_2___\n'\
+    ' \/ 7 '
+
+    z = Symbol("x_17")
+    assert upretty(7**(1/z)) == \
+u("""\
+x₁₇___\n\
+ ╲╱ 7 \
+""")
+    assert pretty(7**(1/z)) == \
+    '  1  \n'\
+    ' ----\n'\
+    ' x_17\n'\
+    '7    '
+
+    z = Symbol("verylong")
+    assert upretty(7**(1/z)) == \
+u("""\
+    1    \n\
+ ────────\n\
+ verylong\n\
+7        \
 """)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6892,3 +6892,31 @@ u("""\
  ‾‾‾    \n\
 n = -∞  \
 """)
+
+
+def test_issue_17616():
+    assert pretty(pi**(exp(-1))) == \
+    'E ____\n'\
+    '\/ pi '
+
+    assert upretty(pi**(exp(-1))) == \
+u("""\
+ℯ ___\n\
+╲╱ π \
+""")
+
+    assert pretty(pi**(1/pi)) == \
+    'pi____\n'\
+    '\/ pi '
+
+    assert upretty(pi**(1/pi)) == \
+u("""\
+π ___\n\
+╲╱ π \
+""")
+
+    assert upretty(pi**(1/EulerGamma)) == \
+u("""\
+γ ___\n\
+╲╱ π \
+""")


### PR DESCRIPTION
pretty: use nth root notation only for small integers and symbols
    
But don't use it if the integer is too big or the symbol is too long:
current threshold set to three characters.

#### References to other Issues or PRs

An alternative to #17620.  Still fixes #17616.  If this is accepted, a similar change could/should be done for LaTeXPrinter as well.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
