### PR TITLE
Use S.Zero for refine.

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -256,7 +256,7 @@ def refine_re(expr, assumptions):
     if ask(Q.real(arg), assumptions):
         return arg
     if ask(Q.imaginary(arg), assumptions):
-        return 0
+        return S.Zero
     return _refine_reim(expr, assumptions)
 
 
@@ -274,7 +274,7 @@ def refine_im(expr, assumptions):
     """
     arg = expr.args[0]
     if ask(Q.real(arg), assumptions):
-        return 0
+        return S.Zero
     if ask(Q.imaginary(arg), assumptions):
         return - S.ImaginaryUnit * arg
     return _refine_reim(expr, assumptions)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -140,7 +140,7 @@ def test_atan2():
 
 def test_re():
     assert refine(re(x), Q.real(x)) == x
-    assert refine(re(x), Q.imaginary(x)) == 0
+    assert refine(re(x), Q.imaginary(x)) is S.Zero
     assert refine(re(x+y), Q.real(x) & Q.real(y)) == x + y
     assert refine(re(x+y), Q.real(x) & Q.imaginary(y)) == x
     assert refine(re(x*y), Q.real(x) & Q.real(y)) == x * y
@@ -150,7 +150,7 @@ def test_re():
 
 def test_im():
     assert refine(im(x), Q.imaginary(x)) == -I*x
-    assert refine(im(x), Q.real(x)) == 0
+    assert refine(im(x), Q.real(x)) is S.Zero
     assert refine(im(x+y), Q.imaginary(x) & Q.imaginary(y)) == -I*x - I*y
     assert refine(im(x+y), Q.real(x) & Q.imaginary(y)) == -I*y
     assert refine(im(x*y), Q.imaginary(x) & Q.real(y)) == -I*x*y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I had found some other mistakes for refining `re` and `im` because of the type issues, while reviewing #17696 
`refine` does not sanitizes the output types, so it can be a gotcha that some authors can make.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- assumptions
  - Fixed `refine(re(x), Q.imaginary(x))` giving python zero instead of sympy zero.
  - Fixed `refine(im(x), Q.real(x))` giving python zero instead of sympy zero.
<!-- END RELEASE NOTES -->
