### PR TITLE
Numpy printing support for some matrix expressions - revived

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -689,12 +689,19 @@ class NumPyPrinter(PythonCodePrinter):
             ')' * (len(expr.args) - 1))
 
     def _print_Adjoint(self, expr):
-        return '{}.getH()'.format(self._print(expr.arg))
+        return '{}({}({}))'.format(
+            self._module_format('numpy.conjugate'),
+            self._module_format('numpy.transpose'),
+            self._print(expr.args[0]))
 
     def _print_DiagonalOf(self, expr):
-        return '{}({})'.format(self._module_format('numpy.diag'), self._print(expr.arg))
+        vect = '{}({})'.format(
+            self._module_format('numpy.diag'),
+            self._print(expr.arg))
+        return '{}({}, (-1, 1))'.format(
+            self._module_format('numpy.reshape'), vect)
 
-    def _print_DiagonalizeVector(self, expr):
+    def _print_DiagMatrix(self, expr):
         return '{}({})'.format(self._module_format('numpy.diagflat'),
             self._print(expr.args[0]))
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -658,6 +658,51 @@ class NumPyPrinter(PythonCodePrinter):
                                self._print(expr.matrix),
                                self._print(expr.vector))
 
+    def _print_ZeroMatrix(self, expr):
+        return '{}({})'.format(self._module_format('numpy.zeros'),
+            self._print(expr.shape))
+
+    def _print_OneMatrix(self, expr):
+        return '{}({})'.format(self._module_format('numpy.ones'),
+            self._print(expr.shape))
+
+    def _print_FunctionMatrix(self, expr):
+        from sympy.core.function import Lambda
+        from sympy.abc import i, j
+        lamda = expr.lamda
+        if not isinstance(lamda, Lambda):
+            lamda = Lambda((i, j), lamda(i, j))
+        return '{}(lambda {}: {}, {})'.format(self._module_format('numpy.fromfunction'),
+            ', '.join(self._print(arg) for arg in lamda.args[0]),
+            self._print(lamda.args[1]), self._print(expr.shape))
+
+    def _print_HadamardProduct(self, expr):
+        func = self._module_format('numpy.multiply')
+        return ''.join('{}({}, '.format(func, self._print(arg)) \
+            for arg in expr.args[:-1]) + "{}{}".format(self._print(expr.args[-1]),
+            ')' * (len(expr.args) - 1))
+
+    def _print_KroneckerProduct(self, expr):
+        func = self._module_format('numpy.kron')
+        return ''.join('{}({}, '.format(func, self._print(arg)) \
+            for arg in expr.args[:-1]) + "{}{}".format(self._print(expr.args[-1]),
+            ')' * (len(expr.args) - 1))
+
+    def _print_Adjoint(self, expr):
+        return '{}.getH()'.format(self._print(expr.arg))
+
+    def _print_DiagonalOf(self, expr):
+        return '{}({})'.format(self._module_format('numpy.diag'), self._print(expr.arg))
+
+    def _print_DiagonalizeVector(self, expr):
+        return '{}({})'.format(self._module_format('numpy.diagflat'),
+            self._print(expr.args[0]))
+
+    def _print_DiagonalMatrix(self, expr):
+        return '{}({}, {}({}, {}))'.format(self._module_format('numpy.multiply'),
+            self._print(expr.arg), self._module_format('numpy.eye'),
+            self._print(expr.shape[0]), self._print(expr.shape[1]))
+
     def _print_Piecewise(self, expr):
         "Piecewise function printer"
         exprs = '[{0}]'.format(','.join(self._print(arg.expr) for arg in expr.args))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -75,9 +75,16 @@ def test_MpmathPrinter():
 
 
 def test_NumPyPrinter():
+    from sympy import (Lambda, ZeroMatrix, OneMatrix, FunctionMatrix,
+        HadamardProduct, KroneckerProduct, Adjoint, DiagonalOf,
+        DiagonalizeVector, DiagonalMatrix)
+    from sympy.abc import a, b
     p = NumPyPrinter()
     assert p.doprint(sign(x)) == 'numpy.sign(x)'
     A = MatrixSymbol("A", 2, 2)
+    B = MatrixSymbol("B", 2, 2)
+    C = MatrixSymbol("C", 1, 5)
+    D = MatrixSymbol("D", 3, 4)
     assert p.doprint(A**(-1)) == "numpy.linalg.inv(A)"
     assert p.doprint(A**5) == "numpy.linalg.matrix_power(A, 5)"
     assert p.doprint(Identity(3)) == "numpy.eye(3)"
@@ -86,6 +93,18 @@ def test_NumPyPrinter():
     v = MatrixSymbol('y', 2, 1)
     assert p.doprint(MatrixSolve(A, u)) == 'numpy.linalg.solve(A, x)'
     assert p.doprint(MatrixSolve(A, u) + v) == 'numpy.linalg.solve(A, x) + y'
+
+    assert p.doprint(ZeroMatrix(2, 3)) == "numpy.zeros((2, 3))"
+    assert p.doprint(OneMatrix(2, 3)) == "numpy.ones((2, 3))"
+    assert p.doprint(FunctionMatrix(4, 5, Lambda((a, b), a + b))) == \
+        "numpy.fromfunction(lambda a, b: a + b, (4, 5))"
+    assert p.doprint(HadamardProduct(A, B)) == "numpy.multiply(A, B)"
+    assert p.doprint(KroneckerProduct(A, B)) == "numpy.kron(A, B)"
+    assert p.doprint(Adjoint(A)) == "A.getH()"
+    assert p.doprint(DiagonalOf(A)) == "numpy.diag(A)"
+    assert p.doprint(DiagonalizeVector(C)) == "numpy.diagflat(C)"
+    assert p.doprint(DiagonalMatrix(D)) == "numpy.multiply(D, numpy.eye(3, 4))"
+
     # Workaround for numpy negative integer power errors
     assert p.doprint(x**-1) == 'x**(-1.0)'
     assert p.doprint(x**-2) == 'x**(-2.0)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -77,7 +77,7 @@ def test_MpmathPrinter():
 def test_NumPyPrinter():
     from sympy import (Lambda, ZeroMatrix, OneMatrix, FunctionMatrix,
         HadamardProduct, KroneckerProduct, Adjoint, DiagonalOf,
-        DiagonalizeVector, DiagonalMatrix)
+        DiagMatrix, DiagonalMatrix)
     from sympy.abc import a, b
     p = NumPyPrinter()
     assert p.doprint(sign(x)) == 'numpy.sign(x)'
@@ -100,9 +100,9 @@ def test_NumPyPrinter():
         "numpy.fromfunction(lambda a, b: a + b, (4, 5))"
     assert p.doprint(HadamardProduct(A, B)) == "numpy.multiply(A, B)"
     assert p.doprint(KroneckerProduct(A, B)) == "numpy.kron(A, B)"
-    assert p.doprint(Adjoint(A)) == "A.getH()"
-    assert p.doprint(DiagonalOf(A)) == "numpy.diag(A)"
-    assert p.doprint(DiagonalizeVector(C)) == "numpy.diagflat(C)"
+    assert p.doprint(Adjoint(A)) == "numpy.conjugate(numpy.transpose(A))"
+    assert p.doprint(DiagonalOf(A)) == "numpy.reshape(numpy.diag(A), (-1, 1))"
+    assert p.doprint(DiagMatrix(C)) == "numpy.diagflat(C)"
     assert p.doprint(DiagonalMatrix(D)) == "numpy.multiply(D, numpy.eye(3, 4))"
 
     # Workaround for numpy negative integer power errors


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17013, Fixes #17029, Fixes #17027

#### Brief description of what is fixed or changed

I made some changes to the conjugate transpose not to use the feature of the deprecated `numpy.matrix`. And made `DiagonalOf` return as a 2-dimensional column vector rather than a 1 dimensional vector.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Added NumPy printing for several matrix expressions. (`ZeroMatrix`, `OneMatrix`, `FunctionMatrix`, `HadamardProduct`, `KroneckerProduct`, `Adjoint`, `DiagonalOf`, `DiagMatrix`, `DiagonalMatrix`)
<!-- END RELEASE NOTES -->
