### PR TITLE
Fixed bugs in is_nthpow_residue

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -638,6 +638,8 @@ def is_nthpow_residue(a, n, m):
         if m == 1:
             return False
         return a == 1
+    if a % m == 0:
+        return True
     if n == 1:
         return True
     if n == 2:

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -134,7 +134,7 @@ def test_residue():
     assert is_nthpow_residue(1, 0, 2) is True
     assert is_nthpow_residue(3, 0, 2) is False
     assert is_nthpow_residue(0, 1, 8) is True
-    assert is_nthpow_residue(2, 3, 2) is False
+    assert is_nthpow_residue(2, 3, 2) is True
     assert is_nthpow_residue(2, 3, 9) is False
     assert is_nthpow_residue(3, 5, 30) is True
     assert is_nthpow_residue(21, 11, 20) is True


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed
`is_nthpow_residue(a, n, m)` returns `False` when `a % m == 0 and primitive_root(m) is not None` but it should return `True`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added check for zero in is_nthpow_residue.
<!-- END RELEASE NOTES -->
