### PR TITLE
fix `ConditionSet.is_subset` when a condition is a subset of another

### DIFF
--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -246,6 +246,30 @@ class ConditionSet(Set):
             return ConditionSet(new, Contains(new, base), base)
         return self.func(self.sym, cond, base)
 
+    def _eval_rewrite_as_Intersection(self, *args, **kwargs):
+        """
+        Try to convert the ConditionSet to an Intersection set.
+
+        Examples
+        ========
+
+        >>> from sympy import  S, ConditionSet, Intersection
+        >>> from sympy.abc import x
+
+        >>> ConditionSet(x, x<1, S.Reals).rewrite(Intersection)
+        Interval.open(-oo, 1)
+
+        >>> ConditionSet(x, x**2 > x, S.Integers).rewrite(Intersection)
+        Union(Range(-oo, 0, 1), Range(2, oo, 1))
+
+        Notes
+        =====
+        Currently this is only implemented for ConditionSets which have a single variable and where the base set
+        is a subset of `Reals`.
+        """
+        if not isinstance(self.sym, Tuple) and self.base_set.is_subset(S.Reals):
+            return self.condition.as_set().intersect(self.base_set)
+
     def dummy_eq(self, other, symbol=None):
         if not isinstance(other, self.func):
             return False

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -1,8 +1,9 @@
 from sympy import S, Symbol
 from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
-from sympy.sets.sets import FiniteSet, Interval, Set, Union
+from sympy.sets.sets import FiniteSet, Interval, Set, Union, Intersection
 from sympy.sets.fancysets import Complexes, Reals, Range, Rationals
+from sympy.sets.conditionset import ConditionSet
 from sympy.multipledispatch import dispatch
 
 
@@ -133,3 +134,24 @@ def is_subset_sets(a, b): # noqa:F811
 @dispatch(Rationals, Range)
 def is_subset_sets(a, b): # noqa:F811
     return False
+
+@dispatch(ConditionSet, ConditionSet)
+def is_subset_sets(a, b):  # noqa:F811
+    if a.condition == b.condition and a.base_set.is_subset(b.base_set):
+        return True
+    a_i = a.rewrite(Intersection)
+    b_i = b.rewrite(Intersection)
+    if (type(a_i), type(b_i)) != (ConditionSet, ConditionSet):
+        return a_i.is_subset(b_i)
+
+@dispatch(Set, ConditionSet)
+def is_subset_sets(a, b):  # noqa:F811
+    b_i = b.rewrite(Intersection)
+    if type(b_i) != ConditionSet:
+        return a.is_subset(b_i)
+
+@dispatch(ConditionSet, Set)
+def is_subset_sets(a, b):  # noqa:F811
+    a_i = a.rewrite(Intersection)
+    if type(a_i) != ConditionSet:
+        return a_i.is_subset(b)

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,5 +1,5 @@
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
-    EmptySet, Union, Contains)
+    EmptySet, Union, Contains, Range)
 from sympy import (Symbol, Eq, S, Abs, sin, pi, Interval,
     And, Mod, oo, Function)
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
@@ -179,3 +179,11 @@ def test_failing_contains():
     # and the comparison is giving an error.
     assert ConditionSet(x, 1/x >= 0, S.Reals).contains(0) == \
         Contains(0, ConditionSet(x, 1/x >= 0, S.Reals), evaluate=False)
+
+def test_eval_rewrite_as_Intersection():
+    assert ConditionSet(x, x**3 > x**2, S.Naturals).rewrite(Intersection) == Range(2, oo, 1)
+    assert ConditionSet(x, Eq(x**2 - x, 0), S.Integers).rewrite(Intersection) == FiniteSet(0, 1)
+    assert ConditionSet(x, x / 12 <= 4, S.Integers).rewrite(Intersection) == Range(-oo, 49, 1)
+    assert ConditionSet(x, x**2 >= 4, Range(-2, 3, 1)).rewrite(Intersection) == Union(Range(-2, -1, 1), Range(2, 3, 1))  # or FiniteSet(-2, 2)
+    # Not implemented:
+    assert ConditionSet((x, y), x > y).rewrite(Intersection) == ConditionSet((x, y), x > y).rewrite(Intersection)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -3,7 +3,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
-    Matrix, Range, Add, symbols, zoo, Rational)
+    Matrix, Range, Add, symbols, zoo, Rational, ConditionSet)
 from mpmath import mpi
 
 from sympy.core.compatibility import range
@@ -712,6 +712,34 @@ def test_is_subset():
     assert Range(3).is_subset(FiniteSet(0, 1, n)) is None
     assert Range(n, n + 2).is_subset(FiniteSet(n, n + 1)) is True
     assert Range(5).is_subset(Interval(0, 4, right_open=True)) is False
+
+    assert ConditionSet(x, x**2 < 15, S.Naturals).is_subset(
+        ConditionSet(x, x**2 < 15, S.Integers)
+    ) is True
+    assert ConditionSet(x, x < 0, FiniteSet(y)).is_subset(ConditionSet(x, x < 0, FiniteSet(y))) is True
+    assert ConditionSet(x, x < 0, FiniteSet(y)).is_subset(ConditionSet(x, x < 0, FiniteSet(y, z))) is True
+    assert Range(-3, 4, 1).is_subset(ConditionSet(x, x**2 <= 9, S.Integers)) is True
+    assert ConditionSet(x, x**2 < 15, S.Integers).is_subset(
+        Interval(-10, 10)
+    ) is True
+    assert ConditionSet(x, x**2 < 15, S.Integers).is_subset(
+        FiniteSet(-10, 10)
+    ) is False
+    assert ConditionSet(x, x**2 > 16, S.Integers).is_subset(
+        ConditionSet(x, 2*x > 0, S.Integers)
+    ) is False
+    assert ConditionSet(x, x**2 <= 4, S.Reals).is_subset(ConditionSet(x, x <= 4, S.Reals)) is True
+    assert ConditionSet(x, x**2 <= 4, S.Reals).is_subset(ConditionSet(x, x <= 4, S.Naturals)) is False
+
+    assert ConditionSet(x, x ** 2 < 0, S.UniversalSet).is_subset(
+        ConditionSet(x, x ** 2 < 0, S.Reals)
+    ) is not True
+    assert ConditionSet((x, y), x < 1, S.Reals * S.Reals).is_subset(
+        ConditionSet((x, y), x > 1, S.Reals * S.Reals)
+    ) is not True
+    assert ConditionSet((x, y), x ** 2 + y ** 2 >= 0, S.Reals * S.Reals).is_subset(
+        ConditionSet((x, y), x ** 2 + y ** 2 > 10, S.Reals * S.Reals)
+    ) is not True
 
 
 def test_is_proper_subset():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This parttially fixes #17550 for ConditionSets when the base sets are real.

#### Brief description of what is fixed or changed
My main intention of this commit was to fix the following code:
```
from sympy import ConditionSet, S
from sympy.abc import x

A = ConditionSet(x, x**2 <= 4, S.Reals)
C = ConditionSet(x, x <= 4, S.Reals)

A.is_subset(C)  # Used to return `None`, now returns `True` (as it should)
```

I've added some logic to handle the case when base sets are not real. However, the actual behavior for complex ConditionSet will most likely be a `NotImplementedError` when calling `is_subset`. This is because `set.condition.as_set` does not work for complex conditions.
For set comparison with complex base sets, True is returned when the first condition is a _real_ subset of the second (`self.condition.as_set(),is_subset(other.condition.as_set())`) and the first base set is a subset of the second base set (`self.base_set.is_subset(other.base_set)`). This is probably not entirely correct (I'd also be happy to remove the entire logic for complex sets and just return None), but it returns True for appropriate comparisons with the default `UniversalSet`.


#### Other comments
I want to share my appreciation for the devs/maintainers of this tool. As a math student I love using SymPy

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Improved `is_subset` for unevaluated ConditionSets
<!-- END RELEASE NOTES -->
