### PR TITLE
Fix zero matrix added with zero matrix giving zero

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -627,6 +627,8 @@ def get_postprocessor(cls):
                 # manipulate them like non-commutative scalars.
                 return cls._from_args(nonmatrices + [mat_class(*matrices).doit(deep=False)])
 
+        if mat_class == MatAdd:
+            return mat_class(*matrices).doit(deep=False)
         return mat_class(cls._from_args(nonmatrices), *matrices).doit(deep=False)
     return _postprocessor
 

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -3,7 +3,7 @@ from sympy.matrices.expressions.blockmatrix import (
     BlockMatrix, bc_dist, bc_matadd, bc_transpose, bc_inverse,
     blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
-        Inverse, trace, Transpose, det)
+        Inverse, trace, Transpose, det, ZeroMatrix)
 from sympy.matrices import (
     Matrix, ImmutableMatrix, ImmutableSparseMatrix)
 from sympy.core import Tuple, symbols, Expr
@@ -103,6 +103,13 @@ def test_block_collapse_explicit_matrices():
 
     A = ImmutableSparseMatrix([[1, 2], [3, 4]])
     assert block_collapse(BlockMatrix([[A]])) == A
+
+def test_issue_17624():
+    a = MatrixSymbol("a", 2, 2)
+    z = ZeroMatrix(2, 2)
+    b = BlockMatrix([[a, z], [z, z]])
+    assert block_collapse(b * b) == BlockMatrix([[a**2, z], [z, z]])
+    assert block_collapse(b * b * b) == BlockMatrix([[a**3, z], [z, z]])
 
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,7 +1,8 @@
 from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
-from sympy.matrices.expressions.matexpr import GenericZeroMatrix
+from sympy.matrices.expressions.matexpr import GenericZeroMatrix, ZeroMatrix
 from sympy.matrices import eye, ImmutableMatrix
-from sympy.core import Basic, S
+from sympy.core import Add, Basic, S
+from sympy.utilities.pytest import XFAIL, raises
 
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 2)
@@ -30,3 +31,11 @@ def test_doit_args():
 def test_generic_identity():
     assert MatAdd.identity == GenericZeroMatrix()
     assert MatAdd.identity != S.Zero
+
+
+def test_zero_matrix_add():
+    assert Add(ZeroMatrix(2, 2), ZeroMatrix(2, 2)) == ZeroMatrix(2, 2)
+
+@XFAIL
+def test_matrix_add_with_scalar():
+    raises(TypeError, lambda: Add(0, ZeroMatrix(2, 2)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17624 

#### Brief description of what is fixed or changed

The problem in #17624 happens because the postprocessor tries to pass `Zero` to `MatAdd`.
I've used some changes in #16839 to fix this.
Ideally, `mat_class(cls._from_args(nonmatrices), *matrices).doit(deep=False)` may also have to be `mat_class(*matrices).doit(deep=False)` for `MatMul`, but due to some test failings tricky to resolve, I'm only added it as a trivial case for MatAdd.

Since `check=False` is default for `MatAdd`, I think that it also gives a wrong result for `Add(0, ZeroMatrix(2, 2))`, but I think that it should later be resolved in #16839 if I find any way to make the tests pass.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `Add(ZeroMatrix(2, 2), ZeroMatrix(2, 2))` or other similar expressions giving `S.Zero` instead of `ZeroMatrix`.
<!-- END RELEASE NOTES -->
