### PR TITLE
ntheory: divisor_sigma symbolic case recognition

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2039,17 +2039,20 @@ class divisor_sigma(Function):
     def eval(cls, n, k=1):
         n = sympify(n)
         k = sympify(k)
+
         if n.is_prime:
             return 1 + n**k
-        if n.is_integer:
-            if n.is_Mul or n.is_Pow:  # prime is already handled
-                p = []
-                for b, e in (_.as_base_exp() for _ in Mul.make_args(n)):
-                    if b.is_prime and e.is_positive:
-                        p.append((b**(e + 1) - 1)/(b - 1))
-                    else:
-                        return
-                return Mul(*p)
+
+        if n.is_integer and not n.is_Integer:
+            p = []
+            for b, e in (_.as_base_exp() for _ in Mul.make_args(n)):
+                if b.is_prime and e.is_positive:
+                    p.append((b**(k*(e + 1)) - 1)/(b**k - 1) if k != 0
+                    else e + 1)
+                else:
+                    return
+            return Mul(*p)
+
         if n.is_Integer:
             if n <= 0:
                 raise ValueError("n must be a positive integer")

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2043,16 +2043,6 @@ class divisor_sigma(Function):
         if n.is_prime:
             return 1 + n**k
 
-        if n.is_integer and not n.is_Integer:
-            p = []
-            for b, e in (_.as_base_exp() for _ in Mul.make_args(n)):
-                if b.is_prime and e.is_positive:
-                    p.append((b**(k*(e + 1)) - 1)/(b**k - 1) if k != 0
-                    else e + 1)
-                else:
-                    return
-            return Mul(*p)
-
         if n.is_Integer:
             if n <= 0:
                 raise ValueError("n must be a positive integer")
@@ -2064,6 +2054,17 @@ class divisor_sigma(Function):
             else:
                 return Mul(*[(p**(k*(e + 1)) - 1)/(p**k - 1) if k != 0
                            else e + 1 for p, e in factorint(n).items()])
+
+        if n.is_integer:  # symbolic case
+            args = []
+            for p, e in (_.as_base_exp() for _ in Mul.make_args(n)):
+                if p.is_prime and e.is_positive:
+                    args.append((p**(k*(e + 1)) - 1)/(p**k - 1) if
+                                k != 0 else e + 1)
+                else:
+                    return
+            return Mul(*args)
+
 
 def core(n, t=2):
     r"""

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2041,6 +2041,15 @@ class divisor_sigma(Function):
         k = sympify(k)
         if n.is_prime:
             return 1 + n**k
+        if n.is_integer:
+            if n.is_Mul or n.is_Pow:  # prime is already handled
+                p = []
+                for b, e in (_.as_base_exp() for _ in Mul.make_args(n)):
+                    if b.is_prime and e.is_positive:
+                        p.append((b**(e + 1) - 1)/(b - 1))
+                    else:
+                        return
+                return Mul(*p)
         if n.is_Integer:
             if n <= 0:
                 raise ValueError("n must be a positive integer")

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -402,6 +402,12 @@ def test_divisor_sigma():
     assert divisor_sigma(23450, 2) == 730747500
     assert divisor_sigma(23450, 3) == 14666785333344
 
+    a = Symbol("a", prime=True)
+    b = Symbol("b", prime=True)
+    j = Symbol("j", integer=True, positive=True)
+    k = Symbol("k", integer=True, positive=True)
+    assert divisor_sigma(a**j*b**k) == (a**(j + 1) - 1)*(b**(k + 1) - 1)/((a - 1)*(b - 1))
+
     m = Symbol("m", integer=True)
     k = Symbol("k", integer=True)
     assert divisor_sigma(m)

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -407,6 +407,8 @@ def test_divisor_sigma():
     j = Symbol("j", integer=True, positive=True)
     k = Symbol("k", integer=True, positive=True)
     assert divisor_sigma(a**j*b**k) == (a**(j + 1) - 1)*(b**(k + 1) - 1)/((a - 1)*(b - 1))
+    assert divisor_sigma(a**j*b**k, 2) == (a**(2*j + 2) - 1)*(b**(2*k + 2) - 1)/((a**2 - 1)*(b**2 - 1))
+    assert divisor_sigma(a**j*b**k, 0) == (j + 1)*(k + 1)
 
     m = Symbol("m", integer=True)
     k = Symbol("k", integer=True)


### PR DESCRIPTION
Fixes: #16123

#### Brief description of what is fixed or changed
**Previously**, the only case which was recognized symbolically by divisor_sigma() function was: `divisor_sigma(a) -> a + 1.`

**Now**, it also recognizes:
`divisor_sigma(a**j*b**k)` where` a and b are prime` and` j and k are positive integers`
`divisor_sigma(a**j*b**k)-> (a**(j + 1) - 1)*(b**(k + 1) - 1)/((a - 1)*(b - 1))`


#### Other Comments
Regression Tests have been added


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* ntheory
  * Made divisor_sigma() symbolically recognize the case: `divisor_sigma(a**j*b**k)`
<!-- END RELEASE NOTES -->
