### PR TITLE
[WIP] Improve matrix slice

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -50,6 +50,8 @@ Matrix Expressions Core Reference
    :members:
 .. autoclass:: MatrixPermute
    :members:
+.. autoclass:: MatrixSlice
+   :members:
 .. autoclass:: Identity
    :members:
 .. autoclass:: ZeroMatrix

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1112,6 +1112,55 @@ class Permutation(Atom):
         rv.sort()
         return rv
 
+    def _block_cyclic_form(self):
+        """Return permutation in block cyclic form.
+
+        This is used internally for decomposing permutation matrix into
+        block diagonal form. But can be introduced to a public API
+        if a suitable notation is found or can be useful.
+        Any suggestions?
+        """
+        result = []
+
+        a, b, c = 0, 0, 0
+        flag = False
+        for cycle in self.full_cyclic_form:
+            l = len(cycle)
+            m = max(cycle)
+
+            if not flag:
+                if m + 1 > a + l:
+                    flag = True
+                    temp = [cycle]
+                    b = m
+                    c = l
+                else:
+                    result.append([cycle])
+                    a += l
+
+            else:
+                if m > b:
+                    if m + 1 == a + c + l:
+                        temp.append(cycle)
+                        result.append(temp)
+                        flag = False
+                        a = m+1
+                    else:
+                        b = m
+                        temp.append(cycle)
+                        c += l
+                else:
+                    if b + 1 == a + c + l:
+                        temp.append(cycle)
+                        result.append(temp)
+                        flag = False
+                        a = b+1
+                    else:
+                        temp.append(cycle)
+                        c += l
+
+        return result
+
     @property
     def size(self):
         """

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -2987,6 +2987,17 @@ class Permutation(Atom):
 
         return self
 
+    def _is_reverse_permutation(self):
+        """Tests if the permutation is a reverse permutation.
+
+        Reverse permutation is a permutation that flips an array.
+        And it is unique with respective to its size.
+
+        e.g. A reverse permutation of size 5 is
+        ``Permutation([4, 3, 2, 1, 0])``
+        """
+        return self.array_form == list(reversed(range(self.size)))
+
     # XXX Deprecated flag
     print_cyclic = None
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import ask, Q
-from sympy.core import Basic, Add
+from sympy.core import Basic, Add, S
 from sympy.strategies import typed, exhaust, condition, do_one, unpack
 from sympy.strategies.traverse import bottom_up
 from sympy.utilities import sift
@@ -129,7 +129,7 @@ class BlockMatrix(MatrixExpr):
 
     @property
     def shape(self):
-        numrows = numcols = 0
+        numrows, numcols = S.Zero, S.Zero
         M = self.blocks
         for i in range(M.shape[0]):
             numrows += M[i, 0].shape[0]
@@ -152,6 +152,20 @@ class BlockMatrix(MatrixExpr):
     @property
     def colblocksizes(self):
         return [self.blocks[0, i].cols for i in range(self.blockshape[1])]
+
+    def _cumulative_rows(self):
+        result = [0]
+        blocks = self.blocks
+        for i in range(blocks.rows):
+            result += [result[-1] + blocks[i, 0].rows]
+        return result
+
+    def _cumulative_cols(self):
+        result = [0]
+        blocks = self.blocks
+        for j in range(blocks.cols):
+            result += [result[-1] + blocks[0, j].cols]
+        return result
 
     def structurally_equal(self, other):
         return (isinstance(other, BlockMatrix)
@@ -305,8 +319,11 @@ class BlockDiagMatrix(BlockMatrix):
 
     @property
     def shape(self):
-        return (sum(block.rows for block in self.args),
-                sum(block.cols for block in self.args))
+        numrows, numcols = S.Zero, S.Zero
+        for block in self.args:
+            numrows += block.rows
+            numcols += block.cols
+        return (numrows, numcols)
 
     @property
     def blockshape(self):
@@ -396,10 +413,12 @@ def block_collapse(expr):
     else:
         return result
 
+
 def bc_unpack(expr):
     if expr.blockshape == (1, 1):
         return expr.blocks[0, 0]
     return expr
+
 
 def bc_matadd(expr):
     args = sift(expr.args, lambda M: isinstance(M, BlockMatrix))
@@ -416,6 +435,7 @@ def bc_matadd(expr):
     else:
         return block
 
+
 def bc_block_plus_ident(expr):
     idents = [arg for arg in expr.args if arg.is_Identity]
     if not idents:
@@ -429,6 +449,7 @@ def bc_block_plus_ident(expr):
         return MatAdd(block_id * len(idents), *blocks).doit()
 
     return expr
+
 
 def bc_dist(expr):
     """ Turn  a*[X, Y] into [a*X, a*Y] """
@@ -475,6 +496,7 @@ def bc_matmul(expr):
             i+=1
     return MatMul(factor, *matrices).doit()
 
+
 def bc_transpose(expr):
     collapse = block_collapse(expr.arg)
     return collapse._eval_transpose()
@@ -489,11 +511,13 @@ def bc_inverse(expr):
         return expr2
     return blockinverse_2x2(Inverse(reblock_2x2(expr.arg)))
 
+
 def blockinverse_1x1(expr):
     if isinstance(expr.arg, BlockMatrix) and expr.arg.blockshape == (1, 1):
         mat = Matrix([[expr.arg.blocks[0].inverse()]])
         return BlockMatrix(mat)
     return expr
+
 
 def blockinverse_2x2(expr):
     if isinstance(expr.arg, BlockMatrix) and expr.arg.blockshape == (2, 2):
@@ -505,6 +529,7 @@ def blockinverse_2x2(expr):
                             [-(D - C*A.I*B).I*C*A.I,     (D - C*A.I*B).I]])
     else:
         return expr
+
 
 def deblock(B):
     """ Flatten a BlockMatrix of BlockMatrices """
@@ -525,7 +550,6 @@ def deblock(B):
         return BlockMatrix(MM)
     except ShapeError:
         return B
-
 
 
 def reblock_2x2(B):
@@ -551,6 +575,7 @@ def bounds(sizes):
         rv.append((low, low + size))
         low += size
     return rv
+
 
 def blockcut(expr, rowsizes, colsizes):
     """ Cut a matrix expression into Blocks

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -103,52 +103,13 @@ class PermutationMatrix(MatrixExpr):
         from .blockmatrix import BlockDiagMatrix
 
         perm = self.args[0]
-        full_cyclic_form = perm.full_cyclic_form
-
-        cycles_picks = []
-
         # Stage 1. Decompose the cycles into the blockable form.
-        a, b, c = 0, 0, 0
-        flag = False
-        for cycle in full_cyclic_form:
-            l = len(cycle)
-            m = max(cycle)
-
-            if not flag:
-                if m + 1 > a + l:
-                    flag = True
-                    temp = [cycle]
-                    b = m
-                    c = l
-                else:
-                    cycles_picks.append([cycle])
-                    a += l
-
-            else:
-                if m > b:
-                    if m + 1 == a + c + l:
-                        temp.append(cycle)
-                        cycles_picks.append(temp)
-                        flag = False
-                        a = m+1
-                    else:
-                        b = m
-                        temp.append(cycle)
-                        c += l
-                else:
-                    if b + 1 == a + c + l:
-                        temp.append(cycle)
-                        cycles_picks.append(temp)
-                        flag = False
-                        a = b+1
-                    else:
-                        temp.append(cycle)
-                        c += l
+        block_cyclic_form = perm._block_cyclic_form()
 
         # Stage 2. Normalize each decomposed cycles and build matrix.
         p = 0
         args = []
-        for pick in cycles_picks:
+        for pick in block_cyclic_form:
             new_cycles = []
             l = 0
             for cycle in pick:

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -260,3 +260,15 @@ class MatrixPermute(MatrixExpr):
             return MatMul(PermutationMatrix(perm), mat)
         elif axis == 1:
             return MatMul(mat, PermutationMatrix(perm**-1))
+
+    def _eval_rewrite_as_MatrixSlice(self, *args, **kwargs):
+        from .slice import MatrixSlice
+
+        mat, perm, axis = self.args
+        if not perm._is_reverse_permutation():
+            return None
+
+        if axis == 0:
+            return MatrixSlice(mat, (self.rows, 0, -1), (0, self.cols, 1))
+        elif axis == 1:
+            return MatrixSlice(mat, (0, self.rows, 1), (self.cols, 0, -1))

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -103,9 +103,9 @@ def normalize(i, parentsize: Basic):
             raise IndexError(
                 "{} must be in the interval ({}, {}]."
                 .format(i, -parentsize, parentsize))
-        if (i < 0) == True:
+        if (i < S.Zero) == True:
             i += parentsize
-        return i, i+1, 1
+        return i, i+S.One, S.One
 
     start, stop, step = _slice_sympify(i)
     start, stop, step = _remove_slice_none(start, stop, step, parentsize)

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -1,8 +1,14 @@
 from __future__ import print_function, division
 
-from sympy.matrices.expressions.matexpr  import MatrixExpr
-from sympy import Tuple, Basic
+from sympy.core.containers import Tuple
+from sympy.core.basic import Basic
+from sympy.core.sympify import _sympify
 from sympy.functions.elementary.integers import floor
+from sympy.matrices.matrices import MatrixBase
+
+from .matexpr import MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix, Identity
+
+
 
 def normalize(i, parentsize):
     if isinstance(i, slice):
@@ -55,15 +61,33 @@ class MatrixSlice(MatrixExpr):
     colslice = property(lambda self: self.args[2])
 
     def __new__(cls, parent, rowslice, colslice):
+        parent = _sympify(parent)
+        if not parent.is_Matrix:
+            raise ValueError("{} must be a matrix.".format(parent))
+
         rowslice = normalize(rowslice, parent.shape[0])
         colslice = normalize(colslice, parent.shape[1])
-        if not (len(rowslice) == len(colslice) == 3):
-            raise IndexError()
-        if ((0 > rowslice[0]) == True or
-            (parent.shape[0] < rowslice[1]) == True or
-            (0 > colslice[0]) == True or
-            (parent.shape[1] < colslice[1]) == True):
-            raise IndexError()
+
+        if len(rowslice) != 3:
+            raise IndexError(
+                "{} is not a valid row slicing.".format(rowslice))
+        if len(colslice) != 3:
+            raise IndexError(
+                "{} is not a valid column slicing.".format(colslice))
+
+        if (rowslice[0] < 0) == True:
+            raise IndexError("{} should not be negative.".format(rowslice[0]))
+        if (colslice[0] < 0) == True:
+            raise IndexError("{} should not be negative.".format(colslice[0]))
+        if (parent.shape[0] < rowslice[1]) == True:
+            raise IndexError(
+                "{} should not exceed {}."
+                .format(rowslice[1], parent.shape[0]))
+        if (parent.shape[1] < colslice[1]) == True:
+            raise IndexError(
+                "{} should not exceed {}."
+                .format(colslice[1], parent.shape[1]))
+
         if isinstance(parent, MatrixSlice):
             return mat_slice_of_slice(parent, rowslice, colslice)
         return Basic.__new__(cls, parent, Tuple(*rowslice), Tuple(*colslice))
@@ -77,13 +101,176 @@ class MatrixSlice(MatrixExpr):
         return rows, cols
 
     def _entry(self, i, j, **kwargs):
-        return self.parent._entry(i*self.rowslice[2] + self.rowslice[0],
-                                  j*self.colslice[2] + self.colslice[0],
-                                  **kwargs)
+        r_start, _, r_step = self.rowslice
+        c_start, _, c_step = self.colslice
+
+        return self.parent._entry(
+            i*r_step + r_start, j*c_step + c_start, **kwargs)
+
+    def doit(self, **kwargs):
+        from sympy.combinatorics.permutations import Permutation
+        from .blockmatrix import BlockMatrix, BlockDiagMatrix
+        from .permutation import PermutationMatrix
+
+        parent, rowslice, colslice = self.parent, self.rowslice, self.colslice
+
+        are_slices_integers = all(x.is_Integer for x in rowslice.args) and \
+            all(x.is_Integer for x in colslice.args)
+
+        if not are_slices_integers:
+            return self
+
+        if rowslice == (0, parent.rows, 1) and \
+            colslice == (0, parent.cols, 1):
+            return parent
+
+        if isinstance(parent, MatrixBase):
+            rowslice = slice(*rowslice)
+            colslice = slice(*colslice)
+            return parent[rowslice, colslice]
+
+        if isinstance(parent, MatrixSymbol):
+            if rowslice[0] == 0 and rowslice[2] == 1 and \
+                colslice[0] == 0 and colslice[2] == 1:
+                return MatrixSymbol(parent.args[0], rowslice[1], colslice[1])
+
+        if isinstance(parent, ZeroMatrix):
+            return ZeroMatrix(*self.shape)
+
+        if isinstance(parent, OneMatrix):
+            return OneMatrix(*self.shape)
+
+        if parent.is_Identity and self.on_diag:
+            return Identity(self.rows)
+
+        if isinstance(parent, BlockDiagMatrix):
+            r_start, r_stop, r_step = rowslice
+            c_start, c_stop, c_step = colslice
+            if not r_step == c_step == 1:
+                return self
+
+            if not parent.rows.is_Integer or not parent.cols.is_Integer:
+                return self
+
+            cumulative_rows = parent._cumulative_rows()
+            cumulative_cols = parent._cumulative_cols()
+            blocks = parent.args
+
+            if not r_start in cumulative_rows:
+                return self
+            if not r_stop in cumulative_rows:
+                return self
+            if not c_start in cumulative_cols:
+                return self
+            if not c_stop in cumulative_cols:
+                return self
+
+            r_start = cumulative_rows.index(r_start)
+            r_stop = cumulative_rows.index(r_stop)
+            c_start = cumulative_cols.index(c_start)
+            c_stop = cumulative_cols.index(c_stop)
+            if r_start == c_start and r_stop == c_stop:
+                return BlockDiagMatrix(*blocks[r_start:r_stop])
+
+        if isinstance(parent, BlockMatrix):
+            r_start, r_stop, r_step = rowslice
+            c_start, c_stop, c_step = colslice
+            if not r_step == c_step == 1:
+                return self
+
+            if not parent.rows.is_Integer or not parent.cols.is_Integer:
+                return self
+
+            cumulative_rows = parent._cumulative_rows()
+            cumulative_cols = parent._cumulative_cols()
+            blocks = parent.blocks
+
+            if not r_start in cumulative_rows:
+                return self
+            if not r_stop in cumulative_rows:
+                return self
+            if not c_start in cumulative_cols:
+                return self
+            if not c_stop in cumulative_cols:
+                return self
+
+            r_start = cumulative_rows.index(r_start)
+            r_stop = cumulative_rows.index(r_stop)
+            c_start = cumulative_cols.index(c_start)
+            c_stop = cumulative_cols.index(c_stop)
+            return BlockMatrix(blocks[r_start:r_stop, c_start:c_stop])
+
+        if isinstance(parent, PermutationMatrix):
+            if not self.on_diag:
+                return self
+
+            r_start, r_stop, r_step = rowslice
+            c_start, c_stop, c_step = colslice
+
+            if not r_step == c_step == 1:
+                return self
+
+            # Block decomposition of permutation matrix
+            perm = parent.args[0]
+            block_cyclic_form = perm._block_cyclic_form()
+
+            cumulative_size = [0]
+            for block in block_cyclic_form:
+                cumulative_size += [
+                    cumulative_size[-1] + sum(len(cycle) for cycle in block)]
+
+            if not r_start in cumulative_size:
+                return self
+            if not r_stop in cumulative_size:
+                return self
+
+            block_r_start = cumulative_size.index(r_start)
+            block_r_stop = cumulative_size.index(r_stop)
+
+            norm = r_start
+            new_cycles = []
+            for block in block_cyclic_form[block_r_start:block_r_stop]:
+                for cycle in block:
+                    new_cycles.append([x-norm for x in cycle])
+
+            return PermutationMatrix(Permutation(new_cycles))
+
+        return self
 
     @property
     def on_diag(self):
         return self.rowslice == self.colslice
+
+    def _eval_rewrite_as_MatrixPermute(self, *args, **kwargs):
+        """Rewrite horizontal or vertical matrix flip as matrix
+        permutation.
+        """
+        from sympy.combinatorics.permutations import Permutation
+        from .permutation import MatrixPermute
+
+        parent = self.parent
+        r_start, r_stop, r_step = self.rowslice
+        c_start, c_stop, c_step = self.colslice
+
+        is_h_id = c_step == 1 and c_start == 0 and c_stop == parent.cols
+        is_v_id = r_step == 1 and r_start == 0 and r_stop == parent.rows
+        is_h_flip = \
+            c_step == -1 and c_start == parent.cols and c_stop == 0
+        is_v_flip = \
+            r_step == -1 and r_start == parent.rows and r_stop == 0
+
+        if is_h_flip and is_v_flip:
+            af_rows = list(reversed(range(parent.rows)))
+            af_cols = list(reversed(range(parent.cols)))
+            return MatrixPermute(
+                MatrixPermute(self.parent, Permutation(af_rows), 0),
+                Permutation(af_cols), 1)
+        elif is_h_flip and is_v_id:
+            af_cols = list(reversed(range(parent.cols)))
+            return MatrixPermute(self.parent, Permutation(af_cols), 1)
+        elif is_v_flip and is_h_id:
+            af_rows = list(reversed(range(parent.rows)))
+            return MatrixPermute(self.parent, Permutation(af_rows), 0)
 
 
 def slice_of_slice(s, t):

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -322,6 +322,16 @@ class MatrixSlice(MatrixExpr):
         return self.parent._entry(
             i*r_step + r_start, j*c_step + c_start, **kwargs)
 
+    def _normalize_slices(self):
+        rowslice, colslice = self.rowslice, self.colslice
+        parent = self.parent
+        rows, cols = parent.shape
+        if rows.is_Integer:
+            rowslice = normalize(rowslice, rows)
+        if cols.is_Integer:
+            colslice = normalize(colslice, cols)
+        return MatrixSlice(parent, rowslice, colslice)
+
     def doit(self, **kwargs):
         from sympy.combinatorics.permutations import Permutation
         from .blockmatrix import BlockMatrix, BlockDiagMatrix
@@ -329,7 +339,8 @@ class MatrixSlice(MatrixExpr):
 
         parent, rowslice, colslice = self.parent, self.rowslice, self.colslice
 
-        are_slices_integers = all(x.is_Integer for x in rowslice.args) and \
+        are_slices_integers = \
+            all(x.is_Integer for x in rowslice.args) and \
             all(x.is_Integer for x in colslice.args)
 
         if not are_slices_integers:

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -3,6 +3,7 @@ from sympy.assumptions import assuming, Q
 from sympy.combinatorics.permutations import Permutation
 from sympy.functions.elementary.integers import floor
 from sympy.matrices import Matrix
+from sympy.matrices.common import ShapeError
 from sympy.matrices.expressions.blockmatrix import \
     BlockMatrix, BlockDiagMatrix
 from sympy.matrices.expressions.matexpr import \
@@ -22,14 +23,16 @@ def test_creation():
 
 def test_shape():
     B = MatrixSlice(X, (a, b), (c, d))
-    assert B.shape == (b - a, d - c)
+    raises(ShapeError, lambda: B.shape)
 
 def test_entry():
+    X = MatrixSymbol('X', n, m)
     B = MatrixSlice(X, (a, b), (c, d))
-    assert B[0,0] == X[a, c]
-    assert B[k,l] == X[a+k, c+l]
+    raises(ShapeError, lambda: B[0, 0])
+    raises(ShapeError, lambda: B[k, l])
     raises(IndexError, lambda : MatrixSlice(X, 1, (2, 5))[1, 0])
 
+    X = MatrixSymbol('X', 5, 5)
     assert X[1::2, :][1, 3] == X[1+2, 3]
     assert X[:, 1::2][3, 1] == X[3, 1+2]
 
@@ -42,14 +45,15 @@ def test_inputs():
     assert MatrixSlice(X, 1, (2, 5)).shape == (1, 3)
 
 def test_slicing():
+    X = MatrixSymbol('X', 5, 5)
     assert X[1:5, 2:4] == MatrixSlice(X, (1, 5), (2, 4))
     assert X[1, 2:4] == MatrixSlice(X, 1, (2, 4))
     assert X[1:5, :].shape == (4, X.shape[1])
     assert X[:, 1:5].shape == (X.shape[0], 4)
 
-    assert X[::2, ::2].shape == (floor(n/2), floor(m/2))
-    assert X[2, :] == MatrixSlice(X, 2, (0, m))
-    assert X[k, :] == MatrixSlice(X, k, (0, m))
+    assert X[::2, ::2].shape == (floor(5/2), floor(5/2))
+    assert X[2, :] == MatrixSlice(X, 2, (0, 5))
+    assert X[k, :] == MatrixSlice(X, k, (0, 5))
 
 def test_exceptions():
     X = MatrixSymbol('x', 10, 20)

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -1,13 +1,24 @@
-from sympy.matrices.expressions.slice import MatrixSlice
-from sympy.matrices.expressions import MatrixSymbol
 from sympy.abc import a, b, c, d, k, l, m, n
-from sympy.testing.pytest import raises, XFAIL
-from sympy.functions.elementary.integers import floor
 from sympy.assumptions import assuming, Q
+from sympy.combinatorics.permutations import Permutation
+from sympy.functions.elementary.integers import floor
+from sympy.matrices import Matrix
+from sympy.matrices.expressions.blockmatrix import \
+    BlockMatrix, BlockDiagMatrix
+from sympy.matrices.expressions.matexpr import \
+    MatrixSymbol, ZeroMatrix, OneMatrix, Identity
+from sympy.matrices.expressions.permutation import \
+    PermutationMatrix, MatrixPermute
+from sympy.matrices.expressions.slice import MatrixSlice
+from sympy.testing.pytest import raises, XFAIL
 
 
 X = MatrixSymbol('X', n, m)
 Y = MatrixSymbol('Y', m, k)
+
+
+def test_creation():
+    raises(ValueError, lambda: MatrixSlice(((1, 2), (3, 4)), (0, 2), (0, 2)))
 
 def test_shape():
     B = MatrixSlice(X, (a, b), (c, d))
@@ -63,3 +74,50 @@ def test_slice_of_slice():
 def test_negative_index():
     X = MatrixSymbol('x', 10, 10)
     assert X[-1, :] == X[9, :]
+
+def test_doit():
+    M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert MatrixSlice(M, (0, 1), (0, 2)).doit() == M[0:1, 0:2]
+
+    M = MatrixSymbol('M', 9, 10)
+    assert MatrixSlice(M, (0, 5), (0, 4)).doit() == MatrixSymbol('M', 5, 4)
+
+    M = ZeroMatrix(9, 10)
+    assert MatrixSlice(M, (1, 5), (2, 4)).doit() == ZeroMatrix(4, 2)
+
+    M = OneMatrix(9, 10)
+    assert MatrixSlice(M, (1, 5), (2, 4)).doit() == OneMatrix(4, 2)
+
+    M = Identity(10)
+    assert MatrixSlice(M, (2, 4), (2, 4)).doit() == Identity(2)
+
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    C = MatrixSymbol('C', 2, 2)
+    D = MatrixSymbol('D', 2, 2)
+    E = MatrixSymbol('E', 2, 2)
+    F = MatrixSymbol('F', 2, 2)
+    G = MatrixSymbol('G', 2, 2)
+    H = MatrixSymbol('H', 2, 2)
+    I = MatrixSymbol('I', 2, 2)
+    M = BlockMatrix([[A, B, C], [D, E, F], [G, H, I]])
+    assert MatrixSlice(M, (2, 6), (2, 6)).doit() == \
+        BlockMatrix([[E, F], [H, I]])
+
+    M = BlockDiagMatrix(A, B, C)
+    assert MatrixSlice(M, (2, 6), (2, 6)).doit() == BlockDiagMatrix(B, C)
+
+    M = PermutationMatrix(Permutation([0, 2, 1]))
+    assert MatrixSlice(M, (1, 3), (1, 3)).doit() == \
+        PermutationMatrix(Permutation([1, 0]))
+
+def test_rewrite_MatrixPermute():
+    M = MatrixSymbol('M', 3, 4)
+    assert MatrixSlice(M, (0, 3, 1), (4, 0, -1)).rewrite(MatrixPermute) == \
+        MatrixPermute(M, Permutation([3, 2, 1, 0]), 1)
+    assert MatrixSlice(M, (3, 0, -1), (0, 4, 1)).rewrite(MatrixPermute) == \
+        MatrixPermute(M, Permutation([2, 1, 0]), 0)
+    assert MatrixSlice(M, (3, 0, -1), (4, 0, -1)).rewrite(MatrixPermute) == \
+        MatrixPermute(
+            MatrixPermute(M, Permutation([2, 1, 0]), 0),
+            Permutation([3, 2, 1, 0]), 1)

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -53,9 +53,9 @@ def test_slicing():
 
 def test_exceptions():
     X = MatrixSymbol('x', 10, 20)
-    raises(IndexError, lambda: X[0:12, 2])
+    assert X[0:12, 2] == MatrixSlice(X, (0, 10, 1), (2, 3, 1))
     raises(IndexError, lambda: X[0:9, 22])
-    raises(IndexError, lambda: X[-1:5, 2])
+    assert X[-1:5, 2] == MatrixSlice(X, (9, 5, 1), (2, 3, 1))
 
 @XFAIL
 def test_symmetry():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I have added `doit` for the following features

1. Identity of slicing 
 ![image](https://user-images.githubusercontent.com/34944973/72315501-55497480-36d6-11ea-80ec-362cc12fabab.png)

2. Block matrix slicing if no blocks are broken
![image](https://user-images.githubusercontent.com/34944973/72315914-c6d5f280-36d7-11ea-8f02-5f84928e3b08.png)

3. Zero matrix, one matrix will be resized to an another zero matrix and one matrix
 ![image](https://user-images.githubusercontent.com/34944973/72316031-28965c80-36d8-11ea-860c-91a3a315813c.png)

4. Slicing matrix symbol into an another matrix symbol with different dimensions
 ![image](https://user-images.githubusercontent.com/34944973/72316166-90e53e00-36d8-11ea-8580-4617c8a015a2.png)

5. Slicing a permutation matrix into an another permutation matrix (Similar to slicing a block diagonal matrix into a block diagonal matrix)
![image](https://user-images.githubusercontent.com/34944973/72316282-005b2d80-36d9-11ea-913c-60b27af3ebc1.png)

Things that are work in progress are
1. Slicing a `FuncMatrix` into an another `FuncMatrix`
   - The obvious thing that can be implemented is, if the slicing begins from zero and if the step is one, it can only reduce the dimension of the `FuncMatrix`
   - The complicated stuff is, the function can also be modified with some shifted and scaled indices. Even if this transformation is possible, I'm not sure that the result can obviously be simpler than the original result, so will find a place to put this in.

2. Slicing a block matrix while breaking some blocks.
   - I'm thinking of implementing this as a feature in `block_collapse` rather than the `doit`.

Also, I've added a rewriting method for `MatrixSlice` to `MatrixPermute`, and `MatrixPermute` to `MatrixSlice` if the permutation is simply a reversing permutation.

I have only implemented for the cases if the slicing specification are integers. But this can be improved later if there are some symbolic cases that can be logically reasonably sliced. 

#### Other comments

This may have to be tested to cover up every cases, And I would try to implement some rewriting schemes from the `MatrixPermute`.

![Screen Shot 2020-01-25 at 19 51 29](https://user-images.githubusercontent.com/34944973/73119987-4a32f600-3fac-11ea-9440-30b51f4a23d4.png)


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Made error messages more descriptive for `MatrixSlice`.
  - Added `doit` for `MatrixSlice` for canonicalization.
<!-- END RELEASE NOTES -->
