### PR TITLE
Add factmod function in ntheory module

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -16,7 +16,7 @@ from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \
     primitive_root, nthroot_mod, is_nthpow_residue, sqrt_mod_iter, mobius, \
-    discrete_log, quadratic_congruence
+    discrete_log, quadratic_congruence, factmod
 from .multinomial import binomial_coefficients, binomial_coefficients_list, \
     multinomial_coefficients
 from .continued_fraction import continued_fraction_periodic, \
@@ -43,7 +43,7 @@ __all__ = [
     'is_primitive_root', 'is_quad_residue', 'legendre_symbol',
     'jacobi_symbol', 'n_order', 'sqrt_mod', 'quadratic_residues',
     'primitive_root', 'nthroot_mod', 'is_nthpow_residue', 'sqrt_mod_iter',
-    'mobius', 'discrete_log', 'quadratic_congruence',
+    'mobius', 'discrete_log', 'quadratic_congruence', 'factmod',
 
     'binomial_coefficients', 'binomial_coefficients_list',
     'multinomial_coefficients',

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -151,6 +151,31 @@ def primitive_root(p):
     return next(_primitive_root_prime_iter(p))
 
 
+def factmod(n, p):
+    '''
+    Returns the value --> (n! mod p) for prime ``p``.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.residue_ntheory import factmod
+    >>> factmod(13, 11)
+    0
+    >>> factmod(6, 11)
+    5
+    '''
+    if n >= p:
+        return 0
+    res = 1
+    while n > 1:
+        var = (p - 1) if (n//p)%2 else 1
+        res = (res * var) % p
+        for num in range(2, n%p+1):
+            res = (res * num) % p
+        n = n // p
+    return (res % p)
+
+
 def is_primitive_root(a, p):
     """
     Returns True if ``a`` is a primitive root of ``p``

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -5,7 +5,7 @@ from sympy.core.compatibility import range
 from sympy.ntheory import n_order, is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, totient, primerange, sqrt_mod, \
     primitive_root, quadratic_residues, is_nthpow_residue, nthroot_mod, \
-    sqrt_mod_iter, mobius, discrete_log, quadratic_congruence
+    sqrt_mod_iter, mobius, discrete_log, quadratic_congruence, factmod
 from sympy.ntheory.residue_ntheory import _primitive_root_prime_iter, \
     _discrete_log_trial_mul, _discrete_log_shanks_steps, \
     _discrete_log_pollard_rho, _discrete_log_pohlig_hellman
@@ -263,3 +263,8 @@ def test_residue():
     assert quadratic_congruence(5, 10, 14, 2) == [0]
     assert quadratic_congruence(10, 17, 19, 2) == [1]
     assert quadratic_congruence(10, 14, 20, 2) == [0, 1]
+
+    assert factmod(6, 11) == 5
+    assert factmod(13, 11) == 0
+    assert factmod(29, 29) == 0
+    assert factmod(55, 61) == 30

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -268,3 +268,6 @@ def test_residue():
     assert factmod(13, 11) == 0
     assert factmod(29, 29) == 0
     assert factmod(55, 61) == 30
+    assert factmod(10, 17) == 14
+    assert factmod(0, 7) == 1
+    assert factmod(10, 109) == 81


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`factmod` computes `n! mod p` for prime ``p`` using iteration technique. 
Overall time complexity: O(p*log(n))
Examples:
```
>>> from sympy.ntheory.residue_ntheory import factmod
>>> factmod(3, 7)
6
>>> factmod(55, 61)
30
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  ntheory
    *  Added `factmod`.
<!-- END RELEASE NOTES -->
