### PR TITLE
migrated all the subspaces-related test to test_subspaces.py

### DIFF
--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -11,8 +11,7 @@ from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.matrices.common import (ShapeError, NonSquareMatrixError,
     _MinimalMatrix, _CastableMatrix, MatrixShaping, MatrixProperties,
     MatrixOperations, MatrixArithmetic, MatrixSpecial)
-from sympy.matrices.matrices import (MatrixDeterminant,
-     MatrixSubspaces, MatrixCalculus)
+from sympy.matrices.matrices import MatrixCalculus
 from sympy.matrices import (Matrix, diag, eye,
     matrix_multiply_elementwise, ones, zeros, SparseMatrix, banded)
 from sympy.utilities.iterables import flatten
@@ -69,19 +68,7 @@ def zeros_Arithmetic(n):
     return ArithmeticOnlyMatrix(n, n, lambda i, j: 0)
 
 
-class DeterminantOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixDeterminant):
-    pass
-
-
-def eye_Determinant(n):
-    return DeterminantOnlyMatrix(n, n, lambda i, j: int(i == j))
-
-
 class SpecialOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSpecial):
-    pass
-
-
-class SubspaceOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSubspaces):
     pass
 
 
@@ -928,50 +915,6 @@ def test_jordan_block():
     # Using alias keyword
     assert SpecialOnlyMatrix.jordan_block(size=3, eigenvalue=2) == \
         SpecialOnlyMatrix.jordan_block(size=3, eigenval=2)
-
-
-# SubspaceOnlyMatrix tests
-def test_columnspace():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
-
-    basis = m.columnspace()
-    assert basis[0] == Matrix([1, -2, 0, 3])
-    assert basis[1] == Matrix([2, -5, -3, 6])
-    assert basis[2] == Matrix([2, -1, 4, -7])
-
-    assert len(basis) == 3
-    assert Matrix.hstack(m, *basis).columnspace() == basis
-
-
-def test_rowspace():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
-
-    basis = m.rowspace()
-    assert basis[0] == Matrix([[1, 2, 0, 2, 5]])
-    assert basis[1] == Matrix([[0, -1, 1, 3, 2]])
-    assert basis[2] == Matrix([[0, 0, 0, 5, 5]])
-
-    assert len(basis) == 3
-
-
-def test_nullspace():
-    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
-                            [-2, -5,  1, -1, -8],
-                            [ 0, -3,  3,  4,  1],
-                            [ 3,  6,  0, -7,  2]])
-
-    basis = m.nullspace()
-    assert basis[0] == Matrix([-2, 1, 1, 0, 0])
-    assert basis[1] == Matrix([-1, -1, 0, -1, 1])
-    # make sure the null space is really gets zeroed
-    assert all(e.is_zero for e in m*basis[0])
-    assert all(e.is_zero for e in m*basis[1])
 
 
 def test_orthogonalize():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -17,7 +17,6 @@ from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture
 from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
-from sympy.solvers import solve
 from sympy.assumptions import Q
 from sympy.tensor.array import Array
 from sympy.matrices.expressions import MatPow
@@ -1056,69 +1055,6 @@ def test_jacobian_hessian():
         [     0, 6*y**2, 2*x],
         [6*y**2,    2*x, 2*y],
         [   2*x,    2*y,   0]])
-
-
-def test_nullspace():
-    # first test reduced row-ech form
-    R = Rational
-
-    M = Matrix([[5, 7, 2,  1],
-                [1, 6, 2, -1]])
-    out, tmp = M.rref()
-    assert out == Matrix([[1, 0, -R(2)/23, R(13)/23],
-                          [0, 1,  R(8)/23, R(-6)/23]])
-
-    M = Matrix([[-5, -1,  4, -3, -1],
-                [ 1, -1, -1,  1,  0],
-                [-1,  0,  0,  0,  0],
-                [ 4,  1, -4,  3,  1],
-                [-2,  0,  2, -2, -1]])
-    assert M*M.nullspace()[0] == Matrix(5, 1, [0]*5)
-
-    M = Matrix([[ 1,  3, 0,  2,  6, 3, 1],
-                [-2, -6, 0, -2, -8, 3, 1],
-                [ 3,  9, 0,  0,  6, 6, 2],
-                [-1, -3, 0,  1,  0, 9, 3]])
-    out, tmp = M.rref()
-    assert out == Matrix([[1, 3, 0, 0, 2, 0, 0],
-                          [0, 0, 0, 1, 2, 0, 0],
-                          [0, 0, 0, 0, 0, 1, R(1)/3],
-                          [0, 0, 0, 0, 0, 0, 0]])
-
-    # now check the vectors
-    basis = M.nullspace()
-    assert basis[0] == Matrix([-3, 1, 0, 0, 0, 0, 0])
-    assert basis[1] == Matrix([0, 0, 1, 0, 0, 0, 0])
-    assert basis[2] == Matrix([-2, 0, 0, -2, 1, 0, 0])
-    assert basis[3] == Matrix([0, 0, 0, 0, 0, R(-1)/3, 1])
-
-    # issue 4797; just see that we can do it when rows > cols
-    M = Matrix([[1, 2], [2, 4], [3, 6]])
-    assert M.nullspace()
-
-
-def test_columnspace():
-    M = Matrix([[ 1,  2,  0,  2,  5],
-                [-2, -5,  1, -1, -8],
-                [ 0, -3,  3,  4,  1],
-                [ 3,  6,  0, -7,  2]])
-
-    # now check the vectors
-    basis = M.columnspace()
-    assert basis[0] == Matrix([1, -2, 0, 3])
-    assert basis[1] == Matrix([2, -5, -3, 6])
-    assert basis[2] == Matrix([2, -1, 4, -7])
-
-    #check by columnspace definition
-    a, b, c, d, e = symbols('a b c d e')
-    X = Matrix([a, b, c, d, e])
-    for i in range(len(basis)):
-        eq=M*X-basis[i]
-        assert len(solve(eq, X)) != 0
-
-    #check if rank-nullity theorem holds
-    assert M.rank() == len(basis)
-    assert len(M.nullspace()) + len(M.columnspace()) == M.cols
 
 
 def test_wronskian():

--- a/sympy/matrices/tests/test_subspaces.py
+++ b/sympy/matrices/tests/test_subspaces.py
@@ -1,0 +1,114 @@
+from sympy.matrices.common import _MinimalMatrix, _CastableMatrix
+from sympy.matrices.matrices import MatrixSubspaces
+from sympy.matrices import Matrix
+from sympy.core.numbers import Rational
+from sympy.core.symbol import symbols
+from sympy.solvers import solve
+
+class SubspaceOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixSubspaces):
+    pass
+
+# SubspaceOnlyMatrix tests
+def test_columnspace_one():
+    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+                            [-2, -5,  1, -1, -8],
+                            [ 0, -3,  3,  4,  1],
+                            [ 3,  6,  0, -7,  2]])
+
+    basis = m.columnspace()
+    assert basis[0] == Matrix([1, -2, 0, 3])
+    assert basis[1] == Matrix([2, -5, -3, 6])
+    assert basis[2] == Matrix([2, -1, 4, -7])
+
+    assert len(basis) == 3
+    assert Matrix.hstack(m, *basis).columnspace() == basis
+
+
+def test_rowspace():
+    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+                            [-2, -5,  1, -1, -8],
+                            [ 0, -3,  3,  4,  1],
+                            [ 3,  6,  0, -7,  2]])
+
+    basis = m.rowspace()
+    assert basis[0] == Matrix([[1, 2, 0, 2, 5]])
+    assert basis[1] == Matrix([[0, -1, 1, 3, 2]])
+    assert basis[2] == Matrix([[0, 0, 0, 5, 5]])
+
+    assert len(basis) == 3
+
+
+def test_nullspace_one():
+    m = SubspaceOnlyMatrix([[ 1,  2,  0,  2,  5],
+                            [-2, -5,  1, -1, -8],
+                            [ 0, -3,  3,  4,  1],
+                            [ 3,  6,  0, -7,  2]])
+
+    basis = m.nullspace()
+    assert basis[0] == Matrix([-2, 1, 1, 0, 0])
+    assert basis[1] == Matrix([-1, -1, 0, -1, 1])
+    # make sure the null space is really gets zeroed
+    assert all(e.is_zero for e in m*basis[0])
+    assert all(e.is_zero for e in m*basis[1])
+
+def test_nullspace_second():
+    # first test reduced row-ech form
+    R = Rational
+
+    M = Matrix([[5, 7, 2,  1],
+                [1, 6, 2, -1]])
+    out, tmp = M.rref()
+    assert out == Matrix([[1, 0, -R(2)/23, R(13)/23],
+                          [0, 1,  R(8)/23, R(-6)/23]])
+
+    M = Matrix([[-5, -1,  4, -3, -1],
+                [ 1, -1, -1,  1,  0],
+                [-1,  0,  0,  0,  0],
+                [ 4,  1, -4,  3,  1],
+                [-2,  0,  2, -2, -1]])
+    assert M*M.nullspace()[0] == Matrix(5, 1, [0]*5)
+
+    M = Matrix([[ 1,  3, 0,  2,  6, 3, 1],
+                [-2, -6, 0, -2, -8, 3, 1],
+                [ 3,  9, 0,  0,  6, 6, 2],
+                [-1, -3, 0,  1,  0, 9, 3]])
+    out, tmp = M.rref()
+    assert out == Matrix([[1, 3, 0, 0, 2, 0, 0],
+                          [0, 0, 0, 1, 2, 0, 0],
+                          [0, 0, 0, 0, 0, 1, R(1)/3],
+                          [0, 0, 0, 0, 0, 0, 0]])
+
+    # now check the vectors
+    basis = M.nullspace()
+    assert basis[0] == Matrix([-3, 1, 0, 0, 0, 0, 0])
+    assert basis[1] == Matrix([0, 0, 1, 0, 0, 0, 0])
+    assert basis[2] == Matrix([-2, 0, 0, -2, 1, 0, 0])
+    assert basis[3] == Matrix([0, 0, 0, 0, 0, R(-1)/3, 1])
+
+    # issue 4797; just see that we can do it when rows > cols
+    M = Matrix([[1, 2], [2, 4], [3, 6]])
+    assert M.nullspace()
+
+
+def test_columnspace_second():
+    M = Matrix([[ 1,  2,  0,  2,  5],
+                [-2, -5,  1, -1, -8],
+                [ 0, -3,  3,  4,  1],
+                [ 3,  6,  0, -7,  2]])
+
+    # now check the vectors
+    basis = M.columnspace()
+    assert basis[0] == Matrix([1, -2, 0, 3])
+    assert basis[1] == Matrix([2, -5, -3, 6])
+    assert basis[2] == Matrix([2, -1, 4, -7])
+
+    #check by columnspace definition
+    a, b, c, d, e = symbols('a b c d e')
+    X = Matrix([a, b, c, d, e])
+    for i in range(len(basis)):
+        eq=M*X-basis[i]
+        assert len(solve(eq, X)) != 0
+
+    #check if rank-nullity theorem holds
+    assert M.rank() == len(basis)
+    assert len(M.nullspace()) + len(M.columnspace()) == M.cols


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #18666

#### Brief description of what is fixed or changed
migrate all the `subspaces-related tests` from `test_commonmatrix.py` and `test_matrices.py`  to a new created file `test_subspaces.py`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*   matrices
     *  Added `test_subspaces.py` file which contain all the reductions-related tests.
<!-- END RELEASE NOTES -->