### PR TITLE
Fix docs of is_diagonalizable

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -352,7 +352,6 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
     Example of a matrix that is diagonalized in terms of non-real entries:
 
-    with complex entries, but not with real entries:
 
     >>> M = Matrix([[0, 1], [-1, 0]])
     >>> M.is_diagonalizable(reals_only=False)

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -322,7 +322,8 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
     reals_only : bool, optional
         If ``True``, it tests whether the matrix can be diagonalized
-        with a diagonal matrix without complex numbers.
+        to contain only real numbers on the diagonal.
+
 
         If ``False``, it tests whether the matrix can be diagonalized
         with a diagonal matrix with complex numbers.

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -352,7 +352,6 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
     Example of a matrix that is diagonalized in terms of non-real entries:
 
-
     >>> M = Matrix([[0, 1], [-1, 0]])
     >>> M.is_diagonalizable(reals_only=False)
     True

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -350,7 +350,8 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
     >>> M.is_diagonalizable()
     False
 
-    Example of a matrix which is diagonalizable with a diagonal matrix
+    Example of a matrix that is diagonalized in terms of non-real entries:
+
     with complex entries, but not with real entries:
 
     >>> M = Matrix([[0, 1], [-1, 0]])

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -322,10 +322,10 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
     reals_only : bool, optional
         If ``True``, it tests whether the matrix can be diagonalized
-        without complex numbers.
+        with a diagonal matrix without complex numbers.
 
         If ``False``, it tests whether the matrix can be diagonalized
-        with complex numbers.
+        with a diagonal matrix with complex numbers.
 
     dotprodsimp : bool, optional
         Specifies whether intermediate term algebraic simplification

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -322,10 +322,10 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
     reals_only : bool, optional
         If ``True``, it tests whether the matrix can be diagonalized
-        without complex numbers. (Orthogonally diagonalizable)
+        without complex numbers.
 
-        If ``False``, it tests whether the matrix can be unitarily
-        diagonalizable.
+        If ``False``, it tests whether the matrix can be diagonalized
+        with complex numbers.
 
     dotprodsimp : bool, optional
         Specifies whether intermediate term algebraic simplification
@@ -348,8 +348,8 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
     >>> M.is_diagonalizable()
     False
 
-    Example of a unitarily diagonalizable, but not orthogonally
-    diagonalizable:
+    Example of a matrix which is diagonalizable with a diagonal matrix
+    with complex entries, but not with real entries:
 
     >>> M = Matrix([[0, 1], [-1, 0]])
     >>> M.is_diagonalizable(reals_only=False)
@@ -384,8 +384,7 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
     if all(e.is_real for e in M) and M.is_symmetric():
         return True
 
-    if all(e.is_complex for e in M) and M.is_hermitian \
-            and not reals_only:
+    if all(e.is_complex for e in M) and M.is_hermitian:
         return True
 
     return _is_diagonalizable_with_eigen(M, reals_only=reals_only,

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -326,7 +326,8 @@ def _is_diagonalizable(M, reals_only=False, dotprodsimp=None, **kwargs):
 
 
         If ``False``, it tests whether the matrix can be diagonalized
-        with a diagonal matrix with complex numbers.
+        at all, even with numbers that may not be real.
+
 
     dotprodsimp : bool, optional
         Specifies whether intermediate term algebraic simplification


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that I have misused the notations like `orthogonally_diagonalizable` in #16778 
And `reals_only` keyword seems like defined with whether all the eigenvalues are real or not.
So, in this case, complex hermitian matrix can also be considered diagonalizable as they have real eigenvalues.
(Even though they can possibly return `P` matrix with complex entries)

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->