### PR TITLE
Fix flake8 warnings for sets and use PowerSet instead of None in .powerset

### DIFF
--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -15,7 +15,7 @@ from sympy.utilities.misc import filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .contains import Contains
-from .sets import Set, EmptySet, Union, FiniteSet, ProductSet, UniversalSet
+from .sets import Set, EmptySet, Union, FiniteSet
 
 
 class ConditionSet(Set):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from functools import reduce
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int, with_metaclass, range, PY3
+from sympy.core.compatibility import with_metaclass, range, PY3
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import Lambda
@@ -411,7 +411,6 @@ class ImageSet(Set):
         def get_equations(expr, candidate):
             '''Find the equations relating symbols in expr and candidate.'''
             queue = [(expr, candidate)]
-            equations = []
             for e, c in queue:
                 if not isinstance(e, Tuple):
                     yield Eq(e, c)
@@ -565,7 +564,7 @@ class Range(Set):
     def __new__(cls, *args):
         from sympy.functions.elementary.integers import ceiling
         if len(args) == 1:
-            if isinstance(args[0], range if PY3 else xrange):
+            if isinstance(args[0], range):
                 raise TypeError(
                     'use sympify(%s) to convert range to Range' % args[0])
 

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -6,7 +6,7 @@ from sympy.core.logic import fuzzy_bool
 from sympy.core.singleton import S
 from sympy.core.sympify import _sympify
 
-from .sets import Set, tfn
+from .sets import Set
 
 
 class PowerSet(Set):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -5,7 +5,7 @@ import inspect
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import (iterable, with_metaclass,
-    ordered, range, PY3, is_sequence, reduce)
+    ordered, range, PY3, reduce)
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.decorators import deprecated
@@ -13,7 +13,6 @@ from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
 from sympy.core.expr import Expr
 from sympy.core.logic import fuzzy_bool, fuzzy_or, fuzzy_and
-from sympy.core.mul import Mul
 from sympy.core.numbers import Float
 from sympy.core.operations import LatticeOp
 from sympy.core.relational import Eq, Ne
@@ -453,7 +452,8 @@ class Set(Basic):
             raise ValueError("Unknown argument '%s'" % other)
 
     def _eval_powerset(self):
-        return None
+        from .powerset import PowerSet
+        return PowerSet(self)
 
     def powerset(self):
         """
@@ -462,14 +462,25 @@ class Set(Basic):
         Examples
         ========
 
-        >>> from sympy import FiniteSet, EmptySet
+        >>> from sympy import EmptySet, FiniteSet, Interval, PowerSet
+
+        A power set of an empty set:
+
         >>> A = EmptySet()
         >>> A.powerset()
         {EmptySet()}
+
+        A power set of a finite set:
+
         >>> A = FiniteSet(1, 2)
         >>> a, b, c = FiniteSet(1), FiniteSet(2), FiniteSet(1, 2)
         >>> A.powerset() == FiniteSet(a, b, c, EmptySet())
         True
+
+        A power set of an interval:
+
+        >>> Interval(1, 2).powerset()
+        PowerSet(Interval(1, 2))
 
         References
         ==========

--- a/sympy/sets/tests/test_powerset.py
+++ b/sympy/sets/tests/test_powerset.py
@@ -2,6 +2,7 @@ from sympy.core.expr import unchanged
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.sets.contains import Contains
+from sympy.sets.fancysets import Interval
 from sympy.sets.powerset import PowerSet
 from sympy.sets.sets import FiniteSet
 from sympy.utilities.pytest import raises, XFAIL
@@ -114,3 +115,21 @@ def test_powerset_contains():
 
     A = PowerSet(FiniteSet(x), evaluate=False)
     assert A.contains(FiniteSet(1)) == Contains(FiniteSet(1), A)
+
+
+def test_powerset_method():
+    # EmptySet
+    A = FiniteSet()
+    pset = A.powerset()
+    assert len(pset) == 1
+    assert pset ==  FiniteSet(S.EmptySet)
+
+    # FiniteSets
+    A = FiniteSet(1, 2)
+    pset = A.powerset()
+    assert len(pset) == 2**len(A)
+    assert pset == FiniteSet(FiniteSet(), FiniteSet(1),
+                             FiniteSet(2), A)
+    # Not finite sets
+    A = Interval(0, 1)
+    assert A.powerset() == PowerSet(A)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    LessThan, Max, Min, And, Or, Eq, Le, Lt, Float,
+    Max, Min, Float,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
@@ -8,8 +8,7 @@ from mpmath import mpi
 
 from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
-from sympy.core.relational import \
-    Eq, Ne, Le, Lt, LessThan
+from sympy.core.relational import Eq, Ne, Le, Lt, LessThan
 from sympy.logic import And, Or, Xor
 from sympy.utilities.pytest import raises, XFAIL, warns_deprecated_sympy
 
@@ -863,7 +862,7 @@ def test_finite_basic():
     assert FiniteSet((1, 2, 3)) != FiniteSet(1, 2, 3)
 
     # Ensure a variety of types can exist in a FiniteSet
-    s = FiniteSet((1, 2), Float, A, -5, x, 'eggs', x**2, Interval)
+    assert FiniteSet((1, 2), Float, A, -5, x, 'eggs', x**2, Interval)
 
     assert (A > B) is False
     assert (A >= B) is False
@@ -876,23 +875,6 @@ def test_finite_basic():
     assert A > AandB and B > AandB
 
     assert FiniteSet(1.0) == FiniteSet(1)
-
-
-def test_powerset():
-    # EmptySet
-    A = FiniteSet()
-    pset = A.powerset()
-    assert len(pset) == 1
-    assert pset ==  FiniteSet(S.EmptySet)
-
-    # FiniteSets
-    A = FiniteSet(1, 2)
-    pset = A.powerset()
-    assert len(pset) == 2**len(A)
-    assert pset == FiniteSet(FiniteSet(), FiniteSet(1),
-                             FiniteSet(2), A)
-    # Not finite sets
-    I = Interval(0, 1)
 
 
 def test_product_basic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I've cleaned up some flake8 warnings for unused imports and variables.

Also, I've changed the behavior of `.powerset` to return `PowerSet` object instead of `None` for infinite sets like interval, which has better capability.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
  - `Set.powerset` will return `PowerSet` instead of `None` for infinite sets.
<!-- END RELEASE NOTES -->
