### PR TITLE
Add OrthogonalBra and OrthogonalKet

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3665,6 +3665,16 @@ def test_sympy__physics__quantum__state__StateBase():
     assert _test_args(StateBase(0))
 
 
+def test_sympy__physics__quantum__state__OrthogonalBra():
+    from sympy.physics.quantum.state import OrthogonalBra
+    assert _test_args(OrthogonalBra(0))
+
+
+def test_sympy__physics__quantum__state__OrthogonalKet():
+    from sympy.physics.quantum.state import OrthogonalKet
+    assert _test_args(OrthogonalKet(0))
+
+
 def test_sympy__physics__quantum__state__TimeDepBra():
     from sympy.physics.quantum.state import TimeDepBra
     assert _test_args(TimeDepBra('psi', 't'))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3675,6 +3675,11 @@ def test_sympy__physics__quantum__state__OrthogonalKet():
     assert _test_args(OrthogonalKet(0))
 
 
+def test_sympy__physics__quantum__state__OrthogonalState():
+    from sympy.physics.quantum.state import OrthogonalState
+    assert _test_args(OrthogonalState(0))
+
+
 def test_sympy__physics__quantum__state__TimeDepBra():
     from sympy.physics.quantum.state import TimeDepBra
     assert _test_args(TimeDepBra('psi', 't'))

--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 
     'KetBase', 'BraBase', 'StateBase', 'State', 'Ket', 'Bra', 'TimeDepState',
     'TimeDepBra', 'TimeDepKet', 'OrthogonalKet', 'OrthogonalBra',
-    'Wavefunction',
+    'OrthogonalState', 'Wavefunction',
 
     'TensorProduct', 'tensor_product_simp',
 
@@ -52,7 +52,7 @@ from .represent import (represent, rep_innerproduct, rep_expectation,
 
 from .state import (KetBase, BraBase, StateBase, State, Ket, Bra,
         TimeDepState, TimeDepBra, TimeDepKet, OrthogonalKet,
-        OrthogonalBra, Wavefunction)
+        OrthogonalBra, OrthogonalState, Wavefunction)
 
 from .tensorproduct import TensorProduct, tensor_product_simp
 

--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -22,7 +22,8 @@ __all__ = [
     'get_basis', 'enumerate_states',
 
     'KetBase', 'BraBase', 'StateBase', 'State', 'Ket', 'Bra', 'TimeDepState',
-    'TimeDepBra', 'TimeDepKet', 'Wavefunction',
+    'TimeDepBra', 'TimeDepKet', 'OrthogonalKet', 'OrthogonalBra',
+    'Wavefunction',
 
     'TensorProduct', 'tensor_product_simp',
 
@@ -50,7 +51,8 @@ from .represent import (represent, rep_innerproduct, rep_expectation,
         integrate_result, get_basis, enumerate_states)
 
 from .state import (KetBase, BraBase, StateBase, State, Ket, Bra,
-        TimeDepState, TimeDepBra, TimeDepKet, Wavefunction)
+        TimeDepState, TimeDepBra, TimeDepKet, OrthogonalKet,
+        OrthogonalBra, Wavefunction)
 
 from .tensorproduct import TensorProduct, tensor_product_simp
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -656,7 +656,7 @@ class OrthogonalKet(Ket):
 
         return 1
 
-    
+
 class OrthogonalBra(Bra):
     """Orthogonal Bra in quantum mechanics.
     """

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -18,6 +18,8 @@ __all__ = [
     'TimeDepState',
     'TimeDepBra',
     'TimeDepKet',
+    'OrthogonalKet',
+    'OrthogonalBra',
     'Wavefunction'
 ]
 
@@ -615,6 +617,56 @@ class TimeDepBra(TimeDepState, BraBase):
     @classmethod
     def dual_class(self):
         return TimeDepKet
+
+
+
+class OrthogonalKet(Ket):
+    """Orthogonal Ket in quantum mechanics.
+
+    The inner product of two states with different labels will give zero,
+    states with the same label will give one.
+
+        >>> from sympy.physics.quantum import OrthogonalBra, OrthogonalKet
+        >>> OrthogonalBra(n)*OrthogonalKet(n)
+        1
+        >>> OrthogonalBra(n)*OrthogonalKet(n+1)
+        0
+        >>> OrthogonalBra(n)*OrthogonalKet(m)
+        <n|m>
+    """
+
+    @classmethod
+    def dual_class(self):
+        return OrthogonalBra
+
+    def _eval_innerproduct(self, bra, **hints):
+
+        if len(self.args) != len(bra.args):
+            raise ValueError('Cannot multiply a ket that has a different number of labels.')
+
+        for i in range(len(self.args)):
+            diff = self.args[i] - bra.args[i]
+            diff.simplify()
+
+            if diff.is_nonzero:
+                return 0
+
+            if not diff.is_zero:
+                return None
+
+        return 1
+
+    
+class OrthogonalBra(Bra):
+    """Orthogonal Bra in quantum mechanics.
+    """
+
+    @classmethod
+    def dual_class(self):
+        return OrthogonalKet
+
+
+
 
 
 class Wavefunction(Function):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -619,8 +619,11 @@ class TimeDepBra(TimeDepState, BraBase):
         return TimeDepKet
 
 
+class OrthogonalState(State, StateBase):
+    """General abstract quantum state used as a base class for Ket and Bra."""
+    pass
 
-class OrthogonalKet(Ket):
+class OrthogonalKet(OrthogonalState, KetBase):
     """Orthogonal Ket in quantum mechanics.
 
     The inner product of two states with different labels will give zero,
@@ -657,7 +660,7 @@ class OrthogonalKet(Ket):
         return 1
 
 
-class OrthogonalBra(Bra):
+class OrthogonalBra(OrthogonalState, BraBase):
     """Orthogonal Bra in quantum mechanics.
     """
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -652,10 +652,10 @@ class OrthogonalKet(OrthogonalState, KetBase):
             diff = self.args[i] - bra.args[i]
             diff = diff.simplify()
 
-            if diff.is_nonzero:
+            if diff.is_zero is False:
                 return 0
 
-            if not diff.is_zero:
+            if diff.is_zero is None:
                 return None
 
         return 1

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -20,6 +20,7 @@ __all__ = [
     'TimeDepKet',
     'OrthogonalKet',
     'OrthogonalBra',
+    'OrthogonalState',
     'Wavefunction'
 ]
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -651,7 +651,7 @@ class OrthogonalKet(OrthogonalState, KetBase):
 
         for i in range(len(self.args)):
             diff = self.args[i] - bra.args[i]
-            diff = diff.simplify()
+            diff = diff.expand()
 
             if diff.is_zero is False:
                 return 0

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -670,9 +670,6 @@ class OrthogonalBra(OrthogonalState, BraBase):
         return OrthogonalKet
 
 
-
-
-
 class Wavefunction(Function):
     """Class for representations in continuous bases
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -629,12 +629,13 @@ class OrthogonalKet(OrthogonalState, KetBase):
     The inner product of two states with different labels will give zero,
     states with the same label will give one.
 
-        >>> from sympy.physics.quantum import OrthogonalBra, OrthogonalKet
-        >>> OrthogonalBra(n)*OrthogonalKet(n)
+        >>> from sympy.physics.quantum import OrthogonalBra, OrthogonalKet, qapply
+        >>> from sympy.abc import m, n
+        >>> (OrthogonalBra(n)*OrthogonalKet(n)).doit()
         1
-        >>> OrthogonalBra(n)*OrthogonalKet(n+1)
+        >>> (OrthogonalBra(n)*OrthogonalKet(n+1)).doit()
         0
-        >>> OrthogonalBra(n)*OrthogonalKet(m)
+        >>> (OrthogonalBra(n)*OrthogonalKet(m)).doit()
         <n|m>
     """
 
@@ -649,7 +650,7 @@ class OrthogonalKet(OrthogonalState, KetBase):
 
         for i in range(len(self.args)):
             diff = self.args[i] - bra.args[i]
-            diff.simplify()
+            diff = diff.simplify()
 
             if diff.is_nonzero:
                 return 0

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -6,7 +6,8 @@ from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.state import (
     Ket, Bra, TimeDepKet, TimeDepBra,
-    KetBase, BraBase, StateBase, Wavefunction
+    KetBase, BraBase, StateBase, Wavefunction,
+    OrthogonalKet, OrthogonalBra
 )
 from sympy.physics.quantum.hilbert import HilbertSpace
 
@@ -226,3 +227,13 @@ def test_wavefunction():
 
     k = Wavefunction(x**2, 'x')
     assert type(k.variables[0]) == Symbol
+
+def test_orthogonal_states():
+    braket = OrthogonalBra(x) * OrthogonalKet(x)
+    assert braket.doit() == 1
+
+    braket = OrthogonalBra(x) * OrthogonalKet(x+1)
+    assert braket.doit() == 0
+
+    braket = OrthogonalBra(x) * OrthogonalKet(y)
+    assert braket.doit() == braket


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Stack Overflow: [Evaluate inner product of bra and ket in Sympy Quantum](https://stackoverflow.com/questions/42423148/evaluate-inner-product-of-bra-and-ket-in-sympy-quantum/59536080#59536080)


#### Brief description of what is fixed or changed
Implemented Bra and Ket classes for frequently used orthogonal states.

Example usage:
```python
>>> OrthogonalBra(n)*OrthogonalKet(n)
1
>>> OrthogonalBra(n)*OrthogonalKet(n+1)
0
>>> OrthogonalBra(n)*OrthogonalKet(m)
<n|m>
```

Given the number of upvotes and answers in the StackOverflow question, I think this would make a great addition to the source code.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * Added new OrthogonalBra and OrthogonalKet classes for orthogonal states.
<!-- END RELEASE NOTES -->
