### PR TITLE
remove exec flag from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Distutils based setup script for SymPy.
 
 This uses Distutils (https://python.org/sigs/distutils-sig/) the standard


### PR DESCRIPTION
It's unusual, unnecessary, and Python 2 isn't supported anymore anyway.