### PR TITLE
1.5: Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ PY3 = sys.version_info[0] > 2
 
 # Make sure I have the right Python version.
 if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
-    (sys.version_info[0] == 3 and sys.version_info[1] < 4)):
-    print("SymPy requires Python 2.7 or 3.4 or newer. Python %d.%d detected"
+    (sys.version_info[0] == 3 and sys.version_info[1] < 5)):
+    print("SymPy requires Python 2.7 or 3.5 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 

--- a/setup.py
+++ b/setup.py
@@ -450,6 +450,7 @@ if __name__ == '__main__':
                     'antlr': antlr,
                     'sdist': sdist_sympy,
                     },
+          python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
           classifiers=[
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -36,8 +36,8 @@ if 'dev' in __version__:
 
 import sys
 if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
-    (sys.version_info[0] == 3 and sys.version_info[1] < 4)):
-    raise ImportError("Python version 2.7 or 3.4 or above "
+    (sys.version_info[0] == 3 and sys.version_info[1] < 5)):
+    raise ImportError("Python version 2.7 or 3.5 or above "
                       "is required for SymPy.")
 
 del sys


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Helps towards #17943 "Removing Python 2 code".

Like https://github.com/sympy/sympy/pull/17968 but for the `1.5` branch.

#### Brief description of what is fixed or changed

Add `python_requires` to help pip install the right version of this package for the user's running Python.

Also update the version check in `setup.py`, Python 3.4 was already dropped in https://github.com/sympy/sympy/pull/16492. This is not strictly necessary with `python_requires`, unless the user has a really old version of pip and could probably be removed entirely.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

[I'm not sure if this requires user-facing release notes, so didn't add any, but please let me know if otherwise.]

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
