### PR TITLE
Make doctest depend on antlr4 rather than antlr

### DIFF
--- a/sympy/parsing/autolev/__init__.py
+++ b/sympy/parsing/autolev/__init__.py
@@ -1,7 +1,7 @@
 from sympy.external import import_module
 from sympy.utilities.decorator import doctest_depends_on
 
-@doctest_depends_on(modules=('antlr',))
+@doctest_depends_on(modules=('antlr4',))
 def parse_autolev(autolev_code, include_numeric=False):
     """Parses Autolev code (version 4.1) to SymPy code.
 

--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -1,8 +1,9 @@
 from sympy.external import import_module
+from sympy.utilities.decorator import doctest_depends_on
 
 from .errors import LaTeXParsingError  # noqa
 
-
+@doctest_depends_on(modules=('antlr4',))
 def parse_latex(s):
     r"""Converts the string ``s`` to a SymPy ``Expr``
 
@@ -18,11 +19,11 @@ def parse_latex(s):
     Examples
     ========
 
-    >>> from sympy.parsing.latex import parse_latex  # doctest: +SKIP
-    >>> expr = parse_latex(r"\frac {1 + \sqrt {\a}} {\b}")  # doctest: +SKIP
-    >>> expr  # doctest: +SKIP
+    >>> from sympy.parsing.latex import parse_latex
+    >>> expr = parse_latex(r"\frac {1 + \sqrt {\a}} {\b}")
+    >>> expr
     (sqrt(a) + 1)/b
-    >>> expr.evalf(4, subs=dict(a=5, b=2))  # doctest: +SKIP
+    >>> expr.evalf(4, subs=dict(a=5, b=2))
     1.618
     """
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See #8446 


#### Brief description of what is fixed or changed

Try changing dependency from antlr to antlr4 for doctests in `autolev/__init__.py`. Hopefully that means that the doctests won't be skipped...

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
