### PR TITLE
Error in function comp parameters returning exception for predefined input

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -53,8 +53,6 @@ def comp(z1, z2, tol=None):
     >>> from sympy.core.numbers import comp, pi
     >>> pi4 = pi.n(4); pi4
     3.142
-    >>> comp(_, 3.142)
-    True
     >>> comp(pi4, 3.141)
     False
     >>> comp(pi4, 3.143)


### PR DESCRIPTION
**Issue is in** 

The issue was found in 
sympy/core/number.py

**Brief description of what is fixed or changed**
The predefined input in number.py is given below with the excepted result
>>Comp(_,3.14)   
True
The Actual Result coming from it 
Traceback (most recent call last): File "<stdin>", line 1, in <module> NameError: name '_' is not defined
<!-- BEGIN RELEASE NOTES -->
**Release Notes**
* Typo fixes
  * Removing the code write now 

<!-- END RELEASE NOTES -->


