### PR TITLE
Simplify code, use list comprehensions over maps in ast.py

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -217,10 +217,12 @@ class Token(Basic):
 
         # Process keyword arguments
         for attrname in cls.__slots__[num_args:]:
-            try:
-                argval = kwargs.pop(attrname, cls.defaults[attrname])
-            except KeyError:
-                raise TypeError(f'No value for {attrname} given and attribute has no default')
+            if attrname in kwargs:
+                argval = kwargs.pop(attrname)
+            elif attrname in cls.defaults:
+                argval = cls.defaults[attrname]
+            else:
+                raise TypeError(f"No value for {attrname} given and attribute has no default")
 
             attrvals.append(cls._construct(attrname, argval))
 

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -218,7 +218,7 @@ class Token(Basic):
         # Process keyword arguments
         for attrname in cls.__slots__[num_args:]:
             try:
-                argval = kwargs.get(attrname, cls.defaults[attrname])
+                argval = kwargs.pop(attrname, cls.defaults[attrname])
             except KeyError:
                 raise TypeError(f'No value for {attrname} given and attribute has no default')
 
@@ -275,7 +275,7 @@ class Token(Basic):
         from sympy.printing.printer import printer_context
         exclude = kwargs.get('exclude', ())
         indent_level = printer._context.get('indent_level', 0)
-        joiner = kwargs.get('joiner', ', ')
+        joiner = kwargs.pop('joiner', ', ')
 
         arg_reprs = []
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Using / unrolling list comprehensions is faster than unrolling a map expression in many of the cases I've tested.
This commit also removes an unnecessary list allocations and uses == none instead of == None - which is more obvious, and as a bonus, doesn't violate PEP-8.
I made some minor changes to a few if statements to hopefully make them clearer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->