### PR TITLE
Removed deprecated from printing

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from sympy.core.compatibility import unicode, u_decode
 from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
 from .latex import latex
 
@@ -137,16 +136,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             except KeyError:
                 raise SystemError("Invalid output format: %s" % output)
     else:
-        if viewer == "file":
-            if filename is None:
-                SymPyDeprecationWarning(feature="Using viewer=\"file\" without a "
-                    "specified filename", deprecated_since_version="0.7.3",
-                    useinstead="viewer=\"file\" and filename=\"desiredname\"",
-                    issue=7018).warn()
-        elif viewer == "StringIO":
-            SymPyDeprecationWarning(feature="The preview() viewer StringIO",
-                useinstead="BytesIO", deprecated_since_version="0.7.4",
-                issue=7083).warn()
+        if viewer == "StringIO":
             viewer = "BytesIO"
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a BytesIO "

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -302,7 +302,6 @@ def test_ccode_Indexed():
     assert p._print_Indexed(x) == 'x[j]'
     assert p._print_Indexed(A) == 'A[%s]' % (m*i+j)
     assert p._print_Indexed(B) == 'B[%s]' % (i*o*m+j*o+k)
-    # assert p._not_c == set()
 
     A = IndexedBase('A', shape=(5,3))[i, j]
     assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -11,7 +11,7 @@ from sympy.sets import Range
 from sympy.logic import ITE
 from sympy.codegen import For, aug_assign, Assignment
 from sympy.testing.pytest import raises, XFAIL
-from sympy.printing.ccode import CCodePrinter, C89CodePrinter, C99CodePrinter, get_math_macros
+from sympy.printing.ccode import C89CodePrinter, C99CodePrinter, get_math_macros
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
     While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall, Return,
@@ -20,7 +20,6 @@ from sympy.codegen.ast import (
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, fma, log10, Cbrt, hypot, Sqrt
 from sympy.codegen.cnodes import restrict
 from sympy.utilities.lambdify import implemented_function
-from sympy.testing.pytest import warns_deprecated_sympy
 from sympy.tensor import IndexedBase, Idx
 from sympy.matrices import Matrix, MatrixSymbol
 
@@ -298,14 +297,12 @@ def test_ccode_Indexed():
     A = IndexedBase('A')[i, j]
     B = IndexedBase('B')[i, j, k]
 
-    with warns_deprecated_sympy():
-        p = CCodePrinter()
-    p._not_c = set()
+    p = C99CodePrinter()
 
     assert p._print_Indexed(x) == 'x[j]'
     assert p._print_Indexed(A) == 'A[%s]' % (m*i+j)
     assert p._print_Indexed(B) == 'B[%s]' % (i*o*m+j*o+k)
-    assert p._not_c == set()
+    # assert p._not_c == set()
 
     A = IndexedBase('A', shape=(5,3))[i, j]
     assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)
@@ -594,13 +591,6 @@ def test_ccode_standard():
     assert ccode(float('nan'), standard='c99') == 'NAN'
 
 
-def test_CCodePrinter():
-    with warns_deprecated_sympy():
-        CCodePrinter()
-    with warns_deprecated_sympy():
-        assert CCodePrinter().language == 'C'
-
-
 def test_C89CodePrinter():
     c89printer = C89CodePrinter()
     assert c89printer.language == 'C'
@@ -782,13 +772,6 @@ def test_MatrixElement_printing():
 
     F = C[0, 0].subs(C, A - B)
     assert(ccode(F) == "(A - B)[0]")
-
-
-def test_subclass_CCodePrinter():
-    # issue gh-12687
-    class MySubClass(CCodePrinter):
-        pass
-
 
 def test_ccode_math_macros():
     assert ccode(z + exp(1)) == 'z + M_E'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Removes depreciations from printing
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* printing
  * Removed deprecated `Ccodeprinter` (Use `C89Printer` or `C99Printer` instead). Deprecated since version `1.1` (Issue : #12220).
  * Removed deprecated `file` viewer option in `preview`. Deprecated since version `0.7.3`(Issue: #7018)
  *  Removed deprecated `StringIO` viewer option in `preview`. Deprecated since version `0.7.2`(Issue: #7083)
<!-- END RELEASE NOTES -->