### PR TITLE
Adding a property for Point's coordinates

### DIFF
--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -1042,7 +1042,7 @@ class Point2D(Point):
         >>> p.coordinates
         (0, 1)
         """
-        return self.args[0], self.args[1]
+        return self.args
 
     @property
     def x(self):
@@ -1336,7 +1336,7 @@ class Point3D(Point):
         >>> p.coordinates
         (0, 1, 2)
         """
-        return self.args[0], self.args[1], self.args[2]
+        return self.args
 
     @property
     def x(self):

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -1030,6 +1030,21 @@ class Point2D(Point):
         return Point(self.x + x, self.y + y)
 
     @property
+    def coordinates(self):
+        """
+        Returns the two coordinates of the Point.
+        
+        Examples
+        ========
+        
+        >>> from sympy import Point2D
+        >>> p = Point2D(0, 1)
+        >>> p.coordinates
+        (0, 1)
+        """
+        return self.args[0], self.args[1]
+
+    @property
     def x(self):
         """
         Returns the X coordinate of the Point.
@@ -1307,6 +1322,21 @@ class Point3D(Point):
 
         """
         return Point3D(self.x + x, self.y + y, self.z + z)
+
+    @property
+    def coordinates(self):
+        """
+        Returns the three coordinates of the Point.
+        
+        Examples
+        ========
+        
+        >>> from sympy import Point3D
+        >>> p = Point3D(0, 1, 2)
+        >>> p.coordinates
+        (0, 1, 2)
+        """
+        return self.args[0], self.args[1], self.args[2]
 
     @property
     def x(self):

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -1327,10 +1327,10 @@ class Point3D(Point):
     def coordinates(self):
         """
         Returns the three coordinates of the Point.
-        
+
         Examples
         ========
-        
+
         >>> from sympy import Point3D
         >>> p = Point3D(0, 1, 2)
         >>> p.coordinates

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -1033,10 +1033,10 @@ class Point2D(Point):
     def coordinates(self):
         """
         Returns the two coordinates of the Point.
-        
+
         Examples
         ========
-        
+
         >>> from sympy import Point2D
         >>> p = Point2D(0, 1)
         >>> p.coordinates

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -172,6 +172,16 @@ def test_point3D():
 
     raises(ValueError, lambda: Point3D(0, 0, 0) + 10)
 
+    # Test coordinate properties
+    assert p1.coordinates == (x1, x2, x3)
+    assert p2.coordinates == (y1, y2, y3)
+    assert p3.coordinates == (0, 0, 0)
+    assert p4.coordinates == (1, 1, 1)
+    assert p5.coordinates == (0, 1, 2)
+    assert p5.x == 0
+    assert p5.y == 1
+    assert p5.z == 2
+
     # Point differences should be simplified
     assert Point3D(x*(x - 1), y, 2) - Point3D(x**2 - x, y + 1, 1) == \
         Point3D(0, -1, 1)
@@ -249,15 +259,6 @@ def test_point3D():
     with warns(UserWarning):
         assert p - p_4d3d == Point(1, 1, 0, 0)
 
-    # Test coordinate properties
-    assert p1.coordinates == (x1, x2, x3)
-    assert p2.coordinates == (y1, y2, y3)
-    assert p3.coordinates == (0, 0, 0)
-    assert p4.coordinates == (1, 1, 1)
-    assert p5.coordinates == (0, 1, 2)
-    assert p5.x == 0
-    assert p5.y == 1
-    assert p5.z == 2
 
 def test_Point2D():
 

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -269,13 +269,13 @@ def test_Point2D():
     assert p1.distance(p2) == sqrt(61)/2
     assert p2.distance(p3) == sqrt(17)/2
 
-	# Test coordinates
-	assert p1.x == 1
-	assert p1.y == 5
-	assert p2.x == 4
-	assert p2.y == 2.5
-	assert p1.coordinates == (1, 5)
-	assert p2.coordinates == (4, 2.5)
+    # Test coordinates
+    assert p1.x == 1
+    assert p1.y == 5
+    assert p2.x == 4
+    assert p2.y == 2.5
+    assert p1.coordinates == (1, 5)
+    assert p2.coordinates == (4, 2.5)
 
 def test_issue_9214():
     p1 = Point3D(4, -2, 6)

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -249,6 +249,15 @@ def test_point3D():
     with warns(UserWarning):
         assert p - p_4d3d == Point(1, 1, 0, 0)
 
+	# Test coordinate properties
+    assert p1.coordinates == (x1, x2, x3)
+    assert p2.coordinates == (y1, y2, y3)
+    assert p3.coordinates == (0, 0, 0)
+    assert p4.coordinates == (1, 1, 1)
+    assert p5.coordinates == (0, 1, 2)
+    assert p5.x == 0
+    assert p5.y == 1
+    assert p5.z == 2
 
 def test_Point2D():
 
@@ -259,6 +268,13 @@ def test_Point2D():
     assert p1.distance(p2) == sqrt(61)/2
     assert p2.distance(p3) == sqrt(17)/2
 
+	# Test coordinates
+	assert p1.x == 1
+	assert p1.y == 5
+	assert p2.x == 4
+	assert p2.y == 2.5
+	assert p1.coordinates == (1, 5)
+	assert p2.coordinates == (4, 2.5)
 
 def test_issue_9214():
     p1 = Point3D(4, -2, 6)

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -249,7 +249,7 @@ def test_point3D():
     with warns(UserWarning):
         assert p - p_4d3d == Point(1, 1, 0, 0)
 
-	# Test coordinate properties
+    # Test coordinate properties
     assert p1.coordinates == (x1, x2, x3)
     assert p2.coordinates == (y1, y2, y3)
     assert p3.coordinates == (0, 0, 0)


### PR DESCRIPTION
From my point of view, there should be a method for getting the coordinates of a point. Currently, the way I do this is using something like this:
`(point.x, point.y, point.z)`
Which would be equal to:
`point.coordinates`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added new method for point's coordinates

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
    * Added new property for getting point's coordinates
<!-- END RELEASE NOTES -->
