### PR TITLE
Fix exp.is_complex for infinite extended reals

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -6,7 +6,7 @@ from sympy.core.cache import cacheit
 from sympy.core.compatibility import range
 from sympy.core.function import (Function, ArgumentIndexError, _coeff_isneg,
         expand_mul)
-from sympy.core.logic import fuzzy_and, fuzzy_not
+from sympy.core.logic import fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.core.mul import Mul
 from sympy.core.numbers import Integer, Rational
 from sympy.core.power import Pow
@@ -402,7 +402,10 @@ class exp(ExpBase):
             return arg2.is_even
 
     def _eval_is_complex(self):
-        return self.args[0].is_complex
+        def complex_extended_negative(arg):
+            yield arg.is_complex
+            yield arg.is_extended_negative
+        return fuzzy_or(complex_extended_negative(self.args[0]))
 
     def _eval_is_algebraic(self):
         s = self.func(*self.args)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -108,6 +108,8 @@ def test_exp_infinity():
     assert refine(exp(-I*oo)) is nan
     assert exp(y*I*oo) != nan
     assert exp(zoo) is nan
+    x = Symbol('x', extended_real=True, finite=False)
+    assert exp(x).is_complex is None
 
 
 def test_exp_subs():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17789 

#### Brief description of what is fixed or changed

Fixes exp.is_complex so that it understands that infinite non-complex inputs like oo and -oo do not necessarily mean that exp(x) is not complex.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
