### PR TITLE
Fixed accumbounds addition in add.py

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -139,8 +139,8 @@ class Add(Expr, AssocOp):
                         o.is_finite is False) and not extra:
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
-                if coeff.is_Number:
-                    coeff += o
+                if coeff.is_Number or isinstance(coeff, AccumBounds):
+                    coeff = coeff + o if coeff.is_Number else coeff.__add__(o)
                     if coeff is S.NaN and not extra:
                         # we know for sure the result will be nan
                         return [S.NaN], [], None

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -140,14 +140,14 @@ class Add(Expr, AssocOp):
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
                 if coeff.is_Number or isinstance(coeff, AccumBounds):
-                    coeff = coeff + o
+                    coeff += o
                     if coeff is S.NaN and not extra:
                         # we know for sure the result will be nan
                         return [S.NaN], [], None
                 continue
 
             elif isinstance(o, AccumBounds):
-                coeff = o.__add__(coeff)
+                coeff += o
                 continue
 
             elif isinstance(o, MatrixExpr):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -140,7 +140,7 @@ class Add(Expr, AssocOp):
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
                 if coeff.is_Number or isinstance(coeff, AccumBounds):
-                    coeff = coeff + o if coeff.is_Number else coeff.__add__(o)
+                    coeff = coeff + o
                     if coeff is S.NaN and not extra:
                         # we know for sure the result will be nan
                         return [S.NaN], [], None

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -147,7 +147,7 @@ class Add(Expr, AssocOp):
                 continue
 
             elif isinstance(o, AccumBounds):
-                coeff += o
+                coeff = o.__add__(coeff)
                 continue
 
             elif isinstance(o, MatrixExpr):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -463,6 +463,8 @@ def test_add():
     ans = (-x*(x) - y*(-x)).expand()
     assert e.subs(-y + 1, x) == ans
 
+    #Test issue 18747
+    assert (exp(x)+cos(x)).subs(x,oo) == oo
 
 def test_subs_issue_4009():
     assert (I*Symbol('a')).subs(1, 2) == I*Symbol('a')

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -464,7 +464,8 @@ def test_add():
     assert e.subs(-y + 1, x) == ans
 
     #Test issue 18747
-    assert (exp(x)+cos(x)).subs(x,oo) == oo
+    assert (exp(x) + cos(x)).subs(x, oo) == oo
+    assert Add(*[AccumBounds(-1, 1), oo]) == oo
 
 def test_subs_issue_4009():
     assert (I*Symbol('a')).subs(1, 2) == I*Symbol('a')

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -466,6 +466,7 @@ def test_add():
     #Test issue 18747
     assert (exp(x) + cos(x)).subs(x, oo) == oo
     assert Add(*[AccumBounds(-1, 1), oo]) == oo
+    assert Add(*[oo, AccumBounds(-1, 1)]) == oo
 
 def test_subs_issue_4009():
     assert (I*Symbol('a')).subs(1, 2) == I*Symbol('a')

--- a/sympy/tensor/tests/test_tensor_operators.py
+++ b/sympy/tensor/tests/test_tensor_operators.py
@@ -7,7 +7,6 @@ from sympy.tensor.tensor import (TensorIndexType,
 from sympy import symbols, diag
 from sympy import Array, Rational
 
-from sympy import sympify
 from random import randint
 
 
@@ -191,21 +190,21 @@ def test_expand_partial_derivative_sum_rule():
 
 
 def test_expand_partial_derivative_constant_factor_rule():
-    pos_random_int1 = sympify(randint(0, 1000))
-    pos_random_int2 = sympify(randint(0, 1000))
-    neg_random_int = sympify(randint(-1000, -1))
+    nneg = randint(0, 1000)
+    pos = randint(1, 1000)
+    neg = -randint(1, 1000)
 
-    c1 = Rational(pos_random_int1, pos_random_int2)
-    c2 = Rational(neg_random_int, pos_random_int2)
-    c3 = Rational(pos_random_int1, neg_random_int)
+    c1 = Rational(nneg, pos)
+    c2 = Rational(neg, pos)
+    c3 = Rational(nneg, neg)
 
-    expr2a = PartialDerivative(pos_random_int1*A(i), D(j))
+    expr2a = PartialDerivative(nneg*A(i), D(j))
     assert expr2a._expand_partial_derivative() ==\
-        pos_random_int1*PartialDerivative(A(i), D(j))
+        nneg*PartialDerivative(A(i), D(j))
 
-    expr2b = PartialDerivative(neg_random_int*A(i), D(j))
+    expr2b = PartialDerivative(neg*A(i), D(j))
     assert expr2b._expand_partial_derivative() ==\
-        neg_random_int*PartialDerivative(A(i), D(j))
+        neg*PartialDerivative(A(i), D(j))
 
     expr2ca = PartialDerivative(c1*A(i), D(j))
     assert expr2ca._expand_partial_derivative() ==\
@@ -221,30 +220,30 @@ def test_expand_partial_derivative_constant_factor_rule():
 
 
 def test_expand_partial_derivative_full_linearity():
-    pos_random_int1 = sympify(randint(0, 1000))
-    pos_random_int2 = sympify(randint(0, 1000))
-    neg_random_int = sympify(randint(-1000, -1))
+    nneg = randint(0, 1000)
+    pos = randint(1, 1000)
+    neg = -randint(1, 1000)
 
-    c1 = Rational(pos_random_int1, pos_random_int2)
-    c2 = Rational(neg_random_int, pos_random_int2)
-    c3 = Rational(pos_random_int1, neg_random_int)
+    c1 = Rational(nneg, pos)
+    c2 = Rational(neg, pos)
+    c3 = Rational(nneg, neg)
 
     # check full linearity
 
-    expr3a = PartialDerivative(pos_random_int1*A(i) + pos_random_int2*B(i), D(j))
+    expr3a = PartialDerivative(nneg*A(i) + pos*B(i), D(j))
     assert expr3a._expand_partial_derivative() ==\
-        pos_random_int1*PartialDerivative(A(i), D(j))\
-        + pos_random_int2*PartialDerivative(B(i), D(j))
+        nneg*PartialDerivative(A(i), D(j))\
+        + pos*PartialDerivative(B(i), D(j))
 
-    expr3b = PartialDerivative(pos_random_int1*A(i) + neg_random_int*B(i), D(j))
+    expr3b = PartialDerivative(nneg*A(i) + neg*B(i), D(j))
     assert expr3b._expand_partial_derivative() ==\
-        pos_random_int1*PartialDerivative(A(i), D(j))\
-        + neg_random_int*PartialDerivative(B(i), D(j))
+        nneg*PartialDerivative(A(i), D(j))\
+        + neg*PartialDerivative(B(i), D(j))
 
-    expr3c = PartialDerivative(neg_random_int*A(i) + pos_random_int2*B(i), D(j))
+    expr3c = PartialDerivative(neg*A(i) + pos*B(i), D(j))
     assert expr3c._expand_partial_derivative() ==\
-        neg_random_int*PartialDerivative(A(i), D(j))\
-        + pos_random_int2*PartialDerivative(B(i), D(j))
+        neg*PartialDerivative(A(i), D(j))\
+        + pos*PartialDerivative(B(i), D(j))
 
     expr3d = PartialDerivative(c1*A(i) + c2*B(i), D(j))
     assert expr3d._expand_partial_derivative() ==\


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixed accumbounds addition
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18474 

#### Brief description of what is fixed or changed
Previously add didn't work properly with Accumbounds and oo.
For example:
```
>>> Add(*[oo, AccumBounds(-1,1)])
oo
>>> Add(*[ AccumBounds(-1, 1), oo])
AccumBounds(-1, 1)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  *  Added check for `AccumBounds`.
<!-- END RELEASE NOTES -->