### PR TITLE
Fix matmul printing for complex scalar coefficients

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -336,15 +336,10 @@ class StrPrinter(Printer):
         sign = ""
         if c.is_number:
             re, im = c.as_real_imag()
-            if im.is_zero:
-                if re.is_negative:
-                    expr = _keep_coeff(-c, m)
-                    sign = "-"
-            elif re.is_zero:
-                if im.is_negative:
-                    expr = _keep_coeff(-c, m)
-                    sign = "-"
-            elif re.is_negative and im.is_negative:
+            if im.is_zero and re.is_negative:
+                expr = _keep_coeff(-c, m)
+                sign = "-"
+            elif re.is_zero and im.is_negative:
                 expr = _keep_coeff(-c, m)
                 sign = "-"
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -332,11 +332,21 @@ class StrPrinter(Printer):
 
     def _print_MatMul(self, expr):
         c, m = expr.as_coeff_mmul()
-        if c.is_number and c < 0:
-            expr = _keep_coeff(-c, m)
-            sign = "-"
-        else:
-            sign = ""
+
+        sign = ""
+        if c.is_number:
+            re, im = c.as_real_imag()
+            if im.is_zero:
+                if re.is_negative:
+                    expr = _keep_coeff(-c, m)
+                    sign = "-"
+            elif re.is_zero:
+                if im.is_negative:
+                    expr = _keep_coeff(-c, m)
+                    sign = "-"
+            elif re.is_negative and im.is_negative:
+                expr = _keep_coeff(-c, m)
+                sign = "-"
 
         return sign + '*'.join(
             [self.parenthesize(arg, precedence(expr)) for arg in expr.args]

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -767,8 +767,14 @@ def test_issue_6387():
 
 def test_MatMul_MatAdd():
     from sympy import MatrixSymbol
-    assert str(2*(MatrixSymbol("X", 2, 2) + MatrixSymbol("Y", 2, 2))) == \
-        "2*(X + Y)"
+
+    X, Y = MatrixSymbol("X", 2, 2), MatrixSymbol("Y", 2, 2)
+    assert str(2*(X + Y)) == "2*(X + Y)"
+
+    assert str(I*X) == "I*X"
+    assert str(-I*X) == "-I*X"
+    assert str((1 + I)*X) == '(1 + I)*X'
+    assert str(-(1 + I)*X) == '-(1 + I)*X'
 
 def test_MatrixSlice():
     from sympy.matrices.expressions import MatrixSymbol

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -774,7 +774,7 @@ def test_MatMul_MatAdd():
     assert str(I*X) == "I*X"
     assert str(-I*X) == "-I*X"
     assert str((1 + I)*X) == '(1 + I)*X'
-    assert str(-(1 + I)*X) == '-(1 + I)*X'
+    assert str(-(1 + I)*X) == '(-1 - I)*X'
 
 def test_MatrixSlice():
     from sympy.matrices.expressions import MatrixSymbol


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18743

#### Brief description of what is fixed or changed

I guess it was an issue introduced in #14248 when it had introduced a logic to switch the sign of the coefficients.
So I have added a logic to handle all the complex cases to preserve the author's intent, rather than removing the logic.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed `MatMul` with complex coefficients raising error when printed.
<!-- END RELEASE NOTES -->