### PR TITLE
Fixes Attribute Error in diophantine.py

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -933,7 +933,7 @@ def _diop_quadratic(var, coeff, t):
     C = coeff[y**2]
     D = coeff[x]
     E = coeff[y]
-    F = coeff[1]
+    F = coeff[S.One]
 
     A, B, C, D, E, F = [as_int(i) for i in _remove_gcd(A, B, C, D, E, F)]
 

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -169,6 +169,13 @@ def test_issue_9106():
         assert not diop_simplify(eq.xreplace(dict(zip(v, sol))))
 
 
+def test_issue_18138():
+    eq = x**2 - x - y**2
+    v = (x, y)
+    for sol in diophantine(eq):
+        assert not diop_simplify(eq.xreplace(dict(zip(v, sol))))
+
+
 @slow
 def test_quadratic_non_perfect_slow():
     assert check_solutions(8*x**2 + 10*x*y - 2*y**2 - 32*x - 13*y - 23)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18138

#### Brief description of what is fixed or changed

The defaultdict `coeff` acquired a integer 1 key when called as `[1]` instead of `[S.One]` so when it was used elsewhere to reconstruct the an expression it raised an error when using a SymPy method on the key.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * diophantine.py - fixed bug where AttributeError was raised in some cases.

<!-- END RELEASE NOTES -->
