### PR TITLE
Add parse_expr to the main __init__.py

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -83,6 +83,7 @@ from .algebras import *
 from .plotting import plot, textplot, plot_backends, plot_implicit, plot_parametric
 from .printing import *
 from .interactive import init_session, init_printing
+from .parsing import *
 
 evalf._create_evalf_table()
 

--- a/sympy/parsing/__init__.py
+++ b/sympy/parsing/__init__.py
@@ -1,1 +1,4 @@
 """Used for translating a string into a SymPy expression. """
+__all__ = ['parse_expr']
+
+from .sympy_parser import parse_expr


### PR DESCRIPTION
It's basically been public API for a while, since it's the only way to access
the advanced parsing features like the input transformers.

I've not added the transformers themselves. They can still be accessed from
the sympy_parser submodule. It seems to me that adding them to __init__.py as
well would pollute the namespace, although I don't feel strongly about it.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - `parse_expr` can now be imported directly from sympy (`from sympy import parse_expr`). The various parsing transformers should still be imported from `sympy.parsing.sympy_parser`. 
<!-- END RELEASE NOTES -->
