### PR TITLE
Fix intersection of ImageSets on Integers

### DIFF
--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -223,39 +223,31 @@ def intersection_sets(self, other):
         return None
     base_set = self.base_sets[0]
 
+    # Intersection between ImageSets with Integers as base set
+    # For {f(n) : n in Integers} & {g(m) : m in Integers} we solve the
+    # diophantine equations f(n)=g(m).
+    # If the solutions for n are {h(t) : t in Integers} then we return
+    # {f(h(t)) : t in integers}.
     if base_set is S.Integers:
-        g = None
+        gm = None
         if isinstance(other, ImageSet) and other.base_sets == (S.Integers,):
-            g = other.lamda.expr
+            gm = other.lamda.expr
             m = other.lamda.variables[0]
         elif other is S.Integers:
-            m = g = Dummy('x')
-        if g is not None:
-            f = self.lamda.expr
+            m = gm = Dummy('x')
+        if gm is not None:
+            fn = self.lamda.expr
             n = self.lamda.variables[0]
-            # Diophantine sorts the solutions according to the alphabetic
-            # order of the variable names, since the result should not depend
-            # on the variable name, they are replaced by the dummy variables
-            # below
-            a, b = Dummy('a'), Dummy('b')
-            fa, ga = f.subs(n, a), g.subs(m, b)
-            solns = list(diophantine(fa - ga))
-            if not solns:
+            solns = list(diophantine(fn - gm, syms=(n, m)))
+            if len(solns) == 0:
                 return EmptySet()
-
-            if len(solns) != 1:
+            elif len(solns) != 1:
                 return
-            nsol = solns[0][0]  # since 'a' < 'b', nsol is first
-            t = nsol.free_symbols.pop()  # diophantine supplied symbol
-            nsol = nsol.subs(t, n)
-            if nsol != n:
-                # if nsol == n and we know were are working with
-                # a base_set of Integers then this was an unevaluated
-                # ImageSet representation of Integers, otherwise
-                # it is a new ImageSet intersection with a subset
-                # of integers
-                nsol = f.subs(n, nsol)
-            return imageset(Lambda(n, nsol), S.Integers)
+            else:
+                soln, solm = solns[0]
+                (t,) = soln.free_symbols
+                expr = fn.subs(n, soln.subs(t, n))
+                return imageset(Lambda(n, expr), S.Integers)
 
     if other == S.Reals:
         from sympy.solvers.solveset import solveset_real

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -528,6 +528,10 @@ def test_infinitely_indexed_set_1():
     assert imageset(x, x/2 + Rational(1, 3), S.Integers).intersect(S.Integers) is S.EmptySet
     assert imageset(x, x/2 + S.Half, S.Integers).intersect(S.Integers) is S.Integers
 
+    # https://github.com/sympy/sympy/issues/17355
+    S53 = ImageSet(Lambda(n, 5*n + 3), S.Integers)
+    assert S53.intersect(S.Integers) == S53
+
 
 def test_infinitely_indexed_set_2():
     from sympy.abc import n


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17355 

#### Brief description of what is fixed or changed

On master:
```julia
In [1]: Intersection(S.Integers, ImageSet(Lambda(n, 5*n + 3), S.Integers))                                                                                    
Out[1]: ℤ
```

With this PR:
```julia
In [1]: Intersection(S.Integers, ImageSet(Lambda(n, 5*n + 3), S.Integers))                                                                                    
Out[1]: {5⋅n + 3 | n ∊ ℤ}
```

The unnecessary check for `if nsol != n` was leading to the wrong result.

#### Other comments

No release note as this was a regression since 1.4

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
