### PR TITLE
Added evalf in Vector and Dyadic

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1310,7 +1310,7 @@ def evalf(x, prec, options):
     try:
         rf = evalf_table[x.func]
         r = rf(x, prec, options)
-    except KeyError:
+    except (AttributeError, KeyError) as e:
         # Fall back to ordinary evalf if possible
         if 'subs' in options:
             x = x.subs(evalf_subs(prec, options['subs']))

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,12 +1,13 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.compatibility import unicode
+from sympy.core.evalf import EvalfMixin
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
 
 __all__ = ['Dyadic']
 
 
-class Dyadic(object):
+class Dyadic(EvalfMixin):
     """A Dyadic object.
 
     See:

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,13 +1,14 @@
 from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros,
     ImmutableMatrix as Matrix)
 from sympy import trigsimp
+from sympy.core.evalf import EvalfMixin
 from sympy.core.compatibility import unicode
 from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']
 
 
-class Vector(object):
+class Vector(EvalfMixin):
     """The class used to define vectors.
 
     It along with ReferenceFrame are the building blocks of describing a


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added evalf in Vector and Dyadic classes.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18064
Closes https://github.com/sympy/sympy/pull/18113

#### Brief description of what is fixed or changed
Now the vector and dyadic classes inherit from EvalfMixin with some necessary changes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
   * Added inheritance in Vector
   * Added inheritance in Dyadic
<!-- END RELEASE NOTES -->
