### PR TITLE
Fixing gmpy in integer_nthroot

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -136,10 +136,9 @@ import sympy
 test_list = [
     # numpy
     '*numpy*',
-    'sympy/core/tests/test_numbers.py',
+    'sympy/core/',
     'sympy/matrices/',
     'sympy/physics/quantum/',
-    'sympy/core/tests/test_sympify.py',
     'sympy/utilities/tests/test_lambdify.py',
 
     # scipy

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -71,7 +71,10 @@ def integer_nthroot(y, n):
         raise ValueError("y must be nonnegative")
     if n < 1:
         raise ValueError("n must be positive")
-    if HAS_GMPY and n < 9223372036854775808:  # n < 2**63
+    if HAS_GMPY and n < 2**63:
+        # Currently it works only for n < 2**63, else it produces TypeError
+        # sympy issue: https://github.com/sympy/sympy/issues/18374
+        # gmpy2 issue: https://github.com/aleaxit/gmpy/issues/257
         if HAS_GMPY >= 2:
             x, t = gmpy.iroot(y, n)
         else:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -71,9 +71,12 @@ def integer_nthroot(y, n):
         raise ValueError("y must be nonnegative")
     if n < 1:
         raise ValueError("n must be positive")
-    if HAS_GMPY:
-        x, t = gmpy.iroot(y, n)
-        return as_int(x), t
+    if HAS_GMPY and n < 2**63:
+        if HAS_GMPY >= 2:
+            x, t = gmpy.iroot(y, n)
+        else:
+            x, t = gmpy.root(y, n)
+        return as_int(x), bool(t)
     return _integer_nthroot_python(y, n)
 
 def _integer_nthroot_python(y, n):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -71,7 +71,7 @@ def integer_nthroot(y, n):
         raise ValueError("y must be nonnegative")
     if n < 1:
         raise ValueError("n must be positive")
-    if HAS_GMPY and n < 9223372036854775808:  # n < 2**63 
+    if HAS_GMPY and n < 9223372036854775808:  # n < 2**63
         if HAS_GMPY >= 2:
             x, t = gmpy.iroot(y, n)
         else:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -71,7 +71,7 @@ def integer_nthroot(y, n):
         raise ValueError("y must be nonnegative")
     if n < 1:
         raise ValueError("n must be positive")
-    if HAS_GMPY and n < 2**63:
+    if HAS_GMPY and n < 9223372036854775808:  # n < 2**63 
         if HAS_GMPY >= 2:
             x, t = gmpy.iroot(y, n)
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixing gmpy in integer_nthroot
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Workaround for #18374
#### Brief description of what is fixed or changed
Added check for `gmpy` version and the bound of `n`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Adding gmpy in integer_nthroot ( It works only for `n < 2**63`)
<!-- END RELEASE NOTES -->