### PR TITLE
Rename is_zero to is_zero_matrix

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -494,7 +494,7 @@ class Plane(GeometryEntity):
         elif isinstance(l, Plane):
             a = Matrix(l.normal_vector)
             b = Matrix(self.normal_vector)
-            if a.cross(b).is_zero:
+            if a.cross(b).is_zero_matrix:
                 return True
             else:
                 return False
@@ -527,7 +527,7 @@ class Plane(GeometryEntity):
         if isinstance(l, LinearEntity3D):
             a = Matrix(l.direction_ratio)
             b = Matrix(self.normal_vector)
-            if a.cross(b).is_zero:
+            if a.cross(b).is_zero_matrix:
                 return True
             else:
                 return False

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -598,7 +598,7 @@ class HolonomicFunction(object):
 
         # if a solution is not obtained then increasing the order by 1 in each
         # iteration
-        while sol.is_zero:
+        while sol.is_zero_matrix:
             dim += 1
 
             diff1 = (gen * rowsself[-1])
@@ -986,7 +986,7 @@ class HolonomicFunction(object):
         sol = (NewMatrix(lin_sys).transpose()).gauss_jordan_solve(homo_sys)
 
         # until a non trivial solution is found
-        while sol[0].is_zero:
+        while sol[0].is_zero_matrix:
 
             # updating the coefficients Dx^i(f).Dx^j(g) for next degree
             for i in range(a - 1, -1, -1):
@@ -1211,19 +1211,19 @@ class HolonomicFunction(object):
         homogeneous = Matrix([[S.Zero for i in range(a)]]).transpose()
         sol = S.Zero
 
-        while sol.is_zero:
+        while True:
             coeffs_next = [p.diff(self.x) for p in coeffs]
             for i in range(a - 1):
                 coeffs_next[i + 1] += (coeffs[i] * diff)
-
             for i in range(a):
                 coeffs_next[i] += (coeffs[-1] * subs[i] * diff)
             coeffs = coeffs_next
-
             # check for linear relations
             system.append(coeffs)
             sol, taus = (Matrix(system).transpose()
                 ).gauss_jordan_solve(homogeneous)
+            if sol.is_zero_matrix is not True:
+                break
 
         tau = list(taus)[0]
         sol = sol.subs(tau, 1)

--- a/sympy/holonomic/linearsolver.py
+++ b/sympy/holonomic/linearsolver.py
@@ -66,7 +66,7 @@ class NewMatrix(MutableDenseMatrix):
 
         # check for existence of solutions
         # rank of aug Matrix should be equal to rank of coefficient matrix
-        if not v[rank:, 0].is_zero:
+        if not v[rank:, 0].is_zero_matrix:
             raise ValueError("Linear system has no solution")
 
         # Get index of free symbols (free parameters)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1114,7 +1114,7 @@ class MatrixProperties(MatrixRequired):
     # sure the names don't clash by adding `_matrix_` in name.
     def _eval_is_matrix_hermitian(self, simpfunc):
         mat = self._new(self.rows, self.cols, lambda i, j: simpfunc(self[i, j] - self[j, i].conjugate()))
-        return mat.is_zero
+        return mat.is_zero_matrix
 
     def _eval_is_Identity(self) -> FuzzyBool:
         def dirac(i, j):
@@ -1141,9 +1141,9 @@ class MatrixProperties(MatrixRequired):
 
     def _eval_is_symmetric(self, simpfunc):
         mat = self._new(self.rows, self.cols, lambda i, j: simpfunc(self[i, j] - self[j, i]))
-        return mat.is_zero
+        return mat.is_zero_matrix
 
-    def _eval_is_zero(self):
+    def _eval_is_zero_matrix(self):
         if any(i.is_zero == False for i in self):
             return False
         if any(i.is_zero is None for i in self):
@@ -1623,7 +1623,7 @@ class MatrixProperties(MatrixRequired):
                    for j in range(min(i, self.cols)))
 
     @property
-    def is_zero(self):
+    def is_zero_matrix(self):
         """Checks if a matrix is a zero matrix.
 
         A matrix is zero if every element is zero.  A matrix need not be square
@@ -1641,17 +1641,17 @@ class MatrixProperties(MatrixRequired):
         >>> c = Matrix([[0, 1], [0, 0]])
         >>> d = Matrix([])
         >>> e = Matrix([[x, 0], [0, 0]])
-        >>> a.is_zero
+        >>> a.is_zero_matrix
         True
-        >>> b.is_zero
+        >>> b.is_zero_matrix
         True
-        >>> c.is_zero
+        >>> c.is_zero_matrix
         False
-        >>> d.is_zero
+        >>> d.is_zero_matrix
         True
-        >>> e.is_zero
+        >>> e.is_zero_matrix
         """
-        return self._eval_is_zero()
+        return self._eval_is_zero_matrix()
 
     def values(self):
         """Return non-zero values of self."""

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -787,7 +787,8 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
 
         self._mat[i0: i0 + self.cols] = [f(x, y) for x, y in zip(ri, rk)]
 
-    # Utility functions
+    is_zero = False
+
 
 MutableMatrix = Matrix = MutableDenseMatrix
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function
 
 from typing import Callable
 
-from sympy.core import Basic, Dict, Integer, S, Tuple, sympify
+from sympy.core import Basic, Dict, Integer, S, Tuple
 from sympy.core.cache import cacheit
 from sympy.core.sympify import converter as sympify_converter
 from sympy.matrices.dense import DenseMatrix
@@ -91,8 +91,11 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
         if isinstance(other, MatrixExpr) and not isinstance(
                 other, ImmutableDenseMatrix):
             return None
-        diff = self - other
-        return sympify(diff.is_zero)
+        diff = (self - other).is_zero_matrix
+        if diff is True:
+            return S.true
+        elif diff is False:
+            return S.false
 
     def _eval_extract(self, rowsList, colsList):
         # self._mat is a Tuple.  It is slightly faster to index a
@@ -121,17 +124,6 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
     is_diagonalizable.__doc__ = DenseMatrix.is_diagonalizable.__doc__
     is_diagonalizable = cacheit(is_diagonalizable)
 
-
-# XXX: The assumptions system correctly infers that is_zero is always False
-# because commutative is False and zero is commutative. This assignment of
-# the property has to take place after the class definition so that the
-# ManagedProperties metaclass that handles the assumptions has finished
-# post-processing the class first. This should be removed because a Matrix
-# should always have is_zero=False.
-# https://github.com/sympy/sympy/issues/7213
-# https://github.com/sympy/sympy/issues/17131
-# mypy (correctly) complains about this line:
-ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero  # type: ignore
 
 # make sure ImmutableDenseMatrix is aliased as ImmutableMatrix
 ImmutableMatrix = ImmutableDenseMatrix

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1970,7 +1970,7 @@ class MatrixBase(MatrixDeprecated,
 
         # check for existence of solutions
         # rank of aug Matrix should be equal to rank of coefficient matrix
-        if not v[rank:, :].is_zero:
+        if not v[rank:, :].is_zero_matrix:
             raise ValueError("Linear system has no solution")
 
         # Get index of free symbols (free parameters)
@@ -3259,7 +3259,7 @@ class MatrixBase(MatrixDeprecated,
         This routine can apply for both cases by checking the shape
         and have small decision.
         """
-        if self.is_zero:
+        if self.is_zero_matrix:
             return self.H
 
         if self.rows >= self.cols:
@@ -3274,7 +3274,7 @@ class MatrixBase(MatrixDeprecated,
         rank matrices, and each matrix can take pseudoinverse
         individually.
         """
-        if self.is_zero:
+        if self.is_zero_matrix:
             return self.H
 
         B, C = self.rank_decomposition()
@@ -3290,7 +3290,7 @@ class MatrixBase(MatrixDeprecated,
         This routine can sometimes fail if SymPy's eigenvalue
         computation is not reliable.
         """
-        if self.is_zero:
+        if self.is_zero_matrix:
             return self.H
 
         A = self
@@ -3364,7 +3364,7 @@ class MatrixBase(MatrixDeprecated,
 
         """
         # Trivial case: pseudoinverse of all-zero matrix is its transpose.
-        if self.is_zero:
+        if self.is_zero_matrix:
             return self.H
 
         if method == 'RD':

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1431,3 +1431,5 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
 
         """
         self.row_op(i, lambda v, j: f(v, self[k, j]))
+
+    is_zero = False

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -202,7 +202,7 @@ def _orthogonalize(cls, *vecs, **kwargs):
     ret  = []
     vecs = list(vecs) # make sure we start with a non-zero vector
 
-    while len(vecs) > 0 and vecs[0].is_zero:
+    while len(vecs) > 0 and vecs[0].is_zero_matrix:
         if rankcheck is False:
             del vecs[0]
         else:
@@ -211,7 +211,7 @@ def _orthogonalize(cls, *vecs, **kwargs):
     for vec in vecs:
         perp = perp_to_subspace(vec, ret)
 
-        if not perp.is_zero:
+        if not perp.is_zero_matrix:
             ret.append(cls(perp))
         elif rankcheck is True:
             raise ValueError("GramSchmidt: vector set not linearly independent")

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -440,14 +440,14 @@ def test_is_hessenberg():
 
 
 def test_is_zero():
-    assert PropertiesOnlyMatrix(0, 0, []).is_zero
-    assert PropertiesOnlyMatrix([[0, 0], [0, 0]]).is_zero
-    assert PropertiesOnlyMatrix(zeros(3, 4)).is_zero
-    assert not PropertiesOnlyMatrix(eye(3)).is_zero
-    assert PropertiesOnlyMatrix([[x, 0], [0, 0]]).is_zero == None
-    assert PropertiesOnlyMatrix([[x, 1], [0, 0]]).is_zero == False
+    assert PropertiesOnlyMatrix(0, 0, []).is_zero_matrix
+    assert PropertiesOnlyMatrix([[0, 0], [0, 0]]).is_zero_matrix
+    assert PropertiesOnlyMatrix(zeros(3, 4)).is_zero_matrix
+    assert not PropertiesOnlyMatrix(eye(3)).is_zero_matrix
+    assert PropertiesOnlyMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert PropertiesOnlyMatrix([[x, 1], [0, 0]]).is_zero_matrix == False
     a = Symbol('a', nonzero=True)
-    assert PropertiesOnlyMatrix([[a, 0], [0, 0]]).is_zero == False
+    assert PropertiesOnlyMatrix([[a, 0], [0, 0]]).is_zero_matrix == False
 
 
 def test_values():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3083,17 +3083,17 @@ def test_zeros_eye():
 
 
 def test_is_zero():
-    assert Matrix().is_zero
-    assert Matrix([[0, 0], [0, 0]]).is_zero
-    assert zeros(3, 4).is_zero
-    assert not eye(3).is_zero
-    assert Matrix([[x, 0], [0, 0]]).is_zero == None
-    assert SparseMatrix([[x, 0], [0, 0]]).is_zero == None
-    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero == None
-    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero == None
-    assert Matrix([[x, 1], [0, 0]]).is_zero == False
+    assert Matrix().is_zero_matrix
+    assert Matrix([[0, 0], [0, 0]]).is_zero_matrix
+    assert zeros(3, 4).is_zero_matrix
+    assert not eye(3).is_zero_matrix
+    assert Matrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert SparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero_matrix == None
+    assert Matrix([[x, 1], [0, 0]]).is_zero_matrix == False
     a = Symbol('a', nonzero=True)
-    assert Matrix([[a, 0], [0, 0]]).is_zero == False
+    assert Matrix([[a, 0], [0, 0]]).is_zero_matrix == False
 
 
 def test_rotation_matrices():

--- a/sympy/polys/multivariate_resultants.py
+++ b/sympy/polys/multivariate_resultants.py
@@ -194,7 +194,7 @@ class DixonResultant():
         the last column. For the precondition to hold the last non-zero
         row of the rref matrix should be of the form [0, 0, ..., 1].
         """
-        if matrix.is_zero:
+        if matrix.is_zero_matrix:
             return False
 
         m, n = matrix.shape
@@ -213,8 +213,10 @@ class DixonResultant():
 
     def delete_zero_rows_and_columns(self, matrix):
         """Remove the zero rows and columns of the matrix."""
-        rows = [i for i in range(matrix.rows) if not matrix.row(i).is_zero]
-        cols = [j for j in range(matrix.cols) if not matrix.col(j).is_zero]
+        rows = [
+            i for i in range(matrix.rows) if not matrix.row(i).is_zero_matrix]
+        cols = [
+            j for j in range(matrix.cols) if not matrix.col(j).is_zero_matrix]
 
         return matrix[rows, cols]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #17131

#### Brief description of what is fixed or changed

This is a problem in assumptions consistency, so I would consider this as a fix rather than deprecation. (Although I'm going to add a stub method to lock is_zero=False for mutable matrix)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - **Not backwards compatible**: The `Matrix.is_zero` property has been renamed to `Matrix.is_zero_matrix`. `Matrix.is_zero` is now always `False`. This is because in general `is_zero` means the number zero so a matrix can never be zero. To get the old behavior of `M.is_zero` in both old and new versions of sympy use `from sympy.core.logic import fuzzy_and; fuzzy_and(m.is_zero for m in M)`.
<!-- END RELEASE NOTES -->