### PR TITLE
Modify digamma and trigamma definitions in documentation

### DIFF
--- a/doc/src/modules/functions/special.rst
+++ b/doc/src/modules/functions/special.rst
@@ -28,8 +28,8 @@ Gamma, Beta and related Functions
    :members:
 .. autoclass:: sympy.functions.special.gamma_functions.polygamma
    :members:
-.. autofunction:: sympy.functions.special.gamma_functions.digamma
-.. autofunction:: sympy.functions.special.gamma_functions.trigamma
+.. autoclass:: sympy.functions.special.gamma_functions.digamma
+.. autoclass:: sympy.functions.special.gamma_functions.trigamma
 .. autoclass:: sympy.functions.special.gamma_functions.uppergamma
    :members:
 .. autoclass:: sympy.functions.special.gamma_functions.lowergamma


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses #17610 

#### Brief description of what is fixed or changed
`digamma` and `trigamma`, which were Python functions before, are now listed as classes in the documentation.

#### Other comments
The two functions became classes after #17615 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
