### PR TITLE
implementation of chinese remainder theorem over cartesian product of vectors

### DIFF
--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -36,7 +36,7 @@ def crt(m, v, symmetric=False, check=True):
     then the wrong result will be obtained.
 
     Parameters
-    =========
+    ==========
 
     m: 1D list
         List of moduli.

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -262,13 +262,17 @@ def crt_cartesian(rem, mod):
     It outputs solutions that leave a remainder matching one of the remainders
     of the vector of remainders corresponding to a modulus.
     Assuming that moduli are pairwise relatively prime.
+    When a pair of moduli aren't relatively prime, it returns None.
     Examples
     ========
     >>> from sympy.ntheory.modular import crt_cartesian
     >>> crt_cartesian([[3,5], [3,7]], [7, 11])
     [3, 73, 47, 40]
-    >>> [(p%7, p%11) for p in [3, 40, 47, 73]]
-    [(3, 3), (5, 7), (5, 3), (3, 7)]
+    >>> [(p%7, p%11) for p in [3, 73, 47, 40]]
+    [(3, 3), (3, 7), (5, 3), (5, 7)]
+    >>> crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14])
+    >>> crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13])
+    [565, 697, 799, 73, 851, 125, 227, 359]
     """
     if len(mod) > len(rem):
         raise ValueError("Too few remainders")
@@ -278,7 +282,10 @@ def crt_cartesian(rem, mod):
     R = rem[0]
     for i in range(1,len(mod)):
         rem2 = []
-        s = mod_inverse(m, mod[i])
+        try:
+            s = mod_inverse(m, mod[i])
+        except ValueError:
+            return None
         _m = m
         m *= mod[i]
         for elem in R:

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -284,8 +284,8 @@ def crt_cartesian(rem, mod):
     ==========
 
     rem: 2D list
-        Consists of list of lists whose cartesian product gives
-        us the remainders.
+        List of lists, each containing the remainders with respect
+        to each modulus.
     mod: 1D list
         List of moduli.
 

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -35,6 +35,22 @@ def crt(m, v, symmetric=False, check=True):
     are co-prime. If it is set to False but the moduli are not co-prime
     then the wrong result will be obtained.
 
+    Parameters
+    =========
+
+    m: 1D list
+        List of moduli.
+    v: 1D list
+        List of remainders.
+    symmetric: bool, optional
+        If true, then the output will be within half of the modulus,
+        otherwise returns the output as it is if false. Default value
+        is False.
+    check: bool, optional
+        If true, the function checks if all the moduli are co-prime or
+        not and raises a ValueError exception if they aren't. If false,
+        then there is no checking involved. Default value is True.
+
     Examples
     ========
 
@@ -264,17 +280,27 @@ def crt_cartesian(rem, mod):
     by each of the supplied moduli. If the moduli are not co-prime,
     you will receive a ValueError.
 
+    Parameters
+    =========
+
+    rem: 2D list
+        Consists of list of lists whose cartesian product gives
+        us the remainders.
+    mod: 1D list
+        List of moduli.
+
     Examples
     ========
 
     >>> from sympy.ntheory.modular import crt_cartesian
     >>> from sympy.utilities.iterables import cartes
+
     >>> rem = [[3, 5], [3, 7]]
     >>> crt_cartesian(rem, [7, 11])
     [3, 73, 47, 40]
+
     >>> [(p%7, p%11) for p in _]
     [(3, 3), (3, 7), (5, 3), (5, 7)]
-    >>> assert _ == list(cartes(*rem))
 
     """
     if len(mod) == 0:

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -281,7 +281,7 @@ def crt_cartesian(rem, mod):
     you will receive a ValueError.
 
     Parameters
-    =========
+    ==========
 
     rem: 2D list
         Consists of list of lists whose cartesian product gives

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.compatibility import as_int, reduce
 from sympy.core.mul import prod
-from sympy.core.numbers import igcdex, igcd
+from sympy.core.numbers import igcdex, igcd, mod_inverse
 from sympy.ntheory.primetest import isprime
 from sympy.polys.domains import ZZ
 from sympy.polys.galoistools import gf_crt, gf_crt1, gf_crt2
@@ -253,3 +253,39 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
+
+
+def crt_cartesian(rem, mod):
+    """
+    Crt over a cartesian product of vectors.given a vector of moduli,
+    and for each modulus given a vector of remainders, instead of usual one remainder in crt.
+    It outputs solutions that leave a remainder matching one of the remainders
+    of the vector of remainders corresponding to a modulus.
+    Assuming that moduli are pairwise relatively prime.
+    Examples
+    ========
+    >>> from sympy.ntheory.modular import crt_cartesian
+    >>> crt_cartesian([[3,5], [3,7]], [7, 11])
+    [3, 73, 47, 40]
+    >>> [(p%7, p%11) for p in [3, 40, 47, 73]]
+    [(3, 3), (5, 7), (5, 3), (3, 7)]
+    """
+    if len(mod) > len(rem):
+        raise ValueError("Too few remainders")
+    if len(mod) == 0:
+        raise ValueError("Moduli Vector can't be empty")
+    m = mod[0]
+    R = rem[0]
+    for i in range(1,len(mod)):
+        rem2 = []
+        s = mod_inverse(m, mod[i])
+        _m = m
+        m *= mod[i]
+        for elem in R:
+            for k in rem[i]:
+                r = elem
+                r += _m*s*(k - r)
+                r %= m
+                rem2.append(r)
+        R = rem2
+    return R

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -261,8 +261,10 @@ def crt_cartesian(rem, mod):
     in the Cartesian product of the supplied remainders when divided
     by each of the supplied moduli. None is returned if the moduli
     are not pairwise-prime.
+
     Examples
     ========
+
     >>> from sympy.ntheory.modular import crt_cartesian
     >>> from sympy.utilities.iterables import cartes
     >>> rem = [[3, 5], [3, 7]]
@@ -271,6 +273,7 @@ def crt_cartesian(rem, mod):
     >>> [(p%7, p%11) for p in _]
     [(3, 3), (3, 7), (5, 3), (5, 7)]
     >>> assert _ == list(cartes(*rem))
+
     """
     if len(mod) == 0:
         raise ValueError("There must be at least 1 modulus.")

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -257,42 +257,34 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
 
 def crt_cartesian(rem, mod):
     """
-    Crt over a cartesian product of vectors.given a vector of moduli,
-    and for each modulus given a vector of remainders, instead of usual one remainder in crt.
-    It outputs solutions that leave a remainder matching one of the remainders
-    of the vector of remainders corresponding to a modulus.
-    Assuming that moduli are pairwise relatively prime.
-    When a pair of moduli aren't relatively prime, it returns None.
+    Return a list of values whose elements give the remainders
+    in the Cartesian product of the supplied remainders when divided
+    by each of the supplied moduli. None is returned if the moduli
+    are not pairwise-prime.
     Examples
     ========
     >>> from sympy.ntheory.modular import crt_cartesian
-    >>> crt_cartesian([[3,5], [3,7]], [7, 11])
-    [3, 73, 47, 40]
-    >>> [(p%7, p%11) for p in [3, 73, 47, 40]]
+    >>> from sympy.utilities.iterables import cartes
+    >>> rem = [[3, 5], [3, 7]]
+    >>> crt_cartesian(rem, [7, 11])
+     [3, 73, 47, 40]
+    >>> [(p%7, p%11) for p in _]
     [(3, 3), (3, 7), (5, 3), (5, 7)]
-    >>> crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14])
-    >>> crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13])
-    [565, 697, 799, 73, 851, 125, 227, 359]
+    >>> assert _ == list(cartes(*rem))
     """
-    if len(mod) > len(rem):
-        raise ValueError("Too few remainders")
     if len(mod) == 0:
-        raise ValueError("Moduli Vector can't be empty")
+        raise ValueError("There must be at least 1 modulus.")
+    if len(mod) != len(rem) or not all(rem):
+        raise ValueError(
+            "There should be a list of remainders for each modulus.")
     m = mod[0]
     R = rem[0]
     for i in range(1,len(mod)):
-        rem2 = []
         try:
-            s = mod_inverse(m, mod[i])
+            mi = mod_inverse(m, mod[i])
         except ValueError:
-            return None
-        _m = m
+            return None  # mod_inverse fails if values are not coprime
+        prev_m = m
         m *= mod[i]
-        for elem in R:
-            for k in rem[i]:
-                r = elem
-                r += _m*s*(k - r)
-                r %= m
-                rem2.append(r)
-        R = rem2
+        R = [(r + prev_m*mi*(ri - r)) % m for r in R for ri in rem[i]]
     return R

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -31,12 +31,9 @@ def crt(m, v, symmetric=False, check=True):
     returned, else \|f\| will be less than or equal to the LCM of the
     moduli, and thus f may be negative.
 
-    If the moduli are not co-prime the correct result will be returned
-    if/when the test of the result is found to be incorrect. This result
-    will be None if there is no solution.
-
     The keyword ``check`` can be set to False if it is known that the moduli
-    are co-prime.
+    are co-prime. If it is set to False but the moduli are not co-prime
+    then the wrong result will be obtained.
 
     Examples
     ========
@@ -60,6 +57,15 @@ def crt(m, v, symmetric=False, check=True):
        Traceback (most recent call last):
        ...
        ValueError: All the moduli should be co-prime with one another
+
+    If you are sure the moduli are co-prime then it is safe to set
+    ``check=False``. But if the moduli are actually not co-prime
+    then the wrong result will be obtained:
+
+        >>> crt([12, 6, 17], [3, 4, 2], check=False)
+        (954, 1224)
+        >>> [954 % m for m in [12, 6, 17]]
+        [6, 0, 2]
 
     Note: the order of gf_crt's arguments is reversed relative to crt,
     and that solve_congruence takes residue, modulus pairs.

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -25,7 +25,7 @@ def symmetric_residue(a, m):
 def crt(m, v, symmetric=False, check=True):
     r"""Chinese Remainder Theorem.
 
-    The moduli in m are assumed to be pairwise coprime.  The output
+    The moduli in m are assumed to be pairwise co-prime.  The output
     is then an integer f, such that f = v_i mod m_i for each pair out
     of v and m. If ``symmetric`` is False a positive integer will be
     returned, else \|f\| will be less than or equal to the LCM of the
@@ -36,7 +36,7 @@ def crt(m, v, symmetric=False, check=True):
     will be None if there is no solution.
 
     The keyword ``check`` can be set to False if it is known that the moduli
-    are coprime.
+    are co-prime.
 
     Examples
     ========
@@ -55,6 +55,11 @@ def crt(m, v, symmetric=False, check=True):
        [49, 76, 65]
 
     If the moduli are not co-prime, you will receive a ValueError.
+
+       >>> crt([12, 6, 17], [3, 4, 2])
+       Traceback (most recent call last):
+       ...
+       ValueError: All the moduli should be co-prime with one another
 
     Note: the order of gf_crt's arguments is reversed relative to crt,
     and that solve_congruence takes residue, modulus pairs.
@@ -274,7 +279,7 @@ def crt_cartesian(rem, mod):
     m = mod[0]
     R = rem[0]
     for i in range(1, len(mod)):
-        mi = mod_inverse(m, mod[i])*m
+        mi = mod_inverse(m, mod[i])*m  # fails if `mod` not pairwise-prime
         m *= mod[i]
         R = [(r + mi*(ri - r)) % m for r in R for ri in rem[i]]
     return R

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -279,12 +279,11 @@ def crt_cartesian(rem, mod):
             "There should be a list of remainders for each modulus.")
     m = mod[0]
     R = rem[0]
-    for i in range(1,len(mod)):
+    for i in range(1, len(mod)):
         try:
-            mi = mod_inverse(m, mod[i])
+            mi = mod_inverse(m, mod[i])*m
         except ValueError:
             return None  # mod_inverse fails if values are not coprime
-        prev_m = m
         m *= mod[i]
-        R = [(r + prev_m*mi*(ri - r)) % m for r in R for ri in rem[i]]
+        R = [(r + mi*(ri - r)) % m for r in R for ri in rem[i]]
     return R

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -54,17 +54,7 @@ def crt(m, v, symmetric=False, check=True):
        >>> [639985 % m for m in [99, 97, 95]]
        [49, 76, 65]
 
-    If the moduli are not co-prime, you may receive an incorrect result
-    if you use ``check=False``:
-
-       >>> crt([12, 6, 17], [3, 4, 2], check=False)
-       (954, 1224)
-       >>> [954 % m for m in [12, 6, 17]]
-       [6, 0, 2]
-       >>> crt([12, 6, 17], [3, 4, 2]) is None
-       True
-       >>> crt([3, 6], [2, 5])
-       (5, 6)
+    If the moduli are not co-prime, you will receive a ValueError.
 
     Note: the order of gf_crt's arguments is reversed relative to crt,
     and that solve_congruence takes residue, modulus pairs.
@@ -92,7 +82,8 @@ def crt(m, v, symmetric=False, check=True):
             result = solve_congruence(*list(zip(v, m)),
                     check=False, symmetric=symmetric)
             if result is None:
-                return result
+                raise ValueError(
+                    "All the moduli should be co-prime with one another")
             result, mm = result
 
     if symmetric:
@@ -259,8 +250,8 @@ def crt_cartesian(rem, mod):
     """
     Return a list of values whose elements give the remainders
     in the Cartesian product of the supplied remainders when divided
-    by each of the supplied moduli. None is returned if the moduli
-    are not pairwise-prime.
+    by each of the supplied moduli. If the moduli are not co-prime,
+    you will receive a ValueError.
 
     Examples
     ========
@@ -269,7 +260,7 @@ def crt_cartesian(rem, mod):
     >>> from sympy.utilities.iterables import cartes
     >>> rem = [[3, 5], [3, 7]]
     >>> crt_cartesian(rem, [7, 11])
-     [3, 73, 47, 40]
+    [3, 73, 47, 40]
     >>> [(p%7, p%11) for p in _]
     [(3, 3), (3, 7), (5, 3), (5, 7)]
     >>> assert _ == list(cartes(*rem))
@@ -283,10 +274,7 @@ def crt_cartesian(rem, mod):
     m = mod[0]
     R = rem[0]
     for i in range(1, len(mod)):
-        try:
-            mi = mod_inverse(m, mod[i])*m
-        except ValueError:
-            return None  # mod_inverse fails if values are not coprime
+        mi = mod_inverse(m, mod[i])*m
         m *= mod[i]
         R = [(r + mi*(ri - r)) % m for r in R for ri in rem[i]]
     return R

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -295,12 +295,12 @@ def crt_cartesian(rem, mod):
     >>> from sympy.ntheory.modular import crt_cartesian
     >>> from sympy.utilities.iterables import cartes
 
-    >>> rem = [[3, 5], [3, 7]]
-    >>> crt_cartesian(rem, [7, 11])
-    [3, 73, 47, 40]
+    >>> rem = [[1, 3], [2, 4]]
+    >>> crt_cartesian(rem, [5, 7])
+    [16, 11, 23, 18]
 
-    >>> [(p%7, p%11) for p in _]
-    [(3, 3), (3, 7), (5, 3), (5, 7)]
+    >>> [(p%5, p%7) for p in _]
+    [(1, 2), (1, 4), (3, 2), (3, 4)]
 
     """
     if len(mod) == 0:

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,4 +1,5 @@
-from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence, crt_cartesian
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence, \
+    crt_cartesian
 from sympy.testing.pytest import raises
 
 
@@ -14,15 +15,20 @@ def test_crt():
     mcrt([2, 3, 5], [-1, -1, -1], -1, True)
     mcrt([2, 3, 5], [-1, -1, -1], 2*3*5 - 1, False)
 
-    assert crt([656, 350], [811, 133], symmetric=True) == (-56917, 114800)
+    assert crt([656, 350], [811, 133], symmetric=True) == (
+        -56917, 114800)
 
 
 def test_modular():
-    assert solve_congruence(*list(zip([3, 4, 2], [12, 35, 17]))) == (1719, 7140)
+    assert solve_congruence(*list(zip([3, 4, 2], [12, 35, 17]))
+        ) == (1719, 7140)
     assert solve_congruence(*list(zip([3, 4, 2], [12, 6, 17]))) is None
-    assert solve_congruence(*list(zip([3, 4, 2], [13, 7, 17]))) == (172, 1547)
-    assert solve_congruence(*list(zip([-10, -3, -15], [13, 7, 17]))) == (172, 1547)
-    assert solve_congruence(*list(zip([-10, -3, 1, -15], [13, 7, 7, 17]))) is None
+    assert solve_congruence(*list(zip([3, 4, 2], [13, 7, 17]))
+        ) == (172, 1547)
+    assert solve_congruence(*list(zip([-10, -3, -15], [13, 7, 17]))
+        ) == (172, 1547)
+    assert solve_congruence(*list(
+        zip([-10, -3, 1, -15], [13, 7, 7, 17]))) is None
     assert solve_congruence(
         *list(zip([-10, -5, 2, -15], [13, 7, 7, 17]))) == (835, 1547)
     assert solve_congruence(
@@ -31,14 +37,27 @@ def test_modular():
         *list(zip([-10, 2, 2, -15], [13, 7, 14, 17]))) == (2382, 3094)
     assert solve_congruence(*list(zip((1, 1, 2), (3, 2, 4)))) is None
     raises(
-        ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
-    assert crt_cartesian([[3, 5], [3, 7]], [7, 11]) == [3, 73, 47, 40]
-    assert crt_cartesian([[3], [3, 7]], [7, 11]) == [3, 73]
-    assert crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13]) == [
-        565, 697, 799, 73, 851, 125, 227, 359]
-    assert crt_cartesian([[5, 3], [7, 9], [3, 7]], [7, 11, 13]) == [887, 579, 614, 306, 458, 150, 185, 878]
-    assert crt_cartesian([[11, 51], [54, 72], [16, 38]], [67, 79, 43]) == [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308]
+        ValueError, lambda: solve_congruence(*list(zip(
+        [3, 4, 2], [12.1, 35, 17]))))
+
+
+def test_crt_cartesian():
+    def check(r, p, ans):
+        a = crt_cartesian(r, p)
+        assert a == ans
+        for i in zip([tuple([n%i for i in p]) for n in a], cartes(*r)):
+            print(i)
+            assert i[0] == i[1]
+
+    check([[3, 5], [3, 7]], [7, 11], [3, 73, 47, 40])
+    check([[3], [3, 7]], [7, 11], [3, 73])
+    check([[1, 5], [4, 7], [6, 8]], [6, 11, 13],
+        [565, 697, 799, 73, 851, 125, 227, 359])
+    check([[5, 3], [7, 9], [3, 7]], [7, 11, 13],
+        [887, 579, 614, 306, 458, 150, 185, 878])
+    check([[11, 51], [54, 72], [16, 38]], [67, 79, 43],
+        [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308])
     assert crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14]) is None
-    assert crt_cartesian([[1,2],[4]],[3,5]) == [4, 14]
-    raises(ValueError, lambda: crt_cartesian([[2, 3], [3, 4]], [4, 5, 6]))
+    raises(ValueError, lambda: crt_cartesian(
+        [[2, 3], [3, 4]], [4, 5, 6]))
     raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -50,7 +50,6 @@ def test_crt_cartesian():
         a = crt_cartesian(r, p)
         assert a == ans
         for i in zip([tuple([n%i for i in p]) for n in a], cartes(*r)):
-            print(i)
             assert i[0] == i[1]
 
     check([[3, 5], [3, 7]], [7, 11], [3, 73, 47, 40])

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,4 +1,4 @@
-from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence, crt_cartesian
 from sympy.testing.pytest import raises
 
 
@@ -32,3 +32,9 @@ def test_modular():
     assert solve_congruence(*list(zip((1, 1, 2), (3, 2, 4)))) is None
     raises(
         ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
+    assert crt_cartesian([[3, 5], [3, 7]], [7, 11]) == [3, 73, 47, 40]
+    assert crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13]) == [565, 697, 799, 73, 851, 125, 227, 359]
+    assert crt_cartesian([[5, 3], [7, 9], [3, 7]], [7, 11, 13]) == [887, 579, 614, 306, 458, 150, 185, 878]
+    assert crt_cartesian([[11, 51], [54, 72], [16, 38]], [67, 79, 43]) == [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308]
+    raises(ValueError, lambda: crt_cartesian([[2, 3], [3, 4]], [4, 5, 6]))
+    raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -19,6 +19,9 @@ def test_crt():
     assert crt([656, 350], [811, 133], symmetric=True) == (
         -56917, 114800)
 
+    raises(ValueError, lambda: crt(
+        [20, 2, 5], [1, 1, 2]))
+
 
 def test_modular():
     assert solve_congruence(*list(zip([3, 4, 2], [12, 35, 17]))
@@ -58,7 +61,8 @@ def test_crt_cartesian():
         [887, 579, 614, 306, 458, 150, 185, 878])
     check([[11, 51], [54, 72], [16, 38]], [67, 79, 43],
         [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308])
-    assert crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14]) is None
+    raises(ValueError, lambda : crt_cartesian(
+        [[4, 2], [5, 7], [1, 3]], [6, 11, 14]))
     raises(ValueError, lambda: crt_cartesian(
         [[2, 3], [3, 4]], [4, 5, 6]))
     raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,6 +1,7 @@
 from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence, \
     crt_cartesian
 from sympy.testing.pytest import raises
+from sympy.utilities.iterables import cartes
 
 
 def test_crt():

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -36,5 +36,7 @@ def test_modular():
     assert crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13]) == [565, 697, 799, 73, 851, 125, 227, 359]
     assert crt_cartesian([[5, 3], [7, 9], [3, 7]], [7, 11, 13]) == [887, 579, 614, 306, 458, 150, 185, 878]
     assert crt_cartesian([[11, 51], [54, 72], [16, 38]], [67, 79, 43]) == [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308]
+    assert crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14]) == None
+    assert crt_cartesian([[1,2],[4]],[3,5]) == [4, 14]
     raises(ValueError, lambda: crt_cartesian([[2, 3], [3, 4]], [4, 5, 6]))
     raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -61,3 +61,4 @@ def test_crt_cartesian():
     raises(ValueError, lambda: crt_cartesian(
         [[2, 3], [3, 4]], [4, 5, 6]))
     raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))
+    raises(ValueError, lambda: crt_cartesian([[4, 7], []], [9, 11]))

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -33,10 +33,12 @@ def test_modular():
     raises(
         ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
     assert crt_cartesian([[3, 5], [3, 7]], [7, 11]) == [3, 73, 47, 40]
-    assert crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13]) == [565, 697, 799, 73, 851, 125, 227, 359]
+    assert crt_cartesian([[3], [3, 7]], [7, 11]) == [3, 73]
+    assert crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13]) == [
+        565, 697, 799, 73, 851, 125, 227, 359]
     assert crt_cartesian([[5, 3], [7, 9], [3, 7]], [7, 11, 13]) == [887, 579, 614, 306, 458, 150, 185, 878]
     assert crt_cartesian([[11, 51], [54, 72], [16, 38]], [67, 79, 43]) == [196053, 111365, 129790, 45102, 189259, 104571, 122996, 38308]
-    assert crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14]) == None
+    assert crt_cartesian([[4, 2], [5, 7], [1, 3]], [6, 11, 14]) is None
     assert crt_cartesian([[1,2],[4]],[3,5]) == [4, 14]
     raises(ValueError, lambda: crt_cartesian([[2, 3], [3, 4]], [4, 5, 6]))
     raises(ValueError, lambda: crt_cartesian([[4, 7], [3, 5]], []))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #18428  and incorporates PR #10949

#### Brief description of what is fixed or changed

--> Added the implementation of chinese remainder theorem over cartesian product(crt_cartesian) of vectors which was added in PR #10949
--> Added test cases to check if the function crt_cartesian function implemented works properly in test_modular.py

#### Other comments

Example of using crt_cartesian:
```
>> from sympy.ntheory.modular import crt_cartesian
>> crt_cartesian([[3,5], [3,7]], [7, 11])
[3, 73, 47, 40]
>> crt_cartesian([[1, 5], [4, 7], [6, 8]], [6, 11, 13])
[565, 697, 799, 73, 851, 125, 227, 359]
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Added new function that implements chinese remainder theorem over cartesian product of vectors 
<!-- END RELEASE NOTES -->