### PR TITLE
Fix FiniteSet union handler for symbolic elements

### DIFF
--- a/sympy/sets/handlers/union.py
+++ b/sympy/sets/handlers/union.py
@@ -135,7 +135,7 @@ def union_sets(a, b): # noqa:F811
     # If `b` set contains one of my elements, remove it from `a`
     if any(b.contains(x) == True for x in a):
         return set((
-            FiniteSet(*[x for x in a if not b.contains(x)]), b))
+            FiniteSet(*[x for x in a if b.contains(x) != True]), b))
     return None
 
 @dispatch(Set, Set)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -186,6 +186,11 @@ def test_union():
 
     assert Union(Interval(0, 1), *[FiniteSet(1.0/n) for n in range(1, 10)]) == \
         Interval(0, 1)
+    # issue #18241:
+    x = Symbol('x')
+    assert Union(Interval(0, 1), FiniteSet(1, x)) == Union(
+        Interval(0, 1), FiniteSet(x))
+    assert unchanged(Union, Interval(0, 1), FiniteSet(2, x))
 
     assert Interval(1, 2).union(Interval(2, 3)) == \
         Interval(1, 2) + Interval(2, 3)


### PR DESCRIPTION

#### References to other Issues or PRs

Fixes #18241.

#### Brief description of what is fixed or changed

Before:
```
In [1]: Interval(0, 1).union(FiniteSet(1, x))
Out[1]: [0, 1]
```

After:
```
In [1]: Interval(0, 1).union(FiniteSet(1, x))
Out[1]: [0, 1] ∪ {x}
```

Reason:
Incorrect handling of `.contains()` ternary logic
(True or False or Contains/Relational)

Tests are added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed a bug in `FiniteSet`'s union handler that could lead to some elements being "dropped" if their membership in the other set can't be determined.
<!-- END RELEASE NOTES -->
