### PR TITLE
solvers: Fixed NoneType Error

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3460,7 +3460,10 @@ def unrad(eq, *syms, **flags):
     # check for trivial case
     # - already a polynomial in integer powers
     if all(_Q(g) == 1 for g in gens):
-        return
+        if (len(gens) == len(poly.gens) and d!=1):
+            return eq, []
+        else:
+            return
     # - an exponent has a symbol of interest (don't handle)
     if any(g.as_base_exp()[1].has(*syms) for g in gens):
         return

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -746,7 +746,8 @@ def _has_rational_power(expr, symbol):
 
 def _solve_radical(f, symbol, solveset_solver):
     """ Helper function to solve equations with radicals """
-    eq, cov = unrad(f)
+    res = unrad(f)
+    eq, cov = res if res else (f, [])
     if not cov:
         result = solveset_solver(eq, symbol) - \
             Union(*[solveset_solver(g, symbol) for g in denoms(f, symbol)])

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2130,6 +2130,7 @@ def test_issue_17882():
     eq = -8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3))
     assert unrad(eq) == (4*x**2 - 12, [])
 
+
 def test_issue_17949():
     assert solve(exp(+x+x**2), x) == []
     assert solve(exp(-x+x**2), x) == []

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -2126,6 +2126,10 @@ def test_issue_17650():
     assert solve(abs((abs(x**2 - 1) - x)) - x) == [1, -1 + sqrt(2), 1 + sqrt(2)]
 
 
+def test_issue_17882():
+    eq = -8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3))
+    assert unrad(eq) == (4*x**2 - 12, [])
+
 def test_issue_17949():
     assert solve(exp(+x+x**2), x) == []
     assert solve(exp(-x+x**2), x) == []

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -178,14 +178,6 @@ def test_issue_11536():
     assert solveset(0**x - 1, x, S.Reals) == FiniteSet(0)
 
 
-def test_issue_17882():
-    equation = solveset(-8*x**2/(9*(x**2 - 1)**(4/3)) + 4/(3*(x**2 - 1)**(1/3)), x, S.Complexes)
-    equation = str(equation)
-    solution = ConditionSet(x, Eq(-8*x**2*(x**2 - 1)**(-1.33333333333333)/9 + 4*(x**2 - 1)**(-0.333333333333333)/3, 0), S.Complexes)
-    solution = str(solution)
-    assert equation == solution
-
-
 def test_issue_17479():
     import sympy as sb
     from sympy.solvers.solveset import nonlinsolve

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -178,6 +178,14 @@ def test_issue_11536():
     assert solveset(0**x - 1, x, S.Reals) == FiniteSet(0)
 
 
+def test_issue_17882():
+    equation = solveset(-8*x**2/(9*(x**2 - 1)**(4/3)) + 4/(3*(x**2 - 1)**(1/3)), x, S.Complexes)
+    equation = str(equation)
+    solution = ConditionSet(x, Eq(-8*x**2*(x**2 - 1)**(-1.33333333333333)/9 + 4*(x**2 - 1)**(-0.333333333333333)/3, 0), S.Complexes)
+    solution = str(solution)
+    assert equation == solution
+
+
 def test_issue_17479():
     import sympy as sb
     from sympy.solvers.solveset import nonlinsolve

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1897,6 +1897,11 @@ def test_issue_14454():
     assert invert_real(x**2, number, x, S.Reals)  # no error
 
 
+def test_issue_17882():
+    assert solveset(-8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3)), x, S.Complexes) == \
+        FiniteSet(sqrt(3), -sqrt(3))
+
+
 def test_term_factors():
     assert list(_term_factors(3**x - 2)) == [-2, 3**x]
     expr = 4**(x + 1) + 4**(x + 2) + 4**(x - 1) - 3**(x + 2) - 3**(x + 3)


### PR DESCRIPTION
Fixes #17882
Closes #18026

**Brief description of what is fixed or changed:**

Fixes an error in solvers.solvers.unrad() where it would return a `TypeError: cannot unpack non-iterable NoneType object`

Unrad() now returns the simplified numerator even when there are radicals left in the denominator, but since the numerator is free of radicals it seems logical to return the simplified numerator.

**Example:**
```
1) eq = -8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3))
   a, b = unrad(eq)
OR
2) solveset(-8*x**2/(9*(x**2 - 1)**(S(4)/3)) + 4/(3*(x**2 - 1)**(S(1)/3)), x, S.Complexes)
```
**Used to return:** `TypeError: cannot unpack non-iterable NoneType object`
 
**Now returns:** `1) (4*x**2 - 12, []) and 2) FiniteSet(sqrt(3), -sqrt(3))`

**Other comments:**
**Added tests**

**Release Notes:**
<!-- BEGIN RELEASE NOTES -->
* solvers
   *  Fixed NoneType Error Bug in solvers.solvers.unrad()