### PR TITLE
[WIP] Make rings sympifyable

### DIFF
--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -21,23 +21,26 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
     has_assoc_Ring = False
     has_assoc_Field = True
 
-    def __init__(self, dom, *ext):
+    def __new__(cls, dom, *ext):
         if not dom.is_QQ:
             raise DomainError("ground domain must be a rational field")
 
         from sympy.polys.numberfields import to_number_field
 
-        self.orig_ext = ext
-        self.ext = to_number_field(ext)
-        self.mod = self.ext.minpoly.rep
-        self.domain = self.dom = dom
+        obj = super(AlgebraicField, cls).__new__(cls)
+        obj.orig_ext = ext
+        obj.ext = to_number_field(ext)
+        obj.mod = obj.ext.minpoly.rep
+        obj.domain = obj.dom = dom
 
-        self.ngens = 1
-        self.symbols = self.gens = (self.ext,)
-        self.unit = self([dom(1), dom(0)])
+        obj.ngens = 1
+        obj.symbols = obj.gens = (obj.ext,)
+        obj.unit = obj([dom(1), dom(0)])
 
-        self.zero = self.dtype.zero(self.mod.rep, dom)
-        self.one = self.dtype.one(self.mod.rep, dom)
+        obj.zero = obj.dtype.zero(obj.mod.rep, dom)
+        obj.one = obj.dtype.one(obj.mod.rep, dom)
+        return obj
+
 
     def new(self, element):
         return self.dtype(element, self.mod.rep, self.dom)

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -42,8 +42,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         obj.one = obj.dtype.one(obj.mod.rep, dom)
         return obj
 
-    @property
-    def args(self):
+    def __getnewargs__(self):
         # XXX Workaround for pickling
         return (self.dom, *self.orig_ext)
 

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from sympy.core.sympify import _sympify
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
@@ -41,6 +42,10 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         obj.one = obj.dtype.one(obj.mod.rep, dom)
         return obj
 
+    @property
+    def args(self):
+        # XXX Workaround for pickling
+        return (self.dom, *self.orig_ext)
 
     def new(self, element):
         return self.dtype(element, self.mod.rep, self.dom)

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function, division
 
-from sympy.core.sympify import _sympify
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -42,14 +42,17 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
     def tolerance(self):
         return self._context.tolerance
 
-    def __init__(self, prec=_default_precision, dps=None, tol=None):
-        context = MPContext(prec, dps, tol, False)
-        context._parent = self
-        self._context = context
+    def __new__(cls, prec=_default_precision, dps=None, tol=None):
+        obj = super(ComplexField, cls).__new__(cls)
 
-        self.dtype = context.mpc
-        self.zero = self.dtype(0)
-        self.one = self.dtype(1)
+        context = MPContext(prec, dps, tol, False)
+        context._parent = obj
+
+        obj._context = context
+        obj.dtype = context.mpc
+        obj.zero = obj.dtype(0)
+        obj.one = obj.dtype(1)
+        return obj
 
     def __eq__(self, other):
         return (isinstance(other, ComplexField)

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from typing import Any, Optional, Type
 
-from sympy.core import Atom, Basic, sympify
+from sympy.core import Basic, sympify
 from sympy.core.compatibility import HAS_GMPY, is_sequence
 from sympy.core.decorators import deprecated
 from sympy.polys.domains.domainelement import DomainElement
@@ -14,7 +14,7 @@ from sympy.polys.polyutils import _unify_gens, _not_a_coeff
 from sympy.utilities import default_sort_key, public
 
 @public
-class Domain(Atom):
+class Domain(Basic):
     """Represents an abstract domain. """
 
     dtype = None  # type: Optional[Type]

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from typing import Any, Optional, Type
 
-from sympy.core import Basic, sympify
+from sympy.core import Atom, Basic, sympify
 from sympy.core.compatibility import HAS_GMPY, is_sequence
 from sympy.core.decorators import deprecated
 from sympy.polys.domains.domainelement import DomainElement
@@ -14,7 +14,7 @@ from sympy.polys.polyutils import _unify_gens, _not_a_coeff
 from sympy.utilities import default_sort_key, public
 
 @public
-class Domain(object):
+class Domain(Atom):
     """Represents an abstract domain. """
 
     dtype = None  # type: Optional[Type]
@@ -58,9 +58,6 @@ class Domain(object):
     @deprecated(useinstead="is_Ring", issue=12723, deprecated_since_version="1.1")
     def has_Ring(self):
         return self.is_Ring
-
-    def __init__(self):
-        raise NotImplementedError
 
     def __str__(self):
         return self.rep

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -59,12 +59,6 @@ class Domain(Atom):
     def has_Ring(self):
         return self.is_Ring
 
-    def __str__(self):
-        return self.rep
-
-    def __repr__(self):
-        return str(self)
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype))
 

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -143,9 +143,6 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
     has_assoc_Ring = False
     has_assoc_Field = True
 
-    def __init__(self):
-        pass
-
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return a.as_expr()

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function, division
 
+from sympy.core.basic import Basic
+from sympy.core.sympify import _sympify
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.groundtypes import SymPyInteger
 from sympy.polys.domains.modularinteger import ModularIntegerFactory
@@ -31,7 +33,8 @@ class FiniteField(Field, SimpleDomain):
             from sympy.polys.domains import ZZ
             dom = ZZ
 
-        obj = super(FiniteField, cls).__new__(cls)
+        mod, dom, symmetric = _sympify(mod), _sympify(dom), _sympify(symmetric)
+        obj = Basic.__new__(cls, mod, dom, symmetric)
         obj.dtype = ModularIntegerFactory(mod, dom, symmetric, obj)
         obj.zero = obj.dtype(0)
         obj.one = obj.dtype(1)

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -24,18 +24,20 @@ class FiniteField(Field, SimpleDomain):
     dom = None
     mod = None
 
-    def __init__(self, mod, dom=None, symmetric=True):
+    def __new__(cls, mod, dom=None, symmetric=True):
         if mod <= 0:
             raise ValueError('modulus must be a positive integer, got %s' % mod)
         if dom is None:
             from sympy.polys.domains import ZZ
             dom = ZZ
 
-        self.dtype = ModularIntegerFactory(mod, dom, symmetric, self)
-        self.zero = self.dtype(0)
-        self.one = self.dtype(1)
-        self.dom = dom
-        self.mod = mod
+        obj = super(FiniteField, cls).__new__(cls)
+        obj.dtype = ModularIntegerFactory(mod, dom, symmetric, obj)
+        obj.zero = obj.dtype(0)
+        obj.one = obj.dtype(1)
+        obj.dom = dom
+        obj.mod = mod
+        return obj
 
     def __str__(self):
         return 'GF(%s)' % self.mod

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -39,7 +39,7 @@ class FiniteField(Field, SimpleDomain):
         obj.zero = obj.dtype(0)
         obj.one = obj.dtype(1)
         obj.dom = dom
-        obj.mod = mod
+        obj.mod = int(mod)
         return obj
 
     def __str__(self):

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -59,9 +59,6 @@ class FractionField(Field, CompositeDomain):
     def get_exact(self):
         return FractionField(self.domain.get_exact(), self.symbols)
 
-    def __str__(self):
-        return str(self.domain) + '(' + ','.join(map(str, self.symbols)) + ')'
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype.field, self.domain, self.symbols))
 

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -16,7 +16,7 @@ class FractionField(Field, CompositeDomain):
     has_assoc_Ring = True
     has_assoc_Field = True
 
-    def __init__(self, domain_or_field, symbols=None, order=None):
+    def __new__(cls, domain_or_field, symbols=None, order=None):
         from sympy.polys.fields import FracField
 
         if isinstance(domain_or_field, FracField) and symbols is None and order is None:
@@ -24,16 +24,18 @@ class FractionField(Field, CompositeDomain):
         else:
             field = FracField(symbols, domain_or_field, order)
 
-        self.field = field
-        self.dtype = field.dtype
+        obj = super(FractionField, cls).__new__(cls)
+        obj.field = field
+        obj.dtype = field.dtype
 
-        self.gens = field.gens
-        self.ngens = field.ngens
-        self.symbols = field.symbols
-        self.domain = field.domain
+        obj.gens = field.gens
+        obj.ngens = field.ngens
+        obj.symbols = field.symbols
+        obj.domain = field.domain
 
         # TODO: remove this
-        self.dom = self.domain
+        obj.dom = obj.domain
+        return obj
 
     def new(self, element):
         return self.field.field_new(element)

--- a/sympy/polys/domains/gmpyfinitefield.py
+++ b/sympy/polys/domains/gmpyfinitefield.py
@@ -16,3 +16,6 @@ class GMPYFiniteField(FiniteField):
     def __new__(cls, mod, symmetric=True):
         return super(GMPYFiniteField, cls).__new__(
             cls, mod, GMPYIntegerRing(), symmetric)
+
+    def __getnewargs__(self):
+        return self.args[0], self.args[2]

--- a/sympy/polys/domains/gmpyfinitefield.py
+++ b/sympy/polys/domains/gmpyfinitefield.py
@@ -13,5 +13,6 @@ class GMPYFiniteField(FiniteField):
 
     alias = 'FF_gmpy'
 
-    def __init__(self, mod, symmetric=True):
-        return super(GMPYFiniteField, self).__init__(mod, GMPYIntegerRing(), symmetric)
+    def __new__(cls, mod, symmetric=True):
+        return super(GMPYFiniteField, cls).__new__(
+            cls, mod, GMPYIntegerRing(), symmetric)

--- a/sympy/polys/domains/gmpyintegerring.py
+++ b/sympy/polys/domains/gmpyintegerring.py
@@ -21,9 +21,6 @@ class GMPYIntegerRing(IntegerRing):
     tp = type(one)
     alias = 'ZZ_gmpy'
 
-    def __init__(self):
-        """Allow instantiation of this domain. """
-
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return SymPyInteger(int(a))

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -20,9 +20,6 @@ class GMPYRationalField(RationalField):
     tp = type(one)
     alias = 'QQ_gmpy'
 
-    def __init__(self):
-        pass
-
     def get_ring(self):
         """Returns ring associated with ``self``. """
         from sympy.polys.domains import GMPYIntegerRing

--- a/sympy/polys/domains/old_fractionfield.py
+++ b/sympy/polys/domains/old_fractionfield.py
@@ -20,18 +20,20 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
     has_assoc_Ring = True
     has_assoc_Field = True
 
-    def __init__(self, dom, *gens):
+    def __new__(cls, dom, *gens):
         if not gens:
             raise GeneratorsNeeded("generators not specified")
 
         lev = len(gens) - 1
-        self.ngens = len(gens)
+        obj = super(FractionField, cls).__new__(cls)
+        obj.ngens = len(gens)
 
-        self.zero = self.dtype.zero(lev, dom, ring=self)
-        self.one = self.dtype.one(lev, dom, ring=self)
+        obj.zero = obj.dtype.zero(lev, dom, ring=obj)
+        obj.one = obj.dtype.one(lev, dom, ring=obj)
 
-        self.domain = self.dom = dom
-        self.symbols = self.gens = gens
+        obj.domain = obj.dom = dom
+        obj.symbols = obj.gens = gens
+        return obj
 
     def new(self, element):
         return self.dtype(element, self.dom, len(self.gens) - 1, ring=self)

--- a/sympy/polys/domains/old_polynomialring.py
+++ b/sympy/polys/domains/old_polynomialring.py
@@ -53,12 +53,6 @@ class PolynomialRingBase(Ring, CharacteristicZero, CompositeDomain):
     def new(self, element):
         return self.dtype(element, self.dom, len(self.gens) - 1, ring=self)
 
-    def __str__(self):
-        s_order = str(self.order)
-        orderstr = (
-            " order=" + s_order) if s_order != self.default_order else ""
-        return str(self.dom) + '[' + ','.join(map(str, self.gens)) + orderstr + ']'
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype, self.dom,
                      self.gens, self.order))

--- a/sympy/polys/domains/old_polynomialring.py
+++ b/sympy/polys/domains/old_polynomialring.py
@@ -33,20 +33,22 @@ class PolynomialRingBase(Ring, CharacteristicZero, CompositeDomain):
 
     default_order = "grevlex"
 
-    def __init__(self, dom, *gens, **opts):
+    def __new__(cls, dom, *gens, **opts):
         if not gens:
             raise GeneratorsNeeded("generators not specified")
 
+        obj = super(PolynomialRingBase, cls).__new__(cls)
+
+        obj.ngens = len(gens)
         lev = len(gens) - 1
-        self.ngens = len(gens)
+        obj.zero = obj.dtype.zero(lev, dom, ring=obj)
+        obj.one = obj.dtype.one(lev, dom, ring=obj)
 
-        self.zero = self.dtype.zero(lev, dom, ring=self)
-        self.one = self.dtype.one(lev, dom, ring=self)
-
-        self.domain = self.dom = dom
-        self.symbols = self.gens = gens
+        obj.domain = obj.dom = dom
+        obj.symbols = obj.gens = gens
         # NOTE 'order' may not be set if inject was called through CompositeDomain
-        self.order = opts.get('order', monomial_key(self.default_order))
+        obj.order = opts.get('order', monomial_key(obj.default_order))
+        return obj
 
     def new(self, element):
         return self.dtype(element, self.dom, len(self.gens) - 1, ring=self)

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -57,9 +57,6 @@ class PolynomialRing(Ring, CompositeDomain):
     def order(self):
         return self.ring.order
 
-    def __str__(self):
-        return str(self.domain) + '[' + ','.join(map(str, self.symbols)) + ']'
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype.ring, self.domain, self.symbols))
 

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -17,7 +17,7 @@ class PolynomialRing(Ring, CompositeDomain):
     has_assoc_Ring  = True
     has_assoc_Field = True
 
-    def __init__(self, domain_or_ring, symbols=None, order=None):
+    def __new__(cls, domain_or_ring, symbols=None, order=None):
         from sympy.polys.rings import PolyRing
 
         if isinstance(domain_or_ring, PolyRing) and symbols is None and order is None:
@@ -25,21 +25,22 @@ class PolynomialRing(Ring, CompositeDomain):
         else:
             ring = PolyRing(symbols, domain_or_ring, order)
 
-        self.ring = ring
-        self.dtype = ring.dtype
+        obj = super(PolynomialRing, cls).__new__(cls)
+        obj.ring = ring
+        obj.dtype = ring.dtype
 
-        self.gens = ring.gens
-        self.ngens = ring.ngens
-        self.symbols = ring.symbols
-        self.domain = ring.domain
-
+        obj.gens = ring.gens
+        obj.ngens = ring.ngens
+        obj.symbols = ring.symbols
+        obj.domain = ring.domain
 
         if symbols:
             if ring.domain.is_Field and ring.domain.is_Exact and len(symbols)==1:
-                self.is_PID = True
+                obj.is_PID = obj
 
         # TODO: remove this
-        self.dom = self.domain
+        obj.dom = obj.domain
+        return obj
 
     def new(self, element):
         return self.ring.ring_new(element)

--- a/sympy/polys/domains/pythonfinitefield.py
+++ b/sympy/polys/domains/pythonfinitefield.py
@@ -13,5 +13,6 @@ class PythonFiniteField(FiniteField):
 
     alias = 'FF_python'
 
-    def __init__(self, mod, symmetric=True):
-        return super(PythonFiniteField, self).__init__(mod, PythonIntegerRing(), symmetric)
+    def __new__(cls, mod, symmetric=True):
+        return super(PythonFiniteField, cls).__new__(
+            cls, mod, PythonIntegerRing(), symmetric)

--- a/sympy/polys/domains/pythonfinitefield.py
+++ b/sympy/polys/domains/pythonfinitefield.py
@@ -16,3 +16,6 @@ class PythonFiniteField(FiniteField):
     def __new__(cls, mod, symmetric=True):
         return super(PythonFiniteField, cls).__new__(
             cls, mod, PythonIntegerRing(), symmetric)
+
+    def __getnewargs__(self):
+        return self.args[0], self.args[2]

--- a/sympy/polys/domains/pythonintegerring.py
+++ b/sympy/polys/domains/pythonintegerring.py
@@ -19,9 +19,6 @@ class PythonIntegerRing(IntegerRing):
     one = dtype(1)
     alias = 'ZZ_python'
 
-    def __init__(self):
-        """Allow instantiation of this domain. """
-
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
         return SymPyInteger(a)

--- a/sympy/polys/domains/pythonrationalfield.py
+++ b/sympy/polys/domains/pythonrationalfield.py
@@ -16,9 +16,6 @@ class PythonRationalField(RationalField):
     one = dtype(1)
     alias = 'QQ_python'
 
-    def __init__(self):
-        pass
-
     def get_ring(self):
         """Returns ring associated with ``self``. """
         from sympy.polys.domains import PythonIntegerRing

--- a/sympy/polys/domains/quotientring.py
+++ b/sympy/polys/domains/quotientring.py
@@ -129,10 +129,6 @@ class QuotientRing(Ring):
         obj.one = obj(obj.ring.one)
         return obj
 
-
-    def __str__(self):
-        return str(self.ring) + "/" + str(self.base_ideal)
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype, self.ring, self.base_ideal))
 

--- a/sympy/polys/domains/quotientring.py
+++ b/sympy/polys/domains/quotientring.py
@@ -118,13 +118,17 @@ class QuotientRing(Ring):
     has_assoc_Field = False
     dtype = QuotientRingElement
 
-    def __init__(self, ring, ideal):
+    def __new__(cls, ring, ideal):
         if not ideal.ring == ring:
             raise ValueError('Ideal must belong to %s, got %s' % (ring, ideal))
-        self.ring = ring
-        self.base_ideal = ideal
-        self.zero = self(self.ring.zero)
-        self.one = self(self.ring.one)
+
+        obj = super(QuotientRing, cls).__new__(cls)
+        obj.ring = ring
+        obj.base_ideal = ideal
+        obj.zero = obj(obj.ring.zero)
+        obj.one = obj(obj.ring.one)
+        return obj
+
 
     def __str__(self):
         return str(self.ring) + "/" + str(self.base_ideal)

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -43,14 +43,16 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
     def tolerance(self):
         return self._context.tolerance
 
-    def __init__(self, prec=_default_precision, dps=None, tol=None):
-        context = MPContext(prec, dps, tol, True)
-        context._parent = self
-        self._context = context
+    def __new__(cls, prec=_default_precision, dps=None, tol=None):
+        obj = super(RealField, cls).__new__(cls)
 
-        self.dtype = context.mpf
-        self.zero = self.dtype(0)
-        self.one = self.dtype(1)
+        context = MPContext(prec, dps, tol, True)
+        context._parent = obj
+        obj._context = context
+        obj.dtype = context.mpf
+        obj.zero = obj.dtype(0)
+        obj.one = obj.dtype(1)
+        return obj
 
     def __eq__(self, other):
         return (isinstance(other, RealField)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -307,17 +307,6 @@ class ReprPrinter(Printer):
         field = self._print(domain.field)
         return "%s(%s)" % (cls, field)
 
-    def _print_PolynomialRingBase(self, ring):
-        cls = ring.__class__.__name__
-        dom = self._print(ring.domain)
-        gens = ', '.join(map(self._print, ring.gens))
-        order = str(ring.order)
-        if order != ring.default_order:
-            orderstr = ", order=" + order
-        else:
-            orderstr = ""
-        return "%s(%s, %s%s)" % (cls, dom, gens, orderstr)
-
     def _print_DMP(self, p):
         cls = p.__class__.__name__
         rep = self._print(p.rep)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -256,6 +256,30 @@ class ReprPrinter(Printer):
         return "%s(%s, %s)" % (expr.__class__.__name__,
             self._print(expr.root), self._print(expr.coeffs()))
 
+    def _print_Domain(self, domain):
+        return domain.rep
+
+    def _print_QuotientRing(self, ring):
+        return self._print(ring.ring) + "/" + self._print(ring.base_ideal)
+
+    def _print_PolynomialRing(self, ring):
+        domain_str = self._print(ring.domain)
+        gens_str = (self._print(x) for x in ring.symbols)
+        gens_str = ', '.join(gens_str)
+        return domain_str + '[' + gens_str + ']'
+
+    def _print_PolynomialRingBase(self, ring):
+        s_order = self._print(ring.order)
+        if s_order != ring.default_order:
+            order_str = " order=" + s_order
+        else:
+            order_str = ""
+
+        domain_str = self._print(ring.dom)
+        gens_str = (self._print(x) for x in ring.gens)
+        gens_str = ', '.join(gens_str)
+        return domain_str + '[' + gens_str + order_str + ']'
+
     def _print_PolyRing(self, ring):
         return "%s(%s, %s, %s)" % (ring.__class__.__name__,
             self._print(ring.symbols), self._print(ring.domain), self._print(ring.order))

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -477,6 +477,11 @@ class StrPrinter(Printer):
             (", ".join(map(lambda fs: self._print(fs), field.symbols)),
             self._print(field.domain), self._print(field.order))
 
+    def _print_FractionField(self, domain):
+        cls = domain.__class__.__name__
+        field = self._print(domain.field)
+        return "%s(%s)" % (cls, field)
+
     def _print_FreeGroupElement(self, elm):
         return elm.__str__()
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -478,9 +478,8 @@ class StrPrinter(Printer):
             self._print(field.domain), self._print(field.order))
 
     def _print_FractionField(self, domain):
-        cls = domain.__class__.__name__
-        field = self._print(domain.field)
-        return "%s(%s)" % (cls, field)
+        return self._print(domain.domain) + \
+            '(' + ','.join(map(self._print, domain.symbols)) + ')'
 
     def _print_FreeGroupElement(self, elm):
         return elm.__str__()

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -443,6 +443,30 @@ class StrPrinter(Printer):
     def _print_Pi(self, expr):
         return 'pi'
 
+    def _print_Domain(self, domain):
+        return domain.rep
+
+    def _print_QuotientRing(self, ring):
+        return self._print(ring.ring) + "/" + self._print(ring.base_ideal)
+
+    def _print_PolynomialRing(self, ring):
+        domain_str = self._print(ring.domain)
+        gens_str = (self._print(x) for x in ring.symbols)
+        gens_str = ', '.join(gens_str)
+        return domain_str + '[' + gens_str + ']'
+
+    def _print_PolynomialRingBase(self, ring):
+        s_order = self._print(ring.order)
+        if s_order != ring.default_order:
+            order_str = " order=" + s_order
+        else:
+            order_str = ""
+
+        domain_str = self._print(ring.dom)
+        gens_str = (self._print(x) for x in ring.gens)
+        gens_str = ', '.join(gens_str)
+        return domain_str + '[' + gens_str + order_str + ']'
+
     def _print_PolyRing(self, ring):
         return "Polynomial ring in %s over %s with %s order" % \
             (", ".join(map(lambda rs: self._print(rs), ring.symbols)),

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -213,13 +213,13 @@ def test_AlgebraicNumber():
 def test_PolyRing():
     assert srepr(ring("x", ZZ, lex)[0]) == "PolyRing((Symbol('x'),), ZZ, lex)"
     assert srepr(ring("x,y", QQ, grlex)[0]) == "PolyRing((Symbol('x'), Symbol('y')), QQ, grlex)"
-    assert srepr(ring("x,y,z", ZZ["t"], lex)[0]) == "PolyRing((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[t], lex)"
+    assert srepr(ring("x,y,z", ZZ["t"], lex)[0]) == "PolyRing((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[Symbol('t')], lex)"
 
 
 def test_FracField():
     assert srepr(field("x", ZZ, lex)[0]) == "FracField((Symbol('x'),), ZZ, lex)"
     assert srepr(field("x,y", QQ, grlex)[0]) == "FracField((Symbol('x'), Symbol('y')), QQ, grlex)"
-    assert srepr(field("x,y,z", ZZ["t"], lex)[0]) == "FracField((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[t], lex)"
+    assert srepr(field("x,y,z", ZZ["t"], lex)[0]) == "FracField((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[Symbol('t')], lex)"
 
 
 def test_PolyElement():
@@ -242,7 +242,7 @@ def test_PolynomialRingBase():
     assert srepr(ZZ.old_poly_ring(x)) == \
         "GlobalPolynomialRing(ZZ, Symbol('x'))"
     assert srepr(ZZ[x].old_poly_ring(y)) == \
-        "GlobalPolynomialRing(ZZ[x], Symbol('y'))"
+        "GlobalPolynomialRing(ZZ[Symbol('x')], Symbol('y'))"
     assert srepr(QQ.frac_field(x).old_poly_ring(y)) == \
         "GlobalPolynomialRing(FractionField(FracField((Symbol('x'),), QQ, lex)), Symbol('y'))"
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -36,6 +36,8 @@ excluded_attrs = set([
     '_mhash',   # Cached after __hash__ is called but set to None after creation
     'message',   # This is an exception attribute that is present but deprecated in Py2 (can be removed when Py2 support is dropped
     'is_EmptySet',  # Deprecated from SymPy 1.5. This can be removed when is_EmptySet is removed.
+    'has_Field',
+    'has_Ring',
     ])
 
 
@@ -432,13 +434,12 @@ def test_pickling_polys_elements():
     #     check(c)
 
 def test_pickling_polys_domains():
-    # from sympy.polys.domains.pythonfinitefield import PythonFiniteField
+    from sympy.polys.domains.pythonfinitefield import PythonFiniteField
     from sympy.polys.domains.pythonintegerring import PythonIntegerRing
     from sympy.polys.domains.pythonrationalfield import PythonRationalField
 
-    # TODO: fix pickling of ModularInteger
-    # for c in (PythonFiniteField, PythonFiniteField(17)):
-    #     check(c)
+    for c in (PythonFiniteField, PythonFiniteField(17)):
+        check(c)
 
     for c in (PythonIntegerRing, PythonIntegerRing()):
         check(c, check_attr=False)
@@ -447,13 +448,12 @@ def test_pickling_polys_domains():
         check(c, check_attr=False)
 
     if HAS_GMPY:
-        # from sympy.polys.domains.gmpyfinitefield import GMPYFiniteField
+        from sympy.polys.domains.gmpyfinitefield import GMPYFiniteField
         from sympy.polys.domains.gmpyintegerring import GMPYIntegerRing
         from sympy.polys.domains.gmpyrationalfield import GMPYRationalField
 
-        # TODO: fix pickling of ModularInteger
-        # for c in (GMPYFiniteField, GMPYFiniteField(17)):
-        #     check(c)
+        for c in (GMPYFiniteField, GMPYFiniteField(17)):
+            check(c)
 
         for c in (GMPYIntegerRing, GMPYIntegerRing()):
             check(c, check_attr=False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is introducing making the rings sympifyable, in order to make polys or matrix to be less reliant on dirty workarounds like #18445.

This may not be the best idea, but I think that there can be a lot of progress (Like making those objects printable in LaTeX or making some picklable).

Another idea would be converting all those `DomainElement` into sympy objects. But I'd first see what kind of test failings would there be, if this is changed.

TODO
- [ ] Define signatures for `AlgebraicField`
- [ ] Define signatures for `ComplexField`
- [ ] Define signatures for `RealField`
- [ ] Define signatures for `FractionField`
- [ ] Define signatures for `PolynomialRingBase`
- [ ] Define signatures for `PolynomialRing`
- [ ] Define signatures for `QuotientRing`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->