### PR TITLE
Fix Variable types for C Parser

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -232,21 +232,27 @@ if cin:
                 while child.kind == cin.CursorKind.TYPE_REF:
                     child = next(children)
 
-                args = self.transform(child)
+                if (node.type.kind == cin.TypeKind.INT):
+                    type = IntBaseType(String('integer'))
+                elif (node.type.kind == cin.TypeKind.FLOAT):
+                    type = FloatBaseType(String('real'))
+                else:
+                    raise NotImplementedError()
+                value = self.transform(child)
                 # List in case of variable assignment, FunctionCall node in case of a funcion call
                 if (child.kind == cin.CursorKind.INTEGER_LITERAL
                     or child.kind == cin.CursorKind.UNEXPOSED_EXPR):
                     return Variable(
                         node.spelling
                     ).as_Declaration(
-                        type = args[0],
-                        value = args[1]
+                        type = type,
+                        value = value
                     )
                 elif (child.kind == cin.CursorKind.CALL_EXPR):
                     return Variable(
                         node.spelling
                     ).as_Declaration(
-                        value = args
+                        value = value
                     )
                 else:
                     raise NotImplementedError()
@@ -376,12 +382,12 @@ if cin:
                     child = next(children)
 
                 # If there is a child, it is the default value of the parameter.
-                args = self.transform(child)
+                val = self.transform(child)
                 param = Variable(
                     node.spelling
                 ).as_Declaration(
-                    type = args[0],
-                    value = args[1]
+                    type = type,
+                    value = val
                 )
             except StopIteration:
                 param = Variable(
@@ -418,14 +424,12 @@ if cin:
             Only Base Integer type supported for now
 
             """
-            type = IntBaseType(String('integer'))
             try:
                 value = next(node.get_tokens()).spelling
             except StopIteration:
                 # No tokens
                 value = Integer(node.literal)
-            val = [type, value]
-            return val
+            return value
 
         def transform_floating_literal(self, node):
             """Transformation function for floating literal
@@ -446,14 +450,12 @@ if cin:
             Only Base Float type supported for now
 
             """
-            type = FloatBaseType(String('real'))
             try:
                 value = next(node.get_tokens()).spelling
             except (StopIteration, ValueError):
                 # No tokens
                 value = Float(node.literal)
-            val = [type, value]
-            return val
+            return value
 
 
         def transform_string_literal(self, node):
@@ -552,9 +554,9 @@ if cin:
                 for child in children:
                     arg = self.transform(child)
                     if (child.kind == cin.CursorKind.INTEGER_LITERAL):
-                        param.append(Integer(arg[1]))
+                        param.append(Integer(arg))
                     elif (child.kind == cin.CursorKind.FLOATING_LITERAL):
-                        param.append(Float(arg[1]))
+                        param.append(Float(arg))
                     else:
                         param.append(arg)
                 return FunctionCall(first_child, param)

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -232,13 +232,16 @@ if cin:
                 while child.kind == cin.CursorKind.TYPE_REF:
                     child = next(children)
 
+                val = self.transform(child)
                 if (node.type.kind == cin.TypeKind.INT):
                     type = IntBaseType(String('integer'))
+                    value = Integer(val)
                 elif (node.type.kind == cin.TypeKind.FLOAT):
                     type = FloatBaseType(String('real'))
+                    value = Float(val)
                 else:
                     raise NotImplementedError()
-                value = self.transform(child)
+
                 # List in case of variable assignment, FunctionCall node in case of a funcion call
                 if (child.kind == cin.CursorKind.INTEGER_LITERAL
                     or child.kind == cin.CursorKind.UNEXPOSED_EXPR):
@@ -382,7 +385,12 @@ if cin:
                     child = next(children)
 
                 # If there is a child, it is the default value of the parameter.
-                val = self.transform(child)
+                lit = self.transform(child)
+                if (node.type.kind == cin.TypeKind.INT):
+                    val = Integer(lit)
+                elif (node.type.kind == cin.TypeKind.FLOAT):
+                    val = Float(lit)
+
                 param = Variable(
                     node.spelling
                 ).as_Declaration(

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -233,18 +233,17 @@ if cin:
                     child = next(children)
 
                 val = self.transform(child)
-                if (node.type.kind == cin.TypeKind.INT):
-                    type = IntBaseType(String('integer'))
-                    value = Integer(val)
-                elif (node.type.kind == cin.TypeKind.FLOAT):
-                    type = FloatBaseType(String('real'))
-                    value = Float(val)
-                else:
-                    raise NotImplementedError()
-
                 # List in case of variable assignment, FunctionCall node in case of a funcion call
                 if (child.kind == cin.CursorKind.INTEGER_LITERAL
                     or child.kind == cin.CursorKind.UNEXPOSED_EXPR):
+                    if (node.type.kind == cin.TypeKind.INT):
+                        type = IntBaseType(String('integer'))
+                        value = Integer(val)
+                    elif (node.type.kind == cin.TypeKind.FLOAT):
+                        type = FloatBaseType(String('real'))
+                        value = Float(val)
+                    else:
+                        raise NotImplementedError()
                     return Variable(
                         node.spelling
                     ).as_Declaration(
@@ -255,7 +254,7 @@ if cin:
                     return Variable(
                         node.spelling
                     ).as_Declaration(
-                        value = value
+                        value = val
                     )
                 else:
                     raise NotImplementedError()
@@ -436,8 +435,8 @@ if cin:
                 value = next(node.get_tokens()).spelling
             except StopIteration:
                 # No tokens
-                value = Integer(node.literal)
-            return value
+                value = node.literal
+            return int(value)
 
         def transform_floating_literal(self, node):
             """Transformation function for floating literal
@@ -462,8 +461,8 @@ if cin:
                 value = next(node.get_tokens()).spelling
             except (StopIteration, ValueError):
                 # No tokens
-                value = Float(node.literal)
-            return value
+                value = node.literal
+            return float(value)
 
 
         def transform_string_literal(self, node):

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -55,8 +55,8 @@ else:
         >>> a.return_expr()
         [Declaration(Variable(a, type=integer, value=0)),
         Declaration(Variable(b, type=integer, value=0)),
-        Declaration(Variable(c, type=real, value=2)),
-        Declaration(Variable(d, type=real, value=4))]
+        Declaration(Variable(c, type=real, value=2.0)),
+        Declaration(Variable(d, type=real, value=4.0))]
 
         An example of variable definiton:
 

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -55,8 +55,8 @@ else:
         >>> a.return_expr()
         [Declaration(Variable(a, type=integer, value=0)),
         Declaration(Variable(b, type=integer, value=0)),
-        Declaration(Variable(c, type=integer, value=2)),
-        Declaration(Variable(d, type=integer, value=4))]
+        Declaration(Variable(c, type=real, value=2)),
+        Declaration(Variable(d, type=real, value=4))]
 
         An example of variable definiton:
 

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -117,7 +117,7 @@ if cin:
 
         assert res4[3] == Declaration(
             Variable(
-                Symbol('1'),
+                Symbol('q'),
                 type=FloatBaseType(String('real')),
                 value=Float('9.67', precision=53)
             )
@@ -131,7 +131,7 @@ if cin:
             'int b = 2;' + '\n'
         )
         c_src3 = 'int a = 2.345, b = 5.67;'
-        c_src4 = 'int p = 6, q = 7.89;'
+        c_src4 = 'int p = 6, q = 23.45;'
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
@@ -190,7 +190,7 @@ if cin:
             Variable(
                 Symbol('q'),
                 type=IntBaseType(String('integer')),
-                value=Integer(7)
+                value=Integer(23)
             )
         )
 
@@ -259,7 +259,7 @@ if cin:
 
         assert res4[1] == Declaration(
             Variable(
-                Symbol('1'),
+                Symbol('e'),
                 type=FloatBaseType(String('real')),
                 value=Float('7.89', precision=53)
             )

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -26,10 +26,15 @@ if cin:
             'float b;' + '\n' +
             'int c;'
         )
+        c_src4 = (
+            'int x = 1, y = 6.78;' + '\n' +
+            'float p = 2, q = 9.67;'
+        )
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
         res3 = SymPyExpression(c_src3, 'c').return_expr()
+        res4 = SymPyExpression(c_src4, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -38,6 +43,7 @@ if cin:
                 value=Integer(0)
             )
         )
+
         assert res1[1] == Declaration(
             Variable(
                 Symbol('b'),
@@ -85,6 +91,38 @@ if cin:
             )
         )
 
+        assert res4[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=IntBaseType(String('integer')),
+                value=Integer(1)
+            )
+        )
+
+        assert res4[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=IntBaseType(String('integer')),
+                value=Integer(6)
+            )
+        )
+
+        assert res4[2] == Declaration(
+            Variable(
+                Symbol('p'),
+                type=FloatBaseType(String('real')),
+                value=Float('2.0', precision=53)
+            )
+        )
+
+        assert res4[3] == Declaration(
+            Variable(
+                Symbol('1'),
+                type=FloatBaseType(String('real')),
+                value=Float('9.67', precision=53)
+            )
+        )
+
 
     def test_int():
         c_src1 = 'int a = 1;'
@@ -92,9 +130,13 @@ if cin:
             'int a = 1;' + '\n' +
             'int b = 2;' + '\n'
         )
+        c_src3 = 'int a = 2.345, b = 5.67;'
+        c_src4 = 'int p = 6, q = 7.89;'
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
+        res3 = SymPyExpression(c_src3, 'c').return_expr()
+        res4 = SymPyExpression(c_src4, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -120,6 +162,38 @@ if cin:
             )
         )
 
+        assert res3[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=IntBaseType(String('integer')),
+                value=Integer(2)
+            )
+        )
+
+        assert res3[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=IntBaseType(String('integer')),
+                value=Integer(5)
+            )
+        )
+
+        assert res4[0] == Declaration(
+            Variable(
+                Symbol('p'),
+                type=IntBaseType(String('integer')),
+                value=Integer(6)
+            )
+        )
+
+        assert res4[1] == Declaration(
+            Variable(
+                Symbol('q'),
+                type=IntBaseType(String('integer')),
+                value=Integer(7)
+            )
+        )
+
 
     def test_float():
         c_src1 = 'float a = 1.0;'
@@ -127,9 +201,13 @@ if cin:
             'float a = 1.25;' + '\n' +
             'float b = 2.39;' + '\n'
         )
+        c_src3 = 'float x = 1, y = 2;'
+        c_src4 = 'float p = 5, e = 7.89;'
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
+        res3 = SymPyExpression(c_src3, 'c').return_expr()
+        res4 = SymPyExpression(c_src4, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -152,6 +230,38 @@ if cin:
                 Symbol('b'),
                 type=FloatBaseType(String('real')),
                 value=Float('2.3900000000000001', precision=53)
+            )
+        )
+
+        assert res3[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=FloatBaseType(String('real')),
+                value=Float('1.0', precision=53)
+            )
+        )
+
+        assert res3[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=FloatBaseType(String('real')),
+                value=Float('2.0', precision=53)
+            )
+        )
+
+        assert res4[0] == Declaration(
+            Variable(
+                Symbol('p'),
+                type=FloatBaseType(String('real')),
+                value=Float('5.0', precision=53)
+            )
+        )
+
+        assert res4[1] == Declaration(
+            Variable(
+                Symbol('1'),
+                type=FloatBaseType(String('real')),
+                value=Float('7.89', precision=53)
             )
         )
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#18044 

#### Brief description of what is fixed or changed

The type of a variable will be decided according to the type of the declared variable in C instead of the type of the assigned literal type.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
