### PR TITLE
Fixed typo in diophantine

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -1004,7 +1004,7 @@ def _diop_quadratic(var, coeff, t):
                 for z0 in range(0, abs(_c)):
                     # Check if the coefficients of y and x obtained are integers or not
                     if (divisible(sqa*g*z0**2 + D*z0 + sqa*F, _c) and
-                            divisible(e*sqc**g*z0**2 + E*z0 + e*sqc*F, _c)):
+                            divisible(e*sqc*g*z0**2 + E*z0 + e*sqc*F, _c)):
                         sol.add((solve_x(z0), solve_y(z0)))
 
     # (3) Method used when B**2 - 4*A*C is a square, is described in p. 6 of the below paper

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -540,6 +540,12 @@ def test_diophantine():
     assert diophantine(x**2 + y**2 +3*x- 5, permute=True) == \
         set([(-1, 1), (-4, -1), (1, -1), (1, 1), (-4, 1), (-1, -1), (4, 1), (4, -1)])
 
+    # issue 18122
+    assert check_solutions(x**2-y)
+    assert check_solutions(y**2-x)
+    assert diophantine((x**2-y), t) == set([(t, t**2)])
+    assert diophantine((y**2-x), t) == set([(t**2, -t)])
+
 
 def test_general_pythagorean():
     from sympy.abc import a, b, c, d, e


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixed typo in diophantine
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18122 
Fixes #18114

#### Brief description of what is fixed or changed
It now correctly provides the output of 
```
>>> diophantine(x**2-y)
(t, t**2)
>>> diophantine(y**2-x)
(t**2, -t)

```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
