### PR TITLE
Fix dead link to galgebra

### DIFF
--- a/sympy/galgebra.py
+++ b/sympy/galgebra.py
@@ -1,1 +1,1 @@
-raise ImportError("""As of SymPy 1.0 the galgebra module is maintained separately at https://github.com/brombo/galgebra""")
+raise ImportError("""As of SymPy 1.0 the galgebra module is maintained separately at https://github.com/pygae/galgebra""")


### PR DESCRIPTION
The @brombo user has been deleted. While @abrombo is the same person, the root fork now lives at pygae/galgebra.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/pygae/galgebra/issues/28


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
