### PR TITLE
Add a simple way to do operations with equations

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -236,6 +236,10 @@ class Relational(Boolean, Expr, EvalfMixin):
                 return r.reversed.reversedsign
 
         return r
+    
+    def do(self, op):
+        """Do the same operation on both sides of the equation."""
+        return self.__class__(op(self.lhs), op(self.rhs))
 
     def equals(self, other, failing_expression=False):
         """Return True if the sides of the relationship are mathematically

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -242,19 +242,19 @@ class Relational(Boolean, Expr, EvalfMixin):
         Calls the function for each side, passing the lhs/rhs as
         an argument, and then returns a new equation consisting of
         the returned values."""
-        return self.__class__(op(self.lhs), op(self.rhs))
+        return self.func(op(self.lhs), op(self.rhs))
 
     def applylhs(self, op):
         """Call the function on the lhs and return a new equation
         whose lhs is the result of that function and rhs is the same
         as in the original equation."""
-        return self.__class__(op(self.lhs), self.rhs)
+        return self.func(op(self.lhs), self.rhs)
 
     def applyrhs(self, op):
         """Call the function on the rhs and return a new equation
         whose rhs is the result of that function and lhs is the same
         as in the original equation."""
-        return self.__class__(self.lhs, op(self.rhs))
+        return self.func(self.lhs, op(self.rhs))
 
     def equals(self, other, failing_expression=False):
         """Return True if the sides of the relationship are mathematically

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -236,7 +236,7 @@ class Relational(Boolean, Expr, EvalfMixin):
                 return r.reversed.reversedsign
 
         return r
-    
+
     def do(self, op):
         """Do the same operation on both sides of the equation."""
         return self.__class__(op(self.lhs), op(self.rhs))

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -237,9 +237,24 @@ class Relational(Boolean, Expr, EvalfMixin):
 
         return r
 
-    def do(self, op):
-        """Do the same operation on both sides of the equation."""
+    def applyfunc(self, op):
+        """Apply the same function to both sides of the equation.
+        Calls the function for each side, passing the lhs/rhs as
+        an argument, and then returns a new equation consisting of
+        the returned values."""
         return self.__class__(op(self.lhs), op(self.rhs))
+
+    def applylhs(self, op):
+        """Call the function on the lhs and return a new equation
+        whose lhs is the result of that function and rhs is the same
+        as in the original equation."""
+        return self.__class__(op(self.lhs), self.rhs)
+
+    def applyrhs(self, op):
+        """Call the function on the rhs and return a new equation
+        whose rhs is the result of that function and lhs is the same
+        as in the original equation."""
+        return self.__class__(self.lhs, op(self.rhs))
 
     def equals(self, other, failing_expression=False):
         """Return True if the sides of the relationship are mathematically

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1081,3 +1081,12 @@ def test_multivariate_linear_function_simplification():
 
 def test_nonpolymonial_relations():
     assert Eq(cos(x), 0).simplify() == Eq(cos(x), 0)
+
+
+def test_applyfunc():
+    def op(x):
+        return x**2
+    
+    assert Ge(x, y).applyfunc(op) == Ge(x**2, y**2)
+    assert Le(x, y).applylhs(op) == Le(x**2, y)
+    assert Eq(x, y).applyrhs(op) == Eq(x, y**2)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1086,7 +1086,7 @@ def test_nonpolymonial_relations():
 def test_applyfunc():
     def op(x):
         return x**2
-    
+
     assert Ge(x, y).applyfunc(op) == Ge(x**2, y**2)
     assert Le(x, y).applylhs(op) == Le(x**2, y)
     assert Eq(x, y).applyrhs(op) == Eq(x, y**2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Could be a very light-weight alternative to #17097.
Compatible with #18053
Fixes #5031.


#### Brief description of what is fixed or changed
One often needs to make some changes to equations and inequalities by hand. Untill this day, sympy didn't have an effective mechanism for this. With this PR you can do `Eq( 2*x, x ).do( lambda s: s - x )` to subtract `x` from both sides. Or you can multiply both sides, take absolute values of them or do anything you like.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * added `do` method for equations and inequalities
<!-- END RELEASE NOTES -->
