### PR TITLE
Include heaviside function in NUMPY_TRANSLATIONS

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -81,7 +81,9 @@ MPMATH_TRANSLATIONS = {
     "FallingFactorial": "ff",
 }
 
-NUMPY_TRANSLATIONS = {}
+NUMPY_TRANSLATIONS = {
+    "Heaviside": "heaviside"
+}
 SCIPY_TRANSLATIONS = {}
 
 TENSORFLOW_TRANSLATIONS = {}


### PR DESCRIPTION


#### References to other Issues or PRs

Fixes #13176

#### Brief description of what is fixed or changed

Heaviside function has been translated from sympy to numpy. 

#### Other comments

It's still missing the inclusion of "x2" that one can find in the documentation of numpy.heaviside

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
