### PR TITLE
Deprecating print_cyclic flag

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -571,7 +571,6 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
         >>> from sympy.codegen.array_utils import (CodegenArrayPermuteDims, CodegenArrayTensorProduct, nest_permutation)
         >>> from sympy import MatrixSymbol
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
 
         >>> M = MatrixSymbol("M", 3, 3)
         >>> N = MatrixSymbol("N", 3, 3)
@@ -1055,7 +1054,6 @@ def parse_indexed_expression(expr, first_indices=None):
     >>> from sympy.codegen.array_utils import parse_indexed_expression
     >>> from sympy import MatrixSymbol, Sum, symbols
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
 
     >>> i, j, k, d = symbols("i j k d")
     >>> M = MatrixSymbol("M", d, d)

--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -15,7 +15,6 @@ def symmetric(n):
     ========
 
     >>> from sympy.combinatorics.permutations import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.generators import symmetric
     >>> list(symmetric(3))
     [(2), (1 2), (2)(0 1), (0 1 2), (0 2 1), (0 2)]
@@ -32,7 +31,6 @@ def cyclic(n):
     ========
 
     >>> from sympy.combinatorics.permutations import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.generators import cyclic
     >>> list(cyclic(5))
     [(4), (0 1 2 3 4), (0 2 4 1 3),
@@ -57,7 +55,6 @@ def alternating(n):
     ========
 
     >>> from sympy.combinatorics.permutations import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.generators import alternating
     >>> list(alternating(3))
     [(2), (0 1 2), (0 2 1)]
@@ -80,7 +77,6 @@ def dihedral(n):
     ========
 
     >>> from sympy.combinatorics.permutations import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.generators import dihedral
     >>> list(dihedral(3))
     [(2), (0 2), (0 1 2), (1 2), (0 2 1), (2)(0 1)]

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -445,7 +445,6 @@ def group_isomorphism(G, H, isomorphism=True):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.perm_groups import PermutationGroup
     >>> from sympy.combinatorics.free_groups import free_group
     >>> from sympy.combinatorics.fp_groups import FpGroup

--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -20,7 +20,6 @@ def AbelianGroup(*cyclic_orders):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import AbelianGroup
     >>> AbelianGroup(3, 4)
     PermutationGroup([

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -36,7 +36,6 @@ class PermutationGroup(Basic):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.permutations import Cycle
     >>> from sympy.combinatorics.polyhedron import Polyhedron
     >>> from sympy.combinatorics.perm_groups import PermutationGroup
@@ -1114,7 +1113,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation, PermutationGroup
-        >>> Permutation.print_cyclic = True
         >>> a = Permutation(0, 1, 3, 7, 6, 4)(2, 5)
         >>> b = Permutation(0, 1, 3, 2)(4, 5, 7, 6)
         >>> G = PermutationGroup([a, b])
@@ -1239,7 +1237,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation(0, 1, 3, 7, 6, 4)(2, 5)
         >>> b = Permutation(0, 1, 3, 2)(4, 5, 7, 6)
@@ -1307,7 +1304,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([1, 0, 2])
         >>> G = PermutationGroup([a])
@@ -1423,7 +1419,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([1, 0, 2, 4, 3])
         >>> b = Permutation([0, 1, 3, 2, 4])
@@ -1471,7 +1466,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics import PermutationGroup
         >>> from sympy.combinatorics.polyhedron import tetrahedron
 
@@ -1518,7 +1512,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([0, 2, 1, 3])
         >>> b = Permutation([0, 2, 3, 1])
@@ -1579,7 +1572,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([0, 2, 1, 3])
         >>> b = Permutation([0, 2, 3, 1])
@@ -1649,7 +1641,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([0, 2, 1])
         >>> b = Permutation([1, 0, 2])
@@ -1675,7 +1666,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
 
         >>> a = Permutation(1, 2)
@@ -1750,7 +1740,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([0, 2, 1])
         >>> b = Permutation([1, 0, 2])
@@ -2055,7 +2044,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a = Permutation([1, 2, 0])
         >>> b = Permutation([1, 0, 2])
@@ -2725,7 +2713,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> from sympy.combinatorics.named_groups import AlternatingGroup
         >>> G = AlternatingGroup(5)
@@ -2768,7 +2755,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> from sympy.combinatorics.named_groups import DihedralGroup
         >>> G = DihedralGroup(6)
@@ -3161,7 +3147,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> a, b = [Permutation([1, 0, 3, 2]), Permutation([1, 3, 0, 2])]
         >>> G = PermutationGroup([a, b])
@@ -3696,7 +3681,6 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> from sympy.combinatorics.named_groups import DihedralGroup
         >>> G = DihedralGroup(6)
@@ -4919,7 +4903,6 @@ def _orbit_transversal(degree, generators, alpha, pairs, af=False, slp=False):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import DihedralGroup
     >>> from sympy.combinatorics.perm_groups import _orbit_transversal
     >>> G = DihedralGroup(6)
@@ -4972,7 +4955,6 @@ def _stabilizer(degree, generators, alpha):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.perm_groups import _stabilizer
     >>> from sympy.combinatorics.named_groups import DihedralGroup
     >>> G = DihedralGroup(6)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -23,7 +23,6 @@ def _af_rmul(a, b):
     ========
 
     >>> from sympy.combinatorics.permutations import _af_rmul, Permutation
-    >>> Permutation.print_cyclic = False
 
     >>> a, b = [1, 0, 2], [0, 2, 1]
     >>> _af_rmul(a, b)
@@ -57,7 +56,6 @@ def _af_rmuln(*abc):
     ========
 
     >>> from sympy.combinatorics.permutations import _af_rmul, Permutation
-    >>> Permutation.print_cyclic = False
 
     >>> a, b = [1, 0, 2], [0, 2, 1]
     >>> _af_rmul(a, b)
@@ -179,7 +177,6 @@ def _af_pow(a, n):
     ========
 
     >>> from sympy.combinatorics.permutations import Permutation, _af_pow
-    >>> Permutation.print_cyclic = False
     >>> p = Permutation([2, 0, 3, 1])
     >>> p.order()
     4
@@ -358,7 +355,6 @@ class Cycle(dict):
 
         >>> from sympy.combinatorics.permutations import Cycle
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> p = Cycle(2, 3)(4, 5)
         >>> p.list()
         [0, 1, 3, 2, 5, 4]
@@ -479,7 +475,8 @@ class Permutation(Atom):
     original ordering, not the elements (a, b, etc...) themselves.
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = False
+    >>> from sympy.interactive import init_printing
+    >>> init_printing(perm_cyclic=False, pretty_print=False)
 
     Permutations Notation
     =====================
@@ -662,17 +659,17 @@ class Permutation(Atom):
 
     There are a few things to note about how Permutations are printed.
 
-    1) If you prefer one form (array or cycle) over another, you can set that
-    with the print_cyclic flag.
+    1) If you prefer one form (array or cycle) over another, you can set
+    ``init_printing`` with the ``perm_cyclic`` flag.
 
-    >>> Permutation(1, 2)(4, 5)(3, 4)
+    >>> from sympy import init_printing
+    >>> p = Permutation(1, 2)(4, 5)(3, 4)
+    >>> p
     Permutation([0, 2, 1, 4, 5, 3])
-    >>> p = _
 
-    >>> Permutation.print_cyclic = True
+    >>> init_printing(perm_cyclic=True, pretty_print=False)
     >>> p
     (1 2)(3 4 5)
-    >>> Permutation.print_cyclic = False
 
     2) Regardless of the setting, a list of elements in the array for cyclic
     form can be obtained and either of those can be copied and supplied as
@@ -688,6 +685,7 @@ class Permutation(Atom):
     3) Printing is economical in that as little as possible is printed while
     retaining all information about the size of the permutation:
 
+    >>> init_printing(perm_cyclic=False, pretty_print=False)
     >>> Permutation([1, 0, 2, 3])
     Permutation([1, 0, 2, 3])
     >>> Permutation([1, 0, 2, 3], size=20)
@@ -696,10 +694,10 @@ class Permutation(Atom):
     Permutation([1, 0, 2, 4, 3], size=20)
 
     >>> p = Permutation([1, 0, 2, 3])
-    >>> Permutation.print_cyclic = True
+    >>> init_printing(perm_cyclic=True, pretty_print=False)
     >>> p
     (3)(0 1)
-    >>> Permutation.print_cyclic = False
+    >>> init_printing(perm_cyclic=False, pretty_print=False)
 
     The 2 was not printed but it is still there as can be seen with the
     array_form and size methods:
@@ -776,7 +774,7 @@ class Permutation(Atom):
     Permutations:
 
     >>> p(['zero', 'one', 'four', 'two'])
-     ['one', 'zero', 'four', 'two']
+    ['one', 'zero', 'four', 'two']
     >>> p('zo42')
     ['o', 'z', '4', '2']
 
@@ -836,7 +834,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
 
         Permutations entered in array-form are left unaltered:
 
@@ -971,8 +970,9 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Perm
-        >>> Perm.print_cyclic = False
-        >>> a = [2,1,3,0]
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
+        >>> a = [2, 1, 3, 0]
         >>> p = Perm._af_new(a)
         >>> p
         Permutation([2, 1, 3, 0])
@@ -996,7 +996,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> p = Permutation([[2, 0], [3, 1]])
         >>> p.array_form
         [2, 3, 0, 1]
@@ -1009,22 +1008,6 @@ class Permutation(Atom):
         """
         return self._array_form[:]
 
-    def __repr__(self):
-        """
-        Default Representation Array Form
-        """
-        from sympy.combinatorics.permutations import Permutation, Cycle
-        s = self.support()
-        if not s:
-            if self.size < 5:
-                return 'Permutation(%s)' % str(self.array_form)
-            return 'Permutation([], size=%s)' % self.size
-        trim = str(self.array_form[:s[-1] + 1]) + ', size=%s' % self.size
-        use = full = str(self.array_form)
-        if len(trim) < len(full):
-            use = trim
-        return 'Permutation(%s)' % use
-
     def list(self, size=None):
         """Return the permutation as an explicit list, possibly
         trimming unmoved elements if size is less than the maximum
@@ -1035,7 +1018,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> p = Permutation(2, 3)(4, 5)
         >>> p.list()
         [0, 1, 3, 2, 5, 4]
@@ -1076,7 +1058,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> p = Permutation([0, 3, 1, 2])
         >>> p.cyclic_form
         [[1, 3, 2]]
@@ -1172,7 +1153,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> I = Permutation([0, 1, 2, 3])
         >>> a = Permutation([2, 1, 3, 0])
         >>> I + a.rank() == a
@@ -1211,7 +1191,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import _af_rmul, Permutation
-        >>> Permutation.print_cyclic = False
 
         >>> a, b = [1, 0, 2], [0, 2, 1]
         >>> a = Permutation(a); b = Permutation(b)
@@ -1276,7 +1255,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import _af_rmul, Permutation
-        >>> Permutation.print_cyclic = False
 
         >>> a, b = [1, 0, 2], [0, 2, 1]
         >>> a = Permutation(a); b = Permutation(b)
@@ -1296,6 +1274,8 @@ class Permutation(Atom):
         It is acceptable for the arrays to have different lengths; the shorter
         one will be padded to match the longer one:
 
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> b*Permutation([1, 0])
         Permutation([1, 2, 0])
         >>> Permutation([1, 0])*b
@@ -1357,8 +1337,9 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
-        >>> p = Permutation([2,0,3,1])
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
+        >>> p = Permutation([2, 0, 3, 1])
         >>> p.order()
         4
         >>> p**4
@@ -1397,7 +1378,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = True
         >>> p = Permutation(1, 2, 9)
         >>> q = Permutation(6, 9, 8)
         >>> p*q != q*p
@@ -1512,7 +1492,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
 
         >>> Permutation.from_sequence('SymPy')
         (4)(0 1 3)
@@ -1538,8 +1517,9 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
-        >>> p = Permutation([[2,0], [3,1]])
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
+        >>> p = Permutation([[2, 0], [3, 1]])
         >>> ~p
         Permutation([2, 3, 0, 1])
         >>> _ == p**-1
@@ -1561,6 +1541,10 @@ class Permutation(Atom):
         """
         for i in self.array_form:
             yield i
+
+    def __repr__(self):
+        from sympy.printing.repr import srepr
+        return srepr(self)
 
     def __call__(self, *i):
         """
@@ -1669,7 +1653,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> Permutation.unrank_nonlex(4, 5)
         Permutation([2, 0, 3, 1])
         >>> Permutation.unrank_nonlex(4, -1)
@@ -1736,7 +1721,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> p = Permutation([2, 0, 3, 1]); p.rank_nonlex()
         5
         >>> p = p.next_nonlex(); p
@@ -2122,7 +2108,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> p = Permutation([0, 2, 3, 1])
         >>> x = Permutation([2, 0, 3, 1])
         >>> c = p.commutator(x); c
@@ -2202,7 +2189,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> p = Permutation([3, 1, 5, 2, 4, 0])
         >>> p.order()
         4
@@ -2247,7 +2235,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics import Permutation
-        >>> Permutation.print_cyclic = True
         >>> Permutation(3).cycle_structure
         {1: 4}
         >>> Permutation(0, 4, 3)(1, 2)(5, 6).cycle_structure
@@ -2342,7 +2329,6 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
         >>> p = Permutation([4, 8, 0, 7, 1, 5, 3, 6, 2])
         >>> p.inversion_vector()
         [4, 7, 0, 5, 0, 2, 1, 1]
@@ -2357,13 +2343,12 @@ class Permutation(Atom):
         >>> while p:
         ...     print('%s %s %s' % (p, p.inversion_vector(), p.rank()))
         ...     p = p.next_lex()
-        ...
-        Permutation([0, 1, 2]) [0, 0] 0
-        Permutation([0, 2, 1]) [0, 1] 1
-        Permutation([1, 0, 2]) [1, 0] 2
-        Permutation([1, 2, 0]) [1, 1] 3
-        Permutation([2, 0, 1]) [2, 0] 4
-        Permutation([2, 1, 0]) [2, 1] 5
+        (2) [0, 0] 0
+        (1 2) [0, 1] 1
+        (2)(0 1) [1, 0] 2
+        (0 1 2) [1, 1] 3
+        (0 2 1) [2, 0] 4
+        (0 2) [2, 1] 5
 
         See Also
         ========
@@ -2433,6 +2418,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> Permutation.unrank_trotterjohnson(5, 10)
         Permutation([0, 3, 1, 2, 4])
 
@@ -2472,7 +2459,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> p = Permutation([3, 0, 2, 1])
         >>> p.rank_trotterjohnson()
         4
@@ -2523,7 +2511,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> p = Permutation.josephus(3, 6, 1)
         >>> p
         Permutation([2, 5, 3, 1, 4, 0])
@@ -2754,7 +2743,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> Permutation.from_inversion_vector([3, 2, 1, 0, 0])
         Permutation([3, 2, 1, 0, 4, 5])
 
@@ -2800,7 +2790,8 @@ class Permutation(Atom):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
+        >>> init_printing(perm_cyclic=False, pretty_print=False)
         >>> a = Permutation.unrank_lex(5, 10)
         >>> a.rank()
         10
@@ -2825,9 +2816,8 @@ class Permutation(Atom):
             psize = new_psize
         return cls._af_new(perm_array)
 
-    # global flag to control how permutations are printed
-    # when True, Permutation([0, 2, 1, 3]) -> Cycle(1, 2)
-    # when False, Permutation([0, 2, 1, 3]) -> Permutation([0, 2, 1])
+    # XXX Deprecated flag
+    print_cyclic = None
 
 
 def _merge(arr, temp, left, mid, right):

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1010,27 +1010,20 @@ class Permutation(Atom):
         return self._array_form[:]
 
     def __repr__(self):
-        if Permutation.print_cyclic:
-            if not self.size:
-                return 'Permutation()'
-            # before taking Cycle notation, see if the last element is
-            # a singleton and move it to the head of the string
-            s = Cycle(self)(self.size - 1).__repr__()[len('Cycle'):]
-            last = s.rfind('(')
-            if not last == 0 and ',' not in s[last:]:
-                s = s[last:] + s[:last]
-            return 'Permutation%s' %s
-        else:
-            s = self.support()
-            if not s:
-                if self.size < 5:
-                    return 'Permutation(%s)' % str(self.array_form)
-                return 'Permutation([], size=%s)' % self.size
-            trim = str(self.array_form[:s[-1] + 1]) + ', size=%s' % self.size
-            use = full = str(self.array_form)
-            if len(trim) < len(full):
-                use = trim
-            return 'Permutation(%s)' % use
+        """
+        Default Representation Array Form
+        """
+        from sympy.combinatorics.permutations import Permutation, Cycle
+        s = self.support()
+        if not s:
+            if self.size < 5:
+                return 'Permutation(%s)' % str(self.array_form)
+            return 'Permutation([], size=%s)' % self.size
+        trim = str(self.array_form[:s[-1] + 1]) + ', size=%s' % self.size
+        use = full = str(self.array_form)
+        if len(trim) < len(full):
+            use = trim
+        return 'Permutation(%s)' % use
 
     def list(self, size=None):
         """Return the permutation as an explicit list, possibly
@@ -2835,7 +2828,6 @@ class Permutation(Atom):
     # global flag to control how permutations are printed
     # when True, Permutation([0, 2, 1, 3]) -> Cycle(1, 2)
     # when False, Permutation([0, 2, 1, 3]) -> Permutation([0, 2, 1])
-    print_cyclic = True
 
 
 def _merge(arr, temp, left, mid, right):

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -60,8 +60,9 @@ class Polyhedron(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> Permutation.print_cyclic = False
+        >>> from sympy.interactive import init_printing
         >>> from sympy.abc import w, x, y, z
+        >>> init_printing(pretty_print=False, perm_cyclic=False)
 
         Here we construct the Polyhedron object for a tetrahedron.
 

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -918,7 +918,6 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
 
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import (get_symmetric_group_sgs, bsgs_direct_product)
-    >>> Permutation.print_cyclic = True
     >>> base1, gens1 = get_symmetric_group_sgs(1)
     >>> base2, gens2 = get_symmetric_group_sgs(2)
     >>> bsgs_direct_product(base1, gens1, base2, gens2)
@@ -953,7 +952,6 @@ def get_symmetric_group_sgs(n, antisym=False):
 
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs
-    >>> Permutation.print_cyclic = True
     >>> get_symmetric_group_sgs(3)
     ([0, 1], [(4)(0 1), (4)(1 2)])
     """
@@ -1028,7 +1026,6 @@ def get_minimal_bsgs(base, gens):
 
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import get_minimal_bsgs
-    >>> Permutation.print_cyclic = True
     >>> riemann_bsgs1 = ([2, 0], ([Permutation(5)(0, 1)(4, 5), Permutation(5)(0, 2)(1, 3)]))
     >>> get_minimal_bsgs(*riemann_bsgs1)
     ([0, 2], [(0 1)(4 5), (5)(0 2)(1 3), (2 3)(4 5)])
@@ -1059,7 +1056,6 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
 
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import tensor_gens, get_symmetric_group_sgs
-    >>> Permutation.print_cyclic = True
 
     two symmetric tensors with 3 indices without free indices
 
@@ -1176,7 +1172,6 @@ def gens_products(*v):
 
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, gens_products
-    >>> Permutation.print_cyclic = True
     >>> base, gens = get_symmetric_group_sgs(2)
     >>> gens_products((base, gens, [[], []], 0))
     (6, [0, 2], [(5)(0 1), (5)(2 3), (5)(0 2)(1 3)])

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -7,8 +7,10 @@ from sympy.core.symbol import Symbol
 from sympy.core.singleton import S
 from sympy.combinatorics.permutations import (Permutation, _af_parity,
     _af_rmul, _af_rmuln, Cycle)
-from sympy.printing import sstr, srepr, pprint, latex
-from sympy.utilities.pytest import raises, SymPyDeprecationWarning
+from sympy.printing import sstr, srepr, pretty, latex
+from sympy.utilities.pytest import raises, SymPyDeprecationWarning, \
+    warns_deprecated_sympy
+
 
 rmul = Permutation.rmul
 a = Symbol('a', integer=True)
@@ -474,17 +476,18 @@ def test_deprecated_print_cyclic():
     p = Permutation(0, 1, 2)
     try:
         Permutation.print_cyclic = True
-        raises(SymPyDeprecationWarning, lambda: sstr(p))
-        raises(SymPyDeprecationWarning, lambda: srepr(p))
-        raises(SymPyDeprecationWarning, lambda: pprint(p))
-        raises(SymPyDeprecationWarning, lambda: latex(p))
+        with warns_deprecated_sympy():
+            assert sstr(p) == '(0 1 2)'
+            assert srepr(p) == 'Permutation(0, 1, 2)'
+            assert pretty(p) == '(0 1 2)'
+            assert latex(p) == r'\left( 0\; 1\; 2\right)'
         Permutation.print_cyclic = False
-        raises(SymPyDeprecationWarning, lambda: sstr(p))
-        raises(SymPyDeprecationWarning, lambda: srepr(p))
-        raises(SymPyDeprecationWarning, lambda: pprint(p))
-        raises(SymPyDeprecationWarning, lambda: latex(p))
-    except:
-        raise AssertionError
+        with warns_deprecated_sympy():
+            assert sstr(p) == 'Permutation([1, 2, 0])'
+            assert srepr(p) == 'Permutation([1, 2, 0])'
+            assert pretty(p, use_unicode=False) == '/0 1 2\\\n\\1 2 0/'
+            assert latex(p) == \
+                r'\begin{pmatrix} 0 & 1 & 2 \\ 1 & 2 & 0 \end{pmatrix}'
     finally:
         Permutation.print_cyclic = None
 

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -7,7 +7,8 @@ from sympy.core.symbol import Symbol
 from sympy.core.singleton import S
 from sympy.combinatorics.permutations import (Permutation, _af_parity,
     _af_rmul, _af_rmuln, Cycle)
-from sympy.utilities.pytest import raises
+from sympy.printing import sstr, srepr, pprint, latex
+from sympy.utilities.pytest import raises, SymPyDeprecationWarning
 
 rmul = Permutation.rmul
 a = Symbol('a', integer=True)
@@ -443,7 +444,6 @@ def test_from_sequence():
 
 
 def test_printing_cyclic():
-    Permutation.print_cyclic = True
     p1 = Permutation([0, 2, 1])
     assert repr(p1) == 'Permutation(1, 2)'
     assert str(p1) == '(1 2)'
@@ -455,19 +455,38 @@ def test_printing_cyclic():
 
 
 def test_printing_non_cyclic():
-    Permutation.print_cyclic = False
+    from sympy.printing import sstr, srepr
     p1 = Permutation([0, 1, 2, 3, 4, 5])
-    assert repr(p1) == 'Permutation([], size=6)'
-    assert str(p1) == 'Permutation([], size=6)'
+    assert srepr(p1, perm_cyclic=False) == 'Permutation([], size=6)'
+    assert sstr(p1, perm_cyclic=False) == 'Permutation([], size=6)'
     p2 = Permutation([0, 1, 2])
-    assert repr(p2) == 'Permutation([0, 1, 2])'
-    assert str(p2) == 'Permutation([0, 1, 2])'
+    assert srepr(p2, perm_cyclic=False) == 'Permutation([0, 1, 2])'
+    assert sstr(p2, perm_cyclic=False) == 'Permutation([0, 1, 2])'
 
     p3 = Permutation([0, 2, 1])
-    assert repr(p3) == 'Permutation([0, 2, 1])'
-    assert str(p3) == 'Permutation([0, 2, 1])'
+    assert srepr(p3, perm_cyclic=False) == 'Permutation([0, 2, 1])'
+    assert sstr(p3, perm_cyclic=False) == 'Permutation([0, 2, 1])'
     p4 = Permutation([0, 1, 3, 2, 4, 5, 6, 7])
-    assert repr(p4) == 'Permutation([0, 1, 3, 2], size=8)'
+    assert srepr(p4, perm_cyclic=False) == 'Permutation([0, 1, 3, 2], size=8)'
+
+
+def test_deprecated_print_cyclic():
+    p = Permutation(0, 1, 2)
+    try:
+        Permutation.print_cyclic = True
+        raises(SymPyDeprecationWarning, lambda: sstr(p))
+        raises(SymPyDeprecationWarning, lambda: srepr(p))
+        raises(SymPyDeprecationWarning, lambda: pprint(p))
+        raises(SymPyDeprecationWarning, lambda: latex(p))
+        Permutation.print_cyclic = False
+        raises(SymPyDeprecationWarning, lambda: sstr(p))
+        raises(SymPyDeprecationWarning, lambda: srepr(p))
+        raises(SymPyDeprecationWarning, lambda: pprint(p))
+        raises(SymPyDeprecationWarning, lambda: latex(p))
+    except:
+        raise AssertionError
+    finally:
+        Permutation.print_cyclic = None
 
 
 def test_permutation_equality():

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -478,14 +478,21 @@ def test_deprecated_print_cyclic():
         Permutation.print_cyclic = True
         with warns_deprecated_sympy():
             assert sstr(p) == '(0 1 2)'
+        with warns_deprecated_sympy():
             assert srepr(p) == 'Permutation(0, 1, 2)'
+        with warns_deprecated_sympy():
             assert pretty(p) == '(0 1 2)'
+        with warns_deprecated_sympy():
             assert latex(p) == r'\left( 0\; 1\; 2\right)'
+
         Permutation.print_cyclic = False
         with warns_deprecated_sympy():
             assert sstr(p) == 'Permutation([1, 2, 0])'
+        with warns_deprecated_sympy():
             assert srepr(p) == 'Permutation([1, 2, 0])'
+        with warns_deprecated_sympy():
             assert pretty(p, use_unicode=False) == '/0 1 2\\\n\\1 2 0/'
+        with warns_deprecated_sympy():
             assert latex(p) == \
                 r'\begin{pmatrix} 0 & 1 & 2 \\ 1 & 2 & 0 \end{pmatrix}'
     finally:

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -143,7 +143,6 @@ def _distribute_gens_by_base(base, gens):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import DihedralGroup
     >>> from sympy.combinatorics.util import _distribute_gens_by_base
     >>> D = DihedralGroup(3)
@@ -211,7 +210,6 @@ def _handle_precomputed_bsgs(base, strong_gens, transversals=None,
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import DihedralGroup
     >>> from sympy.combinatorics.util import _handle_precomputed_bsgs
     >>> D = DihedralGroup(3)
@@ -271,7 +269,6 @@ def _orbits_transversals_from_bsgs(base, strong_gens_distr,
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import SymmetricGroup
     >>> from sympy.combinatorics.util import _orbits_transversals_from_bsgs
     >>> from sympy.combinatorics.util import (_orbits_transversals_from_bsgs,
@@ -415,7 +412,6 @@ def _strip(g, base, orbits, transversals):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import SymmetricGroup
     >>> from sympy.combinatorics.permutations import Permutation
     >>> from sympy.combinatorics.util import _strip
@@ -509,7 +505,6 @@ def _strong_gens_from_distr(strong_gens_distr):
     ========
 
     >>> from sympy.combinatorics import Permutation
-    >>> Permutation.print_cyclic = True
     >>> from sympy.combinatorics.named_groups import SymmetricGroup
     >>> from sympy.combinatorics.util import (_strong_gens_from_distr,
     ... _distribute_gens_by_base)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -550,13 +550,16 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         _stringify_func = stringify_func
 
         if pretty_print:
-            stringify_func = lambda expr: \
+            stringify_func = lambda expr, **settings: \
                              _stringify_func(expr, order=order,
                                              use_unicode=use_unicode,
                                              wrap_line=wrap_line,
-                                             num_columns=num_columns)
+                                             num_columns=num_columns,
+                                             **settings)
         else:
-            stringify_func = lambda expr: _stringify_func(expr, order=order)
+            stringify_func = \
+                lambda expr, **settings: _stringify_func(
+                    expr, order=order, **settings)
 
     if in_ipython:
         mode_in_settings = settings.pop("mode", None)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -379,7 +379,16 @@ class LatexPrinter(Printer):
         if self._settings.get("perm_cyclic",True):
             return self._print_Cycle(expr)
         else:
-            pass
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+            use = full = self._print(expr.array_form)
+            if len(trim) < len(full):
+                use = trim
+            return 'Permutation(%s)' % use
 
 
     def _print_Float(self, expr):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -141,6 +141,7 @@ class LatexPrinter(Printer):
         "imaginary_unit": "i",
         "gothic_re_im": False,
         "decimal_separator": "period",
+        "perm_cyclic": True,
     }
 
     def __init__(self, settings=None):
@@ -374,7 +375,12 @@ class LatexPrinter(Printer):
         term_tex = term_tex.replace(']', r"\right)")
         return term_tex
 
-    _print_Permutation = _print_Cycle
+    def _print_Permutation(self, expr):
+        if self._settings.get("perm_cyclic",True):
+            return self._print_Cycle(expr)
+        else:
+            pass
+
 
     def _print_Float(self, expr):
         # Based off of that in StrPrinter
@@ -2501,7 +2507,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
           mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
           order=None, symbol_names=None, root_notation=True,
           mat_symbol_style="plain", imaginary_unit="i", gothic_re_im=False,
-          decimal_separator="period" ):
+          decimal_separator="period", perm_cyclic=True):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2702,6 +2708,7 @@ def latex(expr, fold_frac_powers=False, fold_func_brackets=False,
         'imaginary_unit': imaginary_unit,
         'gothic_re_im': gothic_re_im,
         'decimal_separator': decimal_separator,
+        'perm_cyclic' : perm_cyclic,
     }
 
     return LatexPrinter(settings).doprint(expr)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -392,7 +392,13 @@ class PrettyPrinter(Printer):
         if self._settings.get("perm_cyclic",True):
             return self._print_Cycle(expr)
         else:
-            pass
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            use = self._print(expr.array_form)
+            return prettyForm('Permutation(%s)' % use)
 
     def _print_PDF(self, pdf):
         lim = self._print(pdf.pdf.args[0])

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -42,6 +42,7 @@ class PrettyPrinter(Printer):
         "root_notation": True,
         "mat_symbol_style": "plain",
         "imaginary_unit": "i",
+        "perm_cyclic": True,
     }
 
     def __init__(self, settings=None):
@@ -386,6 +387,29 @@ class PrettyPrinter(Printer):
             l = self._print(str(tuple(i)).replace(',', ''))
             cyc = prettyForm(*cyc.right(l))
         return cyc
+
+    def _print_Permutation(self,expr):
+        if self._settings.get("perm_cyclic",True):
+            return self._print_Cycle(expr)
+        else:
+            pass
+
+    def _print_PDF(self, pdf):
+        lim = self._print(pdf.pdf.args[0])
+        lim = prettyForm(*lim.right(', '))
+        lim = prettyForm(*lim.right(self._print(pdf.domain[0])))
+        lim = prettyForm(*lim.right(', '))
+        lim = prettyForm(*lim.right(self._print(pdf.domain[1])))
+        lim = prettyForm(*lim.parens())
+
+        f = self._print(pdf.pdf.args[1])
+        f = prettyForm(*f.right(', '))
+        f = prettyForm(*f.right(lim))
+        f = prettyForm(*f.parens())
+
+        pform = prettyForm('PDF')
+        pform = prettyForm(*pform.right(f))
+        return pform
 
     def _print_Integral(self, integral):
         f = integral.function
@@ -2615,7 +2639,8 @@ def pretty(expr, **settings):
 
 def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
                  full_prec="auto", order=None, use_unicode_sqrt_char=True,
-                 root_notation = True, mat_symbol_style="plain", imaginary_unit="i"):
+                 root_notation = True, mat_symbol_style="plain",
+                 imaginary_unit="i", perm_cyclic=True):
     """Prints expr in pretty form.
 
     pprint is just a shortcut for this function.
@@ -2662,7 +2687,7 @@ def pretty_print(expr, wrap_line=True, num_columns=None, use_unicode=None,
                  use_unicode=use_unicode, full_prec=full_prec, order=order,
                  use_unicode_sqrt_char=use_unicode_sqrt_char,
                  root_notation=root_notation, mat_symbol_style=mat_symbol_style,
-                 imaginary_unit=imaginary_unit))
+                 imaginary_unit=imaginary_unit, perm_cyclic=perm_cyclic))
 
 pprint = pretty_print
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -365,6 +365,18 @@ def test_pretty_Cycle():
     assert pretty(Cycle()) == '()'
 
 
+def test_pretty_Permutation():
+    from sympy.combinatorics.permutations import Permutation
+    p1 = Permutation(1, 2)(3, 4)
+    assert xpretty(p1, perm_cyclic=True, use_unicode=True) == "(1 2)(3 4)"
+    assert xpretty(p1, perm_cyclic=True, use_unicode=False) == "(1 2)(3 4)"
+    assert xpretty(p1, perm_cyclic=False, use_unicode=True) == \
+    u'⎛0 1 2 3 4⎞\n'\
+    u'⎝0 2 1 4 3⎠'
+    assert xpretty(p1, perm_cyclic=False, use_unicode=False) == \
+    "/0 1 2 3 4\\\n"\
+    "\\0 2 1 4 3/"
+
 def test_pretty_basic():
     assert pretty( -Rational(1)/2 ) == '-1/2'
     assert pretty( -Rational(13)/22 ) == \

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -8,16 +8,19 @@ relation eval(srepr(expr))=expr holds in an appropriate environment.
 from __future__ import print_function, division
 
 from sympy.core.function import AppliedUndef
-from .printer import Printer
 from mpmath.libmp import repr_dps, to_str as mlib_to_str
 from sympy.core.compatibility import range, string_types
+
+from .printer import Printer
+from .str import sstr
 
 
 class ReprPrinter(Printer):
     printmethod = "_sympyrepr"
 
     _default_settings = {
-        "order": None
+        "order": None,
+        "perm_cyclic" : True,
     }
 
     def reprify(self, args, sep):
@@ -57,7 +60,41 @@ class ReprPrinter(Printer):
         return expr.__repr__()
 
     def _print_Permutation(self, expr):
-        return expr.__repr__()
+        from sympy.combinatorics.permutations import Permutation, Cycle
+        from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+        perm_cyclic = Permutation.print_cyclic
+        if perm_cyclic is not None:
+            SymPyDeprecationWarning(
+                feature="Permutation.print_cyclic = {}".format(perm_cyclic),
+                useinstead="init_printing(perm_cyclic={})"
+                .format(perm_cyclic),
+                issue=15201,
+                deprecated_since_version="1.6").warn()
+        else:
+            perm_cyclic = self._settings.get("perm_cyclic", True)
+
+        if perm_cyclic:
+            if not expr.size:
+                return 'Permutation()'
+            # before taking Cycle notation, see if the last element is
+            # a singleton and move it to the head of the string
+            s = Cycle(expr)(expr.size - 1).__repr__()[len('Cycle'):]
+            last = s.rfind('(')
+            if not last == 0 and ',' not in s[last:]:
+                s = s[last:] + s[:last]
+            return 'Permutation%s' %s
+        else:
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % str(expr.array_form)
+                return 'Permutation([], size=%s)' % expr.size
+            trim = str(expr.array_form[:s[-1] + 1]) + ', size=%s' % expr.size
+            use = full = str(expr.array_form)
+            if len(trim) < len(full):
+                use = trim
+            return 'Permutation(%s)' % use
 
     def _print_Function(self, expr):
         r = self._print(expr.func)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -354,28 +354,16 @@ class StrPrinter(Printer):
 
     def _print_Permutation(self, expr):
         from sympy.combinatorics.permutations import Permutation, Cycle
-        if Permutation.print_cyclic:
-            if not expr.size:
-                return '()'
-            # before taking Cycle notation, see if the last element is
-            # a singleton and move it to the head of the string
-            s = Cycle(expr)(expr.size - 1).__repr__()[len('Cycle'):]
-            last = s.rfind('(')
-            if not last == 0 and ',' not in s[last:]:
-                s = s[last:] + s[:last]
-            s = s.replace(',', '')
-            return s
-        else:
-            s = expr.support()
-            if not s:
-                if expr.size < 5:
-                    return 'Permutation(%s)' % self._print(expr.array_form)
-                return 'Permutation([], size=%s)' % self._print(expr.size)
-            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
-            use = full = self._print(expr.array_form)
-            if len(trim) < len(full):
-                use = trim
-            return 'Permutation(%s)' % use
+        s = expr.support()
+        if not s:
+            if expr.size < 5:
+                return 'Permutation(%s)' % self._print(expr.array_form)
+            return 'Permutation([], size=%s)' % self._print(expr.size)
+        trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+        use = full = self._print(expr.array_form)
+        if len(trim) < len(full):
+            use = trim
+        return 'Permutation(%s)' % use
 
     def _print_Subs(self, obj):
         expr, old, new = obj.args

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -22,7 +22,7 @@ class StrPrinter(Printer):
         "full_prec": "auto",
         "sympy_integers": False,
         "abbrev": False,
-        "perm_cyclic": False,
+        "perm_cyclic": True,
     }
 
     _relationals = dict()
@@ -355,7 +355,20 @@ class StrPrinter(Printer):
 
     def _print_Permutation(self, expr):
         from sympy.combinatorics.permutations import Permutation, Cycle
-        if self._settings.get("perm_cyclic",True):
+        from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+        perm_cyclic = Permutation.print_cyclic
+        if perm_cyclic is not None:
+            SymPyDeprecationWarning(
+                feature="Permutation.print_cyclic = {}".format(perm_cyclic),
+                useinstead="init_printing(perm_cyclic={})"
+                .format(perm_cyclic),
+                issue=15201,
+                deprecated_since_version="1.6").warn()
+        else:
+            perm_cyclic = self._settings.get("perm_cyclic", True)
+
+        if perm_cyclic:
             if not expr.size:
                 return '()'
             # before taking Cycle notation, see if the last element is

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -22,6 +22,7 @@ class StrPrinter(Printer):
         "full_prec": "auto",
         "sympy_integers": False,
         "abbrev": False,
+        "perm_cyclic": False,
     }
 
     _relationals = dict()
@@ -354,16 +355,28 @@ class StrPrinter(Printer):
 
     def _print_Permutation(self, expr):
         from sympy.combinatorics.permutations import Permutation, Cycle
-        s = expr.support()
-        if not s:
-            if expr.size < 5:
-                return 'Permutation(%s)' % self._print(expr.array_form)
-            return 'Permutation([], size=%s)' % self._print(expr.size)
-        trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
-        use = full = self._print(expr.array_form)
-        if len(trim) < len(full):
-            use = trim
-        return 'Permutation(%s)' % use
+        if self._settings.get("perm_cyclic",True):
+            if not expr.size:
+                return '()'
+            # before taking Cycle notation, see if the last element is
+            # a singleton and move it to the head of the string
+            s = Cycle(expr)(expr.size - 1).__repr__()[len('Cycle'):]
+            last = s.rfind('(')
+            if not last == 0 and ',' not in s[last:]:
+                s = s[last:] + s[:last]
+            s = s.replace(',', '')
+            return s
+        else:
+            s = expr.support()
+            if not s:
+                if expr.size < 5:
+                    return 'Permutation(%s)' % self._print(expr.array_form)
+                return 'Permutation([], size=%s)' % self._print(expr.size)
+            trim = self._print(expr.array_form[:s[-1] + 1]) + ', size=%s' % self._print(expr.size)
+            use = full = self._print(expr.array_form)
+            if len(trim) < len(full):
+                use = trim
+            return 'Permutation(%s)' % use
 
     def _print_Subs(self, obj):
         expr, old, new = obj.args

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -198,6 +198,13 @@ def test_latex_permutation():
         r"\left( 2\; 4\right)\left( 5\right)"
     assert latex(Permutation(5)) == r"\left( 5\right)"
 
+    assert latex(Permutation(0, 1), perm_cyclic=False) == \
+        r"\begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix}"
+    assert latex(Permutation(0, 1)(2, 3), perm_cyclic=False) == \
+        r"\begin{pmatrix} 0 & 1 & 2 & 3 \\ 1 & 0 & 3 & 2 \end{pmatrix}"
+    assert latex(Permutation(), perm_cyclic=False) == \
+        r"\left( \right)"
+
 
 def test_latex_Float():
     assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -302,9 +302,4 @@ def test_Cycle():
 
 def test_Permutation():
     import_stmt = "from sympy.combinatorics import Permutation"
-    print_cyclic = Permutation.print_cyclic
-    try:
-        Permutation.print_cyclic = True
-        sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
-    finally:
-        Permutation.print_cyclic = print_cyclic
+    sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -274,9 +274,8 @@ def test_Permutation_Cycle():
         (Cycle(3, 4)(1, 2)(3, 4),
         '(1 2)(4)'),
     ]:
-        assert str(p) == s
+        assert sstr(p) == s
 
-    Permutation.print_cyclic = False
     for p, s in [
         (Permutation([]),
         'Permutation([])'),
@@ -293,9 +292,8 @@ def test_Permutation_Cycle():
         (Permutation([1, 0, 2, 3, 4, 5], size=10),
         'Permutation([1, 0], size=10)'),
     ]:
-        assert str(p) == s
+        assert sstr(p, perm_cyclic=False) == s
 
-    Permutation.print_cyclic = True
     for p, s in [
         (Permutation([]),
         '()'),
@@ -314,7 +312,7 @@ def test_Permutation_Cycle():
         (Permutation([0, 1, 3, 2, 4, 5], size=10),
         '(9)(2 3)'),
     ]:
-        assert str(p) == s
+        assert sstr(p) == s
 
 
 def test_Pi():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #15691
Fixes #15201

#### Brief description of what is fixed or changed

This issue is blocking the tests in #18032, so I'm going to fix this first.

I don't think that it's easy to implement https://github.com/sympy/sympy/pull/15691#issuecomment-450695556 since `print_cyclic` is a class attribute,
but I'd rather raise the deprecation warnings from the printers itself.

Besides, I've implemented latex printer to print
![image](https://user-images.githubusercontent.com/34944973/70507056-f2147180-1b6e-11ea-826d-e1bff6755fbc.png)
 if `perm_cyclic=False`,
~~And I'm trying to implement the same feature for the pretty printer as well.~~
And I've added this for pretty printing as well
```
/0 1 2 3 4\
\0 2 1 4 3/
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Using `Permutation.print_cyclic` will raise deprecation warnings
- printing
  - Added a new flag `perm_cyclic` for string, LaTeX, and pretty printers.
  - LaTeX and pretty printer will print permutation in 2-line array notation when `perm_cyclic=False`.
<!-- END RELEASE NOTES -->
