### PR TITLE
migrate all the decomposition-related test to test_decompositions.py

### DIFF
--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -1,0 +1,336 @@
+from sympy import Rational, I, expand_mul, S, simplify
+from sympy.matrices.matrices import NonSquareMatrixError
+from sympy.matrices import Matrix, zeros, eye, SparseMatrix
+from sympy.abc import x, y, z
+from sympy.testing.pytest import raises
+
+def test_LUdecomp():
+    testmat = Matrix([[0, 2, 5, 3],
+                      [3, 3, 7, 4],
+                      [8, 4, 0, 2],
+                      [-2, 6, 3, 4]])
+    L, U, p = testmat.LUdecomposition()
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4)
+
+    testmat = Matrix([[6, -2, 7, 4],
+                      [0, 3, 6, 7],
+                      [1, -2, 7, 4],
+                      [-9, 2, 6, 3]])
+    L, U, p = testmat.LUdecomposition()
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4)
+
+    # non-square
+    testmat = Matrix([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 9],
+                      [10, 11, 12]])
+    L, U, p = testmat.LUdecomposition(rankcheck=False)
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4, 3)
+
+    # square and singular
+    testmat = Matrix([[1, 2, 3],
+                      [2, 4, 6],
+                      [4, 5, 6]])
+    L, U, p = testmat.LUdecomposition(rankcheck=False)
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(3)
+
+    M = Matrix(((1, x, 1), (2, y, 0), (y, 0, z)))
+    L, U, p = M.LUdecomposition()
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permute_rows(p, 'backward') - M == zeros(3)
+
+    mL = Matrix((
+        (1, 0, 0),
+        (2, 3, 0),
+    ))
+    assert mL.is_lower is True
+    assert mL.is_upper is False
+    mU = Matrix((
+        (1, 2, 3),
+        (0, 4, 5),
+    ))
+    assert mU.is_lower is False
+    assert mU.is_upper is True
+
+    # test FF LUdecomp
+    M = Matrix([[1, 3, 3],
+                [3, 2, 6],
+                [3, 2, 2]])
+    P, L, Dee, U = M.LUdecompositionFF()
+    assert P*M == L*Dee.inv()*U
+
+    M = Matrix([[1,  2, 3,  4],
+                [3, -1, 2,  3],
+                [3,  1, 3, -2],
+                [6, -1, 0,  2]])
+    P, L, Dee, U = M.LUdecompositionFF()
+    assert P*M == L*Dee.inv()*U
+
+    M = Matrix([[0, 0, 1],
+                [2, 3, 0],
+                [3, 1, 4]])
+    P, L, Dee, U = M.LUdecompositionFF()
+    assert P*M == L*Dee.inv()*U
+
+    # issue 15794
+    M = Matrix(
+        [[1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]]
+    )
+    raises(ValueError, lambda : M.LUdecomposition_Simple(rankcheck=True))
+
+def test_QR():
+    A = Matrix([[1, 2], [2, 3]])
+    Q, S = A.QRdecomposition()
+    R = Rational
+    assert Q == Matrix([
+        [  5**R(-1, 2),  (R(2)/5)*(R(1)/5)**R(-1, 2)],
+        [2*5**R(-1, 2), (-R(1)/5)*(R(1)/5)**R(-1, 2)]])
+    assert S == Matrix([[5**R(1, 2), 8*5**R(-1, 2)], [0, (R(1)/5)**R(1, 2)]])
+    assert Q*S == A
+    assert Q.T * Q == eye(2)
+
+    A = Matrix([[1, 1, 1], [1, 1, 3], [2, 3, 4]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+def test_QR_non_square():
+    # Narrow (cols < rows) matrices
+    A = Matrix([[9, 0, 26], [12, 0, -7], [0, 4, 4], [0, -3, -3]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix(2, 1, [1, 2])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    # Wide (cols > rows) matrices
+    A = Matrix([[1, 2, 3], [4, 5, 6]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, 2, 3, 4], [1, 4, 9, 16], [1, 8, 27, 64]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix(1, 2, [1, 2])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+def test_QR_trivial():
+    # Rank deficient matrices
+    A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    # Zero rank matrices
+    A = Matrix([[0, 0, 0]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0], [0, 0, 0]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0], [0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    # Rank deficient matrices with zero norm from beginning columns
+    A = Matrix([[0, 0, 0], [1, 2, 3]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0], [2, 4, 6, 8]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+    A = Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0], [1, 2, 3]]).T
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
+def test_LUdecomposition_Simple_iszerofunc():
+    # Test if callable passed to matrices.LUdecomposition_Simple() as iszerofunc keyword argument is used inside
+    # matrices.LUdecomposition_Simple()
+    magic_string = "I got passed in!"
+    def goofyiszero(value):
+        raise ValueError(magic_string)
+
+    try:
+        lu, p = Matrix([[1, 0], [0, 1]]).LUdecomposition_Simple(iszerofunc=goofyiszero)
+    except ValueError as err:
+        assert magic_string == err.args[0]
+        return
+
+    assert False
+
+def test_LUdecomposition_iszerofunc():
+    # Test if callable passed to matrices.LUdecomposition() as iszerofunc keyword argument is used inside
+    # matrices.LUdecomposition_Simple()
+    magic_string = "I got passed in!"
+    def goofyiszero(value):
+        raise ValueError(magic_string)
+
+    try:
+        l, u, p = Matrix([[1, 0], [0, 1]]).LUdecomposition(iszerofunc=goofyiszero)
+    except ValueError as err:
+        assert magic_string == err.args[0]
+        return
+
+    assert False
+
+def test_LDLdecomposition():
+    raises(NonSquareMatrixError, lambda: Matrix((1, 2)).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((5 + I, 0), (0, 1))).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((1, 5), (5, 1))).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).LDLdecomposition(hermitian=False))
+    A = Matrix(((1, 5), (5, 1)))
+    L, D = A.LDLdecomposition(hermitian=False)
+    assert L * D * L.T == A
+    A = Matrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
+    L, D = A.LDLdecomposition()
+    assert L * D * L.T == A
+    assert L.is_lower
+    assert L == Matrix([[1, 0, 0], [ Rational(3, 5), 1, 0], [Rational(-1, 5), Rational(1, 3), 1]])
+    assert D.is_diagonal()
+    assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
+    A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
+    L, D = A.LDLdecomposition()
+    assert expand_mul(L * D * L.H) == A
+    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S.Half - I/2, 0, 1)))
+    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
+
+    raises(NonSquareMatrixError, lambda: SparseMatrix((1, 2)).LDLdecomposition())
+    raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).LDLdecomposition())
+    raises(ValueError, lambda: SparseMatrix(((5 + I, 0), (0, 1))).LDLdecomposition())
+    raises(ValueError, lambda: SparseMatrix(((1, 5), (5, 1))).LDLdecomposition())
+    raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).LDLdecomposition(hermitian=False))
+    A = SparseMatrix(((1, 5), (5, 1)))
+    L, D = A.LDLdecomposition(hermitian=False)
+    assert L * D * L.T == A
+    A = SparseMatrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
+    L, D = A.LDLdecomposition()
+    assert L * D * L.T == A
+    assert L.is_lower
+    assert L == Matrix([[1, 0, 0], [ Rational(3, 5), 1, 0], [Rational(-1, 5), Rational(1, 3), 1]])
+    assert D.is_diagonal()
+    assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
+    A = SparseMatrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
+    L, D = A.LDLdecomposition()
+    assert expand_mul(L * D * L.H) == A
+    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S.Half - I/2, 0, 1)))
+    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
+
+def test_pinv_succeeds_with_rank_decomposition_method():
+    # Test rank decomposition method of pseudoinverse succeeding
+    As = [Matrix([
+        [61, 89, 55, 20, 71, 0],
+        [62, 96, 85, 85, 16, 0],
+        [69, 56, 17,  4, 54, 0],
+        [10, 54, 91, 41, 71, 0],
+        [ 7, 30, 10, 48, 90, 0],
+        [0,0,0,0,0,0]])]
+    for A in As:
+        A_pinv = A.pinv(method="RD")
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
+
+def test_rank_decomposition():
+    a = Matrix(0, 0, [])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
+    assert c * f == a
+
+    a = Matrix(1, 1, [5])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
+    assert c * f == a
+
+    a = Matrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
+    assert c * f == a
+
+    a = Matrix([
+        [0, 0, 1, 2, 2, -5, 3],
+        [-1, 5, 2, 2, 1, -7, 5],
+        [0, 0, -2, -3, -3, 8, -5],
+        [-1, 5, 0, -1, -2, 1, 0]])
+    c, f = a.rank_decomposition()
+    assert f.is_echelon
+    assert c.cols == f.rows == a.rank()
+    assert c * f == a

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -883,92 +883,6 @@ def test_random():
                 zero_count += 1
     assert zero_count == 30
 
-
-def test_LUdecomp():
-    testmat = Matrix([[0, 2, 5, 3],
-                      [3, 3, 7, 4],
-                      [8, 4, 0, 2],
-                      [-2, 6, 3, 4]])
-    L, U, p = testmat.LUdecomposition()
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4)
-
-    testmat = Matrix([[6, -2, 7, 4],
-                      [0, 3, 6, 7],
-                      [1, -2, 7, 4],
-                      [-9, 2, 6, 3]])
-    L, U, p = testmat.LUdecomposition()
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4)
-
-    # non-square
-    testmat = Matrix([[1, 2, 3],
-                      [4, 5, 6],
-                      [7, 8, 9],
-                      [10, 11, 12]])
-    L, U, p = testmat.LUdecomposition(rankcheck=False)
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(4, 3)
-
-    # square and singular
-    testmat = Matrix([[1, 2, 3],
-                      [2, 4, 6],
-                      [4, 5, 6]])
-    L, U, p = testmat.LUdecomposition(rankcheck=False)
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permute_rows(p, 'backward') - testmat == zeros(3)
-
-    M = Matrix(((1, x, 1), (2, y, 0), (y, 0, z)))
-    L, U, p = M.LUdecomposition()
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permute_rows(p, 'backward') - M == zeros(3)
-
-    mL = Matrix((
-        (1, 0, 0),
-        (2, 3, 0),
-    ))
-    assert mL.is_lower is True
-    assert mL.is_upper is False
-    mU = Matrix((
-        (1, 2, 3),
-        (0, 4, 5),
-    ))
-    assert mU.is_lower is False
-    assert mU.is_upper is True
-
-    # test FF LUdecomp
-    M = Matrix([[1, 3, 3],
-                [3, 2, 6],
-                [3, 2, 2]])
-    P, L, Dee, U = M.LUdecompositionFF()
-    assert P*M == L*Dee.inv()*U
-
-    M = Matrix([[1,  2, 3,  4],
-                [3, -1, 2,  3],
-                [3,  1, 3, -2],
-                [6, -1, 0,  2]])
-    P, L, Dee, U = M.LUdecompositionFF()
-    assert P*M == L*Dee.inv()*U
-
-    M = Matrix([[0, 0, 1],
-                [2, 3, 0],
-                [3, 1, 4]])
-    P, L, Dee, U = M.LUdecompositionFF()
-    assert P*M == L*Dee.inv()*U
-
-    # issue 15794
-    M = Matrix(
-        [[1, 2, 3],
-        [4, 5, 6],
-        [7, 8, 9]]
-    )
-    raises(ValueError, lambda : M.LUdecomposition_Simple(rankcheck=True))
-
 def test_LUsolve():
     A = Matrix([[2, 3, 5],
                 [3, 6, 2],
@@ -1142,134 +1056,6 @@ def test_jacobian_hessian():
         [     0, 6*y**2, 2*x],
         [6*y**2,    2*x, 2*y],
         [   2*x,    2*y,   0]])
-
-
-def test_QR():
-    A = Matrix([[1, 2], [2, 3]])
-    Q, S = A.QRdecomposition()
-    R = Rational
-    assert Q == Matrix([
-        [  5**R(-1, 2),  (R(2)/5)*(R(1)/5)**R(-1, 2)],
-        [2*5**R(-1, 2), (-R(1)/5)*(R(1)/5)**R(-1, 2)]])
-    assert S == Matrix([[5**R(1, 2), 8*5**R(-1, 2)], [0, (R(1)/5)**R(1, 2)]])
-    assert Q*S == A
-    assert Q.T * Q == eye(2)
-
-    A = Matrix([[1, 1, 1], [1, 1, 3], [2, 3, 4]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-
-def test_QR_non_square():
-    # Narrow (cols < rows) matrices
-    A = Matrix([[9, 0, 26], [12, 0, -7], [0, 4, 4], [0, -3, -3]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[1, -1, 4], [1, 4, -2], [1, 4, 2], [1, -1, 0]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix(2, 1, [1, 2])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    # Wide (cols > rows) matrices
-    A = Matrix([[1, 2, 3], [4, 5, 6]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[1, 2, 3, 4], [1, 4, 9, 16], [1, 8, 27, 64]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix(1, 2, [1, 2])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-def test_QR_trivial():
-    # Rank deficient matrices
-    A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    # Zero rank matrices
-    A = Matrix([[0, 0, 0]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0], [0, 0, 0]])
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0], [0, 0, 0]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    # Rank deficient matrices with zero norm from beginning columns
-    A = Matrix([[0, 0, 0], [1, 2, 3]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0, 0], [1, 2, 3, 4], [0, 0, 0, 0], [2, 4, 6, 8]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
-
-    A = Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0], [1, 2, 3]]).T
-    Q, R = A.QRdecomposition()
-    assert Q.T * Q == eye(Q.cols)
-    assert R.is_upper
-    assert A == Q*R
 
 
 def test_nullspace():
@@ -2399,35 +2185,6 @@ def test_has():
     A = A.subs(x, 2)
     assert not A.has(x)
 
-def test_LUdecomposition_Simple_iszerofunc():
-    # Test if callable passed to matrices.LUdecomposition_Simple() as iszerofunc keyword argument is used inside
-    # matrices.LUdecomposition_Simple()
-    magic_string = "I got passed in!"
-    def goofyiszero(value):
-        raise ValueError(magic_string)
-
-    try:
-        lu, p = Matrix([[1, 0], [0, 1]]).LUdecomposition_Simple(iszerofunc=goofyiszero)
-    except ValueError as err:
-        assert magic_string == err.args[0]
-        return
-
-    assert False
-
-def test_LUdecomposition_iszerofunc():
-    # Test if callable passed to matrices.LUdecomposition() as iszerofunc keyword argument is used inside
-    # matrices.LUdecomposition_Simple()
-    magic_string = "I got passed in!"
-    def goofyiszero(value):
-        raise ValueError(magic_string)
-
-    try:
-        l, u, p = Matrix([[1, 0], [0, 1]]).LUdecomposition(iszerofunc=goofyiszero)
-    except ValueError as err:
-        assert magic_string == err.args[0]
-        return
-
-    assert False
 
 def test_find_reasonable_pivot_naive_finds_guaranteed_nonzero1():
     # Test if matrices._find_reasonable_pivot_naive()
@@ -2694,50 +2451,6 @@ def test_cholesky():
     assert L == Matrix([[5, 0, 0], [3, 3, 0], [-1, 1, 3]])
     A = SparseMatrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
     assert A.cholesky() == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
-
-
-def test_LDLdecomposition():
-    raises(NonSquareMatrixError, lambda: Matrix((1, 2)).LDLdecomposition())
-    raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).LDLdecomposition())
-    raises(ValueError, lambda: Matrix(((5 + I, 0), (0, 1))).LDLdecomposition())
-    raises(ValueError, lambda: Matrix(((1, 5), (5, 1))).LDLdecomposition())
-    raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).LDLdecomposition(hermitian=False))
-    A = Matrix(((1, 5), (5, 1)))
-    L, D = A.LDLdecomposition(hermitian=False)
-    assert L * D * L.T == A
-    A = Matrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
-    L, D = A.LDLdecomposition()
-    assert L * D * L.T == A
-    assert L.is_lower
-    assert L == Matrix([[1, 0, 0], [ Rational(3, 5), 1, 0], [Rational(-1, 5), Rational(1, 3), 1]])
-    assert D.is_diagonal()
-    assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
-    A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
-    L, D = A.LDLdecomposition()
-    assert expand_mul(L * D * L.H) == A
-    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S.Half - I/2, 0, 1)))
-    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
-
-    raises(NonSquareMatrixError, lambda: SparseMatrix((1, 2)).LDLdecomposition())
-    raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).LDLdecomposition())
-    raises(ValueError, lambda: SparseMatrix(((5 + I, 0), (0, 1))).LDLdecomposition())
-    raises(ValueError, lambda: SparseMatrix(((1, 5), (5, 1))).LDLdecomposition())
-    raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).LDLdecomposition(hermitian=False))
-    A = SparseMatrix(((1, 5), (5, 1)))
-    L, D = A.LDLdecomposition(hermitian=False)
-    assert L * D * L.T == A
-    A = SparseMatrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
-    L, D = A.LDLdecomposition()
-    assert L * D * L.T == A
-    assert L.is_lower
-    assert L == Matrix([[1, 0, 0], [ Rational(3, 5), 1, 0], [Rational(-1, 5), Rational(1, 3), 1]])
-    assert D.is_diagonal()
-    assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
-    A = SparseMatrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
-    L, D = A.LDLdecomposition()
-    assert expand_mul(L * D * L.H) == A
-    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S.Half - I/2, 0, 1)))
-    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
 
 
 def test_cholesky_solve():
@@ -3558,23 +3271,6 @@ def test_pinv_rank_deficient_when_diagonalization_fails():
         assert AAp.H == AAp
         assert ApA.H == ApA
 
-def test_pinv_succeeds_with_rank_decomposition_method():
-    # Test rank decomposition method of pseudoinverse succeeding
-    As = [Matrix([
-        [61, 89, 55, 20, 71, 0],
-        [62, 96, 85, 85, 16, 0],
-        [69, 56, 17,  4, 54, 0],
-        [10, 54, 91, 41, 71, 0],
-        [ 7, 30, 10, 48, 90, 0],
-        [0,0,0,0,0,0]])]
-    for A in As:
-        A_pinv = A.pinv(method="RD")
-        AAp = A * A_pinv
-        ApA = A_pinv * A
-        assert simplify(AAp * A) == A
-        assert simplify(ApA * A_pinv) == A_pinv
-        assert AAp.H == AAp
-        assert ApA.H == ApA
 
 def test_gauss_jordan_solve():
 
@@ -3927,35 +3623,6 @@ def test_iszero_substitution():
     assert m_diff.norm() < 1e-15
     # if a zero-substitution wasn't made, this entry will be -1.11022302462516e-16
     assert m_rref[2,2] == 0
-
-def test_rank_decomposition():
-    a = Matrix(0, 0, [])
-    c, f = a.rank_decomposition()
-    assert f.is_echelon
-    assert c.cols == f.rows == a.rank()
-    assert c * f == a
-
-    a = Matrix(1, 1, [5])
-    c, f = a.rank_decomposition()
-    assert f.is_echelon
-    assert c.cols == f.rows == a.rank()
-    assert c * f == a
-
-    a = Matrix(3, 3, [1, 2, 3, 1, 2, 3, 1, 2, 3])
-    c, f = a.rank_decomposition()
-    assert f.is_echelon
-    assert c.cols == f.rows == a.rank()
-    assert c * f == a
-
-    a = Matrix([
-        [0, 0, 1, 2, 2, -5, 3],
-        [-1, 5, 2, 2, 1, -7, 5],
-        [0, 0, -2, -3, -3, 8, -5],
-        [-1, 5, 0, -1, -2, 1, 0]])
-    c, f = a.rank_decomposition()
-    assert f.is_echelon
-    assert c.cols == f.rows == a.rank()
-    assert c * f == a
 
 def test_issue_11238():
     from sympy import Point


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #18666

#### Brief description of what is fixed or changed
migrate all the `decomposition-related tests` from `test_matrices.py` to a new created file `test_decomposition.py`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   matrices
     *  Added `test_decomposition.py` file which contain all the decomposition-related tests.
<!-- END RELEASE NOTES -->