### PR TITLE
`memoize_property` decorator now caches value locally

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -21,9 +21,6 @@ deprecated_predicates = [
     'infinitesimal'
 ]
 
-# Memoization storage for predicates
-predicate_storage = {}
-predicate_memo = memoize_property(predicate_storage)
 # Memoization is necessary for the properties of AssumptionKeys to
 # ensure that only one object of Predicate objects are created.
 # This is because assumption handlers are registered on those objects.
@@ -34,7 +31,7 @@ class AssumptionKeys(object):
     This class contains all the supported keys by ``ask``.
     """
 
-    @predicate_memo
+    @memoize_property
     def hermitian(self):
         """
         Hermitian predicate.
@@ -51,7 +48,7 @@ class AssumptionKeys(object):
         # TODO: Add examples
         return Predicate('hermitian')
 
-    @predicate_memo
+    @memoize_property
     def antihermitian(self):
         """
         Antihermitian predicate.
@@ -69,7 +66,7 @@ class AssumptionKeys(object):
         # TODO: Add examples
         return Predicate('antihermitian')
 
-    @predicate_memo
+    @memoize_property
     def real(self):
         r"""
         Real number predicate.
@@ -126,7 +123,7 @@ class AssumptionKeys(object):
         """
         return Predicate('real')
 
-    @predicate_memo
+    @memoize_property
     def extended_real(self):
         r"""
         Extended real predicate.
@@ -150,7 +147,7 @@ class AssumptionKeys(object):
         """
         return Predicate('extended_real')
 
-    @predicate_memo
+    @memoize_property
     def imaginary(self):
         """
         Imaginary number predicate.
@@ -178,7 +175,7 @@ class AssumptionKeys(object):
         """
         return Predicate('imaginary')
 
-    @predicate_memo
+    @memoize_property
     def complex(self):
         """
         Complex number predicate.
@@ -206,7 +203,7 @@ class AssumptionKeys(object):
         """
         return Predicate('complex')
 
-    @predicate_memo
+    @memoize_property
     def algebraic(self):
         r"""
         Algebraic number predicate.
@@ -233,7 +230,7 @@ class AssumptionKeys(object):
         """
         return Predicate('algebraic')
 
-    @predicate_memo
+    @memoize_property
     def transcendental(self):
         """
         Transcedental number predicate.
@@ -246,7 +243,7 @@ class AssumptionKeys(object):
         # TODO: Add examples
         return Predicate('transcendental')
 
-    @predicate_memo
+    @memoize_property
     def integer(self):
         """
         Integer predicate.
@@ -270,7 +267,7 @@ class AssumptionKeys(object):
         """
         return Predicate('integer')
 
-    @predicate_memo
+    @memoize_property
     def rational(self):
         """
         Rational number predicate.
@@ -297,7 +294,7 @@ class AssumptionKeys(object):
         """
         return Predicate('rational')
 
-    @predicate_memo
+    @memoize_property
     def irrational(self):
         """
         Irrational number predicate.
@@ -326,7 +323,7 @@ class AssumptionKeys(object):
         """
         return Predicate('irrational')
 
-    @predicate_memo
+    @memoize_property
     def finite(self):
         """
         Finite predicate.
@@ -357,7 +354,7 @@ class AssumptionKeys(object):
         """
         return Predicate('finite')
 
-    @predicate_memo
+    @memoize_property
     @deprecated(useinstead="finite", issue=9425, deprecated_since_version="1.0")
     def bounded(self):
         """
@@ -365,7 +362,7 @@ class AssumptionKeys(object):
         """
         return Predicate('finite')
 
-    @predicate_memo
+    @memoize_property
     def infinite(self):
         """
         Infinite number predicate.
@@ -377,7 +374,7 @@ class AssumptionKeys(object):
         # TODO: Add examples
         return Predicate('infinite')
 
-    @predicate_memo
+    @memoize_property
     @deprecated(useinstead="infinite", issue=9426, deprecated_since_version="1.0")
     def infinity(self):
         """
@@ -385,7 +382,7 @@ class AssumptionKeys(object):
         """
         return Predicate('infinite')
 
-    @predicate_memo
+    @memoize_property
     @deprecated(useinstead="zero", issue=9675, deprecated_since_version="1.0")
     def infinitesimal(self):
         """
@@ -393,7 +390,7 @@ class AssumptionKeys(object):
         """
         return Predicate('zero')
 
-    @predicate_memo
+    @memoize_property
     def positive(self):
         r"""
         Positive real number predicate.
@@ -431,7 +428,7 @@ class AssumptionKeys(object):
         """
         return Predicate('positive')
 
-    @predicate_memo
+    @memoize_property
     def negative(self):
         r"""
         Negative number predicate.
@@ -469,7 +466,7 @@ class AssumptionKeys(object):
         """
         return Predicate('negative')
 
-    @predicate_memo
+    @memoize_property
     def zero(self):
         """
         Zero number predicate.
@@ -495,7 +492,7 @@ class AssumptionKeys(object):
         """
         return Predicate('zero')
 
-    @predicate_memo
+    @memoize_property
     def nonzero(self):
         """
         Nonzero real number predicate.
@@ -535,7 +532,7 @@ class AssumptionKeys(object):
         """
         return Predicate('nonzero')
 
-    @predicate_memo
+    @memoize_property
     def nonpositive(self):
         """
         Nonpositive real number predicate.
@@ -569,7 +566,7 @@ class AssumptionKeys(object):
         """
         return Predicate('nonpositive')
 
-    @predicate_memo
+    @memoize_property
     def nonnegative(self):
         """
         Nonnegative real number predicate.
@@ -602,7 +599,7 @@ class AssumptionKeys(object):
         """
         return Predicate('nonnegative')
 
-    @predicate_memo
+    @memoize_property
     def even(self):
         """
         Even number predicate.
@@ -626,7 +623,7 @@ class AssumptionKeys(object):
         """
         return Predicate('even')
 
-    @predicate_memo
+    @memoize_property
     def odd(self):
         """
         Odd number predicate.
@@ -649,7 +646,7 @@ class AssumptionKeys(object):
         """
         return Predicate('odd')
 
-    @predicate_memo
+    @memoize_property
     def prime(self):
         """
         Prime number predicate.
@@ -676,7 +673,7 @@ class AssumptionKeys(object):
         """
         return Predicate('prime')
 
-    @predicate_memo
+    @memoize_property
     def composite(self):
         """
         Composite number predicate.
@@ -700,7 +697,7 @@ class AssumptionKeys(object):
         """
         return Predicate('composite')
 
-    @predicate_memo
+    @memoize_property
     def commutative(self):
         """
         Commutative predicate.
@@ -712,7 +709,7 @@ class AssumptionKeys(object):
         # TODO: Add examples
         return Predicate('commutative')
 
-    @predicate_memo
+    @memoize_property
     def is_true(self):
         """
         Generic predicate.
@@ -731,7 +728,7 @@ class AssumptionKeys(object):
         """
         return Predicate('is_true')
 
-    @predicate_memo
+    @memoize_property
     def symmetric(self):
         """
         Symmetric matrix predicate.
@@ -764,7 +761,7 @@ class AssumptionKeys(object):
         # actual matrices and add more examples in the docstring.
         return Predicate('symmetric')
 
-    @predicate_memo
+    @memoize_property
     def invertible(self):
         """
         Invertible matrix predicate.
@@ -794,7 +791,7 @@ class AssumptionKeys(object):
         """
         return Predicate('invertible')
 
-    @predicate_memo
+    @memoize_property
     def orthogonal(self):
         """
         Orthogonal matrix predicate.
@@ -829,7 +826,7 @@ class AssumptionKeys(object):
         """
         return Predicate('orthogonal')
 
-    @predicate_memo
+    @memoize_property
     def unitary(self):
         """
         Unitary matrix predicate.
@@ -861,7 +858,7 @@ class AssumptionKeys(object):
         """
         return Predicate('unitary')
 
-    @predicate_memo
+    @memoize_property
     def positive_definite(self):
         r"""
         Positive definite matrix predicate.
@@ -893,7 +890,7 @@ class AssumptionKeys(object):
         """
         return Predicate('positive_definite')
 
-    @predicate_memo
+    @memoize_property
     def upper_triangular(self):
         """
         Upper triangular matrix predicate.
@@ -918,7 +915,7 @@ class AssumptionKeys(object):
         """
         return Predicate('upper_triangular')
 
-    @predicate_memo
+    @memoize_property
     def lower_triangular(self):
         """
         Lower triangular matrix predicate.
@@ -942,7 +939,7 @@ class AssumptionKeys(object):
         """
         return Predicate('lower_triangular')
 
-    @predicate_memo
+    @memoize_property
     def diagonal(self):
         """
         Diagonal matrix predicate.
@@ -970,7 +967,7 @@ class AssumptionKeys(object):
         """
         return Predicate('diagonal')
 
-    @predicate_memo
+    @memoize_property
     def fullrank(self):
         """
         Fullrank matrix predicate.
@@ -995,7 +992,7 @@ class AssumptionKeys(object):
         """
         return Predicate('fullrank')
 
-    @predicate_memo
+    @memoize_property
     def square(self):
         """
         Square matrix predicate.
@@ -1026,7 +1023,7 @@ class AssumptionKeys(object):
         """
         return Predicate('square')
 
-    @predicate_memo
+    @memoize_property
     def integer_elements(self):
         """
         Integer elements matrix predicate.
@@ -1045,7 +1042,7 @@ class AssumptionKeys(object):
         """
         return Predicate('integer_elements')
 
-    @predicate_memo
+    @memoize_property
     def real_elements(self):
         """
         Real elements matrix predicate.
@@ -1064,7 +1061,7 @@ class AssumptionKeys(object):
         """
         return Predicate('real_elements')
 
-    @predicate_memo
+    @memoize_property
     def complex_elements(self):
         """
         Complex elements matrix predicate.
@@ -1085,7 +1082,7 @@ class AssumptionKeys(object):
         """
         return Predicate('complex_elements')
 
-    @predicate_memo
+    @memoize_property
     def singular(self):
         """
         Singular matrix predicate.
@@ -1110,7 +1107,7 @@ class AssumptionKeys(object):
         """
         return Predicate('singular')
 
-    @predicate_memo
+    @memoize_property
     def normal(self):
         """
         Normal matrix predicate.
@@ -1133,7 +1130,7 @@ class AssumptionKeys(object):
         """
         return Predicate('normal')
 
-    @predicate_memo
+    @memoize_property
     def triangular(self):
         """
         Triangular matrix predicate.
@@ -1158,7 +1155,7 @@ class AssumptionKeys(object):
         """
         return Predicate('triangular')
 
-    @predicate_memo
+    @memoize_property
     def unit_triangular(self):
         """
         Unit triangular matrix predicate.

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -226,13 +226,19 @@ def public(obj):
     return obj
 
 
-def memoize_property(storage):
-    """Create a property, where the lookup is stored in ``storage``"""
-    def decorator(method):
-        name = method.__name__
-        def wrapper(self):
-            if name not in storage:
-                storage[name] = method(self)
-            return storage[name]
-        return property(update_wrapper(wrapper, method))
-    return decorator
+def memoize_property(propfunc):
+    """Property decorator that caches the value of potentially expensive
+    `propfunc` after the first evaluation. The cached value is stored in
+    the corresponding property name with an attached underscore."""
+    attrname = '_' + propfunc.__name__
+    sentinel = object()
+
+    @wraps(propfunc)
+    def accessor(self):
+        val = getattr(self, attrname, sentinel)
+        if val is sentinel:
+            val = propfunc(self)
+            setattr(self, attrname, val)
+        return val
+
+    return property(accessor)

--- a/sympy/utilities/tests/test_decorator.py
+++ b/sympy/utilities/tests/test_decorator.py
@@ -1,6 +1,6 @@
-from sympy.utilities.decorator import threaded, xthreaded
+from sympy.utilities.decorator import threaded, xthreaded, memoize_property
 
-from sympy import Eq, Matrix
+from sympy import Eq, Matrix, Basic
 
 from sympy.abc import x, y
 from sympy.core.decorators import wraps
@@ -50,3 +50,15 @@ def test_wraps():
     assert new_my_func.__doc__ == 'My function. '
     assert hasattr(new_my_func, 'is_my_func')
     assert new_my_func.is_my_func is True
+
+
+def test_memoize_property():
+    class TestMemoize(Basic):
+        @memoize_property
+        def prop(self):
+            return Basic()
+
+    member = TestMemoize()
+    obj1 = member.prop
+    obj2 = member.prop
+    assert obj1 is obj2


### PR DESCRIPTION
#### Brief description of what is fixed or changed
`memoize_property` decorator now does not require a storage and saves
cached values locally. This allows a one-line use of this decorator for caching
expensive properties without creating and managing a storage explicitly.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
