### PR TITLE
WIP: Add UnitQuaternion class

### DIFF
--- a/sympy/algebras/__init__.py
+++ b/sympy/algebras/__init__.py
@@ -1,3 +1,3 @@
-from .quaternion import Quaternion
+from .quaternion import Quaternion, UnitQuaternion
 
-__all__ = ["Quaternion",]
+__all__ = ["Quaternion", "UnitQuaternion"]

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -124,7 +124,7 @@ class Quaternion(Expr):
 
     def diff(self, *symbols, **kwargs):
         kwargs.setdefault('evaluate', True)
-        return self.func(*[a.diff(*symbols, **kwargs) for a  in self.args])
+        return Quaternion(*[a.diff(*symbols, **kwargs) for a  in self.args])
 
     def add(self, other):
         """Adds quaternions.

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -765,6 +765,11 @@ def test_sympy__algebras__quaternion__Quaternion():
     assert _test_args(Quaternion(x, 1, 2, 3))
 
 
+def test_sympy__algebras__quaternion__UnitQuaternion():
+    from sympy.algebras.quaternion import UnitQuaternion
+    assert _test_args(UnitQuaternion(S.Half, S.Half, S.Half, S.Half))
+
+
 def test_sympy__core__relational__Equality():
     from sympy.core.relational import Equality
     assert _test_args(Equality(x, 2))


### PR DESCRIPTION
This is a slight variation of #17694.

This never tries to actually calculate the norm of quaternions. The unit-ness of `UnitQuaternion` is just assumed. This way, the components can be symbolic expressions.
If this assumption is violated, the results will be nonsensical (as expected?):

```pycon
>>> from sympy.algebras import UnitQuaternion
>>> q = UnitQuaternion(6, 7, 8, 9)
>>> q
6 + 7*i + 8*j + 9*k
>>> q.norm()
1
```

#### References to other Issues or PRs

This is (hopefully) an improvement over #17694, therefore it is also an alternative to  #18065 and #18086.

#### Brief description of what is fixed or changed

Same motivation as #17694.

#### Other comments

I've tried to make the result type a `UnitQuaternion` wherever this is guaranteed.
I might have missed some places, though.

Currently, a `UnitQuaternion` is never equal to a `Quaternion`, even if they have the same components:

```pycon
>>> from sympy.algebras import Quaternion, UnitQuaternion
>>> Quaternion(1, 0, 0, 0) == UnitQuaternion(1, 0, 0, 0)
False
```

I'm not sure whether this makes sense or not.

This is a "draft" PR because some docs and deprecation warnings are missing for now.
Probably some methods are missing as well?

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Added a UnitQuaternion class 
<!-- END RELEASE NOTES -->