### PR TITLE
Remove except Exception from codebase

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -4,7 +4,7 @@
 from __future__ import print_function
 
 from sympy import S, Rational
-from sympy import re, im, conjugate
+from sympy import re, im, conjugate, sign
 from sympy import sqrt, sin, cos, acos, exp, ln
 from sympy import trigsimp
 from sympy import integrate
@@ -143,7 +143,7 @@ class Quaternion(Expr):
         >>> M = Matrix([[cos(x), -sin(x), 0], [sin(x), cos(x), 0], [0, 0, 1]])
         >>> q = trigsimp(Quaternion.from_rotation_matrix(M))
         >>> q
-        sqrt(2)*sqrt(cos(x) + 1)/2 + 0*i + 0*j + sqrt(2 - 2*cos(x))/2*k
+        sqrt(2)*sqrt(cos(x) + 1)/2 + 0*i + 0*j + sqrt(2 - 2*cos(x))*sign(sin(x))/2*k
         """
 
         absQ = M.det()**Rational(1, 3)
@@ -153,25 +153,11 @@ class Quaternion(Expr):
         c = sqrt(absQ - M[0, 0] + M[1, 1] - M[2, 2]) / 2
         d = sqrt(absQ - M[0, 0] - M[1, 1] + M[2, 2]) / 2
 
-        try:
-            b = Quaternion.__copysign(b, M[2, 1] - M[1, 2])
-            c = Quaternion.__copysign(c, M[0, 2] - M[2, 0])
-            d = Quaternion.__copysign(d, M[1, 0] - M[0, 1])
-
-        except Exception:
-            pass
+        b = b * sign(M[2, 1] - M[1, 2])
+        c = c * sign(M[0, 2] - M[2, 0])
+        d = d * sign(M[1, 0] - M[0, 1])
 
         return Quaternion(a, b, c, d)
-
-    @staticmethod
-    def __copysign(x, y):
-
-        # Takes the sign from the second term and sets the sign of the first
-        # without altering the magnitude.
-
-        if y == 0:
-            return 0
-        return x if x*y > 0 else -x
 
     def __add__(self, other):
         return self.add(other)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,4 +1,4 @@
-from sympy import symbols, re, im, I, Abs, Symbol, \
+from sympy import symbols, re, im, sign, I, Abs, Symbol, \
      cos, sin, sqrt, conjugate, log, acos, E, pi, \
      Matrix, diff, integrate, trigsimp, S, Rational
 from sympy.algebras.quaternion import Quaternion
@@ -18,7 +18,7 @@ def test_quaternion_construction():
 
     M = Matrix([[cos(phi), -sin(phi), 0], [sin(phi), cos(phi), 0], [0, 0, 1]])
     q3 = trigsimp(Quaternion.from_rotation_matrix(M))
-    assert q3 == Quaternion(sqrt(2)*sqrt(cos(phi) + 1)/2, 0, 0, sqrt(-2*cos(phi) + 2)/2)
+    assert q3 == Quaternion(sqrt(2)*sqrt(cos(phi) + 1)/2, 0, 0, sqrt(2 - 2*cos(phi))*sign(sin(phi))/2)
 
     nc = Symbol('nc', commutative=False)
     raises(ValueError, lambda: Quaternion(w, x, nc, z))

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -236,7 +236,7 @@ def test_Permutation_subclassing():
             try:
                 perm_obj = i[0]
                 return [self._array_form[j] for j in perm_obj]
-            except Exception:
+            except TypeError:
                 raise TypeError('unrecognized argument')
 
         def __eq__(self, other):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1771,10 +1771,13 @@ class Basic(with_metaclass(ManagedProperties)):
             if isinstance(args[-1], str):
                 rule = '_eval_rewrite_as_' + args[-1]
             else:
-                name = getattr(args[-1], '__name__', None)
-                if name is None:
-                    name = args[-1].__class__.__name__
-                rule = '_eval_rewrite_as_' + name
+                # rewrite arg is usually a class but can also be a
+                # singleton (e.g. GoldenRatio) so we check
+                # __name__ or __class__.__name__
+                clsname = getattr(args[-1], "__name__", None)
+                if clsname is None:
+                    clsname = args[-1].__class__.__name__
+                rule = '_eval_rewrite_as_' + clsname
 
             if not pattern:
                 return self._eval_rewrite(None, rule, **hints)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -494,9 +494,6 @@ def kernS(s):
         try:
             expr = sympify(s)
             break
-        # XXX: What exception can be caught here? Broad except should not be
-        # used without a clear reason. Running the test suite does not lead to
-        # any errors at this point...
         except TypeError:  # the kern might cause unknown errors...
             if hit:
                 s = olds  # maybe it didn't like the kern; use un-kerned s

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1113,10 +1113,7 @@ class _LeftRightArgs(object):
         self._second_pointer_parent[self._second_pointer_index] = value
 
     def __repr__(self):
-        try:
-            built = [self._build(i) for i in self._lines]
-        except Exception:
-            built = self._lines
+        built = [self._build(i) for i in self._lines]
         return "_LeftRightArgs(lines=%s, higher=%s)" % (
             built,
             self.higher,

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -236,9 +236,12 @@ def state_to_operators(state, **options):
 
 
 def _make_default(expr):
+    # XXX: Catching TypeError like this is a bad way of distinguishing between
+    # classes and instances. The logic using this function should be rewritten
+    # somehow.
     try:
         ret = expr()
-    except Exception:
+    except TypeError:
         ret = expr
 
     return ret

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -496,9 +496,12 @@ def get_basis(expr, **options):
 
 
 def _make_default(expr):
+    # XXX: Catching TypeError like this is a bad way of distinguishing
+    # instances from classes. The logic using this function should be
+    # rewritten somehow.
     try:
         expr = expr()
-    except Exception:
+    except TypeError:
         return expr
 
     return expr

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -1,3 +1,5 @@
+from sympy import S
+
 from sympy.physics.quantum.operatorset import (
     operators_to_state, state_to_operators
 )
@@ -15,31 +17,28 @@ from sympy.physics.quantum.spin import (
 
 from sympy.testing.pytest import raises
 
-from sympy.testing.pytest import XFAIL
 
-
-@XFAIL
 def test_spin():
-    assert operators_to_state({J2Op, JxOp}) == JxKet()
-    assert operators_to_state({J2Op, JyOp}) == JyKet()
-    assert operators_to_state({J2Op, JzOp}) == JzKet()
-    assert operators_to_state({J2Op(), JxOp()}) == JxKet()
-    assert operators_to_state({J2Op(), JyOp()}) == JyKet()
-    assert operators_to_state({J2Op(), JzOp()}) == JzKet()
+    assert operators_to_state({J2Op, JxOp}) == JxKet
+    assert operators_to_state({J2Op, JyOp}) == JyKet
+    assert operators_to_state({J2Op, JzOp}) == JzKet
+    assert operators_to_state({J2Op(), JxOp()}) == JxKet
+    assert operators_to_state({J2Op(), JyOp()}) == JyKet
+    assert operators_to_state({J2Op(), JzOp()}) == JzKet
 
-    assert state_to_operators(JxKet) == {J2Op(), JxOp()}
-    assert state_to_operators(JyKet) == {J2Op(), JyOp()}
-    assert state_to_operators(JzKet) == {J2Op(), JzOp()}
-    assert state_to_operators(JxBra) == {J2Op(), JxOp()}
-    assert state_to_operators(JyBra) == {J2Op(), JyOp()}
-    assert state_to_operators(JzBra) == {J2Op(), JzOp()}
+    assert state_to_operators(JxKet) == {J2Op, JxOp}
+    assert state_to_operators(JyKet) == {J2Op, JyOp}
+    assert state_to_operators(JzKet) == {J2Op, JzOp}
+    assert state_to_operators(JxBra) == {J2Op, JxOp}
+    assert state_to_operators(JyBra) == {J2Op, JyOp}
+    assert state_to_operators(JzBra) == {J2Op, JzOp}
 
-    assert state_to_operators(JxKet()) == {J2Op(), JxOp()}
-    assert state_to_operators(JyKet()) == {J2Op(), JyOp()}
-    assert state_to_operators(JzKet()) == {J2Op(), JzOp()}
-    assert state_to_operators(JxBra()) == {J2Op(), JxOp()}
-    assert state_to_operators(JyBra()) == {J2Op(), JyOp()}
-    assert state_to_operators(JzBra()) == {J2Op(), JzOp()}
+    assert state_to_operators(JxKet(S.Half, S.Half)) == {J2Op(), JxOp()}
+    assert state_to_operators(JyKet(S.Half, S.Half)) == {J2Op(), JyOp()}
+    assert state_to_operators(JzKet(S.Half, S.Half)) == {J2Op(), JzOp()}
+    assert state_to_operators(JxBra(S.Half, S.Half)) == {J2Op(), JxOp()}
+    assert state_to_operators(JyBra(S.Half, S.Half)) == {J2Op(), JyOp()}
+    assert state_to_operators(JzBra(S.Half, S.Half)) == {J2Op(), JzOp()}
 
 
 def test_op_to_state():

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2612,12 +2612,11 @@ def odesimp(ode, eq, func, hint):
             # future. In addition, collect is splitting exponentials with
             # rational powers for no reason.  We have to do a match
             # to fix this using Wilds.
+            #
+            # XXX: This global collectterms hack should be removed.
             global collectterms
-            try:
-                collectterms.sort(key=default_sort_key)
-                collectterms.reverse()
-            except Exception:
-                pass
+            collectterms.sort(key=default_sort_key)
+            collectterms.reverse()
             assert len(eq) == 1 and eq[0].lhs == f(x)
             sol = eq[0].rhs
             sol = expand_mul(sol)
@@ -3213,7 +3212,7 @@ def constantsimp(expr, constants):
             else:
                 rexpr = rexpr.subs(*s)
         expr = rexpr
-    except Exception:
+    except IndexError:
         pass
     expr = __remove_linear_redundancies(expr, Cs)
 
@@ -3311,6 +3310,7 @@ def constant_renumber(expr, variables=None, newconstants=None):
     else:
         iter_constants = (sym for sym in newconstants if sym not in variables)
 
+    # XXX: This global newstartnumber hack should be removed
     global newstartnumber
     newstartnumber = 1
     endnumber = len(constantsymbols)
@@ -3372,6 +3372,7 @@ def _handle_Integral(expr, func, hint):
     For most hints, this simply runs ``expr.doit()``.
 
     """
+    # XXX: This global y hack should be removed
     global y
     x = func.args[0]
     f = func.func
@@ -3480,6 +3481,7 @@ def ode_1st_exact(eq, func, order, match):
     r = match  # d+e*diff(f(x),x)
     e = r[r['e']]
     d = r[r['d']]
+    # XXX: This global y hack should be removed
     global y  # This is the only way to pass dummy y to _handle_Integral
     y = r['y']
     C1 = get_numbered_constants(eq, num=1)
@@ -4897,6 +4899,7 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
     # indirect doctest
 
     """
+    # XXX: This global collectterms hack should be removed.
     global collectterms
     collectterms = []
 
@@ -5569,6 +5572,8 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
         charroots[root] += 1
     # We need to keep track of terms so we can run collect() at the end.
     # This is necessary for constantsimp to work properly.
+    #
+    # XXX: This global collectterms hack should be removed.
     global collectterms
     collectterms = []
     gensols = []
@@ -5714,6 +5719,7 @@ def _solve_undetermined_coefficients(eq, func, order, match):
     gsol = r['sol']
     trialset = r['trialset']
     notneedset = set([])
+    # XXX: This global collectterms hack should be removed.
     global collectterms
     if len(gensols) != order:
         raise NotImplementedError("Cannot find " + str(order) +

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -527,12 +527,12 @@ def _solve_trig(f, symbol, domain):
     sol1 = sol = None
     try:
         sol1 = _solve_trig1(f, symbol, domain)
-    except BaseException:
+    except NotImplementedError:
         pass
     if sol1 is None or isinstance(sol1, ConditionSet):
         try:
             sol = _solve_trig2(f, symbol, domain)
-        except BaseException:
+        except ValueError:
             sol = sol1
         if isinstance(sol1, ConditionSet) and isinstance(sol, ConditionSet):
             if sol1.count_ops() < sol.count_ops():

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -13,6 +13,7 @@ from __future__ import print_function, division
 from sympy import (Interval, Intersection, symbols, sympify, Dummy, nan,
         Integral, And, Or, Piecewise, cacheit, integrate, oo, Lambda,
         Basic, S, exp, I, FiniteSet, Ne, Eq, Union, poly, series, factorial)
+from sympy.core.function import PoleError
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy.polys.polyerrors import PolynomialError
 from sympy.solvers.solveset import solveset
@@ -517,7 +518,7 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         x = self.value.symbol
         try:
             return self.distribution.expectation(expr, x, evaluate=evaluate, **kwargs)
-        except Exception:
+        except PoleError:
             return Integral(expr * self.pdf, (x, self.set), **kwargs)
 
     def compute_cdf(self, expr, **kwargs):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1139,14 +1139,11 @@ def sample_iter_lambdify(expr, condition=None, numsamples=S.Infinity, **kwargs):
 
     # Check that lambdify can handle the expression
     # Some operations like Sum can prove difficult
-    try:
-        d = ps.sample()  # a dictionary that maps RVs to values
-        args = [d[rv] for rv in rvs]
-        fn(*args)
-        if condition:
-            given_fn(*args)
-    except Exception:
-        raise TypeError("Expr/condition too complex for lambdify")
+    d = ps.sample()  # a dictionary that maps RVs to values
+    args = [d[rv] for rv in rvs]
+    fn(*args)
+    if condition:
+        given_fn(*args)
 
     def return_generator():
         count = 0

--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -69,12 +69,12 @@ def null_safe(rule):
             return result
     return null_safe_rl
 
-def tryit(rule):
+def tryit(rule, exception):
     """ Return original expr if rule raises exception """
     def try_rl(expr):
         try:
             return rule(expr)
-        except Exception:
+        except exception:
             return expr
     return try_rl
 

--- a/sympy/strategies/rl.py
+++ b/sympy/strategies/rl.py
@@ -154,7 +154,7 @@ def rebuild(expr):
     This forces canonicalization and removes ugliness introduced by the use of
     Basic.__new__
     """
-    try:
-        return type(expr)(*list(map(rebuild, expr.args)))
-    except Exception:
+    if expr.is_Atom:
         return expr
+    else:
+        return expr.func(*list(map(rebuild, expr.args)))

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -1,3 +1,4 @@
+from sympy import S
 from sympy.strategies.core import (null_safe, exhaust, memoize, condition,
         chain, tryit, do_one, debug, switch, minimize)
 from sympy.core.compatibility import get_function_name
@@ -41,8 +42,8 @@ def test_chain():
 def test_tryit():
     def rl(expr):
         assert False
-    safe_rl = tryit(rl)
-    assert safe_rl(1) == 1
+    safe_rl = tryit(rl, AssertionError)
+    assert safe_rl(S(1)) == 1
 
 def test_do_one():
     rl = do_one(posdec, posdec)

--- a/sympy/strategies/tests/test_rl.py
+++ b/sympy/strategies/tests/test_rl.py
@@ -1,3 +1,4 @@
+from sympy import S
 from sympy.strategies.rl import (rm_id, glom, flatten, unpack, sort, distribute,
         subs, rebuild)
 from sympy import Basic
@@ -55,5 +56,5 @@ def test_subs():
 
 def test_rebuild():
     from sympy import Add
-    expr = Basic.__new__(Add, 1, 2)
+    expr = Basic.__new__(Add, S(1), S(2))
     assert rebuild(expr) == 3

--- a/sympy/strategies/tests/test_traverse.py
+++ b/sympy/strategies/tests/test_traverse.py
@@ -69,6 +69,6 @@ def test_bottom_up_once():
 def test_expr_fns():
     expr = x + y**3
     e = bottom_up(lambda v: v + 1, expr_fns)(expr)
-    b = bottom_up(lambda v: Basic.__new__(Add, v, 1), basic_fns)(expr)
+    b = bottom_up(lambda v: Basic.__new__(Add, v, S(1)), basic_fns)(expr)
 
     assert rebuild(b) == e

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -900,19 +900,13 @@ def lambdastr(args, expr, printer=None, dummify=None):
                 return str(args)
 
     def sub_expr(expr, dummies_dict):
-        try:
-            expr = sympify(expr).xreplace(dummies_dict)
-        except Exception:
-            if isinstance(expr, DeferredVector):
-                pass
-            elif isinstance(expr, dict):
-                k = [sub_expr(sympify(a), dummies_dict) for a in expr.keys()]
-                v = [sub_expr(sympify(a), dummies_dict) for a in expr.values()]
-                expr = dict(zip(k, v))
-            elif isinstance(expr, tuple):
-                expr = tuple(sub_expr(sympify(a), dummies_dict) for a in expr)
-            elif isinstance(expr, list):
-                expr = [sub_expr(sympify(a), dummies_dict) for a in expr]
+        expr = sympify(expr)
+        # dict/tuple are sympified to Basic
+        if isinstance(expr, Basic):
+            expr = expr.xreplace(dummies_dict)
+        # list is not sympified to Basic
+        elif isinstance(expr, list):
+            expr = [sub_expr(a, dummies_dict) for a in expr]
         return expr
 
     # Transform args


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Removes many instances of `except Exception:` and `except BaseException:` from the codebase. 
I've tried to either fix the code or catch a more specific exception. In some cases I can't tell what exception would ever be caught and I've just removed the `try/except`. If those are problematic then we can add a more specific `try/except` later.

#### Other comments

I've already removed all bare `except:` as part of the flake8 work. Catching `Exception` is almost as bad though. The problem is that many bugs in different places can be hidden if the exception is caught internally and ignored: catching `Exception` will catch almost all exceptions regardless of what causes the exception to be raised. In a large codebase like sympy it is impossible to anticipate all possible sources of exceptions.

In strategies there is even a rule called `tryit` which swallows all exceptions using `except Exception:`. It doesn't seem to be used anywhere and I've changed it so that it is necessary to specify which exception you want to catch.

In future I think that we should only allow `try/except` when the `try` block is as narrow as possible and the exception is as precise as possible. Most cases can be removed altogether e.g.:
```python
# bad
try:
    return f(x).func(y).simplify(g)[0]
except IndexError:
    return 0

# better
items = f(x).func(y).simplify(g)
try:
    return items[0]
except IndexError:
    return 0

# best
items = f(x).func(y).simplify(g)
if items:
    return items[0]
else:
    return 0
```

There is a place for catching exceptions and it can be done well but there are too many poor examples in the codebase so I think it's important to remove things like `except Exception` to set an example to new contributors if nothing else.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
