### PR TITLE
Replace nbsp with ASCII space in test_pickling.py

### DIFF
--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -395,9 +395,9 @@ def test_pickling_polys_fields():
     # NOTE: can't use protocols < 2 because we have to execute __new__ to
     # make sure caching of fields works properly.
 
-    # from sympy.polys.fields import FracField
+    # from sympy.polys.fields import FracField
 
-    # field = FracField("x,y,z", ZZ, lex)
+    # field = FracField("x,y,z", ZZ, lex)
 
     # TODO: AssertionError: assert id(obj) not in self.memo
     # for c in (FracField, field):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/pull/16272#issuecomment-561387674

#### Brief description of what is fixed or changed

Replaced non-ASCII non-braking space characters with ASCII space characters in test_pickling.py

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
