### PR TITLE
Add dra, drm functions in ntheory module

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -10,7 +10,7 @@ from .factor_ import divisors, proper_divisors, factorint, multiplicity, \
     divisor_count, proper_divisor_count, divisor_sigma, factorrat, \
     reduced_totient, primenu, primeomega, mersenne_prime_exponent, \
     is_perfect, is_mersenne_prime, is_abundant, is_deficient, is_amicable, \
-    abundance
+    abundance, dra, drm
 from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \
@@ -34,7 +34,7 @@ __all__ = [
     'divisor_count', 'proper_divisor_count', 'divisor_sigma', 'factorrat',
     'reduced_totient', 'primenu', 'primeomega', 'mersenne_prime_exponent',
     'is_perfect', 'is_mersenne_prime', 'is_abundant', 'is_deficient', 'is_amicable',
-    'abundance',
+    'abundance', 'dra', 'drm', 
 
     'npartitions',
 

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -33,8 +33,8 @@ __all__ = [
     'pollard_pm1', 'pollard_rho', 'primefactors', 'totient', 'trailing',
     'divisor_count', 'proper_divisor_count', 'divisor_sigma', 'factorrat',
     'reduced_totient', 'primenu', 'primeomega', 'mersenne_prime_exponent',
-    'is_perfect', 'is_mersenne_prime', 'is_abundant', 'is_deficient', 'is_amicable',
-    'abundance', 'dra', 'drm', 
+    'is_perfect', 'is_mersenne_prime', 'is_abundant', 'is_deficient', 'is_amicable', 'abundance',
+    'dra', 'drm',
 
     'npartitions',
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2398,7 +2398,7 @@ def dra(n):
 
 def drm(n):
     """Return the multiplicative digital root of integer n which is
-    a value < 10 obtained by mutiplying the digits of n together
+    a value < 10 obtained by multiplying the digits of n together
     (and repeating with the product) until a single digit is obtained.
     e.g. 345 -> 3*4*5 = 60 -> 6*0 = 0.
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2371,3 +2371,49 @@ def is_amicable(m, n):
         return False
     a, b = map(lambda i: divisor_sigma(i), (m, n))
     return a == b == (m + n)
+
+
+def dra(n):
+    """Return the additive digital root of integer n which is
+    a value < 10 obtained by adding the digits of n together
+    (and repeating with the sum) until a single digit is obtained.
+    e.g. 789 -> 7 + 8 + 9 = 24 -> 2 + 4 = 6
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.factor_ import dra
+    >>> dra(789)
+    6
+    """
+    a = abs(as_int(n))
+    while a > 9:
+        s = 0
+        while a:
+            a, d = divmod(a, 10)
+            s += d
+        a = s
+    return a
+
+
+def drm(n):
+    """Return the multiplicative digital root of integer n which is
+    a value < 10 obtained by mutiplying the digits of n together
+    (and repeating with the product) until a single digit is obtained.
+    e.g. 345 -> 3*4*5 = 60 -> 6*0 = 0.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.factor_ import drm
+    >>> drm(345)
+    0
+    """
+    m = abs(as_int(n))
+    while m > 9:
+        p = 1
+        while m:
+            m, d = divmod(m, 10)
+            p *= d
+        m = p
+    return m

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -662,14 +662,14 @@ def test_is_amicable():
 
 def test_dra():
     assert dra(789) == 6
-    assert dra(1234) == 1
+    assert dra(1234) == dra(-1234) == 1
     assert dra(23456789) == 8
     assert dra(1000) == 1
 
 
 def test_drm():
     assert drm(345) == 0
-    assert drm(1234) == 8
+    assert drm(1234) == drm(-1234) == 8
     assert drm(23456789) == 0
     assert drm(10000) == 0
     assert drm(234161) == 6

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -12,7 +12,7 @@ from sympy.ntheory.factor_ import (smoothness, smoothness_p, proper_divisors,
     antidivisors, antidivisor_count, core, digits, udivisors, udivisor_sigma,
     udivisor_count, proper_divisor_count, primenu, primeomega, small_trailing,
     mersenne_prime_exponent, is_perfect, is_mersenne_prime, is_abundant,
-    is_deficient, is_amicable)
+    is_deficient, is_amicable, dra, drm)
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.multinomial import (
     multinomial_coefficients, multinomial_coefficients_iterator)
@@ -658,3 +658,18 @@ def test_is_amicable():
     assert is_amicable(173, 129) is False
     assert is_amicable(220, 284) is True
     assert is_amicable(8756, 8756) is False
+
+
+def test_dra():
+    assert dra(789) == 6
+    assert dra(1234) == 1
+    assert dra(23456789) == 8
+    assert dra(1000) == 1
+
+
+def test_drm():
+    assert drm(345) == 0
+    assert drm(1234) == 8
+    assert drm(23456789) == 0
+    assert drm(10000) == 0
+    assert drm(234161) == 6


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
similar to #16496

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
    *  `dra`  function returns the additive digital root of integer `n` which is a value < 10
        obtained by adding the digits of n together (and repeating with the sum) until a single digit is obtained.
    *  `drm`  function returns the multiplicative digital root of integer n which is a value < 10 obtained by multiplying the digits of n together (and repeating with the product) until a single digit is obtained.
<!-- END RELEASE NOTES -->
