### PR TITLE
#17427 integral step breaking issue

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1182,7 +1182,7 @@ def derivative_rule(integral):
 
 def rewrites_rule(integral):
     integrand, symbol = integral
-
+    _parts_u_cache.clear()
     if integrand.match(1/sympy.cos(symbol)):
         rewritten = integrand.subs(1/sympy.cos(symbol), sympy.sec(symbol))
         return RewriteRule(rewritten, integral_steps(rewritten, symbol), integrand, symbol)
@@ -1321,7 +1321,6 @@ def integral_steps(integrand, symbol, **options):
             null_safe(trig_substitution_rule)
         ),
         fallback_rule)(integral)
-    _parts_u_cache.clear()
     del _integral_cache[cachekey]
     return result
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1321,6 +1321,7 @@ def integral_steps(integrand, symbol, **options):
             null_safe(trig_substitution_rule)
         ),
         fallback_rule)(integral)
+    _parts_u_cache.clear()
     del _integral_cache[cachekey]
     return result
 


### PR DESCRIPTION
Fixes #17427

In the previous implementation, the **_parts_u_cached was not being cleared** before returning the Integral_steps final Rule, so when running the same function multiple times resulted in returning "DontKnowRule" because of the limit set on u not used for same cacheKey more than 3 times (as it was remaining in the memory from the previous runs).  

Now I have **added "_parts_u_cache.clear()" to clear the cache before returning** the final rule.

I have **tested Integral_step function** with many examples multiple times (where it was failing before) and **also run all the tests** to make sure nothing is broken.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
