### PR TITLE
Fix two issues related to infinite Range objects

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1903,7 +1903,12 @@ class LatexPrinter(Printer):
     def _print_Range(self, s):
         dots = r'\ldots'
 
-        if s.start.is_infinite:
+        if s.start.is_infinite and s.stop.is_infinite:
+            if s.step.is_positive:
+                printset = dots, -1, 0, 1, dots
+            else:
+                printset = dots, 1, 0, -1, dots
+        elif s.start.is_infinite:
             printset = dots, s[-1] - s.step, s[-1]
         elif s.stop.is_infinite:
             it = iter(s)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1431,7 +1431,12 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         brac.setAttribute('close', '}')
         brac.setAttribute('open', '{')
 
-        if s.start.is_infinite:
+        if s.start.is_infinite and s.stop.is_infinite:
+            if s.step.is_positive:
+                printset = dots, -1, 0, 1, dots
+            else:
+                printset = dots, 1, 0, -1, dots
+        elif s.start.is_infinite:
             printset = dots, s[-1] - s.step, s[-1]
         elif s.stop.is_infinite:
             it = iter(s)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1914,7 +1914,12 @@ class PrettyPrinter(Printer):
         else:
             dots = '...'
 
-        if s.start.is_infinite:
+        if s.start.is_infinite and s.stop.is_infinite:
+            if s.step.is_positive:
+                printset = dots, -1, 0, 1, dots
+            else:
+                printset = dots, 1, 0, -1, dots
+        elif s.start.is_infinite:
             printset = dots, s[-1] - s.step, s[-1]
         elif s.stop.is_infinite:
             it = iter(s)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6928,3 +6928,8 @@ def test_is_combining():
     line = u("v̇_m")
     assert [is_combining(sym) for sym in line] == \
         [False, True, False, False]
+
+
+def test_issue_17857():
+    assert pretty(Range(-oo, oo)) == '{..., -1, 0, 1, ...}'
+    assert pretty(Range(oo, -oo, -1)) == '{..., 1, 0, -1, ...}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2507,3 +2507,8 @@ def test_latex_decimal_separator():
     raises(ValueError, lambda: latex([1,2.3,4.5], decimal_separator='non_existing_decimal_separator_in_list'))
     raises(ValueError, lambda: latex(FiniteSet(1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_set'))
     raises(ValueError, lambda: latex((1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_tuple'))
+
+
+def test_issue_17857():
+    assert latex(Range(-oo, oo)) == r'\left\{\ldots, -1, 0, 1, \ldots\right\}'
+    assert latex(Range(oo, -oo, -1)) == r'\left\{\ldots, 1, 0, -1, \ldots\right\}'

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1897,3 +1897,10 @@ def test_mathml_piecewise():
         '<piecewise><piece><ci>x</ci><apply><leq/><ci>x</ci><cn>1</cn></apply></piece><otherwise><apply><power/><ci>x</ci><cn>2</cn></apply></otherwise></piecewise>'
 
     raises(ValueError, lambda: mathml(Piecewise((x, x <= 1))))
+
+
+def test_issue_17857():
+    assert mathml(Range(-oo, oo), printer='presentation') == \
+        '<mfenced close="}" open="{"><mi>&#8230;</mi><mn>-1</mn><mn>0</mn><mn>1</mn><mi>&#8230;</mi></mfenced>'
+    assert mathml(Range(oo, -oo, -1), printer='presentation') == \
+        '<mfenced close="}" open="{"><mi>&#8230;</mi><mn>1</mn><mn>0</mn><mn>-1</mn><mi>&#8230;</mi></mfenced>'

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -659,8 +659,11 @@ class Range(Set):
                 _ = self.size  # validate
             except ValueError:
                 return
-        ref = self.start if self.start.is_finite else self.stop
-        if (ref - other) % self.step:  # off sequence
+        if self.start.is_finite:
+            ref = self.start
+        else:
+            ref = self.stop
+        if (ref - other) % self.step is S.true:  # off sequence
             return S.false
         return _sympify(other >= self.inf and other <= self.sup)
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -663,8 +663,9 @@ class Range(Set):
             ref = self.start
         else:
             ref = self.stop
-        if (ref - other) % self.step is S.true:  # off sequence
-            return S.false
+        if (ref - other).is_finite:
+            if (ref - other) % self.step:  # off sequence
+                return S.false
         return _sympify(other >= self.inf and other <= self.sup)
 
     def __iter__(self):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -661,11 +661,12 @@ class Range(Set):
                 return
         if self.start.is_finite:
             ref = self.start
-        else:
+        elif self.stop.is_finite:
             ref = self.stop
-        if (ref - other).is_finite:
-            if (ref - other) % self.step:  # off sequence
-                return S.false
+        else:
+            return other.is_Integer
+        if (ref - other) % self.step:  # off sequence
+            return S.false
         return _sympify(other >= self.inf and other <= self.sup)
 
     def __iter__(self):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -945,3 +945,10 @@ def test_imageset_intersection():
         log(Abs(sqrt(-I))))), S.Integers)
     assert s.intersect(S.Reals) == ImageSet(
         Lambda(n, 2*pi*n + pi*Rational(7, 4)), S.Integers)
+
+
+def test_issue_17858():
+    assert 1 in Range(-oo, oo)
+    assert 0 in Range(oo, -oo, -1)
+    assert oo not in Range(-oo, oo)
+    assert -oo not in Range(-oo, oo)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17858. Fixes #17857.

#### Brief description of what is fixed or changed
Check if both sides are infinite and print `{..., -1, 0, 1, ...}`.

Fix membership checking if both sides are infinite.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
