### PR TITLE
2**oo / pi**oo now gives correct result

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -506,7 +506,7 @@ class Pow(Expr):
             if self.base.is_extended_nonnegative:
                 return True
         elif self.base.is_positive:
-            if self.exp.is_extended_real:
+            if self.exp.is_real:
                 return True
         elif self.base.is_extended_negative:
             if self.exp.is_even:

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -9,7 +9,7 @@ from sympy.functions.special.error_functions import erf
 from sympy.functions.elementary.trigonometric import (
     sin, cos, tan, sec, csc, sinh, cosh, tanh, atan)
 from sympy.series.order import O
-from sympy.core.expr import unchanged 
+from sympy.core.expr import unchanged
 
 
 def test_rational():

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -507,3 +507,8 @@ def test_issue_17450():
 
 def test_issue_18190():
     assert sqrt(1 / tan(1 + I)) == 1 / sqrt(tan(1 + I))
+
+
+def test_issue_18509():
+    assert 2**oo / pi**oo == oo*pi**(-oo)
+    assert (1/pi**oo).is_extended_positive == False

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -9,6 +9,7 @@ from sympy.functions.special.error_functions import erf
 from sympy.functions.elementary.trigonometric import (
     sin, cos, tan, sec, csc, sinh, cosh, tanh, atan)
 from sympy.series.order import O
+from sympy.core.expr import unchanged 
 
 
 def test_rational():
@@ -510,5 +511,5 @@ def test_issue_18190():
 
 
 def test_issue_18509():
-    assert 2**oo / pi**oo == oo*pi**(-oo)
+    assert unchanged(Mul, oo, 1/pi**oo)
     assert (1/pi**oo).is_extended_positive == False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #18509 
#### Brief description of what is fixed or changed
Now,
```
>>> 2**oo / pi**oo
oo*pi**(-oo)
>>> (1/pi**oo).is_extended_positive
False
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->