### PR TITLE
Make Relational not subclass from Expr

### DIFF
--- a/doc/src/tutorial/solvers.rst
+++ b/doc/src/tutorial/solvers.rst
@@ -65,7 +65,7 @@ is not able to find solutions then a ``ConditionSet`` is returned.
     >>> solveset(exp(x), x)     # No solution exists
     ∅
     >>> solveset(cos(x) - x, x)  # Not able to find solution
-    {x | x ∊ ℂ ∧ -x + cos(x) = 0}
+    {x | x ∊ ℂ ∧ (-x + cos(x) = 0)}
 
 
 In the ``solveset`` module, the linear system of equations is solved using ``linsolve``.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1664,6 +1664,11 @@ class Basic(with_metaclass(ManagedProperties)):
         else:
             return self
 
+    def simplify(self, **kwargs):
+        """See the simplify function in sympy.simplify"""
+        from sympy.simplify import simplify
+        return simplify(self, **kwargs)
+
     def _eval_rewrite(self, pattern, rule, **hints):
         if self.is_Atom:
             if hasattr(self, rule):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3525,11 +3525,6 @@ class Expr(Basic, EvalfMixin):
         from sympy.integrals import integrate
         return integrate(self, *args, **kwargs)
 
-    def simplify(self, **kwargs):
-        """See the simplify function in sympy.simplify"""
-        from sympy.simplify import simplify
-        return simplify(self, **kwargs)
-
     def nsimplify(self, constants=[], tolerance=None, full=False):
         """See the nsimplify function in sympy.simplify"""
         from sympy.simplify import nsimplify

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3251,6 +3251,10 @@ def nfloat(expr, n=15, exponent=False, dkeys=False):
         return rv
     elif rv.is_Atom:
         return rv
+    elif rv.is_Relational:
+        args_nfloat = (nfloat(arg, **kw) for arg in rv.args)
+        return rv.func(*args_nfloat)
+
 
     # watch out for RootOf instances that don't like to have
     # their exponents replaced with Dummies and also sometimes have

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -31,6 +31,11 @@ class AssocOp(Basic):
         args = list(map(_sympify, args))
         args = [a for a in args if a is not cls.identity]
 
+        # XXX: Maybe only Expr should be allowed here...
+        from sympy.core.relational import Relational
+        if any(isinstance(arg, Relational) for arg in args):
+            raise ValueError("Relational can not be used in %s" % cls.__name__)
+
         evaluate = options.get('evaluate')
         if evaluate is None:
             evaluate = global_evaluate[0]

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -34,7 +34,7 @@ class AssocOp(Basic):
         # XXX: Maybe only Expr should be allowed here...
         from sympy.core.relational import Relational
         if any(isinstance(arg, Relational) for arg in args):
-            raise ValueError("Relational can not be used in %s" % cls.__name__)
+            raise TypeError("Relational can not be used in %s" % cls.__name__)
 
         evaluate = options.get('evaluate')
         if evaluate is None:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -262,6 +262,12 @@ class Pow(Expr):
 
         b = _sympify(b)
         e = _sympify(e)
+
+        # XXX: Maybe only Expr should be allowed...
+        from sympy.core.relational import Relational
+        if isinstance(b, Relational) or isinstance(e, Relational):
+            raise ValueError('Relational can not be used in Pow')
+
         if evaluate:
             if e is S.ComplexInfinity:
                 return S.NaN

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -266,7 +266,7 @@ class Pow(Expr):
         # XXX: Maybe only Expr should be allowed...
         from sympy.core.relational import Relational
         if isinstance(b, Relational) or isinstance(e, Relational):
-            raise ValueError('Relational can not be used in Pow')
+            raise TypeError('Relational can not be used in Pow')
 
         if evaluate:
             if e is S.ComplexInfinity:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -398,6 +398,24 @@ class Relational(Boolean, EvalfMixin):
     def as_numer_denom(self):
         return (self, S.One)
 
+    # XXX: This method should be removed. All places that call it should be
+    # fixed...
+    def as_expr(self):
+        return self
+
+    # XXX: This method should be removed. All places that call it should be
+    # fixed...
+    def as_coeff_Mul(self, *deps, **kwargs):
+        if deps:
+            if not self.has(*deps):
+                return self, tuple()
+        return S.One, (self,)
+
+    def integrate(self, *args, **kwargs):
+        """See the integrate function in sympy.integrals"""
+        from sympy.integrals import integrate
+        return integrate(self, *args, **kwargs)
+
     def __nonzero__(self):
         raise TypeError("cannot determine truth value of Relational")
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -395,11 +395,6 @@ class Relational(Boolean, EvalfMixin):
 
     # XXX: This method should be removed. All places that call it should be
     # fixed...
-    def as_expr(self):
-        return self
-
-    # XXX: This method should be removed. All places that call it should be
-    # fixed...
     def as_coeff_Mul(self, *deps, **kwargs):
         if deps:
             if not self.has(*deps):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -390,11 +390,6 @@ class Relational(Boolean, EvalfMixin):
 
     # XXX: This method should be removed. All places that call it should be
     # fixed...
-    def as_independent(self, *args, **kwargs):
-        return Expr.as_independent(self, *args, **kwargs)
-
-    # XXX: This method should be removed. All places that call it should be
-    # fixed...
     def as_numer_denom(self):
         return (self, S.One)
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -291,13 +291,6 @@ class Relational(Boolean, EvalfMixin):
                     return right
                 return left
 
-    # XXX: This is copied from Expr. Maybe it should be defined on Basic or in
-    # a mixin instead.
-    def simplify(self, **kwargs):
-        """See the simplify function in sympy.simplify"""
-        from sympy.simplify import simplify
-        return simplify(self, **kwargs)
-
     def _eval_simplify(self, **kwargs):
         r = self
         r = r.func(*[i.simplify(**kwargs) for i in r.args])

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -665,6 +665,19 @@ class Equality(Relational):
                 pass
         return e.canonical
 
+    def as_poly(self, *gens, **kwargs):
+        '''Returns lhs-rhs as a Poly
+
+        Examples
+        ========
+
+        >>> from sympy import Eq
+        >>> from sympy.abc import x, y
+        >>> Eq(x**2, 1).as_poly(x)
+        Poly(x**2 - 1, x, domain='ZZ')
+        '''
+        return (self.lhs - self.rhs).as_poly(*gens, **kwargs)
+
 
 Eq = Equality
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -388,11 +388,6 @@ class Relational(Boolean, EvalfMixin):
         args = (arg.expand(**kwargs) for arg in self.args)
         return self.func(*args)
 
-    def integrate(self, *args, **kwargs):
-        """See the integrate function in sympy.integrals"""
-        from sympy.integrals import integrate
-        return integrate(self, *args, **kwargs)
-
     def __nonzero__(self):
         raise TypeError("cannot determine truth value of Relational")
 
@@ -664,6 +659,11 @@ class Equality(Relational):
             except ValueError:
                 pass
         return e.canonical
+
+    def integrate(self, *args, **kwargs):
+        """See the integrate function in sympy.integrals"""
+        from sympy.integrals import integrate
+        return integrate(self, *args, **kwargs)
 
     def as_poly(self, *gens, **kwargs):
         '''Returns lhs-rhs as a Poly

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -388,19 +388,6 @@ class Relational(Boolean, EvalfMixin):
         args = (arg.expand(**kwargs) for arg in self.args)
         return self.func(*args)
 
-    # XXX: This method should be removed. All places that call it should be
-    # fixed...
-    def as_numer_denom(self):
-        return (self, S.One)
-
-    # XXX: This method should be removed. All places that call it should be
-    # fixed...
-    def as_coeff_Mul(self, *deps, **kwargs):
-        if deps:
-            if not self.has(*deps):
-                return self, tuple()
-        return S.One, (self,)
-
     def integrate(self, *args, **kwargs):
         """See the integrate function in sympy.integrals"""
         from sympy.integrals import integrate

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -384,6 +384,19 @@ class Relational(Boolean, EvalfMixin):
         from sympy.simplify import trigsimp
         return self.func(trigsimp(self.lhs, **opts), trigsimp(self.rhs, **opts))
 
+    def expand(self, **kwargs):
+        args = (arg.expand(**kwargs) for arg in self.args)
+        return self.func(*args)
+
+    # XXX: This method should be removed. All places that call it should be
+    # fixed...
+    def as_independent(self, *args, **kwargs):
+        return Expr.as_independent(self, *args, **kwargs)
+
+    # XXX: This method should be removed. All places that call it should be
+    # fixed...
+    def as_numer_denom(self):
+        return (self, S.One)
 
     def __nonzero__(self):
         raise TypeError("cannot determine truth value of Relational")

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -356,8 +356,7 @@ def test_evalf_relational():
     # one that doesn't
     assert unchanged(Eq, (3 - I)**2/2 + I, 0)
     assert Eq((3 - I)**2/2 + I, 0).n() is S.false
-    # note: these don't always evaluate to Boolean
-    assert nfloat(Eq((3 - I)**2 + I, 0)) == Eq((3.0 - I)**2 + I, 0)
+    assert nfloat(Eq((3 - I)**2 + I, 0)) == S.false
 
 
 def test_issue_5486():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -132,6 +132,17 @@ def test_Eq():
     assert Eq((), 1) is S.false
 
 
+def test_as_poly():
+    from sympy.polys.polytools import Poly
+    # Only Eq should have an as_poly method:
+    assert Eq(x, 1).as_poly() == Poly(x - 1, x, domain='ZZ')
+    raises(AttributeError, lambda: Ne(x, 1).as_poly())
+    raises(AttributeError, lambda: Ge(x, 1).as_poly())
+    raises(AttributeError, lambda: Gt(x, 1).as_poly())
+    raises(AttributeError, lambda: Le(x, 1).as_poly())
+    raises(AttributeError, lambda: Lt(x, 1).as_poly())
+
+
 def test_rel_Infinity():
     # NOTE: All of these are actually handled by sympy.core.Number, and do
     # not create Relational objects.

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
-    log, cos, sin, Add, floor, ceiling, trigsimp)
+    log, cos, sin, Add, Mul, Pow, floor, ceiling, trigsimp)
 from sympy.core.compatibility import range, PY3
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
@@ -362,6 +362,19 @@ def test_new_relational():
     assert all(Relational(x, 0, op).rel_op == '<' for op in ('lt', '<'))
     assert all(Relational(x, 0, op).rel_op == '>=' for op in ('ge', '>='))
     assert all(Relational(x, 0, op).rel_op == '<=' for op in ('le', '<='))
+
+
+def test_relational_arithmetic():
+    for cls in [Eq, Ne, Le, Lt, Ge, Gt]:
+        rel = cls(x, y)
+        raises(TypeError, lambda: 0+rel)
+        raises(TypeError, lambda: 1*rel)
+        raises(TypeError, lambda: 1**rel)
+        raises(TypeError, lambda: rel**1)
+        raises(TypeError, lambda: Add(0, rel))
+        raises(TypeError, lambda: Mul(1, rel))
+        raises(TypeError, lambda: Pow(1, rel))
+        raises(TypeError, lambda: Pow(rel, 1))
 
 
 def test_relational_bool_output():

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1547,7 +1547,7 @@ class Circle(Ellipse):
         from sympy.geometry.util import find
         from .polygon import Triangle
         evaluate = kwargs.get('evaluate', global_evaluate[0])
-        if len(args) == 1 and isinstance(args[0], Expr):
+        if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
             x = kwargs.get('x', 'x')
             y = kwargs.get('y', 'y')
             equation = args[0]

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1104,7 +1104,7 @@ class Line(LinearEntity):
     def __new__(cls, *args, **kwargs):
         from sympy.geometry.util import find
 
-        if len(args) == 1 and isinstance(args[0], Expr):
+        if len(args) == 1 and isinstance(args[0], (Expr, Eq)):
             x = kwargs.get('x', 'x')
             y = kwargs.get('y', 'y')
             equation = args[0]

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -1,4 +1,4 @@
-from sympy import Rational, S, Symbol, symbols, pi, sqrt, oo, Point2D, Segment2D, Abs
+from sympy import Eq, Rational, S, Symbol, symbols, pi, sqrt, oo, Point2D, Segment2D, Abs
 from sympy.core.compatibility import range
 from sympy.geometry import (Circle, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment,
@@ -34,6 +34,7 @@ def test_object_from_equation():
     assert Circle(x**2 + y**2 + 6*x + 8) == Circle(Point2D(-3, 0), 1)
     assert Circle(x**2 + y**2 + 6*y + 8) == Circle(Point2D(0, -3), 1)
     assert Circle(6*(x**2) + 6*(y**2) + 6*x + 8*y - 25) == Circle(Point2D(Rational(-1, 2), Rational(-2, 3)), 5*sqrt(37)/6)
+    assert Circle(Eq(a**2 + b**2, 25), x='a', y=b) == Circle(Point2D(0, 0), 5)
     raises(GeometryError, lambda: Circle(x**2 + y**2 + 3*x + 4*y + 26))
     raises(GeometryError, lambda: Circle(x**2 + y**2 + 25))
     raises(GeometryError, lambda: Circle(a**2 + b**2 + 25, x='a', y='b'))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -1,4 +1,4 @@
-from sympy import (Rational, Float, S, Symbol, cos, oo, pi, simplify,
+from sympy import (Eq, Rational, Float, S, Symbol, cos, oo, pi, simplify,
     sin, sqrt, symbols, acos)
 from sympy.core.compatibility import range
 from sympy.functions.elementary.trigonometric import tan
@@ -29,6 +29,7 @@ def test_object_from_equation():
     assert Line(3*a + b + 18, x='a', y='b') == Line2D(Point2D(0, -18), Point2D(1, -21))
     assert Line(3*x + y) == Line2D(Point2D(0, 0), Point2D(1, -3))
     assert Line(x + y) == Line2D(Point2D(0, 0), Point2D(1, -1))
+    assert Line(Eq(3*a + b, -18), x='a', y=b) == Line2D(Point2D(0, -18), Point2D(1, -21))
     raises(ValueError, lambda: Line(x))
     raises(ValueError, lambda: Line(y))
     raises(ValueError, lambda: Line(x/y))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -14,7 +14,8 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.utilities.pytest import raises, slow, skip, ON_TRAVIS
+from sympy.utilities.pytest import (raises, slow, skip, ON_TRAVIS,
+    warns_deprecated_sympy)
 from sympy.utilities.randtest import verify_numerically
 
 x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')
@@ -1504,9 +1505,18 @@ def test_issue_15124():
 
 
 def test_issue_15218():
-    assert Eq(x, y).integrate(x) == Eq(x**2/2, x*y)
-    assert Integral(Eq(x, y), x) == Eq(Integral(x, x), Integral(y, x))
-    assert Integral(Eq(x, y), x).doit() == Eq(x**2/2, x*y)
+    with warns_deprecated_sympy():
+        Integral(Eq(x, y))
+    with warns_deprecated_sympy():
+        assert Integral(Eq(x, y), x) == Eq(Integral(x, x), Integral(y, x))
+    with warns_deprecated_sympy():
+        assert Integral(Eq(x, y), x).doit() == Eq(x**2/2, x*y)
+    with warns_deprecated_sympy():
+        assert Eq(x, y).integrate(x) == Eq(x**2/2, x*y)
+
+    # These are not deprecated because they are definite integrals
+    assert integrate(Eq(x, y), (x, 0, 1)) == Eq(S.Half, y)
+    assert Eq(x, y).integrate((x, 0, 1)) == Eq(S.Half, y)
 
 
 def test_issue_15292():

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5498,10 +5498,12 @@ def terms_gcd(f, *gens, **args):
 
     orig = sympify(f)
 
-    # XXX: Should any Relational be accepted here? Why does this accept
-    # any Relational at all? Perhaps it should not and any code that calls
-    # this with Relational should be changed.
-    if not isinstance(f, (Expr, Relational)) or f.is_Atom:
+    if isinstance(f, Equality):
+        return Equality(*(terms_gcd(s, *gens, **args) for s in [f.lhs, f.rhs]))
+    elif isinstance(f, Relational):
+        raise TypeError("Inequalities can not be used with terms_gcd. Found: %s" %(f,))
+
+    if not isinstance(f, Expr) or f.is_Atom:
         return orig
 
     if args.get('deep', False):
@@ -5509,9 +5511,6 @@ def terms_gcd(f, *gens, **args):
         args.pop('deep')
         args['expand'] = False
         return terms_gcd(new, *gens, **args)
-
-    if isinstance(f, Equality):
-        return f
 
     clear = args.pop('clear', True)
     options.allowed_flags(args, ['polys'])

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5497,7 +5497,11 @@ def terms_gcd(f, *gens, **args):
     from sympy.core.relational import Equality
 
     orig = sympify(f)
-    if not isinstance(f, Expr) or f.is_Atom:
+
+    # XXX: Should any Relational be accepted here? Why does this accept
+    # any Relational at all? Perhaps it should not and any code that calls
+    # this with Relational should be changed.
+    if not isinstance(f, (Expr, Relational)) or f.is_Atom:
         return orig
 
     if args.get('deep', False):

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import (S, Add, Mul, Pow, Expr,
+from sympy.core import (S, Add, Mul, Pow, Eq, Expr,
     expand_mul, expand_multinomial)
 from sympy.core.compatibility import range
 from sympy.core.exprtools import decompose_power, decompose_power_rat
@@ -353,7 +353,7 @@ def _dict_from_expr(expr, opt):
                 and expr.base.is_Add)
 
     if opt.expand is not False:
-        if not isinstance(expr, Expr):
+        if not isinstance(expr, (Expr, Eq)):
             raise PolynomialError('expression must be of type Expr')
         expr = expr.expand()
         # TODO: Integrate this into expand() itself

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2032,8 +2032,10 @@ def test_terms_gcd():
         sin(x*(y + 1))
 
     eq = Eq(2*x, 2*y + 2*z*y)
-    assert terms_gcd(eq) == eq
+    assert terms_gcd(eq) == Eq(2*x, 2*y*(z + 1))
     assert terms_gcd(eq, deep=True) == Eq(2*x, 2*y*(z + 1))
+
+    raises(TypeError, lambda: terms_gcd(x < 2))
 
 
 def test_trunc():

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2123,7 +2123,7 @@ class LatexPrinter(Printer):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
         if s.base_set is S.UniversalSet:
             return r"\left\{%s \mid %s \right\}" % \
-                (vars_print, self._print(s.condition.as_expr()))
+                (vars_print, self._print(s.condition))
 
         return r"\left\{%s \mid %s \in %s \wedge %s \right\}" % (
             vars_print,

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1193,37 +1193,6 @@ x %= y\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-def test_issue_7117():
-    # See also issue #5031 (hence the evaluate=False in these).
-    e = Eq(x + 1, x/2)
-    q = Mul(2, e, evaluate=False)
-    assert upretty(q) == u("""\
-  ⎛        x⎞\n\
-2⋅⎜x + 1 = ─⎟\n\
-  ⎝        2⎠\
-""")
-    q = Add(e, 6, evaluate=False)
-    assert upretty(q) == u("""\
-    ⎛        x⎞\n\
-6 + ⎜x + 1 = ─⎟\n\
-    ⎝        2⎠\
-""")
-    q = Pow(e, 2, evaluate=False)
-    assert upretty(q) == u("""\
-           2\n\
-⎛        x⎞ \n\
-⎜x + 1 = ─⎟ \n\
-⎝        2⎠ \
-""")
-    e2 = Eq(x, 2)
-    q = Mul(e, e2, evaluate=False)
-    assert upretty(q) == u("""\
-⎛        x⎞        \n\
-⎜x + 1 = ─⎟⋅(x = 2)\n\
-⎝        2⎠        \
-""")
-
-
 def test_pretty_rational():
     expr = y*x**-2
     ascii_str = \
@@ -3864,7 +3833,7 @@ def test_pretty_ImageSet():
 def test_pretty_ConditionSet():
     from sympy import ConditionSet
     ascii_str = '{x | x in (-oo, oo) and sin(x) = 0}'
-    ucode_str = u'{x | x ∊ ℝ ∧ sin(x) = 0}'
+    ucode_str = u'{x | x ∊ ℝ ∧ (sin(x) = 0)}'
     assert pretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ascii_str
     assert upretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ucode_str
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2094,17 +2094,6 @@ def test_issue_8470():
     assert latex(e) == r"A \left(- B\right)"
 
 
-def test_issue_7117():
-    # See also issue #5031 (hence the evaluate=False in these).
-    e = Eq(x + 1, 2*x)
-    q = Mul(2, e, evaluate=False)
-    assert latex(q) == r"2 \left(x + 1 = 2 x\right)"
-    q = Add(6, e, evaluate=False)
-    assert latex(q) == r"6 + \left(x + 1 = 2 x\right)"
-    q = Pow(e, 2, evaluate=False)
-    assert latex(q) == r"\left(x + 1 = 2 x\right)^{2}"
-
-
 def test_issue_15439():
     x = MatrixSymbol('x', 2, 2)
     y = MatrixSymbol('y', 2, 2)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -10,6 +10,7 @@ from sympy.core.evaluate import global_evaluate
 from sympy.core.function import expand_log, count_ops, _mexpand, _coeff_isneg, \
     nfloat, expand_mul, expand_multinomial
 from sympy.core.numbers import Float, I, pi, Rational, Integer
+from sympy.core.relational import Relational
 from sympy.core.rules import Transform
 from sympy.core.sympify import _sympify
 from sympy.functions import gamma, exp, sqrt, log, exp_polar, re
@@ -379,10 +380,10 @@ def signsimp(expr, evaluate=None):
     if evaluate is None:
         evaluate = global_evaluate[0]
     expr = sympify(expr)
-    if not isinstance(expr, Expr) or expr.is_Atom:
+    if not isinstance(expr, (Expr, Relational)) or expr.is_Atom:
         return expr
     e = sub_post(sub_pre(expr))
-    if not isinstance(e, Expr) or e.is_Atom:
+    if not isinstance(e, (Expr, Relational)) or e.is_Atom:
         return e
     if e.is_Add:
         return e.func(*[signsimp(a, evaluate) for a in e.args])

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -391,7 +391,7 @@ def iter_numbered_constants(eq, start=1, prefix='C'):
     in eq already.
     """
 
-    if isinstance(eq, Expr):
+    if isinstance(eq, (Expr, Eq)):
         eq = [eq]
     elif not iterable(eq):
         raise ValueError("Expected Expr or iterable but got %s" % eq)
@@ -702,10 +702,10 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
         # attempt to solve for func, and apply any other hint specific
         # simplifications
         sols = solvefunc(eq, func, order, match)
-        if isinstance(sols, Expr):
-            rv =  odesimp(eq, sols, func, hint)
-        else:
+        if iterable(sols):
             rv = [odesimp(eq, s, func, hint) for s in sols]
+        else:
+            rv =  odesimp(eq, sols, func, hint)
     else:
         # We still want to integrate (you can disable it separately with the hint)
         match['simplify'] = False  # Some hints can take advantage of this option
@@ -720,7 +720,7 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
         if len(rv) == 1:
             rv = rv[0]
     if ics and not 'power_series' in hint:
-        if isinstance(rv, Expr):
+        if isinstance(rv, (Expr, Eq)):
             solved_constants = solve_ics([rv], [r['func']], cons(rv), ics)
             rv = rv.subs(solved_constants)
         else:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3442,7 +3442,12 @@ def unrad(eq, *syms, **flags):
 
     # preconditioning
     eq = powdenest(factor_terms(eq, radical=True, clear=True))
-    eq, d = eq.as_numer_denom()
+
+    if isinstance(eq, Relational):
+        eq, d = eq, 1
+    else:
+        eq, d = eq.as_numer_denom()
+
     eq = _mexpand(eq, recursive=True)
     if eq.is_number:
         return

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -161,6 +161,9 @@ def denoms(eq, *symbols):
     pot = preorder_traversal(eq)
     dens = set()
     for p in pot:
+        # lhs and rhs will be traversed after anyway
+        if isinstance(p, Relational):
+            continue
         den = denom(p)
         if den is S.One:
             continue

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1004,8 +1004,11 @@ def _solveset(f, symbol, domain, _check=False):
 
         # whittle away all but the symbol-containing core
         # to use this for testing
-        fx = orig_f.as_independent(symbol, as_Add=True)[1]
-        fx = fx.as_independent(symbol, as_Add=False)[1]
+        if isinstance(orig_f, Expr):
+            fx = orig_f.as_independent(symbol, as_Add=True)[1]
+            fx = fx.as_independent(symbol, as_Add=False)[1]
+        else:
+            fx = orig_f
 
         if isinstance(result, FiniteSet):
             # check the result for invalid solutions

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -22,7 +22,7 @@ from sympy.core.function import (Lambda, expand_complex, AppliedUndef,
                                 expand_log, _mexpand)
 from sympy.core.mod import Mod
 from sympy.core.numbers import igcd
-from sympy.core.relational import Eq, Ne
+from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import _sympify
 from sympy.simplify.simplify import simplify, fraction, trigsimp
@@ -1960,10 +1960,10 @@ def solveset(f, symbol=None, domain=S.Complexes):
     if f is S.false:
         return S.EmptySet
 
-    if not isinstance(f, (Expr, Number)):
+    if not isinstance(f, (Expr, Relational, Number)):
         raise ValueError("%s is not a valid SymPy expression" % f)
 
-    if not isinstance(symbol, Expr) and  symbol is not None:
+    if not isinstance(symbol, (Expr, Relational)) and  symbol is not None:
         raise ValueError("%s is not a valid SymPy symbol" % symbol)
 
     if not isinstance(domain, Set):
@@ -2326,7 +2326,7 @@ def linear_eq_to_matrix(equations, *symbols):
     equations = sympify(equations)
     if isinstance(equations, MatrixBase):
         equations = list(equations)
-    elif isinstance(equations, Expr):
+    elif isinstance(equations, (Expr, Eq)):
         equations = [equations]
     elif not is_sequence(equations):
         raise ValueError(filldedent('''

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -989,7 +989,10 @@ def _solveset(f, symbol, domain, _check=False):
             result = ConditionSet(symbol, Eq(f, 0), domain)
 
     if isinstance(result, ConditionSet):
-        num, den = f.as_numer_denom()
+        if isinstance(f, Expr):
+            num, den = f.as_numer_denom()
+        else:
+            num, den = f, S.One
         if den.has(symbol):
             _result = _solveset(num, symbol, domain)
             if not isinstance(_result, ConditionSet):

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1105,6 +1105,10 @@ def test_unrad1():
     raises(NotImplementedError,
            lambda: unrad(root(x, 3) + root(y, 3) + root(x*y, 5)))
 
+    # Test unrad with an Equality
+    eq = Eq(-x**(S(1)/5) + x**(S(1)/3), -3**(S(1)/3) - (-1)**(S(3)/5)*3**(S(1)/5))
+    assert check(unrad(eq),
+        (-s**5 + s**3 - 3**(S(1)/3) - (-1)**(S(3)/5)*3**(S(1)/5), [s, s**15 - x]))
 
 @slow
 def test_unrad_slow():

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -655,7 +655,7 @@ def given(expr, condition=None, **kwargs):
             if temp == True:
                 return True
             if temp != False:
-                # XXX: This seems nonsensical but preserves existing behavoiur
+                # XXX: This seems nonsensical but preserves existing behaviour
                 # after the change that Relational is no longer a subclass of
                 # Expr. Here expr is sometimes Relational and sometimes Expr
                 # but we are trying to add them with +=. This needs to be

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -655,7 +655,15 @@ def given(expr, condition=None, **kwargs):
             if temp == True:
                 return True
             if temp != False:
-                sums += expr.subs(rv, res)
+                # XXX: This seems nonsensical but preserves existing behavoiur
+                # after the change that Relational is no longer a subclass of
+                # Expr. Here expr is sometimes Relational and sometimes Expr
+                # but we are trying to add them with +=. This needs to be
+                # fixed somehow.
+                if sums == 0 and isinstance(expr, Relational):
+                    sums = expr.subs(rv, res)
+                else:
+                    sums += expr.subs(rv, res)
         if sums == 0:
             return False
         return sums


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #5031
Related to #4986
Fixes #14077
Fixes #10422

#### Brief description of what is fixed or changed

This PR makes `Relational` not a subclass of `Expr`. This means that arithmetic operations on `Relational` fail with `TypeError`:
```julia
In [5]: (x < 1) + 1
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-f2c05cd6b40f> in <module>
----> 1 (x < 1) + 1

TypeError: unsupported operand type(s) for +: 'StrictLessThan' and 'int'
```
This is compare to the behaviour on master which creates a nonsensical object:
```julia
In [1]: (x < 1) + 1
Out[1]: 1 + (x < 1)
```

This PR means that arithmetic operations on `Relational` give `TypeError` and that `Relational` can not be used in `Add`, `Mul` or `Pow`. There are still some nonsensical results:
```julia
In [2]: exp(x < 1)
Out[2]: 
 x < 1
ℯ  
```
I'm not sure how to fix those in a general way.

This PR also fixes various places in the codebase (mostly printing and solvers) that use expr methods like `as_coeff_Mul` on `Relational` instances.

#### Other comments

This makes `Relational` a more sensible `Boolean` subclass. There are a number of open issues about users wanting to be able to do arithmetic with equations like:
```julia
In [3]: eq = Eq(x, 1)

In [4]: eq
Out[4]: x = 1

In [5]: 2*eq
Out[5]: 2⋅x = 2
```
For that we need a new `Equation` class that handles "symbolic" (rather than `Boolean`) equations and does not evaluate to True/False. The related issue #4986 can stay open for adding an `Equation` class.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Relational is no longer a subclass of Expr and does not produce nonsensical results in arithmetic operations. This affects all Relational subclasses (Eq, Ne, Gt, Ge, Lt, Le). It is no longer possible to call meaningless `Expr` methods like `as_coeff_Mul` on `Relational` instances.
<!-- END RELEASE NOTES -->