### PR TITLE
Fixes recursion error in  Limit

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -452,14 +452,14 @@ def test_AccumBounds_pow():
     assert AccumBounds(-1, 2)**oo == AccumBounds(-oo, oo)
     assert AccumBounds(-2, S.Half)**oo == AccumBounds(-oo, oo)
 
-    assert AccumBounds(1, 2)**x == Pow(AccumBounds(1, 2), x, evaluate=False)
+    assert AccumBounds(1, 2)**x == Pow(AccumBounds(1, 2), x)
 
     assert AccumBounds(2, 3)**(-oo) is S.Zero
     assert AccumBounds(0, 2)**(-oo) == AccumBounds(0, oo)
     assert AccumBounds(-1, 2)**(-oo) == AccumBounds(-oo, oo)
 
     assert (tan(x)**sin(2*x)).subs(x, AccumBounds(0, pi/2)) == \
-        Pow(AccumBounds(-oo, oo), AccumBounds(0, 1), evaluate=False)
+        Pow(AccumBounds(-oo, oo), AccumBounds(0, 1))
 
 
 def test_comparison_AccumBounds():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1341,7 +1341,7 @@ class AccumulationBounds(AtomicExpr):
                 if den!=1:
                     num_pow = self**num
                     return num_pow**(1 / den)
-            return Pow(self, other, evaluate=False)
+            return AccumBounds(-oo, oo)
 
         return NotImplemented
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1338,8 +1338,9 @@ class AccumulationBounds(AtomicExpr):
                                 return AccumBounds(0, real_root(self.max, den))
                     return AccumBounds(real_root(self.min, den),
                                        real_root(self.max, den))
-                num_pow = self**num
-                return num_pow**(1 / den)
+                if den!=1:
+                    num_pow = self**num
+                    return num_pow**(1 / den)
             return Pow(self, other, evaluate=False)
 
         return NotImplemented

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -608,3 +608,7 @@ def test_issue_17671():
 
 def test_issue_18306():
     assert limit(sin(sqrt(x))/sqrt(sin(x)), x, 0, '+') == 1
+
+def test_issue_18442():
+    assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == \
+            AccumBounds(-oo, oo)*AccumBounds(-oo, oo)**(2**(sqrt(pi)))

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -610,5 +610,4 @@ def test_issue_18306():
     assert limit(sin(sqrt(x))/sqrt(sin(x)), x, 0, '+') == 1
 
 def test_issue_18442():
-    assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == \
-            AccumBounds(-oo, oo)*AccumBounds(-oo, oo)**(2**(sqrt(pi)))
+    assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == AccumBounds(-oo, oo)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes recursion error in  Limit
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18442 

#### Brief description of what is fixed or changed
Before fixing:
```
>>> limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-')
RecursionError: maximum recursion depth exceeded
```

After fixing:
```
>>> limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-')
AccumBounds(-oo, oo)*AccumBounds(-oo, oo)**(2**(sqrt(pi)))
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixes Recursion Error in `AccumulationBounds.__pow__` by adding a check on denominator
<!-- END RELEASE NOTES -->