### PR TITLE
Run LaTeX build in silent mode

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -24,8 +24,13 @@ if [[ "${TEST_SPHINX}" == "true" ]]; then
     make man
     make latex
     cd _build/latex
-    export LATEXOPTIONS="-interaction=nonstopmode"
-    make all
+    export LATEXMKOPTS="-halt-on-error -xelatex -silent"
+    make all || {
+        echo "An error had occured during the LaTeX build";
+        tail -n 1000 *.log;
+        sleep 1; # A guard against travis running tail concurrently.
+        exit -1;
+    }
 fi
 
 if [[ "${TEST_SAGE}" == "true" ]]; then

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -82,11 +82,10 @@ htmlhelp:
 latex: $(PDFFILES)
 	mkdir -p _build/latex _build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTSlatex) _build/latex
-	sed -i'' -e "s/pdflatex/xelatex/g" _build/latex/Makefile
-	sed -i'' -e "s/latexmk/latexmk -xelatex/g" _build/latex/Makefile
 	@echo
 	@echo "Build finished; the LaTeX files are in _build/latex."
-	@echo "Run \`make all' in that directory to run these through xelatex."
+	@echo "Set the environment variable LATEXMKOPTS='-xelatex -silent'"
+	@echo "And run \`make all' in that directory to run these through xelatex."
 
 .svg.pdf:
 	inkscape --file=$< --export-area-drawing --without-gui --export-pdf=$@


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that most of the latex warnings are harmless and they are throwing such warnings from splitting the overflow paragraphs and tables.
And I don't think that we have any control over the sphinx generating overfull tables or paragraphs for the latex build.

This also fixes the broken command `make clean` from the generated makefile. Before, it looks like it had substituted every `latexmk` with `xelatex` and it had broken some scripts.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->