### PR TITLE
Deprecate DeferredVector

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2784,11 +2784,6 @@ def test_sympy__logic__boolalg__Xnor():
     assert _test_args(Xnor(x, y, 2))
 
 
-def test_sympy__matrices__matrices__DeferredVector():
-    from sympy.matrices.matrices import DeferredVector
-    assert _test_args(DeferredVector("X"))
-
-
 @SKIP("abstract class")
 def test_sympy__matrices__expressions__matexpr__MatrixBase():
     pass

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -23,7 +23,7 @@ import sympy
 import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 # first, systematically check, that all operations are implemented and don't
@@ -263,19 +263,20 @@ def test_lambdify_matrix_multi_input():
 
 
 def test_lambdify_matrix_vec_input():
-    X = sympy.DeferredVector('X')
-    M = Matrix([
-        [X[0]**2, X[0]*X[1], X[0]*X[2]],
-        [X[1]*X[0], X[1]**2, X[1]*X[2]],
-        [X[2]*X[0], X[2]*X[1], X[2]**2]])
-    f = lambdify(X, M, [{'ImmutableMatrix': numpy.array}, "numpy"])
+    with warns_deprecated_sympy():
+        X = sympy.DeferredVector('X')
+        M = Matrix([
+            [X[0]**2, X[0]*X[1], X[0]*X[2]],
+            [X[1]*X[0], X[1]**2, X[1]*X[2]],
+            [X[2]*X[0], X[2]*X[1], X[2]**2]])
+        f = lambdify(X, M, [{'ImmutableMatrix': numpy.array}, "numpy"])
 
-    Xh = array([1.0, 2.0, 3.0])
-    expected = array([[Xh[0]**2, Xh[0]*Xh[1], Xh[0]*Xh[2]],
-                      [Xh[1]*Xh[0], Xh[1]**2, Xh[1]*Xh[2]],
-                      [Xh[2]*Xh[0], Xh[2]*Xh[1], Xh[2]**2]])
-    actual = f(Xh)
-    assert numpy.allclose(actual, expected)
+        Xh = array([1.0, 2.0, 3.0])
+        expected = array([[Xh[0]**2, Xh[0]*Xh[1], Xh[0]*Xh[2]],
+                        [Xh[1]*Xh[0], Xh[1]**2, Xh[1]*Xh[2]],
+                        [Xh[2]*Xh[0], Xh[2]*Xh[1], Xh[2]**2]])
+        actual = f(Xh)
+        assert numpy.allclose(actual, expected)
 
 
 def test_lambdify_transl():

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4,14 +4,13 @@ from typing import Any
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic
-from sympy.core.compatibility import (
-    Callable, NotIterable, as_int, is_sequence)
+from sympy.core.compatibility import Callable, as_int, is_sequence
 from sympy.core.decorators import deprecated
 from sympy.core.expr import Expr
 from sympy.core.numbers import mod_inverse
 from sympy.core.power import Pow
 from sympy.core.singleton import S
-from sympy.core.symbol import Dummy, Symbol, _uniquely_named_symbol, symbols
+from sympy.core.symbol import Dummy, _uniquely_named_symbol, symbols
 from sympy.core.sympify import sympify
 from sympy.functions import exp, factorial, log
 from sympy.functions.elementary.miscellaneous import Max, Min, sqrt

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -54,8 +54,8 @@ from .solvers import (
     _cholesky_solve, _LDLsolve, _LUsolve, _QRsolve, _gauss_jordan_solve)
 
 
-class DeferredVector(Symbol, NotIterable):
-    """A vector whose components are deferred (e.g. for use with lambdify)
+def DeferredVector(*args, **kwargs):
+    """A vector whose components are deferred.
 
     Examples
     ========
@@ -64,25 +64,22 @@ class DeferredVector(Symbol, NotIterable):
     >>> X = DeferredVector( 'X' )
     >>> X
     X
-    >>> expr = (X[0] + 2, X[2] + 3)
-    >>> func = lambdify( X, expr)
-    >>> func( [1, 2, 3] )
+
+    Using DeferredVector with lambdify:
+
+    >>> expr = X[0] + 2, X[2] + 3
+    >>> func = lambdify(X, expr)
+    >>> func([1, 2, 3])
     (3, 6)
     """
-
-    def __getitem__(self, i):
-        if i == -0:
-            i = 0
-        if i < 0:
-            raise IndexError('DeferredVector index out of range')
-        component_name = '%s[%d]' % (self.name, i)
-        return Symbol(component_name)
-
-    def __str__(self):
-        return sstr(self)
-
-    def __repr__(self):
-        return "DeferredVector('%s')" % self.name
+    from sympy.tensor.indexed import IndexedBase
+    SymPyDeprecationWarning(
+        feature="DeferredVector",
+        useinstead="IndexedBase",
+        issue=99999,
+        deprecated_since_version="1.6"
+    ).warn()
+    return IndexedBase(*args, **kwargs)
 
 
 class MatrixDeterminant(MatrixCommon):
@@ -993,8 +990,7 @@ class MatrixBase(MatrixDeprecated,
                         "SymPy supports just 1D and 2D matrices")
 
             # Matrix([1, 2, 3]) or Matrix([[1, 2], [3, 4]])
-            elif is_sequence(args[0]) \
-                    and not isinstance(args[0], DeferredVector):
+            elif is_sequence(args[0]):
                 dat = list(args[0])
                 ismat = lambda i: isinstance(i, MatrixBase) and (
                     evaluate or

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3161,17 +3161,13 @@ def test_rotation_matrices():
 
 
 def test_DeferredVector():
-    assert str(DeferredVector("vector")[4]) == "vector[4]"
-    assert sympify(DeferredVector("d")) == DeferredVector("d")
-    raises(IndexError, lambda: DeferredVector("d")[-1])
-    assert str(DeferredVector("d")) == "d"
-    assert repr(DeferredVector("test")) == "DeferredVector('test')"
-
-def test_DeferredVector_not_iterable():
-    assert not iterable(DeferredVector('X'))
-
-def test_DeferredVector_Matrix():
-    raises(TypeError, lambda: Matrix(DeferredVector("V")))
+    with warns_deprecated_sympy():
+        assert str(DeferredVector("vector")[4]) == "vector[4]"
+        assert sympify(DeferredVector("d")) == DeferredVector("d")
+        assert str(DeferredVector("d")) == "d"
+        assert repr(DeferredVector("test")) == "test"
+        assert not iterable(DeferredVector('X'))
+        raises(TypeError, lambda: Matrix(DeferredVector("V")))
 
 def test_GramSchmidt():
     R = Rational

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -521,7 +521,6 @@ class CodePrinter(StrPrinter):
     _print_ImmutableDenseMatrix = _print_not_supported
     _print_MutableDenseMatrix = _print_not_supported
     _print_MatrixBase = _print_not_supported
-    _print_DeferredVector = _print_not_supported
     _print_NaN = _print_not_supported
     _print_NegativeInfinity = _print_not_supported
     _print_Order = _print_not_supported

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -275,9 +275,6 @@ class StrPrinter(Printer):
                 strslice(expr.rowslice) + ', ' +
                 strslice(expr.colslice) + ']')
 
-    def _print_DeferredVector(self, expr):
-        return expr.name
-
     def _print_Mul(self, expr):
 
         prec = precedence(expr)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -868,7 +868,6 @@ def lambdastr(args, expr, printer=None, dummify=None):
     'lambda _0,_1: (lambda x,y,z: (x + y))(_0,_1[0],_1[1])'
     """
     # Transforming everything to strings.
-    from sympy.matrices import DeferredVector
     from sympy import Dummy, sympify, Symbol, Function, flatten, Derivative, Basic
 
     if printer is not None:
@@ -886,8 +885,6 @@ def lambdastr(args, expr, printer=None, dummify=None):
     def sub_args(args, dummies_dict):
         if isinstance(args, str):
             return args
-        elif isinstance(args, DeferredVector):
-            return str(args)
         elif iterable(args):
             dummies = flatten([sub_args(a, dummies_dict) for a in args])
             return ",".join(str(a) for a in dummies)
@@ -912,7 +909,7 @@ def lambdastr(args, expr, printer=None, dummify=None):
 
     # Transform args
     def isiter(l):
-        return iterable(l, exclude=(str, DeferredVector, NotIterable))
+        return iterable(l, exclude=(str, NotIterable))
 
     def flat_indexes(iterable):
         n = 0
@@ -948,7 +945,7 @@ def lambdastr(args, expr, printer=None, dummify=None):
     else:
         if isinstance(args, str):
             pass
-        elif iterable(args, exclude=DeferredVector):
+        elif iterable(args):
             args = ",".join(str(a) for a in args)
 
     # Transform expr
@@ -1035,7 +1032,6 @@ class _EvaluatorPrinter(object):
         Returns string form of args, and updated expr.
         """
         from sympy import Dummy, Function, flatten, Derivative, ordered, Basic
-        from sympy.matrices import DeferredVector
         from sympy.core.symbol import _uniquely_named_symbol
         from sympy.core.expr import Expr
 
@@ -1049,8 +1045,6 @@ class _EvaluatorPrinter(object):
         for arg, i in reversed(list(ordered(zip(args, range(len(args)))))):
             if iterable(arg):
                 s, expr = self._preprocess(arg, expr)
-            elif isinstance(arg, DeferredVector):
-                s = str(arg)
             elif isinstance(arg, Basic) and arg.is_symbol:
                 s = self._argrepr(arg)
                 if dummify or not self._is_safe_ident(s):
@@ -1069,7 +1063,6 @@ class _EvaluatorPrinter(object):
         return argstrs, expr
 
     def _subexpr(self, expr, dummies_dict):
-        from sympy.matrices import DeferredVector
         from sympy import sympify
 
         expr = sympify(expr)
@@ -1077,9 +1070,7 @@ class _EvaluatorPrinter(object):
         if xreplace is not None:
             expr = xreplace(dummies_dict)
         else:
-            if isinstance(expr, DeferredVector):
-                pass
-            elif isinstance(expr, dict):
+            if isinstance(expr, dict):
                 k = [self._subexpr(sympify(a), dummies_dict) for a in expr.keys()]
                 v = [self._subexpr(sympify(a), dummies_dict) for a in expr.values()]
                 expr = dict(zip(k, v))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #6386
Closes #6788
Closes #7326 

#### Brief description of what is fixed or changed

`DeferredVector` looks like a degraded version of `MatrixSymbol` or `Indexed` which is not maintained actively and improved any more.

Although I'm aware that switching to `Indexed` can be not perfect because `Indexed` allows negative indices while the previous one was not, I think that most of the usage examples (lambdifying with arbitrary array indices) can be switched to `Indexed`.
It also cleans up some code in the `lambdify` and `Matrix` about how to treat the `DeferredVector` as a trivial case. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->