### PR TITLE
raise error if seq change is detected in uniq

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2091,9 +2091,10 @@ def uniq(seq, result=None):
     parameter ``result``  is used internally; it is not necessary
     to pass anything for this.
 
-    Note: changing the sequence during iteration will change the
-    output or raise a RuntimeError (when not dealing with an
-    iterator whose length is not known).
+    Note: changing the sequence during iteration will raise a
+    RuntimeError if the size of the sequence is known; if you pass
+    an iterator and advance the iterator you will change the
+    output of this routine but there will be no warning.
 
     Examples
     ========

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2088,8 +2088,12 @@ def has_variety(seq):
 def uniq(seq, result=None):
     """
     Yield unique elements from ``seq`` as an iterator. The second
-    parameter ``result``  is used internally; it is not necessary to pass
-    anything for this.
+    parameter ``result``  is used internally; it is not necessary
+    to pass anything for this.
+
+    Note: changing the sequence during iteration will change the
+    output or raise a RuntimeError (when not dealing with an
+    iterator whose length is not known).
 
     Examples
     ========
@@ -2107,14 +2111,26 @@ def uniq(seq, result=None):
     [[1], [2, 1]]
     """
     try:
+        n = len(seq)
+    except TypeError:
+        n = None
+    def check():
+        # check that size of seq did not change during iteration;
+        # if n == None the object won't support size changing, e.g.
+        # an iterator can't be changed
+        if n is not None and len(seq) != n:
+            raise RuntimeError('sequence changed size during iteration')
+    try:
         seen = set()
         result = result or []
         for i, s in enumerate(seq):
             if not (s in seen or seen.add(s)):
                 yield s
+                check()
     except TypeError:
         if s not in result:
             yield s
+            check()
             result.append(s)
         if hasattr(seq, '__getitem__'):
             for s in uniq(seq[i + 1:], result):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -703,6 +703,10 @@ def test_uniq():
         [([1], 2, 2), (2, [1], 2), (2, 2, [1])]
     assert list(uniq([2, 3, 2, 4, [2], [1], [2], [3], [1]])) == \
         [2, 3, 4, [2], [1], [3]]
+    f = [1]
+    raises(RuntimeError, lambda: [f.remove(i) for i in uniq(f)])
+    f = [[1]]
+    raises(RuntimeError, lambda: [f.remove(i) for i in uniq(f)])
 
 
 def test_kbins():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #18832 

#### Brief description of what is fixed or changed

When easily detectable, [Python raises an error](https://stackoverflow.com/a/50167042/1089161) when an item being iterated over is changed and would thus cause the iteration to fail.

When iterating over the unique elements of an iterable as detected by `uniq`, changing the iterable during iteration will cause a failure in `uniq` to detect the unique elements. It is not clear that `uniq` will do this so an error is now raised in the cases when this is easy to detect and a note is added to the docstring.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * iterables - `uniq` will now raise a RuntimeError if a size change of the sequence is detected
<!-- END RELEASE NOTES -->