### PR TITLE
Fix FunctionMatrix and make ElementwiseApplyFunc arg-invariant

### DIFF
--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -1,5 +1,7 @@
 from sympy.matrices.expressions import MatrixExpr
 from sympy import MatrixBase, Dummy, Lambda, Function, FunctionClass
+from sympy.core.basic import Basic
+from sympy.core.sympify import sympify, _sympify
 
 
 class ElementwiseApplyFunction(MatrixExpr):
@@ -17,14 +19,14 @@ class ElementwiseApplyFunction(MatrixExpr):
     >>> from sympy import exp
     >>> X = MatrixSymbol("X", 3, 3)
     >>> X.applyfunc(exp)
-    exp(X...)
+    Lambda(_d, exp(_d))(X...)
 
     Otherwise using the class constructor:
 
     >>> from sympy import eye
     >>> expr = ElementwiseApplyFunction(exp, eye(3))
     >>> expr
-    exp(Matrix([
+    Lambda(_d, exp(_d))(Matrix([
     [1, 0, 0],
     [0, 1, 0],
     [0, 0, 1]])...)
@@ -44,39 +46,42 @@ class ElementwiseApplyFunction(MatrixExpr):
     """
 
     def __new__(cls, function, expr):
-        obj = MatrixExpr.__new__(cls, expr)
-        if not isinstance(function, FunctionClass):
-            d = Dummy("d")
-            function = Lambda(d, function(d))
-        obj._function = function
-        obj._expr = expr
-        return obj
+        expr = _sympify(expr)
+        if not expr.is_Matrix:
+            raise ValueError("{} must be a matrix instance.".format(expr))
 
-    def _hashable_content(self):
-        return (self.function, self.expr)
+        if not isinstance(function, FunctionClass):
+            d = Dummy('d')
+            function = Lambda(d, function(d))
+
+        function = sympify(function)
+        if not isinstance(function, (FunctionClass, Lambda)):
+            raise ValueError(
+                "{} should be compatible with SymPy function classes."
+                .format(function))
+
+        if 1 not in function.nargs:
+            raise ValueError(
+                '{} should be able to accept 1 arguments.'.format(function))
+
+        if not isinstance(function, Lambda):
+            d = Dummy('d')
+            function = Lambda(d, function(d))
+
+        obj = MatrixExpr.__new__(cls, function, expr)
+        return obj
 
     @property
     def function(self):
-        return self._function
+        return self.args[0]
 
     @property
     def expr(self):
-        return self._expr
+        return self.args[1]
 
     @property
     def shape(self):
         return self.expr.shape
-
-    @property
-    def func(self):
-        # This strange construction is required by the assumptions:
-        # (.func needs to be a class)
-
-        class _(ElementwiseApplyFunction):
-            def __new__(cls, expr):
-                return ElementwiseApplyFunction(self.function, expr)
-
-        return _
 
     def doit(self, **kwargs):
         deep = kwargs.get("deep", True)

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from .matexpr import MatrixExpr
 from sympy.core.function import FunctionClass, Lambda
+from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify, sympify
 from sympy.matrices import Matrix
 from sympy.functions.elementary.complexes import re, im
@@ -92,6 +93,10 @@ class FunctionMatrix(MatrixExpr):
         if 2 not in lamda.nargs:
             raise ValueError(
                 '{} should be able to accept 2 arguments.'.format(lamda))
+
+        if not isinstance(lamda, Lambda):
+            i, j = Dummy('i'), Dummy('j')
+            lamda = Lambda((i, j), lamda(i, j))
 
         return super(FunctionMatrix, cls).__new__(cls, rows, cols, lamda)
 

--- a/sympy/matrices/expressions/tests/test_applyfunc.py
+++ b/sympy/matrices/expressions/tests/test_applyfunc.py
@@ -1,5 +1,6 @@
+from sympy.core.symbol import symbols, Dummy
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
-from sympy import (Matrix, Lambda, MatrixSymbol, exp, symbols, MatMul, sin, simplify)
+from sympy import Matrix, Lambda, MatrixSymbol, exp, MatMul, sin, simplify
 from sympy.utilities.pytest import raises
 from sympy.matrices.common import ShapeError
 
@@ -16,6 +17,7 @@ x, y, z, t = symbols("x y z t")
 
 
 def test_applyfunc_matrix():
+    x = Dummy('x')
     double = Lambda(x, x**2)
 
     expr = ElementwiseApplyFunction(double, Xd)
@@ -34,7 +36,7 @@ def test_applyfunc_matrix():
 
     expr = ElementwiseApplyFunction(exp, X*Y)
     assert expr.expr == X*Y
-    assert expr.function == exp
+    assert expr.function == Lambda(x, exp(x))
     assert expr == (X*Y).applyfunc(exp)
     assert expr.func(*expr.args) == expr
 
@@ -53,7 +55,7 @@ def test_applyfunc_matrix():
     M = Matrix([[x, y], [z, t]])
     expr = ElementwiseApplyFunction(sin, M)
     assert isinstance(expr, ElementwiseApplyFunction)
-    assert expr.function == sin
+    assert expr.function == Lambda(x, sin(x))
     assert expr.expr == M
     assert expr.doit() == M.applyfunc(sin)
     assert expr.doit() == Matrix([[sin(x), sin(y)], [sin(z), sin(t)]])

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -25,8 +25,9 @@ def test_funcmatrix_creation():
     assert FunctionMatrix(2, 2, "lambda i, j: 0") == \
         FunctionMatrix(2, 2, Lambda((i, j), 0))
 
-    assert FunctionMatrix(2, 2, KroneckerDelta).as_explicit() == \
-        Identity(2).as_explicit()
+    m = FunctionMatrix(2, 2, KroneckerDelta)
+    assert m.as_explicit() == Identity(2).as_explicit()
+    assert m.args[2] == Lambda((i, j), KroneckerDelta(i, j))
 
     n = symbols('n')
     assert FunctionMatrix(n, n, Lambda((i, j), 0))

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -46,3 +46,8 @@ def test_funcmatrix():
     assert X.rows == X.cols == 3
     assert Matrix(X) == Matrix(3, 3, lambda i, j: i - j)
     assert isinstance(X*X + X, MatrixExpr)
+
+
+def test_replace_issue():
+    X = FunctionMatrix(3, 3, KroneckerDelta)
+    assert X.replace(lambda x: True, lambda x: x) == X

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3210,12 +3210,12 @@ def test_MatrixExpressions():
     expr = (X.T*X).applyfunc(sin)
 
     ascii_str = """\
-    / T  \\\n\
-sin.\\X *X/\
+              / T  \\\n\
+(d -> sin(d)).\X *X/\
 """
     ucode_str = u("""\
-    ⎛ T  ⎞\n\
-sin˳⎝X ⋅X⎠\
+             ⎛ T  ⎞\n\
+(d ↦ sin(d))˳⎝X ⋅X⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3211,7 +3211,7 @@ def test_MatrixExpressions():
 
     ascii_str = """\
               / T  \\\n\
-(d -> sin(d)).\X *X/\
+(d -> sin(d)).\\X *X/\
 """
     ucode_str = u("""\
              ⎛ T  ⎞\n\

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1798,7 +1798,7 @@ def test_ElementwiseApplyFunction():
     from sympy.matrices import MatrixSymbol
     X = MatrixSymbol('X', 2, 2)
     expr = (X.T*X).applyfunc(sin)
-    assert latex(expr) == r"{\sin}_{\circ}\left({X^{T} X}\right)"
+    assert latex(expr) == r"{\left( d \mapsto \sin{\left(d \right)} \right)}_{\circ}\left({X^{T} X}\right)"
     expr = X.applyfunc(Lambda(x, 1/x))
     assert latex(expr) == r'{\left( d \mapsto \frac{1}{d} \right)}_{\circ}\left({X}\right)'
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

1. `FunctionMatrix(3, 3, KroneckerDelta).replace(lambda x: True, lambda x: x)` or some similar cases had thrown error because having a sympy function class itself as the argument had mangled with the traversal.

2. `ElementwiseApplyFunc` was not a properly formed sympy class, so this removes some hacks.

Currently, `Lambda` is the only function that can properly work inside `Basic`, so every sympy functions should be wrapped with `Lambda` if used inside some other sympy objects,
unless the function class itself can be made a `Basic` instance.

The printing had changed though.


#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed `FunctionMatrix.replace` raising `TypeError: 'property' object is not iterable` when the function is not a `Lambda` instance.
  - `FunctionMatrix` and `ElementwiseApplyFunction` will always wrap the function inside `Lambda`.
<!-- END RELEASE NOTES -->
