### PR TITLE
Add `strict=False` option to AssocOp

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -105,11 +105,11 @@ class AssocOp(Basic):
            all. This is best used when you are rebuilding an Add or Mul after
            simply removing one or more args. If, for example, modifications,
            result in extra 1s being inserted (as when collecting an
-           expression's numerators and denominators) they will not show up in
-           the result but a Mul will be returned nonetheless:
+           expression's numerators and denominators) Mul instance with its
+           identity not removed will be returned:
 
                >>> m = (x*y)._new_rawargs(S.One, x); m
-               x
+               1*x
                >>> m == x
                False
                >>> m.is_Mul

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1535,6 +1535,15 @@ def test_suppressed_evaluation():
     assert c.func is Pow
     assert c.args == (3, 2)
 
+def test_suppressed_evaluation_strict():
+    a = Add(0, 3, 2, evaluate=False, strict=True)
+    b = Mul(1, 3, 2, evaluate=False, strict=True)
+    assert a != 6
+    assert a.func is Add
+    assert a.args == (0, 3, 2)
+    assert b != 6
+    assert b.func is Mul
+    assert b.args == (1, 3, 2)
 
 def test_Add_as_coeff_mul():
     # issue 5524.  These should all be (1, self)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1800,6 +1800,8 @@ class PrettyPrinter(Printer):
                     a.append( Rational(item.p) )
                 if item.q != 1:
                     b.append( Rational(item.q) )
+                if item == 1:
+                    a.append( item )
             else:
                 a.append(item)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -310,6 +310,8 @@ class StrPrinter(Printer):
                     a.append(Rational(item.p))
                 if item.q != 1:
                     b.append(Rational(item.q))
+                if item == 1:
+                    a.append( item )
             else:
                 a.append(item)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This PR allows the behavior proposed in #13188

#### Brief description of what is fixed or changed
By passing `evaluate=False` and `strict=True`, one can keep identities in `AssocOp` instances.  
For example,
```python
>>> from sympy import Add
>>> from sympy.abc import x
>>> Add(x,x,0, evaluate=True) # flattened
2*x
>>> Add(x,x,0, evaluate=False) # not flattened, but 0 is removed
x + x
>>> Add(x,x,0, evaluate=False, strict=True) # not flattened and 0 is not removed
x + x + 0
```

#### Other comments
Although #13188 suggested that passing only `evaluate=False` keep `cls.identity`, I decided to introduce another option (`strict`) because:
1. Changing the behavior of `evaluate=False` affects everything too much, and may lead to compatibility issue.
2. One might want not to flatten the arguments but still remove the identities.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- core
    - `strict` option is added to `AssocOps`, which determines whether to remove `cls.identity` from the arguments or not.

<!-- END RELEASE NOTES -->