### PR TITLE
Functions: Combinatorial-DP based implementation of Stirling Numbers

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1711,44 +1711,26 @@ def nC(n, k=None, replacement=False):
 
 @cacheit
 def _stirling1(n, k):
-    if n == k == 0:
-        return S.One
-    if 0 in (n, k):
-        return S.Zero
-    n1 = n - 1
-
-    # some special values
-    if n == k:
-        return S.One
-    elif k == 1:
-        return factorial(n1)
-    elif k == n1:
-        return binomial(n, 2)
-    elif k == n - 2:
-        return (3*n - 1)*binomial(n, 3)/4
-    elif k == n - 3:
-        return binomial(n, 2)*binomial(n, 4)
-
-    # general recurrence
-    return n1*_stirling1(n1, k) + _stirling1(n1, k - 1)
+    row = [1]+[0 for _ in range(k)]
+    for i in range(1, n+1):
+        new = [0]
+        for j in range(1, k+1):
+            stirling = (i-1) * row[j] + row[j-1]
+            new.append(stirling)
+        row = new
+    return row[k]
 
 
 @cacheit
 def _stirling2(n, k):
-    if n == k == 0:
-        return S.One
-    if 0 in (n, k):
-        return S.Zero
-    n1 = n - 1
-
-    # some special values
-    if k == n1:
-        return binomial(n, 2)
-    elif k == 2:
-        return 2**n1 - 1
-
-    # general recurrence
-    return k*_stirling2(n1, k) + _stirling2(n1, k - 1)
+    row = [1]+[0 for _ in range(k)]
+    for i in range(1, n+1):
+        new = [0]
+        for j in range(1, k+1):
+            stirling = j * row[j] + row[j-1]
+            new.append(stirling)
+        row = new
+    return row[k]
 
 
 def stirling(n, k, d=None, kind=2, signed=False):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1741,8 +1741,12 @@ def _stirling2(n, k):
         return S.Zero
 
     # some special values
-    if k == n - 1:
+    if n == k:
+        return S.One
+    elif k == n - 1:
         return binomial(n, 2)
+    elif k == 1:
+        return S.One
     elif k == 2:
         return Integer(2**(n - 1) - 1)
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1711,26 +1711,46 @@ def nC(n, k=None, replacement=False):
 
 @cacheit
 def _stirling1(n, k):
-    row = [1]+[0 for _ in range(k)]
-    for i in range(1, n+1):
-        new = [0]
-        for j in range(1, k+1):
-            stirling = (i-1) * row[j] + row[j-1]
-            new.append(stirling)
-        row = new
-    return row[k]
+    if n == k == 0:
+        return S.One
+    if 0 in (n, k):
+        return S.Zero
+
+    # some special values
+    if n == k:
+        return S.One
+    elif k == n - 1:
+        return binomial(n, 2)
+    elif k == n - 2:
+        return (3*n - 1)*binomial(n, 3)/4
+    elif k == n - 3:
+        return binomial(n, 2)*binomial(n, 4)
+
+    row = [0, 1]+[0]*(k-1) # for n = 1
+    for i in range(2, n+1):
+        for j in range(k, 0, -1):
+            row[j] = (i-1) * row[j] + row[j-1]
+    return Integer(row[k])
 
 
 @cacheit
 def _stirling2(n, k):
-    row = [1]+[0 for _ in range(k)]
-    for i in range(1, n+1):
-        new = [0]
-        for j in range(1, k+1):
-            stirling = j * row[j] + row[j-1]
-            new.append(stirling)
-        row = new
-    return row[k]
+    if n == k == 0:
+        return S.One
+    if 0 in (n, k):
+        return S.Zero
+
+    # some special values
+    if k == n - 1:
+        return binomial(n, 2)
+    elif k == 2:
+        return Integer(2**(n - 1) - 1)
+
+    row = [0, 1]+[0]*(k-1) # for n = 1
+    for i in range(2, n+1):
+        for j in range(k, 0, -1):
+            row[j] = j * row[j] + row[j-1]
+    return Integer(row[k])
 
 
 def stirling(n, k, d=None, kind=2, signed=False):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1718,7 +1718,7 @@ def _stirling1(n, k):
             stirling = (i-1) * row[j] + row[j-1]
             new.append(stirling)
         row = new
-    return row[k]
+    return Integer(row[k])
 
 
 @cacheit
@@ -1730,7 +1730,7 @@ def _stirling2(n, k):
             stirling = j * row[j] + row[j-1]
             new.append(stirling)
         row = new
-    return row[k]
+    return Integer(row[k])
 
 
 def stirling(n, k, d=None, kind=2, signed=False):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1709,8 +1709,7 @@ def nC(n, k=None, replacement=False):
         return nC(_multiset_histogram(n), k, replacement)
 
 
-@cacheit
-def _stirling1(n, k):
+def _eval_stirling1(n, k):
     if n == k == 0:
         return S.One
     if 0 in (n, k):
@@ -1726,6 +1725,11 @@ def _stirling1(n, k):
     elif k == n - 3:
         return binomial(n, 2)*binomial(n, 4)
 
+    return _stirling1(n, k)
+
+
+@cacheit
+def _stirling1(n, k):
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
         for j in range(min(k,i), 0, -1):
@@ -1733,8 +1737,7 @@ def _stirling1(n, k):
     return Integer(row[k])
 
 
-@cacheit
-def _stirling2(n, k):
+def _eval_stirling2(n, k):
     if n == k == 0:
         return S.One
     if 0 in (n, k):
@@ -1750,7 +1753,11 @@ def _stirling2(n, k):
     elif k == 2:
         return Integer(2**(n - 1) - 1)
 
+    return _stirling2(n, k)
 
+
+@cacheit
+def _stirling2(n, k):
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
         for j in range(min(k,i), 0, -1):
@@ -1854,15 +1861,15 @@ def stirling(n, k, d=None, kind=2, signed=False):
     if d:
         # assert k >= d
         # kind is ignored -- only kind=2 is supported
-        return _stirling2(n - d + 1, k - d + 1)
+        return _eval_stirling2(n - d + 1, k - d + 1)
     elif signed:
         # kind is ignored -- only kind=1 is supported
-        return (-1)**(n - k)*_stirling1(n, k)
+        return (-1)**(n - k)*_eval_stirling1(n, k)
 
     if kind == 1:
-        return _stirling1(n, k)
+        return _eval_stirling1(n, k)
     elif kind == 2:
-        return _stirling2(n, k)
+        return _eval_stirling2(n, k)
     else:
         raise ValueError('kind must be 1 or 2, not %s' % k)
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1728,7 +1728,7 @@ def _stirling1(n, k):
 
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
-        for j in range(k, 0, -1):
+        for j in range(min(k,i), 0, -1):
             row[j] = (i-1) * row[j] + row[j-1]
     return Integer(row[k])
 
@@ -1749,7 +1749,7 @@ def _stirling2(n, k):
 
     row = [0, 1]+[0]*(k-1) # for n = 1
     for i in range(2, n+1):
-        for j in range(k, 0, -1):
+        for j in range(min(k,i), 0, -1):
             row[j] = j * row[j] + row[j-1]
     return Integer(row[k])
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1711,6 +1711,21 @@ def nC(n, k=None, replacement=False):
 
 @cacheit
 def _stirling1(n, k):
+    if n == k == 0:
+        return S.One
+    if 0 in (n, k):
+        return S.Zero
+
+    # some special values
+    if n == k:
+        return S.One
+    elif k == n - 1:
+        return binomial(n, 2)
+    elif k == n - 2:
+        return (3*n - 1)*binomial(n, 3)/4
+    elif k == n - 3:
+        return binomial(n, 2)*binomial(n, 4)
+
     row = [1]+[0 for _ in range(k)]
     for i in range(1, n+1):
         new = [0]
@@ -1723,6 +1738,17 @@ def _stirling1(n, k):
 
 @cacheit
 def _stirling2(n, k):
+    if n == k == 0:
+        return S.One
+    if 0 in (n, k):
+        return S.Zero
+
+    # some special values
+    if k == n - 1:
+        return binomial(n, 2)
+    elif k == 2:
+        return Integer(2**(n - 1) - 1)
+
     row = [1]+[0 for _ in range(k)]
     for i in range(1, n+1):
         new = [0]

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -12,7 +12,7 @@ from sympy.functions.combinatorial.numbers import _nT
 
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
-from sympy.core.numbers import GoldenRatio
+from sympy.core.numbers import GoldenRatio, Integer
 
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -473,7 +473,8 @@ def test_nC_nP_nT():
         multiset_permutations, multiset_combinations, multiset_partitions,
         partitions, subsets, permutations)
     from sympy.functions.combinatorial.numbers import (
-        nP, nC, nT, stirling, _multiset_histogram, _AOP_product)
+        nP, nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram,
+        _AOP_product)
     from sympy.combinatorics.permutations import Permutation
     from sympy.core.numbers import oo
     from random import choice
@@ -595,6 +596,10 @@ def test_nC_nP_nT():
             0, 1, 255, 3025, 7770, 6951, 2646, 462, 36, 1]
     assert stirling(3, 4, kind=1) == stirling(3, 4, kind=1) == 0
     raises(ValueError, lambda: stirling(-2, 2))
+
+    # Assertion that the return type is SymPy Integer.
+    assert isinstance(_stirling1(6, 3), Integer)
+    assert isinstance(_stirling2(6, 3), Integer)
 
     def delta(p):
         if len(p) == 1:

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -12,7 +12,7 @@ from sympy.functions.combinatorial.numbers import _nT
 
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
-from sympy.core.numbers import GoldenRatio
+from sympy.core.numbers import GoldenRatio, Integer
 
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -473,7 +473,7 @@ def test_nC_nP_nT():
         multiset_permutations, multiset_combinations, multiset_partitions,
         partitions, subsets, permutations)
     from sympy.functions.combinatorial.numbers import (
-        nP, nC, nT, stirling, _multiset_histogram, _AOP_product)
+        nP, nC, nT, stirling, _stirling1, _stirling2, _multiset_histogram, _AOP_product)
     from sympy.combinatorics.permutations import Permutation
     from sympy.core.numbers import oo
     from random import choice
@@ -595,6 +595,10 @@ def test_nC_nP_nT():
             0, 1, 255, 3025, 7770, 6951, 2646, 462, 36, 1]
     assert stirling(3, 4, kind=1) == stirling(3, 4, kind=1) == 0
     raises(ValueError, lambda: stirling(-2, 2))
+
+    # Assertion that the return type is SymPy Integer.
+    assert isinstance(_stirling1(6, 3), Integer)
+    assert isinstance(_stirling2(6, 3), Integer)
 
     def delta(p):
         if len(p) == 1:


### PR DESCRIPTION
Fixes #11650

Recursive implementation was slower as it was getting executed in exponential time hence maximum recursion depth got reached, when both kinds of stirling numbers were called.

**[stirling(200, i, kind=1) for i in range(201)]
RuntimeError: maximum recursion depth exceeded while calling a Python object**

Similarly,

**[stirling(200, i, kind=2) for i in range(201)]
RuntimeError: maximum recursion depth exceeded while calling a Python object**

Now DP based implementation takes O(n*k) time and is also a space optimized solution and **we don't get the above Runtime Error**.

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed maximum recursion errors and improved performance for `stirling`. 

<!-- END RELEASE NOTES -->
