### PR TITLE
Addition of a test to verify if replace works with Equality/Relational or not

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -849,6 +849,11 @@ def test_issue_10304():
     assert simplify(Eq(e, 0)) is S.false
 
 
+def test_issue_18412():
+    d = (Rational(1, 6) + z / 4 / y)
+    assert Eq(x, pi * y**3 * d).replace(y**3, z) == Eq(x, pi * z * d)
+
+
 def test_issue_10401():
     x = symbols('x')
     fin = symbols('inf', finite=True)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18412 

#### Brief description of what is fixed or changed
--> Added test case for verification of correct behaviour of replace method with Equality

#### Other comments

Example of correct behaviour:
```
>> import sympy as sp
>> x, y, z = sp.symbols("x, y, z")
>> Xeq = sp.Eq(x, sp.pi * y**3 * (sp.Rational(1, 6) + z / 4 / y))
>> Xeq.replace(y**3, z)
Eq(x, pi*z*(1/6 + z/(4*y)))
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Added new test case for relational
<!-- END RELEASE NOTES -->