### PR TITLE
Sqrtmod

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -243,6 +243,8 @@ def sqrt_mod(a, p, all_roots=False):
     >>> sqrt_mod(17, 32, True)
     [7, 9, 23, 25]
     """
+    if isprime(p) == True and legendre_symbol(a, p) == -1:
+        return None
     if all_roots:
         return sorted(list(sqrt_mod_iter(a, p)))
     try:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -393,7 +393,7 @@ def _sqrt_mod_prime_power(a, p, k):
     if k == 1:
         if p == 2:
             return [ZZ(a)]
-        if not (pow(a, (p - 1) // 2, p) == 1 or p < 3 or a % p < 2):
+        if not (pow(a, (p - 1) // 2, p) == 1 or a % p < 2):
             return None
 
         if p % 4 == 3:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -243,9 +243,7 @@ def sqrt_mod(a, p, all_roots=False):
     >>> sqrt_mod(17, 32, True)
     [7, 9, 23, 25]
     """
-    if isprime(p) == True and p != 2:
-        if legendre_symbol(a, p) == -1:
-            return None
+
     if all_roots:
         return sorted(list(sqrt_mod_iter(a, p)))
     try:
@@ -320,11 +318,15 @@ def sqrt_mod_iter(a, p, domain=int):
     >>> list(sqrt_mod_iter(11, 43))
     [21, 22]
     """
+
     from sympy.polys.galoistools import gf_crt1, gf_crt2
     from sympy.polys.domains import ZZ
     a, p = as_int(a), abs(as_int(p))
     if isprime(p):
         a = a % p
+        if p != 2:
+            if a and pow(a, (p - 1) // 2, p) != 1:
+                return None
         if a == 0:
             res = _sqrt_mod1(a, p, 1)
         else:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -393,7 +393,7 @@ def _sqrt_mod_prime_power(a, p, k):
     if k == 1:
         if p == 2:
             return [ZZ(a)]
-        if not (pow(a, (p - 1) // 2, p) == 1 or a % p < 2):
+        if not (a % p < 2 or pow(a, (p - 1) // 2, p) == 1):
             return None
 
         if p % 4 == 3:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -243,7 +243,6 @@ def sqrt_mod(a, p, all_roots=False):
     >>> sqrt_mod(17, 32, True)
     [7, 9, 23, 25]
     """
-
     if all_roots:
         return sorted(list(sqrt_mod_iter(a, p)))
     try:
@@ -318,15 +317,11 @@ def sqrt_mod_iter(a, p, domain=int):
     >>> list(sqrt_mod_iter(11, 43))
     [21, 22]
     """
-
     from sympy.polys.galoistools import gf_crt1, gf_crt2
     from sympy.polys.domains import ZZ
     a, p = as_int(a), abs(as_int(p))
     if isprime(p):
         a = a % p
-        if p != 2:
-            if a and pow(a, (p - 1) // 2, p) != 1:
-                return None
         if a == 0:
             res = _sqrt_mod1(a, p, 1)
         else:
@@ -398,7 +393,7 @@ def _sqrt_mod_prime_power(a, p, k):
     if k == 1:
         if p == 2:
             return [ZZ(a)]
-        if not is_quad_residue(a, p):
+        if not (pow(a, (p - 1) // 2, p) == 1 or p < 3 or a % p < 2):
             return None
 
         if p % 4 == 3:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -243,8 +243,9 @@ def sqrt_mod(a, p, all_roots=False):
     >>> sqrt_mod(17, 32, True)
     [7, 9, 23, 25]
     """
-    if isprime(p) == True and legendre_symbol(a, p) == -1:
-        return None
+    if isprime(p) == True and p != 2:
+        if legendre_symbol(a, p) == -1:
+            return None
     if all_roots:
         return sorted(list(sqrt_mod_iter(a, p)))
     try:

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -78,6 +78,8 @@ def test_residue():
     assert sqrt_mod(3, -13) == 4
     assert sqrt_mod(6, 23) == 11
     assert sqrt_mod(345, 690) == 345
+    assert sqrt_mod(67, 101) == None
+    assert sqrt_mod(1020, 104729) == None
 
     for p in range(3, 100):
         d = defaultdict(list)


### PR DESCRIPTION
 <!-- BEGIN RELEASE NOTES -->
* ntheory
  *  In `def _sqrt_mod_prime_power(a, p, k):` it is assumed that p is a prime number. And this function calls `if not is_quad_residue(a, p):` in line 396. But `is_quad_residue(a, p)` again checks that p is prime or not. This leads to extra computation cost. 
<!-- END RELEASE NOTES -->
