### PR TITLE
calculus: Enhance expandability of `periodicity`

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,10 +1,11 @@
 from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
                    cot, sec, csc, Abs, symbols, I, re, simplify,
-                   expint, Rational)
+                   expint, Rational, Function)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex,
                                  stationary_points, minimum, maximum)
 from sympy.core import Add, Mul, Pow
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.sets.sets import (Interval, FiniteSet, EmptySet, Complement,
                             Union)
 from sympy.utilities.pytest import raises
@@ -177,6 +178,26 @@ def test_periodicity_check():
     assert periodicity(sec(x), x) == 2*pi
     assert periodicity(sin(x*y), x) == 2*pi/abs(y)
     assert periodicity(Abs(sec(sec(x))), x) == pi
+
+
+def test_periodicity_customclass():
+    x = Symbol('x')
+    y = Symbol('y')
+    class f(Function):
+        nargs = 1
+        _period = TrigonometricFunction._period
+        def period(self, symbol=None):
+            return self._period(2*pi, symbol)
+
+    assert periodicity(f(x), x) == 2*pi
+    assert periodicity(f(2*x), x) == pi
+    assert periodicity(2*f(x), x) == 2*pi
+    assert periodicity(x*f(2*x), x) is None
+    assert periodicity(f(x)*f(x), x) == 2*pi
+    assert periodicity(exp(f(x)), x) == 2*pi
+    assert periodicity(sin(x/2)*f(x), x) == 4*pi
+
+
 
 
 def test_lcim():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -401,8 +401,7 @@ def periodicity(f, symbol, check=False):
 
     Examples
     ========
-    >>> from sympy import Symbol, sin, cos, tan, exp, Function, pi
-    >>> from sympy.functions.elementary.trigonometric import TrigonometricFunction
+    >>> from sympy import Symbol, sin, cos, tan, exp, Function, pi, S
     >>> from sympy.calculus.util import periodicity
     >>> x = Symbol('x')
     >>> f = sin(x) + sin(2*x) + sin(3*x)
@@ -417,12 +416,28 @@ def periodicity(f, symbol, check=False):
     pi
     >>> periodicity(exp(x), x)
 
-    >>> class g(Function):
+    >>> class F(Function):
     ...     nargs = 1
-    ...     _period = TrigonometricFunction._period
-    ...     def period(self, symbol=None):
+    ...     def _period(self, general_period, symbol):  # This emulates trigonometric function's method.
+    ...         arg = self.args[0]
+    ...         if not arg.has(symbol):
+    ...             return S.Zero
+    ...         if arg == symbol:
+    ...             return general_period
+    ...         if symbol is arg.free_symbols:
+    ...             if arg.is_Mul:
+    ...                 g, h = arg.as_independent(symbol)
+    ...                 if h == symbol:
+    ...                     return general_period/abs(g)
+    ...             if arg.is_Add:
+    ...                 a, h = arg.as_independent(symbol)
+    ...                 g, h = h.as_independent(symbol, as_Add=False)
+    ...                 if h == symbol:
+    ...                     return general_period/abs(g)
+    ...         raise NotImplementedError("Use the periodicity function instead.")
+    ...     def period(self, symbol):
     ...         return self._period(2*pi, symbol)
-    >>> periodicity(g(x), x)
+    >>> periodicity(F(x), x)
     2*pi
     """
     from sympy.core.mod import Mod

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -424,7 +424,7 @@ def periodicity(f, symbol, check=False):
     ...             return S.Zero
     ...         if arg == symbol:
     ...             return general_period
-    ...         if symbol is arg.free_symbols:
+    ...         if symbol in arg.free_symbols:
     ...             if arg.is_Mul:
     ...                 g, h = arg.as_independent(symbol)
     ...                 if h == symbol:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17995


#### Brief description of what is fixed or changed
If the function has `period` method (as trigonometric function does), it will be used to determine its periodicity.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
    * Added support for periodicity method to determine the periodicity of a Function with period attribute
<!-- END RELEASE NOTES -->
