### PR TITLE
Fixed compute_expectation to use non-sympify parameters

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -350,7 +350,6 @@ class ContinuousPSpace(PSpace):
         else:
             rvs = frozenset(rvs)
 
-        expr = _sympify(expr)
         expr = expr.xreplace(dict((rv, rv.symbol) for rv in rvs))
 
         domain_symbols = frozenset(rv.symbol for rv in rvs)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -18,6 +18,7 @@ from sympy.functions.special.delta_functions import DiracDelta
 from sympy.polys.polyerrors import PolynomialError
 from sympy.solvers.solveset import solveset
 from sympy.solvers.inequalities import reduce_rational_inequalities
+from sympy.core.sympify import _sympify
 from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain,
         ProductDomain, PSpace, SinglePSpace, random_symbols, NamedArgsMixin)
 import random
@@ -349,6 +350,7 @@ class ContinuousPSpace(PSpace):
         else:
             rvs = frozenset(rvs)
 
+        expr = _sympify(expr)
         expr = expr.xreplace(dict((rv, rv.symbol) for rv in rvs))
 
         domain_symbols = frozenset(rv.symbol for rv in rvs)
@@ -518,6 +520,7 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         if self.value not in rvs:
             return expr
 
+        expr = _sympify(expr)
         expr = expr.xreplace(dict((rv, rv.symbol) for rv in rvs))
 
         x = self.value.symbol

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -16,6 +16,7 @@ from sympy.sets.fancysets import Range, FiniteSet
 from sympy.sets.sets import Union
 from sympy.sets.contains import Contains
 from sympy.utilities import filldedent
+from sympy.core.sympify import _sympify
 import random
 
 
@@ -330,6 +331,7 @@ class SingleDiscretePSpace(DiscretePSpace, SinglePSpace):
         if self.value not in rvs:
             return expr
 
+        expr = _sympify(expr)
         expr = expr.xreplace(dict((rv, rv.symbol) for rv in rvs))
 
         x = self.value.symbol

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -18,6 +18,7 @@ from sympy import (Basic, Symbol, cacheit, sympify, Mul,
 from sympy.core.containers import Dict
 from sympy.core.logic import Logic
 from sympy.core.relational import Relational
+from sympy.core.sympify import _sympify
 from sympy.sets.sets import FiniteSet
 from sympy.stats.rv import (RandomDomain, ProductDomain, ConditionalDomain,
                             PSpace, IndependentProductPSpace, SinglePSpace, random_symbols,
@@ -298,6 +299,7 @@ class FinitePSpace(PSpace):
 
     def compute_expectation(self, expr, rvs=None, **kwargs):
         rvs = rvs or self.values
+        expr = _sympify(expr)
         expr = rv_subs(expr, rvs)
         probs = [self.prob_of(elem) for elem in self.domain]
         if isinstance(expr, (Logic, Relational)):
@@ -453,6 +455,8 @@ class SingleFinitePSpace(SinglePSpace, FinitePSpace):
             func = self.pmf(k) * k if cond != True else self.pmf(k) * expr
             return Sum(Piecewise((func, cond), (S.Zero, True)),
                 (k, self.distribution.low, self.distribution.high)).doit()
+
+        expr = _sympify(expr)
         expr = rv_subs(expr, rvs)
         return FinitePSpace(self.domain, self.distribution).compute_expectation(expr, rvs, **kwargs)
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -299,7 +299,6 @@ class FinitePSpace(PSpace):
 
     def compute_expectation(self, expr, rvs=None, **kwargs):
         rvs = rvs or self.values
-        expr = _sympify(expr)
         expr = rv_subs(expr, rvs)
         probs = [self.prob_of(elem) for elem in self.domain]
         if isinstance(expr, (Logic, Relational)):

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -46,6 +46,8 @@ def test_single_normal():
     assert quantile(Y)(x) == Intersection(S.Reals, FiniteSet(sqrt(2)*sigma*(sqrt(2)*mu/(2*sigma) + erfinv(2*x - 1))))
     assert E(X, Eq(X, mu)) == mu
 
+    # issue 8248
+    assert X.pspace.compute_expectation(1).doit() == 1
 
 def test_conditional_1d():
     X = Normal('x', 0, 1)

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -33,7 +33,8 @@ def test_Poisson():
     assert density(x) == PoissonDistribution(l)
     assert isinstance(E(x, evaluate=False), Sum)
     assert isinstance(E(2*x, evaluate=False), Sum)
-
+    # issue 8248
+    assert x.pspace.compute_expectation(1) == 1
 
 def test_GeometricDistribution():
     p = S.One / 5

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -192,6 +192,9 @@ def test_bernoulli():
     raises(ValueError, lambda: Bernoulli('B', 1.5))
     raises(ValueError, lambda: Bernoulli('B', -0.5))
 
+    #issue 8248
+    assert X.pspace.compute_expectation(1) == 1
+
 def test_cdf():
     D = Die('D', 6)
     o = S.One


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixed compute_expectation to use non-sympify parameters
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #8248

#### Brief description of what is fixed or changed
Before fixing:
```
>>> from sympy.stats import *
>>> Poisson('p', 3).pspace.compute_expectation(1)
Traceback (most recent call last):
  ...
AttributeError: 'int' object has no attribute 'xreplace'
```

After fixing:
```
>>> from sympy.stats import *
>>> Poisson('p', 3).pspace.compute_expectation(1)
1
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * sympify expression in compute_expectation
<!-- END RELEASE NOTES -->