### PR TITLE
Fix flake8 warnings in a number of packages

### DIFF
--- a/doc/src/modules/interactive.rst
+++ b/doc/src/modules/interactive.rst
@@ -3,7 +3,6 @@
 =============
 
 .. automodule:: sympy.interactive
-   :members:
 
 Session
 =======

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -3,8 +3,6 @@ from sympy import (Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt,
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
-from sympy.utilities.pytest import slow
-from sympy.core import S
 
 
 def test_Abs():

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -10,7 +10,6 @@ from sympy import MatrixSymbol, Sum
 from sympy.combinatorics import Permutation
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.expressions.diagonal import DiagMatrix
-from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.matrices import Trace, MatAdd, MatMul, Transpose
 from sympy.utilities.pytest import raises
 

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -12,6 +12,8 @@ from sympy.combinatorics import PermutationGroup
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 from sympy.core.compatibility import string_types
+from sympy.utilities.magic import pollute
+from sympy import symbols
 
 from itertools import product
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -3,8 +3,8 @@ from __future__ import print_function, division
 import random
 from collections import defaultdict
 
-from sympy.core.basic import Atom, Basic
 from sympy.core.parameters import global_parameters
+from sympy.core.basic import Atom
 from sympy.core.expr import Expr
 from sympy.core.compatibility import \
     is_sequence, reduce, range, as_int, Iterable

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -9,8 +9,7 @@ from sympy.core.singleton import S
 from sympy.combinatorics.permutations import \
     Permutation, _af_parity, _af_rmul, _af_rmuln, AppliedPermutation, Cycle
 from sympy.printing import sstr, srepr, pretty, latex
-from sympy.utilities.pytest import raises, SymPyDeprecationWarning, \
-    warns_deprecated_sympy
+from sympy.utilities.pytest import raises, warns_deprecated_sympy
 
 
 rmul = Permutation.rmul

--- a/sympy/concrete/__init__.py
+++ b/sympy/concrete/__init__.py
@@ -1,2 +1,8 @@
 from .products import product, Product
 from .summations import summation, Sum
+
+__all__ = [
+    'product', 'Product',
+
+    'summation', 'Sum',
+]

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -402,9 +402,9 @@ def test_euler_maclaurin():
     # Not exact
     assert Sum(k**6, (k, a, b)).euler_maclaurin(0, 2)[1] != 0
     # Numerical test
-    for mi, n in [(2, 4), (2, 20), (10, 20), (18, 20)]:
+    for mi, ni in [(2, 4), (2, 20), (10, 20), (18, 20)]:
         A = Sum(1/k**3, (k, 1, oo))
-        s, e = A.euler_maclaurin(mi, n)
+        s, e = A.euler_maclaurin(mi, ni)
         assert abs((s - zeta(3)).evalf()) < e.evalf()
 
     raises(ValueError, lambda: Sum(1, (x, 0, 1), (k, 0, 1)).euler_maclaurin())

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -402,9 +402,9 @@ def test_euler_maclaurin():
     # Not exact
     assert Sum(k**6, (k, a, b)).euler_maclaurin(0, 2)[1] != 0
     # Numerical test
-    for m, n in [(2, 4), (2, 20), (10, 20), (18, 20)]:
+    for mi, n in [(2, 4), (2, 20), (10, 20), (18, 20)]:
         A = Sum(1/k**3, (k, 1, oo))
-        s, e = A.euler_maclaurin(m, n)
+        s, e = A.euler_maclaurin(mi, n)
         assert abs((s - zeta(3)).evalf()) < e.evalf()
 
     raises(ValueError, lambda: Sum(1, (x, 0, 1), (k, 0, 1)).euler_maclaurin())

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -33,3 +33,55 @@ Catalan = S.Catalan
 EulerGamma = S.EulerGamma
 GoldenRatio = S.GoldenRatio
 TribonacciConstant = S.TribonacciConstant
+
+__all__ = [
+    'sympify', 'SympifyError',
+
+    'cacheit',
+
+    'Basic', 'Atom', 'preorder_traversal',
+
+    'S',
+
+    'Expr', 'AtomicExpr', 'UnevaluatedExpr',
+
+    'Symbol', 'Wild', 'Dummy', 'symbols', 'var',
+
+    'Number', 'Float', 'Rational', 'Integer', 'NumberSymbol', 'RealNumber',
+    'igcd', 'ilcm', 'seterr', 'E', 'I', 'nan', 'oo', 'pi', 'zoo',
+    'AlgebraicNumber', 'comp', 'mod_inverse',
+
+    'Pow', 'integer_nthroot', 'integer_log',
+
+    'Mul', 'prod',
+
+    'Add',
+
+    'Mod',
+
+    'Rel', 'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge', 'Equality', 'GreaterThan',
+    'LessThan', 'Unequality', 'StrictGreaterThan', 'StrictLessThan',
+
+    'vectorize',
+
+    'Lambda', 'WildFunction', 'Derivative', 'diff', 'FunctionClass',
+    'Function', 'Subs', 'expand', 'PoleError', 'count_ops', 'expand_mul',
+    'expand_log', 'expand_func', 'expand_trig', 'expand_complex',
+    'expand_multinomial', 'nfloat', 'expand_power_base', 'expand_power_exp',
+    'arity',
+
+    'PrecisionExhausted', 'N',
+
+    'evalf', # The module?
+
+    'Tuple', 'Dict',
+
+    'gcd_terms', 'factor_terms', 'factor_nc',
+
+    'evaluate',
+
+    'Catalan',
+    'EulerGamma',
+    'GoldenRatio',
+    'TribonacciConstant',
+]

--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -7,7 +7,7 @@ if USE_SYMENGINE:
         SympifyError, exp, log, gamma, sqrt, I, E, pi, Matrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
         sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth,
-        lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
+        lambdify, symarray, diff, zeros, eye, diag, ones,
         expand, Function, symbols, var, Add, Mul, Derivative,
         ImmutableMatrix, MatrixBase, Rational, Basic)
     from symengine.lib.symengine_wrapper import gcd as igcd
@@ -17,7 +17,17 @@ else:
         SympifyError, exp, log, gamma, sqrt, I, E, pi, Matrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
         sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth,
-        lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
+        lambdify, symarray, diff, zeros, eye, diag, ones,
         expand, Function, symbols, var, Add, Mul, Derivative,
         ImmutableMatrix, MatrixBase, Rational, Basic, igcd)
     from sympy.core.function import AppliedUndef
+
+__all__ = [
+    'Symbol', 'Integer', 'sympify', 'S', 'SympifyError', 'exp', 'log',
+    'gamma', 'sqrt', 'I', 'E', 'pi', 'Matrix', 'sin', 'cos', 'tan', 'cot',
+    'csc', 'sec', 'asin', 'acos', 'atan', 'acot', 'acsc', 'asec', 'sinh',
+    'cosh', 'tanh', 'coth', 'asinh', 'acosh', 'atanh', 'acoth', 'lambdify',
+    'symarray', 'diff', 'zeros', 'eye', 'diag', 'ones', 'expand', 'Function',
+    'symbols', 'var', 'Add', 'Mul', 'Derivative', 'ImmutableMatrix',
+    'MatrixBase', 'Rational', 'Basic', 'igcd', 'AppliedUndef',
+]

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1771,10 +1771,10 @@ class Basic(with_metaclass(ManagedProperties)):
             if isinstance(args[-1], string_types):
                 rule = '_eval_rewrite_as_' + args[-1]
             else:
-                try:
-                    rule = '_eval_rewrite_as_' + args[-1].__name__
-                except:
-                    rule = '_eval_rewrite_as_' + args[-1].__class__.__name__
+                name = getattr(args[-1], '__name__', None)
+                if name is None:
+                    name = args[-1].__class__.__name__
+                rule = '_eval_rewrite_as_' + name
 
             if not pattern:
                 return self._eval_rewrite(None, rule, **hints)

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -40,7 +40,6 @@ CACHE = _cache()
 print_cache = CACHE.print_cache
 clear_cache = CACHE.clear_cache
 
-from sympy.core.compatibility import lru_cache
 from functools import update_wrapper
 
 try:
@@ -62,6 +61,7 @@ try:
     lru_cache = fastcache.clru_cache
 
 except ImportError:
+    from sympy.core.compatibility import lru_cache
 
     def __cacheit(maxsize):
         """caching decorator.

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -61,6 +61,18 @@ Metaclasses:
                 pass
 """
 
+__all__ = [
+    'PY3', 'class_types', 'integer_types', 'string_types', 'long', 'int_info',
+    'unicode', 'unichr', 'u_decode', 'Iterator', 'get_function_code',
+    'get_function_globals', 'get_function_name', 'builtins', 'reduce',
+    'StringIO', 'cStringIO', 'exec_', 'range', 'round', 'Mapping', 'Callable',
+    'MutableMapping', 'MutableSet', 'Iterable', 'Hashable', 'unwrap',
+    'accumulate', 'with_metaclass', 'NotIterable', 'iterable', 'is_sequence',
+    'zip_longest', 'maketrans', 'as_int', 'default_sort_key', 'ordered',
+    'GROUND_TYPES', 'HAS_GMPY', 'gmpy', 'SYMPY_INTS', 'lru_cache',
+    'filterfalse', 'clock',
+]
+
 import sys
 PY3 = sys.version_info[0] > 2
 
@@ -101,7 +113,6 @@ if PY3:
     from inspect import unwrap
     from itertools import accumulate
 else:
-    import codecs
     import types
 
     class_types = (type, types.ClassType)
@@ -143,7 +154,7 @@ else:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
 
-    range = xrange
+    range = xrange  # noqa:F821
     _round = round
     def round(x, *args):
         try:
@@ -810,143 +821,143 @@ def _make_key(args, kwds, typed,
         return key[0]
     return _HashedSeq(key)
 
-def lru_cache(maxsize=100, typed=False):
-    """Least-recently-used cache decorator.
-
-    If *maxsize* is set to None, the LRU features are disabled and the cache
-    can grow without bound.
-
-    If *typed* is True, arguments of different types will be cached separately.
-    For example, f(3.0) and f(3) will be treated as distinct calls with
-    distinct results.
-
-    Arguments to the cached function must be hashable.
-
-    View the cache statistics named tuple (hits, misses, maxsize, currsize) with
-    f.cache_info().  Clear the cache and statistics with f.cache_clear().
-    Access the underlying function with f.__wrapped__.
-
-    See:  https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
-
-    """
-
-    # Users should only access the lru_cache through its public API:
-    #       cache_info, cache_clear, and f.__wrapped__
-    # The internals of the lru_cache are encapsulated for thread safety and
-    # to allow the implementation to change (including a possible C version).
-
-    def decorating_function(user_function):
-
-        cache = dict()
-        stats = [0, 0]                  # make statistics updateable non-locally
-        HITS, MISSES = 0, 1             # names for the stats fields
-        make_key = _make_key
-        cache_get = cache.get           # bound method to lookup key or return None
-        _len = len                      # localize the global len() function
-        lock = RLock()                  # because linkedlist updates aren't threadsafe
-        root = []                       # root of the circular doubly linked list
-        root[:] = [root, root, None, None]      # initialize by pointing to self
-        nonlocal_root = [root]                  # make updateable non-locally
-        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3    # names for the link fields
-
-        if maxsize == 0:
-
-            def wrapper(*args, **kwds):
-                # no caching, just do a statistics update after a successful call
-                result = user_function(*args, **kwds)
-                stats[MISSES] += 1
-                return result
-
-        elif maxsize is None:
-
-            def wrapper(*args, **kwds):
-                # simple caching without ordering or size limit
-                key = make_key(args, kwds, typed)
-                result = cache_get(key, root)   # root used here as a unique not-found sentinel
-                if result is not root:
-                    stats[HITS] += 1
-                    return result
-                result = user_function(*args, **kwds)
-                cache[key] = result
-                stats[MISSES] += 1
-                return result
-
-        else:
-
-            def wrapper(*args, **kwds):
-                # size limited caching that tracks accesses by recency
-                try:
-                    key = make_key(args, kwds, typed) if kwds or typed else args
-                except TypeError:
-                    stats[MISSES] += 1
-                    return user_function(*args, **kwds)
-                with lock:
-                    link = cache_get(key)
-                    if link is not None:
-                        # record recent use of the key by moving it to the front of the list
-                        root, = nonlocal_root
-                        link_prev, link_next, key, result = link
-                        link_prev[NEXT] = link_next
-                        link_next[PREV] = link_prev
-                        last = root[PREV]
-                        last[NEXT] = root[PREV] = link
-                        link[PREV] = last
-                        link[NEXT] = root
-                        stats[HITS] += 1
-                        return result
-                result = user_function(*args, **kwds)
-                with lock:
-                    root, = nonlocal_root
-                    if key in cache:
-                        # getting here means that this same key was added to the
-                        # cache while the lock was released.  since the link
-                        # update is already done, we need only return the
-                        # computed result and update the count of misses.
-                        pass
-                    elif _len(cache) >= maxsize:
-                        # use the old root to store the new key and result
-                        oldroot = root
-                        oldroot[KEY] = key
-                        oldroot[RESULT] = result
-                        # empty the oldest link and make it the new root
-                        root = nonlocal_root[0] = oldroot[NEXT]
-                        oldkey = root[KEY]
-                        root[KEY] = root[RESULT] = None
-                        # now update the cache dictionary for the new links
-                        del cache[oldkey]
-                        cache[key] = oldroot
-                    else:
-                        # put result in a new link at the front of the list
-                        last = root[PREV]
-                        link = [last, root, key, result]
-                        last[NEXT] = root[PREV] = cache[key] = link
-                    stats[MISSES] += 1
-                return result
-
-        def cache_info():
-            """Report cache statistics"""
-            with lock:
-                return _CacheInfo(stats[HITS], stats[MISSES], maxsize, len(cache))
-
-        def cache_clear():
-            """Clear the cache and cache statistics"""
-            with lock:
-                cache.clear()
-                root = nonlocal_root[0]
-                root[:] = [root, root, None, None]
-                stats[:] = [0, 0]
-
-        wrapper.__wrapped__ = user_function
-        wrapper.cache_info = cache_info
-        wrapper.cache_clear = cache_clear
-        return update_wrapper(wrapper, user_function)
-
-    return decorating_function
-### End of backported lru_cache
-
 if sys.version_info[:2] >= (3, 3):
     # 3.2 has an lru_cache with an incompatible API
     from functools import lru_cache
+else:
+    def lru_cache(maxsize=100, typed=False):
+        """Least-recently-used cache decorator.
+
+        If *maxsize* is set to None, the LRU features are disabled and the cache
+        can grow without bound.
+
+        If *typed* is True, arguments of different types will be cached separately.
+        For example, f(3.0) and f(3) will be treated as distinct calls with
+        distinct results.
+
+        Arguments to the cached function must be hashable.
+
+        View the cache statistics named tuple (hits, misses, maxsize, currsize) with
+        f.cache_info().  Clear the cache and statistics with f.cache_clear().
+        Access the underlying function with f.__wrapped__.
+
+        See:  https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+
+        """
+
+        # Users should only access the lru_cache through its public API:
+        #       cache_info, cache_clear, and f.__wrapped__
+        # The internals of the lru_cache are encapsulated for thread safety and
+        # to allow the implementation to change (including a possible C version).
+
+        def decorating_function(user_function):
+
+            cache = dict()
+            stats = [0, 0]                  # make statistics updateable non-locally
+            HITS, MISSES = 0, 1             # names for the stats fields
+            make_key = _make_key
+            cache_get = cache.get           # bound method to lookup key or return None
+            _len = len                      # localize the global len() function
+            lock = RLock()                  # because linkedlist updates aren't threadsafe
+            root = []                       # root of the circular doubly linked list
+            root[:] = [root, root, None, None]      # initialize by pointing to self
+            nonlocal_root = [root]                  # make updateable non-locally
+            PREV, NEXT, KEY, RESULT = 0, 1, 2, 3    # names for the link fields
+
+            if maxsize == 0:
+
+                def wrapper(*args, **kwds):
+                    # no caching, just do a statistics update after a successful call
+                    result = user_function(*args, **kwds)
+                    stats[MISSES] += 1
+                    return result
+
+            elif maxsize is None:
+
+                def wrapper(*args, **kwds):
+                    # simple caching without ordering or size limit
+                    key = make_key(args, kwds, typed)
+                    result = cache_get(key, root)   # root used here as a unique not-found sentinel
+                    if result is not root:
+                        stats[HITS] += 1
+                        return result
+                    result = user_function(*args, **kwds)
+                    cache[key] = result
+                    stats[MISSES] += 1
+                    return result
+
+            else:
+
+                def wrapper(*args, **kwds):
+                    # size limited caching that tracks accesses by recency
+                    try:
+                        key = make_key(args, kwds, typed) if kwds or typed else args
+                    except TypeError:
+                        stats[MISSES] += 1
+                        return user_function(*args, **kwds)
+                    with lock:
+                        link = cache_get(key)
+                        if link is not None:
+                            # record recent use of the key by moving it to the front of the list
+                            root, = nonlocal_root
+                            link_prev, link_next, key, result = link
+                            link_prev[NEXT] = link_next
+                            link_next[PREV] = link_prev
+                            last = root[PREV]
+                            last[NEXT] = root[PREV] = link
+                            link[PREV] = last
+                            link[NEXT] = root
+                            stats[HITS] += 1
+                            return result
+                    result = user_function(*args, **kwds)
+                    with lock:
+                        root, = nonlocal_root
+                        if key in cache:
+                            # getting here means that this same key was added to the
+                            # cache while the lock was released.  since the link
+                            # update is already done, we need only return the
+                            # computed result and update the count of misses.
+                            pass
+                        elif _len(cache) >= maxsize:
+                            # use the old root to store the new key and result
+                            oldroot = root
+                            oldroot[KEY] = key
+                            oldroot[RESULT] = result
+                            # empty the oldest link and make it the new root
+                            root = nonlocal_root[0] = oldroot[NEXT]
+                            oldkey = root[KEY]
+                            root[KEY] = root[RESULT] = None
+                            # now update the cache dictionary for the new links
+                            del cache[oldkey]
+                            cache[key] = oldroot
+                        else:
+                            # put result in a new link at the front of the list
+                            last = root[PREV]
+                            link = [last, root, key, result]
+                            last[NEXT] = root[PREV] = cache[key] = link
+                        stats[MISSES] += 1
+                    return result
+
+            def cache_info():
+                """Report cache statistics"""
+                with lock:
+                    return _CacheInfo(stats[HITS], stats[MISSES], maxsize, len(cache))
+
+            def cache_clear():
+                """Clear the cache and cache statistics"""
+                with lock:
+                    cache.clear()
+                    root = nonlocal_root[0]
+                    root[:] = [root, root, None, None]
+                    stats[:] = [0, 0]
+
+            wrapper.__wrapped__ = user_function
+            wrapper.cache_info = cache_info
+            wrapper.cache_clear = cache_clear
+            return update_wrapper(wrapper, user_function)
+
+        return decorating_function
+    ### End of backported lru_cache
 
 try:
     from itertools import filterfalse

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function, division
 
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 
 from sympy.core import S
 from sympy.core.basic import Basic

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -28,7 +28,7 @@ from mpmath.ctx_mp import mpnumeric
 from mpmath.libmp.libmpf import (
     finf as _mpf_inf, fninf as _mpf_ninf,
     fnan as _mpf_nan, fzero, _normalize as mpf_normalize,
-    prec_to_dps, fone, fnone)
+    prec_to_dps)
 from sympy.utilities.misc import debug, filldedent
 from .parameters import global_parameters
 
@@ -1416,7 +1416,6 @@ class Float(Number):
         return not self == other
 
     def _Frel(self, other, op):
-        from sympy.core.evalf import evalf
         from sympy.core.numbers import prec_to_dps
         try:
             other = _sympify(other)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -464,7 +464,6 @@ class Equality(Relational):
 
     def __new__(cls, lhs, rhs=None, **options):
         from sympy.core.add import Add
-        from sympy.core.containers import Tuple
         from sympy.core.logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
         from sympy.core.expr import _n2
         from sympy.functions.elementary.complexes import arg

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -214,6 +214,7 @@ class Symbol(AtomicExpr, Boolean):
         base = self.assumptions0
         for k in set(assumptions) & set(base):
             if assumptions[k] != base[k]:
+                from sympy.utilities.misc import filldedent
                 raise ValueError(filldedent('''
                     non-matching assumptions for %s: existing value
                     is %s and new value is %s''' % (

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division
 
 from inspect import getmro
 
-from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .parameters import global_parameters
 
@@ -495,6 +494,9 @@ def kernS(s):
         try:
             expr = sympify(s)
             break
+        # XXX: What exception can be caught here? Broad except should not be
+        # used without a clear reason. Running the test suite does not lead to
+        # any errors at this point...
         except:  # the kern might cause unknown errors, so use bare except
             if hit:
                 s = olds  # maybe it didn't like the kern; use un-kerned s

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4680,27 +4680,31 @@ def test_sympy__vector__point__Point():
 
 
 def test_sympy__vector__basisdependent__BasisDependent():
-    from sympy.vector.basisdependent import BasisDependent
+    #from sympy.vector.basisdependent import BasisDependent
     #These classes have been created to maintain an OOP hierarchy
     #for Vectors and Dyadics. Are NOT meant to be initialized
+    pass
 
 
 def test_sympy__vector__basisdependent__BasisDependentMul():
-    from sympy.vector.basisdependent import BasisDependentMul
+    #from sympy.vector.basisdependent import BasisDependentMul
     #These classes have been created to maintain an OOP hierarchy
     #for Vectors and Dyadics. Are NOT meant to be initialized
+    pass
 
 
 def test_sympy__vector__basisdependent__BasisDependentAdd():
-    from sympy.vector.basisdependent import BasisDependentAdd
+    #from sympy.vector.basisdependent import BasisDependentAdd
     #These classes have been created to maintain an OOP hierarchy
     #for Vectors and Dyadics. Are NOT meant to be initialized
+    pass
 
 
 def test_sympy__vector__basisdependent__BasisDependentZero():
-    from sympy.vector.basisdependent import BasisDependentZero
+    #from sympy.vector.basisdependent import BasisDependentZero
     #These classes have been created to maintain an OOP hierarchy
     #for Vectors and Dyadics. Are NOT meant to be initialized
+    pass
 
 
 def test_sympy__vector__vector__BaseVector():
@@ -4735,7 +4739,7 @@ def test_sympy__vector__vector__VectorZero():
 
 
 def test_sympy__vector__vector__Vector():
-    from sympy.vector.vector import Vector
+    #from sympy.vector.vector import Vector
     #Vector is never to be initialized using args
     pass
 
@@ -4755,7 +4759,7 @@ def test_sympy__vector__vector__Dot():
 
 
 def test_sympy__vector__dyadic__Dyadic():
-    from sympy.vector.dyadic import Dyadic
+    #from sympy.vector.dyadic import Dyadic
     #Dyadic is never to be initialized using args
     pass
 
@@ -4821,13 +4825,15 @@ def test_sympy__vector__operators__Gradient():
 
 
 def test_sympy__vector__orienters__Orienter():
-    from sympy.vector.orienters import Orienter
+    #from sympy.vector.orienters import Orienter
     #Not to be initialized
+    pass
 
 
 def test_sympy__vector__orienters__ThreeAngleOrienter():
-    from sympy.vector.orienters import ThreeAngleOrienter
+    #from sympy.vector.orienters import ThreeAngleOrienter
     #Not to be initialized
+    pass
 
 
 def test_sympy__vector__orienters__AxisOrienter():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -20,7 +20,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from mpmath import mpf
 from mpmath.rational import mpq
 import mpmath
-from sympy import numbers
+from sympy.core import numbers
 t = Symbol('t', real=False)
 
 _ninf = float(-oo)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -1,9 +1,8 @@
 from sympy.core import (
     Rational, Symbol, S, Float, Integer, Mul, Number, Pow,
-    Basic, I, nan, pi, symbols, oo, zoo, Rational, N)
+    Basic, I, nan, pi, symbols, oo, zoo, N)
 from sympy.core.tests.test_evalf import NS
 from sympy.core.function import expand_multinomial
-from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.special.error_functions import erf

--- a/sympy/core/tests/test_singleton.py
+++ b/sympy/core/tests/test_singleton.py
@@ -1,6 +1,6 @@
 from sympy.core.basic import Basic
 from sympy.core.numbers import Rational
-from sympy.core.singleton import S, Singleton, SingletonRegistry
+from sympy.core.singleton import S, Singleton
 
 from sympy.core.compatibility import with_metaclass, exec_
 

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -51,11 +51,11 @@ def test_var_keywords():
 
 def test_var_cls():
     ns = {"var": var, "Function": Function}
-    f = eval("var('f', cls=Function)", ns)
+    eval("var('f', cls=Function)", ns)
 
     assert isinstance(ns['f'], FunctionClass)
 
-    g, h = eval("var('g,h', cls=Function)", ns)
+    eval("var('g,h', cls=Function)", ns)
 
     assert isinstance(ns['g'], FunctionClass)
     assert isinstance(ns['h'], FunctionClass)

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -195,10 +195,10 @@ def test_functions():
 def test_issue_4023():
     sage.var("a x")
     log = sage.log
-    i = sympy.integrate(log(x)/a, (x, a, a + 1))
+    i = sympy.integrate(log(x)/a, (x, a, a + 1)) # noqa:F821
     i2 = sympy.simplify(i)
     s = sage.SR(i2)
-    is_trivially_equal(s, -log(a) + log(a + 1) + log(a + 1)/a - 1/a)
+    is_trivially_equal(s, -log(a) + log(a + 1) + log(a + 1)/a - 1/a) # noqa:F821
 
 def test_integral():
     #test Sympy-->Sage

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -8,9 +8,7 @@ from sympy.functions.elementary.exponential import exp, log, match_real_imag
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.integers import floor
 
-from sympy import pi, Eq
-from sympy.logic import Or, And
-from sympy.core.logic import fuzzy_or, fuzzy_and, fuzzy_bool
+from sympy.core.logic import fuzzy_or, fuzzy_and
 
 
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1100,7 +1100,6 @@ def test_cosh_expansion():
 def test_cosh_positive():
     # See issue 11721
     # cosh(x) is positive for real values of x
-    x = symbols('x')
     k = symbols('k', real=True)
     n = symbols('n', integer=True)
 
@@ -1110,7 +1109,6 @@ def test_cosh_positive():
     assert cosh(3*I*pi/4, evaluate=False).is_positive is False
 
 def test_cosh_nonnegative():
-    x = symbols('x')
     k = symbols('k', real=True)
     n = symbols('n', integer=True)
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -3,7 +3,7 @@ from itertools import product
 from sympy import (jn, yn, symbols, Symbol, sin, cos, pi, S, jn_zeros, besselj,
                    bessely, besseli, besselk, hankel1, hankel2, hn1, hn2,
                    expand_func, sqrt, sinh, cosh, diff, series, gamma, hyper,
-                   Abs, I, O, oo, conjugate, uppergamma, exp, Integral, Sum,
+                   I, O, oo, conjugate, uppergamma, exp, Integral, Sum,
                    Rational)
 from sympy.functions.special.bessel import fn
 from sympy.functions.special.bessel import (airyai, airybi,

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -475,7 +475,7 @@ class Polygon(GeometrySet):
         Examples
         ========
 
-        >>> from sympy import Point, Polygon, symbol
+        >>> from sympy import Point, Polygon
         >>> a, b = 50, 10
         >>> p1, p2, p3, p4 = [(0, b), (0, 0), (a, 0), (a, b)]
         >>> p = Polygon(p1, p2, p3, p4)

--- a/sympy/interactive/__init__.py
+++ b/sympy/interactive/__init__.py
@@ -2,3 +2,5 @@
 
 from .printing import init_printing
 from .session import init_session
+
+__all__ = ['init_printing', 'init_session']

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division
 
 from distutils.version import LooseVersion as V
 
-from sympy.external import import_module
 from sympy.interactive.printing import init_printing
 
 preexec_source = """\

--- a/sympy/liealgebras/__init__.py
+++ b/sympy/liealgebras/__init__.py
@@ -1,1 +1,3 @@
 from sympy.liealgebras.cartan_type import CartanType
+
+__all__ = ['CartanType']

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -46,7 +46,8 @@ __all__ = [
 
     'hadamard_product', 'HadamardProduct', 'hadamard_power', 'HadamardPower',
 
-    'DiagonalMatrix', 'DiagonalOf', 'DiagonalizeVector', 'diagonalize_vector',
+    'DiagonalMatrix', 'DiagonalOf', 'DiagMatrix', 'DiagonalizeVector',
+    'diagonalize_vector',
 
     'DotProduct',
 

--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -1,6 +1,5 @@
 from sympy.matrices.expressions import MatrixExpr
 from sympy import MatrixBase, Dummy, Lambda, Function, FunctionClass
-from sympy.core.basic import Basic
 from sympy.core.sympify import sympify, _sympify
 
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -13,7 +13,7 @@ from .matexpr import \
     MatrixExpr, ShapeError, Identity, ZeroMatrix, GenericIdentity
 from .matpow import MatPow
 from .transpose import transpose
-from .permutation import MatrixPermute, PermutationMatrix
+from .permutation import PermutationMatrix
 
 
 # XXX: MatMul should perhaps not subclass directly from Mul
@@ -160,7 +160,6 @@ class MatMul(MatrixExpr, Mul):
                 arg.inverse() if isinstance(arg, MatrixExpr) else arg**-1
                     for arg in self.args[::-1]]).doit()
         except ShapeError:
-            from sympy.matrices.expressions.inverse import Inverse
             return Inverse(self)
 
     def doit(self, **kwargs):

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -1,8 +1,7 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic, S
+from sympy.core import S
 from sympy.core.sympify import _sympify
-from sympy.core.compatibility import iterable
 from sympy.functions import KroneckerDelta
 
 from .matexpr import MatrixExpr, Identity, ZeroMatrix, OneMatrix
@@ -288,7 +287,6 @@ class MatrixPermute(MatrixExpr):
 
     def _eval_rewrite_as_MatMul(self, *args, **kwargs):
         from .matmul import MatMul
-        from .inverse import Inverse
 
         mat, perm, axis = self.args
 

--- a/sympy/matrices/expressions/tests/test_permutation.py
+++ b/sympy/matrices/expressions/tests/test_permutation.py
@@ -1,4 +1,4 @@
-from sympy.combinatorics import Permutation, SymmetricGroup
+from sympy.combinatorics import Permutation
 from sympy.core.expr import unchanged
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import \

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -296,7 +296,7 @@ if cin:
             if (c_ret_type == 'void'):
                 ret_type = none
             elif(c_ret_type == 'int'):
-                ret_type = type = IntBaseType(String('integer'))
+                ret_type = IntBaseType(String('integer'))
             elif (c_ret_type == 'float'):
                 ret_type = FloatBaseType(String('real'))
             else:

--- a/sympy/parsing/tests/test_ast_parser.py
+++ b/sympy/parsing/tests/test_ast_parser.py
@@ -1,4 +1,4 @@
-from sympy import symbols, S, Rational, Lambda
+from sympy import symbols, S
 from sympy.parsing.ast_parser import parse_expr
 from sympy.utilities.pytest import raises
 from sympy.core.sympify import SympifyError

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -1,10 +1,3 @@
-# Testing import
-from sympy.parsing.latex._build_latex_antlr import (
-    build_parser,
-    check_antlr_version,
-    dir_latex_antlr
-)
-
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.external import import_module
 
@@ -48,6 +41,16 @@ def _factorial(a):
 
 def _log(a, b):
     return log(a, b, evaluate=False)
+
+
+def test_import():
+    from sympy.parsing.latex._build_latex_antlr import (
+        build_parser,
+        check_antlr_version,
+        dir_latex_antlr
+    )
+    # XXX: It would be better to come up with a test for these...
+    del build_parser, check_antlr_version, dir_latex_antlr
 
 
 # These LaTeX strings should parse to the corresponding SymPy expression

--- a/sympy/parsing/tests/test_maxima.py
+++ b/sympy/parsing/tests/test_maxima.py
@@ -15,11 +15,11 @@ def test_parser():
 def test_injection():
     parse_maxima('c: x+1', globals=globals())
     # c created by parse_maxima
-    assert c == x + 1
+    assert c == x + 1 # noqa:F821
 
     parse_maxima('g: sqrt(81)', globals=globals())
     # g created by parse_maxima
-    assert g == 9
+    assert g == 9 # noqa:F821
 
 
 def test_maxima_functions():

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -4,6 +4,8 @@ from sympy.core.backend import sympify
 from sympy.core.compatibility import string_types
 from sympy.physics.vector import Point
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 __all__ = ['Particle']
 
 

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -4,6 +4,8 @@ from sympy.core.backend import sympify
 from sympy.core.compatibility import string_types
 from sympy.physics.vector import Point, ReferenceFrame, Dyadic
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 __all__ = ['RigidBody']
 
 

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,6 +1,5 @@
 from sympy import symbols
-from sympy.physics.mechanics import (Point, Particle, ReferenceFrame, inertia,
-                                     inertia_of_point_mass)
+from sympy.physics.mechanics import Point, Particle, ReferenceFrame, inertia
 
 from sympy.utilities.pytest import raises
 

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,4 +1,4 @@
-from sympy import symbols, S
+from sympy import symbols
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
 from sympy.physics.mechanics import dynamicsymbols, outer, inertia
 from sympy.physics.mechanics import inertia_of_point_mass

--- a/sympy/physics/optics/__init__.py
+++ b/sympy/physics/optics/__init__.py
@@ -35,4 +35,4 @@ from .utils import (refraction_angle, deviation, fresnel_coefficients,
 from .polarization import (jones_vector, stokes_vector, jones_2_stokes,
         linear_polarizer, phase_retarder, half_wave_retarder,
         quarter_wave_retarder, transmissive_filter, reflective_filter,
-        mueller_matrix, polarizing_beam_splitter)
+        mueller_matrix)

--- a/sympy/physics/quantum/tests/test_identitysearch.py
+++ b/sympy/physics/quantum/tests/test_identitysearch.py
@@ -1,6 +1,5 @@
 from sympy.external import import_module
 from sympy import Mul, Integer
-from sympy.core.compatibility import PY3
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.gate import (X, Y, Z, H, CNOT,
         IdentityGate, CGate, PhaseGate, TGate)
@@ -8,7 +7,7 @@ from sympy.physics.quantum.identitysearch import (generate_gate_rules,
         generate_equivalent_ids, GateIdentity, bfs_identity_search,
         is_scalar_sparse_matrix,
         is_scalar_nonsparse_matrix, is_degenerate, is_reducible)
-from sympy.utilities.pytest import skip, XFAIL
+from sympy.utilities.pytest import skip
 
 
 def create_gate_sequence(qubit=0):

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -14,7 +14,7 @@ from sympy import (Dummy, expand, Function, I, S, simplify, sqrt, Sum,
                    Symbol, symbols, srepr, Rational)
 
 from sympy.core.compatibility import range
-from sympy.utilities.pytest import XFAIL, slow, raises
+from sympy.utilities.pytest import slow, raises
 from sympy.printing.latex import latex
 
 

--- a/sympy/physics/units/definitions/unit_definitions.py
+++ b/sympy/physics/units/definitions/unit_definitions.py
@@ -2,7 +2,7 @@ from sympy.physics.units.definitions.dimension_definitions import current, tempe
     luminous_intensity, angle, charge, voltage, impedance, conductance, capacitance, inductance, magnetic_density, \
     magnetic_flux, information
 
-from sympy import Rational, pi, sqrt, S
+from sympy import Rational, pi, S
 from sympy.physics.units.prefixes import kilo, milli, micro, deci, centi, nano, pico, kibi, mebi, gibi, tebi, pebi, exbi
 from sympy.physics.units.quantities import Quantity
 

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division
 
 from sympy.core import S, Basic, Add, Mul, symbols, Dummy
 from sympy.core.compatibility import range
-from sympy.functions.combinatorial.factorials import factorial
 from sympy.polys.polyerrors import (
     PolificationFailed, ComputationFailed,
     MultivariatePolynomialError, OptionError)

--- a/sympy/polys/tests/test_multivariate_resultants.py
+++ b/sympy/polys/tests/test_multivariate_resultants.py
@@ -1,6 +1,6 @@
 """Tests for Dixon's and Macaulay's classes. """
 
-from sympy import Matrix
+from sympy import Matrix, factor
 from sympy.core import symbols
 from sympy.tensor.indexed import IndexedBase
 

--- a/sympy/polys/tests/test_multivariate_resultants.py
+++ b/sympy/polys/tests/test_multivariate_resultants.py
@@ -211,7 +211,6 @@ def test_get_KSY_Dixon_resultant_example_two():
     dixon = DixonResultant([p, q, h], [x, y])
     dixon_poly = dixon.get_dixon_polynomial()
     dixon_matrix = dixon.get_dixon_matrix(dixon_poly)
-    from sympy import factor, simplify
     D = factor(dixon.get_KSY_Dixon_resultant(dixon_matrix))
 
     assert D == -8*A*(A - 1)*(A + 2)*(2*A - 1)**2

--- a/sympy/polys/tests/test_specialpolys.py
+++ b/sympy/polys/tests/test_specialpolys.py
@@ -1,6 +1,6 @@
 """Tests for functions for generating interesting polynomials. """
 
-from sympy import Poly, ZZ, symbols, sqrt, prime, Add, S
+from sympy import Poly, ZZ, symbols, sqrt, prime, Add
 from sympy.utilities.iterables import permute_signs
 from sympy.utilities.pytest import raises
 

--- a/sympy/printing/maple.py
+++ b/sympy/printing/maple.py
@@ -10,11 +10,8 @@ FIXME: This module is still under actively developed. Some functions may be not 
 
 from __future__ import print_function, division
 
-from sympy.codegen.ast import Assignment
 from sympy.core import S
-from sympy.core.basic import Atom
 from sympy.core.numbers import Integer, IntegerConstant
-from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -390,7 +390,6 @@ class PrettyPrinter(Printer):
         return cyc
 
     def _print_Permutation(self, expr):
-        from ..str import sstr
         from sympy.combinatorics.permutations import Permutation, Cycle
 
         perm_cyclic = Permutation.print_cyclic

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -13,7 +13,7 @@ from sympy import (
 
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
     SubAugmentedAssignment, MulAugmentedAssignment, DivAugmentedAssignment, ModAugmentedAssignment)
-from sympy.core.compatibility import range, u_decode as u, unicode, PY3
+from sympy.core.compatibility import range, u_decode as u, PY3
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.trace import Tr
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -12,7 +12,6 @@ from mpmath.libmp import repr_dps, to_str as mlib_to_str
 from sympy.core.compatibility import range, string_types
 
 from .printer import Printer
-from .str import sstr
 
 
 class ReprPrinter(Printer):

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -54,7 +54,7 @@ if theano:
             sympy.Max: tt.maximum,  # Sympy accept >2 inputs, Theano only 2
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
             sympy.conjugate: tt.conj,
-            sympy.numbers.ImaginaryUnit: lambda:tt.complex(0,1),
+            sympy.core.numbers.ImaginaryUnit: lambda:tt.complex(0,1),
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
             sympy.HadamardProduct: tt.Elemwise(ts.mul),

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -12,13 +12,10 @@ from .fourier import fourier_series
 from .formal import fps
 from .limitseq import difference_delta, limit_seq
 
-from ..core.singleton import S
-EmptySequence = S.EmptySequence
-del S
-
 O = Order
 
-__all__ = ['Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'residue',
-           'EmptySequence', 'SeqPer', 'SeqFormula', 'sequence',
-           'SeqAdd', 'SeqMul', 'fourier_series', 'fps', 'difference_delta',
-           'limit_seq']
+__all__ = ['Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'approximants',
+        'residue', 'EmptySequence', 'SeqPer', 'SeqFormula', 'sequence',
+        'SeqAdd', 'SeqMul', 'fourier_series', 'fps', 'difference_delta',
+        'limit_seq'
+        ]

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -12,6 +12,9 @@ from .fourier import fourier_series
 from .formal import fps
 from .limitseq import difference_delta, limit_seq
 
+from sympy.core.singleton import S
+EmptySequence = S.EmptySequence
+
 O = Order
 
 __all__ = ['Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'approximants',

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -6,8 +6,7 @@ from .gruntz import gruntz
 from .series import series
 from .approximants import approximants
 from .residues import residue
-from .sequences import (EmptySequence, SeqPer, SeqFormula, sequence, SeqAdd,
-                        SeqMul)
+from .sequences import SeqPer, SeqFormula, sequence, SeqAdd, SeqMul
 from .fourier import fourier_series
 from .formal import fps
 from .limitseq import difference_delta, limit_seq

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -124,9 +124,6 @@ from sympy.core.compatibility import reduce
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp, powdenest
-from sympy import cacheit
-
-from sympy.core.compatibility import reduce
 
 from sympy.utilities.misc import debug_decorator as debug
 from sympy.utilities.timeutils import timethis

--- a/sympy/series/tests/test_demidovich.py
+++ b/sympy/series/tests/test_demidovich.py
@@ -89,7 +89,6 @@ def test_bounded():
 
 
 def test_f1a():
-    h = Symbol("h")
     #issue 3508:
     assert limit((sin(2*x)/x)**(1 + x), x, 0) == 2  # Primer 7
 

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -371,7 +371,6 @@ def test_series2():
 
 def test_series3():
     w = Symbol("w", real=True)
-    x = Symbol("x", real=True)
     e = w**(-6)*(w**3*tan(w) - w**3*sin(w))
     assert e.nseries(w, n=8) == Integer(1)/2 + O(w**2)
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -8,7 +8,7 @@ from sympy.abc import w, x, y, z
 def test_caching_bug():
     #needs to be a first test, so that all caches are clean
     #cache it
-    e = O(w)
+    O(w)
     #and test that this won't raise an exception
     O(w**(-1/x/log(3)*log(5)), w)
 

--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -1,4 +1,4 @@
-from sympy import (residue, Symbol, Function, sin, S, I, exp, log, pi,
+from sympy import (residue, Symbol, Function, sin, I, exp, log, pi,
                    factorial, sqrt, Rational)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, z, a, s

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,6 +1,5 @@
 from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
-    Function, log, sqrt, Symbol, Subs, pi, symbols, IndexedBase, atan, \
-    LambertW, Rational
+    Function, log, sqrt, Symbol, Subs, pi, symbols, atan, LambertW, Rational
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,6 +1,5 @@
 from sympy import sqrt, root, Symbol, sqrtdenest, Integral, cos, Rational, I
 from sympy.simplify.sqrtdenest import _subsets as subsets
-from sympy.simplify.sqrtdenest import _sqrt_match
 from sympy.utilities.pytest import slow
 
 r2, r3, r5, r6, r7, r10, r15, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 10,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -58,7 +58,6 @@ from sympy.solvers.inequalities import reduce_inequalities
 
 from types import GeneratorType
 from collections import defaultdict
-import itertools
 import warnings
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -9,7 +9,7 @@ from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
-    atanh, sinh, tanh, cosh, sech, coth)
+    sinh, tanh, cosh, sech, coth)
 from sympy.functions.elementary.miscellaneous import sqrt, Min, Max
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,7 +4,7 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, N, atan, erfi, besselj)
+                   factorial, binomial, erfi, besselj)
 from sympy.core.compatibility import range
 from sympy.external import import_module
 from sympy.functions.special.error_functions import erfinv
@@ -20,10 +20,7 @@ from sympy.stats import (P, E, where, density, variance, covariance, skewness, k
                          Pareto, QuadraticU, RaisedCosine, Rayleigh, Reciprocal, ShiftedGompertz, StudentT,
                          Trapezoidal, Triangular, Uniform, UniformSum, VonMises, Weibull,
                          WignerSemicircle, Wald, correlation, moment, cmoment, smoment, quantile)
-from sympy.stats.crv_types import (NormalDistribution, GumbelDistribution, GompertzDistribution, LaplaceDistribution,
-                                  ParetoDistribution, RaisedCosineDistribution, BeniniDistribution, BetaDistribution,
-                                  CauchyDistribution, GammaInverseDistribution, LogNormalDistribution, StudentTDistribution,
-                                  QuadraticUDistribution, WignerSemicircleDistribution, ChiDistribution, ReciprocalDistribution)
+from sympy.stats.crv_types import NormalDistribution
 from sympy.stats.joint_rv import JointPSpace
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 from sympy.utilities.randtest import verify_numerically as tn
@@ -437,7 +434,6 @@ def test_betaprime():
 def test_cauchy():
     x0 = Symbol("x0")
     gamma = Symbol("gamma", positive=True)
-    t = Symbol('t')
     p = Symbol("p", positive=True)
 
     X = Cauchy('x', x0, gamma)

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -1,5 +1,5 @@
 from sympy import (S, Symbol, Sum, I, lambdify, re, im, log, simplify, sqrt,
-                   zeta, pi, besseli, Dummy, oo, Piecewise, Rational, erf, beta,
+                   zeta, pi, besseli, Dummy, oo, Piecewise, Rational, beta,
                    floor)
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.exponential import exp

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,18 +1,16 @@
 from __future__ import unicode_literals
-from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
-        symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
-        DiracDelta, Lambda, log, pi, exp, log, FallingFactorial, Rational)
-from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance, covariance,
-        skewness, density, given, independent, dependent, where, pspace,
+from sympy import (S, Symbol, Interval, exp,
+        symbols, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
+        DiracDelta, Lambda, log, pi, FallingFactorial, Rational)
+from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
+        density, given, independent, dependent, where, pspace,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
-        DiscreteUniform, Poisson, characteristic_function, moment_generating_function, sample_iter)
+        DiscreteUniform, Poisson, characteristic_function, moment_generating_function)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace)
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.numbers import comp
-from sympy.abc import x
-from sympy.stats import Normal, DiscreteUniform, Poisson, characteristic_function, moment_generating_function, sample_iter
 from sympy.stats.frv_types import BernoulliDistribution
 
 def test_where():

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -1,4 +1,4 @@
-from sympy import symbols, Mul, sin, Integral, oo, Eq, Sum,
+from sympy import symbols, Mul, sin, Integral, oo, Eq, Sum
 from sympy.core.expr import unchanged
 from sympy.stats import (Normal, Poisson, variance, Covariance, Variance,
                          Probability, Expectation)

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -1,8 +1,7 @@
-from sympy import symbols, Mul, sin, Integral, oo, Eq, Sum, sqrt, pi, exp
+from sympy import symbols, Mul, sin, Integral, oo, Eq, Sum,
 from sympy.core.expr import unchanged
 from sympy.stats import (Normal, Poisson, variance, Covariance, Variance,
                          Probability, Expectation)
-from sympy.utilities.pytest import raises
 from sympy.stats.rv import probability, expectation
 
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1013,10 +1013,10 @@ class TensorIndexType(Basic):
             if metric is not None:
                 if metric in (True, False, 0, 1):
                     metric_name = 'metric'
-                    metric_antisym = metric
+                    #metric_antisym = metric
                 else:
                     metric_name = metric.name
-                    metric_antisym = metric.antisym
+                    #metric_antisym = metric.antisym
 
                 if metric:
                     metric_symmetry = -1

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -427,11 +427,13 @@ class MultisetPartitionTraverser():
         """Useful for usderstanding/debugging the algorithms.  Not
         generally activated in end-user code."""
         if self.debug:
-            letters = 'abcdefghijklmnopqrstuvwxyz'
-            state = [self.f, self.lpart, self.pstack]
-            print("DBG:", msg,
-                  ["".join(part) for part in list_visitor(state, letters)],
-                  animation_visitor(state))
+            # XXX: animation_visitor is undefined...
+            raise RuntimeError
+            #letters = 'abcdefghijklmnopqrstuvwxyz'
+            #state = [self.f, self.lpart, self.pstack]
+            #print("DBG:", msg,
+            #      ["".join(part) for part in list_visitor(state, letters)],
+            #      animation_visitor(state))
 
     #
     # Helper methods for enumeration

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -424,10 +424,11 @@ class MultisetPartitionTraverser():
         self.p1 = 0
 
     def db_trace(self, msg):
-        """Useful for usderstanding/debugging the algorithms.  Not
+        """Useful for understanding/debugging the algorithms.  Not
         generally activated in end-user code."""
         if self.debug:
-            # XXX: animation_visitor is undefined...
+            # XXX: animation_visitor is undefined... Clearly this does not
+            # work and was not tested. Previous code in comments below.
             raise RuntimeError
             #letters = 'abcdefghijklmnopqrstuvwxyz'
             #state = [self.f, self.lpart, self.pstack]

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -11,8 +11,6 @@ import re
 import textwrap
 import linecache
 
-from types import FunctionType
-
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, string_types, range, builtins, PY3)
 from sympy.utilities.misc import filldedent
@@ -114,7 +112,7 @@ def _import(module, reload=False):
     other modules.
     """
     # Required despite static analysis claiming it is not used
-    from sympy.external import import_module
+    from sympy.external import import_module # noqa:F401
     try:
         namespace, namespace_default, translations, import_commands = MODULES[
             module]

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -3,7 +3,7 @@ from sympy.functions import (log, sin, cos, tan, cot, csc, sec, erf, gamma, uppe
 from sympy.functions.elementary.hyperbolic import acosh, asinh, atanh, acoth, acsch, asech, cosh, sinh, tanh, coth, sech, csch
 from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei
-from sympy import (Basic, Mul, Add, Pow, Integral, UnevaluatedExpr, exp)
+from sympy import (Basic, Mul, Add, Pow, Integral, exp)
 
 matchpy = import_module("matchpy")
 

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -14,13 +14,24 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
 
 try:
-    import py
-    from _pytest.python_api import raises
-    from _pytest.recwarn import warns
-    from _pytest.outcomes import skip, Failed
+    import pytest
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False
+
+
+if USE_PYTEST:
+    raises = pytest.raises
+    warns = pytest.warns
+    skip = pytest.skip
+    XFAIL = pytest.mark.xfail
+    SKIP = pytest.mark.skip
+    slow = pytest.mark.slow
+    nocache_fail = pytest.mark.nocache_fail
+
+else:
+    # Not using pytest so define the things that would have been imported from
+    # there.
 
     def raises(expectedException, code=None):
         """
@@ -197,13 +208,6 @@ except ImportError:
                    ' The list of emitted warnings is: %s.'
                    ) % (warningcls, [w.message for w in warnrec])
             raise Failed(msg)
-
-
-else:
-    XFAIL = py.test.mark.xfail
-    SKIP = py.test.mark.skip
-    slow = py.test.mark.slow
-    nocache_fail = py.test.mark.nocache_fail
 
 
 @contextlib.contextmanager

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -11,6 +11,8 @@ import warnings
 from sympy.core.compatibility import get_function_name, string_types
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
+ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
+
 try:
     import py
     from _pytest.python_api import raises
@@ -20,9 +22,6 @@ try:
 except ImportError:
     USE_PYTEST = False
 
-ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
-
-if not USE_PYTEST:
     def raises(expectedException, code=None):
         """
         Tests that ``code`` raises the exception ``expectedException``.

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -34,7 +34,8 @@ import stat
 import tempfile
 
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import exec_, PY3, string_types, range, unwrap
+from sympy.core.compatibility import (exec_, PY3, string_types, range, unwrap,
+        unicode)
 from sympy.utilities.misc import find_executable
 from sympy.external import import_module
 from sympy.utilities.exceptions import SymPyDeprecationWarning

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -4,7 +4,6 @@ from os import walk, sep, pardir
 from os.path import split, join, abspath, exists, isfile
 from glob import glob
 import re
-import fnmatch
 import random
 import ast
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -695,12 +695,12 @@ def test_kbins():
     assert len(list(kbins('1123', 2, ordered=0))) == 5
     assert len(list(kbins('1123', 2, ordered=None))) == 3
 
-    def test():
+    def test1():
         for orderedval in [None, 0, 1, 10, 11]:
             print('ordered =', orderedval)
             for p in kbins([0, 0, 1], 2, ordered=orderedval):
                 print('   ', p)
-    assert capture(lambda : test()) == dedent('''\
+    assert capture(lambda : test1()) == dedent('''\
         ordered = None
             [[0], [0, 1]]
             [[0, 0], [1]]
@@ -724,12 +724,12 @@ def test_kbins():
             [[1], [0, 0]]
             [[1, 0], [0]]\n''')
 
-    def test():
+    def test2():
         for orderedval in [None, 0, 1, 10, 11]:
             print('ordered =', orderedval)
             for p in kbins(list(range(3)), 2, ordered=orderedval):
                 print('   ', p)
-    assert capture(lambda : test()) == dedent('''\
+    assert capture(lambda : test2()) == dedent('''\
         ordered = None
             [[0], [1, 2]]
             [[0, 1], [2]]

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion as V
 from itertools import product
 import math
 import inspect
@@ -12,7 +11,7 @@ from sympy import (
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk, S, beta,
     MatrixSymbol, fresnelc, fresnels)
-from sympy.functions.elementary.complexes import re, im, Abs, arg
+from sympy.functions.elementary.complexes import re, im, arg
 from sympy.functions.special.polynomials import \
     chebyshevt, chebyshevu, legendre, hermite, laguerre, gegenbauer, \
     assoc_legendre, assoc_laguerre, jacobi


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Fixes most warnings still seen under flake8 bringing the total down from 658 to 342. This fixes most of the smaller issues from around the codebase so that the remaining warnings all come from a handful of places.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
