### PR TITLE
Improve free_symbols method in Point class

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -403,7 +403,6 @@ class Point(Basic):
 
     @property
     def free_symbols(self):
-        raise NotImplementedError
         return self._coords.free_symbols
 
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -48,7 +48,7 @@ def test_R3():
 def test_point():
     x, y = symbols('x, y')
     p = R2_r.point([x, y])
-    #TODO assert p.free_symbols() == set([x, y])
+    assert p.free_symbols == {x, y}
     assert p.coords(R2_r) == p.coords() == Matrix([x, y])
     assert p.coords(R2_p) == Matrix([sqrt(x**2 + y**2), atan2(y, x)])
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
Before: 
```
>>> from sympy.diffgeom.rn import R2_r
>>> from sympy.abc import x, y
>>> p = R2_r.point([x, y])
>>> p.free_symbols()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/namannimmo/sympy/sympy/diffgeom/diffgeom.py", line 406, in free_symbols
    raise NotImplementedError
NotImplementedError
```

After:
```
>>> p.free_symbols
{y, x}
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->