### PR TITLE
Fix error for is_primitive() for non transitive group

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2077,6 +2077,10 @@ class PermutationGroup(Basic):
         """
         if self._is_primitive is not None:
             return self._is_primitive
+
+        if self.is_transitive() is False:
+            return False
+
         if randomized:
             random_stab_gens = []
             v = self.schreier_vector(0)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -504,6 +504,11 @@ def test_is_primitive():
     C = CyclicGroup(7)
     assert C.is_primitive() is True
 
+    a = Permutation(0, 1, 2, size=6)
+    b = Permutation(3, 4, 5, size=6)
+    G = PermutationGroup(a, b)
+    assert G.is_primitive() is False
+
 
 def test_random_stab():
     S = SymmetricGroup(5)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There is an error like below
```python3
from sympy import *
from sympy.combinatorics import *

a = Permutation(0, 1, 2, size=6)
b = Permutation(3, 4, 5, size=6)
G = PermutationGroup(a, b)
G.is_primitive()
```
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-f8050e054cf4> in <module>
      6 b = Permutation(3, 4, 5, size=6)
      7 G = PermutationGroup(a, b)
----> 8 G.is_primitive()

~\Documents\Github\sympy\sympy\combinatorics\perm_groups.py in is_primitive(self, randomized)
   2089         for orb in orbits:
   2090             x = orb.pop()
-> 2091             if x != 0 and any(e != 0 for e in self.minimal_block([0, x])):
   2092                 self._is_primitive = False
   2093                 return False

TypeError: 'bool' object is not iterable
```
I've discovered an issue with it because `minimal_block` can give `False` instead of an array, if the group is not transitive.
And only transitive group can be primitive group by the definition.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Fixed `PermutationGroup.is_primitive()` giving an error for a group that is not transitive, instead of giving `False`.
<!-- END RELEASE NOTES -->
