### PR TITLE
Fixed aspect_ratio parameter with MatplotlibBackend

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1033,7 +1033,7 @@ class MatplotlibBackend(BaseBackend):
         self.plt = self.matplotlib.pyplot
         self.cm = self.matplotlib.cm
         self.LineCollection = self.matplotlib.collections.LineCollection
-        aspect = self.parent.aspect_ratio
+        aspect = getattr(self.parent, 'aspect_ratio', 'auto')
         if aspect != 'auto':
             aspect = float(aspect[1]) / aspect[0]
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1033,6 +1033,9 @@ class MatplotlibBackend(BaseBackend):
         self.plt = self.matplotlib.pyplot
         self.cm = self.matplotlib.cm
         self.LineCollection = self.matplotlib.collections.LineCollection
+        aspect = self.parent.aspect_ratio
+        if aspect != 'auto':
+            aspect = float(aspect[1]) / aspect[0]
 
         if isinstance(self.parent, Plot):
             nrows, ncolumns = 1, 1
@@ -1054,10 +1057,10 @@ class MatplotlibBackend(BaseBackend):
                 # projection='3d'
                 mpl_toolkits = import_module('mpl_toolkits', # noqa
                                      import_kwargs={'fromlist': ['mplot3d']})
-                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1, projection='3d'))
+                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1, projection='3d', aspect=aspect))
 
             elif not any(are_3D):
-                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1))
+                self.ax.append(self.fig.add_subplot(nrows, ncolumns, i + 1, aspect=aspect))
                 self.ax[i].spines['left'].set_position('zero')
                 self.ax[i].spines['right'].set_color('none')
                 self.ax[i].spines['bottom'].set_position('zero')

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -586,3 +586,14 @@ def test_issue_11461():
     # that there are segments generated, as opposed to when the bug was present
     # and that there are no exceptions.
     assert len(p[0].get_segments()) >= 30
+
+def test_issue_11764():
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if not matplotlib:
+        skip("Matplotlib not the default backend")
+    x = Symbol('x')
+    p = plot_parametric(cos(x), sin(x), (x, 0, 2 * pi), aspect_ratio=(1,1), show=False)
+    p.aspect_ratio = (1, 1)
+    # Random number of segments, probably more than 100, but we want to see
+    # that there are segments generated, as opposed to when the bug was present
+    assert len(p[0].get_segments()) >= 30

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -593,7 +593,7 @@ def test_issue_11764():
         skip("Matplotlib not the default backend")
     x = Symbol('x')
     p = plot_parametric(cos(x), sin(x), (x, 0, 2 * pi), aspect_ratio=(1,1), show=False)
-    p.aspect_ratio = (1, 1)
+    p.aspect_ratio == (1, 1)
     # Random number of segments, probably more than 100, but we want to see
     # that there are segments generated, as opposed to when the bug was present
     assert len(p[0].get_segments()) >= 30


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixed aspect_ratio parameter with MatplotlibBackend in Plotting
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #11764

#### Brief description of what is fixed or changed
 MatlpotlibBackend now aquires `aspect_ratio` attribute from Plot object which was initially `'auto'` in matplotlib plot.

#### Other comments

```
from sympy import cos, sin, Symbol, pi
from sympy.plotting import plot_parametric
%matplotlib inline
x = Symbol('x')
p = plot_parametric(cos(x), sin(x), (x, 0, 2 * pi), aspect_ratio=(1,1))
```
This plotted a ellipse like shape though the axis were correct but the `aspect ratio='auto'`, made it to look like a ellipse.
After fixing it forms a circle.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Fixed aspect_ratio in plot
<!-- END RELEASE NOTES -->