### PR TITLE
Fixed as_poly() by making it raise error with unsupported data types eg: tuples

### DIFF
--- a/doc/src/modules/polys/basics.rst
+++ b/doc/src/modules/polys/basics.rst
@@ -69,7 +69,7 @@ keyword parameter. By default, it is determined by the coefficients
 of the polynomial arguments.
 
 Polynomial expressions can be transformed into polynomials by the
-method :obj:`sympy.core.basic.Basic.as_poly`::
+method :obj:`sympy.core.expr.Expr.as_poly`::
 
     >>> e = (x + y)*(y - 2*z)
     >>> e.as_poly()

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -766,33 +766,7 @@ class Basic(with_metaclass(ManagedProperties)):
         return self.args
 
 
-    def as_poly(self, *gens, **args):
-        """Converts ``self`` to a polynomial or returns ``None``.
 
-        >>> from sympy import sin
-        >>> from sympy.abc import x, y
-
-        >>> print((x**2 + x*y).as_poly())
-        Poly(x**2 + x*y, x, y, domain='ZZ')
-
-        >>> print((x**2 + x*y).as_poly(x, y))
-        Poly(x**2 + x*y, x, y, domain='ZZ')
-
-        >>> print((x**2 + sin(y)).as_poly(x, y))
-        None
-
-        """
-        from sympy.polys import Poly, PolynomialError
-
-        try:
-            poly = Poly(self, *gens, **args)
-
-            if not poly.is_Poly:
-                return None
-            else:
-                return poly
-        except PolynomialError:
-            return None
 
     def as_content_primitive(self, radical=False, clear=True):
         """A stub to allow Basic args (like Tuple) to be skipped when computing

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -765,9 +765,6 @@ class Basic(with_metaclass(ManagedProperties)):
         """
         return self.args
 
-
-
-
     def as_content_primitive(self, radical=False, clear=True):
         """A stub to allow Basic args (like Tuple) to be skipped when computing
         the content and primitive components of an expression.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1076,6 +1076,34 @@ class Expr(Basic, EvalfMixin):
         """Return list of ordered factors (if Mul) else [self]."""
         return [self]
 
+    def as_poly(self, *gens, **args):
+        """Converts ``self`` to a polynomial or returns ``None``.
+
+        >>> from sympy import sin
+        >>> from sympy.abc import x, y
+
+        >>> print((x**2 + x*y).as_poly())
+        Poly(x**2 + x*y, x, y, domain='ZZ')
+
+        >>> print((x**2 + x*y).as_poly(x, y))
+        Poly(x**2 + x*y, x, y, domain='ZZ')
+
+        >>> print((x**2 + sin(y)).as_poly(x, y))
+        None
+
+        """
+        from sympy.polys import Poly, PolynomialError
+
+        try:
+            poly = Poly(self, *gens, **args)
+
+            if not poly.is_Poly:
+                return None
+            else:
+                return poly
+        except PolynomialError:
+            return None
+
     def as_ordered_terms(self, order=None, data=False):
         """
         Transform an expression to an ordered list of terms.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -934,6 +934,9 @@ def test_as_poly_as_expr():
 
     assert p.as_poly() == p
 
+    raises(AttributeError, lambda: Tuple(x, x).as_poly(x))
+    raises(AttributeError, lambda: Tuple(x ** 2, x, y).as_poly(x))
+
 
 def test_nonzero():
     assert bool(S.Zero) is False

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -216,7 +216,7 @@ def test_issue_3560():
 
 
 def test_issue_18038():
-    raises(AttributeError, lambda: integrate((x, x))
+    raises(AttributeError, lambda: integrate((x, x)))
 
 
 def test_integrate_poly():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -215,6 +215,10 @@ def test_issue_3560():
     assert integrate(1/sqrt(x)**3, x) == -2/sqrt(x)
 
 
+def test_issue_18038():
+    raises(AttributeError, lambda: integrate((x, x))
+
+
 def test_integrate_poly():
     p = Poly(x + x**2*y + y**3, x, y)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18038 


#### Brief description of what is fixed or changed

The commit fixes Issue #18038 in which as_poly() would work with tuples and give wrong output. This was fixed by making it an attribute of Expr as tuples are not a subclass Expr. Tests for the same were added  in sympy/core/tests/test_expr.py and sympy/integrals/tests/test_integrals.py . This ultimately fixed the issue where integrate((x, x)) would give a wrong result.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Moved .as_poly() from Basic to Expr.
<!-- END RELEASE NOTES -->
