### PR TITLE
updated lamdify to give the minimum over the first axis

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -827,6 +827,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
     funcstr = funcprinter.doprint(funcname, args, expr)
 
+    from sympy import Min, Max
+    if type(expr)== Min or type(expr)== Max:
+        length = len(funcstr);  
+        funcstr = funcstr[0:length-3]+", axis=0))"
+
     # Collect the module imports from the code printers.
     imp_mod_lines = []
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

fix for issue #18742

#### Brief description of what is fixed or changed
Lambdify when used with Min() or Max() was giving a minimum over the entire array. It should only give a minimum over the first axis. Lambdify converts an expression into a string, I added axis=0 at the end of the string, 
amin((x + 1,0.1*x + 3,0.5*x + 1)) got updated to amin((x + 1,0.1*x + 3,0.5*x + 1), axis=0)
please suggest changes.

#### Other comments
I also want to apply for GSOC 2020, I am getting familiar with sympy, I have used sympy before to solve handwritten equations. 

<!-- END RELEASE NOTES -->