### PR TITLE
Updated piecewise.py to ignore None object

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -19,6 +19,8 @@ class ExprCondPair(Tuple):
     """Represents an expression, condition pair."""
 
     def __new__(cls, expr, cond):
+        if expr is None:
+            return
         expr = as_Basic(expr)
         if cond == True:
             return Tuple.__new__(cls, expr, true)
@@ -128,6 +130,8 @@ class Piecewise(Function):
         for ec in args:
             # ec could be a ExprCondPair or a tuple
             pair = ExprCondPair(*getattr(ec, 'args', ec))
+            if pair is None:
+                continue
             cond = pair.cond
             if cond is false:
                 continue


### PR DESCRIPTION
Modified piecewise.py to ignore None object

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18140



#### Brief description of what is fixed or changed
Output is now 
`In [3]: integrate(x**n*log(x),x)`
`Out[3]: Piecewise((n*x*x**n*log(x)/(n**2 + 2*n + 1) + x*x**n*log(x)/(n**2 + 2*n + 1) - x*x**n/(n**2 + 2*n + 1), Ne(n, -1)))`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Added condition to ignore None object.
<!-- END RELEASE NOTES -->
