### PR TITLE
Proof of Concept: Add UnitQuaternion class

### DIFF
--- a/sympy/algebras/__init__.py
+++ b/sympy/algebras/__init__.py
@@ -1,3 +1,3 @@
-from .quaternion import Quaternion
+from .quaternion import Quaternion, UnitQuaternion
 
-__all__ = ["Quaternion",]
+__all__ = ["Quaternion", "UnitQuaternion"]

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -57,6 +57,8 @@ class Quaternion(Expr):
             obj._c = c
             obj._d = d
             obj._real_field = real_field
+            if obj.norm().simplify() == 1:
+                obj.__class__ = UnitQuaternion
             return obj
 
     @property
@@ -296,7 +298,7 @@ class Quaternion(Expr):
     def normalize(self):
         """Returns the normalized form of the quaternion."""
         q = self
-        return UnitQuaternion(*(q * (1/q.norm())).args)
+        return q * (1/q.norm())
 
     def inverse(self):
         """Returns the inverse of the quaternion."""
@@ -448,20 +450,11 @@ class UnitQuaternion(Quaternion):
     """
     """
 
-    def __new__(cls, a=0, b=1, c=0, d=0):
-        quat = Quaternion.__new__(cls, a, b, c, d)
-        if quat.norm().simplify() != 1:
-            raise ValueError("invalid arguments for unit norm")
-        return quat
+    def __new__(cls, *args, **kwargs):
+        raise TypeError("TODO: meaningful error message")
 
-    def __eq__(self, other):
-        if isinstance(other, UnitQuaternion):
-            return Quaternion.__eq__(self, other)
-        else:
-            return Quaternion.__eq__(Quaternion(*self.args), other)
-
-    @classmethod
-    def from_axis_angle(cls, vector, angle):
+    @staticmethod
+    def from_axis_angle(vector, angle):
         """Returns a rotation quaternion given the axis and the angle of rotation.
 
         Parameters
@@ -496,10 +489,10 @@ class UnitQuaternion(Quaternion):
         b = x * s
         c = y * s
         d = z * s
-        return cls(a, b, c, d)
+        return Quaternion(a, b, c, d)
 
-    @classmethod
-    def from_rotation_matrix(cls, M):
+    @staticmethod
+    def from_rotation_matrix(M):
         """Returns the equivalent quaternion of a rotation matrix.
 
         The matrix has to be special orthogonal (orthogonal and det(M) = 1).
@@ -543,7 +536,7 @@ class UnitQuaternion(Quaternion):
         except Exception:
             pass
 
-        return cls(a, b, c, d)
+        return Quaternion(a, b, c, d)
 
     @staticmethod
     def __copysign(x, y):
@@ -554,18 +547,6 @@ class UnitQuaternion(Quaternion):
         if y == 0:
             return 0
         return x if x*y > 0 else -x
-
-    def __mul__(self, other):
-        q = Quaternion.__mul__(self, other)
-        if isinstance(other, UnitQuaternion):
-            q = UnitQuaternion(*q.args)
-        return q
-
-    def __pow__(self, p):
-        return UnitQuaternion(*Quaternion.__pow__(self, p).args)
-
-    def inverse(self):
-        return UnitQuaternion(*Quaternion.inverse(self).args)
 
     def rotate_point(self, pin):
         """Returns the coordinates of the point pin(a 3 tuple) after rotation.

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,7 +1,7 @@
 from sympy import symbols, re, im, I, Abs, Symbol, \
      cos, sin, sqrt, conjugate, log, acos, E, pi, \
      Matrix, diff, integrate, trigsimp, S, Rational
-from sympy.algebras.quaternion import Quaternion
+from sympy.algebras.quaternion import Quaternion, UnitQuaternion
 from sympy.utilities.pytest import raises
 
 x, y, z, w = symbols("x y z w")
@@ -10,13 +10,13 @@ def test_quaternion_construction():
     q = Quaternion(x, y, z, w)
     assert q + q == Quaternion(2*x, 2*y, 2*z, 2*w)
 
-    q2 = Quaternion.from_axis_angle((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3),
+    q2 = UnitQuaternion.from_axis_angle((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3),
                                     pi*Rational(2, 3))
     assert q2 == Quaternion(S.Half, S.Half,
                             S.Half, S.Half)
 
     M = Matrix([[cos(x), -sin(x), 0], [sin(x), cos(x), 0], [0, 0, 1]])
-    q3 = trigsimp(Quaternion.from_rotation_matrix(M))
+    q3 = trigsimp(UnitQuaternion.from_rotation_matrix(M))
     assert q3 == Quaternion(sqrt(2)*sqrt(cos(x) + 1)/2, 0, 0, sqrt(-2*cos(x) + 2)/2)
 
     nc = Symbol('nc', commutative=False)
@@ -96,7 +96,7 @@ def test_quaternion_functions():
     assert integrate(Quaternion(x, x, x, x), x) == \
     Quaternion(x**2 / 2, x**2 / 2, x**2 / 2, x**2 / 2)
 
-    assert Quaternion.rotate_point((1, 1, 1), q1) == (S.One / 5, 1, S(7) / 5)
+    assert q1.normalize().rotate_point((1, 1, 1)) == (S.One / 5, 1, S(7) / 5)
     n = Symbol('n')
     raises(TypeError, lambda: q1**n)
     n = Symbol('n', integer=True)
@@ -106,22 +106,22 @@ def test_quaternion_functions():
 def test_quaternion_conversions():
     q1 = Quaternion(1, 2, 3, 4)
 
-    assert q1.to_axis_angle() == ((2 * sqrt(29)/29,
+    assert q1.normalize().to_axis_angle() == ((2 * sqrt(29)/29,
                                    3 * sqrt(29)/29,
                                    4 * sqrt(29)/29),
                                    2 * acos(sqrt(30)/30))
 
-    assert q1.to_rotation_matrix() == Matrix([[Rational(-2, 3), Rational(2, 15), Rational(11, 15)],
+    assert q1.normalize().to_rotation_matrix() == Matrix([[Rational(-2, 3), Rational(2, 15), Rational(11, 15)],
                                               [Rational(2, 3), Rational(-1, 3), Rational(2, 3)],
                                               [Rational(1, 3), Rational(14, 15), Rational(2, 15)]])
 
-    assert q1.to_rotation_matrix((1, 1, 1)) == Matrix([[Rational(-2, 3), Rational(2, 15), Rational(11, 15), Rational(4, 5)],
+    assert q1.normalize().to_rotation_matrix((1, 1, 1)) == Matrix([[Rational(-2, 3), Rational(2, 15), Rational(11, 15), Rational(4, 5)],
                                                        [Rational(2, 3), Rational(-1, 3), Rational(2, 3), S.Zero],
                                                        [Rational(1, 3), Rational(14, 15), Rational(2, 15), Rational(-2, 5)],
                                                        [S.Zero, S.Zero, S.Zero, S.One]])
 
     theta = symbols("theta", real=True)
-    q2 = Quaternion(cos(theta/2), 0, 0, sin(theta/2))
+    q2 = UnitQuaternion(cos(theta/2), 0, 0, sin(theta/2))
 
     assert trigsimp(q2.to_rotation_matrix()) == Matrix([
                                                [cos(theta), -sin(theta), 0],
@@ -147,7 +147,7 @@ def test_quaternion_rotation_iss1593():
     https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Quaternion-derived_rotation_matrix
     for the correct definition
     """
-    q = Quaternion(cos(x/2), sin(x/2), 0, 0)
+    q = UnitQuaternion(cos(x/2), sin(x/2), 0, 0)
     assert(trigsimp(q.to_rotation_matrix()) == Matrix([
                 [1,      0,      0],
                 [0, cos(x), -sin(x)],

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -757,6 +757,11 @@ def test_sympy__algebras__quaternion__Quaternion():
     assert _test_args(Quaternion(x, 1, 2, 3))
 
 
+def test_sympy__algebras__quaternion__UnitQuaternion():
+    from sympy.algebras.quaternion import UnitQuaternion
+    assert _test_args(UnitQuaternion(S.Half, S.Half, S.Half, S.Half))
+
+
 def test_sympy__core__relational__Equality():
     from sympy.core.relational import Equality
     assert _test_args(Equality(x, 2))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Previously, the `Quaternion` class had methods like `from_axis_angle()` and `from_rotation_matrix()`, which are supposed to create a unit quaternion.
That's OK, because a unit quaternion *is a* quaternion, but then there were also the methods `to_axis_angle()`, `to_rotation_matrix()` and `rotate_point()`, which really only make sense for unit quaternions.

In this PR I'm adding a separate `UnitQuaternion` class for those cases.

#### Other comments

I'm not sure if that makes sense from a mathematical standpoint, please tell me if it doesn't.
I've gotten the idea for a separate class from https://www.nalgebra.org/rustdoc/nalgebra/geometry/type.UnitQuaternion.html, but I'm not sure if it makes sense within SymPy.

For now, I've just moved some methods from `Quaternion` to `UnitQuaternion`, which is a breaking change.

I would like to get some feedback first, but if this turns out to be considered for merging, we'd have to add some compatibility stubs and probably some deprecation warnings.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added a UnitQuaternion class 
<!-- END RELEASE NOTES -->
