### PR TITLE
convenience methods for matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3966,6 +3966,72 @@ class MatrixBase(MatrixDeprecated,
                     count += 1
         return v
 
+    def upper(a, diag=0):
+        """
+        Examples
+        ========
+
+        >>> from sympy import Matrix, ones
+        >>> Matrix.upper(ones(4,2))
+        Matrix([
+        [1, 1],
+        [0, 1],
+        [0, 0],
+        [0, 0]])
+        >>> Matrix.upper(ones(2,4))
+        Matrix([
+        [1, 1, 1, 1],
+        [0, 1, 1, 1]])
+        >>> Matrix.upper(ones(3), diag=1)
+        Matrix([
+        [0, 1, 1],
+        [0, 0, 1],
+        [0, 0, 0]])
+        """
+        from sympy import Matrix
+
+        b = Matrix(a)
+        d = min(a.rows, a.cols)
+        for i in range(d):
+            for j in range(i + diag):
+                b[i, j] = 0
+        for i in range(d, a.rows):
+            for j in range(a.cols):
+                b[i, j] = 0
+        return b
+
+    def lower(a, diag=0):
+        """
+        Examples
+        ========
+
+        >>> from sympy import Matrix, ones
+        >>> Matrix.lower(ones(4), -1)
+        Matrix([
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 1, 0]])
+        >>> Matrix.lower(ones(2, 4))
+        Matrix([
+        [1, 0, 0, 0],
+        [1, 1, 0, 0]])
+        >>> Matrix.lower(ones(4, 2))
+        Matrix([
+        [1, 0],
+        [1, 1],
+        [1, 1],
+        [1, 1]])
+        """
+        from sympy import Matrix
+
+        b = Matrix(a)
+        i0 = diag + 1
+        for i in range(a.rows):
+            for j in range(i + i0, a.cols):
+                b[i, j] = 0
+        return b
+
 @deprecated(
     issue=15109,
     useinstead="from sympy.matrices.common import classof",
@@ -3981,69 +4047,3 @@ def classof(A, B):
 def a2idx(j, n=None):
     from sympy.matrices.common import a2idx as a2idx_
     return a2idx_(j, n)
-
-def upper(a, diag=0):
-    """
-    Examples
-    ========
-
-    >>> from sympy.matrices.matrices import upper
-    >>> from sympy.matrices.dense import ones
-    >>> upper(ones(4,2))
-    Matrix([
-    [1, 1],
-    [0, 1],
-    [0, 0],
-    [0, 0]])
-    >>> upper(ones(2,4))
-    Matrix([
-    [1, 1, 1, 1],
-    [0, 1, 1, 1]])
-    >>> upper(ones(3), diag=1)
-    Matrix([
-    [0, 1, 1],
-    [0, 0, 1],
-    [0, 0, 0]])
-    """
-    from sympy import Matrix
-    b = Matrix(a)
-    d = min(a.rows, a.cols)
-    for i in range(d):
-        for j in range(i + diag):
-            b[i, j] = 0
-    for i in range(d, a.rows):
-        for j in range(a.cols):
-            b[i, j] = 0
-    return b
-
-def lower(a, diag=0):
-    """
-    Examples
-    ========
-
-    >>> from sympy.matrices.matrices import lower
-    >>> from sympy.matrices.dense import ones
-    >>> lower(ones(4), -1)
-    Matrix([
-    [0, 0, 0, 0],
-    [1, 0, 0, 0],
-    [1, 1, 0, 0],
-    [1, 1, 1, 0]])
-    >>> lower(ones(2, 4))
-    Matrix([
-    [1, 0, 0, 0],
-    [1, 1, 0, 0]])
-    >>> lower(ones(4, 2))
-    Matrix([
-    [1, 0],
-    [1, 1],
-    [1, 1],
-    [1, 1]])
-    """
-    from sympy import Matrix
-    b = Matrix(a)
-    i0 = diag + 1
-    for i in range(a.rows):
-        for j in range(i + i0, a.cols):
-            b[i, j] = 0
-    return b

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3981,3 +3981,69 @@ def classof(A, B):
 def a2idx(j, n=None):
     from sympy.matrices.common import a2idx as a2idx_
     return a2idx_(j, n)
+
+def upper(a, diag=0):
+    from sympy import Matrix
+    """
+    Examples
+    ========
+
+    >>> from sympy.matrices.matrices import upper
+    >>> from sympy.matrices.dense import ones
+    >>> upper(ones(4,2))
+    Matrix([
+    [1, 1],
+    [0, 1],
+    [0, 0],
+    [0, 0]])
+    >>> upper(ones(2,4))
+    Matrix([
+    [1, 1, 1, 1],
+    [0, 1, 1, 1]])
+    >>> upper(ones(3), diag=1)
+    Matrix([
+    [0, 1, 1],
+    [0, 0, 1],
+    [0, 0, 0]])
+    """
+    b = Matrix(a)
+    d = min(a.rows, a.cols)
+    for i in range(d):
+        for j in range(i + diag):
+            b[i, j] = 0
+    for i in range(d, a.rows):
+        for j in range(a.cols):
+            b[i, j] = 0
+    return b
+
+def lower(a, diag=0):
+    from sympy import Matrix
+    """
+    Examples
+    ========
+
+    >>> from sympy.matrices.matrices import lower
+    >>> from sympy.matrices.dense import ones
+    >>> lower(ones(4), -1)
+    Matrix([
+    [0, 0, 0, 0],
+    [1, 0, 0, 0],
+    [1, 1, 0, 0],
+    [1, 1, 1, 0]])
+    >>> lower(ones(2, 4))
+    Matrix([
+    [1, 0, 0, 0],
+    [1, 1, 0, 0]])
+    >>> lower(ones(4, 2))
+    Matrix([
+    [1, 0],
+    [1, 1],
+    [1, 1],
+    [1, 1]])
+    """
+    b = Matrix(a)
+    i0 = diag + 1
+    for i in range(a.rows):
+        for j in range(i + i0, a.cols):
+            b[i, j] = 0
+    return b

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3983,7 +3983,6 @@ def a2idx(j, n=None):
     return a2idx_(j, n)
 
 def upper(a, diag=0):
-    from sympy import Matrix
     """
     Examples
     ========
@@ -4006,6 +4005,7 @@ def upper(a, diag=0):
     [0, 0, 1],
     [0, 0, 0]])
     """
+    from sympy import Matrix
     b = Matrix(a)
     d = min(a.rows, a.cols)
     for i in range(d):
@@ -4017,7 +4017,6 @@ def upper(a, diag=0):
     return b
 
 def lower(a, diag=0):
-    from sympy import Matrix
     """
     Examples
     ========
@@ -4041,6 +4040,7 @@ def lower(a, diag=0):
     [1, 1],
     [1, 1]])
     """
+    from sympy import Matrix
     b = Matrix(a)
     i0 = diag + 1
     for i in range(a.rows):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4191,3 +4191,9 @@ def test_issue_8207():
     e = diff(d, a[0, 0])
     assert d == b[0, 0]
     assert e == 0
+
+def test_upper():
+    assert (lower(ones(4), -1) == Matrix([[0, 0, 0, 0], [1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]))
+
+def test_lower():
+    assert (upper(ones(4,2)) == Matrix([[1, 1], [0, 1], [0, 0], [0, 0]]))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -21,7 +21,7 @@ from sympy.solvers import solve
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
-
+from sympy.matrices.matrices import lower,upper
 from sympy.abc import a, b, c, d, x, y, z, t
 
 # don't re-order this list

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -21,7 +21,6 @@ from sympy.solvers import solve
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
-from sympy.matrices.matrices import lower,upper
 from sympy.abc import a, b, c, d, x, y, z, t
 
 # don't re-order this list
@@ -4193,7 +4192,8 @@ def test_issue_8207():
     assert e == 0
 
 def test_upper():
-    assert (lower(ones(4), -1) == Matrix([[0, 0, 0, 0], [1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]))
+    assert (Matrix.lower(ones(4), -1) == Matrix([[0, 0, 0, 0], [1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]))
 
 def test_lower():
-    assert (upper(ones(4,2)) == Matrix([[1, 1], [0, 1], [0, 0], [0, 0]]))
+    assert (Matrix.
+    upper(ones(4,2)) == Matrix([[1, 1], [0, 1], [0, 0], [0, 0]]))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #16619

#### Brief description of what is fixed or changed
Added Two convenience methods for matrices
1.) `lower`
2.) `upper`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   matrices
     *  Added `lower`, `upper` convenience methods for matrices in matrices.py
<!-- END RELEASE NOTES -->