### PR TITLE
Add is_symmetric for permutation groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1873,6 +1873,58 @@ class PermutationGroup(Basic):
         """
         return self.is_abelian and all(g.order() == p for g in self.generators)
 
+    def _eval_is_alt_sym_naive(self, only_sym=False, only_alt=False):
+        """A naive test using the group order."""
+        if only_sym and only_alt:
+            raise ValueError(
+                "Both {} and {} cannot be set to True"
+                .format(only_sym, only_alt))
+
+        n = self.degree
+        sym_order = 1
+        for i in range(2, n+1):
+            sym_order *= i
+        order = self.order()
+
+        if order == sym_order:
+            self._is_sym = True
+            self._is_alt = False
+            if only_sym:
+                return self._is_sym
+            elif only_alt:
+                return self._is_alt
+            return True
+
+        elif 2*order == sym_order:
+            self._is_sym = False
+            self._is_alt = True
+            if only_sym:
+                return self._is_sym
+            elif only_alt:
+                return self._is_alt
+            return True
+
+        return False
+
+    def _eval_is_alt_sym_monte_carlo(self, eps=0.05, perms=None):
+        """A test using monte-carlo algorithm."""
+        if perms is None:
+            n = self.degree
+            if n < 17:
+                c_n = 0.34
+            else:
+                c_n = 0.57
+            d_n = (c_n*log(2))/log(n)
+            N_eps = int(-log(eps)/d_n)
+
+            perms = (self.random_pr() for i in range(N_eps))
+            return self._eval_is_alt_sym_monte_carlo(perms=perms)
+
+        for perm in perms:
+            if _check_cycles_alt_sym(perm):
+                return True
+        return False
+
     def is_alt_sym(self, eps=0.05, _random_prec=None):
         r"""Monte Carlo test for the symmetric/alternating group for degrees
         >= 8.
@@ -1913,41 +1965,24 @@ class PermutationGroup(Basic):
         _check_cycles_alt_sym
 
         """
-        if _random_prec is None:
-            if self._is_sym or self._is_alt:
-                return True
-            n = self.degree
-            if n < 8:
-                sym_order = 1
-                for i in range(2, n+1):
-                    sym_order *= i
-                order = self.order()
-                if order == sym_order:
-                    self._is_sym = True
-                    return True
-                elif 2*order == sym_order:
-                    self._is_alt = True
-                    return True
-                return False
-            if not self.is_transitive():
-                return False
-            if n < 17:
-                c_n = 0.34
-            else:
-                c_n = 0.57
-            d_n = (c_n*log(2))/log(n)
-            N_eps = int(-log(eps)/d_n)
-            for i in range(N_eps):
-                perm = self.random_pr()
-                if _check_cycles_alt_sym(perm):
-                    return True
+        if _random_prec is not None:
+            N_eps = _random_prec['N_eps']
+            perms= (_random_prec[i] for i in range(N_eps))
+            return self._eval_is_alt_sym_monte_carlo(perms=perms)
+
+        if self._is_sym or self._is_alt:
+            return True
+        if self._is_sym is False and self._is_alt is False:
             return False
-        else:
-            for i in range(_random_prec['N_eps']):
-                perm = _random_prec[i]
-                if _check_cycles_alt_sym(perm):
-                    return True
-            return False
+
+        n = self.degree
+        if n < 8:
+            return self._eval_is_alt_sym_naive()
+        elif self.is_transitive():
+            return self._eval_is_alt_sym_monte_carlo(eps=eps)
+
+        self._is_sym, self._is_alt = False, False
+        return False
 
     @property
     def is_nilpotent(self):
@@ -2860,10 +2895,24 @@ class PermutationGroup(Basic):
             return _is_sym
 
         n = self.degree
-        order = self.order()
-        is_sym = factorial(n) == order
-        self._is_sym = is_sym
-        return is_sym
+        if n >= 8:
+            if self.is_transitive():
+                _is_alt_sym = self._eval_is_alt_sym_monte_carlo()
+                if _is_alt_sym:
+                    if any(g.is_odd for g in self.generators):
+                        self._is_sym, self._is_alt = True, False
+                        return True
+
+                    self._is_sym, self._is_alt = False, True
+                    return False
+
+                return self._eval_is_alt_sym_naive(only_sym=True)
+
+            self._is_sym, self._is_alt = False, False
+            return False
+
+        return self._eval_is_alt_sym_naive(only_sym=True)
+
 
     @property
     def is_alternating(self):
@@ -2905,10 +2954,23 @@ class PermutationGroup(Basic):
             return _is_alt
 
         n = self.degree
-        order = self.order()
-        _is_alt = factorial(n)/2 == order
-        self._is_alt = _is_alt
-        return _is_alt
+        if n >= 8:
+            if self.is_transitive():
+                _is_alt_sym = self._eval_is_alt_sym_monte_carlo()
+                if _is_alt_sym:
+                    if all(g.is_even for g in self.generators):
+                        self._is_sym, self._is_alt = False, True
+                        return True
+
+                    self._is_sym, self._is_alt = True, False
+                    return False
+
+                return self._eval_is_alt_sym_naive(only_alt=True)
+
+            self._is_sym, self._is_alt = False, False
+            return False
+
+        return self._eval_is_alt_sym_naive(only_alt=True)
 
     @property
     def is_cyclic(self):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1903,7 +1903,26 @@ class PermutationGroup(Basic):
         return False
 
     def _eval_is_alt_sym_monte_carlo(self, eps=0.05, perms=None):
-        """A test using monte-carlo algorithm."""
+        """A test using monte-carlo algorithm.
+
+        Parameters
+        ==========
+
+        eps : float, optional
+            The criterion for the incorrect ``False`` return.
+
+        perms : list[Permutation], optional
+            If explicitly given, it tests over the given candidats
+            for testing.
+
+            If ``None``, it randomly computes ``N_eps`` and chooses
+            ``N_eps`` sample of the permutation from the group.
+
+        See Also
+        ========
+
+        _check_cycles_alt_sym
+        """
         if perms is None:
             n = self.degree
             if n < 17:

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2821,6 +2821,42 @@ class PermutationGroup(Basic):
             return self.order()//H.order()
 
     @property
+    def is_symmetric(self):
+        """Return ``True`` if the group is symmetric.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.named_groups import SymmetricGroup
+        >>> g = SymmetricGroup(5)
+        >>> g.is_symmetric
+        True
+
+        >>> from sympy.combinatorics import Permutation, PermutationGroup
+        >>> g = PermutationGroup(
+        ...     Permutation(0, 1, 2, 3, 4),
+        ...     Permutation(2, 3))
+        >>> g.is_symmetric
+        True
+
+        Notes
+        =====
+
+        Symmetric groups have an order of `n!` for permutation groups
+        where `n` is the cardinality of the set every permutation is
+        based on.
+        """
+        _is_sym = self._is_sym
+        if _is_sym is not None:
+            return _is_sym
+
+        size = self.generators[0].size
+        order = self.order()
+        is_sym = factorial(size) == order
+        self._is_sym = is_sym
+        return is_sym
+
+    @property
     def is_cyclic(self):
         """
         Return ``True`` if the group is Cyclic.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1889,19 +1889,15 @@ class PermutationGroup(Basic):
         if order == sym_order:
             self._is_sym = True
             self._is_alt = False
-            if only_sym:
-                return self._is_sym
-            elif only_alt:
-                return self._is_alt
+            if only_alt:
+                return False
             return True
 
         elif 2*order == sym_order:
             self._is_sym = False
             self._is_alt = True
             if only_sym:
-                return self._is_sym
-            elif only_alt:
-                return self._is_alt
+                return False
             return True
 
         return False

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2850,9 +2850,9 @@ class PermutationGroup(Basic):
         if _is_sym is not None:
             return _is_sym
 
-        size = self.generators[0].size
+        n = self.degree
         order = self.order()
-        is_sym = factorial(size) == order
+        is_sym = factorial(n) == order
         self._is_sym = is_sym
         return is_sym
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2842,9 +2842,18 @@ class PermutationGroup(Basic):
         Notes
         =====
 
-        Symmetric groups have an order of `n!` for permutation groups
-        where `n` is the cardinality of the set every permutation is
-        based on.
+        This uses a naive test involving the computation of the full
+        group order.
+        If you need more quicker taxonomy for large groups, you can use
+        :meth:`PermutationGroup.is_alt_sym`.
+        However, :meth:`PermutationGroup.is_alt_sym` may not be accurate
+        and is not able to distinguish between an alternating group and
+        a symmetric group.
+
+        See Also
+        ========
+
+        is_alt_sym
         """
         _is_sym = self._is_sym
         if _is_sym is not None:
@@ -2855,6 +2864,51 @@ class PermutationGroup(Basic):
         is_sym = factorial(n) == order
         self._is_sym = is_sym
         return is_sym
+
+    @property
+    def is_alternating(self):
+        """Return ``True`` if the group is alternating.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.named_groups import AlternatingGroup
+        >>> g = AlternatingGroup(5)
+        >>> g.is_alternating
+        True
+
+        >>> from sympy.combinatorics import Permutation, PermutationGroup
+        >>> g = PermutationGroup(
+        ...     Permutation(0, 1, 2, 3, 4),
+        ...     Permutation(2, 3, 4))
+        >>> g.is_alternating
+        True
+
+        Notes
+        =====
+
+        This uses a naive test involving the computation of the full
+        group order.
+        If you need more quicker taxonomy for large groups, you can use
+        :meth:`PermutationGroup.is_alt_sym`.
+        However, :meth:`PermutationGroup.is_alt_sym` may not be accurate
+        and is not able to distinguish between an alternating group and
+        a symmetric group.
+
+        See Also
+        ========
+
+        is_alt_sym
+        """
+        _is_alt = self._is_alt
+        if _is_alt is not None:
+            return _is_alt
+
+        n = self.degree
+        order = self.order()
+        _is_alt = factorial(n)/2 == order
+        self._is_alt = _is_alt
+        return _is_alt
 
     @property
     def is_cyclic(self):

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -465,6 +465,11 @@ def test_is_alt_sym():
         9: Permutation([[4, 9, 6], [3, 8], [1, 2], [0, 5, 7]])}
     assert A.is_alt_sym(_random_prec=_random_prec) is False
 
+    G = PermutationGroup(
+        Permutation(1, 3, size=8)(0, 2, 4, 6),
+        Permutation(5, 7, size=8)(0, 2, 4, 6))
+    assert G.is_alt_sym() is False
+
 
 def test_minimal_block():
     D = DihedralGroup(6)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -437,7 +437,15 @@ def test_random_pr():
 def test_is_alt_sym():
     G = DihedralGroup(10)
     assert G.is_alt_sym() is False
+    assert G._eval_is_alt_sym_naive() is False
+    assert G._eval_is_alt_sym_naive(only_alt=True) is False
+    assert G._eval_is_alt_sym_naive(only_sym=True) is False
+
     S = SymmetricGroup(10)
+    assert S._eval_is_alt_sym_naive() is True
+    assert S._eval_is_alt_sym_naive(only_alt=True) is False
+    assert S._eval_is_alt_sym_naive(only_sym=True) is True
+
     N_eps = 10
     _random_prec = {'N_eps': N_eps,
         0: Permutation([[2], [1, 4], [0, 6, 7, 8, 9, 3, 5]]),
@@ -451,7 +459,12 @@ def test_is_alt_sym():
         8: Permutation([[1, 5, 6, 3], [0, 2, 7, 8, 4, 9]]),
         9: Permutation([[8], [6, 7], [2, 3, 4, 5], [0, 1, 9]])}
     assert S.is_alt_sym(_random_prec=_random_prec) is True
+
     A = AlternatingGroup(10)
+    assert A._eval_is_alt_sym_naive() is True
+    assert A._eval_is_alt_sym_naive(only_alt=True) is True
+    assert A._eval_is_alt_sym_naive(only_sym=True) is False
+
     _random_prec = {'N_eps': N_eps,
         0: Permutation([[1, 6, 4, 2, 7, 8, 5, 9, 3], [0]]),
         1: Permutation([[1], [0, 5, 8, 4, 9, 2, 3, 6, 7]]),

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -483,6 +483,13 @@ def test_is_alt_sym():
         Permutation(5, 7, size=8)(0, 2, 4, 6))
     assert G.is_alt_sym() is False
 
+    # Tests for monte-carlo c_n parameter setting, and which guarantees
+    # to give False.
+    G = DihedralGroup(10)
+    assert G._eval_is_alt_sym_monte_carlo() is False
+    G = DihedralGroup(20)
+    assert G._eval_is_alt_sym_monte_carlo() is False
+
 
 def test_minimal_block():
     D = DihedralGroup(6)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -492,7 +492,7 @@ def test_is_alt_sym():
 
     # A dry-running test to check if it looks up for the updated cache.
     G = DihedralGroup(6)
-    assert G.is_alt_sym()
+    G.is_alt_sym()
     assert G.is_alt_sym() == False
 
 

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -490,6 +490,11 @@ def test_is_alt_sym():
     G = DihedralGroup(20)
     assert G._eval_is_alt_sym_monte_carlo() is False
 
+    # A dry-running test to check if it looks up for the updated cache.
+    G = DihedralGroup(6)
+    assert G.is_alt_sym()
+    assert G.is_alt_sym() == False
+
 
 def test_minimal_block():
     D = DihedralGroup(6)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1013,3 +1013,17 @@ def test_composition_series():
     assert is_isomorphic(series[1], CyclicGroup(4))
     assert is_isomorphic(series[2], CyclicGroup(2))
     assert series[3].is_trivial
+
+
+def test_is_symmetric():
+    a = Permutation(0, 1, 2)
+    b = Permutation(0, 1, size=3)
+    assert PermutationGroup(a, b).is_symmetric == True
+
+    a = Permutation(0, 2, 1)
+    b = Permutation(1, 2, size=3)
+    assert PermutationGroup(a, b).is_symmetric == True
+
+    a = Permutation(0, 1, 2, 3)
+    b = Permutation(0, 3)(1, 2)
+    assert PermutationGroup(a, b).is_symmetric == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that `is_symmetric` predicate is missing even if `_is_sym` cache is used in permutation groups.
I've used a naive test that the symmetric group is the largest permutation group that can be created from a base set of cardinality `n`, and have an order of `n!`.

#### Other comments

I think that permutation group is using custom cache for assumptions. But if there is a way to directly manipulate the global LRU cache or assumptions0 cache if some predicates are revealed during the computation, it may have to use those.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Added a new predicate `is_symmetric` to test out if a permutation group is a symmetric group.
  - Added a new predicate `is_alternating` to test out if a permutation group is a alternating group.
<!-- END RELEASE NOTES -->
