### PR TITLE
Handle noncommutative scalars in matrix multiplication

### DIFF
--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -89,8 +89,8 @@ def validate(*args):
         if A.shape != B.shape:
             raise ShapeError("Matrices %s and %s are not aligned"%(A, B))
 
-factor_of = lambda arg: arg.as_coeff_mmul()[0]
-matrix_of = lambda arg: unpack(arg.as_coeff_mmul()[1])
+factor_of = lambda arg: arg._as_commutative_coeff_mmul()[0]
+matrix_of = lambda arg: unpack(arg._as_commutative_coeff_mmul()[1])
 def combine(cnt, mat):
     if cnt == 1:
         return mat

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.core.compatibility import reduce
 from operator import add
 
-from sympy.core import Add, Basic, sympify
+from sympy.core import Add, Basic, S, sympify
 from sympy.functions import adjoint
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.expressions.transpose import transpose
@@ -89,8 +89,16 @@ def validate(*args):
         if A.shape != B.shape:
             raise ShapeError("Matrices %s and %s are not aligned"%(A, B))
 
-factor_of = lambda arg: arg._as_commutative_coeff_mmul()[0]
-matrix_of = lambda arg: unpack(arg._as_commutative_coeff_mmul()[1])
+def factor_of(arg):
+    if arg.is_Matrix:
+        return arg._as_commutative_coeff_mmul()[0]
+    return S.One
+
+def matrix_of(arg):
+    if arg.is_Matrix:
+        return unpack(arg._as_commutative_coeff_mmul()[1])
+    return arg
+
 def combine(cnt, mat):
     if cnt == 1:
         return mat

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -352,6 +352,8 @@ def combine_powers(mul):
                 new_args[-1] = MatPow(A_base, new_exp).doit(deep=False)
             else:
                 new_args.append(B)
+        else:
+            new_args.append(B)
 
     return newmul(factor, *new_args)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -61,6 +61,10 @@ class MatMul(MatrixExpr, Mul):
 
     @property
     def shape(self):
+        for arg in self.args:
+            if arg.is_Matrix is False and arg.is_commutative is False:
+                raise NotImplementedError
+
         matrices = [arg for arg in self.args if arg.is_Matrix]
         return (matrices[0].rows, matrices[-1].cols)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -51,7 +51,7 @@ class MatMul(MatrixExpr, Mul):
         matrices, _ = sift(others, lambda x: x.is_Matrix, binary=True)
 
         if check:
-            validate(*matrices)
+            validate(*others)
         if not matrices:
             # Should it be
             #
@@ -216,12 +216,12 @@ class MatMul(MatrixExpr, Mul):
         return lines
 
 
-def validate(*matrices):
-    """ Checks for valid shapes for args of MatMul """
-    for i in range(len(matrices)-1):
-        A, B = matrices[i:i+2]
-        if A.cols != B.rows:
-            raise ShapeError("Matrices %s and %s are not aligned"%(A, B))
+def validate(*mats_or_ncs):
+    """Screens out some invalid shapes of ``MatMul``"""
+    for i in range(len(mats_or_ncs)-1):
+        A, B = mats_or_ncs[i], mats_or_ncs[i+1]
+        if A.is_Matrix and B.is_Matrix and A.cols != B.rows:
+            raise ShapeError("Matrices %s and %s are not aligned" % (A, B))
 
 # Rules
 

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,7 +1,7 @@
 from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
 from sympy.matrices.expressions.matexpr import GenericZeroMatrix, ZeroMatrix
 from sympy.matrices import eye, ImmutableMatrix
-from sympy.core import Add, Basic, S
+from sympy.core import Add, Basic, S, symbols
 from sympy.utilities.pytest import XFAIL, raises
 
 X = MatrixSymbol('X', 2, 2)
@@ -39,3 +39,10 @@ def test_zero_matrix_add():
 @XFAIL
 def test_matrix_add_with_scalar():
     raises(TypeError, lambda: Add(0, ZeroMatrix(2, 2)))
+
+
+def test_noncommutative_scalar_subs():
+    x, y = symbols('x y', commutative=False)
+
+    expr = (x*y)**-1 + x*y
+    assert expr.subs({x: X}) ==

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -45,4 +45,7 @@ def test_noncommutative_scalar_subs():
     x, y = symbols('x y', commutative=False)
 
     expr = (x*y)**-1 + x*y
-    assert expr.subs({x: X}) ==
+    assert expr.subs(x, X) == MatAdd(X*y, MatPow(X*y, -1))
+
+    expr = x + y
+    assert expr.subs(x, X) == MatAdd(y, X)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -561,6 +561,14 @@ def test_MatMul_postprocessor():
 
     assert Mul(A, x, M, M, x) == MatMul(A, Mx**2)
 
+    # Test whether the postprocessor mangles the ordering of
+    # noncommutative scalars
+    X = MatrixSymbol('X', 2, 2)
+    y = Symbol('y', commutative=False)
+    assert Mul(X, y).args == (X, y)
+    assert Mul(y, X).args == (y, X)
+
+
 @XFAIL
 def test_MatAdd_postprocessor_xfail():
     # This is difficult to get working because of the way that Add processes

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -52,9 +52,13 @@ def test_factor_in_front():
 
 def test_remove_ids():
     assert remove_ids(MatMul(A, Identity(m), B, evaluate=False)) == \
-                      MatMul(A, B, evaluate=False)
+        MatMul(A, B, evaluate=False)
     assert null_safe(remove_ids)(MatMul(Identity(n), evaluate=False)) == \
-                                 MatMul(Identity(n), evaluate=False)
+        MatMul(Identity(n), evaluate=False)
+
+    x = symbols('x', commutative=False)
+    assert remove_ids(MatMul(x, Identity(3), evaluate=False)).args == \
+        (x, Identity(3))
 
 
 def test_combine_powers():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -136,7 +136,6 @@ def test_matmul_args_cnc():
     assert MatMul(n, A, A.T).args_cnc() == [[n], [A, A.T]]
     assert MatMul(A, A.T).args_cnc() == [[], [A, A.T]]
 
-@XFAIL
 def test_matmul_args_cnc_symbols():
     # Not currently supported
     a, b = symbols('a b', commutative=False)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -314,7 +314,7 @@ class StrPrinter(Printer):
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
     def _print_MatMul(self, expr):
-        c, m = expr.as_coeff_mmul()
+        c, m = expr._as_commutative_coeff_mmul()
         if c.is_number and c < 0:
             expr = _keep_coeff(-c, m)
             sign = "-"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17876

#### Brief description of what is fixed or changed

This is a crude fix and some improvements may be needed. But see if the tests pass.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `MatMul` can be constructed or canonicalized with non-commutative scalars.
<!-- END RELEASE NOTES -->
