### PR TITLE
Fixed an error with coefficient in rsolve function

### DIFF
--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -66,7 +66,6 @@ from sympy.matrices import Matrix, casoratian
 from sympy.concrete import product
 from sympy.core.compatibility import default_sort_key
 from sympy.utilities.iterables import numbered_symbols
-from sympy.core.basic import preorder_traversal
 
 
 def rsolve_poly(coeffs, f, n, **hints):
@@ -728,7 +727,7 @@ def rsolve(f, y, init=None):
         coeff = S.One
         kspec = None
         for h in Mul.make_args(g):
-            if y.func not in map(lambda x: x.func, preorder_traversal(h)):
+            if not h.has(y.func):
                 coeff *= h
             elif h.is_Function and h.func == y.func:
                 result = h.args[0].match(n + k)
@@ -753,7 +752,7 @@ def rsolve(f, y, init=None):
     common = S.One
 
     if not i_part.is_zero and not i_part.is_hypergeometric(n) and \
-       not (i_part.is_Add and all(map(lambda x: i_part.is_hypergeometric(n), f.expand().args))):
+       not (i_part.is_Add and all(map(lambda x: x.is_hypergeometric(n), f.expand().args))):
         raise ValueError("The independent term should be a sum of hypergeometric functions, got '%s'" % i_part)
 
     for coeff in h_part.values():

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -752,7 +752,7 @@ def rsolve(f, y, init=None):
     common = S.One
 
     if not i_part.is_zero and not i_part.is_hypergeometric(n) and \
-       not (i_part.is_Add and all(map(lambda x: x.is_hypergeometric(n), f.expand().args))):
+       not (i_part.is_Add and all(map(lambda x: x.is_hypergeometric(n), i_part.expand().args))):
         raise ValueError("The independent term should be a sum of hypergeometric functions, got '%s'" % i_part)
 
     for coeff in h_part.values():

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -729,7 +729,7 @@ def rsolve(f, y, init=None):
             i_part.append(coeff)
             continue
         for h in dep:
-             if h.is_Function and h.func == y.func:
+            if h.is_Function and h.func == y.func:
                 result = h.args[0].match(n + k)
                 if result is not None:
                     h_part[int(result[k])].append(coeff)
@@ -738,6 +738,7 @@ def rsolve(f, y, init=None):
                 "'%s(%s + k)' expected, got '%s'" % (y.func, n, h))
     for k in h_part:
         h_part[k] = Add(*h_part[k])
+    h_part.default_factory = lambda: 0
     i_part = Add(*i_part)
 
     for k, coeff in h_part.items():

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -1,5 +1,5 @@
 from sympy import Eq, factorial, Function, Lambda, rf, S, sqrt, symbols, I, \
-    expand_func, binomial, gamma, Rational
+    expand_func, binomial, gamma, Rational, Symbol, cos, sin, Abs
 from sympy.solvers.recurr import rsolve, rsolve_hyper, rsolve_poly, rsolve_ratio
 from sympy.testing.pytest import raises, slow
 from sympy.abc import a, b
@@ -202,6 +202,16 @@ def test_issue_6844():
     f = y(n + 2) - y(n + 1) + y(n)/4
     assert rsolve(f, y(n)) == 2**(-n)*(C0 + C1*n)
     assert rsolve(f, y(n), {y(0): 0, y(1): 1}) == 2*2**(-n)*n
+
+
+def test_issue_18751():
+    n = Symbol('n', integer=True)
+    y = Function('y')
+    r = Symbol('r', real=True, positive=True)
+    theta = Symbol('theta', real=True)
+    f = y(n) - 2 * r * cos(theta) * y(n - 1) + r**2 * y(n - 2)
+    assert rsolve(f, y(n)) == \
+        C0*(r*(cos(theta) - I*Abs(sin(theta))))**n + C1*(r*(cos(theta) + I*Abs(sin(theta))))**n
 
 
 @slow

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -205,8 +205,6 @@ def test_issue_6844():
 
 
 def test_issue_18751():
-    n = Symbol('n', integer=True)
-    y = Function('y')
     r = Symbol('r', real=True, positive=True)
     theta = Symbol('theta', real=True)
     f = y(n) - 2 * r * cos(theta) * y(n - 1) + r**2 * y(n - 2)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -188,6 +188,8 @@ def test_rsolve():
     assert (rsolve((k + 1)*y(k) + (k + 3)*y(k + 1) + (k + 5)*y(k + 2), y(k))
             is None)
 
+    assert rsolve(y(n) + y(n + 1) + 2**n + 3**n, y(n)) == (-1)**n*C0 - 2**n/3 - 3**n/4
+
 
 def test_rsolve_raises():
     x = Function('x')
@@ -196,6 +198,7 @@ def test_rsolve_raises():
     raises(ValueError, lambda: rsolve(y(n) - x(n + 1), y(n)))
     raises(ValueError, lambda: rsolve(y(n) - sqrt(n)*y(n + 1), y(n)))
     raises(ValueError, lambda: rsolve(y(n) - y(n + 1), y(n), {x(0): 0}))
+    raises(ValueError, lambda: rsolve(y(n) + y(n + 1) + 2**n + cos(n), y(n)))
 
 
 def test_issue_6844():


### PR DESCRIPTION
#### References to other Issues or PRs

This PR fixed issue #18751.

#### Brief description of what is fixed or changed

There is a problem with passing equations like `f(n) - sin(a)f(n-1)-cos(b)f(n-2)=0` to rsolve function. The current logic of checking parameters doesn't allow them to be of type Function. I changed slightly that logic. I also added a check for the independent term of the equation and a test.

#### Other comments

It is my first contribution to SymPy, so please tell if I did something completely wrong :smile:

#### Release notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
