### PR TITLE
Fix Pow assumptions for possible zero base

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -582,16 +582,16 @@ class Pow(Expr):
         if real_b and real_e:
             if self.base.is_extended_positive:
                 return True
-            elif self.base.is_extended_nonnegative:
-                if self.exp.is_extended_nonnegative:
-                    return True
-            else:
-                if self.exp.is_integer:
-                    return True
-                elif self.base.is_extended_negative:
-                    if self.exp.is_Rational:
-                        return False
-        if real_e and self.exp.is_extended_negative:
+            elif self.base.is_extended_nonnegative and self.exp.is_extended_nonnegative:
+                return True
+            elif self.exp.is_integer and self.base.is_extended_nonzero:
+                return True
+            elif self.exp.is_integer and self.exp.is_nonnegative:
+                return True
+            elif self.base.is_extended_negative:
+                if self.exp.is_Rational:
+                    return False
+        if real_e and self.exp.is_extended_negative and self.base.is_zero is False:
             return Pow(self.base, -self.exp).is_extended_real
         im_b = self.base.is_imaginary
         im_e = self.exp.is_imaginary
@@ -1279,7 +1279,13 @@ class Pow(Expr):
         elif self.exp.is_rational:
             if self.base.is_algebraic is False:
                 return self.exp.is_zero
-            return self.base.is_algebraic
+            if self.base.is_zero is False:
+                if self.exp.is_nonzero:
+                    return self.base.is_algebraic
+                elif self.base.is_algebraic:
+                    return True
+            if self.exp.is_positive:
+                return self.base.is_algebraic
         elif self.base.is_algebraic and self.exp.is_algebraic:
             if ((fuzzy_not(self.base.is_zero)
                 and fuzzy_not(_is_one(self.base)))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1036,6 +1036,10 @@ def test_Pow_is_real():
 
     assert sqrt(-I).is_real is False  # issue 7843
 
+    i = Symbol('i', integer=True)
+    assert (1/(i-1)).is_real is None
+    assert (1/(i-1)).is_extended_real is None
+
 
 def test_real_Pow():
     k = Symbol('k', integer=True, nonzero=True)
@@ -1047,6 +1051,7 @@ def test_Pow_is_finite():
     xr = Symbol('xr', real=True)
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
+    i = Symbol('i', integer=True)
 
     assert (xe**2).is_finite is None  # xe could be oo
     assert (xr**2).is_finite is True
@@ -1082,6 +1087,7 @@ def test_Pow_is_finite():
 
     assert (1/S.Pi).is_finite is True
 
+    assert (1/(i-1)).is_finite is None
 
 def test_Pow_is_even_odd():
     x = Symbol('x')
@@ -1243,8 +1249,10 @@ def test_Pow_is_nonpositive_nonnegative():
     assert (I**i).is_nonnegative is True
     assert (exp(I)**i).is_nonnegative is True
 
-    assert ((-k)**n).is_nonnegative is True
-    assert ((-k)**m).is_nonpositive is True
+    assert ((-l)**n).is_nonnegative is True
+    assert ((-l)**m).is_nonpositive is True
+    assert ((-k)**n).is_nonnegative is None
+    assert ((-k)**m).is_nonpositive is None
 
 
 def test_Mul_is_imaginary_real():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -799,12 +799,12 @@ def test_Add_is_algebraic():
 
 def test_Mul_is_algebraic():
     a = Symbol('a', algebraic=True)
-    b = Symbol('a', algebraic=True)
+    b = Symbol('b', algebraic=True)
     na = Symbol('na', algebraic=False)
     an = Symbol('an', algebraic=True, nonzero=True)
     nb = Symbol('nb', algebraic=False)
     x = Symbol('x')
-    assert (a*b).is_algebraic
+    assert (a*b).is_algebraic is True
     assert (na*nb).is_algebraic is None
     assert (a*na).is_algebraic is None
     assert (an*na).is_algebraic is False
@@ -819,15 +819,18 @@ def test_Pow_is_algebraic():
     assert Pow(0, e, evaluate=False).is_algebraic
 
     a = Symbol('a', algebraic=True)
+    azf = Symbol('azf', algebraic=True, zero=False)
     na = Symbol('na', algebraic=False)
     ia = Symbol('ia', algebraic=True, irrational=True)
     ib = Symbol('ib', algebraic=True, irrational=True)
     r = Symbol('r', rational=True)
     x = Symbol('x')
-    assert (a**r).is_algebraic
+    assert (a**2).is_algebraic is True
+    assert (a**r).is_algebraic is None
+    assert (azf**r).is_algebraic is True
     assert (a**x).is_algebraic is None
     assert (na**r).is_algebraic is None
-    assert (ia**r).is_algebraic
+    assert (ia**r).is_algebraic is True
     assert (ia**ib).is_algebraic is False
 
     assert (a**e).is_algebraic is None

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -993,25 +993,13 @@ class AiryBase(Function):
     def _eval_is_extended_real(self):
         return self.args[0].is_extended_real
 
-    def _as_real_imag(self, deep=True, **hints):
-        if self.args[0].is_extended_real:
-            if deep:
-                hints['complex'] = False
-                return (self.expand(deep, **hints), S.Zero)
-            else:
-                return (self, S.Zero)
-        if deep:
-            re, im = self.args[0].expand(deep, **hints).as_real_imag()
-        else:
-            re, im = self.args[0].as_real_imag()
-        return (re, im)
-
     def as_real_imag(self, deep=True, **hints):
-        x, y = self._as_real_imag(deep=deep, **hints)
-        sq = -y**2/x**2
-        re = S.Half*(self.func(x+x*sqrt(sq))+self.func(x-x*sqrt(sq)))
-        im = x/(2*y) * sqrt(sq) * (self.func(x-x*sqrt(sq)) - self.func(x+x*sqrt(sq)))
-        return (re, im)
+        z = self.args[0]
+        zc = z.conjugate()
+        f = self.func
+        u = (f(z)+f(zc))/2
+        v = I*(f(zc)-f(z))/2
+        return u, v
 
     def _eval_expand_complex(self, deep=True, **hints):
         re_part, im_part = self.as_real_imag(deep=deep, **hints)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -414,9 +414,8 @@ def test_airy_base():
     assert airyai(x).is_extended_real
 
     assert airyai(x+I*y).as_real_imag() == (
-        airyai(x - I*x*Abs(y)/Abs(x))/2 + airyai(x + I*x*Abs(y)/Abs(x))/2,
-        I*x*(airyai(x - I*x*Abs(y)/Abs(x)) -
-             airyai(x + I*x*Abs(y)/Abs(x)))*Abs(y)/(2*y*Abs(x)))
+            airyai(x - I*y)/2 + airyai(x + I*y)/2,
+            I*(airyai(x - I*y) - airyai(x + I*y))/2)
 
 
 def test_airyai():

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1031,7 +1031,7 @@ def roots(f, *gens, **flags):
         handlers = {
             'Z': lambda r: r.is_Integer,
             'Q': lambda r: r.is_Rational,
-            'R': lambda r: all(a.is_extended_real for a in r.as_numer_denom()),
+            'R': lambda r: all(a.is_real for a in r.as_numer_denom()),
             'I': lambda r: r.is_imaginary,
         }
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1031,7 +1031,7 @@ def roots(f, *gens, **flags):
         handlers = {
             'Z': lambda r: r.is_Integer,
             'Q': lambda r: r.is_Rational,
-            'R': lambda r: r.is_extended_real,
+            'R': lambda r: all(a.is_extended_real for a in r.as_numer_denom()),
             'I': lambda r: r.is_imaginary,
         }
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -478,6 +478,10 @@ def test_roots0():
     assert roots(x**4 - 1, x, filter='Z', multiple=True) == [-S.One, S.One]
     assert roots(x**4 - 1, x, filter='I', multiple=True) == [I, -I]
 
+    ar, br = symbols('a, b', real=True)
+    p = x**2*(ar-br)**2 + 2*x*(br-ar) + 1
+    assert roots(p, x, filter='R') == {1/(ar - br): 2}
+
     assert roots(x**3, x, multiple=True) == [S.Zero, S.Zero, S.Zero]
     assert roots(1234, x, multiple=True) == []
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1990,11 +1990,10 @@ def test_exponential_symbols():
     w = symbols('w')
     f1 = 2*x**w - 4*y**w
     f2 = (x/y)**w - 2
-    ans1 = solveset(f1, w, S.Reals)
-    ans2 = solveset(f2, w, S.Reals)
-    assert len(ans1) == len(ans2) == 1
-    a1, a2 = [list(i)[0] for i in (ans1, ans2)]
-    assert a1.equals(a2)
+    sol1 = Intersection({log(2)/(log(x) - log(y))}, S.Reals)
+    sol2 = Intersection({log(2)/log(x/y)}, S.Reals)
+    assert solveset(f1, w, S.Reals) == sol1
+    assert solveset(f2, w, S.Reals) == sol2
 
     assert solveset(x**x, x, S.Reals) == S.EmptySet
     assert solveset(x**y - 1, y, S.Reals) == FiniteSet(0)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -274,7 +274,10 @@ def test_garbage_input():
 
 def test_solve_mul():
     assert solveset_real((a*x + b)*(exp(x) - 3), x) == \
-        FiniteSet(-b/a, log(3))
+        Union({log(3)}, Intersection({-b/a}, S.Reals))
+    anz = Symbol('anz', nonzero=True)
+    assert solveset_real((anz*x + b)*(exp(x) - 3), x) == \
+        FiniteSet(-b/anz, log(3))
     assert solveset_real((2*x + 8)*(8 + exp(x)), x) == FiniteSet(S(-4))
     assert solveset_real(x/log(x), x) == EmptySet()
 
@@ -1717,6 +1720,12 @@ def test_issue_14987():
 
 def test_simplification():
     eq = x + (a - b)/(-2*a + 2*b)
+    assert solveset(eq, x) == FiniteSet(S.Half)
+    assert solveset(eq, x, S.Reals) == Intersection({-((a - b)/(-2*a + 2*b))}, S.Reals)
+    # So that ap - bn is not zero:
+    ap = Symbol('ap', positive=True)
+    bn = Symbol('bn', negative=True)
+    eq = x + (ap - bn)/(-2*ap + 2*bn)
     assert solveset(eq, x) == FiniteSet(S.Half)
     assert solveset(eq, x, S.Reals) == FiniteSet(S.Half)
 

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1381,7 +1381,7 @@ def test_P8():
 
 
 def test_P9():
-    a, b, c = symbols('a b c', real=True)
+    a, b, c = symbols('a b c', nonzero=True)
     M = Matrix([[a/(b*c), 1/c, 1/b],
                 [1/c, b/(a*c), 1/a],
                 [1/b, 1/a, c/(a*b)]])

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2542,7 +2542,6 @@ def test_W22():
         (-sin(Min(1, u)) + sin(Min(2, u)), True))
 
 
-@XFAIL
 @slow
 def test_W23():
     a, b = symbols('a b', real=True, positive=True)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2542,6 +2542,7 @@ def test_W22():
         (-sin(Min(1, u)) + sin(Min(2, u)), True))
 
 
+@XFAIL
 @slow
 def test_W23():
     a, b = symbols('a b', real=True, positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17453 
Closes #17505 

#### Brief description of what is fixed or changed

Fixes a few bugs in the old assumptions for Pow to do with when the base is possibly zero.

#### Other comments

No release note as this is a regression since 1.4

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
