### PR TITLE
Fix breakage caused by fix to #2993

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -389,13 +389,14 @@ class Add(Expr, AssocOp):
             c, m = zip(*[i.as_coeff_Mul() for i in self.args])
             big = 0
             float = False
+            s = dict()
             for i in c:
                 float = float or i.is_Float
-                if abs(i) > big:
+                if abs(i) >= big:
                     big = 1.0*abs(i)
-                    s = -1 if i < 0 else 1
+                    s[i] = -1 if i < 0 else 1
             if float and big and big != 1:
-                addpow = Add(*[(s if abs(c[i]) == big else c[i]/big)*m[i]
+                addpow = Add(*[(s[c[i]] if abs(c[i]) == big else c[i]/big)*m[i]
                              for i in range(len(c))])**e
                 return big**e*addpow
 

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -471,6 +471,9 @@ def test_issue_2993():
     eq = (2.3*x + 4)
     assert eq**2 == 16.0*(0.575*x + 1)**2
     assert (1/eq).args == (eq, -1)  # don't change trivial power
+    # issue 17735
+    q=.5*exp(x) - .5*exp(-x) + 0.1
+    assert int((q**2).subs(x, 1)) == 1
 
 
 def test_issue_17450():


### PR DESCRIPTION
…3 (fixes Issue #17735); make `Add._eval_power` handle Float coefficients better; resulted in 
```python
q=.5*exp(x) - .5*exp(-x) + 0.1 ; assert int((q**2).subs(x, 1)) != 1.
```
#### References to other Issues or PRs
Fixes #17735 ; also this is a more correct implementation of PR #16762, which itself fixes #2993

#### Brief description of what is fixed or changed

The minimal example of @isuruf:
```python
from sympy import *
x = symbols('x')
expr = 0.5*exp(x) + 0.1 - 0.5*exp(-x)
print(expr)
print(expr**2)
```
resulted in an erroneous sign flip in the final print() statement in SymPy master ca. Oct 15, 2019. After some bisection, it was found that the merged PR #16762 was to blame.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY

<!-- END RELEASE NOTES -->
