### PR TITLE
Minor Interval fixes

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -917,7 +917,8 @@ class Interval(Set, EvalfMixin):
 
         inftys = [S.Infinity, S.NegativeInfinity]
         # Only allow real intervals (use symbols with 'is_extended_real=True').
-        if not all(i.is_extended_real is not False or i in inftys for i in (start, end)):
+        if not all(i.is_extended_real is not False or i in inftys
+            for i in (start, end, end - start)):
             raise ValueError("Non-real intervals are not supported")
 
         # evaluate if possible

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1063,16 +1063,18 @@ class Interval(Set, EvalfMixin):
         return FiniteSet(*finite_points)
 
     def _contains(self, other):
-        if not isinstance(other, Expr) or (
+        if (not isinstance(other, Expr) or
                 other is S.Infinity or
                 other is S.NegativeInfinity or
                 other is S.NaN or
-                other is S.ComplexInfinity) or other.is_extended_real is False:
+                other is S.ComplexInfinity or
+                other.is_extended_real is False or
+                other.is_real is False):
             return false
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
-            if not other.is_extended_real is None:
-                return other.is_extended_real
+            if not other.is_real is None:
+                return other.is_real
 
         d = Dummy()
         return self.as_relational(d).subs(d, other)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -915,10 +915,8 @@ class Interval(Set, EvalfMixin):
                 "left_open and right_open can have only true/false values, "
                 "got %s and %s" % (left_open, right_open))
 
-        inftys = [S.Infinity, S.NegativeInfinity]
-        # Only allow real intervals (use symbols with 'is_extended_real=True').
-        if not all(i.is_extended_real is not False or i in inftys
-            for i in (start, end, end - start)):
+        # Only allow real intervals
+        if fuzzy_not(fuzzy_and(i.is_extended_real for i in (start, end, end-start))):
             raise ValueError("Non-real intervals are not supported")
 
         # evaluate if possible
@@ -1064,17 +1062,12 @@ class Interval(Set, EvalfMixin):
         return FiniteSet(*finite_points)
 
     def _contains(self, other):
-        if (not isinstance(other, Expr) or
-                other is S.Infinity or
-                other is S.NegativeInfinity or
-                other is S.NaN or
-                other is S.ComplexInfinity or
-                other.is_extended_real is False or
-                other.is_real is False):
-            return false
+        if (not isinstance(other, Expr) or other is S.NaN
+            or other.is_real is False):
+                return false
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
-            if not other.is_real is None:
+            if other.is_real is not None:
                 return other.is_real
 
         d = Dummy()

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -826,6 +826,11 @@ def test_interval_symbolic():
     raises(TypeError, lambda: x in e)
     e = Interval(0, 1, True, True)
     assert e.contains(x) == And(S.Zero < x, x < 1)
+    c = Symbol('c', real=False)
+    assert Interval(x, x + 1).contains(c) == False
+    e = Symbol('e', extended_real=True)
+    assert Interval(-oo, oo).contains(e) == And(
+        S.NegativeInfinity < e, e < S.Infinity)
 
 
 def test_union_contains():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -118,6 +118,7 @@ def test_interval_arguments():
     assert Interval(Symbol('a', real=True, positive=True), 0) == S.EmptySet
     raises(ValueError, lambda: Interval(0, S.ImaginaryUnit))
     raises(ValueError, lambda: Interval(0, Symbol('z', extended_real=False)))
+    raises(ValueError, lambda: Interval(x, x + S.ImaginaryUnit))
 
     raises(NotImplementedError, lambda: Interval(0, 1, And(x, y)))
     raises(NotImplementedError, lambda: Interval(0, 1, False, And(x, y)))


### PR DESCRIPTION
#### References to other Issues or PRs
none

#### Brief description of what is fixed or changed
Sympy `Interval`s are purely real and hence `._contains()` rejects e.g. `S.Infinity`. This commit fixes the following two results that were not quite consistent with this definition:
```
In [1]: c = Symbol('c', real=False)
In [2]: Interval(m, m + 1).contains(c)
Out[2]: c ≥ m ∧ c ≤ m + 1  # should be False
In [3]: e = Symbol('e', extended_real=True)
In [4]: Interval(-oo, oo).contains(e)
Out[4]: True  # is in fact unknown!
```

The second commit makes `Interval` reject some obvious non-real intervals.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * Fixed minor issues in `Interval.contains()`
<!-- END RELEASE NOTES -->