### PR TITLE
Make `Function.nargs` inheritable

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -170,8 +170,8 @@ class FunctionClass(ManagedProperties):
     def __init__(cls, *args, **kwargs):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
-        if not getattr(self, '_nargs', None) or 'nargs' in self.__dict__:
-            nargs = kwargs.pop('nargs', self.__dict__.get('nargs', arity(self)))
+        if not getattr(cls, '_nargs', None) or 'nargs' in cls.__dict__:
+            nargs = kwargs.pop('nargs', cls.__dict__.get('nargs', arity(cls)))
 
         # Canonicalize nargs here; change to set in nargs.
         if is_sequence(nargs):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -170,7 +170,8 @@ class FunctionClass(ManagedProperties):
     def __init__(cls, *args, **kwargs):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
-        nargs = kwargs.pop('nargs', cls.__dict__.get('nargs', arity(cls)))
+        if not getattr(self, '_nargs', None) or 'nargs' in self.__dict__:
+            nargs = kwargs.pop('nargs', self.__dict__.get('nargs', arity(self)))
 
         # Canonicalize nargs here; change to set in nargs.
         if is_sequence(nargs):


### PR DESCRIPTION
Subclass of `Function` can inherit its `nargs` down to its subclasses.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17989
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Subclass of Function can inherit its `nargs` class attributes to its subclasses.

#### Other comments
Before this PR,
```python
>>> class f1(Function):
...     nargs = 2
>>> class f2(f1):
...     pass

>>> f1.nargs
(2,)
>>> f2.nargs
```

After this PR,
```python
>>> class f1(Function):
...     nargs = 2
>>> class f2(f1):
...     pass

>>> f1.nargs
(2,)
>>> f2.nargs
(2,)
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
