### PR TITLE
Fix for double angle formula in trigsimp

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1034,6 +1034,8 @@ def _TR11(rv):
     4*sin(x/8)*sin(x/6)*sin(2*x)
     >>> T(sin(x/3)/cos(x/6))
     2*sin(x/6)
+    >>> T(sin(2*x)*cos(x/8)/sin(x/4))
+    sin(2*x)/(2*sin(x/8))
 
     """
     def f(rv):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1049,7 +1049,7 @@ def _TR11(rv):
                     arg_num = fi.args[0]
                     for arg_denom in list(arg_denoms):
                         base = arg_num/arg_denom
-                        if fi.func != arg_denoms[arg_denom]:
+                        if not (fi.func is cos and arg_denoms[arg_denom] is cos) :
                             if base % 2 == 0:
                                 rv = TR11(rv, arg_denom)
                                 arg_denoms.pop(arg_denom)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1049,7 +1049,7 @@ def _TR11(rv):
                     arg_num = fi.args[0]
                     for arg_denom in list(arg_denoms):
                         base = arg_num/arg_denom
-                        if not (fi.func is cos and arg_denoms[arg_denom] is cos) :
+                        if not (fi.func == cos and arg_denoms[arg_denom] == cos) :
                             if base % 2 == 0:
                                 rv = TR11(rv, arg_denom)
                                 arg_denoms.pop(arg_denom)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1020,6 +1020,46 @@ def TR11(rv, base=None):
 
     return bottom_up(rv, f)
 
+def _TR11(rv):
+    """
+    Helper for TR11 to find the `base` argument of TR11.
+
+    Examples
+    ========
+
+    >>> from sympy.simplify.fu import _TR11 as T
+    >>> from sympy import cos, sin, pi
+    >>> from sympy.abc import x
+    >>> T(sin(x/3)*sin(2*x)*sin(x/4)/(cos(x/6)*cos(x/8)))
+    4*sin(x/8)*sin(x/6)*sin(2*x)
+    >>> T(sin(x/3)/cos(x/6))
+    2*sin(x/6)
+
+    """
+    def f(rv):
+        arg_denoms = dict()
+        for fi in rv.args:
+            if fi.is_Pow and fi.exp.is_negative and fi.base.func in (sin, cos):
+                arg_denoms[fi.base.args[0]] = fi.base.func
+
+            elif fi.func in (sin, cos):
+                if len(arg_denoms):
+                    arg_num = fi.args[0]
+                    for arg_denom in list(arg_denoms):
+                        base = arg_num/arg_denom
+                        if fi.func != arg_denoms[arg_denom]:
+                            if base % 2 == 0:
+                                rv = TR11(rv, arg_denom)
+                                arg_denoms.pop(arg_denom)
+
+                            elif (1/base) % 2 == 0:
+                                rv = TR11(rv, arg_num)
+                                arg_denoms.pop(arg_denom)
+
+        return rv
+
+    return bottom_up(rv, f)
+
 
 def TR12(rv, first=True):
     """Separate sums in ``tan``.

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1020,6 +1020,7 @@ def TR11(rv, base=None):
 
     return bottom_up(rv, f)
 
+
 def _TR11(rv):
     """
     Helper for TR11 to find half-arguments for sin in factors of
@@ -1075,7 +1076,10 @@ def _TR11(rv):
         rv = handle_match(rv, den_args, num_args)
         return rv
 
-    return bottom_up(rv, f)
+    if getattr(rv, "as_numer_denom()", False):
+        return bottom_up(rv, f)
+
+    return rv
 
 
 def TR12(rv, first=True):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1043,6 +1043,9 @@ def _TR11(rv):
 
     """
     def f(rv):
+        if not isinstance(rv, Expr):
+            return rv
+
         def sincos_args(flat):
             # find arguments of sin and cos that
             # appears as bases in args of flat
@@ -1076,10 +1079,7 @@ def _TR11(rv):
         rv = handle_match(rv, den_args, num_args)
         return rv
 
-    if getattr(rv, "as_numer_denom()", False):
-        return bottom_up(rv, f)
-
-    return rv
+    return bottom_up(rv, f)
 
 
 def TR12(rv, first=True):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1045,18 +1045,17 @@ def _TR11(rv):
                 arg_denoms[fi.base.args[0]] = fi.base.func
 
             elif fi.func in (sin, cos):
-                if len(arg_denoms):
-                    arg_num = fi.args[0]
-                    for arg_denom in list(arg_denoms):
-                        base = arg_num/arg_denom
-                        if not (fi.func == cos and arg_denoms[arg_denom] == cos) :
-                            if base % 2 == 0:
-                                rv = TR11(rv, arg_denom)
-                                arg_denoms.pop(arg_denom)
+                arg_num = fi.args[0]
+                for arg_denom in ordered(arg_denoms):
+                    base = arg_num/arg_denom
+                    if not (fi.func == cos and arg_denoms[arg_denom] == cos) :
+                        if base % 2 == 0:
+                            rv = TR11(rv, arg_denom)
+                            arg_denoms.pop(arg_denom)
 
-                            elif (1/base) % 2 == 0:
-                                rv = TR11(rv, arg_num)
-                                arg_denoms.pop(arg_denom)
+                        elif (1/base) % 2 == 0:
+                            rv = TR11(rv, arg_num)
+                            arg_denom = arg_denom/2
 
         return rv
 

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -228,6 +228,9 @@ def test__TR11():
         4*sin(x/8)*sin(x/6)*sin(2*x)
     assert _TR11(sin(x/3)/cos(x/6)) == 2*sin(x/6)
 
+    assert _TR11(cos(x/6)/sin(x/3)) == 1/(2*sin(x/6))
+    assert _TR11(sin(2*x)*cos(x/8)/sin(x/4)) == sin(2*x)/(2*sin(x/8))
+
 
 def test_TR12():
     assert TR12(tan(x + y)) == (tan(x) + tan(y))/(-tan(x)*tan(y) + 1)

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -2,7 +2,7 @@ from sympy import (
     Add, Mul, S, Symbol, cos, cot, pi, I, sin, sqrt, tan, root, csc, sec,
     powsimp, symbols, sinh, cosh, tanh, coth, sech, csch, Dummy, Rational)
 from sympy.simplify.fu import (
-    L, TR1, TR10, TR10i, TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
+    L, TR1, TR10, TR10i, TR11, _TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
     TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
     TRpower, hyper_as_trig, fu, process_common_addends, trig_split,
     as_f_sign_1)
@@ -221,6 +221,12 @@ def test_TR11():
     assert TR11(cos(4), 2) == -sin(2)**2 + cos(2)**2
     assert TR11(cos(6), 2) == cos(6)
     assert TR11(sin(x)/cos(x/2), x/2) == 2*sin(x/2)
+
+def test__TR11():
+
+    assert _TR11(sin(x/3)*sin(2*x)*sin(x/4)/(cos(x/6)*cos(x/8))) == \
+        4*sin(x/8)*sin(x/6)*sin(2*x)
+    assert _TR11(sin(x/3)/cos(x/6)) == 2*sin(x/6)
 
 
 def test_TR12():

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -225,11 +225,11 @@ def test_TR11():
 def test__TR11():
 
     assert _TR11(sin(x/3)*sin(2*x)*sin(x/4)/(cos(x/6)*cos(x/8))) == \
-        4*sin(x/8)*sin(x/6)*sin(2*x)
+        4*sin(x/8)*sin(x/6)*sin(2*x),_TR11(sin(x/3)*sin(2*x)*sin(x/4)/(cos(x/6)*cos(x/8)))
     assert _TR11(sin(x/3)/cos(x/6)) == 2*sin(x/6)
 
     assert _TR11(cos(x/6)/sin(x/3)) == 1/(2*sin(x/6))
-    assert _TR11(sin(2*x)*cos(x/8)/sin(x/4)) == sin(2*x)/(2*sin(x/8))
+    assert _TR11(sin(2*x)*cos(x/8)/sin(x/4)) == sin(2*x)/(2*sin(x/8)), _TR11(sin(2*x)*cos(x/8)/sin(x/4))
     assert _TR11(sin(x)/sin(x/2)) == 2*cos(x/2)
 
 

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -230,6 +230,7 @@ def test__TR11():
 
     assert _TR11(cos(x/6)/sin(x/3)) == 1/(2*sin(x/6))
     assert _TR11(sin(2*x)*cos(x/8)/sin(x/4)) == sin(2*x)/(2*sin(x/8))
+    assert _TR11(sin(x)/sin(x/2)) == 2*cos(x/2)
 
 
 def test_TR12():

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1114,7 +1114,7 @@ def _futrig(e, **kwargs):
     """Helper for futrig."""
     from sympy.simplify.fu import (
         TR1, TR2, TR3, TR2i, TR10, L, TR10i,
-        TR8, TR6, TR15, TR16, TR111, TR5, TRmorrie, TR11, TR14, TR22,
+        TR8, TR6, TR15, TR16, TR111, TR5, TRmorrie, TR11, _TR11, TR14, TR22,
         TR12)
     from sympy.core.compatibility import _nodes
 
@@ -1142,7 +1142,7 @@ def _futrig(e, **kwargs):
         TR14,  # factored identities
         TR5,  # sin-pow -> cos_pow
         TR10,  # sin-cos of sums -> sin-cos prod
-        TR11, TR6, # reduce double angles and rewrite cos pows
+        TR11, _TR11, TR6, # reduce double angles and rewrite cos pows
         lambda x: _eapply(factor, x, trigs),
         TR14,  # factored powers of identities
         [identity, lambda x: _eapply(_mexpand, x, trigs)],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18533 

#### Brief description of what is fixed or changed
Earlier
```
>>> trigsimp(sin(x/3)/cos(x/6))
sin(x/3)/cos(x/6)
```
Now
```
>>> trigsimp(sin(x/3)/cos(x/6))
2*sin(x/6)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * `fu` routine `TR11` has a helper that allows double angle reduction in fractions
<!-- END RELEASE NOTES -->