### PR TITLE
Add appropriate error message when infinite ranges are sliced

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -713,6 +713,7 @@ class Range(Set):
         from sympy.functions.elementary.integers import ceiling
         ooslice = "cannot slice from the end with an infinite value"
         zerostep = "slice step cannot be zero"
+        infinite = "slicing not possible on range with infinite start"
         # if we had to take every other element in the following
         # oo, ..., 6, 4, 2, 0
         # we might get oo, ..., 4, 0 or oo, ..., 6, 2
@@ -735,6 +736,12 @@ class Range(Set):
                     raise ValueError(zerostep)
                 step = i.step or 1
                 ss = step*self.step
+                #---------------------
+                # handle infinite Range
+                #   i.e. Range(-oo, oo) or Range(oo, -oo, -1)
+                # --------------------
+                if self.start.is_infinite and self.stop.is_infinite:
+                    raise ValueError(infinite)
                 #---------------------
                 # handle infinite on right
                 #   e.g. Range(0, oo) or Range(0, -oo, -1)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -952,3 +952,12 @@ def test_issue_17858():
     assert 0 in Range(oo, -oo, -1)
     assert oo not in Range(-oo, oo)
     assert -oo not in Range(-oo, oo)
+
+def test_issue_17859():
+    r = Range(-oo,oo)
+    raises(ValueError,lambda: r[::2])
+    raises(ValueError, lambda: r[::-2])
+    r = Range(oo,-oo,-1)
+    raises(ValueError,lambda: r[::2])
+    raises(ValueError, lambda: r[::-2])
+

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -960,4 +960,3 @@ def test_issue_17859():
     r = Range(oo,-oo,-1)
     raises(ValueError,lambda: r[::2])
     raises(ValueError, lambda: r[::-2])
-


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses issue #17859 

#### Brief description of what is fixed or changed
Before, 
```
r = Range(-oo,oo)
r[::2]
```
gave `RecursionError`

Now, it gives
<pre><font color="#CC0000">ValueError</font>: slicing not possible on range with infinite start</pre>


#### Other comments
Added tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * added appropriate error message when infinite ranges are sliced
<!-- END RELEASE NOTES -->
