### PR TITLE
Dropping Python 2: Removed Python 2 compatibility

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3678,18 +3678,7 @@ class Expr(Basic, EvalfMixin):
         p = as_int(n or 0)
 
         if x.is_Integer:
-            # XXX return Integer(round(int(x), p)) when Py2 is dropped
-            if p >= 0:
-                return x
-            m = 10**-p
-            i, r = divmod(abs(x), m)
-            if i%2 and 2*r == m:
-              i += 1
-            elif 2*r > m:
-                i += 1
-            if x < 0:
-                i *= -1
-            return i*m
+            return Integer(round(int(x), p))
 
         digits_to_decimal = _mag(x)  # _mag(12) = 2, _mag(.012) = -1
         allow = digits_to_decimal + p
@@ -3767,7 +3756,7 @@ class Expr(Basic, EvalfMixin):
         # shift p to the new position
         ip = p - shift
         # let Python handle the int rounding then rescale
-        xr = xi.round(ip) # when Py2 is drop make this round(xi.p, ip)
+        xr = round(xi.p, ip)
         # restore scale
         rv = Rational(xr, Pow(10, shift))
         # return Float or Integer

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -329,9 +329,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
                 coerced = coerce(a)
             except (TypeError, ValueError):
                 continue
-            # XXX: AttributeError only needed here for Py2
-            except AttributeError:
-                continue
             try:
                 return sympify(coerced)
             except SympifyError:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -8,7 +8,7 @@ from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, 
                    integrate, gammasimp, Gt)
 from sympy.core.expr import ExprBuilder, unchanged
 from sympy.core.function import AppliedUndef
-from sympy.core.compatibility import round, PY3
+from sympy.core.compatibility import round
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
 
@@ -19,7 +19,7 @@ from sympy.abc import a, b, c, n, t, u, x, y, z
 
 # replace 3 instances with int when PY2 is dropped and
 # delete this line
-_rint = int if PY3 else float
+_rint = int
 
 class DummyNumber(object):
     """
@@ -337,16 +337,14 @@ def test_cooperative_operations():
             raises(TypeError, lambda : divmod(na, e))
             raises(TypeError, lambda : e ** na)
             raises(TypeError, lambda : na ** e)
-            # XXX: Remove the if when PY2 support is dropped:
-            if PY3:
-                raises(TypeError, lambda : e > na)
-                raises(TypeError, lambda : na > e)
-                raises(TypeError, lambda : e < na)
-                raises(TypeError, lambda : na < e)
-                raises(TypeError, lambda : e >= na)
-                raises(TypeError, lambda : na >= e)
-                raises(TypeError, lambda : e <= na)
-                raises(TypeError, lambda : na <= e)
+            raises(TypeError, lambda : e > na)
+            raises(TypeError, lambda : na > e)
+            raises(TypeError, lambda : e < na)
+            raises(TypeError, lambda : na < e)
+            raises(TypeError, lambda : e >= na)
+            raises(TypeError, lambda : na >= e)
+            raises(TypeError, lambda : e <= na)
+            raises(TypeError, lambda : na <= e)
 
 
 def test_relational():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -17,10 +17,6 @@ from sympy.testing.pytest import raises, XFAIL
 from sympy.abc import a, b, c, n, t, u, x, y, z
 
 
-# replace 3 instances with int when PY2 is dropped and
-# delete this line
-_rint = int
-
 class DummyNumber(object):
     """
     Minimal implementation of a number that works with SymPy.
@@ -1952,14 +1948,14 @@ def test_round():
     for i in range(2):
         f = float(i)
         # 2 args
-        assert all(type(round(i, p)) is _rint for p in (-1, 0, 1))
+        assert all(type(round(i, p)) is int for p in (-1, 0, 1))
         assert all(S(i).round(p).is_Integer for p in (-1, 0, 1))
         assert all(type(round(f, p)) is float for p in (-1, 0, 1))
         assert all(S(f).round(p).is_Float for p in (-1, 0, 1))
         # 1 arg (p is None)
-        assert type(round(i)) is _rint
+        assert type(round(i)) is int
         assert S(i).round().is_Integer
-        assert type(round(f)) is _rint
+        assert type(round(f)) is int
         assert S(f).round().is_Integer
 
 

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -1,13 +1,12 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from sympy import Poly, symbols, oo, I, Rational
-from sympy.core.compatibility import PY3
 from sympy.integrals.risch import (DifferentialExtension,
     NonElementaryIntegralException)
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     normal_denom, special_denom, bound_degree, spde, solve_poly_rde,
     no_cancel_equal, cancel_primitive, cancel_exp, rischDE)
 
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises
 from sympy.abc import x, t, z, n
 
 t0, t1, t2, k = symbols('t:3 k')

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -92,8 +92,6 @@ def test_special_denom():
     Poly(t, t), DE, case='unrecognized_case'))
 
 
-# @XFAIL
-# Probably only fails in Python 2.7
 def test_bound_degree_fail():
     # Primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x),
@@ -101,10 +99,6 @@ def test_bound_degree_fail():
     assert bound_degree(Poly(t**2, t), Poly(-(1/x**2*t**2 + 1/x), t),
         Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/2*x*t**2 + x*t,
         t), DE) == 3
-
-
-if not PY3:
-    test_bound_degree_fail = XFAIL(test_bound_degree_fail)
 
 
 def test_bound_degree():

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -106,15 +106,13 @@ class DenseMatrix(MatrixBase):
                     return MatrixElement(self, i, j)
 
                 if isinstance(i, slice):
-                    # XXX remove list() when PY2 support is dropped
-                    i = list(range(self.rows))[i]
+                    i = range(self.rows)[i]
                 elif is_sequence(i):
                     pass
                 else:
                     i = [i]
                 if isinstance(j, slice):
-                    # XXX remove list() when PY2 support is dropped
-                    j = list(range(self.cols))[j]
+                    j = range(self.cols)[j]
                 elif is_sequence(j):
                     pass
                 else:

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -234,8 +234,7 @@ class SparseMatrix(MatrixBase):
                 return self._smat.get((i, j), S.Zero)
             except (TypeError, IndexError):
                 if isinstance(i, slice):
-                    # XXX remove list() when PY2 support is dropped
-                    i = list(range(self.rows))[i]
+                    i = range(self.rows)[i]
                 elif is_sequence(i):
                     pass
                 elif isinstance(i, Expr) and not i.is_number:
@@ -246,8 +245,7 @@ class SparseMatrix(MatrixBase):
                         raise IndexError('Row index out of bounds')
                     i = [i]
                 if isinstance(j, slice):
-                    # XXX remove list() when PY2 support is dropped
-                    j = list(range(self.cols))[j]
+                    j = range(self.cols)[j]
                 elif is_sequence(j):
                     pass
                 elif isinstance(j, Expr) and not j.is_number:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3228,17 +3228,11 @@ def test_keep_coeff():
     assert _keep_coeff(x + 1, S(2)) == u
 
 
-# @XFAIL
-# Seems to pass on Python 3.X, but not on Python 2.7
 def test_poly_matching_consistency():
     # Test for this issue:
     # https://github.com/sympy/sympy/issues/5514
     assert I * Poly(x, x) == Poly(I*x, x)
     assert Poly(x, x) * I == Poly(I*x, x)
-
-
-if not PY3:
-    test_poly_matching_consistency = XFAIL(test_poly_matching_consistency)
 
 
 @XFAIL

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -56,7 +56,7 @@ from sympy import (
     exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
 
 from sympy.core.basic import _aresame
-from sympy.core.compatibility import iterable, PY3
+from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
 from sympy.testing.pytest import raises, XFAIL
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removed code that was Python 2 compatible

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->