### PR TITLE
Make the headers in docstrings render bigger in Sphinx

### DIFF
--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -340,7 +340,7 @@ code{
 
 
 p.rubric {
-    font-size: 24px;
+    font-size: 18px;
     color: #2f441e;
     font-family: "Trebuchet MS", sans-serif;
 }

--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -337,3 +337,10 @@ code{
     border-radius: 3px;
     padding: 2px;
 }
+
+
+p.rubric {
+    font-size: 24px;
+    color: #2f441e;
+    font-family: "Trebuchet MS", sans-serif;
+}


### PR DESCRIPTION
Fixes #17599

I did not figure out how to add anchors to the headers. I think that would
require writing a little Sphinx extension, or doing it in Javascript. If someone knows how to do it let me know. 

@sympy/gsod 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

## Before

![before](https://user-images.githubusercontent.com/71486/65786892-e93a0500-e114-11e9-956f-9f71420f43c3.png)

## After

![after](https://user-images.githubusercontent.com/71486/65919180-c881e180-e398-11e9-92d0-66d58743aedb.png)

I might try using a different font for the headers. Right now it's the same font as the section headers. If anyone has any suggestions let me know.  I don't want to use webfonts. 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * The headers in docstrings for "Examples", "See Also", "References" and so on are now rendered larger in the HTML documentation. 
<!-- END RELEASE NOTES -->
