### PR TITLE
solving type error and Coercion error in algebraicfield.py

### DIFF
--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -26,8 +26,10 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
             raise DomainError("ground domain must be a rational field")
 
         from sympy.polys.numberfields import to_number_field
-
-        self.orig_ext = ext
+        if len(ext) == 1 and type(ext[0]) is tuple:
+            self.orig_ext = ext[0][1:]
+        else:
+            self.orig_ext = ext
         self.ext = to_number_field(ext)
         self.mod = self.ext.minpoly.rep
         self.domain = self.dom = dom

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -126,3 +126,8 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
     def denom(self, a):
         """Returns denominator of ``a``. """
         return self.one
+
+    def from_AlgebraicField(K1, a, K0):
+        """Convert a polynomial to ``dtype``. """
+        a = K0.to_sympy(a)
+        return K1.from_sympy(a)

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -26,7 +26,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
             raise DomainError("ground domain must be a rational field")
 
         from sympy.polys.numberfields import to_number_field
-        if len(ext) == 1 and type(ext[0]) is tuple:
+        if len(ext) == 1 and isinstance(ext[0], tuple):
             self.orig_ext = ext[0][1:]
         else:
             self.orig_ext = ext

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -128,6 +128,5 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         return self.one
 
     def from_AlgebraicField(K1, a, K0):
-        """Convert a polynomial to ``dtype``. """
-        a = K0.to_sympy(a)
-        return K1.from_sympy(a)
+        """Convert AlgebraicField element 'a' to another AlgebraicField """
+        return K1.from_sympy(K0.to_sympy(a))

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -778,4 +778,7 @@ def test_issue_18248():
 def test_issue_13230():
     c1 = Circle(Point2D(3, sqrt(5)), 5)
     c2 = Circle(Point2D(4, sqrt(7)), 6)
-    assert intersection(c1, c2) == [Point2D(-1 + (-sqrt(7) + sqrt(5))*(-2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
+    assert intersection(c1, c2) == [Point2D(-1 + (-sqrt(7) + sqrt(5))*(-2*sqrt(7)/29
+    + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29
+    + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)
+    + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -2,9 +2,11 @@
 
 from sympy import (S, Rational, Symbol, Poly, sqrt, I, oo, Tuple, expand,
     pi, cos, sin, exp, GoldenRatio, TribonacciConstant, cbrt)
-
+from sympy.solvers.solveset import nonlinsolve
+from sympy.geometry import Circle, intersection
 from sympy.testing.pytest import raises, slow
-
+from sympy.sets.sets import FiniteSet
+from sympy import Point2D
 from sympy.polys.numberfields import (
     minimal_polynomial,
     primitive_element,
@@ -765,3 +767,15 @@ def test_issue_14831():
     e = (-3*sqrt(12*sqrt(2) + 17) + 12*sqrt(2) +
          17 - 2*sqrt(2)*sqrt(12*sqrt(2) + 17))
     assert minimal_polynomial(e, x) == x
+
+
+def test_issue_18248():
+    assert nonlinsolve([x*y**3-sqrt(2)/3, x*y**6-4/(9*(sqrt(3)))],x,y) == \
+            FiniteSet((sqrt(3)/2, sqrt(6)/3), (sqrt(3)/2, -sqrt(6)/6 - sqrt(2)*I/2),
+            (sqrt(3)/2, -sqrt(6)/6 + sqrt(2)*I/2))
+
+
+def test_issue_13230():
+    c1 = Circle(Point2D(3, sqrt(5)), 5)
+    c2 = Circle(Point2D(4, sqrt(7)), 6)
+    assert intersection(c1, c2) == [Point2D(-1 + (-sqrt(7) + sqrt(5))*(-2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2313,3 +2313,8 @@ def test_solve_modular_fail():
             ImageSet(Lambda(n, 74*n + 31), S.Integers)
 
 # end of modular tests
+
+def test_issue_18248():
+    assert nonlinsolve([x*y**3-sqrt(2)/3, x*y**6-4/(9*(sqrt(3)))],x,y) == \
+            FiniteSet((sqrt(3)/2, sqrt(6)/3), (sqrt(3)/2, -sqrt(6)/6 - sqrt(2)*I/2),
+            (sqrt(3)/2, -sqrt(6)/6 + sqrt(2)*I/2))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2313,8 +2313,3 @@ def test_solve_modular_fail():
             ImageSet(Lambda(n, 74*n + 31), S.Integers)
 
 # end of modular tests
-
-def test_issue_18248():
-    assert nonlinsolve([x*y**3-sqrt(2)/3, x*y**6-4/(9*(sqrt(3)))],x,y) == \
-            FiniteSet((sqrt(3)/2, sqrt(6)/3), (sqrt(3)/2, -sqrt(6)/6 - sqrt(2)*I/2),
-            (sqrt(3)/2, -sqrt(6)/6 + sqrt(2)*I/2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18248
Fixes #13230
#### Brief description of what is fixed or changed
It solves the type error by:

- Adding a check for type of `ext` in `AlgebraicField.__init__`.

It also solves the Coercion error by:

- adding a `AlgebraicField.from_AlgebraicField(K1, a, K0)` method.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   polys
     *  Fixed initialization of `orig_ext` and added `from_AlgebraicField()` to `AlgebraicField`.
<!-- END RELEASE NOTES -->