### PR TITLE
Fix sympify when evaluate=False and using undefined functions

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -699,4 +699,4 @@ def test_issue_16759():
 
 def test_issue_17811():
     a = Function('a')
-    assert sympify('a(x)*5', evaluate=False).doit() == 5*a(x)
+    assert sympify('a(x)*5', evaluate=False) == Mul(a(x), 5, evaluate=False)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -695,3 +695,8 @@ def test_issue_16759():
     assert S.Half not in d
     assert Float(.5) in d
     assert d[.5] is S.One
+
+
+def test_issue_17811():
+    a = Function('a')
+    assert sympify('a(x)*5', evaluate=False).doit() == 5*a(x)

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1035,8 +1035,14 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
     def flatten(self, args, func):
         result = []
         for arg in args:
-            if isinstance(arg, ast.Call) and arg.func.id == func:
-                result.extend(self.flatten(arg.args, func))
+            if isinstance(arg, ast.Call):
+                arg_func = arg.func
+                if isinstance(arg_func, ast.Call):
+                    arg_func = arg_func.func
+                if arg_func.id == func:
+                    result.extend(self.flatten(arg.args, func))
+                else:
+                    result.append(arg)
             else:
                 result.append(arg)
         return result


### PR DESCRIPTION
#### References to other Issues or PRs
Addresses part of #17811.

#### Brief description of what is fixed or changed
Update `flatten` in in `sympy_parser` to go one level deeper when extracting a function.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * fix sympify(evaluate=False) with undefined functions
<!-- END RELEASE NOTES -->
