### PR TITLE
Make Expr.__add__ etc return NotImplemented for non-Expr Basic subclasses

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -86,14 +86,17 @@ class CodegenArrayContraction(_CodegenArrayAbstract):
         obj._shape = shape
         return obj
 
-    # XXX: Maybe __mul__ and __rmul__ should have some type checking. These
-    # methods were added because Expr no longer accepts non-Expr in __mul__.
-
     def __mul__(self, other):
-        return Mul(self, other)
+        if other == 1:
+            return self
+        else:
+            raise NotImplementedError("Product of N-dim arrays is not uniquely defined. Use another method.")
 
     def __rmul__(self, other):
-        return Mul(other, self)
+        if other == 1:
+            return self
+        else:
+            raise NotImplementedError("Product of N-dim arrays is not uniquely defined. Use another method.")
 
     @staticmethod
     def _validate(expr, *contraction_indices):

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -86,6 +86,15 @@ class CodegenArrayContraction(_CodegenArrayAbstract):
         obj._shape = shape
         return obj
 
+    # XXX: Maybe __mul__ and __rmul__ should have some type checking. These
+    # methods were added because Expr no longer accepts non-Expr in __mul__.
+
+    def __mul__(self, other):
+        return Mul(self, other)
+
+    def __rmul__(self, other):
+        return Mul(other, self)
+
     @staticmethod
     def _validate(expr, *contraction_indices):
         shape = expr.shape

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -157,7 +157,7 @@ def sympify_method_args(cls):
     In the above it is important that we return NotImplemented when other is
     not sympifiable and also when the sympified result is not of the expected
     type. This allows the MyTuple class to be used cooperatively with other
-    classes that overload __add__ and want to do something else in bombination
+    classes that overload __add__ and want to do something else in combination
     with instance of Tuple.
 
     Using this decorator the above can be written as

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -235,7 +235,8 @@ class _SympifyWrapper(object):
             raise RuntimeError('sympify_return can only be used with 2 argument functions')
         # only b is _sympified
         if get_function_code(func).co_varnames[1] != parameter:
-            raise RuntimeError('parameter name mismatch %s' % parameter)
+            raise RuntimeError('parameter name mismatch "%s" in %s' %
+                    (parameter, func.__name__))
 
         @wraps(func)
         def _func(self, other):
@@ -247,7 +248,7 @@ class _SympifyWrapper(object):
                     other = sympify(other, strict=True)
                 except SympifyError:
                     return retval
-            if not isinstance(other, cls):
+            if not isinstance(other, expectedcls):
                 return retval
             return func(self, other)
 

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -239,10 +239,14 @@ class _SympifyWrapper(object):
 
         @wraps(func)
         def _func(self, other):
-            try:
-                other = sympify(other, strict=True)
-            except SympifyError:
-                return retval
+            # XXX: The check for _op_priority here should be removed. It is
+            # needed to stop mutable matrices from being sympified to
+            # immutable matrices which breaks things in quantum...
+            if not hasattr(other, '_op_priority'):
+                try:
+                    other = sympify(other, strict=True)
+                except SympifyError:
+                    return retval
             if not isinstance(other, cls):
                 return retval
             return func(self, other)

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -129,3 +129,122 @@ def call_highest_priority(method_name):
             return func(self, other)
         return binary_op_wrapper
     return priority_decorator
+
+
+def sympify_method_args(cls):
+    '''Decorator for a class with methods that sympify arguments.
+
+    The sympify_method_args decorator is to be used with the sympify_return
+    decorator for automatic sympification of method arguments. This is
+    intended for the common idiom of writing a class like
+
+    >>> from sympy.core.basic import Basic
+    >>> from sympy.core.sympify import _sympify, SympifyError
+
+    >>> class MyTuple(Basic):
+    ...     def __add__(self, other):
+    ...         try:
+    ...             other = _sympify(other)
+    ...         except SympifyError:
+    ...             return NotImplemented
+    ...         if not isinstance(other, MyTuple):
+    ...             return NotImplemented
+    ...         return MyTuple(*(self.args + other.args))
+
+    >>> MyTuple(1, 2) + MyTuple(3, 4)
+    MyTuple(1, 2, 3, 4)
+
+    In the above it is important that we return NotImplemented when other is
+    not sympifiable and also when the sympified result is not of the expected
+    type. This allows the MyTuple class to be used cooperatively with other
+    classes that overload __add__ and want to do something else in bombination
+    with instance of Tuple.
+
+    Using this decorator the above can be written as
+
+    >>> from sympy.core.decorators import sympify_method_args, sympify_return
+
+    >>> @sympify_method_args
+    ... class MyTuple(Basic):
+    ...     @sympify_return([('other', 'MyTuple')], NotImplemented)
+    ...     def __add__(self, other):
+    ...          return MyTuple(*(self.args + other.args))
+
+    >>> MyTuple(1, 2) + MyTuple(3, 4)
+    MyTuple(1, 2, 3, 4)
+
+    The idea here is that the decorators take care of the boiler-plate code
+    for making this happen in each method that potentially needs to accept
+    unsympified arguments. Then the body of e.g. the __add__ method can be
+    written without needing to worry about calling _sympify or checking the
+    type of the resulting object.
+
+    The parameters for sympify_return are a list of tuples of the form
+    (parameter_name, expected_type) and the value to return (e.g.
+    NotImplemented). The expected_type parameter can be a type e.g. Tuple or a
+    string 'Tuple'. Using a string is useful for specifying a Type within its
+    class body (as in the above example).
+
+    Notes: Currently sympify_return only works for methods that take a single
+    argument (not including self). Specifying an expected_type as a string
+    only works for the class in which the method is defined.
+    '''
+    # Extract the wrapped methods from each of the wrapper objects created by
+    # the sympify_return decorator. Doing this here allows us to provide the
+    # cls argument which is used for forward string referencing.
+    for attrname, obj in cls.__dict__.items():
+        if isinstance(obj, _SympifyWrapper):
+            setattr(cls, attrname, obj.make_wrapped(cls))
+    return cls
+
+
+def sympify_return(*args):
+    '''Function/method decorator to sympify arguments automatically
+
+    See the docstring of sympify_method_args for explanation.
+    '''
+    # Store a wrapper object for the decorated method
+    def wrapper(func):
+        return _SympifyWrapper(func, args)
+    return wrapper
+
+
+class _SympifyWrapper(object):
+    '''Internal class used by sympify_return and sympify_method_args'''
+
+    def __init__(self, func, args):
+        self.func = func
+        self.args = args
+
+    def make_wrapped(self, cls):
+        func = self.func
+        parameters, retval = self.args
+
+        # XXX: Handle more than one parameter?
+        [(parameter, expectedcls)] = parameters
+
+        # Handle forward references to the current class using strings
+        if expectedcls == cls.__name__:
+            expectedcls = cls
+
+        # Raise RuntimeError since this is a failure at import time and should
+        # not be recoverable.
+        nargs = get_function_code(func).co_argcount
+        # we support f(a, b) only
+        if nargs != 2:
+            raise RuntimeError('sympify_return can only be used with 2 argument functions')
+        # only b is _sympified
+        if get_function_code(func).co_varnames[1] != parameter:
+            raise RuntimeError('parameter name mismatch %s' % parameter)
+
+        @wraps(func)
+        def _func(self, other):
+            try:
+                other = sympify(other, strict=True)
+            except SympifyError:
+                return retval
+            if not isinstance(other, cls):
+                return retval
+            return func(self, other)
+
+        return _func

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -173,36 +173,50 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__radd__')
     def __add__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Add(self, other)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__add__')
     def __radd__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Add(other, self)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Add(self, -other)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Add(other, -self)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rmul__')
     def __mul__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mul(self, other)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__mul__')
     def __rmul__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mul(other, self)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rpow__')
     def _pow(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Pow(self, other)
 
     def __pow__(self, other, mod=None):
@@ -225,16 +239,22 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__pow__')
     def __rpow__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Pow(other, self)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rdiv__')
     def __div__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mul(self, Pow(other, S.NegativeOne))
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__div__')
     def __rdiv__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mul(other, Pow(self, S.NegativeOne))
 
     __truediv__ = __div__
@@ -243,11 +263,15 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rmod__')
     def __mod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mod(self, other)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__mod__')
     def __rmod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return Mod(other, self)
 
     @_sympifyit('other', NotImplemented)
@@ -259,6 +283,8 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__floordiv__')
     def __rfloordiv__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(other / self)
 
@@ -266,12 +292,16 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rdivmod__')
     def __divmod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(self / other), Mod(self, other)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__divmod__')
     def __rdivmod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(other / self), Mod(other, self)
 
@@ -335,6 +365,10 @@ class Expr(Basic, EvalfMixin):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s %s %s" % (self, op, other))
+
+        if not isinstance(other, Expr):
+            return NotImplemented
+
         for me in (self, other):
             if me.is_extended_real is False:
                 raise TypeError("Invalid comparison of non-real %s" % me)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4,7 +4,7 @@ from .sympify import sympify, _sympify, SympifyError
 from .basic import Basic, Atom
 from .singleton import S
 from .evalf import EvalfMixin, pure_complex
-from .decorators import _sympifyit, call_highest_priority
+from .decorators import call_highest_priority, sympify_method_args, sympify_return
 from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, range, Iterable
 from sympy.utilities.misc import func_name
@@ -12,6 +12,8 @@ from mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict
 
+
+@sympify_method_args
 class Expr(Basic, EvalfMixin):
     """
     Base class for algebraic expressions.
@@ -170,53 +172,39 @@ class Expr(Basic, EvalfMixin):
         from sympy import Abs
         return Abs(self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__radd__')
     def __add__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Add(self, other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__add__')
     def __radd__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Add(other, self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Add(self, -other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Add(other, -self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmul__')
     def __mul__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mul(self, other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__mul__')
     def __rmul__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mul(other, self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rpow__')
     def _pow(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Pow(self, other)
 
     def __pow__(self, other, mod=None):
@@ -236,74 +224,56 @@ class Expr(Basic, EvalfMixin):
             except TypeError:
                 return NotImplemented
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__pow__')
     def __rpow__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Pow(other, self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rdiv__')
     def __div__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mul(self, Pow(other, S.NegativeOne))
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__div__')
     def __rdiv__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mul(other, Pow(self, S.NegativeOne))
 
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmod__')
     def __mod__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mod(self, other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__mod__')
     def __rmod__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         return Mod(other, self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rfloordiv__')
     def __floordiv__(self, other):
         from sympy.functions.elementary.integers import floor
-        if not isinstance(other, Expr):
-            return NotImplemented
         return floor(self / other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__floordiv__')
     def __rfloordiv__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(other / self)
 
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rdivmod__')
     def __divmod__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(self / other), Mod(self, other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__divmod__')
     def __rdivmod__(self, other):
-        if not isinstance(other, Expr):
-            return NotImplemented
         from sympy.functions.elementary.integers import floor
         return floor(other / self), Mod(other, self)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -366,7 +366,7 @@ class Expr(Basic, EvalfMixin):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s %s %s" % (self, op, other))
+            return NotImplemented
 
         if not isinstance(other, Expr):
             return NotImplemented

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -278,6 +278,8 @@ class Expr(Basic, EvalfMixin):
     @call_highest_priority('__rfloordiv__')
     def __floordiv__(self, other):
         from sympy.functions.elementary.integers import floor
+        if not isinstance(other, Expr):
+            return NotImplemented
         return floor(self / other)
 
     @_sympifyit('other', NotImplemented)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1421,7 +1421,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if other.is_Rational:
             # test self*other.q <?> other.p without losing precision
             '''
@@ -1916,7 +1916,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if other.is_Number:
             op = None
             s, o = self, other
@@ -2252,7 +2252,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
+            return NotImplemented
         if other.is_Integer:
             return _sympify(self.p > other.p)
         return Rational.__gt__(self, other)
@@ -2261,7 +2261,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
+            return NotImplemented
         if other.is_Integer:
             return _sympify(self.p < other.p)
         return Rational.__lt__(self, other)
@@ -2270,7 +2270,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+            return NotImplemented
         if other.is_Integer:
             return _sympify(self.p >= other.p)
         return Rational.__ge__(self, other)
@@ -2279,7 +2279,7 @@ class Integer(Rational):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+            return NotImplemented
         if other.is_Integer:
             return _sympify(self.p <= other.p)
         return Rational.__le__(self, other)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -632,8 +632,7 @@ class Number(AtomicExpr):
             if self.is_infinite or S.NaN in (self, other):
                 return (S.NaN, S.NaN)
         except TypeError:
-            msg = "unsupported operand type(s) for divmod(): '%s' and '%s'"
-            raise TypeError(msg % (type(self).__name__, type(other).__name__))
+            return NotImplemented
         if not other:
             raise ZeroDivisionError('modulo by zero')
         if self.is_Integer and other.is_Integer:
@@ -654,8 +653,7 @@ class Number(AtomicExpr):
         try:
             other = Number(other)
         except TypeError:
-            msg = "unsupported operand type(s) for divmod(): '%s' and '%s'"
-            raise TypeError(msg % (type(other).__name__, type(self).__name__))
+            return NotImplemented
         return divmod(other, self)
 
     def _as_mpf_val(self, prec):
@@ -2416,7 +2414,10 @@ class Integer(Rational):
     def as_numer_denom(self):
         return self, S.One
 
+    @_sympifyit('other', NotImplemented)
     def __floordiv__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         if isinstance(other, Integer):
             return Integer(self.p // other)
         return Integer(divmod(self, other)[0])
@@ -2954,7 +2955,10 @@ class Infinity(with_metaclass(Singleton, Number)):
     __lt__ = Expr.__lt__
     __le__ = Expr.__le__
 
+    @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return S.NaN
 
     __rmod__ = __mod__
@@ -3116,7 +3120,10 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     __lt__ = Expr.__lt__
     __le__ = Expr.__le__
 
+    @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
+        if not isinstance(other, Expr):
+            return NotImplemented
         return S.NaN
 
     __rmod__ = __mod__

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -331,14 +331,16 @@ def test_cooperative_operations():
         raises(TypeError, lambda : divmod(na, e))
         raises(TypeError, lambda : e ** na)
         raises(TypeError, lambda : na ** e)
-        raises(TypeError, lambda : e > na)
-        raises(TypeError, lambda : na > e)
-        raises(TypeError, lambda : e < na)
-        raises(TypeError, lambda : na < e)
-        raises(TypeError, lambda : e >= na)
-        raises(TypeError, lambda : na >= e)
-        raises(TypeError, lambda : e <= na)
-        raises(TypeError, lambda : na <= e)
+        # XXX: Remove the if when PY2 support is dropped:
+        if PY3:
+            raises(TypeError, lambda : e > na)
+            raises(TypeError, lambda : na > e)
+            raises(TypeError, lambda : e < na)
+            raises(TypeError, lambda : na < e)
+            raises(TypeError, lambda : e >= na)
+            raises(TypeError, lambda : na >= e)
+            raises(TypeError, lambda : e <= na)
+            raises(TypeError, lambda : na <= e)
 
 
 def test_relational():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -286,7 +286,6 @@ def test_cooperative_operations():
         # Test that these classes can override arithmetic operations in
         # combination with various Expr types.
         for ne in [NonBasic(), NonExpr()]:
-            ne = NonExpr()
 
             results = [
                 (ne + e, ('+', ne, e)),

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -257,8 +257,15 @@ class NonArithmetic(Basic):
 
 
 def test_cooperative_operations():
-    '''Tests that Expr allows binary operations to be overridden by non-Expr
-    objects when interacting with Expr instances.'''
+    '''Tests that Expr uses binary operations cooperatively.
+
+    In particular it should be possible for non-Expr classes to override
+    binary operators like +, - etc when used with Expr instances. This should
+    work for non-Expr classes whether they are Basic subclasses or not. Also
+    non-Expr classes that do not define binary operators with Expr should give
+    TypeError.
+    '''
+    # A bunch of instances of Expr subclasses
     exprs = [
         Expr(),
         S.Zero,
@@ -276,7 +283,7 @@ def test_cooperative_operations():
     ]
 
     for e in exprs:
-        # Test that these classes can override airthmetic operations in
+        # Test that these classes can override arithmetic operations in
         # combination with various Expr types.
         for ne in [NonBasic(), NonExpr()]:
             ne = NonExpr()
@@ -311,36 +318,36 @@ def test_cooperative_operations():
             for res, args in results:
                 assert type(res) is SpecialOp and res.args == args
 
-        # This class does not support arithmetic operations. Every operation
-        # should raise in combination with any of the Expr types.
-        na = NonArithmetic()
+        # These classes do not support binary operators with Expr. Every
+        # operation should raise in combination with any of the Expr types.
+        for na in [NonArithmetic(), object()]:
 
-        raises(TypeError, lambda : e + na)
-        raises(TypeError, lambda : na + e)
-        raises(TypeError, lambda : e - na)
-        raises(TypeError, lambda : na - e)
-        raises(TypeError, lambda : e * na)
-        raises(TypeError, lambda : na * e)
-        raises(TypeError, lambda : e / na)
-        raises(TypeError, lambda : na / e)
-        raises(TypeError, lambda : e // na)
-        raises(TypeError, lambda : na // e)
-        raises(TypeError, lambda : e % na)
-        raises(TypeError, lambda : na % e)
-        raises(TypeError, lambda : divmod(e, na))
-        raises(TypeError, lambda : divmod(na, e))
-        raises(TypeError, lambda : e ** na)
-        raises(TypeError, lambda : na ** e)
-        # XXX: Remove the if when PY2 support is dropped:
-        if PY3:
-            raises(TypeError, lambda : e > na)
-            raises(TypeError, lambda : na > e)
-            raises(TypeError, lambda : e < na)
-            raises(TypeError, lambda : na < e)
-            raises(TypeError, lambda : e >= na)
-            raises(TypeError, lambda : na >= e)
-            raises(TypeError, lambda : e <= na)
-            raises(TypeError, lambda : na <= e)
+            raises(TypeError, lambda : e + na)
+            raises(TypeError, lambda : na + e)
+            raises(TypeError, lambda : e - na)
+            raises(TypeError, lambda : na - e)
+            raises(TypeError, lambda : e * na)
+            raises(TypeError, lambda : na * e)
+            raises(TypeError, lambda : e / na)
+            raises(TypeError, lambda : na / e)
+            raises(TypeError, lambda : e // na)
+            raises(TypeError, lambda : na // e)
+            raises(TypeError, lambda : e % na)
+            raises(TypeError, lambda : na % e)
+            raises(TypeError, lambda : divmod(e, na))
+            raises(TypeError, lambda : divmod(na, e))
+            raises(TypeError, lambda : e ** na)
+            raises(TypeError, lambda : na ** e)
+            # XXX: Remove the if when PY2 support is dropped:
+            if PY3:
+                raises(TypeError, lambda : e > na)
+                raises(TypeError, lambda : na > e)
+                raises(TypeError, lambda : e < na)
+                raises(TypeError, lambda : na < e)
+                raises(TypeError, lambda : e >= na)
+                raises(TypeError, lambda : na >= e)
+                raises(TypeError, lambda : e <= na)
+                raises(TypeError, lambda : na <= e)
 
 
 def test_relational():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -7,7 +7,7 @@ from sympy import (Rational, Symbol, Float, I, sqrt, cbrt, oo, nan, pi, E,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
                    AlgebraicNumber, simplify, sin, fibonacci, RealField,
                    sympify, srepr, Dummy, Sum)
-from sympy.core.compatibility import long
+from sympy.core.compatibility import long, PY3
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
     igcd2, igcd_lehmer, mpf_norm, comp, mod_inverse)
@@ -1901,14 +1901,15 @@ def test_comparisons_with_unknown_type():
         assert foo != n
         assert not n == foo
         assert not foo == n
-        raises(TypeError, lambda: n < foo)
-        raises(TypeError, lambda: foo > n)
-        raises(TypeError, lambda: n > foo)
-        raises(TypeError, lambda: foo < n)
-        raises(TypeError, lambda: n <= foo)
-        raises(TypeError, lambda: foo >= n)
-        raises(TypeError, lambda: n >= foo)
-        raises(TypeError, lambda: foo <= n)
+        if PY3:
+            raises(TypeError, lambda: n < foo)
+            raises(TypeError, lambda: foo > n)
+            raises(TypeError, lambda: n > foo)
+            raises(TypeError, lambda: foo < n)
+            raises(TypeError, lambda: n <= foo)
+            raises(TypeError, lambda: foo >= n)
+            raises(TypeError, lambda: n >= foo)
+            raises(TypeError, lambda: foo <= n)
 
     class Bar(object):
         """
@@ -1942,14 +1943,15 @@ def test_comparisons_with_unknown_type():
         assert not bar == n
 
     for n in ni, nf, nr, oo, -oo, zoo, nan:
-        raises(TypeError, lambda: n < bar)
-        raises(TypeError, lambda: bar > n)
-        raises(TypeError, lambda: n > bar)
-        raises(TypeError, lambda: bar < n)
-        raises(TypeError, lambda: n <= bar)
-        raises(TypeError, lambda: bar >= n)
-        raises(TypeError, lambda: n >= bar)
-        raises(TypeError, lambda: bar <= n)
+        if PY3:
+            raises(TypeError, lambda: n < bar)
+            raises(TypeError, lambda: bar > n)
+            raises(TypeError, lambda: n > bar)
+            raises(TypeError, lambda: bar < n)
+            raises(TypeError, lambda: n <= bar)
+            raises(TypeError, lambda: bar >= n)
+            raises(TypeError, lambda: n >= bar)
+            raises(TypeError, lambda: bar <= n)
 
 def test_NumberSymbol_comparison():
     from sympy.core.tests.test_relational import rel_check
@@ -2018,11 +2020,12 @@ def test_NegativeInfinity():
     assert (-oo)**12 is oo
 
 def test_issue_6133():
-    raises(TypeError, lambda: (-oo < None))
-    raises(TypeError, lambda: (S(-2) < None))
-    raises(TypeError, lambda: (oo < None))
-    raises(TypeError, lambda: (oo > None))
-    raises(TypeError, lambda: (S(2) < None))
+    if PY3:
+        raises(TypeError, lambda: (-oo < None))
+        raises(TypeError, lambda: (S(-2) < None))
+        raises(TypeError, lambda: (oo < None))
+        raises(TypeError, lambda: (oo > None))
+        raises(TypeError, lambda: (S(2) < None))
 
 def test_abc():
     x = numbers.Float(5)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
     log, cos, sin, Add, floor, ceiling, trigsimp)
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, PY3
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -611,7 +611,8 @@ def test_inequalities_cant_sympify_other():
 
     for a in (x, S.Zero, S.One/3, pi, I, zoo, oo, -oo, nan, Rational(1, 3)):
         for op in (lt, gt, le, ge):
-            raises(TypeError, lambda: op(a, bar))
+            if PY3:
+                raises(TypeError, lambda: op(a, bar))
 
 
 def test_ineq_avoid_wild_symbol_flip():

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -8,7 +8,8 @@ from sympy.core.compatibility import (iterable, with_metaclass,
     ordered, range, PY3, reduce)
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
-from sympy.core.decorators import deprecated, _sympifyit
+from sympy.core.decorators import (deprecated, sympify_method_args,
+    sympify_return)
 from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
 from sympy.core.expr import Expr
@@ -35,6 +36,8 @@ tfn = defaultdict(lambda: None, {
     False: S.false,
     S.false: S.false})
 
+
+@sympify_method_args
 class Set(Basic):
     """
     The base class for any kind of set.
@@ -625,48 +628,34 @@ class Set(Basic):
     def _measure(self):
         raise NotImplementedError("(%s)._measure" % self)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __add__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return self.union(other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __or__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return self.union(other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __and__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return self.intersect(other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __mul__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return ProductSet(self, other)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __xor__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return SymmetricDifference(self, other)
 
-    @_sympifyit('exp', NotImplemented)
+    @sympify_return([('exp', Expr)], NotImplemented)
     def __pow__(self, exp):
-        if not isinstance(exp, Expr):
-            return NotImplemented
         if not (exp.is_Integer and exp >= 0):
             raise ValueError("%s: Exponent must be a positive Integer" % exp)
         return ProductSet(*[self]*exp)
 
-    @_sympifyit('other', NotImplemented)
+    @sympify_return([('other', 'Set')], NotImplemented)
     def __sub__(self, other):
-        if not isinstance(other, Set):
-            return NotImplemented
         return Complement(self, other)
 
     def __contains__(self, other):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -8,7 +8,7 @@ from sympy.core.compatibility import (iterable, with_metaclass,
     ordered, range, PY3, reduce)
 from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
-from sympy.core.decorators import deprecated
+from sympy.core.decorators import deprecated, _sympifyit
 from sympy.core.evalf import EvalfMixin
 from sympy.core.evaluate import global_evaluate
 from sympy.core.expr import Expr
@@ -625,31 +625,52 @@ class Set(Basic):
     def _measure(self):
         raise NotImplementedError("(%s)._measure" % self)
 
+    @_sympifyit('other', NotImplemented)
     def __add__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return self.union(other)
 
+    @_sympifyit('other', NotImplemented)
     def __or__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return self.union(other)
 
+    @_sympifyit('other', NotImplemented)
     def __and__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return self.intersect(other)
 
+    @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return ProductSet(self, other)
 
+    @_sympifyit('other', NotImplemented)
     def __xor__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return SymmetricDifference(self, other)
 
+    @_sympifyit('exp', NotImplemented)
     def __pow__(self, exp):
-        if not (sympify(exp).is_Integer and exp >= 0):
+        if not isinstance(exp, Expr):
+            return NotImplemented
+        if not (exp.is_Integer and exp >= 0):
             raise ValueError("%s: Exponent must be a positive Integer" % exp)
         return ProductSet(*[self]*exp)
 
+    @_sympifyit('other', NotImplemented)
     def __sub__(self, other):
+        if not isinstance(other, Set):
+            return NotImplemented
         return Complement(self, other)
 
     def __contains__(self, other):
-        other = sympify(other)
+        other = _sympify(other)
         c = self._contains(other)
         b = tfn[c]
         if b is None:

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -319,12 +319,16 @@ def test_set_operations_nonsets():
         lambda a, b: a * b,
         lambda a, b: a / b,
         lambda a, b: a // b,
+        lambda a, b: a | b,
+        lambda a, b: a & b,
+        lambda a, b: a ^ b,
         # FiniteSet(1) ** 2 gives a ProductSet
         #lambda a, b: a ** b,
     ]
     Sx = FiniteSet(x)
     Sy = FiniteSet(y)
     sets = [
+        {1},
         FiniteSet(1),
         Interval(1, 2),
         Union(Sx, Interval(1, 2)),
@@ -340,6 +344,8 @@ def test_set_operations_nonsets():
             for op in ops:
                 raises(TypeError, lambda : op(s, n))
                 raises(TypeError, lambda : op(n, s))
+        raises(TypeError, lambda: s ** object())
+        raises(TypeError, lambda: s ** {1})
 
 
 def test_complement():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -311,6 +311,37 @@ def test_Complement():
     assert B3 - A2 == B3
 
 
+def test_set_operations_nonsets():
+    '''Tests that e.g. FiniteSet(1) * 2 raises TypeError'''
+    ops = [
+        lambda a, b: a + b,
+        lambda a, b: a - b,
+        lambda a, b: a * b,
+        lambda a, b: a / b,
+        lambda a, b: a // b,
+        # FiniteSet(1) ** 2 gives a ProductSet
+        #lambda a, b: a ** b,
+    ]
+    Sx = FiniteSet(x)
+    Sy = FiniteSet(y)
+    sets = [
+        FiniteSet(1),
+        Interval(1, 2),
+        Union(Sx, Interval(1, 2)),
+        Intersection(Sx, Sy),
+        Complement(Sx, Sy),
+        ProductSet(Sx, Sy),
+        S.EmptySet,
+    ]
+    nums = [0, 1, 2, S(0), S(1), S(2)]
+
+    for s in sets:
+        for n in nums:
+            for op in ops:
+                raises(TypeError, lambda : op(s, n))
+                raises(TypeError, lambda : op(n, s))
+
+
 def test_complement():
     assert Interval(0, 1).complement(S.Reals) == \
         Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1124,7 +1124,7 @@ def _futrig(e, **kwargs):
     if e.is_Mul:
         coeff, e = e.as_independent(TrigonometricFunction)
     else:
-        coeff = S.One
+        coeff = None
 
     Lops = lambda x: (L(x), x.count_ops(), _nodes(x), len(x.args), x.is_Add)
     trigs = lambda x: x.has(TrigonometricFunction)
@@ -1167,7 +1167,11 @@ def _futrig(e, **kwargs):
             factor_terms, TR12(x), trigs)],  # expand tan of sum
         )]
     e = greedy(tree, objective=Lops)(e)
-    return coeff*e
+
+    if coeff is not None:
+        e = coeff * e
+
+    return e
 
 
 def _is_Expr(e):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1466,7 +1466,11 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         if r is not None:
             coeff = r[order]
             factor = x**order / coeff
-            r_rescaled = {i: factor*r[i] for i in r}
+            r_rescaled = {i: factor*r[i] for i in r if i != 'trialset'}
+
+        # XXX: Mixing up the trialset with the coefficients is error-prone.
+        # These should be separated as something like r['coeffs'] and
+        # r['trialset']
 
         if r_rescaled and not any(not _test_term(r_rescaled[i], i) for i in
                 r_rescaled if i != 'trialset' and i >= 0):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -7,7 +7,7 @@ from sympy import symbols, MatrixBase, ImmutableDenseMatrix
 from sympy.solvers import solve
 from sympy.vector.scalar import BaseScalar
 from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sin, cos,\
-    sqrt, diff, Tuple, acos, atan2, simplify, Mul
+    sqrt, diff, Tuple, acos, atan2, simplify
 import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
@@ -261,15 +261,6 @@ class CoordSys3D(Basic):
 
     def __iter__(self):
         return iter(self.base_vectors())
-
-    # XXX: Not sure if __mul__ and __rmul__ make sense but they are needed for
-    # some operations now that Expr__mul__ doesn't accept non-Expr
-
-    def __mul__(self, other):
-        return Mul(self, other)
-
-    def __rmul__(self, other):
-        return Mul(self, other)
 
     @staticmethod
     def _check_orthogonality(equations):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -7,7 +7,7 @@ from sympy import symbols, MatrixBase, ImmutableDenseMatrix
 from sympy.solvers import solve
 from sympy.vector.scalar import BaseScalar
 from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sin, cos,\
-    sqrt, diff, Tuple, acos, atan2, simplify
+    sqrt, diff, Tuple, acos, atan2, simplify, Mul
 import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
@@ -261,6 +261,15 @@ class CoordSys3D(Basic):
 
     def __iter__(self):
         return iter(self.base_vectors())
+
+    # XXX: Not sure if __mul__ and __rmul__ make sense but they are needed for
+    # some operations now that Expr__mul__ doesn't accept non-Expr
+
+    def __mul__(self, other):
+        return Mul(self, other)
+
+    def __rmul__(self, other):
+        return Mul(self, other)
 
     @staticmethod
     def _check_orthogonality(equations):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

I found that I needed this when attempting to fix #4986 by introducing a new 

#### Brief description of what is fixed or changed

Return `NotImplemented` from `__add__` etc methods in `Set` and `Expr` if the sympified `other` operand is not of the expected type (i.e. `Set` or `Expr`). On current master `NotImplemented` is only returned if `_sympify` fails. With this PR it will be returned also if `_sympify` returns an object that is not of the expected type. There are two improvements resulting from this:

1. This makes it possible to define other non-`Expr` `Basic` classes that support arithmetic operations with `Expr` so if `a` is non-`Expr` and `b` is `Expr` then `type(a)` can control both `a + b` and `b + a`. On current master `Expr` will force `a` into an `Add` even if it doesn't belong there.

Master:
```julia
In [10]: class A(Basic): 
    ...:     def __mul__(self, other): 
    ...:         return -1 
    ...:     def __rmul__(self, other): 
    ...:         return -2 
    ...:          
    ...:                                                                                                                          

In [11]: A() * Symbol('x')                                                                                                        
Out[11]: -1

In [12]: Symbol('x') * A()                                                                                                        
Out[12]: x⋅A()
```

PR
```julia
In [4]: A() * Symbol('x')                                                                                                         
Out[4]: -1

In [5]: Symbol('x') * A()                                                                                                         
Out[5]: -2
```

2. This prevents garbage results like creating a `Mul` of a `Set`.

Master:
```julia
In [13]: Symbol('x') * FiniteSet(1)                                                                                               
Out[13]: x⋅{1}

In [14]: FiniteSet(1) * Symbol('x')                                                                                               
---------------------------------------------------------------------------
TypeError 
```

PR
```julia
In [1]: Symbol('x') * FiniteSet(1)                                                                                                
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-d040ce0e457f> in <module>
----> 1 Symbol('x') * FiniteSet(1)

TypeError: unsupported operand type(s) for *: 'Symbol' and 'FiniteSet'

In [2]: FiniteSet(1) * Symbol('x')                                                                                                
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-320969da0219> in <module>
----> 1 FiniteSet(1) * Symbol('x')

TypeError: unsupported operand type(s) for *: 'FiniteSet' and 'Symbol'
```

There was a bug in `dsolve` due to these garbage results. Because a `set` will `sympify` to a `FiniteSet` the following would happen:
```julia
In [1]: Symbol('x') * {1}                                                                                                         
Out[1]: x⋅{1}

In [2]: {1} * Symbol('x')                                                                                                         
Out[2]: x⋅{1}
```
Under this PR both of those gives `TypeError`.

#### Other comments

There were apparently a couple of parts of the codebase depending on this behaviour. I've added a couple of fixes for those. In general I expect that there are lots of bugs to do with this hiding in different places due to e.g. expecting to do something like `trigsimp(non-expr)` which will sometimes work even though it is really aimed at `Expr`. We need a docmented way for functions like `trigsimp` to be able to identify `Expr` parts of a non-`Expr` object (like `Set`, `Tuple`, `Matrix` etc).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Expr now uses cooperative dispatch for binary operations so it is possible for non-Expr Basic subclasses to override the behaviour of e.g. `a + b` where one of `a` or `b` is an instance of Expr. This also means that any non-Expr Basic subclasses can not depend on `Expr.__add__` to create `Add(a, b)`: if a class is not a subclass of Expr and wants to define binary operations with Expr it must do so explicitly in its own `__add__` method. For classes depending on this this is not a backward compatible change.
* sets
    * Set now uses cooperative dispatch for binary operations so it is possible for non-Set Basic subclasses to override the behaviour of e.g. `a + b` where one of `a` or `b` is an instance of Set. This also means that any non-Set Basic subclasses can not depend on `Expr.__add__` to create `Union(a, b)`: if a class is not a subclass of Set and wants to define binary operations with Set it must do so explicitly in its own `__add__` method. For classes depending on this this is not a backward compatible change.
<!-- END RELEASE NOTES -->
