### PR TITLE
Better canonicalization for matrix multiplication and inverse

### DIFF
--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -62,10 +62,15 @@ class Inverse(MatPow):
     def doit(self, **hints):
         if 'inv_expand' in hints and hints['inv_expand'] == False:
             return self
+
+        arg = self.arg
         if hints.get('deep', True):
-            return self.arg.doit(**hints).inverse()
-        else:
-            return self.arg.inverse()
+            arg = arg.doit(**hints)
+
+        if isinstance(arg, MatPow):
+            return MatPow(arg.base, self.exp * arg.exp)
+        return arg.inverse()
+
 
     def _eval_derivative_matrix_lines(self, x):
         arg = self.args[0]

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -336,8 +336,9 @@ def combine_powers(mul):
 
     return newmul(factor, *new_args)
 
-rules = (any_zeros, remove_ids, unpack, rm_id(lambda x: x == 1),
-         merge_explicit, factor_in_front, flatten, combine_powers)
+rules = (
+    any_zeros, remove_ids, combine_powers, unpack, rm_id(lambda x: x == 1),
+    merge_explicit, factor_in_front, flatten,)
 canonicalize = exhaust(typed({MatMul: do_one(*rules)}))
 
 def only_squares(*matrices):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -305,7 +305,6 @@ def combine_powers(mul):
     e.g. Y * X * X.I -> Y
     """
     factor, args = mul.as_coeff_matrices()
-
     new_args = [args[0]]
 
     for B in args[1:]:
@@ -326,11 +325,11 @@ def combine_powers(mul):
 
         if A_base == B_base:
             new_exp = A_exp + B_exp
-            new_args[-1] = MatPow(A_base, new_exp).doit()
+            new_args[-1] = MatPow(A_base, new_exp).doit(deep=False)
         elif not isinstance(B_base, MatrixBase) and \
             A_base == B_base.inverse():
             new_exp = A_exp - B_exp
-            new_args[-1] = MatPow(A_base, new_exp).doit()
+            new_args[-1] = MatPow(A_base, new_exp).doit(deep=False)
         else:
             new_args.append(B)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -4,13 +4,15 @@ from sympy import Number
 from sympy.core import Mul, Basic, sympify, S
 from sympy.core.compatibility import range
 from sympy.functions import adjoint
-from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
         do_one, new)
-from sympy.matrices.expressions.matexpr import (MatrixExpr, ShapeError,
-        Identity, ZeroMatrix, GenericIdentity)
-from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.matrices import MatrixBase
+
+from .inverse import Inverse
+from .matexpr import \
+    MatrixExpr, ShapeError, Identity, ZeroMatrix, GenericIdentity
+from .matpow import MatPow
+from .transpose import transpose
 
 # XXX: MatMul should perhaps not subclass directly from Mul
 class MatMul(MatrixExpr, Mul):
@@ -302,7 +304,6 @@ def combine_powers(mul):
 
     e.g. Y * X * X.I -> Y
     """
-    from sympy.matrices.expressions import MatPow
     factor, args = mul.as_coeff_matrices()
 
     new_args = [args[0]]

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -1,5 +1,5 @@
 from sympy.core import symbols, S
-from sympy.matrices.expressions import MatrixSymbol, Inverse
+from sympy.matrices.expressions import MatrixSymbol, Inverse, MatPow
 from sympy.matrices import eye, Identity, ShapeError
 from sympy.utilities.pytest import raises
 from sympy import refine, Q
@@ -44,3 +44,8 @@ def test_inverse():
 
 def test_refine():
     assert refine(C.I, Q.orthogonal(C)) == C.T
+
+
+def test_inverse_matpow_canonicalization():
+    A = MatrixSymbol('A', 3, 3)
+    assert Inverse(MatPow(A, 3)).doit() == MatPow(Inverse(A), 3).doit()

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -5,7 +5,7 @@ from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
 from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
 from sympy.matrices.expressions.matexpr import GenericIdentity
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
-        MatMul, xxinv, any_zeros, unpack, only_squares)
+        MatMul, combine_powers, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
 from sympy import refine, Q, Symbol
 
@@ -57,8 +57,8 @@ def test_remove_ids():
                                  MatMul(Identity(n), evaluate=False)
 
 
-def test_xxinv():
-    assert xxinv(MatMul(D, Inverse(D), D, evaluate=False)) == \
+def test_combine_powers():
+    assert combine_powers(MatMul(D, Inverse(D), D, evaluate=False)) == \
                  MatMul(Identity(n), D, evaluate=False)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

1. I've found that the `MatMul` tries to compute matrix inverse while canonicalizing, even for explicit matrices. 
This may cause a huge slowdown from `183758 function calls (176911 primitive calls) in 0.077 seconds` to `331411 function calls (325520 primitive calls) in 1.392 seconds` for canonicalizing two 15*15 matrices.
2. I have merged `xxinv` and `combine_powers`.
3. `Inverse(MatPow(A, 3))` and `MatPow(Inverse(A), 3)` had been canonicalized differently, so I've made both to be canonicalized same as `MatPow(A, -3)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Cleaned up unnecessary slowdown for `MatMul.doit` when it contains explicit matrices.
  - Fixed `MatPow(Inverse(A), 3)` and `Inverse(MatPow(A, 3))` canonicalized into different objects.

<!-- END RELEASE NOTES -->
