### PR TITLE
Fixing bug in replacing indices in PartialDerivative tensor objects

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1973,6 +1973,10 @@ class TensExpr(with_metaclass(_TensorMetaclass, Expr)):
     def get_free_indices(self):  # type: () -> List[TensorIndex]
         raise NotImplemented("abstract method")
 
+    @abstractmethod
+    def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr
+        raise NotImplemented("abstract method")
+
     def fun_eval(self, *index_tuples):
         deprecate_fun_eval()
         return self.substitute_indices(*index_tuples)
@@ -2310,6 +2314,10 @@ class TensAdd(TensExpr, AssocOp):
     def get_free_indices(self):  # type: () -> List[TensorIndex]
         return self.free_indices
 
+    def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr
+        newargs = [arg._replace_indices(repl) if isinstance(arg, TensExpr) else arg for arg in self.args]
+        return self.func(*newargs)
+
     @memoize_property
     def rank(self):
         if isinstance(self.args[0], TensExpr):
@@ -2369,7 +2377,7 @@ class TensAdd(TensExpr, AssocOp):
         def sort_key(t):
             if not isinstance(t, TensExpr):
                 return [], [], []
-            if hasattr(t, "_index_structure"):
+            if hasattr(t, "_index_structure") and hasattr(t, "components"):
                 x = get_index_structure(t)
                 return t.components, x.free, x.dum
             return [], [], []
@@ -2797,6 +2805,11 @@ class Tensor(TensExpr):
         """
         return self._index_structure.get_free_indices()
 
+    def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> Tensor
+        # TODO: this could be optimized by only swapping the indices
+        # instead of visiting the whole expression tree:
+        return self.xreplace(repl)
+
     def as_base_exp(self):
         return self, S.One
 
@@ -3136,7 +3149,9 @@ class TensMul(TensExpr, AssocOp):
                 replacements[pos1contra][-old_index] = -dummy
                 indices[pos2cov] = dummy
                 indices[pos2contra] = -dummy
-            args = [arg.xreplace(repl) for arg, repl in zip(args, replacements)]
+            args = [
+                arg._replace_indices(repl) if isinstance(arg, TensExpr) else arg
+                for arg, repl in zip(args, replacements)]
 
         dum = TensMul._dummy_data_to_dum(dummy_data)
         return args, indices, free, dum
@@ -3336,6 +3351,9 @@ class TensMul(TensExpr, AssocOp):
         [m2]
         """
         return self._index_structure.get_free_indices()
+
+    def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr
+        return self.func(*[arg._replace_indices(repl) if isinstance(arg, TensExpr) else arg for arg in self.args])
 
     def split(self):
         """
@@ -3824,6 +3842,10 @@ class TensorElement(TensExpr):
 
     def get_free_indices(self):
         return self._free_indices
+
+    def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr
+        # TODO: can be improved:
+        return self.xreplace(repl)
 
     def get_indices(self):
         return self.get_free_indices()

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -52,6 +52,7 @@ def test_tensor_partial_deriv():
 
 
 def test_replace_arrays_partial_derivative():
+
     x, y, z, t = symbols("x y z t")
 
     # d(A^i)/d(A_j) = d(g^ik A_k)/d(A_j) = g^ik delta_jk
@@ -108,3 +109,11 @@ def test_replace_arrays_partial_derivative():
     expr = A(j)*A(-j) + expr
     assert expr.get_indices() == [L_0, -L_0, L_1, -L_1]
     assert expr.get_free_indices() == []
+
+    expr = A(i)*(B(j)*PartialDerivative(C(-j), D(i)) + C(j)*PartialDerivative(D(-j), B(i)))
+    assert expr.get_indices() == [L_0, L_1, -L_1, -L_0]
+    assert expr.get_free_indices() == []
+
+    expr = A(i)*PartialDerivative(C(-j), D(i))
+    assert expr.get_indices() == [L_0, -j, -L_0]
+    assert expr.get_free_indices() == [-j]

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -93,6 +93,12 @@ class PartialDerivative(TensExpr):
         free = sorted(self._free, key=lambda x: x[1])
         return [i[0] for i in free]
 
+    def _replace_indices(self, repl):
+        expr = self.expr.xreplace(repl)
+        mirrored = {-k: -v for k, v in repl.items()}
+        variables = [i.xreplace(mirrored) for i in self.variables]
+        return self.func(expr, *variables)
+
     @property
     def expr(self):
         return self.args[0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixing bug in replacing indices in PartialDerivative tensor objects.
<!-- END RELEASE NOTES -->
