### PR TITLE
Improve is_cyclic

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3016,7 +3016,7 @@ class PermutationGroup(Basic):
             self._is_abelian = True
             return True
 
-        if not self._is_abelian:
+        if self._is_abelian == False:
             self._is_cyclic = False
             return False
         for p in primefactors(self.order()):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3016,7 +3016,7 @@ class PermutationGroup(Basic):
             self._is_abelian = True
             return True
 
-        if self._is_abelian == False:
+        if self._is_abelian is False:
             self._is_cyclic = False
             return False
         for p in primefactors(self.order()):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2991,7 +2991,8 @@ class PermutationGroup(Basic):
 
         return self._eval_is_alt_sym_naive(only_alt=True)
 
-    def _eval_is_cyclic_distinct_primes(self, primes):
+    @classmethod
+    def _distinct_primes_lemma(cls, primes):
         """Subroutine to test if there is only one cyclic group for the
         order."""
         primes = sorted(primes)
@@ -3056,7 +3057,7 @@ class PermutationGroup(Basic):
         factors = factorint(order)
         if all(v == 1 for v in factors.values()):
             primes = list(factors.keys())
-            if self._eval_is_cyclic_distinct_primes(primes) is True:
+            if PermutationGroup._distinct_primes_lemma(primes) is True:
                 self._is_cyclic = True
                 self._is_abelian = True
                 return True

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2991,6 +2991,17 @@ class PermutationGroup(Basic):
 
         return self._eval_is_alt_sym_naive(only_alt=True)
 
+    def _eval_is_cyclic_distinct_primes(self, primes):
+        """Subroutine to test if there is only one cyclic group for the
+        order."""
+        primes = sorted(primes)
+        l = len(primes)
+        for i in range(l):
+            for j in range(i+1, l):
+                if primes[j] % primes[i] == 1:
+                    return None
+        return True
+
     @property
     def is_cyclic(self):
         """
@@ -3019,7 +3030,17 @@ class PermutationGroup(Basic):
         if self._is_abelian is False:
             self._is_cyclic = False
             return False
-        for p in primefactors(self.order()):
+
+        order = self.order()
+        factors = factorint(order)
+        if all(v == 1 for v in factors.values()):
+            primes = list(factors.keys())
+            if self._eval_is_cyclic_distinct_primes(primes) is True:
+                self._is_cyclic = True
+                self._is_abelian = True
+                return True
+
+        for p in factors:
             pgens = []
             for g in self.generators:
                 pgens.append(g**p)

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3004,7 +3004,7 @@ class PermutationGroup(Basic):
 
     @property
     def is_cyclic(self):
-        """
+        r"""
         Return ``True`` if the group is Cyclic.
 
         Examples
@@ -3018,6 +3018,27 @@ class PermutationGroup(Basic):
         >>> G.is_cyclic
         False
 
+        Notes
+        =====
+
+        If the order of a group $n$ can be factored into the distinct
+        primes $p_1, p_2, ... , p_s$ and if
+
+        .. math::
+            \forall i, j \in \{1, 2, \ldots, s \}:
+            p_i \not \equiv 1 \pmod {p_j}
+
+        holds true, there is only one group of the order $n$ which
+        is a cyclic group. [1]_
+
+        This is a generalization of the lemma that the group of order
+        $15, 35, ...$ are cyclic.
+
+        References
+        ==========
+
+        .. [1] 1978: John S. Rose: A Course on Group Theory,
+            Introduction to Finite Group Theory: 1.4
         """
         if self._is_cyclic is not None:
             return self._is_cyclic

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3010,10 +3010,12 @@ class PermutationGroup(Basic):
         """
         if self._is_cyclic is not None:
             return self._is_cyclic
-        self._is_cyclic = True
 
         if len(self.generators) == 1:
+            self._is_cyclic = True
+            self._is_abelian = True
             return True
+
         if not self._is_abelian:
             self._is_cyclic = False
             return False
@@ -3026,6 +3028,8 @@ class PermutationGroup(Basic):
                 return False
             else:
                 continue
+        self._is_cyclic = True
+        self._is_abelian = True
         return True
 
     def pointwise_stabilizer(self, points, incremental=True):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3022,6 +3022,8 @@ class PermutationGroup(Basic):
         Notes
         =====
 
+        Lemma 1:
+
         If the order of a group $n$ can be factored into the distinct
         primes $p_1, p_2, ... , p_s$ and if
 
@@ -3034,6 +3036,11 @@ class PermutationGroup(Basic):
 
         This is a generalization of the lemma that the group of order
         $15, 35, ...$ are cyclic.
+
+        Lemma 2:
+
+        If the group is abelian and the order of the group is
+        square-free, the group is cyclic.
 
         References
         ==========
@@ -3056,6 +3063,10 @@ class PermutationGroup(Basic):
         order = self.order()
         factors = factorint(order)
         if all(v == 1 for v in factors.values()):
+            if self._is_abelian:
+                self._is_cyclic = True
+                return True
+
             primes = list(factors.keys())
             if PermutationGroup._distinct_primes_lemma(primes) is True:
                 self._is_cyclic = True

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3022,8 +3022,6 @@ class PermutationGroup(Basic):
         Notes
         =====
 
-        Lemma 1:
-
         If the order of a group $n$ can be factored into the distinct
         primes $p_1, p_2, ... , p_s$ and if
 
@@ -3032,15 +3030,17 @@ class PermutationGroup(Basic):
             p_i \not \equiv 1 \pmod {p_j}
 
         holds true, there is only one group of the order $n$ which
-        is a cyclic group. [1]_
+        is a cyclic group. [1]_ This is a generalization of the lemma
+        that the group of order $15, 35, ...$ are cyclic.
 
-        This is a generalization of the lemma that the group of order
-        $15, 35, ...$ are cyclic.
+        And also, these additional lemmas can be used to test if a
+        group is cyclic if the order of the group is already found.
 
-        Lemma 2:
-
-        If the group is abelian and the order of the group is
-        square-free, the group is cyclic.
+        - If the group is abelian and the order of the group is
+          square-free, the group is cyclic.
+        - If the order of the group is less than $6$ and is not $4$, the
+          group is cyclic.
+        - If the order of the group is prime, the group is cyclic.
 
         References
         ==========
@@ -3061,6 +3061,13 @@ class PermutationGroup(Basic):
             return False
 
         order = self.order()
+
+        if order < 6:
+            self._is_abelian == True
+            if order != 4:
+                self._is_cyclic == True
+                return True
+
         factors = factorint(order)
         if all(v == 1 for v in factors.values()):
             if self._is_abelian:
@@ -3080,8 +3087,7 @@ class PermutationGroup(Basic):
             if self.index(self.subgroup(pgens)) != p:
                 self._is_cyclic = False
                 return False
-            else:
-                continue
+
         self._is_cyclic = True
         self._is_abelian = True
         return True

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -996,6 +996,22 @@ def test_cyclic():
     G = AlternatingGroup(4)
     assert not G.is_cyclic
 
+    # Order less than 6
+    G = PermutationGroup(Permutation(0, 1, 2), Permutation(0, 2, 1))
+    assert G.is_cyclic
+    G = PermutationGroup(
+        Permutation(0, 1, 2, 3),
+        Permutation(0, 2)(1, 3)
+    )
+    assert G.is_cyclic
+    G = PermutationGroup(
+        Permutation(3),
+        Permutation(0, 1)(2, 3),
+        Permutation(0, 2)(1, 3),
+        Permutation(0, 3)(1, 2)
+    )
+    assert G.is_cyclic is False
+
     # Order 15
     G = PermutationGroup(
         Permutation(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -996,6 +996,26 @@ def test_cyclic():
     G = AlternatingGroup(4)
     assert not G.is_cyclic
 
+    # Order 15
+    G = PermutationGroup(
+        Permutation(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+        Permutation(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13)
+    )
+    assert G.is_cyclic
+
+    # Distinct prime orders
+    assert PermutationGroup._distinct_primes_lemma([3, 5]) is True
+    assert PermutationGroup._distinct_primes_lemma([5, 7]) is True
+    assert PermutationGroup._distinct_primes_lemma([2, 3]) is None
+    assert PermutationGroup._distinct_primes_lemma([3, 5, 7]) is None
+    assert PermutationGroup._distinct_primes_lemma([5, 7, 13]) is True
+
+    G = PermutationGroup(
+        Permutation(0, 1, 2, 3),
+        Permutation(0, 2)(1, 3))
+    assert G.is_cyclic
+    assert G._is_abelian
+
 
 def test_abelian_invariants():
     G = AbelianGroup(2, 3, 4)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

1. There were some wrong results for `is_cyclic`
```python3
>>> PermutationGroup(
...     Permutation(0, 1, 2, 3),
...     Permutation(0, 2)(1, 3)
... ).is_cyclic
False
```
because of `if not self._is_abelian:` which gives a false positive for `None`

2. I've made `is_abelian` cache to update whenever `is_cyclic` holds ``True``. 

3. I've also added an additional lemma when the order is square-free.

#### Other comments

I've also updated the documentation
![image](https://user-images.githubusercontent.com/34944973/67360735-9fbcc880-f5a1-11e9-9941-9c47d2ae8468.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Fixed `PermutationGroup.is_cyclic` giving wrong result for the cyclic groups created with explicitly specified generators.
  - `PermutationGroup.is_cyclic` automatically updates the cache for `is_abelian`.
  - Improved the algorithm of `PermutationGroup.is_cyclic` to detect some trivial cases like the group order of `15`, `35`, etc.
<!-- END RELEASE NOTES -->
