### PR TITLE
Sympify eq in diophantine

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -11,6 +11,7 @@ from sympy.core.power import integer_nthroot, isqrt
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, symbols
+from sympy.core.sympify import _sympify
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -168,6 +169,8 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
     from sympy.utilities.iterables import (
         subsets, permute_signs, signed_permutations)
 
+    eq = _sympify(eq)
+
     if isinstance(eq, Eq):
         eq = eq.lhs - eq.rhs
 
@@ -199,7 +202,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None,
         assert not any(g.is_number for g in p.gens)
         eq = p.as_expr()
         assert eq.is_polynomial()
-    except (GeneratorsNeeded, AssertionError, AttributeError):
+    except (GeneratorsNeeded, AssertionError):
         raise TypeError(filldedent('''
     Equation should be a polynomial with Rational coefficients.'''))
 

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -35,9 +35,12 @@ def diop_simplify(eq):
 
 def test_input_format():
     raises(TypeError, lambda: diophantine(sin(x)))
-    raises(TypeError, lambda: diophantine(3))
     raises(TypeError, lambda: diophantine(x/pi - 3))
 
+def test_nosols():
+    # diophantine should sympify eq so that these are equivalent
+    assert diophantine(3) == set()
+    assert diophantine(S(3)) == set()
 
 def test_univariate():
     assert diop_solve((x - 1)*(x - 2)**2) == set([(1,), (2,)])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Don't catch `AttributeError` in diophantine and sympify the input equation.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * The diophantine solver no longer raises for unsympified inputs.
<!-- END RELEASE NOTES -->
