### PR TITLE
Fixed results for `Q.antihermitian`

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -656,7 +656,6 @@ class AskAntiHermitianHandler(AskImaginaryHandler):
         for i in range(rows):
             for j in range(i, cols):
                 cond = fuzzy_bool(Eq(mat[i, j], -conjugate(mat[j, i])))
-                print(mat[i, j], -conjugate(mat[j, i]), cond)
                 if cond == None:
                     ret_val = None
                 if cond == False:

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -643,6 +643,19 @@ class AskAntiHermitianHandler(AskImaginaryHandler):
             elif ask(Q.odd(expr.exp), assumptions):
                 return True
 
+    @staticmethod
+    def MatrixBase(mat, assumptions):
+        rows, cols = mat.shape
+        ret_val = True
+        for i in range(rows):
+            for j in range(i, cols):
+                cond = fuzzy_bool(Eq(mat[i, j], -conjugate(mat[j, i])))
+                if cond == None:
+                    ret_val = None
+                if cond == False:
+                    return False
+        return ret_val
+
 
 class AskAlgebraicHandler(CommonHandler):
     """Handler for Q.algebraic key. """

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -592,6 +592,12 @@ class AskAntiHermitianHandler(AskImaginaryHandler):
     """
 
     @staticmethod
+    def Expr(expr, assumptions):
+        if isinstance(expr, MatrixBase):
+            return None
+        return AskImaginaryHandler.Expr(expr, assumptions)
+
+    @staticmethod
     def Add(expr, assumptions):
         """
         Antihermitian + Antihermitian  -> Antihermitian
@@ -650,6 +656,7 @@ class AskAntiHermitianHandler(AskImaginaryHandler):
         for i in range(rows):
             for j in range(i, cols):
                 cond = fuzzy_bool(Eq(mat[i, j], -conjugate(mat[j, i])))
+                print(mat[i, j], -conjugate(mat[j, i]), cond)
                 if cond == None:
                     ret_val = None
                 if cond == False:

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1903,6 +1903,16 @@ def test_matrix():
     assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, I, 0), (-5, 0, 11))))) == False
     assert ask(Q.hermitian(SparseMatrix(((25, 15, -5), (15, z, 0), (-5, 0, 11))))) == None
 
+    # antihermitian
+    A = Matrix([[0, -2 - I, 0], [2 - I, 0, -I], [0, -I, 0]])
+    B = Matrix([[-I, 2 + I, 0], [-2 + I, 0, 2 + I], [0, -2 + I, -I]])
+    assert ask(Q.antihermitian(A)) is True
+    assert ask(Q.antihermitian(B)) is True
+    assert ask(Q.antihermitian(A**2)) is False
+    assert ask(Q.antihermitian(B**3)) is True
+    _A = Matrix([[0, -2 - I, 0], [z, 0, -I], [0, -I, 0]])
+    assert ask(Q.antihermitian(_A)) is None
+
 
 def test_algebraic():
     assert ask(Q.algebraic(x)) is None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1909,7 +1909,9 @@ def test_matrix():
     assert ask(Q.antihermitian(A)) is True
     assert ask(Q.antihermitian(B)) is True
     assert ask(Q.antihermitian(A**2)) is False
-    assert ask(Q.antihermitian(B**3)) is True
+    C = (B**3)
+    C.simplify()
+    assert ask(Q.antihermitian(C)) is True
     _A = Matrix([[0, -2 - I, 0], [z, 0, -I], [0, -I, 0]])
     assert ask(Q.antihermitian(_A)) is None
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Closes https://github.com/sympy/sympy/issues/9478

#### Brief description of what is fixed or changed


#### Other comments
ping @quaeritis

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Matrices can now be checked for antihermitian property by using ask(Q.antihermitian()) which earlier generated incorrect results.
<!-- END RELEASE NOTES -->
