### PR TITLE
Removed string_types from stats

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -16,7 +16,6 @@ from sympy.stats.stochastic_process import StochasticPSpace
 from sympy.stats.symbolic_probability import Probability, Expectation
 from sympy.stats.frv_types import Bernoulli, BernoulliDistribution
 from sympy.core.sympify import _sympify
-from sympy.core.compatibility import string_types
 
 __all__ = [
     'StochasticProcess',
@@ -71,7 +70,7 @@ def _sym_sympify(arg):
     The converted parameter.
 
     """
-    if isinstance(arg, string_types):
+    if isinstance(arg, str):
         return Symbol(arg)
     else:
         return _sympify(arg)
@@ -800,10 +799,10 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     Parameters
     ==========
 
-    sym: Symbol/string_types
-    success: Integer/string_types
+    sym: Symbol/str
+    success: Integer/str
             The event which is considered to be success, by default is 1.
-    failure: Integer/string_types
+    failure: Integer/str
             The event which is considered to be failure, by default is 0.
     p: Real Number between 0 and 1
             Represents the probability of getting success.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
This should probably fix the current build failure on `master`. A commit before the merging of https://github.com/sympy/sympy/pull/18173 removed `sympy.core.compatibility.string_types` and hence it wasn't reflected in https://github.com/sympy/sympy/pull/18173 's CI.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
