### PR TITLE
MAINT: Replace inspect.getargspec with getfullargspec

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -207,7 +207,7 @@ def _get_arg_list(name, fobj):
 
     trunc = 20  # Sometimes argument length can be huge
 
-    argspec = inspect.getargspec(fobj)
+    argspec = inspect.getfullargspec(fobj)
 
     arg_list = []
 

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -463,10 +463,7 @@ class FunctionDoc(NumpyDocString):
             func, func_name = self.get_func()
             try:
                 # try to read signature
-                if sys.version_info[0] >= 3:
-                    argspec = inspect.getfullargspec(func)
-                else:
-                    argspec = inspect.getargspec(func)
+                argspec = inspect.getfullargspec(func)
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*', '\*')
                 signature = '%s%s' % (func_name, argspec)

--- a/sympy/multipledispatch/core.py
+++ b/sympy/multipledispatch/core.py
@@ -81,9 +81,5 @@ def ismethod(func):
     Note that this has to work as the method is defined but before the class is
     defined.  At this stage methods look like functions.
     """
-    if hasattr(inspect, "signature"):
-        signature = inspect.signature(func)
-        return signature.parameters.get('self', None) is not None
-    else:
-        spec = inspect.getargspec(func)
-        return spec and spec.args and spec.args[0] == 'self'
+    signature = inspect.signature(func)
+    return signature.parameters.get('self', None) is not None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #11255

#### Brief description of what is fixed or changed
Now that Python 3.5 is required for sympy this is an easy cleanup.
https://docs.python.org/3/library/inspect.html#inspect.signature
https://docs.python.org/3/library/inspect.html#inspect.getargspec


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * Replace inspect.getargspec with getfullargspec
<!-- END RELEASE NOTES -->