### PR TITLE
[DON'T MERGE] Fix tensor index structure abc meta

### DIFF
--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -4,6 +4,8 @@ from __future__ import print_function, division
 # used for canonical ordering of symbolic sequences
 # via __cmp__ method:
 # FIXME this is *so* irrelevant and outdated!
+from abc import ABCMeta
+
 ordering_of_classes = [
     # singleton numbers
     'Zero', 'One', 'Half', 'Infinity', 'NaN', 'NegativeOne', 'NegativeInfinity',
@@ -65,7 +67,7 @@ class Registry(object):
 all_classes = set()
 
 
-class BasicMeta(type):
+class BasicMeta(ABCMeta):
 
     def __init__(cls, *args, **kws):
         all_classes.add(cls)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -31,7 +31,7 @@ lowered when the tensor is put in canonical form.
 
 from __future__ import print_function, division
 
-from abc import abstractmethod, ABCMeta
+from abc import abstractmethod
 from collections import defaultdict
 import operator
 import itertools
@@ -41,7 +41,7 @@ from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
 from sympy.core.assumptions import ManagedProperties
-from sympy.core.compatibility import string_types, reduce, range, SYMPY_INTS, with_metaclass
+from sympy.core.compatibility import string_types, reduce, range, SYMPY_INTS
 from sympy.core.containers import Tuple, Dict
 from sympy.core.decorators import deprecated
 from sympy.core.symbol import Symbol, symbols
@@ -1846,11 +1846,7 @@ def tensor_heads(s, index_types, symmetry=None, comm=0):
     return thlist
 
 
-class _TensorMetaclass(ManagedProperties, ABCMeta):
-    pass
-
-
-class TensExpr(with_metaclass(_TensorMetaclass, Expr)):
+class TensExpr(Expr):
     """
     Abstract base class for tensor expressions
 

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -10,7 +10,7 @@ from sympy import Array
 L = TensorIndexType("L")
 i, j, k = tensor_indices("i j k", L)
 i0 = tensor_indices("i0", L)
-L_0 = tensor_indices("L_0", L)
+L_0, L_1 = tensor_indices("L_0 L_1", L)
 
 A, B, C, D = tensor_heads("A B C D", [L])
 
@@ -92,3 +92,19 @@ def test_replace_arrays_partial_derivative():
     assert expr.get_indices() == [-L_0, L_0]
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, 1)}, []) == 2
     assert expr.replace_with_arrays({A(i): [x, y], L: diag(1, -1)}, []) == 2
+
+    expr = PartialDerivative(H(i, j) + H(j, i), A(i))
+    assert expr.get_indices() == [L_0, j, -L_0]
+    assert expr.get_free_indices() == [j]
+
+    expr = PartialDerivative(H(i, j) + H(j, i), A(k))*B(-i)
+    assert expr.get_indices() == [L_0, j, -k, -L_0]
+    assert expr.get_free_indices() == [j, -k]
+
+    expr = PartialDerivative(A(i)*(H(-i, j) + H(j, -i)), A(j))
+    assert expr.get_indices() == [L_0, -L_0, L_1, -L_1]
+    assert expr.get_free_indices() == []
+
+    expr = A(j)*A(-j) + expr
+    assert expr.get_indices() == [L_0, -L_0, L_1, -L_1]
+    assert expr.get_free_indices() == []

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -1,4 +1,4 @@
-from sympy import tensorproduct, MutableDenseNDimArray
+from sympy import tensorproduct, MutableDenseNDimArray, S
 from sympy.tensor.tensor import (TensExpr, TensMul, TensorIndex)
 
 
@@ -52,6 +52,14 @@ class PartialDerivative(TensExpr):
         obj._free = free
         obj._dum = dum
         return obj
+
+    @property
+    def coeff(self):
+        return S.One
+
+    @property
+    def nocoeff(self):
+        return self
 
     @classmethod
     def _contract_indices_for_derivative(cls, expr, variables):


### PR DESCRIPTION
### Warning: possible slowdown of SymPy!

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `ABCMeta` is now metaclass to all SymPy objects.

* tensor
  * Tensor module: refactory to allow mixing PartialDerivative and TensAdd.
<!-- END RELEASE NOTES -->
