### PR TITLE
Refactored sym_expr to fix documentation problems with SymPyExpression

### DIFF
--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -105,7 +105,7 @@ SymPy Expression Reference
 Runtime Installation
 --------------------
 
-The currently-packaged parser backend is partially generated with
+The currently-packaged LaTeX parser backend is partially generated with
 `ANTLR4 <http://antlr4.org>`_,
 but to use the parser, you only need the ``antlr4`` Python package available.
 
@@ -121,3 +121,8 @@ or ``pip`` (Python 2 only)::
 or ``conda`` (Python 2 or Python 3)::
 
     $ conda install --channel=conda-forge antlr-python-runtime
+
+The C parser depends on ``clang`` and the Fortran parser depends on ``LFortran``.
+You can install these packages using::
+
+    $ conda install -c conda-forge lfortran clang

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -102,18 +102,6 @@ SymPy Expression Reference
 .. autoclass:: SymPyExpression
   :members:
 
-`Fortran` Parsing Reference
----------------------------------
-
-.. module:: sympy.parsing.fortran.fortran_parser
-
-.. autoclass:: ASR2PyVisitor
-  :members:
-
-.. autofunction:: call_visitor
-
-.. autofunction:: src_to_sympy
-
 Runtime Installation
 --------------------
 

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -5,281 +5,275 @@ from sympy.utilities.decorator import doctest_depends_on
 lfortran = import_module('lfortran')
 cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
 
-if not lfortran and not cin:
-    class SymPyExpression(object):
-        def __init__(self, *args, **kwargs):
-            raise ImportError('Module not available.')
+if lfortran:
+    from sympy.parsing.fortran.fortran_parser import src_to_sympy
+if cin:
+    from sympy.parsing.c.c_parser import parse_c
 
-else:
-    if lfortran:
-        from sympy.parsing.fortran.fortran_parser import src_to_sympy
-    if cin:
-        from sympy.parsing.c.c_parser import parse_c
+@doctest_depends_on(modules=['lfortran', 'clang.cindex'])
+class SymPyExpression(object):  # type: ignore
+    """Class to store and handle SymPy expressions
 
-    @doctest_depends_on(modules=['lfortran', 'clang.cindex'])
-    class SymPyExpression(object):  # type: ignore
-        """Class to store and handle SymPy expressions
+    This class will hold SymPy Expressions and handle the API for the
+    conversion to and from different languages.
 
-        This class will hold SymPy Expressions and handle the API for the
-        conversion to and from different languages.
+    It works with the C and the Fortran Parser to generate SymPy expressions
+    which are stored here and which can be converted to multiple language's
+    source code.
 
-        It works with the C and the Fortran Parser to generate SymPy expressions
-        which are stored here and which can be converted to multiple language's
-        source code.
+    Notes
+    =====
 
-        Notes
-        =====
+    The module and its API are currently under development and experimental
+    and can be changed during development.
 
-        The module and its API are currently under development and experimental
-        and can be changed during development.
+    The Fortran parser does not support numeric assignments, so all the
+    variables have been Initialized to zero.
 
-        The Fortran parser does not support numeric assignments, so all the
-        variables have been Initialized to zero.
+    The module also depends on external dependencies:
 
-        The module also depends on external dependencies:
+    - LFortran which is required to use the Fortran parser
+    - Clang which is required for the C parser
 
-        - LFortran which is required to use the Fortran parser
-        - Clang which is required for the C parser
+    Examples
+    ========
+
+    Example of parsing C code:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src = '''
+    ... int a,b;
+    ... float c = 2, d =4;
+    ... '''
+    >>> a = SymPyExpression(src, 'c')
+    >>> a.return_expr()
+    [Declaration(Variable(a, type=integer, value=0)),
+    Declaration(Variable(b, type=integer, value=0)),
+    Declaration(Variable(c, type=real, value=2.0)),
+    Declaration(Variable(d, type=real, value=4.0))]
+
+    An example of variable definiton:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src2 = '''
+    ... integer :: a, b, c, d
+    ... real :: p, q, r, s
+    ... '''
+    >>> p = SymPyExpression()
+    >>> p.convert_to_expr(src2, 'f')
+    >>> p.convert_to_c()
+    ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0']
+
+    An example of Assignment:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src3 = '''
+    ... integer :: a, b, c, d, e
+    ... d = a + b - c
+    ... e = b * d + c * e / a
+    ... '''
+    >>> p = SymPyExpression(src3, 'f')
+    >>> p.convert_to_python()
+    ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'e = 0', 'd = a + b - c', 'e = b*d + c*e/a']
+
+    An example of function definition:
+
+    >>> from sympy.parsing.sym_expr import SymPyExpression
+    >>> src = '''
+    ... integer function f(a,b)
+    ... integer, intent(in) :: a, b
+    ... integer :: r
+    ... end function
+    ... '''
+    >>> a = SymPyExpression(src, 'f')
+    >>> a.convert_to_python()
+    ['def f(a, b):\\n   f = 0\\n    r = 0\\n    return f']
+
+    """
+
+    def __init__(self, source_code = None, mode = None):
+        """Constructor for SymPyExpression class"""
+        super(SymPyExpression, self).__init__()
+        if not(mode or source_code):
+            self._expr = []
+        elif mode:
+            if source_code:
+                if mode.lower() == 'f':
+                    if lfortran:
+                        self._expr = src_to_sympy(source_code)
+                    else:
+                        raise ImportError("LFortran is not installed, cannot parse Fortran code")
+                elif mode.lower() == 'c':
+                    if cin:
+                        self._expr = parse_c(source_code)
+                    else:
+                        raise ImportError("Clang is not installed, cannot parse C code")
+                else:
+                    raise NotImplementedError(
+                        'Parser for specified language is not implemented'
+                    )
+            else:
+                raise ValueError('Source code not present')
+        else:
+            raise ValueError('Please specify a mode for conversion')
+
+    def convert_to_expr(self, src_code, mode):
+        """Converts the given source code to sympy Expressions
+
+        Attributes
+        ==========
+
+        src_code : String
+            the source code or filename of the source code that is to be
+            converted
+
+        mode: String
+            the mode to determine which parser is to be used according to
+            the language of the source code
+            f or F for Fortran
+            c or C for C/C++
 
         Examples
         ========
 
-        Example of parsing C code:
-
         >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src = '''
-        ... int a,b;
-        ... float c = 2, d =4;
+        >>> src3 = '''
+        ... integer function f(a,b) result(r)
+        ... integer, intent(in) :: a, b
+        ... integer :: x
+        ... r = a + b -x
+        ... end function
         ... '''
-        >>> a = SymPyExpression(src, 'c')
-        >>> a.return_expr()
-        [Declaration(Variable(a, type=integer, value=0)),
-        Declaration(Variable(b, type=integer, value=0)),
-        Declaration(Variable(c, type=real, value=2.0)),
-        Declaration(Variable(d, type=real, value=4.0))]
+        >>> p = SymPyExpression()
+        >>> p.convert_to_expr(src3, 'f')
+        >>> p.return_expr()
+        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+        Declaration(Variable(r, type=integer, value=0)),
+        Declaration(Variable(x, type=integer, value=0)),
+        Assignment(Variable(r), a + b - x),
+        Return(Variable(r))
+        ))]
 
-        An example of variable definiton:
+
+
+
+        """
+        if mode.lower() == 'f':
+            if lfortran:
+                self._expr = src_to_sympy(src_code)
+            else:
+                raise ImportError("LFortran is not installed, cannot parse Fortran code")
+        elif mode.lower() == 'c':
+            if cin:
+                self._expr = parse_c(src_code)
+            else:
+                raise ImportError("Clang is not installed, cannot parse C code")
+        else:
+            raise NotImplementedError(
+                "Parser for specified language has not been implemented"
+            )
+
+    def convert_to_python(self):
+        """Returns a list with python code for the sympy expressions
+
+        Examples
+        ========
 
         >>> from sympy.parsing.sym_expr import SymPyExpression
         >>> src2 = '''
         ... integer :: a, b, c, d
         ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
+        ... '''
+        >>> p = SymPyExpression(src2, 'f')
+        >>> p.convert_to_python()
+        ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'p = 0.0', 'q = 0.0', 'r = 0.0', 's = 0.0', 'c = a/b', 'd = c/a', 's = p/q', 'r = q/p']
+
+        """
+        self._pycode = []
+        for iter in self._expr:
+            self._pycode.append(pycode(iter))
+        return self._pycode
+
+    def convert_to_c(self):
+        """Returns a list with the c source code for the sympy expressions
+
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src2 = '''
+        ... integer :: a, b, c, d
+        ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
         ... '''
         >>> p = SymPyExpression()
         >>> p.convert_to_expr(src2, 'f')
         >>> p.convert_to_c()
-        ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0']
+        ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0', 'c = a/b;', 'd = c/a;', 's = p/q;', 'r = q/p;']
 
-        An example of Assignment:
+        """
+        self._ccode = []
+        for iter in self._expr:
+            self._ccode.append(ccode(iter))
+        return self._ccode
+
+    def convert_to_fortran(self):
+        """Returns a list with the fortran source code for the sympy expressions
+
+        Examples
+        ========
+
+        >>> from sympy.parsing.sym_expr import SymPyExpression
+        >>> src2 = '''
+        ... integer :: a, b, c, d
+        ... real :: p, q, r, s
+        ... c = a/b
+        ... d = c/a
+        ... s = p/q
+        ... r = q/p
+        ... '''
+        >>> p = SymPyExpression(src2, 'f')
+        >>> p.convert_to_fortran()
+        ['      integer*4 a', '      integer*4 b', '      integer*4 c', '      integer*4 d', '      real*8 p', '      real*8 q', '      real*8 r', '      real*8 s', '      c = a/b', '      d = c/a', '      s = p/q', '      r = q/p']
+
+        """
+        self._fcode = []
+        for iter in self._expr:
+            self._fcode.append(fcode(iter))
+        return self._fcode
+
+    def return_expr(self):
+        """Returns the expression list
+
+        Examples
+        ========
 
         >>> from sympy.parsing.sym_expr import SymPyExpression
         >>> src3 = '''
-        ... integer :: a, b, c, d, e
-        ... d = a + b - c
-        ... e = b * d + c * e / a
-        ... '''
-        >>> p = SymPyExpression(src3, 'f')
-        >>> p.convert_to_python()
-        ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'e = 0', 'd = a + b - c', 'e = b*d + c*e/a']
-
-        An example of function definition:
-
-        >>> from sympy.parsing.sym_expr import SymPyExpression
-        >>> src = '''
         ... integer function f(a,b)
         ... integer, intent(in) :: a, b
         ... integer :: r
+        ... r = a+b
+        ... f = r
         ... end function
         ... '''
-        >>> a = SymPyExpression(src, 'f')
-        >>> a.convert_to_python()
-        ['def f(a, b):\\n   f = 0\\n    r = 0\\n    return f']
+        >>> p = SymPyExpression()
+        >>> p.convert_to_expr(src3, 'f')
+        >>> p.return_expr()
+        [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
+        Declaration(Variable(f, type=integer, value=0)),
+        Declaration(Variable(r, type=integer, value=0)),
+        Assignment(Variable(f), Variable(r)),
+        Return(Variable(f))
+        ))]
 
         """
-
-        def __init__(self, source_code = None, mode = None):
-            """Constructor for SymPyExpression class"""
-            super(SymPyExpression, self).__init__()
-            if not(mode or source_code):
-                self._expr = []
-            elif mode:
-                if source_code:
-                    if mode.lower() == 'f':
-                        if lfortran:
-                            self._expr = src_to_sympy(source_code)
-                        else:
-                            raise ImportError("LFortran is not installed, cannot parse Fortran code")
-                    elif mode.lower() == 'c':
-                        if cin:
-                            self._expr = parse_c(source_code)
-                        else:
-                            raise ImportError("Clang is not installed, cannot parse C code")
-                    else:
-                        raise NotImplementedError(
-                            'Parser for specified language is not implemented'
-                        )
-                else:
-                    raise ValueError('Source code not present')
-            else:
-                raise ValueError('Please specify a mode for conversion')
-
-        def convert_to_expr(self, src_code, mode):
-            """Converts the given source code to sympy Expressions
-
-            Attributes
-            ==========
-
-            src_code : String
-                the source code or filename of the source code that is to be
-                converted
-
-            mode: String
-                the mode to determine which parser is to be used according to
-                the language of the source code
-                f or F for Fortran
-                c or C for C/C++
-
-            Examples
-            ========
-
-            >>> from sympy.parsing.sym_expr import SymPyExpression
-            >>> src3 = '''
-            ... integer function f(a,b) result(r)
-            ... integer, intent(in) :: a, b
-            ... integer :: x
-            ... r = a + b -x
-            ... end function
-            ... '''
-            >>> p = SymPyExpression()
-            >>> p.convert_to_expr(src3, 'f')
-            >>> p.return_expr()
-            [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
-            Declaration(Variable(r, type=integer, value=0)),
-            Declaration(Variable(x, type=integer, value=0)),
-            Assignment(Variable(r), a + b - x),
-            Return(Variable(r))
-            ))]
-
-
-
-
-            """
-            if mode.lower() == 'f':
-                if lfortran:
-                    self._expr = src_to_sympy(src_code)
-                else:
-                    raise ImportError("LFortran is not installed, cannot parse Fortran code")
-            elif mode.lower() == 'c':
-                if cin:
-                    self._expr = parse_c(src_code)
-                else:
-                    raise ImportError("Clang is not installed, cannot parse C code")
-            else:
-                raise NotImplementedError(
-                    "Parser for specified language has not been implemented"
-                )
-
-        def convert_to_python(self):
-            """Returns a list with python code for the sympy expressions
-
-            Examples
-            ========
-
-            >>> from sympy.parsing.sym_expr import SymPyExpression
-            >>> src2 = '''
-            ... integer :: a, b, c, d
-            ... real :: p, q, r, s
-            ... c = a/b
-            ... d = c/a
-            ... s = p/q
-            ... r = q/p
-            ... '''
-            >>> p = SymPyExpression(src2, 'f')
-            >>> p.convert_to_python()
-            ['a = 0', 'b = 0', 'c = 0', 'd = 0', 'p = 0.0', 'q = 0.0', 'r = 0.0', 's = 0.0', 'c = a/b', 'd = c/a', 's = p/q', 'r = q/p']
-
-            """
-            self._pycode = []
-            for iter in self._expr:
-                self._pycode.append(pycode(iter))
-            return self._pycode
-
-        def convert_to_c(self):
-            """Returns a list with the c source code for the sympy expressions
-
-
-            Examples
-            ========
-
-            >>> from sympy.parsing.sym_expr import SymPyExpression
-            >>> src2 = '''
-            ... integer :: a, b, c, d
-            ... real :: p, q, r, s
-            ... c = a/b
-            ... d = c/a
-            ... s = p/q
-            ... r = q/p
-            ... '''
-            >>> p = SymPyExpression()
-            >>> p.convert_to_expr(src2, 'f')
-            >>> p.convert_to_c()
-            ['int a = 0', 'int b = 0', 'int c = 0', 'int d = 0', 'double p = 0.0', 'double q = 0.0', 'double r = 0.0', 'double s = 0.0', 'c = a/b;', 'd = c/a;', 's = p/q;', 'r = q/p;']
-
-            """
-            self._ccode = []
-            for iter in self._expr:
-                self._ccode.append(ccode(iter))
-            return self._ccode
-
-        def convert_to_fortran(self):
-            """Returns a list with the fortran source code for the sympy expressions
-
-            Examples
-            ========
-
-            >>> from sympy.parsing.sym_expr import SymPyExpression
-            >>> src2 = '''
-            ... integer :: a, b, c, d
-            ... real :: p, q, r, s
-            ... c = a/b
-            ... d = c/a
-            ... s = p/q
-            ... r = q/p
-            ... '''
-            >>> p = SymPyExpression(src2, 'f')
-            >>> p.convert_to_fortran()
-            ['      integer*4 a', '      integer*4 b', '      integer*4 c', '      integer*4 d', '      real*8 p', '      real*8 q', '      real*8 r', '      real*8 s', '      c = a/b', '      d = c/a', '      s = p/q', '      r = q/p']
-
-            """
-            self._fcode = []
-            for iter in self._expr:
-                self._fcode.append(fcode(iter))
-            return self._fcode
-
-        def return_expr(self):
-            """Returns the expression list
-
-            Examples
-            ========
-
-            >>> from sympy.parsing.sym_expr import SymPyExpression
-            >>> src3 = '''
-            ... integer function f(a,b)
-            ... integer, intent(in) :: a, b
-            ... integer :: r
-            ... r = a+b
-            ... f = r
-            ... end function
-            ... '''
-            >>> p = SymPyExpression()
-            >>> p.convert_to_expr(src3, 'f')
-            >>> p.return_expr()
-            [FunctionDefinition(integer, name=f, parameters=(Variable(a), Variable(b)), body=CodeBlock(
-            Declaration(Variable(f, type=integer, value=0)),
-            Declaration(Variable(r, type=integer, value=0)),
-            Assignment(Variable(f), Variable(r)),
-            Return(Variable(f))
-            ))]
-
-            """
-            return self._expr
+        return self._expr

--- a/sympy/parsing/tests/test_sym_expr.py
+++ b/sympy/parsing/tests/test_sym_expr.py
@@ -198,4 +198,5 @@ if lfortran and cin:
 
 elif not lfortran and not cin:
     def test_raise():
-        raises(ImportError, lambda: SymPyExpression())
+        raises(ImportError, lambda: SymPyExpression('int a;', 'c'))
+        raises(ImportError, lambda: SymPyExpression('integer :: a', 'f'))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18219 

#### Brief description of what is fixed or changed
Modified sym_expr to remove the dummy SymPyExpression class and moved the actual SymPyExpression class to the top level.

Removed the Fortran Parsing Reference from the documentation as it is the backend implementation and the end users would not interact with it. The developers can still check out the required documentation in the docstrings.

 Also updated the installation instructions to include clang and LFortran installation instructions.

#### Other comments

Should I add `SymPyExpression` to the `__init__.py` file for the parsing module?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->