### PR TITLE
Fixed sqf_list in polys

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6211,11 +6211,20 @@ def sqf_list(f, *gens, **args):
     (2, [(x + 1, 2), (x + 2, 3)])
 
     """
-    numer = Poly(f, *gens, **args)
-    fp = Poly.sqf_list(numer)
-    coeff = fp[0]
-    fp = [(s.as_expr(), k) for s, k in fp[1]]
-    return coeff ,fp
+    options.allowed_flags(args, ['frac', 'polys'])
+    opt = options.build_options(gens, args)
+    f = sympify(f)
+    if isinstance(f, Expr) and not f.is_Relational:
+        numer, denom = together(f).as_numer_denom()
+        numer = Poly(numer, *gens, **args)
+        if denom!=1 and not opt.frac:
+            raise PolynomialError("a polynomial expected, got %s" % f)
+        fp = Poly.sqf_list(numer)
+        coeff = fp[0]
+        fp = [(s.as_expr(), k) for s, k in fp[1]]
+        return coeff ,fp
+    else:
+        raise PolynomialError("a polynomial expected, got %s" % f)
 
 @public
 def sqf(f, *gens, **args):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4265,6 +4265,7 @@ def poly_from_expr(expr, *gens, **args):
 def _poly_from_expr(expr, opt):
     """Construct a polynomial from an expression. """
     orig, expr = expr, sympify(expr)
+
     if not isinstance(expr, Basic):
         raise PolificationFailed(opt, orig, expr)
     elif expr.is_Poly:
@@ -4280,7 +4281,7 @@ def _poly_from_expr(expr, opt):
     elif opt.expand:
         expr = expr.expand()
 
-    rep, opt = _dict_from_expr(expr, opt)  
+    rep, opt = _dict_from_expr(expr, opt)
     if not opt.gens:
         raise PolificationFailed(opt, orig, expr)
 
@@ -4294,6 +4295,7 @@ def _poly_from_expr(expr, opt):
 
     rep = dict(list(zip(monoms, coeffs)))
     poly = Poly._from_dict(rep, opt)
+
     if opt.polys is None:
         opt.polys = False
 
@@ -5902,8 +5904,9 @@ def _factors_product(factors):
 def _symbolic_factor_list(expr, opt, method):
     """Helper function for :func:`_symbolic_factor`. """
     coeff, factors = S.One, []
+
     args = [i._eval_factor() if hasattr(i, '_eval_factor') else i
-        for i in Mul.make_args(expr)] #same as appending list elements by looping over. e.g Mul.make_args(x*y) will separate into terms (x, y), also Mul.make_args(x*y*x) = (y, x**2)  )
+        for i in Mul.make_args(expr)]
     for arg in args:
         if arg.is_Number:
             coeff *= arg
@@ -5928,6 +5931,7 @@ def _symbolic_factor_list(expr, opt, method):
             factors.append((exc.expr, exp))
         else:
             func = getattr(poly, method + '_list')
+
             _coeff, _factors = func()
             if _coeff is not S.One:
                 if exp.is_Integer:
@@ -5936,6 +5940,7 @@ def _symbolic_factor_list(expr, opt, method):
                     factors.append((_coeff, exp))
                 else:
                     _factors.append((_coeff, S.One))
+
             if exp is S.One:
                 factors.extend(_factors)
             elif exp.is_integer:
@@ -5950,6 +5955,7 @@ def _symbolic_factor_list(expr, opt, method):
                         other.append((f, k))
 
                 factors.append((_factors_product(other), exp))
+
     return coeff, factors
 
 
@@ -5972,14 +5978,15 @@ def _generic_factor_list(expr, gens, args, method):
     """Helper function for :func:`sqf_list` and :func:`factor_list`. """
     options.allowed_flags(args, ['frac', 'polys'])
     opt = options.build_options(gens, args)
+
     expr = sympify(expr)
-    
+
     if isinstance(expr, Expr) and not expr.is_Relational:
         numer, denom = together(expr).as_numer_denom()
-        
+
         cp, fp = _symbolic_factor_list(numer, opt, method)
         cq, fq = _symbolic_factor_list(denom, opt, method)
-        
+
         if fq and not opt.frac:
             raise PolynomialError("a polynomial expected, got %s" % expr)
 
@@ -5993,7 +6000,7 @@ def _generic_factor_list(expr, gens, args, method):
 
         fp = _sorted_factors(fp, method)
         fq = _sorted_factors(fq, method)
-        
+
         if not opt.polys:
             fp = [(f.as_expr(), k) for f, k in fp]
             fq = [(f.as_expr(), k) for f, k in fq]

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4265,7 +4265,6 @@ def poly_from_expr(expr, *gens, **args):
 def _poly_from_expr(expr, opt):
     """Construct a polynomial from an expression. """
     orig, expr = expr, sympify(expr)
-
     if not isinstance(expr, Basic):
         raise PolificationFailed(opt, orig, expr)
     elif expr.is_Poly:
@@ -4281,7 +4280,7 @@ def _poly_from_expr(expr, opt):
     elif opt.expand:
         expr = expr.expand()
 
-    rep, opt = _dict_from_expr(expr, opt)
+    rep, opt = _dict_from_expr(expr, opt)  
     if not opt.gens:
         raise PolificationFailed(opt, orig, expr)
 
@@ -4295,7 +4294,6 @@ def _poly_from_expr(expr, opt):
 
     rep = dict(list(zip(monoms, coeffs)))
     poly = Poly._from_dict(rep, opt)
-
     if opt.polys is None:
         opt.polys = False
 
@@ -5904,9 +5902,8 @@ def _factors_product(factors):
 def _symbolic_factor_list(expr, opt, method):
     """Helper function for :func:`_symbolic_factor`. """
     coeff, factors = S.One, []
-
     args = [i._eval_factor() if hasattr(i, '_eval_factor') else i
-        for i in Mul.make_args(expr)]
+        for i in Mul.make_args(expr)] #same as appending list elements by looping over. e.g Mul.make_args(x*y) will separate into terms (x, y), also Mul.make_args(x*y*x) = (y, x**2)  )
     for arg in args:
         if arg.is_Number:
             coeff *= arg
@@ -5931,7 +5928,6 @@ def _symbolic_factor_list(expr, opt, method):
             factors.append((exc.expr, exp))
         else:
             func = getattr(poly, method + '_list')
-
             _coeff, _factors = func()
             if _coeff is not S.One:
                 if exp.is_Integer:
@@ -5940,7 +5936,6 @@ def _symbolic_factor_list(expr, opt, method):
                     factors.append((_coeff, exp))
                 else:
                     _factors.append((_coeff, S.One))
-
             if exp is S.One:
                 factors.extend(_factors)
             elif exp.is_integer:
@@ -5955,7 +5950,6 @@ def _symbolic_factor_list(expr, opt, method):
                         other.append((f, k))
 
                 factors.append((_factors_product(other), exp))
-
     return coeff, factors
 
 
@@ -5978,15 +5972,14 @@ def _generic_factor_list(expr, gens, args, method):
     """Helper function for :func:`sqf_list` and :func:`factor_list`. """
     options.allowed_flags(args, ['frac', 'polys'])
     opt = options.build_options(gens, args)
-
     expr = sympify(expr)
-
+    
     if isinstance(expr, Expr) and not expr.is_Relational:
         numer, denom = together(expr).as_numer_denom()
-
+        
         cp, fp = _symbolic_factor_list(numer, opt, method)
         cq, fq = _symbolic_factor_list(denom, opt, method)
-
+        
         if fq and not opt.frac:
             raise PolynomialError("a polynomial expected, got %s" % expr)
 
@@ -6000,7 +5993,7 @@ def _generic_factor_list(expr, gens, args, method):
 
         fp = _sorted_factors(fp, method)
         fq = _sorted_factors(fq, method)
-
+        
         if not opt.polys:
             fp = [(f.as_expr(), k) for f, k in fp]
             fq = [(f.as_expr(), k) for f, k in fq]
@@ -6218,8 +6211,11 @@ def sqf_list(f, *gens, **args):
     (2, [(x + 1, 2), (x + 2, 3)])
 
     """
-    return _generic_factor_list(f, gens, args, method='sqf')
-
+    numer = Poly(f, *gens, **args)
+    fp = Poly.sqf_list(numer)
+    coeff = fp[0]
+    fp = [(s.as_expr(), k) for s, k in fp[1]]
+    return coeff ,fp
 
 @public
 def sqf(f, *gens, **args):

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -313,7 +313,7 @@ def dup_sqf_list(f, K, all=False):
         return coeff, []
 
     result, i = [], 1
-    
+
     h = dup_diff(f, 1, K)
     g, p, q = dup_inner_gcd(f, h, K)
 

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -313,7 +313,7 @@ def dup_sqf_list(f, K, all=False):
         return coeff, []
 
     result, i = [], 1
-
+    
     h = dup_diff(f, 1, K)
     g, p, q = dup_inner_gcd(f, h, K)
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -999,7 +999,7 @@ def solve(f, *symbols, **flags):
 
         if fi.is_Relational:
             return reduce_inequalities(f, symbols=symbols)
-        
+
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()
 
@@ -1030,7 +1030,7 @@ def solve(f, *symbols, **flags):
         if flags.get('set', False):
             return [], set()
         return []
-    
+
     for i, fi in enumerate(f):
         # Abs
         while True:
@@ -1045,7 +1045,7 @@ def solve(f, *symbols, **flags):
             if e.has(*symbols):
                 raise NotImplementedError('solving %s when the argument '
                     'is not real or imaginary.' % e)
-        
+
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]
         fi = fi.xreplace(dict(list(zip(_arg,
@@ -1053,7 +1053,7 @@ def solve(f, *symbols, **flags):
 
         # save changes
         f[i] = fi
-    
+
     # see if re(s) or im(s) appear
     irf = []
     for s in symbols:
@@ -1082,10 +1082,10 @@ def solve(f, *symbols, **flags):
 
     # we can solve for non-symbol entities by replacing them with Dummy symbols
     f, symbols, swap_sym = recast_to_symbols(f, symbols)
-    
+
     # this is needed in the next two events
     symset = set(symbols)
-    
+
     # get rid of equations that have no symbols of interest; we don't
     # try to solve them because the user didn't ask and they might be
     # hard to solve; this means that solutions may be given in terms
@@ -1124,7 +1124,7 @@ def solve(f, *symbols, **flags):
         return []
     f = newf
     del newf
-    
+
     # mask off any Object that we aren't going to invert: Derivative,
     # Integral, etc... so that solving for anything that they contain will
     # give an implicit solution
@@ -1663,9 +1663,9 @@ def _solve(f, *symbols, **flags):
             # in) so recast the poly in terms of our generator of interest.
             # Also use composite=True with f_num since Poly won't update
             # poly as documented in issue 8810.
-            
+
             poly = Poly(f_num, gens[0], composite=True)
-            
+
             # if we aren't on the tsolve-pass, use roots
             if not flags.pop('tsolve', False):
                 soln = None
@@ -3679,3 +3679,4 @@ def unrad(eq, *syms, **flags):
 
 from sympy.solvers.bivariate import (
     bivariate_type, _solve_lambert, _filtered_gens)
+    

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -999,7 +999,7 @@ def solve(f, *symbols, **flags):
 
         if fi.is_Relational:
             return reduce_inequalities(f, symbols=symbols)
-
+        
         if isinstance(fi, Poly):
             f[i] = fi.as_expr()
 
@@ -1030,7 +1030,7 @@ def solve(f, *symbols, **flags):
         if flags.get('set', False):
             return [], set()
         return []
-
+    
     for i, fi in enumerate(f):
         # Abs
         while True:
@@ -1045,7 +1045,7 @@ def solve(f, *symbols, **flags):
             if e.has(*symbols):
                 raise NotImplementedError('solving %s when the argument '
                     'is not real or imaginary.' % e)
-
+        
         # arg
         _arg = [a for a in fi.atoms(arg) if a.has(*symbols)]
         fi = fi.xreplace(dict(list(zip(_arg,
@@ -1053,7 +1053,7 @@ def solve(f, *symbols, **flags):
 
         # save changes
         f[i] = fi
-
+    
     # see if re(s) or im(s) appear
     irf = []
     for s in symbols:
@@ -1082,10 +1082,10 @@ def solve(f, *symbols, **flags):
 
     # we can solve for non-symbol entities by replacing them with Dummy symbols
     f, symbols, swap_sym = recast_to_symbols(f, symbols)
-
+    
     # this is needed in the next two events
     symset = set(symbols)
-
+    
     # get rid of equations that have no symbols of interest; we don't
     # try to solve them because the user didn't ask and they might be
     # hard to solve; this means that solutions may be given in terms
@@ -1124,7 +1124,7 @@ def solve(f, *symbols, **flags):
         return []
     f = newf
     del newf
-
+    
     # mask off any Object that we aren't going to invert: Derivative,
     # Integral, etc... so that solving for anything that they contain will
     # give an implicit solution
@@ -1663,9 +1663,9 @@ def _solve(f, *symbols, **flags):
             # in) so recast the poly in terms of our generator of interest.
             # Also use composite=True with f_num since Poly won't update
             # poly as documented in issue 8810.
-
+            
             poly = Poly(f_num, gens[0], composite=True)
-
+            
             # if we aren't on the tsolve-pass, use roots
             if not flags.pop('tsolve', False):
                 soln = None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The issue #8695 is resolved i.e 
Before the output of sqf_list was sometimes containing factors of same multiplicity, like in this case: 

```
 sqf_list(  (x**2 + 1)  * (x - 1)**2 * (x - 2)**3 * (x - 3)**3  )
 >>> (1, [(x**2 + 1, 1), (x - 1, 2), (x - 3, 3), (x - 2, 3)])
```
This issue is now resolved, now the output comes:
`>>> (1, [(x**2 + 1, 1), (x - 1, 2),(x  - 5⋅x + 6, 3)])
`
#### Other comments


#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
