### PR TITLE
Fix flake8 in deprecated diffgeome and discrete

### DIFF
--- a/sympy/deprecated/__init__.py
+++ b/sympy/deprecated/__init__.py
@@ -9,4 +9,4 @@ Since no modules in SymPy ever depend on deprecated code, SymPy always imports
 this last, after all other modules have been imported.
 """
 
-from sympy.deprecated.class_registry import C, ClassRegistry
+from sympy.deprecated.class_registry import C, ClassRegistry  # noqa

--- a/sympy/diffgeom/__init__.py
+++ b/sympy/diffgeom/__init__.py
@@ -7,3 +7,13 @@ from .diffgeom import (
     Point, TensorProduct, twoform_to_matrix, vectors_in_basis,
     WedgeProduct,
 )
+
+__all__ = [
+    'BaseCovarDerivativeOp', 'BaseScalarField', 'BaseVectorField',
+    'Commutator', 'contravariant_order', 'CoordSystem', 'CovarDerivativeOp',
+    'covariant_order', 'Differential', 'intcurve_diffequ', 'intcurve_series',
+    'LieDerivative', 'Manifold', 'metric_to_Christoffel_1st',
+    'metric_to_Christoffel_2nd', 'metric_to_Ricci_components',
+    'metric_to_Riemann_components', 'Patch', 'Point', 'TensorProduct',
+    'twoform_to_matrix', 'vectors_in_basis', 'WedgeProduct',
+]

--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -11,3 +11,10 @@ Convolutions - ``convolution``, ``convolution_fft``, ``convolution_ntt``,
 from .transforms import (fft, ifft, ntt, intt, fwht, ifwht,
     mobius_transform, inverse_mobius_transform)
 from .convolutions import convolution, covering_product, intersecting_product
+
+__all__ = [
+    'fft', 'ifft', 'ntt', 'intt', 'fwht', 'ifwht', 'mobius_transform',
+    'inverse_mobius_transform',
+
+    'convolution', 'covering_product', 'intersecting_product',
+]

--- a/sympy/discrete/tests/test_convolutions.py
+++ b/sympy/discrete/tests/test_convolutions.py
@@ -1,6 +1,5 @@
 from sympy import sqrt, pi, E, exp, Rational
-from sympy.core import S, Symbol, symbols, I
-from sympy.core.compatibility import range
+from sympy.core import S, symbols, I
 from sympy.discrete.convolutions import (
     convolution, convolution_fft, convolution_ntt, convolution_fwht,
     convolution_subset, covering_product, intersecting_product)
@@ -181,7 +180,7 @@ def test_convolution_ntt():
     p = 7*17*2**23 + 1
     q = 19*2**10 + 1
     r = 2*500000003 + 1 # only for sequences of length 1 or 2
-    s = 2*3*5*7 # composite modulus
+    # s = 2*3*5*7 # composite modulus
 
     assert all(convolution_ntt([], x, prime=y) == [] for x in ([], [1]) for y in (p, q, r))
     assert convolution_ntt([2], [3], r) == [6]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Attempting to fix flake8 errors in some modules I am getting a test failure in tensorflow printing. I can't reproduce the failure locally so this PR is an attempt to isolate it by testing a subset of the changes from #17930 on Travis. If I see the failure here then it means at least that the other parts of #17930 are probably okay...

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
