### PR TITLE
fix(logic): Check for negated relationals after flattening

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -683,7 +683,7 @@ class And(LatticeOp, BooleanFunction):
         args = LatticeOp._new_args_filter(args, And)
         newargs = []
         rel = set()
-        for x in args:
+        for x in ordered(args):
             if x.is_Relational:
                 c = x.canonical
                 if c in rel:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -679,20 +679,21 @@ class And(LatticeOp, BooleanFunction):
 
     @classmethod
     def _new_args_filter(cls, args):
-        newargs = []
-        rel = []
         args = BooleanFunction.binary_check_and_simplify(*args)
-        for x in reversed(args):
+        args = LatticeOp._new_args_filter(args, And)
+        newargs = []
+        rel = set()
+        for x in args:
             if x.is_Relational:
                 c = x.canonical
                 if c in rel:
                     continue
-                nc = c.negated.canonical
-                if any(r == nc for r in rel):
+                elif c.negated.canonical in rel:
                     return [S.false]
-                rel.append(c)
+                else:
+                    rel.add(c)
             newargs.append(x)
-        return LatticeOp._new_args_filter(newargs, And)
+        return newargs
 
     def _eval_subs(self, old, new):
         args = []

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -20,9 +20,9 @@ from sympy.logic.boolalg import (
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
-from sympy.utilities import cartes
+from sympy.utilities.iterables import cartes
 
-from itertools import combinations
+from itertools import combinations, permutations
 
 A, B, C, D = symbols('A:D')
 a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
@@ -61,6 +61,7 @@ def test_And():
     assert And(e, e.canonical) == e.canonical
     g, l, ge, le = A > B, B < A, A >= B, B <= A
     assert And(g, l, ge, le) == And(ge, g)
+    assert set([And(*i) for i in permutations((l,g,le,ge))]) == {And(ge, g)}
     assert And(And(Eq(a, 0), Eq(b, 0)), And(Ne(a, 0), Eq(c, 0))) is false
 
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -60,7 +60,8 @@ def test_And():
     e = A > 1
     assert And(e, e.canonical) == e.canonical
     g, l, ge, le = A > B, B < A, A >= B, B <= A
-    assert And(g, l, ge, le) == And(l, le)
+    assert And(g, l, ge, le) == And(ge, g)
+    assert And(And(Eq(a, 0), Eq(b, 0)), And(Ne(a, 0), Eq(c, 0))) is false
 
 
 def test_Or():


### PR DESCRIPTION
Previously And(a, b, c, d) would check for negated Relationals like
And(x>1,x<=1) and would flatten nested Ands like And(And(a, b), And(c,
d)). However flattening would happen after checking for negated
Relationals so would miss the negated Relationals in e.g.
And(And(x<1, y>2), And(x>=1, z>2)). This commit ensures that checking
for negated Relationals happens after flattening nested Ands.

On master we have:
```julia
In [2]: a, b = symbols('a, b')                                                                                                                                

In [3]: (Eq(a, 1) & Ne(b, 1)) & (Ne(a, 1) & Eq(b, 2))                                                                                                         
Out[3]: a = 1 ∧ b = 2 ∧ a ≠ 1 ∧ b ≠ 1
```
This PR gives
```julia
In [1]: a, b = symbols('a, b')                                                                                                                                

In [2]: (Eq(a, 1) & Ne(b, 1)) & (Ne(a, 1) & Eq(b, 2))                                                                                                         
Out[2]: False
```

<!-- BEGIN RELEASE NOTES -->
* logic
    * Opposing Relationals are now detected correctly in nested Ands allowing evaluation to False in more cases.
<!-- END RELEASE NOTES -->