### PR TITLE
Fix Factors().as_expr(): don't multiply rational exponents

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -448,14 +448,12 @@ class Factors(object):
         args = []
         for factor, exp in self.factors.items():
             if exp != 1:
-                b, e = factor.as_base_exp()
                 if isinstance(exp, int):
+                    b, e = factor.as_base_exp()
                     e = _keep_coeff(Integer(exp), e)
-                elif isinstance(exp, Rational):
-                    e = _keep_coeff(exp, e)
+                    args.append(b**e)
                 else:
-                    e *= exp
-                args.append(b**e)
+                    args.append(factor**exp)
             else:
                 args.append(factor)
         return Mul(*args)

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -358,8 +358,8 @@ class Factors(object):
             for f in list(factors.keys()):
                 if isinstance(f, Rational) and not isinstance(f, Integer):
                     p, q = Integer(f.p), Integer(f.q)
-                    factors[p] = (factors[p] if p in factors else 0) + factors[f]
-                    factors[q] = (factors[q] if q in factors else 0) - factors[f]
+                    factors[p] = (factors[p] if p in factors else S.Zero) + factors[f]
+                    factors[q] = (factors[q] if q in factors else S.Zero) - factors[f]
                     factors.pop(f)
             if i:
                 factors[I] = S.One*i
@@ -448,9 +448,9 @@ class Factors(object):
         args = []
         for factor, exp in self.factors.items():
             if exp != 1:
-                if isinstance(exp, (int, Integer)):
+                if isinstance(exp, Integer):
                     b, e = factor.as_base_exp()
-                    e = _keep_coeff(Integer(exp), e)
+                    e = _keep_coeff(exp, e)
                     args.append(b**e)
                 else:
                     args.append(factor**exp)

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -448,7 +448,7 @@ class Factors(object):
         args = []
         for factor, exp in self.factors.items():
             if exp != 1:
-                if isinstance(exp, int):
+                if isinstance(exp, (int, Integer)):
                     b, e = factor.as_base_exp()
                     e = _keep_coeff(Integer(exp), e)
                     args.append(b**e)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -27,6 +27,8 @@ def test_Factors():
     assert Factors({x: 2, y: 3, sin(x): 4}).as_expr() == x**2*y**3*sin(x)**4
     assert Factors(S.Infinity) == Factors({oo: 1})
     assert Factors(S.NegativeInfinity) == Factors({oo: 1, -1: 1})
+    # issue #18059:
+    assert Factors((x**2)**S.Half).as_expr() == (x**2)**S.Half
 
     a = Factors({x: 5, y: 3, z: 7})
     b = Factors({      y: 4, z: 3, t: 10})

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -276,6 +276,9 @@ def test_fu():
     expr = Mul(*[cos(2**i) for i in range(10)])
     assert fu(expr) == sin(1024)/(1024*sin(1))
 
+    # issue #18059:
+    assert fu(cos(x) + sqrt(sin(x)**2)) == cos(x) + sqrt(sin(x)**2)
+
 
 def test_objective():
     assert fu(sin(x)/cos(x), measure=lambda x: x.count_ops()) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18059 

#### Brief description of what is fixed or changed
This commit fixes an invalid simplification in exprtools.py:

Before:
`Factors(sqrt(x**2)).as_expr() == x`
After:
`Factors(sqrt(x**2)).as_expr() == sqrt(x**2)`

This invalid simplification also led to a wrong result
by fu() (and hence trigsimp and simplify). Issue #18059.

Test cases are added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in `Factors().as_expr()` that led to simplifications that are not generally valid for complex numbers. (Exponents were always multiplied in power-of-a-power situations.)
<!-- END RELEASE NOTES -->
