### PR TITLE
Fix flake8 and blacklist test-examples in parsing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,5 @@ ignore = F403
 select = F,E722
 exclude = sympy/parsing/latex/_antlr/*,
           sympy/parsing/autolev/_antlr/*,
+          sympy/parsing/autolev/test-examples/*,
           sympy/integrals/rubi/*

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -1,5 +1,4 @@
 import collections
-import sys
 import warnings
 
 from sympy.external import import_module
@@ -1173,7 +1172,7 @@ if AutolevListener:
             elif func_name == "mass":
                 l = []
                 try:
-                    a = ch.ID(0).getText().lower()
+                    ch.ID(0).getText().lower()
                     for i in range((ch.getChildCount()-1)//2):
                         l.append(self.symbol_table2[ch.ID(i).getText().lower()] + ".mass")
                     self.setValue(ctx, "+".join(l))
@@ -2046,7 +2045,7 @@ if AutolevListener:
         def exitInertiaDecl(self, ctx):
             inertia_list = []
             try:
-                a = ctx.ID(1).getText()
+                ctx.ID(1).getText()
                 num = 5
             except Exception:
                 num = 2

--- a/sympy/parsing/autolev/_parse_autolev_antlr.py
+++ b/sympy/parsing/autolev/_parse_autolev_antlr.py
@@ -1,4 +1,3 @@
-import sys
 from sympy.external import import_module
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See #18025

#### Brief description of what is fixed or changed

Blacklist the autolev test examples from flake8 as these are autogenerated files from autolev. The tests will fail if the flake8 warnings in these files are fixed because the test is that they match what is produced by autolev.

Also fixes a few flake8 warnings in parsing.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
