### PR TITLE
Fixes bug in Series

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -716,17 +716,15 @@ class Function(Application, Expr):
             return e1.nseries(x, n=n, logx=logx)
         arg = self.args[0]
         l = []
+        i = 0
         g = None
-        # try to predict a number of terms needed
-        nterms = n + 2
-        cf = Order(arg.as_leading_term(x), x).getn()
-        if cf != 0:
-            nterms = int(nterms / cf)
-        for i in range(nterms):
+        while len(l) <= n:
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
-            l.append(g)
-        return Add(*l) + Order(x**n, x)
+            if g:
+                l.append(g)
+            i += 1
+        return Add(*l) + Order(g,x)
 
     def fdiff(self, argindex=1):
         """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -721,7 +721,7 @@ class Function(Application, Expr):
         nterms = n + 2
         cf = Order(arg.as_leading_term(x), x).getn()
         if cf != 0:
-            nterms = (n + cf - 1) // cf
+            nterms = (n/cf).ceiling()
         for i in range(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -716,15 +716,17 @@ class Function(Application, Expr):
             return e1.nseries(x, n=n, logx=logx)
         arg = self.args[0]
         l = []
-        i = 0
         g = None
-        while len(l) <= n:
+        # try to predict a number of terms needed
+        nterms = n + 2
+        cf = Order(arg.as_leading_term(x), x).getn()
+        if cf != 0:
+            nterms = (n + cf - 1) // cf
+        for i in range(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
-            if g:
-                l.append(g)
-            i += 1
-        return Add(*l) + Order(g,x)
+            l.append(g)
+        return Add(*l) + Order(x**n, x)
 
     def fdiff(self, argindex=1):
         """

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1350,3 +1350,8 @@ def test_Derivative_free_symbols():
     f = Function('f')
     n = Symbol('n', integer=True, positive=True)
     assert diff(f(x), (x, n)).free_symbols == {n, x}
+
+
+def test_issue_10503():
+    f=exp(x**3)*cos(x**6)
+    assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1353,5 +1353,5 @@ def test_Derivative_free_symbols():
 
 
 def test_issue_10503():
-    f=exp(x**3)*cos(x**6)
+    f = exp(x**3)*cos(x**6)
     assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#Fixes #10503
#### Brief description of what is fixed or changed
Now, 
`f=exp(x**3)*cos(x**6)`
`f.series(x, 0, 14)`
return correct result.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->