### PR TITLE
WIP - Mark tests that fail when run with the cache off

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,6 @@ norecursedirs =
     sympy/integrals/rubi/rubi_tests
 
 doctestplus = enabled
+
+markers =
+    nocache_fail

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -155,7 +155,7 @@ def test_periodicity():
         cos, sin, sec, csc, tan, cot))
     assert periodicity(Abs(sin(tan(x))), x) == pi
     assert periodicity(Abs(sin(sin(x) + tan(x))), x) == 2*pi
-    assert periodicity(sin(x) > S.Half, x) is 2*pi
+    assert periodicity(sin(x) > S.Half, x) == 2*pi
 
     assert periodicity(x > 2, x) is None
     assert periodicity(x**3 - x**2 + 1, x) is None

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1036,8 +1036,8 @@ class BaseCovarDerivativeOp(Expr):
                       for k in range(v._coord_sys.dim)])
             derivs.append(d)
         to_subs = [wrt_vector(d) for d in d_funcs]
-        # This substitution can fail when there are Dummy symbols and the
-        # cache is disabled:
+        # XXX: This substitution can fail when there are Dummy symbols and the
+        # cache is disabled: https://github.com/sympy/sympy/issues/17794
         result = d_result.subs(list(zip(to_subs, derivs)))
 
         # Remove the dummies

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1036,6 +1036,8 @@ class BaseCovarDerivativeOp(Expr):
                       for k in range(v._coord_sys.dim)])
             derivs.append(d)
         to_subs = [wrt_vector(d) for d in d_funcs]
+        # This substitution can fail when there are Dummy symbols and the
+        # cache is disabled:
         result = d_result.subs(list(zip(to_subs, derivs)))
 
         # Remove the dummies

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -8,7 +8,7 @@ from sympy.core import Symbol, symbols
 from sympy.simplify import trigsimp, simplify
 from sympy.functions import sqrt, atan2, sin
 from sympy.matrices import Matrix
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, nocache_fail
 
 TP = TensorProduct
 
@@ -110,6 +110,7 @@ def test_lie_derivative():
         R2.e_x, TensorProduct(R2.dx, R2.dy))(R2.e_x, R2.e_y) == 0
 
 
+@nocache_fail
 def test_covar_deriv():
     ch = metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
     cvd = BaseCovarDerivativeOp(R2_r, 0, ch)

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -114,6 +114,7 @@ def test_covar_deriv():
     ch = metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
     cvd = BaseCovarDerivativeOp(R2_r, 0, ch)
     assert cvd(R2.x) == 1
+    # This line fails if the cache is disabled:
     assert cvd(R2.x*R2.e_x) == R2.e_x
     cvd = CovarDerivativeOp(R2.x*R2.e_x, ch)
     assert cvd(R2.x) == R2.x

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -439,6 +439,7 @@ def test_genocchi():
     raises(ValueError, lambda: genocchi(-2))
 
 
+@nocache_fail
 def test_partition():
     partition_nums = [1, 1, 2, 3, 5, 7, 11, 15, 22]
     for n, p in enumerate(partition_nums):

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -167,6 +167,8 @@ def test_bell():
     # For large numbers, this is too slow
     # For nonintegers, there are significant precision errors
     for i in [0, 2, 3, 7, 13, 42, 55]:
+        # Running without the cache this is either very slow or goes into an
+        # infinite loop.
         assert bell(i).evalf() == bell(n).rewrite(Sum).evalf(subs={n: i})
 
     m = Symbol("m")

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -14,7 +14,7 @@ from sympy.core.compatibility import range
 from sympy.core.expr import unchanged
 from sympy.core.numbers import GoldenRatio, Integer
 
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, nocache_fail
 
 
 x = Symbol('x')
@@ -131,6 +131,7 @@ def test_tribonacci():
     raises(ValueError, lambda: tribonacci(-1, x))
 
 
+@nocache_fail
 def test_bell():
     assert [bell(n) for n in range(8)] == [1, 1, 2, 5, 15, 52, 203, 877]
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -12,7 +12,7 @@ from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, nocache_fail
 
 from sympy.abc import x, y, z, k
 n = Symbol('n', integer=True, positive=True)
@@ -547,6 +547,7 @@ def test_issue_15984():
     assert limit((-x + log(exp(x) + 1))/x, x, oo, dir='-').doit() == 0
 
 
+@nocache_fail
 def test_issue_13575():
     # This fails with infinite recursion when run without the cache:
     result = limit(acos(erfi(x)), x, 1)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -548,6 +548,7 @@ def test_issue_15984():
 
 
 def test_issue_13575():
+    # This fails with infinite recursion when run without the cache:
     result = limit(acos(erfi(x)), x, 1)
     assert isinstance(result, Add)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -791,6 +791,7 @@ def test_solve_trig():
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
 
+    # This fails when running with the cache off:
     assert solveset_complex(cos(x) - S.Half, x) == \
         Union(imageset(Lambda(n, 2*n*pi + pi*Rational(5, 3)), S.Integers),
               imageset(Lambda(n, 2*n*pi + pi/3), S.Integers))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -30,7 +30,8 @@ from sympy.sets.sets import (Complement, EmptySet, FiniteSet,
 from sympy.tensor.indexed import Indexed
 from sympy.utilities.iterables import numbered_symbols
 
-from sympy.utilities.pytest import XFAIL, raises, skip, slow, SKIP
+from sympy.utilities.pytest import (XFAIL, raises, skip, slow, SKIP,
+    nocache_fail)
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.physics.units import cm
 
@@ -772,6 +773,7 @@ def test_solveset_complex_tan():
         imageset(Lambda(n, pi*n + pi/2), S.Integers)
 
 
+@nocache_fail
 def test_solve_trig():
     from sympy.abc import n
     assert solveset_real(sin(x), x) == \

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -482,6 +482,7 @@ class HypergeometricDistribution(SingleFiniteDistribution):
         return S(binomial(m, k) * binomial(N - m, n - k))/binomial(N, n)
 
     def _sample_scipy(self, size):
+        import scipy.stats # Make sure that stats is imported
         N, m, n = int(self.N), int(self.m), int(self.n)
         return scipy.stats.hypergeom.rvs(M=m, n=n, N=N, size=size)
 

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -11,7 +11,7 @@ from sympy.stats.drv_types import (PoissonDistribution, GeometricDistribution,
                                    Poisson, Geometric, Logarithmic, NegativeBinomial, Skellam,
                                    YuleSimon, Zeta)
 from sympy.stats.rv import sample
-from sympy.utilities.pytest import slow, raises
+from sympy.utilities.pytest import slow, nocache_fail
 
 x = Symbol('x')
 
@@ -51,6 +51,7 @@ def test_Logarithmic():
     assert isinstance(E(x, evaluate=False), Sum)
 
 
+@nocache_fail
 def test_negative_binomial():
     r = 5
     p = S.One / 3

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -56,6 +56,7 @@ def test_negative_binomial():
     p = S.One / 3
     x = NegativeBinomial('x', r, p)
     assert E(x) == p*r / (1-p)
+    # This hangs when run with the cache disabled:
     assert variance(x) == p*r / (1-p)**2
     assert E(x**5 + 2*x + 3) == Rational(9207, 4)
     assert isinstance(E(x, evaluate=False), Sum)

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -158,6 +158,10 @@ if not USE_PYTEST:
         func_wrapper.__wrapped__ = func
         return func_wrapper
 
+    def nocache_fail(func):
+        "Dummy decorator for marking tests that fail when cache is disabled"
+        return func
+
     @contextlib.contextmanager
     def warns(warningcls, **kwargs):
         '''Like raises but tests that warnings are emitted.
@@ -200,6 +204,7 @@ else:
     XFAIL = py.test.mark.xfail
     SKIP = py.test.mark.skip
     slow = py.test.mark.slow
+    nocache_fail = py.test.mark.nocache_fail
 
 
 @contextlib.contextmanager

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -935,6 +935,7 @@ def test_M14():
     assert solveset_real(tan(x) - 1, x) == ImageSet(Lambda(n, n*pi + pi/4), S.Integers)
 
 
+# This test fails when running with the cache off:
 def test_M15():
     if PY3:
         n = Dummy('n')

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -27,7 +27,8 @@ from sympy.functions.combinatorial.numbers import stirling
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.special.error_functions import Ci, Si, erf
 from sympy.functions.special.zeta_functions import zeta
-from sympy.utilities.pytest import XFAIL, slow, SKIP, skip, ON_TRAVIS
+from sympy.utilities.pytest import (XFAIL, slow, SKIP, skip, ON_TRAVIS,
+    raises, nocache_fail)
 from sympy.utilities.iterables import partitions
 from mpmath import mpi, mpc
 from sympy.matrices import Matrix, GramSchmidt, eye
@@ -935,10 +936,11 @@ def test_M14():
     assert solveset_real(tan(x) - 1, x) == ImageSet(Lambda(n, n*pi + pi/4), S.Integers)
 
 
-# This test fails when running with the cache off:
+@nocache_fail
 def test_M15():
     if PY3:
         n = Dummy('n')
+        # This test fails when running with the cache off:
         assert solveset(sin(x) - S.Half) in (Union(ImageSet(Lambda(n, 2*n*pi + pi/6), S.Integers),
                                                ImageSet(Lambda(n, 2*n*pi + pi*R(5, 6)), S.Integers)),
                                                Union(ImageSet(Lambda(n, 2*n*pi + pi*R(5, 6)), S.Integers),
@@ -1334,7 +1336,6 @@ def test_P3():
     A222 = -A[(3, 0), (2, 1)]
     A22 = BlockMatrix([[A221, A222]]).T
     rows = [[-A11, A12], [A21, A22]]
-    from sympy.utilities.pytest import raises
     raises(ValueError, lambda: BlockMatrix(rows))
     B = Matrix(rows)
     assert B == Matrix([

--- a/sympy/vector/tests/test_dyadic.py
+++ b/sympy/vector/tests/test_dyadic.py
@@ -4,10 +4,12 @@ from sympy.vector import (CoordSys3D, Vector, Dyadic,
                           DyadicAdd, DyadicMul, DyadicZero,
                           BaseDyadic, express)
 
+from sympy.utilities.pytest import nocache_fail
 
 A = CoordSys3D('A')
 
 
+@nocache_fail
 def test_dyadic():
     a, b = symbols('a, b')
     assert Dyadic.zero != 0

--- a/sympy/vector/tests/test_dyadic.py
+++ b/sympy/vector/tests/test_dyadic.py
@@ -62,6 +62,7 @@ def test_dyadic():
     q = symbols('q')
     B = A.orient_new_axis('B', q, A.k)
     assert express(d1, B) == express(d1, B, B)
+    # This assertion fails when running with the cache off:
     assert express(d1, B) == ((cos(q)**2) * (B.i | B.i) + (-sin(q) * cos(q)) *
             (B.i | B.j) + (-sin(q) * cos(q)) * (B.j | B.i) + (sin(q)**2) *
             (B.j | B.j))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #12910

#### Brief description of what is fixed or changed

Fixes a few tests that fail when run with the cache off and marks others that fail with a new `@nocache_fail` decorator.

#### Other comments

I did intend to fix the tests that fail with the cache off but at this stage I think it would be good just to get this merged. Perhaps a new issue can be opened explaining that all tests marked with `@nocache_fail` represent issues to be solved in future.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
