### PR TITLE
Fix Rationals.boundary, Rationals.is_open, Rationals.is_closed

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -66,7 +66,7 @@ class Rationals(with_metaclass(Singleton, Set)):
 
     @property
     def _boundary(self):
-        return self
+        return S.Reals
 
 
 class Naturals(with_metaclass(Singleton, Set)):

--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -1,9 +1,34 @@
 from sympy import (Interval, Intersection, Set, EmptySet, S, sympify,
                    FiniteSet, Union, ComplexRegion, ProductSet)
 from sympy.multipledispatch import dispatch
-from sympy.sets.fancysets import Integers
+from sympy.sets.fancysets import (Naturals, Naturals0, Integers, Rationals,
+                                  Reals)
 from sympy.sets.sets import UniversalSet
 
+
+@dispatch(Naturals0, Naturals)
+def union_sets(a, b): # noqa:F811
+    return a
+
+@dispatch(Rationals, Naturals)
+def union_sets(a, b): # noqa:F811
+    return a
+
+@dispatch(Rationals, Naturals0)
+def union_sets(a, b): # noqa:F811
+    return a
+
+@dispatch(Reals, Naturals)
+def union_sets(a, b): # noqa:F811
+    return a
+
+@dispatch(Reals, Naturals0)
+def union_sets(a, b): # noqa:F811
+    return a
+
+@dispatch(Reals, Rationals)
+def union_sets(a, b): # noqa:F811
+    return a
 
 @dispatch(Integers, Set)
 def union_sets(a, b): # noqa:F811

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -555,25 +555,29 @@ class Set(Basic):
     def is_open(self):
         """
         Property method to check whether a set is open.
+
         A set is open if and only if it has an empty intersection with its
-        boundary.
+        boundary. The openness of a subset of the reals is determined with
+        respect to R and its standard topology.
 
         Examples
         ========
         >>> from sympy import S
         >>> S.Reals.is_open
         True
+        >>> S.Rationals.is_open
+        False
         """
-        if not Intersection(self, self.boundary):
-            return True
-        # We can't confidently claim that an intersection exists
-        return None
+        return Intersection(self, self.boundary).is_empty
 
     @property
     def is_closed(self):
         """
-        A property method to check whether a set is closed. A set is closed
-        if its complement is an open set.
+        A property method to check whether a set is closed.
+
+        A set is closed if its complement is an open set. The closedness of a
+        subset of the reals is determined with respect to R and its standard
+        topology.
 
         Examples
         ========

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -557,8 +557,9 @@ class Set(Basic):
         Property method to check whether a set is open.
 
         A set is open if and only if it has an empty intersection with its
-        boundary. The openness of a subset of the reals is determined with
-        respect to R and its standard topology.
+        boundary. In particular, a subset A of the reals is open if and only
+        if each one of its points is contained in an open interval that is a
+        subset of A.
 
         Examples
         ========

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -954,8 +954,17 @@ def test_Rationals():
     raises(TypeError, lambda: x in S.Rationals)
     # issue #18134:
     assert S.Rationals.boundary == S.Reals
+    assert S.Rationals.closure == S.Reals
     assert S.Rationals.is_open == False
     assert S.Rationals.is_closed == False
+
+
+def test_NZQRC_unions():
+    # check that all trivial number set unions are simplified:
+    nbrsets = (S.Naturals, S.Naturals0, S.Integers, S.Rationals,
+        S.Reals, S.Complexes)
+    unions = (Union(a, b) for a in nbrsets for b in nbrsets)
+    assert all(u.is_Union is False for u in unions)
 
 
 def test_imageset_intersection():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -29,6 +29,8 @@ def test_naturals():
     assert N.intersect(Interval(-5, 5, True, True)) == Range(1, 5)
 
     assert N.boundary == N
+    assert N.is_open == False
+    assert N.is_closed == True
 
     assert N.inf == 1
     assert N.sup is oo
@@ -71,6 +73,8 @@ def test_integers():
     assert Z.sup is oo
 
     assert Z.boundary == Z
+    assert Z.is_open == False
+    assert Z.is_closed == True
 
     assert Z.as_relational(x) == And(Eq(floor(x), x), -oo < x, x < oo)
 
@@ -948,7 +952,10 @@ def test_Rationals():
     r = symbols('r', rational=True)
     assert r in S.Rationals
     raises(TypeError, lambda: x in S.Rationals)
-    assert S.Rationals.boundary == S.Rationals
+    # issue #18134:
+    assert S.Rationals.boundary == S.Reals
+    assert S.Rationals.is_open == False
+    assert S.Rationals.is_closed == False
 
 
 def test_imageset_intersection():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1124,16 +1124,16 @@ def test_boundary_ProductSet_line():
 
 
 def test_is_open():
-    assert not Interval(0, 1, False, False).is_open
-    assert not Interval(0, 1, True, False).is_open
-    assert Interval(0, 1, True, True).is_open
-    assert not FiniteSet(1, 2, 3).is_open
+    assert Interval(0, 1, False, False).is_open is False
+    assert Interval(0, 1, True, False).is_open is False
+    assert Interval(0, 1, True, True).is_open is True
+    assert FiniteSet(1, 2, 3).is_open is False
 
 
 def test_is_closed():
-    assert Interval(0, 1, False, False).is_closed
-    assert not Interval(0, 1, True, False).is_closed
-    assert FiniteSet(1, 2, 3).is_closed
+    assert Interval(0, 1, False, False).is_closed is True
+    assert Interval(0, 1, True, False).is_closed is False
+    assert FiniteSet(1, 2, 3).is_closed is True
 
 
 def test_closure():


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18134

#### Brief description of what is fixed or changed
This commit fixes #18134 by
- correcting `Rationals.boundary`,
- improving the `is_open` logic by using `is_empty`
  (previously `is_open` could never return `False`),
- updating the docstrings of `is_open` and `is_closed`.

It also makes a few related tests stricter by changing
`assert not ...` to `assert ... is False`.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed `Rationals.boundary` to be `Reals`. (`is_open` and `is_closed` now both return `False`.)
  * `is_open` logic is improved.
<!-- END RELEASE NOTES -->
