### PR TITLE
Addressing the overflow issues when working with exponential operations

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1811,6 +1811,8 @@ class Rational(Number):
                 if self.is_negative:
                     return S.NegativeOne**expt*Rational(self.q, -self.p)**ne
                 else:
+                    if abs(self) >= 16**16 or abs(ne) >= 16**16:
+                        return Rational(self.q, self.p)**ne
                     x = mp.fdiv(self.q, self.p)
                     y = mp.fdiv(ne.p, ne.q)
                     return sympify(mp.power(x, y))
@@ -1824,16 +1826,24 @@ class Rational(Number):
                 return S.Zero
             if isinstance(expt, Integer):
                 # (4/3)**2 -> 4**2 / 3**2
+                if abs(self) >= 16**16 or abs(ne) >= 16**16:
+                    return Rational(self.p**expt.p, self.q**expt.p, 1)
                 a = Integer(mp.power(self.p, expt.p))
                 b = Integer(mp.power(self.q, expt.p))
                 return Rational(a, b, 1)
             if isinstance(expt, Rational):
                 if self.p != 1:
                     # (4/3)**(5/6) -> 4**(5/6)*3**(-5/6)
+                    if abs(self) >= 16**16 or abs(expt) >= 16**16:
+                        return Integer(self.p)**expt*Integer(self.q)**(-expt)
                     a = mp.fdiv(self.p, self.q)
                     b = mp.fdiv(expt.p, expt.q)
                     return sympify(mp.power(a, b))
                 # as the above caught negative self.p, now self is positive
+                if abs(self) >= 16**16 or abs(expt) >= 16**16:
+                    return Integer(self.q)**Rational(
+                expt.p*(expt.q - 1), expt.q) / \
+                    Integer(self.q)**Integer(expt.p)
                 x = mp.fmul(expt.p, (expt.q - 1))
                 a = mp.fdiv(x, expt.q)
                 b = mp.power(self.q, expt.p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2358,6 +2358,8 @@ class Integer(Rational):
             else:
                 return Rational(1, self.p)**ne
         # see if base is a perfect root, sqrt(4) --> 2
+        if abs(self) >= 16**16 or abs(expt) >= 16**16:
+            return Pow(self, expt, evaluate=False)
         x, xexact = integer_nthroot(abs(self.p), expt.q)
         if xexact:
             # if it's a perfect root we've finished

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1803,6 +1803,8 @@ class Rational(Number):
         mp.dps = 15
         if isinstance(expt, Number):
             if isinstance(expt, Float):
+                if abs(self) >= 16**16 or abs(expt) >= 16**16:
+                    return Pow(self, expt, evaluate=False)
                 return self._eval_evalf(expt._prec)**expt
             if expt.is_extended_negative:
                 # (3/4)**-2 -> (4/3)**2

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -96,13 +96,13 @@ def integer_nthroot(y, n):
             shift = mp.fsub(exp, EXP_CONSTANT, rounding='d')
             k = mp.fsub(exp, shift, rounding='d')
             d = mp.power(2, k)
-            guess = mp.power((d + 1), shift, rounding='d')
+            guess = mp.power((d + 1), shift)
             del d
             del k
             del c
             del shift
         else:
-            guess = mp.power(2, exp, rounding='d')
+            guess = mp.power(2, exp)
         del exp
     if guess > mp.power(2, 50):
         # Newton iteration
@@ -122,13 +122,13 @@ def integer_nthroot(y, n):
     else:
         x = guess
     # Compensate
-    t = mp.power(x, n, rounding='d')
+    t = mp.power(x, n)
     while t < y:
         x = mp.fadd(x, 1)
-        t = mp.power(x, n, rounding='d')
+        t = mp.power(x, n)
     while t > y:
         x = mp.fsub(x, 1)
-        t = mp.power(x, n, rounding='d')
+        t = mp.power(x, n)
     return int(x), mp.almosteq(t, y)  # int converts long to int if possible
 
 def integer_log(y, x):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -179,6 +179,18 @@ def test_relational():
     assert Lt(x + I, x + I + 2).func == Lt  # issue 8288
 
 
+def test_optimized_nthroot():
+    from sympy.abc import a, b, c
+    import mpmath as mp
+    mp.dps = 15
+    input_value = -144
+    b = a ** a
+    c = b ** b
+    observed_out = c.subs({a: input_value})
+    expected_out = 1.000
+    assert mp.almosteq(observed_out, expected_out)
+
+
 def test_relational_assumptions():
     from sympy import Lt, Gt, Le, Ge
     m1 = Symbol("m1", nonnegative=False)


### PR DESCRIPTION
#### A mitigation of OverflowErrors when performing exponential operations

Fixes #14704
Closes https://github.com/sympy/sympy/pull/14707
Closes https://github.com/sympy/sympy/pull/14722

#### Files changed in this PR
The related files are:
1. integer_nthroot method in sympy\core\power.py
2.  _eval_power method in sympy\core\numbers.py

#### Brief description of what is fixed or changed
This PR fixed the overflow error that occurs when working with decimals. This precision loss occurs when we sloopingly round values during computation.

The approach adopted in the PR was to use the mpmath library that is native to the Sympy and offloading calculations to the library and not converted back to normal Python objects at any point during the computation or it would overflow. 

During my benching test, mpmath library was multitude times faster than Decimal module for exponential operations.

The work was made more efficient by deleting object as soon as it is no longer used and not waiting for the garbage collector.

The integer_nthroot module is used in many routines, care will be ensured that the precision level does not interfere with setting in existing tests.

The changes in the _eval_power module have specific optimizations to improve space and time complexity.

```python
>>> from sympy.abc import a, b, c
>>> 
>>> b = a ** a
>>> c = b ** b
>>> c.subs({a: -144})
1.00000000000
```
This is the beginning of my contribution process with Sympy! :)

<!-- BEGIN RELEASE NOTES -->
* core
  * Added an improvement to prevent overflow error in either arbitrary long decimal number or long integers during exponential operations. 

* functions
  * Optimized integer_nthroot method in sympy\core\power.py.
  * Optimized _eval_power method in sympy\core\numbers.py
<!-- END RELEASE NOTES -->

