### PR TITLE
Tensor: Added _eval_simplify method for class ImmutableDenseNDimArray.

### DIFF
--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -151,7 +151,7 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray):
         return MutableDenseNDimArray(self)
 
     def _eval_simplify(self, **kwargs):
-        return [simplify(x, **kwargs) for x in self]
+        return self.applyfunc(simplify)
 
 class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
 

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -5,7 +5,7 @@ from sympy import Basic, Tuple, S
 from sympy.core.sympify import _sympify
 from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
 from sympy.tensor.array.ndim_array import NDimArray, ImmutableNDimArray
-
+from sympy.simplify import simplify
 
 
 class DenseNDimArray(NDimArray):
@@ -150,6 +150,8 @@ class ImmutableDenseNDimArray(DenseNDimArray, ImmutableNDimArray):
     def as_mutable(self):
         return MutableDenseNDimArray(self)
 
+    def _eval_simplify(self, **kwargs):
+        return [simplify(x, **kwargs) for x in self]
 
 class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
 

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -1,8 +1,10 @@
 from sympy.testing.pytest import raises
 from sympy import (
     Array, ImmutableDenseNDimArray, ImmutableSparseNDimArray,
-    MutableDenseNDimArray, MutableSparseNDimArray
+    MutableDenseNDimArray, MutableSparseNDimArray, sin, cos,
+    simplify
 )
+from sympy.abc import x, y
 
 
 array_types = [
@@ -31,3 +33,12 @@ def test_array_negative_indices():
         raises(ValueError, lambda: test_array[-3, :])
 
         assert test_array[-1, -1] == 10
+
+
+def test_issue_18361():
+    A = Array([sin(2 * x) - 2 * sin(x) * cos(x)])
+    B = Array([sin(x)**2 + cos(x)**2, 0])
+    C = Array([(x + x**2)/(x*sin(y)**2 + x*cos(y)**2), 2*sin(x)*cos(x)])
+    assert simplify(A) == [0]
+    assert simplify(B) == [1, 0]
+    assert simplify(C) == [x + 1, sin(2*x)]

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -39,6 +39,6 @@ def test_issue_18361():
     A = Array([sin(2 * x) - 2 * sin(x) * cos(x)])
     B = Array([sin(x)**2 + cos(x)**2, 0])
     C = Array([(x + x**2)/(x*sin(y)**2 + x*cos(y)**2), 2*sin(x)*cos(x)])
-    assert simplify(A) == [0]
-    assert simplify(B) == [1, 0]
-    assert simplify(C) == [x + 1, sin(2*x)]
+    assert simplify(A) == Array([0])
+    assert simplify(B) == Array([1, 0])
+    assert simplify(C) == Array([x + 1, sin(2*x)])


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18361 

#### Brief description of what is fixed or changed
--> _evalf_simplify simplifies each element of the array.
--> Added Tests


#### Other comments
```
>>> from sympy.abc import x, y
>>> from sympy import sin, cos, simplify, Array
>>> B = Array([sin(x)**2 + cos(x)**2, 0])
>>> simplify(B)
[1, 0]
>>> C = Array([(x + x**2)/(x*sin(y)**2 + x*cos(y)**2), 2*sin(x)*cos(x)])
>>> simplify(C)
[x + 1, sin(2*x)]
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added _eval_simplify method for class ImmutableDenseNDimArray
<!-- END RELEASE NOTES -->