### PR TITLE
Fix issues with ImageSet creation

### DIFF
--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -914,9 +914,20 @@ def test_issue_16871b():
     assert ImageSet(Lambda(x, x - 3), S.Integers).is_subset(S.Integers)
 
 
-def test_no_mod_on_imaginary():
+def test_issue_18050():
+    assert imageset(Lambda(x, I*x + 1), S.Integers
+        ) == ImageSet(Lambda(x, I*x + 1), S.Integers)
+    assert imageset(Lambda(x, 3*I*x + 4 + 8*I), S.Integers
+        ) == ImageSet(Lambda(x, 3*I*x + 4 + 2*I), S.Integers)
+    # no 'Mod' for next 2 tests:
     assert imageset(Lambda(x, 2*x + 3*I), S.Integers
-        ) == ImageSet(Lambda(x, 2*x + I), S.Integers)
+        ) == ImageSet(Lambda(x, 2*x + 3*I), S.Integers)
+    r = Symbol('r', positive=True)
+    assert imageset(Lambda(x, r*x + 10), S.Integers
+        ) == ImageSet(Lambda(x, r*x + 10), S.Integers)
+    # reduce real part:
+    assert imageset(Lambda(x, 3*x + 8 + 5*I), S.Integers
+        ) == ImageSet(Lambda(x, 3*x + 2 + 5*I), S.Integers)
 
 
 def test_Rationals():

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -1,9 +1,8 @@
 from sympy.sets.setexpr import SetExpr
 from sympy.sets import Interval, FiniteSet, Intersection, ImageSet, Union
-from sympy import (Expr, Set, exp, log, cos, Symbol, Min, Max, S, oo,
+from sympy import (Expr, Set, exp, log, cos, Symbol, Min, Max, S, oo, I,
         symbols, Lambda, Dummy, Rational)
 
-I = Interval(0, 2)
 a, x = symbols("a, x")
 _d = Dummy("d")
 
@@ -285,3 +284,17 @@ def test_SetExpr_Interval_pow():
     assert SetExpr(Interval(2, 3))**(-oo) == SetExpr(FiniteSet(0))
     assert SetExpr(Interval(0, 2))**(-oo) == SetExpr(Interval(0, oo))
     assert (SetExpr(Interval(-1, 2))**(-oo)).dummy_eq(SetExpr(ImageSet(Lambda(_d, _d**(-oo)), Interval(-1, 2))))
+
+
+def test_SetExpr_Integers():
+    assert SetExpr(S.Integers) + 1 == SetExpr(S.Integers)
+    assert SetExpr(S.Integers) + I == SetExpr(ImageSet(Lambda(_d, _d + I), S.Integers))
+    assert SetExpr(S.Integers)*(-1) == SetExpr(S.Integers)
+    assert SetExpr(S.Integers)*2 == SetExpr(ImageSet(Lambda(_d, 2*_d), S.Integers))
+    assert SetExpr(S.Integers)*I == SetExpr(ImageSet(Lambda(_d, I*_d), S.Integers))
+    # issue #18050:
+    assert SetExpr(S.Integers)._eval_func(Lambda(x, I*x + 1)) == SetExpr(
+            ImageSet(Lambda(_d, I*_d + 1), S.Integers))
+    # needs improvement:
+    assert SetExpr(S.Integers)*I + 1 == SetExpr(
+            ImageSet(Lambda(x, x + 1), ImageSet(Lambda(_d, _d*I), S.Integers)))


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18050

#### Brief description of what is fixed or changed
Some fixes for `ImageSets` with a linear map `a*n+b` as lambda function. When creating an `ImageSet` (either via `imageset` or `ImageSet.doit()`), linear maps are canonicalized in the sense that .e.g `Lambda(n, 2*n+7)` is reduced to `Lambda(n, 2*n + 1)`. The current code in master has some issues when dealing with complex numbers.

The relevant code is actually in `SetExpr._eval_func()`, so this PR modifies it
- to correct a check that should only apply to real `a` with abs=1,
- to correct reduction modulo `a` in `a*n+b`,
- to add reduction modulo `a` for pure imaginary `a`.

It also
- fixes a wrong `imageset` test and adds some new ones,
- adds specific tests for `SetExpr(Integers)`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * `SetExpr._eval_func()` is fixed so that `ImageSets` with linear maps involving complex numbers are now instantiated correctly.
<!-- END RELEASE NOTES -->
