### PR TITLE
sp.core.function.nfloat: Correctly handle boolean expression composed of Or, And, etc.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3248,6 +3248,9 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
         else:
             pass  # pure_complex(rv) is likely True
         return rv
+    elif rv.is_Boolean and (not rv.is_Atom):
+        # this case catches boolean expression like Or, And, Not
+        return expr.func(*[nfloat(a, **kw) for a in expr.args])
     elif rv.is_Atom:
         return rv
 


### PR DESCRIPTION

#### Brief description of what is fixed or changed
`sympy.core.function.nfloat` did not correctly handle objects composed of `Or`, `And` etc., it tried to call `expr.n()` which is not implemented for these objects.

This change manually handles this for these objects.

I do not know if this is the _correct_ way of fixing this issue or if `Or`,`And` and other `Boolean` expressions should get a `.n()` method. Please advice.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * nfloat: correctly handle Boolean expressions composed of And/Or etc.
<!-- END RELEASE NOTES -->