### PR TITLE
Update internal diophantine solvers to have consistent return types

### DIFF
--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -51,6 +51,96 @@ diop_known = {
     "univariate"}
 
 
+class DiophantineSolutionSet(set):
+    """
+    Container for a set of solutions to a particular diophantine equation.
+
+    The base representation is a set of tuples representing each of the solutions.
+
+    Parameters
+    ==========
+
+    symbols : list
+        List of free symbols in the original equation.
+    parameters: list (optional)
+        List of parameters to be used in the solution
+
+    Examples
+    ========
+
+    Adding solutions:
+
+        >>> from sympy.solvers.diophantine.diophantine import DiophantineSolutionSet
+        >>> from sympy.abc import x, y, t, u
+        >>> s1 = DiophantineSolutionSet([x, y], [t, u])
+        >>> s1
+        set()
+        >>> s1.add_solution(2, 3)
+        >>> s1.add_solution(-1)
+        >>> s1
+        {(-1, u), (2, 3)}
+        >>> s2 = DiophantineSolutionSet([x, y], [t, u])
+        >>> s2.add_solution(3, 4)
+        >>> s1.update(s2)
+        >>> s1
+        {(-1, u), (2, 3), (3, 4)}
+
+    Conversion of solutions into dicts:
+
+        >>> list(s1.dict_iterator())
+        [{x: -1, y: u}, {x: 2, y: 3}, {x: 3, y: 4}]
+
+    Substituting values:
+
+        >>> s3 = DiophantineSolutionSet([x, y], [t, u])
+        >>> s3.add_solution(t**2, t + u)
+        >>> s3
+        {(t**2, t + u)}
+        >>> s3.substitute_parameters(2, 3)
+        {(4, 5)}
+        >>> s3.substitute_parameters(-1)
+        {(1, u - 1)}
+    """
+
+    def __init__(self, symbols_list, parameters=None):
+        super().__init__()
+        self.symbols = symbols_list
+
+        if parameters is None:
+            self.parameters = symbols('%s1:%i' % ('t', len(self.symbols) + 1), integer=True)
+        else:
+            self.parameters = parameters
+
+    def _pad_solution(self, solution):
+        assert len(solution) <= len(self.parameters)
+
+        result = list(solution)
+        while len(result) < len(self.parameters):
+            result.append(self.parameters[len(result)])
+        return tuple(result)
+
+    def add_solution(self, *solution):
+        self.add(self._pad_solution(solution))
+
+    def update(self, *s):
+        for sol_group in s:
+            for sol in sol_group:
+                self.add_solution(*sol)
+
+    def dict_iterator(self):
+        for solution in sorted(self):
+            yield dict(zip(self.symbols, solution))
+
+    def substitute_parameters(self, *values):
+        assert len(values) <= len(self.parameters)
+
+        result = DiophantineSolutionSet(self.symbols, self.parameters)
+        subs_dict = dict(zip(self.parameters, values))
+        for solution in self:
+            result.add_solution(*[s.subs(subs_dict) for s in solution])
+        return result
+
+
 def _is_int(i):
     try:
         as_int(i)
@@ -436,36 +526,28 @@ def diop_solve(eq, param=symbols("t", integer=True)):
     var, coeff, eq_type = classify_diop(eq, _dict=False)
 
     if eq_type == "linear":
-        return _diop_linear(var, coeff, param)
+        return diop_linear(eq, param)
 
     elif eq_type == "binary_quadratic":
-        return _diop_quadratic(var, coeff, param)
+        return diop_quadratic(eq, param)
 
     elif eq_type == "homogeneous_ternary_quadratic":
-        x_0, y_0, z_0 = _diop_ternary_quadratic(var, coeff)
-        return _parametrize_ternary_quadratic(
-            (x_0, y_0, z_0), var, coeff)
+        return diop_ternary_quadratic(eq, parameterize=True)
 
     elif eq_type == "homogeneous_ternary_quadratic_normal":
-        x_0, y_0, z_0 = _diop_ternary_quadratic_normal(var, coeff)
-        return _parametrize_ternary_quadratic(
-            (x_0, y_0, z_0), var, coeff)
+        return diop_ternary_quadratic_normal(eq, parameterize=True)
 
     elif eq_type == "general_pythagorean":
-        return _diop_general_pythagorean(var, coeff, param)
+        return diop_general_pythagorean(eq, param)
 
     elif eq_type == "univariate":
-        return set([(int(i),) for i in solveset_real(
-            eq, var[0]).intersect(S.Integers)])
+        return diop_univariate(eq)
 
     elif eq_type == "general_sum_of_squares":
-        return _diop_general_sum_of_squares(var, -int(coeff[1]), limit=S.Infinity)
+        return diop_general_sum_of_squares(eq, limit=S.Infinity)
 
     elif eq_type == "general_sum_of_even_powers":
-        for k in coeff.keys():
-            if k.is_Pow and coeff[k]:
-                p = k.exp
-        return _diop_general_sum_of_even_powers(var, p, -int(coeff[1]), limit=S.Infinity)
+        return diop_general_sum_of_even_powers(eq, limit=S.Infinity)
 
     if eq_type is not None and eq_type not in diop_known:
             raise ValueError(filldedent('''
@@ -641,7 +723,15 @@ def diop_linear(eq, param=symbols("t", integer=True)):
     var, coeff, diop_type = classify_diop(eq, _dict=False)
 
     if diop_type == "linear":
-        return _diop_linear(var, coeff, param)
+        result = _diop_linear(var, coeff, param)
+
+        if param is None:
+            result = result.substitute_parameters(*[0]*len(result.parameters))
+
+        if len(result) > 0:
+            return list(result)[0]
+        else:
+            return tuple([None] * len(result.parameters))
 
 
 def _diop_linear(var, coeff, param):
@@ -667,12 +757,15 @@ def _diop_linear(var, coeff, param):
         temp = str(param) + "_%i"
         params = [symbols(temp % i, integer=True) for i in range(len(var))]
 
+    result = DiophantineSolutionSet(var, params)
+
     if len(var) == 1:
         q, r = divmod(c, coeff[var[0]])
         if not r:
-            return (q,)
+            result.add_solution(q)
+            return result
         else:
-            return (None,)
+            return result
 
     '''
     base_solution_linear() can solve diophantine equations of the form:
@@ -800,7 +893,7 @@ def _diop_linear(var, coeff, param):
 
             if p is S.One:
                 if None in sol:
-                    return tuple([None]*len(var))
+                    return result
             else:
                 # convert a + b*pnew -> a*p + b*pnew
                 if isinstance(sol_x, Add):
@@ -818,7 +911,9 @@ def _diop_linear(var, coeff, param):
     if param is None:
         # just keep the additive constant (i.e. replace t with 0)
         solutions = [i.as_coeff_Add()[0] for i in solutions]
-    return tuple(solutions)
+
+    result.update([solutions])
+    return result
 
 
 def base_solution_linear(c, a, b, t=None):
@@ -875,6 +970,41 @@ def base_solution_linear(c, a, b, t=None):
             return (None, None)
 
 
+def diop_univariate(eq):
+    """
+    Solves a univariate diophantine equations.
+
+    A univariate diophantine equation is an equation of the form
+    `a_{0} + a_{1}x + a_{2}x^2 + .. + a_{n}x^n = 0` where `a_{1}, a_{2}, ..a_{n}` are
+    integer constants and `x` is an integer variable.
+
+    Usage
+    =====
+
+    ``diop_univariate(eq)``: Returns a set containing solutions to the
+    diophantine equation ``eq``.
+
+    Details
+    =======
+
+    ``eq`` is a univariate diophantine equation which is assumed to be zero.
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.diophantine.diophantine import diop_univariate
+    >>> from sympy.abc import x
+    >>> diop_univariate((x - 2)*(x - 3)**2) # solves equation (x - 2)*(x - 3)**2 == 0
+    {(2,), (3,)}
+
+    """
+    var, coeff, diop_type = classify_diop(eq, _dict=False)
+
+    if diop_type == "univariate":
+        return set([(int(i),) for i in solveset_real(
+            eq, var[0]).intersect(S.Integers)])
+
+
 def divisible(a, b):
     """
     Returns `True` if ``a`` is divisible by ``b`` and `False` otherwise.
@@ -928,10 +1058,12 @@ def diop_quadratic(eq, param=symbols("t", integer=True)):
     var, coeff, diop_type = classify_diop(eq, _dict=False)
 
     if diop_type == "binary_quadratic":
-        return _diop_quadratic(var, coeff, param)
+        return set(_diop_quadratic(var, coeff, param))
 
 
 def _diop_quadratic(var, coeff, t):
+
+    u = Symbol('u', integer=True)
 
     x, y = var
 
@@ -949,17 +1081,18 @@ def _diop_quadratic(var, coeff, t):
     # We consider two cases; DE - BF = 0 and DE - BF != 0
     # More details, http://www.alpertron.com.ar/METHODS.HTM#SHyperb
 
-    sol = set([])
+    result = DiophantineSolutionSet(var, [t, u])
+
     discr = B**2 - 4*A*C
     if A == 0 and C == 0 and B != 0:
 
         if D*E - B*F == 0:
             q, r = divmod(E, B)
             if not r:
-                sol.add((-q, t))
+                result.add_solution(-q, t)
             q, r = divmod(D, B)
             if not r:
-                sol.add((t, -q))
+                result.add_solution(t, -q)
         else:
             div = divisors(D*E - B*F)
             div = div + [-term for term in div]
@@ -970,7 +1103,7 @@ def _diop_quadratic(var, coeff, t):
                     if not r:
                         y0, r = divmod(q - D, B)
                         if not r:
-                            sol.add((x0, y0))
+                            result.add_solution(x0, y0)
 
     # (2) Parabolic case: B**2 - 4*A*C = 0
     # There are two subcases to be considered in this case.
@@ -982,7 +1115,7 @@ def _diop_quadratic(var, coeff, t):
         if A == 0:
             s = _diop_quadratic([y, x], coeff, t)
             for soln in s:
-                sol.add((soln[1], soln[0]))
+                result.add_solution(soln[1], soln[0])
 
         else:
             g = sign(A)*igcd(A, C)
@@ -999,7 +1132,7 @@ def _diop_quadratic(var, coeff, t):
                 roots = solveset_real(eq, z).intersect(S.Integers)
                 for root in roots:
                     ans = diop_solve(sqa*x + e*sqc*y - root)
-                    sol.add((ans[0], ans[1]))
+                    result.add_solution(ans[0], ans[1])
 
             elif _is_int(c):
                 solve_x = lambda u: -e*sqc*g*_c*t**2 - (E + 2*e*sqc*g*u)*t\
@@ -1012,7 +1145,7 @@ def _diop_quadratic(var, coeff, t):
                     # Check if the coefficients of y and x obtained are integers or not
                     if (divisible(sqa*g*z0**2 + D*z0 + sqa*F, _c) and
                             divisible(e*sqc*g*z0**2 + E*z0 + e*sqc*F, _c)):
-                        sol.add((solve_x(z0), solve_y(z0)))
+                        result.add_solution(solve_x(z0), solve_y(z0))
 
     # (3) Method used when B**2 - 4*A*C is a square, is described in p. 6 of the below paper
     # by John P. Robertson.
@@ -1036,15 +1169,15 @@ def _diop_quadratic(var, coeff, t):
                 if isinstance(s0, Symbol) or isinstance(t0, Symbol):
                     if check_param(x_0, y_0, 4*A*r, t) != (None, None):
                         ans = check_param(x_0, y_0, 4*A*r, t)
-                        sol.add((ans[0], ans[1]))
+                        result.add_solution(ans[0], ans[1])
                 elif x_0.is_Integer and y_0.is_Integer:
                     if is_solution_quad(var, coeff, x_0, y_0):
-                        sol.add((x_0, y_0))
+                        result.add_solution(x_0, y_0)
 
         else:
             s = _diop_quadratic(var[::-1], coeff, t)  # Interchange x and y
-            while s:                                  #         |
-                sol.add(s.pop()[::-1])  # and solution <--------+
+            while s:
+                result.add_solution(*s.pop()[::-1]) # and solution <--------+
 
 
     # (4) B**2 - 4*A*C > 0 and B**2 - 4*A*C not a square or B**2 - 4*A*C < 0
@@ -1061,7 +1194,7 @@ def _diop_quadratic(var, coeff, t):
                     for y in [-y0, y0]:
                         s = P*Matrix([x, y]) + Q
                         try:
-                            sol.add(tuple([as_int(_) for _ in s]))
+                            result.add_solution(*[as_int(_) for _ in s])
                         except ValueError:
                             pass
         else:
@@ -1082,7 +1215,7 @@ def _diop_quadratic(var, coeff, t):
                     x_n = _mexpand(S(_a + _b)/2)
                     y_n = _mexpand(S(_a - _b)/(2*sqrt(D)))
                     s = P*Matrix([x_n, y_n]) + Q
-                    sol.add(tuple(s))
+                    result.add_solution(*s)
 
             else:
                 L = ilcm(*[_.q for _ in P[:4] + Q[:2]])
@@ -1105,11 +1238,11 @@ def _diop_quadratic(var, coeff, t):
                             Xt = S(_a + _b)/2
                             Yt = S(_a - _b)/(2*sqrt(D))
                             s = P*Matrix([Xt, Yt]) + Q
-                            sol.add(tuple(s))
+                            result.add_solution(*s)
 
                         X, Y = X*T + D*U*Y, X*U + Y*T
 
-    return sol
+    return result
 
 
 def is_solution_quad(var, coeff, u, v):
@@ -1928,7 +2061,7 @@ def check_param(x, y, a, t):
     return diop_solve(eq, t)
 
 
-def diop_ternary_quadratic(eq):
+def diop_ternary_quadratic(eq, parameterize=False):
     """
     Solves the general quadratic ternary form,
     `ax^2 + by^2 + cz^2 + fxy + gyz + hxz = 0`.
@@ -1967,8 +2100,16 @@ def diop_ternary_quadratic(eq):
     if diop_type in (
             "homogeneous_ternary_quadratic",
             "homogeneous_ternary_quadratic_normal"):
-        return _diop_ternary_quadratic(var, coeff)
+        sol = _diop_ternary_quadratic(var, coeff)
+        if len(sol) > 0:
+            x_0, y_0, z_0 = list(sol)[0]
+        else:
+            x_0, y_0, z_0 = None, None, None
 
+        if parameterize:
+            return _parametrize_ternary_quadratic(
+                (x_0, y_0, z_0), var, coeff)
+        return x_0, y_0, z_0
 
 def _diop_ternary_quadratic(_var, coeff):
 
@@ -1984,6 +2125,13 @@ def _diop_ternary_quadratic(_var, coeff):
     # using methods for binary quadratic diophantine equations. Let's select the
     # solution which minimizes |x| + |z|
 
+    result = DiophantineSolutionSet(var)
+
+    def unpack_sol(sol):
+        if len(sol) > 0:
+            return list(sol)[0]
+        return None, None, None
+
     if not any(coeff[i**2] for i in var):
         if coeff[x*z]:
             sols = diophantine(coeff[x*y]*x + coeff[y*z]*z - x*z)
@@ -1996,23 +2144,25 @@ def _diop_ternary_quadratic(_var, coeff):
                     s = r
                     min_sum = m
 
-            x_0, y_0, z_0 = _remove_gcd(s[0], -coeff[x*z], s[1])
+            result.add_solution(*_remove_gcd(s[0], -coeff[x*z], s[1]))
+            return result
 
         else:
             var[0], var[1] = _var[1], _var[0]
-            y_0, x_0, z_0 = _diop_ternary_quadratic(var, coeff)
-
-        return x_0, y_0, z_0
+            y_0, x_0, z_0 = unpack_sol(_diop_ternary_quadratic(var, coeff))
+            if x_0 is not None:
+                result.add_solution(x_0, y_0, z_0)
+            return result
 
     if coeff[x**2] == 0:
         # If the coefficient of x is zero change the variables
         if coeff[y**2] == 0:
             var[0], var[2] = _var[2], _var[0]
-            z_0, y_0, x_0 = _diop_ternary_quadratic(var, coeff)
+            z_0, y_0, x_0 = unpack_sol(_diop_ternary_quadratic(var, coeff))
 
         else:
             var[0], var[1] = _var[1], _var[0]
-            y_0, x_0, z_0 = _diop_ternary_quadratic(var, coeff)
+            y_0, x_0, z_0 = unpack_sol(_diop_ternary_quadratic(var, coeff))
 
     else:
         if coeff[x*y] or coeff[x*z]:
@@ -2033,10 +2183,10 @@ def _diop_ternary_quadratic(_var, coeff):
             _coeff[x*y] = 0
             _coeff[x*z] = 0
 
-            x_0, y_0, z_0 = _diop_ternary_quadratic(var, _coeff)
+            x_0, y_0, z_0 = unpack_sol(_diop_ternary_quadratic(var, _coeff))
 
             if x_0 is None:
-                return (None, None, None)
+                return result
 
             p, q = _rational_pq(B*y_0 + C*z_0, 2*A)
             x_0, y_0, z_0 = x_0*q - p, y_0*q, z_0*q
@@ -2055,18 +2205,22 @@ def _diop_ternary_quadratic(_var, coeff):
                 else:
                     # Ax**2 + E*y*z + F*z**2  = 0
                     var[0], var[2] = _var[2], _var[0]
-                    z_0, y_0, x_0 = _diop_ternary_quadratic(var, coeff)
+                    z_0, y_0, x_0 = unpack_sol(_diop_ternary_quadratic(var, coeff))
 
             else:
                 # A*x**2 + D*y**2 + E*y*z + F*z**2 = 0, C may be zero
                 var[0], var[1] = _var[1], _var[0]
-                y_0, x_0, z_0 = _diop_ternary_quadratic(var, coeff)
+                y_0, x_0, z_0 = unpack_sol(_diop_ternary_quadratic(var, coeff))
 
         else:
             # Ax**2 + D*y**2 + F*z**2 = 0, C may be zero
-            x_0, y_0, z_0 = _diop_ternary_quadratic_normal(var, coeff)
+            x_0, y_0, z_0 = unpack_sol(_diop_ternary_quadratic_normal(var, coeff))
 
-    return _remove_gcd(x_0, y_0, z_0)
+    if x_0 is None:
+        return result
+
+    result.add_solution(*_remove_gcd(x_0, y_0, z_0))
+    return result
 
 
 def transformation_to_normal(eq):
@@ -2229,7 +2383,7 @@ def parametrize_ternary_quadratic(eq):
     if diop_type in (
             "homogeneous_ternary_quadratic",
             "homogeneous_ternary_quadratic_normal"):
-        x_0, y_0, z_0 = _diop_ternary_quadratic(var, coeff)
+        x_0, y_0, z_0 = list(_diop_ternary_quadratic(var, coeff))[0]
         return _parametrize_ternary_quadratic(
             (x_0, y_0, z_0), var, coeff)
 
@@ -2274,7 +2428,7 @@ def _parametrize_ternary_quadratic(solution, _var, coeff):
     return _remove_gcd(x, y, z)
 
 
-def diop_ternary_quadratic_normal(eq):
+def diop_ternary_quadratic_normal(eq, parameterize=False):
     """
     Solves the quadratic ternary diophantine equation,
     `ax^2 + by^2 + cz^2 = 0`.
@@ -2304,8 +2458,15 @@ def diop_ternary_quadratic_normal(eq):
     """
     var, coeff, diop_type = classify_diop(eq, _dict=False)
     if diop_type == "homogeneous_ternary_quadratic_normal":
-        return _diop_ternary_quadratic_normal(var, coeff)
-
+        sol = _diop_ternary_quadratic_normal(var, coeff)
+        if len(sol) > 0:
+            x_0, y_0, z_0 = list(sol)[0]
+        else:
+            x_0, y_0, z_0 = None, None, None
+        if parameterize:
+            return _parametrize_ternary_quadratic(
+                (x_0, y_0, z_0), var, coeff)
+        return x_0, y_0, z_0
 
 def _diop_ternary_quadratic_normal(var, coeff):
 
@@ -2329,15 +2490,17 @@ def _diop_ternary_quadratic_normal(var, coeff):
     A = -a_2*c_2
     B = -b_2*c_2
 
+    result = DiophantineSolutionSet(var)
+
     # If following two conditions are satisfied then there are no solutions
     if A < 0 and B < 0:
-        return (None, None, None)
+        return result
 
     if (
             sqrt_mod(-b_2*c_2, a_2) is None or
             sqrt_mod(-c_2*a_2, b_2) is None or
             sqrt_mod(-a_2*b_2, c_2) is None):
-        return (None, None, None)
+        return result
 
     z_0, x_0, y_0 = descent(A, B)
 
@@ -2365,7 +2528,8 @@ def _diop_ternary_quadratic_normal(var, coeff):
     y_0 = abs(y_0*sq_lcm//sqf_of_b)
     z_0 = abs(z_0*sq_lcm//sqf_of_c)
 
-    return _remove_gcd(x_0, y_0, z_0)
+    result.add_solution(*_remove_gcd(x_0, y_0, z_0))
+    return result
 
 
 def sqf_normal(a, b, c, steps=False):
@@ -2742,7 +2906,7 @@ def diop_general_pythagorean(eq, param=symbols("m", integer=True)):
     var, coeff, diop_type  = classify_diop(eq, _dict=False)
 
     if diop_type == "general_pythagorean":
-        return _diop_general_pythagorean(var, coeff, param)
+        return list(_diop_general_pythagorean(var, coeff, param))[0]
 
 
 def _diop_general_pythagorean(var, coeff, t):
@@ -2775,7 +2939,9 @@ def _diop_general_pythagorean(var, coeff, t):
     for i, v in enumerate(var):
         sol[i] = (lcm*sol[i]) / sqrt(abs(coeff[v**2]))
 
-    return tuple(sol)
+    result = DiophantineSolutionSet(var)
+    result.add_solution(*sol)
+    return result
 
 
 def diop_general_sum_of_squares(eq, limit=1):
@@ -2815,7 +2981,7 @@ def diop_general_sum_of_squares(eq, limit=1):
     var, coeff, diop_type = classify_diop(eq, _dict=False)
 
     if diop_type == "general_sum_of_squares":
-        return _diop_general_sum_of_squares(var, -coeff[1], limit)
+        return set(_diop_general_sum_of_squares(var, -int(coeff[1]), limit))
 
 
 def _diop_general_sum_of_squares(var, k, limit=1):
@@ -2824,10 +2990,10 @@ def _diop_general_sum_of_squares(var, k, limit=1):
     if n < 3:
         raise ValueError('n must be greater than 2')
 
-    s = set()
+    result = DiophantineSolutionSet(var)
 
     if k < 0 or limit < 1:
-        return s
+        return result
 
     sign = [-1 if x.is_nonpositive else 1 for x in var]
     negs = sign.count(-1) != 0
@@ -2835,13 +3001,13 @@ def _diop_general_sum_of_squares(var, k, limit=1):
     took = 0
     for t in sum_of_squares(k, n, zeros=True):
         if negs:
-            s.add(tuple([sign[i]*j for i, j in enumerate(t)]))
+            result.add_solution(*[sign[i]*j for i, j in enumerate(t)])
         else:
-            s.add(t)
+            result.add_solution(*t)
         took += 1
         if took == limit:
             break
-    return s
+    return result
 
 
 def diop_general_sum_of_even_powers(eq, limit=1):
@@ -2877,17 +3043,17 @@ def diop_general_sum_of_even_powers(eq, limit=1):
         for k in coeff.keys():
             if k.is_Pow and coeff[k]:
                 p = k.exp
-        return _diop_general_sum_of_even_powers(var, p, -coeff[1], limit)
+        return set(_diop_general_sum_of_even_powers(var, p, -coeff[1], limit))
 
 
 def _diop_general_sum_of_even_powers(var, p, n, limit=1):
     # solves Eq(sum(i**2 for i in var), n)
     k = len(var)
 
-    s = set()
+    result = DiophantineSolutionSet(var)
 
     if n < 0 or limit < 1:
-        return s
+        return result
 
     sign = [-1 if x.is_nonpositive else 1 for x in var]
     negs = sign.count(-1) != 0
@@ -2895,13 +3061,13 @@ def _diop_general_sum_of_even_powers(var, p, n, limit=1):
     took = 0
     for t in power_representation(n, p, k):
         if negs:
-            s.add(tuple([sign[i]*j for i, j in enumerate(t)]))
+            result.add_solution(*[sign[i]*j for i, j in enumerate(t)])
         else:
-            s.add(t)
+            result.add_solution(*t)
         took += 1
         if took == limit:
             break
-    return s
+    return result
 
 
 ## Functions below this comment can be more suitably grouped under

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -76,7 +76,7 @@ class DiophantineSolutionSet(set):
         >>> s1
         set()
         >>> s1.add_solution(2, 3)
-        >>> s1.add_solution(-1)
+        >>> s1.add_solution(-1, u)
         >>> s1
         {(-1, u), (2, 3)}
         >>> s2 = DiophantineSolutionSet([x, y], [t, u])
@@ -111,16 +111,10 @@ class DiophantineSolutionSet(set):
         else:
             self.parameters = parameters
 
-    def _pad_solution(self, solution):
-        result = list(solution)
-        while len(result) < len(self.parameters):
-            result.append(self.parameters[len(result)])
-        return tuple(result)
-
     def add_solution(self, *solution):
-        if len(solution) > len(self.parameters):
-            raise ValueError("Solution has too many values")
-        self.add(self._pad_solution(solution))
+        if len(solution) != len(self.parameters):
+            raise ValueError("Solution is of incorrect length")
+        self.add(solution)
 
     def update(self, *s):
         for sol_group in s:

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -122,6 +122,8 @@ class DiophantineSolutionSet(set):
         else:
             self.parameters = tuple(parameters)
 
+        self.kw_parameter_mapping = {str(p): p for p in self.parameters}
+
     def add(self, solution):
         if len(solution) != len(self.symbols):
             raise ValueError("Solution should have a length of %s, not %s" % (len(self.symbols), len(solution)))
@@ -142,7 +144,11 @@ class DiophantineSolutionSet(set):
         result = DiophantineSolutionSet(self.symbols, self.parameters)
 
         subs_dict = dict(zip(self.parameters, values))
-        subs_dict.update(kw_values)
+
+        for parameter in kw_values:
+            if parameter not in self.kw_parameter_mapping:
+                raise ValueError("Unknown parameter %s specified in substitution" % parameter)
+            subs_dict[self.kw_parameter_mapping[parameter]] = kw_values[parameter]
 
         for solution in self:
             result.add(solution.subs(subs_dict))

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -112,7 +112,7 @@ class DiophantineSolutionSet(set):
             self.parameters = parameters
 
     def add_solution(self, *solution):
-        if len(solution) != len(self.parameters):
+        if len(solution) != len(self.symbols):
             raise ValueError("Solution is of incorrect length")
         self.add(solution)
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -111,12 +111,12 @@ class DiophantineSolutionSet(set):
 
     def __init__(self, symbols_list, parameters=None):
         super().__init__()
-        self.symbols = symbols_list
+        self.symbols = list(symbols_list)
 
         if parameters is None:
             self.parameters = symbols('%s1:%i' % ('t', len(self.symbols) + 1), integer=True)
         else:
-            self.parameters = parameters
+            self.parameters = list(parameters)
 
         self.kw_parameter_mapping = {str(p): p for p in self.parameters}
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -112,14 +112,14 @@ class DiophantineSolutionSet(set):
             self.parameters = parameters
 
     def _pad_solution(self, solution):
-        assert len(solution) <= len(self.parameters)
-
         result = list(solution)
         while len(result) < len(self.parameters):
             result.append(self.parameters[len(result)])
         return tuple(result)
 
     def add_solution(self, *solution):
+        if len(solution) > len(self.parameters):
+            raise ValueError("Solution has too many values")
         self.add(self._pad_solution(solution))
 
     def update(self, *s):
@@ -132,7 +132,8 @@ class DiophantineSolutionSet(set):
             yield dict(zip(self.symbols, solution))
 
     def substitute_parameters(self, *values):
-        assert len(values) <= len(self.parameters)
+        if len(values) > len(self.parameters):
+            raise ValueError("Substitution has too many values")
 
         result = DiophantineSolutionSet(self.symbols, self.parameters)
         subs_dict = dict(zip(self.parameters, values))

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -961,14 +961,14 @@ def test_diophantine_solution_set():
     assert set(s1) == set()
     assert s1.symbols == []
     assert s1.parameters == ()
-    raises(ValueError, lambda: s1.add_solution(x))
+    raises(ValueError, lambda: s1.add(x))
     assert list(s1.dict_iterator()) == []
 
     s2 = DiophantineSolutionSet([x, y], [t, u])
     assert s2.symbols == [x, y]
     assert s2.parameters == [t, u]
-    raises(ValueError, lambda: s2.add_solution(1))
-    s2.add_solution(3, 4)
+    raises(ValueError, lambda: s2.add(1))
+    s2.add(3, 4)
     assert set(s2) == {(3, 4)}
     s2.update([(3, 4), (-1, u)])
     assert set(s2) == {(3, 4), (-1, u)}
@@ -976,11 +976,14 @@ def test_diophantine_solution_set():
 
     s3 = DiophantineSolutionSet([x, y, z], [t, u])
     assert len(s3.parameters) == 2
-    s3.add_solution(t**2 + u, t - u)
-    assert set(s3) == {(t**2 + u, t - u)}
-    assert s3.substitute_parameters(2) == {(u + 4, 2 - u)}
-    assert s3.substitute_parameters(7, 8) == {(57, -1)}
+    s3.add(t**2 + u, t - u, 1)
+    assert set(s3) == {(t**2 + u, t - u, 1)}
+    assert s3.substitute_parameters(2) == {(u + 4, 2 - u, 1)}
+    assert s3.substitute_parameters(7, 8) == {(57, -1, 1)}
     raises(ValueError, lambda: s3.substitute_parameters(1, 2, 3))
+    raises(ValueError, lambda: s3.add())
+    raises(ValueError, lambda: s3.add(1, 2, 3, 4))
+    raises(ValueError, lambda: s3.add(1, 2))
 
     s4 = DiophantineSolutionSet([x])
     assert len(s4.parameters) == 1

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -961,29 +961,41 @@ def test_diophantine_solution_set():
     assert set(s1) == set()
     assert s1.symbols == []
     assert s1.parameters == ()
-    raises(ValueError, lambda: s1.add(x))
+    raises(ValueError, lambda: s1.add((x,)))
     assert list(s1.dict_iterator()) == []
 
     s2 = DiophantineSolutionSet([x, y], [t, u])
     assert s2.symbols == [x, y]
     assert s2.parameters == [t, u]
-    raises(ValueError, lambda: s2.add(1))
-    s2.add(3, 4)
+    raises(ValueError, lambda: s2.add((1,)))
+    s2.add((3, 4))
     assert set(s2) == {(3, 4)}
-    s2.update([(3, 4), (-1, u)])
+    s2.update((3, 4), (-1, u))
     assert set(s2) == {(3, 4), (-1, u)}
+    raises(ValueError, lambda: s1.update(s2))
     assert list(s2.dict_iterator()) == [{x: -1, y: u}, {x: 3, y: 4}]
 
     s3 = DiophantineSolutionSet([x, y, z], [t, u])
     assert len(s3.parameters) == 2
-    s3.add(t**2 + u, t - u, 1)
+    s3.add((t**2 + u, t - u, 1))
     assert set(s3) == {(t**2 + u, t - u, 1)}
-    assert s3.substitute_parameters(2) == {(u + 4, 2 - u, 1)}
-    assert s3.substitute_parameters(7, 8) == {(57, -1, 1)}
-    raises(ValueError, lambda: s3.substitute_parameters(1, 2, 3))
-    raises(ValueError, lambda: s3.add())
-    raises(ValueError, lambda: s3.add(1, 2, 3, 4))
-    raises(ValueError, lambda: s3.add(1, 2))
+    assert s3.subs(2) == {(u + 4, 2 - u, 1)}
+    assert s3(2) == {(u + 4, 2 - u, 1)}
+    assert s3.subs(7, 8) == {(57, -1, 1)}
+    assert s3(7, 8) == {(57, -1, 1)}
+    assert s3.subs(t=5) == {(u + 25, 5 - u, 1)}
+    assert s3(t=5) == {(u + 25, 5 - u, 1)}
+    assert s3.subs(u=-3) == {(t**2 - 3, t + 3, 1)}
+    assert s3(u=-3) == {(t**2 - 3, t + 3, 1)}
+    assert s3.subs(2, u=8) == {(12, -6, 1)}
+    assert s3(2, u=8) == {(12, -6, 1)}
+    assert s3.subs(t=5, u=-3) == {(22, 8, 1)}
+    assert s3(t=5, u=-3) == {(22, 8, 1)}
+    raises(ValueError, lambda: s3.subs(x=1))
+    raises(ValueError, lambda: s3.subs(1, 2, 3))
+    raises(ValueError, lambda: s3.add(()))
+    raises(ValueError, lambda: s3.add((1, 2, 3, 4)))
+    raises(ValueError, lambda: s3.add((1, 2)))
 
     s4 = DiophantineSolutionSet([x])
     assert len(s4.parameters) == 1

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -967,12 +967,12 @@ def test_diophantine_solution_set():
     s2 = DiophantineSolutionSet([x, y], [t, u])
     assert s2.symbols == [x, y]
     assert s2.parameters == [t, u]
-    s2.add_solution(1)
+    raises(ValueError, lambda: s2.add_solution(1))
     s2.add_solution(3, 4)
-    assert set(s2) == {(1, u), (3, 4)}
-    s2.update([(3, 4), (-1,)])
-    assert set(s2) == {(1, u), (3, 4), (-1, u)}
-    assert list(s2.dict_iterator()) == [{x: -1, y: u}, {x: 1, y: u}, {x: 3, y: 4}]
+    assert set(s2) == {(3, 4)}
+    s2.update([(3, 4), (-1, u)])
+    assert set(s2) == {(3, 4), (-1, u)}
+    assert list(s2.dict_iterator()) == [{x: -1, y: u}, {x: 3, y: 4}]
 
     s3 = DiophantineSolutionSet([x, y, z], [t, u])
     assert len(s3.parameters) == 2

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -15,7 +15,7 @@ from sympy.solvers.diophantine.diophantine import (diop_DN,
     classify_diop, base_solution_linear, cornacchia, sqf_normal, gaussian_reduce, holzer,
     check_param, parametrize_ternary_quadratic, sum_of_powers, sum_of_squares,
     _diop_ternary_quadratic_normal, _diop_general_sum_of_squares, _nint_or_floor,
-    _odd, _even, _remove_gcd, _can_do_sum_of_squares)
+    _odd, _even, _remove_gcd, _can_do_sum_of_squares, DiophantineSolutionSet)
 from sympy.utilities import default_sort_key
 
 from sympy.testing.pytest import slow, raises, XFAIL
@@ -954,3 +954,33 @@ def test_ternary_quadratic():
         124*x**2 - 30*y**2 - 7729*z**2) == (
         -1410*p**2 - 363263*q**2, 2700*p**2 + 30916*p*q -
         695610*q**2, -60*p**2 + 5400*p*q + 15458*q**2)
+
+
+def test_diophantine_solution_set():
+    s1 = DiophantineSolutionSet([])
+    assert set(s1) == set()
+    assert s1.symbols == []
+    assert s1.parameters == ()
+    raises(ValueError, lambda: s1.add_solution(x))
+    assert list(s1.dict_iterator()) == []
+
+    s2 = DiophantineSolutionSet([x, y], [t, u])
+    assert s2.symbols == [x, y]
+    assert s2.parameters == [t, u]
+    s2.add_solution(1)
+    s2.add_solution(3, 4)
+    assert set(s2) == {(1, u), (3, 4)}
+    s2.update([(3, 4), (-1,)])
+    assert set(s2) == {(1, u), (3, 4), (-1, u)}
+    assert list(s2.dict_iterator()) == [{x: -1, y: u}, {x: 1, y: u}, {x: 3, y: 4}]
+
+    s3 = DiophantineSolutionSet([x, y, z], [t, u])
+    assert len(s3.parameters) == 2
+    s3.add_solution(t**2 + u, t - u)
+    assert set(s3) == {(t**2 + u, t - u)}
+    assert s3.substitute_parameters(2) == {(u + 4, 2 - u)}
+    assert s3.substitute_parameters(7, 8) == {(57, -1)}
+    raises(ValueError, lambda: s3.substitute_parameters(1, 2, 3))
+
+    s4 = DiophantineSolutionSet([x])
+    assert len(s4.parameters) == 1

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -979,23 +979,25 @@ def test_diophantine_solution_set():
     assert len(s3.parameters) == 2
     s3.add((t**2 + u, t - u, 1))
     assert set(s3) == {(t**2 + u, t - u, 1)}
-    assert s3.subs(2) == {(u + 4, 2 - u, 1)}
+    assert s3.subs(t, 2) == {(u + 4, 2 - u, 1)}
     assert s3(2) == {(u + 4, 2 - u, 1)}
-    assert s3.subs(7, 8) == {(57, -1, 1)}
+    assert s3.subs({t: 7, u: 8}) == {(57, -1, 1)}
     assert s3(7, 8) == {(57, -1, 1)}
-    assert s3.subs(t=5) == {(u + 25, 5 - u, 1)}
-    assert s3(t=5) == {(u + 25, 5 - u, 1)}
-    assert s3.subs(u=-3) == {(t**2 - 3, t + 3, 1)}
-    assert s3(u=-3) == {(t**2 - 3, t + 3, 1)}
-    assert s3.subs(2, u=8) == {(12, -6, 1)}
-    assert s3(2, u=8) == {(12, -6, 1)}
-    assert s3.subs(t=5, u=-3) == {(22, 8, 1)}
-    assert s3(t=5, u=-3) == {(22, 8, 1)}
+    assert s3.subs({t: 5}) == {(u + 25, 5 - u, 1)}
+    assert s3(5) == {(u + 25, 5 - u, 1)}
+    assert s3.subs(u, -3) == {(t**2 - 3, t + 3, 1)}
+    assert s3(None, -3) == {(t**2 - 3, t + 3, 1)}
+    assert s3.subs({t: 2, u: 8}) == {(12, -6, 1)}
+    assert s3(2, 8) == {(12, -6, 1)}
+    assert s3.subs({t: 5, u: -3}) == {(22, 8, 1)}
+    assert s3(5, -3) == {(22, 8, 1)}
     raises(ValueError, lambda: s3.subs(x=1))
     raises(ValueError, lambda: s3.subs(1, 2, 3))
     raises(ValueError, lambda: s3.add(()))
     raises(ValueError, lambda: s3.add((1, 2, 3, 4)))
     raises(ValueError, lambda: s3.add((1, 2)))
+    raises(ValueError, lambda: s3(1, 2, 3))
+    raises(TypeError, lambda: s3(t=1))
 
     s4 = DiophantineSolutionSet([x])
     assert len(s4.parameters) == 1

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -510,28 +510,28 @@ def test_diophantine():
     eq = 92*x**2 - 99*y**2 - z**2
     coeff = eq.as_coefficients_dict()
     assert _diop_ternary_quadratic_normal((x, y, z), coeff) == \
-        (9, 7, 51)
+           {(9, 7, 51)}
     assert diophantine(eq) == {(
         891*p**2 + 9*q**2, -693*p**2 - 102*p*q + 7*q**2,
         5049*p**2 - 1386*p*q - 51*q**2)}
     eq = 2*x**2 + 2*y**2 - z**2
     coeff = eq.as_coefficients_dict()
     assert _diop_ternary_quadratic_normal((x, y, z), coeff) == \
-        (1, 1, 2)
+           {(1, 1, 2)}
     assert diophantine(eq) == {(
         2*p**2 - q**2, -2*p**2 + 4*p*q - q**2,
         4*p**2 - 4*p*q + 2*q**2)}
     eq = 411*x**2+57*y**2-221*z**2
     coeff = eq.as_coefficients_dict()
     assert _diop_ternary_quadratic_normal((x, y, z), coeff) == \
-        (2021, 2645, 3066)
+           {(2021, 2645, 3066)}
     assert diophantine(eq) == \
            {(115197*p**2 - 446641*q**2, -150765*p**2 + 1355172*p*q -
              584545*q**2, 174762*p**2 - 301530*p*q + 677586*q**2)}
     eq = 573*x**2+267*y**2-984*z**2
     coeff = eq.as_coefficients_dict()
     assert _diop_ternary_quadratic_normal((x, y, z), coeff) == \
-        (49, 233, 127)
+           {(49, 233, 127)}
     assert diophantine(eq) == \
            {(4361*p**2 - 16072*q**2, -20737*p**2 + 83312*p*q - 76424*q**2,
              11303*p**2 - 41474*p*q + 41656*q**2)}
@@ -539,7 +539,7 @@ def test_diophantine():
     eq = x**2 + 3*y**2 - 12*z**2
     coeff = eq.as_coefficients_dict()
     assert _diop_ternary_quadratic_normal((x, y, z), coeff) == \
-        (0, 2, 1)
+           {(0, 2, 1)}
     assert diophantine(eq) == \
            {(24*p*q, 2*p**2 - 24*q**2, p**2 + 12*q**2)}
     # solvers have not been written for every type

--- a/sympy/solvers/diophantine/tests/test_diophantine.py
+++ b/sympy/solvers/diophantine/tests/test_diophantine.py
@@ -959,14 +959,14 @@ def test_ternary_quadratic():
 def test_diophantine_solution_set():
     s1 = DiophantineSolutionSet([])
     assert set(s1) == set()
-    assert s1.symbols == []
+    assert s1.symbols == ()
     assert s1.parameters == ()
     raises(ValueError, lambda: s1.add((x,)))
     assert list(s1.dict_iterator()) == []
 
     s2 = DiophantineSolutionSet([x, y], [t, u])
-    assert s2.symbols == [x, y]
-    assert s2.parameters == [t, u]
+    assert s2.symbols == (x, y)
+    assert s2.parameters == (t, u)
     raises(ValueError, lambda: s2.add((1,)))
     s2.add((3, 4))
     assert set(s2) == {(3, 4)}


### PR DESCRIPTION
#### References to other Issues or PRs
#18493

#### Brief description of what is fixed or changed
Add a new class `DiophantineSolutionSet` to represent a set of solutions of a particular diophantine equation.

Update internal solvers (`_diop_linear`, `_diop_quadratic`, `_diop_ternary_quadratic`, `_diop_ternary_quadratic_normal`, `_diop_general_pythagorean`, `_diop_general_sum_of_squares`, `_diop_general_sum_of_even_powers`) to have the same return type (`DiophantineSolutionSet`).

Added a new function `diop_univariate` to move solution algorithm from `diop_solve`.

Simplified `diop_solve` to simply call the various solvers and move any postprocessing to that solver.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->