### PR TITLE
Solves latex printing error of nested differentiation

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -719,7 +719,7 @@ class LatexPrinter(Printer):
         tex = ""
         dim = 0
         for x, num in reversed(expr.variable_count):
-            dim = dim + num
+            dim += num
             if num == 1:
                 tex += r"%s %s" % (diff_symbol, self._print(x))
             else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -207,7 +207,10 @@ class LatexPrinter(Printer):
 
     def parenthesize(self, item, level, is_neg=False, strict=False):
         prec_val = precedence_traditional(item)
-        if (((prec_val < level) or ((not strict) and prec_val <= level)) or (is_neg and strict)):
+        if is_neg and strict:
+            return r"\left({}\right)".format(self._print(item))
+        
+        if (prec_val < level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)
@@ -716,6 +719,7 @@ class LatexPrinter(Printer):
             diff_symbol = r'\partial'
         else:
             diff_symbol = r'd'
+        
         tex = ""
         dim = 0
         for x, num in reversed(expr.variable_count):
@@ -737,6 +741,7 @@ class LatexPrinter(Printer):
                                                   PRECEDENCE["Mul"],
                                                   is_neg=True,
                                                   strict=True))
+
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
                                                   is_neg=False,

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -209,7 +209,7 @@ class LatexPrinter(Printer):
         prec_val = precedence_traditional(item)
         if is_neg and strict:
             return r"\left({}\right)".format(self._print(item))
-        
+
         if (prec_val < level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:
@@ -719,7 +719,7 @@ class LatexPrinter(Printer):
             diff_symbol = r'\partial'
         else:
             diff_symbol = r'd'
-        
+
         tex = ""
         dim = 0
         for x, num in reversed(expr.variable_count):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -205,9 +205,9 @@ class LatexPrinter(Printer):
             self._settings['imaginary_unit_latex'] = \
                 self._settings['imaginary_unit']
 
-    def parenthesize(self, item, level, strict=False):
+    def parenthesize(self, item, level, diff=False, strict=False):
         prec_val = precedence_traditional(item)
-        if (prec_val < level) or ((not strict) and prec_val <= level):
+        if ((prec_val < level) or ((not strict) and prec_val <= level) or (diff == True)):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)
@@ -735,6 +735,7 @@ class LatexPrinter(Printer):
 
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
+                                                  diff=True,
                                                   strict=True))
 
     def _print_Subs(self, subs):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -205,9 +205,9 @@ class LatexPrinter(Printer):
             self._settings['imaginary_unit_latex'] = \
                 self._settings['imaginary_unit']
 
-    def parenthesize(self, item, level, diff=False, strict=False):
+    def parenthesize(self, item, level, is_neg=False, strict=False):
         prec_val = precedence_traditional(item)
-        if (((prec_val < level) or ((not strict) and prec_val <= level)) or ((diff == True) and (strict == True))):
+        if (((prec_val < level) or ((not strict) and prec_val <= level)) or (is_neg and strict)):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)
@@ -735,11 +735,11 @@ class LatexPrinter(Printer):
         if any(_coeff_isneg(i) for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff=True,
+                                                  is_neg=True,
                                                   strict=True))
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff=False,
+                                                  is_neg=False,
                                                   strict=True))
 
     def _print_Subs(self, subs):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -209,7 +209,7 @@ class LatexPrinter(Printer):
         prec_val = precedence_traditional(item)
         if is_neg and strict:
             return r"\left({}\right)".format(self._print(item))
-    
+        
         if (prec_val < level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -737,7 +737,7 @@ class LatexPrinter(Printer):
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
 
-        if neg == True:
+        if any(_coeff_isneg(i) for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
                                                   diff = True,

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -205,9 +205,9 @@ class LatexPrinter(Printer):
             self._settings['imaginary_unit_latex'] = \
                 self._settings['imaginary_unit']
 
-    def parenthesize(self, item, level, strict=False):
+    def parenthesize(self, item, level, diff=False, strict=False):
         prec_val = precedence_traditional(item)
-        if (prec_val <= level) or ((not strict) and prec_val <= level):
+        if (((prec_val < level) or ((not strict) and prec_val <= level)) or ((diff == True) and (strict == True))):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)
@@ -735,6 +735,7 @@ class LatexPrinter(Printer):
 
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
+                                                  diff = True,
                                                   strict=True))
 
     def _print_Subs(self, subs):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -744,7 +744,7 @@ class LatexPrinter(Printer):
                                                   strict=True))
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = False,
+                                                  diff=False,
                                                   strict=True))
 
     def _print_Subs(self, subs):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -731,10 +731,12 @@ class LatexPrinter(Printer):
         for i,term in enumerate(terms):
             if _coeff_isneg(term):
                 neg = True
+
         if dim == 1:
             tex = r"\frac{%s}{%s}" % (diff_symbol, tex)
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
+
         if neg == True:
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -207,7 +207,7 @@ class LatexPrinter(Printer):
 
     def parenthesize(self, item, level, strict=False):
         prec_val = precedence_traditional(item)
-        if (prec_val < level) or ((not strict) and prec_val <= level):
+        if (prec_val <= level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -209,7 +209,7 @@ class LatexPrinter(Printer):
         prec_val = precedence_traditional(item)
         if is_neg and strict:
             return r"\left({}\right)".format(self._print(item))
-        
+    
         if (prec_val < level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -740,7 +740,7 @@ class LatexPrinter(Printer):
         if any(_coeff_isneg(i) for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = True,
+                                                  diff=True,
                                                   strict=True))
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -719,32 +719,27 @@ class LatexPrinter(Printer):
         tex = ""
         dim = 0
         for x, num in reversed(expr.variable_count):
-            dim = dim + num
+            dim += num
             if num == 1:
                 tex += r"%s %s" % (diff_symbol, self._print(x))
             else:
                 tex += r"%s %s^{%s}" % (diff_symbol,
                                         self.parenthesize_super(self._print(x)),
                                         self._print(num))
-        neg = False
-        terms = expr.args
-        for i,term in enumerate(terms):
-            if _coeff_isneg(term):
-                neg = True
 
         if dim == 1:
             tex = r"\frac{%s}{%s}" % (diff_symbol, tex)
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
 
-        if neg == True:
+        if any(_coeff_isneg(i) for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = True,
+                                                  diff=True,
                                                   strict=True))
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = False,
+                                                  diff=False,
                                                   strict=True))
 
     def _print_Subs(self, subs):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -683,7 +683,6 @@ def test_latex_derivatives():
     assert latex(diff(f(x), (x, n))) == \
         r"\frac{d^{n}}{d x^{n}} f{\left(x \right)}"
 
-
     x1 = Symbol('x1')
     x2 = Symbol('x2')
     assert latex(diff(f(x1, x2), x1)) == r'\frac{\partial}{\partial x_{1}} f{\left(x_{1},x_{2} \right)}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -667,8 +667,8 @@ def test_latex_derivatives():
     # for negative nested Derivative
     assert latex(diff(-diff(y**2,x,evaluate=False),x,evaluate=False)) == r'\frac{d}{d x} \left(- \frac{d}{d x} y^{2}\right)'
     assert latex(diff(diff(-diff(diff(y,x,evaluate=False),x,evaluate=False),x,evaluate=False),x,evaluate=False)) == \
-     r'\frac{d^{2}}{d x^{2}} \left(- \frac{d^{2}}{d x^{2}} y\right)'
-     
+        r'\frac{d^{2}}{d x^{2}} \left(- \frac{d^{2}}{d x^{2}} y\right)'
+
     # use ordinary d when one of the variables has been integrated out
     assert latex(diff(Integral(exp(-x*y), (x, 0, oo)), y, evaluate=False)) == \
         r"\frac{d}{d y} \int\limits_{0}^{\infty} e^{- x y}\, dx"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -664,6 +664,11 @@ def test_latex_derivatives():
     assert latex(diff(diff(diff(f(x, y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
         r"\frac{\partial^{3}}{\partial y\partial x^{2}} " + latex(f(x, y))
 
+    # for negative nested Derivative
+    assert latex(diff(-diff(y**2,x,evaluate=False),x,evaluate=False)) == r'\frac{d}{d x} \left(- \frac{d}{d x} y^{2}\right)'
+    assert latex(diff(diff(-diff(diff(y,x,evaluate=False),x,evaluate=False),x,evaluate=False),x,evaluate=False)) == \
+     r'\frac{d^{2}}{d x^{2}} \left(- \frac{d^{2}}{d x^{2}} y\right)'
+     
     # use ordinary d when one of the variables has been integrated out
     assert latex(diff(Integral(exp(-x*y), (x, 0, oo)), y, evaluate=False)) == \
         r"\frac{d}{d y} \int\limits_{0}^{\infty} e^{- x y}\, dx"
@@ -677,6 +682,7 @@ def test_latex_derivatives():
 
     assert latex(diff(f(x), (x, n))) == \
         r"\frac{d^{n}}{d x^{n}} f{\left(x \right)}"
+
 
     x1 = Symbol('x1')
     x2 = Symbol('x2')


### PR DESCRIPTION
Fixes issue #18731 

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


A check for negative derivative is added.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

   
* printing
   * fixes nested differentiation problem in latex format

<!-- END RELEASE NOTES -->