### PR TITLE
fixes periodicity computation of trigonometric functions

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -533,3 +533,6 @@ def test_issue_16469():
     x = Symbol("x", real=True)
     f = abs(x)
     assert function_range(f, x, S.Reals) == Interval(0, oo, False, True)
+
+def test_issue_18747():
+    assert periodicity(exp(pi*I*(x/4+S.Half/2)), x) == 8

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -3,6 +3,7 @@ from sympy.core import Add, Mul, Pow
 from sympy.core.basic import Basic
 from sympy.core.compatibility import iterable
 from sympy.core.expr import AtomicExpr, Expr
+from sympy.core.function import expand_mul
 from sympy.core.numbers import _sympifyit, oo
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.miscellaneous import Min, Max
@@ -481,6 +482,7 @@ def periodicity(f, symbol, check=False):
             # checked below
 
     if isinstance(f, exp):
+        f = f.func(expand_mul(f.args[0]))
         if im(f) != 0:
             period_real = periodicity(re(f), symbol)
             period_imag = periodicity(im(f), symbol)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1836,3 +1836,8 @@ def test_as_real_imag():
     # please open up the issue again.
     expr = atan(I/(I + I*tan(1)))
     assert expr.as_real_imag() == (expr, 0)
+
+
+def test_issue_18746():
+    e3 = cos(S.Pi*(x/4 + 1/4))
+    assert e3.period() == 8

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.add import Add
 from sympy.core.basic import sympify, cacheit
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import Function, ArgumentIndexError, expand_mul
 from sympy.core.logic import fuzzy_not, fuzzy_or, FuzzyBool
 from sympy.core.numbers import igcdex, Rational, pi
 from sympy.core.relational import Ne
@@ -65,7 +65,7 @@ class TrigonometricFunction(Function):
         return (re, im)
 
     def _period(self, general_period, symbol=None):
-        f = self.args[0]
+        f = expand_mul(self.args[0])
         if symbol is None:
             symbol = tuple(f.free_symbols)[0]
 
@@ -1640,7 +1640,7 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
             return 1/t
 
     def _period(self, symbol):
-        f = self.args[0]
+        f = expand_mul(self.args[0])
         return self._reciprocal_of(f).period(symbol)
 
     def fdiff(self, argindex=1):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #18736 #18747 
#### Brief description of what is fixed or changed
Now,
```
>>> e3 = cos(S.Pi*(x/4 + 1/4))
>>> e3.period()
8
>>> periodicity(exp(pi*I*(x/4+S.Half/2)), x)
8


```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * periodicity of trigonometric functions with a non-zero phase component is now calculated.
* calculus
  * periodicity of exponential functions with a non-zero phase component is now calculated.
<!-- END RELEASE NOTES -->