### PR TITLE
Final flake8 PR...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ matrix:
       sudo: true
       script: bin/test quality
       env:
+    - python: 3.8
+      dist: xenial
+      sudo: true
+      env:
+        - TEST_FLAKE8="true"
 
     - stage: baseline
       python: 3.8
@@ -191,12 +196,7 @@ matrix:
             - pypy3
 
     - stage: allowed_failures
-      python: 3.8
-      dist: xenial
-      sudo: true
-      env:
-        - TEST_FLAKE8="true"
-    - python: 3.6
+      python: 3.6
       dist: xenial
       sudo: true
       env:

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -203,7 +203,7 @@ from .utilities import (flatten, group, take, subsets, variations,
         interactive_traversal, prefixes, postfixes, sift, topological_sort,
         unflatten, has_dups, has_variety, reshape, default_sort_key, ordered,
         rotations, filldedent, lambdify, source, threaded, xthreaded, public,
-        memoize_property, test, doctest, timed)
+        memoize_property, timed)
 
 from .integrals import (integrate, Integral, line_integrate, mellin_transform,
         inverse_mellin_transform, MellinTransform, InverseMellinTransform,

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -48,26 +48,200 @@ def __sympy_debug():
                            debug_str)
 SYMPY_DEBUG = __sympy_debug()
 
-from .core import *
-from .logic import *
-from .assumptions import *
-from .polys import *
-from .series import *
-from .functions import *
-from .ntheory import *
-from .concrete import *
-from .discrete import *
-from .simplify import *
-from .sets import *
-from .solvers import *
-from .matrices import *
-from .geometry import *
-from .utilities import *
-from .integrals import *
-from .tensor import *
-from .parsing import *
-from .calculus import *
-from .algebras import *
+from .core import (sympify, SympifyError, cacheit, Basic, Atom,
+        preorder_traversal, S, Expr, AtomicExpr, UnevaluatedExpr, Symbol,
+        Wild, Dummy, symbols, var, Number, Float, Rational, Integer,
+        NumberSymbol, RealNumber, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo,
+        AlgebraicNumber, comp, mod_inverse, Pow, integer_nthroot, integer_log,
+        Mul, prod, Add, Mod, Rel, Eq, Ne, Lt, Le, Gt, Ge, Equality,
+        GreaterThan, LessThan, Unequality, StrictGreaterThan, StrictLessThan,
+        vectorize, Lambda, WildFunction, Derivative, diff, FunctionClass,
+        Function, Subs, expand, PoleError, count_ops, expand_mul, expand_log,
+        expand_func, expand_trig, expand_complex, expand_multinomial, nfloat,
+        expand_power_base, expand_power_exp, arity, PrecisionExhausted, N,
+        evalf, Tuple, Dict, gcd_terms, factor_terms, factor_nc, evaluate,
+        Catalan, EulerGamma, GoldenRatio, TribonacciConstant)
+
+from .logic import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor,
+        Implies, Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map,
+        true, false, satisfiable)
+
+from .assumptions import (AppliedPredicate, Predicate, AssumptionsContext,
+        assuming, Q, ask, register_handler, remove_handler, refine)
+
+from .polys import (Poly, PurePoly, poly_from_expr, parallel_poly_from_expr,
+        degree, total_degree, degree_list, LC, LM, LT, pdiv, prem, pquo,
+        pexquo, div, rem, quo, exquo, half_gcdex, gcdex, invert,
+        subresultants, resultant, discriminant, cofactors, gcd_list, gcd,
+        lcm_list, lcm, terms_gcd, trunc, monic, content, primitive, compose,
+        decompose, sturm, gff_list, gff, sqf_norm, sqf_part, sqf_list, sqf,
+        factor_list, factor, intervals, refine_root, count_roots, real_roots,
+        nroots, ground_roots, nth_power_roots_poly, cancel, reduced, groebner,
+        is_zero_dimensional, GroebnerBasis, poly, symmetrize, horner,
+        interpolate, rational_interpolate, viete, together,
+        BasePolynomialError, ExactQuotientFailed, PolynomialDivisionFailed,
+        OperationNotSupported, HeuristicGCDFailed, HomomorphismFailed,
+        IsomorphismFailed, ExtraneousFactors, EvaluationFailed,
+        RefinementFailed, CoercionFailed, NotInvertible, NotReversible,
+        NotAlgebraic, DomainError, PolynomialError, UnificationFailed,
+        GeneratorsError, GeneratorsNeeded, ComputationFailed,
+        UnivariatePolynomialError, MultivariatePolynomialError,
+        PolificationFailed, OptionError, FlagError, minpoly,
+        minimal_polynomial, primitive_element, field_isomorphism,
+        to_number_field, isolate, itermonomials, Monomial, lex, grlex,
+        grevlex, ilex, igrlex, igrevlex, CRootOf, rootof, RootOf,
+        ComplexRootOf, RootSum, roots, Domain, FiniteField, IntegerRing,
+        RationalField, RealField, ComplexField, PythonFiniteField,
+        GMPYFiniteField, PythonIntegerRing, GMPYIntegerRing, PythonRational,
+        GMPYRationalField, AlgebraicField, PolynomialRing, FractionField,
+        ExpressionDomain, FF_python, FF_gmpy, ZZ_python, ZZ_gmpy, QQ_python,
+        QQ_gmpy, GF, FF, ZZ, QQ, RR, CC, EX, construct_domain,
+        swinnerton_dyer_poly, cyclotomic_poly, symmetric_poly, random_poly,
+        interpolating_poly, jacobi_poly, chebyshevt_poly, chebyshevu_poly,
+        hermite_poly, legendre_poly, laguerre_poly, apart, apart_list,
+        assemble_partfrac_list, Options, ring, xring, vring, sring, field,
+        xfield, vfield, sfield)
+
+from .series import (Order, O, limit, Limit, gruntz, series, approximants,
+        residue, EmptySequence, SeqPer, SeqFormula, sequence, SeqAdd, SeqMul,
+        fourier_series, fps, difference_delta, limit_seq)
+
+from .functions import (factorial, factorial2, rf, ff, binomial,
+        RisingFactorial, FallingFactorial, subfactorial, carmichael,
+        fibonacci, lucas, tribonacci, harmonic, bernoulli, bell, euler,
+        catalan, genocchi, partition, sqrt, root, Min, Max, Id, real_root,
+        cbrt, re, im, sign, Abs, conjugate, arg, polar_lift,
+        periodic_argument, unbranched_argument, principal_branch, transpose,
+        adjoint, polarify, unpolarify, sin, cos, tan, sec, csc, cot, sinc,
+        asin, acos, atan, asec, acsc, acot, atan2, exp_polar, exp, ln, log,
+        LambertW, sinh, cosh, tanh, coth, sech, csch, asinh, acosh, atanh,
+        acoth, asech, acsch, floor, ceiling, frac, Piecewise, piecewise_fold,
+        erf, erfc, erfi, erf2, erfinv, erfcinv, erf2inv, Ei, expint, E1, li,
+        Li, Si, Ci, Shi, Chi, fresnels, fresnelc, gamma, lowergamma,
+        uppergamma, polygamma, loggamma, digamma, trigamma, multigamma,
+        dirichlet_eta, zeta, lerchphi, polylog, stieltjes, Eijk, LeviCivita,
+        KroneckerDelta, SingularityFunction, DiracDelta, Heaviside,
+        bspline_basis, bspline_basis_set, interpolating_spline, besselj,
+        bessely, besseli, besselk, hankel1, hankel2, jn, yn, jn_zeros, hn1,
+        hn2, airyai, airybi, airyaiprime, airybiprime, marcumq, hyper,
+        meijerg, appellf1, legendre, assoc_legendre, hermite, chebyshevt,
+        chebyshevu, chebyshevu_root, chebyshevt_root, laguerre,
+        assoc_laguerre, gegenbauer, jacobi, jacobi_normalized, Ynm, Ynm_c,
+        Znm, elliptic_k, elliptic_f, elliptic_e, elliptic_pi, beta, mathieus,
+        mathieuc, mathieusprime, mathieucprime)
+
+from .ntheory import (nextprime, prevprime, prime, primepi, primerange,
+        randprime, Sieve, sieve, primorial, cycle_length, composite,
+        compositepi, isprime, divisors, proper_divisors, factorint,
+        multiplicity, perfect_power, pollard_pm1, pollard_rho, primefactors,
+        totient, trailing, divisor_count, proper_divisor_count, divisor_sigma,
+        factorrat, reduced_totient, primenu, primeomega,
+        mersenne_prime_exponent, is_perfect, is_mersenne_prime, is_abundant,
+        is_deficient, is_amicable, abundance, npartitions, is_primitive_root,
+        is_quad_residue, legendre_symbol, jacobi_symbol, n_order, sqrt_mod,
+        quadratic_residues, primitive_root, nthroot_mod, is_nthpow_residue,
+        sqrt_mod_iter, mobius, discrete_log, quadratic_congruence,
+        binomial_coefficients, binomial_coefficients_list,
+        multinomial_coefficients, continued_fraction_periodic,
+        continued_fraction_iterator, continued_fraction_reduce,
+        continued_fraction_convergents, continued_fraction, egyptian_fraction)
+
+from .concrete import product, Product, summation, Sum
+
+from .discrete import (fft, ifft, ntt, intt, fwht, ifwht, mobius_transform,
+        inverse_mobius_transform, convolution, covering_product,
+        intersecting_product)
+
+from .simplify import (simplify, hypersimp, hypersimilar, logcombine,
+        separatevars, posify, besselsimp, kroneckersimp, signsimp, bottom_up,
+        nsimplify, FU, fu, sqrtdenest, cse, use, epath, EPath, hyperexpand,
+        collect, rcollect, radsimp, collect_const, fraction, numer, denom,
+        trigsimp, exptrigsimp, powsimp, powdenest, combsimp, gammasimp,
+        ratsimp, ratsimpmodprime)
+
+from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
+        Intersection, imageset, Complement, SymmetricDifference, ImageSet,
+        Range, ComplexRegion, Reals, Contains, ConditionSet, Ordinal,
+        OmegaPower, ord0, PowerSet, Naturals, Naturals0, UniversalSet,
+        Integers, Rationals)
+
+from .solvers import (solve, solve_linear_system, solve_linear_system_LU,
+        solve_undetermined_coeffs, nsolve, solve_linear, checksol, det_quick,
+        inv_quick, check_assumptions, failing_assumptions, diophantine,
+        rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper, checkodesol,
+        classify_ode, dsolve, homogeneous_order, solve_poly_system,
+        solve_triangulated, pde_separate, pde_separate_add, pde_separate_mul,
+        pdsolve, classify_pde, checkpdesol, ode_order, reduce_inequalities,
+        reduce_abs_inequality, reduce_abs_inequalities, solve_poly_inequality,
+        solve_rational_inequalities, solve_univariate_inequality, decompogen,
+        solveset, linsolve, linear_eq_to_matrix, nonlinsolve, substitution,
+        Complexes)
+
+from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
+        casoratian, diag, eye, hessian, jordan_cell, list2numpy, matrix2numpy,
+        matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
+        rot_axis3, symarray, wronskian, zeros, MutableDenseMatrix,
+        DeferredVector, MatrixBase, Matrix, MutableMatrix,
+        MutableSparseMatrix, banded, ImmutableDenseMatrix,
+        ImmutableSparseMatrix, ImmutableMatrix, SparseMatrix, MatrixSlice,
+        BlockDiagMatrix, BlockMatrix, FunctionMatrix, Identity, Inverse,
+        MatAdd, MatMul, MatPow, MatrixExpr, MatrixSymbol, Trace, Transpose,
+        ZeroMatrix, OneMatrix, blockcut, block_collapse, matrix_symbols,
+        Adjoint, hadamard_product, HadamardProduct, HadamardPower,
+        Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
+        DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
+        PermutationMatrix, MatrixPermute)
+
+from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
+        Segment2D, Ray2D, Line3D, Segment3D, Ray3D, Plane, Ellipse, Circle,
+        Polygon, RegularPolygon, Triangle, rad, deg, are_similar, centroid,
+        convex_hull, idiff, intersection, closest_points, farthest_points,
+        GeometryError, Curve, Parabola)
+
+from .utilities import (flatten, group, take, subsets, variations,
+        numbered_symbols, cartes, capture, dict_merge, postorder_traversal,
+        interactive_traversal, prefixes, postfixes, sift, topological_sort,
+        unflatten, has_dups, has_variety, reshape, default_sort_key, ordered,
+        rotations, filldedent, lambdify, source, threaded, xthreaded, public,
+        memoize_property, test, doctest, timed)
+
+from .integrals import (integrate, Integral, line_integrate, mellin_transform,
+        inverse_mellin_transform, MellinTransform, InverseMellinTransform,
+        laplace_transform, inverse_laplace_transform, LaplaceTransform,
+        InverseLaplaceTransform, fourier_transform, inverse_fourier_transform,
+        FourierTransform, InverseFourierTransform, sine_transform,
+        inverse_sine_transform, SineTransform, InverseSineTransform,
+        cosine_transform, inverse_cosine_transform, CosineTransform,
+        InverseCosineTransform, hankel_transform, inverse_hankel_transform,
+        HankelTransform, InverseHankelTransform, singularityintegrate)
+
+from .tensor import (IndexedBase, Idx, Indexed, get_contraction_structure,
+        get_indices, MutableDenseNDimArray, ImmutableDenseNDimArray,
+        MutableSparseNDimArray, ImmutableSparseNDimArray, NDimArray,
+        tensorproduct, tensorcontraction, derive_by_array, permutedims, Array,
+        DenseNDimArray, SparseNDimArray)
+
+from .parsing import parse_expr
+
+from .calculus import (euler_equations, singularities, is_increasing,
+        is_strictly_increasing, is_decreasing, is_strictly_decreasing,
+        is_monotonic, finite_diff_weights, apply_finite_diff, as_finite_diff,
+        differentiate_finite, periodicity, not_empty_in, AccumBounds,
+        is_convex, stationary_points, minimum, maximum)
+
+from .algebras import Quaternion
+
+from .printing import (pager_print, pretty, pretty_print, pprint,
+        pprint_use_unicode, pprint_try_use_unicode, latex, print_latex,
+        multiline_latex, mathml, print_mathml, python, print_python, pycode,
+        ccode, print_ccode, glsl_code, print_glsl, cxxcode, fcode,
+        print_fcode, rcode, print_rcode, jscode, print_jscode, julia_code,
+        mathematica_code, octave_code, rust_code, print_gtk, preview, srepr,
+        print_tree, StrPrinter, sstr, sstrrepr, TableForm, dotprint,
+        maple_code, print_maple_code)
+
+from .testing import test, doctest
+
 # This module causes conflicts with other modules:
 # from .stats import *
 # Adds about .04-.05 seconds of import time
@@ -75,14 +249,226 @@ from .algebras import *
 # This module is slow to import:
 #from physics import units
 from .plotting import plot, textplot, plot_backends, plot_implicit, plot_parametric
-from .printing import *
 from .interactive import init_session, init_printing
-from .parsing import *
 
 evalf._create_evalf_table()
 
 # This is slow to import:
 #import abc
 
-from .deprecated import *
-from .testing import *
+from .deprecated import C, ClassRegistry, class_registry
+
+__all__ = [
+    'sympify', 'SympifyError', 'cacheit', 'Basic', 'Atom',
+    'preorder_traversal', 'S', 'Expr', 'AtomicExpr', 'UnevaluatedExpr',
+    'Symbol', 'Wild', 'Dummy', 'symbols', 'var', 'Number', 'Float',
+    'Rational', 'Integer', 'NumberSymbol', 'RealNumber', 'igcd', 'ilcm',
+    'seterr', 'E', 'I', 'nan', 'oo', 'pi', 'zoo', 'AlgebraicNumber', 'comp',
+    'mod_inverse', 'Pow', 'integer_nthroot', 'integer_log', 'Mul', 'prod',
+    'Add', 'Mod', 'Rel', 'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge', 'Equality',
+    'GreaterThan', 'LessThan', 'Unequality', 'StrictGreaterThan',
+    'StrictLessThan', 'vectorize', 'Lambda', 'WildFunction', 'Derivative',
+    'diff', 'FunctionClass', 'Function', 'Subs', 'expand', 'PoleError',
+    'count_ops', 'expand_mul', 'expand_log', 'expand_func', 'expand_trig',
+    'expand_complex', 'expand_multinomial', 'nfloat', 'expand_power_base',
+    'expand_power_exp', 'arity', 'PrecisionExhausted', 'N', 'evalf', 'Tuple',
+    'Dict', 'gcd_terms', 'factor_terms', 'factor_nc', 'evaluate', 'Catalan',
+    'EulerGamma', 'GoldenRatio', 'TribonacciConstant',
+
+    'to_cnf', 'to_dnf', 'to_nnf', 'And', 'Or', 'Not', 'Xor', 'Nand', 'Nor',
+    'Implies', 'Equivalent', 'ITE', 'POSform', 'SOPform', 'simplify_logic',
+    'bool_map', 'true', 'false', 'satisfiable',
+
+    'AppliedPredicate', 'Predicate', 'AssumptionsContext', 'assuming', 'Q',
+    'ask', 'register_handler', 'remove_handler', 'refine',
+
+    'Poly', 'PurePoly', 'poly_from_expr', 'parallel_poly_from_expr', 'degree',
+    'total_degree', 'degree_list', 'LC', 'LM', 'LT', 'pdiv', 'prem', 'pquo',
+    'pexquo', 'div', 'rem', 'quo', 'exquo', 'half_gcdex', 'gcdex', 'invert',
+    'subresultants', 'resultant', 'discriminant', 'cofactors', 'gcd_list',
+    'gcd', 'lcm_list', 'lcm', 'terms_gcd', 'trunc', 'monic', 'content',
+    'primitive', 'compose', 'decompose', 'sturm', 'gff_list', 'gff',
+    'sqf_norm', 'sqf_part', 'sqf_list', 'sqf', 'factor_list', 'factor',
+    'intervals', 'refine_root', 'count_roots', 'real_roots', 'nroots',
+    'ground_roots', 'nth_power_roots_poly', 'cancel', 'reduced', 'groebner',
+    'is_zero_dimensional', 'GroebnerBasis', 'poly', 'symmetrize', 'horner',
+    'interpolate', 'rational_interpolate', 'viete', 'together',
+    'BasePolynomialError', 'ExactQuotientFailed', 'PolynomialDivisionFailed',
+    'OperationNotSupported', 'HeuristicGCDFailed', 'HomomorphismFailed',
+    'IsomorphismFailed', 'ExtraneousFactors', 'EvaluationFailed',
+    'RefinementFailed', 'CoercionFailed', 'NotInvertible', 'NotReversible',
+    'NotAlgebraic', 'DomainError', 'PolynomialError', 'UnificationFailed',
+    'GeneratorsError', 'GeneratorsNeeded', 'ComputationFailed',
+    'UnivariatePolynomialError', 'MultivariatePolynomialError',
+    'PolificationFailed', 'OptionError', 'FlagError', 'minpoly',
+    'minimal_polynomial', 'primitive_element', 'field_isomorphism',
+    'to_number_field', 'isolate', 'itermonomials', 'Monomial', 'lex', 'grlex',
+    'grevlex', 'ilex', 'igrlex', 'igrevlex', 'CRootOf', 'rootof', 'RootOf',
+    'ComplexRootOf', 'RootSum', 'roots', 'Domain', 'FiniteField',
+    'IntegerRing', 'RationalField', 'RealField', 'ComplexField',
+    'PythonFiniteField', 'GMPYFiniteField', 'PythonIntegerRing',
+    'GMPYIntegerRing', 'PythonRational', 'GMPYRationalField',
+    'AlgebraicField', 'PolynomialRing', 'FractionField', 'ExpressionDomain',
+    'FF_python', 'FF_gmpy', 'ZZ_python', 'ZZ_gmpy', 'QQ_python', 'QQ_gmpy',
+    'GF', 'FF', 'ZZ', 'QQ', 'RR', 'CC', 'EX', 'construct_domain',
+    'swinnerton_dyer_poly', 'cyclotomic_poly', 'symmetric_poly',
+    'random_poly', 'interpolating_poly', 'jacobi_poly', 'chebyshevt_poly',
+    'chebyshevu_poly', 'hermite_poly', 'legendre_poly', 'laguerre_poly',
+    'apart', 'apart_list', 'assemble_partfrac_list', 'Options', 'ring',
+    'xring', 'vring', 'sring', 'field', 'xfield', 'vfield', 'sfield',
+
+    'Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'approximants',
+    'residue', 'EmptySequence', 'SeqPer', 'SeqFormula', 'sequence', 'SeqAdd',
+    'SeqMul', 'fourier_series', 'fps', 'difference_delta', 'limit_seq',
+
+    'factorial', 'factorial2', 'rf', 'ff', 'binomial', 'RisingFactorial',
+    'FallingFactorial', 'subfactorial', 'carmichael', 'fibonacci', 'lucas',
+    'tribonacci', 'harmonic', 'bernoulli', 'bell', 'euler', 'catalan',
+    'genocchi', 'partition', 'sqrt', 'root', 'Min', 'Max', 'Id', 'real_root',
+    'cbrt', 're', 'im', 'sign', 'Abs', 'conjugate', 'arg', 'polar_lift',
+    'periodic_argument', 'unbranched_argument', 'principal_branch',
+    'transpose', 'adjoint', 'polarify', 'unpolarify', 'sin', 'cos', 'tan',
+    'sec', 'csc', 'cot', 'sinc', 'asin', 'acos', 'atan', 'asec', 'acsc',
+    'acot', 'atan2', 'exp_polar', 'exp', 'ln', 'log', 'LambertW', 'sinh',
+    'cosh', 'tanh', 'coth', 'sech', 'csch', 'asinh', 'acosh', 'atanh',
+    'acoth', 'asech', 'acsch', 'floor', 'ceiling', 'frac', 'Piecewise',
+    'piecewise_fold', 'erf', 'erfc', 'erfi', 'erf2', 'erfinv', 'erfcinv',
+    'erf2inv', 'Ei', 'expint', 'E1', 'li', 'Li', 'Si', 'Ci', 'Shi', 'Chi',
+    'fresnels', 'fresnelc', 'gamma', 'lowergamma', 'uppergamma', 'polygamma',
+    'loggamma', 'digamma', 'trigamma', 'multigamma', 'dirichlet_eta', 'zeta',
+    'lerchphi', 'polylog', 'stieltjes', 'Eijk', 'LeviCivita',
+    'KroneckerDelta', 'SingularityFunction', 'DiracDelta', 'Heaviside',
+    'bspline_basis', 'bspline_basis_set', 'interpolating_spline', 'besselj',
+    'bessely', 'besseli', 'besselk', 'hankel1', 'hankel2', 'jn', 'yn',
+    'jn_zeros', 'hn1', 'hn2', 'airyai', 'airybi', 'airyaiprime',
+    'airybiprime', 'marcumq', 'hyper', 'meijerg', 'appellf1', 'legendre',
+    'assoc_legendre', 'hermite', 'chebyshevt', 'chebyshevu',
+    'chebyshevu_root', 'chebyshevt_root', 'laguerre', 'assoc_laguerre',
+    'gegenbauer', 'jacobi', 'jacobi_normalized', 'Ynm', 'Ynm_c', 'Znm',
+    'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
+    'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime',
+
+    'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',
+    'Sieve', 'sieve', 'primorial', 'cycle_length', 'composite', 'compositepi',
+    'isprime', 'divisors', 'proper_divisors', 'factorint', 'multiplicity',
+    'perfect_power', 'pollard_pm1', 'pollard_rho', 'primefactors', 'totient',
+    'trailing', 'divisor_count', 'proper_divisor_count', 'divisor_sigma',
+    'factorrat', 'reduced_totient', 'primenu', 'primeomega',
+    'mersenne_prime_exponent', 'is_perfect', 'is_mersenne_prime',
+    'is_abundant', 'is_deficient', 'is_amicable', 'abundance', 'npartitions',
+    'is_primitive_root', 'is_quad_residue', 'legendre_symbol',
+    'jacobi_symbol', 'n_order', 'sqrt_mod', 'quadratic_residues',
+    'primitive_root', 'nthroot_mod', 'is_nthpow_residue', 'sqrt_mod_iter',
+    'mobius', 'discrete_log', 'quadratic_congruence', 'binomial_coefficients',
+    'binomial_coefficients_list', 'multinomial_coefficients',
+    'continued_fraction_periodic', 'continued_fraction_iterator',
+    'continued_fraction_reduce', 'continued_fraction_convergents',
+    'continued_fraction', 'egyptian_fraction',
+
+    'product', 'Product', 'summation', 'Sum',
+
+    'fft', 'ifft', 'ntt', 'intt', 'fwht', 'ifwht', 'mobius_transform',
+    'inverse_mobius_transform', 'convolution', 'covering_product',
+    'intersecting_product',
+
+    'simplify', 'hypersimp', 'hypersimilar', 'logcombine', 'separatevars',
+    'posify', 'besselsimp', 'kroneckersimp', 'signsimp', 'bottom_up',
+    'nsimplify', 'FU', 'fu', 'sqrtdenest', 'cse', 'use', 'epath', 'EPath',
+    'hyperexpand', 'collect', 'rcollect', 'radsimp', 'collect_const',
+    'fraction', 'numer', 'denom', 'trigsimp', 'exptrigsimp', 'powsimp',
+    'powdenest', 'combsimp', 'gammasimp', 'ratsimp', 'ratsimpmodprime',
+
+    'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
+    'Intersection', 'imageset', 'Complement', 'SymmetricDifference',
+    'ImageSet', 'Range', 'ComplexRegion', 'Reals', 'Contains', 'ConditionSet',
+    'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Reals', 'Naturals',
+    'Naturals0', 'UniversalSet', 'Integers', 'Rationals',
+
+    'solve', 'solve_linear_system', 'solve_linear_system_LU',
+    'solve_undetermined_coeffs', 'nsolve', 'solve_linear', 'checksol',
+    'det_quick', 'inv_quick', 'check_assumptions', 'failing_assumptions',
+    'diophantine', 'rsolve', 'rsolve_poly', 'rsolve_ratio', 'rsolve_hyper',
+    'checkodesol', 'classify_ode', 'dsolve', 'homogeneous_order',
+    'solve_poly_system', 'solve_triangulated', 'pde_separate',
+    'pde_separate_add', 'pde_separate_mul', 'pdsolve', 'classify_pde',
+    'checkpdesol', 'ode_order', 'reduce_inequalities',
+    'reduce_abs_inequality', 'reduce_abs_inequalities',
+    'solve_poly_inequality', 'solve_rational_inequalities',
+    'solve_univariate_inequality', 'decompogen', 'solveset', 'linsolve',
+    'linear_eq_to_matrix', 'nonlinsolve', 'substitution', 'Complexes',
+
+    'ShapeError', 'NonSquareMatrixError', 'GramSchmidt', 'casoratian', 'diag',
+    'eye', 'hessian', 'jordan_cell', 'list2numpy', 'matrix2numpy',
+    'matrix_multiply_elementwise', 'ones', 'randMatrix', 'rot_axis1',
+    'rot_axis2', 'rot_axis3', 'symarray', 'wronskian', 'zeros',
+    'MutableDenseMatrix', 'DeferredVector', 'MatrixBase', 'Matrix',
+    'MutableMatrix', 'MutableSparseMatrix', 'banded', 'ImmutableDenseMatrix',
+    'ImmutableSparseMatrix', 'ImmutableMatrix', 'SparseMatrix', 'MatrixSlice',
+    'BlockDiagMatrix', 'BlockMatrix', 'FunctionMatrix', 'Identity', 'Inverse',
+    'MatAdd', 'MatMul', 'MatPow', 'MatrixExpr', 'MatrixSymbol', 'Trace',
+    'Transpose', 'ZeroMatrix', 'OneMatrix', 'blockcut', 'block_collapse',
+    'matrix_symbols', 'Adjoint', 'hadamard_product', 'HadamardProduct',
+    'HadamardPower', 'Determinant', 'det', 'diagonalize_vector', 'DiagMatrix',
+    'DiagonalMatrix', 'DiagonalOf', 'trace', 'DotProduct',
+    'kronecker_product', 'KroneckerProduct', 'PermutationMatrix',
+    'MatrixPermute',
+
+    'Point', 'Point2D', 'Point3D', 'Line', 'Ray', 'Segment', 'Line2D',
+    'Segment2D', 'Ray2D', 'Line3D', 'Segment3D', 'Ray3D', 'Plane', 'Ellipse',
+    'Circle', 'Polygon', 'RegularPolygon', 'Triangle', 'rad', 'deg',
+    'are_similar', 'centroid', 'convex_hull', 'idiff', 'intersection',
+    'closest_points', 'farthest_points', 'GeometryError', 'Curve', 'Parabola',
+
+    'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
+    'cartes', 'capture', 'dict_merge', 'postorder_traversal',
+    'interactive_traversal', 'prefixes', 'postfixes', 'sift',
+    'topological_sort', 'unflatten', 'has_dups', 'has_variety', 'reshape',
+    'default_sort_key', 'ordered', 'rotations', 'filldedent', 'lambdify',
+    'source', 'threaded', 'xthreaded', 'public', 'memoize_property', 'test',
+    'doctest', 'timed',
+
+    'integrate', 'Integral', 'line_integrate', 'mellin_transform',
+    'inverse_mellin_transform', 'MellinTransform', 'InverseMellinTransform',
+    'laplace_transform', 'inverse_laplace_transform', 'LaplaceTransform',
+    'InverseLaplaceTransform', 'fourier_transform',
+    'inverse_fourier_transform', 'FourierTransform',
+    'InverseFourierTransform', 'sine_transform', 'inverse_sine_transform',
+    'SineTransform', 'InverseSineTransform', 'cosine_transform',
+    'inverse_cosine_transform', 'CosineTransform', 'InverseCosineTransform',
+    'hankel_transform', 'inverse_hankel_transform', 'HankelTransform',
+    'InverseHankelTransform', 'singularityintegrate',
+
+    'IndexedBase', 'Idx', 'Indexed', 'get_contraction_structure',
+    'get_indices', 'MutableDenseNDimArray', 'ImmutableDenseNDimArray',
+    'MutableSparseNDimArray', 'ImmutableSparseNDimArray', 'NDimArray',
+    'tensorproduct', 'tensorcontraction', 'derive_by_array', 'permutedims',
+    'Array', 'DenseNDimArray', 'SparseNDimArray',
+
+    'parse_expr',
+
+    'euler_equations', 'singularities', 'is_increasing',
+    'is_strictly_increasing', 'is_decreasing', 'is_strictly_decreasing',
+    'is_monotonic', 'finite_diff_weights', 'apply_finite_diff',
+    'as_finite_diff', 'differentiate_finite', 'periodicity', 'not_empty_in',
+    'AccumBounds', 'is_convex', 'stationary_points', 'minimum', 'maximum',
+
+    'Quaternion',
+
+    'pager_print', 'pretty', 'pretty_print', 'pprint', 'pprint_use_unicode',
+    'pprint_try_use_unicode', 'latex', 'print_latex', 'multiline_latex',
+    'mathml', 'print_mathml', 'python', 'print_python', 'pycode', 'ccode',
+    'print_ccode', 'glsl_code', 'print_glsl', 'cxxcode', 'fcode',
+    'print_fcode', 'rcode', 'print_rcode', 'jscode', 'print_jscode',
+    'julia_code', 'mathematica_code', 'octave_code', 'rust_code', 'print_gtk',
+    'preview', 'srepr', 'print_tree', 'StrPrinter', 'sstr', 'sstrrepr',
+    'TableForm', 'dotprint', 'maple_code', 'print_maple_code',
+
+    'plot', 'textplot', 'plot_backends', 'plot_implicit', 'plot_parametric',
+
+    'init_session', 'init_printing',
+
+    'test', 'doctest',
+
+    # deprecated:
+    'C', 'ClassRegistry', 'class_registry',
+]

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -259,6 +259,7 @@ evalf._create_evalf_table()
 from .deprecated import C, ClassRegistry, class_registry
 
 __all__ = [
+    # sympy.core
     'sympify', 'SympifyError', 'cacheit', 'Basic', 'Atom',
     'preorder_traversal', 'S', 'Expr', 'AtomicExpr', 'UnevaluatedExpr',
     'Symbol', 'Wild', 'Dummy', 'symbols', 'var', 'Number', 'Float',
@@ -275,13 +276,16 @@ __all__ = [
     'Dict', 'gcd_terms', 'factor_terms', 'factor_nc', 'evaluate', 'Catalan',
     'EulerGamma', 'GoldenRatio', 'TribonacciConstant',
 
+    # sympy.logic
     'to_cnf', 'to_dnf', 'to_nnf', 'And', 'Or', 'Not', 'Xor', 'Nand', 'Nor',
     'Implies', 'Equivalent', 'ITE', 'POSform', 'SOPform', 'simplify_logic',
     'bool_map', 'true', 'false', 'satisfiable',
 
+    # sympy.assumptions
     'AppliedPredicate', 'Predicate', 'AssumptionsContext', 'assuming', 'Q',
     'ask', 'register_handler', 'remove_handler', 'refine',
 
+    # sympy.polys
     'Poly', 'PurePoly', 'poly_from_expr', 'parallel_poly_from_expr', 'degree',
     'total_degree', 'degree_list', 'LC', 'LM', 'LT', 'pdiv', 'prem', 'pquo',
     'pexquo', 'div', 'rem', 'quo', 'exquo', 'half_gcdex', 'gcdex', 'invert',
@@ -317,10 +321,12 @@ __all__ = [
     'apart', 'apart_list', 'assemble_partfrac_list', 'Options', 'ring',
     'xring', 'vring', 'sring', 'field', 'xfield', 'vfield', 'sfield',
 
+    # sympy.series
     'Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'approximants',
     'residue', 'EmptySequence', 'SeqPer', 'SeqFormula', 'sequence', 'SeqAdd',
     'SeqMul', 'fourier_series', 'fps', 'difference_delta', 'limit_seq',
 
+    # sympy.functions
     'factorial', 'factorial2', 'rf', 'ff', 'binomial', 'RisingFactorial',
     'FallingFactorial', 'subfactorial', 'carmichael', 'fibonacci', 'lucas',
     'tribonacci', 'harmonic', 'bernoulli', 'bell', 'euler', 'catalan',
@@ -348,6 +354,7 @@ __all__ = [
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime',
 
+    # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primepi', 'primerange', 'randprime',
     'Sieve', 'sieve', 'primorial', 'cycle_length', 'composite', 'compositepi',
     'isprime', 'divisors', 'proper_divisors', 'factorint', 'multiplicity',
@@ -365,12 +372,15 @@ __all__ = [
     'continued_fraction_reduce', 'continued_fraction_convergents',
     'continued_fraction', 'egyptian_fraction',
 
+    # sympy.concrete
     'product', 'Product', 'summation', 'Sum',
 
+    # sympy.discrete
     'fft', 'ifft', 'ntt', 'intt', 'fwht', 'ifwht', 'mobius_transform',
     'inverse_mobius_transform', 'convolution', 'covering_product',
     'intersecting_product',
 
+    # sympy.simplify
     'simplify', 'hypersimp', 'hypersimilar', 'logcombine', 'separatevars',
     'posify', 'besselsimp', 'kroneckersimp', 'signsimp', 'bottom_up',
     'nsimplify', 'FU', 'fu', 'sqrtdenest', 'cse', 'use', 'epath', 'EPath',
@@ -378,12 +388,14 @@ __all__ = [
     'fraction', 'numer', 'denom', 'trigsimp', 'exptrigsimp', 'powsimp',
     'powdenest', 'combsimp', 'gammasimp', 'ratsimp', 'ratsimpmodprime',
 
+    # sympy.sets
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
     'Intersection', 'imageset', 'Complement', 'SymmetricDifference',
     'ImageSet', 'Range', 'ComplexRegion', 'Reals', 'Contains', 'ConditionSet',
     'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Reals', 'Naturals',
     'Naturals0', 'UniversalSet', 'Integers', 'Rationals',
 
+    # sympy.solvers
     'solve', 'solve_linear_system', 'solve_linear_system_LU',
     'solve_undetermined_coeffs', 'nsolve', 'solve_linear', 'checksol',
     'det_quick', 'inv_quick', 'check_assumptions', 'failing_assumptions',
@@ -397,6 +409,7 @@ __all__ = [
     'solve_univariate_inequality', 'decompogen', 'solveset', 'linsolve',
     'linear_eq_to_matrix', 'nonlinsolve', 'substitution', 'Complexes',
 
+    # sympy.matrices
     'ShapeError', 'NonSquareMatrixError', 'GramSchmidt', 'casoratian', 'diag',
     'eye', 'hessian', 'jordan_cell', 'list2numpy', 'matrix2numpy',
     'matrix_multiply_elementwise', 'ones', 'randMatrix', 'rot_axis1',
@@ -413,12 +426,14 @@ __all__ = [
     'kronecker_product', 'KroneckerProduct', 'PermutationMatrix',
     'MatrixPermute',
 
+    # sympy.geometry
     'Point', 'Point2D', 'Point3D', 'Line', 'Ray', 'Segment', 'Line2D',
     'Segment2D', 'Ray2D', 'Line3D', 'Segment3D', 'Ray3D', 'Plane', 'Ellipse',
     'Circle', 'Polygon', 'RegularPolygon', 'Triangle', 'rad', 'deg',
     'are_similar', 'centroid', 'convex_hull', 'idiff', 'intersection',
     'closest_points', 'farthest_points', 'GeometryError', 'Curve', 'Parabola',
 
+    # sympy.utilities
     'flatten', 'group', 'take', 'subsets', 'variations', 'numbered_symbols',
     'cartes', 'capture', 'dict_merge', 'postorder_traversal',
     'interactive_traversal', 'prefixes', 'postfixes', 'sift',
@@ -427,6 +442,7 @@ __all__ = [
     'source', 'threaded', 'xthreaded', 'public', 'memoize_property', 'test',
     'doctest', 'timed',
 
+    # sympy.integrals
     'integrate', 'Integral', 'line_integrate', 'mellin_transform',
     'inverse_mellin_transform', 'MellinTransform', 'InverseMellinTransform',
     'laplace_transform', 'inverse_laplace_transform', 'LaplaceTransform',
@@ -438,22 +454,27 @@ __all__ = [
     'hankel_transform', 'inverse_hankel_transform', 'HankelTransform',
     'InverseHankelTransform', 'singularityintegrate',
 
+    # sympy.tensor
     'IndexedBase', 'Idx', 'Indexed', 'get_contraction_structure',
     'get_indices', 'MutableDenseNDimArray', 'ImmutableDenseNDimArray',
     'MutableSparseNDimArray', 'ImmutableSparseNDimArray', 'NDimArray',
     'tensorproduct', 'tensorcontraction', 'derive_by_array', 'permutedims',
     'Array', 'DenseNDimArray', 'SparseNDimArray',
 
+    # sympy.parsing
     'parse_expr',
 
+    # sympy.calculus
     'euler_equations', 'singularities', 'is_increasing',
     'is_strictly_increasing', 'is_decreasing', 'is_strictly_decreasing',
     'is_monotonic', 'finite_diff_weights', 'apply_finite_diff',
     'as_finite_diff', 'differentiate_finite', 'periodicity', 'not_empty_in',
     'AccumBounds', 'is_convex', 'stationary_points', 'minimum', 'maximum',
 
+    # sympy.algebras
     'Quaternion',
 
+    # sympy.printing
     'pager_print', 'pretty', 'pretty_print', 'pprint', 'pprint_use_unicode',
     'pprint_try_use_unicode', 'latex', 'print_latex', 'multiline_latex',
     'mathml', 'print_mathml', 'python', 'print_python', 'pycode', 'ccode',
@@ -463,12 +484,15 @@ __all__ = [
     'preview', 'srepr', 'print_tree', 'StrPrinter', 'sstr', 'sstrrepr',
     'TableForm', 'dotprint', 'maple_code', 'print_maple_code',
 
+    # sympy.plotting
     'plot', 'textplot', 'plot_backends', 'plot_implicit', 'plot_parametric',
 
+    # sympy.interactive
     'init_session', 'init_printing',
 
+    # sympy.testing
     'test', 'doctest',
 
-    # deprecated:
+    # sympy.deprecated:
     'C', 'ClassRegistry', 'class_registry',
 ]

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -7,8 +7,8 @@ from sympy.core import (Basic, S, Add, Mul, Pow, Symbol, sympify,
                         expand_power_exp, Eq)
 from sympy.core.compatibility import iterable, ordered, range, as_int
 from sympy.core.parameters import global_parameters
-from sympy.core.function import expand_log, count_ops, _mexpand, _coeff_isneg, \
-    nfloat, expand_mul, expand_multinomial
+from sympy.core.function import (expand_log, count_ops, _mexpand, _coeff_isneg,
+    nfloat, expand_mul)
 from sympy.core.numbers import Float, I, pi, Rational, Integer
 from sympy.core.relational import Relational
 from sympy.core.rules import Transform

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -31,6 +31,8 @@ lowered when the tensor is put in canonical form.
 
 from __future__ import print_function, division
 
+from typing import List, Set
+
 from abc import abstractmethod, ABCMeta
 from collections import defaultdict
 import operator
@@ -1958,20 +1960,20 @@ class TensExpr(with_metaclass(_TensorMetaclass, Expr)):
     @property
     @abstractmethod
     def nocoeff(self):
-        raise NotImplemented("abstract method")
+        raise NotImplementedError("abstract method")
 
     @property
     @abstractmethod
     def coeff(self):
-        raise NotImplemented("abstract method")
+        raise NotImplementedError("abstract method")
 
     @abstractmethod
     def get_indices(self):
-        raise NotImplemented("abstract method")
+        raise NotImplementedError("abstract method")
 
     @abstractmethod
     def get_free_indices(self):  # type: () -> List[TensorIndex]
-        raise NotImplemented("abstract method")
+        raise NotImplementedError("abstract method")
 
     @abstractmethod
     def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1977,7 +1977,7 @@ class TensExpr(with_metaclass(_TensorMetaclass, Expr)):
 
     @abstractmethod
     def _replace_indices(self, repl):  # type: (Dict[TensorIndex, TensorIndex]) -> TensExpr
-        raise NotImplemented("abstract method")
+        raise NotImplementedError("abstract method")
 
     def fun_eval(self, *index_tuples):
         deprecate_fun_eval()

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 import tempfile
 import warnings
-import glob
 from distutils.errors import CompileError
 from distutils.sysconfig import get_config_var
 

--- a/sympy/utilities/benchmarking.py
+++ b/sympy/utilities/benchmarking.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.benchmarking import *
+from sympy.testing.benchmarking import *  # noqa:F401

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -484,7 +484,7 @@ def translate(s, a, b=None, c=None):
                 a = ''.join(a)
                 b = ''.join(b)
         s = replace(s, mr)
-        table = maketrans(a, b)
+        table = str.maketrans(a, b)
         # s may have become unicode which uses the py3 syntax for translate
         if isinstance(table, str) and isinstance(s, str):
             s = s.translate(table)

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.pytest import *
+from sympy.testing.pytest import *  # noqa:F401

--- a/sympy/utilities/quality_unicode.py
+++ b/sympy/utilities/quality_unicode.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.quality_unicode import *
+from sympy.testing.quality_unicode import *  # noqa:F401

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.randtest import *
+from sympy.testing.randtest import *  # noqa:F401

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.runtests import *
+from sympy.testing.runtests import *  # noqa:F401

--- a/sympy/utilities/tests/test_deprecated.py
+++ b/sympy/utilities/tests/test_deprecated.py
@@ -4,18 +4,18 @@ from sympy.testing.pytest import warns_deprecated_sympy, XFAIL
 
 def test_deprecated_utilities():
     with warns_deprecated_sympy():
-        import sympy.utilities.pytest
+        import sympy.utilities.pytest  # noqa:F401
     with warns_deprecated_sympy():
-        import sympy.utilities.runtests
+        import sympy.utilities.runtests  # noqa:F401
     with warns_deprecated_sympy():
-        import sympy.utilities.randtest
+        import sympy.utilities.randtest  # noqa:F401
     with warns_deprecated_sympy():
-        import sympy.utilities.tmpfiles
+        import sympy.utilities.tmpfiles  # noqa:F401
     with warns_deprecated_sympy():
-        import sympy.utilities.quality_unicode
+        import sympy.utilities.quality_unicode  # noqa:F401
 
 # This fails because benchmarking isn't importable...
 @XFAIL
 def test_deprecated_benchmarking():
     with warns_deprecated_sympy():
-        import sympy.utilities.benchmarking
+        import sympy.utilities.benchmarking  # noqa:F401

--- a/sympy/utilities/tmpfiles.py
+++ b/sympy/utilities/tmpfiles.py
@@ -6,4 +6,4 @@ SymPyDeprecationWarning(
     issue=18095,
     deprecated_since_version="1.6").warn()
 
-from sympy.testing.tmpfiles import *
+from sympy.testing.tmpfiles import *  # noqa:F401


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


Fixes https://github.com/sympy/sympy/issues/13525
Fixes https://github.com/sympy/sympy/issues/13592

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- other
  - Submodule names are no longer imported with `from sympy import *`. They can still be imported directly like `from sympy import core` or accessed like `sympy.core`, or like `sys.modules['sympy.simplify']` for modules that share names with SymPy functions.
<!-- END RELEASE NOTES -->
