### PR TITLE
Fix/silence flake8 warnings in sets

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -544,7 +544,7 @@ class GeometrySet(GeometryEntity, Set):
         return self.__contains__(other)
 
 @dispatch(GeometrySet, Set)
-def union_sets(self, o):
+def union_sets(self, o): # noqa:F811
     """ Returns the union of self and o
     for use with sympy.sets.Set, if possible. """
 
@@ -563,7 +563,7 @@ def union_sets(self, o):
 
 
 @dispatch(GeometrySet, Set)
-def intersection_sets(self, o):
+def intersection_sets(self, o): # noqa:F811
     """ Returns a sympy.sets.Set of intersection objects,
     if possible. """
 

--- a/sympy/multipledispatch/__init__.py
+++ b/sympy/multipledispatch/__init__.py
@@ -3,3 +3,9 @@ from .dispatcher import (Dispatcher, halt_ordering, restart_ordering,
     MDNotImplementedError)
 
 __version__ = '0.4.9'
+
+__all__ = [
+    'dispatch',
+
+    'Dispatcher', 'halt_ordering', 'restart_ordering', 'MDNotImplementedError',
+]

--- a/sympy/multipledispatch/tests/test_core.py
+++ b/sympy/multipledispatch/tests/test_core.py
@@ -12,15 +12,15 @@ dispatch = partial(dispatch, namespace=test_namespace)
 @XFAIL
 def test_singledispatch():
     @dispatch(int)
-    def f(x):
+    def f(x): # noqa:F811
         return x + 1
 
     @dispatch(int)
-    def g(x):
+    def g(x): # noqa:F811
         return x + 2
 
     @dispatch(float)
-    def f(x):
+    def f(x): # noqa:F811
         return x - 1
 
     assert f(1) == 2
@@ -32,11 +32,11 @@ def test_singledispatch():
 
 def test_multipledispatch():
     @dispatch(int, int)
-    def f(x, y):
+    def f(x, y): # noqa:F811
         return x + y
 
     @dispatch(float, float)
-    def f(x, y):
+    def f(x, y): # noqa:F811
         return x - y
 
     assert f(1, 2) == 3
@@ -52,11 +52,11 @@ class E(C): pass
 
 def test_inheritance():
     @dispatch(A)
-    def f(x):
+    def f(x): # noqa:F811
         return 'a'
 
     @dispatch(B)
-    def f(x):
+    def f(x): # noqa:F811
         return 'b'
 
     assert f(A()) == 'a'
@@ -67,11 +67,11 @@ def test_inheritance():
 @XFAIL
 def test_inheritance_and_multiple_dispatch():
     @dispatch(A, A)
-    def f(x, y):
+    def f(x, y): # noqa:F811
         return type(x), type(y)
 
     @dispatch(A, B)
-    def f(x, y):
+    def f(x, y): # noqa:F811
         return 0
 
     assert f(A(), A()) == (A, A)
@@ -83,11 +83,11 @@ def test_inheritance_and_multiple_dispatch():
 
 def test_competing_solutions():
     @dispatch(A)
-    def h(x):
+    def h(x): # noqa:F811
         return 1
 
     @dispatch(C)
-    def h(x):
+    def h(x): # noqa:F811
         return 2
 
     assert h(D()) == 2
@@ -95,11 +95,11 @@ def test_competing_solutions():
 
 def test_competing_multiple():
     @dispatch(A, B)
-    def h(x, y):
+    def h(x, y): # noqa:F811
         return 1
 
     @dispatch(C, B)
-    def h(x, y):
+    def h(x, y): # noqa:F811
         return 2
 
     assert h(D(), B()) == 2
@@ -110,12 +110,12 @@ def test_competing_ambiguous():
     dispatch = partial(orig_dispatch, namespace=test_namespace)
 
     @dispatch(A, C)
-    def f(x, y):
+    def f(x, y): # noqa:F811
         return 2
 
     with warns(AmbiguityWarning):
         @dispatch(C, A)
-        def f(x, y):
+        def f(x, y): # noqa:F811
             return 2
 
     assert f(A(), C()) == f(C(), A()) == 2
@@ -124,13 +124,13 @@ def test_competing_ambiguous():
 
 def test_caching_correct_behavior():
     @dispatch(A)
-    def f(x):
+    def f(x): # noqa:F811
         return 1
 
     assert f(C()) == 1
 
     @dispatch(C)
-    def f(x):
+    def f(x): # noqa:F811
         return 2
 
     assert f(C()) == 2
@@ -138,7 +138,7 @@ def test_caching_correct_behavior():
 
 def test_union_types():
     @dispatch((A, C))
-    def f(x):
+    def f(x): # noqa:F811
         return 1
 
     assert f(A()) == 1
@@ -166,7 +166,7 @@ Fails
 def test_dispatch_on_dispatch():
     @dispatch(A)
     @dispatch(C)
-    def q(x):
+    def q(x): # noqa:F811
         return 1
 
     assert q(A()) == 1
@@ -177,15 +177,15 @@ def test_dispatch_on_dispatch():
 def test_methods():
     class Foo(object):
         @dispatch(float)
-        def f(self, x):
+        def f(self, x): # noqa:F811
             return x - 1
 
         @dispatch(int)
-        def f(self, x):
+        def f(self, x): # noqa:F811
             return x + 1
 
         @dispatch(int)
-        def g(self, x):
+        def g(self, x): # noqa:F811
             return x + 3
 
 
@@ -198,11 +198,11 @@ def test_methods():
 def test_methods_multiple_dispatch():
     class Foo(object):
         @dispatch(A, A)
-        def f(x, y):
+        def f(x, y): # noqa:F811
             return 1
 
         @dispatch(A, C)
-        def f(x, y):
+        def f(x, y): # noqa:F811
             return 2
 
 

--- a/sympy/multipledispatch/tests/test_dispatcher.py
+++ b/sympy/multipledispatch/tests/test_dispatcher.py
@@ -41,11 +41,11 @@ def test_dispatcher_as_decorator():
     f = Dispatcher('f')
 
     @f.register(int)
-    def inc(x):
+    def inc(x): # noqa:F811
         return x + 1
 
     @f.register(float)
-    def inc(x):
+    def inc(x): # noqa:F811
         return x - 1
 
     assert f(1) == 2

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,4 +1,4 @@
-from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
+from .sets import (Set, Interval, Union, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference)
 from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains

--- a/sympy/sets/handlers/add.py
+++ b/sympy/sets/handlers/add.py
@@ -1,23 +1,26 @@
-from sympy import symbols, S
+from sympy import symbols, S, oo
 from sympy.core import Basic, Expr
 from sympy.core.numbers import Infinity, NegativeInfinity
 from sympy.multipledispatch import dispatch
 from sympy.sets import Interval, FiniteSet
 
 
+# XXX: The functions in this module are clearly not tested and are broken in a
+# number of ways.
+
 _x, _y = symbols("x y")
 
 
 @dispatch(Basic, Basic)
-def _set_add(x, y):
+def _set_add(x, y): # noqa:F811
     return None
 
 @dispatch(Expr, Expr)
-def _set_add(x, y):
+def _set_add(x, y): # noqa:F811
     return x+y
 
 @dispatch(Interval, Interval)
-def _set_add(x, y):
+def _set_add(x, y): # noqa:F811
     """
     Additions in interval arithmetic
     https://en.wikipedia.org/wiki/Interval_arithmetic
@@ -26,28 +29,28 @@ def _set_add(x, y):
         x.left_open or y.left_open, x.right_open or y.right_open)
 
 @dispatch(Interval, Infinity)
-def _set_add(x, y):
+def _set_add(x, y): # noqa:F811
     if x.start is S.NegativeInfinity:
         return Interval(-oo, oo)
     return FiniteSet({S.Infinity})
 
 @dispatch(Interval, NegativeInfinity)
-def _set_add(x, y):
+def _set_add(x, y): # noqa:F811
     if x.end is S.Infinity:
         return Interval(-oo, oo)
     return FiniteSet({S.NegativeInfinity})
 
 
 @dispatch(Basic, Basic)
-def _set_sub(x, y):
+def _set_sub(x, y): # noqa:F811
     return None
 
 @dispatch(Expr, Expr)
-def _set_sub(x, y):
+def _set_sub(x, y): # noqa:F811
     return x-y
 
 @dispatch(Interval, Interval)
-def _set_sub(x, y):
+def _set_sub(x, y): # noqa:F811
     """
     Subtractions in interval arithmetic
     https://en.wikipedia.org/wiki/Interval_arithmetic
@@ -56,13 +59,13 @@ def _set_sub(x, y):
         x.left_open or y.right_open, x.right_open or y.left_open)
 
 @dispatch(Interval, Infinity)
-def _set_sub(x, y):
-    if self.start is S.NegativeInfinity:
+def _set_sub(x, y): # noqa:F811
+    if x.start is S.NegativeInfinity:
         return Interval(-oo, oo)
     return FiniteSet(-oo)
 
 @dispatch(Interval, NegativeInfinity)
-def _set_sub(x, y):
-    if self.start is S.NegativeInfinity:
+def _set_sub(x, y): # noqa:F811
+    if x.start is S.NegativeInfinity:
         return Interval(-oo, oo)
     return FiniteSet(-oo)

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -1,7 +1,6 @@
 from sympy import Set, symbols, exp, log, S, Wild, Dummy, oo
 from sympy.core import Expr, Add
 from sympy.core.function import Lambda, _coeff_isneg, FunctionClass
-from sympy.core.mod import Mod
 from sympy.logic.boolalg import true
 from sympy.multipledispatch import dispatch
 from sympy.sets import (imageset, Interval, FiniteSet, Union, ImageSet,
@@ -16,15 +15,15 @@ FunctionUnion = (FunctionClass, Lambda)
 
 
 @dispatch(FunctionClass, Set)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     return None
 
 @dispatch(FunctionUnion, FiniteSet)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     return FiniteSet(*map(f, x))
 
 @dispatch(Lambda, Interval)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     from sympy.functions.elementary.miscellaneous import Min, Max
     from sympy.solvers.solveset import solveset
     from sympy.core.function import diff, Lambda
@@ -113,7 +112,7 @@ def _set_function(f, x):
             imageset(f, Interval(sing[-1], x.end, True, x.right_open))
 
 @dispatch(FunctionClass, Interval)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     if f == exp:
         return Interval(exp(x.start), exp(x.end), x.left_open, x.right_open)
     elif f == log:
@@ -121,11 +120,11 @@ def _set_function(f, x):
     return ImageSet(Lambda(_x, f(_x)), x)
 
 @dispatch(FunctionUnion, Union)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     return Union(*(imageset(f, arg) for arg in x.args))
 
 @dispatch(FunctionUnion, Intersection)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     from sympy.sets.sets import is_function_invertible_in_set
     # If the function is invertible, intersect the maps of the sets.
     if is_function_invertible_in_set(f, x):
@@ -134,15 +133,15 @@ def _set_function(f, x):
         return ImageSet(Lambda(_x, f(_x)), x)
 
 @dispatch(FunctionUnion, type(EmptySet))
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     return x
 
 @dispatch(FunctionUnion, Set)
-def _set_function(f, x):
+def _set_function(f, x): # noqa:F811
     return ImageSet(Lambda(_x, f(_x)), x)
 
 @dispatch(FunctionUnion, Range)
-def _set_function(f, self):
+def _set_function(f, self): # noqa:F811
     from sympy.core.function import expand_mul
     if not self:
         return S.EmptySet
@@ -167,7 +166,7 @@ def _set_function(f, self):
         return imageset(x, F, Range(self.size))
 
 @dispatch(FunctionUnion, Integers)
-def _set_function(f, self):
+def _set_function(f, self): # noqa:F811
     expr = f.expr
     if not isinstance(expr, Expr):
         return
@@ -217,7 +216,7 @@ def _set_function(f, self):
 
 
 @dispatch(FunctionUnion, Naturals)
-def _set_function(f, self):
+def _set_function(f, self): # noqa:F811
     expr = f.expr
     if not isinstance(expr, Expr):
         return
@@ -244,7 +243,7 @@ def _set_function(f, self):
 
 
 @dispatch(FunctionUnion, Reals)
-def _set_function(f, self):
+def _set_function(f, self): # noqa:F811
     expr = f.expr
     if not isinstance(expr, Expr):
         return

--- a/sympy/sets/handlers/intersection.py
+++ b/sympy/sets/handlers/intersection.py
@@ -1,5 +1,5 @@
 from sympy import (S, Dummy, Lambda, symbols, Interval, Intersection, Set,
-                   EmptySet, FiniteSet, Union, ComplexRegion, ProductSet)
+                   EmptySet, FiniteSet, Union, ComplexRegion)
 from sympy.multipledispatch import dispatch
 from sympy.sets.conditionset import ConditionSet
 from sympy.sets.fancysets import (Integers, Naturals, Reals, Range,
@@ -8,27 +8,27 @@ from sympy.sets.sets import UniversalSet, imageset, ProductSet
 
 
 @dispatch(ConditionSet, ConditionSet)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return None
 
 @dispatch(ConditionSet, Set)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return ConditionSet(a.sym, a.condition, Intersection(a.base_set, b))
 
 @dispatch(Naturals, Integers)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 @dispatch(Naturals, Naturals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a if a is S.Naturals else b
 
 @dispatch(Interval, Naturals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return intersection_sets(b, a)
 
 @dispatch(ComplexRegion, Set)
-def intersection_sets(self, other):
+def intersection_sets(self, other): # noqa:F811
     if other.is_ComplexRegion:
         # self in rectangular form
         if (not self.polar) and (not other.polar):
@@ -75,11 +75,11 @@ def intersection_sets(self, other):
             return Intersection(new_interval, other)
 
 @dispatch(Integers, Reals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 @dispatch(Range, Interval)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     from sympy.functions.elementary.integers import floor, ceiling
     if not all(i.is_number for i in b.args[:2]):
         return
@@ -99,11 +99,11 @@ def intersection_sets(a, b):
     return intersection_sets(a, Range(start, end + 1))
 
 @dispatch(Range, Naturals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return intersection_sets(a, Interval(b.inf, S.Infinity))
 
 @dispatch(Range, Range)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     from sympy.solvers.diophantine import diop_linear
     from sympy.core.numbers import ilcm
     from sympy import sign
@@ -216,12 +216,12 @@ def intersection_sets(a, b):
 
 
 @dispatch(Range, Integers)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 
 @dispatch(ImageSet, Set)
-def intersection_sets(self, other):
+def intersection_sets(self, other): # noqa:F811
     from sympy.solvers.diophantine import diophantine
 
     # Only handle the straight-forward univariate case
@@ -349,14 +349,14 @@ def intersection_sets(self, other):
 
 
 @dispatch(ProductSet, ProductSet)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     if len(b.args) != len(a.args):
         return S.EmptySet
     return ProductSet(*(i.intersect(j) for i, j in zip(a.sets, b.sets)))
 
 
 @dispatch(Interval, Interval)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     # handle (-oo, oo)
     infty = S.NegativeInfinity, S.Infinity
     if a == Interval(*infty):
@@ -403,38 +403,38 @@ def intersection_sets(a, b):
     return Interval(start, end, left_open, right_open)
 
 @dispatch(type(EmptySet), Set)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return S.EmptySet
 
 @dispatch(UniversalSet, Set)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return b
 
 @dispatch(FiniteSet, FiniteSet)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return FiniteSet(*(a._elements & b._elements))
 
 @dispatch(FiniteSet, Set)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     try:
         return FiniteSet(*[el for el in a if el in b])
     except TypeError:
         return None  # could not evaluate `el in b` due to symbolic ranges.
 
 @dispatch(Set, Set)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return None
 
 @dispatch(Integers, Rationals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 @dispatch(Naturals, Rationals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 @dispatch(Rationals, Reals)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return a
 
 def _intlike_interval(a, b):
@@ -448,9 +448,9 @@ def _intlike_interval(a, b):
         return None
 
 @dispatch(Integers, Interval)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return _intlike_interval(a, b)
 
 @dispatch(Naturals, Interval)
-def intersection_sets(a, b):
+def intersection_sets(a, b): # noqa:F811
     return _intlike_interval(a, b)

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -2,18 +2,18 @@ from sympy import S
 from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
 from sympy.sets.sets import FiniteSet, Interval, Set, Union
-from sympy.sets.fancysets import Complexes, Naturals, Reals, Range, Rationals
+from sympy.sets.fancysets import Complexes, Reals, Range, Rationals
 from sympy.multipledispatch import dispatch
 
 
 _inf_sets = [S.Naturals, S.Naturals0, S.Integers, S.Rationals, S.Reals, S.Complexes]
 
 @dispatch(Set, Set)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return None
 
 @dispatch(Interval, Interval)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     # This is correct but can be made more comprehensive...
     if fuzzy_bool(a.start < b.start):
         return False
@@ -25,14 +25,14 @@ def is_subset_sets(a, b):
         return False
 
 @dispatch(Interval, FiniteSet)
-def is_subset_sets(a_interval, b_fs):
+def is_subset_sets(a_interval, b_fs): # noqa:F811
     # An Interval can only be a subset of a finite set if it is finite
     # which can only happen if it has zero measure.
     if fuzzy_not(a_interval.measure.is_zero):
         return False
 
 @dispatch(Interval, Union)
-def is_subset_sets(a_interval, b_u):
+def is_subset_sets(a_interval, b_u): # noqa:F811
     if all(isinstance(s, (Interval, FiniteSet)) for s in b_u.args):
         intervals = [s for s in b_u.args if isinstance(s, Interval)]
         if all(fuzzy_bool(a_interval.start < s.start) for s in intervals):
@@ -48,13 +48,13 @@ def is_subset_sets(a_interval, b_u):
                 return False
 
 @dispatch(Range, Range)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     if a.step == b.step == 1:
         return fuzzy_and([fuzzy_bool(a.start >= b.start),
                           fuzzy_bool(a.stop <= b.stop)])
 
 @dispatch(Range, Interval)
-def is_subset_sets(a_range, b_interval):
+def is_subset_sets(a_range, b_interval): # noqa:F811
     if a_range.step.is_positive:
         if b_interval.left_open and a_range.inf.is_finite:
             cond_left = a_range.inf > b_interval.left
@@ -67,35 +67,35 @@ def is_subset_sets(a_range, b_interval):
         return fuzzy_and([cond_left, cond_right])
 
 @dispatch(Interval, Range)
-def is_subset_sets(a_interval, b_range):
+def is_subset_sets(a_interval, b_range): # noqa:F811
     if a_interval.measure.is_extended_nonzero:
         return False
 
 @dispatch(Interval, Rationals)
-def is_subset_sets(a_interval, b_rationals):
+def is_subset_sets(a_interval, b_rationals): # noqa:F811
     if a_interval.measure.is_extended_nonzero:
         return False
 
 @dispatch(Range, Complexes)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return True
 
 @dispatch(Complexes, Interval)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return False
 
 @dispatch(Complexes, Range)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return False
 
 @dispatch(Complexes, Rationals)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return False
 
 @dispatch(Rationals, Reals)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return True
 
 @dispatch(Rationals, Range)
-def is_subset_sets(a, b):
+def is_subset_sets(a, b): # noqa:F811
     return False

--- a/sympy/sets/handlers/mul.py
+++ b/sympy/sets/handlers/mul.py
@@ -7,19 +7,19 @@ _x, _y = symbols("x y")
 
 
 @dispatch(Basic, Basic)
-def _set_mul(x, y):
+def _set_mul(x, y): # noqa:F811
     return None
 
 @dispatch(Set, Set)
-def _set_mul(x, y):
+def _set_mul(x, y): # noqa:F811
     return None
 
 @dispatch(Expr, Expr)
-def _set_mul(x, y):
+def _set_mul(x, y): # noqa:F811
     return x*y
 
 @dispatch(Interval, Interval)
-def _set_mul(x, y):
+def _set_mul(x, y): # noqa:F811
     """
     Multiplications in interval arithmetic
     https://en.wikipedia.org/wiki/Interval_arithmetic
@@ -40,23 +40,21 @@ def _set_mul(x, y):
         minopen,
         maxopen
     )
-    return SetExpr(Interval(start, end))
-
 
 @dispatch(Basic, Basic)
-def _set_div(x, y):
+def _set_div(x, y): # noqa:F811
     return None
 
 @dispatch(Expr, Expr)
-def _set_div(x, y):
+def _set_div(x, y): # noqa:F811
     return x/y
 
 @dispatch(Set, Set)
-def _set_div(x, y):
+def _set_div(x, y): # noqa:F811
     return None
 
 @dispatch(Interval, Interval)
-def _set_div(x, y):
+def _set_div(x, y): # noqa:F811
     """
     Divisions in interval arithmetic
     https://en.wikipedia.org/wiki/Interval_arithmetic

--- a/sympy/sets/handlers/power.py
+++ b/sympy/sets/handlers/power.py
@@ -9,23 +9,23 @@ _x, _y = symbols("x y")
 
 
 @dispatch(Basic, Basic)
-def _set_pow(x, y):
+def _set_pow(x, y): # noqa:F811
     return None
 
 @dispatch(Set, Set)
-def _set_pow(x, y):
+def _set_pow(x, y): # noqa:F811
     return ImageSet(Lambda((_x, _y), (_x ** _y)), x, y)
 
 @dispatch(Expr, Expr)
-def _set_pow(x, y):
+def _set_pow(x, y): # noqa:F811
     return x**y
 
 @dispatch(Interval, Zero)
-def _set_pow(x, z):
+def _set_pow(x, z): # noqa:F811
     return FiniteSet(S.One)
 
 @dispatch(Interval, Integer)
-def _set_pow(x, exponent):
+def _set_pow(x, exponent): # noqa:F811
     """
     Powers in interval arithmetic
     https://en.wikipedia.org/wiki/Interval_arithmetic
@@ -73,7 +73,7 @@ def _set_pow(x, exponent):
             return Interval(S.Zero, sleft, S.Zero not in x, left_open)
 
 @dispatch(Interval, Infinity)
-def _set_pow(b, e):
+def _set_pow(b, e): # noqa:F811
     # TODO: add logic for open intervals?
     if b.start.is_nonnegative:
         if b.end < 1:
@@ -95,6 +95,6 @@ def _set_pow(b, e):
         return Interval(-oo, oo)
 
 @dispatch(Interval, NegativeInfinity)
-def _set_pow(b, e):
+def _set_pow(b, e): # noqa:F811
     from sympy.sets.setexpr import set_div
     return _set_pow(set_div(S.One, b), oo)

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -6,7 +6,7 @@ from sympy.sets.sets import UniversalSet
 
 
 @dispatch(Integers, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     intersect = Intersection(a, b)
     if intersect == a:
         return b
@@ -14,7 +14,7 @@ def union_sets(a, b):
         return a
 
 @dispatch(ComplexRegion, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     if b.is_subset(S.Reals):
         # treat a subset of reals as a complex region
         b = ComplexRegion.from_real(b)
@@ -29,16 +29,16 @@ def union_sets(a, b):
     return None
 
 @dispatch(type(EmptySet), Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     return b
 
 
 @dispatch(UniversalSet, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     return a
 
 @dispatch(ProductSet, ProductSet)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     if b.is_subset(a):
         return a
     if len(b.sets) != len(a.sets):
@@ -53,13 +53,13 @@ def union_sets(a, b):
     return None
 
 @dispatch(ProductSet, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     if b.is_subset(a):
         return a
     return None
 
 @dispatch(Interval, Interval)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     if a._is_comparable(b):
         from sympy.functions.elementary.miscellaneous import Min, Max
         # Non-overlapping intervals
@@ -79,11 +79,11 @@ def union_sets(a, b):
             return Interval(start, end, left_open, right_open)
 
 @dispatch(Interval, UniversalSet)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     return S.UniversalSet
 
 @dispatch(Interval, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     # If I have open end points and these endpoints are contained in b
     # But only in case, when endpoints are finite. Because
     # interval does not contain oo or -oo.
@@ -102,11 +102,11 @@ def union_sets(a, b):
     return None
 
 @dispatch(FiniteSet, FiniteSet)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     return FiniteSet(*(a._elements | b._elements))
 
 @dispatch(FiniteSet, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     # If `b` set contains one of my elements, remove it from `a`
     if any(b.contains(x) == True for x in a):
         return set((
@@ -114,5 +114,5 @@ def union_sets(a, b):
     return None
 
 @dispatch(Set, Set)
-def union_sets(a, b):
+def union_sets(a, b): # noqa:F811
     return None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See #17795 

#### Brief description of what is fixed or changed

Use #noqa to silence flake8 warnings in sets. These are spurious warnings but there isn't a good way to ignore them.

Also fix some imports in sets.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
