### PR TITLE
Define equality for permutations

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 from sympy.core.basic import Atom
 from sympy.core.compatibility import is_sequence, reduce, range, as_int
+from sympy.core.sympify import _sympify
+from sympy.logic.boolalg import as_Boolean
 from sympy.matrices import zeros
 from sympy.polys.polytools import lcm
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
@@ -947,6 +949,16 @@ class Permutation(Atom):
             aform.extend(list(range(len(aform), size)))
 
         return cls._af_new(aform)
+
+    def _eval_Eq(self, other):
+        other = _sympify(other)
+        if not isinstance(other, Permutation):
+            return None
+
+        if self._size != other._size:
+            return None
+
+        return as_Boolean(self._array_form == other._array_form)
 
     @classmethod
     def _af_new(cls, perm):

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -1,7 +1,10 @@
 from itertools import permutations
 
 from sympy.core.compatibility import range
+from sympy.core.expr import unchanged
+from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
+from sympy.core.singleton import S
 from sympy.combinatorics.permutations import (Permutation, _af_parity,
     _af_rmul, _af_rmuln, Cycle)
 from sympy.utilities.pytest import raises
@@ -465,3 +468,20 @@ def test_printing_non_cyclic():
     assert str(p3) == 'Permutation([0, 2, 1])'
     p4 = Permutation([0, 1, 3, 2, 4, 5, 6, 7])
     assert repr(p4) == 'Permutation([0, 1, 3, 2], size=8)'
+
+
+def test_permutation_equality():
+    a = Permutation(0, 1, 2)
+    b = Permutation(0, 1, 2)
+    assert Eq(a, b) is S.true
+    c = Permutation(0, 2, 1)
+    assert Eq(a, c) is S.false
+
+    d = Permutation(0, 1, 2, size=4)
+    assert unchanged(Eq, a, d)
+    e = Permutation(0, 2, 1, size=4)
+    assert unchanged(Eq, a, e)
+
+    i = Permutation()
+    assert unchanged(Eq, i, 0)
+    assert unchanged(Eq, 0, i)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

`_eval_Eq` have to be defined to make `Permutation` to work in `Eq` and `Ne`, and many other places.
I have left the equivalence undefined for different sized permutation.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Defined `Eq` for `Permutation` of same degree.
<!-- END RELEASE NOTES -->
