### PR TITLE
Expand log terms into prime factors.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2820,7 +2820,7 @@ def expand_multinomial(expr, deep=True):
     power_base=False, basic=False, multinomial=True, log=False)
 
 
-def expand_log(expr, deep=True, force=False):
+def expand_log(expr, deep=True, factor=False, force=False):
     """
     Wrapper around expand that only uses the log hint.  See the expand
     docstring for more information.
@@ -2836,7 +2836,7 @@ def expand_log(expr, deep=True, force=False):
     """
     return sympify(expr).expand(deep=deep, log=True, mul=False,
         power_exp=False, power_base=False, multinomial=False,
-        basic=False, force=force)
+        basic=False, force=force, factor=factor)
 
 
 def expand_func(expr, deep=True):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -764,13 +764,18 @@ class log(Function):
         if arg.is_Integer:
             # remove perfect powers
             p = perfect_power(int(arg))
+            logarg = None
+            coeff = 1
             if p is not False:
-                return p[1]*self.func(p[0])
+                arg, coeff = p
+                logarg = self.func(arg)
             # expand as product of its prime factors if factor=True
             if factor:
                 p = factorint(int(arg))
                 if int(arg) not in p.keys():
-                    return sum(n*log(val) for val, n in p.items())
+                    logarg = sum(n*log(val) for val, n in p.items())
+            if logarg is not None:
+                return coeff*logarg
         elif arg.is_Rational:
             return log(arg.p) - log(arg.q)
         elif arg.is_Mul:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -753,10 +753,11 @@ class log(Function):
                 return powsimp((-n) * p * x / (n + 1), deep=True, combine='exp')
         return (1 - 2*(n % 2)) * x**(n + 1)/(n + 1)
 
-    def _eval_expand_log(self, deep=True, factor=False, **hints):
+    def _eval_expand_log(self, deep=True, **hints):
         from sympy import unpolarify, expand_log, factorint
         from sympy.concrete import Sum, Product
         force = hints.get('force', False)
+        factor = hints.get('factor', False)
         if (len(self.args) == 2):
             return expand_log(self.func(*self.args), deep=deep, force=force)
         arg = self.args[0]

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -762,15 +762,10 @@ class log(Function):
             return expand_log(self.func(*self.args), deep=deep, force=force)
         arg = self.args[0]
         if arg.is_Integer:
-            # remove perfect powers
-            p = perfect_power(int(arg))
-            if p is not False:
-                return p[1]*self.func(p[0])
-            # expand as product of its prime factors if factor=True
-            if factor:
-                p = factorint(int(arg))
-                if int(arg) not in p.keys():
-                    return sum(log(arg / val**n) for val, n in p.items())
+            # expand log as product of its prime factors
+            p = factorint(int(arg))
+            if int(arg) not in p.keys() and factor:
+                return sum(n*log(val) for val, n in p.items())
         elif arg.is_Rational:
             return log(arg.p) - log(arg.q)
         elif arg.is_Mul:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -753,8 +753,8 @@ class log(Function):
                 return powsimp((-n) * p * x / (n + 1), deep=True, combine='exp')
         return (1 - 2*(n % 2)) * x**(n + 1)/(n + 1)
 
-    def _eval_expand_log(self, deep=True, **hints):
-        from sympy import unpolarify, expand_log
+    def _eval_expand_log(self, deep=True, factor=False, **hints):
+        from sympy import unpolarify, expand_log, factorint
         from sympy.concrete import Sum, Product
         force = hints.get('force', False)
         if (len(self.args) == 2):
@@ -765,6 +765,11 @@ class log(Function):
             p = perfect_power(int(arg))
             if p is not False:
                 return p[1]*self.func(p[0])
+            # expand as product of its prime factors if factor=True
+            if factor:
+                p = factorint(int(arg))
+                if int(arg) not in p.keys():
+                    return sum(log(arg / val**n) for val, n in p.items())
         elif arg.is_Rational:
             return log(arg.p) - log(arg.q)
         elif arg.is_Mul:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -13,7 +13,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.ntheory import multiplicity
+from sympy.ntheory import multiplicity, perfect_power
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -762,10 +762,15 @@ class log(Function):
             return expand_log(self.func(*self.args), deep=deep, force=force)
         arg = self.args[0]
         if arg.is_Integer:
-            # expand log as product of its prime factors
-            p = factorint(int(arg))
-            if int(arg) not in p.keys() and factor:
-                return sum(n*log(val) for val, n in p.items())
+            # remove perfect powers
+            p = perfect_power(int(arg))
+            if p is not False:
+                return p[1]*self.func(p[0])
+            # expand as product of its prime factors if factor=True
+            if factor:
+                p = factorint(int(arg))
+                if int(arg) not in p.keys():
+                    return sum(n*log(val) for val, n in p.items())
         elif arg.is_Rational:
             return log(arg.p) - log(arg.q)
         elif arg.is_Mul:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -13,7 +13,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.ntheory import multiplicity, perfect_power
+from sympy.ntheory import multiplicity
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18674

#### Brief description of what is fixed or changed
expand log term into its prime factors if factor flag is True
example:
`x = log(12)/log(2)`
`expand(x, factor=True) = log(3)/log(2) + 2
`

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
    - expand log term into its prime factors if the factor flag is True.
<!-- END RELEASE NOTES -->