### PR TITLE
Fixed the issue of expansion of irrational conjugates when calling cancel()

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6656,7 +6656,12 @@ def cancel(f, *gens, **args):
     c, P, Q = F.cancel(G)
 
     if not isinstance(f, (tuple, Tuple)):
-        return c*(P.as_expr()/Q.as_expr())
+        # checks if there is only I as a Generator
+        if I in opt.gens and len(opt.gens) == 1:
+            return f
+        else:
+            return c*(P.as_expr()/Q.as_expr())
+
     else:
         if not opt.polys:
             return c, P.as_expr(), Q.as_expr()

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3321,3 +3321,7 @@ def test_issue_17988():
     p = poly(x - 1)
     M = Matrix([[poly(x + 1), poly(x + 1)]])
     assert p * M == M * p == Matrix([[poly(x**2 - 1), poly(x**2 - 1)]])
+
+def test_issue_18205():
+    assert cancel((2+I)*(3-I)) == (2 + I)*(3 - I)
+    assert cancel((2+I)*(2-I)) == (2 - I)*(2 + I)

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from .simplify import (simplify, hypersimp, hypersimilar,
     logcombine, separatevars, posify, besselsimp, kroneckersimp,
-    signsimp, bottom_up, nsimplify)
+    signsimp, bottom_up, nsimplify, dotprodsimp)
 
 from .fu import FU, fu
 
@@ -61,4 +61,6 @@ __all__ = [
     'gammasimp',
 
     'ratsimp', 'ratsimpmodprime',
+
+    'dotprodsimp',
 ]


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18205

#### Brief description of what is fixed or changed
--> referring to issue #18205
>>> cancel((2+I)*(3-I))
>>> 7+I

>>> cancel((2+I)*(2-I))
>>> (2+I)*(2-I)

whereas cancel((2+I)*(3-I)) should return (2 + I)*(3 - I).
The cause of an expanded output was the Generator I in opt.gens,
which raised PolificationError in case of cancel((2+I)*(2-I)) as in this
case opt.gens was empty but in case of cancel((2+I)*(3-I)) opt.gens was not empty
it has 'I' as a generator. Adding an if statement in poytools.py did the trick.

--> Added tests for same
--> Added dotprodsimp in sympy/simplify/init.py because it was causing Importerror after I pulled from master


#### Other comments
After the fix
>>> cancel((2+I)*(3-I))
(2 + I)*(3 - I)

>>> cancel((2+I)*(2-I))
(2 - I)*(2 + I)


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed the issue of expansion of irrational conjugates when calling cancel()



<!-- END RELEASE NOTES -->
