### PR TITLE
Added docs for multiple point initialization

### DIFF
--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -169,15 +169,29 @@ Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and
 methods. Don't mix and match symbols representing time.
 
-Point
------
-Multiple instances of ``Point`` can also be created in a single step, using the 
-``symbols()`` function. An example of this is shown below. ::
+Shortcut to create multiple mechanics objects
+---------------------------------------------
+Multiple instances of ``Point``, ``ReferenceFrame``, ``Particle`` and
+``RigidBody`` can also be created in a single step, using the ``symbols()``
+function. Examples of this are shown below. ::
 
-  >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
   >>> from sympy import symbols
-  >>> N = ReferenceFrame('N')
-  >>> A, B = symbols('A B', cls=Point)
+  >>> from sympy.physics.vector import Point, ReferenceFrame
+  >>> from sympy.physics.mechanics import outer, Particle, RigidBody
+  >>> x, y, z = symbols('x y z', cls=Point)
+  >>> m = symbols('m')
+  >>> type(m)
+  <class 'sympy.core.symbol.Symbol'>
+  >>> pa, pb = symbols('pa pb', point=x, mass=m, cls=Particle)
+  >>> type(pa)
+  <class 'sympy.physics.mechanics.particle.Particle'>
+  >>> pa.point, pa.mass
+  (x, m)
+  >>> N, O = symbols('N O', cls=ReferenceFrame)
+  >>> I = outer(N.x, N.x)
+  >>> inertia_tuple = (I, x)
+  >>> A, B = symbols('A B', masscenter=x, frame=N, mass=m, inertia=inertia_tuple, cls=RigidBody)
   >>> type(A)
-  <class 'sympy.physics.vector.point.Point'>
-  
+  <class 'sympy.physics.mechanics.rigidbody.RigidBody'>
+  >>> A.masscenter, A.frame, A.mass, A.inertia
+  (x, N, m, ((N.x|N.x), x))

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -170,18 +170,14 @@ Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 methods. Don't mix and match symbols representing time.
 
 Point
---------------
+-----
 Multiple instances of ``Point`` can also be created in a single step, using the 
-``symbols()`` function. An example of this is shown below. :
+``symbols()`` function. An example of this is shown below. ::
 
   >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
   >>> from sympy import symbols
   >>> N = ReferenceFrame('N')
-  >>> u1, u2 = dynamicsymbols('u1 u2')
   >>> A, B = symbols('A B', cls=Point)
   >>> type(A)
   <class 'sympy.physics.vector.point.Point'>
-  >>> A.set_vel(N, u1 * N.x + u2 * N.y)
-  >>> B.set_vel(N, u2 * N.x + u1 * N.y)
-  >>> A.acc(N) - B.acc(N)
-  (u1' - u2')*N.x + (-u1' + u2')*N.y
+  

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -85,7 +85,7 @@ Advanced Interfaces
 ===================
 
 Here we will cover advanced options in: ``ReferenceFrame``, ``dynamicsymbols``,
-and some associated functionality.
+``Point``, and some associated functionality.
 
 ReferenceFrame
 --------------
@@ -117,6 +117,22 @@ that would be used if there were custom indices. ::
   '\\mathbf{n}_2'
   >>> vlatex(N.z)
   'cat'
+
+Multiple ReferenceFrame can be created in a single step using ``symbols()``. An 
+example of this is shown below. ::
+
+  >>> from sympy.physics.vector import ReferenceFrame
+  >>> from sympy import symbols
+  >>> A, B, C = symbols('A B C', cls=ReferenceFrame)
+  >>> D, E = symbols('D E', cls=ReferenceFrame, indices=('1', '2', '3'))
+  >>> A[0]
+  A_x
+  >>> D.x
+  D['1']
+  >>> E.y
+  E['2']
+  >>> type(A) == type(D)
+  True
 
 dynamicsymbols
 --------------
@@ -152,3 +168,20 @@ so dynamic symbols created before or after will print the same way.
 Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and
 methods. Don't mix and match symbols representing time.
+
+Point
+--------------
+Multiple instances of ``Point`` can also be created in a single step, using the 
+``symbols()`` function. An example of this is shown below. :
+
+  >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
+  >>> from sympy import symbols
+  >>> N = ReferenceFrame('N')
+  >>> u1, u2 = dynamicsymbols('u1 u2')
+  >>> A, B = symbols('A B', cls=Point)
+  >>> type(A)
+  <class 'sympy.physics.vector.point.Point'>
+  >>> A.set_vel(N, u1 * N.x + u2 * N.y)
+  >>> B.set_vel(N, u2 * N.x + u1 * N.y)
+  >>> A.acc(N) - B.acc(N)
+  (u1' - u2')*N.x + (-u1' + u2')*N.y


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17787

#### Brief description of what is fixed or changed
#17773 adds examples for initialization of multiple instances of ReferenceFrame and Point in their respective docstrings.
This PR adds the examples to the documentation in doc/.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
