### PR TITLE
bug fix in checkodesol

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2809,7 +2809,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
             else:
                 testnum += 1
                 continue
-            ss = simplify(s)
+            ss = simplify(s.rewrite(exp))
             if ss:
                 # with the new numer_denom in power.py, if we do a simple
                 # expansion then testnum == 0 verifies all solutions.

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2333,13 +2333,13 @@ def test_nth_linear_constant_coeff_variation_of_parameters_simplify_False():
     # eq.subs(*sol_simp.args) doesn't simplify to zero without help
     (t, zero) = checkodesol(eq, sol_simp, order=5, solve_for_func=False)
     # if this fails because zero.is_zero, replace this block with
-    # assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
-    assert not zero.is_zero and zero.rewrite(exp).simplify() == 0
+    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
+    # assert not zero.is_zero and zero.rewrite(exp).simplify() == 0
     # \-----------
     (t, zero) = checkodesol(eq, sol_nsimp, order=5, solve_for_func=False)
     # if this fails because zero.is_zero, replace this block with
-    # assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
-    assert zero == 0
+    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
+    # assert zero == 0
     # \-----------
     assert t
 
@@ -3827,4 +3827,16 @@ def test_issue_5096():
     eq = 2*x**2*f(x).diff(x, 2) + f(x) + sin(log(2*x)/2)
     sol = Eq(f(x), C1*sqrt(x)*sin(log(x)/2) + C2*sqrt(x)*cos(log(x)/2) - 2*sin(log(2*x)/2)/5 - 4*cos(log(2*x)/2)/5)
     assert sol == dsolve(eq, hint='nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients')
+    assert checkodesol(eq, sol) == (True, 0)
+
+
+def test_issue_15996():
+    eq = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x) - 2*x - exp(I*x)
+    sol = Eq(f(x), C1 + x**2 + (C2 - x**2/8 + x*(C3 + 3*exp(I*x)/2 + 3*exp(-I*x)/2) + 5*exp(2*I*x)/16 + 2*I*exp(I*x) - 2*I*exp(-I*x))*sin(x) + (C4 + I*x**2/8 + x*(C5 + 3*I*exp(I*x)/2 - 3*I*exp(-I*x)/2) + 5*I*exp(2*I*x)/16 - 2*exp(I*x) - 2*exp(-I*x))*cos(x) - I*exp(I*x))
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_variation_of_parameters')
+    assert checkodesol(eq, sol) == (True, 0)
+
+    eq = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x) - exp(I*x)
+    sol = Eq(f(x), C1 + (C2 + C3*x - x**2/8 + 5*exp(2*I*x)/16)*sin(x) + (C4 + C5*x + I*x**2/8 + 5*I*exp(2*I*x)/16)*cos(x) - I*exp(I*x))
+    assert sol == dsolve(eq, hint='nth_linear_constant_coeff_variation_of_parameters')
     assert checkodesol(eq, sol) == (True, 0)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2329,19 +2329,9 @@ def test_nth_linear_constant_coeff_variation_of_parameters_simplify_False():
     sol_simp = dsolve(eq, f(x), hint=our_hint, simplify=True)
     sol_nsimp = dsolve(eq, f(x), hint=our_hint, simplify=False)
     assert sol_simp != sol_nsimp
-    # /----------
-    # eq.subs(*sol_simp.args) doesn't simplify to zero without help
-    (t, zero) = checkodesol(eq, sol_simp, order=5, solve_for_func=False)
-    # if this fails because zero.is_zero, replace this block with
-    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
-    # assert not zero.is_zero and zero.rewrite(exp).simplify() == 0
-    # \-----------
-    (t, zero) = checkodesol(eq, sol_nsimp, order=5, solve_for_func=False)
-    # if this fails because zero.is_zero, replace this block with
-    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False)[0]
-    # assert zero == 0
-    # \-----------
-    assert t
+    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False) == (True, 0)
+    assert checkodesol(eq, sol_simp, order=5, solve_for_func=False) == (True, 0)
+
 
 def test_Liouville_ODE():
     hint = 'Liouville'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #15996 

#### Brief description of what is fixed or changed
`rewrite(exp)`  is used inside `checkodesol` because the solution returned by `variation of parameters` was correct but `checkodesol` couldn't simplify

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  *  Fixed `checkodesol` for some cases when the solution returned by `variation of parameters` was correct but `chekodesol` couldn't simplify it.

<!-- END RELEASE NOTES -->