### PR TITLE
Make Function.nargs inheritable

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -171,6 +171,13 @@ class FunctionClass(ManagedProperties):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
         nargs = kwargs.pop('nargs', cls.__dict__.get('nargs', arity(cls)))
+        if nargs is None and 'nargs' not in cls.__dict__:
+            for supcls in cls.__mro__:
+                if hasattr(supcls, '_nargs'):
+                    nargs = supcls._nargs
+                    break
+                else:
+                    continue
 
         # Canonicalize nargs here; change to set in nargs.
         if is_sequence(nargs):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -160,6 +160,40 @@ def test_nargs():
     assert Function('f', nargs=None).nargs == S.Naturals0
     raises(ValueError, lambda: Function('f', nargs=()))
 
+def test_nargs_inheritance():
+    class f1(Function):
+        nargs = 2
+    class f2(f1):
+        pass
+    class f3(f2):
+        pass
+    class f4(f3):
+        nargs = 1,2
+    class f5(f4):
+        pass
+    class f6(f5):
+        pass
+    class f7(f6):
+        nargs=None
+    class f8(f7):
+        pass
+    class f9(f8):
+        pass
+    class f10(f9):
+        nargs = 1
+    class f11(f10):
+        pass
+    assert f1.nargs == FiniteSet(2)
+    assert f2.nargs == FiniteSet(2)
+    assert f3.nargs == FiniteSet(2)
+    assert f4.nargs == FiniteSet(1, 2)
+    assert f5.nargs == FiniteSet(1, 2)
+    assert f6.nargs == FiniteSet(1, 2)
+    assert f7.nargs == S.Naturals0
+    assert f8.nargs == S.Naturals0
+    assert f9.nargs == S.Naturals0
+    assert f10.nargs == FiniteSet(1)
+    assert f11.nargs == FiniteSet(1)
 
 def test_arity():
     f = lambda x, y: 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #17989
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Subclass of `Function` can inherit its `nargs` down to its subclasses.

#### Other comments
Before this commit:
```python
>>> class f1(Function):
...     nargs = 2
>>> class f2(f1):
...     pass
>>> f1.nargs
FiniteSet(2)
>>> f2.nargs
Naturals0
```

After this commit:
```python
>>> class f1(Function):
...     nargs = 2
>>> class f2(f1):
...     pass
>>> class f3(f2):
...     nargs = None
>>> f1.nargs
FiniteSet(2)
>>> f2.nargs
FiniteSet(2)
>>> f3.nargs
Naturals0
```

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Subclass of `Function` can inherit its `nargs` attribute to its subclasses.
<!-- END RELEASE NOTES -->
