### PR TITLE
Diagonal Difference for Square Matrices

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1773,6 +1773,8 @@ class MatrixOperations(MatrixRequired):
         ========
         trace: the sum of the diagonal elements.
         """
+        if self.rows != self.cols:
+            raise NonSquareMatrixError()
 
     def doit(self, **kwargs):
         return self.applyfunc(lambda x: x.doit())

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1757,6 +1757,11 @@ class MatrixOperations(MatrixRequired):
         """
         return self._eval_conjugate()
 
+    def diagonal_difference(self):
+        """Returns the diagonal difference, or absolute difference
+        between the sum of diagonals of square matrix. 
+        """
+
     def doit(self, **kwargs):
         return self.applyfunc(lambda x: x.doit())
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1661,6 +1661,9 @@ class MatrixOperations(MatrixRequired):
     def _eval_adjoint(self):
         return self.transpose().conjugate()
 
+    def _eval_antidiagonal_sum(self):
+        return sum(self[i, self.rows-i-1] for i in range(self.rows))
+
     def _eval_applyfunc(self, f):
         out = self._new(self.rows, self.cols, [f(x) for x in self])
         return out
@@ -1775,6 +1778,7 @@ class MatrixOperations(MatrixRequired):
         """
         if self.rows != self.cols:
             raise NonSquareMatrixError()
+
 
     def doit(self, **kwargs):
         return self.applyfunc(lambda x: x.doit())

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1759,7 +1759,19 @@ class MatrixOperations(MatrixRequired):
 
     def diagonal_difference(self):
         """Returns the diagonal difference, or absolute difference
-        between the sum of diagonals of square matrix. 
+        between the sum of diagonals of square matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import Matrix
+        >>> a = Matrix([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        >>> a.diagonal_difference()
+        2
+
+        See Also
+        ========
+        trace: the sum of the diagonal elements.
         """
 
     def doit(self, **kwargs):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1768,7 +1768,7 @@ class MatrixOperations(MatrixRequired):
         ========
 
         >>> from sympy.matrices import Matrix
-        >>> a = Matrix([1, 2, 3], [4, 5, 6], [7, 8, 9])
+        >>> a = Matrix(2, 2, [1, 0, 0, 1])
         >>> a.diagonal_difference()
         2
 
@@ -1778,7 +1778,10 @@ class MatrixOperations(MatrixRequired):
         """
         if self.rows != self.cols:
             raise NonSquareMatrixError()
-
+        trace = self._eval_trace()
+        antidiag_sum = self._eval_antidiagonal_sum()
+        diag_diff = Abs(trace - antidiag_sum)
+        return diag_diff
 
     def doit(self, **kwargs):
         return self.applyfunc(lambda x: x.doit())

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1260,7 +1260,7 @@ def test_diagonal():
 def test_diagonal_difference():
     m = Matrix(3, 3, range(9))
     diag_diff = m.diagonal_difference()
-    assert m == 2
+    assert diag_diff == 2
 
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1257,6 +1257,10 @@ def test_diagonal():
     assert banded({i: list(M.diagonal(i))
         for i in range(1-M.rows, M.cols)}) == M
 
+def test_diagonal_difference():
+    m = Matrix(3, 3, range(9))
+    diag_diff = m.diagonal_difference()
+    assert m == 2
 
 def test_jordan_block():
     assert SpecialOnlyMatrix.jordan_block(3, 2) == SpecialOnlyMatrix.jordan_block(3, eigenvalue=2) \


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Introduces a diagonal difference for square matrix (absolute difference between the sums of its diagonals).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
- matrices
    - Introduces diagonal_difference method to sympy.matrices.common
<!-- END RELEASE NOTES -->