### PR TITLE
Printing: Added ascii printing for symbols with Alphabetical Subscripts & Superscripts

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1427,8 +1427,8 @@ class CoupledSpinState(SpinState):
         label = [self.j, self.m]
         for i, ji in enumerate(self.jn, start=1):
             symb = 'j%d' % i
-            symb = pretty_symbol(symb)
-            symb = prettyForm(symb + '=')
+            symb = prettyForm(pretty_symbol(symb))
+            symb = prettyForm(*symb.right("="))
             item = prettyForm(*symb.right(printer._print(ji)))
             label.append(item)
         for jn, (n1, n2) in zip(self.coupled_jn[:-1], self.coupled_n[:-1]):

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -440,7 +440,13 @@ def test_innerproduct():
     assert latex(ip3) == r'\left\langle 1,1 \right. {\left|1,1\right\rangle }'
     sT(ip3, "InnerProduct(JzBra(Integer(1),Integer(1)),JzKet(Integer(1),Integer(1)))")
     assert str(ip4) == "<1,1,j1=1,j2=1|1,1,j1=1,j2=1>"
-    assert pretty(ip4) == '<1,1,j1=1,j2=1|1,1,j1=1,j2=1>'
+    ascii_str = \
+"""\
+/             |             \\\n\
+\\1,1,j =1,j =1|1,1,j =1,j =1/\n\
+      1    2        1    2   \
+"""
+    assert pretty(ip4) == ascii_str
     assert upretty(ip4) == u'⟨1,1,j₁=1,j₂=1❘1,1,j₁=1,j₂=1⟩'
     assert latex(ip4) == \
         r'\left\langle 1,1,j_{1}=1,j_{2}=1 \right. {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }'
@@ -658,25 +664,49 @@ J \n\
     assert latex(bra) == r'{\left\langle 1,0\right|}'
     sT(bra, "JzBra(Integer(1),Integer(0))")
     assert str(cket) == '|1,0,j1=1,j2=2>'
-    assert pretty(cket) == '|1,0,j1=1,j2=2>'
+    ascii_str = \
+"""\
+|             \\\n\
+|1,0,j =1,j =2/\n\
+      1    2   \
+"""
+    assert pretty(cket) == ascii_str
     assert upretty(cket) == u'❘1,0,j₁=1,j₂=2⟩'
     assert latex(cket) == r'{\left|1,0,j_{1}=1,j_{2}=2\right\rangle }'
     sT(cket, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
     assert str(cbra) == '<1,0,j1=1,j2=2|'
-    assert pretty(cbra) == '<1,0,j1=1,j2=2|'
+    ascii_str = \
+"""\
+/             |\n\
+\\1,0,j =1,j =2|\n\
+      1    2   \
+"""
+    assert pretty(cbra) == ascii_str
     assert upretty(cbra) == u'⟨1,0,j₁=1,j₂=2❘'
     assert latex(cbra) == r'{\left\langle 1,0,j_{1}=1,j_{2}=2\right|}'
     sT(cbra, "JzBraCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
     assert str(cket_big) == '|1,0,j1=1,j2=2,j3=3,j(1,2)=3>'
     # TODO: Fix non-unicode pretty printing
     # i.e. j1,2 -> j(1,2)
-    assert pretty(cket_big) == '|1,0,j1=1,j2=2,j3=3,j1,2=3>'
+    ascii_str = \
+"""\
+|                           \\\n\
+|1,0,j =1,j =2,j =3,j 1, 2=3/\n\
+      1    2    3            \
+"""
+    assert pretty(cket_big) == ascii_str
     assert upretty(cket_big) == u'❘1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3⟩'
     assert latex(cket_big) == \
         r'{\left|1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right\rangle }'
     sT(cket_big, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2), Integer(3)),Tuple(Tuple(Integer(1), Integer(2), Integer(3)), Tuple(Integer(1), Integer(3), Integer(1))))")
     assert str(cbra_big) == '<1,0,j1=1,j2=2,j3=3,j(1,2)=3|'
-    assert pretty(cbra_big) == u'<1,0,j1=1,j2=2,j3=3,j1,2=3|'
+    ascii_str = \
+"""\
+/                           |\n\
+\\1,0,j =1,j =2,j =3,j 1, 2=3|\n\
+      1    2    3            \
+"""
+    assert pretty(cbra_big) == ascii_str
     assert upretty(cbra_big) == u'⟨1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3❘'
     assert latex(cbra_big) == \
         r'{\left\langle 1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right|}'
@@ -852,9 +882,9 @@ u("""\
         "Wigner3j(1, 2, 3, 4, 5, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x|1,-1,j1=1,j2=1>"
     ascii_str = \
 """\
-          [ +          ]  /   2     \\                                                                 \n\
-/1  3  5\\*[B  + A,C + D]x |- J  + J |*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x |1,-1,j1=1,j2=1>\n\
-|       |                 \\        z/                                                                 \n\
+          [ +          ]  /   2     \\            /|             \\   |             \\\\  |              \\\n\
+/1  3  5\\*[B  + A,C + D]x |- J  + J |*|1,0><1,1|*||1,0,j =1,j =1/ + |1,1,j =1,j =1/|x |1,-1,j =1,j =1/\n\
+|       |                 \\        z/            \\      1    2            1    2   /         1    2   \n\
 \\2  4  6/                                                                                             \
 """
     ucode_str = \

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -533,10 +533,23 @@ def pretty_symbol(symb_name, bold_name=False):
     # UC: beta1
     # UC: f_beta
 
-    if not _use_unicode:
-        return symb_name
+    # imported here to avoid circular ImportError
+    from .stringpict import prettyForm
+    from .pretty import PrettyPrinter
 
     name, sups, subs = split_super_sub(symb_name)
+
+    if not _use_unicode:
+        # glue all items together:
+        ascii_pretty = PrettyPrinter()
+        pform_sym = ascii_pretty._print(name)
+        pform = ascii_pretty._print(' ' * max(len(sups), len(subs)))
+        if len(sups) > 0:
+            pform = prettyForm(*pform.above(ascii_pretty._print(''.join(sups))))
+        if len(subs) > 0:
+            pform = prettyForm(*pform.below(ascii_pretty._print(''.join(subs))))
+
+        return prettyForm(*pform_sym.right(pform))
 
     def translate(s, bold_name) :
         if bold_name:

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -30,7 +30,7 @@ class stringPict(object):
         """
         self.s = s
         #picture is a string that just can be printed
-        self.picture = stringPict.equalLengths(s.splitlines())
+        self.picture = stringPict.equalLengths(str(s).splitlines())
         #baseline is the line number of the "base line"
         self.baseline = baseline
         self.binding = None

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5800,12 +5800,6 @@ u("""\
     assert pretty(1/sqrt(x)) == ascii_str
     assert upretty(1/sqrt(x)) == ucode_str
 
-
-def test_complicated_symbol_unchanged():
-    for symb_name in ["dexpr2_d1tau", "dexpr2^d1tau"]:
-        assert pretty(Symbol(symb_name)) == symb_name
-
-
 def test_categories():
     from sympy.categories import (Object, IdentityMorphism,
         NamedMorphism, Category, Diagram, DiagramGrid)
@@ -5819,19 +5813,44 @@ def test_categories():
     id_A1 = IdentityMorphism(A1)
 
     K1 = Category("K1")
-
-    assert pretty(A1) == "A1"
+    ascii_str = \
+"""\
+A \n\
+ 1\
+"""
+    assert pretty(A1) == ascii_str
     assert upretty(A1) == u"A₁"
 
-    assert pretty(f1) == "f1:A1-->A2"
+    ascii_str = \
+"""\
+f :A -->A \n\
+ 1  1    2\
+"""
+    assert pretty(f1) == ascii_str
     assert upretty(f1) == u"f₁:A₁——▶A₂"
-    assert pretty(id_A1) == "id:A1-->A1"
+
+    ascii_str = \
+"""\
+id:A -->A \n\
+    1    1\
+"""
+    assert pretty(id_A1) == ascii_str
     assert upretty(id_A1) == u"id:A₁——▶A₁"
 
-    assert pretty(f2*f1) == "f2*f1:A1-->A3"
+    ascii_str = \
+"""\
+f *f :A -->A \n\
+ 2  1  1    3\
+"""
+    assert pretty(f2*f1) == ascii_str
     assert upretty(f2*f1) == u"f₂∘f₁:A₁——▶A₃"
 
-    assert pretty(K1) == "K1"
+    ascii_str = \
+"""\
+K \n\
+ 1\
+"""
+    assert pretty(K1) == ascii_str
     assert upretty(K1) == u"K₁"
 
     # Test how diagrams are printed.
@@ -5840,24 +5859,38 @@ def test_categories():
     assert upretty(d) == u"∅"
 
     d = Diagram({f1: "unique", f2: S.EmptySet})
-    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
-        "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
-        "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}"
 
+    ascii_str = \
+"""\
+{f *f :A -->A : EmptySet, id:A -->A : EmptySet, id:A -->A : EmptySet, id:A -->A : EmptySet, f :A -->A : {unique}, f :A -->A : EmptySet}\n\
+  2  1  1    3                1    1                2    2                3    3             1  1    2             2  2    3           \
+"""
+    assert pretty(d) == ascii_str
     assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
         "id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}")
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
-    assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
-        "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
-        "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}" \
-        " ==> {f2*f1:A1-->A3: {unique}}"
+
+    ascii_str = \
+"""\
+{f *f :A -->A : EmptySet, id:A -->A : EmptySet, id:A -->A : EmptySet, id:A -->A : EmptySet, f :A -->A : {unique}, f :A -->A : EmptySet} ==> {f *f :A -->A : {unique}}\n\
+  2  1  1    3                1    1                2    2                3    3             1  1    2             2  2    3                  2  1  1    3           \
+"""
+    assert pretty(d) == ascii_str
     assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
         "∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
         " ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}")
 
     grid = DiagramGrid(d)
-    assert pretty(grid) == "A1  A2\n      \nA3    "
+    ascii_str = \
+"""\
+A   A \n\
+ 1   2\n\
+      \n\
+A     \n\
+ 3    \
+"""
+    assert pretty(grid) == ascii_str
     assert upretty(grid) == u"A₁  A₂\n      \nA₃    "
 
 
@@ -6338,12 +6371,20 @@ def test_MatrixElement_printing():
     B = MatrixSymbol("B", 1, 3)
     C = MatrixSymbol("C", 1, 3)
 
-    ascii_str1 = "A_00"
+    ascii_str1 = \
+'''\
+A  \n\
+ 00\
+'''
     ucode_str1 = u("A₀₀")
     assert pretty(A[0, 0])  == ascii_str1
     assert upretty(A[0, 0]) == ucode_str1
 
-    ascii_str1 = "3*A_00"
+    ascii_str1 = \
+'''\
+3*A  \n\
+   00\
+'''
     ucode_str1 = u("3⋅A₀₀")
     assert pretty(3*A[0, 0])  == ascii_str1
     assert upretty(3*A[0, 0]) == ucode_str1
@@ -6376,6 +6417,24 @@ u("""\
 """)
     assert upretty((1/y)*e.j) == ucode_str
 
+
+def test_issue_12158():
+    sym1 = Symbol('x_2__i')
+    ascii_str1 = \
+'''\
+ i\n\
+x \n\
+ 2\
+'''
+    assert pretty(sym1) == ascii_str1
+    sym2 = Symbol('x^k^t_j_i')
+    ascii_str2 = \
+'''\
+ kt\n\
+x  \n\
+ ji\
+'''
+    assert pretty(sym2) == ascii_str2
 
 def test_MatrixSymbol_printing():
     # test cases for issue #14237
@@ -6462,9 +6521,10 @@ A \n\
     expr = A(i0)
     ascii_str = \
 """\
- i_0\n\
-A   \n\
-    \
+ i \n\
+  0\n\
+A  \n\
+   \
 """
     ucode_str = \
 u("""\
@@ -6526,9 +6586,11 @@ H  \n\
     expr = H(i, -i)
     ascii_str = \
 """\
- L_0   \n\
-H      \n\
-    L_0\
+ L   \n\
+  0  \n\
+H    \n\
+   L \n\
+    0\
 """
     ucode_str = \
 u("""\
@@ -6542,9 +6604,11 @@ H    \n\
     expr = H(i, -j)*A(j)*B(k)
     ascii_str = \
 """\
- i     L_0  k\n\
-H    *A   *B \n\
-  L_0        \
+      L    \n\
+ i     0  k\n\
+H   *A  *B \n\
+  L        \n\
+   0       \
 """
     ucode_str = \
 u("""\
@@ -6622,12 +6686,14 @@ u("""\
     expr = A(i)*PartialDerivative(H(k, -i), A(j))
     ascii_str = \
 """\
- L_0  d / k   \\\n\
-A   *---|H    |\n\
-       j\\  L_0/\n\
-     dA        \n\
-               \
+ L           \n\
+  0  d / k  \\\n\
+A  *---|H   |\n\
+      j|  L |\n\
+    dA \\   0/\n\
+             \
 """
+
     ucode_str = \
 u("""\
  L₀  ∂ ⎛ k  ⎞\n\
@@ -6642,11 +6708,12 @@ A  ⋅───⎜H   ⎟\n\
     expr = A(i)*PartialDerivative(B(k)*C(-i) + 3*H(k, -i), A(j))
     ascii_str = \
 """\
- L_0  d / k           k   \\\n\
-A   *---|B *C    + 3*H    |\n\
-       j\\    L_0       L_0/\n\
-     dA                    \n\
-                           \
+ L                      \n\
+  0  d / k          k  \\\n\
+A  *---|B *C   + 3*H   |\n\
+      j|    L        L |\n\
+    dA \\     0        0/\n\
+                        \
 """
     ucode_str = \
 u("""\
@@ -6662,11 +6729,12 @@ A  ⋅───⎜B ⋅C   + 3⋅H   ⎟\n\
     expr = (A(i) + B(i))*PartialDerivative(C(-j), D(j))
     ascii_str = \
 """\
-/ i    i\\   d  /    \\\n\
-|A  + B |*-----|C   |\n\
-\\       /   L_0\\ L_0/\n\
-          dD         \n\
-                     \
+/ i    i\\  d  /   \\\n\
+|A  + B |*----|C  |\n\
+\\       /   L | L |\n\
+             0\\  0/\n\
+          dD       \n\
+                   \
 """
     ucode_str = \
 u("""\
@@ -6682,11 +6750,12 @@ u("""\
     expr = (A(i) + B(i))*PartialDerivative(C(-i), D(j))
     ascii_str = \
 """\
-/ L_0    L_0\\  d /    \\\n\
-|A    + B   |*---|C   |\n\
-\\           /   j\\ L_0/\n\
-              dD       \n\
-                       \
+/ L     L \\         \n\
+|  0     0|  d /   \\\n\
+|A   + B  |*---|C  |\n\
+\\         /   j| L |\n\
+            dD \\  0/\n\
+                    \
 """
     ucode_str = \
 u("""\


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #12158

#### Brief description of what is fixed or changed
Current Version of Sympy can't print alphabetical superscripts and subscipts
Example:
```py
>>> from sympy import *
>>> sym1 = Symbol('x_2__i')
>>> pprint(sym1,use_unicode=false)
x_2__i
>>> pprint(Integral(sym1),use_unicode = false)
  /
 |
 | x_2__i d(x_2__i)
 |
/
```
After adding the ascii printer for alphabetical superscripts and subscripts
Example:
```py
>>> from sympy import *
>>> sym1 = Symbol('x_2__i')
>>> pprint(sym1,use_unicode=false)
 i
x
 2
>>> pprint(Integral(sym1),use_unicode = false)
  /
 |
 |  i  / i\
 | x  d|x |
 |  2  \ 2/
 |
/
```
#### Other comments

--> Added the ascii logic in pretty_symbol, _print_symbol
--> Changed Some Test Cases Accordingly in test_pretty, test_printing
--> Little Tweaks in stringpict, spin.py to make sure all test pass
--> added a global variable has_function to avoid function names getting prettified
Example:
After applying new ascii logic
```py

>>> pprint(dirichlet_eta(x),use_unicode = False)
dirichlet    (x)
            eta
```
But after adding has_function variable to make sure expr is not treated as a normal string
```py
>>> pprint(dirichlet_eta(x),use_unicode = False)
dirichlet_eta(x)
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Added the ASCII printer for alphabetical superscripts and subscripts
<!-- END RELEASE NOTES -->
