### PR TITLE
Add ntheory module for arithmetic properties of integers

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -177,6 +177,9 @@ Ntheory Functions Reference
 .. automodule:: sympy.ntheory.continued_fraction
    :members:
 
+.. automodule:: sympy.ntheory.digits
+   :members:
+
 .. autoclass:: sympy.ntheory.mobius
    :members:
 

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -22,6 +22,10 @@ from .multinomial import binomial_coefficients, binomial_coefficients_list, \
 from .continued_fraction import continued_fraction_periodic, \
     continued_fraction_iterator, continued_fraction_reduce, \
     continued_fraction_convergents, continued_fraction
+from .digits import (
+    count_digits,
+    is_palindromic_integer,
+)
 from .egyptian_fraction import egyptian_fraction
 
 __all__ = [
@@ -51,6 +55,9 @@ __all__ = [
     'continued_fraction_periodic', 'continued_fraction_iterator',
     'continued_fraction_reduce', 'continued_fraction_convergents',
     'continued_fraction',
+
+    'count_digits',
+    'is_palindromic_integer',
 
     'egyptian_fraction',
 ]

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -24,7 +24,7 @@ from .continued_fraction import continued_fraction_periodic, \
     continued_fraction_convergents, continued_fraction
 from .digits import (
     count_digits,
-    is_palindromic_integer,
+    is_palindromic,
 )
 from .egyptian_fraction import egyptian_fraction
 
@@ -57,7 +57,7 @@ __all__ = [
     'continued_fraction',
 
     'count_digits',
-    'is_palindromic_integer',
+    'is_palindromic',
 
     'egyptian_fraction',
 ]

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -1,0 +1,60 @@
+from __future__ import print_function, division
+
+import re
+
+from collections import Counter
+
+
+def is_pandigital(n, zeroless=False, freq='1+'):
+    """
+    Checks whether a positive integer ``n`` is pandigital with respect
+    to the (decimal) base and has a digit frequency given by the
+    string ``freq``. The optional ``zeroless`` argument can be used
+    to indicate whether ``0`` should or should not be included in
+    checking for the pandigital property, i.e. whether ``0`` should be
+    included in the base digit set.
+
+    Note: ``freq`` is an integer string with an optional ``+``
+    suffix to indicate min. digit frequency - otherwise the digit
+    frequency is taken to be exact.
+
+    Some examples are given below.
+    ::
+        915286437, False, '1+'           ->   False
+        915286437, True, '1+'            ->   True
+        9152860437, False, '1+'          ->   True
+        112233445566778899, False, '2'   -> False
+        112233445566778899, True, '2'    -> True
+        11223344556677889900, False, '2' -> True
+    """
+    digits = Counter(str(n))
+
+    _dfreq, dfreq_min = re.match(r'(\d+)(\+)?', freq).groups()
+    _dfreq = int(_dfreq)
+
+    base = set(Counter(str(1234567890)).keys()).difference(['0'] if zeroless else [])
+
+    return base.issubset(digits.keys()) and (
+        min(digits.values()) == max(digits.values()) == _dfreq if dfreq_min != '+' else
+        min(digits.values()) >= _dfreq
+    )
+
+
+def is_palindromic_integer(n):
+    """
+    Checks whether a given positive integer ``n`` has the property that the
+    sequence of its digits is the same left to right as it is right to left.
+    Examples below.
+    ::
+
+        1 -> True
+        33 -> True
+        919 - > True
+        1234321 -? True
+        14987778941 -> True
+        14987678941 -> False
+    """
+    s = str(n)
+    m = len(s)
+
+    return s[:int(m / 2)] == (s[int(m / 2):] if not m % 2 else s[int(m / 2) + 1:])[::-1]

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division
 
-import math
+import re
 
-from collections import (
-    Counter,
-    OrderedDict,
-)
+from collections import defaultdict
+
+from sympy.ntheory.factor_ import digits as _digits
+from sympy.utilities.iterables import multiset
 
 
 def count_digits(n, base=10):
@@ -23,40 +23,33 @@ def count_digits(n, base=10):
     Examples
     ========
 
-    >>> sympy.ntheory import count_digits
+    >>> from sympy.ntheory import count_digits
 
     >>> count_digits(1903413094, 10)
-    OrderedDict([(0, 2), (1, 2), (3, 2), (4, 2), (9, 2)])
+    {0: 2, 1: 2, 3: 2, 4: 2, 9: 2}
 
     >>> count_digits(122333, 10)
-    OrderedDict([(1, 1), (2, 2), (3, 3)])
+    {1: 1, 2: 2, 3: 3}
 
-    >>> count_digits(0b1001001), 2)
-    OrderedDict([(0, 4), (1, 3)])
+    >>> count_digits(0b1001001, 2)
+    {0: 4, 1: 3}
 
     >>> count_digits(0xF321, 16)
-    OrderedDict([(1, 1), (2, 1), (3, 1), (15, 1)])
+    {1: 1, 2: 1, 3: 1, 15: 1}
 
     The base 11 number 10321, with digits 10, 3, 2, 1 (from most significant digit)
     >>> count_digits(13696, 11)
-    OrderedDict([(1, 1), (2, 1), (3, 1), (10, 1)]
+    {1: 1, 2: 1, 3: 1, 10: 1}
 
     The base 100 number 990512, with digits 99, 0, 51, 2 (from most significant digit)
     >>> count_digits(99005102, 100)
-    OrderedDict([(0, 1), (2, 1), (51, 1), (99, 1)])
+    {0: 1, 2: 1, 51: 1, 99: 1}
 
     """
-    m = math.floor(math.log(n, base)) + 1
-
-    return OrderedDict(
-        sorted(
-            Counter(((n // base ** k) % base for k in range(m))).items(),
-            key=lambda t: t[0]
-        )
-    )
+    return defaultdict(int, multiset(_digits(n, base)[1:]).items())
 
 
-def is_palindromic_integer(n, base=10):
+def is_palindromic(n, base=10):
     """
     Checks whether a given positive integer ``n``, specified either as a
     numeric literal (binary, octal, decimal or hexadecimal) or a string, has
@@ -66,37 +59,44 @@ def is_palindromic_integer(n, base=10):
     Examples
     ========
 
-    >>> is_palindromic_integer(1, 10)
+    >>> from sympy.ntheory import is_palindromic
+
+    >>> is_palindromic(1, 10)
     True
 
-    >>> is_palindromic_integer(33, 10)
+    >>> is_palindromic(33, 10)
     True
 
-    >>> is_palindromic_integer(919, 10)
+    >>> is_palindromic(-919, 10)
     True
 
-    >>> is_palindromic_integer(0b101, 2)
+    >>> is_palindromic(0b101, 2)
     True
 
-    >>> is_palindromic_integer(0b01010010,2)
+    >>> is_palindromic(-0b01010010,2)
     False
 
-    >>> is_palindromic_integer(0o7610167, 8)
+    >>> is_palindromic(0o7610167, 8)
     True
 
-    >>> is_palindromic_integer(0o7611167, 8)
+    >>> is_palindromic(-0o7611167, 8)
+    True
+
+    >>> is_palindromic(0xFA0100AF, 16)
     False
 
-    >>> is_palindromic_integer(0xFA0100AF, 16)
-    False
-
-    >>> is_palindromic_integer(0xFA0110AF, 16)
+    >>> is_palindromic(0xFA0110AF, 16)
     True
 
     """
     if base < 2:
         raise ValueError('The base must be at least 2')
-    s = str(n)
+
+    if not (isinstance(n, int) and isinstance(base, int)):
+        raise TypeError('`n` and `base` must both be integer literals')
+
+    base_func = {**{base: str}, **{2: bin, 8: oct, 10: str, 16: hex}}
+    s = re.sub(r'^(-)?(0[a-z]{1})?', '', base_func[base](n))
     m = len(s)
 
     return s[:int(m / 2)] == (s[int(m / 2):] if not m % 2 else s[int(m / 2) + 1:])[::-1]

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -1,59 +1,101 @@
 from __future__ import print_function, division
 
-import re
+import math
 
-from collections import Counter
+from collections import (
+    Counter,
+    OrderedDict,
+)
 
 
-def is_pandigital(n, zeroless=False, freq='1+'):
+def count_digits(n, base=10):
     """
-    Checks whether a positive integer ``n`` is pandigital with respect
-    to the (decimal) base and has a digit frequency given by the
-    string ``freq``. The optional ``zeroless`` argument can be used
-    to indicate whether ``0`` should or should not be included in
-    checking for the pandigital property, i.e. whether ``0`` should be
-    included in the base digit set.
+    Returs an ordered dict. frequency counter for the digits of a decimal
+    integer ``n`` representing an integer in a base ``base``, where the
+    base digits are mapped to the positive decimal integers, e.g. the
+    base ``11`` integer ``10321``, with digits ``10``, ``3``, ``2``, ``1``
+    (from most significant to least), is equal to the decimal integer
+    ``13696``, as ``10 * 11**3 + 3 * 11**2 + 2 * 11**1 + 1 * 11**0 = 13696``.
 
-    Note: ``freq`` is an integer string with an optional ``+``
-    suffix to indicate min. digit frequency - otherwise the digit
-    frequency is taken to be exact.
+    For binary, octal or hexadecimal bases the integer ``n``
+    can also be specified as a numeric literal in those bases, e.g. ``0xF321``.
 
-    Some examples are given below.
-    ::
-        915286437, False, '1+'           ->   False
-        915286437, True, '1+'            ->   True
-        9152860437, False, '1+'          ->   True
-        112233445566778899, False, '2'   -> False
-        112233445566778899, True, '2'    -> True
-        11223344556677889900, False, '2' -> True
+    Examples
+    ========
+
+    >>> sympy.ntheory import count_digits
+
+    >>> count_digits(1903413094, 10)
+    OrderedDict([(0, 2), (1, 2), (3, 2), (4, 2), (9, 2)])
+
+    >>> count_digits(122333, 10)
+    OrderedDict([(1, 1), (2, 2), (3, 3)])
+
+    >>> count_digits(0b1001001), 2)
+    OrderedDict([(0, 4), (1, 3)])
+
+    >>> count_digits(0xF321, 16)
+    OrderedDict([(1, 1), (2, 1), (3, 1), (15, 1)])
+
+    The base 11 number 10321, with digits 10, 3, 2, 1 (from most significant digit)
+    >>> count_digits(13696, 11)
+    OrderedDict([(1, 1), (2, 1), (3, 1), (10, 1)]
+
+    The base 100 number 990512, with digits 99, 0, 51, 2 (from most significant digit)
+    >>> count_digits(99005102, 100)
+    OrderedDict([(0, 1), (2, 1), (51, 1), (99, 1)])
+
     """
-    digits = Counter(str(n))
+    m = math.floor(math.log(n, base)) + 1
 
-    _dfreq, dfreq_min = re.match(r'(\d+)(\+)?', freq).groups()
-    _dfreq = int(_dfreq)
-
-    base = set(Counter(str(1234567890)).keys()).difference(['0'] if zeroless else [])
-
-    return base.issubset(digits.keys()) and (
-        min(digits.values()) == max(digits.values()) == _dfreq if dfreq_min != '+' else
-        min(digits.values()) >= _dfreq
+    return OrderedDict(
+        sorted(
+            Counter(((n // base ** k) % base for k in range(m))).items(),
+            key=lambda t: t[0]
+        )
     )
 
 
-def is_palindromic_integer(n):
+def is_palindromic_integer(n, base=10):
     """
-    Checks whether a given positive integer ``n`` has the property that the
-    sequence of its digits is the same left to right as it is right to left.
-    Examples below.
-    ::
+    Checks whether a given positive integer ``n``, specified either as a
+    numeric literal (binary, octal, decimal or hexadecimal) or a string, has
+    a symmetrical digit sequence, i.e. the sequence of its digits is the same
+    left to right vs right to left.
 
-        1 -> True
-        33 -> True
-        919 - > True
-        1234321 -? True
-        14987778941 -> True
-        14987678941 -> False
+    Examples
+    ========
+
+    >>> is_palindromic_integer(1, 10)
+    True
+
+    >>> is_palindromic_integer(33, 10)
+    True
+
+    >>> is_palindromic_integer(919, 10)
+    True
+
+    >>> is_palindromic_integer(0b101, 2)
+    True
+
+    >>> is_palindromic_integer(0b01010010,2)
+    False
+
+    >>> is_palindromic_integer(0o7610167, 8)
+    True
+
+    >>> is_palindromic_integer(0o7611167, 8)
+    False
+
+    >>> is_palindromic_integer(0xFA0100AF, 16)
+    False
+
+    >>> is_palindromic_integer(0xFA0110AF, 16)
+    True
+
     """
+    if base < 2:
+        raise ValueError('The base must be at least 2')
     s = str(n)
     m = len(s)
 

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -1,0 +1,165 @@
+import os
+import random
+import re
+
+random.seed(os.urandom(10 ** 6))
+
+from itertools import chain
+
+from sympy.ntheory.digits import (
+    is_pandigital,
+    is_palindromic_integer,
+)
+
+
+# The first 18 zerofull pandigitals - obtained from Online
+# Encyclopedia of Integer Sequences (OEIS) sequence A171102
+#
+# https://oeis.org/A171102/list
+#
+sample_zerofull_pandigitals = [
+    1023456789,1023456798,1023456879,1023456897,
+    1023456978,1023456987,1023457689,1023457698,
+    1023457869,1023457896,1023457968,1023457986,
+    1023458679,1023458697,1023458769,1023458796,
+    1023458967,1023458976
+]
+smallest_zerofull_pandigital = min(sample_zerofull_pandigitals)
+sample_zeroless_pandigitals = [
+    int(str(n).replace('0', ''))
+    for n in sample_zerofull_pandigitals
+]
+smallest_zeroless_pandigital = min(sample_zeroless_pandigitals)
+
+
+def test_is_pandigital__zerofull_of_insufficient_length__returns_false():
+    sample_size = random.choice(range(100, 10 ** 6 + 1))
+    sample = random.sample(range(smallest_zerofull_pandigital), sample_size)
+    for n in sample:
+        assert is_pandigital(n) is False
+
+
+def test_is_pandigital__zerofull_of_insufficient_digit_frequency__returns_false():
+    sample = sample_zerofull_pandigitals[::]
+    ch, idx, fr = random.choice(str(1234567890)), random.choice(range(10)), random.choice(range(2, 11))
+    for n in sample:
+        digits = list(str(n))
+        [digits.insert(idx, ch) for j in range(fr)]
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, freq='{}+'.format(fr)) is False
+
+
+def test_is_pandigital__zerofull_of_inexact_digit_frequency__returns_false():
+    sample = sample_zerofull_pandigitals[::]
+    ch, idx, fr = random.choice(str(1234567890)), random.choice(range(10)), random.choice(range(2, 11))
+    for n in sample:
+        digits = list(str(n))
+        [digits.insert(idx, ch) for j in range(fr)]
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, freq='{}+'.format(fr)) is False
+
+
+def test_is_pandigital__valid_zerofull__returns_true():
+    for n in sample_zerofull_pandigitals:
+        assert is_pandigital(n) is True
+
+
+def test_is_pandigital__valid_zerofull_of_sufficient_digit_frequency__returns_true():
+    sample = sample_zerofull_pandigitals[::]
+    ch, fr = random.choice(str(1234567890)), random.choice(range(2, 11))
+    for n in sample:
+        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
+        random.shuffle(digits)
+        digits.insert(0, (ch if ch != '0' else '1'))
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, freq='{}+'.format(fr)) is True
+
+
+def test_is_pandigital__valid_zerofull_of_exact_digit_frequency__returns_true():
+    sample = sample_zerofull_pandigitals[::]
+    fr = random.choice(range(2, 11))
+    for n in sample:
+        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
+        while digits[0] == '0':
+            random.shuffle(digits)
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, freq='{}'.format(fr)) is True
+
+
+def test_is_pandigital__zeroless_of_insufficient_length__returns_false():
+    sample_size = random.choice(range(100, 10 ** 6 + 1))
+    sample = random.sample(range(smallest_zerofull_pandigital), sample_size)
+    for n in sample:
+        assert is_pandigital(n) is False
+
+
+def test_is_pandigital__zeroless_of_insufficient_digit_frequency__returns_false():
+    sample = sample_zeroless_pandigitals[::]
+    ch, idx, fr = random.choice(str(123456789)), random.choice(range(9)), random.choice(range(2, 10))
+    for n in sample:
+        digits = list(str(n))
+        [digits.insert(idx, ch) for j in range(fr)]
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is False
+
+
+def test_is_pandigital__zeroless_of_inexact_digit_frequency__returns_false():
+    sample = sample_zeroless_pandigitals[::]
+    ch, idx, fr = random.choice(str(123456789)), random.choice(range(9)), random.choice(range(2, 10))
+    for n in sample:
+        digits = list(str(n))
+        [digits.insert(idx, ch) for j in range(fr)]
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is False
+
+
+def test_is_pandigital__valid_zeroless_of_sufficient_digit_frequency__returns_true():
+    sample = sample_zeroless_pandigitals[::]
+    ch, fr = random.choice(str(123456789)), random.choice(range(2, 10))
+    for n in sample:
+        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
+        random.shuffle(digits)
+        digits.insert(0, ch)
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is True
+
+
+def test_is_pandigital__valid_zeroless_of_exact_digit_frequency__returns_true():
+    sample = sample_zeroless_pandigitals[::]
+    fr = random.choice(range(2, 10))
+    for n in sample:
+        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
+        random.shuffle(digits)
+        _n = int(''.join(digits))
+        assert is_pandigital(_n, zeroless=True, freq='{}'.format(fr)) is True
+
+
+def test_is_pandigital__valid_zeroless__returns_true():
+    for n in sample_zeroless_pandigitals:
+        assert is_pandigital(n, zeroless=True) is True
+
+
+def test_is_palindromic_integer__valid_palindrome__returns_true():
+    sample_size = random.choice(range(100, 10 ** 6 + 1))
+    sample = random.sample(range(10 ** 12 + 1), sample_size)
+    for N in sample:
+        st = str(N)
+        pal = st + st[::-1]
+        if random.choice([True, False]):
+            ch = pal[int(len(pal) / 2)]
+            pal = re.sub(r'{}+'.format(ch), ch, pal)
+        N = int(pal)
+        assert is_palindromic_integer(N) is True
+
+
+def test_is_palindromic_integer__non_palindrome__returns_false():
+    sample_size = random.choice(range(100, 10 ** 6 + 1))
+    sample = random.sample(range(10 ** 12 + 1), sample_size)
+    for N in sample:
+        st = str(N)
+        nonpal = list(st + st)
+        random.shuffle(nonpal)
+        while nonpal[0] == nonpal[-1]:
+            random.shuffle(nonpal)
+        N = int(''.join(nonpal))
+        assert is_palindromic_integer(N) is False

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -1,147 +1,48 @@
 import os
 import random
 import re
+import sys
 
-random.seed(os.urandom(10 ** 6))
+from collections import Counter
 
-from itertools import chain
-
-from sympy.ntheory.digits import (
-    is_pandigital,
+from sympy.ntheory import (
+    count_digits,
     is_palindromic_integer,
 )
 
 
-# The first 18 zerofull pandigitals - obtained from Online
-# Encyclopedia of Integer Sequences (OEIS) sequence A171102
-#
-# https://oeis.org/A171102/list
-#
-sample_zerofull_pandigitals = [
-    1023456789,1023456798,1023456879,1023456897,
-    1023456978,1023456987,1023457689,1023457698,
-    1023457869,1023457896,1023457968,1023457986,
-    1023458679,1023458697,1023458769,1023458796,
-    1023458967,1023458976
-]
-smallest_zerofull_pandigital = min(sample_zerofull_pandigitals)
-sample_zeroless_pandigitals = [
-    int(str(n).replace('0', ''))
-    for n in sample_zerofull_pandigitals
-]
-smallest_zeroless_pandigital = min(sample_zeroless_pandigitals)
+random.seed(os.urandom(10 ** 6))
+py_version = sys.version_info
 
 
-def test_is_pandigital__zerofull_of_insufficient_length__returns_false():
-    sample_size = random.choice(range(100, 10 ** 6 + 1))
-    sample = random.sample(range(smallest_zerofull_pandigital), sample_size)
-    for n in sample:
-        assert is_pandigital(n) is False
-
-
-def test_is_pandigital__zerofull_of_insufficient_digit_frequency__returns_false():
-    sample = sample_zerofull_pandigitals[::]
-    ch, idx, fr = random.choice(str(1234567890)), random.choice(range(10)), random.choice(range(2, 11))
-    for n in sample:
-        digits = list(str(n))
-        [digits.insert(idx, ch) for j in range(fr)]
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, freq='{}+'.format(fr)) is False
-
-
-def test_is_pandigital__zerofull_of_inexact_digit_frequency__returns_false():
-    sample = sample_zerofull_pandigitals[::]
-    ch, idx, fr = random.choice(str(1234567890)), random.choice(range(10)), random.choice(range(2, 11))
-    for n in sample:
-        digits = list(str(n))
-        [digits.insert(idx, ch) for j in range(fr)]
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, freq='{}+'.format(fr)) is False
-
-
-def test_is_pandigital__valid_zerofull__returns_true():
-    for n in sample_zerofull_pandigitals:
-        assert is_pandigital(n) is True
-
-
-def test_is_pandigital__valid_zerofull_of_sufficient_digit_frequency__returns_true():
-    sample = sample_zerofull_pandigitals[::]
-    ch, fr = random.choice(str(1234567890)), random.choice(range(2, 11))
-    for n in sample:
-        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
-        random.shuffle(digits)
-        digits.insert(0, (ch if ch != '0' else '1'))
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, freq='{}+'.format(fr)) is True
-
-
-def test_is_pandigital__valid_zerofull_of_exact_digit_frequency__returns_true():
-    sample = sample_zerofull_pandigitals[::]
-    fr = random.choice(range(2, 11))
-    for n in sample:
-        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
-        while digits[0] == '0':
+def test_count_digits():
+    for i in range(10):
+        base = random.choice(range(2, 101))
+        m = random.choice(range(1, 101))
+        digits = (
+            random.choices(range(base), k=m) if py_version[0] == 3 and py_version[1] >= 6
+            else [random.choice(range(base)) for i in range(m)]
+        )
+        while digits[0] == 0:
             random.shuffle(digits)
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, freq='{}'.format(fr)) is True
+        N = sum(d * base ** i for i, d in enumerate(reversed(digits)))
+        counter = Counter(digits)
+        res_counter = count_digits(N, base=base)
+        assert counter == res_counter
 
 
-def test_is_pandigital__zeroless_of_insufficient_length__returns_false():
-    sample_size = random.choice(range(100, 10 ** 6 + 1))
-    sample = random.sample(range(smallest_zerofull_pandigital), sample_size)
-    for n in sample:
-        assert is_pandigital(n) is False
-
-
-def test_is_pandigital__zeroless_of_insufficient_digit_frequency__returns_false():
-    sample = sample_zeroless_pandigitals[::]
-    ch, idx, fr = random.choice(str(123456789)), random.choice(range(9)), random.choice(range(2, 10))
-    for n in sample:
-        digits = list(str(n))
-        [digits.insert(idx, ch) for j in range(fr)]
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is False
-
-
-def test_is_pandigital__zeroless_of_inexact_digit_frequency__returns_false():
-    sample = sample_zeroless_pandigitals[::]
-    ch, idx, fr = random.choice(str(123456789)), random.choice(range(9)), random.choice(range(2, 10))
-    for n in sample:
-        digits = list(str(n))
-        [digits.insert(idx, ch) for j in range(fr)]
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is False
-
-
-def test_is_pandigital__valid_zeroless_of_sufficient_digit_frequency__returns_true():
-    sample = sample_zeroless_pandigitals[::]
-    ch, fr = random.choice(str(123456789)), random.choice(range(2, 10))
-    for n in sample:
-        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
-        random.shuffle(digits)
-        digits.insert(0, ch)
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, zeroless=True, freq='{}+'.format(fr)) is True
-
-
-def test_is_pandigital__valid_zeroless_of_exact_digit_frequency__returns_true():
-    sample = sample_zeroless_pandigitals[::]
-    fr = random.choice(range(2, 10))
-    for n in sample:
-        digits = [_d for _d in chain(*[list(str(n)) for i in range(fr)])]
-        random.shuffle(digits)
-        _n = int(''.join(digits))
-        assert is_pandigital(_n, zeroless=True, freq='{}'.format(fr)) is True
-
-
-def test_is_pandigital__valid_zeroless__returns_true():
-    for n in sample_zeroless_pandigitals:
-        assert is_pandigital(n, zeroless=True) is True
+def test_is_palindromic_integer__base_smaller_than_2__raises_value_error():
+    def base_smaller_than_2__raises_value_error():
+        try:
+            is_palindromic_integer(random.choice(range(10 ** 12 + 1)), random.choice(range(-(10 ** 12 + 1), 2)))
+        except ValueError:
+            return True
+        return False
+    assert base_smaller_than_2__raises_value_error()
 
 
 def test_is_palindromic_integer__valid_palindrome__returns_true():
-    sample_size = random.choice(range(100, 10 ** 6 + 1))
-    sample = random.sample(range(10 ** 12 + 1), sample_size)
+    sample = random.sample(range(10 ** 12 + 1), 10)
     for N in sample:
         st = str(N)
         pal = st + st[::-1]
@@ -153,8 +54,7 @@ def test_is_palindromic_integer__valid_palindrome__returns_true():
 
 
 def test_is_palindromic_integer__non_palindrome__returns_false():
-    sample_size = random.choice(range(100, 10 ** 6 + 1))
-    sample = random.sample(range(10 ** 12 + 1), sample_size)
+    sample = random.sample(range(10 ** 12 + 1), 10)
     for N in sample:
         st = str(N)
         nonpal = list(st + st)

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -7,7 +7,7 @@ from collections import Counter
 
 from sympy.ntheory import (
     count_digits,
-    is_palindromic_integer,
+    is_palindromic,
 )
 
 
@@ -18,7 +18,7 @@ py_version = sys.version_info
 def test_count_digits():
     for i in range(10):
         base = random.choice(range(2, 101))
-        m = random.choice(range(1, 101))
+        m = random.choice(range(1, 51))
         digits = (
             random.choices(range(base), k=m) if py_version[0] == 3 and py_version[1] >= 6
             else [random.choice(range(base)) for i in range(m)]
@@ -31,17 +31,30 @@ def test_count_digits():
         assert counter == res_counter
 
 
-def test_is_palindromic_integer__base_smaller_than_2__raises_value_error():
+def test_is_palindromic__base_smaller_than_2__raises_value_error():
     def base_smaller_than_2__raises_value_error():
         try:
-            is_palindromic_integer(random.choice(range(10 ** 12 + 1)), random.choice(range(-(10 ** 12 + 1), 2)))
+            is_palindromic(random.choice(range(10 ** 12 + 1)), random.choice(range(-(10 ** 12 + 1), 2)))
         except ValueError:
             return True
         return False
     assert base_smaller_than_2__raises_value_error()
 
 
-def test_is_palindromic_integer__valid_palindrome__returns_true():
+def test_is_palindromic__n_not_int_literal__raises_type_error():
+    def n_not_int_literal__raises_type_error(n, b):
+        try:
+            is_palindromic(n, b)
+        except TypeError:
+            return True
+        return False
+    for t in [float, complex, str, None]:
+        n = t(random.choice(range(10 ** 12 + 1))) if t is not None else t
+        b = random.choice(range(2, (10 ** 12 + 1)))
+        assert n_not_int_literal__raises_type_error(n, b) is True
+
+
+def test_is_palindromic__valid_palindrome__returns_true():
     sample = random.sample(range(10 ** 12 + 1), 10)
     for N in sample:
         st = str(N)
@@ -49,11 +62,12 @@ def test_is_palindromic_integer__valid_palindrome__returns_true():
         if random.choice([True, False]):
             ch = pal[int(len(pal) / 2)]
             pal = re.sub(r'{}+'.format(ch), ch, pal)
+            pal = '-' + pal
         N = int(pal)
-        assert is_palindromic_integer(N) is True
+        assert is_palindromic(N) is True
 
 
-def test_is_palindromic_integer__non_palindrome__returns_false():
+def test_is_palindromic__non_palindrome__returns_false():
     sample = random.sample(range(10 ** 12 + 1), 10)
     for N in sample:
         st = str(N)
@@ -61,5 +75,7 @@ def test_is_palindromic_integer__non_palindrome__returns_false():
         random.shuffle(nonpal)
         while nonpal[0] == nonpal[-1]:
             random.shuffle(nonpal)
+        if random.choice([True, False]):
+            nonpal.insert(0, '-')
         N = int(''.join(nonpal))
-        assert is_palindromic_integer(N) is False
+        assert is_palindromic(N) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added new `ntheory` module `digits.py` containing methods related to arithmetic properties of integers - currently it consists of only two methods:

* `count_digits`, to generate a frequency counter for the digits of integers in arbitrary bases
* `is_palindrome`, to check for palindromic numbers (numbers whose digit sequences are the same left to right vs right left).

Test cases for both have been added in a new test module`tests/tests_digits.py`.

#### Other comments

Future additions to this module could be related to (among others):

* (reduced) digit sums
* sums of digits and generalised sums of digits (sums of `k`-th powers of digits modulo `n`)
* (reduced) digit products
* products of digits and generalised products of digits (products of `k`-th powers of digits modulo `n`)
* additive and multiplicative persistence
* sum-product numbers (numbers whose sum of digits multipled by the product of digits is the same)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * added new `ntheory` module `digits.py` containing methods related to arithmetic properties of integers (currently, frequency counters for digits of integers, palindromic numbers)
<!-- END RELEASE NOTES -->