### PR TITLE
Further improvements of guide.rst

### DIFF
--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -294,9 +294,9 @@ How to create a new function with one variable::
     ...             return S.NaN
     ...         if arg is S.Zero:
     ...             return S.Zero
-    ...         if arg.is_positive:
+    ...         if arg.is_extended_positive:
     ...             return S.One
-    ...         if arg.is_negative:
+    ...         if arg.is_extended_negative:
     ...             return S.NegativeOne
     ...         if isinstance(arg, Mul):
     ...             coeff, terms = arg.as_coeff_mul()
@@ -309,8 +309,9 @@ How to create a new function with one variable::
     ...     def _eval_conjugate(self):
     ...         return self
 
-The applied function ``sign(x)`` is constructed using
+The applied function ``sign(x)`` is constructed using::
 
+    >>> from sympy.abc import x
     >>> sign(x)
     sign(x)
 
@@ -325,7 +326,7 @@ should return either an another SymPy object or ``None``.
 If it returns ``None``, it becomes an unevaluated function.
 (see ``core/function.py`` in ``Function.__new__`` for implementation details)
 
-Here are some examples that how ``eval`` works
+Here are some examples that how ``eval`` works::
 
     >>> sign(S.NaN)
     nan
@@ -347,7 +348,7 @@ Here are some examples that how ``eval`` works
 The ``_eval_*`` functions are automatically called when something is
 needed.
 For example, ``conjugate`` or ``is_finite`` will automatically call
-``_eval_is_finite``, ``_eval_conjugate`` if you have these defined.
+``_eval_is_finite``, ``_eval_conjugate`` if you have these defined::
 
     >>> sign(x).is_finite
     True

--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -34,7 +34,7 @@ why I call it that way)::
 
     e = x + y + x
 
-    print e
+    print(e)
 
 And I try if it works
 
@@ -147,10 +147,12 @@ and ``__rdiv__`` is replaced by ``__rtruediv__``.)
 
 So, you can write normal expressions using python arithmetics like this::
 
-    a = Symbol("a")
-    b = Symbol("b")
-    e = (a + b)**2
-    print e
+    >>> from sympy import Symbol
+    >>> a = Symbol("a")
+    >>> b = Symbol("b")
+    >>> e = (a + b)**2
+    >>> e
+    (a + b)**2
 
 but from the SymPy point of view, we just need the classes ``Add``, ``Mul``,
 ``Pow``, ``Rational``, ``Integer``.
@@ -238,8 +240,11 @@ need.
 
 You can define the ``cos`` class like this::
 
-    class cos(Function):
-        pass
+    >>> from sympy import Function
+    >>> class cos(Function):
+    ...     pass
+    >>> 1 + cos(x)
+    cos(x) + 1
 
 and use it like ``1 + cos(x)``, but if you don't implement the ``fdiff()`` method,
 you will not be able to call ``(1 + cos(x)).series()``.
@@ -279,52 +284,86 @@ Functions
 
 How to create a new function with one variable::
 
-    class sign(Function):
-
-        nargs = 1
-
-        @classmethod
-        def eval(cls, arg):
-            if arg is S.NaN:
-                return S.NaN
-            if arg is S.Zero:
-                return S.Zero
-            if arg.is_positive:
-                return S.One
-            if arg.is_negative:
-                return S.NegativeOne
-            if isinstance(arg, Basic.Mul):
-                coeff, terms = arg.as_coeff_mul()
-                if not isinstance(coeff, Basic.One):
-                    return cls(coeff) * cls(Basic.Mul(*terms))
-
-        is_finite = True
-
-        def _eval_conjugate(self):
-            return self
-
-        def _eval_is_zero(self):
-            return isinstance(self[0], Basic.Zero)
-
-and that's it. The ``_eval_*`` functions are called when something is needed.
-The ``eval`` is called when the class is about to be instantiated and it
-should return either some simplified instance of some other class or if the
-class should be unmodified, return ``None`` (see ``core/function.py`` in
-``Function.__new__`` for implementation details). See also tests in
-`sympy/functions/elementary/tests/test_interface.py
-<https://github.com/sympy/sympy/blob/master/sympy/functions/elementary/tests/test_interface.py>`_ that test this interface. You can use them to create your own new functions.
+    >>> from sympy import Mul, S
+    >>> class sign(Function):
+    ...     nargs = 1
+    ...
+    ...     @classmethod
+    ...     def eval(cls, arg):
+    ...         if arg is S.NaN:
+    ...             return S.NaN
+    ...         if arg is S.Zero:
+    ...             return S.Zero
+    ...         if arg.is_positive:
+    ...             return S.One
+    ...         if arg.is_negative:
+    ...             return S.NegativeOne
+    ...         if isinstance(arg, Mul):
+    ...             coeff, terms = arg.as_coeff_mul()
+    ...             if coeff is not S.One:
+    ...                 return cls(coeff) * cls(Mul(*terms))
+    ...
+    ...     def _eval_is_finite(self):
+    ...         return True
+    ...
+    ...     def _eval_conjugate(self):
+    ...         return self
 
 The applied function ``sign(x)`` is constructed using
-::
 
+    >>> sign(x)
     sign(x)
 
 both inside and outside of SymPy. Unapplied functions ``sign`` is just the class
 itself::
 
+    >>> sign
     sign
 
-both inside and outside of SymPy. This is the current structure of classes in
+The ``eval`` is called when the class is about to be instantiated and it
+should return either an another SymPy object or ``None``.
+If it is returned ``None``, it becomes a
+(see ``core/function.py`` in ``Function.__new__`` for implementation details)
+
+Here are some examples that how ``eval`` works
+
+    >>> sign(S.NaN)
+    nan
+    >>> sign(S.Zero)
+    0
+
+    >>> x = Symbol('x')
+    >>> sign(2*x)
+    sign(x)
+
+    >>> x = Symbol('x', positive=True)
+    >>> sign(x)
+    1
+
+    >>> x = Symbol('x', negative=True)
+    >>> sign(x)
+    -1
+
+The ``_eval_*`` functions are automatically called when something is
+needed.
+For example, ``conjugate`` or ``is_finite`` will automatically call
+``_eval_is_finite``, ``_eval_conjugate`` if you have these defined.
+
+    >>> sign(x).is_finite
+    True
+
+    >>> from sympy.functions import conjugate
+    >>> x = Symbol('x')
+    >>> conjugate(sign(x))
+    sign(x)
+
+If you want to check out some other examples of implementing custom
+SymPy functions, see the tests in
+`sympy/functions/elementary/tests/test_interface.py
+<https://github.com/sympy/sympy/blob/master/sympy/functions/elementary/tests/test_interface.py>`_
+that test this interface. You can use them to create your own new functions.
+
+Both inside and outside of SymPy. This is the current structure of classes in
 SymPy::
 
     class BasicType(type):

--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -386,15 +386,23 @@ can be changed in the future.
 
 This is how to create a function with two variables::
 
-    class chebyshevt_root(Function):
-        nargs = 2
+    >>> class chebyshevt_root(Function):
+    ...     nargs = 2
+    ...
+    ...     @classmethod
+    ...     def eval(cls, n, k):
+    ...         if not (0 <= k) & (k < n):
+    ...             raise ValueError("must have 0 <= k < n")
+    ...         return cos(S.Pi*(2*k + 1)/(2*n))
 
-        @classmethod
-        def eval(cls, n, k):
-            if not 0 <= k < n:
-                raise ValueError("must have 0 <= k < n")
-            return cos(S.Pi*(2*k + 1)/(2*n))
-
+    >>> from sympy import symbols
+    >>> n, k = symbols('n k')
+    >>> chebyshevt_root(n, k)
+    cos(pi*(2*k + 1)/(2*n))
+    >>> chebyshevt_root(2, 3)
+    Traceback (most recent call last):
+    ...
+    ValueError: must have 0 <= k < n
 
 .. note:: the first argument of a @classmethod should be ``cls`` (i.e. not
           ``self``).

--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -322,7 +322,7 @@ itself::
 
 The ``eval`` is called when the class is about to be instantiated and it
 should return either an another SymPy object or ``None``.
-If it is returned ``None``, it becomes a
+If it returns ``None``, it becomes an unevaluated function.
 (see ``core/function.py`` in ``Function.__new__`` for implementation details)
 
 Here are some examples that how ``eval`` works


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

There were some python 2 printing commands, and the tutorial had some more errors that have not been addressed in #18100. 

I've removed some bad practices like overriding `is_finite = True`, and removed `_eval_is_zero` there because it would not likely be testable from the logic there without introducing the concept of an unevaluated object, which may not be suitable for the introductory tutorial.

The only things I haven't touched are some shell commands from ondrej's approach section, which may not be doctested, and code snippets there can also be obsolete, but this may not be much of a concern.

I also don't think that the class structure of basic is accurate there, but haven't updated that part yet.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
