### PR TITLE
printing:Fix Permutation repr test failure in master 

### DIFF
--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -302,4 +302,6 @@ def test_Cycle():
 
 def test_Permutation():
     import_stmt = "from sympy.combinatorics import Permutation"
+    Permutation.print_cyclic = True
     sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
+    Permutation.print_cyclic = False

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -302,6 +302,7 @@ def test_Cycle():
 
 def test_Permutation():
     import_stmt = "from sympy.combinatorics import Permutation"
+    print_cyclic = Permutation.print_cyclic
     Permutation.print_cyclic = True
     sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
-    Permutation.print_cyclic = False
+    Permutation.print_cyclic = print_cyclic


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17884 

#### Brief description of what is fixed or changed
Modified the tests to specify the variable temporarily and made it automatically revert to the default value. This fixed the AssertionError in test_Permutation().


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
