### PR TITLE
polys: Improved speed of get_dixon_matrix() and revised tests

### DIFF
--- a/sympy/polys/multivariate_resultants.py
+++ b/sympy/polys/multivariate_resultants.py
@@ -12,7 +12,7 @@ system has common roots. That is when the resultant is equal to zero.
 from sympy import IndexedBase, Matrix, Mul, Poly
 from sympy import rem, prod, degree_list, diag
 from sympy.core.compatibility import range
-from sympy.polys.monomials import monomial_deg, itermonomials
+from sympy.polys.monomials import itermonomials
 from sympy.polys.orderings import monomial_key
 from sympy.polys.polytools import poly_from_expr, total_degree
 from sympy.functions.combinatorial.factorials import binomial
@@ -121,7 +121,7 @@ class DixonResultant():
 
         return poly_from_expr(dixon_polynomial, self.dummy_variables)[0]
 
-    def get_upper_degrees(self, polynomial):
+    def get_max_degrees(self, polynomial):
         r"""
         Returns a list of the maximum degree of each variable appearing
         in the coefficients of the Dixon polynomial. The coefficients are
@@ -140,7 +140,7 @@ class DixonResultant():
         x_n.
         """
 
-        max_degrees = self.get_upper_degrees(polynomial)
+        max_degrees = self.get_max_degrees(polynomial)
 
         # list of column headers of the Dixon matrix.
         monomials = itermonomials(self.variables, max_degrees)

--- a/sympy/polys/multivariate_resultants.py
+++ b/sympy/polys/multivariate_resultants.py
@@ -85,11 +85,6 @@ class DixonResultant():
         # A list of n alpha variables (the replacing variables)
         self.dummy_variables = [a[i] for i in range(self.n)]
 
-        # A list of the d_max of each variable.
-        self.max_degrees = [
-            max(degree_list(poly)[i] for poly in self.polynomials)
-            for i in range(self.n)]
-
     def get_dixon_polynomial(self):
         r"""
         Returns
@@ -126,13 +121,17 @@ class DixonResultant():
 
         return poly_from_expr(dixon_polynomial, self.dummy_variables)[0]
 
-    def get_upper_degree(self):
-        list_of_products = [self.variables[i] ** self.max_degrees[i]
-                            for i in range(self.n)]
-        product = prod(list_of_products)
-        product = Poly(product).monoms()
+    def get_upper_degrees(self, polynomial):
+        r"""
+        Returns a list of the maximum degree of each variable appearing
+        in the coefficients of the Dixon polynomial. The coefficients are
+        viewed as polys in x_1, ... , x_n.
+        """
+        max_degrees = [
+            max(degree_list(Poly(poly, self.variables))[i] for poly
+                in polynomial.coeffs()) for i in range(self.n)]
 
-        return monomial_deg(*product)
+        return max_degrees
 
     def get_dixon_matrix(self, polynomial):
         r"""
@@ -141,23 +140,26 @@ class DixonResultant():
         x_n.
         """
 
-        # A list of coefficients (in x_i, ..., x_n terms) of the power
-        # products a_1, ..., a_n in Dixon's polynomial.
-        coefficients = polynomial.coeffs()
+        max_degrees = self.get_upper_degrees(polynomial)
 
-        monomials = list(itermonomials(self.variables,
-                                       self.get_upper_degree()))
+        # list of column headers of the Dixon matrix.
+        monomials = itermonomials(self.variables, max_degrees)
         monomials = sorted(monomials, reverse=True,
                            key=monomial_key('lex', self.variables))
 
         dixon_matrix = Matrix([[Poly(c, *self.variables).coeff_monomial(m)
                                 for m in monomials]
-                                for c in coefficients])
+                                for c in polynomial.coeffs()])
 
-        keep = [column for column in range(dixon_matrix.shape[-1])
-                if any([element != 0 for element
+        # remove columns if needed
+        if dixon_matrix.shape[0] != dixon_matrix.shape[1]:
+            keep = [column for column in range(dixon_matrix.shape[-1])
+                    if any([element != 0 for element
                         in dixon_matrix[:, column]])]
-        return dixon_matrix[:, keep]
+
+            dixon_matrix = dixon_matrix[:, keep]
+
+        return dixon_matrix
 
 class MacaulayResultant():
     """

--- a/sympy/polys/tests/test_multivariate_resultants.py
+++ b/sympy/polys/tests/test_multivariate_resultants.py
@@ -25,7 +25,6 @@ def test_dixon_resultant_init():
     assert dixon.n == 2
     assert dixon.m == 2
     assert dixon.dummy_variables == [a[0], a[1]]
-    assert dixon.max_degrees == [1, 1]
 
 def test_get_dixon_polynomial_numerical():
     """Test Dixon's polynomial for a numerical example."""
@@ -43,12 +42,17 @@ def test_get_dixon_polynomial_numerical():
 
     assert dixon.get_dixon_polynomial().factor() == polynomial
 
-def test_get_upper_degree():
-    """Tests upper degree function."""
-    h = c * x ** 2 + y
-    dixon = DixonResultant(polynomials=[h, q], variables=[x, y])
+def test_get_upper_degrees():
+    """Tests upper degrees function."""
 
-    assert dixon.get_upper_degree() == 3
+    p = x + y
+    q = x ** 2 + y **3
+    h = x ** 2 + y
+
+    dixon = DixonResultant(polynomials=[p, q, h], variables=[x, y])
+    dixon_polynomial = dixon.get_dixon_polynomial()
+
+    assert dixon.get_upper_degrees(dixon_polynomial) == [1, 2]
 
 def test_get_dixon_matrix_example_two():
     """Test Dixon's matrix for example from [Palancz08]_."""


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Dixon DixonResultant()'s `__init__()` method used to calculate `max_degrees`
for each variable of the input polynomials, instead of those of the dixon
polynomial, thus computing redundant monomials.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->




<!-- BEGIN RELEASE NOTES -->
* polys
  * `get_dixon_matrix()` now computes only the necessary monomials
<!-- END RELEASE NOTES -->
