### PR TITLE
remove all set_smart_bounds methods

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1066,8 +1066,6 @@ class MatplotlibBackend(BaseBackend):
                 self.ax[i].spines['right'].set_color('none')
                 self.ax[i].spines['bottom'].set_position('zero')
                 self.ax[i].spines['top'].set_color('none')
-                self.ax[i].spines['left'].set_smart_bounds(True)
-                self.ax[i].spines['bottom'].set_smart_bounds(False)
                 self.ax[i].xaxis.set_ticks_position('bottom')
                 self.ax[i].yaxis.set_ticks_position('left')
 
@@ -1096,9 +1094,6 @@ class MatplotlibBackend(BaseBackend):
                     cmap=getattr(self.cm, 'viridis', self.cm.jet),
                     rstride=1, cstride=1, linewidth=0.1)
             elif s.is_implicit:
-                # Smart bounds have to be set to False for implicit plots.
-                ax.spines['left'].set_smart_bounds(False)
-                ax.spines['bottom'].set_smart_bounds(False)
                 points = s.get_raster()
                 if len(points) == 2:
                     # interval math plotting


### PR DESCRIPTION
#### Brief description of what is fixed or changed
removed all set_smart_bounds_mtehods from plot.py

#### Other comments
The set_smart_bounds function was deprecated in Matplotlib 3.2 and will be removed two minor releases later.
[API Changes — Matplotlib 3.2.0 documentation, Deprecations, smart_bounds](https://matplotlib.org/api/api_changes.html#smart-bounds)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Removed all set_smart_bounds methods.
<!-- END RELEASE NOTES -->