### PR TITLE
Remove __add__ method  from  sympy.core.numbers.Infinity  class

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2843,15 +2843,6 @@ class Infinity(with_metaclass(Singleton, Number)):
         return self._eval_evalf(prec)
 
     @_sympifyit('other', NotImplemented)
-    def __add__(self, other):
-        if isinstance(other, Number):
-            if other is S.NegativeInfinity or other is S.NaN:
-                return S.NaN
-            return self
-        return NotImplemented
-    __radd__ = __add__
-
-    @_sympifyit('other', NotImplemented)
     def __sub__(self, other):
         if isinstance(other, Number):
             if other is S.Infinity or other is S.NaN:


### PR DESCRIPTION
Fixes #18052 

<!-- BEGIN RELEASE NOTES -->
Removing the __add__ method in sympy.core.numbers.Infinity class, as suggested by @oscarbenjamin in the comments.
<!-- END RELEASE NOTES -->