### PR TITLE
Add in ordering='none' capability to srepr printer

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -346,10 +346,7 @@ class LatexPrinter(Printer):
         return r"\text{%s}" % e
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'none':
-            terms = list(expr.args)
-        else:
-            terms = self._as_ordered_terms(expr, order=order)
+        terms = self._as_ordered_terms(expr, order=order)
 
         tex = ""
         for i, term in enumerate(terms):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1704,10 +1704,7 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'none':
-            terms = list(expr.args)
-        else:
-            terms = self._as_ordered_terms(expr, order=order)
+        terms = self._as_ordered_terms(expr, order=order)
         pforms, indices = [], []
 
         def pretty_negative(pform, index):

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -302,5 +302,7 @@ class Printer(object):
 
         if order == 'old':
             return sorted(Add.make_args(expr), key=cmp_to_key(Basic._compare_pretty))
+        elif order == 'none':
+            return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -49,10 +49,7 @@ class ReprPrinter(Printer):
             return str(expr)
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'none':
-            args = list(expr.args)
-        else:
-            args = self._as_ordered_terms(expr, order=order)
+        args = self._as_ordered_terms(expr, order=order)
         nargs = len(args)
         args = map(self._print, args)
         clsname = type(expr).__name__

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -10,6 +10,7 @@ from __future__ import print_function, division
 from typing import Any, Dict
 
 from sympy.core.function import AppliedUndef
+from sympy.core.mul import Mul
 from mpmath.libmp import repr_dps, to_str as mlib_to_str
 
 from .printer import Printer
@@ -48,7 +49,10 @@ class ReprPrinter(Printer):
             return str(expr)
 
     def _print_Add(self, expr, order=None):
-        args = self._as_ordered_terms(expr, order=order)
+        if self.order == 'none':
+            args = list(expr.args)
+        else:
+            args = self._as_ordered_terms(expr, order=order)
         nargs = len(args)
         args = map(self._print, args)
         clsname = type(expr).__name__
@@ -191,11 +195,11 @@ class ReprPrinter(Printer):
         return "nan"
 
     def _print_Mul(self, expr, order=None):
-        terms = expr.args
-        if self.order != 'old':
-            args = expr._new_rawargs(*terms).as_ordered_factors()
+        if self.order not in ('old', 'none'):
+            args = expr.as_ordered_factors()
         else:
-            args = terms
+            # use make_args in case expr was something like -x -> x
+            args = Mul.make_args(expr)
 
         nargs = len(args)
         args = map(self._print, args)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -48,10 +48,7 @@ class StrPrinter(Printer):
             return str(expr)
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'none':
-            terms = list(expr.args)
-        else:
-            terms = self._as_ordered_terms(expr, order=order)
+        terms = self._as_ordered_terms(expr, order=order)
 
         PREC = precedence(expr)
         l = []

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from sympy.testing.pytest import raises
-from sympy import (symbols, Function, Integer, Matrix, Abs,
+from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
     sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol)
 from sympy.combinatorics import Cycle, Permutation
@@ -48,6 +48,7 @@ def test_Add():
     sT(x + y, "Add(Symbol('x'), Symbol('y'))")
     assert srepr(x**2 + 1, order='lex') == "Add(Pow(Symbol('x'), Integer(2)), Integer(1))"
     assert srepr(x**2 + 1, order='old') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
+    assert srepr(sympify('x + 3 - 2'), order='none') == "Add(Symbol('x'), Integer(3), Mul(Integer(-1), Integer(2)))"
 
 
 def test_more_than_255_args_issue_10259():
@@ -203,6 +204,7 @@ def test_settins():
 def test_Mul():
     sT(3*x**3*y, "Mul(Integer(3), Pow(Symbol('x'), Integer(3)), Symbol('y'))")
     assert srepr(3*x**3*y, order='old') == "Mul(Integer(3), Symbol('y'), Pow(Symbol('x'), Integer(3)))"
+    assert srepr((x-4)*2*x, order='none') == "Mul(Add(Symbol('x'), Integer(-4)), Mul(Integer(2), Symbol('x')))"
 
 def test_AlgebraicNumber():
     a = AlgebraicNumber(sqrt(2))

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -48,7 +48,7 @@ def test_Add():
     sT(x + y, "Add(Symbol('x'), Symbol('y'))")
     assert srepr(x**2 + 1, order='lex') == "Add(Pow(Symbol('x'), Integer(2)), Integer(1))"
     assert srepr(x**2 + 1, order='old') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
-    assert srepr(sympify('x + 3 - 2'), order='none') == "Add(Symbol('x'), Integer(3), Mul(Integer(-1), Integer(2)))"
+    assert srepr(sympify('x + 3 - 2', evaluate=False), order='none') == "Add(Symbol('x'), Integer(3), Mul(Integer(-1), Integer(2)))"
 
 
 def test_more_than_255_args_issue_10259():
@@ -204,7 +204,7 @@ def test_settins():
 def test_Mul():
     sT(3*x**3*y, "Mul(Integer(3), Pow(Symbol('x'), Integer(3)), Symbol('y'))")
     assert srepr(3*x**3*y, order='old') == "Mul(Integer(3), Symbol('y'), Pow(Symbol('x'), Integer(3)))"
-    assert srepr((x-4)*2*x, order='none') == "Mul(Add(Symbol('x'), Integer(-4)), Mul(Integer(2), Symbol('x')))"
+    assert srepr(sympify('(x+4)*2*x*7', evaluate=False), order='none') == "Mul(Add(Symbol('x'), Integer(4)), Integer(2), Symbol('x'), Integer(7))"
 
 def test_AlgebraicNumber():
     a = AlgebraicNumber(sqrt(2))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Currently the `LatexPrinter` and `StrPrinter` allow for ordering to be turned off (similar to `evaluate=False` in sympify. This capability however doesn't exist in the `ReprPrinter`.

`StrPrinter(dict(order='none')).doprint(expr)`

Now this is equivalent:

`ReprPrinter(dict(order='none')).doprint(sympify('x + 3 - 2', evaluate=False)) == 'Add(Symbol('x'), Integer(3), Integer(-2))'`

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * allowed ReprPrinter to maintain original expr order via turning ordering off
<!-- END RELEASE NOTES -->