### PR TITLE
Addition of schur number in combinatorics

### DIFF
--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -16,7 +16,7 @@ def schur_number_lower_bound(n):
     elif n <= 3:
         min_k = 1
     else:
-        min_k = math.ceil(math.log(2*n + 1,3))
+        min_k = math.ceil(math.log(2*n + 1, 3))
 
     return min_k
 
@@ -30,10 +30,27 @@ def schur_partition(n):
     S(1) = 1, S(2) = 4 , S(3) = 13, S(4) = 44.
     e.g for n = 44 the lower bound from the function above is 5 subsets but it has been proven
     that can be done with 4 subsets.
+
+    Examples
+    ========
+
+    For n = 1, 2, 3 the answer is the set itself
+
+    >>> from sympy.combinatorics.schur_number import schur_partition
+    >>> schur_partition(2)
+    [[1, 2]]
+
+    For n > 3, the answer is the minimum number of sum-free subsets:
+
+    >>> schur_partition(5)
+    [[3, 2], [5], [1, 4]]
+
+    >>> schur_partition(8)
+    [[3, 2], [6, 5, 8], [1, 4, 7]]
     """
     n = int(n)
     number_of_subsets = schur_number_lower_bound(n)
-    if  n == 1:
+    if n == 1:
         sum_free_subsets = [[1]]
     elif n == 2:
         sum_free_subsets = [[1,2]]
@@ -43,20 +60,21 @@ def schur_partition(n):
         sum_free_subsets = [[1,4],[2,3]]
 
     while len(sum_free_subsets) < number_of_subsets  :
-            sum_free_subsets = _generate_next_list(sum_free_subsets,n)
-            missed_elements = [3*k + 1 for k in range(len(sum_free_subsets),(n-1)//3 + 1)]
-            sum_free_subsets[-1] += missed_elements
+        sum_free_subsets = _generate_next_list(sum_free_subsets, n)
+        missed_elements = [3*k + 1 for k in range(len(sum_free_subsets),(n-1)//3 + 1)]
+        sum_free_subsets[-1] += missed_elements
 
     return sum_free_subsets
 
 def _generate_next_list(current_list,n):
     new_list = []
+
     for item in current_list:
-        new_item = []
         temp_1 = [number*3 for number in item if number*3 <= n]
         temp_2 = [number*3 - 1 for number in item if number*3 - 1 <= n]
         new_item = temp_1 + temp_2
         new_list.append(new_item)
+
     last_list = [3*k + 1 for k in range(0, len(current_list)+1) if 3*k +1 <= n]
     new_list.append(last_list)
     current_list = new_list

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -52,13 +52,12 @@ def schur_partition(n):
 def _generate_next_list(current_list,n):
     new_list = []
     for item in current_list:
-        for number in item:
-            new_item = []
-            temp_1 = [number*3 for number in item if number*3 <= n]
-            temp_2 = [number*3 - 1 for number in item if number*3 - 1 <= n]
-            new_item = temp_1 + temp_2
+        new_item = []
+        temp_1 = [number*3 for number in item if number*3 <= n]
+        temp_2 = [number*3 - 1 for number in item if number*3 - 1 <= n]
+        new_item = temp_1 + temp_2
         new_list.append(new_item)
-    last_list = [3*k + 1 for k in range(0,len(current_list)+1) if 3*k +1 <= n]
+    last_list = [3*k + 1 for k in range(0, len(current_list)+1) if 3*k +1 <= n]
     new_list.append(last_list)
     current_list = new_list
 

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -4,21 +4,50 @@ can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumbe
 """
 import math
 from sympy import Symbol
+from sympy.core import S
+from sympy.core.function import Function
 
 
-def schur_number_lower_bound(n):
+class schur_number_lower_bound(Function):
+    """
+    Gives the value for 1/2 * (3**n  - 1)
+    """
+
+    @classmethod
+    def eval(cls, k):
+        expr = (1/2) * (3**k - 1)
+
+        if k.is_Number:
+            if k is S.Infinity:
+                return S.Infinity
+            if k.is_zero:
+                return 0
+            if not k.is_Integer or k.is_negative:
+                raise ValueError("k should be a positive integer")
+            expr = int(expr)
+
+        return expr
+
+
+class schur_number_subsets_lower_bound(Function):
     """
     This function returns a lower bound to Schur's Number
     """
-    n = int(n)
-    if n <= 0:
-        raise ValueError("n must be a positive integer.")
-    elif n <= 3:
-        min_k = 1
-    else:
-        min_k = math.ceil(math.log(2*n + 1, 3))
 
-    return min_k
+    @classmethod
+    def eval(cls, n):
+        n = int(n)
+
+        if n is S.Infinity:
+            return S.Infinity
+        if n <= 0:
+            raise ValueError("n must be a positive integer.")
+        elif n <= 3:
+            min_k = 1
+        else:
+            min_k = math.ceil(math.log(2*n + 1, 3))
+
+        return min_k
 
 def schur_partition(n):
     """
@@ -49,7 +78,7 @@ def schur_partition(n):
     [[3, 2], [6, 5, 8], [1, 4, 7]]
     """
     n = int(n)
-    number_of_subsets = schur_number_lower_bound(n)
+    number_of_subsets = schur_number_subsets_lower_bound(n)
     if n == 1:
         sum_free_subsets = [[1]]
     elif n == 2:
@@ -59,7 +88,7 @@ def schur_partition(n):
     else:
         sum_free_subsets = [[1,4],[2,3]]
 
-    while len(sum_free_subsets) < number_of_subsets  :
+    while len(sum_free_subsets) < number_of_subsets:
         sum_free_subsets = _generate_next_list(sum_free_subsets, n)
         missed_elements = [3*k + 1 for k in range(len(sum_free_subsets),(n-1)//3 + 1)]
         sum_free_subsets[-1] += missed_elements

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -57,6 +57,7 @@ class SchurNumber(Function):
 class SchurSubsetsNumber(Function):
     """
     This function returns a lower bound to Schur's Number
+    using the formula log(2n+1, 3)
     """
 
     @classmethod

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -3,9 +3,9 @@ The Schur number S(k) is the largest integer n for which the interval [1,n]
 can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumber.html)
 """
 import math
-from sympy import Symbol
 from sympy.core import S
 from sympy.core.function import Function
+from sympy.core.numbers import Integer
 
 
 class schur_number_lower_bound(Function):
@@ -15,7 +15,7 @@ class schur_number_lower_bound(Function):
 
     @classmethod
     def eval(cls, k):
-        expr = (1/2) * (3**k - 1)
+        expr = (3**k - 1)/2
 
         if k.is_Number:
             if k is S.Infinity:
@@ -24,9 +24,8 @@ class schur_number_lower_bound(Function):
                 return 0
             if not k.is_Integer or k.is_negative:
                 raise ValueError("k should be a positive integer")
-            expr = int(expr)
 
-        return expr
+        return Integer(expr)
 
 
 class schur_number_subsets_lower_bound(Function):
@@ -47,14 +46,33 @@ class schur_number_subsets_lower_bound(Function):
         else:
             min_k = math.ceil(math.log(2*n + 1, 3))
 
-        return min_k
+        return Integer(min_k)
+
 
 def schur_partition(n):
     """
-    This function makes the partition in the minimum number of sum-free subsets
+
+    This function returns the partition in the minimum number of sum-free subsets
     according to the lower bound given by the Schur Number.
-    The partition is returned in a list of lists.
-    *** Note that it is possible for some n to make the partition into less
+
+    Parameters
+    ==========
+
+    n: a number
+        n is the upper limit of the range [1, n] for which we need to find and
+        return the minimum number of free subsets according to the lower bound
+        of schur number
+
+    Returns
+    =======
+
+    List of lists
+        List of the minimum number of sum-free subsets
+
+    Notes
+    =====
+
+    It is possible for some n to make the partition into less
     subsets since the only known Schur numbers are:
     S(1) = 1, S(2) = 4 , S(3) = 13, S(4) = 44.
     e.g for n = 44 the lower bound from the function above is 5 subsets but it has been proven
@@ -82,20 +100,21 @@ def schur_partition(n):
     if n == 1:
         sum_free_subsets = [[1]]
     elif n == 2:
-        sum_free_subsets = [[1,2]]
+        sum_free_subsets = [[1, 2]]
     elif n == 3:
-        sum_free_subsets = [[1,2,3]]
+        sum_free_subsets = [[1, 2, 3]]
     else:
-        sum_free_subsets = [[1,4],[2,3]]
+        sum_free_subsets = [[1, 4], [2, 3]]
 
     while len(sum_free_subsets) < number_of_subsets:
         sum_free_subsets = _generate_next_list(sum_free_subsets, n)
-        missed_elements = [3*k + 1 for k in range(len(sum_free_subsets),(n-1)//3 + 1)]
+        missed_elements = [3*k + 1 for k in range(len(sum_free_subsets), (n-1)//3 + 1)]
         sum_free_subsets[-1] += missed_elements
 
     return sum_free_subsets
 
-def _generate_next_list(current_list,n):
+
+def _generate_next_list(current_list, n):
     new_list = []
 
     for item in current_list:
@@ -104,17 +123,8 @@ def _generate_next_list(current_list,n):
         new_item = temp_1 + temp_2
         new_list.append(new_item)
 
-    last_list = [3*k + 1 for k in range(0, len(current_list)+1) if 3*k +1 <= n]
+    last_list = [3*k + 1 for k in range(0, len(current_list)+1) if 3*k + 1 <= n]
     new_list.append(last_list)
     current_list = new_list
 
     return current_list
-
-def Schur_number_lower_bound():
-    """
-    This function returns the inequality to be solved symbolically
-    in order to find the Schur Number
-    """
-    n = Symbol("n")
-    k = Symbol("k")
-    return k >= 1/2*(3**n-1)

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -4,31 +4,57 @@ can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumbe
 """
 import math
 from sympy.core import S
+from sympy.core.basic import Basic
 from sympy.core.function import Function
 from sympy.core.numbers import Integer
 
 
-class schur_number_lower_bound(Function):
+class SchurNumber(Function):
     """
-    Gives the value for 1/2 * (3**n  - 1)
+    This function creates a SchurNumber object
+    which is evaluated for k <= 4 otherwise only
+    the lower bound information can be retrieved.
+
+    Examples
+    ========
+
+    >>> from sympy.combinatorics.schur_number import SchurNumber
+
+    Since S(3) = 13, hence the output is a number
+    >>> SchurNumber(3)
+    13
+
+    We don't know the schur number for values greater than 4, hence
+    only the object is returned
+    >>> SchurNumber(6)
+    SchurNumber(6)
+
+    Now, the lower bound information can be retrieved using lower_bound()
+    method
+    >>> SchurNumber(6).lower_bound()
+    364
+
     """
 
     @classmethod
     def eval(cls, k):
-        expr = (3**k - 1)/2
-
         if k.is_Number:
             if k is S.Infinity:
                 return S.Infinity
             if k.is_zero:
                 return 0
-            if not k.is_Integer or k.is_negative:
+            if not k.is_integer or k.is_negative:
                 raise ValueError("k should be a positive integer")
+            first_known_schur_numbers = {1: 1, 2: 4, 3: 13, 4: 44}
+            if k <= 4:
+                return Integer(first_known_schur_numbers[k])
 
-        return Integer(expr)
+    def lower_bound(self):
+        f_ = self.args[0]
+        return (3**f_ - 1)/2
 
 
-class schur_number_subsets_lower_bound(Function):
+class SchurSubsetsNumber(Function):
     """
     This function returns a lower bound to Schur's Number
     """
@@ -95,8 +121,12 @@ def schur_partition(n):
     >>> schur_partition(8)
     [[3, 2], [6, 5, 8], [1, 4, 7]]
     """
+
+    if isinstance(n, Basic) and not n.is_Number:
+        raise ValueError("Input value must be a number")
+
     n = int(n)
-    number_of_subsets = schur_number_subsets_lower_bound(n)
+    number_of_subsets = SchurSubsetsNumber(n)
     if n == 1:
         sum_free_subsets = [[1]]
     elif n == 2:

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -54,26 +54,19 @@ class SchurNumber(Function):
         return (3**f_ - 1)/2
 
 
-class SchurSubsetsNumber(Function):
-    """
-    This function returns a lower bound to Schur's Number
-    using the formula log(2n+1, 3)
-    """
+def _schur_subsets_number(n):
+    n = int(n)
 
-    @classmethod
-    def eval(cls, n):
-        n = int(n)
+    if n is S.Infinity:
+        return S.Infinity
+    if n <= 0:
+        raise ValueError("n must be a positive integer.")
+    elif n <= 3:
+        min_k = 1
+    else:
+        min_k = math.ceil(math.log(2*n + 1, 3))
 
-        if n is S.Infinity:
-            return S.Infinity
-        if n <= 0:
-            raise ValueError("n must be a positive integer.")
-        elif n <= 3:
-            min_k = 1
-        else:
-            min_k = math.ceil(math.log(2*n + 1, 3))
-
-        return Integer(min_k)
+    return Integer(min_k)
 
 
 def schur_partition(n):
@@ -127,7 +120,7 @@ def schur_partition(n):
         raise ValueError("Input value must be a number")
 
     n = int(n)
-    number_of_subsets = SchurSubsetsNumber(n)
+    number_of_subsets = _schur_subsets_number(n)
     if n == 1:
         sum_free_subsets = [[1]]
     elif n == 2:

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -55,12 +55,11 @@ class SchurNumber(Function):
 
 
 def _schur_subsets_number(n):
-    n = int(n)
 
     if n is S.Infinity:
-        return S.Infinity
+        raise ValueError("Input must be finite")
     if n <= 0:
-        raise ValueError("n must be a positive integer.")
+        raise ValueError("n must be a non-zero positive integer.")
     elif n <= 3:
         min_k = 1
     else:
@@ -119,7 +118,6 @@ def schur_partition(n):
     if isinstance(n, Basic) and not n.is_Number:
         raise ValueError("Input value must be a number")
 
-    n = int(n)
     number_of_subsets = _schur_subsets_number(n)
     if n == 1:
         sum_free_subsets = [[1]]

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -1,0 +1,65 @@
+#fix problem
+
+"""
+The Schur number S(k) is the largest integer n for which the interval [1,n]
+can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumber.html)
+"""
+import math
+
+def schur_number_lower_bound(n):
+    """
+    This function returns a lower bound to Schur's Number
+    """
+    n = int(n)
+    if n <= 0:
+        raise ValueError("n must be a positive integer.")
+    elif n <= 3:
+        min_k = 1
+    else:
+        min_k = math.ceil(math.log(2*n + 1,3))
+
+    return min_k
+
+def schur_partition(n):
+    """
+    This function makes the partition in the minimum number of sum-free subsets
+    according to the lower bound given by the Schur Number.
+    The partition is returned in a list of lists.
+    *** Note that it is possible for some n to make the partition into less
+    subsets since the only known Schur numbers are:
+    S(1) = 1, S(2) = 4 , S(3) = 13, S(4) = 44.
+    e.g for n = 44 the lower bound from the function above is 5 subsets but it has been proven
+    that can be done with 4 subsets.
+    """
+
+    n = int(n)
+    number_of_subsets = schur_number_lower_bound(n)
+    if  n == 1:
+        sum_free_subsets = [[1]]
+    elif n == 2:
+        sum_free_subsets = [[1,2]]
+    elif n == 3:
+        sum_free_subsets = [[1,2,3]]
+    else:
+        sum_free_subsets = [[1,4],[2,3]]
+
+    while len(sum_free_subsets) < number_of_subsets  :
+            sum_free_subsets = _generate_next_list(sum_free_subsets,n)
+            missed_elements = [3*k + 1 for k in range(len(sum_free_subsets),(n-1)//3 + 1)]
+            sum_free_subsets[-1] += missed_elements
+
+    return sum_free_subsets
+
+def _generate_next_list(current_list,n):
+    new_list = []
+    for item in current_list:
+        for number in item:
+            new_item = []
+            temp_1 = [number*3 for number in item if number*3 <= n]
+            temp_2 = [number*3 - 1 for number in item if number*3 - 1 <= n]
+            new_item = temp_1 + temp_2
+        new_list.append(new_item)
+    last_list = [3*k + 1 for k in range(0,len(current_list)+1) if 3*k +1 <= n]
+    new_list.append(last_list)
+    current_list = new_list
+    return current_list

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -3,6 +3,8 @@ The Schur number S(k) is the largest integer n for which the interval [1,n]
 can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumber.html)
 """
 import math
+from sympy import Symbol
+
 
 def schur_number_lower_bound(n):
     """
@@ -29,7 +31,6 @@ def schur_partition(n):
     e.g for n = 44 the lower bound from the function above is 5 subsets but it has been proven
     that can be done with 4 subsets.
     """
-
     n = int(n)
     number_of_subsets = schur_number_lower_bound(n)
     if  n == 1:
@@ -60,4 +61,14 @@ def _generate_next_list(current_list,n):
     last_list = [3*k + 1 for k in range(0,len(current_list)+1) if 3*k +1 <= n]
     new_list.append(last_list)
     current_list = new_list
+
     return current_list
+
+def Schur_number_lower_bound():
+    """
+    This function returns the inequality to be solved symbolically
+    in order to find the Schur Number
+    """
+    n = Symbol("n")
+    k = Symbol("k")
+    return k >= 1/2*(3**n-1)

--- a/sympy/combinatorics/schur_number.py
+++ b/sympy/combinatorics/schur_number.py
@@ -1,5 +1,3 @@
-#fix problem
-
 """
 The Schur number S(k) is the largest integer n for which the interval [1,n]
 can be partitioned into k sum-free sets.(http://mathworld.wolfram.com/SchurNumber.html)

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,4 +1,5 @@
 from sympy.combinatorics.schur_number import schur_partition
+from sympy.testing.randtest import _randint
 import random
 
 def _sum_free_test(subset):
@@ -11,10 +12,9 @@ def _sum_free_test(subset):
             assert (i + j in subset) is False
 
 def test_schur_number():
-    random.seed(1000)
-
+    random_number_generator = _randint(1000)
     for _ in range(5):
-        n = random.randint(1, 1000)
+        n = random_number_generator(1, 1000)
         result = schur_partition(n)
         t = 0
         numbers = []

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -12,18 +12,21 @@ def _sum_free_test(subset):
                 raise AssertionError("This subset is not sum free")
 
 def test_schur_number():
-    n = random.randint(1, 1000)
-    result = schur_partition(n)
-    t = 0
-    numbers = []
-    for item in result:
-        _sum_free_test(item)
-        """
-        Checks if the occurance of all numbers  is exactly one
-        """
-        t += len(item)
-        for l in item:
-            if l in numbers:
-                raise AssertionError("Every number must exist once")
-            numbers.append(l)
-    assert n == t
+    random.seed(1000)
+
+    for _ in range(5):
+        n = random.randint(1, 1000)
+        result = schur_partition(n)
+        t = 0
+        numbers = []
+        for item in result:
+            _sum_free_test(item)
+            """
+            Checks if the occurance of all numbers  is exactly one
+            """
+            t += len(item)
+            for l in item:
+                if l in numbers:
+                    raise AssertionError("Every number must exist once")
+                numbers.append(l)
+        assert n == t

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -8,8 +8,7 @@ def _sum_free_test(subset):
     """
     for i in subset:
         for j in subset:
-            if i + j in subset:
-                raise AssertionError("This subset is not sum free")
+            assert (i + j in subset) is False
 
 def test_schur_number():
     random.seed(1000)
@@ -26,7 +25,6 @@ def test_schur_number():
             """
             t += len(item)
             for l in item:
-                if l in numbers:
-                    raise AssertionError("Every number must exist once")
+                assert (l in numbers) is False
                 numbers.append(l)
         assert n == t

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -12,7 +12,7 @@ def _sum_free_test(subset):
                 raise AssertionError("This subset is not sum free")
 
 def test_schur_number():
-    n = random.randint(1,1000)
+    n = random.randint(1, 1000)
     result = schur_partition(n)
     t = 0
     numbers = []

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,6 +1,5 @@
 from sympy.combinatorics.schur_number import schur_partition
 from sympy.testing.randtest import _randint
-import random
 
 def _sum_free_test(subset):
     """

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,5 +1,8 @@
 from sympy.combinatorics.schur_number import schur_partition
 from sympy.testing.randtest import _randint
+from sympy.testing.pytest import raises
+from sympy.core.symbol import symbols
+
 
 def _sum_free_test(subset):
     """
@@ -9,6 +12,7 @@ def _sum_free_test(subset):
     for i in subset:
         for j in subset:
             assert (i + j in subset) is False
+
 
 def test_schur_number():
     random_number_generator = _randint(1000)
@@ -27,3 +31,6 @@ def test_schur_number():
                 assert (l in numbers) is False
                 numbers.append(l)
         assert n == t
+
+    x = symbols("x")
+    raises(ValueError, lambda: schur_partition(x))

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,4 +1,5 @@
-from sympy.combinatorics.schur_number import schur_partition
+from sympy.core import S, Rational
+from sympy.combinatorics.schur_number import schur_partition, SchurNumber
 from sympy.testing.randtest import _randint
 from sympy.testing.pytest import raises
 from sympy.core.symbol import symbols
@@ -14,7 +15,12 @@ def _sum_free_test(subset):
             assert (i + j in subset) is False
 
 
-def test_schur_number():
+def test_schur_partition():
+    raises(ValueError, lambda: schur_partition(S.Infinity))
+    raises(ValueError, lambda: schur_partition(-1))
+    raises(ValueError, lambda: schur_partition(0))
+    assert schur_partition(2) == [[1, 2]]
+
     random_number_generator = _randint(1000)
     for _ in range(5):
         n = random_number_generator(1, 1000)
@@ -34,3 +40,16 @@ def test_schur_number():
 
     x = symbols("x")
     raises(ValueError, lambda: schur_partition(x))
+
+def test_schur_number():
+    first_known_schur_numbers = {1: 1, 2: 4, 3: 13, 4: 44}
+    for k in first_known_schur_numbers:
+        assert SchurNumber(k) == first_known_schur_numbers[k]
+
+    assert SchurNumber(S.Infinity) == S.Infinity
+    assert SchurNumber(0) == 0
+    raises(ValueError, lambda: SchurNumber(0.5))
+
+    n = symbols("n")
+    assert SchurNumber(n).lower_bound() == 3**n/2 - Rational(1, 2)
+    assert SchurNumber(6).lower_bound() == 364

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,0 +1,31 @@
+from sympy.combinatorics.schur_number import schur_partition
+import random
+
+"""
+Checks if every subset is sum-free(There are no x,y,z in the subset such that
+x + y = z)
+"""
+def _sum_free_test(subset):
+    for i in subset:
+        for j in subset:
+            if i + j in subset:
+                raise AssertionError("This subset is not sum free")
+    return "Everything is correct"
+
+
+n = random.randint(1,1000)
+result = schur_partition(n)
+
+"""
+Checks if the occurance of all numbers  is exactly one
+"""
+t = 0
+numbers = []
+for item in result:
+    _sum_free_test(item)
+    t += len(item)
+    for l in item:
+        if l in numbers:
+            raise AssertionError("Every number must exist once")
+        numbers.append(l)
+assert n == t

--- a/sympy/combinatorics/tests/test_schur_number.py
+++ b/sympy/combinatorics/tests/test_schur_number.py
@@ -1,31 +1,29 @@
 from sympy.combinatorics.schur_number import schur_partition
 import random
 
-"""
-Checks if every subset is sum-free(There are no x,y,z in the subset such that
-x + y = z)
-"""
 def _sum_free_test(subset):
+    """
+    Checks if subset is sum-free(There are no x,y,z in the subset such that
+    x + y = z)
+    """
     for i in subset:
         for j in subset:
             if i + j in subset:
                 raise AssertionError("This subset is not sum free")
-    return "Everything is correct"
 
-
-n = random.randint(1,1000)
-result = schur_partition(n)
-
-"""
-Checks if the occurance of all numbers  is exactly one
-"""
-t = 0
-numbers = []
-for item in result:
-    _sum_free_test(item)
-    t += len(item)
-    for l in item:
-        if l in numbers:
-            raise AssertionError("Every number must exist once")
-        numbers.append(l)
-assert n == t
+def test_schur_number():
+    n = random.randint(1,1000)
+    result = schur_partition(n)
+    t = 0
+    numbers = []
+    for item in result:
+        _sum_free_test(item)
+        """
+        Checks if the occurance of all numbers  is exactly one
+        """
+        t += len(item)
+        for l in item:
+            if l in numbers:
+                raise AssertionError("Every number must exist once")
+            numbers.append(l)
+    assert n == t

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4921,3 +4921,11 @@ def test_sympy__integrals__rubi__utility_function__PolyGamma():
 def test_sympy__integrals__rubi__utility_function__ProductLog():
     from sympy.integrals.rubi.utility_function import ProductLog
     assert _test_args(ProductLog(1))
+
+def test_sympy__combinatorics__schur_number__schur_number_lower_bound():
+    from sympy.combinatorics.schur_number import schur_number_lower_bound
+    assert _test_args(schur_number_lower_bound(1))
+
+def test_sympy__combinatorics__schur_number__schur_number_subsets_lower_bound():
+    from sympy.combinatorics.schur_number import schur_number_subsets_lower_bound
+    assert _test_args(schur_number_subsets_lower_bound(4))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4922,10 +4922,10 @@ def test_sympy__integrals__rubi__utility_function__ProductLog():
     from sympy.integrals.rubi.utility_function import ProductLog
     assert _test_args(ProductLog(1))
 
-def test_sympy__combinatorics__schur_number__schur_number_lower_bound():
-    from sympy.combinatorics.schur_number import schur_number_lower_bound
-    assert _test_args(schur_number_lower_bound(1))
+def test_sympy__combinatorics__schur_number__SchurNumber():
+    from sympy.combinatorics.schur_number import SchurNumber
+    assert _test_args(SchurNumber(1))
 
-def test_sympy__combinatorics__schur_number__schur_number_subsets_lower_bound():
-    from sympy.combinatorics.schur_number import schur_number_subsets_lower_bound
-    assert _test_args(schur_number_subsets_lower_bound(4))
+def test_sympy__combinatorics__schur_number__SchurSubsetsNumber():
+    from sympy.combinatorics.schur_number import SchurSubsetsNumber
+    assert _test_args(SchurSubsetsNumber(4))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4925,7 +4925,3 @@ def test_sympy__integrals__rubi__utility_function__ProductLog():
 def test_sympy__combinatorics__schur_number__SchurNumber():
     from sympy.combinatorics.schur_number import SchurNumber
     assert _test_args(SchurNumber(1))
-
-def test_sympy__combinatorics__schur_number__SchurSubsetsNumber():
-    from sympy.combinatorics.schur_number import SchurSubsetsNumber
-    assert _test_args(SchurSubsetsNumber(4))


### PR DESCRIPTION
#### References to other Issues or PRs
Revives #14493 
Closes #14493 

#### Brief description of what is fixed or changed
--> Added schur number in combinatorics which computes and returns the sum-free subsets based on the lower bound of the schur number

#### Other comments
For example:
```
>>> from sympy import *
>>> from sympy.abc import *
>>> from sympy.combinatorics.schur_number import *
>>> schur_partition(2)
[[1, 2]]
>>> schur_partition(5)
[[3, 2], [5], [1, 4]]
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added schur number utilities in combinatorics
<!-- END RELEASE NOTES -->