### PR TITLE
Core: Fixed subs method which was not working with a partial derivative

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -751,24 +751,16 @@ class Function(Application, Expr):
         ix = argindex - 1
         A = self.args[ix]
         if A._diff_wrt:
-            if len(self.args) == 1:
+            if len(self.args) == 1 or not A.is_Symbol:
                 return Derivative(self, A)
-            if A.is_Symbol:
-                for i, v in enumerate(self.args):
-                    if i != ix and A in v.free_symbols:
-                        # it can't be in any other argument's free symbols
-                        # issue 8510
-                        break
-                else:
-                    return Derivative(self, A)
+            for i, v in enumerate(self.args):
+                if i != ix and A in v.free_symbols:
+                    # it can't be in any other argument's free symbols
+                    # issue 8510
+                    break
             else:
-                free = A.free_symbols
-                for i, a in enumerate(self.args):
-                    if ix != i and a.free_symbols & free:
-                        break
-                else:
-                    # there is no possible interaction bewtween args
                     return Derivative(self, A)
+
         # See issue 4624 and issue 4719, 5600 and 8510
         D = Dummy('xi_%i' % argindex, dummy_index=hash(A))
         args = self.args[:ix] + (D,) + self.args[ix + 1:]

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -669,8 +669,8 @@ def test_diff_wrt():
     assert diff(f(g(x), h(y)), x) == \
         Derivative(g(x), x)*Derivative(f(g(x), h(y)), g(x))
     assert diff(f(g(x), h(x)), x) == (
-        Subs(Derivative(f(y, h(x)), y), y, g(x))*Derivative(g(x), x) +
-        Subs(Derivative(f(g(x), y), y), y, h(x))*Derivative(h(x), x))
+        Derivative(f(g(x), h(x)), g(x))*Derivative(g(x), x) +
+        Derivative(f(g(x), h(x)), h(x))*Derivative(h(x), x))
     assert f(
         sin(x)).diff(x) == cos(x)*Subs(Derivative(f(x), x), x, sin(x))
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -535,17 +535,17 @@ class BaseVectorField(AtomicExpr):
 
     >>> v = BaseVectorField(R2_r, 1)
     >>> pprint(v(s_field))
-    /  d              \|
-    |-----(g(x, xi_2))||
-    \dxi_2            /|xi_2=y
+    / d           \|
+    |---(g(x, xi))||
+    \dxi          /|xi=y
     >>> pprint(v(s_field).rcall(point_r).doit())
      d
     ---(g(x0, y0))
     dy0
     >>> pprint(v(s_field).rcall(point_p))
-    /  d                           \|
-    |-----(g(r0*cos(theta0), xi_2))||
-    \dxi_2                         /|xi_2=r0*sin(theta0)
+    / d                        \|
+    |---(g(r0*cos(theta0), xi))||
+    \dxi                       /|xi=r0*sin(theta0)
 
     """
 
@@ -704,13 +704,13 @@ class Differential(Expr):
     >>> dg
     d(g(x, y))
     >>> pprint(dg(e_x))
-    /  d              \|
-    |-----(g(xi_1, y))||
-    \dxi_1            /|xi_1=x
+    / d           \|
+    |---(g(xi, y))||
+    \dxi          /|xi=x
     >>> pprint(dg(e_y))
-    /  d              \|
-    |-----(g(x, xi_2))||
-    \dxi_2            /|xi_2=y
+    / d           \|
+    |---(g(x, xi))||
+    \dxi          /|xi=y
 
     Applying the exterior derivative operator twice always results in:
 


### PR DESCRIPTION
Fixes #16140 

#### Brief description of what is fixed or changed
Subs now works correctly with partial derivative.





#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
    * Changed some partial derivatives like `diff(f(g(x), h(x)), x)` not to have dummy symbols.
    * `subs` now works correctly with partial derivatives.
<!-- END RELEASE NOTES -->
