### PR TITLE
correcting #17940 to get rid of conditionset for simple exp equation

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -327,7 +327,12 @@ def _invert_complex(f, g_ys, symbol):
                                imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
 
     if isinstance(f, exp):
-        if isinstance(g_ys, FiniteSet):
+        x = Symbol('x')
+        if (len((f.args)) < 2) and (f.args == (exp(x),)):
+            print(len((f.args)))
+            return _invert_complex(f.args[0],
+                               imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
+        elif isinstance(g_ys, FiniteSet):
             exp_invs = Union(*[imageset(Lambda(n, I*(2*n*pi + arg(g_y)) +
                                                log(Abs(g_y))), S.Integers)
                                for g_y in g_ys if g_y != 0])

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -329,7 +329,6 @@ def _invert_complex(f, g_ys, symbol):
     if isinstance(f, exp):
         x = Symbol('x')
         if (len((f.args)) < 2) and (f.args == (exp(x),)):
-            print(len((f.args)))
             return _invert_complex(f.args[0],
                                imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
         elif isinstance(g_ys, FiniteSet):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1008,6 +1008,9 @@ def test_solveset():
     assert solveset(exp(x) - 1, x) == imageset(Lambda(n, 2*I*pi*n), S.Integers)
     assert solveset(Eq(exp(x), 1), x) == imageset(Lambda(n, 2*I*pi*n),
                                                   S.Integers)
+    # ISSUE 17940
+    _n = Dummy('n')
+    assert solveset(exp(exp(x))-5,x) == ImageSet(Lambda(_n, 2*_n*I*pi + log(log(5))), S.Integers)
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
 


### PR DESCRIPTION

correcting #17940 to get rid of conditionset for simple exp equation

```
INPUT:
solveset(exp(exp(x))-5, x)

AFTER MODIFICATION
OUTPUT:
ImageSet(Lambda(_n, 2*_n*I*pi + log(log(5))), Integers)

```
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->