### PR TITLE
Fix represent for negative matrix powers

### DIFF
--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -171,7 +171,14 @@ def represent(expr, **options):
         base, exp = expr.as_base_exp()
         if format == 'numpy' or format == 'scipy.sparse':
             exp = _sympy_to_scalar(exp)
-        return represent(base, **options)**exp
+        base = represent(base, **options)
+        # scipy.sparse doesn't support negative exponents
+        # and warns when inverting a matrix in csr format.
+        if format == 'scipy.sparse' and exp < 0:
+            from scipy.sparse.linalg import inv
+            exp = - exp
+            base = inv(base.tocsc()).tocsr()
+        return base ** exp
     elif isinstance(expr, TensorProduct):
         new_args = [represent(arg, **options) for arg in expr.args]
         return TensorProduct(*new_args)

--- a/sympy/physics/quantum/tests/test_identitysearch.py
+++ b/sympy/physics/quantum/tests/test_identitysearch.py
@@ -484,18 +484,9 @@ def test_bfs_identity_search():
     assert bfs_identity_search(gate_list, 1, max_depth=4) == id_set
 
 
-# @XFAIL
-# Seems to fail on Python 2.7, but not 3.X, unless scipy is installed
 def test_bfs_identity_search_xfail():
-    scipy = import_module('scipy', __import__kwargs={'fromlist': ['sparse']})
-    if scipy:
-        skip("scipy installed.")
     s = PhaseGate(0)
     t = TGate(0)
     gate_list = [Dagger(s), t]
     id_set = {GateIdentity(Dagger(s), t, t)}
     assert bfs_identity_search(gate_list, 1, max_depth=3) == id_set
-
-
-if not PY3:
-    test_bfs_identity_search_xfail = XFAIL(test_bfs_identity_search_xfail)


### PR DESCRIPTION
See #8446

Fixes the quantum represent function for  negative matrix powers. The problem was that scipy.sparse doesn't allow negative powers so we use the inv function instead.

This should mean that no tests are skipped in the optional dependency job on Travis for `test_identitysearch.py`.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
