### PR TITLE
Fixed the way of creating trialset 

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1424,7 +1424,8 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         if r and not any(r[i].has(x) for i in r if i >= 0):
             # Inhomogeneous case: F(x) is not identically 0
             if r[-1]:
-                undetcoeff = _undetermined_coefficients_match(r[-1], x)
+                eq_homogeneous = Add(eq,-r[-1])
+                undetcoeff = _undetermined_coefficients_match(r[-1], x, func, eq_homogeneous)
                 s = "nth_linear_constant_coeff_variation_of_parameters"
                 matching_hints[s] = r
                 matching_hints[s + "_Integral"] = r
@@ -5039,7 +5040,8 @@ def ode_nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients(eq, func, o
     eq += e.subs(re)
 
     match = _nth_linear_match(eq, f(x), ode_order(eq, f(x)))
-    match['trialset'] = r['trialset']
+    eq_homogeneous = Add(eq,-match[-1])
+    match['trialset'] = _undetermined_coefficients_match(match[-1], x, func, eq_homogeneous)['trialset']
     return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
 
 
@@ -5718,51 +5720,14 @@ def _solve_undetermined_coefficients(eq, func, order, match):
     gensols = r['list']
     gsol = r['sol']
     trialset = r['trialset']
-    notneedset = set([])
-    # XXX: This global collectterms hack should be removed.
-    global collectterms
     if len(gensols) != order:
         raise NotImplementedError("Cannot find " + str(order) +
         " solutions to the homogeneous equation necessary to apply" +
         " undetermined coefficients to " + str(eq) +
         " (number of terms != order)")
-    usedsin = set([])
-    mult = 0  # The multiplicity of the root
-    getmult = True
-    for i, reroot, imroot in collectterms:
-        if getmult:
-            mult = i + 1
-            getmult = False
-        if i == 0:
-            getmult = True
-        if imroot:
-            # Alternate between sin and cos
-            if (i, reroot) in usedsin:
-                check = x**i*exp(reroot*x)*cos(imroot*x)
-            else:
-                check = x**i*exp(reroot*x)*sin(abs(imroot)*x)
-                usedsin.add((i, reroot))
-        else:
-            check = x**i*exp(reroot*x)
-
-        if check in trialset:
-            # If an element of the trial function is already part of the
-            # homogeneous solution, we need to multiply by sufficient x to
-            # make it linearly independent.  We also don't need to bother
-            # checking for the coefficients on those elements, since we
-            # already know it will be 0.
-            while True:
-                if check*x**mult in trialset:
-                    mult += 1
-                else:
-                    break
-            trialset.add(check*x**mult)
-            notneedset.add(check)
-
-    newtrialset = trialset - notneedset
 
     trialfunc = 0
-    for i in newtrialset:
+    for i in trialset:
         c = next(coeffs)
         coefflist.append(c)
         trialfunc += c*i
@@ -5775,7 +5740,10 @@ def _solve_undetermined_coefficients(eq, func, order, match):
 
     for i in Add.make_args(eqs):
         s = separatevars(i, dict=True, symbols=[x])
-        coeffsdict[s[x]] += s['coeff']
+        if coeffsdict.get(s[x]):
+            coeffsdict[s[x]] += s['coeff']
+        else:
+            coeffsdict[s[x]] = s['coeff']
 
     coeffvals = solve(list(coeffsdict.values()), coefflist)
 
@@ -5790,7 +5758,7 @@ def _solve_undetermined_coefficients(eq, func, order, match):
     return Eq(f(x), gsol.rhs + psol)
 
 
-def _undetermined_coefficients_match(expr, x):
+def _undetermined_coefficients_match(expr, x, func=None, eq_homogeneous=S.Zero):
     r"""
     Returns a trial function match if undetermined coefficients can be applied
     to ``expr``, and ``None`` otherwise.
@@ -5922,6 +5890,11 @@ def _undetermined_coefficients_match(expr, x):
             exprs = tmpset
         return exprs
 
+    def is_homogeneous_solution(term):
+        r""" This function checks whether the given trialset contains any root
+             of homogenous equation"""
+        return expand(sub_func_doit(eq_homogeneous, func, term)).is_zero
+
     retdict['test'] = _test_term(expr, x)
     if retdict['test']:
         # Try to generate a list of trial solutions that will have the
@@ -5930,7 +5903,15 @@ def _undetermined_coefficients_match(expr, x):
         # then they will need to be multiplied by sufficient x to make them so.
         # This function DOES NOT do that (it doesn't even look at the
         # homogeneous equation).
-        retdict['trialset'] = _get_trial_set(expr, x)
+        temp_set = set([])
+        for i in Add.make_args(expr):
+            act = _get_trial_set(i,x)
+            if eq_homogeneous is not S.Zero:
+                while any(is_homogeneous_solution(ts) for ts in act):
+                    act = {x*ts for ts in act}
+            temp_set = temp_set.union(act)
+
+        retdict['trialset'] = temp_set
 
     return retdict
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3796,3 +3796,35 @@ def test_issue_15889():
     sol = Eq(f(x), 4/(C1**2 + 2*C1*x + x**2))
     assert sol == dsolve(eq, hint='lie_group')
     assert checkodesol(eq, sol) == (True, 0)
+
+
+def test_issue_5096():
+    eq = f(x).diff(x, x) + f(x) - x*sin(x - 2)
+    sol = Eq(f(x), C1*sin(x) + C2*cos(x) - x**2*cos(x - 2)/4 + x*sin(x - 2)/4)
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = f(x).diff(x, 2) + f(x) - x**4*sin(x-1)
+    sol = Eq(f(x), C1*sin(x) + C2*cos(x) - x**5*cos(x - 1)/10 + x**4*sin(x - 1)/4 + x**3*cos(x - 1)/2 - 3*x**2*sin(x - 1)/4 - 3*x*cos(x - 1)/4)
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = f(x).diff(x, 2) - f(x) - exp(x - 1)
+    sol = Eq(f(x), C1*exp(-x) + C2*exp(x) + x*exp(x - 1)/2)
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = f(x).diff(x, 2)+f(x)-(sin(x-2)+1)
+    sol = Eq(f(x), C1*sin(x) + C2*cos(x) - x*cos(x - 2)/2 + 1)
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = 2*x**2*f(x).diff(x, 2) + f(x) + sqrt(2*x)*sin(log(2*x)/2)
+    sol = Eq(f(x), sqrt(x)*(C1*sin(log(x)/2) + C2*cos(log(x)/2) + sqrt(2)*log(x)*cos(log(2*x)/2)/2))
+    assert sol == dsolve(eq, hint='nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = 2*x**2*f(x).diff(x, 2) + f(x) + sin(log(2*x)/2)
+    sol = Eq(f(x), C1*sqrt(x)*sin(log(x)/2) + C2*sqrt(x)*cos(log(x)/2) - 2*sin(log(2*x)/2)/5 - 4*cos(log(2*x)/2)/5)
+    assert sol == dsolve(eq, hint='nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #5096 


#### Brief description of what is fixed or changed
Currently the trial set included linear dependent solution which were part of complimentary solutions,now the function `_undeterminant_coefficient_match` has been modified to generate linearly independent trialset.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  *  Fixed `dsolve` for some cases of linear non-homogeneous ODEs when using the method of undetermined coefficients.
<!-- END RELEASE NOTES -->
