### PR TITLE
Quaternion: Add normalize flag

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -101,9 +101,14 @@ class Quaternion(Expr):
 
         >>> from sympy.algebras.quaternion import Quaternion
         >>> from sympy import pi, sqrt
-        >>> q = Quaternion.from_axis_angle((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), 2*pi/3)
-        >>> q
+        >>> Quaternion.from_axis_angle((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), 2*pi/3)
         1/2 + 1/2*i + 1/2*j + 1/2*k
+
+        The given vector will be normalized:
+
+        >>> Quaternion.from_axis_angle((99, 99, 99), 2*pi/3)
+        1/2 + 1/2*i + 1/2*j + 1/2*k
+
         """
         (x, y, z) = vector
         norm = sqrt(x**2 + y**2 + z**2)
@@ -571,7 +576,7 @@ class Quaternion(Expr):
         >>> from sympy import symbols, trigsimp, cos, sin
         >>> x = symbols('x')
         >>> q = Quaternion(cos(x/2), 0, 0, sin(x/2))
-        >>> trigsimp(Quaternion.rotate_point((1, 1, 1), q))
+        >>> trigsimp(Quaternion.rotate_point((1, 1, 1), q, normalize=False))
         (sqrt(2)*cos(x + pi/4), sqrt(2)*sin(x + pi/4), 1)
         >>> (axis, angle) = q.to_axis_angle()
         >>> trigsimp(Quaternion.rotate_point((1, 1, 1), (axis, angle)))
@@ -607,12 +612,12 @@ class Quaternion(Expr):
         ========
 
         >>> from sympy.algebras.quaternion import Quaternion
-        >>> q = Quaternion(1, 1, 1, 1)
-        >>> (axis, angle) = q.to_axis_angle()
-        >>> axis
-        (sqrt(3)/3, sqrt(3)/3, sqrt(3)/3)
-        >>> angle
-        2*pi/3
+        >>> from sympy import S
+        >>> Quaternion(1, 1, 1, 1).to_axis_angle()
+        ((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), 2*pi/3)
+        >>> Quaternion(S.Half, S.Half, S.Half, S.Half).to_axis_angle(normalize=False)
+        ((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), 2*pi/3)
+
         """
         q = self
         if q.a.is_negative:
@@ -660,7 +665,7 @@ class Quaternion(Expr):
         >>> from sympy import symbols, trigsimp, cos, sin
         >>> x = symbols('x')
         >>> q = Quaternion(cos(x/2), 0, 0, sin(x/2))
-        >>> trigsimp(q.to_rotation_matrix())
+        >>> trigsimp(q.to_rotation_matrix(normalize=False))
         Matrix([
         [cos(x), -sin(x), 0],
         [sin(x),  cos(x), 0],
@@ -669,14 +674,11 @@ class Quaternion(Expr):
         Generates a 4x4 transformation matrix (used for rotation about a point
         other than the origin) if the point(v) is passed as an argument.
 
-        Examples
-        ========
-
         >>> from sympy.algebras.quaternion import Quaternion
         >>> from sympy import symbols, trigsimp, cos, sin
         >>> x = symbols('x')
         >>> q = Quaternion(cos(x/2), 0, 0, sin(x/2))
-        >>> trigsimp(q.to_rotation_matrix((1, 1, 1)))
+        >>> trigsimp(q.to_rotation_matrix((1, 1, 1), normalize=False))
          Matrix([
         [cos(x), -sin(x), 0,  sin(x) - cos(x) + 1],
         [sin(x),  cos(x), 0, -sin(x) - cos(x) + 1],

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -114,7 +114,7 @@ class Quaternion(Expr):
         c = y * s
         d = z * s
 
-        return cls(a, b, c, d).normalize()
+        return cls(a, b, c, d)
 
     @classmethod
     def from_rotation_matrix(cls, M):

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -574,13 +574,14 @@ class Quaternion(Expr):
         >>> trigsimp(Quaternion.rotate_point((1, 1, 1), (axis, angle)))
         (sqrt(2)*cos(x + pi/4), sqrt(2)*sin(x + pi/4), 1)
         """
+        x, y, z = pin
         if isinstance(r, tuple):
-            # if r is of the form (vector, angle)
-            q = Quaternion.from_axis_angle(r[0], r[1])
+            vector, angle = r
+            q = Quaternion.from_axis_angle(vector, angle)
         else:
             # if r is a quaternion
             q = r.normalize()
-        pout = q * Quaternion(0, pin[0], pin[1], pin[2]) * conjugate(q)
+        pout = q * Quaternion(0, x, y, z) * conjugate(q)
         return (pout.b, pout.c, pout.d)
 
     def to_axis_angle(self):

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -98,6 +98,8 @@ def test_quaternion_functions():
     Quaternion(x**2 / 2, x**2 / 2, x**2 / 2, x**2 / 2)
 
     assert Quaternion.rotate_point((1, 1, 1), q1) == (S.One / 5, 1, S(7) / 5)
+    assert Quaternion.rotate_point((1, 0, 0), q, normalize=False) == \
+        (w**2 + x**2 - y**2 - z**2, 2*w*z + 2*x*y, -2*w*y + 2*x*z)
     n = Symbol('n')
     raises(TypeError, lambda: q1**n)
     n = Symbol('n', integer=True)
@@ -124,15 +126,15 @@ def test_quaternion_conversions():
     theta = symbols("theta", real=True)
     q2 = Quaternion(cos(theta/2), 0, 0, sin(theta/2))
 
-    assert trigsimp(q2.to_rotation_matrix()) == Matrix([
+    assert trigsimp(q2.to_rotation_matrix(normalize=False)) == Matrix([
                                                [cos(theta), -sin(theta), 0],
                                                [sin(theta),  cos(theta), 0],
                                                [0,           0,          1]])
 
-    assert q2.to_axis_angle() == ((0, 0, sin(theta/2)/Abs(sin(theta/2))),
-                                   2*acos(cos(theta/2)))
+    assert q2.to_axis_angle(normalize=False) == ((0, 0, sin(theta/2)/Abs(sin(theta/2))),
+                                                 2*acos(cos(theta/2)))
 
-    assert trigsimp(q2.to_rotation_matrix((1, 1, 1))) == Matrix([
+    assert trigsimp(q2.to_rotation_matrix((1, 1, 1), normalize=False)) == Matrix([
                [cos(theta), -sin(theta), 0, sin(theta) - cos(theta) + 1],
                [sin(theta),  cos(theta), 0, -sin(theta) - cos(theta) + 1],
                [0,           0,          1,  0],


### PR DESCRIPTION
... as suggested by @oscarbenjamin in https://github.com/sympy/sympy/pull/18065#issuecomment-566808193.

#### References to other Issues or PRs

This is an alternative to  #17694 and #18065. Probably the third time it's the charm?

#### Brief description of what is fixed or changed

I added a `normalize` flag to some of the `Quaternion` methods.

The default behavior is unchanged, but if `normalize=False` is given, the quaternion is assumed to already have unit length and no normalization will happen.

It works like this:

```pycon
>>> import sympy as sp
>>> sp.init_printing()
>>> a, b, c, d = sp.symbols('a:d')
>>> q = sp.Quaternion(a, b, c, d)
>>> q.to_rotation_matrix(normalize=False)
⎡     2      2                                          ⎤
⎢- 2⋅c  - 2⋅d  + 1   -2⋅a⋅d + 2⋅b⋅c      2⋅a⋅c + 2⋅b⋅d  ⎥
⎢                                                       ⎥
⎢                        2      2                       ⎥
⎢  2⋅a⋅d + 2⋅b⋅c    - 2⋅b  - 2⋅d  + 1   -2⋅a⋅b + 2⋅c⋅d  ⎥
⎢                                                       ⎥
⎢                                           2      2    ⎥
⎣ -2⋅a⋅c + 2⋅b⋅d      2⋅a⋅b + 2⋅c⋅d    - 2⋅b  - 2⋅c  + 1⎦
```

#### Other comments

This is a smaller and less intrusive change than my previous attempts (and I hope it has less problems, too), but it is also less powerful: If `inverse()` is called (either explicitly or implicitly by some other operation), a division by the squared norm still happens (which could be avoided in my previous attempts).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added `normalize` flag to `Quaternion`
<!-- END RELEASE NOTES -->
