### PR TITLE
Remove Python2 Travis stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,6 @@ matrix:
             - gfortran
             - python-scipy
 
-    - stage: test
-      python: 2.7
-      dist: xenial
-      sudo: true
-      env:
-        - TEST_PY2_IMPORT="true"
     - python: 3.7
       dist: xenial
       env:
@@ -257,28 +251,6 @@ install:
   # Once https://github.com/fredrik-johansson/mpmath/pull/403 is in a released
   # version of mpmath remove this line.
   - pip install mpmath
-  # -We:invalid makes invalid escape sequences error in Python 3.6. See
-  # -#12028.
-  # SyntaxWarning flag for catching errors in Python3.8
-  # Issue -  #16973. -We:invalid can be dropped from 3.8 onwards, but
-  # it needs to be there for earlier versions.
-  #
-  # This would fail due to invalid Python 2.7 syntax so we disable it while
-  # testing import under Python 2.
-  - |
-    if [[ -z "${TEST_PY2_IMPORT}" ]]; then
-        if [[ "${TEST_SETUP}" == "true" ]]; then
-          # The install cycle below is to test installation on systems without
-          # setuptools.
-          virtualenv ~/.venv-no-setuptools;
-          ~/.venv-no-setuptools/bin/pip install mpmath;
-          ~/.venv-no-setuptools/bin/pip uninstall -y setuptools;
-          ~/.venv-no-setuptools/bin/python -We:invalid setup.py -q install;
-        fi
-        python -We:invalid -We::SyntaxWarning -m compileall -f -q sympy/;
-        python -We:invalid setup.py -q install;
-        pip list --format=columns;
-    fi
 script:
   # Don't run doctr if the build fails
   - set -e


### PR DESCRIPTION
Per the [1.5.1 release notes](https://github.com/sympy/sympy/wiki/Release-Notes-for-1.5.1) it looks like Python 2, won't be supported in 1.6, maybe this should wait for that release (in case bugs need to be backported to 1.5.X)


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->