### PR TITLE
Fix flake8 warnings in a few modules

### DIFF
--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -1,7 +1,10 @@
 # conceal the implicit import from the code quality tester
 from __future__ import print_function, division
 
-exec("from sympy import *")
+from sympy import (exp, gamma, integrate, oo, pi, sqrt, Symbol, symbols,
+        besseli, laplace_transform, fourier_transform, mellin_transform,
+        inverse_fourier_transform, inverse_laplace_transform,
+        inverse_mellin_transform)
 
 LT = laplace_transform
 FT = fourier_transform
@@ -10,7 +13,7 @@ IFT = inverse_fourier_transform
 ILT = inverse_laplace_transform
 IMT = inverse_mellin_transform
 
-from sympy.abc import a, b, s, t, x, y, z
+from sympy.abc import x, y
 nu, beta, rho = symbols('nu beta rho')
 
 apos, bpos, cpos, dpos, posk, p = symbols('a b c d k p', positive=True)
@@ -50,9 +53,9 @@ tpos = Symbol('t', positive=True)
 
 
 def E(expr):
-    res1 = integrate(expr*exponential(x, rate)*normal(y, mu1, sigma1),
+    integrate(expr*exponential(x, rate)*normal(y, mu1, sigma1),
                      (x, 0, oo), (y, -oo, oo), meijerg=True)
-    res2 = integrate(expr*exponential(x, rate)*normal(y, mu1, sigma1),
+    integrate(expr*exponential(x, rate)*normal(y, mu1, sigma1),
                      (y, -oo, oo), (x, 0, oo), meijerg=True)
 
 bench = [
@@ -250,5 +253,5 @@ if __name__ == '__main__':
 
     timings.sort(key=lambda x: -x[0])
 
-    for t, string in timings:
-        print('%.2fs %s' % (t, string))
+    for ti, string in timings:
+        print('%.2fs %s' % (ti, string))

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -12,7 +12,7 @@ def bench_R1():
     "real(f(f(f(f(f(f(f(f(f(f(i/2)))))))))))"
     def f(z):
         return sqrt(Integer(1)/3)*z**2 + I/3
-    e = f(f(f(f(f(f(f(f(f(f(I/2)))))))))).as_real_imag()[0]
+    f(f(f(f(f(f(f(f(f(f(I/2)))))))))).as_real_imag()[0]
 
 
 def bench_R2():
@@ -24,13 +24,13 @@ def bench_R2():
             return 1
         return (2*y*hermite(n - 1, y) - 2*(n - 1)*hermite(n - 2, y)).expand()
 
-    a = hermite(15, y)
+    hermite(15, y)
 
 
 def bench_R3():
     "a = [bool(f==f) for _ in range(10)]"
     f = x + y + z
-    a = [bool(f == f) for _ in range(10)]
+    [bool(f == f) for _ in range(10)]
 
 
 def bench_R4():
@@ -54,13 +54,13 @@ def bench_R5():
 
 def bench_R6():
     "sum(simplify((x+sin(i))/x+(x-sin(i))/x) for i in range(100))"
-    s = sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in range(100))
+    sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in range(100))
 
 
 def bench_R7():
     "[f.subs(x, random()) for _ in range(10**4)]"
     f = x**24 + 34*x**12 + 45*x**3 + 9*x**18 + 34*x**10 + 32*x**21
-    a = [f.subs(x, random()) for _ in range(10**4)]
+    [f.subs(x, random()) for _ in range(10**4)]
 
 
 def bench_R8():
@@ -78,7 +78,7 @@ def bench_R8():
             est += f.subs(x, c)
         return est*Deltax
 
-    a = right(x**2, 0, 5, 10**4)
+    right(x**2, 0, 5, 10**4)
 
 
 def _bench_R9():
@@ -93,19 +93,19 @@ def bench_R10():
         while (max - v[-1]).evalf() > 0:
             v.append(v[-1] + step)
         return v[:-1]
-    v = srange(-pi, pi, sympify(1)/10)
+    srange(-pi, pi, sympify(1)/10)
 
 
 def bench_R11():
     "a = [random() + random()*I for w in [0..1000]]"
-    a = [random() + random()*I for w in range(1000)]
+    [random() + random()*I for w in range(1000)]
 
 
 def bench_S1():
     "e=(x+y+z+1)**7;f=e*(e+1);f.expand()"
     e = (x + y + z + 1)**7
     f = e*(e + 1)
-    f = f.expand()
+    f.expand()
 
 
 if __name__ == '__main__':

--- a/sympy/categories/__init__.py
+++ b/sympy/categories/__init__.py
@@ -23,3 +23,11 @@ from .baseclasses import (Object, Morphism, IdentityMorphism,
 
 from .diagram_drawing import (DiagramGrid, XypicDiagramDrawer,
                              xypic_draw_diagram, preview_diagram)
+
+__all__ = [
+    'Object', 'Morphism', 'IdentityMorphism', 'NamedMorphism',
+    'CompositeMorphism', 'Category', 'Diagram',
+
+    'DiagramGrid', 'XypicDiagramDrawer', 'xypic_draw_diagram',
+    'preview_diagram',
+]

--- a/sympy/combinatorics/__init__.py
+++ b/sympy/combinatorics/__init__.py
@@ -12,3 +12,29 @@ from sympy.combinatorics.graycode import GrayCode
 from sympy.combinatorics.named_groups import (SymmetricGroup, DihedralGroup,
     CyclicGroup, AlternatingGroup, AbelianGroup, RubikGroup)
 from sympy.combinatorics.pc_groups import PolycyclicGroup, Collector
+
+__all__ = [
+    'Permutation', 'Cycle',
+
+    'Prufer',
+
+    'cyclic', 'alternating', 'symmetric', 'dihedral',
+
+    'Subset',
+
+    'Partition', 'IntegerPartition', 'RGS_rank', 'RGS_unrank', 'RGS_enum',
+
+    'Polyhedron', 'tetrahedron', 'cube', 'octahedron', 'dodecahedron',
+    'icosahedron',
+
+    'PermutationGroup',
+
+    'DirectProduct',
+
+    'GrayCode',
+
+    'SymmetricGroup', 'DihedralGroup', 'CyclicGroup', 'AlternatingGroup',
+    'AbelianGroup', 'RubikGroup',
+
+    'PolycyclicGroup', 'Collector',
+]

--- a/sympy/combinatorics/tests/test_pc_groups.py
+++ b/sympy/combinatorics/tests/test_pc_groups.py
@@ -62,7 +62,7 @@ def test_exponent_vector():
         collector = PcGroup.collector
 
         pcgs = PcGroup.pcgs
-        free_group = collector.free_group
+        # free_group = collector.free_group
 
         for gen in G.generators:
             exp = collector.exponent_vector(gen)


### PR DESCRIPTION
Attempting to fix flake8 errors in some modules I am getting a test failure in tensorflow printing. I can't reproduce the failure locally so this PR is an attempt to isolate it by testing a subset of the changes from #17930 on Travis. If I see the failure here then it means at least that the other parts of #17930 are probably okay...

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
