### PR TITLE
Add automatic evaluation for polygamma(n, 1/2)

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -720,6 +720,10 @@ class polygamma(Function):
                 if z != nz:
                     return polygamma(n, nz)
 
+            if n.is_positive:
+                if z is S.Half:
+                    return (-1)**(n + 1)*factorial(n)*(2**(n + 1) - 1)*zeta(n + 1)
+
             if n is S.NegativeOne:
                 return loggamma(z)
             else:

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -231,6 +231,10 @@ def test_polygamma():
     assert polygamma(3, 5) == 6*(Rational(-22369, 20736) + pi**4/90)
     assert polygamma(5, 1) == 8 * pi**6 / 63
 
+    assert polygamma(1, S.Half) == pi**2 / 2
+    assert polygamma(2, S.Half) == -14*zeta(3)
+    assert polygamma(11, S.Half) == 176896*pi**12
+
     def t(m, n):
         x = S(m)/n
         r = polygamma(0, x)


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Add automatic evaluation for `polygamma(n, 1/2)` for `n` a positive integer in terms of the zeta function. For example, `polygamma(1, 1/2)` now evaluates to `pi**2/6`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * polygamma(n, 1/2) with n a positive integer is automatically evaluated
<!-- END RELEASE NOTES -->