### PR TITLE
Fix(old assumptions): Define infinite as not finite

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -212,7 +212,7 @@ _assume_rules = FactRules([
 
     'imaginary      ->  !extended_real',
 
-    'infinite       ->  !finite',
+    'infinite       ==  !finite',
     'noninteger     ==  extended_real & !integer',
     'extended_nonzero == extended_real & !zero',
 ])

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1180,6 +1180,10 @@ def test_issue_16579():
     assert c.is_finite is True
     raises(InconsistentAssumptions, lambda: Dummy(complex=True, finite=False))
 
+    # Now infinite == !finite
+    nf = Symbol('nf', finite=False)
+    assert nf.is_infinite is True
+
 def test_issue_17556():
     z = I*oo
     assert z.is_imaginary is False


### PR DESCRIPTION
Change the implication rule for infinite and finite in the old
assumptions from
```
  infinite -> !finite
```
to
```
  infinite == !finite
```
The effect of this is to add a new implication !finite->infinite which
means that is_infinite is the same as fuzzy_not(finite). Previously
inferring that an object had infinite=True would require a specific
_eval_is_infinite handler even if all of the logic was correctly
implemented in _eval_is_finite.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Now finite and infinite are logical opposites in the old assumptions system so e.g. a Symbol declared with finite=False will have infinite=True.
<!-- END RELEASE NOTES -->
