### PR TITLE
Improve matrix permute docs and refactor

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1923,15 +1923,15 @@ class MatrixOperations(MatrixRequired):
             raise TypeError("orientation='{}' is an invalid kwarg. "
                             "Try 'rows' or 'cols'".format(orientation))
 
-        # ensure all swaps are in range
-        max_index = self.rows if orientation == 'rows' else self.cols
-        if not all(0 <= t <= max_index for t in flatten(list(perm))):
-            raise IndexError("`swap` indices out of range.")
-
         if not isinstance(perm, (Permutation, Iterable)):
             raise ValueError(
                 "{} must be a list, a list of lists, "
                 "or a SymPy permutation object.".format(perm))
+
+        # ensure all swaps are in range
+        max_index = self.rows if orientation == 'rows' else self.cols
+        if not all(0 <= t <= max_index for t in flatten(list(perm))):
+            raise IndexError("`swap` indices out of range.")
 
         if perm and not isinstance(perm, Permutation) and \
             isinstance(perm[0], Iterable):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1936,18 +1936,8 @@ class MatrixOperations(MatrixRequired):
         if perm and not isinstance(perm, Permutation) and \
             isinstance(perm[0], Iterable):
             if direction == 'forward':
-                perm = reversed(perm)
-
-            perm_obj = Permutation(size=max_index)
-            for item in perm:
-                if not isinstance(item, Iterable):
-                    raise ValueError(
-                        "{} is expected to be a list of lists " \
-                        "representing cycles, but {} is not consistent."
-                        .format(perm, item))
-
-                perm_obj = perm_obj(*item)
-            perm = perm_obj
+                perm = list(reversed(perm))
+            perm = Permutation(perm, size=max_index)
         else:
             perm = Permutation(perm, size=max_index)
 

--- a/sympy/matrices/normalforms.py
+++ b/sympy/matrices/normalforms.py
@@ -110,11 +110,11 @@ def invariant_factors(m, domain = None):
 
     # permute the rows and columns until m[0,0] is non-zero if possible
     ind = [i for i in range(m.rows) if m[i,0] != 0]
-    if ind:
+    if ind and ind[0] != 0:
         m = m.permute_rows([[0, ind[0]]])
     else:
         ind = [j for j in range(m.cols) if m[0,j] != 0]
-        if ind:
+        if ind and ind[0] != 0:
             m = m.permute_cols([[0, ind[0]]])
 
     # make the first row and column except m[0,0] zero

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -602,6 +602,7 @@ def test_permute():
     a = OperationsOnlyMatrix(3, 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
     raises(IndexError, lambda: a.permute([[0, 5]]))
+    raises(ValueError, lambda: a.permute(Symbol('x')))
     b = a.permute_rows([[0, 2], [0, 1]])
     assert a.permute([[0, 2], [0, 1]]) == b == Matrix([
                                             [5,  6,  7,  8],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Since #12479 had fixed, there is no need to preprocess the cycles
And I think that this also expands the capability to use 3-length cycle or more.

The only problem is that `Permutation([0, 0])` is still illegal. Which had made `smith_normal_form` to fail the tests, but I'm not clear about the reason why. 

One other problem was that the definition for the `direction` is not clear, and it is agreeing on the `Permutation` itself about how direction how the each cycles are applied consecutively, so I had given some examples.

And also the way how the row is permuted does not agree the definition in
https://en.wikipedia.org/wiki/Permutation_matrix, and it can often be confusing, so I have added the docs that it is applied always in the inverse way.

I've also fixed the misuse of backticks in `permute_rows` and `permute_cols`

#### Other comments

![Screen Shot 2019-12-09 at 02 58 26](https://user-images.githubusercontent.com/34944973/70393678-d5bdeb00-1a2f-11ea-8073-0c793d432a37.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
