### PR TITLE
printing: Add Finally block in Permutation repr test

### DIFF
--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -304,5 +304,7 @@ def test_Permutation():
     import_stmt = "from sympy.combinatorics import Permutation"
     print_cyclic = Permutation.print_cyclic
     Permutation.print_cyclic = True
-    sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
-    Permutation.print_cyclic = print_cyclic
+    try:
+    	sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
+    finally:
+    	Permutation.print_cyclic = print_cyclic

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -305,6 +305,6 @@ def test_Permutation():
     print_cyclic = Permutation.print_cyclic
     Permutation.print_cyclic = True
     try:
-    	sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
+        sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
     finally:
-    	Permutation.print_cyclic = print_cyclic
+        Permutation.print_cyclic = print_cyclic


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
PR #17891 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added Finally block so that even if the tests fail, Permutation.print_cyclic gets reset.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
