### PR TITLE
Series: Removed incosistency in order in case of Zero

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -265,9 +265,11 @@ class Add(Expr, AssocOp):
                     newseq2.append(t)
 
             # 2 + O(0) -> 2
+            new_order_factors = []
             for o in order_factors:
-                if o.expr.is_zero:
-                    order_factors.remove(o)
+                if not o.expr.is_zero:
+                    new_order_factors.append(o)
+                order_factors = new_order_factors
 
             newseq = newseq2 + order_factors
             # 1 + O(1) -> O(1)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -263,6 +263,12 @@ class Add(Expr, AssocOp):
                 # x + O(x**2) -> x + O(x**2)
                 if t is not None:
                     newseq2.append(t)
+
+            # 2 + O(0) -> 2
+            for o in order_factors:
+                if o.expr.is_zero:
+                    order_factors.remove(o)
+
             newseq = newseq2 + order_factors
             # 1 + O(1) -> O(1)
             for o in order_factors:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -123,6 +123,8 @@ class Add(Expr, AssocOp):
 
             # O(x)
             if o.is_Order:
+                if o.expr.is_zero:
+                    continue
                 for o1 in order_factors:
                     if o1.contains(o):
                         o = None
@@ -263,14 +265,6 @@ class Add(Expr, AssocOp):
                 # x + O(x**2) -> x + O(x**2)
                 if t is not None:
                     newseq2.append(t)
-
-            # 2 + O(0) -> 2
-            new_order_factors = []
-            for o in order_factors:
-                if not o.expr.is_zero:
-                    new_order_factors.append(o)
-                order_factors = new_order_factors
-
             newseq = newseq2 + order_factors
             # 1 + O(1) -> O(1)
             for o in order_factors:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -257,13 +257,10 @@ class Order(Expr):
 
             expr = expr.subs(rs)
 
-        if expr.is_zero:
-            return expr
-
         if expr.is_Order:
             expr = expr.expr
 
-        if not expr.has(*variables):
+        if not expr.has(*variables) and not expr.is_zero:
             expr = S.One
 
         # create Order instance:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -636,3 +636,8 @@ def test_issue_18508():
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0) == sqrt(2)
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='+') == sqrt(2)
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
+
+def test_issue_13715():
+    n = Symbol('n')
+    p = Symbol('p', zero=True)
+    assert limit(n + p, n, 0) == 0

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,6 +1,7 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
     S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
     Function, Add)
+from sympy.core.expr import unchanged
 from sympy.testing.pytest import raises
 from sympy.abc import w, x, y, z
 
@@ -437,4 +438,4 @@ def test_issue_15539():
     assert O(1/x, (x, oo)).subs(x, -x) == O(-1/x, (x, -oo))
 
 def test_issue_18606():
-    assert Order(0) == O(0)
+    assert unchanged(Order, 0)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -435,3 +435,6 @@ def test_issue_15539():
     assert O(1/x**4 + exp(x), (x, -oo)) == O(1/x**4, (x, -oo))
     assert O(1/x**4 + exp(-x), (x, -oo)) == O(exp(-x), (x, -oo))
     assert O(1/x, (x, oo)).subs(x, -x) == O(-1/x, (x, -oo))
+
+def test_issue_18606():
+    assert Order(0) == O(0)


### PR DESCRIPTION
Added tests

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #13715, #18606 

#### Brief description of what is fixed or changed
Order(0) now returns an object of Order Type
```
>>> type(Order(0))
<class 'sympy.series.order.Order'>
>>> Order(0)
O(0)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Order(0) now returns an object of Order Type
<!-- END RELEASE NOTES -->