### PR TITLE
Removed Python 2 compatibility from matrices.py

### DIFF
--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -132,7 +132,7 @@ class HadamardProduct(MatrixExpr):
                                 ExprBuilder(_make_matrix, [l2]),
                             ]
                         ),
-                    ] + diagonal,  # turn into *diagonal after dropping Python 2.7
+                    *diagonal],
 
                 )
                 i._first_pointer_parent = subexpr.args[0].args[0].args
@@ -451,7 +451,7 @@ class HadamardPower(MatrixExpr):
                             ExprBuilder(_make_matrix, [l2]),
                         ]
                     ),
-                ] + diagonal,  # turn into *diagonal after dropping Python 2.7
+                *diagonal],
                 validator=CodegenArrayDiagonal._validate
             )
             i._first_pointer_parent = subexpr.args[0].args[0].args

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -818,9 +818,6 @@ class MatrixBase(MatrixDeprecated,
             mml += "</matrixrow>"
         return "<matrix>" + mml + "</matrix>"
 
-    # needed for python 2 compatibility
-    def __ne__(self, other):
-        return not self == other
 
     def _diagonal_solve(self, rhs):
         """Helper function of function diagonal_solve, without the error


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Removed Python 2 compatibility from matrices.py
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Removed `MatrixBase.__ne__` which was for python 2 compatibility

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->