### PR TITLE
Backward substitution based RREF computation

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -589,12 +589,6 @@ class MatrixReductions(MatrixDeterminant):
             return zeros_below and self[:, 1:]._eval_is_echelon(iszerofunc)
         return zeros_below and self[1:, 1:]._eval_is_echelon(iszerofunc)
 
-    def _eval_rref(self, iszerofunc, simpfunc, normalize_last=True):
-        reduced, pivot_cols, swaps = self._row_reduce(iszerofunc, simpfunc,
-                                                      normalize_last, normalize=True,
-                                                      zero_above=True)
-        return reduced, pivot_cols
-
     def _normalize_op_args(self, op, col, k, col1, col2, error_str="col"):
         """Validate the arguments for a row/column operation.  ``error_str``
         can be one of "row" or "col" depending on the arguments being parsed."""
@@ -915,7 +909,9 @@ class MatrixReductions(MatrixDeterminant):
         echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
         return len(pivots)
 
-    def rref(self, iszerofunc=_iszero, simplify=False, pivots=True, normalize_last=True):
+    def rref(
+        self, iszerofunc=_iszero, simplify=False, pivots=True,
+        normalize_last=True, normalize=True):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 
         Parameters
@@ -969,11 +965,13 @@ class MatrixReductions(MatrixDeterminant):
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify
 
-        ret, pivot_cols = self._eval_rref(iszerofunc=iszerofunc,
-                                          simpfunc=simpfunc,
-                                          normalize_last=normalize_last)
+        ret, pivot_cols, _ = self._row_reduce(
+            iszerofunc=iszerofunc, simpfunc=simpfunc,
+            normalize_last=normalize_last, normalize=normalize,
+            zero_above=True)
+
         if pivots:
-            ret = (ret, pivot_cols)
+            return ret, pivot_cols
         return ret
 
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -789,7 +789,7 @@ class MatrixReductions(MatrixDeterminant):
         iszerofunc : function
             See the doc of :meth:`rref` for the same parameter.
 
-        simpfunc : function
+        simplify : function or bool
             See the doc of :meth:`rref` for the same parameter.
 
         normalize : bool
@@ -966,7 +966,7 @@ class MatrixReductions(MatrixDeterminant):
             A function used for detecting whether an element can
             act as a pivot.  ``lambda x: x.is_zero`` is used by default.
 
-        simpfunc : function
+        simplify : function or bool
             A function used to simplify elements when looking for a pivot.
             By default SymPy's ``simplify`` is used.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -572,15 +572,6 @@ class MatrixReductions(MatrixDeterminant):
             return self[i, j]
         return self._new(self.rows, self.cols, entry)
 
-    def _eval_echelon_form(self, iszerofunc, simpfunc):
-        """Returns (mat, swaps) where ``mat`` is a row-equivalent matrix
-        in echelon form and ``swaps`` is a list of row-swaps performed."""
-        reduced, pivot_cols, swaps = self._row_reduce(iszerofunc, simpfunc,
-                                                      normalize_last=True,
-                                                      normalize=False,
-                                                      zero_above=False)
-        return reduced, pivot_cols, swaps
-
     def _eval_is_echelon(self, iszerofunc):
         if self.rows <= 0 or self.cols <= 0:
             return True
@@ -789,7 +780,9 @@ class MatrixReductions(MatrixDeterminant):
 
         return self._new(self.rows, self.cols, mat), tuple(pivot_cols), tuple(swaps)
 
-    def echelon_form(self, iszerofunc=_iszero, simplify=False, with_pivots=False):
+    def echelon_form(
+        self, iszerofunc=_iszero, simplify=False, with_pivots=False,
+        normalize_last=True, normalize=False):
         """Returns a matrix row-equivalent to ``self`` that is
         in echelon form.  Note that echelon form of a matrix
         is *not* unique, however, properties like the row
@@ -797,7 +790,10 @@ class MatrixReductions(MatrixDeterminant):
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify
 
-        mat, pivots, swaps = self._eval_echelon_form(iszerofunc, simpfunc)
+        mat, pivots, _ = self._row_reduce(
+            iszerofunc=iszerofunc, simpfunc=simpfunc, zero_above=False,
+            normalize_last=normalize_last, normalize=normalize)
+
         if with_pivots:
             return mat, pivots
         return mat
@@ -906,7 +902,8 @@ class MatrixReductions(MatrixDeterminant):
                 return 2
 
         mat, _ = self._permute_complexity_right(iszerofunc=iszerofunc)
-        echelon_form, pivots, swaps = mat._eval_echelon_form(iszerofunc=iszerofunc, simpfunc=simpfunc)
+        _, pivots = mat.echelon_form(
+            iszerofunc=iszerofunc, simplify=simpfunc, with_pivots=True)
         return len(pivots)
 
     def rref(

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -763,12 +763,16 @@ class MatrixReductions(MatrixDeterminant):
         prev_col = cols
         if zero_above:
             for r, c in reversed(list(enumerate(pivot_cols))):
+                # If the last N pivot columns are attatched each other
+                # from the end, the backward substitution can be
+                # done simply by replacing the elements of the column
+                # into zero.
                 if c == prev_col - 1:
                     mat[c: c + r*cols: cols] = (self.zero,) * r
+                    prev_col = c
                 else:
                     for i in reversed(range(r)):
                         cross_cancel(mat[r*cols + c], i, mat[i*cols + c], r)
-                prev_col = c
 
         # normalize each row
         if normalize_last is True and normalize is True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -663,8 +663,9 @@ class MatrixReductions(MatrixDeterminant):
 
         return (self.permute(perm, orientation='cols'), perm)
 
-    def _row_reduce(self, iszerofunc, simpfunc, normalize_last=True,
-                    normalize=True, zero_above=True):
+    def _row_reduce(
+        self, iszerofunc=_iszero, simpfunc=_simplify, normalize_last=True,
+        normalize=True, zero_above=True):
         """A subroutine used both in the ``rref`` and the
         ``echelon_form``.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -756,7 +756,7 @@ class MatrixReductions(MatrixDeterminant):
         if zero_above:
             for r, c in reversed(list(enumerate(pivot_cols))):
                 if c == prev_col - 1:
-                    get_col(c)[:r] = [self.zero] * r
+                    mat[c: c + r*cols: cols] = (self.zero,) * r
                 else:
                     for i in reversed(range(r)):
                         cross_cancel(mat[r*cols + c], i, mat[i*cols + c], r)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -658,22 +658,16 @@ class MatrixReductions(MatrixDeterminant):
         ==========
 
         iszerofunc : function
-            Determines if an entry can be used as a pivot
+            See the doc of :meth:`rref` for the same parameter.
 
         simpfunc : function
-            Used to simplify elements and test if they are
-            zero if ``iszerofunc`` returns `None`
+            See the doc of :meth:`rref` for the same parameter.
 
         normalize_last : bool
-            Indicates where all row reduction should
-            happen in a fraction-free manner and then the rows are
-            normalized (so that the pivots are 1), or whether
-            rows should be normalized along the way (like the naive
-            row reduction algorithm)
+            See the doc of :meth:`rref` for the same parameter.
 
         normalize : bool
-            Whether pivot rows should be normalized so that
-            the pivot value is 1
+            See the doc of :meth:`rref` for the same parameter.
 
         zero_above : bool
             Whether entries above the pivot should be zeroed.
@@ -787,10 +781,60 @@ class MatrixReductions(MatrixDeterminant):
     def echelon_form(
         self, iszerofunc=_iszero, simplify=False, with_pivots=False,
         normalize_last=True, normalize=False):
-        """Returns a matrix row-equivalent to ``self`` that is
-        in echelon form.  Note that echelon form of a matrix
-        is *not* unique, however, properties like the row
-        space and the null space are preserved."""
+        """Compute the row echelon form of a matrix.
+
+        Parameters
+        ==========
+
+        iszerofunc : function
+            See the doc of :meth:`rref` for the same parameter.
+
+        simpfunc : function
+            See the doc of :meth:`rref` for the same parameter.
+
+        normalize : bool
+            See the doc of :meth:`rref` for the same parameter.
+
+        normalize_last : bool
+            See the doc of :meth:`rref` for the same parameter.
+
+        pivots : bool
+            See the doc of :meth:`rref` for the parameter
+            ``with_pivots``.
+
+        Returns
+        =======
+
+        (matrix, pivot_cols) : (Matrix, tuple[int])
+            See the doc of :meth:`rref` for the returns.
+
+        matrix : Matrix
+            See the doc of :meth:`rref` for the returns.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> m = Matrix([[1, 2, 1], [-2, -3, 1], [3, 5, 0]])
+        >>> m.echelon_form()
+        Matrix([
+        [1, 2, 1],
+        [0, 1, 3],
+        [0, 0, 0]])
+
+        Notes
+        =====
+
+        Echelon form of a matrix is not unique.
+        However, properties like the row space and the null space are
+        preserved.
+
+        See Also
+        ========
+
+        rref
+        sympy.matrices.matrices.MatrixBase.LUdecomposition
+        """
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify
 
@@ -913,28 +957,64 @@ class MatrixReductions(MatrixDeterminant):
     def rref(
         self, iszerofunc=_iszero, simplify=False, pivots=True,
         normalize_last=True, normalize=True):
-        """Return reduced row-echelon form of matrix and indices of pivot vars.
+        """Compute the reduced row echelon form of a matrix.
 
         Parameters
         ==========
 
-        iszerofunc : Function
+        iszerofunc : function
             A function used for detecting whether an element can
             act as a pivot.  ``lambda x: x.is_zero`` is used by default.
-        simplify : Function
+
+        simpfunc : function
             A function used to simplify elements when looking for a pivot.
             By default SymPy's ``simplify`` is used.
-        pivots : True or False
-            If ``True``, a tuple containing the row-reduced matrix and a tuple
-            of pivot columns is returned.  If ``False`` just the row-reduced
-            matrix is returned.
-        normalize_last : True or False
+
+        normalize : bool
+            Whether pivot rows should be normalized so that
+            the pivot value is `1`.
+
+        normalize_last : bool
             If ``True``, no pivots are normalized to `1` until after all
-            entries above and below each pivot are zeroed.  This means the row
-            reduction algorithm is fraction free until the very last step.
+            entries above and below each pivot are zeroed. This means
+            the row reduction algorithm is fraction free until the very
+            last step.
+
             If ``False``, the naive row reduction procedure is used where
             each pivot is normalized to be `1` before row operations are
             used to zero above and below the pivot.
+
+            This keyword won't take any effect if ``normalize`` is set
+            to ``False``.
+
+        pivots : bool
+            If ``True``, it specifies an option to return a 2-tuple
+            containing a row-reduced matrix and a tuple containing the
+            indices of pivot columns.
+
+            If ``False``, it specifies an option only to return the
+            row-reduced matrix.
+
+            See the ``Returns`` section for more information.
+
+        Returns
+        =======
+
+        (matrix, pivot_cols) : (Matrix, tuple[int])
+            ``matrix`` contains the resulting matrix of the
+            row-reduction.
+
+            ``pivot_cols`` contains only the column indices of the
+            pivots.
+            Note that computing the row indices is trivial and can be
+            done easily by ``for r, c in enumerate(pivot_cols)``
+
+            ``swaps`` contains the array-form of the permutation that
+            is used in permuting the rows during the pivoting process.
+
+        matrix : Matrix
+            Return the matrix of above,
+            if the option is specified not to return ``pivot_cols``.
 
         Notes
         =====
@@ -943,7 +1023,6 @@ class MatrixReductions(MatrixDeterminant):
         speedup to row reduction, especially on matrices with symbols.  However,
         if you depend on the form row reduction algorithm leaves entries
         of the matrix, set ``noramlize_last=False``
-
 
         Examples
         ========
@@ -962,6 +1041,12 @@ class MatrixReductions(MatrixDeterminant):
         [0, 1]])
         >>> rref_pivots
         (0, 1)
+
+        See Also
+        ========
+
+        echelon_form
+        sympy.matrices.matrices.MatrixBase.rank_decomposition
         """
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -727,7 +727,7 @@ class MatrixReductions(MatrixDeterminant):
 
             # if we aren't normalizing last, we normalize
             # before we zero the other rows
-            if normalize_last is False:
+            if normalize_last is False and normalize is True:
                 i, j = piv_row, piv_col
                 mat[i*cols + j] = self.one
                 for p in range(i*cols + j + 1, (i + 1)*cols):
@@ -735,14 +735,12 @@ class MatrixReductions(MatrixDeterminant):
                 # after normalizing, the pivot value is 1
                 pivot_val = self.one
 
-            # zero above and below the pivot
+            # zero below the pivot
             for row in range(rows):
-                # don't zero our current row
-                if row == piv_row:
+                # Zero above the pivot after computing the echelon form.
+                if row <= piv_row:
                     continue
-                # don't zero above the pivot unless we're told.
-                if zero_above is False and row < piv_row:
-                    continue
+
                 # if we're already a zero, don't do anything
                 val = mat[row*cols + piv_col]
                 if iszerofunc(val):
@@ -751,6 +749,16 @@ class MatrixReductions(MatrixDeterminant):
                 cross_cancel(pivot_val, row, val, piv_row)
             piv_row += 1
             piv_col += 1
+
+        # Compute RREF after computing echelon form with
+        # backward substitution.
+        if zero_above:
+            for r, c in reversed(list(enumerate(pivot_cols))):
+                if c == cols-1 or c+1 in pivot_cols:
+                    get_col(c)[:r] = [self.zero] * r
+
+                for i in reversed(range(r)):
+                    cross_cancel(mat[r*cols + c], i, mat[i*cols + c], r)
 
         # normalize each row
         if normalize_last is True and normalize is True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -665,26 +665,48 @@ class MatrixReductions(MatrixDeterminant):
 
     def _row_reduce(self, iszerofunc, simpfunc, normalize_last=True,
                     normalize=True, zero_above=True):
-        """Row reduce ``self`` and return a tuple (rref_matrix,
-        pivot_cols, swaps) where pivot_cols are the pivot columns
-        and swaps are any row swaps that were used in the process
-        of row reduction.
+        """A subroutine used both in the ``rref`` and the
+        ``echelon_form``.
 
         Parameters
         ==========
 
-        iszerofunc : determines if an entry can be used as a pivot
-        simpfunc : used to simplify elements and test if they are
+        iszerofunc : function
+            Determines if an entry can be used as a pivot
+
+        simpfunc : function
+            Used to simplify elements and test if they are
             zero if ``iszerofunc`` returns `None`
-        normalize_last : indicates where all row reduction should
+
+        normalize_last : bool
+            Indicates where all row reduction should
             happen in a fraction-free manner and then the rows are
             normalized (so that the pivots are 1), or whether
             rows should be normalized along the way (like the naive
             row reduction algorithm)
-        normalize : whether pivot rows should be normalized so that
+
+        normalize : bool
+            Whether pivot rows should be normalized so that
             the pivot value is 1
-        zero_above : whether entries above the pivot should be zeroed.
+
+        zero_above : bool
+            Whether entries above the pivot should be zeroed.
             If ``zero_above=False``, an echelon matrix will be returned.
+
+        Returns
+        =======
+
+        (matrix, pivot_cols, swaps) : (Matrix, tuple, tuple)
+            ``matrix`` contains the resulting matrix of the
+            row-reduction.
+
+            ``pivot_cols`` contains only the column indices of the
+            pivots.
+            Note that computing the row indices is trivial and can be
+            done easily by ``for r, c in enumerate(pivot_cols)``
+
+            ``swaps`` contains the array-form of the permutation that
+            is used in permuting the rows during the pivoting process.
         """
         rows, cols = self.rows, self.cols
         mat = list(self)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -752,13 +752,15 @@ class MatrixReductions(MatrixDeterminant):
 
         # Compute RREF after computing echelon form with
         # backward substitution.
+        prev_col = cols
         if zero_above:
             for r, c in reversed(list(enumerate(pivot_cols))):
-                if c == cols-1 or c+1 in pivot_cols:
+                if c == prev_col - 1:
                     get_col(c)[:r] = [self.zero] * r
-
-                for i in reversed(range(r)):
-                    cross_cancel(mat[r*cols + c], i, mat[i*cols + c], r)
+                else:
+                    for i in reversed(range(r)):
+                        cross_cancel(mat[r*cols + c], i, mat[i*cols + c], r)
+                prev_col = c
 
         # normalize each row
         if normalize_last is True and normalize is True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -750,6 +750,7 @@ class MatrixReductions(MatrixDeterminant):
 
                 cross_cancel(pivot_val, row, val, piv_row)
             piv_row += 1
+            piv_col += 1
 
         # normalize each row
         if normalize_last is True and normalize is True:

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1135,6 +1135,18 @@ def test_rref():
         assert simplify(i - j).is_zero
 
 
+def test_echelon_form_rref_normalize():
+    M = ReductionsOnlyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert M.echelon_form(normalize=True) == \
+        Matrix([[1, 2, 3], [0, 1, 2], [0, 0, 0]])
+    assert M.echelon_form(normalize=False) == \
+        Matrix([[1, 2, 3], [0, -3, -6], [0, 0, 0]])
+    assert M.rref(normalize=True, pivots=False) == \
+        Matrix([[1, 0, -1], [0, 1, 2], [0, 0, 0]])
+    assert M.rref(normalize=False, pivots=False) == \
+        Matrix([[-3, 0, 3], [0, -3, -6], [0, 0, 0]])
+
+
 # SpecialOnlyMatrix tests
 def test_eye():
     assert list(SpecialOnlyMatrix.eye(2, 2)) == [1, 0, 0, 1]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Also addressing #12006, but examples have not been added.

#### Brief description of what is fixed or changed

1. It is usually better to compute RREF by a backward substitution from an echelon form, which is computationally more efficient than cross canceling every rows above the pivot each time the pivot is found. But I think that the performance boost is only visible when the `_find_reasonable_pivot` is not dominating, mostly simple numerical cases.

2. I've made `piv_col` variable to increment if a pivot is found for the column. There were some redundant computation by this before.

3. I added a keyword `normalize` which was already used internally, but not exposed for the API-level. But I think that it can be useful for both in `rref` and `echelon_form` to return either a fraction-free result. I think that normalization can introduce a lot of bloated-up expression for symbolic computation.
 
4. I've improved the documentation of `echelon_form` and `rref`.
![Screen Shot 2019-10-16 at 19 47 58](https://user-images.githubusercontent.com/34944973/66946080-25fd7a00-f08b-11e9-8ae0-d5f7b2a29591.png)
![Screen Shot 2019-10-16 at 19 48 05](https://user-images.githubusercontent.com/34944973/66946085-28f86a80-f08b-11e9-8bc1-e89fe0e6a097.png)

#### Other comments

I've also removed some redundant private methods like `_eval_echelon_form` and `_eval_rref`.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added `normalized` keyword for `rref` and `echelon_form` to control whether to normalize the pivot into `1` or not.
  - Improved `rref` performance for numeric or rational matrices.
<!-- END RELEASE NOTES -->
