### PR TITLE
Modify doit method of Application

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -354,7 +354,7 @@ class Application(Basic, metaclass=FunctionClass):
             args = [a.doit(**hints) for a in self.args]
         else:
             args = self.args
-        return self.func(*self.args, evaluate=True)
+        return self.func(*args, evaluate=True)
 
 class Function(Application, Expr):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -348,6 +348,13 @@ class Application(Basic, metaclass=FunctionClass):
             old == self.func and len(self.args) in new.nargs):
             return new(*[i._subs(old, new) for i in self.args])
 
+    def doit(self, **hints):
+        deep = hints.get('deep', True)
+        if deep:
+            args = [a.doit(**hints) for a in self.args]
+        else:
+            args = self.args
+        return self.func(*self.args, evaluate=True)
 
 class Function(Application, Expr):
     """

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -547,6 +547,16 @@ def test_function__eval_nseries():
 
 
 def test_doit():
+
+    class F(Function):
+        @classmethod
+        def eval(self, x):
+            return x
+
+    Fdx = F(Derivative(x,x), evaluate=False)
+    assert Fdx.doit(deep=False) == Derivative(x,x)
+    assert Fdx.doit() == 1
+
     n = Symbol('n', integer=True)
     f = Sum(2 * n * x, (n, 1, 3))
     d = Derivative(f, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #18837

#### Brief description of what is fixed or changed
`doit(deep=False)` now evaluates `Application` (such as `Function`).

#### Other comments
This applies to `Min` and `Max`, which subclass `Application`, but not `BooleanFunction` such as `And` and `Or`.  
Whether these `And` and `Or` should take `evaluate` option needs more discussion.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->