### PR TITLE
Solves Unpickling simple expressions errors

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2605,6 +2605,9 @@ class Zero(IntegerConstant, metaclass=Singleton):
 
     __slots__ = ()
 
+    def __getnewargs__(self):
+        return ()
+
     @staticmethod
     def __abs__():
         return S.Zero
@@ -2666,6 +2669,9 @@ class One(IntegerConstant, metaclass=Singleton):
     q = 1
 
     __slots__ = ()
+
+    def __getnewargs__(self):
+        return ()
 
     @staticmethod
     def __abs__():
@@ -2774,6 +2780,9 @@ class Half(RationalConstant, metaclass=Singleton):
     q = 2
 
     __slots__ = ()
+
+    def __getnewargs__(self):
+        return ()
 
     @staticmethod
     def __abs__():

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2726,6 +2726,9 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
 
     __slots__ = ()
 
+    def __getnewargs__(self):
+        return ()
+
     @staticmethod
     def __abs__():
         return S.One

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -49,6 +49,13 @@ class IdentityFunction(Lambda, metaclass=Singleton):
         #construct "by hand" to avoid infinite loop
         return Expr.__new__(cls, Tuple(x), x)
 
+    @property
+    def args(self):
+        return ()
+
+    def __getnewargs__(self):
+        return ()
+
 Id = S.IdentityFunction
 
 ###############################################################################

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -694,3 +694,6 @@ def test_concrete():
 def test_deprecation_warning():
     w = SymPyDeprecationWarning('value', 'feature', issue=12345, deprecated_since_version='1.0')
     check(w)
+
+def test_issue_18438():
+    assert pickle.loads(pickle.dumps(S.Half)) == 1/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18438 
#### Brief description of what is fixed or changed
Solves Unpickling simple expressions errors by:
- Adding `Zero.__getnewargs__()`,  `One.__getnewargs__()`,  `NegativeOne.__getnewargs__()`, 
  `Half.__getnewargs__()`.
- Adding  `__getnewargs__()` and `args()` in miscellaneous.py.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   core
     * `__getnewargs__()` added to  `Zero`,  `One`,  `NegativeOne`, `Half`.
*   functions
     * `__getnewargs__()` and `args()` added to `IdentityFunction`.
<!-- END RELEASE NOTES -->