### PR TITLE
Implement __hash__ for MutableDenseMatrix

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -489,6 +489,9 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
             i, j, value = rv
             self._mat[i*self.cols + j] = value
 
+    def __hash__(self):
+        return hash(tuple(self))
+
     def as_mutable(self):
         return self.copy()
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4191,3 +4191,11 @@ def test_issue_8207():
     e = diff(d, a[0, 0])
     assert d == b[0, 0]
     assert e == 0
+
+
+def matrix_in_dict():
+    a = Matrix(MatrixSymbol('a', 3, 1))
+    b = Matrix([[Symbol('b'), 1], [1, 2]])
+
+    {a: 1, b: 2}
+


### PR DESCRIPTION
Shouldn't we implement `__hash__` for MutableDenseMatrix? So that we can have Matrices in dicts.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
N/A

#### Brief description of what is fixed or changed
Implement `__hash__` for `MutableDenseMatrix`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
   * Implement `__hash__` for `MutableDenseMatrix`
<!-- END RELEASE NOTES -->