### PR TITLE
make interpolate more robust

### DIFF
--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import S, Basic, Add, Mul, symbols
+from sympy.core import S, Basic, Add, Mul, symbols, Dummy
 from sympy.core.compatibility import range
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.polys.polyerrors import (
@@ -205,13 +205,14 @@ def horner(f, *gens, **args):
 @public
 def interpolate(data, x):
     """
-    Construct an interpolating polynomial for the data points.
+    Construct an interpolating polynomial for the data points
+    evaluated at point x (which can be symbolic or numeric).
 
     Examples
     ========
 
     >>> from sympy.polys.polyfuncs import interpolate
-    >>> from sympy.abc import x
+    >>> from sympy.abc import a, b, x
 
     A list is interpreted as though it were paired with a range starting
     from 1:
@@ -232,30 +233,39 @@ def interpolate(data, x):
     >>> interpolate({-1: 2, 1: 2, 2: 5}, x)
     x**2 + 1
 
+    If the interpolation is going to be used only once then the
+    value of interest can be passed instead of passing a symbol:
+
+    >>> interpolate([1, 4, 9], 5)
+    25
+
+    Symbolic coordinates are also supported:
+
+    >>> [(i,interpolate((a, b), i)) for i in range(1, 4)]
+    [(1, a), (2, b), (3, -a + 2*b)]
     """
     n = len(data)
-    poly = None
 
     if isinstance(data, dict):
+        if x in data:
+            return S(data[x])
         X, Y = list(zip(*data.items()))
-        poly = interpolating_poly(n, x, X, Y)
     else:
         if isinstance(data[0], tuple):
             X, Y = list(zip(*data))
-            poly = interpolating_poly(n, x, X, Y)
+            if x in X:
+                return S(Y[X.index(x)])
         else:
+            if x in range(1, n + 1):
+                return S(data[x - 1])
             Y = list(data)
+            X = list(range(1, n + 1))
 
-            numert = Mul(*[(x - i) for i in range(1, n + 1)])
-            denom = -factorial(n - 1) if n%2 == 0 else factorial(n - 1)
-            coeffs = []
-            for i in range(1, n + 1):
-                coeffs.append(numert/(x - i)/denom)
-                denom = denom/(i - n)*i
-
-            poly = Add(*[coeff*y for coeff, y in zip(coeffs, Y)])
-
-    return poly.expand()
+    try:
+        return interpolating_poly(n, x, X, Y).expand()
+    except ValueError:
+        d = Dummy()
+        return interpolating_poly(n, d, X, Y).expand().subs(d, x)
 
 
 @public

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division
 
 from sympy.core import Add, Mul, Symbol, sympify, Dummy, symbols
 from sympy.core.compatibility import range, string_types
+from sympy.core.containers import Tuple
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import nextprime
@@ -19,7 +20,7 @@ from sympy.polys.factortools import dup_zz_cyclotomic_poly
 from sympy.polys.polyclasses import DMP
 from sympy.polys.polytools import Poly, PurePoly
 from sympy.polys.polyutils import _analyze_gens
-from sympy.utilities import subsets, public
+from sympy.utilities import subsets, public, filldedent
 
 
 @public
@@ -142,15 +143,29 @@ def random_poly(x, n, inf, sup, domain=ZZ, polys=False):
 
 @public
 def interpolating_poly(n, x, X='x', Y='y'):
-    """Construct Lagrange interpolating polynomial for ``n`` data points. """
+    """Construct Lagrange interpolating polynomial for ``n``
+    data points. If a sequence of values are given for ``X`` and ``Y``
+    then the first ``n`` values will be used.
+    """
+    ok = getattr(x, 'free_symbols', None)
+
     if isinstance(X, string_types):
         X = symbols("%s:%s" % (X, n))
+    elif ok and ok & Tuple(*X).free_symbols:
+        ok = False
 
     if isinstance(Y, string_types):
         Y = symbols("%s:%s" % (Y, n))
+    elif ok and ok & Tuple(*Y).free_symbols:
+        ok = False
+
+    if not ok:
+        raise ValueError(filldedent('''
+            Expecting symbol for x that does not appear in X or Y.
+            Use `interpolate(list(zip(X, Y)), x)` instead.'''))
 
     coeffs = []
-    numert = Mul(*[(x - u) for u in X])
+    numert = Mul(*[x - X[i] for i in range(n)])
 
     for i in range(n):
         numer = numert/(x - X[i])

--- a/sympy/polys/tests/test_polyfuncs.py
+++ b/sympy/polys/tests/test_polyfuncs.py
@@ -84,6 +84,11 @@ def test_interpolate():
         -S(13)*x**3/24 + S(12)*x**2 - S(2003)*x/24 + 187
     assert interpolate([(1, 3), (0, 6), (2, 5), (5, 7), (-2, 4)], x) == \
         S(-61)*x**4/280 + S(247)*x**3/210 + S(139)*x**2/280 - S(1871)*x/420 + 6
+    assert interpolate((9, 4, 9), 3) == 9
+    assert interpolate((1, 9, 16), 1) is S.One
+    assert interpolate(((x, 1), (2, 3)), x) is S.One
+    assert interpolate(dict([(x, 1), (2, 3)]), x) is S.One
+    assert interpolate(((2, x), (1, 3)), x) == x**2 - 4*x + 6
 
 
 def test_rational_interpolate():

--- a/sympy/polys/tests/test_specialpolys.py
+++ b/sympy/polys/tests/test_specialpolys.py
@@ -1,6 +1,6 @@
 """Tests for functions for generating interesting polynomials. """
 
-from sympy import Poly, ZZ, symbols, sqrt, prime, Add
+from sympy import Poly, ZZ, symbols, sqrt, prime, Add, S
 from sympy.utilities.iterables import permute_signs
 from sympy.utilities.pytest import raises
 
@@ -95,6 +95,20 @@ def test_interpolating_poly():
         y1*(x - x0)*(x - x2)*(x - x3)/((x1 - x0)*(x1 - x2)*(x1 - x3)) + \
         y2*(x - x0)*(x - x1)*(x - x3)/((x2 - x0)*(x2 - x1)*(x2 - x3)) + \
         y3*(x - x0)*(x - x1)*(x - x2)/((x3 - x0)*(x3 - x1)*(x3 - x2))
+
+    raises(ValueError, lambda:
+        interpolating_poly(2, x, (x, 2), (1, 3)))
+    raises(ValueError, lambda:
+        interpolating_poly(2, x, (x + y, 2), (1, 3)))
+    raises(ValueError, lambda:
+        interpolating_poly(2, x + y, (x, 2), (1, 3)))
+    raises(ValueError, lambda:
+        interpolating_poly(2, 3, (4, 5), (6, 7)))
+    raises(ValueError, lambda:
+        interpolating_poly(2, 3, (4, 5), (6, 7, 8)))
+    assert interpolating_poly(0, x, (1, 2), (3, 4)) == 0
+    assert interpolating_poly(1, x, (1, 2), (3, 4)) == 3
+    assert interpolating_poly(2, x, (1, 2), (3, 4)) == x + 2
 
 
 def test_fateman_poly_F_1():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
fixes #18011 

#### Brief description of what is fixed or changed

Formerly, interpolation would return nan if the point was in the domain used to construct the interpolating polynomial. Now it doesn't:
```python
>>> interpolate((2,3),1)
2
```

#### Other comments

As a first approach, when a concrete x value in the data points was provided, the polynomial was constructed symbolically and then the value of x substituted. This fails, however, if the symbol provided is in the domain values provided. 

Now a simple check for x in the domain (and return of the corresponding y) is done.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * `interpolate` will no longer return nan when `x` is a supplied coordinate
  * `interpolating_poly` will raise an error if either `x` is not a symbol
  * `interpolating_poly` will raise an error if `X` or `Y` depend on `x`
  * `interpolating-poly` will now use only the first `n` points in `X` and `Y`
<!-- END RELEASE NOTES -->
