### PR TITLE
Solves AttributeError in solveset.py

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2991,6 +2991,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # list.
                             result.remove(res)
                     continue  # skip as it's independent of desired symbols
+                eq2 = eq2.rewrite(Add)
                 depen = eq2.as_independent(unsolved_syms)[0]
                 if depen.has(Abs) and solver == solveset_complex:
                     # Absolute values cannot be inverted in the

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2991,8 +2991,7 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # list.
                             result.remove(res)
                     continue  # skip as it's independent of desired symbols
-                eq2 = eq2.rewrite(Add)
-                depen = eq2.as_independent(unsolved_syms)[0]
+                depen = (eq2.rewrite(Add)).as_independent(unsolved_syms)[0]
                 if depen.has(Abs) and solver == solveset_complex:
                     # Absolute values cannot be inverted in the
                     # complex domain

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat, diff)
 from sympy.core.mod import Mod
-from sympy.core.numbers import (E, I, Rational, oo, pi)
+from sympy.core.numbers import (E, I, Rational, oo, pi, Integer)
 from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S
@@ -2315,5 +2315,5 @@ def test_solve_modular_fail():
 # end of modular tests
 
 def test_issue_17276():
-    assert nonlinsolve([Eq(x,5**1/5), Eq(x*y, 25*sqrt(5))], x, y) == \
-    FiniteSet((1.0, 25.0*sqrt(5)))
+    assert nonlinsolve([Eq(x, 5**(Integer(S(1))/5)), Eq(x*y, 25*sqrt(5))], x, y) == \
+     FiniteSet((5**(S(1)/5), 25*5**(S(3)/10)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat, diff)
 from sympy.core.mod import Mod
-from sympy.core.numbers import (E, I, Rational, oo, pi, Integer)
+from sympy.core.numbers import (E, I, Rational, oo, pi)
 from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat, diff)
 from sympy.core.mod import Mod
-from sympy.core.numbers import (E, I, Rational, oo, pi, Integer)
+from sympy.core.numbers import (E, I, Rational, oo, pi)
 from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S
@@ -2315,5 +2315,5 @@ def test_solve_modular_fail():
 # end of modular tests
 
 def test_issue_17276():
-    assert nonlinsolve([Eq(x, 5**(Integer(S(1))/5)), Eq(x*y, 25*sqrt(5))], x, y) == \
+    assert nonlinsolve([Eq(x, 5**(S(1)/5)), Eq(x*y, 25*sqrt(5))], x, y) == \
      FiniteSet((5**(S(1)/5), 25*5**(S(3)/10)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat, diff)
 from sympy.core.mod import Mod
-from sympy.core.numbers import (E, I, Rational, oo, pi)
+from sympy.core.numbers import (E, I, Rational, oo, pi, Integer)
 from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S
@@ -2313,3 +2313,7 @@ def test_solve_modular_fail():
             ImageSet(Lambda(n, 74*n + 31), S.Integers)
 
 # end of modular tests
+
+def test_issue_17276():
+    assert nonlinsolve([Eq(x,5**1/5), Eq(x*y, 25*sqrt(5))], x, y) == \
+    FiniteSet((1.0, 25.0*sqrt(5)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17276

#### Brief description of what is fixed or changed
Now,
```
>>> nonlinsolve([Eq(x, 5**(Integer(1)/5)), Eq(x*y, 25*sqrt(5))], x, y)
FiniteSet((5**(1/5), 25*5**(3/10)))
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
    - Rewrite equation as expression in `solveset`.
<!-- END RELEASE NOTES -->