### PR TITLE
Fix the wrong judgement of elementary_row_op()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -601,6 +601,9 @@ class MatrixReductions(MatrixDeterminant):
         if op not in ["n->kn", "n<->m", "n->n+km"]:
             raise ValueError("Unknown {} operation '{}'. Valid col operations "
                              "are 'n->kn', 'n<->m', 'n->n+km'".format(error_str, op))
+            
+        # define self_col according to error_str
+        self_cols = self.cols if error_str == 'col' else self.rows
 
         # normalize and validate the arguments
         if op == "n->kn":
@@ -608,7 +611,7 @@ class MatrixReductions(MatrixDeterminant):
             if col is None or k is None:
                 raise ValueError("For a {0} operation 'n->kn' you must provide the "
                                  "kwargs `{0}` and `k`".format(error_str))
-            if not 0 <= col <= self.cols:
+            if not 0 <= col < self_cols:
                 raise ValueError("This matrix doesn't have a {} '{}'".format(error_str, col))
 
         if op == "n<->m":
@@ -623,9 +626,9 @@ class MatrixReductions(MatrixDeterminant):
                 raise ValueError("For a {0} operation 'n<->m' you must provide the "
                                  "kwargs `{0}1` and `{0}2`".format(error_str))
             col1, col2 = cols
-            if not 0 <= col1 <= self.cols:
+            if not 0 <= col1 < self_cols:
                 raise ValueError("This matrix doesn't have a {} '{}'".format(error_str, col1))
-            if not 0 <= col2 <= self.cols:
+            if not 0 <= col2 < self_cols:
                 raise ValueError("This matrix doesn't have a {} '{}'".format(error_str, col2))
 
         if op == "n->n+km":
@@ -637,9 +640,9 @@ class MatrixReductions(MatrixDeterminant):
             if col == col2:
                 raise ValueError("For a {0} operation 'n->n+km' `{0}` and `{0}2` must "
                                  "be different.".format(error_str))
-            if not 0 <= col <= self.cols:
+            if not 0 <= col < self_cols:
                 raise ValueError("This matrix doesn't have a {} '{}'".format(error_str, col))
-            if not 0 <= col2 <= self.cols:
+            if not 0 <= col2 < self_cols:
                 raise ValueError("This matrix doesn't have a {} '{}'".format(error_str, col2))
 
         return op, col, k, col1, col2

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -601,7 +601,7 @@ class MatrixReductions(MatrixDeterminant):
         if op not in ["n->kn", "n<->m", "n->n+km"]:
             raise ValueError("Unknown {} operation '{}'. Valid col operations "
                              "are 'n->kn', 'n<->m', 'n->n+km'".format(error_str, op))
-            
+
         # define self_col according to error_str
         self_cols = self.cols if error_str == 'col' else self.rows
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3822,3 +3822,27 @@ def test_gramschmidt_conjugate_dot():
     mat = Matrix([[1, I], [1, -I]])
     Q, R = mat.QRdecomposition()
     assert Q * Q.H == Matrix.eye(2)
+
+def test_issue_17827():
+    C = Matrix([
+        [3, 4, -1, 1],
+        [9, 12, -3, 3],
+        [0, 2, 1, 3],
+        [2, 3, 0, -2],
+        [0, 3, 3, -5],
+        [8, 15, 0, 6]
+    ])
+    # Tests for row/col within valid range
+    D = C.elementary_row_op('n<->m', row1=2, row2=5)
+    E = C.elementary_row_op('n->n+km', row1=5, row2=3, k=-4)
+    F = C.elementary_row_op('n->kn', row=5, k=2)
+    assert(D[5, 0] == 0)
+    assert(E[5, 0] == 0)
+    assert(F[5, 0] == 16)
+    # Tests for row/col out of range
+    wrong_row = False
+    try:
+        C.elementary_row_op('n<->m', row1=2, row2=6)
+    except ValueError:
+        wrong_row = True
+    assert(wrong_row)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3836,13 +3836,10 @@ def test_issue_17827():
     D = C.elementary_row_op('n<->m', row1=2, row2=5)
     E = C.elementary_row_op('n->n+km', row1=5, row2=3, k=-4)
     F = C.elementary_row_op('n->kn', row=5, k=2)
-    assert(D[5, 0] == 0)
-    assert(E[5, 0] == 0)
-    assert(F[5, 0] == 16)
+    assert(D[5, :] == Matrix([[0, 2, 1, 3]]))
+    assert(E[5, :] == Matrix([[0, 3, 0, 14]]))
+    assert(F[5, :] == Matrix([[16, 30, 0, 12]]))
     # Tests for row/col out of range
-    wrong_row = False
-    try:
-        C.elementary_row_op('n<->m', row1=2, row2=6)
-    except ValueError:
-        wrong_row = True
-    assert(wrong_row)
+    raises(ValueError, lambda: C.elementary_row_op('n<->m', row1=2, row2=6))
+    raises(ValueError, lambda: C.elementary_row_op('n->kn', row=7, k=2))
+    raises(ValueError, lambda: C.elementary_row_op('n->n+km', row1=-1, row2=5, k=2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17827

#### Brief description of what is fixed or changed
Fix the problem that Matrix.elementary_row_op() check if the count of rows is within valid range wrongly and does non-strict comparison in judgment.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * fix the problem that Matrix.elementary_row_op() could judge whether col/row is within the valid range wrongly.
<!-- END RELEASE NOTES -->
