### PR TITLE
Make doit(deep=False) of Add and Mul return evaluated result

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -375,6 +375,13 @@ class AssocOp(Basic):
         else:
             return (sympify(expr),)
 
+    def doit(self, **hints):
+        if hints.get('deep', True):
+            terms = [term.doit(**hints) if isinstance(term, Basic) else term
+                                         for term in self.args]
+        else:
+            terms = self.args
+        return self.func(*terms, evaluate=True)
 
 class ShortCircuit(Exception):
     pass

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -377,8 +377,7 @@ class AssocOp(Basic):
 
     def doit(self, **hints):
         if hints.get('deep', True):
-            terms = [term.doit(**hints) if isinstance(term, Basic) else term
-                                         for term in self.args]
+            terms = [term.doit(**hints) for term in self.args]
         else:
             terms = self.args
         return self.func(*terms, evaluate=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1535,6 +1535,19 @@ def test_suppressed_evaluation():
     assert c.func is Pow
     assert c.args == (3, 2)
 
+def test_AssocOp_doit():
+    a = Add(x,x, evaluate=False)
+    b = Mul(y,y, evaluate=False)
+    c = Add(b,b, evaluate=False)
+    d = Mul(a,a, evaluate=False)
+    assert c.doit(deep=False).func == Mul
+    assert c.doit(deep=False).args == (2,y,y)
+    assert c.doit().func == Mul
+    assert c.doit().args == (2, Pow(y,2))
+    assert d.doit(deep=False).func == Pow
+    assert d.doit(deep=False).args == (a, 2*S.One)
+    assert d.doit().func == Mul
+    assert d.doit().args == (4*S.One, Pow(x,2))
 
 def test_Add_as_coeff_mul():
     # issue 5524.  These should all be (1, self)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Partial fix for #17280
Partial fix for #18837

#### Brief description of what is fixed or changed

`doit(deep=False)` on `Add` and `Mul` now returns evaluated result.

```python
>>> from sympy import Add, Mul
>>> from sympy.abc import x
>>> Add(x, x, evaluate=False).doit(deep=False)
2*x
>>> Mul(x, x, evaluate=False).doit(deep=False)
x**2
```


#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `doit(deep=False)` now evaluates `Add` and `Mul`.
<!-- END RELEASE NOTES -->