### PR TITLE
Updated the docstring of some functions in util.py

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -728,6 +728,13 @@ def stationary_points(f, symbol, domain=S.Reals):
         The domain over which the stationary points have to be checked.
         If unspecified, S.Reals will be the default domain.
 
+    Returns
+    =======
+
+    Set
+        A set of stationary points for the function. If there are no
+        stationary point, an EmptySet is returned.
+
     Examples
     ========
 
@@ -773,6 +780,12 @@ def maximum(f, symbol, domain=S.Reals):
         The domain over which the maximum have to be checked.
         If unspecified, then Global maximum is returned.
 
+    Returns
+    =======
+
+    number
+        Maximum value of the function in given domain.
+
     Examples
     ========
 
@@ -816,6 +829,12 @@ def minimum(f, symbol, domain=S.Reals):
     domain : Interval
         The domain over which the minimum have to be checked.
         If unspecified, then Global minimum is returned.
+
+    Returns
+    =======
+
+    number
+        Minimum value of the function in the given domain.
 
     Examples
     ========
@@ -1539,6 +1558,19 @@ class AccumulationBounds(AtomicExpr):
         """
         Returns the intersection of 'self' and 'other'.
         Here other can be an instance of FiniteSet or AccumulationBounds.
+
+        Parameters
+        ==========
+
+        other: AccumulationBounds
+             Another AccumulationBounds object with which the intersection
+             has to be computed.
+
+        Returns
+        =======
+
+        AccumulationBounds
+            Intersection of 'self' and 'other'.
 
         Examples
         ========


### PR DESCRIPTION
#### References to other Issues or PRs
Worked on [3rd point ](https://github.com/sympy/sympy/blob/master/sympy/calculus/util.py) for issue #15370 

#### Brief description of what is fixed or changed

--> Updated docstring of maximum, minimum, stationary_points and AccumBounds.intersection of calculus/util.py to numpy docstring format

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Updated docstrings of maximum, minimum, stationary_points and AccumBounds.intersection 
<!-- END RELEASE NOTES -->