### PR TITLE
Core: simplification error resolved

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1022,6 +1022,11 @@ class Pow(Expr):
 
         rv = S.One
         if cargs:
+            if e.is_Rational:
+                npow, cargs = sift(cargs, lambda x: x.is_Pow and
+                    x.exp.is_Rational and x.base.is_number,
+                    binary=True)
+                rv = Mul(*[self.func(b.func(*b.args), e) for b in npow])
             rv *= Mul(*[self.func(b, e, evaluate=False) for b in cargs])
         if other:
             rv *= self.func(Mul(*other), e, evaluate=False)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1459,11 +1459,12 @@ def test_Pow_as_coeff_mul_doesnt_expand():
     assert exp(x + exp(x + y)) != exp(x + exp(x)*exp(y))
 
 
-def test_issue_3514():
+def test_issue_3514_18626():
     assert sqrt(S.Half) * sqrt(6) == 2 * sqrt(3)/2
     assert S.Half*sqrt(6)*sqrt(2) == sqrt(3)
     assert sqrt(6)/2*sqrt(2) == sqrt(3)
     assert sqrt(6)*sqrt(2)/2 == sqrt(3)
+    assert sqrt(8)**Rational(2, 3) == 2
 
 
 def test_make_args():


### PR DESCRIPTION
Fixes #18626 


#### Brief description of what is fixed or changed
This pull request improves the simplification of powers with numerical products in the base. 

**Previously:**
```
In[1]: sqrt(8)**Rational(2, 3)
Out[1]: 2**(1/3)*2**(2/3)
```
**Now:**
```
In[1]: sqrt(8)**Rational(2, 3)
Out[1]: 2
```

#### Other comments
Regression test has been added.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
  * simplification of powers with numerical products in the base is improved
<!-- END RELEASE NOTES -->
