### PR TITLE
atoms() method return value updated

### DIFF
--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -1,6 +1,6 @@
 from sympy.core.symbol import symbols
 from sympy.printing.ccode import ccode
-from sympy.codegen.ast import Declaration, Variable, float64, int64
+from sympy.codegen.ast import Declaration, Variable, float64, int64, String
 from sympy.codegen.cnodes import (
     alignof, CommaOperator, goto, Label, PreDecrement, PostDecrement, PreIncrement, PostIncrement,
     sizeof, union, struct
@@ -66,7 +66,7 @@ def test_sizeof():
     assert ccode(sz) == 'sizeof(%s)' % typename
     assert sz.func(*sz.args) == sz
     assert not sz.is_Atom
-    assert all(atom == typename for atom in sz.atoms())
+    assert sz.atoms() == set([String('unsigned int'), String('sizeof')])
 
 
 def test_struct():

--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -66,7 +66,7 @@ def test_sizeof():
     assert ccode(sz) == 'sizeof(%s)' % typename
     assert sz.func(*sz.args) == sz
     assert not sz.is_Atom
-    assert sz.atoms() == set([String('unsigned int'), String('sizeof')])
+    assert sz.atoms() == {String('unsigned int'), String('sizeof')}
 
 
 def test_struct():

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -503,7 +503,6 @@ class Basic(metaclass=ManagedProperties):
         if types:
             types = tuple(
                 [t if isinstance(t, type) else type(t) for t in types])
-        result = set()
         nodes = preorder_traversal(self)
         if types:
             result = {node for node in nodes if isinstance(node, types)}

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -504,11 +504,11 @@ class Basic(metaclass=ManagedProperties):
             types = tuple(
                 [t if isinstance(t, type) else type(t) for t in types])
         result = set()
-        for expr in preorder_traversal(self):
-            if not (types or expr.args):
-                result.add(expr)
-            elif isinstance(expr, types):
-                result.add(expr)
+        nodes = preorder_traversal(self)
+        if types:
+            result = {node for node in nodes if isinstance(node, types)}
+        else:
+            result = {node for node in nodes if not node.args}
         return result
 
     @property

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -503,11 +503,11 @@ class Basic(metaclass=ManagedProperties):
         if types:
             types = tuple(
                 [t if isinstance(t, type) else type(t) for t in types])
-        else:
-            types = (Atom,)
         result = set()
         for expr in preorder_traversal(self):
-            if isinstance(expr, types):
+            if not (types or expr.args):
+                result.add(expr)
+            elif isinstance(expr, types):
                 result.add(expr)
         return result
 

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -137,7 +137,7 @@ def test_subs_with_unicode_symbols():
 
 
 def test_atoms():
-    assert b21.atoms() == set()
+    assert b21.atoms() == set([Basic()])
 
 
 def test_free_symbols_empty():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #10152 and aims to complete the work started in 
PR #10246


#### Brief description of what is fixed or changed
--> Updated the atoms() method of class Basic to check if .args value of an object is empty or not to check if a sympy object is a leaf node or not.

#### Other comments
Let us consider an example to see how this PR has updated the .atoms() method. 
So, now we will define 3 basic sympy objects.

```
>>> b1 = Basic()
>>> b2 = Basic()
>>> b12 = Basic(b1, b2)
```

Now, before the fix, the output of ```b12.atoms()``` is:

```
>>> b12.atoms()
set()
```

After the fix, the output is:

```
>>> b12.atoms()
set({Basic()})
```
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Updated the definition of atoms method of class Basic
<!-- END RELEASE NOTES -->