### PR TITLE
changed none to []

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1203,7 +1203,7 @@ def _invert_modular(modterm, rhs, n, symbol):
         elif base.has(symbol) and not expo.has(symbol):
             try:
                 remainder_list = nthroot_mod(rhs, expo, m, all_roots=True)
-                if remainder_list is None:
+                if remainder_list == []:
                     return symbol, EmptySet
             except (ValueError, NotImplementedError):
                 return modterm, rhs

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2185,6 +2185,7 @@ def test_invert_modular():
             (x, ImageSet(Lambda(n, 2*n + 1), S.Naturals0))
     assert invert_modular(Mod(2**(x**2 + x + 1), 7), S(2), n, x) == \
             (x**2 + x + 1, ImageSet(Lambda(n, 3*n + 1), S.Naturals0))
+    assert invert_modular(Mod(sin(x)**4, 7), S(5), n, x) == (x, EmptySet())
 
 
 def test_solve_modular():
@@ -2243,6 +2244,7 @@ def test_solve_modular():
             Intersection(ImageSet(Lambda(n, Intersection({log(2*n + 1)/log(3)},
             S.Integers)), S.Naturals0), S.Integers)
     # Implemented for m without primitive root
+    assert solveset(Mod(x**3, 7) - 2, x, S.Integers) == EmptySet()
     assert solveset(Mod(x**3, 8) - 1, x, S.Integers) == \
             ImageSet(Lambda(n, 8*n + 1), S.Integers)
     assert solveset(Mod(x**4, 9) - 4, x, S.Integers) == \


### PR DESCRIPTION
 <!-- BEGIN RELEASE NOTES -->
* solvers
  *  Changed return type from None to [], as in #18199 the return type of nth_root was changed when all_root = True and no root exists
<!-- END RELEASE NOTES -->

