### PR TITLE
Fix test collection of skipped tests on pytest

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -198,16 +198,8 @@ if not USE_PYTEST:
 
 else:
     XFAIL = py.test.mark.xfail
+    SKIP = py.test.mark.skip
     slow = py.test.mark.slow
-
-    def SKIP(reason):
-        def skipping(func):
-            @functools.wraps(func)
-            def inner(*args, **kwargs):
-                skip(reason)
-            return inner
-
-        return skipping
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Changes the SKIP decorator to be the standard one from pytest when the tests are run under pytest. This fixes a problem during test collection under pytest-xdist that prevents running the tests in parallel. The problem manifests as:
```console
$ pytest -m 'not slow' -n4
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.5.7, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/enojb/current/sympy/sympy/.hypothesis/examples')
rootdir: /Users/enojb/current/sympy/sympy, inifile: pytest.ini
plugins: xdist-1.27.0, instafail-0.4.1, forked-1.0.2, doctestplus-0.3.0, cov-2.7.1, hypothesis-4.32.3
gw0 [9140] / gw1 [9140] / gw2 [9140] / gw3 [9140]
collecting 0 items / 1 errors                                                                                                                                
=========================================================================== ERRORS ===========================================================================
____________________________________________________________________ ERROR collecting gw2 ____________________________________________________________________
Different tests were collected between gw0 and gw2. The difference is:
--- gw0

+++ gw2

@@ -6722,8 +6722,8 @@

 sympy/printing/tests/test_theanocode.py::test_Relationals
 sympy/printing/tests/test_theanocode.py::test_complexfunctions
 sympy/printing/tests/test_theanocode.py::test_constantfunctions
+sympy/printing/tests/test_theanocode.py::test_MatrixSymbol_wrong_dims
 sympy/printing/tests/test_theanocode.py::test_BlockMatrix_Inverse_execution
-sympy/printing/tests/test_theanocode.py::test_MatrixSymbol_wrong_dims
 sympy/printing/tests/test_tree.py::test_print_tree_MatAdd
 sympy/printing/tests/test_tree.py::test_print_tree_MatAdd_noassumptions
 sympy/sandbox/tests/test_indexed_integrals.py::test_indexed_integrals
```

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
