### PR TITLE
Fix for numpy arrays when the size 1 arrays were treated as scalars

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -8,7 +8,8 @@ import re as regex
 from collections import defaultdict
 
 from .containers import Tuple
-from .sympify import converter, sympify, _sympify, SympifyError, _convert_numpy_types
+from .sympify import (SympifyError, converter, sympify, _convert_numpy_types, _sympify,
+                      _is_numpy_instance)
 from .singleton import S, Singleton
 from .expr import Expr, AtomicExpr
 from .decorators import _sympifyit
@@ -980,7 +981,7 @@ class Float(Number):
             num = '+inf'
         elif num is S.NegativeInfinity:
             num = '-inf'
-        elif type(num).__module__ == 'numpy': # support for numpy datatypes
+        elif _is_numpy_instance(num):  # support for numpy datatypes
             num = _convert_numpy_types(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -57,10 +57,8 @@ def _is_numpy_instance(a):
     """
     # This check avoids unnecessarily importing NumPy.  We check the whole
     # __mro__ in case any base type is a numpy type.
-    for type_ in type(a).__mro__:
-        if type_.__module__ == 'numpy':
-            return True
-    return False
+    return any(type_.__module__ == 'numpy'
+               for type_ in type(a).__mro__)
 
 
 def _convert_numpy_types(a):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -326,14 +326,18 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if not isinstance(a, string_types):
         if _is_numpy_instance(a):
             import numpy as np
-            if isinstance(a, np.number):
-                return sympify(a)
-            elif isinstance(a, np.ndarray):
+            assert not isinstance(a, np.number)
+            if isinstance(a, np.ndarray):
                 # Scalar arrays (those with zero dimensions) have sympify
                 # called on the scalar element.
                 if a.ndim == 0:
                     try:
-                        return sympify(a.item())
+                        return sympify(a.item(),
+                                       locals=locals,
+                                       convert_xor=convert_xor,
+                                       strict=strict,
+                                       rational=rational,
+                                       evaluate=evaluate)
                     except SympifyError:
                         pass
         else:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -734,13 +734,13 @@ def test_issue_14706():
     assert numpy.all(x + y2 == numpy.full((2, 2), x + 1.0))
     assert numpy.all(y1 + x == numpy.full((1, 1), x + 1.0))
     assert numpy.all(y2 + x == numpy.full((2, 2), x + 1.0))
-    for y in [y3,
+    for y_ in [y3,
               numpy.int(1),
               numpy.float(1),
               numpy.complex(1)]:
-        assert x + y == y + x
-        assert isinstance(x + y, Add)
-        assert isinstance(y + x, Add)
+        assert x + y_ == y_ + x
+        assert isinstance(x + y_, Add)
+        assert isinstance(y_ + x, Add)
 
     assert x + numpy.array(x) == 2 * x
     assert x + numpy.array([x]) == numpy.array([2*x], dtype=object)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -722,4 +722,13 @@ def test_issue_14706():
     assert x + numpy.array(x) == 2 * x
     assert x + numpy.array([x]) == numpy.array([2*x], dtype=object)
 
+    assert sympify(numpy.array([1])) == ImmutableDenseNDimArray([1], 1)
+    assert sympify(numpy.array([[[1]]])) == ImmutableDenseNDimArray([1], (1, 1, 1))
+    assert sympify(z1) == ImmutableDenseNDimArray([0], (1, 1))
+    assert sympify(z2) == ImmutableDenseNDimArray([0, 0, 0, 0], (2, 2))
+    assert sympify(z3) == ImmutableDenseNDimArray([0], ())
+    assert sympify(z3, strict=True) == 0.0
+
     raises(SympifyError, lambda: sympify(numpy.array([1]), strict=True))
+    raises(SympifyError, lambda: sympify(z1, strict=True))
+    raises(SympifyError, lambda: sympify(z2, strict=True))

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -702,18 +702,45 @@ def test_issue_14706():
     if not numpy:
         skip("numpy not installed.")
 
-    z1 = numpy.zeros((1,1), dtype=numpy.float)
-    z2 = numpy.zeros((2,2), dtype=numpy.float)
+    z1 = numpy.zeros((1, 1), dtype=numpy.float)
+    z2 = numpy.zeros((2, 2), dtype=numpy.float)
     z3 = numpy.zeros((), dtype=numpy.float)
+
+    y1 = numpy.ones((1, 1), dtype=numpy.float)
+    y2 = numpy.ones((2, 2), dtype=numpy.float)
+    y3 = numpy.ones((), dtype=numpy.float)
 
     assert numpy.all(x + z1 == numpy.full((1, 1), x))
     assert numpy.all(x + z2 == numpy.full((2, 2), x))
+    assert numpy.all(z1 + x == numpy.full((1, 1), x))
+    assert numpy.all(z2 + x == numpy.full((2, 2), x))
     for z in [z3,
               numpy.int(0),
               numpy.float(0),
               numpy.complex(0)]:
         assert x + z == x
+        assert z + x == x
         assert isinstance(x + z, Symbol)
+        assert isinstance(z + x, Symbol)
+
+    # If these tests fail, then it means that numpy has finally
+    # fixed the issue of scalar conversion for rank>0 arrays
+    # which is mentioned in numpy/numpy#10404. In that case,
+    # some changes have to be made in sympify.py.
+    # Note: For future reference, for anyone who takes up this
+    # issue when numpy has finally fixed their side of the problem,
+    # the changes for this temporary fix were introduced in PR 18651
+    assert numpy.all(x + y1 == numpy.full((1, 1), x + 1.0))
+    assert numpy.all(x + y2 == numpy.full((2, 2), x + 1.0))
+    assert numpy.all(y1 + x == numpy.full((1, 1), x + 1.0))
+    assert numpy.all(y2 + x == numpy.full((2, 2), x + 1.0))
+    for y in [y3,
+              numpy.int(1),
+              numpy.float(1),
+              numpy.complex(1)]:
+        assert x + y == y + x
+        assert isinstance(x + y, Add)
+        assert isinstance(y + x, Add)
 
     assert x + numpy.array(x) == 2 * x
     assert x + numpy.array([x]) == numpy.array([2*x], dtype=object)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -702,10 +702,6 @@ def test_issue_14706():
     if not numpy:
         skip("numpy not installed.")
 
-    from sympy import symbols
-
-    x = symbols('x')
-
     z1 = numpy.zeros((1,1), dtype=numpy.float)
     z2 = numpy.zeros((2,2), dtype=numpy.float)
     z3 = numpy.zeros((), dtype=numpy.float)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -615,3 +615,23 @@ def test_issue_13924():
     a = sympify(numpy.array([1]))
     assert isinstance(a, ImmutableDenseNDimArray)
     assert a[0] == 1
+
+
+def test_issue_14706():
+    if not numpy:
+        skip("numpy not installed.")
+
+    from sympy import symbols
+
+    x = symbols('x')
+
+    z1 = np.zeros((1,1), dtype=np.float)
+    z2 = np.zeros((2,2), dtype=np.float)
+    z3 = np.zeros((), dtype=np.float)
+
+    assert np.all(x + z1 == np.full((1, 1), x))
+    assert np.all(x + z2 == np.full((2, 2), x))
+    assert x + z3 == x
+    assert x + np.int(0) == x
+    assert x + np.float(0) == x
+    assert x + np.complex(0) == x

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -631,7 +631,12 @@ def test_issue_14706():
 
     assert np.all(x + z1 == np.full((1, 1), x))
     assert np.all(x + z2 == np.full((2, 2), x))
-    assert x + z3 == x
-    assert x + np.int(0) == x
-    assert x + np.float(0) == x
-    assert x + np.complex(0) == x
+    for z in [z3,
+              np.int(0),
+              np.float(0),
+              np.complex(0)]:
+        assert x + z == x
+        assert isinstance(x + z, Symbol)
+
+    assert x + np.array(x) == 2 * x
+    assert x + np.array([x]) == np.array([2*x], dtype=object)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -625,18 +625,20 @@ def test_issue_14706():
 
     x = symbols('x')
 
-    z1 = np.zeros((1,1), dtype=np.float)
-    z2 = np.zeros((2,2), dtype=np.float)
-    z3 = np.zeros((), dtype=np.float)
+    z1 = numpy.zeros((1,1), dtype=numpy.float)
+    z2 = numpy.zeros((2,2), dtype=numpy.float)
+    z3 = numpy.zeros((), dtype=numpy.float)
 
-    assert np.all(x + z1 == np.full((1, 1), x))
-    assert np.all(x + z2 == np.full((2, 2), x))
+    assert numpy.all(x + z1 == numpy.full((1, 1), x))
+    assert numpy.all(x + z2 == numpy.full((2, 2), x))
     for z in [z3,
-              np.int(0),
-              np.float(0),
-              np.complex(0)]:
+              numpy.int(0),
+              numpy.float(0),
+              numpy.complex(0)]:
         assert x + z == x
         assert isinstance(x + z, Symbol)
 
-    assert x + np.array(x) == 2 * x
-    assert x + np.array([x]) == np.array([2*x], dtype=object)
+    assert x + numpy.array(x) == 2 * x
+    assert x + numpy.array([x]) == numpy.array([2*x], dtype=object)
+
+    assert isinstance(sympify(numpy.array([1]), strict=True), numpy.ndarray)


### PR DESCRIPTION
#### References to other Issues or PRs
Revives and closes #14720 
Fixes #14706

#### Brief description of what is fixed or changed

--> Added a bug fix in sympify whereby the numpy arrays of size 1 won't be treated as scalars

#### Other comments

Example:
```
>>> from sympy import *
>>> from sympy.abc import *
>>> import numpy
>>> z = np.zeros((1,1))
```

Before the fix:
```
>>> f = x + z
x
```

After the fix:
```
>>> f = x + z
array([[x]], dtype=object)
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  *  sympify no longer converts numpy arrays with size to scalars
<!-- END RELEASE NOTES -->