### PR TITLE
Change the logic of the eval method present in RoundFunction Class (integers.py)

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -32,8 +32,6 @@ class RoundFunction(Function):
                 return cls(i)*S.ImaginaryUnit
             return cls(arg, evaluate=False)
 
-
-
         # Integral, numerical, symbolic part
         ipart = npart = spart = S.Zero
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -20,10 +20,11 @@ class RoundFunction(Function):
 
     @classmethod
     def eval(cls, arg):
+        from sympy import im
         v = cls._eval_number(arg)
         if v is not None:
             return v
-        from sympy import im
+
         if arg.is_integer or arg.is_finite is False:
             return arg
         if arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -20,6 +20,9 @@ class RoundFunction(Function):
 
     @classmethod
     def eval(cls, arg):
+        v = cls._eval_number(arg)
+        if v is not None:
+            return v
         from sympy import im
         if arg.is_integer or arg.is_finite is False:
             return arg
@@ -29,9 +32,7 @@ class RoundFunction(Function):
                 return cls(i)*S.ImaginaryUnit
             return cls(arg, evaluate=False)
 
-        v = cls._eval_number(arg)
-        if v is not None:
-            return v
+
 
         # Integral, numerical, symbolic part
         ipart = npart = spart = S.Zero

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -560,8 +560,8 @@ def test_nested_floor_ceiling():
     assert ceiling(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
     assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
-    
-    
+
+
 def test_issue_18421():
     assert floor(float(0)) is S.Zero
     assert ceiling(float(0)) is S.Zero

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -562,4 +562,4 @@ def test_nested_floor_ceiling():
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
 def test_issue_18421():
     assert floor(float(0)) is S.Zero
-    assert ceil(float(0)) is S.Zero
+    assert ceiling(float(0)) is S.Zero

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -560,6 +560,8 @@ def test_nested_floor_ceiling():
     assert ceiling(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
     assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
+    
+    
 def test_issue_18421():
     assert floor(float(0)) is S.Zero
     assert ceiling(float(0)) is S.Zero

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -560,6 +560,6 @@ def test_nested_floor_ceiling():
     assert ceiling(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
     assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
-def test__issue_18421():
+def test_issue_18421():
     assert floor(float(0)) is S.Zero
     assert ceil(float(0)) is S.Zero

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -560,3 +560,6 @@ def test_nested_floor_ceiling():
     assert ceiling(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
     assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
+def test__issue_18421():
+    assert floor(float(0)) is S.Zero
+    assert ceil(float(0)) is S.Zero


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18421

#### Brief description of what is fixed or changed
`floor(float(0))` now give 0 instead of `0.0` and `ceiling(float(0))` now gives 0 instead of `0.0`.

I have Called the _eval_number first in the eval method present in RoundFunction Class which is present in functions/elementary/integers.py
#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   functions
     *  floor and ceiling with float arguments now return Integers
<!-- END RELEASE NOTES -->