### PR TITLE
Fix get_integer_part for the case that `expr` is 0

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -324,7 +324,10 @@ def get_integer_part(expr, no, options, return_ints=False):
         gap = fastlog(iim) - iim_acc
     else:
         # ... or maybe the expression was exactly zero
-        return None, None, None, None
+        if return_ints:
+            return 0, 0
+        else:
+            return None, None, None, None
 
     margin = 10
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -494,6 +494,16 @@ def test_issue_8853():
     assert get_integer_part(Rational(-1, 2), 1, {}, True) == (0, 0)
 
 
+def test_issue_17681():
+    class identity_func(Function):
+
+        def _eval_evalf(self, *args, **kwargs):
+            return self.args[0].evalf(*args, **kwargs)
+
+    assert floor(identity_func(S(0))) == 0
+    assert get_integer_part(S(0), 1, {}, True) == (0, 0)
+
+
 def test_issue_9326():
     from sympy import Dummy
     d1 = Dummy('d')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fix issue #17681 


#### Brief description of what is fixed or changed

When trying to evaluate an expression that was implicitly 0 I got an error message that get_integer_part did return four return values instead of two.

The reason is that the early return of `get_integer_part` was ignoring the function parameter `return_ints`
```
        # ... or maybe the expression was exactly zero
            return None, None, None, None
```
A fix would be

```
        # ... or maybe the expression was exactly zero
        if return_ints:
            return 0, 0
        else:
            return None, None, None, None
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fix `get_integer_part` for the case `expr=S(0)`, `return_ints=True` (should return `0,0` instead of `None, None, None, None`)
<!-- END RELEASE NOTES -->
