### PR TITLE
Fix solve for exponential equations w infinities

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2830,6 +2830,8 @@ def _tsolve(eq, sym, **flags):
     if flags.pop('force', True):
         flags['force'] = False
         pos, reps = posify(lhs - rhs)
+        if rhs == S.ComplexInfinity:
+            return []
         for u, s in reps.items():
             if s == sym:
                 break

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2121,3 +2121,10 @@ def test_issue_17799():
 def test_issue_17650():
     x = Symbol('x', real=True)
     assert solve(abs((abs(x**2 - 1) - x)) - x) == [1, -1 + sqrt(2), 1 + sqrt(2)]
+
+
+def test_issue_17949():
+    assert solve(exp(+x+x**2), x) == []
+    assert solve(exp(-x+x**2), x) == []
+    assert solve(exp(+x-x**2), x) == []
+    assert solve(exp(-x-x**2), x) == []


### PR DESCRIPTION
Given an equation like solve(exp(-x-x**2), x) there can be only infinite
solutions. If solve inverts the exp and finds that the rhs is zoo then
lhs-rhs will just give zoo and will not be solvable for x so we return
an empty list.

#### References to other Issues or PRs

Fixes #17949 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
