### PR TITLE
Implementing disjoint union

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ class clean(Command):
                     os.remove(os.path.join(root, file))
 
         os.chdir(dir_setup)
-        names = ["python3.6-build-stamp-2.4", "MANIFEST", "build",
+        names = ["python-build-stamp-2.4", "MANIFEST", "build",
                  "dist", "doc/_build", "sample.tex"]
 
         for f in names:

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ class clean(Command):
                     os.remove(os.path.join(root, file))
 
         os.chdir(dir_setup)
-        names = ["python-build-stamp-2.4", "MANIFEST", "build",
+        names = ["python3.6-build-stamp-2.4", "MANIFEST", "build",
                  "dist", "doc/_build", "sample.tex"]
 
         for f in names:

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -160,7 +160,7 @@ from .simplify import (simplify, hypersimp, hypersimilar, logcombine,
         ratsimp, ratsimpmodprime)
 
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
-        Intersection, external_disjoint_union, imageset, Complement, SymmetricDifference, ImageSet,
+        Intersection, DisjointUnion, imageset, Complement, SymmetricDifference, ImageSet,
         Range, ComplexRegion, Reals, Contains, ConditionSet, Ordinal,
         OmegaPower, ord0, PowerSet, Naturals, Naturals0, UniversalSet,
         Integers, Rationals)
@@ -390,7 +390,7 @@ __all__ = [
 
     # sympy.sets
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
-    'Intersection', 'imageset', 'external_disjoint_union', 'Complement', 'SymmetricDifference',
+    'Intersection', 'imageset', 'DisjointUnion', 'Complement', 'SymmetricDifference',
     'ImageSet', 'Range', 'ComplexRegion', 'Reals', 'Contains', 'ConditionSet',
     'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Reals', 'Naturals',
     'Naturals0', 'UniversalSet', 'Integers', 'Rationals',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -160,7 +160,7 @@ from .simplify import (simplify, hypersimp, hypersimilar, logcombine,
         ratsimp, ratsimpmodprime)
 
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
-        Intersection, imageset, Complement, SymmetricDifference, ImageSet,
+        Intersection, external_disjoint_union, imageset, Complement, SymmetricDifference, ImageSet,
         Range, ComplexRegion, Reals, Contains, ConditionSet, Ordinal,
         OmegaPower, ord0, PowerSet, Naturals, Naturals0, UniversalSet,
         Integers, Rationals)
@@ -390,7 +390,7 @@ __all__ = [
 
     # sympy.sets
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
-    'Intersection', 'imageset', 'Complement', 'SymmetricDifference',
+    'Intersection', 'imageset', 'external_disjoint_union', 'Complement', 'SymmetricDifference',
     'ImageSet', 'Range', 'ComplexRegion', 'Reals', 'Contains', 'ConditionSet',
     'Ordinal', 'OmegaPower', 'ord0', 'PowerSet', 'Reals', 'Naturals',
     'Naturals0', 'UniversalSet', 'Integers', 'Rationals',

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -894,6 +894,11 @@ def test_sympy__sets__sets__SymmetricDifference():
     assert _test_args(SymmetricDifference(FiniteSet(1, 2, 3), \
            FiniteSet(2, 3, 4)))
 
+def test_sympy__sets__sets__DisjointUnion():
+    from sympy.sets.sets import FiniteSet, DisjointUnion
+    assert _test_args(DisjointUnion(FiniteSet(1, 2, 3), \
+           FiniteSet(2, 3, 4)))
+
 
 def test_sympy__core__trace__Tr():
     from sympy.core.trace import Tr

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,5 +1,6 @@
 from .sets import (Set, Interval, Union, FiniteSet, ProductSet,
-        Intersection, imageset, Complement, SymmetricDifference)
+        Intersection, imageset, Complement, SymmetricDifference,
+        external_disjoint_union)
 from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet
@@ -17,7 +18,7 @@ Rationals = S.Rationals
 
 __all__ = [
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
-    'Intersection', 'imageset', 'Complement', 'SymmetricDifference',
+    'Intersection', 'imageset', 'Complement', 'SymmetricDifference', 'external_disjoint_union',
 
     'ImageSet', 'Range', 'ComplexRegion', 'Reals',
 

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,6 +1,6 @@
 from .sets import (Set, Interval, Union, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference,
-        external_disjoint_union)
+        DisjointUnion)
 from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet
@@ -18,7 +18,7 @@ Rationals = S.Rationals
 
 __all__ = [
     'Set', 'Interval', 'Union', 'EmptySet', 'FiniteSet', 'ProductSet',
-    'Intersection', 'imageset', 'Complement', 'SymmetricDifference', 'external_disjoint_union',
+    'Intersection', 'imageset', 'Complement', 'SymmetricDifference', 'DisjointUnion',
 
     'ImageSet', 'Range', 'ComplexRegion', 'Reals',
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2060,7 +2060,7 @@ class DisjointUnion(Set):
             if isinstance(set_i, Set):
                 dj_collection.append(set_i)
             else:
-                raise ValueError("Invalid input: '%s', input args \
+                raise TypeError("Invalid input: '%s', input args \
                     to DisjointUnion must be Sets" % set_i)
         obj = Basic.__new__(cls, *dj_collection)
         return obj
@@ -2144,7 +2144,7 @@ class DisjointUnion(Set):
 
             return iter(roundrobin(*iters))
         else:
-            raise TypeError("'%s' is not iterable." % self)
+            raise ValueError("'%s' is not iterable." % self)
 
     def __len__(self):
         """
@@ -2173,7 +2173,7 @@ class DisjointUnion(Set):
                 size += len(set)
             return size
         else:
-            raise TypeError("'%s' is not a finite set." % self)
+            raise ValueError("'%s' is not a finite set." % self)
 
 
 def imageset(*args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2101,8 +2101,6 @@ class DisjointUnion(Set):
                 cross = ProductSet(set_i, FiniteSet(index))
                 dj_union = Union(dj_union, cross)
                 index = index + 1
-            else:
-                continue
         return dj_union
 
     def _contains(self, element):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2138,24 +2138,30 @@ class DisjointUnion(Set):
 
     def __iter__(self):
         if self.is_iterable:
-            return iter(self.rewrite(Union))
-        #     index = 0
-        #     exhausted = []
-        #     component_set_iters = []
-        #     for set_i in self.sets:
-        #         i = iter(set_i)
-        #         component_set_iters.append(i)
-        #         yield (next(i), index)
-        #         index += 1
-        #     while len(exhausted) != len(self.sets):
-        #         index = 0
-        #         for set_i in self.sets:
-        #             try:
-        #                 for iter_j in component_set_iters:
-        #                     yield (next(iter_j), index)
-        #             except StopIteration:
-        #                 continue
-        #             index += 1
+            component_set_iters = []
+
+            for set_i in self.sets:
+                component_set_iters.append(iter(set_i)) #setting up all component iterators
+
+            visited = 0
+            size = 0
+            infinite_iter = False
+            try:
+                size = len(self)
+            except TypeError:
+                infinite_iter = True
+            while (visited <= size) or infinite_iter:
+                index = 0
+                for set_i in self.sets:
+                    try:
+                        yield (next(component_set_iters[index]), index)
+                        index += 1
+                    except StopIteration:
+                        index += 1
+                        continue
+                    visited += 1
+                if visited == size:
+                    visited += 1
         else:
             raise TypeError("'%s' is not iterable." % self)
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2138,30 +2138,13 @@ class DisjointUnion(Set):
 
     def __iter__(self):
         if self.is_iterable:
-            component_set_iters = []
+            from sympy.core.numbers import Integer
 
-            for set_i in self.sets:
-                component_set_iters.append(iter(set_i)) #setting up all component iterators
+            iters = []
+            for i, s in enumerate(self.sets):
+                iters.append(iproduct(s, {Integer(i)}))
 
-            visited = 0
-            size = 0
-            infinite_iter = False
-            try:
-                size = len(self)
-            except TypeError:
-                infinite_iter = True
-            while (visited <= size) or infinite_iter:
-                index = 0
-                for set_i in self.sets:
-                    try:
-                        yield (next(component_set_iters[index]), index)
-                        index += 1
-                    except StopIteration:
-                        index += 1
-                        continue
-                    visited += 1
-                if visited == size:
-                    visited += 1
+            return iter(roundrobin(*iters))
         else:
             raise TypeError("'%s' is not iterable." % self)
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2357,6 +2357,12 @@ def set_function(f, x):
     return _set_function(f, x)
 
 def disjoint_union(*sets):
+    """
+    Iterates over ``sets`` and computes their disjoint union
+    Find the  definition and examples here:
+    https://en.wikipedia.org/wiki/Disjoint_union
+    """
+
     index = 1
     dj_union = EmptySet
     for set_i in sets:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2035,18 +2035,18 @@ class DisjointUnion(Set):
     Examples
     ========
 
-    >>> from sympy import DisjointUnion, FiniteSet, Interval
+    >>> from sympy import DisjointUnion, FiniteSet, Interval, Union, Symbol
     >>> A = FiniteSet(1, 2, 3)
     >>> B = Interval(0, 5)
     >>> DisjointUnion(A, B)
     DisjointUnion(FiniteSet(1, 2, 3), Interval(0, 5))
     >>> DisjointUnion(A, B).rewrite(Union)
-    ({1, 2, 3} x {0}) U ([0, 5] x {1})
+    Union(ProductSet(FiniteSet(1, 2, 3), FiniteSet(0)), ProductSet(Interval(0, 5), FiniteSet(1)))
     >>> C = FiniteSet(Symbol('x'), Symbol('y'), Symbol('z'))
     >>> DisjointUnion(C, C)
     DisjointUnion(FiniteSet(x, y, z), FiniteSet(x, y, z))
     >>> DisjointUnion(C, C).rewrite(Union)
-    {x, y, z} x {0, 1}
+    ProductSet(FiniteSet(x, y, z), FiniteSet(0, 1))
 
     References
     ==========
@@ -2166,14 +2166,14 @@ class DisjointUnion(Set):
         Examples
         ========
 
-        >>> from sympy import FiniteSet, DisjointUnion
-        >>> D1 = DisjointUnion(FiniteSet(1, 2, 3, 4), S.EmptySet, FiniteSet(3, 4, 5))
+        >>> from sympy import FiniteSet, DisjointUnion, EmptySet
+        >>> D1 = DisjointUnion(FiniteSet(1, 2, 3, 4), EmptySet, FiniteSet(3, 4, 5))
         >>> len(D1)
         7
-        >>> D2 = DisjointUnion(FiniteSet(3, 5, 7), S.EmptySet, FiniteSet(3, 5, 7))
+        >>> D2 = DisjointUnion(FiniteSet(3, 5, 7), EmptySet, FiniteSet(3, 5, 7))
         >>> len(D2)
         6
-        >>> D3 = DisjointUnion(S.EmptySet, S.EmptySet)
+        >>> D3 = DisjointUnion(EmptySet, EmptySet)
         >>> len(D3)
         0
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2355,3 +2355,14 @@ def set_pow(x, y):
 def set_function(f, x):
     from sympy.sets.handlers.functions import _set_function
     return _set_function(f, x)
+
+def disjoint_union(*sets):
+    index = 1
+    dj_union = EmptySet
+    for set_i in sets:
+        if isinstance(set_i, Set):
+            dj_union = dj_union + set_i*FiniteSet(index)
+            index = index+1
+        else:
+            raise ValueError("Unknown argument '%s'" % set_i)
+    return product

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2037,16 +2037,16 @@ class DisjointUnion(Set):
 
     >>> from sympy import DisjointUnion, FiniteSet, Interval
     >>> A = FiniteSet(1, 2, 3)
-    >>> B = Interval(0, oo)
+    >>> B = Interval(0, 5)
     >>> DisjointUnion(A, B)
-    DisjointUnion(FiniteSet(1, 2, 3), Interval(0, oo))
+    DisjointUnion(FiniteSet(1, 2, 3), Interval(0, 5))
     >>> DisjointUnion(A, B).rewrite(Union)
-    ({1, 2, 3} × {0}) ∪ ([0, ∞) × {1})
+    ({1, 2, 3} x {0}) U ([0, 5] x {1})
     >>> C = FiniteSet(Symbol('x'), Symbol('y'), Symbol('z'))
     >>> DisjointUnion(C, C)
     DisjointUnion(FiniteSet(x, y, z), FiniteSet(x, y, z))
     >>> DisjointUnion(C, C).rewrite(Union)
-    {x, y, z} × {0, 1}
+    {x, y, z} x {0, 1}
 
     References
     ==========
@@ -2065,21 +2065,17 @@ class DisjointUnion(Set):
         obj = Basic.__new__(cls, *dj_collection)
         return obj
 
-    def rewrite(self, obj):
-        if obj == Union:
-            index = 0
-            dj_union = EmptySet()
-            for set_i in self.args:
-                if isinstance(set_i, Set):
-                    cross = ProductSet(set_i, FiniteSet(index))
-                    dj_union = Union(dj_union, cross)
-                    index = index + 1
-                else:
-                    continue
-            return dj_union
-        else:
-            raise ValueError("Invalid input: '%s'", obj)
-            return None
+    def _eval_rewrite_as_Union(self, *sets):
+        index = 0
+        dj_union = EmptySet()
+        for set_i in sets:
+            if isinstance(set_i, Set):
+                cross = ProductSet(set_i, FiniteSet(index))
+                dj_union = Union(dj_union, cross)
+                index = index + 1
+            else:
+                continue
+        return dj_union
 
 
 def imageset(*args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2361,8 +2361,8 @@ def disjoint_union(*sets):
     dj_union = EmptySet
     for set_i in sets:
         if isinstance(set_i, Set):
-            dj_union = dj_union + set_i*FiniteSet(index)
-            index = index+1
+            dj_union = dj_union + (set_i * FiniteSet(index))
+            index = index + 1
         else:
             raise ValueError("Unknown argument '%s'" % set_i)
     return product

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2356,19 +2356,21 @@ def set_function(f, x):
     from sympy.sets.handlers.functions import _set_function
     return _set_function(f, x)
 
-def disjoint_union(*sets):
+def external_disjoint_union(*sets):
     """
     Iterates over ``sets`` and computes their disjoint union
     Find the  definition and examples here:
     https://en.wikipedia.org/wiki/Disjoint_union
     """
 
-    index = 1
-    dj_union = EmptySet
+    index = 0
+    dj_union = EmptySet()
     for set_i in sets:
         if isinstance(set_i, Set):
-            dj_union = dj_union + (set_i * FiniteSet(index))
+            cross = set_i * FiniteSet(index)
+            dj_union = Union(dj_union, cross)
             index = index + 1
         else:
-            raise ValueError("Unknown argument '%s'" % set_i)
-    return product
+            raise ValueError("Invalid input: '%s', input args \
+                to external_disjoint_union must be Sets" % set_i)
+    return dj_union

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    Max, Min, Float,
+    Max, Min, Float, external_disjoint_union,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
@@ -1494,7 +1494,7 @@ def test_external_disjoint_union():
     assert external_disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0,5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
     assert external_disjoint_union(Interval(-1,2), S.EmptySet, S.EmptySet) == Interval(-1,2)*FiniteSet(0)
     assert external_disjoint_union(Interval(-1,2)) == Interval(-1,2)*FiniteSet(0)
-    assert external_disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(1) 
+    assert external_disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(1)
     #could skip indices for which sets are empty while computing disjoint union
     assert external_disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(0)
     assert external_disjoint_union(S.EmptySet) == S.EmptySet

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1488,19 +1488,19 @@ def test_issue_16878b():
     # for Integers
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
 
-def test_disjoint_union():
-    assert disjoint_union(FiniteSet(1,2,3), FiniteSet(1,2,3), FiniteSet(1,2,3)) == (FiniteSet(1,2,3)*FiniteSet(1,2,3))
-    assert disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1,3) * FiniteSet(1), Interval(2, 4) * FiniteSet(2))
-    assert disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0,5) * FiniteSet(1), Interval(0, 5) * FiniteSet(2))
-    assert disjoint_union(Interval(-1,2), S.EmptySet, S.EmptySet) == Interval(-1,2)*FiniteSet(1)
-    assert disjoint_union(Interval(-1,2)) == Interval(-1,2)*FiniteSet(1)
-    assert disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(2) 
+def test_external_disjoint_union():
+    assert external_disjoint_union(FiniteSet(1,2,3), FiniteSet(1,2,3), FiniteSet(1,2,3)) == (FiniteSet(1,2,3)*FiniteSet(0, 1,2))
+    assert external_disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1,3) * FiniteSet(0), Interval(2, 4) * FiniteSet(1))
+    assert external_disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0,5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
+    assert external_disjoint_union(Interval(-1,2), S.EmptySet, S.EmptySet) == Interval(-1,2)*FiniteSet(0)
+    assert external_disjoint_union(Interval(-1,2)) == Interval(-1,2)*FiniteSet(0)
+    assert external_disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(1) 
     #could skip indices for which sets are empty while computing disjoint union
-    assert disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(1)
-    assert disjoint_union(S.EmptySet) == S.EmptySet
-    assert disjoint_union() == S.EmptySet
+    assert external_disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(0)
+    assert external_disjoint_union(S.EmptySet) == S.EmptySet
+    assert external_disjoint_union() == S.EmptySet
 
     x = Symbol("x")
     y = Symbol("y")
     z = Symbol("z")
-    assert disjoint_union(FiniteSet(x), FiniteSet(y,z)) == (FiniteSet(x) * FiniteSet(1)) + (FiniteSet(y, z) * FiniteSet(2))
+    assert external_disjoint_union(FiniteSet(x), FiniteSet(y,z)) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1546,8 +1546,8 @@ def test_DisjointUnion_contains():
 def test_DisjointUnion_iter():
     D = DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))
     it = iter(D)
-    L2 = [(x, 1), (y, 1), (z, 1)]
-    L1 = [(3, 0), (5, 0), (7, 0), (9, 0)]
+    L1 = [(x, 1), (y, 1), (z, 1)]
+    L2 = [(3, 0), (5, 0), (7, 0), (9, 0)]
     nxt = next(it)
     assert nxt in L2
     L2.remove(nxt)
@@ -1567,8 +1567,8 @@ def test_DisjointUnion_iter():
     assert nxt in L1
     L1.remove(nxt)
     nxt = next(it)
-    assert nxt in L1
-    L1.remove(nxt)
+    assert nxt in L2
+    L2.remove(nxt)
     stop_called = False
     try:
         next(it)
@@ -1578,10 +1578,19 @@ def test_DisjointUnion_iter():
 
     not_iterable = False
     try:
-        iter(DisjointUnion(Interval(0, 1), S.EmptySet))
+        i = iter(DisjointUnion(Interval(0, 1), S.EmptySet))
+        next(i)
     except TypeError:
         not_iterable = True
     assert not_iterable is True
+
+    not_iterable = False
+    try:
+        i = iter(DisjointUnion(S.Integers, S.Rationals))
+        next(i)
+    except TypeError:
+        not_iterable = True
+    assert not_iterable is False
 
 def test_DisjointUnion_len():
     assert len(DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))) == 7

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1504,4 +1504,3 @@ def test_DisjointUnion():
     y = Symbol("y")
     z = Symbol("z")
     assert DisjointUnion(FiniteSet(x), FiniteSet(y, z)).rewrite(Union) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))
-

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1529,14 +1529,6 @@ def test_DisjointUnion_contains():
     assert (x, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
     assert (y, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
     assert (z, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # assert (x, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # assert (y, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # assert (z, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # assert (x, 2) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # assert (z, 2) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
-    # the tests above won't work because even something like
-    # x in FiniteSet(y, z)
-    # raises a TypeError.
     assert (y, 2) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
     assert (0.5, 0) in DisjointUnion(Interval(0, 1), Interval(0, 2))
     assert (0.5, 1) in DisjointUnion(Interval(0, 1), Interval(0, 2))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1487,3 +1487,20 @@ def test_issue_16878b():
     # that handles the base_set of S.Reals like there is
     # for Integers
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
+
+def test_disjoint_union():
+    assert disjoint_union(FiniteSet(1,2,3), FiniteSet(1,2,3), FiniteSet(1,2,3)) == (FiniteSet(1,2,3)*FiniteSet(1,2,3))
+    assert disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1,3) * FiniteSet(1), Interval(2, 4) * FiniteSet(2))
+    assert disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0,5) * FiniteSet(1), Interval(0, 5) * FiniteSet(2))
+    assert disjoint_union(Interval(-1,2), S.EmptySet, S.EmptySet) == Interval(-1,2)*FiniteSet(1)
+    assert disjoint_union(Interval(-1,2)) == Interval(-1,2)*FiniteSet(1)
+    assert disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(2) 
+    #could skip indices for which sets are empty while computing disjoint union
+    assert disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(1)
+    assert disjoint_union(S.EmptySet) == S.EmptySet
+    assert disjoint_union() == S.EmptySet
+
+    x = Symbol("x")
+    y = Symbol("y")
+    z = Symbol("z")
+    assert disjoint_union(FiniteSet(x), FiniteSet(y,z)) == (FiniteSet(x) * FiniteSet(1)) + (FiniteSet(y, z) * FiniteSet(2))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -82,6 +82,8 @@ def test_is_finiteset():
     assert Complement(FiniteSet(1), Interval(x, y)).is_finite_set is True
     assert Complement(Interval(x, y), FiniteSet(1)).is_finite_set is None
     assert Complement(Interval(1, 2), FiniteSet(x)).is_finite_set is False
+    assert DisjointUnion(Interval(-5, 3), FiniteSet(x, y)).is_finite_set is False
+    assert DisjointUnion(S.EmptySet, FiniteSet(x, y), S.EmptySet).is_finite_set is True
 
 
 def test_deprecated_is_EmptySet():
@@ -402,7 +404,7 @@ def test_complement():
 
     assert FiniteSet(0, x).complement(S.Reals) == Complement(Interval(-oo, 0, True, True) +
                                                              Interval(0, oo, True, True)
-                                                             ,FiniteSet(x), evaluate=False)
+                                                             , FiniteSet(x), evaluate=False)
 
     square = Interval(0, 1) * Interval(0, 1)
     notsquare = square.complement(S.Reals*S.Reals)
@@ -1272,11 +1274,11 @@ def test_SymmetricDifference():
 
     assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \
             FiniteSet(2, 4, 6, 8, 10)) == FiniteSet(0, 1, 3, 5, 6, 8, 10)
-    assert SymmetricDifference(FiniteSet(2, 3, 4), FiniteSet(2, 3 ,4 ,5 )) \
+    assert SymmetricDifference(FiniteSet(2, 3, 4), FiniteSet(2, 3 , 4 , 5)) \
             == FiniteSet(5)
     assert FiniteSet(1, 2, 3, 4, 5) ^ FiniteSet(1, 2, 5, 6) == \
             FiniteSet(3, 4, 6)
-    assert Set(1, 2 ,3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
+    assert Set(1, 2 , 3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
             Set(2, 3, 4) - Set(1, 2, 3))
     assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
             Interval(2, 5), Interval(2, 5) - Interval(0, 4))
@@ -1495,7 +1497,6 @@ def test_DisjointUnion():
     assert DisjointUnion(Interval(-1, 2), S.EmptySet, S.EmptySet).rewrite(Union) == Interval(-1, 2) * FiniteSet(0)
     assert DisjointUnion(Interval(-1, 2)).rewrite(Union) == Interval(-1, 2) * FiniteSet(0)
     assert DisjointUnion(S.EmptySet, Interval(-1, 2), S.EmptySet).rewrite(Union) == Interval(-1, 2) * FiniteSet(1)
-    #could skip indices for which sets are empty while computing disjoint union
     assert DisjointUnion(Interval(-oo, oo)).rewrite(Union) == Interval(-oo, oo) * FiniteSet(0)
     assert DisjointUnion(S.EmptySet).rewrite(Union) == S.EmptySet
     assert DisjointUnion().rewrite(Union) == S.EmptySet
@@ -1504,3 +1505,90 @@ def test_DisjointUnion():
     y = Symbol("y")
     z = Symbol("z")
     assert DisjointUnion(FiniteSet(x), FiniteSet(y, z)).rewrite(Union) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))
+
+def test_DisjointUnion_is_empty():
+    assert DisjointUnion(S.EmptySet).is_empty is True
+    assert DisjointUnion(S.EmptySet, S.EmptySet).is_empty is True
+    assert DisjointUnion(S.EmptySet, FiniteSet(1, 2, 3)).is_empty is False
+
+def test_DisjointUnion_is_iterable():
+    assert DisjointUnion(S.Integers, S.Naturals, S.Rationals).is_iterable is True
+    assert DisjointUnion(S.EmptySet, S.Reals).is_iterable is False
+    assert DisjointUnion(FiniteSet(1, 2, 3), S.EmptySet, FiniteSet(x, y)).is_iterable is True
+
+def test_DisjointUnion_contains():
+    assert (0, 0) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (0, 1) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (0, 2) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (1, 0) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (1, 1) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (1, 2) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (2, 0) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (2, 1) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (2, 2) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (x, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    assert (y, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    assert (z, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # assert (x, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # assert (y, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # assert (z, 1) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # assert (x, 2) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # assert (z, 2) not in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    # the tests above won't work because even something like
+    # x in FiniteSet(y, z)
+    # raises a TypeError.
+    assert (y, 2) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
+    assert (0.5, 0) in DisjointUnion(Interval(0, 1), Interval(0, 2))
+    assert (0.5, 1) in DisjointUnion(Interval(0, 1), Interval(0, 2))
+    assert (1.5, 0) not in DisjointUnion(Interval(0, 1), Interval(0, 2))
+    assert (1.5, 1) in DisjointUnion(Interval(0, 1), Interval(0, 2))
+
+def test_DisjointUnion_iter():
+    D = DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))
+    it = iter(D)
+    L2 = [(x, 1), (y, 1), (z, 1)]
+    L1 = [(3, 0), (5, 0), (7, 0), (9, 0)]
+    nxt = next(it)
+    assert nxt in L2
+    L2.remove(nxt)
+    nxt = next(it)
+    assert nxt in L1
+    L1.remove(nxt)
+    nxt = next(it)
+    assert nxt in L2
+    L2.remove(nxt)
+    nxt = next(it)
+    assert nxt in L1
+    L1.remove(nxt)
+    nxt = next(it)
+    assert nxt in L2
+    L2.remove(nxt)
+    nxt = next(it)
+    assert nxt in L1
+    L1.remove(nxt)
+    nxt = next(it)
+    assert nxt in L1
+    L1.remove(nxt)
+    stop_called = False
+    try:
+        next(it)
+    except StopIteration:
+        stop_called = True
+    assert stop_called is True
+
+    not_iterable = False
+    try:
+        iter(DisjointUnion(Interval(0, 1), S.EmptySet))
+    except TypeError:
+        not_iterable = True
+    assert not_iterable is True
+
+def test_DisjointUnion_len():
+    assert len(DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))) == 7
+    assert len(DisjointUnion(S.EmptySet, S.EmptySet, FiniteSet(x, y, z), S.EmptySet)) == 3
+    not_finite = False
+    try:
+        len(DisjointUnion(Interval(0, 1), S.EmptySet))
+    except TypeError:
+        not_finite = True
+    assert not_finite is True

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1500,6 +1500,12 @@ def test_DisjointUnion():
     assert DisjointUnion(Interval(-oo, oo)).rewrite(Union) == Interval(-oo, oo) * FiniteSet(0)
     assert DisjointUnion(S.EmptySet).rewrite(Union) == S.EmptySet
     assert DisjointUnion().rewrite(Union) == S.EmptySet
+    error_raised = False
+    try:
+        DisjointUnion(Symbol('n'))
+    except ValueError:
+        error_raised = True
+    assert error_raised is True
 
     x = Symbol("x")
     y = Symbol("y")
@@ -1515,6 +1521,7 @@ def test_DisjointUnion_is_iterable():
     assert DisjointUnion(S.Integers, S.Naturals, S.Rationals).is_iterable is True
     assert DisjointUnion(S.EmptySet, S.Reals).is_iterable is False
     assert DisjointUnion(FiniteSet(1, 2, 3), S.EmptySet, FiniteSet(x, y)).is_iterable is True
+    assert DisjointUnion(S.EmptySet, S.EmptySet).is_iterable is False
 
 def test_DisjointUnion_contains():
     assert (0, 0) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
@@ -1526,6 +1533,9 @@ def test_DisjointUnion_contains():
     assert (2, 0) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
     assert (2, 1) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
     assert (2, 2) in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (0, 1, 2) not in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
+    assert (0, 0.5) not in DisjointUnion(FiniteSet(0.5))
+    assert (0, 5) not in DisjointUnion(FiniteSet(0, 1, 2), FiniteSet(0, 1, 2), FiniteSet(0, 1, 2))
     assert (x, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
     assert (y, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))
     assert (z, 0) in DisjointUnion(FiniteSet(x, y, z), S.EmptySet, FiniteSet(y))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1489,12 +1489,12 @@ def test_issue_16878b():
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
 
 def test_external_disjoint_union():
-    assert external_disjoint_union(FiniteSet(1,2,3), FiniteSet(1,2,3), FiniteSet(1,2,3)) == (FiniteSet(1,2,3)*FiniteSet(0, 1,2))
-    assert external_disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1,3) * FiniteSet(0), Interval(2, 4) * FiniteSet(1))
-    assert external_disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0,5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
-    assert external_disjoint_union(Interval(-1,2), S.EmptySet, S.EmptySet) == Interval(-1,2)*FiniteSet(0)
-    assert external_disjoint_union(Interval(-1,2)) == Interval(-1,2)*FiniteSet(0)
-    assert external_disjoint_union(S.EmptySet, Interval(-1,2), S.EmptySet) == Interval(-1,2)*FiniteSet(1)
+    assert external_disjoint_union(FiniteSet(1, 2, 3), FiniteSet(1, 2, 3), FiniteSet(1, 2, 3)) == (FiniteSet(1, 2, 3) * FiniteSet(0, 1, 2))
+    assert external_disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1, 3) * FiniteSet(0), Interval(2, 4) * FiniteSet(1))
+    assert external_disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0, 5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
+    assert external_disjoint_union(Interval(-1, 2), S.EmptySet, S.EmptySet) == Interval(-1, 2) * FiniteSet(0)
+    assert external_disjoint_union(Interval(-1, 2)) == Interval(-1, 2) * FiniteSet(0)
+    assert external_disjoint_union(S.EmptySet, Interval(-1, 2), S.EmptySet) == Interval(-1, 2) * FiniteSet(1)
     #could skip indices for which sets are empty while computing disjoint union
     assert external_disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(0)
     assert external_disjoint_union(S.EmptySet) == S.EmptySet
@@ -1503,4 +1503,4 @@ def test_external_disjoint_union():
     x = Symbol("x")
     y = Symbol("y")
     z = Symbol("z")
-    assert external_disjoint_union(FiniteSet(x), FiniteSet(y,z)) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))
+    assert external_disjoint_union(FiniteSet(x), FiniteSet(y, z)) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    Max, Min, Float, external_disjoint_union,
+    Max, Min, Float, DisjointUnion,
     FiniteSet, Intersection, imageset, I, true, false, ProductSet,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
     Pow, Contains, Sum, rootof, SymmetricDifference, Piecewise,
@@ -1488,19 +1488,20 @@ def test_issue_16878b():
     # for Integers
     assert imageset(x, (x, x), S.Reals).is_subset(S.Reals**2) is True
 
-def test_external_disjoint_union():
-    assert external_disjoint_union(FiniteSet(1, 2, 3), FiniteSet(1, 2, 3), FiniteSet(1, 2, 3)) == (FiniteSet(1, 2, 3) * FiniteSet(0, 1, 2))
-    assert external_disjoint_union(Interval(1, 3), Interval(2, 4)) == Union(Interval(1, 3) * FiniteSet(0), Interval(2, 4) * FiniteSet(1))
-    assert external_disjoint_union(Interval(0, 5), Interval(0, 5)) == Union(Interval(0, 5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
-    assert external_disjoint_union(Interval(-1, 2), S.EmptySet, S.EmptySet) == Interval(-1, 2) * FiniteSet(0)
-    assert external_disjoint_union(Interval(-1, 2)) == Interval(-1, 2) * FiniteSet(0)
-    assert external_disjoint_union(S.EmptySet, Interval(-1, 2), S.EmptySet) == Interval(-1, 2) * FiniteSet(1)
+def test_DisjointUnion():
+    assert DisjointUnion(FiniteSet(1, 2, 3), FiniteSet(1, 2, 3), FiniteSet(1, 2, 3)).rewrite(Union) == (FiniteSet(1, 2, 3) * FiniteSet(0, 1, 2))
+    assert DisjointUnion(Interval(1, 3), Interval(2, 4)).rewrite(Union) == Union(Interval(1, 3) * FiniteSet(0), Interval(2, 4) * FiniteSet(1))
+    assert DisjointUnion(Interval(0, 5), Interval(0, 5)).rewrite(Union) == Union(Interval(0, 5) * FiniteSet(0), Interval(0, 5) * FiniteSet(1))
+    assert DisjointUnion(Interval(-1, 2), S.EmptySet, S.EmptySet).rewrite(Union) == Interval(-1, 2) * FiniteSet(0)
+    assert DisjointUnion(Interval(-1, 2)).rewrite(Union) == Interval(-1, 2) * FiniteSet(0)
+    assert DisjointUnion(S.EmptySet, Interval(-1, 2), S.EmptySet).rewrite(Union) == Interval(-1, 2) * FiniteSet(1)
     #could skip indices for which sets are empty while computing disjoint union
-    assert external_disjoint_union(Interval(-oo, oo)) == Interval(-oo, oo) * FiniteSet(0)
-    assert external_disjoint_union(S.EmptySet) == S.EmptySet
-    assert external_disjoint_union() == S.EmptySet
+    assert DisjointUnion(Interval(-oo, oo)).rewrite(Union) == Interval(-oo, oo) * FiniteSet(0)
+    assert DisjointUnion(S.EmptySet).rewrite(Union) == S.EmptySet
+    assert DisjointUnion().rewrite(Union) == S.EmptySet
 
     x = Symbol("x")
     y = Symbol("y")
     z = Symbol("z")
-    assert external_disjoint_union(FiniteSet(x), FiniteSet(y, z)) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))
+    assert DisjointUnion(FiniteSet(x), FiniteSet(y, z)).rewrite(Union) == (FiniteSet(x) * FiniteSet(0)) + (FiniteSet(y, z) * FiniteSet(1))
+

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1500,12 +1500,7 @@ def test_DisjointUnion():
     assert DisjointUnion(Interval(-oo, oo)).rewrite(Union) == Interval(-oo, oo) * FiniteSet(0)
     assert DisjointUnion(S.EmptySet).rewrite(Union) == S.EmptySet
     assert DisjointUnion().rewrite(Union) == S.EmptySet
-    error_raised = False
-    try:
-        DisjointUnion(Symbol('n'))
-    except ValueError:
-        error_raised = True
-    assert error_raised is True
+    raises(TypeError, lambda: DisjointUnion(Symbol('n')))
 
     x = Symbol("x")
     y = Symbol("y")
@@ -1571,35 +1566,11 @@ def test_DisjointUnion_iter():
     nxt = next(it)
     assert nxt in L2
     L2.remove(nxt)
-    stop_called = False
-    try:
-        next(it)
-    except StopIteration:
-        stop_called = True
-    assert stop_called is True
+    raises(StopIteration, lambda: next(it))
 
-    not_iterable = False
-    try:
-        i = iter(DisjointUnion(Interval(0, 1), S.EmptySet))
-        next(i)
-    except TypeError:
-        not_iterable = True
-    assert not_iterable is True
-
-    not_iterable = False
-    try:
-        i = iter(DisjointUnion(S.Integers, S.Rationals))
-        next(i)
-    except TypeError:
-        not_iterable = True
-    assert not_iterable is False
+    raises(ValueError, lambda: iter(DisjointUnion(Interval(0, 1), S.EmptySet)))
 
 def test_DisjointUnion_len():
     assert len(DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))) == 7
     assert len(DisjointUnion(S.EmptySet, S.EmptySet, FiniteSet(x, y, z), S.EmptySet)) == 3
-    not_finite = False
-    try:
-        len(DisjointUnion(Interval(0, 1), S.EmptySet))
-    except TypeError:
-        not_finite = True
-    assert not_finite is True
+    raises(ValueError, lambda: len(DisjointUnion(Interval(0, 1), S.EmptySet)))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18833


#### Brief description of what is fixed or changed
Created a `DisjointUnion` object derived from `sympy.sets.sets.Set`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- sets
  -  Added a new `DisjointUnion` class to compute the disjoint union of instances of `sympy.sets.sets.Set`

<!-- END RELEASE NOTES -->