### PR TITLE
Replaces ast.Name to ast.NameConstant for booleans

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1058,7 +1058,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
                     args=[ast.UnaryOp(op=ast.USub(), operand=ast.Num(1)), right],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1069,7 +1069,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     left = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[left, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1077,7 +1077,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     right = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[right, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1085,7 +1085,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],
-                keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
+                keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load()))],
                 starargs=None,
                 kwargs=None
             )

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1058,7 +1058,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
                     args=[ast.UnaryOp(op=ast.USub(), operand=ast.Num(1)), right],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1069,7 +1069,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     left = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[left, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1077,7 +1077,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                     right = ast.Call(
                     func=ast.Name(id='Pow', ctx=ast.Load()),
                     args=[right, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None
                 )
@@ -1085,7 +1085,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
                 args=[left, right],
-                keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(id='False', ctx=ast.Load()))],
                 starargs=None,
                 kwargs=None
             )


### PR DESCRIPTION
## References to other Issues or PRs

Fixes #18789 — Replace ast.Name to ast.NameConstant for booleans

#### Brief description of what is fixed or changed

If you clone default python and build it without ```-DNDEBUG``` and run something like this:
```
from sympy.parsing.sympy_parser import parse_expr

parse_expr('2*2', False)
``` 
you will get:
```
.../python3/src/Python/compile.c:3173: int compiler_nameop(struct compiler *, identifier, expr_context_ty): Assertion `!_PyUnicode_EqualToASCIIString(name, "None") && !_PyUnicode_EqualToASCIIString(name, "True") && !_PyUnicode_EqualToASCIIString(name, "False")' failed.
```

This occurs due to the ```assert```-block in python source:
https://github.com/python/cpython/blob/master/Python/compile.c#L3526

This issue doesn't happen if you build python with ```-DNDEBUG``` option. But ideologically ```NameConstant``` and ```Name``` are very different things. 

I've tried to replace  this four ```ast.Name(id='False', ...)```  to ```ast.NameConstant(id='False', ...)``` and it completely solved the problem. 

#### Other comments
This fix will work only for python3.* But as @oscarbenjamin says, Python 2 support is already removed in master. The next release will not support Python 2.

Otherwise we should invent a more complex solution. For example:
1) Create a dummy variable ```__False = False```.
2) Put it to ```globals```.
3) Replace ```ast.Name(id='False', ...)``` to  ```ast.Name(id='__False', ...)```.

As I see it, ```NameConstant``` should be used instead of  ```Name``` for ```True``` and ```False```.

## Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->