### PR TITLE
Fix Incorrect parenthesizing of Subs

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -703,7 +703,7 @@ class LatexPrinter(Printer):
         latex_new = (self._print(e) for e in new)
         latex_subs = r'\\ '.join(
             e[0] + '=' + e[1] for e in zip(latex_old, latex_new))
-        return r'\left. %s \right|_{\substack{ %s }}' % (latex_expr,
+        return r'\left. \left(%s\right) \right|_{\substack{ %s }}' % (latex_expr,
                                                          latex_subs)
 
     def _print_Integral(self, expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -674,7 +674,8 @@ def test_latex_derivatives():
 
 def test_latex_subs():
     assert latex(Subs(x*y, (
-        x, y), (1, 2))) == r'\left. x y \right|_{\substack{ x=1\\ y=2 }}'
+        x, y), (1, 2))) == r'\left. \left(x y\right) \right|_{\substack{ x=1\\ y=2 }}'
+    assert latex(3*Subs(-x+y, (x,),(1,))) == r'3 \left. \left(- x + y\right) \right|_{\substack{ x=1 }}'
 
 
 def test_latex_integrals():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18755 


#### Brief description of what is fixed or changed
When printing expressions with substitutions, it may be hard to interpret where the substitution begins, and where it ends. This commit adds parenthesis to the latex output around the substitution in the expression, making the output easier to interpret.


#### Other comments
Example:
<pre>
In[1]: from sympy import *
In[2]: from sympy.abc import x, y
In[3]: expr = 3*Subs(-x+y, (x,),(1,))
In[4]: print(latex(expr))
3 \left. \left(- x + y\right) \right|_{\substack{ x=1 }}
In[5]: pprint(expr)
3⋅(-x + y)│
          │x=1
</pre>

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Makes latex substitution printing clearer by adding parenthesis.
<!-- END RELEASE NOTES -->
