### PR TITLE
Fixes ValueError from meijerg

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -375,7 +375,6 @@ def test_issue_13749():
 
 def test_issue_18133():
     assert integrate(exp(x)/(1 + x)**2, x) == NonElementaryIntegral(exp(x)/(x + 1)**2, x)
-    assert str(integrate(exp(x)/(1 + x)**2, x)) == Integral(exp(x)/(x + 1)**2, x)
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -373,6 +373,9 @@ def test_issue_13749():
     assert integrate(1 / (2 + cos(x)), (x, 0, pi)) == pi/sqrt(3)
     assert integrate(1/(2 + cos(x))) == 2*sqrt(3)*(atan(sqrt(3)*tan(x/2)/3) + pi*floor((x/2 - pi/2)/pi))/3
 
+def test_issue_18133():
+    assert integrate(exp(x)/(1 + x)**2, x) == NonElementaryIntegral(exp(x)/(x + 1)**2, x)
+    assert str(integrate(exp(x)/(1 + x)**2, x)) == Integral(exp(x)/(x + 1)**2, x)
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -737,7 +737,10 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
             a, b, C, e, fac = _rewrite_gamma(g, s, strip[0], strip[1])
         except IntegralTransformError:
             continue
-        G = meijerg(a, b, C/x**e)
+        try:
+            G = meijerg(a, b, C/x**e)
+        except ValueError:
+            continue
         if as_meijerg:
             h = G
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes ValueError from meijerg in integrate module.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18133 

#### Brief description of what is fixed or changed
It now produces the following output:
```
>>>integrate(exp(t)/(1+t)**2,t)
Integral(exp(t)/(t + 1)**2, t)
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Catch ValueError from meijerg() in _inverse_mellin_transform().
<!-- END RELEASE NOTES -->
