### PR TITLE
Core: Reduces sensitivity of computation of order terms

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1590,7 +1590,6 @@ class Pow(Expr):
                 # (lt + rest + O(x**m))**e =
                 # lt**e*(1 + rest/lt + O(x**m)/lt)**e =
                 # lt**e + ... + O(x**m)*lt**(e - 1) = ... + O(x**n)
-
                 try:
                     cf = Order(lt, x).getn()
                     nuse = ceiling(n - cf*(e - 1))
@@ -1629,7 +1628,11 @@ class Pow(Expr):
         # either b0 is bounded but neither 1 nor 0 or e is infinite
         # b -> b0 + (b - b0) -> b0 * (1 + (b/b0 - 1))
         o2 = order*(b0**-e)
-        z = (b/b0 - 1).simplify()
+        from sympy import AccumBounds
+        if isinstance(b0, AccumBounds):  # "XXX This can be removed and simply "z = (b - b0)/b0" would be enough when the operations on AccumBounds have been fixed."
+            z = (b/b0 - 1)
+        else:
+            z = (b - b0)/b0
         o = O(z, x)
         if o is S.Zero or o2 is S.Zero:
             infinite = True

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1629,7 +1629,9 @@ class Pow(Expr):
         # b -> b0 + (b - b0) -> b0 * (1 + (b/b0 - 1))
         o2 = order*(b0**-e)
         from sympy import AccumBounds
-        if isinstance(b0, AccumBounds):  # "XXX This can be removed and simply "z = (b - b0)/b0" would be enough when the operations on AccumBounds have been fixed."
+        # Issue: #18795 -"XXX This can be removed and simply "z = (b - b0)/b0"
+        # would be enough when the operations on AccumBounds have been fixed."
+        if isinstance(b0, AccumBounds):
             z = (b/b0 - 1)
         else:
             z = (b - b0)/b0

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1590,6 +1590,7 @@ class Pow(Expr):
                 # (lt + rest + O(x**m))**e =
                 # lt**e*(1 + rest/lt + O(x**m)/lt)**e =
                 # lt**e + ... + O(x**m)*lt**(e - 1) = ... + O(x**n)
+
                 try:
                     cf = Order(lt, x).getn()
                     nuse = ceiling(n - cf*(e - 1))
@@ -1628,7 +1629,7 @@ class Pow(Expr):
         # either b0 is bounded but neither 1 nor 0 or e is infinite
         # b -> b0 + (b - b0) -> b0 * (1 + (b/b0 - 1))
         o2 = order*(b0**-e)
-        z = (b/b0 - 1)
+        z = (b/b0 - 1).simplify()
         o = O(z, x)
         if o is S.Zero or o2 is S.Zero:
             infinite = True

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -529,8 +529,6 @@ def test_issue_18509():
 
 
 def test_issue_18762():
-    from sympy.abc import psi, epsilon
-    g0 = Symbol('g')
-    g0 = sqrt(1 + (epsilon)**2 - 2*(epsilon)*cos(psi))
-    assert str(g0.series(x = epsilon, x0 = 1, n = 3)) == '(epsilon - 1)*(-cos(psi)/sqrt(2 - 2*cos(psi)) + 1/sqrt(2 - 2*cos(psi))) + (epsilon - 1)**2*(-sqrt(2 - 2*cos(psi))*cos(psi)**2/(2*(4*cos(psi)**2 - 8*cos(psi) + 4)) + sqrt(2 - 2*cos(psi))*cos(psi)/(4*cos(psi)**2 - 8*cos(psi) + 4) - sqrt(2 - 2*cos(psi))/(2*(4*cos(psi)**2 - 8*cos(psi) + 4)) + 1/(2*sqrt(2 - 2*cos(psi)))) + sqrt(2 - 2*cos(psi)) + O((epsilon - 1)**3, (epsilon, 1))'
-    assert str(g0.series(x = epsilon, x0 = 0.5, n = 3)) == '(epsilon - 0.5)*(-1.11803398874989*sqrt(1 - 0.8*cos(psi))*cos(psi)/(1.25 - 1.0*cos(psi)) + 0.559016994374947*sqrt(1 - 0.8*cos(psi))/(1.25 - 1.0*cos(psi))) + (epsilon - 0.5)**2*(-0.357770876399966*sqrt(1 - 0.8*cos(psi))*cos(psi)**2/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) + 0.357770876399966*sqrt(1 - 0.8*cos(psi))*cos(psi)/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) - 0.0894427190999916*sqrt(1 - 0.8*cos(psi))/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) + 0.559016994374947*sqrt(1 - 0.8*cos(psi))/(1.25 - 1.0*cos(psi))) + 1.11803398874989*sqrt(1 - 0.8*cos(psi)) + O((epsilon - 0.5)**3, (epsilon, 0.5))'
+    e, p = symbols('e p')
+    g0 = sqrt(1 + e**2 - 2*e*cos(p))
+    assert len(g0.series(e, 1, 3).args) == 4

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -526,3 +526,11 @@ def test_issue_14815():
 def test_issue_18509():
     assert unchanged(Mul, oo, 1/pi**oo)
     assert (1/pi**oo).is_extended_positive == False
+
+
+def test_issue_18762():
+    from sympy.abc import psi, epsilon
+    g0 = Symbol('g')
+    g0 = sqrt(1 + (epsilon)**2 - 2*(epsilon)*cos(psi))
+    assert str(g0.series(x = epsilon, x0 = 1, n = 3)) == '(epsilon - 1)*(-cos(psi)/sqrt(2 - 2*cos(psi)) + 1/sqrt(2 - 2*cos(psi))) + (epsilon - 1)**2*(-sqrt(2 - 2*cos(psi))*cos(psi)**2/(2*(4*cos(psi)**2 - 8*cos(psi) + 4)) + sqrt(2 - 2*cos(psi))*cos(psi)/(4*cos(psi)**2 - 8*cos(psi) + 4) - sqrt(2 - 2*cos(psi))/(2*(4*cos(psi)**2 - 8*cos(psi) + 4)) + 1/(2*sqrt(2 - 2*cos(psi)))) + sqrt(2 - 2*cos(psi)) + O((epsilon - 1)**3, (epsilon, 1))'
+    assert str(g0.series(x = epsilon, x0 = 0.5, n = 3)) == '(epsilon - 0.5)*(-1.11803398874989*sqrt(1 - 0.8*cos(psi))*cos(psi)/(1.25 - 1.0*cos(psi)) + 0.559016994374947*sqrt(1 - 0.8*cos(psi))/(1.25 - 1.0*cos(psi))) + (epsilon - 0.5)**2*(-0.357770876399966*sqrt(1 - 0.8*cos(psi))*cos(psi)**2/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) + 0.357770876399966*sqrt(1 - 0.8*cos(psi))*cos(psi)/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) - 0.0894427190999916*sqrt(1 - 0.8*cos(psi))/(0.64*cos(psi)**2 - 1.6*cos(psi) + 1) + 0.559016994374947*sqrt(1 - 0.8*cos(psi))/(1.25 - 1.0*cos(psi))) + 1.11803398874989*sqrt(1 - 0.8*cos(psi)) + O((epsilon - 0.5)**3, (epsilon, 0.5))'


### PR DESCRIPTION
Fixes: #18762 

#### Brief description of what is fixed or changed
**Previously:**
```
from sympy.abc import psi
e = symbols("epsilon")
g0 = symbols("g", cls=Function)
g0 = sqrt(1 + e**2 - 2* (e)*cos(psi))
g0.series(x=e,x0=1,n=3) or for any x0!=0
```
This was producing **too many terms (almost 100 extra terms)**.

**Now this has been fixed.**




#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
  * Reduces sensitivity of computation of order terms in `Pow._eval_nseries`
<!-- END RELEASE NOTES -->
