### PR TITLE
Substitute generalized speeds for all time derivatives in KanesMethod.forcing

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -210,8 +210,11 @@ class KanesMethod(object):
             self._k_nh = (vel - self._f_nh).jacobian(self.u)
             # If no acceleration constraints given, calculate them.
             if not acc:
-                self._f_dnh = (self._k_nh.diff(dynamicsymbols._t) * self.u +
-                               self._f_nh.diff(dynamicsymbols._t))
+                _f_dnh = (self._k_nh.diff(dynamicsymbols._t) * self.u +
+                          self._f_nh.diff(dynamicsymbols._t))
+                if self._qdot_u_map is not None:
+                    _f_dnh = msubs(_f_dnh, self._qdot_u_map)
+                self._f_dnh = _f_dnh
                 self._k_dnh = self._k_nh
             else:
                 if self._qdot_u_map is not None:

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,9 +1,10 @@
 from sympy.core.compatibility import range
 from sympy.core.backend import cos, Matrix, sin, zeros, tan, pi, symbols
 from sympy import trigsimp, simplify, solve
-from sympy.physics.mechanics import (cross, dot, dynamicsymbols, KanesMethod,
-                                     inertia, inertia_of_point_mass,
-                                     Point, ReferenceFrame, RigidBody)
+from sympy.physics.mechanics import (cross, dot, dynamicsymbols,
+                                     find_dynamicsymbols, KanesMethod, inertia,
+                                     inertia_of_point_mass, Point,
+                                     ReferenceFrame, RigidBody)
 from sympy.utilities.pytest import warns_deprecated_sympy
 
 
@@ -188,6 +189,10 @@ def test_aux_dep():
     assert Matrix(Fr_star_c.subs(kdd)).expand() == frstar.expand()
     assert (simplify(Matrix(Fr_star_steady).expand()) ==
             simplify(frstar_steady.expand()))
+
+    syms_in_forcing = find_dynamicsymbols(kane.forcing)
+    for qdi in qd:
+        assert qdi not in syms_in_forcing
 
 
 def test_non_central_inertia():

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -81,7 +81,7 @@ def test_linearize_rolling_disc_kane():
     linearizer = KM.to_linearizer()
     assert linearizer.f_c == f_c
     assert linearizer.f_v == f_v
-    assert linearizer.f_a == f_v.diff(t)
+    assert linearizer.f_a == f_v.diff(t).subs(KM.kindiffdict())
     sol = solve(linearizer.f_0 + linearizer.f_1, qd)
     for qi in qdots.keys():
         assert sol[qi] == qdots[qi]


### PR DESCRIPTION
There should be no time derivatives of generalized coordinates present
in the outputs of KanesMethod if kinematical differential equations are
supplied.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.mechanics
  * KanesMethod.forcing no longer contains time derivatives of generalized coordinates if kinematical differential equations are supplied.

<!-- END RELEASE NOTES -->
