### PR TITLE
Fixes the issue for floor and ceiling functions returning floats for zero

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -20,6 +20,10 @@ class RoundFunction(Function):
 
     @classmethod
     def eval(cls, arg):
+
+        if arg == 0.0:
+            return S.Zero
+
         from sympy import im
         if arg.is_integer or arg.is_finite is False:
             return arg


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18421 

#### Brief description of what is fixed or changed

Added a check in the file ```integers.py``` which looks for the input to the floor and ceiling. The check is as follows :

If the ```arg``` is 0.0 then directly return ```S.Zero``` which is returning ```0``` instead of ```0.0```.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->