### PR TITLE
Dropping Python 2 support 

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -6,7 +6,7 @@ from itertools import chain, zip_longest
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
-from .compatibility import iterable, Iterator, ordered, Mapping
+from .compatibility import iterable, ordered, Mapping
 from .singleton import S
 
 from inspect import getmro
@@ -1953,7 +1953,7 @@ def _atomic(e, recursive=False):
     return atoms
 
 
-class preorder_traversal(Iterator):
+class preorder_traversal(object):
     """
     Do a pre-order traversal of a tree.
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -51,7 +51,7 @@ __all__ = [
     'PY3', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
     'unicode', 'u_decode', 'get_function_code', 'gmpy',
     'get_function_globals', 'get_function_name', 'builtins', 'reduce',
-    'StringIO', 'cStringIO', 'exec_', 'round', 'Mapping', 'Callable',
+    'StringIO', 'cStringIO', 'exec_', 'Mapping', 'Callable',
     'MutableMapping', 'MutableSet', 'Iterable', 'Hashable', 'unwrap',
     'accumulate', 'with_metaclass', 'NotIterable', 'iterable', 'is_sequence',
     'as_int', 'default_sort_key', 'ordered', 'GROUND_TYPES', 'HAS_GMPY',
@@ -80,8 +80,6 @@ if PY3:
     cStringIO = StringIO
 
     exec_ = getattr(builtins, "exec")
-
-    round = round
 
     from collections.abc import (Mapping, Callable, MutableMapping,
         MutableSet, Iterable, Hashable)
@@ -118,13 +116,6 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
-
-    _round = round
-    def round(x, *args):
-        try:
-            return x.__round__(*args)
-        except (AttributeError, TypeError):
-            return _round(x, *args)
 
     from collections import (Mapping, Callable, MutableMapping,
         MutableSet, Iterable, Hashable)

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -49,7 +49,7 @@ Metaclasses:
 
 __all__ = [
     'PY3', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
-    'unicode', 'u_decode', 'get_function_code', 'gmpy'
+    'unicode', 'u_decode', 'get_function_code', 'gmpy',
     'get_function_globals', 'get_function_name', 'builtins', 'reduce',
     'StringIO', 'cStringIO', 'exec_', 'round', 'Mapping', 'Callable',
     'MutableMapping', 'MutableSet', 'Iterable', 'Hashable', 'unwrap',

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -49,12 +49,12 @@ Metaclasses:
 
 __all__ = [
     'PY3', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
-    'unicode', 'u_decode', 'Iterator', 'get_function_code',
+    'unicode', 'u_decode', 'get_function_code', 'gmpy'
     'get_function_globals', 'get_function_name', 'builtins', 'reduce',
     'StringIO', 'cStringIO', 'exec_', 'round', 'Mapping', 'Callable',
     'MutableMapping', 'MutableSet', 'Iterable', 'Hashable', 'unwrap',
     'accumulate', 'with_metaclass', 'NotIterable', 'iterable', 'is_sequence',
-    'as_int', 'default_sort_key', 'ordered', 'GROUND_TYPES', 'HAS_GMPY', 'gmpy',
+    'as_int', 'default_sort_key', 'ordered', 'GROUND_TYPES', 'HAS_GMPY',
 ]
 
 import sys
@@ -68,8 +68,6 @@ if PY3:
 
     def u_decode(x):
         return x
-
-    Iterator = object
 
     # Moved definitions
     get_function_code = operator.attrgetter("__code__")
@@ -98,10 +96,6 @@ else:
 
     def u_decode(x):
         return x.decode('utf-8')
-
-    class Iterator(object):
-        def next(self):
-            return type(self).__next__(self)
 
     # Moved definitions
     get_function_code = operator.attrgetter("func_code")

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -20,10 +20,6 @@ String and Unicode compatible changes:
     * Use `u()` for escaped unicode sequences (e.g. u'\u2020' -> u('\u2020'))
     * Use `u_decode()` to decode utf-8 formatted unicode strings
 
-Integer related changes:
-    * `long()` removed in Python 3, import `long` for Python 2/3 compatible
-      function
-
 Renamed function attributes:
     * Python 2 `.func_code`, Python 3 `.__func__`, access with
       `get_function_code()`

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -48,7 +48,7 @@ Metaclasses:
 """
 
 __all__ = [
-    'PY3', 'long', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
+    'PY3', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
     'unicode', 'u_decode', 'Iterator', 'get_function_code',
     'get_function_globals', 'get_function_name', 'builtins', 'reduce',
     'StringIO', 'cStringIO', 'exec_', 'round', 'Mapping', 'Callable',
@@ -61,7 +61,6 @@ import sys
 PY3 = sys.version_info[0] > 2
 
 if PY3:
-    long = int
     int_info = sys.int_info
 
     # String / unicode compatibility
@@ -92,7 +91,6 @@ if PY3:
     from inspect import unwrap
     from itertools import accumulate
 else:
-    long = long
     int_info = sys.long_info
 
     # String / unicode compatibility

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -17,8 +17,6 @@ Python 2 and Python 3 compatible imports
 String and Unicode compatible changes:
     * `unicode()` removed in Python 3, import `unicode` for Python 2/3
       compatible function
-    * `unichr()` removed in Python 3, import `unichr` for Python 2/3 compatible
-      function
     * Use `u()` for escaped unicode sequences (e.g. u'\u2020' -> u('\u2020'))
     * Use `u_decode()` to decode utf-8 formatted unicode strings
 
@@ -55,7 +53,7 @@ Metaclasses:
 
 __all__ = [
     'PY3', 'long', 'int_info', 'SYMPY_INTS', 'lru_cache', 'clock',
-    'unicode', 'unichr', 'u_decode', 'Iterator', 'get_function_code',
+    'unicode', 'u_decode', 'Iterator', 'get_function_code',
     'get_function_globals', 'get_function_name', 'builtins', 'reduce',
     'StringIO', 'cStringIO', 'exec_', 'round', 'Mapping', 'Callable',
     'MutableMapping', 'MutableSet', 'Iterable', 'Hashable', 'unwrap',
@@ -72,7 +70,6 @@ if PY3:
 
     # String / unicode compatibility
     unicode = str
-    unichr = chr
 
     def u_decode(x):
         return x
@@ -104,7 +101,6 @@ else:
 
     # String / unicode compatibility
     unicode = unicode
-    unichr = unichr
 
     def u_decode(x):
         return x.decode('utf-8')

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3653,7 +3653,6 @@ class Expr(Basic, EvalfMixin):
         For a consistent behavior, and Python 3 rounding
         rules, import `round` from sympy.core.compatibility.
 
-        >>> from sympy.core.compatibility import round
         >>> isinstance(round(S(123), -2), Number)
         True
         """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -14,7 +14,7 @@ from .evalf import pure_complex
 from .decorators import _sympifyit
 from .cache import cacheit, clear_cache
 from .logic import fuzzy_not
-from sympy.core.compatibility import (as_int, long, HAS_GMPY, SYMPY_INTS,
+from sympy.core.compatibility import (as_int, HAS_GMPY, SYMPY_INTS,
     int_info, gmpy)
 from sympy.core.cache import lru_cache
 
@@ -1175,7 +1175,7 @@ class Float(Number):
                     if not all((
                             num[0] in (0, 1),
                             num[1] >= 0,
-                            all(type(i) in (long, int) for i in num)
+                            all(type(i) in (int, int) for i in num)
                             )):
                         raise ValueError('malformed mpf: %s' % (num,))
                     # don't compute number or else it may
@@ -3885,13 +3885,13 @@ converter[fractions.Fraction] = sympify_fractions
 
 if HAS_GMPY:
     def sympify_mpz(x):
-        return Integer(long(x))
+        return Integer(int(x))
 
     # XXX: The sympify_mpq function here was never used because it is
     # overridden by the other sympify_mpq function below. Maybe it should just
     # be removed or maybe it should be used for something...
     def sympify_mpq(x):
-        return Rational(long(x.numerator), long(x.denominator))
+        return Rational(int(x.numerator), int(x.denominator))
 
     converter[type(gmpy.mpz(1))] = sympify_mpz
     converter[type(gmpy.mpq(1, 2))] = sympify_mpq

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -7,7 +7,6 @@ from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath, evalf)
 from mpmath import inf, ninf
 from mpmath.libmp.libmpf import from_float
-from sympy.core.compatibility import long
 from sympy.core.expr import unchanged
 from sympy.testing.pytest import raises, XFAIL
 from sympy.abc import n, x, y
@@ -245,9 +244,9 @@ def test_evalf_integer_parts():
     assert ceiling(10*(sin(1)**2 + cos(1)**2)) == 10
 
     assert int(floor(factorial(50)/E, evaluate=False).evalf(70)) == \
-        long(11188719610782480504630258070757734324011354208865721592720336800)
+        int(11188719610782480504630258070757734324011354208865721592720336800)
     assert int(ceiling(factorial(50)/E, evaluate=False).evalf(70)) == \
-        long(11188719610782480504630258070757734324011354208865721592720336801)
+        int(11188719610782480504630258070757734324011354208865721592720336801)
     assert int(floor((GoldenRatio**999 / sqrt(5) + S.Half))
                .evalf(1000)) == fibonacci(999)
     assert int(floor((GoldenRatio**1000 / sqrt(5) + S.Half))
@@ -450,8 +449,8 @@ def test_infinities():
 
 
 def test_to_mpmath():
-    assert sqrt(3)._to_mpmath(20)._mpf_ == (0, long(908093), -19, 20)
-    assert S(3.2)._to_mpmath(20)._mpf_ == (0, long(838861), -18, 20)
+    assert sqrt(3)._to_mpmath(20)._mpf_ == (0, int(908093), -19, 20)
+    assert S(3.2)._to_mpmath(20)._mpf_ == (0, int(838861), -18, 20)
 
 
 def test_issue_6632_evalf():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -8,7 +8,6 @@ from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, 
                    integrate, gammasimp, Gt)
 from sympy.core.expr import ExprBuilder, unchanged
 from sympy.core.function import AppliedUndef
-from sympy.core.compatibility import round
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -7,7 +7,6 @@ from sympy import (Rational, Symbol, Float, I, sqrt, cbrt, oo, nan, pi, E,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
                    AlgebraicNumber, simplify, sin, fibonacci, RealField,
                    sympify, srepr, Dummy, Sum)
-from sympy.core.compatibility import long
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr,
     igcd2, igcd_lehmer, mpf_norm, comp, mod_inverse)
@@ -282,7 +281,7 @@ def _test_rational_new(cls):
     i = Integer(10)
     assert _strictly_equal(i, cls('10'))
     assert _strictly_equal(i, cls(u'10'))
-    assert _strictly_equal(i, cls(long(10)))
+    assert _strictly_equal(i, cls(int(10)))
     assert _strictly_equal(i, cls(i))
 
     raises(TypeError, lambda: cls(Symbol('x')))
@@ -439,7 +438,7 @@ def test_Float():
     mpf = (0, 5404319552844595, -52, 53)
     x_str =  Float((0, '13333333333333', -52, 53))
     x2_str = Float((0, '26666666666666', -53, 54))
-    x_hex = Float((0, long(0x13333333333333), -52, 53))
+    x_hex = Float((0, int(0x13333333333333), -52, 53))
     x_dec = Float(mpf)
     assert x_str == x_hex == x_dec == Float(1.2)
     # x2_str was entered slightly malformed in that the mantissa
@@ -450,13 +449,13 @@ def test_Float():
     assert Float(1.2)._mpf_ == mpf
     assert x2_str._mpf_ == mpf
 
-    assert Float((0, long(0), -123, -1)) is S.NaN
-    assert Float((0, long(0), -456, -2)) is S.Infinity
-    assert Float((1, long(0), -789, -3)) is S.NegativeInfinity
+    assert Float((0, int(0), -123, -1)) is S.NaN
+    assert Float((0, int(0), -456, -2)) is S.Infinity
+    assert Float((1, int(0), -789, -3)) is S.NegativeInfinity
     # if you don't give the full signature, it's not special
-    assert Float((0, long(0), -123)) == Float(0)
-    assert Float((0, long(0), -456)) == Float(0)
-    assert Float((1, long(0), -789)) == Float(0)
+    assert Float((0, int(0), -123)) == Float(0)
+    assert Float((0, int(0), -456)) == Float(0)
+    assert Float((1, int(0), -789)) == Float(0)
 
     raises(ValueError, lambda: Float((0, 7, 1, 3), ''))
 
@@ -1248,19 +1247,6 @@ def test_int():
     assert type(int(a)) is type(int(-a)) is int
 
 
-def test_long():
-    a = Rational(5)
-    assert long(a) == 5
-    a = Rational(9, 10)
-    assert long(a) == long(-a) == 0
-    a = Integer(2**100)
-    assert long(a) == a
-    assert long(pi) == 3
-    assert long(E) == 2
-    assert long(GoldenRatio) == 1
-    assert long(TribonacciConstant) == 2
-
-
 def test_real_bug():
     x = Symbol("x")
     assert str(2.0*x*x) in ["(2.0*x)*x", "2.0*x**2", "2.00000000000000*x**2"]
@@ -1649,12 +1635,12 @@ def test_mpmath_issues():
     from mpmath.libmp.libmpf import _normalize
     import mpmath.libmp as mlib
     rnd = mlib.round_nearest
-    mpf = (0, long(0), -123, -1, 53, rnd)  # nan
-    assert _normalize(mpf, 53) != (0, long(0), 0, 0)
-    mpf = (0, long(0), -456, -2, 53, rnd)  # +inf
-    assert _normalize(mpf, 53) != (0, long(0), 0, 0)
-    mpf = (1, long(0), -789, -3, 53, rnd)  # -inf
-    assert _normalize(mpf, 53) != (0, long(0), 0, 0)
+    mpf = (0, int(0), -123, -1, 53, rnd)  # nan
+    assert _normalize(mpf, 53) != (0, int(0), 0, 0)
+    mpf = (0, int(0), -456, -2, 53, rnd)  # +inf
+    assert _normalize(mpf, 53) != (0, int(0), 0, 0)
+    mpf = (1, int(0), -789, -3, 53, rnd)  # -inf
+    assert _normalize(mpf, 53) != (0, int(0), 0, 0)
 
     from mpmath.libmp.libmpf import fnan
     assert mlib.mpf_eq(fnan, fnan)
@@ -1663,13 +1649,13 @@ def test_mpmath_issues():
 def test_Catalan_EulerGamma_prec():
     n = GoldenRatio
     f = Float(n.n(), 5)
-    assert f._mpf_ == (0, long(212079), -17, 18)
+    assert f._mpf_ == (0, int(212079), -17, 18)
     assert f._prec == 20
     assert n._as_mpf_val(20) == f._mpf_
 
     n = EulerGamma
     f = Float(n.n(), 5)
-    assert f._mpf_ == (0, long(302627), -19, 19)
+    assert f._mpf_ == (0, int(302627), -19, 19)
     assert f._prec == 20
     assert n._as_mpf_val(20) == f._mpf_
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -352,10 +352,9 @@ def test_new_relational():
 
     # finally, some fuzz testing
     from random import randint
-    from sympy.core.compatibility import unichr
     for i in range(100):
         while 1:
-            strtype, length = (unichr, 65535) if randint(0, 1) else (chr, 255)
+            strtype, length = (chr, 65535) if randint(0, 1) else (chr, 255)
             relation_type = strtype(randint(0, length))
             if randint(0, 1):
                 relation_type += strtype(randint(0, length))

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -2,7 +2,6 @@ from sympy import (
     adjoint, conjugate, Dummy, Eijk, KroneckerDelta, LeviCivita, Symbol,
     symbols, transpose, Piecewise, Ne
 )
-from sympy.core.compatibility import long
 from sympy.physics.secondquant import evaluate_deltas, F
 
 x, y = symbols('x y')
@@ -11,7 +10,7 @@ x, y = symbols('x y')
 def test_levicivita():
     assert Eijk(1, 2, 3) == LeviCivita(1, 2, 3)
     assert LeviCivita(1, 2, 3) == 1
-    assert LeviCivita(long(1), long(2), long(3)) == 1
+    assert LeviCivita(int(1), int(2), int(3)) == 1
     assert LeviCivita(1, 3, 2) == -1
     assert LeviCivita(1, 2, 2) == 0
     i, j, k = symbols('i j k')

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -3,7 +3,6 @@ from sympy import (KroneckerDelta, diff, Piecewise, Sum, Dummy, factor,
 
 from sympy.core import S, symbols, Add, Mul, SympifyError, Rational
 from sympy.core.expr import unchanged
-from sympy.core.compatibility import long
 from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
@@ -341,7 +340,7 @@ def test_indexing():
 def test_single_indexing():
     A = MatrixSymbol('A', 2, 3)
     assert A[1] == A[0, 1]
-    assert A[long(1)] == A[0, 1]
+    assert A[int(1)] == A[0, 1]
     assert A[3] == A[1, 0]
     assert list(A[:2, :2]) == [A[0, 0], A[0, 1], A[1, 0], A[1, 1]]
     raises(IndexError, lambda: A[6])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -12,7 +12,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix, MatrixSymbol)
-from sympy.core.compatibility import long, iterable, Hashable
+from sympy.core.compatibility import iterable, Hashable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture
@@ -2104,13 +2104,13 @@ def test_creation_args():
     """
     raises(ValueError, lambda: zeros(3, -1))
     raises(TypeError, lambda: zeros(1, 2, 3, 4))
-    assert zeros(long(3)) == zeros(3)
+    assert zeros(int(3)) == zeros(3)
     assert zeros(Integer(3)) == zeros(3)
     raises(ValueError, lambda: zeros(3.))
-    assert eye(long(3)) == eye(3)
+    assert eye(int(3)) == eye(3)
     assert eye(Integer(3)) == eye(3)
     raises(ValueError, lambda: eye(3.))
-    assert ones(long(3), Integer(4)) == ones(3, 4)
+    assert ones(int(3), Integer(4)) == ones(3, 4)
     raises(TypeError, lambda: Matrix(5))
     raises(TypeError, lambda: Matrix(1, 2))
     raises(ValueError, lambda: Matrix([1, [2]]))

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -892,10 +892,9 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     semi-prime factor that cannot be reduced easily:
 
     >>> from sympy.ntheory import isprime
-    >>> from sympy.core.compatibility import long
     >>> a = 1407633717262338957430697921446883
     >>> f = factorint(a, limit=10000)
-    >>> f == {991: 1, long(202916782076162456022877024859): 1, 7: 1}
+    >>> f == {991: 1, int(202916782076162456022877024859): 1, 7: 1}
     True
     >>> isprime(max(f))
     False

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -1,7 +1,6 @@
 from sympy import Mul, S, Pow, Symbol, summation, Dict, factorial as fac
 from sympy.core.evalf import bitcount
 from sympy.core.numbers import Integer, Rational
-from sympy.core.compatibility import long
 
 from sympy.ntheory import (totient,
     factorint, primefactors, divisors, nextprime,
@@ -226,7 +225,7 @@ def test_factorint():
     assert factorint(13*17*19, limit=15) == {13: 1, 17*19: 1}
     assert factorint(1951*15013*15053, limit=2000) == {225990689: 1, 1951: 1}
     assert factorint(primorial(17) + 1, use_pm1=0) == \
-        {long(19026377261): 1, 3467: 1, 277: 1, 105229: 1}
+        {int(19026377261): 1, 3467: 1, 277: 1, 105229: 1}
     # when prime b is closer than approx sqrt(8*p) to prime p then they are
     # "close" and have a trivial factorization
     a = nextprime(2**2**8)  # 78 digits

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -1,7 +1,6 @@
 import random
 
 from sympy import Integer, Matrix, Rational, sqrt, symbols, S
-from sympy.core.compatibility import long
 from sympy.physics.quantum.qubit import (measure_all, measure_partial,
                                          matrix_to_qubit, matrix_to_density,
                                          qubit_to_matrix, IntQubit,
@@ -153,7 +152,7 @@ def test_measure_partial():
     state = Qubit('01') + Qubit('10')
     assert measure_partial(state, (0,)) == \
         [(Qubit('10'), S.Half), (Qubit('01'), S.Half)]
-    assert measure_partial(state, long(0)) == \
+    assert measure_partial(state, int(0)) == \
         [(Qubit('10'), S.Half), (Qubit('01'), S.Half)]
     assert measure_partial(state, (0,)) == \
         measure_partial(state, (1,))[::-1]

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -44,7 +44,6 @@ from sympy.polys.domains import FF, ZZ, QQ, EX
 from sympy.polys.rings import ring
 
 from sympy import S, I, sin
-from sympy.core.compatibility import long
 
 from sympy.abc import x
 
@@ -213,7 +212,7 @@ def test_dmp_eval_in():
     assert dmp_eval_in(f_6, 7, 2, 3, ZZ) == dmp_swap(
         dmp_eval(dmp_swap(f_6, 0, 2, 3, ZZ), 7, 3, ZZ), 0, 1, 2, ZZ)
 
-    f = [[[long(45)]], [[]], [[]], [[long(-9)], [-1], [], [long(3), long(0), long(10), long(0)]]]
+    f = [[[int(45)]], [[]], [[]], [[int(-9)], [-1], [], [int(3), int(0), int(10), int(0)]]]
 
     assert dmp_eval_in(f, -2, 2, 2, ZZ) == \
         [[45], [], [], [-9, -1, 0, -44]]

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -1,6 +1,5 @@
 """Tests for OO layer of several polynomial representations. """
 
-from sympy.core.compatibility import long
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.polyclasses import DMP, DMF, ANP
 from sympy.polys.polyerrors import ExactQuotientFailed, NotInvertible
@@ -528,12 +527,12 @@ def test_ANP_unify():
 def test___hash__():
     # issue 5571
     # Make sure int vs. long doesn't affect hashing with Python ground types
-    assert DMP([[1, 2], [3]], ZZ) == DMP([[long(1), long(2)], [long(3)]], ZZ)
-    assert hash(DMP([[1, 2], [3]], ZZ)) == hash(DMP([[long(1), long(2)], [long(3)]], ZZ))
+    assert DMP([[1, 2], [3]], ZZ) == DMP([[int(1), int(2)], [int(3)]], ZZ)
+    assert hash(DMP([[1, 2], [3]], ZZ)) == hash(DMP([[int(1), int(2)], [int(3)]], ZZ))
     assert DMF(
-        ([[1, 2], [3]], [[1]]), ZZ) == DMF(([[long(1), long(2)], [long(3)]], [[long(1)]]), ZZ)
-    assert hash(DMF(([[1, 2], [3]], [[1]]), ZZ)) == hash(DMF(([[long(1),
-                long(2)], [long(3)]], [[long(1)]]), ZZ))
-    assert ANP([1, 1], [1, 0, 1], ZZ) == ANP([long(1), long(1)], [long(1), long(0), long(1)], ZZ)
+        ([[1, 2], [3]], [[1]]), ZZ) == DMF(([[int(1), int(2)], [int(3)]], [[int(1)]]), ZZ)
+    assert hash(DMF(([[1, 2], [3]], [[1]]), ZZ)) == hash(DMF(([[int(1),
+                int(2)], [int(3)]], [[int(1)]]), ZZ))
+    assert ANP([1, 1], [1, 0, 1], ZZ) == ANP([int(1), int(1)], [int(1), int(0), int(1)], ZZ)
     assert hash(
-        ANP([1, 1], [1, 0, 1], ZZ)) == hash(ANP([long(1), long(1)], [long(1), long(0), long(1)], ZZ))
+        ANP([1, 1], [1, 0, 1], ZZ)) == hash(ANP([int(1), int(1)], [int(1), int(0), int(1)], ZZ))

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -4,7 +4,6 @@ from sympy import (
     Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise , Rational
     )
 
-from sympy.core.compatibility import long
 from sympy.testing.pytest import XFAIL
 
 from sympy.abc import x, y
@@ -330,7 +329,7 @@ def test_trigsimp_groebner():
 
     # Test quick=False works
     assert trigsimp_groebner(ex, hints=[2]) in results
-    assert trigsimp_groebner(ex, hints=[long(2)]) in results
+    assert trigsimp_groebner(ex, hints=[int(2)]) in results
 
     # test "I"
     assert trigsimp_groebner(sin(I*x)/cos(I*x), hints=[tanh]) == I*tanh(x)

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -2,7 +2,6 @@ from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 from sympy import Symbol, Rational, SparseMatrix, Dict, diff, symbols, Indexed, IndexedBase, S
-from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import ImmutableSparseNDimArray
 from sympy.testing.pytest import raises
@@ -70,18 +69,18 @@ def test_ndim_array_initiation():
     assert array_with_many_args[0, 0] == 0
     assert array_with_many_args.rank() == 2
 
-    shape = (long(3), long(3))
+    shape = (int(3), int(3))
     array_with_long_shape = ImmutableSparseNDimArray.zeros(*shape)
     assert len(array_with_long_shape) == 3 * 3
     assert array_with_long_shape.shape == shape
-    assert array_with_long_shape[long(0), long(0)] == 0
+    assert array_with_long_shape[int(0), int(0)] == 0
     assert array_with_long_shape.rank() == 2
 
-    vector_with_long_shape = ImmutableDenseNDimArray(range(5), long(5))
+    vector_with_long_shape = ImmutableDenseNDimArray(range(5), int(5))
     assert len(vector_with_long_shape) == 5
-    assert vector_with_long_shape.shape == (long(5),)
+    assert vector_with_long_shape.shape == (int(5),)
     assert vector_with_long_shape.rank() == 1
-    raises(ValueError, lambda: vector_with_long_shape[long(5)])
+    raises(ValueError, lambda: vector_with_long_shape[int(5)])
 
     from sympy.abc import x
     for ArrayType in [ImmutableDenseNDimArray, ImmutableSparseNDimArray]:

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -2,7 +2,6 @@ from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
 from sympy import Symbol, Rational, SparseMatrix, diff, sympify, S
-from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
 from sympy.testing.pytest import raises
@@ -61,18 +60,18 @@ def test_ndim_array_initiation():
     assert array_with_many_args[0, 0] == 0
     assert array_with_many_args.rank() == 2
 
-    shape = (long(3), long(3))
+    shape = (int(3), int(3))
     array_with_long_shape = MutableSparseNDimArray.zeros(*shape)
     assert len(array_with_long_shape) == 3 * 3
     assert array_with_long_shape.shape == shape
-    assert array_with_long_shape[long(0), long(0)] == 0
+    assert array_with_long_shape[int(0), int(0)] == 0
     assert array_with_long_shape.rank() == 2
 
-    vector_with_long_shape = MutableDenseNDimArray(range(5), long(5))
+    vector_with_long_shape = MutableDenseNDimArray(range(5), int(5))
     assert len(vector_with_long_shape) == 5
-    assert vector_with_long_shape.shape == (long(5),)
+    assert vector_with_long_shape.shape == (int(5),)
     assert vector_with_long_shape.rank() == 1
-    raises(ValueError, lambda: vector_with_long_shape[long(5)])
+    raises(ValueError, lambda: vector_with_long_shape[int(5)])
 
     from sympy.abc import x
     for ArrayType in [MutableDenseNDimArray, MutableSparseNDimArray]:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -412,7 +412,6 @@ def translate(s, a, b=None, c=None):
     ========
 
     >>> from sympy.utilities.misc import translate
-    >>> from sympy.core.compatibility import unichr
     >>> abc = 'abc'
     >>> translate(abc, None, 'a')
     'bc'

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -3,7 +3,6 @@ import sys
 from subprocess import Popen, PIPE
 import os
 
-from sympy.core.compatibility import unichr
 from sympy.utilities.misc import translate, replace, ordinal, rawlines, strlines
 
 def test_translate():
@@ -16,7 +15,7 @@ def test_translate():
     assert translate(abc, {'ab': ''}, 'c') == ''
     assert translate(abc, {'bc': 'x'}, 'c') == 'ab'
     assert translate(abc, {'abc': 'x', 'a': 'y'}) == 'x'
-    u = unichr(4096)
+    u = chr(4096)
     assert translate(abc, 'a', 'x', u) == 'xbc'
     assert (u in translate(abc, 'a', u, u)) is True
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#17943 

#### Brief description of what is fixed or changed
 --> Removes `unichr`, `long`, `Iterator` and `round` imports from compatibility since python-2 support is dropped. 
 
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->