### PR TITLE
Fixed documentation(docstring) in FormalPowerSeries

### DIFF
--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1222,10 +1222,10 @@ class FormalPowerSeries(SeriesBase):
         .. math::
             B_{n,k}(x_1, x_2,\dotsc x_{n-k+1}) =
                 \sum_{j_1+j_2+j_2+\dotsb=k \atop j_1+2j_2+3j_2+\dotsb=n}
-                    \frac{n!}{j_1!j_2!\dotsb j_{n-k+1}!}
-                        \left(\frac{x_1}{1!} \right)^{j_1}
-                            \left(\frac{x_2}{2!} \right)^{j_2} \dotsb
-                                \left(\frac{x_{n-k+1}}{(n-k+1)!} \right) ^{j_{n-k+1}}.
+                \frac{n!}{j_1!j_2!\dotsb j_{n-k+1}!}
+                \left(\frac{x_1}{1!} \right)^{j_1}
+                \left(\frac{x_2}{2!} \right)^{j_2} \dotsb
+                \left(\frac{x_{n-k+1}}{(n-k+1)!} \right) ^{j_{n-k+1}}.
 
         * ``bell(n, k, (x1, x2, ...))`` gives Bell polynomials of the second kind,
           `B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})`.

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1219,12 +1219,13 @@ class FormalPowerSeries(SeriesBase):
         The second kind of Bell polynomials (are sometimes called "partial" Bell
         polynomials or incomplete Bell polynomials) are defined as
 
-        .. math:: B_{n,k}(x_1, x_2,\dotsc x_{n-k+1}) =
+        .. math::
+            B_{n,k}(x_1, x_2,\dotsc x_{n-k+1}) =
                 \sum_{j_1+j_2+j_2+\dotsb=k \atop j_1+2j_2+3j_2+\dotsb=n}
                     \frac{n!}{j_1!j_2!\dotsb j_{n-k+1}!}
-                    \left(\frac{x_1}{1!} \right)^{j_1}
-                    \left(\frac{x_2}{2!} \right)^{j_2} \dotsb
-                    \left(\frac{x_{n-k+1}}{(n-k+1)!} \right) ^{j_{n-k+1}}.
+                        \left(\frac{x_1}{1!} \right)^{j_1}
+                            \left(\frac{x_2}{2!} \right)^{j_2} \dotsb
+                                \left(\frac{x_{n-k+1}}{(n-k+1)!} \right) ^{j_{n-k+1}}.
 
         * ``bell(n, k, (x1, x2, ...))`` gives Bell polynomials of the second kind,
           `B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})`.
@@ -1251,8 +1252,7 @@ class FormalPowerSeries(SeriesBase):
         will be as follows.
 
         .. math::
-
-        \sum\limits_{k=0}^{n} b_k B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})
+            \sum\limits_{k=0}^{n} b_k B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})
 
         Parameters
         ==========
@@ -1325,8 +1325,7 @@ class FormalPowerSeries(SeriesBase):
         will be as follows.
 
         .. math::
-
-        \sum\limits_{k=0}^{n} (-1)^{k} x_0^{-k-1} B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})
+            \sum\limits_{k=0}^{n} (-1)^{k} x_0^{-k-1} B_{n,k}(x_1, x_2, \dotsc, x_{n-k+1})
 
         Parameters
         ==========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18808 

#### Brief description of what is fixed or changed
Docstrings for the following function in sympy.series.formal.FormalPowerSeries are fixed (latex):
- coeff_bell
- compose
- inverse

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- series
    - Corrected docstrings related to latex in FormalPowerSeries
<!-- END RELEASE NOTES -->