### PR TITLE
[Testing] Test what happens if zero*(possibly infinite) does not evaluate

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2251,6 +2251,9 @@ class Expr(Basic, EvalfMixin):
                 return Add._from_args(newargs)
         elif self.is_Mul:
             args = list(self.args)
+            # XXX: If we have a Mul with a zero in it
+            if any(arg.is_zero for arg in args):
+                return None
             for i, arg in enumerate(args):
                 newarg = arg.extract_multiplicatively(c)
                 if newarg is not None:
@@ -2334,8 +2337,9 @@ class Expr(Basic, EvalfMixin):
         if c.is_Add and c.args[0].is_Number:
             # whole term as a term factor
             co = self.coeff(c)
-            xa0 = (co.extract_additively(1) or 0)*c
-            if xa0:
+            coea = co.extract_additively(1)
+            if coea:
+                xa0 = coea*c
                 diff = self - co*c
                 return (xa0 + (diff.extract_additively(c) or diff)) or None
             # term-wise
@@ -2351,8 +2355,9 @@ class Expr(Basic, EvalfMixin):
 
         # whole term as a term factor
         co = self.coeff(c)
-        xa0 = (co.extract_additively(1) or 0)*c
-        if xa0:
+        coea = co.extract_additively(1)
+        if coea:
+            xa0 = coea*c
             diff = self - co*c
             return (xa0 + (diff.extract_additively(c) or diff)) or None
         # term-wise

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -607,7 +607,8 @@ class Mul(Expr, AssocOp):
                 return [coeff], nc_part, order_symbols
             if any(c.is_finite == False for c in c_part):
                 return [S.NaN], [], order_symbols
-            return [coeff], [], order_symbols
+            elif all(c.is_finite == True for c in c_part):
+                return [coeff], [], order_symbols
 
         # check for straggling Numbers that were produced
         _new = []


### PR DESCRIPTION
This means that in `a*b` or `Mul(a, b)` if `a.is_zero` is `True` and `b.is_finite` is
`None` then the `Mul` will be unevaluated e.g.:
```julia
In [1]: x = Symbol('x')

In [2]: 0*x
Out[2]: 0⋅x

In [3]: x = Symbol('x', real=True)

In [4]: 0 * (1/x)
Out[4]:
0
─
x

In [5]: x = Symbol('x', nonzero=True)

In [6]: 0 * (1/x)
Out[6]: 0
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open. -->

See #18365 and #17224

This will give a lot of test failures. I'm just running it as a demonstration to see how bad the problems are.

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
