### PR TITLE
Add assume_unit to Quaternion class

### DIFF
--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -97,7 +97,7 @@ def test_quaternion_functions():
     assert integrate(Quaternion(x, x, x, x), x) == \
     Quaternion(x**2 / 2, x**2 / 2, x**2 / 2, x**2 / 2)
 
-    assert Quaternion.rotate_point((1, 1, 1), q1) == (S.One / 5, 1, S(7) / 5)
+    assert Quaternion.rotate_point((1, 1, 1), q1.normalize()) == (S.One / 5, 1, S(7) / 5)
     n = Symbol('n')
     raises(TypeError, lambda: q1**n)
     n = Symbol('n', integer=True)
@@ -105,7 +105,7 @@ def test_quaternion_functions():
 
 
 def test_quaternion_conversions():
-    q1 = Quaternion(1, 2, 3, 4)
+    q1 = Quaternion(1, 2, 3, 4).normalize()
 
     assert q1.to_axis_angle() == ((2 * sqrt(29)/29,
                                    3 * sqrt(29)/29,


### PR DESCRIPTION
... and disable `rotate_point()`, `to_axis_angle()` and `to_rotation_matrix()`
for non-unit quaternions.

#### References to other Issues or PRs

This is an alternative to #17694.

#### Brief description of what is fixed or changed

I've added an `assume_unit` argument to the `Quaternion` constructor as well as an `.assume_unit()` method.
Probably one of them would suffice?

The `_assume_unit` attribute is propagated through mathematical operations, as far as I am aware that's possible. Most likely I missed something.

Here's an example that illustrates the change:

**Before this PR:**

```pycon
>>> import sympy as sp
>>> sp.init_printing()
>>> a, b, c, d = sp.symbols('a:d')
>>> q = sp.Quaternion(a, b, c, d)
>>> q.to_rotation_matrix()
⎡       ⎛ 2    2⎞                                                         ⎤
⎢     2⋅⎝c  + d ⎠              2⋅(-a⋅d + b⋅c)           2⋅(a⋅c + b⋅d)     ⎥
⎢- ───────────────── + 1     ─────────────────        ─────────────────   ⎥
⎢   2    2    2    2          2    2    2    2         2    2    2    2   ⎥
⎢  a  + b  + c  + d          a  + b  + c  + d         a  + b  + c  + d    ⎥
⎢                                                                         ⎥
⎢                                ⎛ 2    2⎞                                ⎥
⎢     2⋅(a⋅d + b⋅c)            2⋅⎝b  + d ⎠              2⋅(-a⋅b + c⋅d)    ⎥
⎢   ─────────────────     - ───────────────── + 1     ─────────────────   ⎥
⎢    2    2    2    2        2    2    2    2          2    2    2    2   ⎥
⎢   a  + b  + c  + d        a  + b  + c  + d          a  + b  + c  + d    ⎥
⎢                                                                         ⎥
⎢                                                         ⎛ 2    2⎞       ⎥
⎢     2⋅(-a⋅c + b⋅d)           2⋅(a⋅b + c⋅d)            2⋅⎝b  + c ⎠       ⎥
⎢   ─────────────────        ─────────────────     - ───────────────── + 1⎥
⎢    2    2    2    2         2    2    2    2        2    2    2    2    ⎥
⎣   a  + b  + c  + d         a  + b  + c  + d        a  + b  + c  + d     ⎦
```

This normalizes the quaternion without asking.

There is no way to avoid the normalization if we want to assume that the quaternion is already a unit quaternion.

**After this PR:**

```pycon
>>> import sympy as sp
>>> sp.init_printing()
>>> a, b, c, d = sp.symbols('a:d')
>>> q = sp.Quaternion(a, b, c, d, assume_unit=True)
>>> q.to_rotation_matrix()
⎡     2      2                                          ⎤
⎢- 2⋅c  - 2⋅d  + 1   -2⋅a⋅d + 2⋅b⋅c      2⋅a⋅c + 2⋅b⋅d  ⎥
⎢                                                       ⎥
⎢                        2      2                       ⎥
⎢  2⋅a⋅d + 2⋅b⋅c    - 2⋅b  - 2⋅d  + 1   -2⋅a⋅b + 2⋅c⋅d  ⎥
⎢                                                       ⎥
⎢                                           2      2    ⎥
⎣ -2⋅a⋅c + 2⋅b⋅d      2⋅a⋅b + 2⋅c⋅d    - 2⋅b  - 2⋅c  + 1⎦
```

#### Other comments

Currently, there is no "official" way to find out if the internal attribute `_assume_unit` is true. Is this needed?

This is still marked as "draft" because ...

* [ ] I don't know if the exponential function has a special case for unit quaternions
* [ ] I don't know if the `pow_cos_sin()` is doing the right thing
* [ ] There might be errors in the implementation
* [ ] Documentation is still missing
* [ ] There is a problem with caching (see below)

This is running fine:

```pycon
>>> import sympy as sp
>>> a, b, c, d = sp.symbols('a:d')
>>> q = sp.Quaternion(a, b, c, d)
>>> u = q.assume_unit()
>>> u.conjugate().to_axis_angle()
((-b/sqrt(1 - a**2), -c/sqrt(1 - a**2), -d/sqrt(1 - a**2)), 2*acos(a))
```

... but if I run `conjugate()` on a non-unit quaternion before (everything else stays the same):

```pycon
>>> import sympy as sp
>>> a, b, c, d = sp.symbols('a:d')
>>> q = sp.Quaternion(a, b, c, d)
>>> q.conjugate()  # <--- this line has been added
a + (-b)*i + (-c)*j + (-d)*k
>>> u = q.assume_unit()
>>> u.conjugate().to_axis_angle()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/sympy/algebras/quaternion.py", line 621, in to_axis_angle
    raise ValueError('A unit quaternion is required')
ValueError: A unit quaternion is required
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added `assume_unit` to `Quaternion`
<!-- END RELEASE NOTES -->
