### PR TITLE
Added factor method to FiniteSet (Non expr class)

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1763,7 +1763,9 @@ class FiniteSet(Set, EvalfMixin):
     is_empty = False
     is_finite_set = True
     def factor(self, *gens, **args): 
-        """See the factor() function in sympy.polys.polytools""" 
+        """
+        See the factor() function in sympy.polys.polytools
+        """ 
         from sympy.polys import factor 
         return factor(self, *gens, **args)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1771,7 +1771,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [fctr(v, *args, **kwargs) * k for
+        fctr_components = [factor(v, *args, **kwargs) * k for
                            k, v in self.components.items()]
         return self._add_func(*fctr_components)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1762,7 +1762,11 @@ class FiniteSet(Set, EvalfMixin):
     is_iterable = True
     is_empty = False
     is_finite_set = True
-
+    def factor(self, *gens, **args): 
+        """See the factor() function in sympy.polys.polytools""" 
+        from sympy.polys import factor 
+        return factor(self, *gens, **args)
+   
     def factor(self, *args, **kwargs):
         from sympy.polys import factor as fctr
         """

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1772,8 +1772,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [fctr(v, *args, **kwargs) * k for
-                           k, v in self.components.items()]
+        fctr_components = [fctr(v, *args, **kwargs) * k for k, v in self.components.items()]
         return self._add_func(*fctr_components)
     
     def __new__(cls, *args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -27,7 +27,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
-
+from sympy.vector.basisdependent import BasisDependent.factor as fctr
 
 tfn = defaultdict(lambda: None, {
     True: S.true,

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1763,8 +1763,8 @@ class FiniteSet(Set, EvalfMixin):
     is_empty = False
     is_finite_set = True
 
-    def factor(self, *gens, **args): 
-        from sympy.polys import factor 
+    def factor(self, *gens, **args):
+        from sympy.polys import factor
         return factor(self, *gens, **args)
 
     def __new__(cls, *args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -27,7 +27,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
-from sympy.polys import factor
+from sympy.vector.basisdependent import factor
 
 tfn = defaultdict(lambda: None, {
     True: S.true,

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1766,18 +1766,6 @@ class FiniteSet(Set, EvalfMixin):
         """See the factor() function in sympy.polys.polytools""" 
         from sympy.polys import factor 
         return factor(self, *gens, **args)
-   
-    def factor(self, *args, **kwargs):
-        from sympy.polys import factor as fctr
-        """
-        Implements the SymPy factor routine, on the scalar parts
-        of a basis-dependent expression.
-        factor's documentation
-        ========================
-        """
-        fctr_components = [fctr(v, *args, **kwargs) * k for
-                           k, v in self.components.items()]
-        return self._add_func(*fctr_components)
     
     def __new__(cls, *args, **kwargs):
         evaluate = kwargs.get('evaluate', global_parameters.evaluate)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1765,6 +1765,17 @@ class FiniteSet(Set, EvalfMixin):
     is_empty = False
     is_finite_set = True
 
+    def factor(self, *args, **kwargs):
+        """
+        Implements the SymPy factor routine, on the scalar parts
+        of a basis-dependent expression.
+        factor's documentation
+        ========================
+        """
+        fctr_components = [fctr(v, *args, **kwargs) * k for
+                           k, v in self.components.items()]
+        return self._add_func(*fctr_components)
+    
     def __new__(cls, *args, **kwargs):
         evaluate = kwargs.get('evaluate', global_parameters.evaluate)
         if evaluate:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -27,7 +27,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
-from sympy.vector.basisdependent import factor as fctr
+from sympy.polys import factor
 
 tfn = defaultdict(lambda: None, {
     True: S.true,
@@ -1771,7 +1771,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [fctr(v, *args, **kwargs) * k for
+        fctr_components = [factor(v, *args, **kwargs) * k for
                            k, v in self.components.items()]
         return self._add_func(*fctr_components)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1771,7 +1771,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [factor(v, *args, **kwargs) * k for
+        fctr_components = [fctr(v, *args, **kwargs) * k for
                            k, v in self.components.items()]
         return self._add_func(*fctr_components)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1762,11 +1762,11 @@ class FiniteSet(Set, EvalfMixin):
     is_iterable = True
     is_empty = False
     is_finite_set = True
-    
+
     def factor(self, *gens, **args): 
         from sympy.polys import factor 
         return factor(self, *gens, **args)
-    
+
     def __new__(cls, *args, **kwargs):
         evaluate = kwargs.get('evaluate', global_parameters.evaluate)
         if evaluate:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -26,7 +26,7 @@ from sympy.utilities import subsets
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
-
+from sympy import factor as fctr
 from mpmath import mpi, mpf
 
 
@@ -1772,7 +1772,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [fctr(v, *args, **kwargs) * k for k, v in self.components.items()]
+        fctr_components = [fctr(v, *args, **kwargs) *k for k, v in self.components.items()]
         return self._add_func(*fctr_components)
     
     def __new__(cls, *args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1762,10 +1762,8 @@ class FiniteSet(Set, EvalfMixin):
     is_iterable = True
     is_empty = False
     is_finite_set = True
+    
     def factor(self, *gens, **args): 
-        """
-        See the factor() function in sympy.polys.polytools
-        """ 
         from sympy.polys import factor 
         return factor(self, *gens, **args)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -27,7 +27,6 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
-from sympy.vector.basisdependent import factor
 
 tfn = defaultdict(lambda: None, {
     True: S.true,
@@ -1765,13 +1764,14 @@ class FiniteSet(Set, EvalfMixin):
     is_finite_set = True
 
     def factor(self, *args, **kwargs):
+        from sympy.polys import factor as fctr
         """
         Implements the SymPy factor routine, on the scalar parts
         of a basis-dependent expression.
         factor's documentation
         ========================
         """
-        fctr_components = [factor(v, *args, **kwargs) * k for
+        fctr_components = [fctr(v, *args, **kwargs) * k for
                            k, v in self.components.items()]
         return self._add_func(*fctr_components)
     

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1771,7 +1771,8 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [factor(v, *args, **kwargs) *k for k, v in self.components.items()]
+        fctr_components = [fctr(v, *args, **kwargs) * k for
+                           k, v in self.components.items()]
         return self._add_func(*fctr_components)
     
     def __new__(cls, *args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -26,7 +26,6 @@ from sympy.utilities import subsets
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
-from sympy import factor as fctr
 from mpmath import mpi, mpf
 
 
@@ -1772,7 +1771,7 @@ class FiniteSet(Set, EvalfMixin):
         factor's documentation
         ========================
         """
-        fctr_components = [fctr(v, *args, **kwargs) *k for k, v in self.components.items()]
+        fctr_components = [factor(v, *args, **kwargs) *k for k, v in self.components.items()]
         return self._add_func(*fctr_components)
     
     def __new__(cls, *args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -27,7 +27,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iproduct, sift, roundrobin
 from sympy.utilities.misc import func_name, filldedent
 from mpmath import mpi, mpf
-from sympy.vector.basisdependent import BasisDependent.factor as fctr
+from sympy.vector.basisdependent import factor as fctr
 
 tfn = defaultdict(lambda: None, {
     True: S.true,

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -3,7 +3,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
-    Matrix, Range, Add, symbols, zoo, Rational)
+    Matrix, Range, Add, symbols, zoo, Rational,factor)
 from mpmath import mpi
 
 from sympy.core.compatibility import range
@@ -1474,3 +1474,7 @@ def test_issue_16878b():
     # that handles the base_set of S.Reals like there is
     # for Integers
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
+def test_issue_18064():
+    # In FiniteSet Class there is no method called factor
+    s = FiniteSet(x**2 + x)
+    assert s.factor() == factor(s)


### PR DESCRIPTION
I have added factor method as mentioned in the issue #18064

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



#### References to other Issues or PRs
fixes #18064 
#### Brief description of what is fixed or changed
Added factor method to FiniteSet (Non expr class)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   sets
     *  Added `factor` method to `FiniteSet` (Non expr class)
<!-- END RELEASE NOTES -->
