### PR TITLE
Fix linsolve  for immutable matrix

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3444,6 +3444,8 @@ class MatrixBase(MatrixDeprecated,
         """
         from sympy.matrices import Matrix, zeros
 
+        cls = self.__class__
+
         aug = self.hstack(self.copy(), B.copy())
         B_cols = B.cols
         row, col = aug[:, :-B_cols].shape
@@ -3479,9 +3481,7 @@ class MatrixBase(MatrixDeprecated,
             col - rank, B_cols)
 
         # Full parametric solution
-        V = A[:rank,:]
-        for c in reversed(pivots):
-            V.col_del(c)
+        V = A[:rank, [c for c in range(A.cols) if c not in pivots]]
         vt = v[:rank, :]
         free_sol = tau.vstack(vt - V * tau, tau)
 
@@ -3490,6 +3490,7 @@ class MatrixBase(MatrixDeprecated,
         for k in range(col):
             sol[permutation[k], :] = free_sol[k,:]
 
+        sol, tau = cls(sol), cls(tau)
         if freevar:
             return sol, tau, free_var_index
         else:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3447,6 +3447,16 @@ def test_gauss_jordan_solve():
     b = Matrix([1, 1, 1])
     raises(ValueError, lambda: A.gauss_jordan_solve(b))
 
+    # Test for immutable matrix
+    A = ImmutableMatrix([[1, 0], [0, 1]])
+    B = ImmutableMatrix([1, 2])
+    sol, params = A.gauss_jordan_solve(B)
+    assert sol == ImmutableMatrix([1, 2])
+    assert params == ImmutableMatrix(0, 1, [])
+    assert sol.__class__ == ImmutableDenseMatrix
+    assert params.__class__ == ImmutableDenseMatrix
+
+
 def test_solve():
     A = Matrix([[1,2], [2,4]])
     b = Matrix([[3], [4]])

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2454,11 +2454,11 @@ def linsolve(system, *symbols):
     if hasattr(system, '__iter__'):
 
         # 1). (A, b)
-        if len(system) == 2 and isinstance(system[0], Matrix):
+        if len(system) == 2 and isinstance(system[0], MatrixBase):
             A, b = system
 
         # 2). (eq1, eq2, ...)
-        if not isinstance(system[0], Matrix):
+        if not isinstance(system[0], MatrixBase):
             if sym_gen or not symbols:
                 raise ValueError(filldedent('''
                     When passing a system of equations, the explicit
@@ -2472,9 +2472,9 @@ def linsolve(system, *symbols):
             A, b = linear_eq_to_matrix(system, symbols)
             syms_needed_msg = 'free symbols in the equations provided'
 
-    elif isinstance(system, Matrix) and not (
+    elif isinstance(system, MatrixBase) and not (
             symbols and not isinstance(symbols, GeneratorType) and
-            isinstance(symbols[0], Matrix)):
+            isinstance(symbols[0], MatrixBase)):
         # 3). A augmented with b
         A, b = system[:, :-1], system[:, -1:]
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -19,6 +19,7 @@ from sympy.functions.special.error_functions import (erf, erfc,
     erfcinv, erfinv)
 from sympy.logic.boolalg import And
 from sympy.matrices.dense import MutableDenseMatrix as Matrix
+from sympy.matrices.immutable import ImmutableDenseMatrix
 from sympy.polys.polytools import Poly
 from sympy.polys.rootoftools import CRootOf
 from sympy.sets.contains import Contains
@@ -1184,6 +1185,16 @@ def test_linsolve():
     assert linsolve([Eq(1/x, 1/x + y)], [x, y]) == {(x, 0)}
     assert linsolve([Eq(y/x, y/x + y)], [x, y]) == {(x, 0)}
     assert linsolve([Eq(x*(x + 1), x**2 + y)], [x, y]) == {(y, y)}
+
+
+def test_linsolve_immutable():
+    A = ImmutableDenseMatrix([[1, 1, 2], [0, 1, 2], [0, 0, 1]])
+    B = ImmutableDenseMatrix([2, 1, -1])
+    c = symbols('c1 c2 c3')
+    assert linsolve([A, B], c) == FiniteSet((1, 3, -1))
+
+    A = ImmutableDenseMatrix([[1, 1, 7], [1, -1, 3]])
+    assert linsolve(A) == FiniteSet((5, 2))
 
 
 def test_solve_decomposition():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17762 
Fixes #17722 

#### Brief description of what is fixed or changed

I've fixed the type checking for `linearsolve`, and also fixed some usage of the mutability of a matrix in `gauss_jordan_solve`.

#### Other comments

I'd also try to check `linsolve` whether it works with matrix expressions.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `Matrix.gauss_jordan_solve` raising `ShapeError` for immutable matrices.
- solvers
  - Fixed `linsolve` raising errors for `ImmutableMatrix`.
<!-- END RELEASE NOTES -->
