### PR TITLE
Solvers: ValueError when linear_coeffs is used on pure sp.numbers.Float expressions

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2193,7 +2193,10 @@ def linear_coeffs(eq, *syms, **_kw):
     ValueError: nonlinear term encountered: x*(y + 1)
     """
     d = defaultdict(list)
-    c, terms = _sympify(eq).as_coeff_add(*syms)
+    eq = _sympify(eq)
+    if not eq.has(*syms):
+        return [S.Zero]*len(syms) + [eq]
+    c, terms = eq.as_coeff_add(*syms)
     d[0].extend(Add.make_args(c))
     for t in terms:
         m, f = t.as_coeff_mul(*syms)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2081,7 +2081,10 @@ def test_solve_logarithm():
 
 
 def test_linear_coeffs():
+    import sympy as sp
     from sympy.solvers.solveset import linear_coeffs
+    syms = sp.symbols('x y')
+    x, y = syms
     assert linear_coeffs(0, x) == [0, 0]
     assert all(i is S.Zero for i in linear_coeffs(0, x))
     assert linear_coeffs(x + 2*y + 3, x, y) == [1, 2, 3]
@@ -2092,6 +2095,7 @@ def test_linear_coeffs():
     raises(ValueError, lambda:
         linear_coeffs(1/x*(x - 1) + 1/x, x))
     assert linear_coeffs(a*(x + y), x, y) == [a, a, 0]
+    assert linear_coeffs(sp.numbers.Float(1.0), *syms) == [0, 0, 1.0]
 
 # modular tests
 def test_is_modular():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2081,10 +2081,7 @@ def test_solve_logarithm():
 
 
 def test_linear_coeffs():
-    import sympy as sp
     from sympy.solvers.solveset import linear_coeffs
-    syms = sp.symbols('x y')
-    x, y = syms
     assert linear_coeffs(0, x) == [0, 0]
     assert all(i is S.Zero for i in linear_coeffs(0, x))
     assert linear_coeffs(x + 2*y + 3, x, y) == [1, 2, 3]
@@ -2095,7 +2092,7 @@ def test_linear_coeffs():
     raises(ValueError, lambda:
         linear_coeffs(1/x*(x - 1) + 1/x, x))
     assert linear_coeffs(a*(x + y), x, y) == [a, a, 0]
-    assert linear_coeffs(sp.numbers.Float(1.0), *syms) == [0, 0, 1.0]
+    assert linear_coeffs(1.0, x, y) == [0, 0, 1.0]
 
 # modular tests
 def test_is_modular():


### PR DESCRIPTION
Fixes #17774 

> In [19]: import sympy as sp
    ...: from sympy.solvers.solveset import linear_coeffs
    ...: syms = sp.symbols('x y')
    ...: x, y = syms
In [20]: linear_coeffs(1, *syms)  # works as expected
Out[20]: [0, 0, 1]
In [21]: linear_coeffs(sp.numbers.One(), *syms)  # works as expected
Out[21]: [0, 0, 1]
In [22]: linear_coeffs(sp.numbers.Integer(1), *syms)  # works as expected
Out[22]: [0, 0, 1]
In [23]: linear_coeffs(sp.numbers.Float(1.0), *syms)  **# throws ValueError**
Traceback (most recent call last):
**ValueError: nonlinear term encountered: 1.00000000000000**

After the change:
>> In [19]: import sympy as sp
    ...: from sympy.solvers.solveset import linear_coeffs
    ...: syms = sp.symbols('x y')
    ...: x, y = syms
In [20]: linear_coeffs(1, *syms)  # works as expected
Out[20]: [0, 0, 1]
In [21]: linear_coeffs(sp.numbers.One(), *syms)  # works as expected
Out[21]: [0, 0, 1]
In [22]: linear_coeffs(sp.numbers.Integer(1), *syms)  # works as expected
Out[22]: [0, 0, 1]
In [23]: linear_coeffs(sp.numbers.Float(1.0), *syms)  **# works as expected**
**Out[23]: [0, 0, 1.0]**



<!-- BEGIN RELEASE NOTES -->
* solvers
  * linear_coeffs gives no longer raises when expr has no symbols of interest

<!-- END RELEASE NOTES -->
