### PR TITLE
Fixed nthroot_mod to work with composite numbers

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -72,7 +72,7 @@ def _primitive_root_prime_iter(p):
 
     """
     # it is assumed that p is an int
-    v = [(p - 1) // i for i in factorint(p - 1).keys()]
+    v = [(totient(p)) // i for i in factorint(totient(p)).keys()]
     a = 2
     while a < p:
         for pw in v:
@@ -191,11 +191,11 @@ def _sqrt_mod_tonelli_shanks(a, p):
     .. [1] R. Crandall and C. Pomerance "Prime Numbers", 2nt Ed., page 101
 
     """
-    s = trailing(p - 1)
+    s = trailing(totient(p))
     t = p >> s
     # find a non-quadratic residue
     while 1:
-        d = randint(2, p - 1)
+        d = randint(2, totient(p))
         r = legendre_symbol(d, p)
         if r == -1:
             break
@@ -206,7 +206,7 @@ def _sqrt_mod_tonelli_shanks(a, p):
     for i in range(s):
         adm = A*pow(D, m, p) % p
         adm = pow(adm, 2**(s - 1 - i), p)
-        if adm % p == p - 1:
+        if adm % p == totient(p):
             m += 2**i
     #assert A*pow(D, m, p) % p == 1
     x = pow(a, (t + 1)//2, p)*pow(D, m//2, p) % p
@@ -399,7 +399,7 @@ def _sqrt_mod_prime_power(a, p, k):
         if p % 4 == 3:
             res = pow(a, (p + 1) // 4, p)
         elif p % 8 == 5:
-            sign = pow(a, (p - 1) // 4, p)
+            sign = pow(a, (totient(p)) // 4, p)
             if sign == 1:
                 res = pow(a, (p + 3) // 8, p)
             else:
@@ -614,7 +614,7 @@ def is_quad_residue(a, p):
         else:
             return True
 
-    return pow(a, (p - 1) // 2, p) == 1
+    return pow(a, (totient(p)) // 2, p) == 1
 
 
 def is_nthpow_residue(a, n, m):
@@ -699,7 +699,7 @@ def _nthroot_mod2(s, q, p):
 
 def _nthroot_mod1(s, q, p, all_roots):
     """
-    Root of ``x**q = s mod p``, ``p`` prime and ``q`` divides ``p - 1``
+    Root of ``x**q = s mod p``, ``p`` prime and ``q`` divides ``totient(p)``
 
     References
     ==========
@@ -711,8 +711,8 @@ def _nthroot_mod1(s, q, p, all_roots):
     if not isprime(q):
         r = _nthroot_mod2(s, q, p)
     else:
-        f = p - 1
-        assert (p - 1) % q == 0
+        f = totient(p)
+        assert (totient(p)) % q == 0
         # determine k
         k = 0
         while f % q == 0:
@@ -731,7 +731,7 @@ def _nthroot_mod1(s, q, p, all_roots):
         r = r1*g3 % p
         #assert pow(r, q, p) == s
     res = [r]
-    h = pow(g, (p - 1) // q, p)
+    h = pow(g, (totient(p)) // q, p)
     #assert pow(h, q, p) == 1
     hx = r
     for i in range(q - 1):
@@ -776,12 +776,12 @@ def nthroot_mod(a, n, p, all_roots=False):
     if primitive_root(p) is None:
         raise NotImplementedError("Not Implemented for m without primitive root")
 
-    if (p - 1) % n == 0:
+    if (totient(p)) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)
     # The roots of ``x**n - a = 0 (mod p)`` are roots of
-    # ``gcd(x**n - a, x**(p - 1) - 1) = 0 (mod p)``
+    # ``gcd(x**n - a, x**(totient(p)) - 1) = 0 (mod p)``
     pa = n
-    pb = p - 1
+    pb = totient(p)
     b = 1
     if pa < pb:
         a, pa, b, pb = b, pb, a, pa
@@ -866,7 +866,7 @@ def legendre_symbol(a, p):
     a = a % p
     if not a:
         return 0
-    if pow(a, (p - 1) // 2, p) == 1:
+    if pow(a, (totient(p)) // 2, p) == 1:
         return 1
     return -1
 

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -164,8 +164,10 @@ def test_residue():
     assert is_nthpow_residue(31, 4, 41)
     assert not is_nthpow_residue(2, 2, 5)
     assert is_nthpow_residue(8547, 12, 10007)
-    assert nthroot_mod(29, 31, 74) == 31
-    assert nthroot_mod(*Tuple(29, 31, 74)) == 31
+    assert nthroot_mod(29, 31, 74) == 45
+    assert nthroot_mod(*Tuple(29, 31, 74)) == 45
+    assert nthroot_mod(29,24,49) == 6
+    assert nthroot_mod(11,4,14) == 3
     assert nthroot_mod(1801, 11, 2663) == 44
     for a, q, p in [(51922, 2, 203017), (43, 3, 109), (1801, 11, 2663),
           (26118163, 1303, 33333347), (1499, 7, 2663), (595, 6, 2663),

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -164,16 +164,11 @@ def test_residue():
     assert is_nthpow_residue(31, 4, 41)
     assert not is_nthpow_residue(2, 2, 5)
     assert is_nthpow_residue(8547, 12, 10007)
-    assert nthroot_mod(29, 31, 74) == 45
-    assert nthroot_mod(*Tuple(29, 31, 74)) == 45
-    assert nthroot_mod(29,24,49) == 6
-    assert nthroot_mod(11,4,14) == 3
-    assert nthroot_mod(1801, 11, 2663) == 44
     for a, q, p in [(51922, 2, 203017), (43, 3, 109), (1801, 11, 2663),
           (26118163, 1303, 33333347), (1499, 7, 2663), (595, 6, 2663),
-          (1714, 12, 2663), (28477, 9, 33343)]:
+          (1714, 12, 2663), (28477, 9, 33343), (11,4,14), (29,24,49), (13,8,9), (29,31,74)]:
         r = nthroot_mod(a, q, p)
-        assert pow(r, q, p) == a
+        assert pow(r, q, p) == a%p
     assert nthroot_mod(11, 3, 109) is None
     raises(NotImplementedError, lambda: nthroot_mod(16, 5, 36))
     raises(NotImplementedError, lambda: nthroot_mod(9, 16, 36))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Change `p-1` to `totient(p)` to accommodate composite numbers
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17373 
Fixes #17377 


#### Brief description of what is fixed or changed
`totient(p) = p - 1` for prime numbers
All `p - 1` have been changed to `totient(p)` , this helps give proper output when p is composite

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Modified residue functions to work with composite numbers.
<!-- END RELEASE NOTES -->
