### PR TITLE
Caching implemented for MatrixReductions operations

### DIFF
--- a/sympy/holonomic/linearsolver.py
+++ b/sympy/holonomic/linearsolver.py
@@ -5,8 +5,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.matrices.common import ShapeError
 from sympy.matrices.dense import MutableDenseMatrix
-
-from ..matrices.reductions import _rref
+from sympy.matrices.reductions import _rref
 
 class NewMatrix(MutableDenseMatrix):
     """

--- a/sympy/holonomic/linearsolver.py
+++ b/sympy/holonomic/linearsolver.py
@@ -6,7 +6,6 @@ from sympy.core import S
 from sympy.matrices.common import ShapeError
 from sympy.matrices.dense import MutableDenseMatrix
 from sympy.matrices.matrices import MatrixNoSympify
-from sympy.matrices.reductions import _rref
 
 class NewMatrix(MatrixNoSympify, MutableDenseMatrix):
     """

--- a/sympy/holonomic/linearsolver.py
+++ b/sympy/holonomic/linearsolver.py
@@ -6,6 +6,7 @@ from sympy.core import S
 from sympy.matrices.common import ShapeError
 from sympy.matrices.dense import MutableDenseMatrix
 
+from ..matrices.reductions import _rref
 
 class NewMatrix(MutableDenseMatrix):
     """
@@ -49,8 +50,10 @@ class NewMatrix(MutableDenseMatrix):
         aug = self.hstack(self.copy(), b.copy())
         row, col = aug[:, :-1].shape
 
-        # solve by reduced row echelon form
-        A, pivots = aug.rref()
+        # solve by reduced row echelon form, use the internal `_rref` function
+        # to avoid matrix method coercion to immutable which would raise due to
+        # use of elements here derived from `CantSimplify`.
+        A, pivots = _rref(aug)
         A, v = A[:, :-1], A[:, -1]
         pivots = list(filter(lambda p: p < col, pivots))
         rank = len(pivots)

--- a/sympy/holonomic/linearsolver.py
+++ b/sympy/holonomic/linearsolver.py
@@ -5,9 +5,10 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.matrices.common import ShapeError
 from sympy.matrices.dense import MutableDenseMatrix
+from sympy.matrices.matrices import MatrixNoSympify
 from sympy.matrices.reductions import _rref
 
-class NewMatrix(MutableDenseMatrix):
+class NewMatrix(MatrixNoSympify, MutableDenseMatrix):
     """
     Supports elements which can't be Sympified.
     See docstrings in sympy/matrices/matrices.py
@@ -49,10 +50,8 @@ class NewMatrix(MutableDenseMatrix):
         aug = self.hstack(self.copy(), b.copy())
         row, col = aug[:, :-1].shape
 
-        # solve by reduced row echelon form, use the internal `_rref` function
-        # to avoid matrix method coercion to immutable which would raise due to
-        # use of elements here derived from `CantSimplify`.
-        A, pivots = _rref(aug)
+        # solve by reduced row echelon form
+        A, pivots = aug.rref()
         A, v = A[:, :-1], A[:, -1]
         pivots = list(filter(lambda p: p < col, pivots))
         rank = len(pivots)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2606,6 +2606,9 @@ class _MinimalMatrix(object):
     def shape(self):
         return (self.rows, self.cols)
 
+    def as_immutable(self): # this is needed here ONLY FOR TESTS.
+        return self
+
 
 class _MatrixWrapper(object):
     """Wrapper class providing the minimum functionality for a matrix-like

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 
 from types import FunctionType
 
+from sympy.core.cache import cacheit
 from sympy.core.numbers import Float, Integer
 from sympy.core.singleton import S
 from sympy.core.symbol import _uniquely_named_symbol
@@ -198,7 +199,7 @@ def _find_reasonable_pivot_naive(col, iszerofunc=_iszero, simpfunc=None):
     return indeterminates[0][0], indeterminates[0][1], True, newly_determined
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _berkowitz_toeplitz_matrix(M, dotprodsimp=None):
     """Return (A,T) where T the Toeplitz matrix used in the Berkowitz algorithm
     corresponding to ``M`` and A is the first principal submatrix.
@@ -253,7 +254,7 @@ def _berkowitz_toeplitz_matrix(M, dotprodsimp=None):
     return (A, toeplitz)
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _berkowitz_vector(M, dotprodsimp=None):
     """ Run the Berkowitz algorithm and return a vector whose entries
         are the coefficients of the characteristic polynomial of ``M``.
@@ -347,7 +348,7 @@ def _adjugate(M, method="berkowitz", dotprodsimp=None):
     return M.cofactor_matrix(method=method, dotprodsimp=dotprodsimp).transpose()
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _charpoly(M, x='lambda', simplify=_simplify, dotprodsimp=None):
     """Computes characteristic polynomial det(x*I - M) where I is
     the identity matrix.
@@ -509,7 +510,6 @@ def _cofactor_matrix(M, method="berkowitz", dotprodsimp=None):
             lambda i, j: M.cofactor(i, j, method, dotprodsimp=dotprodsimp))
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
 def _det(M, method="bareiss", iszerofunc=None, dotprodsimp=None):
     """Computes the determinant of a matrix if ``M`` is a concrete matrix object
     otherwise return an expressions ``Determinant(M)`` if ``M`` is a
@@ -627,7 +627,7 @@ def _det(M, method="bareiss", iszerofunc=None, dotprodsimp=None):
         raise MatrixError('unknown method for calculating determinant')
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _det_bareiss(M, iszerofunc=_is_zero_after_expand_mul, dotprodsimp=None):
     """Compute matrix determinant using Bareiss' fraction-free
     algorithm which is an extension of the well known Gaussian
@@ -664,7 +664,7 @@ def _det_bareiss(M, iszerofunc=_is_zero_after_expand_mul, dotprodsimp=None):
         # With the default iszerofunc, _find_reasonable_pivot slows down
         # the computation by the factor of 2.5 in one test.
         # Relevant issues: #10279 and #13877.
-        pivot_pos, pivot_val, _, _ = mat[:, 0]._find_reasonable_pivot(iszerofunc=iszerofunc)
+        pivot_pos, pivot_val, _, _ = _find_reasonable_pivot(mat[:, 0], iszerofunc=iszerofunc)
         if pivot_pos is None:
             return mat.zero
 
@@ -724,7 +724,7 @@ def _det_berkowitz(M, dotprodsimp=None):
     return (-1)**(len(berk_vector) - 1) * berk_vector[-1]
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _det_LU(M, iszerofunc=_iszero, simpfunc=None, dotprodsimp=None):
     """ Computes the determinant of a matrix from its LU decomposition.
     This function uses the LU decomposition computed by

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -4,6 +4,7 @@ from types import FunctionType
 
 from mpmath.libmp.libmpf import prec_to_dps
 
+from sympy.core.cache import cacheit
 from sympy.core.compatibility import default_sort_key
 from sympy.core.logic import fuzzy_and, fuzzy_or
 from sympy.core.numbers import Float
@@ -19,7 +20,7 @@ from .common import (MatrixError, NonSquareMatrixError,
 from .utilities import _iszero
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _eigenvals(M, error_when_incomplete=True, dotprodsimp=None, **flags):
     r"""Return eigenvalues using the Berkowitz agorithm to compute
     the characteristic polynomial.
@@ -156,7 +157,7 @@ def _eigenvals(M, error_when_incomplete=True, dotprodsimp=None, **flags):
         return [simplify(value) for value in eigs]
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _eigenvects(M, error_when_incomplete=True, iszerofunc=_iszero,
         dotprodsimp=None, **flags):
     """Return list of triples (eigenval, multiplicity, eigenspace).
@@ -670,6 +671,7 @@ _is_negative_semidefinite.__doc__ = _doc_positive_definite
 _is_indefinite.__doc__            = _doc_positive_definite
 
 
+@cacheit
 def _jordan_form(M, calc_transform=True, dotprodsimp=None, **kwargs):
     """Return ``(P, J)`` where `J` is a Jordan block
     matrix and `P` is a matrix such that

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -7,7 +7,7 @@ from sympy.core.cache import cacheit
 from sympy.core.sympify import converter as sympify_converter
 from sympy.matrices.dense import DenseMatrix
 from sympy.matrices.expressions import MatrixExpr
-from sympy.matrices.matrices import MatrixBase
+from sympy.matrices.matrices import MatrixBase, MatrixNoSympify
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
 from .reductions import _is_echelon, _echelon_form, _rank, _rref
@@ -18,20 +18,7 @@ def sympify_matrix(arg):
 sympify_converter[MatrixBase] = sympify_matrix
 
 
-class _ImmutableNoWrappers:
-    """Mixin class to eliminate the method wrappers for underlying functions
-    needed in a mutable matrix. This class overrides MatrixBase wrappers for
-    these functions by assigning the underlying functions directly to class
-    methods and thus removing the wrapper layer. Since the class is already
-    immutable those wrappers are not needed to convert to immutable."""
-
-    echelon_form = _echelon_form
-    is_echelon   = property(_is_echelon)
-    rank         = _rank
-    rref         = _rref
-
-
-class ImmutableDenseMatrix(_ImmutableNoWrappers, DenseMatrix, MatrixExpr): # type: ignore
+class ImmutableDenseMatrix(MatrixNoSympify, DenseMatrix, MatrixExpr): # type: ignore
     """Create an immutable version of a matrix.
 
     Examples
@@ -153,7 +140,7 @@ ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero  # type: ignore
 ImmutableMatrix = ImmutableDenseMatrix
 
 
-class ImmutableSparseMatrix(_ImmutableNoWrappers, SparseMatrix, Basic):
+class ImmutableSparseMatrix(MatrixNoSympify, SparseMatrix, Basic):
     """Create an immutable version of a sparse matrix.
 
     Examples

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -10,12 +10,27 @@ from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
+from .reductions import _is_echelon, _echelon_form, _rank, _rref
+
 
 def sympify_matrix(arg):
     return arg.as_immutable()
 sympify_converter[MatrixBase] = sympify_matrix
 
-class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
+
+class _ImmutableNoWrappers:
+    """Mixin class to eliminate the method wrappers for underlying functions
+    needed in a mutable matrix. This just points the methods to the underlying
+    functions since the matrix is already immutable for the underlying caching
+    to work properly."""
+
+    echelon_form = _echelon_form
+    is_echelon   = property(_is_echelon)
+    rank         = _rank
+    rref         = _rref
+
+
+class ImmutableDenseMatrix(_ImmutableNoWrappers, DenseMatrix, MatrixExpr): # type: ignore
     """Create an immutable version of a matrix.
 
     Examples
@@ -137,7 +152,7 @@ ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero  # type: ignore
 ImmutableMatrix = ImmutableDenseMatrix
 
 
-class ImmutableSparseMatrix(SparseMatrix, Basic):
+class ImmutableSparseMatrix(_ImmutableNoWrappers, SparseMatrix, Basic):
     """Create an immutable version of a sparse matrix.
 
     Examples

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -20,9 +20,10 @@ sympify_converter[MatrixBase] = sympify_matrix
 
 class _ImmutableNoWrappers:
     """Mixin class to eliminate the method wrappers for underlying functions
-    needed in a mutable matrix. This just points the methods to the underlying
-    functions since the matrix is already immutable for the underlying caching
-    to work properly."""
+    needed in a mutable matrix. This class overrides MatrixBase wrappers for
+    these functions by assigning the underlying functions directly to class
+    methods and thus removing the wrapper layer. Since the class is already
+    immutable those wrappers are not needed to convert to immutable."""
 
     echelon_form = _echelon_form
     is_echelon   = property(_is_echelon)

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -10,8 +10,6 @@ from sympy.matrices.expressions import MatrixExpr
 from sympy.matrices.matrices import MatrixBase, MatrixNoSympify
 from sympy.matrices.sparse import MutableSparseMatrix, SparseMatrix
 
-from .reductions import _is_echelon, _echelon_form, _rank, _rref
-
 
 def sympify_matrix(arg):
     return arg.as_immutable()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -31,7 +31,6 @@ from .common import (
 from .utilities import _iszero, _is_zero_after_expand_mul, _toselfclass
 
 from .determinant import (
-    _find_reasonable_pivot, _find_reasonable_pivot_naive,
     _adjugate, _charpoly, _cofactor, _cofactor_matrix,
     _det, _det_bareiss, _det_berkowitz, _det_LU, _minor, _minor_submatrix)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -28,7 +28,7 @@ from .common import (
     MatrixCommon, MatrixError, NonSquareMatrixError, NonInvertibleMatrixError,
     ShapeError)
 
-from .utilities import _iszero, _is_zero_after_expand_mul
+from .utilities import _iszero, _is_zero_after_expand_mul, _toselfclass
 
 from .determinant import (
     _find_reasonable_pivot, _find_reasonable_pivot_naive,
@@ -147,21 +147,32 @@ class MatrixReductions(MatrixDeterminant):
 
     def echelon_form(self, iszerofunc=_iszero, simplify=False, with_pivots=False,
             dotprodsimp=None):
-        return _echelon_form(self, iszerofunc=iszerofunc, simplify=simplify,
+        matpiv = _echelon_form(self.as_immutable(), iszerofunc=iszerofunc, simplify=simplify,
                 with_pivots=with_pivots, dotprodsimp=dotprodsimp)
+
+        if with_pivots:
+            return _toselfclass(self, matpiv[0]), matpiv[1]
+
+        return _toselfclass(self, matpiv)
 
     @property
     def is_echelon(self):
         return _is_echelon(self)
 
     def rank(self, iszerofunc=_iszero, simplify=False, dotprodsimp=None):
-        return _rank(self, iszerofunc=iszerofunc, simplify=simplify,
+        return _rank(self.as_immutable(), iszerofunc=iszerofunc, simplify=simplify,
                 dotprodsimp=dotprodsimp)
 
     def rref(self, iszerofunc=_iszero, simplify=False, pivots=True,
             normalize_last=True, dotprodsimp=None):
-        return _rref(self, iszerofunc=iszerofunc, simplify=simplify,
-            pivots=pivots, normalize_last=normalize_last, dotprodsimp=dotprodsimp)
+        matpiv = _rref(self.as_immutable(), iszerofunc=iszerofunc,
+            simplify=simplify, pivots=pivots, normalize_last=normalize_last,
+            dotprodsimp=dotprodsimp)
+
+        if pivots:
+            return _toselfclass(self, matpiv[0]), matpiv[1]
+
+        return _toselfclass(self, matpiv)
 
     echelon_form.__doc__ = _echelon_form.__doc__
     is_echelon.__doc__   = _is_echelon.__doc__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -595,6 +595,22 @@ class MatrixCalculus(MatrixCommon):
         return self.applyfunc(lambda x: x.limit(*args))
 
 
+class MatrixNoSympify:
+    """Mixin class to eliminate the method wrappers which may sympify self for
+    underlying functions needed in a mutable matrix. This class overrides
+    MatrixBase wrappers for these functions by assigning the underlying
+    functions directly to class methods and thus removing the wrapper layer. The
+    wrapper layer may need to be removed for one of two reasons, to avoid the
+    overhead of the wrappers for classes which are already immutable, or to
+    avoid sympification of matrix elements for matrix types which contain
+    unsympifiable elements."""
+
+    echelon_form = _echelon_form
+    is_echelon   = property(_is_echelon)
+    rank         = _rank
+    rref         = _rref
+
+
 # https://github.com/sympy/sympy/pull/12854
 class MatrixDeprecated(MatrixCommon):
     """A class to house deprecated matrix methods."""

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -31,6 +31,7 @@ from .common import (
 from .utilities import _iszero, _is_zero_after_expand_mul, _toselfclass
 
 from .determinant import (
+    _find_reasonable_pivot_naive,
     _adjugate, _charpoly, _cofactor, _cofactor_matrix,
     _det, _det_bareiss, _det_berkowitz, _det_LU, _minor, _minor_submatrix)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -81,64 +81,59 @@ class MatrixDeterminant(MatrixCommon):
     """Provides basic matrix determinant operations. Should not be instantiated
     directly. See ``determinant.py`` for their implementations."""
 
-    def _find_reasonable_pivot(self, iszerofunc=_iszero, simpfunc=_simplify):
-        return _find_reasonable_pivot(self, iszerofunc=iszerofunc,
-                simpfunc=iszerofunc)
-
-    def _find_reasonable_pivot_naive(self, iszerofunc=_iszero, simpfunc=None):
-        return _find_reasonable_pivot_naive(self, iszerofunc=iszerofunc,
-                simpfunc=simpfunc)
-
     def _eval_det_bareiss(self, iszerofunc=_is_zero_after_expand_mul,
             dotprodsimp=None):
-        return _det_bareiss(self, iszerofunc=iszerofunc,
+        return _det_bareiss(self.as_immutable(), iszerofunc=iszerofunc,
                 dotprodsimp=dotprodsimp)
 
     def _eval_det_berkowitz(self, dotprodsimp=None):
-        return _det_berkowitz(self, dotprodsimp=dotprodsimp)
+        return _det_berkowitz(self.as_immutable(), dotprodsimp=dotprodsimp)
 
     def _eval_det_lu(self, iszerofunc=_iszero, simpfunc=None, dotprodsimp=None):
-        return _det_LU(self, iszerofunc=iszerofunc, simpfunc=simpfunc,
-                dotprodsimp=dotprodsimp)
+        return _det_LU(self.as_immutable(), iszerofunc=iszerofunc,
+                simpfunc=simpfunc, dotprodsimp=dotprodsimp)
 
     def _eval_determinant(self): # for expressions.determinant.Determinant
-        return _det(self)
+        return _det(self.as_immutable())
 
     def adjugate(self, method="berkowitz", dotprodsimp=None):
-        return _adjugate(self, method=method, dotprodsimp=dotprodsimp)
+        return _toselfclass(self, _adjugate(self.as_immutable(), method=method,
+                dotprodsimp=dotprodsimp))
 
     def charpoly(self, x='lambda', simplify=_simplify, dotprodsimp=None):
-        return _charpoly(self, x=x, simplify=simplify, dotprodsimp=dotprodsimp)
+        return _charpoly(self.as_immutable(), x=x, simplify=simplify,
+                dotprodsimp=dotprodsimp)
 
     def cofactor(self, i, j, method="berkowitz", dotprodsimp=None):
-        return _cofactor(self, i, j, method=method, dotprodsimp=dotprodsimp)
+        return _cofactor(self.as_immutable(), i, j, method=method,
+                dotprodsimp=dotprodsimp)
 
     def cofactor_matrix(self, method="berkowitz", dotprodsimp=None):
-        return _cofactor_matrix(self, method=method, dotprodsimp=dotprodsimp)
+        return _toselfclass(self, _cofactor_matrix(self.as_immutable(),
+                method=method, dotprodsimp=dotprodsimp))
 
     def det(self, method="bareiss", iszerofunc=None, dotprodsimp=None):
-        return _det(self, method=method, iszerofunc=iszerofunc,
+        return _det(self.as_immutable(), method=method, iszerofunc=iszerofunc,
                 dotprodsimp=dotprodsimp)
 
     def minor(self, i, j, method="berkowitz", dotprodsimp=None):
-        return _minor(self, i, j, method=method, dotprodsimp=dotprodsimp)
+        return _minor(self.as_immutable(), i, j, method=method,
+                dotprodsimp=dotprodsimp)
 
     def minor_submatrix(self, i, j):
-        return _minor_submatrix(self, i, j)
+        return _toselfclass(self, _minor_submatrix(self.as_immutable(), i, j))
 
-    _find_reasonable_pivot.__doc__       = _find_reasonable_pivot.__doc__
-    _find_reasonable_pivot_naive.__doc__ = _find_reasonable_pivot_naive.__doc__
-    _eval_det_bareiss.__doc__            = _det_bareiss.__doc__
-    _eval_det_berkowitz.__doc__          = _det_berkowitz.__doc__
-    _eval_det_lu.__doc__                 = _det_LU.__doc__
-    _eval_determinant.__doc__            = _det.__doc__
-    adjugate.__doc__                     = _adjugate.__doc__
-    charpoly.__doc__                     = _charpoly.__doc__
-    cofactor.__doc__                     = _cofactor.__doc__
-    cofactor_matrix.__doc__              = _cofactor_matrix.__doc__
-    det.__doc__                          = _det.__doc__
-    minor.__doc__                        = _minor.__doc__
-    minor_submatrix.__doc__              = _minor_submatrix.__doc__
+    _eval_det_bareiss.__doc__   = _det_bareiss.__doc__
+    _eval_det_berkowitz.__doc__ = _det_berkowitz.__doc__
+    _eval_det_lu.__doc__        = _det_LU.__doc__
+    _eval_determinant.__doc__   = _det.__doc__
+    adjugate.__doc__            = _adjugate.__doc__
+    charpoly.__doc__            = _charpoly.__doc__
+    cofactor.__doc__            = _cofactor.__doc__
+    cofactor_matrix.__doc__     = _cofactor_matrix.__doc__
+    det.__doc__                 = _det.__doc__
+    minor.__doc__               = _minor.__doc__
+    minor_submatrix.__doc__     = _minor_submatrix.__doc__
 
 
 class MatrixReductions(MatrixDeterminant):
@@ -157,7 +152,7 @@ class MatrixReductions(MatrixDeterminant):
 
     @property
     def is_echelon(self):
-        return _is_echelon(self)
+        return _is_echelon(self.as_immutable())
 
     def rank(self, iszerofunc=_iszero, simplify=False, dotprodsimp=None):
         return _rank(self.as_immutable(), iszerofunc=iszerofunc, simplify=simplify,
@@ -344,14 +339,16 @@ class MatrixSubspaces(MatrixReductions):
     implementations."""
 
     def columnspace(self, simplify=False, dotprodsimp=None):
-        return _columnspace(self, simplify=simplify, dotprodsimp=dotprodsimp)
+        return [_toselfclass(self, m) for m in _columnspace(self.as_immutable(),
+                simplify=simplify, dotprodsimp=dotprodsimp)]
 
     def nullspace(self, simplify=False, iszerofunc=_iszero, dotprodsimp=None):
-        return _nullspace(self, simplify=simplify, iszerofunc=iszerofunc,
-                dotprodsimp=dotprodsimp)
+        return [_toselfclass(self, m) for m in _nullspace(self.as_immutable(),
+                simplify=simplify, iszerofunc=iszerofunc, dotprodsimp=dotprodsimp)]
 
     def rowspace(self, simplify=False, dotprodsimp=None):
-        return _rowspace(self, simplify=simplify, dotprodsimp=dotprodsimp)
+        return [_toselfclass(self, m) for m in _rowspace(self.as_immutable(),
+                simplify=simplify, dotprodsimp=dotprodsimp)]
 
     # This is a classmethod but is converted to such later in order to allow
     # assignment of __doc__ since that does not work for already wrapped
@@ -373,56 +370,68 @@ class MatrixEigen(MatrixSubspaces):
     implementations."""
 
     def _eval_is_positive_definite(self, method="eigen", dotprodsimp=None):
-        return _eval_is_positive_definite(self, method=method,
+        return _eval_is_positive_definite(self.as_immutable(), method=method,
                 dotprodsimp=dotprodsimp)
 
     def eigenvals(self, error_when_incomplete=True, dotprodsimp=None, **flags):
-        return _eigenvals(self, error_when_incomplete=error_when_incomplete,
+        return _eigenvals(self.as_immutable(),
+                error_when_incomplete=error_when_incomplete,
                 dotprodsimp=dotprodsimp, **flags)
 
     def eigenvects(self, error_when_incomplete=True, iszerofunc=_iszero,
             dotprodsimp=None, **flags):
-        return _eigenvects(self, error_when_incomplete=error_when_incomplete,
+        ret = _eigenvects(self.as_immutable(),
+                error_when_incomplete=error_when_incomplete,
                 iszerofunc=iszerofunc, dotprodsimp=dotprodsimp, **flags)
 
+        return [(v, m, [_toselfclass(self, ev) for ev in es]) for v, m, es in ret]
+
     def is_diagonalizable(self, reals_only=False, dotprodsimp=None, **kwargs):
-        return _is_diagonalizable(self, reals_only=reals_only,
+        return _is_diagonalizable(self.as_immutable(), reals_only=reals_only,
                 dotprodsimp=dotprodsimp, **kwargs)
 
     def diagonalize(self, reals_only=False, sort=False, normalize=False,
             dotprodsimp=None):
-        return _diagonalize(self, reals_only=reals_only, sort=sort,
-                normalize=normalize, dotprodsimp=dotprodsimp)
+        return tuple(_toselfclass(self, m) for m in _diagonalize(self.as_immutable(),
+                reals_only=reals_only, sort=sort, normalize=normalize,
+                dotprodsimp=dotprodsimp))
 
     @property
     def is_positive_definite(self):
-        return _is_positive_definite(self)
+        return _is_positive_definite(self.as_immutable())
 
     @property
     def is_positive_semidefinite(self):
-        return _is_positive_semidefinite(self)
+        return _is_positive_semidefinite(self.as_immutable())
 
     @property
     def is_negative_definite(self):
-        return _is_negative_definite(self)
+        return _is_negative_definite(self.as_immutable())
 
     @property
     def is_negative_semidefinite(self):
-        return _is_negative_semidefinite(self)
+        return _is_negative_semidefinite(self.as_immutable())
 
     @property
     def is_indefinite(self):
-        return _is_indefinite(self)
+        return _is_indefinite(self.as_immutable())
 
     def jordan_form(self, calc_transform=True, dotprodsimp=None, **kwargs):
-        return _jordan_form(self, calc_transform=calc_transform,
+        ret = _jordan_form(self.as_immutable(), calc_transform=calc_transform,
                 dotprodsimp=dotprodsimp, **kwargs)
 
+        if calc_transform:
+            return tuple(_toselfclass(self, m) for m in ret)
+
+        return _toselfclass(self, ret)
+
     def left_eigenvects(self, **flags):
-        return _left_eigenvects(self, **flags)
+        ret = _left_eigenvects(self.as_immutable(), **flags)
+
+        return [(v, m, [_toselfclass(self, ev) for ev in es]) for v, m, es in ret]
 
     def singular_values(self, dotprodsimp=None):
-        return _singular_values(self, dotprodsimp=dotprodsimp)
+        return _singular_values(self.as_immutable(), dotprodsimp=dotprodsimp)
 
     _eval_is_positive_definite.__doc__ = _eval_is_positive_definite.__doc__
     eigenvals.__doc__                  = _eigenvals.__doc__
@@ -605,10 +614,41 @@ class MatrixNoSympify:
     avoid sympification of matrix elements for matrix types which contain
     unsympifiable elements."""
 
-    echelon_form = _echelon_form
-    is_echelon   = property(_is_echelon)
-    rank         = _rank
-    rref         = _rref
+    _eval_det_bareiss          = _det_bareiss
+    _eval_det_berkowitz        = _det_berkowitz
+    _eval_det_lu               = _det_LU
+    _eval_determinant          = _det
+    adjugate                   = _adjugate
+    charpoly                   = _charpoly
+    cofactor                   = _cofactor
+    cofactor_matrix            = _cofactor_matrix
+    det                        = _det
+    minor                      = _minor
+    minor_submatrix            = _minor_submatrix
+
+    echelon_form               = _echelon_form
+    is_echelon                 = property(_is_echelon)
+    rank                       = _rank
+    rref                       = _rref
+
+    columnspace                = _columnspace
+    nullspace                  = _nullspace
+    rowspace                   = _rowspace
+    orthogonalize              = classmethod(_orthogonalize)
+
+    _eval_is_positive_definite = _eval_is_positive_definite
+    eigenvals                  = _eigenvals
+    eigenvects                 = _eigenvects
+    is_diagonalizable          = _is_diagonalizable
+    diagonalize                = _diagonalize
+    is_positive_definite       = property(_is_positive_definite)
+    is_positive_semidefinite   = property(_is_positive_semidefinite)
+    is_negative_definite       = property(_is_negative_definite)
+    is_negative_semidefinite   = property(_is_negative_semidefinite)
+    is_indefinite              = property(_is_indefinite)
+    jordan_form                = _jordan_form
+    left_eigenvects            = _left_eigenvects
+    singular_values            = _singular_values
 
 
 # https://github.com/sympy/sympy/pull/12854

--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 
 from types import FunctionType
 
+from sympy.core.cache import cacheit
 from sympy.simplify.simplify import (
     simplify as _simplify, dotprodsimp as _dotprodsimp)
 
@@ -128,7 +129,7 @@ def _row_reduce_list(mat, rows, cols, one, iszerofunc, simpfunc,
     return mat, tuple(pivot_cols), tuple(swaps)
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
+@cacheit
 def _row_reduce(M, iszerofunc, simpfunc, normalize_last=True,
                 normalize=True, zero_above=True, dotprodsimp=None):
 
@@ -192,7 +193,6 @@ def _echelon_form(M, iszerofunc=_iszero, simplify=False, with_pivots=False,
     return mat
 
 
-# This functions is a candidate for caching if it gets implemented for matrices.
 def _rank(M, iszerofunc=_iszero, simplify=False, dotprodsimp=None):
     """Returns the rank of a matrix.
 

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function
 
-from sympy.core.cache import cacheit
 from sympy.core.compatibility import reduce
 
 from .utilities import _iszero

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
 
+from sympy.core.cache import cacheit
 from sympy.core.compatibility import reduce
 
 from .utilities import _iszero

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -12,3 +12,9 @@ def _is_zero_after_expand_mul(x):
     """Tests by expand_mul only, suitable for polynomials and rational
     functions."""
     return expand_mul(x) == 0
+
+
+def _toselfclass(self, obj):
+  cls = self.__class__
+
+  return obj if isinstance(obj, cls) else cls(obj)

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division
 
 from sympy.matrices import MutableDenseMatrix, zeros
 from sympy.matrices.matrices import MatrixNoSympify
-from sympy.matrices.reductions import _rref
 
 class RawMatrix(MatrixNoSympify, MutableDenseMatrix):
     _sympify = staticmethod(lambda x: x)

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -3,9 +3,10 @@
 from __future__ import print_function, division
 
 from sympy.matrices import MutableDenseMatrix, zeros
+from sympy.matrices.matrices import MatrixNoSympify
 from sympy.matrices.reductions import _rref
 
-class RawMatrix(MutableDenseMatrix):
+class RawMatrix(MatrixNoSympify, MutableDenseMatrix):
     _sympify = staticmethod(lambda x: x)
 
 def eqs_to_matrix(eqs, ring):
@@ -35,10 +36,8 @@ def solve_lin_sys(eqs, ring, _raw=True):
     # transform from equations to matrix form
     matrix = eqs_to_matrix(eqs, ring)
 
-    # solve by row-reduction, use the internal `_rref` function to avoid matrix
-    # method coercion to immutable which would raise due to use of elements
-    # here derived from `CantSimplify`.
-    echelon, pivots = _rref(matrix, iszerofunc=lambda x: not x, simplify=lambda x: x)
+    # solve by row-reduction
+    echelon, pivots = matrix.rref(iszerofunc=lambda x: not x, simplify=lambda x: x)
 
     # construct the returnable form of the solutions
     keys = ring.symbols if as_expr else ring.gens

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -3,8 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.matrices import MutableDenseMatrix, zeros
-
-from ..matrices.reductions import _rref
+from sympy.matrices.reductions import _rref
 
 class RawMatrix(MutableDenseMatrix):
     _sympify = staticmethod(lambda x: x)

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -4,6 +4,8 @@ from __future__ import print_function, division
 
 from sympy.matrices import MutableDenseMatrix, zeros
 
+from ..matrices.reductions import _rref
+
 class RawMatrix(MutableDenseMatrix):
     _sympify = staticmethod(lambda x: x)
 
@@ -34,8 +36,10 @@ def solve_lin_sys(eqs, ring, _raw=True):
     # transform from equations to matrix form
     matrix = eqs_to_matrix(eqs, ring)
 
-    # solve by row-reduction
-    echelon, pivots = matrix.rref(iszerofunc=lambda x: not x, simplify=lambda x: x)
+    # solve by row-reduction, use the internal `_rref` function to avoid matrix
+    # method coercion to immutable which would raise due to use of elements
+    # here derived from `CantSimplify`.
+    echelon, pivots = _rref(matrix, iszerofunc=lambda x: not x, simplify=lambda x: x)
 
     # construct the returnable form of the solutions
     keys = ring.symbols if as_expr else ring.gens


### PR DESCRIPTION

#### References to other Issues or PRs
Caching for some functions from #18420 

#### Brief description of what is fixed or changed
Until recently caching could not be implemented for matrix functions due to mutable and immutable matrices using the same method entry points and the fact that certain mutable matrices could not be sympified into immutable ones to allow caching due to the presence of `CantSympify` elements from `polys/solvers.py` and `holonomic/linearsolve.py`.

Due to the separation of matrix operation implementations from the matrix definition itself it is now possible for mutable matrices to convert themselves to immutable before calling the function so the underlying function itself can be cached with `cacheit`. The problems with sympification of linear solvers' unsympifiable matrices have been resolved with a small change to `solvers.py` and `linearsolve.py` where they call the underlying `_rref` function which does not attempt sympification instead of the matrix method `rref` which now does.

I have applied this technique only to `MatrixReductions` so far so that it can be examined more easily, but if this method is accepted I can apply it very easily to all the other matrix functions which have so far been pulled out. I would also like to have an answer on this before I start pulling functions out of `MatrixBase` since those are more complicated functions to separate and I would like to either implement the caching along the way since I will see the best place to put it or at least prepare for caching should some other idea on how to implement it come out of this PR.

This method of caching will work for both mutable and immutable matrices and in fact an equivalent mutable and immutable matrix will cache in the same entry.

#### Other comments

The addition of the `_ImmutableNoWrappers` mixin in `matrices/immutable.py` is a result of @oscarbenjamin's request that internal functions call themselves directly instead of matrix methods to avoid wrapper overhead. This can not be done as it would prevent overloading of deeper methods which are used by higher level methods but the wrapper overhead can be removed by pointing immutable methods directly at the underlying functions since sympification does not need to be done for immutable matrices in order for caching to work.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Implemented caching for MatrixReductions operations.
<!-- END RELEASE NOTES -->