### PR TITLE
added hypergeometic method for 1F1 type ode

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1504,12 +1504,18 @@ def equivalence(max_num_pow, dem_pow):
     if max_num_pow == 2:
         if dem_pow in [[2, 2], [2, 2, 2]]:
             return "2F1"
+        elif dem_pow in [[2, 4], [0], [2], [6], [4]]:
+            return "1F1"
     elif max_num_pow == 1:
         if dem_pow in [[1, 2, 2], [2, 2, 2], [1, 2], [2, 2]]:
             return "2F1"
+        elif dem_pow in [[1, 4], [1], [4], [6]]:
+            return "1F1"
     elif max_num_pow == 0:
         if dem_pow in [[1, 1, 2], [2, 2], [1 ,2, 2], [1, 1], [2], [1, 2], [2, 2]]:
             return "2F1"
+        elif dem_pow in [[0, 4], [0], [4], [6]]:
+            return "1F1"
 
     return None
 
@@ -1555,7 +1561,6 @@ def equivalence_hypergeometric(A, B, func):
 
     _pow = pow_dem
     k = gcd(_pow)
-
     # computing I0 of the given equation
     I0 = powdenest(simplify(factor(((J1/k**2) - S(1)/4)/((x**k)**2))), force=True)
     I0 = factor(cancel(powdenest(I0.subs(x, x**(S(1)/k)), force=True)))
@@ -1582,6 +1587,8 @@ def equivalence_hypergeometric(A, B, func):
 
     if equivalence(max_num_pow, dem_pow) == "2F1":
         return {'I0':I0, 'k':k, 'sing_point':sing_point, 'type':"2F1"}
+    elif equivalence(max_num_pow, dem_pow) == "1F1":
+        return {'I0':I0, 'k':k, 'sing_point':sing_point, 'type':"1F1"}
     else:
         return None
 
@@ -1633,6 +1640,8 @@ def ode_2nd_hypergeometric(eq, func, order, match):
 
         sol = cancel((e)*x**((-match['k']+1)/2))*sol
         sol = Eq(func, sol)
+    elif match['type'] == "1F1":
+        sol = None
 
     return sol
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

related #17603 
#### Brief description of what is fixed or changed
By implementing this method, any differential equation that can be transform into `eq = x*f(x).diff(x, 2) + (c-x)*f(x).diff(x) -a*f(x)` by applying the following transformations 
```
1- x --> x**k
2- x --> (a*x + b)/(c*x+d)
3- y --> P(x)*y
```
then the given equation can be solve.

It will cover a class of ode- 
```
In [5]: eq = x*f(x).diff(x, 2) + (c-x)*f(x).diff(x) -a*f(x)

In [6]: eq
Out[6]: 
              2                         
             d                  d       
-a⋅f(x) + x⋅───(f(x)) + (c - x)⋅──(f(x))
              2                 dx      
            dx                          


```
Which is solvable in the series solution.



#### Other comments
Work is  still in progress.
sources-
https://en.wikipedia.org/wiki/Frobenius_solution_to_the_hypergeometric_equation
https://drive.google.com/file/d/1wcJlEd6DMTRHAprH2N2oXaCHpa8PLDwp/view
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - added method in dsolve to solve 2nd order ode in 1F1 hyper function
<!-- END RELEASE NOTES -->