### PR TITLE
Fixes Idx object to accept non-integer bound

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -111,7 +111,7 @@ from sympy.core import Expr, Tuple, sympify, S
 from sympy.core.symbol import _filter_assumptions, Symbol
 from sympy.core.compatibility import (is_sequence, NotIterable,
                                       Iterable)
-from sympy.core.logic import fuzzy_bool, fuzzy_and, fuzzy_not
+from sympy.core.logic import fuzzy_bool, fuzzy_not
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 
@@ -663,7 +663,7 @@ class Idx(Expr):
                     raise TypeError("Idx object requires integer bounds.")
             args = label, Tuple(*range)
         elif isinstance(range, Expr):
-            if fuzzy_and([fuzzy_not(range.is_integer), fuzzy_not(range is S.Infinity)]):
+            if range is not S.Infinity and fuzzy_not(range.is_integer):
                 raise TypeError("Idx object requires an integer dimension.")
             args = label, Tuple(0, range - 1)
         elif range:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -111,7 +111,7 @@ from sympy.core import Expr, Tuple, sympify, S
 from sympy.core.symbol import _filter_assumptions, Symbol
 from sympy.core.compatibility import (is_sequence, NotIterable,
                                       Iterable)
-from sympy.core.logic import fuzzy_bool
+from sympy.core.logic import fuzzy_bool, fuzzy_and, fuzzy_not
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 
@@ -663,7 +663,7 @@ class Idx(Expr):
                     raise TypeError("Idx object requires integer bounds.")
             args = label, Tuple(*range)
         elif isinstance(range, Expr):
-            if not (range.is_integer or range is S.Infinity):
+            if fuzzy_and([fuzzy_not(range.is_integer), fuzzy_not(range is S.Infinity)]):
                 raise TypeError("Idx object requires an integer dimension.")
             args = label, Tuple(0, range - 1)
         elif range:

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -427,7 +427,8 @@ def test_issue_18604():
     assert Idx("i", m).name == 'i'
     assert Idx("i", m).lower == 0
     assert Idx("i", m).upper == m - 1
-
+    m = symbols("m", real=False)
+    raises(TypeError, lambda: Idx("i", m))
 
 def test_Subs_with_Indexed():
     A = IndexedBase("A")

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -422,6 +422,13 @@ def test_issue_12780():
     raises(TypeError, lambda: i.subs(n, 1.5))
 
 
+def test_issue_18604():
+    m = symbols("m")
+    assert Idx("i", m).name == 'i'
+    assert Idx("i", m).lower == 0
+    assert Idx("i", m).upper == m - 1
+
+
 def test_Subs_with_Indexed():
     A = IndexedBase("A")
     i, j, k = symbols("i,j,k")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes Idx object to accept non-integer bound
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18604 

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fix Idx object to accept non-integer bound
<!-- END RELEASE NOTES -->