### PR TITLE
Solvers: NotImplementedError for an equation containing absolute value in Python 3

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1020,8 +1020,13 @@ def solve(f, *symbols, **flags):
         # Abs
         fi = fi.replace(Abs, lambda arg:
             separatevars(Abs(arg)) if arg.has(*symbols) else Abs(arg))
-        fi = fi.replace(Abs, lambda arg:
-            Abs(arg).rewrite(Piecewise) if arg.has(*symbols) else Abs(arg))
+        while True:
+            was = fi
+            fi = fi.replace(Abs, lambda arg:
+                (Abs(arg).rewrite(Piecewise) if arg.has(*symbols)
+                else Abs(arg)))
+            if was == fi:
+                break
 
         for e in fi.find(Abs):
             if e.has(*symbols):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1018,13 +1018,11 @@ def solve(f, *symbols, **flags):
 
     for i, fi in enumerate(f):
         # Abs
-        fi = fi.replace(Abs, lambda arg:
-            separatevars(Abs(arg)) if arg.has(*symbols) else Abs(arg))
         while True:
             was = fi
             fi = fi.replace(Abs, lambda arg:
-                (Abs(arg).rewrite(Piecewise) if arg.has(*symbols)
-                else Abs(arg)))
+                separatevars(Abs(arg)).rewrite(Piecewise) if arg.has(*symbols)
+                else Abs(arg))
             if was == fi:
                 break
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2117,4 +2117,4 @@ def test_issue_17452():
 
 def test_issue_17650():
     x = Symbol('x', real=True)
-    assert solve(abs((abs(x**2-1)-x))-x) == [1, -1 + sqrt(2), 1 + sqrt(2)]
+    assert solve(abs((abs(x**2 - 1) - x)) - x) == [1, -1 + sqrt(2), 1 + sqrt(2)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2113,3 +2113,8 @@ def test_issue_17452():
     assert solve((7**x)**x + pi, x) == [-sqrt(log(pi) + I*pi)/sqrt(log(7)),
                                         sqrt(log(pi) + I*pi)/sqrt(log(7))]
     assert solve(x**(x/11) + pi/11, x) == [exp(LambertW(-11*log(11) + 11*log(pi) + 11*I*pi))]
+
+
+def test_issue_17650():
+    x = Symbol('x', real=True)
+    assert solve(abs((abs(x**2-1)-x))-x) == [1, -1 + sqrt(2), 1 + sqrt(2)]


### PR DESCRIPTION
Fixes #17650 

||x² - 1| - x| = x

When did:

from sympy import *
x = Symbol('x', real=True)
solve(abs((abs(x**2-1)-x))-x)

The following error was encountered:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python36-32\lib\site-packages\sympy\solvers\solvers.py", line 1065, in solve
solution = _solve(f[0], *symbols, **flags)
  File "C:\Python36-32\lib\site-packages\sympy\solvers\solvers.py", line 1366, in _solve
candidates = _solve(piecewise_fold(expr), symbol, **flags)
  File "C:\Python36-32\lib\site-packages\sympy\solvers\solvers.py", line 1634, in _solve
raise NotImplementedError('\n'.join([msg, not_impl_msg % f]))
NotImplementedError: multiple generators [x, Abs(-x**2 + x + 1)]
No algorithms are implemented to solve equation -x + Abs(-x**2 + x + 1)

Now this error is resolved.

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixes **NotImplementedError** for an equation containing absolute value in Python 3
<!-- END RELEASE NOTES -->
