### PR TITLE
Some tweaks and documentation improvements for is_diagonalizable

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1587,10 +1587,6 @@ class MatrixEigen(MatrixSubspaces):
 
         eigenvecs = self.eigenvects(simplify=True, dotprodsimp=dotprodsimp)
 
-        if all(e.is_real for e in self) and self.is_symmetric():
-            # every real symmetric matrix is real diagonalizable
-            return True, eigenvecs
-
         for val, mult, basis in eigenvecs:
             # if we have a complex eigenvalue
             if reals_only and not val.is_real:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1602,50 +1602,44 @@ class MatrixEigen(MatrixSubspaces):
         return True, eigenvecs
 
     def is_diagonalizable(self, reals_only=False, dotprodsimp=None, **kwargs):
-        """Returns true if a matrix is diagonalizable.
+        """Returns ``True`` if a matrix is diagonalizable.
 
         Parameters
         ==========
 
-        reals_only : bool. If reals_only=True, determine whether the matrix can be
-                     diagonalized without complex numbers. (Default: False)
+        reals_only : bool, optional
+            If ``True``, it tests whether the matrix can be diagonalized
+            without complex numbers. (Orthogonally diagonalizable)
+
+            If ``False``, it tests whether the matrix can be unitarily
+            diagonalizable.
 
         dotprodsimp : bool, optional
-            Specifies whether intermediate term algebraic simplification is used
-            during matrix multiplications to control expression blowup and thus
-            speed up calculation.
-
-        kwargs
-        ======
-
-        clear_cache : bool. If True, clear the result of any computations when finished.
-                      (Default: True)
+            Specifies whether intermediate term algebraic simplification
+            is used during matrix multiplications to control expression
+            blowup and thus speed up calculation.
 
         Examples
         ========
 
+        Example of a diagonalizable matrix:
+
         >>> from sympy import Matrix
-        >>> m = Matrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
-        >>> m
-        Matrix([
-        [1,  2, 0],
-        [0,  3, 0],
-        [2, -4, 2]])
+        >>> m = Matrix([[1, 2, 0], [0, 3, 0], [2, -4, 2]])
         >>> m.is_diagonalizable()
         True
-        >>> m = Matrix(2, 2, [0, 1, 0, 0])
-        >>> m
-        Matrix([
-        [0, 1],
-        [0, 0]])
+
+        Example of a non-diagonalizable matrix:
+
+        >>> m = Matrix([[0, 1], [0, 0]])
         >>> m.is_diagonalizable()
         False
-        >>> m = Matrix(2, 2, [0, 1, -1, 0])
-        >>> m
-        Matrix([
-        [ 0, 1],
-        [-1, 0]])
-        >>> m.is_diagonalizable()
+
+        Example of a unitarily diagonalizable, but not orthogonally
+        diagonalizable:
+
+        >>> m = Matrix([[0, 1], [-1, 0]])
+        >>> m.is_diagonalizable(reals_only=False)
         True
         >>> m.is_diagonalizable(reals_only=True)
         False
@@ -1669,6 +1663,16 @@ class MatrixEigen(MatrixSubspaces):
                 deprecated_since_version=1.4,
                 issue=15887
             ).warn()
+
+        if not self.is_square:
+            return False
+
+        if all(e.is_real for e in self) and self.is_symmetric():
+            return True
+
+        if all(e.is_complex for e in self) and self.is_hermitian \
+            and not reals_only:
+            return True
 
         return self.is_diagonalizable_with_eigen(reals_only=reals_only,
                 dotprodsimp=dotprodsimp)[0]

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1981,6 +1981,9 @@ def test_diagonal_symmetrical():
 
 
 def test_diagonalization():
+    m = Matrix([[1, 2+I], [2-I, 3]])
+    assert m.is_diagonalizable()
+
     m = Matrix(3, 2, [-3, 1, -3, 20, 3, 10])
     assert not m.is_diagonalizable()
     assert not m.is_symmetric()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Eigenvalues were unnecessarily computed even if the matrix is symmetric in #18049, 
I've tested out some simple `2*2` symmetric matrices and can say that the overhead of computing eigenvectors can eigenvectors easily surpass the overhead of failing some gamble. (And would turn worse for more larger cases)

```
M = Matrix([[92, 92], [92, 178]])
cProfile.run('M.is_diagonalizable(dotprodsimp=True)')
```
`955687 function calls (912842 primitive calls) in 0.500 seconds`
`444 function calls in 0.000 seconds`

```
M = Matrix([[92, 92+I], [92-I, 178]])
cProfile.run('M.is_diagonalizable(dotprodsimp=True)')
```
`1185302 function calls (1126456 primitive calls) in 0.650 seconds`
`2438 function calls (2323 primitive calls) in 0.001 seconds`

and it would be more worse for matrices larger than this.
Even before #18049, the gamble for hermitian case was missing, but it would be worth it.

I've also found that the doc was using not-very-intuitive way to create matrices and redundant tests for printing out the matrix, so I've sligntly changed the examples.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
