### PR TITLE
Make Add and Mul call _matches_commutative correctly

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -416,7 +416,7 @@ class Add(Expr, AssocOp):
         return
 
     def matches(self, expr, repl_dict={}, old=False):
-        return AssocOp._matches_commutative(self, expr, repl_dict, old)
+        return self._matches_commutative(expr, repl_dict, old)
 
     @staticmethod
     def _combine_inverse(lhs, rhs):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -955,7 +955,7 @@ class Mul(Expr, AssocOp):
     def matches(self, expr, repl_dict={}, old=False):
         expr = sympify(expr)
         if self.is_commutative and expr.is_commutative:
-            return AssocOp._matches_commutative(self, expr, repl_dict, old)
+            return self._matches_commutative(expr, repl_dict, old)
         elif self.is_commutative is not expr.is_commutative:
             return None
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`Mul.matches` and `Add.matches` now call `self._matches_commutative([...])`, instead of `AssocOp._matches_commutative(self, [...])`.

#### Other comments
Since `_matches_commutative` is instance method, this is the right way to call another method. It makes their subclasses able to define new `_matches_commutative` to change matching behavior.

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->