### PR TITLE
Core: test_var is using `exec` instead of calling `var` directly

### DIFF
--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -1,4 +1,3 @@
-# Tests for var are in their own file, because var pollutes global namespace.
 from sympy import Symbol, var, Function, FunctionClass
 from sympy.utilities.pytest import raises
 
@@ -25,12 +24,12 @@ assert v == [d, e, fg]
 # make z1 with call-depth = 1
 
 def _make_z1():
-    z1 = var("z1")
+    var("z1")
 
 # make z2 with call-depth = 2
 
 def __make_z2():
-    z2 = var("z2")
+    var("z2")
 
 def _make_z2():
     __make_z2()

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -1,83 +1,91 @@
 # Tests for var are in their own file, because var pollutes global namespace.
-
+import textwrap
 from sympy import Symbol, var, Function, FunctionClass
 from sympy.utilities.pytest import raises
 
 # make z1 with call-depth = 1
 
 
-def _make_z1():
-    var("z1")
 
 # make z2 with call-depth = 2
 
 
-def __make_z2():
-    var("z2")
+def test_var():
+    exec(textwrap.dedent("""
+var("a")
+assert a == Symbol("a")
 
+var("b bb cc zz _x")
+assert b == Symbol("b")
+assert bb == Symbol("bb")
+assert cc == Symbol("cc")
+assert zz == Symbol("zz")
+assert _x == Symbol("_x")
+
+v = var(['d', 'e', 'fg'])
+assert d == Symbol('d')
+assert e == Symbol('e')
+assert fg == Symbol('fg')
+
+# check return value
+assert v == [d, e, fg]
+
+def _make_z1():
+    z1 = var("z1")
+
+def __make_z2():
+    z2 = var("z2")
 
 def _make_z2():
-    __make_z2()
+    __make_z2()        
 
+# see if var() really injects into global namespace
+raises(NameError, lambda: z1)
+_make_z1()
+assert z1 == Symbol("z1")
 
-def test_var():
-    var("a")
-    assert a == Symbol("a")
-
-    var("b bb cc zz _x")
-    assert b == Symbol("b")
-    assert bb == Symbol("bb")
-    assert cc == Symbol("cc")
-    assert zz == Symbol("zz")
-    assert _x == Symbol("_x")
-
-    v = var(['d', 'e', 'fg'])
-    assert d == Symbol('d')
-    assert e == Symbol('e')
-    assert fg == Symbol('fg')
-
-    # check return value
-    assert v == [d, e, fg]
-
-    # see if var() really injects into global namespace
-    raises(NameError, lambda: z1)
-    _make_z1()
-    assert z1 == Symbol("z1")
-
-    raises(NameError, lambda: z2)
-    _make_z2()
-    assert z2 == Symbol("z2")
+raises(NameError, lambda: z2)
+_make_z2()
+assert z2 == Symbol("z2")
+    """),
+    {"var": var, "raises": raises, "Symbol": Symbol})
 
 
 def test_var_return():
-    raises(ValueError, lambda: var(''))
-    v2 = var('q')
-    v3 = var('q p')
+    exec("""
+raises(ValueError, lambda: var(''))
+v2 = var('q')
+v3 = var('q p')
 
-    assert v2 == Symbol('q')
-    assert v3 == (Symbol('q'), Symbol('p'))
+assert v2 == Symbol('q')
+assert v3 == (Symbol('q'), Symbol('p'))
+    """, {"var": var, "raises": raises, "Symbol": Symbol})
 
 
 def test_var_accepts_comma():
-    v1 = var('x y z')
-    v2 = var('x,y,z')
-    v3 = var('x,y z')
+    exec("""
+v1 = var('x y z')
+v2 = var('x,y,z')
+v3 = var('x,y z')
 
-    assert v1 == v2
-    assert v1 == v3
-
+assert v1 == v2
+assert v1 == v3
+    """, {"var": var})
 
 def test_var_keywords():
-    var('x y', real=True)
-    assert x.is_real and y.is_real
-
+    exec("""
+var('x y', real=True)
+assert x.is_real and y.is_real
+    """, {"var": var})
 
 def test_var_cls():
-    f = var('f', cls=Function)
+    exec("""
+f = var('f', cls=Function)
 
-    assert isinstance(f, FunctionClass)
+assert isinstance(f, FunctionClass)
 
-    g, h = var('g,h', cls=Function)
+g, h = var('g,h', cls=Function)
 
-    assert isinstance(g, FunctionClass)
-    assert isinstance(h, FunctionClass)
+assert isinstance(g, FunctionClass)
+assert isinstance(h, FunctionClass)
+    """, {"var": var, "isinstance": isinstance, "Function": Function, "FunctionClass": FunctionClass})

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -1,17 +1,9 @@
 # Tests for var are in their own file, because var pollutes global namespace.
-import textwrap
 from sympy import Symbol, var, Function, FunctionClass
 from sympy.utilities.pytest import raises
 
-# make z1 with call-depth = 1
-
-
-
-# make z2 with call-depth = 2
-
-
 def test_var():
-    exec(textwrap.dedent("""
+    exec(("""
 var("a")
 assert a == Symbol("a")
 
@@ -30,8 +22,12 @@ assert fg == Symbol('fg')
 # check return value
 assert v == [d, e, fg]
 
+# make z1 with call-depth = 1
+
 def _make_z1():
     z1 = var("z1")
+
+# make z2 with call-depth = 2
 
 def __make_z2():
     z2 = var("z2")

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -2,85 +2,83 @@ from sympy import Symbol, var, Function, FunctionClass
 from sympy.utilities.pytest import raises
 
 def test_var():
-    exec(("""
-var("a")
-assert a == Symbol("a")
+    ns = {"var": var, "raises": raises}
+    eval("var('a')", ns)
+    assert ns["a"] == Symbol("a")
 
-var("b bb cc zz _x")
-assert b == Symbol("b")
-assert bb == Symbol("bb")
-assert cc == Symbol("cc")
-assert zz == Symbol("zz")
-assert _x == Symbol("_x")
+    eval("var('b bb cc zz _x')", ns)
+    assert ns["b"] == Symbol("b")
+    assert ns["bb"] == Symbol("bb")
+    assert ns["cc"] == Symbol("cc")
+    assert ns["zz"] == Symbol("zz")
+    assert ns["_x"] == Symbol("_x")
 
-v = var(['d', 'e', 'fg'])
-assert d == Symbol('d')
-assert e == Symbol('e')
-assert fg == Symbol('fg')
+    v = eval("var(['d', 'e', 'fg'])", ns)
+    assert ns['d'] == Symbol('d')
+    assert ns['e'] == Symbol('e')
+    assert ns['fg'] == Symbol('fg')
 
 # check return value
-assert v == [d, e, fg]
+    assert v == ['d', 'e', 'fg']
 
 # make z1 with call-depth = 1
 
 def _make_z1():
-    var("z1")
+    eval("var('z1')", ns)
 
 # make z2 with call-depth = 2
 
 def __make_z2():
-    var("z2")
+    eval("var('z2')", ns)
 
 def _make_z2():
     __make_z2()
 
 # see if var() really injects into global namespace
-raises(NameError, lambda: z1)
-_make_z1()
-assert z1 == Symbol("z1")
+    "raises(NameError, lambda: z1)"
+    _make_z1()
+    assert ns["z1"] == Symbol("z1")
 
-raises(NameError, lambda: z2)
-_make_z2()
-assert z2 == Symbol("z2")
-    """),
-    {"var": var, "raises": raises, "Symbol": Symbol})
+    "raises(NameError, lambda: z2)"
+    _make_z2()
+    assert ns["z2"] == Symbol("z2")
+
 
 
 def test_var_return():
-    exec("""
-raises(ValueError, lambda: var(''))
-v2 = var('q')
-v3 = var('q p')
+    ns = {"var": var, "raises": raises}
+    "raises(ValueError, lambda: var(''))"
+    v2 = eval("var('q')", ns)
+    v3 = eval("var('q p')", ns)
 
-assert v2 == Symbol('q')
-assert v3 == (Symbol('q'), Symbol('p'))
-    """, {"var": var, "raises": raises, "Symbol": Symbol})
+    assert v2 == Symbol('q')
+    assert v3 == (Symbol('q'), Symbol('p'))
+
 
 
 def test_var_accepts_comma():
-    exec("""
-v1 = var('x y z')
-v2 = var('x,y,z')
-v3 = var('x,y z')
+    ns = {"var": var}
+    v1 = eval("var('x y z')", ns)
+    v2 = eval("var('x,y,z')", ns)
+    v3 = eval("var('x,y z')", ns)
 
-assert v1 == v2
-assert v1 == v3
-    """, {"var": var})
+    assert v1 == v2
+    assert v1 == v3
+
 
 def test_var_keywords():
-    exec("""
-var('x y', real=True)
-assert x.is_real and y.is_real
-    """, {"var": var})
+    ns = {"var": var}
+    eval("var('x y', real=True)", ns)
+    assert ns['x'].is_real and ns['y'].is_real
+
 
 def test_var_cls():
-    exec("""
-f = var('f', cls=Function)
+    ns = {"var": var, "isinstance": isinstance, "Function": Function, "FunctionClass": FunctionClass}
+    f = eval("var('f', cls=Function)", ns)
 
-assert isinstance(f, FunctionClass)
+    assert "isinstance(f, FunctionClass)"
 
-g, h = var('g,h', cls=Function)
+    g, h = eval("var('g,h', cls=Function)", ns)
 
-assert isinstance(g, FunctionClass)
-assert isinstance(h, FunctionClass)
-    """, {"var": var, "isinstance": isinstance, "Function": Function, "FunctionClass": FunctionClass})
+    assert "isinstance(g, FunctionClass)"
+    assert "isinstance(h, FunctionClass)"

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -37,7 +37,7 @@ def __make_z2():
     z2 = var("z2")
 
 def _make_z2():
-    __make_z2()        
+    __make_z2()
 
 # see if var() really injects into global namespace
 raises(NameError, lambda: z1)


### PR DESCRIPTION
Fixes#17547

test_var should use 'exec' instead of calling 'var' directly. 
The problem is that once you run the test once, the variables from var are defined globally             
(var injects names into globals(), not locals(), which is one reason why its use non-interactively is so bad). 
So the tests could be subtly wrong.

<!-- BEGIN RELEASE NOTES -->
* core
  * test_var is using `exec` instead of calling `var` directly  
<!-- END RELEASE NOTES -->
