### PR TITLE
Fix recursion error in pow

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -371,7 +371,8 @@ class Pow(Expr):
                         if b.is_negative is True:
                             return S.NegativeOne**other*Pow(-b, e*other)
                         if b.is_extended_real is False:
-                            return Pow(b.conjugate()/Abs(b)**2, other)
+                            if b.conjugate() != Abs(b)**2/b:
+                                return Pow(b.conjugate()/Abs(b)**2, other)
                 elif e.is_even:
                     if b.is_extended_real:
                         b = abs(b)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -370,9 +370,8 @@ class Pow(Expr):
                     if _half(other):
                         if b.is_negative is True:
                             return S.NegativeOne**other*Pow(-b, e*other)
-                        if b.is_extended_real is False:
-                            if b.conjugate() != Abs(b)**2/b:
-                                return Pow(b.conjugate()/Abs(b)**2, other)
+                        elif b.is_negative is False:
+                            return Pow(b, -other)
                 elif e.is_even:
                     if b.is_extended_real:
                         b = abs(b)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -433,7 +433,7 @@ def test_better_sqrt():
     assert sqrt(1/(3 - I)) == sqrt(10)*sqrt(3 + I)/10
     # symbolic
     i = symbols('i', imaginary=True)
-    assert sqrt(3/i) == Mul(sqrt(3), sqrt(-i)/abs(i), evaluate=False)
+    assert sqrt(3/i) == Mul(sqrt(3), 1/sqrt(i), evaluate=False)
     # multiples of 1/2; don't make this too automatic
     assert sqrt((3 + 4*I))**3 == (2 + I)**3
     assert Pow(3 + 4*I, Rational(3, 2)) == 2 + 11*I

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -504,3 +504,7 @@ def test_issue_17450():
     assert (Pow(exp(1+sqrt(2)), ((1-sqrt(2))*I*pi), evaluate=False)).is_real is None
     assert ((-10)**(10*I*pi/3)).is_real is False
     assert ((-5)**(4*I*pi)).is_real is False
+
+
+def test_issue_18190():
+    assert sqrt(1 / tan(1 + I)) == 1 / sqrt(tan(1 + I))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18190.

#### Brief description of what is fixed or changed
Check that `b.conjugate() != Abs(b)**2/b` before doing recursive call.

The only other place that this seems to be tested is here:

https://github.com/sympy/sympy/blob/1923822ddf8265199dbd9ef9ce09641d3fd042b9/sympy/core/tests/test_power.py#L435-L436

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
