### PR TITLE
Last small tweaks for dotprodsimp

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2377,7 +2377,7 @@ class MatrixArithmetic(MatrixRequired):
 
         return self.pow(exp)
 
-    def pow(self, exp, jordan=None):
+    def pow(self, exp, jordan=None, dotprodsimp=None):
         """Return self**exp a scalar or symbol.
 
         Parameters
@@ -2388,6 +2388,11 @@ class MatrixArithmetic(MatrixRequired):
             certain conditions, True specifies that jordan_pow should always
             be used if possible and False means it should not be used unless
             it is the only way to calculate the power.
+
+        dotprodsimp : bool, optional
+            Specifies whether intermediate term algebraic simplification is used
+            during matrix multiplications to control expression blowup and thus
+            speed up calculation.
         """
 
         if self.rows != self.cols:
@@ -2422,7 +2427,7 @@ class MatrixArithmetic(MatrixRequired):
                     if jordan:
                         raise
 
-            if _get_intermediate_simp_bool(True):
+            if _get_intermediate_simp_bool(True, dotprodsimp):
                 return a._eval_pow_by_recursion_dotprodsimp(exp)
             else:
                 return a._eval_pow_by_recursion(exp)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2310,7 +2310,7 @@ class MatrixArithmetic(MatrixRequired):
         dotprodsimp : bool, optional
             Specifies whether intermediate term algebraic simplification is used
             during matrix multiplications to control expression blowup and thus
-            speed up calculation.
+            speed up calculation. Default is off.
         """
 
         isimpbool = _get_intermediate_simp_bool(False, dotprodsimp)
@@ -2391,8 +2391,9 @@ class MatrixArithmetic(MatrixRequired):
 
         dotprodsimp : bool, optional
             Specifies whether intermediate term algebraic simplification is used
-            during matrix multiplications to control expression blowup and thus
-            speed up calculation.
+            during naive matrix power to control expression blowup and thus
+            speed up calculation. If the power is calculated using Jordan form
+            then this option has no effect. Default is on.
         """
 
         if self.rows != self.cols:

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -38,6 +38,11 @@ from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 #
 # This second form uses lighter simplification by default but may still do
 # better than nothing.
+#
+# The other place where dotprodsimp may be added is any place where matrices are
+# multiplied via:
+#
+# A.multiply(B) -> A.multiply(B, dotprodsimp=True)
 
 # True, False or None
 _DOTPRODSIMP_MODE = False if os.environ.get('SYMPY_DOTPRODSIMP', '').lower() in \


### PR DESCRIPTION
#### References to other Issues or PRs
Small tweaks for #18572

#### Brief description of what is fixed or changed
Added dotprodsimp keyword to MatrixArithmetic.pow since it may come in handy sometimes to turn it off. Also documented how to progress with more dotprodsimp implementations if someone wants to try and a small fix for if dotprodsimp is turned on everywhere by global.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added dotprodsimp keyword to MatrixArithmetic.pow
<!-- END RELEASE NOTES -->