### PR TITLE
Removed comment containing Non-ASCII character

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1593,7 +1593,6 @@ def ode_2nd_hypergeometric(eq, func, order, match):
     c = match['c']
 
     A = match['A']
-    # B = match['B']
 
     sol = None
     if match['type'] == "2F1":

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -12,10 +12,6 @@ from sympy.utilities.iterables import postorder_traversal
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei, expint, li, Si, Ci, Shi, Chi
 from sympy.functions.elementary.complexes import im, re, Abs
 from sympy.core.exprtools import factor_terms
-from sympy import (Basic, E, polylog, N, Wild, WildFunction, factor, gcd, Sum, S, I, Mul, Integer, Float, Dict, Symbol, Rational,
-    Add, hyper, symbols, sqf_list, sqf, Max, factorint, factorrat, Min, sign, E, Function, collect, FiniteSet, nsimplify,
-    expand_trig, expand, poly, apart, lcm, And, Pow, pi, zoo, oo, Integral, UnevaluatedExpr, PolynomialError, Dummy, exp,
-    powdenest, PolynomialDivisionFailed, discriminant, UnificationFailed, appellf1)
 from sympy.functions.special.hyper import TupleArg
 from sympy.functions.special.elliptic_integrals import elliptic_f, elliptic_e, elliptic_pi
 from sympy.utilities.iterables import flatten

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -12,6 +12,7 @@ from sympy.utilities.iterables import postorder_traversal
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei, expint, li, Si, Ci, Shi, Chi
 from sympy.functions.elementary.complexes import im, re, Abs
 from sympy.core.exprtools import factor_terms
+from sympy import (Basic, Mul, Add, Pow, Integral, UnevaluatedExpr, exp)
 from sympy.functions.special.hyper import TupleArg
 from sympy.functions.special.elliptic_integrals import elliptic_f, elliptic_e, elliptic_pi
 from sympy.utilities.iterables import flatten

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -1,31 +1,15 @@
 from sympy.external import import_module
-from sympy.utilities.decorator import doctest_depends_on
-from sympy.functions.elementary.integers import floor, frac
-from sympy.functions import (log, sin, cos, tan, cot, csc, sec, sqrt, erf, gamma, uppergamma, polygamma, digamma,
-    loggamma, factorial, zeta, LambertW)
+from sympy.functions import (log, sin, cos, tan, cot, csc, sec, erf, gamma, uppergamma)
 from sympy.functions.elementary.hyperbolic import acosh, asinh, atanh, acoth, acsch, asech, cosh, sinh, tanh, coth, sech, csch
-from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec, atan2
-from sympy.polys.polytools import Poly, quo, rem, total_degree, degree
-from sympy.simplify.simplify import fraction, simplify, cancel, powsimp
-from sympy.core.sympify import sympify
-from sympy.utilities.iterables import postorder_traversal
-from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei, expint, li, Si, Ci, Shi, Chi
-from sympy.functions.elementary.complexes import im, re, Abs
-from sympy.core.exprtools import factor_terms
+from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec
+from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei
 from sympy import (Basic, Mul, Add, Pow, Integral, UnevaluatedExpr, exp)
-from sympy.functions.special.hyper import TupleArg
-from sympy.functions.special.elliptic_integrals import elliptic_f, elliptic_e, elliptic_pi
-from sympy.utilities.iterables import flatten
-from random import randint
-from sympy.logic.boolalg import Or
 
 matchpy = import_module("matchpy")
 
 if matchpy:
-    from matchpy import Arity, Operation, CommutativeOperation, AssociativeOperation, OneIdentityOperation, CustomConstraint, Pattern, ReplacementRule, ManyToOneReplacer
+    from matchpy import Operation, CommutativeOperation, AssociativeOperation, OneIdentityOperation
     from matchpy.expressions.functions import op_iter, create_operation_expression, op_len
-    from sympy.integrals.rubi.symbol import WC
-    from matchpy import is_match, replace_all
 
     Operation.register(Integral)
     Operation.register(Pow)


### PR DESCRIPTION
This change results in ./setup.py test to work properly.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
When running ./setup.py test, the error: 'SyntaxError: Non-ASCII character '\xc2' in file /sympy/sympy/solvers/ode.py on line 1596, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details' appears. Upon locating this error, deleting the comment causes ./setup.py test to run without issue.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
