### PR TITLE
Avoid upcasting of subclasses of Symbol in IndexedBase.__new__

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -437,10 +437,9 @@ class IndexedBase(Expr, NotIterable):
 
         assumptions, kw_args = _filter_assumptions(kw_args)
         if isinstance(label, string_types):
-            label = Symbol(label)
+            label = Symbol(label, **assumptions)
         elif isinstance(label, Symbol):
             assumptions = label._merge(assumptions)
-            label = Symbol(label.name)
         elif isinstance(label, (MatrixBase, NDimArray)):
             return label
         elif isinstance(label, Iterable):

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -229,7 +229,24 @@ def test_IndexedBase_assumptions_inheritance():
 
     assert I_inherit.is_integer
     assert I_explicit.is_integer
+    assert I_inherit.label.is_integer
+    assert I_explicit.label.is_integer
     assert I_inherit == I_explicit
+
+
+def test_issue_17652():
+    """Regression test issue #17652.
+
+    IndexedBase.label should not upcast subclasses of Symbol
+    """
+    class SubClass(Symbol):
+        pass
+
+    x = SubClass('X')
+    assert type(x) == SubClass
+    base = IndexedBase(x)
+    assert type(x) == SubClass
+    assert type(base.label) == SubClass
 
 
 def test_Indexed_constructor():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17652


#### Brief description of what is fixed or changed
Motivation is described in #17652.

If you call `a = IndexedBase(label)` where label is an instance of a subclass of  `sympy.Symbol` the type of `a.label` will be `sympy.Symbol` instead of the subclass.

Reason (this line in IndexedBase.__new__):
```python
label = Symbol(label.name)
```
that deletes all additional information that label might have as a subclass and also the assumptions that have been derived from it the line before. So the this test needs to should be adapted:

```
def test_IndexedBase_assumptions_inheritance():
    I = Symbol('I', integer=True)
    I_inherit = IndexedBase(I)
    I_explicit = IndexedBase('I', integer=True)

    assert I_inherit.is_integer
    assert I_explicit.is_integer
    assert I_inherit.label.is_integer # add this line ,previously None
    assert I_explicit.label.is_integer # add this line, previously None
    assert I_inherit == I_explicit
```

If you just delete the line `label = Symbol(label.name)`  #17652 would also be fixed. 
However,  `assert I_inherit == I_explicit` will no longer hold since `I_inherit.label.is_integer == True` while  `I_explicit.label.is_integer == None`.

#### Other comments

For me, it is not clear whether the constructor of `IndexedBase` should transfer the assumptions it generated back to `IndexedBase.label`. However, this seems more logical for me given the statement *the same assumptions for IndexedBase and IndexedBase.label (the symbol it was constructed from should hold*

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
   * Allow construction of `IndexedBase` with subclasses of `Symbol` without upcasting to `Symbol`
<!-- END RELEASE NOTES -->
