### PR TITLE
Refactor dsolve to use classes for each solver

### DIFF
--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -88,7 +88,7 @@ factorable
 
 1st_linear
 ^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode.ode_1st_linear
+.. autoclass:: sympy.solvers.ode.single.FirstLinear
 
 2nd_linear_airy
 ^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ factorable
 
 Bernoulli
 ^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode.ode_Bernoulli
+.. autoclass:: sympy.solvers.ode.single.Bernoulli
 
 Liouville
 ^^^^^^^^^
@@ -136,7 +136,7 @@ separable
 
 almost_linear
 ^^^^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode.ode_almost_linear
+.. autoclass:: sympy.solvers.ode.single.AlmostLinear
 
 linear_coefficients
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -124,7 +124,7 @@ nth_linear_constant_coeff_variation_of_parameters
 
 nth_algebraic
 ^^^^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode.ode_nth_algebraic
+.. autoclass:: sympy.solvers.ode.single.NthAlgebraic
 
 nth_order_reducible
 ^^^^^^^^^^^^^^^^^^^

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -953,6 +953,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         raise ValueError("dsolve() and classify_ode() only "
         "work with functions of one variable, not %s" % func)
 
+    if isinstance(eq, Equality):
+        eq = eq.lhs - eq.rhs
+
     # Some methods want the unprocessed equation
     eq_orig = eq
 
@@ -966,12 +969,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     xi = kwargs.get('xi')
     eta = kwargs.get('eta')
     terms = kwargs.get('n')
-
-    if isinstance(eq, Equality):
-        if eq.rhs != 0:
-            return classify_ode(eq.lhs - eq.rhs, func, dict=dict, ics=ics, xi=xi,
-                n=terms, eta=eta, prep=False)
-        eq = eq.lhs
 
     order = ode_order(eq, f(x))
     # hint:matchdict or hint:(tuple of matchdicts)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -930,14 +930,17 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     >>> from sympy.abc import x
     >>> f = Function('f')
     >>> classify_ode(Eq(f(x).diff(x), 0), f(x))
-    ('nth_algebraic', 'separable', '1st_linear', 'Bernoulli',
+    ('nth_algebraic',
+    'separable',
+    '1st_linear',
+    'Bernoulli',
     '1st_homogeneous_coeff_best',
     '1st_homogeneous_coeff_subs_indep_div_dep',
     '1st_homogeneous_coeff_subs_dep_div_indep',
-    '1st_power_series', 'lie_group',
-    'nth_linear_constant_coeff_homogeneous',
-    'nth_linear_euler_eq_homogeneous', 'nth_algebraic_Integral',
-    'separable_Integral', '1st_linear_Integral', 'Bernoulli_Integral',
+    '1st_power_series', 'lie_group', 'nth_linear_constant_coeff_homogeneous',
+    'nth_linear_euler_eq_homogeneous',
+    'nth_algebraic_Integral', 'separable_Integral',
+    '1st_linear_Integral', 'Bernoulli_Integral',
     '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
     '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
     >>> classify_ode(f(x).diff(x, 2) + 3*f(x).diff(x) + 2*f(x) - 4)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -930,13 +930,14 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     >>> from sympy.abc import x
     >>> f = Function('f')
     >>> classify_ode(Eq(f(x).diff(x), 0), f(x))
-    ('nth_algebraic', 'separable', '1st_linear', '1st_homogeneous_coeff_best',
+    ('nth_algebraic', 'separable', '1st_linear', 'Bernoulli',
+    '1st_homogeneous_coeff_best',
     '1st_homogeneous_coeff_subs_indep_div_dep',
     '1st_homogeneous_coeff_subs_dep_div_indep',
     '1st_power_series', 'lie_group',
     'nth_linear_constant_coeff_homogeneous',
     'nth_linear_euler_eq_homogeneous', 'nth_algebraic_Integral',
-    'separable_Integral', '1st_linear_Integral',
+    'separable_Integral', '1st_linear_Integral', 'Bernoulli_Integral',
     '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
     '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
     >>> classify_ode(f(x).diff(x, 2) + 3*f(x).diff(x) + 2*f(x) - 4)

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -231,8 +231,6 @@ of those tests will surely fail.
 """
 from __future__ import print_function, division
 
-from typing import Dict, Type
-
 from collections import defaultdict
 from itertools import islice
 
@@ -275,6 +273,8 @@ from sympy.utilities import numbered_symbols, default_sort_key, sift
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 
 from .subscheck import sub_func_doit
+from .single import NthAlgebraic, SingleODEProblem, SingleODESolver
+
 
 #: This is a list of hints in the order that they should be preferred by
 #: :py:meth:`~sympy.solvers.ode.classify_ode`. In general, hints earlier in the
@@ -661,13 +661,16 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
     :py:meth:`~sympy.solvers.deutils._desolve` multiple times.
     """
     r = match
-    if hint.endswith('_Integral'):
-        solvefunc = globals()['ode_' + hint[:-len('_Integral')]]
-    else:
-        solvefunc = globals()['ode_' + hint]
     func = r['func']
     order = r['order']
     match = r[hint]
+
+    if isinstance(match, SingleODESolver):
+        solvefunc = match
+    elif hint.endswith('_Integral'):
+        solvefunc = globals()['ode_' + hint[:-len('_Integral')]]
+    else:
+        solvefunc = globals()['ode_' + hint]
 
     free = eq.free_symbols
     cons = lambda s: s.free_symbols.difference(free)
@@ -676,15 +679,21 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
         # odesimp() will attempt to integrate, if necessary, apply constantsimp(),
         # attempt to solve for func, and apply any other hint specific
         # simplifications
-        sols = solvefunc(eq, func, order, match)
+        if isinstance(solvefunc, SingleODESolver):
+            sols = solvefunc.get_general_solution()
+        else:
+            sols = solvefunc(eq, func, order, match)
         if iterable(sols):
             rv = [odesimp(eq, s, func, hint) for s in sols]
         else:
             rv =  odesimp(eq, sols, func, hint)
     else:
         # We still want to integrate (you can disable it separately with the hint)
-        match['simplify'] = False  # Some hints can take advantage of this option
-        exprs = solvefunc(eq, func, order, match)
+        if isinstance(solvefunc, SingleODESolver):
+            exprs = solvefunc.get_general_solution(simplify=False)
+        else:
+            match['simplify'] = False  # Some hints can take advantage of this option
+            exprs = solvefunc(eq, func, order, match)
         if isinstance(exprs, list):
             rv = [_handle_Integral(expr, func, hint) for expr in exprs]
         else:
@@ -1038,10 +1047,11 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     # Any ODE that can be solved with a combination of algebra and
     # integrals e.g.:
     # d^3/dx^3(x y) = F(x)
-    r = _nth_algebraic_match(eq_orig, func)
-    if r['solutions']:
-        matching_hints['nth_algebraic'] = r
-        matching_hints['nth_algebraic_Integral'] = r
+    ode = SingleODEProblem(eq_orig, func, x)
+    solver = NthAlgebraic(ode)
+    if solver.matches():
+        matching_hints['nth_algebraic'] = solver
+        matching_hints['nth_algebraic_Integral'] = solver
 
     eq = expand(eq)
     # Precondition to try remove f(x) from highest order derivative
@@ -4209,103 +4219,6 @@ def ode_nth_order_reducible(eq, func, order, match):
 
     return fsol
 
-# This needs to produce an invertible function but the inverse depends
-# which variable we are integrating with respect to. Since the class can
-# be stored in cached results we need to ensure that we always get the
-# same class back for each particular integration variable so we store these
-# classes in a global dict:
-_nth_algebraic_diffx_stored = {}  # type: Dict[Symbol, Type[Function]]
-
-def _nth_algebraic_diffx(var):
-    cls = _nth_algebraic_diffx_stored.get(var, None)
-
-    if cls is None:
-        # A class that behaves like Derivative wrt var but is "invertible".
-        class diffx(Function):
-            def inverse(self):
-                # don't use integrate here because fx has been replaced by _t
-                # in the equation; integrals will not be correct while solve
-                # is at work.
-                return lambda expr: Integral(expr, var) + Dummy('C')
-
-        cls = _nth_algebraic_diffx_stored.setdefault(var, diffx)
-
-    return cls
-
-def _nth_algebraic_match(eq, func):
-    r"""
-    Matches any differential equation that nth_algebraic can solve. Uses
-    `sympy.solve` but teaches it how to integrate derivatives.
-
-    This involves calling `sympy.solve` and does most of the work of finding a
-    solution (apart from evaluating the integrals).
-    """
-
-    # The independent variable
-    var = func.args[0]
-
-    # Derivative that solve can handle:
-    diffx = _nth_algebraic_diffx(var)
-
-    # Replace derivatives wrt the independent variable with diffx
-    def replace(eq, var):
-        def expand_diffx(*args):
-            differand, diffs = args[0], args[1:]
-            toreplace = differand
-            for v, n in diffs:
-                for _ in range(n):
-                    if v == var:
-                        toreplace = diffx(toreplace)
-                    else:
-                        toreplace = Derivative(toreplace, v)
-            return toreplace
-        return eq.replace(Derivative, expand_diffx)
-
-    # Restore derivatives in solution afterwards
-    def unreplace(eq, var):
-        return eq.replace(diffx, lambda e: Derivative(e, var))
-
-    subs_eqn = replace(eq, var)
-    try:
-        # turn off simplification to protect Integrals that have
-        # _t instead of fx in them and would otherwise factor
-        # as t_*Integral(1, x)
-        solns = solve(subs_eqn, func, simplify=False)
-    except NotImplementedError:
-        solns = []
-
-    solns = [simplify(unreplace(soln, var)) for soln in solns]
-    solns = [Equality(func, soln) for soln in solns]
-    return {'var':var, 'solutions':solns}
-
-def ode_nth_algebraic(eq, func, order, match):
-    r"""
-    Solves an `n`\th order ordinary differential equation using algebra and
-    integrals.
-
-    There is no general form for the kind of equation that this can solve. The
-    the equation is solved algebraically treating differentiation as an
-    invertible algebraic function.
-
-    Examples
-    ========
-
-    >>> from sympy import Function, dsolve, Eq
-    >>> from sympy.abc import x
-    >>> f = Function('f')
-    >>> eq = Eq(f(x) * (f(x).diff(x)**2 - 1), 0)
-    >>> dsolve(eq, f(x), hint='nth_algebraic')
-    ... # doctest: +NORMALIZE_WHITESPACE
-    [Eq(f(x), 0), Eq(f(x), C1 - x), Eq(f(x), C1 + x)]
-
-    Note that this solver can return algebraic solutions that do not have any
-    integration constants (f(x) = 0 in the above example).
-
-    # indirect doctest
-
-    """
-
-    return match['solutions']
 
 def _remove_redundant_solutions(eq, solns, order, var):
     r"""

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -273,7 +273,7 @@ from sympy.utilities import numbered_symbols, default_sort_key, sift
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 
 from .subscheck import sub_func_doit
-from .single import NthAlgebraic, SingleODEProblem, SingleODESolver
+from .single import NthAlgebraic, FirstLinear, AlmostLinear, Bernoulli, SingleODEProblem, SingleODESolver
 
 
 #: This is a list of hints in the order that they should be preferred by
@@ -980,8 +980,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
     df = f(x).diff(x)
     a = Wild('a', exclude=[f(x)])
-    b = Wild('b', exclude=[f(x)])
-    c = Wild('c', exclude=[f(x)])
     d = Wild('d', exclude=[df, f(x).diff(x, 2)])
     e = Wild('e', exclude=[df])
     k = Wild('k', exclude=[df])
@@ -1047,11 +1045,21 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     # Any ODE that can be solved with a combination of algebra and
     # integrals e.g.:
     # d^3/dx^3(x y) = F(x)
-    ode = SingleODEProblem(eq_orig, func, x)
-    solver = NthAlgebraic(ode)
-    if solver.matches():
-        matching_hints['nth_algebraic'] = solver
-        matching_hints['nth_algebraic_Integral'] = solver
+    ode = SingleODEProblem(eq_orig, func, x, prep=prep)
+    solvers = {
+        NthAlgebraic: ('nth_algebraic',),
+        FirstLinear: ('1st_linear',),
+        AlmostLinear: ('almost_linear',),
+        Bernoulli: ('Bernoulli',)
+        }
+
+    for solvercls in solvers:
+        solver = solvercls(ode)
+        if solver.matches():
+            for hints in solvers[solvercls]:
+                matching_hints[hints] = solver
+                if solvercls.has_integral:
+                    matching_hints[hints + "_Integral"] = solver
 
     eq = expand(eq)
     # Precondition to try remove f(x) from highest order derivative
@@ -1067,36 +1075,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         reduced_eq = eq
 
     if order == 1:
-
-        ## Linear case: a(x)*y'+b(x)*y+c(x) == 0
-        if eq.is_Add:
-            ind, dep = reduced_eq.as_independent(f)
-        else:
-            u = Dummy('u')
-            ind, dep = (reduced_eq + u).as_independent(f)
-            ind, dep = [tmp.subs(u, 0) for tmp in [ind, dep]]
-        r = {a: dep.coeff(df),
-             b: dep.coeff(f(x)),
-             c: ind}
-        # double check f[a] since the preconditioning may have failed
-        if not r[a].has(f) and not r[b].has(f) and (
-                r[a]*df + r[b]*f(x) + r[c]).expand() - reduced_eq == 0:
-            r['a'] = a
-            r['b'] = b
-            r['c'] = c
-            matching_hints["1st_linear"] = r
-            matching_hints["1st_linear_Integral"] = r
-
-        ## Bernoulli case: a(x)*y'+b(x)*y+c(x)*y**n == 0
-        r = collect(
-            reduced_eq, f(x), exact=True).match(a*df + b*f(x) + c*f(x)**n)
-        if r and r[c] != 0 and r[n] != 1:  # See issue 4676
-            r['a'] = a
-            r['b'] = b
-            r['c'] = c
-            r['n'] = n
-            matching_hints["Bernoulli"] = r
-            matching_hints["Bernoulli_Integral"] = r
 
         ## Riccati special n == -2 case: a2*y'+b2*y**2+c2*y/x+d2/x**2 == 0
         r = collect(reduced_eq,
@@ -1288,26 +1266,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
                         r2.update({'power': xpart.as_base_exp()[1], 'u': test})
                         matching_hints["separable_reduced"] = r2
                         matching_hints["separable_reduced_Integral"] = r2
-
-        ## Almost-linear equation of the form f(x)*g(y)*y' + k(x)*l(y) + m(x) = 0
-        r = collect(eq, [df, f(x)]).match(e*df + d)
-        if r:
-            r2 = r.copy()
-            r2[c] = S.Zero
-            if r2[d].is_Add:
-                # Separate the terms having f(x) to r[d] and
-                # remaining to r[c]
-                no_f, r2[d] = r2[d].as_independent(f(x))
-                r2[c] += no_f
-            factor = simplify(r2[d].diff(f(x))/r[e])
-            if factor and not factor.has(f(x)):
-                r2[d] = factor_terms(r2[d])
-                u = r2[d].as_independent(f(x), as_Add=False)[1]
-                r2.update({'a': e, 'b': d, 'c': c, 'u': u})
-                r2[d] /= u
-                r2[e] /= u.diff(f(x))
-                matching_hints["almost_linear"] = r2
-                matching_hints["almost_linear_Integral"] = r2
 
 
     elif order == 2:
@@ -3484,151 +3442,6 @@ def homogeneous_order(eq, *symbols):
         return e
 
 
-def ode_1st_linear(eq, func, order, match):
-    r"""
-    Solves 1st order linear differential equations.
-
-    These are differential equations of the form
-
-    .. math:: dy/dx + P(x) y = Q(x)\text{.}
-
-    These kinds of differential equations can be solved in a general way.  The
-    integrating factor `e^{\int P(x) \,dx}` will turn the equation into a
-    separable equation.  The general solution is::
-
-        >>> from sympy import Function, dsolve, Eq, pprint, diff, sin
-        >>> from sympy.abc import x
-        >>> f, P, Q = map(Function, ['f', 'P', 'Q'])
-        >>> genform = Eq(f(x).diff(x) + P(x)*f(x), Q(x))
-        >>> pprint(genform)
-                    d
-        P(x)*f(x) + --(f(x)) = Q(x)
-                    dx
-        >>> pprint(dsolve(genform, f(x), hint='1st_linear_Integral'))
-               /       /                   \
-               |      |                    |
-               |      |         /          |     /
-               |      |        |           |    |
-               |      |        | P(x) dx   |  - | P(x) dx
-               |      |        |           |    |
-               |      |       /            |   /
-        f(x) = |C1 +  | Q(x)*e           dx|*e
-               |      |                    |
-               \     /                     /
-
-
-    Examples
-    ========
-
-    >>> f = Function('f')
-    >>> pprint(dsolve(Eq(x*diff(f(x), x) - f(x), x**2*sin(x)),
-    ... f(x), '1st_linear'))
-    f(x) = x*(C1 - cos(x))
-
-    References
-    ==========
-
-    - https://en.wikipedia.org/wiki/Linear_differential_equation#First_order_equation
-    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
-      Dover 1963, pp. 92
-
-    # indirect doctest
-
-    """
-    x = func.args[0]
-    f = func.func
-    r = match  # a*diff(f(x),x) + b*f(x) + c
-    C1 = get_numbered_constants(eq, num=1)
-    t = exp(Integral(r[r['b']]/r[r['a']], x))
-    tt = Integral(t*(-r[r['c']]/r[r['a']]), x)
-    f = match.get('u', f(x))  # take almost-linear u if present, else f(x)
-    return Eq(f, (tt + C1)/t)
-
-
-def ode_Bernoulli(eq, func, order, match):
-    r"""
-    Solves Bernoulli differential equations.
-
-    These are equations of the form
-
-    .. math:: dy/dx + P(x) y = Q(x) y^n\text{, }n \ne 1`\text{.}
-
-    The substitution `w = 1/y^{1-n}` will transform an equation of this form
-    into one that is linear (see the docstring of
-    :py:meth:`~sympy.solvers.ode.ode.ode_1st_linear`).  The general solution is::
-
-        >>> from sympy import Function, dsolve, Eq, pprint
-        >>> from sympy.abc import x, n
-        >>> f, P, Q = map(Function, ['f', 'P', 'Q'])
-        >>> genform = Eq(f(x).diff(x) + P(x)*f(x), Q(x)*f(x)**n)
-        >>> pprint(genform)
-                    d                n
-        P(x)*f(x) + --(f(x)) = Q(x)*f (x)
-                    dx
-        >>> pprint(dsolve(genform, f(x), hint='Bernoulli_Integral'), num_columns=100)
-                                                                                      1
-                                                                                    -----
-                                                                                    1 - n
-               //               /                            \                     \
-               ||              |                             |                     |
-               ||              |                  /          |             /       |
-               ||              |                 |           |            |        |
-               ||              |        (1 - n)* | P(x) dx   |  -(1 - n)* | P(x) dx|
-               ||              |                 |           |            |        |
-               ||              |                /            |           /         |
-        f(x) = ||C1 + (n - 1)* | -Q(x)*e                   dx|*e                   |
-               ||              |                             |                     |
-               \\              /                            /                     /
-
-
-    Note that the equation is separable when `n = 1` (see the docstring of
-    :py:meth:`~sympy.solvers.ode.ode.ode_separable`).
-
-    >>> pprint(dsolve(Eq(f(x).diff(x) + P(x)*f(x), Q(x)*f(x)), f(x),
-    ... hint='separable_Integral'))
-     f(x)
-       /
-      |                /
-      |  1            |
-      |  - dy = C1 +  | (-P(x) + Q(x)) dx
-      |  y            |
-      |              /
-     /
-
-
-    Examples
-    ========
-
-    >>> from sympy import Function, dsolve, Eq, pprint, log
-    >>> from sympy.abc import x
-    >>> f = Function('f')
-
-    >>> pprint(dsolve(Eq(x*f(x).diff(x) + f(x), log(x)*f(x)**2),
-    ... f(x), hint='Bernoulli'))
-                    1
-    f(x) = -------------------
-             /     log(x)   1\
-           x*|C1 + ------ + -|
-             \       x      x/
-
-    References
-    ==========
-
-    - https://en.wikipedia.org/wiki/Bernoulli_differential_equation
-    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
-      Dover 1963, pp. 95
-
-    # indirect doctest
-
-    """
-    x = func.args[0]
-    f = func.func
-    r = match  # a*diff(f(x),x) + b*f(x) + c*f(x)**n, n != 1
-    C1 = get_numbered_constants(eq, num=1)
-    t = exp((1 - r[r['n']])*Integral(r[r['b']]/r[r['a']], x))
-    tt = (r[r['n']] - 1)*Integral(t*r[r['c']]/r[r['a']], x)
-    return Eq(f(x), ((tt + C1)/t)**(1/(1 - r[r['n']])))
-
 
 def ode_Riccati_special_minus2(eq, func, order, match):
     r"""
@@ -4663,75 +4476,6 @@ def ode_nth_linear_euler_eq_nonhomogeneous_variation_of_parameters(eq, func, ord
     sol = _solve_variation_of_parameters(eq, func, order, match)
     return Eq(f(x), r['sol'].rhs + (sol.rhs - r['sol'].rhs)*r[ode_order(eq, f(x))])
 
-
-def ode_almost_linear(eq, func, order, match):
-    r"""
-    Solves an almost-linear differential equation.
-
-    The general form of an almost linear differential equation is
-
-    .. math:: f(x) g(y) y + k(x) l(y) + m(x) = 0
-                \text{where} l'(y) = g(y)\text{.}
-
-    This can be solved by substituting `l(y) = u(y)`.  Making the given
-    substitution reduces it to a linear differential equation of the form `u'
-    + P(x) u + Q(x) = 0`.
-
-    The general solution is
-
-        >>> from sympy import Function, dsolve, Eq, pprint
-        >>> from sympy.abc import x, y, n
-        >>> f, g, k, l = map(Function, ['f', 'g', 'k', 'l'])
-        >>> genform = Eq(f(x)*(l(y).diff(y)) + k(x)*l(y) + g(x), 0)
-        >>> pprint(genform)
-             d
-        f(x)*--(l(y)) + g(x) + k(x)*l(y) = 0
-             dy
-        >>> pprint(dsolve(genform, hint = 'almost_linear'))
-               /     //       y*k(x)                \\
-               |     ||       ------                ||
-               |     ||        f(x)                 ||  -y*k(x)
-               |     ||-g(x)*e                      ||  --------
-               |     ||--------------  for k(x) != 0||    f(x)
-        l(y) = |C1 + |<     k(x)                    ||*e
-               |     ||                             ||
-               |     ||   -y*g(x)                   ||
-               |     ||   --------       otherwise  ||
-               |     ||     f(x)                    ||
-               \     \\                             //
-
-
-    See Also
-    ========
-    :meth:`sympy.solvers.ode.ode.ode_1st_linear`
-
-    Examples
-    ========
-
-    >>> from sympy import Function, Derivative, pprint
-    >>> from sympy.solvers.ode import dsolve, classify_ode
-    >>> from sympy.abc import x
-    >>> f = Function('f')
-    >>> d = f(x).diff(x)
-    >>> eq = x*d + x*f(x) + 1
-    >>> dsolve(eq, f(x), hint='almost_linear')
-    Eq(f(x), (C1 - Ei(x))*exp(-x))
-    >>> pprint(dsolve(eq, f(x), hint='almost_linear'))
-                         -x
-    f(x) = (C1 - Ei(x))*e
-
-    References
-    ==========
-
-    - Joel Moses, "Symbolic Integration - The Stormy Decade", Communications
-      of the ACM, Volume 14, Number 8, August 1971, pp. 558
-    """
-
-    # Since ode_1st_linear has already been implemented, and the
-    # coefficients have been modified to the required form in
-    # classify_ode, just passing eq, func, order and match to
-    # ode_1st_linear will give the required output.
-    return ode_1st_linear(eq, func, order, match)
 
 def _linear_coeff_match(expr, func):
     r"""

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -83,7 +83,7 @@ class SingleODEProblem:
         self.eq = eq
         self.func = func
         self.sym = sym
-        self.prep = True
+        self.prep = prep
 
     @cached_property
     def order(self):

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -348,7 +348,7 @@ class FirstLinear(SingleODESolver):
 
     - https://en.wikipedia.org/wiki/Linear_differential_equation#First_order_equation
     - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
-    Dover 1963, pp. 92
+      Dover 1963, pp. 92
 
     # indirect doctest
 
@@ -473,7 +473,7 @@ class AlmostLinear(FirstLinear):
     ==========
 
     - Joel Moses, "Symbolic Integration - The Stormy Decade", Communications
-    of the ACM, Volume 14, Number 8, August 1971, pp. 558
+      of the ACM, Volume 14, Number 8, August 1971, pp. 558
     """
     hint = "almost_linear"
     has_integral = True
@@ -585,8 +585,9 @@ class Bernoulli(SingleODESolver):
     ==========
 
     - https://en.wikipedia.org/wiki/Bernoulli_differential_equation
+
     - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
-    Dover 1963, pp. 95
+      Dover 1963, pp. 95
 
     # indirect doctest
 

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1,0 +1,243 @@
+#
+# This is the module for ODE solver classes for single ODEs.
+#
+
+from typing import ClassVar, Dict, List, Optional, Type
+
+from sympy.core.expr import Expr
+from sympy.core.function import AppliedUndef, Derivative, Function
+from sympy.core.relational import Equality
+from sympy.core.symbol import Symbol, Dummy
+from sympy.integrals import Integral
+from sympy.simplify import simplify
+
+from sympy.solvers.solvers import solve
+
+
+class ODEMatchError(NotImplementedError):
+    """Raised if a SingleODESolver is asked to solve an ODE it does not match"""
+    pass
+
+
+class SingleODEProblem:
+    """Represents an ordinary differential equation (ODE)
+
+    This class is used internally in the by dsolve and related
+    functions/classes so that properties of an ODE can be computed
+    efficiently.
+
+    Examples
+    ========
+
+    This class is used internally by dsolve. To instantiate an instance
+    directly first define an ODE problem:
+
+    >>> from sympy import Eq, Function, Symbol
+    >>> x = Symbol('x')
+    >>> f = Function('f')
+    >>> eq = f(x).diff(x, 2)
+
+    Now you can create a SingleODEProblem instance and query its properties:
+
+    >>> from sympy.solvers.ode.single import SingleODEProblem
+    >>> problem = SingleODEProblem(f(x).diff(x), f(x), x)
+    >>> problem.eq
+    Derivative(f(x), x)
+    >>> problem.func
+    f(x)
+    >>> problem.sym
+    x
+    """
+
+    # Instance attributes:
+    eq = None  # type: Expr
+    func = None  # type: AppliedUndef
+    sym = None  # type: Symbol
+
+    def __init__(self, eq, func, sym):
+        self.eq = eq
+        self.func = func
+        self.sym = sym
+
+    # TODO: Add methods that can be used by many ODE solvers:
+    # order
+    # is_linear()
+    # get_linear_coefficients()
+    # eq_prepared (the ODE in prepared form)
+
+
+class SingleODESolver:
+    """
+    Base class for Single ODE solvers.
+
+    Subclasses should implement the _matches and _get_general_solution
+    methods. This class is not intended to be instantiated directly but its
+    subclasses are as part of dsolve.
+
+    Examples
+    ========
+
+    You can use a subclass of SingleODEProblem to solve a particular type of
+    ODE. We first define a particular ODE problem:
+
+    >>> from sympy import Eq, Function, Symbol
+    >>> x = Symbol('x')
+    >>> f = Function('f')
+    >>> eq = f(x).diff(x, 2)
+
+    Now we solve this problem using the NthAlgebraic solver which is a
+    subclass of SingleODESolver:
+
+    >>> from sympy.solvers.ode.single import NthAlgebraic, SingleODEProblem
+    >>> problem = SingleODEProblem(eq, f(x), x)
+    >>> solver = NthAlgebraic(problem)
+    >>> solver.get_general_solution()
+    [Eq(f(x), _C*x + _C)]
+
+    The normal way to solve an ODE is to use dsolve (which would use
+    NthAlgebraic and other solvers internally). When using dsolve a number of
+    other things are done such as evaluating integrals, simplifying the
+    solution and renumbering the constants:
+
+    >>> from sympy import dsolve
+    >>> dsolve(eq, hint='nth_algebraic')
+    Eq(f(x), C1 + C2*x)
+    """
+
+    # Subclasses should store the hint name (the argument to dsolve) in this
+    # attribute
+    hint = None  # type: ClassVar[str]
+
+    # Subclasses should define this to indicate if they support an _Integral
+    # hint.
+    has_integral = None  # type: ClassVar[bool]
+
+    # The ODE to be solved
+    ode_problem = None  # type: SingleODEProblem
+
+    # Cache whether or not the equation has matched the method
+    _matched = None  # type: Optional[bool]
+
+    def __init__(self, ode_problem):
+        self.ode_problem = ode_problem
+
+    def matches(self) -> bool:
+        if self._matched is None:
+            self._matched = self._matches()
+        return self._matched
+
+    def get_general_solution(self, *, simplify: bool = True) -> List[Equality]:
+        if not self.matches():
+            msg = "%s solver can not solve:\n%s"
+            raise ODEMatchError(msg % (self.hint, self.ode_problem.eq))
+        return self._get_general_solution()
+
+    def _matches(self) -> bool:
+        msg = "Subclasses of SingleODESolver should implement matches."
+        raise NotImplementedError(msg)
+
+    def _get_general_solution(self, *, simplify: bool = True) -> List[Equality]:
+        msg = "Subclasses of SingleODESolver should implement get_general_solution."
+        raise NotImplementedError(msg)
+
+
+class NthAlgebraic(SingleODESolver):
+    r"""
+    Solves an `n`\th order ordinary differential equation using algebra and
+    integrals.
+
+    There is no general form for the kind of equation that this can solve. The
+    the equation is solved algebraically treating differentiation as an
+    invertible algebraic function.
+
+    Examples
+    ========
+
+    >>> from sympy import Function, dsolve, Eq
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> eq = Eq(f(x) * (f(x).diff(x)**2 - 1), 0)
+    >>> dsolve(eq, f(x), hint='nth_algebraic')
+    [Eq(f(x), 0), Eq(f(x), C1 - x), Eq(f(x), C1 + x)]
+
+    Note that this solver can return algebraic solutions that do not have any
+    integration constants (f(x) = 0 in the above example).
+    """
+
+    hint = 'nth_algebraic'
+    has_integral = True  # nth_algebraic_Integral hint
+
+    def _matches(self):
+        r"""
+        Matches any differential equation that nth_algebraic can solve. Uses
+        `sympy.solve` but teaches it how to integrate derivatives.
+
+        This involves calling `sympy.solve` and does most of the work of finding a
+        solution (apart from evaluating the integrals).
+        """
+        eq = self.ode_problem.eq
+        func = self.ode_problem.func
+        var = self.ode_problem.sym
+
+        # Derivative that solve can handle:
+        diffx = self._get_diffx(var)
+
+        # Replace derivatives wrt the independent variable with diffx
+        def replace(eq, var):
+            def expand_diffx(*args):
+                differand, diffs = args[0], args[1:]
+                toreplace = differand
+                for v, n in diffs:
+                    for _ in range(n):
+                        if v == var:
+                            toreplace = diffx(toreplace)
+                        else:
+                            toreplace = Derivative(toreplace, v)
+                return toreplace
+            return eq.replace(Derivative, expand_diffx)
+
+        # Restore derivatives in solution afterwards
+        def unreplace(eq, var):
+            return eq.replace(diffx, lambda e: Derivative(e, var))
+
+        subs_eqn = replace(eq, var)
+        try:
+            # turn off simplification to protect Integrals that have
+            # _t instead of fx in them and would otherwise factor
+            # as t_*Integral(1, x)
+            solns = solve(subs_eqn, func, simplify=False)
+        except NotImplementedError:
+            solns = []
+
+        solns = [simplify(unreplace(soln, var)) for soln in solns]
+        solns = [Equality(func, soln) for soln in solns]
+
+        self.solutions = solns
+        return len(solns) != 0
+
+    def _get_general_solution(self, *, simplify: bool = True):
+        return self.solutions
+
+    # This needs to produce an invertible function but the inverse depends
+    # which variable we are integrating with respect to. Since the class can
+    # be stored in cached results we need to ensure that we always get the
+    # same class back for each particular integration variable so we store these
+    # classes in a global dict:
+    _diffx_stored = {}  # type: Dict[Symbol, Type[Function]]
+
+    @staticmethod
+    def _get_diffx(var):
+        diffcls = NthAlgebraic._diffx_stored.get(var, None)
+
+        if diffcls is None:
+            # A class that behaves like Derivative wrt var but is "invertible".
+            class diffx(Function):
+                def inverse(self):
+                    # don't use integrate here because fx has been replaced by _t
+                    # in the equation; integrals will not be correct while solve
+                    # is at work.
+                    return lambda expr: Integral(expr, var) + Dummy('C')
+
+            diffcls = NthAlgebraic._diffx_stored.setdefault(var, diffx)
+
+        return diffcls

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -10,7 +10,7 @@ from sympy.core.relational import Equality
 from sympy.core.symbol import Symbol, Dummy
 from sympy.integrals import Integral
 from sympy.simplify import simplify
-
+from sympy.solvers.deutils import ode_order
 from sympy.solvers.solvers import solve
 
 
@@ -53,12 +53,18 @@ class SingleODEProblem:
     eq = None  # type: Expr
     func = None  # type: AppliedUndef
     sym = None  # type: Symbol
+    _order = None
 
     def __init__(self, eq, func, sym):
         self.eq = eq
         self.func = func
         self.sym = sym
 
+    @property
+    def order(self):
+        if self._order is None:
+            self._order = ode_order(self.eq, self.func)
+        return self._order
     # TODO: Add methods that can be used by many ODE solvers:
     # order
     # is_linear()

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -58,14 +58,15 @@ class SingleODEProblem:
     eq = None  # type: Expr
     func = None  # type: AppliedUndef
     sym = None  # type: Symbol
-    _order = None
-    _eq_expanded = None
-    _eq_preprocessed = None
+    _order = None  # type: int
+    _eq_expanded = None  # type: Expr
+    _eq_preprocessed = None  # type: Expr
 
     def __init__(self, eq, func, sym, prep=True):
-        if isinstance(eq, Equality):
-            eq = eq.lhs - eq.rhs
-
+        assert isinstance(eq, Expr)
+        assert isinstance(func, AppliedUndef)
+        assert isinstance(sym, Symbol)
+        assert isinstance(prep, bool)
         self.eq = eq
         self.func = func
         self.sym = sym

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -19,9 +19,22 @@ from sympy.functions import exp
 from sympy.solvers.solvers import solve
 from sympy.solvers.deutils import ode_order, _preprocess
 
+
 class ODEMatchError(NotImplementedError):
     """Raised if a SingleODESolver is asked to solve an ODE it does not match"""
     pass
+
+
+def cached_property(func):
+    '''Decorator to cache property method'''
+    attrname = '_' + func.__name__
+    def propfunc(self):
+        val = getattr(self, attrname, None)
+        if val is None:
+            val = func(self)
+            setattr(self, attrname, val)
+        return val
+    return property(propfunc)
 
 
 class SingleODEProblem:
@@ -72,23 +85,17 @@ class SingleODEProblem:
         self.sym = sym
         self.prep = True
 
-    @property
+    @cached_property
     def order(self):
-        if self._order is None:
-            self._order = ode_order(self.eq, self.func)
-        return self._order
+        return ode_order(self.eq, self.func)
 
-    @property
+    @cached_property
     def eq_preprocessed(self):
-        if self._eq_preprocessed is None:
-            self._eq_preprocessed = self._get_eq_preprocessed()
-        return self._eq_preprocessed
+        return self._get_eq_preprocessed()
 
-    @property
+    @cached_property
     def eq_expanded(self):
-        if self._eq_expanded is None:
-            self._eq_expanded = expand(self.eq_preprocessed)
-        return self._eq_expanded
+        return expand(self.eq_preprocessed)
 
     def _get_eq_preprocessed(self):
         if self.prep:

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -4,15 +4,20 @@
 
 from typing import ClassVar, Dict, List, Optional, Type
 
+from sympy.core import Add, S
+from sympy.core.compatibility import iterable
+from sympy.core.exprtools import factor_terms
 from sympy.core.expr import Expr
-from sympy.core.function import AppliedUndef, Derivative, Function
-from sympy.core.relational import Equality
-from sympy.core.symbol import Symbol, Dummy
+from sympy.core.function import AppliedUndef, Derivative, Function, expand
+from sympy.core.relational import Equality, Eq
+from sympy.core.symbol import Symbol, Dummy, Wild
 from sympy.integrals import Integral
-from sympy.simplify import simplify
-from sympy.solvers.deutils import ode_order
-from sympy.solvers.solvers import solve
+from sympy.simplify import simplify, collect
+from sympy.utilities import numbered_symbols
+from sympy.functions import exp
 
+from sympy.solvers.solvers import solve
+from sympy.solvers.deutils import ode_order, _preprocess
 
 class ODEMatchError(NotImplementedError):
     """Raised if a SingleODESolver is asked to solve an ODE it does not match"""
@@ -54,17 +59,39 @@ class SingleODEProblem:
     func = None  # type: AppliedUndef
     sym = None  # type: Symbol
     _order = None
+    exp_eq = None
 
-    def __init__(self, eq, func, sym):
-        self.eq = eq
+    def __init__(self, eq, func, sym, prep=True):
+        self.eq_preprocessed = eq
         self.func = func
         self.sym = sym
+
+        if prep:
+            process_eq, process_func = _preprocess(eq, func)
+            self.eq = process_eq
+            if func is None:
+                self.func = process_func
+
+            if isinstance(self.eq, Equality):
+                if self.eq.rhs != 0:
+                    self.eq = self.eq.lhs - self.eq.rhs
+                self.eq = self.eq.lhs
+
+        else:
+            self.eq = eq
 
     @property
     def order(self):
         if self._order is None:
             self._order = ode_order(self.eq, self.func)
         return self._order
+
+    @property
+    def expanded_eq(self):
+        if self.exp_eq is None:
+            self.exp_eq = expand(self.eq)
+        return self.exp_eq
+
     # TODO: Add methods that can be used by many ODE solvers:
     # order
     # is_linear()
@@ -145,6 +172,32 @@ class SingleODESolver:
     def _get_general_solution(self, *, simplify: bool = True) -> List[Equality]:
         msg = "Subclasses of SingleODESolver should implement get_general_solution."
         raise NotImplementedError(msg)
+
+    def get_numbered_constants(self, eq, num=1, start=1, prefix='C'):
+        """
+        Returns a list of constants that do not occur
+        in eq already.
+        """
+        ncs = self.iter_numbered_constants(eq, start, prefix)
+        Cs = [next(ncs) for i in range(num)]
+        return (Cs[0] if num == 1 else tuple(Cs))
+
+    def iter_numbered_constants(self, eq, start=1, prefix='C'):
+        """
+        Returns an iterator of constants that do not occur
+        in eq already.
+        """
+
+        if isinstance(eq, (Expr, Eq)):
+            eq = [eq]
+        elif not iterable(eq):
+            raise ValueError("Expected Expr or iterable but got %s" % eq)
+
+        atom_set = set().union(*[i.free_symbols for i in eq])
+        func_set = set().union(*[i.atoms(Function) for i in eq])
+        if func_set:
+            atom_set |= {Symbol(str(f.func)) for f in func_set}
+        return numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
 
 
 class NthAlgebraic(SingleODESolver):
@@ -247,3 +300,343 @@ class NthAlgebraic(SingleODESolver):
             diffcls = NthAlgebraic._diffx_stored.setdefault(var, diffx)
 
         return diffcls
+
+
+class FirstLinear(SingleODESolver):
+    r"""
+    Solves 1st order linear differential equations.
+
+    These are differential equations of the form
+
+    .. math:: dy/dx + P(x) y = Q(x)\text{.}
+
+    These kinds of differential equations can be solved in a general way.  The
+    integrating factor `e^{\int P(x) \,dx}` will turn the equation into a
+    separable equation.  The general solution is::
+
+        >>> from sympy import Function, dsolve, Eq, pprint, diff, sin
+        >>> from sympy.abc import x
+        >>> f, P, Q = map(Function, ['f', 'P', 'Q'])
+        >>> genform = Eq(f(x).diff(x) + P(x)*f(x), Q(x))
+        >>> pprint(genform)
+                    d
+        P(x)*f(x) + --(f(x)) = Q(x)
+                    dx
+        >>> pprint(dsolve(genform, f(x), hint='1st_linear_Integral'))
+                /       /                   \
+                |      |                    |
+                |      |         /          |     /
+                |      |        |           |    |
+                |      |        | P(x) dx   |  - | P(x) dx
+                |      |        |           |    |
+                |      |       /            |   /
+        f(x) = |C1 +  | Q(x)*e           dx|*e
+                |      |                    |
+                \     /                     /
+
+
+    Examples
+    ========
+
+    >>> f = Function('f')
+    >>> pprint(dsolve(Eq(x*diff(f(x), x) - f(x), x**2*sin(x)),
+    ... f(x), '1st_linear'))
+    f(x) = x*(C1 - cos(x))
+
+    References
+    ==========
+
+    - https://en.wikipedia.org/wiki/Linear_differential_equation#First_order_equation
+    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
+    Dover 1963, pp. 92
+
+    # indirect doctest
+
+    """
+    hint = '1st_linear'
+    has_integral = True
+
+    def _matches(self):
+        eq = self.ode_problem.expanded_eq
+        f = self.ode_problem.func.func
+        x = self.ode_problem.sym
+        order = self.ode_problem.order
+        a = Wild('a', exclude=[f(x)])
+        b = Wild('b', exclude=[f(x)])
+        c = Wild('c', exclude=[f(x)])
+        c1 = Wild('c1', exclude=[x])
+        df = f(x).diff(x)
+
+        if order != 1:
+            return False
+
+        reduced_eq = None
+        if eq.is_Add:
+            deriv_coef = eq.coeff(f(x).diff(x, order))
+            if deriv_coef not in (1, 0):
+                r = deriv_coef.match(a*f(x)**c1)
+                if r and r[c1]:
+                    den = f(x)**r[c1]
+                    reduced_eq = Add(*[arg/den for arg in eq.args])
+        if not reduced_eq:
+            reduced_eq = eq
+
+        if eq.is_Add:
+            ind, dep = reduced_eq.as_independent(f)
+        else:
+            u = Dummy('u')
+            ind, dep = (reduced_eq + u).as_independent(f)
+            ind, dep = [tmp.subs(u, 0) for tmp in [ind, dep]]
+        coefficients = {a: dep.coeff(df),
+                        b: dep.coeff(f(x)),
+                        c: ind}
+        # double check f[a] since the preconditioning may have failed
+        if not coefficients[a].has(f) and not coefficients[b].has(f) and (
+                coefficients[a]*df + coefficients[b]*f(x) + coefficients[c]).expand() - reduced_eq == 0:
+            coefficients['a'] = a
+            coefficients['b'] = b
+            coefficients['c'] = c
+            self.coeffs = coefficients
+            return True
+
+        return False
+
+    def _get_general_solution(self, *, simplify: bool = True):
+        x = self.ode_problem.sym
+        f = self.ode_problem.func.func
+        r = self.coeffs  # a*diff(f(x),x) + b*f(x) + c
+        C1 = self.get_numbered_constants(self.ode_problem.eq, num=1)
+
+        t = exp(Integral(r[r['b']]/r[r['a']], x))
+        tt = Integral(t*(-r[r['c']]/r[r['a']]), x)
+        f = r.get('u', f(x))  # take almost-linear u if present, else f(x)
+        return Eq(f, (tt + C1)/t)
+
+
+class AlmostLinear(FirstLinear):
+    r"""
+    Solves an almost-linear differential equation.
+
+    The general form of an almost linear differential equation is
+
+    .. math:: f(x) g(y) y + k(x) l(y) + m(x) = 0
+                \text{where} l'(y) = g(y)\text{.}
+
+    This can be solved by substituting `l(y) = u(y)`.  Making the given
+    substitution reduces it to a linear differential equation of the form `u'
+    + P(x) u + Q(x) = 0`.
+
+    The general solution is
+
+        >>> from sympy import Function, dsolve, Eq, pprint
+        >>> from sympy.abc import x, y, n
+        >>> f, g, k, l = map(Function, ['f', 'g', 'k', 'l'])
+        >>> genform = Eq(f(x)*(l(y).diff(y)) + k(x)*l(y) + g(x), 0)
+        >>> pprint(genform)
+            d
+        f(x)*--(l(y)) + g(x) + k(x)*l(y) = 0
+            dy
+        >>> pprint(dsolve(genform, hint = 'almost_linear'))
+                /     //       y*k(x)                \\
+                |     ||       ------                ||
+                |     ||        f(x)                 ||  -y*k(x)
+                |     ||-g(x)*e                      ||  --------
+                |     ||--------------  for k(x) != 0||    f(x)
+        l(y) = |C1 + |<     k(x)                    ||*e
+                |     ||                             ||
+                |     ||   -y*g(x)                   ||
+                |     ||   --------       otherwise  ||
+                |     ||     f(x)                    ||
+                \     \\                             //
+
+
+    See Also
+    ========
+    :meth:`sympy.solvers.ode.single.FirstLinear`
+
+    Examples
+    ========
+
+    >>> from sympy import Function, Derivative, pprint
+    >>> from sympy.solvers.ode import dsolve, classify_ode
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> d = f(x).diff(x)
+    >>> eq = x*d + x*f(x) + 1
+    >>> dsolve(eq, f(x), hint='almost_linear')
+    Eq(f(x), (C1 - Ei(x))*exp(-x))
+    >>> pprint(dsolve(eq, f(x), hint='almost_linear'))
+                        -x
+    f(x) = (C1 - Ei(x))*e
+
+    References
+    ==========
+
+    - Joel Moses, "Symbolic Integration - The Stormy Decade", Communications
+    of the ACM, Volume 14, Number 8, August 1971, pp. 558
+    """
+    hint = "almost_linear"
+    has_integral = True
+
+    def _matches(self):
+        ## Almost-linear equation of the form f(x)*g(y)*y' + k(x)*l(y) + m(x) = 0
+        eq = self.ode_problem.expanded_eq
+        f = self.ode_problem.func.func
+        x = self.ode_problem.sym
+        order = self.ode_problem.order
+
+        if order != 1:
+            return False
+
+        df = f(x).diff(x)
+        c = Wild('c', exclude=[f(x)])
+        d = Wild('d', exclude=[df, f(x).diff(x, 2)])
+        e = Wild('e', exclude=[df])
+
+        r = collect(eq, [df, f(x)]).match(e*df + d)
+        if r:
+            r2 = r.copy()
+            r2[c] = S.Zero
+            if r2[d].is_Add:
+                # Separate the terms having f(x) to r[d] and
+                # remaining to r[c]
+                no_f, r2[d] = r2[d].as_independent(f(x))
+                r2[c] += no_f
+            factor = simplify(r2[d].diff(f(x))/r[e])
+            if factor and not factor.has(f(x)):
+                r2[d] = factor_terms(r2[d])
+                u = r2[d].as_independent(f(x), as_Add=False)[1]
+                r2.update({'a': e, 'b': d, 'c': c, 'u': u})
+                r2[d] /= u
+                r2[e] /= u.diff(f(x))
+                self.coeffs = r2
+                return True
+
+        return False
+
+
+class Bernoulli(SingleODESolver):
+    r"""
+    Solves Bernoulli differential equations.
+
+    These are equations of the form
+
+    .. math:: dy/dx + P(x) y = Q(x) y^n\text{, }n \ne 1`\text{.}
+
+    The substitution `w = 1/y^{1-n}` will transform an equation of this form
+    into one that is linear (see the docstring of
+    :py:meth:`~sympy.solvers.ode.single.FirstLinear`).  The general solution is::
+
+        >>> from sympy import Function, dsolve, Eq, pprint
+        >>> from sympy.abc import x, n
+        >>> f, P, Q = map(Function, ['f', 'P', 'Q'])
+        >>> genform = Eq(f(x).diff(x) + P(x)*f(x), Q(x)*f(x)**n)
+        >>> pprint(genform)
+                    d                n
+        P(x)*f(x) + --(f(x)) = Q(x)*f (x)
+                    dx
+        >>> pprint(dsolve(genform, f(x), hint='Bernoulli_Integral'), num_columns=100)
+                                                                                    1
+                                                                                    -----
+                                                                                    1 - n
+                //               /                            \                     \
+                ||              |                             |                     |
+                ||              |                  /          |             /       |
+                ||              |                 |           |            |        |
+                ||              |        (1 - n)* | P(x) dx   |  -(1 - n)* | P(x) dx|
+                ||              |                 |           |            |        |
+                ||              |                /            |           /         |
+        f(x) = ||C1 + (n - 1)* | -Q(x)*e                   dx|*e                   |
+                ||              |                             |                     |
+                \\              /                            /                     /
+
+
+    Note that the equation is separable when `n = 1` (see the docstring of
+    :py:meth:`~sympy.solvers.ode.ode.ode_separable`).
+
+    >>> pprint(dsolve(Eq(f(x).diff(x) + P(x)*f(x), Q(x)*f(x)), f(x),
+    ... hint='separable_Integral'))
+    f(x)
+        /
+    |                /
+    |  1            |
+    |  - dy = C1 +  | (-P(x) + Q(x)) dx
+    |  y            |
+    |              /
+    /
+
+
+    Examples
+    ========
+
+    >>> from sympy import Function, dsolve, Eq, pprint, log
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+
+    >>> pprint(dsolve(Eq(x*f(x).diff(x) + f(x), log(x)*f(x)**2),
+    ... f(x), hint='Bernoulli'))
+                    1
+    f(x) = -------------------
+            /     log(x)   1\
+            x*|C1 + ------ + -|
+            \       x      x/
+
+    References
+    ==========
+
+    - https://en.wikipedia.org/wiki/Bernoulli_differential_equation
+    - M. Tenenbaum & H. Pollard, "Ordinary Differential Equations",
+    Dover 1963, pp. 95
+
+    # indirect doctest
+
+    """
+    hint = "Bernoulli"
+    has_integral = True
+
+    def _matches(self):
+        eq = self.ode_problem.expanded_eq
+        f = self.ode_problem.func.func
+        x = self.ode_problem.sym
+        order = self.ode_problem.order
+        df = f(x).diff(x)
+
+        if order != 1:
+            return False
+
+        a = Wild('a', exclude=[f(x)])
+        b = Wild('b', exclude=[f(x)])
+        c = Wild('c', exclude=[f(x)])
+        n = Wild('n', exclude=[x, f(x), df])
+        c1 = Wild('c1', exclude=[x])
+
+        reduced_eq = None
+        if eq.is_Add:
+            deriv_coef = eq.coeff(f(x).diff(x, order))
+            if deriv_coef not in (1, 0):
+                r = deriv_coef.match(a*f(x)**c1)
+                if r and r[c1]:
+                    den = f(x)**r[c1]
+                    reduced_eq = Add(*[arg/den for arg in eq.args])
+        if not reduced_eq:
+            reduced_eq = eq
+
+        r = collect(
+            reduced_eq, f(x), exact=True).match(a*df + b*f(x) + c*f(x)**n)
+        if r and r[c] != 0 and r[n] != 1:  # See issue 4676
+            r['a'] = a
+            r['b'] = b
+            r['c'] = c
+            r['n'] = n
+            self.coeffs = r
+            return True
+        return False
+
+    def _get_general_solution(self, *, simplify: bool = True):
+        x = self.ode_problem.sym
+        f = self.ode_problem.func.func
+        r = self.coeffs  # a*diff(f(x),x) + b*f(x) + c*f(x)**n, n != 1
+        C1 = self.get_numbered_constants(self.ode_problem.eq, num=1)
+        t = exp((1 - r[r['n']])*Integral(r[r['b']]/r[r['a']], x))
+        tt = (r[r['n']] - 1)*Integral(t*r[r['c']]/r[r['a']], x)
+        return Eq(f(x), ((tt + C1)/t)**(1/(1 - r[r['n']])))

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -76,6 +76,8 @@ def test_dsolve_all_hint():
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral': Eq(f(x), C1),
         'separable_Integral': Eq(Integral(1, (_y, f(x))), C1 + Integral(0, x)),
         'separable': Eq(f(x), C1),
+        'Bernoulli': Eq(f(x), C1),
+        'Bernoulli_Integral': Eq(f(x), C1 + Integral(0, x)),
         'lie_group': Eq(f(x), C1),
         'nth_linear_constant_coeff_homogeneous': Eq(f(x), C1),
         'nth_algebraic_Integral': Eq(f(x), C1),
@@ -918,14 +920,15 @@ def test_dsolve_options():
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral', '1st_linear',
-        '1st_linear_Integral', 'almost_linear', 'almost_linear_Integral',
-        'best', 'best_hint', 'default', 'lie_group',
+        '1st_linear_Integral', 'Bernoulli', 'Bernoulli_Integral',
+        'almost_linear', 'almost_linear_Integral', 'best', 'best_hint',
+        'default', 'lie_group',
         'nth_linear_euler_eq_homogeneous', 'order',
         'separable', 'separable_Integral']
     Integral_keys = ['1st_exact_Integral',
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral', '1st_linear_Integral',
-        'almost_linear_Integral', 'best', 'best_hint', 'default',
+        'Bernoulli_Integral', 'almost_linear_Integral', 'best', 'best_hint', 'default',
         'nth_linear_euler_eq_homogeneous',
         'order', 'separable_Integral']
     assert sorted(a.keys()) == keys
@@ -993,7 +996,9 @@ def test_classify_ode():
     assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == (
         'nth_algebraic',
         'separable',
-        '1st_linear', '1st_homogeneous_coeff_best',
+        '1st_linear',
+        'Bernoulli',
+        '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
         '1st_power_series', 'lie_group',
@@ -1002,11 +1007,13 @@ def test_classify_ode():
         'nth_algebraic_Integral',
         'separable_Integral',
         '1st_linear_Integral',
+        'Bernoulli_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
     assert classify_ode(f(x).diff(x)**2, f(x)) == ('nth_algebraic',
          'separable',
          '1st_linear',
+         'Bernoulli',
          '1st_homogeneous_coeff_best',
          '1st_homogeneous_coeff_subs_indep_div_dep',
          '1st_homogeneous_coeff_subs_dep_div_indep',
@@ -1017,6 +1024,7 @@ def test_classify_ode():
          'nth_algebraic_Integral',
          'separable_Integral',
          '1st_linear_Integral',
+         'Bernoulli_Integral',
          '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
          '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
     # issue 4749: f(x) should be cleared from highest derivative before classifying
@@ -1092,15 +1100,17 @@ def test_classify_ode():
                         prep=True) == ans
 
     assert classify_ode(Eq(2*x**3*f(x).diff(x), 0), f(x)) == \
-        ('factorable', 'nth_algebraic', 'separable', '1st_linear', '1st_power_series',
+        ('factorable', 'nth_algebraic', 'separable', '1st_linear',
+         'Bernoulli', '1st_power_series',
          'lie_group', 'nth_linear_euler_eq_homogeneous',
          'nth_algebraic_Integral', 'separable_Integral',
-         '1st_linear_Integral')
+         '1st_linear_Integral', 'Bernoulli_Integral')
 
 
     assert classify_ode(Eq(2*f(x)**3*f(x).diff(x), 0), f(x)) == \
-        ('factorable', 'nth_algebraic', 'separable', '1st_power_series', 'lie_group',
-                'nth_algebraic_Integral', 'separable_Integral')
+        ('factorable', 'nth_algebraic', 'separable', 'Bernoulli',
+         '1st_power_series', 'lie_group', 'nth_algebraic_Integral',
+         'separable_Integral', 'Bernoulli_Integral')
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -72,29 +72,27 @@ def test_dsolve_all_hint():
     sol1 = output['1st_homogeneous_coeff_subs_dep_div_indep_Integral']
     _u1 = sol1.rhs.args[1].args[1][0]
 
-    expected = {
-        '1st_homogeneous_coeff_subs_indep_div_dep_Integral': Eq(f(x), C1),
-        'separable_Integral': Eq(Integral(1, (_y, f(x))), C1 + Integral(0, x)),
-        'separable': Eq(f(x), C1),
+    expected = {'Bernoulli_Integral': Eq(f(x), C1 + Integral(0, x)),
+        '1st_homogeneous_coeff_best': Eq(f(x), C1),
         'Bernoulli': Eq(f(x), C1),
-        'Bernoulli_Integral': Eq(f(x), C1 + Integral(0, x)),
-        'lie_group': Eq(f(x), C1),
+        'nth_algebraic': Eq(f(x), C1),
+        'nth_linear_euler_eq_homogeneous': Eq(f(x), C1),
         'nth_linear_constant_coeff_homogeneous': Eq(f(x), C1),
-        'nth_algebraic_Integral': Eq(f(x), C1),
-        '1st_power_series': Eq(f(x), C1),
+        'separable': Eq(f(x), C1),
         '1st_homogeneous_coeff_subs_indep_div_dep': Eq(f(x), C1),
+        'nth_algebraic_Integral': Eq(f(x), C1),
         '1st_linear': Eq(f(x), C1),
+        '1st_linear_Integral': Eq(f(x), C1 + Integral(0, x)),
+        'lie_group': Eq(f(x), C1),
         '1st_homogeneous_coeff_subs_dep_div_indep': Eq(f(x), C1),
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral': Eq(log(x), C1 + Integral(-1/_u1, (_u1, f(x)/x))),
-        '1st_homogeneous_coeff_best': Eq(f(x), C1),
-        'nth_linear_euler_eq_homogeneous': Eq(f(x), C1),
-        'nth_algebraic': Eq(f(x), C1),
-        '1st_linear_Integral': Eq(f(x), C1 + Integral(0, x)),
+        '1st_power_series': Eq(f(x), C1),
+        'separable_Integral': Eq(Integral(1, (_y, f(x))), C1 + Integral(0, x)),
+        '1st_homogeneous_coeff_subs_indep_div_dep_Integral': Eq(f(x), C1),
         'best': Eq(f(x), C1),
         'best_hint': 'nth_algebraic',
         'default': 'nth_algebraic',
-        'order': 1
-    }
+        'order': 1}
     assert output == expected
 
     assert dsolve(eq, hint='best') == Eq(f(x), C1)
@@ -1073,8 +1071,9 @@ def test_classify_ode():
     k = Symbol('k')
     assert classify_ode(f(x).diff(x)/(k*f(x) + k*x*f(x)) + 2*f(x)/(k*f(x) +
         k*x*f(x)) + x*f(x).diff(x)/(k*f(x) + k*x*f(x)) + z, f(x)) == \
-        ('separable', '1st_exact', '1st_power_series', 'lie_group',
-         'separable_Integral', '1st_exact_Integral')
+        ('separable', '1st_exact', '1st_linear', 'Bernoulli',
+        '1st_power_series', 'lie_group', 'separable_Integral', '1st_exact_Integral',
+        '1st_linear_Integral', 'Bernoulli_Integral')
     # preprocessing
     ans = ('nth_algebraic', 'separable', '1st_exact', '1st_linear', 'Bernoulli',
         '1st_homogeneous_coeff_best',
@@ -1108,9 +1107,9 @@ def test_classify_ode():
 
 
     assert classify_ode(Eq(2*f(x)**3*f(x).diff(x), 0), f(x)) == \
-        ('factorable', 'nth_algebraic', 'separable', 'Bernoulli',
+        ('factorable', 'nth_algebraic', 'separable', '1st_linear', 'Bernoulli',
          '1st_power_series', 'lie_group', 'nth_algebraic_Integral',
-         'separable_Integral', 'Bernoulli_Integral')
+         'separable_Integral', '1st_linear_Integral', 'Bernoulli_Integral')
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -35,3 +35,11 @@ def test_SingleODESolver():
 
     solver = NthAlgebraic(problem)
     assert solver.matches() is False
+
+    #These are just test for order of ODE
+
+    problem = SingleODEProblem(f(x).diff(x) + f(x), f(x), x)
+    assert problem.order == 1
+
+    problem = SingleODEProblem(f(x).diff(x,4) + f(x).diff(x,2) - f(x).diff(x,3), f(x), x)
+    assert problem.order == 4

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1,0 +1,37 @@
+#
+# The main tests for the code in single.py are currently located in
+# sympy/solvers/tests/test_ode.py
+#
+
+from sympy.core import Function, Symbol
+from sympy.solvers.ode.single import (NthAlgebraic, ODEMatchError,
+    SingleODEProblem, SingleODESolver)
+
+from sympy.testing.pytest import raises
+
+
+x = Symbol('x')
+f = Function('f')
+
+
+def test_SingleODESolver():
+    # Test that not implemented methods give NotImplementedError
+    # Subclasses should override these methods.
+    problem = SingleODEProblem(f(x).diff(x), f(x), x)
+    solver = SingleODESolver(problem)
+    raises(NotImplementedError, lambda: solver.matches())
+    raises(NotImplementedError, lambda: solver.get_general_solution())
+    raises(NotImplementedError, lambda: solver._matches())
+    raises(NotImplementedError, lambda: solver._get_general_solution())
+
+    # This ODE can not be solved by the NthAlgebraic solver. Here we test that
+    # it does not match and the asking for a general solution gives
+    # ODEMatchError
+
+    problem = SingleODEProblem(f(x).diff(x) + f(x), f(x), x)
+
+    solver = NthAlgebraic(problem)
+    raises(ODEMatchError, lambda: solver.get_general_solution())
+
+    solver = NthAlgebraic(problem)
+    assert solver.matches() is False

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -4,7 +4,7 @@
 #
 
 from sympy.core import Function, Symbol
-from sympy.solvers.ode.single import (NthAlgebraic, ODEMatchError,
+from sympy.solvers.ode.single import (FirstLinear, ODEMatchError,
     SingleODEProblem, SingleODESolver)
 
 from sympy.testing.pytest import raises
@@ -24,16 +24,16 @@ def test_SingleODESolver():
     raises(NotImplementedError, lambda: solver._matches())
     raises(NotImplementedError, lambda: solver._get_general_solution())
 
-    # This ODE can not be solved by the NthAlgebraic solver. Here we test that
+    # This ODE can not be solved by the FirstLinear solver. Here we test that
     # it does not match and the asking for a general solution gives
     # ODEMatchError
 
-    problem = SingleODEProblem(f(x).diff(x) + f(x), f(x), x)
+    problem = SingleODEProblem(f(x).diff(x) + f(x)*f(x), f(x), x)
 
-    solver = NthAlgebraic(problem)
+    solver = FirstLinear(problem)
     raises(ODEMatchError, lambda: solver.get_general_solution())
 
-    solver = NthAlgebraic(problem)
+    solver = FirstLinear(problem)
     assert solver.matches() is False
 
     #These are just test for order of ODE


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See #18348

#### Brief description of what is fixed or changed

Makes a start at refactoring dsolve to use classes for each solver. Refactors the `nth_algebraic` solver code to use the new classes.

Adds a new `sympy.solvers.odesolvers` package. I hope that code from the `ode` module can be refactored into multiple files because the `ode` module is large and messy. Eventually the idea would be to rename this package as `ode`.

#### Other comments

The design here is very much a work in progress but it works now and I hope that the work would be completed over many PRs (possibly as a GSOC project). I would like to get this one merged as a start so that contributors can try out moving other solvers to see what issues emerge.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->