### PR TITLE
Fix lambdify tests

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -697,7 +697,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
             else:
                 modules = ["numpy"]
         else:
-            modules = ["scipy", "numpy"]
+            modules = ["numpy", "scipy"]
 
     # Get the needed namespaces.
     namespaces = []

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1012,10 +1012,11 @@ def test_scipy_fns():
         f = lambdify(x, sympy_fn(x), modules="scipy")
         for i in range(20):
             tv = numpy.random.uniform(-10, 10) + 1j*numpy.random.uniform(-5, 5)
-            # SciPy thinks that factorial(z) is 0 when re(z) < 0.
+            # SciPy thinks that factorial(z) is 0 when re(z) < 0 and
+            # does not support complex numbers.
             # SymPy does not think so.
-            if sympy_fn == factorial and numpy.real(tv) < 0:
-                tv = tv + 2*numpy.abs(numpy.real(tv))
+            if sympy_fn == factorial:
+                tv = numpy.abs(tv)
             # SciPy supports gammaln for real arguments only,
             # and there is also a branch cut along the negative real axis
             if sympy_fn == loggamma:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18079 

#### Brief description of what is fixed or changed

A better fix would be a rework of the lambdify to use fully qualified modules instead of overriding the global namespace,
But this workaround may fix the travis issues now.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- utilities
  - lambdify: avoid using scipy versions of numpy functions, which are deprecated, in lambdify.
<!-- END RELEASE NOTES -->
