### PR TITLE
Implemented _eval_nseries() for Hyper

### DIFF
--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -244,7 +244,7 @@ class hyper(TupleParametersBase):
             for b in bq:
                 Rf2 *= RisingFactorial(b, i)
 
-            terms.append(((Rf1 / Rf2) * (x ** i)) / factorial(i))
+            terms.append(((Rf1/Rf2) * (arg**i)) / factorial(i))
 
         return (Add(*terms) + Order(x**n,x))
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -231,7 +231,7 @@ class hyper(TupleParametersBase):
         bq = self.args[1]
 
         if x0 != 0:
-            return super()._eval_nseries(self, x, n, logx)
+            return super(hyper, self)._eval_nseries(x, n, logx)
 
         terms = []
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -231,7 +231,7 @@ class hyper(TupleParametersBase):
         bq = self.args[1]
 
         if x0 != 0:
-            return super()._eval_nseries(x, n, logx)
+            return super()._eval_nseries(self, x, n, logx)
 
         terms = []
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -236,15 +236,15 @@ class hyper(TupleParametersBase):
         terms = []
 
         for i in range(n):
-            Rf1 = 1
-            Rf2 = 1
+            num = 1
+            den = 1
             for a in ap:
-                Rf1 *= RisingFactorial(a, i)
+                num *= RisingFactorial(a, i)
 
             for b in bq:
-                Rf2 *= RisingFactorial(b, i)
+                den *= RisingFactorial(b, i)
 
-            terms.append(((Rf1/Rf2) * (arg**i)) / factorial(i))
+            terms.append(((num/den) * (arg**i)) / factorial(i))
 
         return (Add(*terms) + Order(x**n,x))
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -225,7 +225,8 @@ class hyper(TupleParametersBase):
         from sympy.functions import factorial, RisingFactorial
         from sympy import Order, Add
 
-        x0 = self.args[2].limit(x, 0)
+        arg = self.args[2]
+        x0 = arg.limit(x, 0)
         ap = self.args[0]
         bq = self.args[1]
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -220,6 +220,33 @@ class hyper(TupleParametersBase):
         return Piecewise((Sum(coeff * z**n / factorial(n), (n, 0, oo)),
                          self.convergence_statement), (self, True))
 
+    def _eval_nseries(self, x, n, logx):
+
+        from sympy.functions import factorial, RisingFactorial
+        from sympy import Order, Add
+
+        x0 = self.args[2].limit(x, 0)
+        ap = self.args[0]
+        bq = self.args[1]
+
+        if x0 != 0:
+            return super()._eval_nseries(x, n, logx)
+
+        terms = []
+
+        for i in range(n):
+            Rf1 = 1
+            Rf2 = 1
+            for a in ap:
+                Rf1 *= RisingFactorial(a, i)
+
+            for b in bq:
+                Rf2 *= RisingFactorial(b, i)
+
+            terms.append(((Rf1 / Rf2) * (x ** i)) / factorial(i))
+
+        return (Add(*terms) + Order(x**n,x))
+
     @property
     def argument(self):
         """ Argument of the hypergeometric function. """

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -341,10 +341,7 @@ def test_meijerg_eval():
 def test_limits():
     k, x = symbols('k, x')
     assert hyper((1,), (Rational(4, 3), Rational(5, 3)), k**2).series(k) == \
-           hyper((1,), (Rational(4, 3), Rational(5, 3)), 0) + \
-           9*k**2*hyper((2,), (Rational(7, 3), Rational(8, 3)), 0)/20 + \
-           81*k**4*hyper((3,), (Rational(10, 3), Rational(11, 3)), 0)/1120 + \
-           O(k**6) # issue 6350
+           1 + 9*k**2/20 + 81*k**4/1120 + O(k**6) # issue 6350
     assert limit(meijerg((), (), (1,), (0,), -x), x, 0) == \
             meijerg(((), ()), ((1,), (0,)), 0) # issue 6052
 
@@ -366,3 +363,10 @@ def test_derivative_appellf1():
     assert diff(appellf1(a, b1, b2, c, x, y), y) == a*b2*appellf1(a + 1, b1, b2 + 1, c + 1, x, y)/c
     assert diff(appellf1(a, b1, b2, c, x, y), z) == 0
     assert diff(appellf1(a, b1, b2, c, x, y), a) ==  Derivative(appellf1(a, b1, b2, c, x, y), a)
+
+
+def test_eval_nseries():
+    a1, b1, a2, b2 = symbols('a1 b1 a2 b2')
+    assert hyper((1,2), (1,2,3), x**2)._eval_nseries(x, 7, None) == 1 + x**2/3 + x**4/24 + x**6/360 + O(x**7)
+    assert exp(x)._eval_nseries(x,7,None) == hyper((a1, b1), (a1, b1), x)._eval_nseries(x, 7, None)
+    assert hyper((a1, a2), (b1, b2), x)._eval_nseries(z, 7, None) == hyper((a1, a2), (b1, b2), x) + O(z**7)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18193 

#### Brief description of what is fixed or changed
In reference to Issue #18193 the function was implemented. Example of
the working code is as follows:

In [1]: from sympy import hyper

In [2]: from sympy.abc import x, y

In [3]: hyper((1, 2),(1, 2), x)._eval_nseries(x, 7, y)
Out[3]: 1 + x + x**2/2 + x**3/6 + x**4/24 + x**5/120 + x**6/720 + O(x**7)

In [4]: hyper((1, 2),(3, 4, 5), x)._eval_nseries(x, 7, y)
Out[4]: 1 + x/30 + x**2/1200 + x**3/63000 + x**4/4233600 + x**5/355622400 + x**6/36578304000 + O(x**7)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
   * Added _eval_nseries() functionality to hyper
<!-- END RELEASE NOTES -->