### PR TITLE
Update lambdify to give the minimum over the first axis

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -778,7 +778,6 @@ class NumPyPrinter(PythonCodePrinter):
     def _print_Max(self, expr):
         return '{0}(({1}))'.format(self._module_format('numpy.amax'), ','.join(self._print(i) for i in expr.args))
 
-
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format('numpy.angle'), self._print(expr.args[0]))
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -827,10 +827,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
     funcstr = funcprinter.doprint(funcname, args, expr)
 
-    from sympy import Min, Max
-    if (type(expr)== Min or type(expr)== Max) and modules == 'numpy':
-        length = len(funcstr)
-        funcstr = funcstr[0:length-3]+", axis=0))"
+    if modules == 'numpy':
+        from sympy import Min, Max
+        if type(expr)== Min or type(expr)== Max:
+            funcstr = funcstr[0:len(funcstr)-3]+", axis=0))"
 
     # Collect the module imports from the code printers.
     imp_mod_lines = []

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -106,7 +106,6 @@ MODULES = {
 def _import(module, reload=False):
     """
     Creates a global translation dictionary for module.
-
     The argument module has to be one of the following strings: "math",
     "mpmath", "numpy", "sympy", "tensorflow".
     These dictionaries map names of python functions to their equivalent in
@@ -171,17 +170,13 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
              dummify=False):
     """Convert a SymPy expression into a function that allows for fast
     numeric evaluation.
-
     .. warning::
        This function uses ``exec``, and thus shouldn't be used on
        unsanitized input.
-
     Explanation
     ===========
-
     For example, to convert the SymPy expression ``sin(x) + cos(x)`` to an
     equivalent NumPy function that numerically evaluates it:
-
     >>> from sympy import sin, cos, symbols, lambdify
     >>> import numpy as np
     >>> x = symbols('x')
@@ -192,7 +187,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> a = np.array([1, 2])
     >>> f(a)
     [1.38177329 0.49315059]
-
     The primary purpose of this function is to provide a bridge from SymPy
     expressions to numerical libraries such as NumPy, SciPy, NumExpr, mpmath,
     and tensorflow. In general, SymPy functions do not work with objects from
@@ -200,7 +194,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     libraries like NumPy or mpmath do not work on SymPy expressions.
     ``lambdify`` bridges the two by converting a SymPy expression to an
     equivalent numeric function.
-
     The basic workflow with ``lambdify`` is to first create a SymPy expression
     representing whatever mathematical function you wish to evaluate. This
     should be done using only SymPy functions and expressions. Then, use
@@ -208,95 +201,70 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     evaluation. For instance, above we created ``expr`` using the SymPy symbol
     ``x`` and SymPy functions ``sin`` and ``cos``, then converted it to an
     equivalent NumPy function ``f``, and called it on a NumPy array ``a``.
-
     Parameters
     ==========
-
     args : List[Symbol]
         A variable or a list of variables whose nesting represents the
         nesting of the arguments that will be passed to the function.
-
         Variables can be symbols, undefined functions, or matrix symbols.
-
         >>> from sympy import Eq
         >>> from sympy.abc import x, y, z
-
         The list of variables should match the structure of how the
         arguments will be passed to the function. Simply enclose the
         parameters as they will be passed in a list.
-
         To call a function like ``f(x)`` then ``[x]``
         should be the first argument to ``lambdify``; for this
         case a single ``x`` can also be used:
-
         >>> f = lambdify(x, x + 1)
         >>> f(1)
         2
         >>> f = lambdify([x], x + 1)
         >>> f(1)
         2
-
         To call a function like ``f(x, y)`` then ``[x, y]`` will
         be the first argument of the ``lambdify``:
-
         >>> f = lambdify([x, y], x + y)
         >>> f(1, 1)
         2
-
         To call a function with a single 3-element tuple like
         ``f((x, y, z))`` then ``[(x, y, z)]`` will be the first
         argument of the ``lambdify``:
-
         >>> f = lambdify([(x, y, z)], Eq(z**2, x**2 + y**2))
         >>> f((3, 4, 5))
         True
-
         If two args will be passed and the first is a scalar but
         the second is a tuple with two arguments then the items
         in the list should match that structure:
-
         >>> f = lambdify([x, (y, z)], x + y + z)
         >>> f(1, (2, 3))
         6
-
     expr : Expr
         An expression, list of expressions, or matrix to be evaluated.
-
         Lists may be nested.
         If the expression is a list, the output will also be a list.
-
         >>> f = lambdify(x, [x, [x + 1, x + 2]])
         >>> f(1)
         [1, [2, 3]]
-
         If it is a matrix, an array will be returned (for the NumPy module).
-
         >>> from sympy import Matrix
         >>> f = lambdify(x, Matrix([x, x + 1]))
         >>> f(1)
         [[1]
         [2]]
-
         Note that the argument order here (variables then expression) is used
         to emulate the Python ``lambda`` keyword. ``lambdify(x, expr)`` works
         (roughly) like ``lambda x: expr``
         (see :ref:`lambdify-how-it-works` below).
-
     modules : str, optional
         Specifies the numeric library to use.
-
         If not specified, *modules* defaults to:
-
         - ``["scipy", "numpy"]`` if SciPy is installed
         - ``["numpy"]`` if only NumPy is installed
         - ``["math", "mpmath", "sympy"]`` if neither is installed.
-
         That is, SymPy functions are replaced as far as possible by
         either ``scipy`` or ``numpy`` functions if available, and Python's
         standard library ``math``, or ``mpmath`` functions otherwise.
-
         *modules* can be one of the following types:
-
         - The strings ``"math"``, ``"mpmath"``, ``"numpy"``, ``"numexpr"``,
           ``"scipy"``, ``"sympy"``, or ``"tensorflow"``. This uses the
           corresponding printer and namespace mapping for that module.
@@ -312,27 +280,21 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
           (e.g., to use the NumPy module but override the ``sin`` function
           with a custom version, you can use
           ``[{'sin': custom_sin}, 'numpy']``).
-
     dummify : bool, optional
         Whether or not the variables in the provided expression that are not
         valid Python identifiers are substituted with dummy symbols.
-
         This allows for undefined functions like ``Function('f')(t)`` to be
         supplied as arguments. By default, the variables are only dummified
         if they are not valid Python identifiers.
-
         Set ``dummify=True`` to replace all arguments with dummy symbols
         (if ``args`` is not a string) - for example, to ensure that the
         arguments do not redefine any built-in names.
-
     Examples
     ========
-
     >>> from sympy.utilities.lambdify import implemented_function
     >>> from sympy import sqrt, sin, Matrix
     >>> from sympy import Function
     >>> from sympy.abc import w, x, y, z
-
     >>> f = lambdify(x, x**2)
     >>> f(2)
     4
@@ -348,95 +310,71 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> row = lambdify((x, y), Matrix((x, x + y)).T, modules='sympy')
     >>> row(1, 2)
     Matrix([[1, 3]])
-
     ``lambdify`` can be used to translate SymPy expressions into mpmath
     functions. This may be preferable to using ``evalf`` (which uses mpmath on
     the backend) in some cases.
-
     >>> import mpmath
     >>> f = lambdify(x, sin(x), 'mpmath')
     >>> f(1)
     0.8414709848078965
-
     Tuple arguments are handled and the lambdified function should
     be called with the same type of arguments as were used to create
     the function:
-
     >>> f = lambdify((x, (y, z)), x + y)
     >>> f(1, (2, 4))
     3
-
     The ``flatten`` function can be used to always work with flattened
     arguments:
-
     >>> from sympy.utilities.iterables import flatten
     >>> args = w, (x, (y, z))
     >>> vals = 1, (2, (3, 4))
     >>> f = lambdify(flatten(args), w + x + y + z)
     >>> f(*flatten(vals))
     10
-
     Functions present in ``expr`` can also carry their own numerical
     implementations, in a callable attached to the ``_imp_`` attribute. This
     can be used with undefined functions using the ``implemented_function``
     factory:
-
     >>> f = implemented_function(Function('f'), lambda x: x+1)
     >>> func = lambdify(x, f(x))
     >>> func(4)
     5
-
     ``lambdify`` always prefers ``_imp_`` implementations to implementations
     in other namespaces, unless the ``use_imps`` input parameter is False.
-
     Usage with Tensorflow:
-
     >>> import tensorflow as tf
     >>> from sympy import Max, sin, lambdify
     >>> from sympy.abc import x
-
     >>> f = Max(x, sin(x))
     >>> func = lambdify(x, f, 'tensorflow')
-
     After tensorflow v2, eager execution is enabled by default.
     If you want to get the compatible result across tensorflow v1 and v2
     as same as this tutorial, run this line.
-
     >>> tf.compat.v1.enable_eager_execution()
-
     If you have eager execution enabled, you can get the result out
     immediately as you can use numpy.
-
     If you pass tensorflow objects, you may get an ``EagerTensor``
     object instead of value.
-
     >>> result = func(tf.constant(1.0))
     >>> print(result)
     tf.Tensor(1.0, shape=(), dtype=float32)
     >>> print(result.__class__)
     <class 'tensorflow.python.framework.ops.EagerTensor'>
-
     You can use ``.numpy()`` to get the numpy value of the tensor.
-
     >>> result.numpy()
     1.0
-
     >>> var = tf.Variable(2.0)
     >>> result = func(var) # also works for tf.Variable and tf.Placeholder
     >>> result.numpy()
     2.0
-
     And it works with any shape array.
-
     >>> tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]])
     >>> result = func(tensor)
     >>> result.numpy()
     [[1. 2.]
      [3. 4.]]
-
     Notes
     =====
-
     - For functions involving large array calculations, numexpr can provide a
       significant speedup over numpy. Please note that the available functions
       for numexpr are more limited than numpy but can be expanded with
@@ -444,13 +382,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
       specified, numexpr may be the only option in modules. The official list
       of numexpr functions can be found at:
       https://numexpr.readthedocs.io/en/latest/user_guide.html#supported-functions
-
     - In previous versions of SymPy, ``lambdify`` replaced ``Matrix`` with
       ``numpy.matrix`` by default. As of SymPy 1.0 ``numpy.array`` is the
       default. To get the old default behavior you must pass in
       ``[{'ImmutableDenseMatrix':  numpy.matrix}, 'numpy']`` to the
       ``modules`` kwarg.
-
       >>> from sympy import lambdify, Matrix
       >>> from sympy.abc import x, y
       >>> import numpy
@@ -459,89 +395,61 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
       >>> f(1, 2)
       [[1]
        [2]]
-
     - In the above examples, the generated functions can accept scalar
       values or numpy arrays as arguments.  However, in some cases
       the generated function relies on the input being a numpy array:
-
       >>> from sympy import Piecewise
       >>> from sympy.testing.pytest import ignore_warnings
       >>> f = lambdify(x, Piecewise((x, x <= 1), (1/x, x > 1)), "numpy")
-
       >>> with ignore_warnings(RuntimeWarning):
       ...     f(numpy.array([-1, 0, 1, 2]))
       [-1.   0.   1.   0.5]
-
       >>> f(0)
       Traceback (most recent call last):
           ...
       ZeroDivisionError: division by zero
-
       In such cases, the input should be wrapped in a numpy array:
-
       >>> with ignore_warnings(RuntimeWarning):
       ...     float(f(numpy.array([0])))
       0.0
-
       Or if numpy functionality is not required another module can be used:
-
       >>> f = lambdify(x, Piecewise((x, x <= 1), (1/x, x > 1)), "math")
       >>> f(0)
       0
-
     .. _lambdify-how-it-works:
-
     How it works
     ============
-
     When using this function, it helps a great deal to have an idea of what it
     is doing. At its core, lambdify is nothing more than a namespace
     translation, on top of a special printer that makes some corner cases work
     properly.
-
     To understand lambdify, first we must properly understand how Python
     namespaces work. Say we had two files. One called ``sin_cos_sympy.py``,
     with
-
     .. code:: python
-
         # sin_cos_sympy.py
-
         from sympy import sin, cos
-
         def sin_cos(x):
             return sin(x) + cos(x)
-
-
     and one called ``sin_cos_numpy.py`` with
-
     .. code:: python
-
         # sin_cos_numpy.py
-
         from numpy import sin, cos
-
         def sin_cos(x):
             return sin(x) + cos(x)
-
     The two files define an identical function ``sin_cos``. However, in the
     first file, ``sin`` and ``cos`` are defined as the SymPy ``sin`` and
     ``cos``. In the second, they are defined as the NumPy versions.
-
     If we were to import the first file and use the ``sin_cos`` function, we
     would get something like
-
     >>> from sin_cos_sympy import sin_cos # doctest: +SKIP
     >>> sin_cos(1) # doctest: +SKIP
     cos(1) + sin(1)
-
     On the other hand, if we imported ``sin_cos`` from the second file, we
     would get
-
     >>> from sin_cos_numpy import sin_cos # doctest: +SKIP
     >>> sin_cos(1) # doctest: +SKIP
     1.38177329068
-
     In the first case we got a symbolic output, because it used the symbolic
     ``sin`` and ``cos`` functions from SymPy. In the second, we got a numeric
     result, because ``sin_cos`` used the numeric ``sin`` and ``cos`` functions
@@ -549,18 +457,15 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     used was not inherent to the ``sin_cos`` function definition. Both
     ``sin_cos`` definitions are exactly the same. Rather, it was based on the
     names defined at the module where the ``sin_cos`` function was defined.
-
     The key point here is that when function in Python references a name that
     is not defined in the function, that name is looked up in the "global"
     namespace of the module where that function is defined.
-
     Now, in Python, we can emulate this behavior without actually writing a
     file to disk using the ``exec`` function. ``exec`` takes a string
     containing a block of Python code, and a dictionary that should contain
     the global variables of the module. It then executes the code "in" that
     dictionary, as if it were the module globals. The following is equivalent
     to the ``sin_cos`` defined in ``sin_cos_sympy.py``:
-
     >>> import sympy
     >>> module_dictionary = {'sin': sympy.sin, 'cos': sympy.cos}
     >>> exec('''
@@ -570,9 +475,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> sin_cos = module_dictionary['sin_cos']
     >>> sin_cos(1)
     cos(1) + sin(1)
-
     and similarly with ``sin_cos_numpy``:
-
     >>> import numpy
     >>> module_dictionary = {'sin': numpy.sin, 'cos': numpy.cos}
     >>> exec('''
@@ -582,7 +485,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> sin_cos = module_dictionary['sin_cos']
     >>> sin_cos(1)
     1.38177329068
-
     So now we can get an idea of how ``lambdify`` works. The name "lambdify"
     comes from the fact that we can think of something like ``lambdify(x,
     sin(x) + cos(x), 'numpy')`` as ``lambda x: sin(x) + cos(x)``, where
@@ -590,9 +492,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     the symbols argument is first in ``lambdify``, as opposed to most SymPy
     functions where it comes after the expression: to better mimic the
     ``lambda`` keyword.
-
     ``lambdify`` takes the input expression (like ``sin(x) + cos(x)``) and
-
     1. Converts it to a string
     2. Creates a module globals dictionary based on the modules that are
        passed in (by default, it uses the NumPy module)
@@ -600,31 +500,25 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
        list of variables separated by commas, and ``{expr}`` is the string
        created in step 1., then ``exec``s that string with the module globals
        namespace and returns ``func``.
-
     In fact, functions returned by ``lambdify`` support inspection. So you can
     see exactly how they are defined by using ``inspect.getsource``, or ``??`` if you
     are using IPython or the Jupyter notebook.
-
     >>> f = lambdify(x, sin(x) + cos(x))
     >>> import inspect
     >>> print(inspect.getsource(f))
     def _lambdifygenerated(x):
         return (sin(x) + cos(x))
-
     This shows us the source code of the function, but not the namespace it
     was defined in. We can inspect that by looking at the ``__globals__``
     attribute of ``f``:
-
     >>> f.__globals__['sin']
     <ufunc 'sin'>
     >>> f.__globals__['cos']
     <ufunc 'cos'>
     >>> f.__globals__['sin'] is numpy.sin
     True
-
     This shows us that ``sin`` and ``cos`` in the namespace of ``f`` will be
     ``numpy.sin`` and ``numpy.cos``.
-
     Note that there are some convenience layers in each of these steps, but at
     the core, this is how ``lambdify`` works. Step 1 is done using the
     ``LambdaPrinter`` printers defined in the printing module (see
@@ -632,11 +526,9 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     to define how they should be converted to a string for different modules.
     You can change which printer ``lambdify`` uses by passing a custom printer
     in to the ``printer`` argument.
-
     Step 2 is augmented by certain translations. There are default
     translations for each module, but you can provide your own by passing a
     list to the ``modules`` argument. For instance,
-
     >>> def mysin(x):
     ...     print('taking the sin of', x)
     ...     return numpy.sin(x)
@@ -645,56 +537,40 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> f(1)
     taking the sin of 1
     0.8414709848078965
-
     The globals dictionary is generated from the list by merging the
     dictionary ``{'sin': mysin}`` and the module dictionary for NumPy. The
     merging is done so that earlier items take precedence, which is why
     ``mysin`` is used above instead of ``numpy.sin``.
-
     If you want to modify the way ``lambdify`` works for a given function, it
     is usually easiest to do so by modifying the globals dictionary as such.
     In more complicated cases, it may be necessary to create and pass in a
     custom printer.
-
     Finally, step 3 is augmented with certain convenience operations, such as
     the addition of a docstring.
-
     Understanding how ``lambdify`` works can make it easier to avoid certain
     gotchas when using it. For instance, a common mistake is to create a
     lambdified function for one module (say, NumPy), and pass it objects from
     another (say, a SymPy expression).
-
     For instance, say we create
-
     >>> from sympy.abc import x
     >>> f = lambdify(x, x + 1, 'numpy')
-
     Now if we pass in a NumPy array, we get that array plus 1
-
     >>> import numpy
     >>> a = numpy.array([1, 2])
     >>> f(a)
     [2 3]
-
     But what happens if you make the mistake of passing in a SymPy expression
     instead of a NumPy array:
-
     >>> f(x + 1)
     x + 2
-
     This worked, but it was only by accident. Now take a different lambdified
     function:
-
     >>> from sympy import sin
     >>> g = lambdify(x, x + sin(x), 'numpy')
-
     This works as expected on NumPy arrays:
-
     >>> g(a)
     [1.84147098 2.90929743]
-
     But if we try to pass in a SymPy expression, it fails
-
     >>> try:
     ...     g(x + 1)
     ... # NumPy release after 1.17 raises TypeError instead of
@@ -704,27 +580,23 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     Traceback (most recent call last):
     ...
     AttributeError:
-
     Now, let's look at what happened. The reason this fails is that ``g``
     calls ``numpy.sin`` on the input expression, and ``numpy.sin`` does not
     know how to operate on a SymPy object. **As a general rule, NumPy
     functions do not know how to operate on SymPy expressions, and SymPy
     functions do not know how to operate on NumPy arrays. This is why lambdify
     exists: to provide a bridge between SymPy and NumPy.**
-
     However, why is it that ``f`` did work? That's because ``f`` doesn't call
     any functions, it only adds 1. So the resulting function that is created,
     ``def _lambdifygenerated(x): return x + 1`` does not depend on the globals
     namespace it is defined in. Thus it works, but only by accident. A future
     version of ``lambdify`` may remove this behavior.
-
     Be aware that certain implementation details described here may change in
     future versions of SymPy. The API of passing in custom modules and
     printers will not change, but the details of how a lambda function is
     created may change. However, the basic idea will remain the same, and
     understanding it will be helpful to understanding the behavior of
     lambdify.
-
     **In general: you should create lambdified functions for one module (say,
     NumPy), and only pass it input types that are compatible with that module
     (say, NumPy arrays).** Remember that by default, if the ``module``
@@ -827,11 +699,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
     funcstr = funcprinter.doprint(funcname, args, expr)
 
-    if modules == 'numpy':
-        from sympy import Min, Max
-        if type(expr)== Min or type(expr)== Max:
-            funcstr = funcstr[0:len(funcstr)-3]+", axis=0))"
-
     # Collect the module imports from the code printers.
     imp_mod_lines = []
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():
@@ -906,21 +773,17 @@ def _get_namespace(m):
 def lambdastr(args, expr, printer=None, dummify=None):
     """
     Returns a string that can be evaluated to a lambda function.
-
     Examples
     ========
-
     >>> from sympy.abc import x, y, z
     >>> from sympy.utilities.lambdify import lambdastr
     >>> lambdastr(x, x**2)
     'lambda x: (x**2)'
     >>> lambdastr((x,y,z), [z,y,x])
     'lambda x,y,z: ([z, y, x])'
-
     Although tuples may not appear as arguments to lambda in Python 3,
     lambdastr will create a lambda function that will unpack the original
     arguments so that nested arguments can be handled:
-
     >>> lambdastr((x, (y, z)), x + y)
     'lambda _0,_1: (lambda x,y,z: (x + y))(_0,_1[0],_1[1])'
     """
@@ -1088,7 +951,6 @@ class _EvaluatorPrinter(object):
     def _preprocess(self, args, expr):
         """Preprocess args, expr to replace arguments that do not map
         to valid Python identifiers.
-
         Returns string form of args, and updated expr.
         """
         from sympy import Dummy, Function, flatten, Derivative, ordered, Basic
@@ -1148,9 +1010,7 @@ class _EvaluatorPrinter(object):
 
     def _print_funcargwrapping(self, args):
         """Generate argument wrapping code.
-
         args is the argument list of the generated function (strings).
-
         Return value is a list of lines of code that will be inserted  at
         the beginning of the function definition.
         """
@@ -1158,7 +1018,6 @@ class _EvaluatorPrinter(object):
 
     def _print_unpacking(self, unpackto, arg):
         """Generate argument unpacking code.
-
         arg is the function argument to be unpacked (a string), and
         unpackto is a list or nested lists of the variable names (strings) to
         unpack to.
@@ -1172,7 +1031,6 @@ class _EvaluatorPrinter(object):
 class _TensorflowEvaluatorPrinter(_EvaluatorPrinter):
     def _print_unpacking(self, lvalues, rvalue):
         """Generate argument unpacking code.
-
         This method is used when the input value is not interable,
         but can be indexed (see issue #14655).
         """
@@ -1197,12 +1055,10 @@ class _TensorflowEvaluatorPrinter(_EvaluatorPrinter):
 
 def _imp_namespace(expr, namespace=None):
     """ Return namespace dict with function implementations
-
     We need to search for functions in anything that can be thrown at
     us - that is - anything that could be passed as ``expr``.  Examples
     include sympy expressions, as well as tuples, lists and dicts that may
     contain sympy expressions.
-
     Parameters
     ----------
     expr : object
@@ -1210,17 +1066,14 @@ def _imp_namespace(expr, namespace=None):
        ``str(expr)``.
     namespace : None or mapping
        Namespace to fill.  None results in new empty dict
-
     Returns
     -------
     namespace : dict
        dict with keys of implemented function names within ``expr`` and
        corresponding values being the numerical implementation of
        function
-
     Examples
     ========
-
     >>> from sympy.abc import x
     >>> from sympy.utilities.lambdify import implemented_function, _imp_namespace
     >>> from sympy import Function
@@ -1265,16 +1118,13 @@ def _imp_namespace(expr, namespace=None):
 
 def implemented_function(symfunc, implementation):
     """ Add numerical ``implementation`` to function ``symfunc``.
-
     ``symfunc`` can be an ``UndefinedFunction`` instance, or a name string.
     In the latter case we create an ``UndefinedFunction`` instance with that
     name.
-
     Be aware that this is a quick workaround, not a general method to create
     special symbolic functions. If you want to create a symbolic function to be
     used by all the machinery of SymPy you should subclass the ``Function``
     class.
-
     Parameters
     ----------
     symfunc : ``str`` or ``UndefinedFunction`` instance
@@ -1283,15 +1133,12 @@ def implemented_function(symfunc, implementation):
        with the same name and the implemented function attached.
     implementation : callable
        numerical implementation to be called by ``evalf()`` or ``lambdify``
-
     Returns
     -------
     afunc : sympy.FunctionClass instance
        function with attached implementation
-
     Examples
     ========
-
     >>> from sympy.abc import x
     >>> from sympy.utilities.lambdify import lambdify, implemented_function
     >>> from sympy import Function

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -828,7 +828,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     funcstr = funcprinter.doprint(funcname, args, expr)
 
     from sympy import Min, Max
-    if type(expr)== Min or type(expr)== Max:
+    if (type(expr)== Min or type(expr)== Max) and modules == 'numpy':
         length = len(funcstr)
         funcstr = funcstr[0:length-3]+", axis=0))"
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -827,6 +827,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         funcprinter = _EvaluatorPrinter(printer, dummify)
     funcstr = funcprinter.doprint(funcname, args, expr)
 
+    from sympy import Min, Max
+    if type(expr)== Min or type(expr)== Max:
+        length = len(funcstr)
+        funcstr = funcstr[0:length-3]+", axis=0))"
+
     # Collect the module imports from the code printers.
     imp_mod_lines = []
     for mod, keys in (getattr(printer, 'module_imports', None) or {}).items():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18742 

#### Brief description of what is fixed or changed

Added axis=0 at the end of the funcstr.
amin((x + 1,0.1*x + 3,0.5*x + 1)) got updated to amin((x + 1,0.1*x + 3,0.5*x + 1), axis=0).

#### Other comments
I also want to apply for GSOC 2020, I am getting more familiar with sympy, I have used sympy before to solve handwritten equations. 
Please suggest changes.

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* utilities
    - Solving inconsistency in the lambdify when used with Min and Max.
<!-- END RELEASE NOTES -->