### PR TITLE
Pulled MatrixReductions and MatrixSubspaces function implementations out of Matrix API

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,5 +1,7 @@
 from __future__ import division, print_function
 
+from typing import Any
+
 from types import FunctionType
 
 from mpmath.libmp.libmpf import prec_to_dps
@@ -27,10 +29,6 @@ from sympy.simplify.simplify import (
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.utilities.misc import filldedent
-
-from .common import (
-    MatrixCommon, MatrixError, NonSquareMatrixError, NonInvertibleMatrixError,
-    ShapeError)
 
 from .common import (
     MatrixCommon, MatrixError, NonSquareMatrixError, NonInvertibleMatrixError,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -341,7 +341,9 @@ class MatrixSubspaces(MatrixReductions):
     def rowspace(self, simplify=False, dotprodsimp=None):
         return _rowspace(self, simplify=simplify, dotprodsimp=dotprodsimp)
 
-    @classmethod
+    # This is a classmethod but is converted to such later in order to allow
+    # assignment of __doc__ since that does not work for already wrapped
+    # classmethods in Python 3.6.
     def orthogonalize(cls, *vecs, **kwargs):
         return _orthogonalize(cls, *vecs, **kwargs)
 
@@ -349,6 +351,8 @@ class MatrixSubspaces(MatrixReductions):
     nullspace.__doc__     = _nullspace.__doc__
     rowspace.__doc__      = _rowspace.__doc__
     orthogonalize.__doc__ = _orthogonalize.__doc__
+
+    orthogonalize         = classmethod(orthogonalize)
 
 
 class MatrixEigen(MatrixSubspaces):

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -1,0 +1,336 @@
+from __future__ import division, print_function
+
+from types import FunctionType
+
+from sympy.core.sympify import sympify
+from sympy.simplify.simplify import (
+    simplify as _simplify, dotprodsimp as _dotprodsimp)
+
+from .utilities import _iszero
+from .determinant import _find_reasonable_pivot
+
+
+def _row_reduce_list(mat, rows, cols, one, iszerofunc, simpfunc,
+                normalize_last=True, normalize=True, zero_above=True,
+                dotprodsimp=None):
+    """Row reduce a flat list representation of a matrix and return a tuple
+    (rref_matrix, pivot_cols, swaps) where ``rref_matrix`` is a flat list,
+    ``pivot_cols`` are the pivot columns and ``swaps`` are any row swaps that
+    were used in the process of row reduction.
+
+    Parameters
+    ==========
+
+    mat : list
+        list of matrix elements, must be ``rows`` * ``cols`` in length
+
+    rows, cols : integer
+        number of rows and columns in flat list representation
+
+    one : SymPy object
+        represents the value one, from ``Matrix.one``
+
+    iszerofunc : determines if an entry can be used as a pivot
+
+    simpfunc : used to simplify elements and test if they are
+        zero if ``iszerofunc`` returns `None`
+
+    normalize_last : indicates where all row reduction should
+        happen in a fraction-free manner and then the rows are
+        normalized (so that the pivots are 1), or whether
+        rows should be normalized along the way (like the naive
+        row reduction algorithm)
+
+    normalize : whether pivot rows should be normalized so that
+        the pivot value is 1
+
+    zero_above : whether entries above the pivot should be zeroed.
+        If ``zero_above=False``, an echelon matrix will be returned.
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+    """
+
+    def get_col(i):
+        return mat[i::cols]
+
+    def row_swap(i, j):
+        mat[i*cols:(i + 1)*cols], mat[j*cols:(j + 1)*cols] = \
+            mat[j*cols:(j + 1)*cols], mat[i*cols:(i + 1)*cols]
+
+    def cross_cancel(a, i, b, j):
+        """Does the row op row[i] = a*row[i] - b*row[j]"""
+        q = (j - i)*cols
+        for p in range(i*cols, (i + 1)*cols):
+            mat[p] = dps(a*mat[p] - b*mat[p + q])
+
+    dps = _dotprodsimp if dotprodsimp else lambda e: e
+    piv_row, piv_col = 0, 0
+    pivot_cols = []
+    swaps = []
+
+    # use a fraction free method to zero above and below each pivot
+    while piv_col < cols and piv_row < rows:
+        pivot_offset, pivot_val, \
+        assumed_nonzero, newly_determined = _find_reasonable_pivot(
+                get_col(piv_col)[piv_row:], iszerofunc, simpfunc)
+
+        # _find_reasonable_pivot may have simplified some things
+        # in the process.  Let's not let them go to waste
+        for (offset, val) in newly_determined:
+            offset += piv_row
+            mat[offset*cols + piv_col] = val
+
+        if pivot_offset is None:
+            piv_col += 1
+            continue
+
+        pivot_cols.append(piv_col)
+        if pivot_offset != 0:
+            row_swap(piv_row, pivot_offset + piv_row)
+            swaps.append((piv_row, pivot_offset + piv_row))
+
+        # if we aren't normalizing last, we normalize
+        # before we zero the other rows
+        if normalize_last is False:
+            i, j = piv_row, piv_col
+            mat[i*cols + j] = one
+            for p in range(i*cols + j + 1, (i + 1)*cols):
+                mat[p] = dps(mat[p] / pivot_val)
+            # after normalizing, the pivot value is 1
+            pivot_val = one
+
+        # zero above and below the pivot
+        for row in range(rows):
+            # don't zero our current row
+            if row == piv_row:
+                continue
+            # don't zero above the pivot unless we're told.
+            if zero_above is False and row < piv_row:
+                continue
+            # if we're already a zero, don't do anything
+            val = mat[row*cols + piv_col]
+            if iszerofunc(val):
+                continue
+
+            cross_cancel(pivot_val, row, val, piv_row)
+        piv_row += 1
+
+    # normalize each row
+    if normalize_last is True and normalize is True:
+        for piv_i, piv_j in enumerate(pivot_cols):
+            pivot_val = mat[piv_i*cols + piv_j]
+            mat[piv_i*cols + piv_j] = one
+            for p in range(piv_i*cols + piv_j + 1, (piv_i + 1)*cols):
+                mat[p] = dps(mat[p] / pivot_val)
+
+    return mat, tuple(pivot_cols), tuple(swaps)
+
+
+# This functions is a candidate for caching if it gets implemented for matrices.
+def _row_reduce(M, iszerofunc, simpfunc, normalize_last=True,
+                normalize=True, zero_above=True, dotprodsimp=None):
+
+    mat, pivot_cols, swaps = _row_reduce_list(list(M), M.rows, M.cols, M.one,
+            iszerofunc, simpfunc, normalize_last=normalize_last,
+            normalize=normalize, zero_above=zero_above, dotprodsimp=dotprodsimp)
+
+    return M._new(M.rows, M.cols, mat), pivot_cols, swaps
+
+
+def _is_echelon(M, iszerofunc=_iszero):
+    """Returns `True` if the matrix is in echelon form. That is, all rows of
+    zeros are at the bottom, and below each leading non-zero in a row are
+    exclusively zeros."""
+
+    if M.rows <= 0 or M.cols <= 0:
+        return True
+
+    zeros_below = all(iszerofunc(t) for t in M[1:, 0])
+
+    if iszerofunc(M[0, 0]):
+        return zeros_below and _is_echelon(M[:, 1:], iszerofunc)
+
+    return zeros_below and _is_echelon(M[1:, 1:], iszerofunc)
+
+
+def _echelon_form(M, iszerofunc=_iszero, simplify=False, with_pivots=False,
+        dotprodsimp=None):
+    """Returns a matrix row-equivalent to ``M`` that is in echelon form. Note
+    that echelon form of a matrix is *not* unique, however, properties like the
+    row space and the null space are preserved.
+
+    Parameters
+    ==========
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> M = Matrix([[1, 2], [3, 4]])
+    >>> M.echelon_form()
+    Matrix([
+    [1,  2],
+    [0, -2]])
+    """
+
+    simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
+
+    mat, pivots, _ = _row_reduce(M, iszerofunc, simpfunc,
+            normalize_last=True, normalize=False, zero_above=False,
+            dotprodsimp=dotprodsimp)
+
+    if with_pivots:
+        return mat, pivots
+
+    return mat
+
+
+# This functions is a candidate for caching if it gets implemented for matrices.
+def _rank(M, iszerofunc=_iszero, simplify=False, dotprodsimp=None):
+    """Returns the rank of a matrix.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> from sympy.abc import x
+    >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
+    >>> m.rank()
+    2
+    >>> n = Matrix(3, 3, range(1, 10))
+    >>> n.rank()
+    2
+    """
+
+    def _permute_complexity_right(M, iszerofunc):
+        """Permute columns with complicated elements as
+        far right as they can go.  Since the ``sympy`` row reduction
+        algorithms start on the left, having complexity right-shifted
+        speeds things up.
+
+        Returns a tuple (mat, perm) where perm is a permutation
+        of the columns to perform to shift the complex columns right, and mat
+        is the permuted matrix."""
+
+        def complexity(i):
+            # the complexity of a column will be judged by how many
+            # element's zero-ness cannot be determined
+            return sum(1 if iszerofunc(e) is None else 0 for e in M[:, i])
+
+        complex = [(complexity(i), i) for i in range(M.cols)]
+        perm    = [j for (i, j) in sorted(complex)]
+
+        return (M.permute(perm, orientation='cols'), perm)
+
+    simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
+
+    # for small matrices, we compute the rank explicitly
+    # if is_zero on elements doesn't answer the question
+    # for small matrices, we fall back to the full routine.
+    if M.rows <= 0 or M.cols <= 0:
+        return 0
+
+    if M.rows <= 1 or M.cols <= 1:
+        zeros = [iszerofunc(x) for x in M]
+
+        if False in zeros:
+            return 1
+
+    if M.rows == 2 and M.cols == 2:
+        zeros = [iszerofunc(x) for x in M]
+
+        if not False in zeros and not None in zeros:
+            return 0
+
+        d = M.det(dotprodsimp=dotprodsimp)
+
+        if iszerofunc(d) and False in zeros:
+            return 1
+        if iszerofunc(d) is False:
+            return 2
+
+    mat, _       = _permute_complexity_right(M, iszerofunc=iszerofunc)
+    _, pivots, _ = _row_reduce(mat, iszerofunc, simpfunc, normalize_last=True,
+            normalize=False, zero_above=False, dotprodsimp=dotprodsimp)
+
+    return len(pivots)
+
+
+def _rref(M, iszerofunc=_iszero, simplify=False, pivots=True,
+        normalize_last=True, dotprodsimp=None):
+    """Return reduced row-echelon form of matrix and indices of pivot vars.
+
+    Parameters
+    ==========
+
+    iszerofunc : Function
+        A function used for detecting whether an element can
+        act as a pivot.  ``lambda x: x.is_zero`` is used by default.
+
+    simplify : Function
+        A function used to simplify elements when looking for a pivot.
+        By default SymPy's ``simplify`` is used.
+
+    pivots : True or False
+        If ``True``, a tuple containing the row-reduced matrix and a tuple
+        of pivot columns is returned.  If ``False`` just the row-reduced
+        matrix is returned.
+
+    normalize_last : True or False
+        If ``True``, no pivots are normalized to `1` until after all
+        entries above and below each pivot are zeroed.  This means the row
+        reduction algorithm is fraction free until the very last step.
+        If ``False``, the naive row reduction procedure is used where
+        each pivot is normalized to be `1` before row operations are
+        used to zero above and below the pivot.
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> from sympy.abc import x
+    >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
+    >>> m.rref()
+    (Matrix([
+    [1, 0],
+    [0, 1]]), (0, 1))
+    >>> rref_matrix, rref_pivots = m.rref()
+    >>> rref_matrix
+    Matrix([
+    [1, 0],
+    [0, 1]])
+    >>> rref_pivots
+    (0, 1)
+
+    Notes
+    =====
+
+    The default value of ``normalize_last=True`` can provide significant
+    speedup to row reduction, especially on matrices with symbols.  However,
+    if you depend on the form row reduction algorithm leaves entries
+    of the matrix, set ``noramlize_last=False``
+    """
+
+    simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
+
+    mat, pivot_cols, _ = _row_reduce(M, iszerofunc, simpfunc,
+            normalize_last, normalize=True, zero_above=True,
+            dotprodsimp=dotprodsimp)
+
+    if pivots:
+        mat = (mat, pivot_cols)
+
+    return mat

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -2,7 +2,6 @@ from __future__ import division, print_function
 
 from types import FunctionType
 
-from sympy.core.sympify import sympify
 from sympy.simplify.simplify import (
     simplify as _simplify, dotprodsimp as _dotprodsimp)
 

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function
 
 from sympy.core.compatibility import reduce
-from sympy.core.sympify import sympify
 
 from .utilities import _iszero
 

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -1,0 +1,223 @@
+from __future__ import division, print_function
+
+from sympy.core.compatibility import reduce
+from sympy.core.sympify import sympify
+
+from .utilities import _iszero
+
+
+def _columnspace(M, simplify=False, dotprodsimp=None):
+    """Returns a list of vectors (Matrix objects) that span columnspace of ``M``
+
+    Parameters
+    ==========
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices import Matrix
+    >>> M = Matrix(3, 3, [1, 3, 0, -2, -6, 0, 3, 9, 6])
+    >>> M
+    Matrix([
+    [ 1,  3, 0],
+    [-2, -6, 0],
+    [ 3,  9, 6]])
+    >>> M.columnspace()
+    [Matrix([
+    [ 1],
+    [-2],
+    [ 3]]), Matrix([
+    [0],
+    [0],
+    [6]])]
+
+    See Also
+    ========
+
+    nullspace
+    rowspace
+    """
+
+    reduced, pivots = M.echelon_form(simplify=simplify, with_pivots=True,
+            dotprodsimp=dotprodsimp)
+
+    return [M.col(i) for i in pivots]
+
+
+def _nullspace(M, simplify=False, iszerofunc=_iszero, dotprodsimp=None):
+    """Returns list of vectors (Matrix objects) that span nullspace of ``M``
+
+    Parameters
+    ==========
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices import Matrix
+    >>> M = Matrix(3, 3, [1, 3, 0, -2, -6, 0, 3, 9, 6])
+    >>> M
+    Matrix([
+    [ 1,  3, 0],
+    [-2, -6, 0],
+    [ 3,  9, 6]])
+    >>> M.nullspace()
+    [Matrix([
+    [-3],
+    [ 1],
+    [ 0]])]
+
+    See Also
+    ========
+
+    columnspace
+    rowspace
+    """
+
+    reduced, pivots = M.rref(iszerofunc=iszerofunc, simplify=simplify,
+            dotprodsimp=dotprodsimp)
+
+    free_vars = [i for i in range(M.cols) if i not in pivots]
+    basis     = []
+
+    for free_var in free_vars:
+        # for each free variable, we will set it to 1 and all others
+        # to 0.  Then, we will use back substitution to solve the system
+        vec           = [M.zero] * M.cols
+        vec[free_var] = M.one
+
+        for piv_row, piv_col in enumerate(pivots):
+            vec[piv_col] -= reduced[piv_row, free_var]
+
+        basis.append(vec)
+
+    return [M._new(M.cols, 1, b) for b in basis]
+
+
+def _rowspace(M, simplify=False, dotprodsimp=None):
+    """Returns a list of vectors that span the row space of ``M``.
+
+    Parameters
+    ==========
+
+    dotprodsimp : bool, optional
+        Specifies whether intermediate term algebraic simplification is used
+        during matrix multiplications to control expression blowup and thus
+        speed up calculation.
+
+    Examples
+    ========
+
+    >>> from sympy import Matrix
+    >>> M = Matrix(3, 3, [1, 3, 0, -2, -6, 0, 3, 9, 6])
+    >>> M
+    Matrix([
+    [ 1,  3, 0],
+    [-2, -6, 0],
+    [ 3,  9, 6]])
+    >>> M.rowspace()
+    [Matrix([[1, 3, 0]]), Matrix([[0, 0, 6]])]
+    """
+
+    reduced, pivots = M.echelon_form(simplify=simplify, with_pivots=True,
+            dotprodsimp=dotprodsimp)
+
+    return [reduced.row(i) for i in range(len(pivots))]
+
+
+def _orthogonalize(cls, *vecs, **kwargs):
+    """Apply the Gram-Schmidt orthogonalization procedure
+    to vectors supplied in ``vecs``.
+
+    Parameters
+    ==========
+
+    vecs
+        vectors to be made orthogonal
+
+    normalize : bool
+        If ``True``, return an orthonormal basis.
+
+    rankcheck : bool
+        If ``True``, the computation does not stop when encountering
+        linearly dependent vectors.
+
+        If ``False``, it will raise ``ValueError`` when any zero
+        or linearly dependent vectors are found.
+
+    Returns
+    =======
+
+    list
+        List of orthogonal (or orthonormal) basis vectors.
+
+    Examples
+    ========
+
+    >>> from sympy import I, Matrix
+    >>> v = [Matrix([1, I]), Matrix([1, -I])]
+    >>> Matrix.orthogonalize(*v)
+    [Matrix([
+    [1],
+    [I]]), Matrix([
+    [ 1],
+    [-I]])]
+
+    See Also
+    ========
+
+    MatrixBase.QRdecomposition
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
+    """
+
+    normalize = kwargs.get('normalize', False)
+    rankcheck = kwargs.get('rankcheck', False)
+
+    def project(a, b):
+        return b * (a.dot(b, hermitian=True) / b.dot(b, hermitian=True))
+
+    def perp_to_subspace(vec, basis):
+        """projects vec onto the subspace given
+        by the orthogonal basis ``basis``"""
+
+        components = [project(vec, b) for b in basis]
+
+        if len(basis) == 0:
+            return vec
+
+        return vec - reduce(lambda a, b: a + b, components)
+
+    ret  = []
+    vecs = list(vecs) # make sure we start with a non-zero vector
+
+    while len(vecs) > 0 and vecs[0].is_zero:
+        if rankcheck is False:
+            del vecs[0]
+        else:
+            raise ValueError("GramSchmidt: vector set not linearly independent")
+
+    for vec in vecs:
+        perp = perp_to_subspace(vec, ret)
+
+        if not perp.is_zero:
+            ret.append(cls(perp))
+        elif rankcheck is True:
+            raise ValueError("GramSchmidt: vector set not linearly independent")
+
+    if normalize:
+        ret = [vec / vec.norm() for vec in ret]
+
+    return ret


### PR DESCRIPTION
#### References to other Issues or PRs
Continues #18342

#### Brief description of what is fixed or changed
Relocated the implementations of several matrix functions from `matrices.py` into two new files `reductions.py` and `subspaces.py`. For a rationalization of this change see the description of #18342.

One minor change to a function here is that `_row_reduce` has been renamed to `_row_reduce_list` and changed to take an explicit list of elements and `rows`, `cols` and `one` arguments. This is how it works internally anyway and the function `_row_reduce`  now just takes these arguments from the matrix and calls `_row_reduce_list` with these instead of the code in `_row_reduce_list` reading them from the matrix as it was doing it before. 

This is done to allow this function to eventually be used in other parts of the codebase to solve linear systems of equations without creating intermediate un-sympifiable `RawMatrix` instances which are currently causing problems with attempts to add caching to matrices due to use of elements subclassed from `CantSympify` which throw an exception when a sympification attempt is made (the full explanation for this is too long for this brief description).

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Pulled relevant MatrixReductions and MatrixSubspaces function implementations out of matrices/matrices.py into separate matrices/reductions.py and matrices/subspaces.py source files for easier maintenance and future matrix class overhaul.
<!-- END RELEASE NOTES -->