### PR TITLE
Explicit error when lower bound is not given to the prime sieve.

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -6,6 +6,7 @@ from __future__ import print_function, division
 
 import random
 from bisect import bisect
+from itertools import count
 # Using arrays for sieving instead of lists greatly reduces
 # memory consumption
 from array import array as _array
@@ -302,12 +303,27 @@ class Sieve:
         a, b = self.search(n)
         return a == b
 
+    def __iter__(self):
+        for n in count(1):
+            yield self[n]
+
     def __getitem__(self, n):
         """Return the nth prime number"""
         if isinstance(n, slice):
             self.extend_to_no(n.stop)
-            return self._list[n.start - 1:n.stop - 1:n.step]
+            # Python 2.7 slices have 0 instead of None for start, so
+            # we can't default to 1.
+            start = n.start if n.start is not None else 0
+            if start < 1:
+                # sieve[:5] would be empty (starting at -1), let's
+                # just be explicit and raise.
+                raise IndexError("Sieve indices start at 1.")
+            return self._list[start - 1:n.stop - 1:n.step]
         else:
+            if n < 1:
+                # offset is one, so forbid explicit access to sieve[0]
+                # (would surprisingly return the last one).
+                raise IndexError("Sieve indices start at 1.")
             n = as_int(n)
             self.extend_to_no(n)
             return self._list[n - 1]

--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -214,3 +214,20 @@ def test_sieve_slice():
     assert sieve[5] == 11
     assert list(sieve[5:10]) == [sieve[x] for x in range(5, 10)]
     assert list(sieve[5:10:2]) == [sieve[x] for x in range(5, 10, 2)]
+    assert list(sieve[1:5]) == [2, 3, 5, 7]
+    raises(IndexError, lambda: sieve[:5])
+    raises(IndexError, lambda: sieve[0])
+    raises(IndexError, lambda: sieve[0:5])
+
+def test_sieve_iter():
+    values = []
+    for value in sieve:
+        if value > 7:
+            break
+        values.append(value)
+    assert values == list(sieve[1:5])
+
+
+def test_sieve_repr():
+    assert "sieve" in repr(sieve)
+    assert "prime" in repr(sieve)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Giving an explicit error when user tries:
```pycon
>>> from sympy.ntheory import sieve
>>> sieve[:10]
```

#### Other comments

Before, in Python 3:
```pycon
>>> sieve[:10]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mdk/clones/JulienPalard/oeis/venv/lib/python3.8/site-packages/sympy/ntheory/generate.py", line 309, in __getitem__
    return self._list[n.start - 1:n.stop - 1:n.step]
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```
Before, in Python 2:
```pycon
>>> sieve[:10]
array('l')
```
After:
```
>>> sieve[:10]
[...]
IndexError: Sieve indices start at 1.
```

Same for:

Before:
```pycon
>>> sieve[0:10]
array('l')  # Now raises IndexError
```
And:

```pycon
>>> sieve[1:10]
array('l', [2, 3, 5, 7, 11, 13, 17, 19, 23])
>>> sieve[0]
31  # Now raises IndexError
```


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Proper exception when index 0 of sieve is accessed.
<!-- END RELEASE NOTES -->
