### PR TITLE
BlockMatrix with 1 matrix can be converted into regular matrix

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -301,7 +301,7 @@ class BlockDiagMatrix(BlockMatrix):
         data = [[mats[i] if i == j else ZeroMatrix(mats[i].rows, mats[j].cols)
                         for j in range(len(mats))]
                         for i in range(len(mats))]
-        return ImmutableDenseMatrix(data)
+        return ImmutableDenseMatrix(data, evaluate=False)
 
     @property
     def shape(self):

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -110,6 +110,10 @@ def test_issue_17624():
     assert block_collapse(b * b) == BlockMatrix([[a**2, z], [z, z]])
     assert block_collapse(b * b * b) == BlockMatrix([[a**3, z], [z, z]])
 
+def test_issue_18612():
+    A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert A == Matrix(BlockDiagMatrix(A))
+
 def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']
     X = BlockMatrix([[A, B], [C, D]])

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -110,7 +110,7 @@ def test_issue_17624():
     assert block_collapse(b * b) == BlockMatrix([[a**2, z], [z, z]])
     assert block_collapse(b * b * b) == BlockMatrix([[a**3, z], [z, z]])
 
-def test_issue_18612():
+def test_issue_18618():
     A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert A == Matrix(BlockDiagMatrix(A))
 


### PR DESCRIPTION
Fixes #18618 
 
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed `BlockDiagMatrix(A).blocks` giving a non-block matrix.
<!-- END RELEASE NOTES -->