### PR TITLE
Updated nthroot to raise NotImplementedError for composite modulo

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -72,8 +72,6 @@ def _primitive_root_prime_iter(p):
 
     """
     # it is assumed that p is an int
-    if isprime(p) is False:
-        raise NotImplementedError("Not implemented for composite p")
     v = [(p - 1) // i for i in factorint(p - 1).keys()]
     a = 2
     while a < p:
@@ -112,8 +110,6 @@ def primitive_root(p):
     p = as_int(p)
     if p < 1:
         raise ValueError('p is required to be positive')
-    if isprime(p) is False:
-        raise NotImplementedError("Not implemented for composite p")
     if p <= 2:
         return 1
     f = factorint(p)
@@ -777,7 +773,7 @@ def nthroot_mod(a, n, p, all_roots=False):
     # see Hackman "Elementary Number Theory" (2009), page 76
     if not is_nthpow_residue(a, n, p):
         return None
-    if isprime(p) is False:
+    if not isprime(p):
         raise NotImplementedError("Not implemented for composite p")
     if primitive_root(p) is None:
         raise NotImplementedError("Not Implemented for m without primitive root")

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -775,8 +775,6 @@ def nthroot_mod(a, n, p, all_roots=False):
         return None
     if not isprime(p):
         raise NotImplementedError("Not implemented for composite p")
-    if primitive_root(p) is None:
-        raise NotImplementedError("Not Implemented for m without primitive root")
 
     if (p - 1) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -72,6 +72,8 @@ def _primitive_root_prime_iter(p):
 
     """
     # it is assumed that p is an int
+    if isprime(p) is False:
+        raise NotImplementedError("Not implemented for composite p")
     v = [(p - 1) // i for i in factorint(p - 1).keys()]
     a = 2
     while a < p:
@@ -110,6 +112,8 @@ def primitive_root(p):
     p = as_int(p)
     if p < 1:
         raise ValueError('p is required to be positive')
+    if isprime(p) is False:
+        raise NotImplementedError("Not implemented for composite p")
     if p <= 2:
         return 1
     f = factorint(p)
@@ -773,6 +777,8 @@ def nthroot_mod(a, n, p, all_roots=False):
     # see Hackman "Elementary Number Theory" (2009), page 76
     if not is_nthpow_residue(a, n, p):
         return None
+    if isprime(p) is False:
+        raise NotImplementedError("Not implemented for composite p")
     if primitive_root(p) is None:
         raise NotImplementedError("Not Implemented for m without primitive root")
 

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -33,14 +33,16 @@ def test_residue():
         it = _primitive_root_prime_iter(p)
         assert len(list(it)) == totient(totient(p))
     assert primitive_root(97) == 5
-    raises(NotImplementedError, lambda: primitive_root(97**2))
+    assert primitive_root(97**2) == 5
     assert primitive_root(40487) == 5
     # note that primitive_root(40487) + 40487 = 40492 is a primitive root
     # of 40487**2, but it is not the smallest
-    raises(NotImplementedError, lambda: primitive_root(40487**2))
-    raises(NotImplementedError, lambda: primitive_root(82))
+    assert primitive_root(40487**2) == 10
+    assert primitive_root(82) == 7
     p = 10**50 + 151
     assert primitive_root(p) == 11
+    assert primitive_root(2*p) == 11
+    assert primitive_root(p**2) == 11
     raises(ValueError, lambda: primitive_root(-3))
 
     assert is_quad_residue(3, 7) is False

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -29,24 +29,18 @@ def test_residue():
     assert is_primitive_root(12, 17) == is_primitive_root(29, 17)
     raises(ValueError, lambda: is_primitive_root(3, 6))
 
-    assert [primitive_root(i) for i in range(2, 31)] == [1, 2, 3, 2, 5, 3, \
-       None, 2, 3, 2, None, 2, 3, None, None, 3, 5, 2, None, None, 7, 5, \
-       None, 2, 7, 2, None, 2, None]
-
     for p in primerange(3, 100):
         it = _primitive_root_prime_iter(p)
         assert len(list(it)) == totient(totient(p))
     assert primitive_root(97) == 5
-    assert primitive_root(97**2) == 5
+    raises(NotImplementedError, lambda: primitive_root(97**2))
     assert primitive_root(40487) == 5
     # note that primitive_root(40487) + 40487 = 40492 is a primitive root
     # of 40487**2, but it is not the smallest
-    assert primitive_root(40487**2) == 10
-    assert primitive_root(82) == 7
+    raises(NotImplementedError, lambda: primitive_root(40487**2))
+    raises(NotImplementedError, lambda: primitive_root(82))
     p = 10**50 + 151
     assert primitive_root(p) == 11
-    assert primitive_root(2*p) == 11
-    assert primitive_root(p**2) == 11
     raises(ValueError, lambda: primitive_root(-3))
 
     assert is_quad_residue(3, 7) is False
@@ -164,8 +158,7 @@ def test_residue():
     assert is_nthpow_residue(31, 4, 41)
     assert not is_nthpow_residue(2, 2, 5)
     assert is_nthpow_residue(8547, 12, 10007)
-    assert nthroot_mod(29, 31, 74) == 31
-    assert nthroot_mod(*Tuple(29, 31, 74)) == 31
+    raises(NotImplementedError, lambda: nthroot_mod(29, 31, 74))
     assert nthroot_mod(1801, 11, 2663) == 44
     for a, q, p in [(51922, 2, 203017), (43, 3, 109), (1801, 11, 2663),
           (26118163, 1303, 33333347), (1499, 7, 2663), (595, 6, 2663),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
#18172 


#### Brief description of what is fixed or changed
`nthroot_mod` , `primitive_root` and `_primitive_root_prime_iter` have been updated to not work for composite modulo.

#### Other comments
A more general algorithm to compute nthroot has to be implemented to work with all possible modulo

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Make `nthroot_mod` , `primitive_root` and `_primitive_root_prime_iter` incompatible with composite modulo.
<!-- END RELEASE NOTES -->
