### PR TITLE
Make Poly subclass Basic rather than Expr

### DIFF
--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -403,7 +403,7 @@ expensive to calculate.
 
     >>> lamda = symbols('lamda')
     >>> p = M.charpoly(lamda)
-    >>> factor(p)
+    >>> factor(p.as_expr())
            2
     (λ - 5) ⋅(λ - 3)⋅(λ + 2)
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1760,8 +1760,6 @@ def test_is_constant():
     assert (3*meter).is_constant() is True
     assert (x*meter).is_constant() is False
 
-    assert Poly(3, x).is_constant() is True
-
 
 def test_equals():
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).equals(0)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -578,7 +578,7 @@ class RisingFactorial(CombinatorialFunction):
                                             "polynomials on one generator")
                             else:
                                 return reduce(lambda r, i:
-                                              r*(x.shift(i).expand()),
+                                              r*(x.shift(i)),
                                               range(0, int(k)), 1)
                         else:
                             return reduce(lambda r, i: r*(x + i),
@@ -597,7 +597,7 @@ class RisingFactorial(CombinatorialFunction):
                                             "polynomials on one generator")
                             else:
                                 return 1/reduce(lambda r, i:
-                                                r*(x.shift(-i).expand()),
+                                                r*(x.shift(-i)),
                                                 range(1, abs(int(k)) + 1), 1)
                         else:
                             return 1/reduce(lambda r, i:
@@ -717,7 +717,7 @@ class FallingFactorial(CombinatorialFunction):
                                             "polynomials on one generator")
                             else:
                                 return reduce(lambda r, i:
-                                              r*(x.shift(-i).expand()),
+                                              r*(x.shift(-i)),
                                               range(0, int(k)), 1)
                         else:
                             return reduce(lambda r, i: r*(x - i),
@@ -735,7 +735,7 @@ class FallingFactorial(CombinatorialFunction):
                                             "polynomials on one generator")
                             else:
                                 return 1/reduce(lambda r, i:
-                                                r*(x.shift(i).expand()),
+                                                r*(x.shift(i)),
                                                 range(1, abs(int(k)) + 1), 1)
                         else:
                             return 1/reduce(lambda r, i: r*(x + i),

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -29,6 +29,7 @@ from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
 from sympy.simplify.fu import sincos_to_sum
 from sympy.utilities.misc import filldedent
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 class Integral(AddWithLimits):
@@ -77,6 +78,13 @@ class Integral(AddWithLimits):
         #of behaviour with Integral.
         if hasattr(function, '_eval_Integral'):
             return function._eval_Integral(*symbols, **assumptions)
+
+        if isinstance(function, Poly):
+            SymPyDeprecationWarning(
+                feature="Using integrate/Integral with Poly",
+                issue=18613,
+                deprecated_since_version="1.6",
+                useinstead="the as_expr or integrate methods of Poly").warn()
 
         obj = AddWithLimits.__new__(cls, function, *symbols, **assumptions)
         return obj
@@ -885,6 +893,11 @@ class Integral(AddWithLimits):
         #
         # see Polynomial for details.
         if isinstance(f, Poly) and not (manual or meijerg or risch):
+            SymPyDeprecationWarning(
+                feature="Using integrate/Integral with Poly",
+                issue=18613,
+                deprecated_since_version="1.6",
+                useinstead="the as_expr or integrate methods of Poly").warn()
             return f.integrate(x)
 
         # Piecewise antiderivatives need to call special integrate.

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -138,7 +138,7 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
                 betaa, alphaa, alphad =  real_imag(ba, bd*a, DE.t)
                 betad = alphad
                 etaa, etad = frac_in(dcoeff, DE.t)
-                if recognize_log_derivative(2*betaa, betad, DE):
+                if recognize_log_derivative(Poly(2, DE.t)*betaa, betad, DE):
                     A = parametric_log_deriv(alphaa, alphad, etaa, etad, DE)
                     B = parametric_log_deriv(betaa, betad, etaa, etad, DE)
                     if A is not None and B is not None:
@@ -451,7 +451,7 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     for i in range(n, -1, -1):
         if DE.case == 'exp': # this re-checking can be avoided
             with DecrementLevel(DE):
-                ba, bd = frac_in(b + i*derivation(DE.t, DE)/DE.t,
+                ba, bd = frac_in(b + (i*(derivation(DE.t, DE)/DE.t)).as_poly(b.gens),
                                 DE.t, field=True)
         with DecrementLevel(DE):
             Qy = [frac_in(q.nth(i), DE.t, field=True) for q in Q]
@@ -470,7 +470,7 @@ def prde_cancel_liouvillian(b, Q, n, DE):
 
         # from eq. on top of p.238 (unnumbered)
         for j in range(ri):
-            hji = fi[j]*DE.t**i
+            hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
             # building up Sum(djn*(D(fjn*t^n) - b*fjnt^n))
             Fi[j] = -(derivation(hji, DE) - b*hji)
@@ -538,7 +538,7 @@ def param_poly_rischDE(a, b, q, n, DE):
 
     # Iterate SPDE as long as possible cumulating coefficient
     # and terms for the recovery of original solutions.
-    alpha, beta = 1, [0]*m
+    alpha, beta = a.one, [a.zero]*m
     while n >= 0:  # and a, b relatively prime
         a, b, q, r, n = prde_spde(a, b, q, n, DE)
         beta = [betai + alpha*ri for betai, ri in zip(beta, r)]
@@ -854,11 +854,12 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
             return None
 
         M, N = s[c1].as_numer_denom()
+        M_poly = M.as_poly(q.gens)
+        N_poly = N.as_poly(q.gens)
 
-        nfmwa = N*fa*wd - M*wa*fd
+        nfmwa = N_poly*fa*wd - M_poly*wa*fd
         nfmwd = fd*wd
-        Qv = is_log_deriv_k_t_radical_in_field(N*fa*wd - M*wa*fd, fd*wd, DE,
-            'auto')
+        Qv = is_log_deriv_k_t_radical_in_field(nfmwa, nfmwd, DE, 'auto')
         if Qv is None:
             # (N*f - M*w) is not the logarithmic derivative of a k(t)-radical.
             return None

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -224,7 +224,8 @@ def ratint_logpart(f, g, x, t=None):
     def _include_sign(c, sqf):
         if c.is_extended_real and (c < 0) == True:
             h, k = sqf[0]
-            sqf[0] = h*c, k
+            c_poly = c.as_poly(h.gens)
+            sqf[0] = h*c_poly, k
 
     C, res_sqf = res.sqf_list()
     _include_sign(C, res_sqf)

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -247,6 +247,7 @@ def ratint_logpart(f, g, x, t=None):
             inv, coeffs = h_lc.invert(q), [S.One]
 
             for coeff in h.coeffs()[1:]:
+                coeff = coeff.as_poly(inv.gens)
                 T = (inv*coeff).rem(q)
                 coeffs.append(T.as_expr())
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -235,8 +235,8 @@ def special_denom(a, ba, bd, ca, cd, DE, case='auto'):
                 betaa, betad = frac_in(re(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
                 etaa, etad = frac_in(dcoeff, DE.t)
 
-                if recognize_log_derivative(2*betaa, betad, DE):
-                    A = parametric_log_deriv(alphaa*sqrt(-1)*betad+alphad*betaa, alphad*betad, etaa, etad, DE)
+                if recognize_log_derivative(Poly(2, DE.t)*betaa, betad, DE):
+                    A = parametric_log_deriv(alphaa*Poly(sqrt(-1), DE.t)*betad+alphad*betaa, alphad*betad, etaa, etad, DE)
                     if A is not None:
                        Q, m, z = A
                        if Q == 1:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -891,7 +891,7 @@ def derivation(p, DE, coefficientD=False, basic=False):
         if basic:
             r += d.as_expr()*pv.diff(v)
         else:
-            r += (d.as_expr()*pv.diff(v)).as_poly(t)
+            r += (d.as_expr()*pv.diff(v).as_expr()).as_poly(t)
 
     if basic:
         r = cancel(r)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1135,8 +1135,10 @@ def laurent_series(a, d, F, n, DE):
         Q = Pa.quo(Pd)
         for i in range(0, j + 1):
             Q = Q.subs(Z[i], V[i])
-        Dha = hd*derivation(ha, DE, basic=True) + ha*derivation(hd, DE, basic=True)
-        Dha += hd*derivation(ha, DE_new, basic=True) + ha*derivation(hd, DE_new, basic=True)
+        Dha = (hd*derivation(ha, DE, basic=True).as_poly(DE.t)
+             + ha*derivation(hd, DE, basic=True).as_poly(DE.t)
+             + hd*derivation(ha, DE_new, basic=True).as_poly(DE.t)
+             + ha*derivation(hd, DE_new, basic=True).as_poly(DE.t))
         Dhd = Poly(j + 1, DE.t)*hd**2
         ha, hd = Dha, Dhd
 
@@ -1282,7 +1284,7 @@ def residue_reduce(a, d, DE, z=None, invert=True):
                 inv, coeffs = h_lc.as_poly(z, field=True).invert(s), [S.One]
 
                 for coeff in h.coeffs()[1:]:
-                    L = reduced(inv*coeff, [s])[1]
+                    L = reduced(inv*coeff.as_poly(inv.gens), [s])[1]
                     coeffs.append(L.as_expr())
 
                 h = Poly(dict(list(zip(h.monoms(), coeffs))), DE.t)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -891,7 +891,7 @@ def derivation(p, DE, coefficientD=False, basic=False):
         if basic:
             r += d.as_expr()*pv.diff(v)
         else:
-            r += (d*pv.diff(v)).as_poly(t)
+            r += (d.as_expr()*pv.diff(v)).as_poly(t)
 
     if basic:
         r = cancel(r)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -16,6 +16,7 @@ from sympy.physics import units
 from sympy.testing.pytest import (raises, slow, skip, ON_TRAVIS,
     warns_deprecated_sympy)
 from sympy.testing.randtest import verify_numerically
+from sympy.testing.pytest import warns_deprecated_sympy
 
 
 x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')
@@ -25,6 +26,15 @@ f = Function('f')
 
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)
+
+
+def test_poly_deprecated():
+    p = Poly(2*x, x)
+    assert p.integrate(x) == Poly(x**2, x, domain='QQ')
+    with warns_deprecated_sympy():
+        integrate(p, x)
+    with warns_deprecated_sympy():
+        Integral(p, (x,))
 
 
 def test_principal_value():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -232,8 +232,10 @@ def test_issue_18038():
 def test_integrate_poly():
     p = Poly(x + x**2*y + y**3, x, y)
 
-    qx = integrate(p, x)
-    qy = integrate(p, y)
+    with warns_deprecated_sympy():
+        qx = integrate(p, x)
+    with warns_deprecated_sympy():
+        qy = integrate(p, y)
 
     assert isinstance(qx, Poly) is True
     assert isinstance(qy, Poly) is True
@@ -248,8 +250,10 @@ def test_integrate_poly():
 def test_integrate_poly_defined():
     p = Poly(x + x**2*y + y**3, x, y)
 
-    Qx = integrate(p, (x, 0, 1))
-    Qy = integrate(p, (y, 0, pi))
+    with warns_deprecated_sympy():
+        Qx = integrate(p, (x, 0, 1))
+    with warns_deprecated_sympy():
+        Qy = integrate(p, (y, 0, pi))
 
     assert isinstance(Qx, Poly) is True
     assert isinstance(Qy, Poly) is True

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -16,7 +16,6 @@ from sympy.physics import units
 from sympy.testing.pytest import (raises, slow, skip, ON_TRAVIS,
     warns_deprecated_sympy)
 from sympy.testing.randtest import verify_numerically
-from sympy.testing.pytest import warns_deprecated_sympy
 
 
 x, y, a, t, x_1, x_2, z, s, b = symbols('x y a t x_1 x_2 z s b')

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -21,15 +21,17 @@ def test_prde_normal_denom():
     fd = Poly(x, t)
     G = [(Poly(t, t), Poly(1 + t**2, t)), (Poly(1, t), Poly(x + x*t**2, t))]
     assert prde_normal_denom(fa, fd, G, DE) == \
-        (Poly(x, t), (Poly(1, t), Poly(1, t)), [(Poly(x*t, t),
-         Poly(t**2 + 1, t)), (Poly(1, t), Poly(t**2 + 1, t))], Poly(1, t))
+        (Poly(x, t, domain='ZZ(x)'), (Poly(1, t, domain='ZZ(x)'), Poly(1, t,
+            domain='ZZ(x)')), [(Poly(x*t, t, domain='ZZ(x)'),
+         Poly(t**2 + 1, t, domain='ZZ(x)')), (Poly(1, t, domain='ZZ(x)'),
+             Poly(t**2 + 1, t, domain='ZZ(x)'))], Poly(1, t, domain='ZZ(x)'))
     G = [(Poly(t, t), Poly(t**2 + 2*t + 1, t)), (Poly(x*t, t),
         Poly(t**2 + 2*t + 1, t)), (Poly(x*t**2, t), Poly(t**2 + 2*t + 1, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     assert prde_normal_denom(Poly(x, t), Poly(1, t), G, DE) == \
-        (Poly(t + 1, t), (Poly((-1 + x)*t + x, t), Poly(1, t)), [(Poly(t, t),
-        Poly(1, t)), (Poly(x*t, t), Poly(1, t)), (Poly(x*t**2, t),
-        Poly(1, t))], Poly(t + 1, t))
+        (Poly(t + 1, t), (Poly((-1 + x)*t + x, t), Poly(1, t, domain='ZZ[x]')), [(Poly(t, t),
+        Poly(1, t)), (Poly(x*t, t), Poly(1, t, domain='ZZ[x]')), (Poly(x*t**2, t),
+        Poly(1, t, domain='ZZ[x]'))], Poly(t + 1, t))
 
 
 def test_prde_special_denom():
@@ -49,15 +51,15 @@ def test_prde_special_denom():
     DE.decrement_level()
     G = [(Poly(t, t), Poly(t**2, t)), (Poly(2*t, t), Poly(t, t))]
     assert prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3 + 2, t), G, DE) == \
-        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t, t), Poly(t**2, t)),
+        (Poly(5*x*t + 1, t), Poly(0, t, domain='ZZ[x]'), [(Poly(t, t), Poly(t**2, t)),
         (Poly(2*t, t), Poly(t, t))], Poly(1, x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly((t**2 + 1)*2*x, t)]})
     G = [(Poly(t + x, t), Poly(t*x, t)), (Poly(2*t, t), Poly(x**2, x))]
     assert prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE) == \
-        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)),
+        (Poly(5*x*t + 1, t), Poly(0, t, domain='ZZ[x]'), [(Poly(t + x, t), Poly(x*t, t)),
         (Poly(2*t, t, x), Poly(x**2, t, x))], Poly(1, t))
     assert prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE) == \
-        (Poly(t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t, x),
+        (Poly(t + 1, t), Poly(0, t, domain='ZZ[x]'), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t, x),
         Poly(x**2, t, x))], Poly(1, t))
 
 
@@ -66,15 +68,17 @@ def test_prde_linear_constraints():
     G = [(Poly(2*x**3 + 3*x + 1, x), Poly(x**2 - 1, x)), (Poly(1, x), Poly(x - 1, x)),
         (Poly(1, x), Poly(x + 1, x))]
     assert prde_linear_constraints(Poly(1, x), Poly(0, x), G, DE) == \
-        ((Poly(2*x, x), Poly(0, x), Poly(0, x)), Matrix([[1, 1, -1], [5, 1, 1]]))
+        ((Poly(2*x, x, domain='QQ'), Poly(0, x, domain='QQ'), Poly(0, x, domain='QQ')),
+            Matrix([[1, 1, -1], [5, 1, 1]]))
     G = [(Poly(t, t), Poly(1, t)), (Poly(t**2, t), Poly(1, t)), (Poly(t**3, t), Poly(1, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     assert prde_linear_constraints(Poly(t + 1, t), Poly(t**2, t), G, DE) == \
-        ((Poly(t, t), Poly(t**2, t), Poly(t**3, t)), Matrix(0, 3, []))
+        ((Poly(t, t, domain='QQ'), Poly(t**2, t, domain='QQ'), Poly(t**3, t, domain='QQ')),
+            Matrix(0, 3, []))
     G = [(Poly(2*x, t), Poly(t, t)), (Poly(-x, t), Poly(t, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     assert prde_linear_constraints(Poly(1, t), Poly(0, t), G, DE) == \
-        ((Poly(0, t), Poly(0, t)), Matrix([[2*x, -x]]))
+        ((Poly(0, t, domain='QQ[x]'), Poly(0, t, domain='QQ[x]')), Matrix([[2*x, -x]]))
 
 
 def test_constant_system():
@@ -95,8 +99,9 @@ def test_prde_spde():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     # TODO: when bound_degree() can handle this, test degree bound from that too
     assert prde_spde(Poly(t, t), Poly(-1/x, t), D, n, DE) == \
-        (Poly(t, t), Poly(0, t), [Poly(2*x, t), Poly(-x, t)],
-        [Poly(-x**2, t), Poly(0, t)], n - 1)
+        (Poly(t, t), Poly(0, t, domain='ZZ(x)'),
+        [Poly(2*x, t, domain='ZZ(x)'), Poly(-x, t, domain='ZZ(x)')],
+        [Poly(-x**2, t, domain='ZZ(x)'), Poly(0, t, domain='ZZ(x)')], n - 1)
 
 
 def test_prde_no_cancel():
@@ -162,7 +167,7 @@ def test_prde_cancel_liouvillian():
     # Not taken from book
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t, t)]})
     assert prde_cancel_liouvillian(Poly(0, t, domain='QQ[x]'), [Poly(1, t, domain='QQ(x)')], 0, DE) == \
-            ([Poly(1, t, domain='QQ'), Poly(x, t)], Matrix([[-1, 0, 1]]))
+            ([Poly(1, t, domain='QQ'), Poly(x, t, domain='ZZ(x)')], Matrix([[-1, 0, 1]]))
 
 
 def test_param_poly_rischDE():
@@ -175,7 +180,7 @@ def test_param_poly_rischDE():
     assert A.nullspace() == [Matrix([0, 1, 1, 1])]  # c1, c2, d1, d2
     # Solution of a*Dp + b*p = c1*q1 + c2*q2 = q2 = x**2
     # is d1*h1 + d2*h2 = h1 + h2 = x.
-    assert h[0] + h[1] == Poly(x, x)
+    assert h[0] + h[1] == Poly(x, x, domain='QQ')
     # a*Dp + b*p = q1 = x has no solution.
 
     a = Poly(x**2 - x, x, field=True)
@@ -186,7 +191,7 @@ def test_param_poly_rischDE():
 
     assert A.nullspace() == [Matrix([3, -5, 1, -5, 1, 1])]
     p = -5*h[0] + h[1] + h[2]  # Poly(1, x)
-    assert a*derivation(p, DE) + b*p == Poly(x**2 - 5*x + 3, x)
+    assert a*derivation(p, DE) + b*p == Poly(x**2 - 5*x + 3, x, domain='QQ')
 
 
 def test_param_rischDE():
@@ -220,8 +225,8 @@ def test_limited_integrate_reduce():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     assert limited_integrate_reduce(Poly(x, t), Poly(t**2, t), [(Poly(x, t),
     Poly(t, t))], DE) == \
-        (Poly(t, t), Poly(-1/x, t), Poly(t, t), 1, (Poly(x, t), Poly(1, t)),
-        [(Poly(-x*t, t), Poly(1, t))])
+        (Poly(t, t), Poly(-1/x, t), Poly(t, t), 1, (Poly(x, t), Poly(1, t, domain='ZZ[x]')),
+        [(Poly(-x*t, t), Poly(1, t, domain='ZZ[x]'))])
 
 
 def test_limited_integrate():
@@ -229,10 +234,10 @@ def test_limited_integrate():
     G = [(Poly(x, x), Poly(x + 1, x))]
     assert limited_integrate(Poly(-(1 + x + 5*x**2 - 3*x**3), x),
     Poly(1 - x - x**2 + x**3, x), G, DE) == \
-        ((Poly(x**2 - x + 2, x), Poly(x - 1, x)), [2])
+        ((Poly(x**2 - x + 2, x), Poly(x - 1, x, domain='QQ')), [2])
     G = [(Poly(1, x), Poly(x, x))]
     assert limited_integrate(Poly(5*x**2, x), Poly(3, x), G, DE) == \
-        ((Poly(5*x**3/9, x), Poly(1, x)), [0])
+        ((Poly(5*x**3/9, x), Poly(1, x, domain='QQ')), [0])
 
 
 def test_is_log_deriv_k_t_radical():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -190,7 +190,7 @@ def test_param_poly_rischDE():
     h, A = param_poly_rischDE(a, b, q, 3, DE)
 
     assert A.nullspace() == [Matrix([3, -5, 1, -5, 1, 1])]
-    p = -5*h[0] + h[1] + h[2]  # Poly(1, x)
+    p = -Poly(5, DE.t)*h[0] + h[1] + h[2]  # Poly(1, x)
     assert a*derivation(p, DE) + b*p == Poly(x**2 - 5*x + 3, x, domain='QQ')
 
 

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -40,8 +40,9 @@ def test_weak_normalizer():
     d = Poly(t**4 - 3*t**2 + 2, t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     r = weak_normalizer(a, d, DE, z)
-    assert r == (Poly(t**5 - t**4 - 4*t**3 + 4*t**2 + 4*t - 4, t),
-        (Poly((1 + x)*t**2 + x*t, t), Poly(t + 1, t)))
+    assert r == (Poly(t**5 - t**4 - 4*t**3 + 4*t**2 + 4*t - 4, t, domain='ZZ[x]'),
+        (Poly((1 + x)*t**2 + x*t, t, domain='ZZ[x]'),
+         Poly(t + 1, t, domain='ZZ[x]')))
     assert weak_normalizer(r[1][0], r[1][1], DE) == (Poly(1, t), r[1])
     r = weak_normalizer(Poly(1 + t**2), Poly(t**2 - 1, t), DE, z)
     assert r == (Poly(t**4 - 2*t**2 + 1, t), (Poly(-3*t**2 + 1, t), Poly(t**2 - 1, t)))
@@ -123,26 +124,27 @@ def test_spde():
     raises(NonElementaryIntegralException, lambda: spde(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     assert spde(Poly(t**2 + x*t*2 + x**2, t), Poly(t**2/x**2 + (2/x - 1)*t, t),
-    Poly(t**2/x**2 + (2/x - 1)*t, t), 0, DE) == \
-        (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t))
+        Poly(t**2/x**2 + (2/x - 1)*t, t), 0, DE) == \
+        (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='ZZ(x)'))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0/x**2, t0), Poly(1/x, t)]})
     assert spde(Poly(t**2, t), Poly(-t**2/x**2 - 1/x, t),
     Poly((2*x - 1)*t**4 + (t0 + x)/x*t**3 - (t0 + 4*x**2)/(2*x)*t**2 + x*t, t), 3, DE) == \
         (Poly(0, t), Poly(0, t), 0, Poly(0, t),
-        Poly(t0*t**2/2 + x**2*t**2 - x**2*t, t))
+        Poly(t0*t**2/2 + x**2*t**2 - x**2*t, t, domain='ZZ(x,t0)'))
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
     assert spde(Poly(x**2 + x + 1, x), Poly(-2*x - 1, x), Poly(x**5/2 +
     3*x**4/4 + x**3 - x**2 + 1, x), 4, DE) == \
-        (Poly(0, x), Poly(x/2 - Rational(1, 4), x), 2, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
+        (Poly(0, x, domain='QQ'), Poly(x/2 - Rational(1, 4), x), 2, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
     assert spde(Poly(x**2 + x + 1, x), Poly(-2*x - 1, x), Poly(x**5/2 +
     3*x**4/4 + x**3 - x**2 + 1, x), n, DE) == \
-        (Poly(0, x), Poly(x/2 - Rational(1, 4), x), -2 + n, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
+        (Poly(0, x, domain='QQ'), Poly(x/2 - Rational(1, 4), x), -2 + n, Poly(x**2 + x + 1, x), Poly(x*Rational(5, 4), x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
     raises(NonElementaryIntegralException, lambda: spde(Poly((t - 1)*(t**2 + 1)**2, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
-    assert spde(Poly(x**2 - x, x), Poly(1, x), Poly(9*x**4 - 10*x**3 + 2*x**2, x), 4, DE) == (Poly(0, x), Poly(0, x), 0, Poly(0, x), Poly(3*x**3 - 2*x**2, x))
+    assert spde(Poly(x**2 - x, x), Poly(1, x), Poly(9*x**4 - 10*x**3 + 2*x**2, x), 4, DE) == \
+        (Poly(0, x, domain='ZZ'), Poly(0, x), 0, Poly(0, x), Poly(3*x**3 - 2*x**2, x, domain='QQ'))
     assert spde(Poly(x**2 - x, x), Poly(x**2 - 5*x + 3, x), Poly(x**7 - x**6 - 2*x**4 + 3*x**3 - x**2, x), 5, DE) == \
-        (Poly(1, x), Poly(x + 1, x), 1, Poly(x**4 - x**3, x), Poly(x**3 - x**2, x))
+        (Poly(1, x, domain='QQ'), Poly(x + 1, x, domain='QQ'), 1, Poly(x**4 - x**3, x), Poly(x**3 - x**2, x, domain='QQ'))
 
 def test_solve_poly_rde_no_cancel():
     # deg(b) large

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -78,7 +78,8 @@ def test_splitfactor():
         (2*x + 7*x**2 + 2*x**3)*t**2 + (1 - 4*x - 4*x**2)*t - 1 + 2*x, t, field=True)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t**2 - 3/(2*x)*t + 1/(2*x), t)]})
     assert splitfactor(p, DE) == (Poly(4*x**4*t**3 + (-8*x**3 - 4*x**4)*t**2 +
-        (4*x**2 + 8*x**3)*t - 4*x**2, t), Poly(t**2 + 1/x*t + (1 - 2*x)/(4*x**2), t, domain='ZZ(x)'))
+        (4*x**2 + 8*x**3)*t - 4*x**2, t, domain='ZZ(x)'),
+        Poly(t**2 + 1/x*t + (1 - 2*x)/(4*x**2), t, domain='ZZ(x)'))
     assert splitfactor(Poly(x, t), DE) == (Poly(x, t), Poly(1, t))
     r = Poly(-4*x**4*z**2 + 4*x**6*z**2 - z*x**3 - 4*x**5*z**3 + 4*x**3*z**3 + x**4 + z*x**5 - x**6, t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
@@ -93,30 +94,34 @@ def test_splitfactor():
 def test_canonical_representation():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1 + t**2, t)]})
     assert canonical_representation(Poly(x - t, t), Poly(t**2, t), DE) == \
-        (Poly(0, t), (Poly(0, t),
-        Poly(1, t)), (Poly(-t + x, t),
+        (Poly(0, t, domain='ZZ[x]'), (Poly(0, t, domain='QQ[x]'),
+        Poly(1, t, domain='ZZ')), (Poly(-t + x, t, domain='QQ[x]'),
         Poly(t**2, t)))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
     assert canonical_representation(Poly(t**5 + t**3 + x**2*t + 1, t),
     Poly((t**2 + 1)**3, t), DE) == \
-        (Poly(0, t), (Poly(t**5 + t**3 + x**2*t + 1, t),
-        Poly(t**6 + 3*t**4 + 3*t**2 + 1, t)), (Poly(0, t), Poly(1, t)))
+        (Poly(0, t, domain='ZZ[x]'), (Poly(t**5 + t**3 + x**2*t + 1, t, domain='QQ[x]'),
+         Poly(t**6 + 3*t**4 + 3*t**2 + 1, t, domain='QQ')),
+        (Poly(0, t, domain='QQ[x]'), Poly(1, t, domain='QQ')))
 
 
 def test_hermite_reduce():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
 
     assert hermite_reduce(Poly(x - t, t), Poly(t**2, t), DE) == \
-        ((Poly(-x, t), Poly(t, t)), (Poly(0, t), Poly(1, t)), (Poly(-x, t), Poly(1, t)))
+        ((Poly(-x, t, domain='QQ[x]'), Poly(t, t, domain='QQ[x]')),
+         (Poly(0, t, domain='QQ[x]'), Poly(1, t, domain='QQ[x]')),
+         (Poly(-x, t, domain='QQ[x]'), Poly(1, t, domain='QQ[x]')))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t**2 - t/x - (1 - nu**2/x**2), t)]})
 
     assert hermite_reduce(
             Poly(x**2*t**5 + x*t**4 - nu**2*t**3 - x*(x**2 + 1)*t**2 - (x**2 - nu**2)*t - x**5/4, t),
             Poly(x**2*t**4 + x**2*(x**2 + 2)*t**2 + x**2 + x**4 + x**6/4, t), DE) == \
-        ((Poly(-x**2 - 4, t), Poly(4*t**2 + 2*x**2 + 4, t)),
-         (Poly((-2*nu**2 - x**4)*t - (2*x**3 + 2*x), t), Poly(2*x**2*t**2 + x**4 + 2*x**2, t)),
-         (Poly(x*t + 1, t), Poly(x, t)))
+        ((Poly(-x**2 - 4, t, domain='ZZ(x,nu)'), Poly(4*t**2 + 2*x**2 + 4, t, domain='ZZ(x,nu)')),
+         (Poly((-2*nu**2 - x**4)*t - (2*x**3 + 2*x), t, domain='ZZ(x,nu)'),
+          Poly(2*x**2*t**2 + x**4 + 2*x**2, t, domain='ZZ(x,nu)')),
+         (Poly(x*t + 1, t, domain='ZZ(x,nu)'), Poly(x, t, domain='ZZ(x,nu)')))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
 
@@ -124,30 +129,33 @@ def test_hermite_reduce():
     d = Poly(x*t**6 - 4*x**2*t**5 + 6*x**3*t**4 - 4*x**4*t**3 + x**5*t**2, t)
 
     assert hermite_reduce(a, d, DE) == \
-        ((Poly(3*t**2 + t + 3*x, t), Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t)),
-         (Poly(0, t), Poly(1, t)),
-         (Poly(0, t), Poly(1, t)))
+        ((Poly(3*t**2 + t + 3*x, t, domain='ZZ(x)'),
+          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')))
 
     assert hermite_reduce(
-            Poly(-t**2 + 2*t + 2, t),
-            Poly(-x*t**2 + 2*x*t - x, t), DE) == \
-        ((Poly(3, t), Poly(t - 1, t)),
-         (Poly(0, t), Poly(1, t)),
-         (Poly(1, t), Poly(x, t)))
+            Poly(-t**2 + 2*t + 2, t, domain='ZZ(x)'),
+            Poly(-x*t**2 + 2*x*t - x, t, domain='ZZ(x)'), DE) == \
+        ((Poly(3, t, domain='ZZ(x)'), Poly(t - 1, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
+         (Poly(1, t, domain='ZZ(x)'), Poly(x, t, domain='ZZ(x)')))
 
     assert hermite_reduce(
-            Poly(-x**2*t**6 + (-1 - 2*x**3 + x**4)*t**3 + (-3 - 3*x**4)*t**2 - 2*x*t - x - 3*x**2, t),
-            Poly(x**4*t**6 - 2*x**2*t**3 + 1, t), DE) == \
-        ((Poly(x**3*t + x**4 + 1, t), Poly(x**3*t**3 - x, t)),
-         (Poly(0, t), Poly(1, t)),
-         (Poly(-1, t), Poly(x**2, t)))
+            Poly(-x**2*t**6 + (-1 - 2*x**3 + x**4)*t**3 + (-3 - 3*x**4)*t**2 -
+                2*x*t - x - 3*x**2, t, domain='ZZ(x)'),
+            Poly(x**4*t**6 - 2*x**2*t**3 + 1, t, domain='ZZ(x)'), DE) == \
+        ((Poly(x**3*t + x**4 + 1, t, domain='ZZ(x)'), Poly(x**3*t**3 - x, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
+         (Poly(-1, t, domain='ZZ(x)'), Poly(x**2, t, domain='ZZ(x)')))
 
     assert hermite_reduce(
             Poly((-2 + 3*x)*t**3 + (-1 + x)*t**2 + (-4*x + 2*x**2)*t + x**2, t),
             Poly(x*t**6 - 4*x**2*t**5 + 6*x**3*t**4 - 4*x**4*t**3 + x**5*t**2, t), DE) == \
-        ((Poly(3*t**2 + t + 3*x, t), Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t)),
-         (Poly(0, t), Poly(1, t)),
-         (Poly(0, t), Poly(1, t)))
+        ((Poly(3*t**2 + t + 3*x, t, domain='ZZ(x)'),
+          Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')),
+         (Poly(0, t, domain='ZZ(x)'), Poly(1, t, domain='ZZ(x)')))
 
 
 def test_polynomial_reduce():
@@ -166,7 +174,7 @@ def test_laurent_series():
     n = 2
     assert laurent_series(a, d, F, n, DE) == \
         (Poly(-3*t**3 + 3*t**2 - 6*t - 8, t), Poly(t**5 + t**4 - 2*t**3 - 2*t**2 + t + 1, t),
-        [Poly(-3*t**3 - 6*t**2, t), Poly(2*t**6 + 6*t**5 - 8*t**3, t)])
+        [Poly(-3*t**3 - 6*t**2, t, domain='QQ'), Poly(2*t**6 + 6*t**5 - 8*t**3, t, domain='QQ')])
 
 
 def test_recognize_derivative():
@@ -205,28 +213,30 @@ def test_residue_reduce():
     d = Poly(t**3 - x**2*t, t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)], 'Tfuncs': [log]})
     assert residue_reduce(a, d, DE, z, invert=False) == \
-        ([(Poly(z**2 - Rational(1, 4), z), Poly((1 + 3*x*z - 6*z**2 -
-        2*x**2 + 4*x**2*z**2)*t - x*z + x**2 + 2*x**2*z**2 - 2*z*x**3, t))], False)
+        ([(Poly(z**2 - Rational(1, 4), z, domain='ZZ(x)'),
+          Poly((1 + 3*x*z - 6*z**2 - 2*x**2 + 4*x**2*z**2)*t - x*z + x**2 +
+              2*x**2*z**2 - 2*z*x**3, t, domain='ZZ(z, x)'))], False)
     assert residue_reduce(a, d, DE, z, invert=True) == \
-        ([(Poly(z**2 - Rational(1, 4), z), Poly(t + 2*x*z, t))], False)
+        ([(Poly(z**2 - Rational(1, 4), z, domain='ZZ(x)'), Poly(t + 2*x*z, t))], False)
     assert residue_reduce(Poly(-2/x, t), Poly(t**2 - 1, t,), DE, z, invert=False) == \
-        ([(Poly(z**2 - 1, z), Poly(-2*z*t/x - 2/x, t))], True)
+        ([(Poly(z**2 - 1, z, domain='QQ'), Poly(-2*z*t/x - 2/x, t, domain='ZZ(z,x)'))], True)
     ans = residue_reduce(Poly(-2/x, t), Poly(t**2 - 1, t), DE, z, invert=True)
-    assert ans == ([(Poly(z**2 - 1, z), Poly(t + z, t))], True)
+    assert ans == ([(Poly(z**2 - 1, z, domain='QQ'), Poly(t + z, t))], True)
     assert residue_reduce_to_basic(ans[0], DE, z) == -log(-1 + log(x)) + log(1 + log(x))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t**2 - t/x - (1 - nu**2/x**2), t)]})
     # TODO: Skip or make faster
     assert residue_reduce(Poly((-2*nu**2 - x**4)/(2*x**2)*t - (1 + x**2)/x, t),
     Poly(t**2 + 1 + x**2/2, t), DE, z) == \
-        ([(Poly(z + S.Half, z, domain='QQ'), Poly(t**2 + 1 + x**2/2, t, domain='EX'))], True)
+        ([(Poly(z + S.Half, z, domain='QQ'), Poly(t**2 + 1 + x**2/2, t,
+            domain='ZZ(x,nu)'))], True)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1 + t**2, t)]})
     assert residue_reduce(Poly(-2*x*t + 1 - x**2, t),
     Poly(t**2 + 2*x*t + 1 + x**2, t), DE, z) == \
         ([(Poly(z**2 + Rational(1, 4), z), Poly(t + x + 2*z, t))], True)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     assert residue_reduce(Poly(t, t), Poly(t + sqrt(2), t), DE, z) == \
-        ([(Poly(z - 1, z), Poly(t + sqrt(2), t))], True)
+        ([(Poly(z - 1, z, domain='QQ'), Poly(t + sqrt(2), t))], True)
 
 
 def test_integrate_hyperexponential():

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -14,7 +14,7 @@ def test_smith_normal():
                 [0, Poly(x), Poly(-1,x)],
                 [Poly(0,x),Poly(-1,x),Poly(x)]])
     setattr(m, 'ring', QQ[x])
-    invs = (Poly(1, x), Poly(x - 1), Poly(x**2 - 1))
+    invs = (Poly(1, x, domain='QQ'), Poly(x - 1, domain='QQ'), Poly(x**2 - 1, domain='QQ'))
     assert invariant_factors(m) == invs
 
     m = Matrix([[2, 4]])

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -93,7 +93,7 @@ def symmetrize(F, *gens, **args):
 
         if not f.is_homogeneous:
             symmetric.append(f.TC())
-            f -= f.TC()
+            f -= f.TC().as_poly(f.gens)
 
         while f:
             _height, _monom, _coeff = -1, None, None

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -470,7 +470,7 @@ def roots_cyclotomic(f, factor=False):
     for n in range(L, U + 1):
         g = cyclotomic_poly(n, f.gen, polys=True)
 
-        if f == g:
+        if f.expr == g.expr:
             break
     else:  # pragma: no cover
         raise RuntimeError("failed to find index of a cyclotomic polynomial")

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -65,13 +65,16 @@ def _polifyit(func):
             try:
                 g = f.from_expr(g, *f.gens)
             except PolynomialError:
+                if g.is_Matrix:
+                    return NotImplemented
                 expr_method = getattr(f.as_expr(), func.__name__)
                 result = expr_method(g)
-                SymPyDeprecationWarning(
-                    feature="Mixing Poly with non-polynomial expressions in binary operations",
-                    issue=18613,
-                    deprecated_since_version="1.6",
-                    useinstead="the as_expr or as_poly method to convert types").warn()
+                if result is not NotImplemented:
+                    SymPyDeprecationWarning(
+                        feature="Mixing Poly with non-polynomial expressions in binary operations",
+                        issue=18613,
+                        deprecated_since_version="1.6",
+                        useinstead="the as_expr or as_poly method to convert types").warn()
                 return result
             else:
                 return func(f, g)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5944,7 +5944,7 @@ def _symbolic_factor_list(expr, opt, method):
 
 def _symbolic_factor(expr, opt, method):
     """Helper function for :func:`_factor`. """
-    if isinstance(expr, Expr) and not expr.is_Relational:
+    if isinstance(expr, Expr):
         if hasattr(expr,'_eval_factor'):
             return expr._eval_factor()
         coeff, factors = _symbolic_factor_list(together(expr, fraction=opt['fraction']), opt, method)
@@ -5964,7 +5964,7 @@ def _generic_factor_list(expr, gens, args, method):
 
     expr = sympify(expr)
 
-    if isinstance(expr, (Expr, Poly)) and not expr.is_Relational:
+    if isinstance(expr, (Expr, Poly)):
         if isinstance(expr, Poly):
             numer, denom = expr, 1
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4064,7 +4064,7 @@ class Poly(Basic):
         if n.is_Integer and n >= 0:
             return f.pow(n)
         else:
-            return f.as_expr()**n
+            return NotImplemented
 
     @_sympifyit_Poly
     def __divmod__(f, g):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -54,7 +54,7 @@ from mpmath.libmp.libhyper import NoConvergence
 
 
 
-def _sympifyit_Poly(func):
+def _polifyit(func):
     @wraps(func)
     def wrapper(f, g):
         g = _sympify(g)
@@ -4035,27 +4035,27 @@ class Poly(Basic):
     def __neg__(f):
         return f.neg()
 
-    @_sympifyit_Poly
+    @_polifyit
     def __add__(f, g):
         return f.add(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __radd__(f, g):
         return g.add(f)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __sub__(f, g):
         return f.sub(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __rsub__(f, g):
         return g.sub(f)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __mul__(f, g):
         return f.mul(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __rmul__(f, g):
         return g.mul(f)
 
@@ -4066,27 +4066,27 @@ class Poly(Basic):
         else:
             return NotImplemented
 
-    @_sympifyit_Poly
+    @_polifyit
     def __divmod__(f, g):
         return f.div(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __rdivmod__(f, g):
         return g.div(f)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __mod__(f, g):
         return f.rem(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __rmod__(f, g):
         return g.rem(f)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __floordiv__(f, g):
         return f.quo(g)
 
-    @_sympifyit_Poly
+    @_polifyit
     def __rfloordiv__(f, g):
         return g.quo(f)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -45,6 +45,7 @@ from sympy.polys.polyutils import (
 from sympy.polys.rationaltools import together
 from sympy.polys.rootisolation import dup_isolate_real_roots_list
 from sympy.utilities import group, sift, public, filldedent
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 # Required to avoid errors
 import sympy.polys
@@ -64,7 +65,14 @@ def _polifyit(func):
             try:
                 g = f.from_expr(g, *f.gens)
             except PolynomialError:
-                return NotImplemented
+                expr_method = getattr(f.as_expr(), func.__name__)
+                result = expr_method(g)
+                SymPyDeprecationWarning(
+                    feature="Mixing Poly with non-polynomial expressions in binary operations",
+                    issue=18613,
+                    deprecated_since_version="1.6",
+                    useinstead="the as_expr or as_poly method to convert types").warn()
+                return result
             else:
                 return func(f, g)
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function, division
 
+from functools import wraps
+
 from sympy.core import (
     S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
 )
@@ -12,7 +14,7 @@ from sympy.core.function import Derivative
 from sympy.core.mul import _keep_coeff
 from sympy.core.relational import Relational
 from sympy.core.symbol import Symbol
-from sympy.core.sympify import sympify
+from sympy.core.sympify import sympify, _sympify
 from sympy.logic.boolalg import BooleanAtom
 from sympy.polys import polyoptions as options
 from sympy.polys.constructor import construct_domain
@@ -50,6 +52,24 @@ import sympy.polys
 import mpmath
 from mpmath.libmp.libhyper import NoConvergence
 
+
+
+def _sympifyit_Poly(func):
+    @wraps(func)
+    def wrapper(f, g):
+        g = _sympify(g)
+        if isinstance(g, Poly):
+            return func(f, g)
+        elif isinstance(g, Expr):
+            try:
+                g = f.from_expr(g, *f.gens)
+            except PolynomialError:
+                return NotImplemented
+            else:
+                return func(f, g)
+        else:
+            return NotImplemented
+    return wrapper
 
 
 
@@ -4015,66 +4035,28 @@ class Poly(Basic):
     def __neg__(f):
         return f.neg()
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __add__(f, g):
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return f.as_expr() + g
-
         return f.add(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __radd__(f, g):
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return g + f.as_expr()
-
         return g.add(f)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __sub__(f, g):
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return f.as_expr() - g
-
         return f.sub(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __rsub__(f, g):
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return g - f.as_expr()
-
         return g.sub(f)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __mul__(f, g):
-        if not isinstance(g, (Expr, Poly)):
-            return NotImplemented
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return f.as_expr()*g
-
         return f.mul(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __rmul__(f, g):
-        if not g.is_Poly:
-            try:
-                g = f.__class__(g, *f.gens)
-            except PolynomialError:
-                return g*f.as_expr()
-
         return g.mul(f)
 
     @_sympifyit('n', NotImplemented)
@@ -4084,46 +4066,28 @@ class Poly(Basic):
         else:
             return f.as_expr()**n
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __divmod__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return f.div(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __rdivmod__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return g.div(f)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __mod__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return f.rem(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __rmod__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return g.rem(f)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __floordiv__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return f.quo(g)
 
-    @_sympifyit('g', NotImplemented)
+    @_sympifyit_Poly
     def __rfloordiv__(f, g):
-        if not g.is_Poly:
-            g = f.__class__(g, *f.gens)
-
         return g.quo(f)
 
     @_sympifyit('g', NotImplemented)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4115,13 +4115,7 @@ class Poly(Basic):
             return False
 
         if f.rep.dom != g.rep.dom:
-            try:
-                dom = f.rep.dom.unify(g.rep.dom, f.gens)
-            except UnificationFailed:
-                return False
-
-            f = f.set_domain(dom)
-            g = g.set_domain(dom)
+            return False
 
         return f.rep == g.rep
 

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -772,7 +772,7 @@ def subresultants_bezout(p, q, x):
 
         # apply Theorem 2.1 in the paper by Toca & Vega 2004
         # to get correct signs
-        SR_L.append((int((-1)**(j*(j-1)/2)) * Poly(coeff_L, x) / F).as_expr())
+        SR_L.append(int((-1)**(j*(j-1)/2)) * (Poly(coeff_L, x) / F).as_expr())
         j = j + 1
 
     return process_matrix_output(SR_L, x)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -79,8 +79,8 @@ def test_minimal_polynomial():
     assert minimal_polynomial(sqrt(2), x) == x**2 - 2
 
     assert minimal_polynomial(sqrt(2), polys=True) == Poly(x**2 - 2)
-    assert minimal_polynomial(sqrt(2), x, polys=True) == Poly(x**2 - 2)
-    assert minimal_polynomial(sqrt(2), x, polys=True, compose=False) == Poly(x**2 - 2)
+    assert minimal_polynomial(sqrt(2), x, polys=True) == Poly(x**2 - 2, domain='QQ')
+    assert minimal_polynomial(sqrt(2), x, polys=True, compose=False) == Poly(x**2 - 2, domain='QQ')
 
     a = AlgebraicNumber(sqrt(2))
     b = AlgebraicNumber(sqrt(3))
@@ -88,8 +88,8 @@ def test_minimal_polynomial():
     assert minimal_polynomial(a, x) == x**2 - 2
     assert minimal_polynomial(b, x) == x**2 - 3
 
-    assert minimal_polynomial(a, x, polys=True) == Poly(x**2 - 2)
-    assert minimal_polynomial(b, x, polys=True) == Poly(x**2 - 3)
+    assert minimal_polynomial(a, x, polys=True) == Poly(x**2 - 2, domain='QQ')
+    assert minimal_polynomial(b, x, polys=True) == Poly(x**2 - 3, domain='QQ')
 
     assert minimal_polynomial(sqrt(a/2 + 17), x) == 2*x**4 - 68*x**2 + 577
     assert minimal_polynomial(sqrt(b/2 + 17), x) == 4*x**4 - 136*x**2 + 1153
@@ -274,9 +274,9 @@ def test_primitive_element():
     assert primitive_element(
         [sqrt(2), sqrt(3)], x) == (x**4 - 10*x**2 + 1, [1, 1])
 
-    assert primitive_element([sqrt(2)], x, polys=True) == (Poly(x**2 - 2), [1])
+    assert primitive_element([sqrt(2)], x, polys=True) == (Poly(x**2 - 2, domain='QQ'), [1])
     assert primitive_element([sqrt(
-        2), sqrt(3)], x, polys=True) == (Poly(x**4 - 10*x**2 + 1), [1, 1])
+        2), sqrt(3)], x, polys=True) == (Poly(x**4 - 10*x**2 + 1, domain='QQ'), [1, 1])
 
     assert primitive_element(
         [sqrt(2)], x, ex=True) == (x**2 - 2, [1], [[1, 0]])
@@ -285,9 +285,9 @@ def test_primitive_element():
          Q(1, 2), 0, Q(11, 2), 0]])
 
     assert primitive_element(
-        [sqrt(2)], x, ex=True, polys=True) == (Poly(x**2 - 2), [1], [[1, 0]])
+        [sqrt(2)], x, ex=True, polys=True) == (Poly(x**2 - 2, domain='QQ'), [1], [[1, 0]])
     assert primitive_element([sqrt(2), sqrt(3)], x, ex=True, polys=True) == \
-        (Poly(x**4 - 10*x**2 + 1), [1, 1], [[Q(1, 2), 0, -Q(9, 2),
+        (Poly(x**4 - 10*x**2 + 1, domain='QQ'), [1, 1], [[Q(1, 2), 0, -Q(9, 2),
          0], [-Q(1, 2), 0, Q(11, 2), 0]])
 
     assert primitive_element([sqrt(2)], polys=True) == (Poly(x**2 - 2), [1])
@@ -631,8 +631,8 @@ def test_AlgebraicNumber():
     a = AlgebraicNumber(sqrt(2), [1, 0])
     b = AlgebraicNumber(sqrt(2), [1, 0], alias=y)
 
-    assert a.as_poly(x) == Poly(x)
-    assert b.as_poly() == Poly(y)
+    assert a.as_poly(x) == Poly(x, domain='QQ')
+    assert b.as_poly() == Poly(y, domain='QQ')
 
     assert a.as_expr() == sqrt(2)
     assert a.as_expr(x) == x
@@ -646,8 +646,8 @@ def test_AlgebraicNumber():
 
     assert p == Poly(2*p.gen + 3)
 
-    assert a.as_poly(x) == Poly(2*x + 3)
-    assert b.as_poly() == Poly(2*y + 3)
+    assert a.as_poly(x) == Poly(2*x + 3, domain='QQ')
+    assert b.as_poly() == Poly(2*y + 3, domain='QQ')
 
     assert a.as_expr() == 2*sqrt(2) + 3
     assert a.as_expr(x) == 2*x + 3
@@ -725,12 +725,12 @@ def test_minpoly_fraction_field():
     assert minimal_polynomial(sqrt(x) / z, y) == z**2*y**2 - x
     assert minimal_polynomial(sqrt(x) / (z + 1), y) == (z**2 + 2*z + 1)*y**2 - x
 
-    assert minimal_polynomial(1/x, y, polys=True) == Poly(-x*y + 1, y)
+    assert minimal_polynomial(1/x, y, polys=True) == Poly(-x*y + 1, y, domain='ZZ(x)')
     assert minimal_polynomial(1 / (x + 1), y, polys=True) == \
-        Poly((x + 1)*y - 1, y)
-    assert minimal_polynomial(sqrt(x), y, polys=True) == Poly(y**2 - x, y)
+        Poly((x + 1)*y - 1, y, domain='ZZ(x)')
+    assert minimal_polynomial(sqrt(x), y, polys=True) == Poly(y**2 - x, y, domain='ZZ(x)')
     assert minimal_polynomial(sqrt(x) / z, y, polys=True) == \
-        Poly(z**2*y**2 - x, y)
+        Poly(z**2*y**2 - x, y, domain='ZZ(x, z)')
 
     # this is (sqrt(1 + x**3)/x).integrate(x).diff(x) - sqrt(1 + x**3)/x
     a = sqrt(x)/sqrt(1 + x**(-3)) - sqrt(x**3 + 1)/x + 1/(x**Rational(5, 2)* \

--- a/sympy/polys/tests/test_orthopolys.py
+++ b/sympy/polys/tests/test_orthopolys.py
@@ -103,7 +103,7 @@ def test_hermite_poly():
 def test_legendre_poly():
     raises(ValueError, lambda: legendre_poly(-1, x))
 
-    assert legendre_poly(1, x, polys=True) == Poly(x)
+    assert legendre_poly(1, x, polys=True) == Poly(x, domain='QQ')
 
     assert legendre_poly(0, x) == 1
     assert legendre_poly(1, x) == x
@@ -121,7 +121,7 @@ def test_legendre_poly():
 def test_laguerre_poly():
     raises(ValueError, lambda: laguerre_poly(-1, x))
 
-    assert laguerre_poly(1, x, polys=True) == Poly(-x + 1)
+    assert laguerre_poly(1, x, polys=True) == Poly(-x + 1, domain='QQ')
 
     assert laguerre_poly(0, x) == 1
     assert laguerre_poly(1, x) == -x + 1

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -58,10 +58,11 @@ from sympy import (
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
 from sympy.abc import a, b, c, d, p, q, t, w, x, y, z
 from sympy import MatrixSymbol, Matrix
+
 
 def _epsilon_eq(a, b):
     for u, v in zip(a, b):
@@ -81,6 +82,16 @@ def _strict_eq(a, b):
             return isinstance(a, Poly) and a.eq(b, strict=True)
     else:
         return False
+
+
+def test_Poly_mixed_operations():
+    p = Poly(x, x)
+    with warns_deprecated_sympy():
+        p * exp(x)
+    with warns_deprecated_sympy():
+        p + exp(x)
+    with warns_deprecated_sympy():
+        p - exp(x)
 
 
 def test_Poly_from_dict():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -696,8 +696,8 @@ def test_Poly_pow():
 
     assert Poly(7*x*y, x, y)**3 == Poly(343*x**3*y**3, x, y)
 
-    assert Poly(x*y + 1, x, y)**(-1) == (x*y + 1)**(-1)
-    assert Poly(x*y + 1, x, y)**x == (x*y + 1)**x
+    raises(TypeError, lambda: Poly(x*y + 1, x, y)**(-1))
+    raises(TypeError, lambda: Poly(x*y + 1, x, y)**x)
 
 
 def test_Poly_divmod():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -650,7 +650,8 @@ def test_Poly_add():
     assert Poly(0, x, y) + Poly(1, x, y) == Poly(1, x, y)
 
     assert Poly(1, x) + x == Poly(x + 1, x)
-    raises(TypeError, lambda: Poly(1, x) + sin(x))
+    with warns_deprecated_sympy():
+        Poly(1, x) + sin(x)
 
     assert Poly(x, x) + 1 == Poly(x + 1, x)
     assert 1 + Poly(x, x) == Poly(x + 1, x)
@@ -666,7 +667,8 @@ def test_Poly_sub():
     assert Poly(0, x, y) - Poly(1, x, y) == Poly(-1, x, y)
 
     assert Poly(1, x) - x == Poly(1 - x, x)
-    raises(TypeError, lambda: Poly(1, x) - sin(x))
+    with warns_deprecated_sympy():
+        Poly(1, x) - sin(x)
 
     assert Poly(x, x) - 1 == Poly(x - 1, x)
     assert 1 - Poly(x, x) == Poly(1 - x, x)
@@ -682,7 +684,8 @@ def test_Poly_mul():
     assert Poly(4, x, y) * Poly(2, x, y) == Poly(8, x, y)
 
     assert Poly(1, x) * x == Poly(x, x)
-    raises(TypeError, lambda: Poly(1, x) * sin(x))
+    with warns_deprecated_sympy():
+        Poly(1, x) * sin(x)
 
     assert Poly(x, x) * 2 == Poly(2*x, x)
     assert 2 * Poly(x, x) == Poly(2*x, x)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -639,7 +639,7 @@ def test_Poly_add():
     assert Poly(0, x, y) + Poly(1, x, y) == Poly(1, x, y)
 
     assert Poly(1, x) + x == Poly(x + 1, x)
-    assert Poly(1, x) + sin(x) == 1 + sin(x)
+    raises(TypeError, lambda: Poly(1, x) + sin(x))
 
     assert Poly(x, x) + 1 == Poly(x + 1, x)
     assert 1 + Poly(x, x) == Poly(x + 1, x)
@@ -655,7 +655,7 @@ def test_Poly_sub():
     assert Poly(0, x, y) - Poly(1, x, y) == Poly(-1, x, y)
 
     assert Poly(1, x) - x == Poly(1 - x, x)
-    assert Poly(1, x) - sin(x) == 1 - sin(x)
+    raises(TypeError, lambda: Poly(1, x) - sin(x))
 
     assert Poly(x, x) - 1 == Poly(x - 1, x)
     assert 1 - Poly(x, x) == Poly(1 - x, x)
@@ -671,7 +671,7 @@ def test_Poly_mul():
     assert Poly(4, x, y) * Poly(2, x, y) == Poly(8, x, y)
 
     assert Poly(1, x) * x == Poly(x, x)
-    assert Poly(1, x) * sin(x) == sin(x)
+    raises(TypeError, lambda: Poly(1, x) * sin(x))
 
     assert Poly(x, x) * 2 == Poly(2*x, x)
     assert 2 * Poly(x, x) == Poly(2*x, x)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -483,11 +483,11 @@ def test_PurePoly_free_symbols():
 
 def test_Poly__eq__():
     assert (Poly(x, x) == Poly(x, x)) is True
-    assert (Poly(x, x, domain=QQ) == Poly(x, x)) is True
-    assert (Poly(x, x) == Poly(x, x, domain=QQ)) is True
+    assert (Poly(x, x, domain=QQ) == Poly(x, x)) is False
+    assert (Poly(x, x) == Poly(x, x, domain=QQ)) is False
 
-    assert (Poly(x, x, domain=ZZ[a]) == Poly(x, x)) is True
-    assert (Poly(x, x) == Poly(x, x, domain=ZZ[a])) is True
+    assert (Poly(x, x, domain=ZZ[a]) == Poly(x, x)) is False
+    assert (Poly(x, x) == Poly(x, x, domain=ZZ[a])) is False
 
     assert (Poly(x*y, x, y) == Poly(x, x)) is False
 
@@ -500,8 +500,8 @@ def test_Poly__eq__():
     f = Poly(x, x, domain=ZZ)
     g = Poly(x, x, domain=QQ)
 
-    assert f.eq(g) is True
-    assert f.ne(g) is False
+    assert f.eq(g) is False
+    assert f.ne(g) is True
 
     assert f.eq(g, strict=True) is False
     assert f.ne(g, strict=True) is True
@@ -511,7 +511,7 @@ def test_Poly__eq__():
     f =  Poly((t0/2 + x**2)*t**2 - x**2*t, t, domain='QQ[x,t0]')
     g =  Poly((t0/2 + x**2)*t**2 - x**2*t, t, domain='ZZ(x,t0)')
 
-    assert (f == g) is True
+    assert (f == g) is False
 
 def test_PurePoly__eq__():
     assert (PurePoly(x, x) == PurePoly(x, x)) is True
@@ -1099,8 +1099,8 @@ def test_Poly_eject():
     assert g.eject(x, y) == Poly(ex, z, t, w, domain='ZZ[x, y]')
     assert g.eject(x, y, z) == Poly(ex, t, w, domain='ZZ[x, y, z]')
     assert g.eject(w) == Poly(ex, x, y, z, t, domain='ZZ[w]')
-    assert g.eject(t, w) == Poly(ex, x, y, z, domain='ZZ[w, t]')
-    assert g.eject(z, t, w) == Poly(ex, x, y, domain='ZZ[w, t, z]')
+    assert g.eject(t, w) == Poly(ex, x, y, z, domain='ZZ[t, w]')
+    assert g.eject(z, t, w) == Poly(ex, x, y, domain='ZZ[z, t, w]')
 
     raises(DomainError, lambda: Poly(x*y, x, y, domain=ZZ[z]).eject(y))
     raises(NotImplementedError, lambda: Poly(x*y, x, y, z).eject(y))
@@ -2177,7 +2177,7 @@ def test_transform():
 
     # Unify ZZ, QQ, and RR
     assert Poly(x**2 - 2*x + 1, x).transform(Poly(x + 1.0), Poly(x - S.Half)) == \
-        Poly(Rational(9, 4), x) == \
+        Poly(Rational(9, 4), x, domain='RR') == \
         cancel((x - S.Half)**2*(x**2 - 2*x + 1).subs(x, (x + 1.0)/(x - S.Half)))
 
     raises(ValueError, lambda: Poly(x*y).transform(Poly(x + 1), Poly(x - 1)))
@@ -2920,8 +2920,8 @@ def test_cancel():
     f = Poly(x**2 - a**2, x)
     g = Poly(x - a, x)
 
-    F = Poly(x + a, x)
-    G = Poly(1, x)
+    F = Poly(x + a, x, domain='ZZ[a]')
+    G = Poly(1, x, domain='ZZ[a]')
 
     assert cancel((f, g)) == (1, F, G)
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1048,7 +1048,7 @@ class UnShiftA(Operator):
         A = Dummy('A')
         n = D = Poly(ai*A - ai, A)
         for b in bq:
-            n *= (D + b - 1)
+            n *= D + (b - 1).as_poly(A)
 
         b0 = -n.nth(0)
         if b0 == 0:
@@ -1090,7 +1090,7 @@ class UnShiftB(Operator):
         D = Poly((bi - 1)*B - bi + 1, B)
         n = Poly(z, B)
         for a in ap:
-            n *= (D + a)
+            n *= (D + a.as_poly(B))
 
         b0 = n.nth(0)
         if b0 == 0:

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -136,7 +136,7 @@ def rsolve_poly(coeffs, f, n, **hints):
 
     for i in range(r + 1):
         for j in range(i, r + 1):
-            polys[i] += coeffs[j]*binomial(j, i)
+            polys[i] += coeffs[j]*(binomial(j, i).as_poly(n))
 
         if not polys[i].is_zero:
             (exp,), coeff = polys[i].LT()
@@ -620,7 +620,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
             if z.is_zero:
                 continue
 
-            (C, s) = rsolve_poly([polys[i]*z**i for i in range(r + 1)], 0, n, symbols=True)
+            (C, s) = rsolve_poly([polys[i].as_expr()*z**i for i in range(r + 1)], 0, n, symbols=True)
 
             if C is not None and C is not S.Zero:
                 symbols |= set(s)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -199,7 +199,7 @@ def test_reduce_abs_inequalities():
 
 def test_reduce_inequalities_general():
     assert reduce_inequalities(Ge(sqrt(2)*x, 1)) == And(sqrt(2)/2 <= x, x < oo)
-    assert reduce_inequalities(PurePoly(x + 1, x) > 0) == And(S.NegativeOne < x, x < oo)
+    assert reduce_inequalities(x + 1 > 0) == And(S.NegativeOne < x, x < oo)
 
 
 def test_reduce_inequalities_boolean():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This makes Poly a subclass of Basic rather than Expr. This means that various things that don't really make sense for Poly don't work and that Poly no longer has methods like `expand` or `as_numer_denom`. Inequalities no longer work with `Poly` either so this raises:
```julia
In [1]: Poly(x, x) > 0                                                                                                                         
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-15540f7b07dd> in <module>
----> 1 Poly(x, x) > 0

TypeError: '>' not supported between instances of 'Poly' and 'int'
```

* Make `Poly` subclass `Basic`.
* Change `Poly.__add__` etc to use `NotImplemented` properly.
* Change `__eq__` so that `Poly` instances with different domains compare unequal. 
* Deprecate mixing Poly and non-polynomial Expr in binary operations.
* Deprecate using `Poly` with `Integral`
* Use explicit `as_expr` and `as_poly` calls in some places to reduce mixing.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * BREAKING CHANGE: Poly and PurePoly now subclass Basic rather than Expr. This means that they no longer have various Expr methods such as `expand` that do not make sense for Poly. Use `as_expr` to convert the Poly to an Expr before using Expr methods.
    * BREAKING CHANGE: Poly instances with different domains now always compare unequal with `p1 == p2` and `p1.eq(p2)`. Previously Poly instances that had the same expression and generators would compare equal even if the domains were different. In some cases it might be necessary to specify the domain when comparing e.g. `if p == Poly(x, x, domain='QQ')`.
    * DEPRECATION: Mixing Poly with non-polynomial Expr in binary operations is now deprecated. For example `Poly(x, x) * exp(x)` will give a deprecation warning but still returne the Expr `x*exp(x)` as before. If the Expr can be converted to Poly (e.g. `Poly(x, x) * x`) then a Poly will be returned. To get an Expr always use the `as_expr` method first to convert the Poly to an Expr. To get a Poly always use `as_poly` to convert the `Expr` to a `Poly`.
    * DEPRECATION: Passing Poly as the integrand to the `integrate` function or `Integral` class is now deprecated. Use the integrate method instead e.g. `Poly(x, x).integrate(x)`
<!-- END RELEASE NOTES -->