### PR TITLE
Extend modular exponentiation capability

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -456,6 +456,9 @@ class Pow(Expr):
 
             if isinstance(exp, Pow) and exp.is_integer and exp.is_number:
                 bit_length = int(q).bit_length()
+                # XXX Mod-Pow actually attempts to do a hanging evaluation
+                # if this dispatched function returns None.
+                # May need some fixes in the dispatcher itself.
                 if bit_length <= 80:
                     phi = totient(q)
                     exp = phi + Mod(exp, phi)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -453,7 +453,7 @@ class Pow(Expr):
 
             if isinstance(base, Pow) and base.is_integer and base.is_number:
                 base = Mod(base, q)
-                return Mod(Pow(base, exp), q)
+                return Mod(Pow(base, exp, evaluate=False), q)
 
             if isinstance(exp, Pow) and exp.is_integer and exp.is_number:
                 bit_length = int(q).bit_length()
@@ -463,7 +463,7 @@ class Pow(Expr):
                 if bit_length <= 80:
                     phi = totient(q)
                     exp = phi + Mod(exp, phi)
-                    return Mod(Pow(base, exp), q)
+                    return Mod(Pow(base, exp, evaluate=False), q)
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -429,9 +429,10 @@ class Pow(Expr):
         check is added.
 
         3. For any unevaluated power found in `b` or `e`, the step 2
-        will be recursed down such that the `b \bmod q` becomes the new
-        base and ``\phi(q) + e \bmod \phi(q)`` becomes the new
-        exponent, and then
+        will be recursed down to the base and the exponent
+        such that the `b \bmod q` becomes the new base and
+        ``\phi(q) + e \bmod \phi(q)`` becomes the new exponent, and then
+        the computation for the reduced expression can be done.
         """
         from sympy.ntheory import totient
         from .mod import Mod

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1708,6 +1708,48 @@ def test_Mod_Pow():
     assert Mod(Pow(78789849597, 333**555, evaluate=False),12**9) == \
         pow(78789849597,333**555,12**9)
 
+    # modular nested exponentiation
+    expr = Pow(2, 2, evaluate=False)
+    expr = Pow(2, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 16
+    expr = Pow(2, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 6487
+    expr = Pow(2, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 32191
+    expr = Pow(2, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 18016
+    expr = Pow(2, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 5137
+
+    expr = Pow(2, 2, evaluate=False)
+    expr = Pow(expr, 2, evaluate=False)
+    assert Mod(expr, 3**10) == 16
+    expr = Pow(expr, 2, evaluate=False)
+    assert Mod(expr, 3**10) == 256
+    expr = Pow(expr, 2, evaluate=False)
+    assert Mod(expr, 3**10) == 6487
+    expr = Pow(expr, 2, evaluate=False)
+    assert Mod(expr, 3**10) == 38281
+    expr = Pow(expr, 2, evaluate=False)
+    assert Mod(expr, 3**10) == 15928
+
+
+@XFAIL
+def test_failing_Mod_Pow_nested():
+    expr = Pow(2, 2, evaluate=False)
+    expr = Pow(expr, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 256
+    expr = Pow(expr, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 9229
+    expr = Pow(expr, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 25708
+    expr = Pow(expr, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 26608
+    # XXX This fails in nondeterministic way because of the overflow
+    # error in mpmath
+    expr = Pow(expr, expr, evaluate=False)
+    assert Mod(expr, 3**10) == 1966
+
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1663,6 +1663,7 @@ def test_Mod():
     # modular exponentiation
     assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
     assert Mod(Pow(2, 10000000000, evaluate=False), 3) == 1
+    assert isinstance(Mod(Pow(2, 10000000000, evaluate=False), 3), Integer)
     assert Mod(Pow(32131231232, 9**10**6, evaluate=False),10**12) == pow(32131231232,9**10**6,10**12)
     assert Mod(Pow(33284959323, 123**999, evaluate=False),11**13) == pow(33284959323,123**999,11**13)
     assert Mod(Pow(78789849597, 333**555, evaluate=False),12**9) == pow(78789849597,333**555,12**9)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1660,14 +1660,6 @@ def test_Mod():
     assert factorial(n + 2) % n == 0
     assert (factorial(n + 4) % (n + 5)).func is Mod
 
-    # modular exponentiation
-    assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
-    assert Mod(Pow(2, 10000000000, evaluate=False), 3) == 1
-    assert isinstance(Mod(Pow(2, 10000000000, evaluate=False), 3), Integer)
-    assert Mod(Pow(32131231232, 9**10**6, evaluate=False),10**12) == pow(32131231232,9**10**6,10**12)
-    assert Mod(Pow(33284959323, 123**999, evaluate=False),11**13) == pow(33284959323,123**999,11**13)
-    assert Mod(Pow(78789849597, 333**555, evaluate=False),12**9) == pow(78789849597,333**555,12**9)
-
     # Wilson's theorem
     factorial(18042, evaluate=False) % 18043 == 18042
     p = Symbol('n', prime=True)
@@ -1701,6 +1693,20 @@ def test_Mod():
     # rewrite
     assert Mod(x, y).rewrite(floor) == x - y*floor(x/y)
     assert ((x - Mod(x, y))/y).rewrite(floor) == floor(x/y)
+
+
+def test_Mod_Pow():
+    # modular exponentiation
+    assert isinstance(Mod(Pow(2, 2, evaluate=False), 3), Integer)
+
+    assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
+    assert Mod(Pow(2, 10000000000, evaluate=False), 3) == 1
+    assert Mod(Pow(32131231232, 9**10**6, evaluate=False),10**12) == \
+        pow(32131231232,9**10**6,10**12)
+    assert Mod(Pow(33284959323, 123**999, evaluate=False),11**13) == \
+        pow(33284959323,123**999,11**13)
+    assert Mod(Pow(78789849597, 333**555, evaluate=False),12**9) == \
+        pow(78789849597,333**555,12**9)
 
 
 def test_Mod_is_integer():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I have found that modular exponentiation had some bugs like returning plain python integers, and I've also found that the evaluation hangs for tetrations because 
```python
from sympy import *

expr = Pow(2, 2, evaluate=False)
expr = Pow(2, expr, evaluate=False)
expr = Pow(2, expr, evaluate=False)
Mod(expr, 3**10)
```
somewhat evaluates like ![image](https://user-images.githubusercontent.com/34944973/65390008-32e1c300-dd96-11e9-8524-766e8193e2a9.png) which probably indicates that it attempts to compute the tetrations in naive way.

I've extended the existing algorithm to compute nested exponential power. 

I think there are only two problems remaining for now. One of the problem is when the modulus and the exponent are too large, we can still see the hanging evaluation,
and another problem is that one of the assumptions handler is throwing overflow error.
But I don't think that those issues are in scope in this PR.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Fixed `Mod(Pow(a, b, evaluate=False), c)` returning non-sympified integer output if `a, b, c` are numeric integers.
  - Extended modular exponentiation computation for nested integer powers, so it can efficiently compute the modulus of a tetration.
<!-- END RELEASE NOTES -->
