### PR TITLE
Fix doctest_depends in sym_expr

### DIFF
--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -16,7 +16,7 @@ else:
     if cin:
         from sympy.parsing.c.c_parser import parse_c
 
-    @doctest_depends_on(modules=['lfortran', 'cin'])
+    @doctest_depends_on(modules=['lfortran', 'clang.cindex'])
     class SymPyExpression(object):
         """Class to store and handle SymPy expressions
 
@@ -46,6 +46,7 @@ else:
 
         Example of parsing C code:
 
+        >>> from sympy.parsing.sym_expr import SymPyExpression
         >>> src = '''
         ... int a,b;
         ... float c = 2, d =4;

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -53,8 +53,10 @@ else:
         ... '''
         >>> a = SymPyExpression(src, 'c')
         >>> a.return_expr()
-        [Declaration(Variable(Symbol('a'), type=IntBaseType(String('integer')), value=Integer(0))), Declaration(Variable(Symbol('b'), type=IntBaseType(String('integer')), value=Integer(0))), Declaration(Variable(Symbol('c'), type=IntBaseType(String('integer')), value=Integer(2))), Declaration(Variable(Symbol('d'),     type=IntBaseType(String('integer')), value=Integer(4)))]
-
+        [Declaration(Variable(a, type=integer, value=0)),
+        Declaration(Variable(b, type=integer, value=0)),
+        Declaration(Variable(c, type=integer, value=2)),
+        Declaration(Variable(d, type=integer, value=4))]
 
         An example of variable definiton:
 


### PR DESCRIPTION

See #8446

Fixes the condition for skipping doctests in sym_expr. It seems the doctest was never run before so might not work (I can't get it working locally because dynamic linking to clang fails)

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
