### PR TITLE
Fixes sqf_list to combine same multiplicity factors

### DIFF
--- a/doc/src/modules/polys/basics.rst
+++ b/doc/src/modules/polys/basics.rst
@@ -536,11 +536,13 @@ factors (not necessarily irreducible) of degree 1, 2 etc.::
     >>> f = 2*x**2 + 5*x**3 + 4*x**4 + x**5
 
     >>> sqf_list(f)
-    (1, [(x + 2, 1), (x, 2), (x + 1, 2)])
+                       2
+    (1, [(x + 2, 1), (x  + x, 2)])
 
     >>> sqf(f)
-     2        2
-    x *(x + 1) *(x + 2)
+                    2
+            / 2    \
+    (x + 2)*\x  + x/
 
 Factorization
 -------------

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2,7 +2,8 @@
 
 from __future__ import print_function, division
 
-from functools import wraps
+from functools import wraps, reduce
+from operator import mul
 
 from sympy.core import (
     S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
@@ -5905,10 +5906,7 @@ def _symbolic_factor_list(expr, opt, method):
         if arg.is_Number:
             coeff *= arg
             continue
-        if arg.is_Mul:
-            args.extend(arg.args)
-            continue
-        if arg.is_Pow:
+        elif arg.is_Pow:
             base, exp = arg.args
             if base.is_Number and exp.is_Number:
                 coeff *= arg
@@ -5949,6 +5947,9 @@ def _symbolic_factor_list(expr, opt, method):
                         other.append((f, k))
 
                 factors.append((_factors_product(other), exp))
+    if method == 'sqf':
+        factors = [(reduce(mul, (f for f, _ in factors if _ == k)), k)
+                   for k in set(dict(factors).values())]
 
     return coeff, factors
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5949,7 +5949,7 @@ def _symbolic_factor_list(expr, opt, method):
                 factors.append((_factors_product(other), exp))
     if method == 'sqf':
         factors = [(reduce(mul, (f for f, _ in factors if _ == k)), k)
-                   for k in set(dict(factors).values())]
+                   for k in set(i for _, i in factors)]
 
     return coeff, factors
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3273,7 +3273,7 @@ def test_to_rational_coeffs():
 def test_factor_terms():
     # issue 7067
     assert factor_list(x*(x + y)) == (1, [(x, 1), (x + y, 1)])
-    assert sqf_list(x*(x + y)) == (1, [(x, 1), (x + y, 1)])
+    assert sqf_list(x*(x + y)) == (1, [(x**2 + x*y, 1)])
 
 
 def test_as_list():
@@ -3333,3 +3333,8 @@ def test_issue_17988():
 def test_issue_18205():
     assert cancel((2 + I)*(3 - I)) == 7 + I
     assert cancel((2 + I)*(2 - I)) == 5
+
+def test_issue_8695():
+    p = (x**2 + 1) * (x - 1)**2 * (x - 2)**3 * (x - 3)**3
+    result = r = (1, [(x**2 + 1, 1), (x - 1, 2), (x**2 - 5*x + 6, 3)])
+    assert sqf_list(p) == result

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3336,5 +3336,5 @@ def test_issue_18205():
 
 def test_issue_8695():
     p = (x**2 + 1) * (x - 1)**2 * (x - 2)**3 * (x - 3)**3
-    result = r = (1, [(x**2 + 1, 1), (x - 1, 2), (x**2 - 5*x + 6, 3)])
+    result = (1, [(x**2 + 1, 1), (x - 1, 2), (x**2 - 5*x + 6, 3)])
     assert sqf_list(p) == result


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes sqf_list to combine same multiplicity factors
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #8695

#### Brief description of what is fixed or changed
Before fixing:
```
 >>> sqf_list((x**2 + 1)  * (x - 1)**2 * (x - 2)**3 * (x - 3)**3)
(1, [(x**2 + 1, 1), (x - 1, 2), (x - 3, 3), (x - 2, 3)])
```

After:
```
>>>  sqf_list((x**2 + 1)  * (x - 1)**2 * (x - 2)**3 * (x - 3)**3)
(1, [(x**2 + 1, 1), (x - 1, 2), (x**2 - 5*x + 6, 3)])
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Combine factors of same multiplicity
<!-- END RELEASE NOTES -->