### PR TITLE
Add .evalf() method to sympy.physics.vector.Vector and Dyadic #18064

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -7,7 +7,7 @@ from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
 __all__ = ['Dyadic']
 
 
-class Dyadic(object):
+class Dyadic(EvalfMixin):
     """A Dyadic object.
 
     See:

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,6 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.compatibility import unicode
+from sympy.core.evalf import EvalfMixin
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
 

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -96,5 +96,5 @@ def test_dyadic_subs():
 def test_check_dyadic():
     raises(TypeError, lambda: _check_dyadic(0))
 
-def test_Dyadic_Evalf():
-    assert (A.x**2).evalf(subs={A.x: 0}) == 0
+
+    

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -95,3 +95,6 @@ def test_dyadic_subs():
 
 def test_check_dyadic():
     raises(TypeError, lambda: _check_dyadic(0))
+
+def test_Dyadic_Evalf():
+    assert (A.x**2).evalf(subs={A.x: 0}) == 0

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -63,6 +63,9 @@ def test_Vector():
     raises(TypeError, lambda: v3.applyfunc(v1))
 
 
+
+
+
 def test_Vector_diffs():
     q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
     q1d, q2d, q3d, q4d = dynamicsymbols('q1 q2 q3 q4', 1)
@@ -169,3 +172,6 @@ def test_vector_simplify():
     test4 = ((-4 * x * y**2 - 2 * y**3 - 2 * x**2 * y) / (x + y)**2) * N.x
     test4 = test4.simplify()
     assert (test4 & N.x) == -2 * y
+
+def test_Vector_Evalf():
+    assert (A.x**2).evalf(subs={A.x: 0}) == 0

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -12,6 +12,7 @@ def test_Vector():
     assert A.x != A.y
     assert A.y != A.z
     assert A.z != A.x
+    assert (A.x**2).evalf(subs={A.x: 0}) == 0
 
     assert A.x + 0 == A.x
 
@@ -173,5 +174,4 @@ def test_vector_simplify():
     test4 = test4.simplify()
     assert (test4 & N.x) == -2 * y
 
-def test_Vector_Evalf():
-    assert (A.x**2).evalf(subs={A.x: 0}) == 0
+

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,7 @@
 from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros,
     ImmutableMatrix as Matrix)
 from sympy import trigsimp
+from sympy.core.evalf import EvalfMixin
 from sympy.core.compatibility import unicode
 from sympy.utilities.misc import filldedent
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -8,7 +8,7 @@ from sympy.utilities.misc import filldedent
 __all__ = ['Vector']
 
 
-class Vector(object):
+class Vector(EvalfMixin):
     """The class used to define vectors.
 
     It along with ReferenceFrame are the building blocks of describing a


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18064
Closes https://github.com/sympy/sympy/pull/18120

#### Brief description of what is fixed or changed
THe Vector and Dyadic now inherit the EvalfMixin class


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
