### PR TITLE
Fix a small typo in the documentation style guide

### DIFF
--- a/doc/src/documentation-style-guide.rst
+++ b/doc/src/documentation-style-guide.rst
@@ -72,8 +72,8 @@ The following lists the processing tools:
     formatting features in this document. (Note that we currently use an older
     modified fork of numpydoc, which is included in the SymPy source code.)
   * ``sphinx_math_dollar``: Allows math to be delimited with dollar signs
-    instead of reStructuredText directives (e.g., ``$a^$`` instead of
-    ``:math:a^2``). See https://www.sympy.org/sphinx-math-dollar/ for more info.
+    instead of reStructuredText directives (e.g., ``$a^2$`` instead of
+    ``:math:`a^2```). See https://www.sympy.org/sphinx-math-dollar/ for more info.
   * ``matplotlib.sphinxext.plot_directive``: Provides directives for included
     matplotlib generated figures in reStructuredText. See
     https://matplotlib.org/devel/plot_directive.html for more info.


### PR DESCRIPTION
Something I noticed after merging https://github.com/sympy/sympy/pull/17715. 

CC @sympy/gsod 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
