### PR TITLE
modify powsimp to handle square roots

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2070,7 +2070,7 @@ def test_jordan_form_issue_15858():
     assert simplify(P) == Matrix([
         [-I, -I/2, I, I/2],
         [-1 + I, 0, -1 - I, 0],
-        [0, I*(-1 + I)/2, 0, I*(1 + I)/2],
+        [0, -1/2 - I/2, 0, -1/2 + I/2],
         [0, 1, 0, 1]])
     assert J == Matrix([
         [-I, 1, 0, 0],

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -393,6 +393,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if not (all(x.is_nonnegative for x in b.as_numer_denom()) or e.is_integer or force or b.is_polar):
                 continue
             exp_c, exp_t = e.as_coeff_Mul(rational=True)
+            if exp_t is S.One and exp_c.is_negative:
+                exp_c, exp_t = -exp_t, -exp_c
             if exp_c is not S.One and exp_t is not S.One:
                 c_powers[i] = [Pow(b, exp_c), exp_t]
 

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -471,6 +471,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                         return sum([_terms(ai) for ai in e.args])
                     if e.is_Mul:
                         return prod([_terms(mi) for mi in e.args])
+                    if e.is_Pow:
+                        return _terms(e.base)
                     return 1
                 xnew_base = expand_mul(new_base, deep=False)
                 if len(Add.make_args(xnew_base)) < _terms(new_base):

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -327,3 +327,11 @@ def test_issue_17524():
     a = symbols("a", real=True)
     e = (-1 - a**2)*sqrt(1 + a**2)
     assert signsimp(powsimp(e)) == signsimp(e) == -(a**2 + 1)**(S(3)/2)
+
+def test_issue_17634():
+    x = Symbol('x')
+    y = Symbol('y')
+    assert powsimp(sqrt(1-x**2)/sqrt(1-x), force=True) == sqrt((1 - x**2)/(1 - x))
+    assert powsimp(sqrt(x)/sqrt(y), force=True) == sqrt(x/y)
+    assert powsimp(x**(S(1)/2)/y**(S(1)/2), force=True) == sqrt(x/y)
+    assert powsimp(x**S.Half/y**S.Half, force=True) == sqrt(x/y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses issue #17634 

#### Brief description of what is fixed or changed
Following the discussion in #17634 the changes were done
Before, `powsimp (sqrt(1-x**2)/sqrt(1-x))` would yield `sqrt(1-x**2)/sqrt(1-x)`
Now it yields `sqrt((1-x**2)/(1-x))`
#### Other comments
Added tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * modified powsimp to better handle square roots
<!-- END RELEASE NOTES -->
