### PR TITLE
Fixes incorrect parenthesizes of Integral

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -786,8 +786,15 @@ class LatexPrinter(Printer):
 
                 symbols.insert(0, r"\, d%s" % self._print(symbol))
 
+        if any(_coeff_isneg(i) for i in expr.args):
+            return r"%s %s%s" % (tex, self.parenthesize(expr.function,
+                                                    PRECEDENCE["Mul"],
+                                                    is_neg=True,
+                                                    strict=True),
+                             "".join(symbols))
         return r"%s %s%s" % (tex, self.parenthesize(expr.function,
                                                     PRECEDENCE["Mul"],
+                                                    is_neg=False,
                                                     strict=True),
                              "".join(symbols))
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -205,9 +205,12 @@ class LatexPrinter(Printer):
             self._settings['imaginary_unit_latex'] = \
                 self._settings['imaginary_unit']
 
-    def parenthesize(self, item, level, diff=False, strict=False):
+    def parenthesize(self, item, level, is_neg=False, strict=False):
         prec_val = precedence_traditional(item)
-        if (((prec_val < level) or ((not strict) and prec_val <= level)) or ((diff == True) and (strict == True))):
+        if is_neg and strict:
+            return r"\left({}\right)".format(self._print(item))
+
+        if (prec_val < level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)
@@ -716,33 +719,32 @@ class LatexPrinter(Printer):
             diff_symbol = r'\partial'
         else:
             diff_symbol = r'd'
+
         tex = ""
         dim = 0
         for x, num in reversed(expr.variable_count):
-            dim = dim + num
+            dim += num
             if num == 1:
                 tex += r"%s %s" % (diff_symbol, self._print(x))
             else:
                 tex += r"%s %s^{%s}" % (diff_symbol,
                                         self.parenthesize_super(self._print(x)),
                                         self._print(num))
-        neg = False
-        terms = expr.args
-        for i,term in enumerate(terms):
-            if _coeff_isneg(term):
-                neg = True
+
         if dim == 1:
             tex = r"\frac{%s}{%s}" % (diff_symbol, tex)
         else:
             tex = r"\frac{%s^{%s}}{%s}" % (diff_symbol, self._print(dim), tex)
-        if neg == True:
+
+        if any(_coeff_isneg(i) for i in expr.args):
             return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = True,
+                                                  is_neg=True,
                                                   strict=True))
+
         return r"%s %s" % (tex, self.parenthesize(expr.expr,
                                                   PRECEDENCE["Mul"],
-                                                  diff = False,
+                                                  is_neg=False,
                                                   strict=True))
 
     def _print_Subs(self, subs):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
fixes issue #18758 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
A check for negative integral is added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
   * fixes incorrect parenthesizes in latex print of integral
<!-- END RELEASE NOTES -->