### PR TITLE
Updated heurisch_wrapper to avoid None object

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -36,6 +36,7 @@ from sympy.polys.solvers import solve_lin_sys
 from sympy.polys.constructor import construct_domain
 
 from sympy.core.compatibility import reduce, ordered
+from sympy.integrals.integrals import integrate
 
 
 def components(f, x):
@@ -171,6 +172,8 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
                         _try_heurisch)
         cond = And(*[Eq(key, value) for key, value in sub_dict.items()])
         generic = Or(*[Ne(key, value) for key, value in sub_dict.items()])
+        if expr is None:
+            expr = integrate(f.subs(sub_dict),x)
         pairs.append((expr, cond))
     # If there is one condition, put the generic case first. Otherwise,
     # doing so may lead to longer Piecewise formulas

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -862,6 +862,15 @@ def test_issue_4884():
             4*I*sqrt(-x)/15, True))
     assert integrate(x**x*(1 + log(x))) == x**x
 
+def test_issue_18153():
+    assert integrate(x**n*log(x),x) == \
+    Piecewise(
+        (n*x*x**n*log(x)/(n**2 + 2*n + 1) +
+    x*x**n*log(x)/(n**2 + 2*n + 1) - x*x**n/(n**2 + 2*n + 1)
+    , Ne(n, -1)), (log(x)**2/2, True)
+    )
+
+
 
 def test_is_number():
     from sympy.abc import x, y, z


### PR DESCRIPTION
In `heurish_wrapper()` evaluate `expr` again using `integrate()` if `heurisch()` returns `None`
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #14613
Fixes partially #15213
Fixes #18140

#### Brief description of what is fixed or changed
The following output is produced :
```
In [5]: integrate(x**n*log(x),x)
Out[5]: 
⎧     n             n                  n                
⎪n⋅x⋅x ⋅log(x)   x⋅x ⋅log(x)        x⋅x                 
⎪───────────── + ──────────── - ────────────  for n ≠ -1
⎪  2              2              2                      
⎪ n  + 2⋅n + 1   n  + 2⋅n + 1   n  + 2⋅n + 1            
⎨                                                       
⎪                     2                                 
⎪                  log (x)                              
⎪                  ───────                    otherwise 
⎪                     2                                 
⎩                                                
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added extra step to evaluate integral if `heurisch()` returns `None` in `heurisch_wrapper()`
<!-- END RELEASE NOTES -->
