### PR TITLE
Remove Deprecation Warning in Symbol

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -189,20 +189,6 @@ class Symbol(AtomicExpr, Boolean):
 
         # sanitize other assumptions so 1 -> True and 0 -> False
         for key in list(assumptions.keys()):
-            from collections import defaultdict
-            from sympy.utilities.exceptions import SymPyDeprecationWarning
-            keymap = defaultdict(lambda: None)
-            keymap.update({'bounded': 'finite', 'unbounded': 'infinite', 'infinitesimal': 'zero'})
-            if keymap[key]:
-                SymPyDeprecationWarning(
-                    feature="%s assumption" % key,
-                    useinstead="%s" % keymap[key],
-                    issue=8071,
-                    deprecated_since_version="0.7.6").warn()
-                assumptions[keymap[key]] = assumptions[key]
-                assumptions.pop(key)
-                key = keymap[key]
-
             v = assumptions[key]
             if v is None:
                 assumptions.pop(key)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Remove Deprecation Warning and features in Symbol
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #8071

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * Remove deprecated `bounded`, `unbounded` and `infinitesimal`. Deprecated since version `0.7.6` (issue #8071)
<!-- END RELEASE NOTES -->