### PR TITLE
Fixes polynomial solve with GoldenRatio and TribonacciConstant

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -4,8 +4,9 @@ from __future__ import print_function, division
 
 from sympy import (
     S, Rational, AlgebraicNumber, GoldenRatio, TribonacciConstant,
-    Add, Mul, sympify, Dummy, expand_mul, I, pi, sqrt, cbrt
+    Add, Mul, sympify, Dummy, expand_mul, I, pi
 )
+from sympy.functions import sqrt, cbrt
 from sympy.core.compatibility import reduce
 from sympy.core.exprtools import Factors
 from sympy.core.function import _mexpand

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -3,8 +3,8 @@
 from __future__ import print_function, division
 
 from sympy import (
-    S, Rational, AlgebraicNumber, GoldenRatio,TribonacciConstant,
-    Add, Mul, sympify, Dummy, expand_mul, I, pi
+    S, Rational, AlgebraicNumber, GoldenRatio, TribonacciConstant,
+    Add, Mul, sympify, Dummy, expand_mul, I, pi, sqrt
 )
 from sympy.core.compatibility import reduce
 from sympy.core.exprtools import Factors

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import (
-    S, Rational, AlgebraicNumber, GoldenRatio,
+    S, Rational, AlgebraicNumber, GoldenRatio,TribonacciConstant,
     Add, Mul, sympify, Dummy, expand_mul, I, pi
 )
 from sympy.core.compatibility import reduce
@@ -517,9 +517,22 @@ def _minpoly_compose(ex, x, dom):
     if ex is I:
         _, factors = factor_list(x**2 + 1, x, domain=dom)
         return x**2 + 1 if len(factors) == 1 else x - I
+
     if ex is GoldenRatio:
         _, factors = factor_list(x**2 - x - 1, x, domain=dom)
-        return x**2 - x - 1 if len(factors) == 1 else x - GoldenRatio
+        if len(factors) == 1:
+            return x**2 - x - 1
+        else:
+            return _choose_factor(factors, x, (1 + sqrt(5))/2, dom=dom)
+
+    if ex is TribonacciConstant:
+        _, factors = factor_list(x**3 - x**2 - x - 1, x, domain=dom)
+        if len(factors) == 1:
+            return x**3 - x**2 - x - 1
+        else:
+            fac = 1/3 + 4/(9*(sqrt(33)/9 + 19/27)**(1/3)) + (sqrt(33)/9 + 19/27)**(1/3)
+            return _choose_factor(factors, x, fac, dom=dom)
+
     if hasattr(dom, 'symbols') and ex in dom.symbols:
         return x - ex
 

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -518,7 +518,8 @@ def _minpoly_compose(ex, x, dom):
         _, factors = factor_list(x**2 + 1, x, domain=dom)
         return x**2 + 1 if len(factors) == 1 else x - I
     if ex is GoldenRatio:
-        return x**2 - x - 1
+        _, factors = factor_list(x**2 - x - 1, x, domain=dom)
+        return x**2 - x - 1 if len(factors) == 1 else x - GoldenRatio
     if hasattr(dom, 'symbols') and ex in dom.symbols:
         return x - ex
 

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import (
-    S, Rational, AlgebraicNumber,
+    S, Rational, AlgebraicNumber, GoldenRatio,
     Add, Mul, sympify, Dummy, expand_mul, I, pi
 )
 from sympy.core.compatibility import reduce
@@ -517,6 +517,8 @@ def _minpoly_compose(ex, x, dom):
     if ex is I:
         _, factors = factor_list(x**2 + 1, x, domain=dom)
         return x**2 + 1 if len(factors) == 1 else x - I
+    if ex is GoldenRatio:
+        return x**2 - x - 1
     if hasattr(dom, 'symbols') and ex in dom.symbols:
         return x - ex
 

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy import (
     S, Rational, AlgebraicNumber, GoldenRatio, TribonacciConstant,
-    Add, Mul, sympify, Dummy, expand_mul, I, pi, sqrt
+    Add, Mul, sympify, Dummy, expand_mul, I, pi, sqrt, cbrt
 )
 from sympy.core.compatibility import reduce
 from sympy.core.exprtools import Factors
@@ -530,7 +530,7 @@ def _minpoly_compose(ex, x, dom):
         if len(factors) == 1:
             return x**3 - x**2 - x - 1
         else:
-            fac = 1/3 + 4/(9*(sqrt(33)/9 + 19/27)**(1/3)) + (sqrt(33)/9 + 19/27)**(1/3)
+            fac = (1 + cbrt(19 - 3*sqrt(33)) + cbrt(19 + 3*sqrt(33))) / 3
             return _choose_factor(factors, x, fac, dom=dom)
 
     if hasattr(dom, 'symbols') and ex in dom.symbols:

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -1,7 +1,7 @@
 """Tests for computational algebraic number field theory. """
 
 from sympy import (S, Rational, Symbol, Poly, sqrt, I, oo, Tuple, expand,
-    pi, cos, sin, exp)
+    pi, cos, sin, exp, GoldenRatio, TribonacciConstant, cbrt)
 
 from sympy.testing.pytest import raises, slow
 
@@ -149,6 +149,14 @@ def test_minimal_polynomial():
     assert minimal_polynomial(I, x, domain=QQ) == x**2 + 1
     assert minimal_polynomial(I, x, domain='QQ(y)') == x**2 + 1
 
+    #issue 11553
+    assert minimal_polynomial(GoldenRatio, x) == x**2 - x - 1
+    assert minimal_polynomial(TribonacciConstant + 3, x) == x**3 - 10*x**2 + 32*x - 34
+    assert minimal_polynomial(GoldenRatio, x, domain=QQ.algebraic_field(sqrt(5))) == \
+            2*x - sqrt(5) - 1
+    assert minimal_polynomial(TribonacciConstant, x, domain=QQ.algebraic_field(cbrt(19 - 3*sqrt(33)))) == \
+    48*x - 19*(19 - 3*sqrt(33))**Rational(2, 3) - 3*sqrt(33)*(19 - 3*sqrt(33))**Rational(2, 3) \
+    - 16*(19 - 3*sqrt(33))**Rational(1, 3) - 16
 
 def test_minimal_polynomial_hi_prec():
     p = 1/sqrt(1 - 9*sqrt(2) + 7*sqrt(3) + Rational(1, 10)**30)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -5,7 +5,7 @@ from sympy import (
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
-    E, cbrt, denom, Add, Piecewise)
+    E, cbrt, denom, Add, Piecewise, GoldenRatio)
 
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -2131,3 +2131,9 @@ def test_issue_17949():
     assert solve(exp(-x+x**2), x) == []
     assert solve(exp(+x-x**2), x) == []
     assert solve(exp(-x-x**2), x) == []
+
+
+def test_issue_11553():
+    eq1 = x + y + 1
+    eq2 = x + GoldenRatio
+    assert solve([eq1, eq2], x, y) == {x: -GoldenRatio, y: -1 + GoldenRatio}

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -5,7 +5,7 @@ from sympy import (
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
-    E, cbrt, denom, Add, Piecewise, GoldenRatio)
+    E, cbrt, denom, Add, Piecewise, GoldenRatio, TribonacciConstant)
 
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -2137,3 +2137,5 @@ def test_issue_11553():
     eq1 = x + y + 1
     eq2 = x + GoldenRatio
     assert solve([eq1, eq2], x, y) == {x: -GoldenRatio, y: -1 + GoldenRatio}
+    eq3 = x + 2 + TribonacciConstant
+    assert solve([eq1, eq3], x, y) == {x: -2 - TribonacciConstant, y: 1 + TribonacciConstant}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes polynomial solve with GoldenRatio and TribonacciConstant
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #11553

#### Brief description of what is fixed or changed
Before fixing:
```
>>> from sympy import *
>>> x,y = symbols('x y')
>>> eq1 = x + y + 1
>>> eq2 = x + GoldenRatio
>>> solve([eq1, eq2], x, y)
Traceback (most recent call last):
   ...
sympy.polys.polyerrors.NotAlgebraic: GoldenRatio doesn't seem to be an algebraic element
```

After fixing:
```
>>> from sympy import *
>>> x,y = symbols('x y')
>>> eq1 = x + y + 1
>>> eq2 = x + GoldenRatio
>>> solve([eq1, eq2], x, y)
{x: -GoldenRatio, y: -1 + GoldenRatio}
```

#### Other comments
GoldenRatio is the number symbol treated as an algebraic expression as `(x**2 - x - 1)
`
TribonacciConstant is the number symbol treated as an algebraic expression as `(x**3 - x**2 - x - 1)
`
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added check for expressions containing GoldenRatio and TribonacciConstant
<!-- END RELEASE NOTES -->