### PR TITLE
Updating #18543

### DIFF
--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -218,29 +218,18 @@ def limit_seq(expr, n=None, trials=5):
     # If there is a negative term raised to a power involving n, or a
     # trigonometric function, then consider even and odd n separately.
     powers = (p.as_base_exp() for p in expr.atoms(Pow))
-    if expr.has(cos, sin):
+    if any(b.is_negative and e.has(n) for b, e in powers) or expr.has(cos, sin):
         L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
         if L1 is not None:
             L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
             if L1 != L2:
-                if L2 == None:
+                if L2 == None and expr.has(cos, sin):
                     L3 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
                     return L3
                 elif L1.is_comparable and L2.is_comparable:
                     return AccumulationBounds(Min(L1, L2), Max(L1, L2))
                 else:
                     return None
-    
-    elif any(b.is_negative and e.has(n) for b, e in powers):
-        L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
-        if L1 is not None:
-            L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
-            if L2 is not None:
-                if L1 != L2:
-                    if L1.is_comparable and L2.is_comparable:
-                        return AccumulationBounds(Min(L1, L2), Max(L1, L2))
-                    else:
-                        return None
     else:
         L1 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
     if L1 is not None:

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -218,8 +218,20 @@ def limit_seq(expr, n=None, trials=5):
     # If there is a negative term raised to a power involving n, or a
     # trigonometric function, then consider even and odd n separately.
     powers = (p.as_base_exp() for p in expr.atoms(Pow))
-    if (any(b.is_negative and e.has(n) for b, e in powers) or
-            expr.has(cos, sin)):
+    if expr.has(cos, sin):
+        L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
+        if L1 is not None:
+            L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
+            if L1 != L2:
+                if L2 == None:
+                    L3 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
+                    return L3
+                elif L1.is_comparable and L2.is_comparable:
+                    return AccumulationBounds(Min(L1, L2), Max(L1, L2))
+                else:
+                    return None
+    
+    elif any(b.is_negative and e.has(n) for b, e in powers):
         L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
         if L1 is not None:
             L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -220,16 +220,15 @@ def limit_seq(expr, n=None, trials=5):
     powers = (p.as_base_exp() for p in expr.atoms(Pow))
     if any(b.is_negative and e.has(n) for b, e in powers) or expr.has(cos, sin):
         L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
-        if L1 is not None:
-            L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
-            if L1 != L2:
-                if L2 == None and expr.has(cos, sin):
-                    L3 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
-                    return L3
-                elif L1.is_comparable and L2.is_comparable:
-                    return AccumulationBounds(Min(L1, L2), Max(L1, L2))
-                else:
-                    return None
+        L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
+        if L1 != L2:
+            if (L1 == None or L2 == None) and expr.has(cos, sin):
+                L3 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
+                return L3
+            elif ((L1 != None and L2 != None) and (L1.is_comparable and L2.is_comparable)):
+                return AccumulationBounds(Min(L1, L2), Max(L1, L2))
+            else:
+                return None
     else:
         L1 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
     if L1 is not None:

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -223,11 +223,12 @@ def limit_seq(expr, n=None, trials=5):
         L1 = _limit_seq(expr.xreplace({n: n1}), n1, trials)
         if L1 is not None:
             L2 = _limit_seq(expr.xreplace({n: n2}), n2, trials)
-            if L1 != L2:
-                if L1.is_comparable and L2.is_comparable:
-                    return AccumulationBounds(Min(L1, L2), Max(L1, L2))
-                else:
-                    return None
+            if L2 is not None:
+                if L1 != L2:
+                    if L1.is_comparable and L2.is_comparable:
+                        return AccumulationBounds(Min(L1, L2), Max(L1, L2))
+                    else:
+                        return None
     else:
         L1 = _limit_seq(expr.xreplace({n: n_}), n_, trials)
     if L1 is not None:

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -101,6 +101,7 @@ def test_alternating_sign():
 def test_accum_bounds():
     assert limit_seq((-1)**n, n) == AccumulationBounds(-1, 1)
     assert limit_seq(cos(pi*n), n) == AccumulationBounds(-1, 1)
+    assert limit_seq(sin(pi*n/2), n) == AccumulationBounds(-1, 1)
     assert limit_seq(sin(pi*n/2)**2, n) == AccumulationBounds(0, 1)
     assert limit_seq(2*(-3)**n/(n + 3**n), n) == AccumulationBounds(-2, 2)
     assert limit_seq(3*n/(n + 1) + 2*(-1)**n, n) == AccumulationBounds(1, 5)

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -102,6 +102,7 @@ def test_accum_bounds():
     assert limit_seq((-1)**n, n) == AccumulationBounds(-1, 1)
     assert limit_seq(cos(pi*n), n) == AccumulationBounds(-1, 1)
     assert limit_seq(sin(pi*n/2), n) == AccumulationBounds(-1, 1)
+    assert limit_seq(cos(pi*n/2), n) == AccumulationBounds(-1, 1)
     assert limit_seq(sin(pi*n/2)**2, n) == AccumulationBounds(0, 1)
     assert limit_seq(2*(-3)**n/(n + 3**n), n) == AccumulationBounds(-2, 2)
     assert limit_seq(3*n/(n + 1) + 2*(-1)**n, n) == AccumulationBounds(1, 5)


### PR DESCRIPTION
To overcome the problem ... limit_seq - AttributeError: 'NoneType' object has no attribute 'is_comparable' 
#18543

For more info [see....] (https://github.com/sympy/sympy/issues/18543#)
<!-- BEGIN RELEASE NOTES -->

* series 
  * adding if loop to overcome the issue...
  * If L2 is not none, then only the comparison is possible else there will be error as shown in #18543 
  
  * In case of sin, there is no error instead None is returned where as in case of cos there comes AttributeError , so as we know that due to the fact that as sin will even returns zero when n is even and cos returns zero when n is odd, so L1 is accepting the odd values where as L2 is accepting even values hence there should be the symmetrical check for both that if both are not none then code should proceed further ....

  * These are the related brief stuff about the explanation .....
<!-- END RELEASE NOTES -->

>  n_ = Dummy("n", integer=True, positive=True)

>  n1 = Dummy("n", odd=True, positive=True)

>  n2 = Dummy("n", even=True, positive=True)

  

> import sympy as sp

> n = sp.symbols("n")

> expr = sp.cos(n * sp.pi / 2)

> sp.limit_seq(expr) 





THANKS FOR READING !!!  :)

