### PR TITLE
Update NumPyPrinter to give the minimum over the first axis.

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -773,11 +773,14 @@ class NumPyPrinter(PythonCodePrinter):
         return self._hprint_Pow(expr, rational=rational, sqrt='numpy.sqrt')
 
     def _print_Min(self, expr):
-        return '{0}(({1}))'.format(self._module_format('numpy.amin'), ','.join(self._print(i) for i in expr.args))
+        mini =  '{0}(({1}))'.format(self._module_format('numpy.amin'), ','.join(self._print(i) for i in expr.args))
+        mini = mini[0:len(mini)-1]+ ", axis=0)"
+        return mini
 
     def _print_Max(self, expr):
-        return '{0}(({1}))'.format(self._module_format('numpy.amax'), ','.join(self._print(i) for i in expr.args))
-
+        maxi = '{0}(({1}))'.format(self._module_format('numpy.amax'), ','.join(self._print(i) for i in expr.args))
+        maxi = maxi[0:len(maxi)-1]+ ", axis=0)"
+        return maxi
 
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format('numpy.angle'), self._print(expr.args[0]))

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -773,14 +773,10 @@ class NumPyPrinter(PythonCodePrinter):
         return self._hprint_Pow(expr, rational=rational, sqrt='numpy.sqrt')
 
     def _print_Min(self, expr):
-        mini =  '{0}(({1}))'.format(self._module_format('numpy.amin'), ','.join(self._print(i) for i in expr.args))
-        mini = mini[0:len(mini)-1]+ ", axis=0)"
-        return mini
+        return '{0}(({1}), axis=0)'.format(self._module_format('numpy.amin'), ','.join(self._print(i) for i in expr.args))
 
     def _print_Max(self, expr):
-        maxi = '{0}(({1}))'.format(self._module_format('numpy.amax'), ','.join(self._print(i) for i in expr.args))
-        maxi = maxi[0:len(maxi)-1]+ ", axis=0)"
-        return maxi
+        return '{0}(({1}), axis=0)'.format(self._module_format('numpy.amax'), ','.join(self._print(i) for i in expr.args))
 
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format('numpy.angle'), self._print(expr.args[0]))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -118,6 +118,20 @@ def test_NumPyPrinter():
     assert p.doprint(S.NegativeInfinity) == 'numpy.NINF'
 
 
+def test_issue_18770():
+    import numpy as np
+    from sympy import lambdify, Min, Max
+
+    expr1 = Min(0.1*x + 3, x + 1, 0.5*x + 1)
+    func = lambdify(x, expr1, "numpy")
+    assert (func(np.linspace(0, 3, 3)) == [1.0 , 1.75, 2.5 ]).all()
+    assert  func(4) == 3
+
+    expr1 = Max(x**2 , x**3)
+    func = lambdify(x,expr1, "numpy")
+    assert (func(np.linspace(-1 , 2, 4)) == [1, 0, 1, 8] ).all()
+    assert func(4) == 64
+
 def test_SciPyPrinter():
     p = SciPyPrinter()
     expr = acos(x)

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -15,6 +15,8 @@ from sympy.printing.pycode import (
 )
 from sympy.testing.pytest import raises
 from sympy.tensor import IndexedBase
+from sympy.testing.pytest import skip
+from sympy.external import import_module
 
 x, y, z = symbols('x y z')
 p = IndexedBase("p")
@@ -119,6 +121,10 @@ def test_NumPyPrinter():
 
 
 def test_issue_18770():
+    numpy = import_module('numpy')
+    if not numpy:
+        skip("numpy not installed.")
+
     import numpy as np
     from sympy import lambdify, Min, Max
 
@@ -131,6 +137,7 @@ def test_issue_18770():
     func = lambdify(x,expr1, "numpy")
     assert (func(np.linspace(-1 , 2, 4)) == [1, 0, 1, 8] ).all()
     assert func(4) == 64
+
 
 def test_SciPyPrinter():
     p = SciPyPrinter()

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -125,17 +125,16 @@ def test_issue_18770():
     if not numpy:
         skip("numpy not installed.")
 
-    import numpy as np
     from sympy import lambdify, Min, Max
 
     expr1 = Min(0.1*x + 3, x + 1, 0.5*x + 1)
     func = lambdify(x, expr1, "numpy")
-    assert (func(np.linspace(0, 3, 3)) == [1.0 , 1.75, 2.5 ]).all()
+    assert (func(numpy.linspace(0, 3, 3)) == [1.0 , 1.75, 2.5 ]).all()
     assert  func(4) == 3
 
     expr1 = Max(x**2 , x**3)
     func = lambdify(x,expr1, "numpy")
-    assert (func(np.linspace(-1 , 2, 4)) == [1, 0, 1, 8] ).all()
+    assert (func(numpy.linspace(-1 , 2, 4)) == [1, 0, 1, 8] ).all()
     assert func(4) == 64
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18770
Fixes #18742 
#### Brief description of what is fixed or changed

Added axis=0 at the end of the _print_Min() and _print_Max() to give minimum/maximum over the first axis of an array.
amin((x + 1,0.1*x + 3,0.5*x + 1)) got updated to amin((x + 1,0.1*x + 3,0.5*x + 1), axis=0).

#### Other comments 
Please suggest changes.

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
    - Fix lambdify with `Min`/`Max` for arrays of more than one dimension
<!-- END RELEASE NOTES -->