### PR TITLE
Function to return Total Energy in physics/mechanics

### DIFF
--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -226,6 +226,33 @@ class Particle(object):
         """
 
         self._pe = sympify(scalar)
+    
+    def total_energy(self, frame):
+        """The total energy of the Particle.
+        The total energy, E, of a particle, P, is given by
+        'E = K.E + P.E.'
+        where P.E. is the potential energy of the particle P, and
+        K.E. is kinetic energy of the particle P, in the supplied ReferenceFrame.
+        Parameters
+        ==========
+        frame : ReferenceFrame
+            The Particle's velocity is typically defined with respect to
+            an inertial frame but any relevant frame in which the velocity is
+            known can be supplied.
+        Examples
+        ========
+        >>> from sympy.physics.mechanics import Particle, Point, ReferenceFrame
+        >>> from sympy import symbols
+        >>> m, v, r, g, h = symbols('m v r g h')
+        >>> N = ReferenceFrame('N')
+        >>> O = Point('O')
+        >>> P = Particle('P', O, m)
+        >>> P.point.set_vel(N, v * N.y)
+        >>> P.potential_energy = m * g * h
+        >>> P.total_energy(N)
+        g*h*m + m*v**2/2
+        """
+        return self.kinetic_energy(frame) + self.potential_energy
 
     def set_potential_energy(self, scalar):
         SymPyDeprecationWarning(

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.backend import sympify
-from sympy.physics.vector import Point
+from sympy.physics.vector import Point, dot
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -180,7 +180,7 @@ class Particle(object):
 
         """
 
-        return (self.mass / sympify(2) * self.point.vel(frame) &
+        return dot(self.mass / sympify(2) * self.point.vel(frame),
                 self.point.vel(frame))
 
     @property

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -226,7 +226,7 @@ class Particle(object):
         """
 
         self._pe = sympify(scalar)
-    
+
     def total_energy(self, frame):
         """The total energy of the Particle.
         The total energy, E, of a particle, P, is given by

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -228,19 +228,24 @@ class Particle(object):
         self._pe = sympify(scalar)
 
     def total_energy(self, frame):
-        """The total energy of the Particle.
+        """
+        The total energy of the Particle.
         The total energy, E, of a particle, P, is given by
         'E = K.E + P.E.'
         where P.E. is the potential energy of the particle P, and
         K.E. is kinetic energy of the particle P, in the supplied ReferenceFrame.
+
         Parameters
         ==========
+
         frame : ReferenceFrame
             The Particle's velocity is typically defined with respect to
             an inertial frame but any relevant frame in which the velocity is
             known can be supplied.
+ 
         Examples
         ========
+
         >>> from sympy.physics.mechanics import Particle, Point, ReferenceFrame
         >>> from sympy import symbols
         >>> m, v, r, g, h = symbols('m v r g h')

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -201,7 +201,7 @@ class RigidBody(object):
         v = self.masscenter.vel(frame)
 
         return I.dot(w) + r.cross(m * v)
-    
+
     def rotational_kinetic_energy(self, frame):
         """Rotational kinetic energy of the rigid body
         The rotational kinetic energy, T, of a rigid body, B, is given by
@@ -235,7 +235,7 @@ class RigidBody(object):
 
         return dot(self.frame.ang_vel_in(frame), dot(self.central_inertia,
                 self.frame.ang_vel_in(frame)) / sympify(2))
-    
+
     def translational_kinetic_energy(self, frame):
         """Translational kinetic energy of the rigid body
         The translational kinetic energy, T, of a rigid body, B, is given by
@@ -359,7 +359,7 @@ class RigidBody(object):
         """
 
         self._pe = sympify(scalar)
-    
+
     def total_energy(self, frame):
         """The total energy of the RigidBody.
         The total energy E, of rigidbody B, is given by

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.backend import sympify
-from sympy.physics.vector import Point, ReferenceFrame, Dyadic
+from sympy.physics.vector import Point, ReferenceFrame, Dyadic, dot
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -241,7 +241,7 @@ class RigidBody(object):
 
         """
 
-        rotational_KE = (self.frame.ang_vel_in(frame) & (self.central_inertia &
+        rotational_KE = dot(self.frame.ang_vel_in(frame), dot(self.central_inertia,
                 self.frame.ang_vel_in(frame)) / sympify(2))
 
         translational_KE = (self.mass * (self.masscenter.vel(frame) &

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -203,20 +203,25 @@ class RigidBody(object):
         return I.dot(w) + r.cross(m * v)
 
     def rotational_kinetic_energy(self, frame):
-        """Rotational kinetic energy of the rigid body
+        """
+        Rotational kinetic energy of the rigid body
         The rotational kinetic energy, T, of a rigid body, B, is given by
         'T = 1/2 (I omega^2)'
         where I is the central inertia dyadic of rigid body B,
         omega is the angular velocity of the body's
         mass center in the supplied ReferenceFrame.
+
         Parameters
-        ==========
+        =========
+
         frame : ReferenceFrame
             The RigidBody's angular velocity and the velocity of it's mass
             center are typically defined with respect to an inertial frame but
             any relevant frame in which the velocities are known can be supplied.
+
         Examples
         ========
+
         >>> from sympy.physics.mechanics import Point, ReferenceFrame, outer
         >>> from sympy.physics.mechanics import RigidBody
         >>> from sympy import symbols
@@ -232,24 +237,28 @@ class RigidBody(object):
         >>> B.rotational_kinetic_energy(N)
         omega**2/2
         """
-
         return dot(self.frame.ang_vel_in(frame), dot(self.central_inertia,
                 self.frame.ang_vel_in(frame)) / sympify(2))
 
     def translational_kinetic_energy(self, frame):
-        """Translational kinetic energy of the rigid body
+        """
+        Translational kinetic energy of the rigid body
         The translational kinetic energy, T, of a rigid body, B, is given by
         'T = 1/2 (m v^2)'
         where m is the mass of rigid body B, v is the velocity of the body's
         mass center in the supplied ReferenceFrame.
+
         Parameters
-        ==========
+        =========
+
         frame : ReferenceFrame
             The RigidBody's angular velocity and the velocity of it's mass
             center are typically defined with respect to an inertial frame but
             any relevant frame in which the velocities are known can be supplied.
+
         Examples
         ========
+
         >>> from sympy.physics.mechanics import Point, ReferenceFrame, outer
         >>> from sympy.physics.mechanics import RigidBody
         >>> from sympy import symbols
@@ -265,7 +274,6 @@ class RigidBody(object):
         >>> B.translational_kinetic_energy(N)
         M*v**2/2
         """
-
         return (self.mass * dot(self.masscenter.vel(frame), self.masscenter.vel(frame)) / sympify(2))
 
     def kinetic_energy(self, frame):
@@ -361,19 +369,24 @@ class RigidBody(object):
         self._pe = sympify(scalar)
 
     def total_energy(self, frame):
-        """The total energy of the RigidBody.
+        """
+        The total energy of the RigidBody.
         The total energy E, of rigidbody B, is given by
         E = K.E. + P.E.
         where P.E. is the potential energy of the rigid body B and
         K.E. is kinetic energy of the rigid body B in the supplied ReferenceFrame.
+
         Parameters
         ==========
+
         frame : ReferenceFrame
             The RigidBody's angular velocity and the velocity of it's mass
             center are typically defined with respect to an inertial frame but
             any relevant frame in which the velocities are known can be supplied.
+
         Examples
         ========
+
         >>> from sympy.physics.mechanics import RigidBody, Point, outer, ReferenceFrame
         >>> from sympy import symbols
         >>> M, v, r, omega, g, h = symbols('M v r omega g h')

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -38,6 +38,8 @@ def test_particle():
     assert p.angular_momentum(O, N) == m2 * r * (v3 * N.x - v1 * N.z)
     p.potential_energy = m * g * h
     assert p.potential_energy == m * g * h
+    assert p.total_energy(
+        N) == m*g*h + m2 * v1**2 / 2 + m2 * v2**2 / 2 + m2 * v3**2 / 2
     # TODO make the result not be system-dependent
     assert p.kinetic_energy(
         N) in [m2*(v1**2 + v2**2 + v3**2)/2,

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -60,7 +60,10 @@ def test_rigidbody2():
     assert B.angular_momentum(O, N) == omega * b.x - M*v*r*b.z
     B.potential_energy = M * g * h
     assert B.potential_energy == M * g * h
+    assert expand(2 * B.translational_kinetic_energy(N)) == M * v**2
+    assert expand(2 * B.rotational_kinetic_energy(N)) == omega**2
     assert expand(2 * B.kinetic_energy(N)) == omega**2 + M * v**2
+    assert B.total_energy(N) == M * g * h + M * v**2/2 + omega**2/2
 
 def test_rigidbody3():
     q1, q2, q3, q4 = dynamicsymbols('q1:5')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Fixes #16201 
Closes #16202

#### Brief description of what is fixed or changed
At present, we have function to get the kinetic energy and potential energy of rigid body, but we do not have any function to give the total energy of the rigid body. This PR adds a function under ```sympy/physics/mechanics/rigidbody.py``` to return the total energy of the body. 
I have defined total_energy = kinetic_energy + potential_energy

#### Other comments
Please review it and comment your suggestions.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.mechanics
    * added functions total_energy, rotational_kinetic_energy, and translational_kinetic_energy, in rigidbody.py
    * added function total_energy in particle.py


<!-- END RELEASE NOTES -->
