### PR TITLE
Fixed bug in Heuristicgcd for polynomial gcd

### DIFF
--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -68,7 +68,7 @@ def heugcd(f, g):
 
     x = max(min(B, 99*domain.sqrt(B)),
             2*min(f_norm // abs(f.LC),
-                  g_norm // abs(g.LC)) + 2)
+                  g_norm // abs(g.LC)) + 4)
 
     for i in range(0, HEU_GCD_MAX):
         ff = f.evaluate(x0, x)

--- a/sympy/polys/tests/test_heuristicgcd.py
+++ b/sympy/polys/tests/test_heuristicgcd.py
@@ -126,3 +126,16 @@ def test_heugcd_multivariate_integers():
     H, cff, cfg = heugcd(f, g)
 
     assert H == h and H*cff == f and H*cfg == g
+
+def test_issue_10996():
+    R, x, y, z = ring("x,y,z", ZZ)
+
+    f = 12*x**6*y**7*z**3 - 3*x**4*y**9*z**3 + 12*x**3*y**5*z**4
+    g = -48*x**7*y**8*z**3 + 12*x**5*y**10*z**3 - 48*x**5*y**7*z**2 + \
+    36*x**4*y**7*z - 48*x**4*y**6*z**4 + 12*x**3*y**9*z**2 - 48*x**3*y**4 \
+    - 9*x**2*y**9*z - 48*x**2*y**5*z**3 + 12*x*y**6 + 36*x*y**5*z**2 - 48*y**2*z
+
+    H, cff, cfg = heugcd(f, g)
+
+    assert H == 12*x**3*y**4 - 3*x*y**6 + 12*y**2*z
+    assert H*cff == f and H*cfg == g


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixed bug in Heuristicgcd for polynomial gcd
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #10996

#### Brief description of what is fixed or changed
Adding `4` to truncated integer quotient `f_norm // |f.LC|` to preserve the validity of strict inequaltiy `|r| < f_norm / |f.LC| + 1`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed polynomial gcd bug

<!-- END RELEASE NOTES -->