### PR TITLE
Fix matexpr import

### DIFF
--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -46,8 +46,7 @@ __all__ = [
 
     'hadamard_product', 'HadamardProduct', 'hadamard_power', 'HadamardPower',
 
-    'DiagonalMatrix', 'DiagonalOf', 'DiagMatrix', 'DiagonalizeVector',
-    'diagonalize_vector',
+    'DiagonalMatrix', 'DiagonalOf', 'DiagMatrix', 'diagonalize_vector',
 
     'DotProduct',
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I see `from sympy.matrices.expressions import *` is not working because of the deleted class.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->