### PR TITLE
Fix evalf for Interval and FiniteSet containing Symbols

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1098,9 +1098,8 @@ class Interval(Set, EvalfMixin):
             mpf(self.end._eval_evalf(prec)))
 
     def _eval_evalf(self, prec):
-        return Interval(self.left._eval_evalf(prec),
-            self.right._eval_evalf(prec),
-                        left_open=self.left_open, right_open=self.right_open)
+        return Interval(self.left._evalf(prec), self.right._evalf(prec),
+            left_open=self.left_open, right_open=self.right_open)
 
     def _is_comparable(self, other):
         is_comparable = self.start.is_comparable
@@ -1912,7 +1911,7 @@ class FiniteSet(Set, EvalfMixin):
         return (hash(self) - hash(other))
 
     def _eval_evalf(self, prec):
-        return FiniteSet(*[elem._eval_evalf(prec) for elem in self])
+        return FiniteSet(*[elem._evalf(prec) for elem in self])
 
     @property
     def _sorted_args(self):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -629,6 +629,15 @@ def test_interval_to_mpi():
     assert type(Interval(0, 1).to_mpi()) == type(mpi(0, 1))
 
 
+def test_set_evalf():
+    assert Interval(S(11)/64, S.Half).evalf() == Interval(
+        Float('0.171875'), Float('0.5'))
+    assert Interval(x, S.Half, right_open=True).evalf() == Interval(
+        x, Float('0.5'), right_open=True)
+    assert Interval(-oo, S.Half).evalf() == Interval(-oo, Float('0.5'))
+    assert FiniteSet(2, x).evalf() == FiniteSet(Float('2.0'), x)
+
+
 def test_measure():
     a = Symbol('a', real=True)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18249 

#### Brief description of what is fixed or changed
In Interval._eval_evalf() and FiniteSet._eval_evalf() the
calls to _eval_evalf() are changed to _evalf(). Otherwise
symbolic expressions will result in a None value.

Before:

```
In [1]: Interval(1, x).n() # raises SympifyError: None

In [2]: FiniteSet(1, x).n()
Out[2]: {None, 1.0}
```
After:
```
In [1]: Interval(1, x).n()
Out[1]: [1.0, x]

In [2]: FiniteSet(1, x).n()
Out[2]: {1.0, x}
```

Tests are added.



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed `evalf()` for `Intervals` and `FiniteSets` having symbolic endpoints or containing symbolic elements.
<!-- END RELEASE NOTES -->
