### PR TITLE
Copy the environ in a subprocess test

### DIFF
--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -1,8 +1,10 @@
 from textwrap import dedent
-from sympy.core.compatibility import unichr
-from sympy.utilities.misc import translate, replace, ordinal, rawlines, strlines
 import sys
 from subprocess import Popen, PIPE
+import os
+
+from sympy.core.compatibility import unichr
+from sympy.utilities.misc import translate, replace, ordinal, rawlines, strlines
 
 def test_translate():
     abc = 'abc'
@@ -107,7 +109,8 @@ def test_translate_args():
 
 
 def test_debug_output():
-    env = {'SYMPY_DEBUG':'True'}
+    env = os.environ.copy()
+    env['SYMPY_DEBUG'] = 'True'
     cmd = 'from sympy import *; x = Symbol("x"); print(integrate((1-cos(x))/x, x))'
     cmdline = [sys.executable, '-c', cmd]
     proc = Popen(cmdline, env=env, stdout=PIPE, stderr=PIPE)
@@ -115,4 +118,4 @@ def test_debug_output():
     out = out.decode('ascii') # utf-8?
     err = err.decode('ascii')
     expected = 'substituted: -x*(cos(x) - 1), u: 1/x, u_var: _u'
-    assert expected in err
+    assert expected in err, err


### PR DESCRIPTION
Otherwise things like PYTHONPATH won't be carried over.

Probably all subprocess tests should be automatically disabled if --no-subprocess is passed to `bin/test`. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->