### PR TITLE
Fix dead link to galgebra

### DIFF
--- a/sympy/galgebra.py
+++ b/sympy/galgebra.py
@@ -1,1 +1,1 @@
-raise ImportError("""As of SymPy 1.0 the galgebra module is maintained separately at https://github.com/brombo/galgebra""")
+raise ImportError("""As of SymPy 1.0 the galgebra module is maintained separately at https://github.com/pygae/galgebra""")


### PR DESCRIPTION
The @brombo user has been deleted. While @abrombo is the same person, the root fork now lives at pygae/galgebra.

Rebase of #17961 for the 1.5 branch

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
