### PR TITLE
Add Min/Max support for decompogen

### DIFF
--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -20,7 +20,7 @@ def decompogen(f, symbol):
 
     >>> from sympy.solvers.decompogen import decompogen
     >>> from sympy.abc import x
-    >>> from sympy import sqrt, sin, cos
+    >>> from sympy import sqrt, sin, cos, Max
     >>> decompogen(sin(cos(x)), x)
     [sin(x), cos(x)]
     >>> decompogen(sin(x)**2 + sin(x) + 1, x)
@@ -31,6 +31,8 @@ def decompogen(f, symbol):
     [sin(x), sqrt(x), cos(x), x**2 + 1]
     >>> decompogen(x**4 + 2*x**3 - x - 1, x)
     [x**2 - x - 1, x**2 + x]
+    >>> decompogen(Max(sin(x), x**2), x)
+    [Max, sin(x), x**2]
 
     """
     f = sympify(f)

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -2,6 +2,7 @@ from sympy.core import (Function, Pow, sympify, Expr)
 from sympy.core.relational import Relational
 from sympy.polys import Poly, decompose
 from sympy.utilities.misc import func_name
+from sympy import Min, Max
 
 
 def decompogen(f, symbol):
@@ -46,6 +47,13 @@ def decompogen(f, symbol):
             return [f]
         result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
         return result
+
+    # ===== Max/Min Functions ===== #
+    if isinstance(f, (Min, Max)):
+        rv = [type(f)]
+        for i in f.args:
+            rv.extend(decompogen(i, symbol))
+        return rv
 
     # ===== Convert to Polynomial ===== #
     fp = Poly(f)

--- a/sympy/solvers/tests/test_decompogen.py
+++ b/sympy/solvers/tests/test_decompogen.py
@@ -1,5 +1,5 @@
 from sympy.solvers.decompogen import decompogen, compogen
-from sympy import sin, cos, sqrt, Abs, exp, symbols
+from sympy import sin, cos, tan, sqrt, Abs, exp, symbols, Max, Min, pi
 from sympy.testing.pytest import XFAIL, raises
 
 x, y = symbols('x y')
@@ -15,6 +15,9 @@ def test_decompogen():
     assert decompogen(Abs(cos(y)**2 + 3*cos(x) - 4), x) == [Abs(x), 3*x + cos(y)**2 - 4, cos(x)]
     assert decompogen(x, y) == [x]
     assert decompogen(1, x) == [1]
+    assert decompogen(Max(x, 3), x) == [Max, 3, x]
+    assert decompogen(Max(Min(sin(tan(x**4)), pi), sin(tan(x))), x) == \
+        [Max, sin(x), tan(x), Min, pi, sin(x), tan(x), x**4]
     raises(TypeError, lambda: decompogen(x < 5, x))
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #13612 

#### Brief description of what is fixed or changed
Before addition ---
```
>>> decompogen(Min(5, x), x)
....
....
....
....
File "sympy\core\compatibility.py", line 462, in default_sort_key
    return item.sort_key(order=order)
  File "sympy\core\cache.py", line 93, in wrapper
    retval = cfunc(*args, **kwargs)
  File "sympy\core\compatibility.py", line 792, in wrapper
    key = make_key(args, kwds, typed) if kwds or typed else args
  File "sympy\core\compatibility.py", line 724, in _make_key
    return _HashedSeq(key)
  File "sympy\core\compatibility.py", line 702, in __init__
    self.hashvalue = hash(tup)
RuntimeError: maximum recursion depth exceeded
```
After addition --- 
```
>>> decompogen(Min(5, x), x)
[Min, 5, x]
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  solvers
    *  Added `Min`/`Max` support for `decompogen`. 
<!-- END RELEASE NOTES -->