### PR TITLE
Add is_subset handler for Range in FiniteSet

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -685,6 +685,8 @@ class Range(Set):
             ref = self.stop
         else:  # both infinite; step is +/- 1 (enforced by __new__)
             return S.true
+        if self.size == 1:
+            return Eq(other, self[0])
         res = (ref - other) % self.step
         if res == S.Zero:
             return And(other >= self.inf, other <= self.sup)
@@ -903,10 +905,13 @@ class Range(Set):
     def as_relational(self, x):
         """Rewrite a Range in terms of equalities and logic operators. """
         from sympy.functions.elementary.integers import floor
-        return And(
-            Eq(x, floor(x)),
-            x >= self.inf if self.inf in self else x > self.inf,
-            x <= self.sup if self.sup in self else x < self.sup)
+        if self.size == 1:
+            return Eq(x, self[0])
+        else:
+            return And(
+                Eq(x, floor(x)),
+                x >= self.inf if self.inf in self else x > self.inf,
+                x <= self.sup if self.sup in self else x < self.sup)
 
 
 # Using range from compatibility above (xrange on Py2)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -683,11 +683,15 @@ class Range(Set):
             ref = self.start
         elif self.stop.is_finite:
             ref = self.stop
-        else:
-            return other.is_Integer
-        if (ref - other) % self.step:  # off sequence
+        else:  # both infinite; step is +/- 1 (enforced by __new__)
+            return S.true
+        res = (ref - other) % self.step
+        if res == S.Zero:
+            return And(other >= self.inf, other <= self.sup)
+        elif res.is_Integer:  # off sequence
             return S.false
-        return _sympify(other >= self.inf and other <= self.sup)
+        else:  # symbolic/unsimplified residue modulo step
+            return None
 
     def __iter__(self):
         if self.has(Symbol):

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -76,7 +76,7 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
     if a_size > len(b_finiteset):
         return False
     else:
-        # Checking A \ B == EmptySet is more efficient than repeated naïve
+        # Checking A \ B == EmptySet is more efficient than repeated naive
         # membership checks on an arbitrary FiniteSet.
         a_set = set([*a_range])
         b_remaining = len(b_finiteset)

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -1,4 +1,4 @@
-from sympy import S
+from sympy import S, Symbol
 from sympy.core.logic import fuzzy_and, fuzzy_bool, fuzzy_not, fuzzy_or
 from sympy.core.relational import Eq
 from sympy.sets.sets import FiniteSet, Interval, Set, Union
@@ -75,6 +75,8 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
         return None
     if a_size > len(b_finiteset):
         return False
+    elif any(arg.has(Symbol) for arg in a_range.args):
+        return fuzzy_and(b_finiteset.contains(x) for x in a_range)
     else:
         # Checking A \ B == EmptySet is more efficient than repeated naive
         # membership checks on an arbitrary FiniteSet.

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -78,7 +78,7 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
     else:
         # Checking A \ B == EmptySet is more efficient than repeated naive
         # membership checks on an arbitrary FiniteSet.
-        a_set = set([*a_range])
+        a_set = set(a_range)
         b_remaining = len(b_finiteset)
         # Symbolic expressions and numbers of unknown type (integer or not) are
         # all counted as "candidates", i.e. *potentially* matching some a in

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -76,7 +76,27 @@ def is_subset_sets(a_range, b_finiteset): # noqa:F811
     if a_size > len(b_finiteset):
         return False
     else:
-        return fuzzy_and(b_finiteset.contains(x) for x in a_range)
+        # Checking A \ B == EmptySet is more efficient than repeated naïve
+        # membership checks on an arbitrary FiniteSet.
+        a_set = set([*a_range])
+        b_remaining = len(b_finiteset)
+        # Symbolic expressions and numbers of unknown type (integer or not) are
+        # all counted as "candidates", i.e. *potentially* matching some a in
+        # a_range.
+        cnt_candidate = 0
+        for b in b_finiteset:
+            if b.is_Integer:
+                a_set.discard(b)
+            elif fuzzy_not(b.is_integer):
+                pass
+            else:
+                cnt_candidate += 1
+            b_remaining -= 1
+            if len(a_set) > b_remaining + cnt_candidate:
+                return False
+            if len(a_set) == 0:
+                return True
+        return None
 
 @dispatch(Interval, Range)
 def is_subset_sets(a_interval, b_range): # noqa:F811

--- a/sympy/sets/handlers/issubset.py
+++ b/sympy/sets/handlers/issubset.py
@@ -66,6 +66,18 @@ def is_subset_sets(a_range, b_interval): # noqa:F811
             cond_right = a_range.sup <= b_interval.right
         return fuzzy_and([cond_left, cond_right])
 
+@dispatch(Range, FiniteSet)
+def is_subset_sets(a_range, b_finiteset): # noqa:F811
+    try:
+        a_size = a_range.size
+    except ValueError:
+        # symbolic Range of unknown size
+        return None
+    if a_size > len(b_finiteset):
+        return False
+    else:
+        return fuzzy_and(b_finiteset.contains(x) for x in a_range)
+
 @dispatch(Interval, Range)
 def is_subset_sets(a_interval, b_range): # noqa:F811
     if a_interval.measure.is_extended_nonzero:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1830,8 +1830,9 @@ class FiniteSet(Set, EvalfMixin):
         """
         Tests whether an element, other, is in the set.
 
-        Relies on Python's set class. This tests for object equality
-        All inputs are sympified
+        This tests for mathematical equality. (In the worst case
+        all elements of the set must be checked. The implementation
+        is not hash-based.)
 
         Examples
         ========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1761,8 +1761,10 @@ class FiniteSet(Set, EvalfMixin):
         else:
             args = list(map(sympify, args))
 
-        args = list(ordered(set(args), Set._infimum_key))
+        _args_set = set(args)
+        args = list(ordered(_args_set, Set._infimum_key))
         obj = Basic.__new__(cls, *args)
+        obj._args_set = _args_set
         return obj
 
     def _eval_Eq(self, other):
@@ -1830,9 +1832,9 @@ class FiniteSet(Set, EvalfMixin):
         """
         Tests whether an element, other, is in the set.
 
-        This tests for mathematical equality. (In the worst case
-        all elements of the set must be checked. The implementation
-        is not hash-based.)
+        The actual test is for mathematical equality (as opposed to
+        syntactical equality). In the worst case all elements of the
+        set must be checked.
 
         Examples
         ========
@@ -1844,9 +1846,13 @@ class FiniteSet(Set, EvalfMixin):
         False
 
         """
-        # evaluate=True is needed to override evaluate=False context;
-        # we need Eq to do the evaluation
-        return fuzzy_or(fuzzy_bool(Eq(e, other, evaluate=True)) for e in self.args)
+        if other in self._args_set:
+            return True
+        else:
+            # evaluate=True is needed to override evaluate=False context;
+            # we need Eq to do the evaluation
+            return fuzzy_or(fuzzy_bool(Eq(e, other, evaluate=True))
+                for e in self.args)
 
     def _eval_is_subset(self, other):
         return fuzzy_and(other._contains(e) for e in self.args)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -384,14 +384,16 @@ def test_Range_symbolic():
     assert Range(ip).inf == 0
     assert Range(ip).sup == ip - 1
     raises(ValueError, lambda: Range(i).inf)
+    # as_relational
     raises(ValueError, lambda: sr.as_relational(x))
     assert ir.as_relational(x) == (
         x >= i) & Eq(x, floor(x)) & (x <= i + 18)
+    assert Range(i, i + 1).as_relational(x) == Eq(x, i)
     # contains() for symbolic values (issue #18146)
     e = Symbol('e', integer=True, even=True)
     o = Symbol('o', integer=True, odd=True)
     assert Range(5).contains(i) == And(i >= 0, i <= 4)
-    # assert Range(1).contains(i) == Eq(i, 0) (unsimplified relational)
+    assert Range(1).contains(i) == Eq(i, 0)
     assert Range(-oo, 5, 1).contains(i) == (i <= 4)
     assert Range(-oo, oo).contains(i) == True
     assert Range(0, 8, 2).contains(i) == Contains(i, Range(0, 8, 2))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -613,6 +613,7 @@ def test_measure():
 def test_is_subset():
     assert Interval(0, 1).is_subset(Interval(0, 2)) is True
     assert Interval(0, 3).is_subset(Interval(0, 2)) is False
+    assert Interval(0, 1).is_subset(FiniteSet(0, 1)) is False
 
     assert FiniteSet(1, 2).is_subset(FiniteSet(1, 2, 3, 4))
     assert FiniteSet(4, 5).is_subset(FiniteSet(1, 2, 3, 4)) is False
@@ -653,6 +654,8 @@ def test_is_subset():
     assert Range(-oo, 1).is_subset(FiniteSet(1)) is False
     assert Range(3).is_subset(FiniteSet(0, 1, n)) is None
     assert Range(n, n + 2).is_subset(FiniteSet(n, n + 1)) is None
+
+    assert Range(5).is_subset(Interval(0, 4, right_open=True)) is False
 
 
 def test_is_proper_subset():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -647,14 +647,14 @@ def test_is_subset():
     assert Interval(0, 1).is_subset(Interval(0, 1, left_open=True)) is False
     assert Interval(-2, 3).is_subset(Union(Interval(-oo, -2), Interval(3, oo))) is False
 
+    n = Symbol('n', integer=True)
     assert Range(-3, 4, 1).is_subset(FiniteSet(-10, 10)) is False
     assert Range(S(10)**100).is_subset(FiniteSet(0, 1, 2)) is False
     assert Range(6, 0, -2).is_subset(FiniteSet(2, 4, 6)) is True
     assert Range(1, oo).is_subset(FiniteSet(1, 2)) is False
     assert Range(-oo, 1).is_subset(FiniteSet(1)) is False
     assert Range(3).is_subset(FiniteSet(0, 1, n)) is None
-    assert Range(n, n + 2).is_subset(FiniteSet(n, n + 1)) is None
-
+    assert Range(n, n + 2).is_subset(FiniteSet(n, n + 1)) is True
     assert Range(5).is_subset(Interval(0, 4, right_open=True)) is False
 
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -646,6 +646,14 @@ def test_is_subset():
     assert Interval(0, 1).is_subset(Interval(0, 1, left_open=True)) is False
     assert Interval(-2, 3).is_subset(Union(Interval(-oo, -2), Interval(3, oo))) is False
 
+    assert Range(-3, 4, 1).is_subset(FiniteSet(-10, 10)) is False
+    assert Range(S(10)**100).is_subset(FiniteSet(0, 1, 2)) is False
+    assert Range(6, 0, -2).is_subset(FiniteSet(2, 4, 6)) is True
+    assert Range(1, oo).is_subset(FiniteSet(1, 2)) is False
+    assert Range(-oo, 1).is_subset(FiniteSet(1)) is False
+    assert Range(3).is_subset(FiniteSet(0, 1, n)) is None
+    assert Range(n, n + 2).is_subset(FiniteSet(n, n + 1)) is None
+
 
 def test_is_proper_subset():
     assert Interval(0, 1).is_proper_subset(Interval(0, 2)) is True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18124.
Fixes #18146.

#### Brief description of what is fixed or changed
Add `is_subset` handler for (Range, FiniteSet) and tests.
Fixes logic errors in `Range.contains()`

#### Other comments
Two missed lines (marked red in codecov.io) in sets/handlers/issubset.py should now also be covered.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Added an `is_subset` handler to check whether a `Range` is included in a `FiniteSet`.
  * Added a simple cache to `FiniteSet` in order to speed up some membership checks.
  * Fixed `Range.contains()` logic for symbolic values.
<!-- END RELEASE NOTES -->
