### PR TITLE
Allow user defined keyword arguments to simplify

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -544,12 +544,13 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
         return shorter(rv, collect_abs(rv))
 
     expr = sympify(expr)
-    kwargs = dict(
+    _kwargs = dict(
         ratio=kwargs.get('ratio', ratio),
         measure=kwargs.get('measure', measure),
         rational=kwargs.get('rational', rational),
         inverse=kwargs.get('inverse', inverse),
         doit=kwargs.get('doit', doit))
+    kwargs.update(_kwargs)
     # no routine for Expr needs to check for is_zero
     if isinstance(expr, Expr) and expr.is_zero and expr*0 == S.Zero:
         return S.Zero

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -554,7 +554,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
     it may not be simplified at all. For this case, pass ``recursive=True`` to simplify
     the arguments of expression recursively.
     Since this may greatly decrease the performance, default value for ``recursive`` is False.
-    
+
     >>> simplify(a+1)
     1 + MyExpr()
     >>> simplify(a+1, recursive=True)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1,7 +1,7 @@
 from sympy import (
     Abs, acos, Add, asin, atan, Basic, binomial, besselsimp,
     cos, cosh, count_ops, csch, diff, E,
-    Eq, erf, exp, exp_polar, expand, expand_multinomial, factor,
+    Eq, erf, exp, exp_polar, expand, expand_multinomial, Expr, factor,
     factorial, Float, Function, gamma, GoldenRatio, hyper,
     hypersimp, I, Integral, integrate, KroneckerDelta, log, logcombine, Lt,
     Matrix, MatrixSymbol, Mul, nsimplify, oo, pi, Piecewise, posify, rad,
@@ -657,6 +657,18 @@ def test_polymorphism():
 
     a = A(5, 2)
     assert simplify(a) == 1
+
+    class B(Expr):
+        def _eval_simplify(self, **kwargs):
+            myoption = kwargs.get('myoption', True)
+            if myoption:
+                return S.One
+            else:
+                return self
+    
+    b = B()
+    assert simplify(b) == 1
+    assert simplify(b, myoption=False) != 1
 
 
 def test_issue_from_PR1599():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -665,10 +665,13 @@ def test_polymorphism():
                 return S.One
             else:
                 return self
-    
+
     b = B()
     assert simplify(b) == 1
     assert simplify(b, myoption=False) != 1
+    assert simplify(b+1) != 2
+    assert simplify(b+1, recursive=True) == 2
+    assert simplify(b+1, recursive=True, myoption=False) != 2
 
 
 def test_issue_from_PR1599():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Before this commit, not every keyword arguments of `simplify` were passed to `_eval_simplify` method of expression.
```python
>>> class MyExpr(Expr):
...     def _eval_simplify(self, **kwargs):
...         myoption = kwargs.get('myoption', True)
...         if myoption:
...             result = S.One
...         else:
...             result = self
...         return result
>>> MyExpr().simplify()
1
>>> MyExpr().simplify(myoption=False)
1
```

With this commit,
```python
>>> MyExpr().simplify()
1
>>> MyExpr().simplify(myoption=False)
MyExpr()
```


#### Other comments

Before this commit, only 'ratio', 'measure', 'rational', 'inverse',
and 'doit' were passed to '_eval_simplify' method of expression.
This commit allows every keyword argument to be passed to it, making
simplification of user-defined object more flexible.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * Every keyword argument is now passed to `_eval_simplify` method, giving more flexibility to user-defined objects.
<!-- END RELEASE NOTES -->