### PR TITLE
Add more constants for pycode

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -501,7 +501,14 @@ _known_functions_mpmath = dict(_in_mpmath, **{
     'sign': 'sign',
 })
 _known_constants_mpmath = {
-    'Pi': 'pi'
+    'Exp1': 'e',
+    'Pi': 'pi',
+    'GoldenRatio': 'phi',
+    'EulerGamma': 'euler',
+    'Catalan': 'catalan',
+    'NaN': 'nan',
+    'Infinity': 'inf',
+    'NegativeInfinity': 'ninf'
 }
 
 
@@ -517,6 +524,7 @@ class MpmathPrinter(PythonCodePrinter):
         _known_functions.items(),
         [(k, 'mpmath.' + v) for k, v in _known_functions_mpmath.items()]
     ))
+    _kc = {k: 'mpmath.'+v for k, v in _known_constants_mpmath.items()}
 
     def _print_Float(self, e):
         # XXX: This does not handle setting mpmath.mp.dps. It is assumed that
@@ -583,6 +591,14 @@ _known_functions_numpy = dict(_in_numpy, **{
     'exp2': 'exp2',
     'sign': 'sign',
 })
+_known_constants_numpy = {
+    'Exp1': 'e',
+    'Pi': 'pi',
+    'EulerGamma': 'euler_gamma',
+    'NaN': 'nan',
+    'Infinity': 'PINF',
+    'NegativeInfinity': 'NINF'
+}
 
 
 class NumPyPrinter(PythonCodePrinter):
@@ -597,7 +613,7 @@ class NumPyPrinter(PythonCodePrinter):
         PythonCodePrinter._kf.items(),
         [(k, 'numpy.' + v) for k, v in _known_functions_numpy.items()]
     ))
-    _kc = {k: 'numpy.'+v for k, v in _known_constants_math.items()}
+    _kc = {k: 'numpy.'+v for k, v in _known_constants_numpy.items()}
 
 
     def _print_seq(self, seq):
@@ -650,7 +666,9 @@ class NumPyPrinter(PythonCodePrinter):
         #     it will behave the same as passing the 'default' kwarg to select()
         #     *as long as* it is the last element in expr.args.
         # If this is not the case, it may be triggered prematurely.
-        return '{0}({1}, {2}, default=numpy.nan)'.format(self._module_format('numpy.select'), conds, exprs)
+        return '{0}({1}, {2}, default={3})'.format(
+            self._module_format('numpy.select'), conds, exprs,
+            self._print(S.NaN))
 
     def _print_Relational(self, expr):
         "Relational printer for Equality and Unequality"
@@ -833,8 +851,6 @@ _known_functions_scipy_special = {
 _known_constants_scipy_constants = {
     'GoldenRatio': 'golden_ratio',
     'Pi': 'pi',
-    'E': 'e',
-    'Exp1': 'e'
 }
 
 class SciPyPrinter(NumPyPrinter):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -861,7 +861,10 @@ class SciPyPrinter(NumPyPrinter):
         NumPyPrinter._kf.items(),
         [(k, 'scipy.special.' + v) for k, v in _known_functions_scipy_special.items()]
     ))
-    _kc = {k: 'scipy.constants.' + v for k, v in _known_constants_scipy_constants.items()}
+    _kc =dict(chain(
+        NumPyPrinter._kc.items(),
+        [(k, 'scipy.constants.' + v) for k, v in _known_constants_scipy_constants.items()]
+    ))
 
     def _print_SparseMatrix(self, expr):
         i, j, data = [], [], []

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -17,14 +17,18 @@ from sympy.external import import_module
 
 np = import_module('numpy')
 
+
 def test_numpy_piecewise_regression():
     """
     NumPyPrinter needs to print Piecewise()'s choicelist as a list to avoid
     breaking compatibility with numpy 1.8. This is not necessary in numpy 1.9+.
     See gh-9747 and gh-9749 for details.
     """
+    printer = NumPyPrinter()
     p = Piecewise((1, x < 0), (0, True))
-    assert NumPyPrinter().doprint(p) == 'numpy.select([numpy.less(x, 0),True], [1,0], default=numpy.nan)'
+    assert printer.doprint(p) == \
+        'numpy.select([numpy.less(x, 0),True], [1,0], default=numpy.nan)'
+    assert printer.module_imports == {'numpy': {'select', 'less', 'nan'}}
 
 
 def test_sum():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -6,6 +6,7 @@ from sympy.codegen.ast import none
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
 from sympy.core.numbers import pi
+from sympy.core.singleton import S
 from sympy.functions import acos, Piecewise, sign, sqrt
 from sympy.logic import And, Or
 from sympy.matrices import SparseMatrix, MatrixSymbol, Identity
@@ -65,6 +66,15 @@ def test_MpmathPrinter():
     assert p.doprint(sign(x)) == 'mpmath.sign(x)'
     assert p.doprint(Rational(1, 2)) == 'mpmath.mpf(1)/mpmath.mpf(2)'
 
+    assert p.doprint(S.Exp1) == 'mpmath.e'
+    assert p.doprint(S.Pi) == 'mpmath.pi'
+    assert p.doprint(S.GoldenRatio) == 'mpmath.phi'
+    assert p.doprint(S.EulerGamma) == 'mpmath.euler'
+    assert p.doprint(S.NaN) == 'mpmath.nan'
+    assert p.doprint(S.Infinity) == 'mpmath.inf'
+    assert p.doprint(S.NegativeInfinity) == 'mpmath.ninf'
+
+
 def test_NumPyPrinter():
     p = NumPyPrinter()
     assert p.doprint(sign(x)) == 'numpy.sign(x)'
@@ -81,6 +91,13 @@ def test_NumPyPrinter():
     assert p.doprint(x**-1) == 'x**(-1.0)'
     assert p.doprint(x**-2) == 'x**(-2.0)'
 
+    assert p.doprint(S.Exp1) == 'numpy.e'
+    assert p.doprint(S.Pi) == 'numpy.pi'
+    assert p.doprint(S.EulerGamma) == 'numpy.euler_gamma'
+    assert p.doprint(S.NaN) == 'numpy.nan'
+    assert p.doprint(S.Infinity) == 'numpy.PINF'
+    assert p.doprint(S.NegativeInfinity) == 'numpy.NINF'
+
 
 def test_SciPyPrinter():
     p = SciPyPrinter()
@@ -92,6 +109,10 @@ def test_SciPyPrinter():
     smat = SparseMatrix(2, 5, {(0, 1): 3})
     assert p.doprint(smat) == 'scipy.sparse.coo_matrix([3], ([0], [1]), shape=(2, 5))'
     assert 'scipy.sparse' in p.module_imports
+
+    assert p.doprint(S.GoldenRatio) == 'scipy.constants.golden_ratio'
+    assert p.doprint(S.Pi) == 'scipy.constants.pi'
+    assert p.doprint(S.Exp1) == 'numpy.e'
 
 
 def test_pycode_reserved_words():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I've added some constants printing for `mpmath`, `numpy` and `scipy`

Also, `scipy.constants.e` is not an exponential constant, but electron mass.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added constants `S.Exp1`, `S.GoldenRatio`, `S.EulerGamma`, `S.Catalan`, `S.Nan`, `S.Infinity` and `S.NegativeInfinity` for `mpmath` printer.
  - Added constants `S.Exp1`, `S.Pi`, `S.EulerGamma`, `S.Nan`, `S.Infinity` and `S.NegativeInfinity` for `numpy` printer.
  - Added constants `S.GoldenRatio`, `S.Pi` for `scipy` printer.
  - Fixed `scipy` printer printing the wrong constant for `S.Exp1`.
<!-- END RELEASE NOTES -->
