### PR TITLE
Fix incorrect mod function printing (thus lambdification) and incorrect parenthesizing of fractions

### DIFF
--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -81,10 +81,10 @@ Here is another simple example of printing a C version of a SymPy expression::
     ────────
       2⋅r
     >>> ccode(expr)
-    -1.0/2.0*Z*pow(e, 2)*k/r
+    -(1.0/2.0)*Z*pow(e, 2)*k/r
     >>> from sympy.codegen.ast import real, float80
     >>> ccode(expr, assign_to="E", type_aliases={real: float80})
-    E = -1.0L/2.0L*Z*powl(e, 2)*k/r;
+    E = -(1.0L/2.0L)*Z*powl(e, 2)*k/r;
 
 To generate code with some math functions provided by e.g. the C99 standard we need
 to import functions from :mod:`sympy.codegen.cfunctions`::

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -187,19 +187,19 @@ An example where line wrapping is required:
 
     >>> expr = sqrt(1-x**2).series(x,n=20).removeO()
     >>> print(fcode(expr))
-        -715.0d0/65536.0d0*x**18 - 429.0d0/32768.0d0*x**16 - 33.0d0/
-        @ 2048.0d0*x**14 - 21.0d0/1024.0d0*x**12 - 7.0d0/256.0d0*x**10 -
-        @ 5.0d0/128.0d0*x**8 - 1.0d0/16.0d0*x**6 - 1.0d0/8.0d0*x**4 - 1.0d0
-        @ /2.0d0*x**2 + 1
+        -(715.0d0/65536.0d0)*x**18 - (429.0d0/32768.0d0)*x**16 - (33.0d0/
+        @ 2048.0d0)*x**14 - (21.0d0/1024.0d0)*x**12 - (7.0d0/256.0d0)*x**10
+        @ - (5.0d0/128.0d0)*x**8 - (1.0d0/16.0d0)*x**6 - (1.0d0/8.0d0)*x**4
+        @ - (1.0d0/2.0d0)*x**2 + 1
 
 In case of line wrapping, it is handy to include the assignment so that lines
 are wrapped properly when the assignment part is added.
 
     >>> print(fcode(expr, assign_to="var"))
-          var = -715.0d0/65536.0d0*x**18 - 429.0d0/32768.0d0*x**16 - 33.0d0/
-         @ 2048.0d0*x**14 - 21.0d0/1024.0d0*x**12 - 7.0d0/256.0d0*x**10 -
-         @ 5.0d0/128.0d0*x**8 - 1.0d0/16.0d0*x**6 - 1.0d0/8.0d0*x**4 - 1.0d0
-         @ /2.0d0*x**2 + 1
+          var = -(715.0d0/65536.0d0)*x**18 - (429.0d0/32768.0d0)*x**16 - (
+         @ 33.0d0/2048.0d0)*x**14 - (21.0d0/1024.0d0)*x**12 - (7.0d0/256.0d0
+         @ )*x**10 - (5.0d0/128.0d0)*x**8 - (1.0d0/16.0d0)*x**6 - (1.0d0/
+         @ 8.0d0)*x**4 - (1.0d0/2.0d0)*x**2 + 1
 
 For piecewise functions, the ``assign_to`` option is mandatory:
 

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -171,7 +171,7 @@ def test_create_expand_pow_optimization():
     assert cc(x**(-4)) == '1.0/(x*x*x*x)'
     assert cc(x**(-5)) == 'pow(x, -5)'
     assert cc(-x**4) == '-(x*x*x*x)'
-    assert cc(x**4 - x**2) == '-x*x + x*x*x*x'
+    assert cc(x**4 - x**2) == '-(x*x) + x*x*x*x'
     i = Symbol('i', integer=True)
     assert cc(x**i - x**2) == 'pow(x, i) - x*x'
 

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -170,7 +170,7 @@ def test_create_expand_pow_optimization():
     # gh issue 15335
     assert cc(x**(-4)) == '1.0/(x*x*x*x)'
     assert cc(x**(-5)) == 'pow(x, -5)'
-    assert cc(-x**4) == '-x*x*x*x'
+    assert cc(-x**4) == '-(x*x*x*x)'
     assert cc(x**4 - x**2) == '-x*x + x*x*x*x'
     i = Symbol('i', integer=True)
     assert cc(x**i - x**2) == 'pow(x, i) - x*x'

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -464,7 +464,7 @@ class CodePrinter(StrPrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
+        #pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
@@ -478,8 +478,8 @@ class CodePrinter(StrPrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
-                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                        pow_paren.append(item)
+                    #if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
+                    #    pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             else:
                 a.append(item)
@@ -490,9 +490,9 @@ class CodePrinter(StrPrinter):
         b_str = [self.parenthesize(x, prec) for x in b]
 
         # To parenthesize Pow with exp = -1 and having more than one Symbol
-        for item in pow_paren:
-            if item.base in b:
-                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
+        #for item in pow_paren:
+        #    if item.base in b:
+        #        b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if not b:
             return sign + '*'.join(a_str)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -464,8 +464,6 @@ class CodePrinter(StrPrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        #pow_paren = []  # Will collect all pow with more than one base element and exp = -1
-
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -478,8 +476,6 @@ class CodePrinter(StrPrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
-                    #if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                    #    pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             else:
                 a.append(item)
@@ -488,11 +484,6 @@ class CodePrinter(StrPrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
-
-        # To parenthesize Pow with exp = -1 and having more than one Symbol
-        #for item in pow_paren:
-        #    if item.base in b:
-        #        b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if not b:
             return sign + '*'.join(a_str)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -137,8 +137,6 @@ class JuliaCodePrinter(CodePrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
-
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -152,8 +150,6 @@ class JuliaCodePrinter(CodePrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
-                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -167,11 +163,6 @@ class JuliaCodePrinter(CodePrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
-
-        # To parenthesize Pow with exp = -1 and having more than one Symbol
-        for item in pow_paren:
-            if item.base in b:
-                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         # from here it differs from str.py to deal with "*" and ".*"
         def multjoin(a, a_str):

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -344,6 +344,6 @@ def mathematica_code(expr, **settings):
     >>> from sympy import mathematica_code as mcode, symbols, sin
     >>> x = symbols('x')
     >>> mcode(sin(x).series(x).removeO())
-    '(1/120)*x^5 - 1/6*x^3 + x'
+    '(1/120)*x^5 - (1/6)*x^3 + x'
     """
     return MCodePrinter(settings).doprint(expr)

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -156,8 +156,6 @@ class OctaveCodePrinter(CodePrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
-
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -171,8 +169,6 @@ class OctaveCodePrinter(CodePrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
-                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -186,11 +182,6 @@ class OctaveCodePrinter(CodePrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
-
-        # To parenthesize Pow with exp = -1 and having more than one Symbol
-        for item in pow_paren:
-            if item.base in b:
-                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         # from here it differs from str.py to deal with "*" and ".*"
         def multjoin(a, a_str):

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -2,8 +2,6 @@
 
 from __future__ import print_function, division
 
-from sympy.core.function import _coeff_isneg
-
 # Default precedence values for some basic types
 PRECEDENCE = {
     "Lambda": 1,

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -35,6 +35,7 @@ PRECEDENCE_VALUES = {
     "And": PRECEDENCE["And"],
     "Add": PRECEDENCE["Add"],
     "Mod": PRECEDENCE["Mod"],
+    "Mul": PRECEDENCE["Mul"],
     "Pow": PRECEDENCE["Pow"],
     "Relational": PRECEDENCE["Relational"],
     "Sub": PRECEDENCE["Add"],
@@ -60,12 +61,6 @@ PRECEDENCE_VALUES = {
 # precedence value.
 
 # Precedence functions
-
-
-def precedence_Mul(item):
-    if _coeff_isneg(item):
-        return PRECEDENCE["Mul"]
-    return PRECEDENCE["Mul"]
 
 
 def precedence_Rational(item):
@@ -110,7 +105,6 @@ def precedence_UnevaluatedExpr(item):
 
 PRECEDENCE_FUNCTIONS = {
     "Integer": precedence_Integer,
-    "Mul": precedence_Mul,
     "Rational": precedence_Rational,
     "Float": precedence_Float,
     "PolyElement": precedence_PolyElement,

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -12,6 +12,7 @@ PRECEDENCE = {
     "And": 30,
     "Relational": 35,
     "Add": 40,
+    "Mod": 45,
     "Mul": 50,
     "Pow": 60,
     "Func": 70,
@@ -33,6 +34,7 @@ PRECEDENCE_VALUES = {
     "Or": PRECEDENCE["Or"],
     "And": PRECEDENCE["And"],
     "Add": PRECEDENCE["Add"],
+    "Mod": PRECEDENCE["Mod"],
     "Pow": PRECEDENCE["Pow"],
     "Relational": PRECEDENCE["Relational"],
     "Sub": PRECEDENCE["Add"],
@@ -62,7 +64,7 @@ PRECEDENCE_VALUES = {
 
 def precedence_Mul(item):
     if _coeff_isneg(item):
-        return PRECEDENCE["Add"]
+        return PRECEDENCE["Mul"]
     return PRECEDENCE["Mul"]
 
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -288,8 +288,6 @@ class StrPrinter(Printer):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
-
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -302,8 +300,6 @@ class StrPrinter(Printer):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
-                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -317,11 +313,6 @@ class StrPrinter(Printer):
 
         a_str = [self.parenthesize(x, prec, strict=False) for x in a]
         b_str = [self.parenthesize(x, prec, strict=False) for x in b]
-
-        # To parenthesize Pow with exp = -1 and having more than one Symbol
-        for item in pow_paren:
-            if item.base in b:
-                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if not b:
             return sign + '*'.join(a_str)

--- a/sympy/printing/tests/test_precedence.py
+++ b/sympy/printing/tests/test_precedence.py
@@ -30,7 +30,7 @@ def test_Integral():
 
 def test_Mul():
     assert precedence(x*y) == PRECEDENCE["Mul"]
-    assert precedence(-x*y) == PRECEDENCE["Add"]
+    assert precedence(-x*y) == PRECEDENCE["Mul"]
 
 
 def test_Number():
@@ -52,7 +52,7 @@ def test_Order():
 
 def test_Pow():
     assert precedence(x**y) == PRECEDENCE["Pow"]
-    assert precedence(-x**y) == PRECEDENCE["Add"]
+    assert precedence(-x**y) == PRECEDENCE["Mul"]
     assert precedence(x**-y) == PRECEDENCE["Pow"]
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17737
Fixes #18788

#### Brief description of what is fixed or changed
I changed the precedence of Mod expressions to fix #17737. They were recognized as a kind of Func expressions and were assigned precedence value of 70. Now apart from other Func expressions, Mod expressions are assigned precedence value of 45 (while Add expressions are assigned 40 and Mul expressions 50).
Due to this change, another issue #18788, where SymPy prints an extra pair of parentheses in a fraction, came to the surface. By "came to the surface" I mean tests failed. I discovered extra steps of parenthesizing in printers, so I just eliminated them.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug with printing of mod function.
  * Fixed a bug with printing of fraction.
<!-- END RELEASE NOTES -->