### PR TITLE
fix issue 17676 bug due to combining Fermat factors in factorint()

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1178,7 +1178,8 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                     facs = factorint(r, limit=limit, use_trial=use_trial,
                                      use_rho=use_rho, use_pm1=use_pm1,
                                      verbose=verbose)
-                    factors.update(facs)
+                    for k, v in facs.items():
+                        factors[k] = factors.get(k, 0) + v
                 raise StopIteration
 
             # ...see if factorization can be terminated

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -624,7 +624,7 @@ def test_is_amicable():
 def test_issue_17676():
     n = 28300421052393658575  #original issue 17676 problematic input
     assert sqrt(n)**2 == n
-    
+
     #some extra tests from issue 17676
     n = 2063**2 * 4127**1 * 4129**1
     assert sqrt(n)**2 == n

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -161,6 +161,11 @@ def test_factorint():
     assert factorint(64015937) == {7993: 1, 8009: 1}
     assert factorint(2**(2**6) + 1) == {274177: 1, 67280421310721: 1}
 
+    #issue 17676
+    assert factorint(28300421052393658575) == {3: 1, 5: 2, 11: 2, 43: 1, 2063: 2, 4127: 1, 4129: 1}
+    assert factorint(2063**2 * 4127**1 * 4129**1) == {2063: 2, 4127: 1, 4129: 1}
+    assert factorint(2347**2 * 7039**1 * 7043**1) == {2347: 2, 7039: 1, 7043: 1}
+
     assert factorint(0, multiple=True) == [0]
     assert factorint(1, multiple=True) == []
     assert factorint(-1, multiple=True) == [-1]
@@ -619,15 +624,3 @@ def test_is_amicable():
     assert is_amicable(173, 129) is False
     assert is_amicable(220, 284) is True
     assert is_amicable(8756, 8756) is False
-
-
-def test_issue_17676():
-    n = 28300421052393658575  #original issue 17676 problematic input
-    assert sqrt(n)**2 == n
-
-    #some extra tests from issue 17676
-    n = 2063**2 * 4127**1 * 4129**1
-    assert sqrt(n)**2 == n
-
-    n = 2347**2 * 7039**1 * 7043**1
-    assert sqrt(n)**2 == n

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -1,5 +1,5 @@
 from sympy import (Mul, S, Pow, Symbol, summation, Dict,
-    factorial as fac)
+                   factorial as fac, sqrt)
 from sympy.core.evalf import bitcount
 from sympy.core.numbers import Integer, Rational
 from sympy.core.compatibility import long, range
@@ -619,3 +619,15 @@ def test_is_amicable():
     assert is_amicable(173, 129) is False
     assert is_amicable(220, 284) is True
     assert is_amicable(8756, 8756) is False
+
+
+def test_issue_17676():
+    n = 28300421052393658575  #original issue 17676 problematic input
+    assert sqrt(n)**2 == n
+    
+    #some extra tests from issue 17676
+    n = 2063**2 * 4127**1 * 4129**1
+    assert sqrt(n)**2 == n
+
+    n = 2347**2 * 7039**1 * 7043**1
+    assert sqrt(n)**2 == n


### PR DESCRIPTION
Fixes issue 17676 where sqrt(28300421052393658575) returns wrong answer
Root cause determined to be in factorint() where factor lists from
Fermat factors were overwriting each other instead of properly combining

Co-authored by: smichr

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17676 

#### Brief description of what is fixed or changed
In factorint() Fermat factoring part the factor lists are now properly merged instead of overwriting each other via dict.update()

#### Other comments
With guidance from smichr on the code convention and adding tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Fixed a bug in factorint() causing wrong answers for certain integers.
<!-- END RELEASE NOTES -->
