### PR TITLE
Fix flake8 errors in codegen

### DIFF
--- a/sympy/codegen/__init__.py
+++ b/sympy/codegen/__init__.py
@@ -16,3 +16,9 @@ from .ast import (
     Assignment, aug_assign, CodeBlock, For, Attribute, Variable, Declaration,
     While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall
 )
+
+__all__ = [
+    'Assignment', 'aug_assign', 'CodeBlock', 'For', 'Attribute', 'Variable',
+    'Declaration', 'While', 'Scope', 'Print', 'FunctionPrototype',
+    'FunctionDefinition', 'FunctionCall',
+]

--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -38,7 +38,6 @@ from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.mul import Mul
-from sympy.core.power import Pow
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.utilities.iterables import sift
 

--- a/sympy/codegen/tests/test_approximations.py
+++ b/sympy/codegen/tests/test_approximations.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, print_function)
 
 import math
-from sympy import symbols, exp, S, Poly
+from sympy import symbols, exp
 from sympy.codegen.rewriting import optimize
 from sympy.codegen.approximations import SumApprox, SeriesApprox
 

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -1,4 +1,4 @@
-from sympy import symbols, IndexedBase, HadamardProduct, Identity, cos
+from sympy import symbols, IndexedBase, Identity, cos
 from sympy.codegen.array_utils import (CodegenArrayContraction,
         CodegenArrayTensorProduct, CodegenArrayDiagonal,
         CodegenArrayPermuteDims, CodegenArrayElementwiseAdd,
@@ -6,13 +6,13 @@ from sympy.codegen.array_utils import (CodegenArrayContraction,
         _RecognizeMatMulLines, _unfold_recognized_expr,
         parse_indexed_expression, recognize_matrix_expression,
         _parse_matrix_expression)
-from sympy import (MatrixSymbol, Sum)
+from sympy import MatrixSymbol, Sum
 from sympy.combinatorics import Permutation
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.expressions.diagonal import DiagMatrix
 from sympy.matrices.expressions.matexpr import MatrixElement
-from sympy.matrices import (Trace, MatAdd, MatMul, Transpose)
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.matrices import Trace, MatAdd, MatMul, Transpose
+from sympy.utilities.pytest import raises
 
 
 A, B = symbols("A B", cls=IndexedBase)
@@ -323,7 +323,6 @@ def test_codegen_permutedims_sink():
     cg = CodegenArrayPermuteDims(CodegenArrayContraction(CodegenArrayTensorProduct(M, N, P), (1, 2), (3, 4)), [1, 0])
     sunk = cg.nest_permutation()
     assert sunk == CodegenArrayContraction(CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N, P), [[0, 5]]), (1, 2), (3, 4))
-    sunk2 = sunk.expr.nest_permutation()
 
 
 def test_parsing_of_matrix_expressions():

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -4,7 +4,7 @@ from sympy import (
     symbols, Symbol, Tuple, Lt, nan, oo
 )
 from sympy.core.relational import StrictLessThan
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises
 
 
 from sympy.codegen.ast import (

--- a/sympy/codegen/tests/test_fnodes.py
+++ b/sympy/codegen/tests/test_fnodes.py
@@ -36,7 +36,7 @@ def test_size_assumed_shape():
     body = [Return((sum_(a**2)/size(a))**.5)]
     arr = array(a, dim=[':'], intent='in')
     fd = FunctionDefinition(real, 'rms', [arr], body)
-    f_mod = render_as_module([fd], 'mod_rms')
+    render_as_module([fd], 'mod_rms')
 
     (stdout, stderr), info = compile_run_strings([
         ('rms.f90', render_as_module([fd], 'mod_rms')),


### PR DESCRIPTION
Attempting to fix flake8 errors in some modules I am getting a test failure in tensorflow printing. I can't reproduce the failure locally so this PR is an attempt to isolate it by testing a subset of the changes from #17930 on Travis. If I see the failure here then it means at least that the other parts of #17930 are probably okay...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
