### PR TITLE
fix is_nthpow_residue(a, n, m) 

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -652,7 +652,7 @@ def _is_nthpow_residue_bign(a, n, m):
     """Returns True if ``x**n == a (mod m)`` has solutions for n > 2."""
     # assert n > 2
     # assert a > 0 and m > 0
-    if primitive_root(m) is None:
+    if primitive_root(m) is None or igcd(a, m) != 1:
         # assert m >= 8
         for prime, power in factorint(m).items():
             if not _is_nthpow_residue_bign_prime_power(a, n, prime, power):

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -147,6 +147,9 @@ def test_residue():
     assert is_nthpow_residue(81, 3, 972) is False
     assert is_nthpow_residue(243, 5, 5103) is True
     assert is_nthpow_residue(243, 3, 1240029) is False
+    assert is_nthpow_residue(36010, 8, 87382) is True
+    assert is_nthpow_residue(28552, 6, 2218) is True
+    assert is_nthpow_residue(92712, 9, 50026) is True
     x = set([pow(i, 56, 1024) for i in range(1024)])
     assert set([a for a in range(1024) if is_nthpow_residue(a, 56, 1024)]) == x
     x = set([ pow(i, 256, 2048) for i in range(2048)])


### PR DESCRIPTION
Fixes #18234 
 <!-- BEGIN RELEASE NOTES -->
* ntheory
    * Fixed is_nthpow_residue for numbers that are not powers of a primitive root.
<!-- END RELEASE NOTES -->
