### PR TITLE
Fix-#6601

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -8,7 +8,7 @@ from .compatibility import reduce, is_sequence
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
-from .operations import AssocOp
+from .exprtools import AssocOp
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -9,7 +9,7 @@ from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal
 from sympy.core.expr import Expr
 from sympy.core.sympify import sympify
-from sympy.core.numbers import Rational, Integer, Number, I
+from sympy.core.numbers import Rational, Integer, Number , I
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.coreerrors import NonCommutativeExpression
@@ -210,6 +210,137 @@ def _monotonic_sign(self):
         if v.is_nonpositive and rv.is_negative:
             return rv.subs(_eps, 0)
 
+# edited1
+
+    def _matches_commutative(self, expr, repl_dict={}, old=False):
+        """
+        Matches Add/Mul "pattern" to an expression "expr".
+
+        repl_dict ... a dictionary of (wild: expression) pairs, that get
+                      returned with the results
+
+        This function is the main workhorse for Add/Mul.
+
+        For instance:
+
+        >>> from sympy import symbols, Wild, sin
+        >>> a = Wild("a")
+        >>> b = Wild("b")
+        >>> c = Wild("c")
+        >>> x, y, z = symbols("x y z")
+        >>> (a+sin(b)*c)._matches_commutative(x+sin(y)*z)
+        {a_: x, b_: y, c_: z}
+
+        In the example above, "a+sin(b)*c" is the pattern, and "x+sin(y)*z" is
+        the expression.
+
+        The repl_dict contains parts that were already matched. For example
+        here:
+
+        >>> (x+sin(b)*c)._matches_commutative(x+sin(y)*z, repl_dict={a: x})
+        {a_: x, b_: y, c_: z}
+
+        the only function of the repl_dict is to return it in the
+        result, e.g. if you omit it:
+
+        >>> (x+sin(b)*c)._matches_commutative(x+sin(y)*z)
+        {b_: y, c_: z}
+
+        the "a: x" is not returned in the result, but otherwise it is
+        equivalent.
+
+        """
+        # make sure expr is Expr if pattern is Expr
+        from .expr import Add, Expr
+        from sympy import Mul
+        if isinstance(self, Expr) and not isinstance(expr, Expr):
+            return None
+
+        # handle simple patterns
+        if self == expr:
+            return repl_dict
+
+        d = self._matches_simple(expr, repl_dict)
+        if d is not None:
+            return d
+
+        # eliminate exact part from pattern: (2+a+w1+w2).matches(expr) -> (w1+w2).matches(expr-a-2)
+        from .function import WildFunction
+        from .symbol import Wild
+        wild_part, exact_part = sift(self.args, lambda p:
+            p.has(Wild, WildFunction) and not expr.has(p),
+            binary=True)
+        if not exact_part:
+            wild_part = list(ordered(wild_part))
+        else:
+            exact = self._new_rawargs(*exact_part)
+            free = expr.free_symbols
+            if free and (exact.free_symbols - free):
+                # there are symbols in the exact part that are not
+                # in the expr; but if there are no free symbols, let
+                # the matching continue
+                return None
+            newexpr = self._combine_inverse(expr, exact)
+            if not old and (expr.is_Add or expr.is_Mul):
+                if newexpr.count_ops() > expr.count_ops():
+                    return None
+            newpattern = self._new_rawargs(*wild_part)
+            return newpattern.matches(newexpr, repl_dict)
+
+        # now to real work ;)
+        i = 0
+        saw = set()
+        while expr not in saw:
+            saw.add(expr)
+            expr_list = (self.identity,) + tuple(ordered(self.make_args(expr)))
+            for last_op in reversed(expr_list):
+                for w in reversed(wild_part):
+                    d1 = w.matches(last_op, repl_dict)
+                    if d1 is not None:
+                        d2 = self.xreplace(d1).matches(expr, d1)
+                        if d2 is not None:
+                            return d2
+
+            if i == 0:
+                if self.is_Mul:
+                    # make e**i look like Mul
+                    if expr.is_Pow and expr.exp.is_Integer:
+                        if expr.exp > 0:
+                            expr = Mul(*[expr.base, expr.base**(expr.exp - 1)], evaluate=False)
+                        else:
+                            expr = Mul(*[1/expr.base, expr.base**(expr.exp + 1)], evaluate=False)
+                        i += 1
+                        continue
+
+                elif self.is_Add:
+                    # make i*e look like Add
+                    c, e = expr.as_coeff_Mul()
+                    if abs(c) > 1:
+                        if c > 0:
+                            expr = Add(*[e, (c - 1)*e], evaluate=False)
+                        else:
+                            expr = Add(*[-e, (c + 1)*e], evaluate=False)
+                        i += 1
+                        continue
+
+                    # try collection on non-Wild symbols
+                    from sympy.simplify.radsimp import collect
+                    was = expr
+                    did = set()
+                    for w in reversed(wild_part):
+                        c, w = w.as_coeff_mul(Wild)
+                        free = c.free_symbols - did
+                        if free:
+                            did.update(free)
+                            expr = collect(expr, free)
+                    if expr != was:
+                        i += 0
+                        continue
+
+                break  # if we didn't continue, there is nothing more to do
+
+        return
+#edited1 end
 
 def decompose_power(expr):
     """

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -7,7 +7,7 @@ import operator
 from .sympify import sympify
 from .basic import Basic
 from .singleton import S
-from .operations import AssocOp
+from .exprtools import AssocOp
 from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -142,7 +142,7 @@ class AssocOp(Basic):
 
         # c_part, nc_part, order_symbols
         return [], new_seq, None
-
+'''
     def _matches_commutative(self, expr, repl_dict={}, old=False):
         """
         Matches Add/Mul "pattern" to an expression "expr".
@@ -271,7 +271,7 @@ class AssocOp(Basic):
                 break  # if we didn't continue, there is nothing more to do
 
         return
-
+'''
     def _has_matcher(self):
         """Helper for .has()"""
         def _ncsplit(expr):
@@ -301,6 +301,7 @@ class AssocOp(Basic):
                                 return True
             return False
         return is_in
+
 
     def _eval_evalf(self, prec):
         """


### PR DESCRIPTION
<!-- Move _matches_commutative out of AssocOp -->
# Move _matches_commutative out of AssocOp
#### References to other Issues or PRs
<!-- PR : Fixes #6601 -->
PR: Fixes #6601 


I have commented  _matches_commutative from AssocOp and use that file in exprtools.py


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->