### PR TITLE
Fixing error in PartialDerivative operator for tensor valence

### DIFF
--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -16,3 +16,4 @@ Contents
     indexed.rst
     index_methods.rst
     tensor.rst
+    toperators.rst

--- a/doc/src/modules/tensor/toperators.rst
+++ b/doc/src/modules/tensor/toperators.rst
@@ -3,3 +3,4 @@ Tensor Operators
 ================
 
 .. automodule:: sympy.tensor.toperators
+   :members:

--- a/doc/src/modules/tensor/toperators.rst
+++ b/doc/src/modules/tensor/toperators.rst
@@ -1,0 +1,5 @@
+
+Tensor Operators
+================
+
+.. automodule:: sympy.tensor.toperators

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1811,6 +1811,19 @@ class LatexPrinter(Printer):
             self._print(expr.args[0])
         )
 
+    def _print_PartialDerivative(self, expr):
+        if len(expr.variables) == 1:
+            return r"\frac{\partial}{\partial {%s}}{%s}" % (
+                self._print(expr.variables[0]),
+                self.parenthesize(expr.expr, PRECEDENCE["Mul"], False)
+            )
+        else:
+            return r"\frac{\partial^{%s}}{%s}{%s}" % (
+                len(expr.variables),
+                " ".join([r"\partial {%s}" % self._print(i) for i in expr.variables]),
+                self.parenthesize(expr.expr, PRECEDENCE["Mul"], False)
+            )
+
     def _print_UniversalSet(self, expr):
         return r"\mathbb{U}"
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1193,6 +1193,9 @@ class PrettyPrinter(Printer):
 
         pform = prettyForm(deriv_symbol)
 
+        if len(deriv.variables) > 1:
+            pform = pform**self._print(len(deriv.variables))
+
         pform = prettyForm(*pform.below(stringPict.LINE, x))
         pform.baseline = pform.baseline + 1
         pform = prettyForm(*stringPict.next(pform, f))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6659,20 +6659,20 @@ A  ⋅───⎜B ⋅C   + 3⋅H   ⎟\n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = (A(i) + B(i))*PartialDerivative(C(-j), D(j))
+    expr = (A(i) + B(i))*PartialDerivative(C(j), D(j))
     ascii_str = \
 """\
-/ i    i\\   d  /    \\\n\
+/ i    i\\   d  / L_0\\\n\
 |A  + B |*-----|C   |\n\
-\\       /   L_0\\ L_0/\n\
+\\       /   L_0\\    /\n\
           dD         \n\
                      \
 """
     ucode_str = \
 u("""\
-⎛ i    i⎞  ∂  ⎛   ⎞\n\
+⎛ i    i⎞  ∂  ⎛ L₀⎞\n\
 ⎜A  + B ⎟⋅────⎜C  ⎟\n\
-⎝       ⎠   L₀⎝ L₀⎠\n\
+⎝       ⎠   L₀⎝   ⎠\n\
           ∂D       \n\
                    \
 """)
@@ -6699,6 +6699,28 @@ u("""\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    expr = PartialDerivative(B(-i) + A(-i), A(-j), A(-n))
+    ucode_str = u("""\
+    2           \n\
+   ∂   ⎛       ⎞\n\
+───────⎜A  + B ⎟\n\
+       ⎝ i    i⎠\n\
+∂A  ∂A          \n\
+  n   j         \
+""")
+    assert upretty(expr) == ucode_str
+
+    expr = PartialDerivative(3*A(-i), A(-j), A(-n))
+    ucode_str = u("""\
+    2        \n\
+   ∂   ⎛    ⎞\n\
+───────⎜3⋅A ⎟\n\
+       ⎝   i⎠\n\
+∂A  ∂A       \n\
+  n   j      \
+""")
+    assert upretty(expr) == ucode_str
+
     expr = TensorElement(H(i, j), {i:1})
     ascii_str = \
 """\
@@ -6710,7 +6732,7 @@ H     \n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = TensorElement(H(i, j), {i:1, j:1})
+    expr = TensorElement(H(i, j), {i: 1, j: 1})
     ascii_str = \
 """\
  i=1,j=1\n\
@@ -6721,7 +6743,7 @@ H       \n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = TensorElement(H(i, j), {j:1})
+    expr = TensorElement(H(i, j), {j: 1})
     ascii_str = \
 """\
  i,j=1\n\
@@ -6730,7 +6752,7 @@ H     \n\
 """
     ucode_str = ascii_str
 
-    expr = TensorElement(H(-i, j), {-i:1})
+    expr = TensorElement(H(-i, j), {-i: 1})
     ascii_str = \
 """\
     j\n\

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,3 +1,5 @@
+from sympy.tensor.toperators import PartialDerivative
+
 from sympy import (
     Add, Abs, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
     FiniteSet, Float, FourierTransform, Function, Indexed, IndexedBase, Integral,
@@ -2310,6 +2312,21 @@ def test_latex_printer_tensor():
 
     expr = TensorElement(K(i, j, -k, -l), {i: 3})
     assert latex(expr) == 'K{}^{i=3,j}{}_{kl}'
+
+    expr = PartialDerivative(A(i), A(i))
+    assert latex(expr) == r"\frac{\partial}{\partial {A{}^{L_{0}}}}{A{}^{L_{0}}}"
+
+    expr = PartialDerivative(A(-i), A(-j))
+    assert latex(expr) == r"\frac{\partial}{\partial {A{}_{j}}}{A{}_{i}}"
+
+    expr = PartialDerivative(K(i, j, -k, -l), A(m), A(-n))
+    assert latex(expr) == r"\frac{\partial^{2}}{\partial {A{}^{m}} \partial {A{}_{n}}}{K{}^{ij}{}_{kl}}"
+
+    expr = PartialDerivative(B(-i) + A(-i), A(-j), A(-n))
+    assert latex(expr) == r"\frac{\partial^{2}}{\partial {A{}_{j}} \partial {A{}_{n}}}{\left(A{}_{i} + B{}_{i}\right)}"
+
+    expr = PartialDerivative(3*A(-i), A(-j), A(-n))
+    assert latex(expr) == r"\frac{\partial^{2}}{\partial {A{}_{j}} \partial {A{}_{n}}}{\left(3A{}_{i}\right)}"
 
 
 def test_multiline_latex():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2545,7 +2545,6 @@ class TensAdd(TensExpr, AssocOp):
         return Add.fromiter(args)
 
 
-
 class Tensor(TensExpr):
     """
     Base tensor class, i.e. this represents a tensor, the single unit to be

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2100,12 +2100,18 @@ class TensExpr(Expr):
 
         # Raise indices:
         for pos in pos2up:
-            metric = replacement_dict[index_types1[pos]]
+            index_type_pos = index_types1[pos]  # type: TensorIndexType
+            if index_type_pos not in replacement_dict:
+                raise ValueError("No metric provided to lower index")
+            metric = replacement_dict[index_type_pos]
             metric_inverse = _TensorDataLazyEvaluator.inverse_matrix(metric)
             array = contract_and_permute(metric_inverse, array, pos)
         # Lower indices:
         for pos in pos2down:
-            metric = replacement_dict[index_types1[pos]]
+            index_type_pos = index_types1[pos]  # type: TensorIndexType
+            if index_type_pos not in replacement_dict:
+                raise ValueError("No metric provided to lower index")
+            metric = replacement_dict[index_type_pos]
             array = contract_and_permute(metric, array, pos)
 
         if free_ind1:
@@ -2537,6 +2543,7 @@ class TensAdd(TensExpr, AssocOp):
 
     def _eval_rewrite_as_Indexed(self, *args):
         return Add.fromiter(args)
+
 
 
 class Tensor(TensExpr):

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -1,3 +1,5 @@
+from sympy.utilities.pytest import raises
+
 from sympy.tensor.toperators import PartialDerivative
 from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorHead, \
     tensor_heads
@@ -15,39 +17,54 @@ A, B, C, D = tensor_heads("A B C D", [L])
 H = TensorHead("H", [L, L])
 
 
+def test_invalid_partial_derivative_valence():
+    raises(ValueError, lambda: PartialDerivative(C(j), D(-j)))
+    raises(ValueError, lambda: PartialDerivative(C(-j), D(j)))
+
+
 def test_tensor_partial_deriv():
     # Test flatten:
-    expr = PartialDerivative(PartialDerivative(A(i), A(j)), A(-i))
+    expr = PartialDerivative(PartialDerivative(A(i), A(j)), A(i))
     assert expr.expr == A(L_0)
-    assert expr.variables == (A(j), A(-L_0))
+    assert expr.variables == (A(j), A(L_0))
 
     expr1 = PartialDerivative(A(i), A(j))
     assert expr1.expr == A(i)
     assert expr1.variables == (A(j),)
 
     expr2 = A(i)*PartialDerivative(H(k, -i), A(j))
-    assert expr2.get_indices() == [L_0, k, -L_0, j]
+    assert expr2.get_indices() == [L_0, k, -L_0, -j]
+
+    expr2b = A(i)*PartialDerivative(H(k, -i), A(-j))
+    assert expr2b.get_indices() == [L_0, k, -L_0, j]
 
     expr3 = A(i)*PartialDerivative(B(k)*C(-i) + 3*H(k, -i), A(j))
-    assert expr3.get_indices() == [L_0, k, -L_0, j]
+    assert expr3.get_indices() == [L_0, k, -L_0, -j]
 
-    expr4 = (A(i) + B(i))*PartialDerivative(C(-j), D(j))
-    assert expr4.get_indices() == [i, -L_0, L_0]
+    expr4 = (A(i) + B(i))*PartialDerivative(C(j), D(j))
+    assert expr4.get_indices() == [i, L_0, -L_0]
+
+    expr4b = (A(i) + B(i))*PartialDerivative(C(-j), D(-j))
+    assert expr4b.get_indices() == [i, -L_0, L_0]
 
     expr5 = (A(i) + B(i))*PartialDerivative(C(-i), D(j))
-    assert expr5.get_indices() == [L_0, -L_0, j]
+    assert expr5.get_indices() == [L_0, -L_0, -j]
 
 
 def test_replace_arrays_partial_derivative():
     x, y, z, t = symbols("x y z t")
 
-    expr = PartialDerivative(A(i), A(j))
-    assert expr.replace_with_arrays({A(i): [x, y]}, [i, j]) == Array([[1, 0], [0, 1]])
+    expr = PartialDerivative(A(i), A(-j))
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [i, j]) == Array([[1, 0], [0, 1]])
 
-    expr = PartialDerivative(A(i), A(-i))
+    expr = PartialDerivative(A(i), A(j))
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, [i, j]) == Array([[1, 0], [0, -1]])
+
+    expr = PartialDerivative(A(i), A(i))
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, []) == 2
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 0
 
-    expr = PartialDerivative(A(-i), A(i))
+    expr = PartialDerivative(A(-i), A(-i))
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, []) == 2
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 0

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -54,17 +54,41 @@ def test_tensor_partial_deriv():
 def test_replace_arrays_partial_derivative():
     x, y, z, t = symbols("x y z t")
 
+    # d(A^i)/d(A_j) = d(g^ik A_k)/d(A_j) = g^ik delta_jk
     expr = PartialDerivative(A(i), A(-j))
-    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [i, j]) == Array([[1, 0], [0, 1]])
-
-    expr = PartialDerivative(A(i), A(j))
+    assert expr.get_free_indices() == [i, j]
+    assert expr.get_indices() == [i, j]
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [i, j]) == Array([[1, 0], [0, 1]])
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, [i, j]) == Array([[1, 0], [0, -1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, 1)}, [i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, -1)}, [i, j]) == Array([[1, 0], [0, -1]])
+
+    expr = PartialDerivative(A(i), A(j))
+    assert expr.get_free_indices() == [i, -j]
+    assert expr.get_indices() == [i, -j]
+    assert expr.replace_with_arrays({A(i): [x, y]}, [i, -j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [i, -j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, [i, -j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, 1)}, [i, -j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, -1)}, [i, -j]) == Array([[1, 0], [0, 1]])
+
+    expr = PartialDerivative(A(-i), A(-j))
+    expr.get_free_indices() == [-i, j]
+    expr.get_indices() == [-i, j]
+    assert expr.replace_with_arrays({A(-i): [x, y]}, [-i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, 1)}, [-i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(-i): [x, y], L: diag(1, -1)}, [-i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, [-i, j]) == Array([[1, 0], [0, 1]])
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, [-i, j]) == Array([[1, 0], [0, 1]])
 
     expr = PartialDerivative(A(i), A(i))
+    assert expr.get_free_indices() == []
+    assert expr.get_indices() == [L_0, -L_0]
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, []) == 2
-    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 0
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 2
 
     expr = PartialDerivative(A(-i), A(-i))
+    assert expr.get_free_indices() == []
+    assert expr.get_indices() == [-L_0, L_0]
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, []) == 2
-    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 0
+    assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 2

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -82,7 +82,8 @@ class PartialDerivative(TensExpr):
         return self._indices
 
     def get_free_indices(self):
-        return [i[0] for i in self._free]
+        free = sorted(self._free, key=lambda x: x[1])
+        return [i[0] for i in free]
 
     @property
     def expr(self):

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -81,6 +81,9 @@ class PartialDerivative(TensExpr):
     def get_indices(self):
         return self._indices
 
+    def get_free_indices(self):
+        return [i[0] for i in self._free]
+
     @property
     def expr(self):
         return self.args[0]
@@ -106,9 +109,7 @@ class PartialDerivative(TensExpr):
                 array[tuple(coeff_index)] /= coeff
             if -varindex in indices:
                 pos = indices.index(-varindex)
-                metric = replacement_dict[varindex.tensor_index_type]
-                # TODO: not valid for spinors (or non-symmetric metrics):
-                array = tensorcontraction(tensorproduct(metric, array), (0, 2), (1, pos+3))
+                array = tensorcontraction(array, (0, pos+1))
                 indices.pop(pos)
             else:
                 indices.append(varindex)

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -1,4 +1,5 @@
-from sympy.tensor.tensor import (TensExpr, TensMul)
+from sympy import tensorproduct, MutableDenseNDimArray
+from sympy.tensor.tensor import (TensExpr, TensMul, TensorIndex)
 
 
 class PartialDerivative(TensExpr):
@@ -22,12 +23,15 @@ class PartialDerivative(TensExpr):
     The ``PartialDerivative`` object behaves like a tensorial expression:
 
     >>> expr.get_indices()
-    [i, j]
+    [i, -j]
 
     Indices can be contracted:
 
-    >>> PartialDerivative(A(i), A(-i))
-    PartialDerivative(A(L_0), A(-L_0))
+    >>> expr = PartialDerivative(A(i), A(i))
+    >>> expr
+    PartialDerivative(A(L_0), A(L_0))
+    >>> expr.get_indices()
+    [L_0, -L_0]
     """
 
     def __new__(cls, expr, *variables):
@@ -39,8 +43,8 @@ class PartialDerivative(TensExpr):
 
         # TODO: check that all variables have rank 1.
 
-        args, indices, free, dum = TensMul._tensMul_contract_indices([expr] +
-            list(variables), replace_indices=True)
+        args, indices, free, dum = cls._contract_indices_for_derivative(
+            expr, variables)
 
         obj = TensExpr.__new__(cls, *args)
 
@@ -49,8 +53,24 @@ class PartialDerivative(TensExpr):
         obj._dum = dum
         return obj
 
+    @classmethod
+    def _contract_indices_for_derivative(cls, expr, variables):
+        variables_opposite_valence = []
+        for i in variables:
+            i_free_indices = i.get_free_indices()
+            variables_opposite_valence.append(i.xreplace({k: -k for k in i_free_indices}))
+
+        args, indices, free, dum = TensMul._tensMul_contract_indices(
+            [expr] + variables_opposite_valence, replace_indices=True)
+
+        for i in range(1, len(args)):
+            i_indices = args[i].get_free_indices()
+            args[i] = args[i].xreplace({k: -k for k in i_indices})
+
+        return args, indices, free, dum
+
     def doit(self):
-        args, indices, free, dum = TensMul._tensMul_contract_indices(self.args)
+        args, indices, free, dum = self._contract_indices_for_derivative(self.expr, self.variables)
 
         obj = self.func(*args)
         obj._indices = indices
@@ -74,10 +94,11 @@ class PartialDerivative(TensExpr):
         indices, array = self.expr._extract_data(replacement_dict)
         for variable in self.variables:
             var_indices, var_array = variable._extract_data(replacement_dict)
+            var_indices = [-i for i in var_indices]
             coeff_array, var_array = zip(*[i.as_coeff_Mul() for i in var_array])
             array = derive_by_array(array, var_array)
-            array = array.as_mutable()
-            varindex = var_indices[0]
+            array = array.as_mutable()  # type: MutableDenseNDimArray
+            varindex = var_indices[0]  # type: TensorIndex
             # Remove coefficients of base vector:
             coeff_index = [0] + [slice(None) for i in range(len(indices))]
             for i, coeff in enumerate(coeff_array):
@@ -85,7 +106,9 @@ class PartialDerivative(TensExpr):
                 array[tuple(coeff_index)] /= coeff
             if -varindex in indices:
                 pos = indices.index(-varindex)
-                array = tensorcontraction(array, (0, pos+1))
+                metric = replacement_dict[varindex.tensor_index_type]
+                # TODO: not valid for spinors (or non-symmetric metrics):
+                array = tensorcontraction(tensorproduct(metric, array), (0, 2), (1, pos+3))
                 indices.pop(pos)
             else:
                 indices.append(varindex)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* tensor
  * Fix PartialDerivative operator to correctly handle the valence (covariant/contravariant) of the deriving variable.
<!-- END RELEASE NOTES -->
