### PR TITLE
Update FUNDING.yml to include new GitHub Sponsor button for NumFOCUS

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
-
-custom: ['https://numfocus.salsalabs.org/donate-to-sympy/index.html']
+github: numfocus
+custom: ['https://numfocus.org/donate-to-sympy']


### PR DESCRIPTION
 ## Brief description of what is fixed or changed

- add NumFOCUS github sponsors button (recurring donations only)
- update custom link to point to the form located at numfocus.org, in case it provides more peace of mind for potential donors.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY