### PR TITLE
Delete dupliate is_commutative

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -530,16 +530,6 @@ class Function(Application, Expr):
 
         return 4, i, name
 
-    @property
-    def is_commutative(self):
-        """
-        Returns whether the function is commutative.
-        """
-        if all(getattr(t, 'is_commutative') for t in self.args):
-            return True
-        else:
-            return False
-
     def _eval_evalf(self, prec):
 
         def _get_mpmath_func(fname):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I see `_eval_is_commutative` is already there. I'm not sure why both are covered, but it's not a good thing that duplicate handers are used individually.
There is no worry of not having `is_commutative` if the `args` is formed in sympy standard, but I'll see if the test passes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
