### PR TITLE
Sum(cos(1/n) - 1, (n, 1, oo)).is_convergent()

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -471,8 +471,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         except NotImplementedError:
             pass
 
-        leading_term = sequence_term.subs(sym, 1/sym).as_leading_term(sym)
-        leading_term = leading_term.subs(sym, 1/sym)
+        leading_term = sequence_term.subs(sym, 1/p).as_leading_term(p)
+        leading_term = leading_term.subs(p, 1/sym)
         order = O(leading_term, (sym, S.Infinity))
 
         ### --------- p-series test (1/n**p) ---------- ###

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -471,7 +471,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         except NotImplementedError:
             pass
 
-        order = O(sequence_term, (sym, S.Infinity))
+        leading_term = sequence_term.subs(sym, 1/sym).as_leading_term(sym)
+        leading_term = leading_term.subs(sym, 1/sym)
+        order = O(leading_term, (sym, S.Infinity))
 
         ### --------- p-series test (1/n**p) ---------- ###
         p_series_test = order.expr.match(sym**p)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1006,6 +1006,7 @@ def test_is_convergent():
     assert Sum(1/n**Rational(6, 5), (n, 1, oo)).is_convergent() is S.true
     assert Sum(2/(n*sqrt(n - 1)), (n, 2, oo)).is_convergent() is S.true
     assert Sum(1/(sqrt(n)*sqrt(n)), (n, 2, oo)).is_convergent() is S.false
+    assert Sum(cos(1/n) - 1, (n, 2, oo)).is_convergent() is S.true
 
     # comparison test --
     assert Sum(1/(n + log(n)), (n, 1, oo)).is_convergent() is S.false


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #12544


#### Brief description of what is fixed or changed

The issue is due to the fact that `order = O(cos(1/n) - 1)` is `O(1)`, which is correct, but not sharp.
Substituting `cos(1/n) - 1` in the argument of `O` with its leading term in the series expansion, i.e. `-1/(2*n**2)`, `order` contains a sharper result.
 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  *  Fixed a bug related to the convergence of a summation.
<!-- END RELEASE NOTES -->
