### PR TITLE
New NumPyMatrix which uses NumPy methods

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -190,7 +190,7 @@ from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         Adjoint, hadamard_product, HadamardProduct, HadamardPower,
         Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
         DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
-        PermutationMatrix, MatrixPermute)
+        PermutationMatrix, MatrixPermute, NumPyMatrix)
 
 from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         Segment2D, Ray2D, Line3D, Segment3D, Ray3D, Plane, Ellipse, Circle,
@@ -424,7 +424,7 @@ __all__ = [
     'HadamardPower', 'Determinant', 'det', 'diagonalize_vector', 'DiagMatrix',
     'DiagonalMatrix', 'DiagonalOf', 'trace', 'DotProduct',
     'kronecker_product', 'KroneckerProduct', 'PermutationMatrix',
-    'MatrixPermute',
+    'MatrixPermute', 'NumPyMatrix',
 
     # sympy.geometry
     'Point', 'Point2D', 'Point3D', 'Line', 'Ray', 'Segment', 'Line2D',

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -11,6 +11,7 @@ from .dense import (
     zeros)
 from .dense import MutableDenseMatrix
 from .matrices import DeferredVector, MatrixBase
+from .numpy import NumPyMatrix
 
 Matrix = MutableMatrix = MutableDenseMatrix
 

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -53,6 +53,8 @@ __all__ = [
 
     'ImmutableMatrix', 'SparseMatrix',
 
+    'NumPyMatrix',
+
     'MatrixSlice', 'BlockDiagMatrix', 'BlockMatrix', 'FunctionMatrix',
     'Identity', 'Inverse', 'MatAdd', 'MatMul', 'MatPow', 'MatrixExpr',
     'MatrixSymbol', 'Trace', 'Transpose', 'ZeroMatrix', 'OneMatrix',

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2505,6 +2505,9 @@ class _MinimalMatrix(object):
 
     is_Matrix = True
     is_MatrixExpr = False
+    is_mutable = None
+    is_sparse = None
+
 
     @classmethod
     def _new(cls, *args, **kwargs):
@@ -2598,6 +2601,8 @@ class _MatrixWrapper(object):
     matrix in a MatrixWrapper allows it to be passed to CommonMatrix.
     """
     is_MatrixLike = True
+    is_mutable = False
+    is_sparse = None
 
     def __init__(self, mat, shape=None):
         self.mat = mat

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -37,11 +37,9 @@ def _compare_sequence(a, b):
     return tuple(a) == tuple(b)
 
 class DenseMatrix(MatrixBase):
-
-    is_MatrixExpr = False
-
-    _op_priority = 10.01
+    _op_priority    = 10.01
     _class_priority = 4
+    is_MatrixExpr   = False
 
     def __eq__(self, other):
         other = sympify(other)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -40,6 +40,7 @@ class DenseMatrix(MatrixBase):
     _op_priority    = 10.01
     _class_priority = 4
     is_MatrixExpr   = False
+    is_sparse       = False
 
     def __eq__(self, other):
         other = sympify(other)
@@ -421,6 +422,8 @@ def _force_mutable(x):
 
 
 class MutableDenseMatrix(DenseMatrix, MatrixBase):
+    is_mutable = True
+
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -14,6 +14,8 @@ def sympify_matrix(arg):
 sympify_converter[MatrixBase] = sympify_matrix
 
 class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
+    is_mutable = False
+
     """Create an immutable version of a matrix.
 
     Examples
@@ -154,6 +156,7 @@ class ImmutableSparseMatrix(SparseMatrix, Basic):
     """
     is_Matrix = True
     _class_priority = 9
+    is_mutable = False
 
     @classmethod
     def _new(cls, *args, **kwargs):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2515,7 +2515,7 @@ class MatrixBase(MatrixDeprecated,
     _class_priority    = 3
     is_Matrix          = True
     is_mutable         = None
-    is_sparse          = False
+    is_sparse          = None
     zero               = S.Zero
     one                = S.One
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1258,7 +1258,7 @@ class MatrixSubspaces(MatrixReductions):
         for vec in vecs:
             perp = perp_to_subspace(vec, ret)
             if not perp.is_zero:
-                ret.append(perp)
+                ret.append(cls(perp))
             elif rankcheck is True:
                 raise ValueError(
                     "GramSchmidt: vector set not linearly independent")
@@ -2510,15 +2510,16 @@ class MatrixBase(MatrixDeprecated,
                  MatrixEigen,
                  MatrixCommon):
     """Base class for matrix objects."""
-    # Added just for numpy compatibility
-    __array_priority__ = 11
 
-    is_Matrix = True
-    _class_priority = 3
+    __array_priority__ = 11 # added just for numpy compatibility
+    _class_priority    = 3
+    is_Matrix          = True
+    is_mutable         = None
+    is_sparse          = False
+    zero               = S.Zero
+    one                = S.One
+
     _sympify = staticmethod(sympify)
-    zero = S.Zero
-    one = S.One
-
     __hash__ = None  # Mutable
 
     # Defined here the same as on Basic.

--- a/sympy/matrices/numpy.py
+++ b/sympy/matrices/numpy.py
@@ -6,6 +6,7 @@ from sympy import Float
 from sympy.core.compatibility import default_sort_key
 from sympy.core.sympify import sympify
 from sympy.simplify import nsimplify
+from sympy.utilities.decorator import doctest_depends_on
 
 from .common import NonSquareMatrixError
 from .dense import MutableDenseMatrix
@@ -217,6 +218,7 @@ class NumPyMatrix(MutableDenseMatrix):
 
         return sympify(npl.matrix_rank(self._arr))
 
+    @doctest_depends_on(modules=('numpy',))
     def eigenvals(self, *args, multiple=False, rational=True, **kwargs):
         """Returns the eigenvalues of the matrix using ``numpy.linalg.eigvals``.
 
@@ -254,6 +256,7 @@ class NumPyMatrix(MutableDenseMatrix):
         else:
             return [simpfunc(v) for v in evals]
 
+    @doctest_depends_on(modules=('numpy',))
     def eigenvects(self, *args, rational=True, **kwargs):
         """Returns the eigenvalues and eigenvectors of the matrix using
         ``numpy.linalg.eigv``.

--- a/sympy/matrices/numpy.py
+++ b/sympy/matrices/numpy.py
@@ -7,7 +7,7 @@ from sympy.core.compatibility import default_sort_key
 from sympy.core.sympify import sympify
 from sympy.simplify import nsimplify
 
-from .common import MatrixError, NonSquareMatrixError
+from .common import NonSquareMatrixError
 from .dense import MutableDenseMatrix
 
 _TOLERANCE   = 1e-13 # tolerance for nsympify rationalization

--- a/sympy/matrices/numpy.py
+++ b/sympy/matrices/numpy.py
@@ -2,40 +2,71 @@ from __future__ import division, print_function
 
 from collections import Counter
 
-from sympy import Float
+from mpmath import mpf, mpc
+
+from sympy import Integer, Float, Rational
 from sympy.core.compatibility import default_sort_key
+from sympy.core.decorators import call_highest_priority
 from sympy.core.sympify import sympify
 from sympy.simplify import nsimplify
 from sympy.utilities.decorator import doctest_depends_on
 
-from .common import NonSquareMatrixError
+from .common import ShapeError, NonSquareMatrixError
 from .dense import MutableDenseMatrix
 
+
+def _is_integer(v):
+    if isinstance(v, (int, Integer)):
+        return True
+    if isinstance(v, str):
+        return False
+
+    try:
+        if int(v) == v:
+            return True
+    except (TypeError, ValueError):
+        pass
+
+    return False
+
+def _is_scalar(v):
+    if isinstance(v, (int, float, complex, mpf, mpc, Integer, Float, Rational)):
+        return True
+    if isinstance(v, str):
+        return False
+
+    try:
+        complex(v)
+    except (TypeError, ValueError):
+        return False
+
+    return True
 
 def _detect_dtype(l): # Is there a better way to do this?
     import numpy as np
 
     try:
-        f = [float(e) for e in l]
-    except TypeError: # complex or symbolic source
+        [float(e) for e in l]
+    except (TypeError, ValueError): # complex or symbolic source
         pass
 
     else:
         try:
             i = [int(e) for e in l]
-        except TypeError: # have infinities and/or nans
+        except (TypeError, ValueError): # have infinities and/or nans
             return np.float64
 
         else:
-            if any(isinstance(e, Float) for e in l) or i != f:
+            if any(isinstance(e, Float) for e in l) or \
+                    any(i != e for i, e in zip(i, l)):
                 return np.float64 # this also catches integers which are too big
             else:
                 return np.int64
 
     try:
-        all(complex(e) for e in l)
-    except TypeError: # non-numeric source data
-        raise TypeError('source data for NumPyMatrix must be numeric') from None
+        [complex(e) for e in l]
+    except (TypeError, ValueError): # non-numeric source data
+        return None
 
     return np.complex128
 
@@ -45,7 +76,8 @@ class NumPyMatrix(MutableDenseMatrix):
     matrix) for use in SymPy. Dispatches supported operations for faster
     execution to NumPy."""
 
-    _class_priority       = 2
+    _op_priority          = 10.0005 # above Expr but below other matrix types
+    _class_priority       = 2 # above _MatrixWrapper but below other matrix types
     _NDArrayFlatSympified = None
 
     # Wraps creation of a single NDArrayFlatSympified class to defer importing
@@ -63,7 +95,8 @@ class NumPyMatrix(MutableDenseMatrix):
             elements is required, such as ``M._mat``."""
 
             def __new__(cls, src):
-                return np.ndarray.__new__(cls, src.size, dtype=src.dtype, buffer=src)
+                return np.ndarray.__new__(cls, src.size, dtype=src.dtype,
+                        buffer=src)
 
             def __getitem__(self, key):
                 return sympify(np.ndarray.__getitem__(self, key))
@@ -102,7 +135,9 @@ class NumPyMatrix(MutableDenseMatrix):
             existing large NumPy matrices, otherwise a copy is always
             performed. If you specify ``copy=False`` for source data which is
             not an ``ndarray`` then the flag will be ignored and the data will
-            be copied anyway. Defaults to ``True``.
+            be copied anyway. If the source data is not numeric then a
+            ``MutableDenseMatrix`` will be created regardless of the ``copy``
+            flag. Defaults to ``True``.
         """
 
         import numpy as np
@@ -119,7 +154,7 @@ class NumPyMatrix(MutableDenseMatrix):
                 if not isinstance(view_arr, np.ndarray):
                     copy, view_arr = True, None
                 elif len(view_arr.shape) != 2:
-                    raise TypeError("'copy=False' for NumPyMatrix without rows and cols specified requires 2D NumPy matrix as source")
+                    raise TypeError("'copy=False' for NumPyMatrix without rows and cols specified requires 2D source NumPy ndarray")
                 else:
                     rows, cols = view_arr.shape
 
@@ -133,42 +168,54 @@ class NumPyMatrix(MutableDenseMatrix):
                 raise TypeError("'copy=False' requires a matrix be initialized as rows, cols, [list]")
 
             if copy is False:
+                if not issubclass(view_arr.dtype.type, np.number):
+                    raise TypeError("'copy=False' for NumPyMatrix with non-numeric source NumPy ndarray not allowed")
                 if dtype is not None and dtype != view_arr.dtype:
-                    raise TypeError("'copy=False' for NumPyMatrix with 'dtype' requires 'dtype' to match source NumPy matrix")
+                    raise TypeError("'copy=False' for NumPyMatrix with 'dtype' requires 'dtype' to match source NumPy ndarray")
 
                 if isinstance(view_arr, np.matrix):
-                    view_arr = np.ndarray(view_arr.shape, dtype=view_arr.dtype, buffer=view_arr)
+                    view_arr = np.ndarray(view_arr.shape, dtype=view_arr.dtype,
+                            buffer=view_arr)
 
         if copy is True:
             if len(args) == 1 and isinstance(args[0], np.ndarray):
-                if dtype is None:
+                if dtype is None and issubclass(args [0].dtype.type, np.number):
                     dtype = args[0].dtype
 
             elif len(args) == 3 and isinstance(args[2], np.ndarray):
-                if dtype is None:
+                if dtype is None and issubclass(args [2].dtype.type, np.number):
                     dtype = args[2].dtype
 
                 if len(args[2].shape) != 1:
-                    args = args[:2] + (np.ndarray(args[2].size, dtype=args[2].dtype, buffer=args[2]),)
+                    args = args[:2] + (np.ndarray(args[2].size,
+                            dtype=args[2].dtype, buffer=args[2]),)
 
             rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
-
-        self      = object.__new__(cls)
-        self.rows = rows
-        self.cols = cols
 
         if view_arr is None:
             if dtype is None:
                 dtype = _detect_dtype(flat_list)
 
+                if dtype is None:
+                    if copy is True:
+                        return MutableDenseMatrix(*args, copy=copy, **kwargs)
+                    else:
+                        raise "'copy=False' for NumPyMatrix requires numeric source data"
+
             view_arr = np.array([flat_list[cols * r : cols * (r + 1)]
                     for r in range (rows)], dtype=dtype)
 
-        self.dtype = np.dtype(dtype)
+        self       = object.__new__(cls)
+        self.rows  = rows
+        self.cols  = cols
+        self.dtype = view_arr.dtype
         self._arr  = view_arr
         self._mat  = self.NDArrayFlatSympified(view_arr)
 
         return self
+
+
+    # basic operations
 
     def __array__(self, *args):
         import numpy as np
@@ -183,19 +230,162 @@ class NumPyMatrix(MutableDenseMatrix):
 
         return self._arr
 
-    def det(self, *args, **kwargs):
+    def __abs__(self):
+        return NumPyMatrix(self._arr.__abs__(), copy=False)
+
+    def __neg__(self):
+        return NumPyMatrix(self._arr.__neg__(), copy=False)
+
+    @call_highest_priority('__sub__')
+    def __rsub__(self, other):
+        return (-self).__add__(other)
+
+    @call_highest_priority('__rsub__')
+    def __sub__(self, other):
+        return self.__add__(-other)
+
+    @call_highest_priority('__add__')
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    @call_highest_priority('__radd__')
+    def __add__(self, other):
+        import numpy as np
+
+        if isinstance(other, NumPyMatrix):
+            other = other._arr
+        elif not isinstance(other, np.ndarray):
+            return super().__add__(other)
+
+        if self.shape != other.shape:
+            raise ShapeError("Matrix size mismatch: %s + %s" % (
+                self.shape, other.shape))
+
+        m = self._arr.__add__(other)
+
+        return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+    @call_highest_priority('__rmatmul__')
+    def __matmul__(self, other):
+        import numpy as np
+
+        if isinstance(other, (NumPyMatrix, np.ndarray)):
+            return self.__mul__(other)
+
+        return super().__matmul__(other)
+
+    @call_highest_priority('__rmul__')
+    def __mul__(self, other):
+        import numpy as np
+
+        if isinstance(other, NumPyMatrix):
+            other = other._arr
+
+        elif not isinstance(other, np.ndarray):
+            if _is_scalar(other):
+                m = self._arr.__mul__(other)
+
+                return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+            return MutableDenseMatrix(self).__mul__(other)
+
+        if self.cols != other.shape[0]:
+            raise ShapeError("Matrix size mismatch: %s * %s." % (
+                self.shape, other.shape))
+
+        m = self._arr.__matmul__(other)
+
+        return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+    @call_highest_priority('__matmul__')
+    def __rmatmul__(self, other):
+        import numpy as np
+
+        if isinstance(other, (NumPyMatrix, np.ndarray)):
+            return self.__rmul__(other)
+
+        return super().__rmatmul__(other)
+
+    @call_highest_priority('__mul__')
+    def __rmul__(self, other):
+        import numpy as np
+
+        if isinstance(other, NumPyMatrix):
+            other = other._arr
+
+        elif not isinstance(other, np.ndarray):
+            if _is_scalar(other):
+                m = self._arr.__rmul__(other)
+
+                return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+            return MutableDenseMatrix(self).__rmul__(other)
+
+        if self.rows != other.shape[1]:
+            raise ShapeError("Matrix size mismatch: %s * %s." % (
+                other.shape, self.shape))
+
+        m = self._arr.__rmatmul__(other)
+
+        return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
+        return self.__div__(other)
+
+    @call_highest_priority('__rdiv__')
+    def __div__(self, other):
+        import numpy as np
+
+        if _is_scalar(other):
+            m = self._arr.__truediv__(other)
+
+            return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+        return MutableDenseMatrix(self).__div__(other)
+
+    @call_highest_priority('__rpow__')
+    def __pow__(self, other):
+        import numpy as np
         import numpy.linalg as npl
 
         if not self.is_square:
             raise NonSquareMatrixError()
 
-        if self.rows == 0:
-            return self.one
-            # sympy/matrices/tests/test_matrices.py contains a test that
-            # suggests that the determinant of a 0 x 0 matrix is one, by
-            # convention.
+        if _is_integer(other):
+            m = npl.linalg.matrix_power(self._arr, int(other))
 
-        return sympify(npl.det(self._arr))
+            return NumPyMatrix(m, copy=not issubclass(m.dtype.type, np.number))
+
+        if _is_scalar(other):
+            return super().__pow__(other)
+
+        return MutableDenseMatrix(self).__pow__(other)
+
+
+    # housekeeping functions
+
+    def as_mutable(self):
+        """Returns a mutable version of this matrix, basically a copy since all
+        NumPy matrices are mutable."""
+
+        return NumPyMatrix(self)
+
+
+    # higher level functions
+
+    def det(self, *args, **kwargs):
+        """Returns the determinant of this matrix using ``numpy.linalg.det``.
+        This determinant may be imprecise for floating point or complex matrices
+        but will always be precise for integer matrices (up to the limit of
+        integer overflow where it will become an imprecise float)."""
+
+        import numpy.linalg as npl
+
+        if not self.is_square:
+            raise NonSquareMatrixError()
+
+        return nsimplify(npl.det(self._arr), full=True)
 
     det_bareiss   = det
     det_berkowitz = det

--- a/sympy/matrices/numpy.py
+++ b/sympy/matrices/numpy.py
@@ -1,15 +1,11 @@
 from __future__ import division, print_function
 
-from collections import Counter
-
 from mpmath import mpf, mpc
 
 from sympy import Integer, Float, Rational
-from sympy.core.compatibility import default_sort_key
 from sympy.core.decorators import call_highest_priority
 from sympy.core.sympify import sympify
 from sympy.simplify import nsimplify
-from sympy.utilities.decorator import doctest_depends_on
 
 from .common import ShapeError, NonSquareMatrixError
 from .dense import MutableDenseMatrix
@@ -200,7 +196,7 @@ class NumPyMatrix(MutableDenseMatrix):
                     if copy is True:
                         return MutableDenseMatrix(*args, copy=copy, **kwargs)
                     else:
-                        raise "'copy=False' for NumPyMatrix requires numeric source data"
+                        raise TypeError("'copy=False' for NumPyMatrix requires numeric source data")
 
             view_arr = np.array([flat_list[cols * r : cols * (r + 1)]
                     for r in range (rows)], dtype=dtype)

--- a/sympy/matrices/numpy.py
+++ b/sympy/matrices/numpy.py
@@ -1,0 +1,305 @@
+from __future__ import division, print_function
+
+from collections import Counter
+
+from sympy import Float
+from sympy.core.compatibility import default_sort_key
+from sympy.core.sympify import sympify
+from sympy.simplify import nsimplify
+
+from .common import MatrixError, NonSquareMatrixError
+from .dense import MutableDenseMatrix
+
+_TOLERANCE   = 1e-13 # tolerance for nsympify rationalization
+_TOLERANCEIM = 1e-6 # much lower tolerance for truncating imaginaries to reals, set to 1e-5 if numerical errors persist
+
+
+def _truncim(x): # truncate very small imaginary component to real
+    return x if abs(x.imag) >= _TOLERANCEIM else x.real
+
+def _fsimplify(x):
+    return nsimplify(_truncim(x), rational=True, tolerance=_TOLERANCE)
+
+
+def _detect_dtype(l): # Is there a better way to do this?
+    import numpy as np
+
+    try:
+        f = [float(e) for e in l]
+    except TypeError: # complex or symbolic source
+        pass
+
+    else:
+        try:
+            i = [int(e) for e in l]
+        except TypeError: # have infinities and/or nans
+            return np.float64
+
+        else:
+            if any(isinstance(e, Float) for e in l) or i != f:
+                return np.float64
+            else:
+                return np.int64
+
+    try:
+        all(complex(e) for e in l)
+    except TypeError: # non-numeric source data
+        raise TypeError('source data for NumPyMatrix must be numeric') from None
+
+    return np.complex128
+
+
+class NumPyMatrix(MutableDenseMatrix):
+    """Matrix class which can wrap or create a new NumPy matrix (ndarray or
+    matrix) for use in SymPy. Dispatches supported operations for faster
+    execution to NumPy."""
+
+    _class_priority       = 2
+    _NDArrayFlatSympified = None
+
+    # Wraps creation of a single NDArrayFlatSympified class to defer importing
+    # numpy until it is needed.
+    @property
+    def NDArrayFlatSympified(self):
+        if NumPyMatrix._NDArrayFlatSympified:
+            return NumPyMatrix._NDArrayFlatSympified
+
+        import numpy as np
+
+        class NDArrayFlatSympified(np.ndarray):
+            """Creates a view on an existing ``numpy.ndarray`` which sympifies
+            all element reads so it can be used anywhere a sympified list of
+            elements is required, such as ``M._mat``."""
+
+            def __new__(cls, src):
+                return np.ndarray.__new__(cls, src.size, dtype=src.dtype, buffer=src)
+
+            def __getitem__(self, key):
+                return sympify(np.ndarray.__getitem__(self, key))
+
+        NumPyMatrix._NDArrayFlatSympified = NDArrayFlatSympified
+
+        return NumPyMatrix._NDArrayFlatSympified
+
+    @classmethod
+    def _new(cls, *args, dtype=None, copy=True, **kwargs):
+        """Create a new NumPy store backed numeric matrix with either a new
+        NumPy ``ndarray`` for the data or by creating a view on an existing
+        ``ndarray``. If a view is being created on an existing ``ndarray`` then
+        the dimensions can be reshaped by passing the new ``rows`` and ``cols``
+        as long as the total number of elements remains the same.
+
+        Parameters
+        ==========
+
+        dtype : numpy.dtype, optional
+            This can be either a NumPy character dtype specification like
+            ``'f4'`` or a class like ``numpy.float32``. Also, a value of
+            ``None`` specifies that the type of matrix should be auto-detected
+            which will result in either an ``int``, a ``float`` or a ``complex``
+            matrix. Note that this could cause problems if you initially create
+            a matrix of integers then carry out an in-place operation which
+            results in floats or complexes. A value of ``True`` specifies the
+            maximal information data type be used which is currently
+            ``numpy.complex128``. Defaults to ``None``.
+
+        copy : bool, optional
+            Specifies whether the source data is to be copied or a view is
+            created for the data. This only makes sense when the source data is
+            a NumPy ``ndarray`` and the specified ``dtype`` is either ``None``
+            or matches the source array ``dtype``. This allows wrapping of
+            existing large NumPy matrices, otherwise a copy is always
+            performed. If you specify ``copy=False`` for source data which is
+            not an ``ndarray`` then the flag will be ignored and the data will
+            be copied anyway. Defaults to ``True``.
+        """
+
+        import numpy as np
+
+        if dtype is True:
+            dtype = np.complex128
+
+        view_arr = None
+
+        if copy is False:
+            if len(args) == 1:
+                view_arr = args[0]
+
+                if not isinstance(view_arr, np.ndarray):
+                    copy, view_arr = True, None
+                elif len(view_arr.shape) != 2:
+                    raise TypeError("'copy=False' for NumPyMatrix without rows and cols specified requires 2D NumPy matrix as source")
+                else:
+                    rows, cols = view_arr.shape
+
+            elif len(args) == 3:
+                rows, cols, view_arr = args
+
+                if not isinstance(view_arr, np.ndarray):
+                    copy, view_arr = True, None
+
+            else:
+                raise TypeError("'copy=False' requires a matrix be initialized as rows, cols, [list]")
+
+            if copy is False:
+                if dtype is not None and dtype != view_arr.dtype:
+                    raise TypeError("'copy=False' for NumPyMatrix with 'dtype' requires 'dtype' to match source NumPy matrix")
+
+                if isinstance(view_arr, np.matrix):
+                    view_arr = np.ndarray(view_arr.shape, dtype=view_arr.dtype, buffer=view_arr)
+
+        if copy is True:
+            if len(args) == 1 and isinstance(args[0], np.ndarray):
+                if dtype is None:
+                    dtype = args[0].dtype
+
+            elif len(args) == 3 and isinstance(args[2], np.ndarray):
+                if dtype is None:
+                    dtype = args[2].dtype
+
+                if len(args[2].shape) != 1:
+                    args = args[:2] + (np.ndarray(args[2].size, dtype=args[2].dtype, buffer=args[2]),)
+
+            rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
+
+        self      = object.__new__(cls)
+        self.rows = rows
+        self.cols = cols
+
+        if view_arr is None:
+            if dtype is None:
+                dtype = _detect_dtype(flat_list)
+
+            view_arr = np.array([flat_list[cols * r : cols * (r + 1)]
+                    for r in range (rows)], dtype=dtype)
+
+        self.dtype = np.dtype(dtype)
+        self._arr  = view_arr
+        self._mat  = self.NDArrayFlatSympified(view_arr)
+
+        return self
+
+    def __array__(self, *args):
+        import numpy as np
+
+        if len(args) > 1:
+            raise TypeError('__array__() takes at most 1 argument (%d given)' % len(args))
+
+        dtype = np.dtype(args[0]) if args else self.dtype
+
+        if dtype != self.dtype:
+            return np.array(self._arr, dtype)
+
+        return self._arr
+
+    def det(self, *args, **kwargs):
+        import numpy.linalg as npl
+
+        if not self.is_square:
+            raise NonSquareMatrixError()
+
+        if self.rows == 0:
+            return self.one
+            # sympy/matrices/tests/test_matrices.py contains a test that
+            # suggests that the determinant of a 0 x 0 matrix is one, by
+            # convention.
+
+        return sympify(npl.det(self._arr))
+
+    det_bareiss   = det
+    det_berkowitz = det
+    det_LU        = det
+
+    def rank(self, *args, **kwargs):
+        """Returns the rank of the matrix using ``numpy.linalg.matrix_rank``."""
+
+        import numpy.linalg as npl
+
+        return sympify(npl.matrix_rank(self._arr))
+
+    def eigenvals(self, *args, multiple=False, rational=True, **kwargs):
+        """Returns the eigenvalues of the matrix using ``numpy.linalg.eigvals``.
+
+        Parameters
+        ==========
+
+        rational : bool, optional
+            When ``True`` (default) this will convert the numerical values
+            returned from NumPy to rationals and truncate imaginary values
+            towards zero below a certain threshold. This is necessary because
+            of numerical inaccuracies which will cause numpy to calculate
+            eigenvalues which are very close to one another giving the matrix an
+            incorrect algebraic multiplicity. When ``False`` the results of
+            ``numpy.linalg.eigvals`` are returned as is in all their numerically
+            inaccurate glory.
+
+        Examples
+        ========
+
+        >>> from sympy import NumPyMatrix
+        >>> M = NumPyMatrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
+        >>> M.eigenvals()
+        {-2: 1, 2: 3}
+        >>> M.eigenvals(rational=False)
+        {-2.0: 1, 2.0: 1, 2.0 - 7.26128422749622e-8*I: 1, 2.0 + 7.26128422749622e-8*I: 1}
+        """
+
+        import numpy.linalg as npl
+
+        evals    = npl.eigvals(self._arr)
+        simpfunc = _fsimplify if rational else sympify
+
+        if not multiple:
+            return {k: v for k, v in Counter(simpfunc(ev) for ev in evals).items()}
+        else:
+            return [simpfunc(v) for v in evals]
+
+    def eigenvects(self, *args, rational=True, **kwargs):
+        """Returns the eigenvalues and eigenvectors of the matrix using
+        ``numpy.linalg.eigv``.
+
+        Parameters
+        ==========
+
+        rational : bool, optional
+            When ``True`` (default) this will convert the numerical values
+            returned from NumPy for the eigenvalues to rationals and truncate
+            imaginary values towards zero below a certain threshold. This is
+            necessary because of numerical inaccuracies which will cause numpy
+            to calculate eigenvalues which are very close to one another giving
+            the matrix an incorrect algebraic multiplicity. When ``False`` the
+            eigenvalues from ``numpy.linalg.eig`` used as is and may return
+            incorrect algebraic and geometric multiplicities.
+
+        Examples
+        ========
+
+        >>> from sympy import NumPyMatrix
+        >>> M = NumPyMatrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
+        >>> ev = M.eigenvects()
+        >>> len(ev), sum(len(e[2]) for e in ev)
+        (2, 3)
+        >>> ev = M.eigenvects(rational=False)
+        >>> len(ev), sum(len(e[2]) for e in ev)
+        (4, 4)
+        """
+
+        import numpy.linalg as npl
+
+        ret          = {}
+        evals, evecs = npl.eig(self._arr)
+        simpfunc     = _fsimplify if rational else sympify
+
+        for i, eval in enumerate(evals):
+            eval    = simpfunc(eval)
+            eig     = ret.setdefault(eval, [eval, 0, []])
+            ev      = evecs[:, i]
+            eig[1] += 1
+
+            for ev2 in eig[2]: # reject colinear eigenvectors
+                if abs(abs(ev.dot(ev2._arr)[0]) - 1) < _TOLERANCE:
+                    break
+            else:
+                eig[2].append(NumPyMatrix(ev))
+
+        return [(v, m, es) for v, m, es in sorted(ret.values(), key=default_sort_key)]

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -108,6 +108,8 @@ class SparseMatrix(MatrixBase):
     ImmutableSparseMatrix
     """
 
+    is_sparse = True
+
     def __new__(cls, *args, **kwargs):
         self = object.__new__(cls)
         if len(args) == 1 and isinstance(args[0], SparseMatrix):
@@ -987,6 +989,8 @@ class SparseMatrix(MatrixBase):
 
 
 class MutableSparseMatrix(SparseMatrix, MatrixBase):
+    is_mutable = True
+
     @classmethod
     def _new(cls, *args, **kwargs):
         return cls(*args)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -11,7 +11,8 @@ from sympy.matrices import (
     GramSchmidt, ImmutableMatrix, ImmutableSparseMatrix, Matrix,
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
-    rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix, MatrixSymbol)
+    rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
+    MutableSparseMatrix, MatrixSymbol)
 from sympy.core.compatibility import long, iterable, Hashable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -11,7 +11,8 @@ from sympy.matrices import (
     GramSchmidt, ImmutableMatrix, ImmutableSparseMatrix, Matrix,
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
-    rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix, MatrixSymbol)
+    rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
+    MutableSparseMatrix, MatrixSymbol)
 from sympy.core.compatibility import long, iterable, range, Hashable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -4145,3 +4146,16 @@ def test_issue_17827():
     raises(ValueError, lambda: C.elementary_row_op('n<->m', row1=2, row2=6))
     raises(ValueError, lambda: C.elementary_row_op('n->kn', row=7, k=2))
     raises(ValueError, lambda: C.elementary_row_op('n->n+km', row1=-1, row2=5, k=2))
+
+
+def test_is_mutable():
+    assert MutableDenseMatrix(0, 0, []).is_mutable is True
+    assert ImmutableDenseMatrix(0, 0, []).is_mutable is False
+    assert MutableSparseMatrix(0, 0, []).is_mutable is True
+    assert ImmutableSparseMatrix(0, 0, []).is_mutable is False
+
+def test_is_sparse():
+    assert MutableDenseMatrix(0, 0, []).is_sparse is False
+    assert ImmutableDenseMatrix(0, 0, []).is_sparse is False
+    assert MutableSparseMatrix(0, 0, []).is_sparse is True
+    assert ImmutableSparseMatrix(0, 0, []).is_sparse is True

--- a/sympy/matrices/tests/test_numpymatrix.py
+++ b/sympy/matrices/tests/test_numpymatrix.py
@@ -1,5 +1,5 @@
-from sympy import (Float, I, N, PurePoly, S, Symbol, oo, nan,
-    Matrix, NumPyMatrix as NPMatrix, NonSquareMatrixError, diag, eye)
+from sympy import (Float, I, N, PurePoly, S, Symbol, oo, nan, Matrix,
+    NumPyMatrix, NonSquareMatrixError, diag, eye)
 from sympy.matrices.matrices import MatrixError
 from sympy.testing.pytest import raises, XFAIL, skip
 
@@ -28,51 +28,51 @@ def test_creation():
     skipcheck()
 
     a = np.array([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(a)
+    M = NumPyMatrix(a)
     assert M == Matrix([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(3, 2, a)
+    M = NumPyMatrix(3, 2, a)
     assert M == Matrix([[1, 2], [3, 4], [5, 6]])
 
     a = np.array([[1, 2], [3, 4]], dtype='i4')
-    M = NPMatrix(a)
+    M = NumPyMatrix(a)
     assert M.dtype == np.int32
-    M = NPMatrix(a, dtype='f4')
+    M = NumPyMatrix(a, dtype='f4')
     assert M.dtype == np.float32
 
     m = np.matrix([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(m)
+    M = NumPyMatrix(m)
     assert M == Matrix([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(3, 2, m)
+    M = NumPyMatrix(3, 2, m)
     assert M == Matrix([[1, 2], [3, 4], [5, 6]])
 
     m = np.matrix([[1, 2, 3], [4, 5, 6]], dtype='i4')
-    M = NPMatrix(m)
+    M = NumPyMatrix(m)
     assert M.dtype == np.int32
-    M = NPMatrix(m, dtype='f4')
+    M = NumPyMatrix(m, dtype='f4')
     assert M.dtype == np.float32
 
 
 def test_detect_dtype():
     skipcheck()
 
-    assert NPMatrix([[1]]).dtype == np.int64
-    assert NPMatrix([[1.0]]).dtype == np.float64
-    assert NPMatrix([[oo]]).dtype == np.float64
-    assert NPMatrix([[nan]]).dtype == np.float64
-    assert NPMatrix([[I]]).dtype == np.complex128
+    assert NumPyMatrix([[1]]).dtype == np.int64
+    assert NumPyMatrix([[1.0]]).dtype == np.float64
+    assert NumPyMatrix([[oo]]).dtype == np.float64
+    assert NumPyMatrix([[nan]]).dtype == np.float64
+    assert NumPyMatrix([[I]]).dtype == np.complex128
 
 
 def test_as_wrapper():
     skipcheck()
 
     a = np.array([[1, 2], [3, 4]])
-    M = NPMatrix(a, copy=False)
+    M = NumPyMatrix(a, copy=False)
     assert M[0] == 1
     a[0, 0] = -1
     assert M[0] == -1
 
     m = np.matrix([[1, 2], [3, 4]])
-    M = NPMatrix(m, copy=False)
+    M = NumPyMatrix(m, copy=False)
     assert M[0] == 1
     m[0, 0] = -1
     assert M[0] == -1
@@ -82,13 +82,13 @@ def test_as_reshaping_wrapper():
     skipcheck()
 
     a = np.array([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(3, 2, a, copy=False)
+    M = NumPyMatrix(3, 2, a, copy=False)
     assert M == Matrix([[1, 2], [3, 4], [5, 6]])
     a[0, 0] = -1
     assert M[0] == -1
 
     m = np.matrix([[1, 2, 3], [4, 5, 6]])
-    M = NPMatrix(3, 2, m, copy=False)
+    M = NumPyMatrix(3, 2, m, copy=False)
     assert M == Matrix([[1, 2], [3, 4], [5, 6]])
     m[0, 0] = -1
     assert M[0] == -1
@@ -98,7 +98,7 @@ def test_array():
     skipcheck()
 
     a = np.array([[1, 2], [3, 4]])
-    M = NPMatrix(a, copy=False)
+    M = NumPyMatrix(a, copy=False)
     assert M.__array__() is a
     assert M.__array__('f4') is not a
 
@@ -106,53 +106,53 @@ def test_array():
 def test_adjugate():
     skipcheck()
 
-    M = NPMatrix(4, 4, [0, 1, 2, 3, 4, 5, 6, 7, 2, 9, 10, 11, 12, 13, 14, 14])
+    M = NumPyMatrix(4, 4, [0, 1, 2, 3, 4, 5, 6, 7, 2, 9, 10, 11, 12, 13, 14, 14])
     A = M.adjugate()
 
-    assert isinstance(A, NPMatrix)
+    assert isinstance(A, NumPyMatrix)
     assert _fcmpseq(A, (4, -8, 4, 0, 76, -68, -8, 24, -122, 142, 4, -48, 48, -72, 0, 24))
 
-    M = NPMatrix(8, 2, M)
+    M = NumPyMatrix(8, 2, M)
     raises(NonSquareMatrixError, lambda: M.adjugate())
 
 
 def test_charpoly():
     skipcheck()
 
-    M = NPMatrix([[1, 2], [3, 4]])
+    M = NumPyMatrix([[1, 2], [3, 4]])
     assert M.charpoly(x='x') == PurePoly(x**2 - 5*x - 2, x, domain='RR')
 
-    M = NPMatrix(4, 1, M)
+    M = NumPyMatrix(4, 1, M)
     raises(NonSquareMatrixError, lambda: M.charpoly())
 
 
 def test_cofactor():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert _fcmp(M.cofactor(1, 1), -12)
 
 
 def test_cofactor_matrix():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     A = M.cofactor_matrix()
 
-    assert isinstance(A, NPMatrix)
+    assert isinstance(A, NumPyMatrix)
     assert _fcmpseq(A, (-3, 6, -3, 6, -12, 6, -3, 6, -3))
 
 
 def test_det():
     skipcheck()
 
-    M = NPMatrix([[1, 2], [3, 4]])
+    M = NumPyMatrix([[1, 2], [3, 4]])
     assert _fcmp(M.det(), -2)
     assert _fcmp(M.det_bareiss(), -2)
     assert _fcmp(M.det_berkowitz(), -2)
     assert _fcmp(M.det_LU(), -2)
 
-    M = NPMatrix(4, 1, M)
+    M = NumPyMatrix(4, 1, M)
     raises(NonSquareMatrixError, lambda: M.det())
     raises(NonSquareMatrixError, lambda: M.det_bareiss())
     raises(NonSquareMatrixError, lambda: M.det_berkowitz())
@@ -162,35 +162,35 @@ def test_det():
 def test_minor():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert _fcmp(M.cofactor(1, 1), -12)
 
 
 def test_minor_submatrix():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     A = M.minor_submatrix(1, 1)
 
-    assert isinstance(A, NPMatrix)
+    assert isinstance(A, NumPyMatrix)
     assert _fcmpseq(A, Matrix([[1, 3], [7, 9]]))
 
 
 def test_echelon():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype='i4') # float gives different result
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype='i4') # float gives different result
     A = M.echelon_form()
 
     assert M.is_echelon is False
-    assert isinstance(A, NPMatrix)
+    assert isinstance(A, NumPyMatrix)
     assert _fcmpseq(A, Matrix([[1, 2, 3], [0, -3, -6], [0, 0, 0]]))
 
 
 def test_rank():
     skipcheck()
 
-    M = NPMatrix([[S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I'),S('3/64+13/64*I'),S('-23/32-59/256*I'),S('15/128-3/32*I'),S('19/256+551/1024*I')],
+    M = NumPyMatrix([[S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I'),S('3/64+13/64*I'),S('-23/32-59/256*I'),S('15/128-3/32*I'),S('19/256+551/1024*I')],
         [S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I'),S('-219/128+115/256*I'),S('6301/4096-6609/1024*I'),S('119/128+143/128*I'),S('-10879/2048+4343/4096*I'),S('129/256-549/512*I'),S('42533/16384+29103/8192*I')],
         [S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I'),S('3/64+13/64*I'),S('-23/32-59/256*I')],
         [S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I'),S('-219/128+115/256*I'),S('6301/4096-6609/1024*I'),S('119/128+143/128*I'),S('-10879/2048+4343/4096*I')],
@@ -208,10 +208,10 @@ def test_rank():
 def test_rref():
     skipcheck()
 
-    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    M = NumPyMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     A = M.rref()
 
-    assert isinstance(A[0], NPMatrix)
+    assert isinstance(A[0], NumPyMatrix)
     assert _fcmpseq(A[0], Matrix([[1, 0, -1], [0, 1, 2], [0, 0, 0]]))
     assert A[1] == (0, 1)
 
@@ -219,14 +219,14 @@ def test_rref():
 def test_columnspace():
     skipcheck()
 
-    M = NPMatrix([
+    M = NumPyMatrix([
         [ 1,  2,  0,  2,  5],
         [-2, -5,  1, -1, -8],
         [ 0, -3,  3,  4,  1],
         [ 3,  6,  0, -7,  2]])
     A = M.columnspace()
 
-    assert all(isinstance(m, NPMatrix) for m in A)
+    assert all(isinstance(m, NumPyMatrix) for m in A)
     assert _fcmpseq(A[0], Matrix([1, -2, 0, 3]))
     assert _fcmpseq(A[1], Matrix([2, -5, -3, 6]))
     assert _fcmpseq(A[2], Matrix([2, -1, 4, -7]))
@@ -235,14 +235,14 @@ def test_columnspace():
 def test_rowspace():
     skipcheck()
 
-    M = NPMatrix([
+    M = NumPyMatrix([
         [ 1,  2,  0,  2,  5],
         [-2, -5,  1, -1, -8],
         [ 0, -3,  3,  4,  1],
         [ 3,  6,  0, -7,  2]], dtype='i4') # float gives different result
     A = M.rowspace()
 
-    assert all(isinstance(m, NPMatrix) for m in A)
+    assert all(isinstance(m, NumPyMatrix) for m in A)
     assert _fcmpseq(A[0], Matrix([[1, 2, 0, 2, 5]]))
     assert _fcmpseq(A[1], Matrix([[0, -1, 1, 3, 2]]))
     assert _fcmpseq(A[2], Matrix([[0, 0, 0, 5, 5]]))
@@ -251,14 +251,14 @@ def test_rowspace():
 def test_nullspace():
     skipcheck()
 
-    M = NPMatrix([
+    M = NumPyMatrix([
         [ 1,  3, 0,  2,  6, 3, 1],
         [-2, -6, 0, -2, -8, 3, 1],
         [ 3,  9, 0,  0,  6, 6, 2],
         [-1, -3, 0,  1,  0, 9, 3]])
     A = M.nullspace()
 
-    assert all(isinstance(m, NPMatrix) for m in A)
+    assert all(isinstance(m, NumPyMatrix) for m in A)
     assert _fcmpseq(A[0], Matrix([-3, 1, 0, 0, 0, 0, 0]))
     assert _fcmpseq(A[1], Matrix([0, 0, 1, 0, 0, 0, 0]))
     assert _fcmpseq(A[2], Matrix([-2, 0, 0, -2, 1, 0, 0]))
@@ -269,9 +269,9 @@ def test_orthogonalize():
     skipcheck()
 
     v = [Matrix([1, I]), Matrix([1, -I])]
-    A = NPMatrix.orthogonalize(*v)
+    A = NumPyMatrix.orthogonalize(*v)
 
-    assert all(isinstance(m, NPMatrix) for m in A)
+    assert all(isinstance(m, NumPyMatrix) for m in A)
     assert _fcmp(A[0][0], 1)
     assert _fcmp(A[0][1] / I, 1)
     assert _fcmp(A[1][0], 1)
@@ -281,15 +281,15 @@ def test_orthogonalize():
 def test_eigenvals():
     skipcheck()
 
-    M = NPMatrix(3, 3, [0, 1, 1, 1, 0, 0, 1, 1, 1])
+    M = NumPyMatrix(3, 3, [0, 1, 1, 1, 0, 0, 1, 1, 1])
     assert M.eigenvals() == {2: 1, -1: 1, 0: 1}
 
-    M = NPMatrix(3, 3, [1.5, 0.75, 1.75, 0, -0.75, 0.5, 0, 0, -0.25])
-    assert M.eigenvals() == {S(3)/2: 1, -S(3)/4: 1, -S(1)/4: 1}
-    assert all(e.epsilon_eq(v) for e, v in zip(M.eigenvals(rational=False),
-        (1.5, -0.75, -0.25)))
+    M = NumPyMatrix(3, 3, [1.5, 0.75, 1.75, 0, -0.75, 0.5, 0, 0, -0.25])
+    e = M.eigenvals()
+    assert _fcmpseqsort(e.keys(), (1.5, -0.75, -0.25))
+    assert all(v == 1 for v in e.values())
 
-    M = NPMatrix(3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    M = NumPyMatrix(3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
     assert M.eigenvals() == {1: 3}
     assert M.eigenvals(multiple=True) == [1, 1, 1]
 
@@ -299,7 +299,7 @@ def test_eigenvects():
 
     M = Matrix(3, 3, [0, 1, 1, 1, 0, 0, 1, 1, 1])
     A = M.eigenvects()
-    B = NPMatrix(M).eigenvects()
+    B = NumPyMatrix(M).eigenvects()
 
     assert _fcmp(B[0][0], A[0][0])
     assert _fcmp(B[1][0], A[1][0])
@@ -307,12 +307,12 @@ def test_eigenvects():
     assert B[0][1] == A[0][1]
     assert B[1][1] == A[1][1]
     assert B[2][1] == A[2][1]
-    assert _fcmp(abs(N(A[0][2][0].normalized().dot(B[0][2][0]))), 1)
-    assert _fcmp(abs(N(A[1][2][0].normalized().dot(B[1][2][0]))), 1)
-    assert _fcmp(abs(N(A[2][2][0].normalized().dot(B[2][2][0]))), 1)
+    assert _fcmpseq(A[0][2][0], B[0][2][0])
+    assert _fcmpseq(A[1][2][0], B[1][2][0])
+    assert _fcmpseq(A[2][2][0], B[2][2][0])
 
     A = M.left_eigenvects()
-    B = NPMatrix(M).left_eigenvects()
+    B = NumPyMatrix(M).left_eigenvects()
 
     assert _fcmp(B[0][0], A[0][0])
     assert _fcmp(B[1][0], A[1][0])
@@ -320,35 +320,35 @@ def test_eigenvects():
     assert B[0][1] == A[0][1]
     assert B[1][1] == A[1][1]
     assert B[2][1] == A[2][1]
-    assert _fcmp(abs(N(A[0][2][0].normalized().dot(B[0][2][0]))), 1)
-    assert _fcmp(abs(N(A[1][2][0].normalized().dot(B[1][2][0]))), 1)
-    assert _fcmp(abs(N(A[2][2][0].normalized().dot(B[2][2][0]))), 1)
+    assert _fcmpseq(A[0][2][0], B[0][2][0])
+    assert _fcmpseq(A[1][2][0], B[1][2][0])
+    assert _fcmpseq(A[2][2][0], B[2][2][0])
 
 
 def test_diagonalization():
     skipcheck ()
 
-    M = NPMatrix([[1, 2+I], [2-I, 3]])
+    M = NumPyMatrix([[1, 2+I], [2-I, 3]])
     assert M.is_diagonalizable()
 
-    M = NPMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
+    M = NumPyMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
     assert not M.is_diagonalizable()
     assert not M.is_symmetric()
     raises(NonSquareMatrixError, lambda: M.diagonalize())
 
     # diagonalizable
-    M = NPMatrix(diag(1, 2, 3))
+    M = NumPyMatrix(diag(1, 2, 3))
     (P, D) = M.diagonalize()
     assert _fcmpseq(P, eye(3))
     assert _fcmpseq(D, M)
 
-    M = NPMatrix(2, 2, [0, 1, 1, 0])
+    M = NumPyMatrix(2, 2, [0, 1, 1, 0])
     assert M.is_symmetric()
     assert M.is_diagonalizable()
     (P, D) = M.diagonalize()
     assert _fcmpseq(P.inv() * M * P, D)
 
-    M = NPMatrix(2, 2, [1, 0, 0, 3])
+    M = NumPyMatrix(2, 2, [1, 0, 0, 3])
     assert M.is_symmetric()
     assert M.is_diagonalizable()
     (P, D) = M.diagonalize()
@@ -356,19 +356,19 @@ def test_diagonalization():
     assert _fcmpseq(P, eye(2))
     assert _fcmpseq(D, M)
 
-    M = NPMatrix(2, 2, [1, 1, 0, 0])
+    M = NumPyMatrix(2, 2, [1, 1, 0, 0])
     assert M.is_diagonalizable()
     (P, D) = M.diagonalize()
     assert _fcmpseq(P.inv() * M * P, D)
 
-    M = NPMatrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
+    M = NumPyMatrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
     assert M.is_diagonalizable()
     (P, D) = M.diagonalize()
     assert _fcmpseq(P.inv() * M * P, D)
     for i in P:
         assert i.as_numer_denom()[1] == 1
 
-    M = NPMatrix(2, 2, [1, 0, 0, 0])
+    M = NumPyMatrix(2, 2, [1, 0, 0, 0])
     assert M.is_diagonal()
     assert M.is_diagonalizable()
     (P, D) = M.diagonalize()
@@ -376,7 +376,7 @@ def test_diagonalization():
     assert _fcmpseq(P, Matrix([[0, 1], [1, 0]]))
 
     # diagonalizable, complex only
-    M = NPMatrix(2, 2, [0, 1, -1, 0])
+    M = NumPyMatrix(2, 2, [0, 1, -1, 0])
     assert not M.is_diagonalizable(True)
     raises(MatrixError, lambda: M.diagonalize(True))
     assert M.is_diagonalizable()
@@ -384,11 +384,11 @@ def test_diagonalization():
     assert P.inv() * M * P == D # _fcmpseq(P.inv() * M * P, D)
 
     # not diagonalizable
-    M = NPMatrix(2, 2, [0, 1, 0, 0])
+    M = NumPyMatrix(2, 2, [0, 1, 0, 0])
     assert not M.is_diagonalizable()
     raises(MatrixError, lambda: M.diagonalize())
 
-    M = NPMatrix(3, 3, [-3, 1, -3, 20, 3, 10, 2, -2, 4])
+    M = NumPyMatrix(3, 3, [-3, 1, -3, 20, 3, 10, 2, -2, 4])
     assert not M.is_diagonalizable()
     raises(MatrixError, lambda: M.diagonalize())
 
@@ -398,14 +398,14 @@ def test_definite():
 
     # Examples from Gilbert Strang, "Introduction to Linear Algebra"
     # Positive definite matrices
-    M = NPMatrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
+    M = NumPyMatrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
     assert M.is_positive_definite == True
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
     assert M.is_negative_semidefinite == False
     assert M.is_indefinite == False
 
-    M = NPMatrix([[5, 4], [4, 5]])
+    M = NumPyMatrix([[5, 4], [4, 5]])
     assert M.is_positive_definite == True
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
@@ -413,14 +413,14 @@ def test_definite():
     assert M.is_indefinite == False
 
     # Positive semidefinite matrices
-    M = NPMatrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
+    M = NumPyMatrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
     assert M.is_positive_definite == False
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
     assert M.is_negative_semidefinite == False
     assert M.is_indefinite == False
 
-    M = NPMatrix([[1, 2], [2, 4]])
+    M = NumPyMatrix([[1, 2], [2, 4]])
     assert M.is_positive_definite == False
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
@@ -429,14 +429,14 @@ def test_definite():
 
     # Examples from Mathematica documentation
     # Non-hermitian positive definite matrices
-    M = NPMatrix([[2, 3], [4, 8]])
+    M = NumPyMatrix([[2, 3], [4, 8]])
     assert M.is_positive_definite == True
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
     assert M.is_negative_semidefinite == False
     assert M.is_indefinite == False
 
-    M = NPMatrix([[1, 2*I], [-I, 4]])
+    M = NumPyMatrix([[1, 2*I], [-I, 4]])
     assert M.is_positive_definite == True
     assert M.is_positive_semidefinite == True
     assert M.is_negative_definite == False
@@ -447,60 +447,52 @@ def test_definite():
 def test_jordan_form():
     skipcheck ()
 
-    m = NPMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
+    m = NumPyMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
     raises(NonSquareMatrixError, lambda: m.jordan_form())
 
     # diagonalizable
-    M = NPMatrix(3, 3, [7, -12, 6, 10, -19, 10, 12, -24, 13])
-    N = NPMatrix(3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
+    M = NumPyMatrix(3, 3, [7, -12, 6, 10, -19, 10, 12, -24, 13])
+    N = NumPyMatrix(3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
     _, J = M.jordan_form()
     assert _fcmpseq(N, J)
     assert _fcmpseq(N, M.diagonalize()[1])
 
     # Jordan cells
     # complexity: one of eigenvalues is zero
-    M = NPMatrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-    N = NPMatrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
+    M = NumPyMatrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+    N = NumPyMatrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
     _, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
     # complexity: all of eigenvalues are equal
-    M = NPMatrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
-    N = NPMatrix(3, 3, [-1, 1, 0, 0, -1, 0, 0, 0, -1])
-    P, J = M.jordan_form()
+    M = NumPyMatrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
+    N = NumPyMatrix(3, 3, [-1, 1, 0, 0, -1, 0, 0, 0, -1])
+    _, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
     # complexity: two of eigenvalues are zero
-    M = NPMatrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
-    N = NPMatrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
+    M = NumPyMatrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
+    N = NumPyMatrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
     P, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
-    M = NPMatrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
-    N = NPMatrix(4, 4, [-2, 0, 0, 0,
+    M = NumPyMatrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
+    N = NumPyMatrix(4, 4, [-2, 0, 0, 0,
                          0, 2, 1, 0,
                          0, 0, 2, 0,
                          0, 0, 0, 2])
     P, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
-    M = NPMatrix(4, 4, [5, 4, 2, 1, 0, 1, -1, -1, -1, -1, 3, 0, 1, 1, -1, 2])
-    assert not M.is_diagonalizable()
-    N = NPMatrix(4, 4, [1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 1, 0, 0, 0, 4])
-    P, J = M.jordan_form()
+    M = NumPyMatrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
+    N = NumPyMatrix(4, 4, [2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2])
+    _, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
-
-# This fails due to numerical tolerance issues, setting _TOLERANCE = 1e-6 in
-# matrices.numpy.py makes this work but that tolerance seems too high for
-# general use.
-@XFAIL
-def test_jordan_form_failing():
-    skipcheck ()
-
-    M = NPMatrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
-    N = NPMatrix(4, 4, [2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2])
-    _, J = M.jordan_form()
+    M = NumPyMatrix(4, 4, [5, 4, 2, 1, 0, 1, -1, -1, -1, -1, 3, 0, 1, 1, -1, 2])
+    assert not M.is_diagonalizable()
+    N = NumPyMatrix(4, 4, [1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 1, 0, 0, 0, 4])
+    P, J = M.jordan_form()
     assert _fcmpseq(N, J)
 
 
@@ -509,9 +501,9 @@ def test_singular_values():
 
     from math import sqrt
 
-    M = NPMatrix([[0, 1*I], [2, 0]])
+    M = NumPyMatrix([[0, 1*I], [2, 0]])
     assert _fcmpseqsort(M.singular_values(), (2, 1))
 
-    M = NPMatrix([[2, 4], [1, 3], [0, 0], [0, 0]])
+    M = NumPyMatrix([[2, 4], [1, 3], [0, 0], [0, 0]])
     assert _fcmpseqsort(M.singular_values(), [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221))])
     assert _fcmpseqsort(M.T.singular_values(), [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0])

--- a/sympy/matrices/tests/test_numpymatrix.py
+++ b/sympy/matrices/tests/test_numpymatrix.py
@@ -1,7 +1,7 @@
 from sympy import (Float, I, N, PurePoly, S, Symbol, oo, nan,
     Matrix, NumPyMatrix as NPMatrix, NonSquareMatrixError, diag, eye)
 from sympy.matrices.matrices import MatrixError
-from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
+from sympy.testing.pytest import raises, XFAIL, skip
 
 try:
     import numpy as np

--- a/sympy/matrices/tests/test_numpymatrix.py
+++ b/sympy/matrices/tests/test_numpymatrix.py
@@ -1,0 +1,517 @@
+from sympy import (Float, I, N, PurePoly, S, Symbol, oo, nan,
+    Matrix, NumPyMatrix as NPMatrix, NonSquareMatrixError, diag, eye)
+from sympy.matrices.matrices import MatrixError
+from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
+
+try:
+    import numpy as np
+
+    skipcheck = lambda: None
+
+except ImportError:
+    skipcheck = lambda: skip('NumPy must be available to test NumPyMatrix')
+
+x = Symbol('x')
+
+
+def _fcmp(a, b):
+    return Float(N(a)).epsilon_eq(b, epsilon=1e-12)
+
+def _fcmpseq(seq1, seq2):
+    return all(_fcmp(a, b) for a, b in zip(seq1, seq2))
+
+def _fcmpseqsort(seq1, seq2):
+    return all(_fcmp(a, b) for a, b in zip(sorted(seq1), sorted(seq2)))
+
+
+def test_creation():
+    skipcheck()
+
+    a = np.array([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(a)
+    assert M == Matrix([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(3, 2, a)
+    assert M == Matrix([[1, 2], [3, 4], [5, 6]])
+
+    a = np.array([[1, 2], [3, 4]], dtype='i4')
+    M = NPMatrix(a)
+    assert M.dtype == np.int32
+    M = NPMatrix(a, dtype='f4')
+    assert M.dtype == np.float32
+
+    m = np.matrix([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(m)
+    assert M == Matrix([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(3, 2, m)
+    assert M == Matrix([[1, 2], [3, 4], [5, 6]])
+
+    m = np.matrix([[1, 2, 3], [4, 5, 6]], dtype='i4')
+    M = NPMatrix(m)
+    assert M.dtype == np.int32
+    M = NPMatrix(m, dtype='f4')
+    assert M.dtype == np.float32
+
+
+def test_detect_dtype():
+    skipcheck()
+
+    assert NPMatrix([[1]]).dtype == np.int64
+    assert NPMatrix([[1.0]]).dtype == np.float64
+    assert NPMatrix([[oo]]).dtype == np.float64
+    assert NPMatrix([[nan]]).dtype == np.float64
+    assert NPMatrix([[I]]).dtype == np.complex128
+
+
+def test_as_wrapper():
+    skipcheck()
+
+    a = np.array([[1, 2], [3, 4]])
+    M = NPMatrix(a, copy=False)
+    assert M[0] == 1
+    a[0, 0] = -1
+    assert M[0] == -1
+
+    m = np.matrix([[1, 2], [3, 4]])
+    M = NPMatrix(m, copy=False)
+    assert M[0] == 1
+    m[0, 0] = -1
+    assert M[0] == -1
+
+
+def test_as_reshaping_wrapper():
+    skipcheck()
+
+    a = np.array([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(3, 2, a, copy=False)
+    assert M == Matrix([[1, 2], [3, 4], [5, 6]])
+    a[0, 0] = -1
+    assert M[0] == -1
+
+    m = np.matrix([[1, 2, 3], [4, 5, 6]])
+    M = NPMatrix(3, 2, m, copy=False)
+    assert M == Matrix([[1, 2], [3, 4], [5, 6]])
+    m[0, 0] = -1
+    assert M[0] == -1
+
+
+def test_array():
+    skipcheck()
+
+    a = np.array([[1, 2], [3, 4]])
+    M = NPMatrix(a, copy=False)
+    assert M.__array__() is a
+    assert M.__array__('f4') is not a
+
+
+def test_adjugate():
+    skipcheck()
+
+    M = NPMatrix(4, 4, [0, 1, 2, 3, 4, 5, 6, 7, 2, 9, 10, 11, 12, 13, 14, 14])
+    A = M.adjugate()
+
+    assert isinstance(A, NPMatrix)
+    assert _fcmpseq(A, (4, -8, 4, 0, 76, -68, -8, 24, -122, 142, 4, -48, 48, -72, 0, 24))
+
+    M = NPMatrix(8, 2, M)
+    raises(NonSquareMatrixError, lambda: M.adjugate())
+
+
+def test_charpoly():
+    skipcheck()
+
+    M = NPMatrix([[1, 2], [3, 4]])
+    assert M.charpoly(x='x') == PurePoly(x**2 - 5*x - 2, x, domain='RR')
+
+    M = NPMatrix(4, 1, M)
+    raises(NonSquareMatrixError, lambda: M.charpoly())
+
+
+def test_cofactor():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert _fcmp(M.cofactor(1, 1), -12)
+
+
+def test_cofactor_matrix():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    A = M.cofactor_matrix()
+
+    assert isinstance(A, NPMatrix)
+    assert _fcmpseq(A, (-3, 6, -3, 6, -12, 6, -3, 6, -3))
+
+
+def test_det():
+    skipcheck()
+
+    M = NPMatrix([[1, 2], [3, 4]])
+    assert _fcmp(M.det(), -2)
+    assert _fcmp(M.det_bareiss(), -2)
+    assert _fcmp(M.det_berkowitz(), -2)
+    assert _fcmp(M.det_LU(), -2)
+
+    M = NPMatrix(4, 1, M)
+    raises(NonSquareMatrixError, lambda: M.det())
+    raises(NonSquareMatrixError, lambda: M.det_bareiss())
+    raises(NonSquareMatrixError, lambda: M.det_berkowitz())
+    raises(NonSquareMatrixError, lambda: M.det_LU())
+
+
+def test_minor():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert _fcmp(M.cofactor(1, 1), -12)
+
+
+def test_minor_submatrix():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    A = M.minor_submatrix(1, 1)
+
+    assert isinstance(A, NPMatrix)
+    assert _fcmpseq(A, Matrix([[1, 3], [7, 9]]))
+
+
+def test_echelon():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype='i4') # float gives different result
+    A = M.echelon_form()
+
+    assert M.is_echelon is False
+    assert isinstance(A, NPMatrix)
+    assert _fcmpseq(A, Matrix([[1, 2, 3], [0, -3, -6], [0, 0, 0]]))
+
+
+def test_rank():
+    skipcheck()
+
+    M = NPMatrix([[S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I'),S('3/64+13/64*I'),S('-23/32-59/256*I'),S('15/128-3/32*I'),S('19/256+551/1024*I')],
+        [S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I'),S('-219/128+115/256*I'),S('6301/4096-6609/1024*I'),S('119/128+143/128*I'),S('-10879/2048+4343/4096*I'),S('129/256-549/512*I'),S('42533/16384+29103/8192*I')],
+        [S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I'),S('3/64+13/64*I'),S('-23/32-59/256*I')],
+        [S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I'),S('-219/128+115/256*I'),S('6301/4096-6609/1024*I'),S('119/128+143/128*I'),S('-10879/2048+4343/4096*I')],
+        [S('-4*I'),S('27/2+6*I'),S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I'),S('-9/32-1/16*I'),S('183/256-97/128*I')],
+        [S('1/4+5/2*I'),S('-23/8-57/16*I'),S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I'),S('-219/128+115/256*I'),S('6301/4096-6609/1024*I')],
+        [S('-4'),S('9-5*I'),S('-4*I'),S('27/2+6*I'),S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I'),S('1/4-5/16*I'),S('65/128+87/64*I')],
+        [S('-2*I'),S('119/8+29/4*I'),S('1/4+5/2*I'),S('-23/8-57/16*I'),S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I'),S('85/256-33/16*I'),S('805/128+2415/512*I')],
+        [S('0'),S('-6'),S('-4'),S('9-5*I'),S('-4*I'),S('27/2+6*I'),S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I'),S('1/4+1/2*I'),S('-129/64-9/64*I')],
+        [S('1'),S('-9/4+3*I'),S('-2*I'),S('119/8+29/4*I'),S('1/4+5/2*I'),S('-23/8-57/16*I'),S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I'),S('125/64+87/64*I'),S('-2063/256+541/128*I')],
+        [S('0'),S('-4*I'),S('0'),S('-6'),S('-4'),S('9-5*I'),S('-4*I'),S('27/2+6*I'),S('-2'),S('17/4-13/2*I'),S('1+I'),S('-19/4+5/4*I'),S('1/2-I'),S('9/4+55/16*I'),S('-3/4'),S('45/32-37/16*I')],
+        [S('0'),S('1/4+1/2*I'),S('1'),S('-9/4+3*I'),S('-2*I'),S('119/8+29/4*I'),S('1/4+5/2*I'),S('-23/8-57/16*I'),S('1/4+13/4*I'),S('-825/64-147/32*I'),S('21/8+I'),S('-537/64+143/16*I'),S('-5/8-39/16*I'),S('2473/256+137/64*I'),S('-149/64+49/32*I'),S('-177/128-1369/128*I')]])
+    assert M.rank() == 8
+
+
+def test_rref():
+    skipcheck()
+
+    M = NPMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    A = M.rref()
+
+    assert isinstance(A[0], NPMatrix)
+    assert _fcmpseq(A[0], Matrix([[1, 0, -1], [0, 1, 2], [0, 0, 0]]))
+    assert A[1] == (0, 1)
+
+
+def test_columnspace():
+    skipcheck()
+
+    M = NPMatrix([
+        [ 1,  2,  0,  2,  5],
+        [-2, -5,  1, -1, -8],
+        [ 0, -3,  3,  4,  1],
+        [ 3,  6,  0, -7,  2]])
+    A = M.columnspace()
+
+    assert all(isinstance(m, NPMatrix) for m in A)
+    assert _fcmpseq(A[0], Matrix([1, -2, 0, 3]))
+    assert _fcmpseq(A[1], Matrix([2, -5, -3, 6]))
+    assert _fcmpseq(A[2], Matrix([2, -1, 4, -7]))
+
+
+def test_rowspace():
+    skipcheck()
+
+    M = NPMatrix([
+        [ 1,  2,  0,  2,  5],
+        [-2, -5,  1, -1, -8],
+        [ 0, -3,  3,  4,  1],
+        [ 3,  6,  0, -7,  2]], dtype='i4') # float gives different result
+    A = M.rowspace()
+
+    assert all(isinstance(m, NPMatrix) for m in A)
+    assert _fcmpseq(A[0], Matrix([[1, 2, 0, 2, 5]]))
+    assert _fcmpseq(A[1], Matrix([[0, -1, 1, 3, 2]]))
+    assert _fcmpseq(A[2], Matrix([[0, 0, 0, 5, 5]]))
+
+
+def test_nullspace():
+    skipcheck()
+
+    M = NPMatrix([
+        [ 1,  3, 0,  2,  6, 3, 1],
+        [-2, -6, 0, -2, -8, 3, 1],
+        [ 3,  9, 0,  0,  6, 6, 2],
+        [-1, -3, 0,  1,  0, 9, 3]])
+    A = M.nullspace()
+
+    assert all(isinstance(m, NPMatrix) for m in A)
+    assert _fcmpseq(A[0], Matrix([-3, 1, 0, 0, 0, 0, 0]))
+    assert _fcmpseq(A[1], Matrix([0, 0, 1, 0, 0, 0, 0]))
+    assert _fcmpseq(A[2], Matrix([-2, 0, 0, -2, 1, 0, 0]))
+    assert _fcmpseq(A[3], Matrix([0, 0, 0, 0, 0, -1/3, 1]))
+
+
+def test_orthogonalize():
+    skipcheck()
+
+    v = [Matrix([1, I]), Matrix([1, -I])]
+    A = NPMatrix.orthogonalize(*v)
+
+    assert all(isinstance(m, NPMatrix) for m in A)
+    assert _fcmp(A[0][0], 1)
+    assert _fcmp(A[0][1] / I, 1)
+    assert _fcmp(A[1][0], 1)
+    assert _fcmp(A[1][1] / I, -1)
+
+
+def test_eigenvals():
+    skipcheck()
+
+    M = NPMatrix(3, 3, [0, 1, 1, 1, 0, 0, 1, 1, 1])
+    assert M.eigenvals() == {2: 1, -1: 1, 0: 1}
+
+    M = NPMatrix(3, 3, [1.5, 0.75, 1.75, 0, -0.75, 0.5, 0, 0, -0.25])
+    assert M.eigenvals() == {S(3)/2: 1, -S(3)/4: 1, -S(1)/4: 1}
+    assert all(e.epsilon_eq(v) for e, v in zip(M.eigenvals(rational=False),
+        (1.5, -0.75, -0.25)))
+
+    M = NPMatrix(3, 3, [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    assert M.eigenvals() == {1: 3}
+    assert M.eigenvals(multiple=True) == [1, 1, 1]
+
+
+def test_eigenvects():
+    skipcheck()
+
+    M = Matrix(3, 3, [0, 1, 1, 1, 0, 0, 1, 1, 1])
+    A = M.eigenvects()
+    B = NPMatrix(M).eigenvects()
+
+    assert _fcmp(B[0][0], A[0][0])
+    assert _fcmp(B[1][0], A[1][0])
+    assert _fcmp(B[2][0], A[2][0])
+    assert B[0][1] == A[0][1]
+    assert B[1][1] == A[1][1]
+    assert B[2][1] == A[2][1]
+    assert _fcmp(abs(N(A[0][2][0].normalized().dot(B[0][2][0]))), 1)
+    assert _fcmp(abs(N(A[1][2][0].normalized().dot(B[1][2][0]))), 1)
+    assert _fcmp(abs(N(A[2][2][0].normalized().dot(B[2][2][0]))), 1)
+
+    A = M.left_eigenvects()
+    B = NPMatrix(M).left_eigenvects()
+
+    assert _fcmp(B[0][0], A[0][0])
+    assert _fcmp(B[1][0], A[1][0])
+    assert _fcmp(B[2][0], A[2][0])
+    assert B[0][1] == A[0][1]
+    assert B[1][1] == A[1][1]
+    assert B[2][1] == A[2][1]
+    assert _fcmp(abs(N(A[0][2][0].normalized().dot(B[0][2][0]))), 1)
+    assert _fcmp(abs(N(A[1][2][0].normalized().dot(B[1][2][0]))), 1)
+    assert _fcmp(abs(N(A[2][2][0].normalized().dot(B[2][2][0]))), 1)
+
+
+def test_diagonalization():
+    skipcheck ()
+
+    M = NPMatrix([[1, 2+I], [2-I, 3]])
+    assert M.is_diagonalizable()
+
+    M = NPMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
+    assert not M.is_diagonalizable()
+    assert not M.is_symmetric()
+    raises(NonSquareMatrixError, lambda: M.diagonalize())
+
+    # diagonalizable
+    M = NPMatrix(diag(1, 2, 3))
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P, eye(3))
+    assert _fcmpseq(D, M)
+
+    M = NPMatrix(2, 2, [0, 1, 1, 0])
+    assert M.is_symmetric()
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P.inv() * M * P, D)
+
+    M = NPMatrix(2, 2, [1, 0, 0, 3])
+    assert M.is_symmetric()
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P.inv() * M * P, D)
+    assert _fcmpseq(P, eye(2))
+    assert _fcmpseq(D, M)
+
+    M = NPMatrix(2, 2, [1, 1, 0, 0])
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P.inv() * M * P, D)
+
+    M = NPMatrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P.inv() * M * P, D)
+    for i in P:
+        assert i.as_numer_denom()[1] == 1
+
+    M = NPMatrix(2, 2, [1, 0, 0, 0])
+    assert M.is_diagonal()
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert _fcmpseq(P.inv() * M * P, D)
+    assert _fcmpseq(P, Matrix([[0, 1], [1, 0]]))
+
+    # diagonalizable, complex only
+    M = NPMatrix(2, 2, [0, 1, -1, 0])
+    assert not M.is_diagonalizable(True)
+    raises(MatrixError, lambda: M.diagonalize(True))
+    assert M.is_diagonalizable()
+    (P, D) = M.diagonalize()
+    assert P.inv() * M * P == D # _fcmpseq(P.inv() * M * P, D)
+
+    # not diagonalizable
+    M = NPMatrix(2, 2, [0, 1, 0, 0])
+    assert not M.is_diagonalizable()
+    raises(MatrixError, lambda: M.diagonalize())
+
+    M = NPMatrix(3, 3, [-3, 1, -3, 20, 3, 10, 2, -2, 4])
+    assert not M.is_diagonalizable()
+    raises(MatrixError, lambda: M.diagonalize())
+
+
+def test_definite():
+    skipcheck ()
+
+    # Examples from Gilbert Strang, "Introduction to Linear Algebra"
+    # Positive definite matrices
+    M = NPMatrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
+    assert M.is_positive_definite == True
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+    M = NPMatrix([[5, 4], [4, 5]])
+    assert M.is_positive_definite == True
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+    # Positive semidefinite matrices
+    M = NPMatrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
+    assert M.is_positive_definite == False
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+    M = NPMatrix([[1, 2], [2, 4]])
+    assert M.is_positive_definite == False
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+    # Examples from Mathematica documentation
+    # Non-hermitian positive definite matrices
+    M = NPMatrix([[2, 3], [4, 8]])
+    assert M.is_positive_definite == True
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+    M = NPMatrix([[1, 2*I], [-I, 4]])
+    assert M.is_positive_definite == True
+    assert M.is_positive_semidefinite == True
+    assert M.is_negative_definite == False
+    assert M.is_negative_semidefinite == False
+    assert M.is_indefinite == False
+
+
+def test_jordan_form():
+    skipcheck ()
+
+    m = NPMatrix(3, 2, [-3, 1, -3, 20, 3, 10])
+    raises(NonSquareMatrixError, lambda: m.jordan_form())
+
+    # diagonalizable
+    M = NPMatrix(3, 3, [7, -12, 6, 10, -19, 10, 12, -24, 13])
+    N = NPMatrix(3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
+    _, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+    assert _fcmpseq(N, M.diagonalize()[1])
+
+    # Jordan cells
+    # complexity: one of eigenvalues is zero
+    M = NPMatrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+    N = NPMatrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
+    _, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+    # complexity: all of eigenvalues are equal
+    M = NPMatrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
+    N = NPMatrix(3, 3, [-1, 1, 0, 0, -1, 0, 0, 0, -1])
+    P, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+    # complexity: two of eigenvalues are zero
+    M = NPMatrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
+    N = NPMatrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
+    P, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+    M = NPMatrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
+    N = NPMatrix(4, 4, [-2, 0, 0, 0,
+                         0, 2, 1, 0,
+                         0, 0, 2, 0,
+                         0, 0, 0, 2])
+    P, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+    M = NPMatrix(4, 4, [5, 4, 2, 1, 0, 1, -1, -1, -1, -1, 3, 0, 1, 1, -1, 2])
+    assert not M.is_diagonalizable()
+    N = NPMatrix(4, 4, [1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 1, 0, 0, 0, 4])
+    P, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+
+# This fails due to numerical tolerance issues, setting _TOLERANCE = 1e-6 in
+# matrices.numpy.py makes this work but that tolerance seems too high for
+# general use.
+@XFAIL
+def test_jordan_form_failing():
+    skipcheck ()
+
+    M = NPMatrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
+    N = NPMatrix(4, 4, [2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2])
+    _, J = M.jordan_form()
+    assert _fcmpseq(N, J)
+
+
+def test_singular_values():
+    skipcheck ()
+
+    from math import sqrt
+
+    M = NPMatrix([[0, 1*I], [2, 0]])
+    assert _fcmpseqsort(M.singular_values(), (2, 1))
+
+    M = NPMatrix([[2, 4], [1, 3], [0, 0], [0, 0]])
+    assert _fcmpseqsort(M.singular_values(), [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221))])
+    assert _fcmpseqsort(M.T.singular_values(), [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0])

--- a/sympy/matrices/tests/test_numpymatrix.py
+++ b/sympy/matrices/tests/test_numpymatrix.py
@@ -2,7 +2,7 @@ from sympy import (Float, I, N, PurePoly, S, Symbol, oo, nan, sqrt, sympify,
     Matrix, ImmutableDenseMatrix, NumPyMatrix, NonSquareMatrixError,
     diag, eye, zeros)
 from sympy.matrices.matrices import MatrixError
-from sympy.testing.pytest import raises, XFAIL, skip
+from sympy.testing.pytest import raises, skip
 
 try:
     import numpy as np


### PR DESCRIPTION
#### References to other Issues or PRs
Implements NumPyMatrix from #18253

#### Brief description of what is fixed or changed
This is basically a new matrix class which either wraps an existing NumPy matrix or creates a new one and uses it for storage and delegates some operations to NumPy for acceleration. This will deprecate the need to use `_MatrixWrapper` for NumPy matrices.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added custom NumPyMatrix which uses NumPy methods to accelerate operations.
<!-- END RELEASE NOTES -->
