### PR TITLE
Make EmptySet the instance rather than the class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
       # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
+        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.5.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
         - TEST_SAGE="true"
         - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       env:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet pycosat python-clang"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap cython wurlitzer python-symengine=0.5.1 tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle python=2.7 pyglet pycosat python-clang"
         - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:
         apt:
@@ -79,7 +79,7 @@ matrix:
       # and we aren't actually using the Travis Python anyway.
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.5.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
+        - TEST_OPT_DEPENDENCY="matchpy numpy scipy gmpy2 matplotlib theano llvmlite autowrap cython wurlitzer python-symengine=0.5.1 tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 cloudpickle pyglet pycosat lfortran python-clang"
         - TEST_SAGE="true"
         - SYMPY_STRICT_COMPILER_CHECKS=1
       addons:

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -258,7 +258,7 @@ What is this domain argument about?
     >>> solveset(x**2 + 1, x) # domain=S.Complexes is default
     {-I, I}
     >>> solveset(x**2 + 1, x, domain=S.Reals)
-    EmptySet()
+    EmptySet
 
 
 What are the general methods employed by solveset to solve an equation?

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -71,7 +71,7 @@ def singularities(expression, symbol):
     >>> x = Symbol('x', real=True)
     >>> y = Symbol('y', real=False)
     >>> singularities(x**2 + x + 1, x)
-    EmptySet()
+    EmptySet
     >>> singularities(1/(x + 1), x)
     {-1}
     >>> singularities(1/(y**2 + 1), y)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -736,7 +736,7 @@ def stationary_points(f, symbol, domain=S.Reals):
     >>> x = Symbol('x')
 
     >>> stationary_points(1/x, x, S.Reals)
-    EmptySet()
+    EmptySet
 
     >>> pprint(stationary_points(sin(x), x), use_unicode=False)
               pi                              3*pi
@@ -1547,7 +1547,7 @@ class AccumulationBounds(AtomicExpr):
         AccumBounds(2, 3)
 
         >>> AccumBounds(1, 3).intersection(AccumBounds(4, 6))
-        EmptySet()
+        EmptySet
 
         >>> AccumBounds(1, 4).intersection(FiniteSet(1, 2, 5))
         {1, 2}

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -444,7 +444,7 @@ class Category(Basic):
     ========
     Diagram
     """
-    def __new__(cls, name, objects=EmptySet.__class__(), commutative_diagrams=EmptySet.__class__()):
+    def __new__(cls, name, objects=EmptySet, commutative_diagrams=EmptySet):
         if not name:
             raise ValueError("A Category cannot have an empty name.")
 
@@ -615,7 +615,7 @@ class Diagram(Basic):
                 return
 
             if add_identities:
-                empty = EmptySet.__class__()
+                empty = EmptySet
 
                 id_dom = IdentityMorphism(morphism.domain)
                 id_cod = IdentityMorphism(morphism.codomain)
@@ -635,7 +635,7 @@ class Diagram(Basic):
             if isinstance(morphism, CompositeMorphism) and recurse_composites:
                 # This is a composite morphism, add its components as
                 # well.
-                empty = EmptySet.__class__()
+                empty = EmptySet
                 for component in morphism.components:
                     Diagram._add_morphism_closure(morphisms, component, empty,
                                                   add_identities)
@@ -685,7 +685,7 @@ class Diagram(Basic):
 
         # Here we will keep track of the objects which appear in the
         # premises.
-        objects = EmptySet.__class__()
+        objects = EmptySet
 
         if len(args) >= 1:
             # We've got some premises in the arguments.
@@ -694,7 +694,7 @@ class Diagram(Basic):
             if isinstance(premises_arg, list):
                 # The user has supplied a list of morphisms, none of
                 # which have any attributes.
-                empty = EmptySet.__class__()
+                empty = EmptySet
 
                 for morphism in premises_arg:
                     objects |= FiniteSet(morphism.domain, morphism.codomain)
@@ -714,7 +714,7 @@ class Diagram(Basic):
             if isinstance(conclusions_arg, list):
                 # The user has supplied a list of morphisms, none of
                 # which have any attributes.
-                empty = EmptySet.__class__()
+                empty = EmptySet
 
                 for morphism in conclusions_arg:
                     # Check that no new objects appear in conclusions.
@@ -838,8 +838,8 @@ class Diagram(Basic):
         ========
         Object, Morphism
         """
-        premises = EmptySet.__class__()
-        conclusions = EmptySet.__class__()
+        premises = EmptySet
+        conclusions = EmptySet
 
         for morphism in self.premises.keys():
             if (morphism.domain == A) and (morphism.codomain == B):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -444,7 +444,7 @@ class Category(Basic):
     ========
     Diagram
     """
-    def __new__(cls, name, objects=EmptySet(), commutative_diagrams=EmptySet()):
+    def __new__(cls, name, objects=EmptySet.__class__(), commutative_diagrams=EmptySet.__class__()):
         if not name:
             raise ValueError("A Category cannot have an empty name.")
 
@@ -615,7 +615,7 @@ class Diagram(Basic):
                 return
 
             if add_identities:
-                empty = EmptySet()
+                empty = EmptySet.__class__()
 
                 id_dom = IdentityMorphism(morphism.domain)
                 id_cod = IdentityMorphism(morphism.codomain)
@@ -635,7 +635,7 @@ class Diagram(Basic):
             if isinstance(morphism, CompositeMorphism) and recurse_composites:
                 # This is a composite morphism, add its components as
                 # well.
-                empty = EmptySet()
+                empty = EmptySet.__class__()
                 for component in morphism.components:
                     Diagram._add_morphism_closure(morphisms, component, empty,
                                                   add_identities)
@@ -685,7 +685,7 @@ class Diagram(Basic):
 
         # Here we will keep track of the objects which appear in the
         # premises.
-        objects = EmptySet()
+        objects = EmptySet.__class__()
 
         if len(args) >= 1:
             # We've got some premises in the arguments.
@@ -694,7 +694,7 @@ class Diagram(Basic):
             if isinstance(premises_arg, list):
                 # The user has supplied a list of morphisms, none of
                 # which have any attributes.
-                empty = EmptySet()
+                empty = EmptySet.__class__()
 
                 for morphism in premises_arg:
                     objects |= FiniteSet(morphism.domain, morphism.codomain)
@@ -714,7 +714,7 @@ class Diagram(Basic):
             if isinstance(conclusions_arg, list):
                 # The user has supplied a list of morphisms, none of
                 # which have any attributes.
-                empty = EmptySet()
+                empty = EmptySet.__class__()
 
                 for morphism in conclusions_arg:
                     # Check that no new objects appear in conclusions.
@@ -838,8 +838,8 @@ class Diagram(Basic):
         ========
         Object, Morphism
         """
-        premises = EmptySet()
-        conclusions = EmptySet()
+        premises = EmptySet.__class__()
+        conclusions = EmptySet.__class__()
 
         for morphism in self.premises.keys():
             if (morphism.domain == A) and (morphism.codomain == B):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -563,8 +563,8 @@ class Diagram(Basic):
     >>> pprint(premises_keys, use_unicode=False)
     [g*f:A-->C, id:A-->A, id:B-->B, id:C-->C, f:A-->B, g:B-->C]
     >>> pprint(d.premises, use_unicode=False)
-    {g*f:A-->C: EmptySet(), id:A-->A: EmptySet(), id:B-->B: EmptySet(), id:C-->C:
-    EmptySet(), f:A-->B: EmptySet(), g:B-->C: EmptySet()}
+    {g*f:A-->C: EmptySet, id:A-->A: EmptySet, id:B-->B: EmptySet, id:C-->C: EmptyS
+    et, f:A-->B: EmptySet, g:B-->C: EmptySet}
     >>> d = Diagram([f, g], {g * f: "unique"})
     >>> pprint(d.conclusions)
     {g*f:A-->C: {unique}}
@@ -759,7 +759,7 @@ class Diagram(Basic):
         >>> id_B = IdentityMorphism(B)
         >>> d = Diagram([f])
         >>> print(pretty(d.premises, use_unicode=False))
-        {id:A-->A: EmptySet(), id:B-->B: EmptySet(), f:A-->B: EmptySet()}
+        {id:A-->A: EmptySet, id:B-->B: EmptySet, f:A-->B: EmptySet}
 
         """
         return self.args[0]

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1324,8 +1324,8 @@ class DiagramGrid(object):
         >>> diagram = Diagram([f, g])
         >>> grid = DiagramGrid(diagram)
         >>> grid.morphisms
-        {NamedMorphism(Object("A"), Object("B"), "f"): EmptySet(),
-        NamedMorphism(Object("B"), Object("C"), "g"): EmptySet()}
+        {NamedMorphism(Object("A"), Object("B"), "f"): EmptySet,
+        NamedMorphism(Object("B"), Object("C"), "g"): EmptySet}
 
         """
         return self._morphisms

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -92,7 +92,7 @@ def test_diagram():
     id_A = IdentityMorphism(A)
     id_B = IdentityMorphism(B)
 
-    empty = EmptySet()
+    empty = EmptySet.__class__()
 
     # Test the addition of identities.
     d1 = Diagram([f])

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -92,7 +92,7 @@ def test_diagram():
     id_A = IdentityMorphism(A)
     id_B = IdentityMorphism(B)
 
-    empty = EmptySet.__class__()
+    empty = EmptySet
 
     # Test the addition of identities.
     d1 = Diagram([f])

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3922,7 +3922,9 @@ def test_sympy__series__sequences__SeqBase():
 
 
 def test_sympy__series__sequences__EmptySequence():
-    from sympy.series.sequences import EmptySequence
+    # Need to imort the instance from series not the class from
+    # series.sequence
+    from sympy.series import EmptySequence
     assert _test_args(EmptySequence)
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3923,7 +3923,7 @@ def test_sympy__series__sequences__SeqBase():
 
 def test_sympy__series__sequences__EmptySequence():
     from sympy.series.sequences import EmptySequence
-    assert _test_args(EmptySequence())
+    assert _test_args(EmptySequence)
 
 
 @SKIP('Abstract Class')

--- a/sympy/core/tests/test_singleton.py
+++ b/sympy/core/tests/test_singleton.py
@@ -83,5 +83,5 @@ def test_names_in_namespace():
             # Accessible by -oo
             continue
 
-        # Use is here because of complications with ==
-        assert any(getattr(S, name) is i or type(getattr(S, name)) is i for i in d.values()), name
+        # Use is here to ensure it is the exact same object
+        assert any(getattr(S, name) is i for i in d.values()), name

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -573,7 +573,7 @@ def test_Range():
 def test_sympify_set():
     n = Symbol('n')
     assert sympify({n}) == FiniteSet(n)
-    assert sympify(set()) == EmptySet()
+    assert sympify(set()) == EmptySet.__class__()
 
 
 def test_sympify_numpy():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -573,7 +573,7 @@ def test_Range():
 def test_sympify_set():
     n = Symbol('n')
     assert sympify({n}) == FiniteSet(n)
-    assert sympify(set()) == EmptySet.__class__()
+    assert sympify(set()) == EmptySet
 
 
 def test_sympify_numpy():

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -903,7 +903,7 @@ class Piecewise(Function):
          (3, Interval(4, oo))]
         >>> p.as_expr_set_pairs(Interval(0, 3))
         [(1, Interval.Ropen(0, 2)),
-         (2, Interval(2, 3)), (3, EmptySet())]
+         (2, Interval(2, 3)), (3, EmptySet)]
         """
         exp_sets = []
         U = domain

--- a/sympy/geometry/tests/test_geometrysets.py
+++ b/sympy/geometry/tests/test_geometrysets.py
@@ -20,7 +20,7 @@ def test_booleans():
     assert Intersection(l1, l2).equals(l1)
     assert Intersection(l1, l4) == FiniteSet(Point(1,1))
     assert Intersection(Union(l1, l4), l3) == FiniteSet(Point(Rational(-1, 3), Rational(-1, 3)), Point(5, 1))
-    assert Intersection(l1, FiniteSet(Point(7,-7))) == EmptySet()
+    assert Intersection(l1, FiniteSet(Point(7,-7))) == EmptySet
     assert Intersection(Circle(Point(0,0), 3), Line(p1,p2)) == FiniteSet(Point(-3,0), Point(3,0))
     assert Intersection(l1, FiniteSet(p1)) == FiniteSet(p1)
     assert Union(l1, FiniteSet(p1)) == l1

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -405,7 +405,7 @@ class BooleanFalse(with_metaclass(Singleton, BooleanAtom)):
 
         >>> from sympy import false
         >>> false.as_set()
-        EmptySet()
+        EmptySet
         """
         return S.EmptySet
 

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,5 +1,5 @@
 from sympy.core.backend import symbols, Matrix, cos, sin, atan, sqrt, S, Rational
-from sympy import solve, simplify
+from sympy import solve, simplify, sympify
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\
     LagrangesMethod
@@ -83,7 +83,7 @@ def test_linearize_rolling_disc_kane():
     assert linearizer.f_v == f_v
     assert linearizer.f_a == f_v.diff(t)
     sol = solve(linearizer.f_0 + linearizer.f_1, qd)
-    for qi in qd:
+    for qi in qdots.keys():
         assert sol[qi] == qdots[qi]
     assert simplify(linearizer.f_2 + linearizer.f_3 - fr - fr_star) == Matrix([0, 0, 0])
 
@@ -127,7 +127,7 @@ def test_linearize_rolling_disc_kane():
     assert B.subs(upright_nominal) == B_sol
 
     # Check eigenvalues at critical speed are all zero:
-    assert A.subs(upright_nominal).subs(q3d, 1/sqrt(3)).eigenvals() == {0: 8}
+    assert sympify(A.subs(upright_nominal).subs(q3d, 1/sqrt(3))).eigenvals() == {0: 8}
 
 def test_linearize_pendulum_kane_minimal():
     q1 = dynamicsymbols('q1')                     # angle of pendulum

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -165,6 +165,8 @@ class PrettyPrinter(Printer):
     _print_Rationals = _print_Atom
     _print_Complexes = _print_Atom
 
+    _print_EmptySequence = _print_Atom
+
     def _print_Reals(self, e):
         if self._use_unicode:
             return self._print_Atom(e)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -509,6 +509,7 @@ atoms_table = {
     'Intersection':            U('INTERSECTION'),
     'Ring':                    U('RING OPERATOR'),
     'Modifier Letter Low Ring':U('Modifier Letter Low Ring'),
+    'EmptySequence':           'EmptySequence',
 }
 
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3848,7 +3848,7 @@ def test_pretty_ConditionSet():
     assert pretty(ConditionSet(x, Contains(x, S.Reals, evaluate=False), FiniteSet(1))) == '{1}'
     assert upretty(ConditionSet(x, Contains(x, S.Reals, evaluate=False), FiniteSet(1))) == u'{1}'
 
-    assert pretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == "EmptySet()"
+    assert pretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == "EmptySet"
     assert upretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == u"∅"
 
     assert pretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == '{2}'
@@ -5813,21 +5813,21 @@ def test_categories():
 
     # Test how diagrams are printed.
     d = Diagram()
-    assert pretty(d) == "EmptySet()"
+    assert pretty(d) == "EmptySet"
     assert upretty(d) == u"∅"
 
     d = Diagram({f1: "unique", f2: S.EmptySet})
-    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet(), id:A1-->A1: " \
-        "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
-        "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}"
+    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
+        "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
+        "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}"
 
     assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
         "id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}")
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
-    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet(), id:A1-->A1: " \
-        "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
-        "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}" \
+    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
+        "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
+        "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}" \
         " ==> {f2*f1:A1-->A3: {unique}}"
     assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
         "∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -97,6 +97,12 @@ class ReprPrinter(Printer):
     def _print_Reals(self, expr):
         return 'Reals'
 
+    def _print_EmptySet(self, expr):
+        return 'EmptySet'
+
+    def _print_EmptySequence(self, expr):
+        return 'EmptySequence'
+
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -617,6 +617,12 @@ class StrPrinter(Printer):
     def _print_Complexes(self, expr):
         return 'Complexes'
 
+    def _print_EmptySet(self, expr):
+        return 'EmptySet'
+
+    def _print_EmptySequence(self, expr):
+        return 'EmptySequence'
+
     def _print_int(self, expr):
         return str(expr)
 

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -12,6 +12,10 @@ from .fourier import fourier_series
 from .formal import fps
 from .limitseq import difference_delta, limit_seq
 
+from ..core.singleton import S
+EmptySequence = S.EmptySequence
+del S
+
 O = Order
 
 __all__ = ['Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'residue',

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -987,7 +987,7 @@ class SeqAdd(SeqExprOp):
     Examples
     ========
 
-    >>> from sympy import EmptySequqnce, oo, SeqAdd, SeqPer, SeqFormula
+    >>> from sympy import EmptySequence, oo, SeqAdd, SeqPer, SeqFormula
     >>> from sympy.abc import n
     >>> SeqAdd(SeqPer((1, 2), (n, 0, oo)), EmptySequence)
     SeqPer((1, 2), (n, 0, oo))

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -374,22 +374,22 @@ class SeqBase(Basic):
 class EmptySequence(with_metaclass(Singleton, SeqBase)):
     """Represents an empty sequence.
 
-    The empty sequence is available as a
-    singleton as ``S.EmptySequence``.
+    The empty sequence is also available as a singleton as
+    ``S.EmptySequence``.
 
     Examples
     ========
 
-    >>> from sympy import S, SeqPer, oo
+    >>> from sympy import EmptySequence, SeqPer, oo
     >>> from sympy.abc import x
-    >>> S.EmptySequence
-    EmptySequence()
-    >>> SeqPer((1, 2), (x, 0, 10)) + S.EmptySequence
+    >>> EmptySequence
+    EmptySequence
+    >>> SeqPer((1, 2), (x, 0, 10)) + EmptySequence
     SeqPer((1, 2), (x, 0, 10))
-    >>> SeqPer((1, 2)) * S.EmptySequence
-    EmptySequence()
-    >>> S.EmptySequence.coeff_mul(-1)
-    EmptySequence()
+    >>> SeqPer((1, 2)) * EmptySequence
+    EmptySequence
+    >>> EmptySequence.coeff_mul(-1)
+    EmptySequence
     """
 
     @property
@@ -987,12 +987,12 @@ class SeqAdd(SeqExprOp):
     Examples
     ========
 
-    >>> from sympy import S, oo, SeqAdd, SeqPer, SeqFormula
+    >>> from sympy import EmptySequqnce, oo, SeqAdd, SeqPer, SeqFormula
     >>> from sympy.abc import n
-    >>> SeqAdd(SeqPer((1, 2), (n, 0, oo)), S.EmptySequence)
+    >>> SeqAdd(SeqPer((1, 2), (n, 0, oo)), EmptySequence)
     SeqPer((1, 2), (n, 0, oo))
     >>> SeqAdd(SeqPer((1, 2), (n, 0, 5)), SeqPer((1, 2), (n, 6, 10)))
-    EmptySequence()
+    EmptySequence
     >>> SeqAdd(SeqPer((1, 2), (n, 0, oo)), SeqFormula(n**2, (n, 0, oo)))
     SeqAdd(SeqFormula(n**2, (n, 0, oo)), SeqPer((1, 2), (n, 0, oo)))
     >>> SeqAdd(SeqFormula(n**3), SeqFormula(n**2))
@@ -1096,12 +1096,12 @@ class SeqMul(SeqExprOp):
     Examples
     ========
 
-    >>> from sympy import S, oo, SeqMul, SeqPer, SeqFormula
+    >>> from sympy import EmptySequence, oo, SeqMul, SeqPer, SeqFormula
     >>> from sympy.abc import n
-    >>> SeqMul(SeqPer((1, 2), (n, 0, oo)), S.EmptySequence)
-    EmptySequence()
+    >>> SeqMul(SeqPer((1, 2), (n, 0, oo)), EmptySequence)
+    EmptySequence
     >>> SeqMul(SeqPer((1, 2), (n, 0, 5)), SeqPer((1, 2), (n, 6, 10)))
-    EmptySequence()
+    EmptySequence
     >>> SeqMul(SeqPer((1, 2), (n, 0, oo)), SeqFormula(n**2))
     SeqMul(SeqFormula(n**2, (n, 0, oo)), SeqPer((1, 2), (n, 0, oo)))
     >>> SeqMul(SeqFormula(n**3), SeqFormula(n**2))

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -9,7 +9,7 @@ n, m = symbols('n m')
 
 
 def test_EmptySequence():
-    assert isinstance(S.EmptySequence, EmptySequence)
+    assert S.EmptySequence is EmptySequence
 
     assert S.EmptySequence.interval is S.EmptySet
     assert S.EmptySequence.length is S.Zero

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -10,6 +10,7 @@ Reals = S.Reals
 Naturals = S.Naturals
 Naturals0 = S.Naturals0
 UniversalSet = S.UniversalSet
+EmptySet = S.EmptySet
 Integers = S.Integers
 Rationals = S.Rationals
 del S

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -55,7 +55,7 @@ class ConditionSet(Set):
     >>> cond = (n > 0); cond
     False
     >>> ConditionSet(n, cond, S.Integers)
-    EmptySet()
+    EmptySet
 
     In addition, substitution of a dummy symbol can only be
     done with a generic symbol with matching commutativity

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -533,9 +533,9 @@ class Range(Set):
         >>> Range(3)[:0]
         Range(0, 0, 1)
         >>> Range(3).intersect(Interval(4, oo))
-        EmptySet()
+        EmptySet
         >>> Range(3).intersect(Range(4, oo))
-        EmptySet()
+        EmptySet
 
     Range will accept symbolic arguments but has very limited support
     for doing anything other than displaying the Range:

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -132,7 +132,7 @@ def _set_function(f, x):
     else:
         return ImageSet(Lambda(_x, f(_x)), x)
 
-@dispatch(FunctionUnion, EmptySet)
+@dispatch(FunctionUnion, EmptySet.__class__)
 def _set_function(f, x):
     return x
 

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -132,7 +132,7 @@ def _set_function(f, x):
     else:
         return ImageSet(Lambda(_x, f(_x)), x)
 
-@dispatch(FunctionUnion, EmptySet.__class__)
+@dispatch(FunctionUnion, type(EmptySet))
 def _set_function(f, x):
     return x
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -238,10 +238,18 @@ def intersection_sets(self, other):
         if gm is not None:
             fn = self.lamda.expr
             n = self.lamda.variables[0]
-            solns = list(diophantine(fn - gm, syms=(n, m)))
-            if len(solns) == 0:
-                return EmptySet()
-            elif len(solns) != 1:
+            # Diophantine sorts the solutions according to the alphabetic
+            # order of the variable names, since the result should not depend
+            # on the variable name, they are replaced by the dummy variables
+            # below
+            a, b = Dummy('a'), Dummy('b')
+            f, g = f.subs(n, a), g.subs(m, b)
+            solns_set = diophantine(f - g)
+            if solns_set == set():
+                return EmptySet
+            solns = list(diophantine(f - g))
+
+            if len(solns) != 1:
                 return
             else:
                 soln, solm = solns[0]
@@ -395,7 +403,7 @@ def intersection_sets(a, b):
 
     return Interval(start, end, left_open, right_open)
 
-@dispatch(EmptySet, Set)
+@dispatch(EmptySet.__class__, Set)
 def intersection_sets(a, b):
     return S.EmptySet
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -240,7 +240,7 @@ def intersection_sets(self, other):
             n = self.lamda.variables[0]
             solns = list(diophantine(fn - gm, syms=(n, m)))
             if len(solns) == 0:
-                return EmptySet()
+                return EmptySet
             elif len(solns) != 1:
                 return
             else:

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -243,7 +243,7 @@ def intersection_sets(self, other):
             # on the variable name, they are replaced by the dummy variables
             # below
             a, b = Dummy('a'), Dummy('b')
-            f, g = f.subs(n, a), g.subs(m, b)
+            f, g = fn.subs(n, a), gm.subs(m, b)
             solns_set = diophantine(f - g)
             if solns_set == set():
                 return EmptySet

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -403,7 +403,7 @@ def intersection_sets(a, b):
 
     return Interval(start, end, left_open, right_open)
 
-@dispatch(EmptySet.__class__, Set)
+@dispatch(type(EmptySet), Set)
 def intersection_sets(a, b):
     return S.EmptySet
 

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -238,18 +238,10 @@ def intersection_sets(self, other):
         if gm is not None:
             fn = self.lamda.expr
             n = self.lamda.variables[0]
-            # Diophantine sorts the solutions according to the alphabetic
-            # order of the variable names, since the result should not depend
-            # on the variable name, they are replaced by the dummy variables
-            # below
-            a, b = Dummy('a'), Dummy('b')
-            f, g = fn.subs(n, a), gm.subs(m, b)
-            solns_set = diophantine(f - g)
-            if solns_set == set():
-                return EmptySet
-            solns = list(diophantine(f - g))
-
-            if len(solns) != 1:
+            solns = list(diophantine(fn - gm, syms=(n, m)))
+            if len(solns) == 0:
+                return EmptySet()
+            elif len(solns) != 1:
                 return
             else:
                 soln, solm = solns[0]

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -28,7 +28,7 @@ def union_sets(a, b):
             return ComplexRegion(Union(a.sets, b.sets), polar=True)
     return None
 
-@dispatch(EmptySet.__class__, Set)
+@dispatch(type(EmptySet), Set)
 def union_sets(a, b):
     return b
 

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -28,7 +28,7 @@ def union_sets(a, b):
             return ComplexRegion(Union(a.sets, b.sets), polar=True)
     return None
 
-@dispatch(EmptySet, Set)
+@dispatch(EmptySet.__class__, Set)
 def union_sets(a, b):
     return b
 

--- a/sympy/sets/powerset.py
+++ b/sympy/sets/powerset.py
@@ -48,9 +48,9 @@ class PowerSet(Set):
     A power set of an empty set:
 
     >>> PowerSet(S.EmptySet)
-    PowerSet(EmptySet())
+    PowerSet(EmptySet)
     >>> PowerSet(PowerSet(S.EmptySet))
-    PowerSet(PowerSet(EmptySet()))
+    PowerSet(PowerSet(EmptySet))
 
     A power set of an infinite set:
 
@@ -60,7 +60,7 @@ class PowerSet(Set):
     Evaluating the power set of a finite set to its explicit form:
 
     >>> PowerSet(FiniteSet(1, 2, 3)).rewrite(FiniteSet)
-    {EmptySet(), {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
+    {EmptySet, {1}, {2}, {3}, {1, 2}, {1, 3}, {2, 3}, {1, 2, 3}}
 
     References
     ==========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -240,7 +240,7 @@ class Set(Basic):
         Union(Interval.open(-oo, 1), Interval.open(10, oo))
 
         >>> from sympy import S, EmptySet
-        >>> S.Reals.symmetric_difference(EmptySet())
+        >>> S.Reals.symmetric_difference(EmptySet.__class__())
         Reals
 
         References
@@ -466,7 +466,8 @@ class Set(Basic):
 
         A power set of an empty set:
 
-        >>> A = EmptySet()
+        >>> from sympy import FiniteSet, EmptySet
+        >>> A = EmptySet
         >>> A.powerset()
         {EmptySet()}
 
@@ -474,7 +475,7 @@ class Set(Basic):
 
         >>> A = FiniteSet(1, 2)
         >>> a, b, c = FiniteSet(1), FiniteSet(2), FiniteSet(1, 2)
-        >>> A.powerset() == FiniteSet(a, b, c, EmptySet())
+        >>> A.powerset() == FiniteSet(a, b, c, EmptySet.__class__())
         True
 
         A power set of an interval:
@@ -1670,7 +1671,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
 
     @property
     def _boundary(self):
-        return EmptySet()
+        return EmptySet.__class__()
 
 
 class FiniteSet(Set, EvalfMixin):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1671,7 +1671,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
 
     @property
     def _boundary(self):
-        return EmptySet.__class__()
+        return EmptySet()
 
 
 class FiniteSet(Set, EvalfMixin):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -240,7 +240,7 @@ class Set(Basic):
         Union(Interval.open(-oo, 1), Interval.open(10, oo))
 
         >>> from sympy import S, EmptySet
-        >>> S.Reals.symmetric_difference(EmptySet.__class__())
+        >>> S.Reals.symmetric_difference(EmptySet)
         Reals
 
         References
@@ -475,7 +475,7 @@ class Set(Basic):
 
         >>> A = FiniteSet(1, 2)
         >>> a, b, c = FiniteSet(1), FiniteSet(2), FiniteSet(1, 2)
-        >>> A.powerset() == FiniteSet(a, b, c, EmptySet.__class__())
+        >>> A.powerset() == FiniteSet(a, b, c, EmptySet)
         True
 
         A power set of an interval:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -134,7 +134,7 @@ class Set(Basic):
         >>> n, m = symbols('n m')
         >>> a = imageset(Lambda(n, 2*n), S.Integers)
         >>> a.intersect(imageset(Lambda(m, 2*m + 1), S.Integers))
-        EmptySet()
+        EmptySet
 
         """
         return Intersection(self, other)
@@ -469,7 +469,7 @@ class Set(Basic):
         >>> from sympy import FiniteSet, EmptySet
         >>> A = EmptySet
         >>> A.powerset()
-        {EmptySet()}
+        {EmptySet}
 
         A power set of a finite set:
 
@@ -600,7 +600,7 @@ class Set(Basic):
         >>> Interval(0, 1).interior
         Interval.open(0, 1)
         >>> Interval(0, 1).boundary.interior
-        EmptySet()
+        EmptySet
         """
         return self - self.boundary
 
@@ -709,8 +709,8 @@ class ProductSet(Set):
         if len(sets) == 0:
             return FiniteSet(())
 
-        if EmptySet() in sets:
-            return EmptySet()
+        if S.EmptySet in sets:
+            return S.EmptySet
 
         return Basic.__new__(cls, *sets, **assumptions)
 
@@ -1520,7 +1520,7 @@ class Complement(Set, EvalfMixin):
 
         """
         if B == S.UniversalSet or A.is_subset(B):
-            return EmptySet()
+            return S.EmptySet
 
         if isinstance(B, Union):
             return Intersection(*(s.complement(A) for s in B.args))
@@ -1570,10 +1570,10 @@ class EmptySet(with_metaclass(Singleton, Set)):
 
     >>> from sympy import S, Interval
     >>> S.EmptySet
-    EmptySet()
+    EmptySet
 
     >>> Interval(1, 2).intersect(S.EmptySet)
-    EmptySet()
+    EmptySet
 
     See Also
     ========
@@ -1671,7 +1671,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
 
     @property
     def _boundary(self):
-        return EmptySet()
+        return S.EmptySet
 
 
 class FiniteSet(Set, EvalfMixin):
@@ -1711,7 +1711,7 @@ class FiniteSet(Set, EvalfMixin):
             args = list(map(sympify, args))
 
             if len(args) == 0:
-                return EmptySet()
+                return S.EmptySet
         else:
             args = list(map(sympify, args))
 

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -69,8 +69,8 @@ def test_issue_9849():
 
 def test_simplified_FiniteSet_in_CondSet():
     assert ConditionSet(x, And(x < 1, x > -3), FiniteSet(0, 1, 2)) == FiniteSet(0)
-    assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet()
-    assert ConditionSet(x, And(x < -3), EmptySet()) == EmptySet()
+    assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet.__class__()
+    assert ConditionSet(x, And(x < -3), EmptySet.__class__()) == EmptySet.__class__()
     y = Symbol('y')
     assert (ConditionSet(x, And(x > 0), FiniteSet(-1, 0, 1, y)) ==
         Union(FiniteSet(1), ConditionSet(x, And(x > 0), FiniteSet(y))))

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -69,8 +69,8 @@ def test_issue_9849():
 
 def test_simplified_FiniteSet_in_CondSet():
     assert ConditionSet(x, And(x < 1, x > -3), FiniteSet(0, 1, 2)) == FiniteSet(0)
-    assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet.__class__()
-    assert ConditionSet(x, And(x < -3), EmptySet.__class__()) == EmptySet.__class__()
+    assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet
+    assert ConditionSet(x, And(x < -3), EmptySet) == EmptySet
     y = Symbol('y')
     assert (ConditionSet(x, And(x > 0), FiniteSet(-1, 0, 1, y)) ==
         Union(FiniteSet(1), ConditionSet(x, And(x > 0), FiniteSet(y))))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -259,8 +259,8 @@ def test_Complement():
     assert -1 in Complement(S.Reals, S.Naturals, evaluate=False)
     assert not 1 in Complement(S.Reals, S.Naturals, evaluate=False)
 
-    assert Complement(S.Integers, S.UniversalSet) == EmptySet()
-    assert S.UniversalSet.complement(S.Integers) == EmptySet()
+    assert Complement(S.Integers, S.UniversalSet) == EmptySet.__class__()
+    assert S.UniversalSet.complement(S.Integers) == EmptySet.__class__()
 
     assert (not 0 in S.Reals.intersect(S.Integers - FiniteSet(0)))
 
@@ -439,7 +439,7 @@ def test_issue_9623():
     c = FiniteSet(n)
 
     assert Intersection(a, b, c) == Intersection(b, c)
-    assert Intersection(Interval(1, 2), Interval(3, 4), FiniteSet(n)) == EmptySet()
+    assert Intersection(Interval(1, 2), Interval(3, 4), FiniteSet(n)) == EmptySet.__class__()
 
 
 def test_is_disjoint():
@@ -1262,7 +1262,7 @@ def test_issue_10337():
 
 def test_issue_10326():
     bad = [
-        EmptySet(),
+        EmptySet.__class__(),
         FiniteSet(1),
         Interval(1, 2),
         S.ComplexInfinity,
@@ -1311,8 +1311,8 @@ def test_issue_8257():
 
 
 def test_issue_10931():
-    assert S.Integers - S.Integers == EmptySet()
-    assert S.Integers - S.Reals == EmptySet()
+    assert S.Integers - S.Integers == EmptySet.__class__()
+    assert S.Integers - S.Reals == EmptySet.__class__()
 
 
 def test_issue_11174():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -259,8 +259,8 @@ def test_Complement():
     assert -1 in Complement(S.Reals, S.Naturals, evaluate=False)
     assert not 1 in Complement(S.Reals, S.Naturals, evaluate=False)
 
-    assert Complement(S.Integers, S.UniversalSet) == EmptySet.__class__()
-    assert S.UniversalSet.complement(S.Integers) == EmptySet.__class__()
+    assert Complement(S.Integers, S.UniversalSet) == EmptySet
+    assert S.UniversalSet.complement(S.Integers) == EmptySet
 
     assert (not 0 in S.Reals.intersect(S.Integers - FiniteSet(0)))
 
@@ -439,7 +439,7 @@ def test_issue_9623():
     c = FiniteSet(n)
 
     assert Intersection(a, b, c) == Intersection(b, c)
-    assert Intersection(Interval(1, 2), Interval(3, 4), FiniteSet(n)) == EmptySet.__class__()
+    assert Intersection(Interval(1, 2), Interval(3, 4), FiniteSet(n)) == EmptySet
 
 
 def test_is_disjoint():
@@ -1262,7 +1262,7 @@ def test_issue_10337():
 
 def test_issue_10326():
     bad = [
-        EmptySet.__class__(),
+        EmptySet,
         FiniteSet(1),
         Interval(1, 2),
         S.ComplexInfinity,
@@ -1311,8 +1311,8 @@ def test_issue_8257():
 
 
 def test_issue_10931():
-    assert S.Integers - S.Integers == EmptySet.__class__()
-    assert S.Integers - S.Reals == EmptySet.__class__()
+    assert S.Integers - S.Integers == EmptySet
+    assert S.Integers - S.Reals == EmptySet
 
 
 def test_issue_11174():

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1281,7 +1281,7 @@ def _solve_modular(f, symbol, domain):
         base_sets = g_n.base_sets
         sol_set = _solveset(f_x - lamda_expr, symbol, S.Integers)
         if isinstance(sol_set, FiniteSet):
-            tmp_sol = EmptySet()
+            tmp_sol = EmptySet
             for sol in sol_set:
                 tmp_sol += ImageSet(Lambda(lamda_vars, sol), *base_sets)
             sol_set = tmp_sol

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -843,7 +843,7 @@ def solve_decomposition(f, symbol, domain):
             elif isinstance(y_s, Union):
                 iter_iset = y_s.args
 
-            elif isinstance(y_s, EmptySet):
+            elif isinstance(y_s, EmptySet.__class__):
                 # y_s is not in the range of g in g_s, so no solution exists
                 #in the given domain
                 return y_s
@@ -893,12 +893,12 @@ def _solveset(f, symbol, domain, _check=False):
     solver = lambda f, x, domain=domain: _solveset(f, x, domain)
     inverter = lambda f, rhs, symbol: _invert(f, rhs, symbol, domain)
 
-    result = EmptySet()
+    result = EmptySet.__class__()
 
     if f.expand().is_zero:
         return domain
     elif not f.has(symbol):
-        return EmptySet()
+        return EmptySet.__class__()
     elif f.is_Mul and all(_is_finite_with_finite_vars(m, domain)
             for m in f.args):
         # if f(x) and g(x) are both finite we can say that the solution of
@@ -915,7 +915,7 @@ def _solveset(f, symbol, domain, _check=False):
         a = f.args[0]
         result = solveset_real(a > 0, symbol)
     elif f.is_Piecewise:
-        result = EmptySet()
+        result = EmptySet.__class__()
         expr_set_pairs = f.as_expr_set_pairs(domain)
         for (expr, in_set) in expr_set_pairs:
             if in_set.is_Relational:
@@ -3395,7 +3395,7 @@ def nonlinsolve(system, *symbols):
 
         # positive dimensional system
         res = _handle_positive_dimensional(polys, symbols, denominators)
-        if isinstance(res, EmptySet) and any(not p.domain.is_Exact for p in polys):
+        if isinstance(res, EmptySet.__class__) and any(not p.domain.is_Exact for p in polys):
             raise NotImplementedError("Equation not in exact domain. Try converting to rational")
         else:
             return res

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1142,7 +1142,7 @@ def _invert_modular(modterm, rhs, n, symbol):
 
     if abs(rhs) >= abs(m):
         # if rhs has value greater than value of m.
-        return symbol, EmptySet()
+        return symbol, EmptySet
 
     if a is symbol:
         return symbol, ImageSet(Lambda(n, m*n + rhs), S.Integers)
@@ -1189,10 +1189,10 @@ def _invert_modular(modterm, rhs, n, symbol):
             try:
                 remainder_list = nthroot_mod(rhs, expo, m, all_roots=True)
                 if remainder_list is None:
-                    return symbol, EmptySet()
+                    return symbol, EmptySet
             except (ValueError, NotImplementedError):
                 return modterm, rhs
-            g_n = EmptySet()
+            g_n = EmptySet
             for rem in remainder_list:
                 g_n += ImageSet(Lambda(n, m*n + rem), S.Integers)
             return base, g_n

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -843,10 +843,10 @@ def solve_decomposition(f, symbol, domain):
             elif isinstance(y_s, Union):
                 iter_iset = y_s.args
 
-            elif isinstance(y_s, type(EmptySet)):
+            elif y_s is EmptySet:
                 # y_s is not in the range of g in g_s, so no solution exists
                 #in the given domain
-                return y_s
+                return EmptySet
 
             for iset in iter_iset:
                 new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)
@@ -1144,7 +1144,7 @@ def _invert_modular(modterm, rhs, n, symbol):
         # if rhs has value greater than value of m.
         return symbol, EmptySet
 
-    if a is symbol:
+    if a == symbol:
         return symbol, ImageSet(Lambda(n, m*n + rhs), S.Integers)
 
     if a.is_Add:
@@ -3395,7 +3395,7 @@ def nonlinsolve(system, *symbols):
 
         # positive dimensional system
         res = _handle_positive_dimensional(polys, symbols, denominators)
-        if isinstance(res, type(EmptySet)) and any(not p.domain.is_Exact for p in polys):
+        if res is EmptySet and any(not p.domain.is_Exact for p in polys):
             raise NotImplementedError("Equation not in exact domain. Try converting to rational")
         else:
             return res

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1128,7 +1128,7 @@ def _invert_modular(modterm, rhs, n, symbol):
     >>> invert_modular(Mod(3*x + 8, 7), S(5), n, x)
     (x, ImageSet(Lambda(_n, 7*_n + 6), Integers))
     >>> invert_modular(Mod(x**4, 7), S(5), n, x)
-    (x, EmptySet())
+    (x, EmptySet)
     >>> invert_modular(Mod(2**(x**2 + x + 1), 7), S(2), n, x)
     (x**2 + x + 1, ImageSet(Lambda(_n, 3*_n + 1), Naturals0))
 
@@ -1240,7 +1240,7 @@ def _solve_modular(f, symbol, domain):
     >>> solve_modulo(Mod(5*x - 8, 7) - 3, x, S.Reals)  # domain should be subset of integers.
     ConditionSet(x, Eq(Mod(5*x + 6, 7) - 3, 0), Reals)
     >>> solve_modulo(-7 + Mod(x, 5), x, S.Integers)
-    EmptySet()
+    EmptySet
     >>> solve_modulo(Mod(12**x, 21) - 18, x, S.Integers)
     ImageSet(Lambda(_n, 6*_n + 2), Naturals0)
     >>> solve_modulo(Mod(sin(x), 7) - 3, x, S.Integers) # not solvable
@@ -2396,7 +2396,7 @@ def linsolve(system, *symbols):
     the tuple in FiniteSet is used to maintain a consistent
     output format throughout solveset.)
 
-    Returns EmptySet(), if the linear system is inconsistent.
+    Returns EmptySet, if the linear system is inconsistent.
 
     Raises
     ======
@@ -2477,7 +2477,7 @@ def linsolve(system, *symbols):
     * For an empty system linsolve returns empty set
 
     >>> linsolve([], x)
-    EmptySet()
+    EmptySet
 
     * An error is raised if, after expansion, any nonlinearity
       is detected:
@@ -2652,7 +2652,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
     * when you want soln should not satisfy eq `x + 1 = 0`
 
     >>> substitution([x + y], [x], [{y: 1}], [y], set([x + 1]), [y, x])
-    EmptySet()
+    EmptySet
     >>> substitution([x + y], [x], [{y: 1}], [y], set([x - 1]), [y, x])
     {(1, -1)}
     >>> substitution([x + y - 1, y - x**2 + 5], [x, y])

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -843,7 +843,7 @@ def solve_decomposition(f, symbol, domain):
             elif isinstance(y_s, Union):
                 iter_iset = y_s.args
 
-            elif isinstance(y_s, EmptySet.__class__):
+            elif isinstance(y_s, type(EmptySet)):
                 # y_s is not in the range of g in g_s, so no solution exists
                 #in the given domain
                 return y_s
@@ -893,12 +893,12 @@ def _solveset(f, symbol, domain, _check=False):
     solver = lambda f, x, domain=domain: _solveset(f, x, domain)
     inverter = lambda f, rhs, symbol: _invert(f, rhs, symbol, domain)
 
-    result = EmptySet.__class__()
+    result = EmptySet
 
     if f.expand().is_zero:
         return domain
     elif not f.has(symbol):
-        return EmptySet.__class__()
+        return EmptySet
     elif f.is_Mul and all(_is_finite_with_finite_vars(m, domain)
             for m in f.args):
         # if f(x) and g(x) are both finite we can say that the solution of
@@ -915,7 +915,7 @@ def _solveset(f, symbol, domain, _check=False):
         a = f.args[0]
         result = solveset_real(a > 0, symbol)
     elif f.is_Piecewise:
-        result = EmptySet.__class__()
+        result = EmptySet
         expr_set_pairs = f.as_expr_set_pairs(domain)
         for (expr, in_set) in expr_set_pairs:
             if in_set.is_Relational:
@@ -3395,7 +3395,7 @@ def nonlinsolve(system, *symbols):
 
         # positive dimensional system
         res = _handle_positive_dimensional(polys, symbols, denominators)
-        if isinstance(res, EmptySet.__class__) and any(not p.domain.is_Exact for p in polys):
+        if isinstance(res, type(EmptySet)) and any(not p.domain.is_Exact for p in polys):
             raise NotImplementedError("Equation not in exact domain. Try converting to rational")
         else:
             return res

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -966,7 +966,7 @@ def test_M19():
 
 
 def test_M20():
-    assert solveset(sqrt(x**2 + 1) - x + 2, x) == EmptySet()
+    assert solveset(sqrt(x**2 + 1) - x + 2, x) == EmptySet.__class__()
 
 
 def test_M21():

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -966,7 +966,7 @@ def test_M19():
 
 
 def test_M20():
-    assert solveset(sqrt(x**2 + 1) - x + 2, x) == EmptySet.__class__()
+    assert solveset(sqrt(x**2 + 1) - x + 2, x) == EmptySet
 
 
 def test_M21():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #16575
Fixes #16337

#### Brief description of what is fixed or changed

Makes EmptySet (as imported from sympy) be the singleton instance of the emptyset rather than the class. This brings EmptySet into line with other classes like Reals.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * EmptySet (as imported from sympy) is now the singleton instance of the empty set rather than the class.
<!-- END RELEASE NOTES -->
