### PR TITLE
Modify Basic.doit

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1673,8 +1673,9 @@ class Basic(metaclass=ManagedProperties):
     def _eval_doit(self, *args, **hints):
         """
         If `deep=True` is passed to `doit` which called this method,
-        `args` are evaluated `self.args`. If `deep=False` is passed,
-        `args` are not-evaluated `self.args`.
+        `self.args` which are evaluated are passed to `args`.
+        If `deep=False` is passed, `self.args` are passed directly 
+        to `args`.
         """
         # May be overridden in subclasses
         return None

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1677,12 +1677,10 @@ class Basic(metaclass=ManagedProperties):
         # May be overridden in subclasses
         return None
 
-    def _eval_doit_evaluatable(self, **hints):
+    def _eval_doit_evaluatable(self, deep=True, properties=[], **hints):
         """Pre-generated method that can be used as `_eval_doit`
         for evaluatable classes, i.e. Add, Mul, etc.
         """
-        deep = hints.get('deep', True)
-        properties = hints.get('properties', [])
         if deep:
             terms = [term.doit(**hints) if isinstance(term, Basic)
                         else term for term in self.args]
@@ -1875,7 +1873,7 @@ class Atom(Basic):
     def xreplace(self, rule, hack2=False):
         return rule.get(self, self)
 
-    def doit(self, **hints):
+    def _eval_doit(self, **hints):
         return self
 
     @classmethod

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1623,7 +1623,7 @@ class Basic(metaclass=ManagedProperties):
         from sympy import count_ops
         return count_ops(self, visual)
 
-    def doit(self, deep=True, properties=[], **hints):
+    def doit(self, **hints):
         """Evaluate objects that are not evaluated like operations, limits,
         integrals, sums and products.
 
@@ -1640,30 +1640,30 @@ class Basic(metaclass=ManagedProperties):
         Examples
         ========
 
-        >>> from sympy import Add, Integral
+        >>> from sympy import Add, Integral, Derivative
         >>> from sympy.abc import x
 
-        >>> Add(Integral(x, x), Integral(x, x), evaluate=False)
-        Integral(x, x) + Integral(x, x)
+        >>> expr = Add(Integral(x, x), Integral(x, x), Derivative(x, x), evaluate=False)
+        >>> expr
+        Derivative(x, x) + Integral(x, x) + Integral(x, x)
 
-        >>> (2*Integral(x, x)).doit()
-        x**2
+        >>> expr.doit()
+        x**2 + 1
 
-        >>> (2*Integral(x, x)).doit(deep=False)
-        2*Integral(x, x)
+        >>> expr.doit(deep=False)
+        Derivative(x, x) + 2*Integral(x, x)
 
         See Also
         ========
 
         core.operations.AssocOp
         """
-        hints.update(deep=deep, properties=properties)
+        deep = hints.get('deep', True)
+        properties = hints.get('properties', [])
+
         eval_doit = self._eval_doit(**hints)
         if eval_doit is not None:
             return eval_doit
-        if self.is_Atom:
-            return self
-
         if deep:
             if any(not f(self) for f in properties):
                 return self

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1862,7 +1862,7 @@ class Atom(Basic):
     def xreplace(self, rule, hack2=False):
         return rule.get(self, self)
 
-    def _eval_doit(self, **hints):
+    def _eval_doit(self, *args, **hints):
         return self
 
     @classmethod

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1652,14 +1652,21 @@ class Basic(metaclass=ManagedProperties):
         if deep:
             terms = [term.doit(**hints) if isinstance(term, Basic)
                         else term for term in self.args]
-            eval_doit = self._eval_doit(*terms, **hints)
-            if eval_doit is not None:
-                return eval_doit
+        else:
+            terms = self.args
+
+        eval_doit = self._eval_doit(*terms, **hints)
+        if eval_doit is not None:
+            return eval_doit
+
+        # Place this condition here so that Atom's subclass
+        # can define its own _eval_doit.
+        if self.is_Atom:
+            return self
+
+        if deep:
             return self.func(*terms)
         else:
-            eval_doit = self._eval_doit(*self.args, **hints)
-            if eval_doit is not None:
-                return eval_doit
             return self
 
     def _eval_doit(self, *args, **hints):
@@ -1861,9 +1868,6 @@ class Atom(Basic):
 
     def xreplace(self, rule, hack2=False):
         return rule.get(self, self)
-
-    def _eval_doit(self, *args, **hints):
-        return self
 
     @classmethod
     def class_key(cls):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1674,7 +1674,7 @@ class Basic(metaclass=ManagedProperties):
         """
         If `deep=True` is passed to `doit` which called this method,
         `self.args` which are evaluated are passed to `args`.
-        If `deep=False` is passed, `self.args` are passed directly 
+        If `deep=False` is passed, `self.args` are passed directly
         to `args`.
         """
         # May be overridden in subclasses

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1649,17 +1649,17 @@ class Basic(metaclass=ManagedProperties):
         """
         hints.update(deep=deep, properties=properties)
 
-        if deep:       
+        if deep:
             terms = [term.doit(**hints) if isinstance(term, Basic)
                         else term for term in self.args]
             eval_doit = self._eval_doit(*terms, **hints)
             if eval_doit is not None:
-                return eval_doit    
+                return eval_doit
             return self.func(*terms)
         else:
             eval_doit = self._eval_doit(*self.args, **hints)
             if eval_doit is not None:
-                return eval_doit    
+                return eval_doit
             return self
 
     def _eval_doit(self, *args, **hints):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1624,11 +1624,12 @@ class Basic(metaclass=ManagedProperties):
         return count_ops(self, visual)
 
     def doit(self, deep=True, properties=[], **hints):
-        """Evaluate objects that are not evaluated like operations, limits,
-        integrals, sums and products.
+        """Evaluate objects that are not evaluated like limits, integrals,
+        sums and products.
 
-        Arguments will be evaluated recursively, unless some species were
+        Arguments will be evaluated recursively, unless some classes were
         excluded via 'properties' or unless the 'deep' hint was set to 'False'.
+
         Evaluatable classes should define their own `_eval_doit` method,
         which returns evaluated result. In this case, non-recursive evaluation
         should also be done when `deep=False` is passed. It is also encouraged

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -302,8 +302,8 @@ class AssocOp(Basic):
             return False
         return is_in
 
-    def _eval_doit(self, **hints):
-        return self._eval_doit_evaluatable(**hints)
+    def _eval_doit(self, *args, **hints):
+        return self._eval_doit_evaluatable(*args, **hints)
 
     def _eval_evalf(self, prec):
         """

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -302,6 +302,9 @@ class AssocOp(Basic):
             return False
         return is_in
 
+    def _eval_doit(self, **hints):
+        return self._eval_doit_evaluatable(**hints)
+
     def _eval_evalf(self, prec):
         """
         Evaluate the parts of self that are numbers; if the whole thing
@@ -375,16 +378,8 @@ class AssocOp(Basic):
         else:
             return (sympify(expr),)
 
-    def doit(self, **hints):
-        if hints.get('deep', True):
-            terms = [term.doit(**hints) for term in self.args]
-        else:
-            terms = self.args
-        return self.func(*terms, evaluate=True)
-
 class ShortCircuit(Exception):
     pass
-
 
 class LatticeOp(AssocOp):
     """

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import symbols, Symbol
 from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
-from sympy import sin, Q, cos, gamma, Tuple, Integral, Sum
+from sympy import sin, Q, cos, gamma, Tuple, Integral, Sum, Add, Mul
 from sympy.functions.elementary.exponential import exp
 from sympy.testing.pytest import raises
 from sympy.core import I, pi
@@ -148,6 +148,12 @@ def test_doit():
     assert b21.doit() == b21
     assert b21.doit(deep=False) == b21
 
+    x,y = symbols('x y')
+    expr1 = Mul(x, x, evaluate=False)
+    expr = Add(expr1, expr1, evaluate=False)
+    assert expr.doit() == Mul(2, x**2)
+    assert expr.doit(deep=False) == Mul(2, x, x, evaluate=False)
+    assert expr.doit(properties=[lambda x: isinstance(x, Mul)]) == Add(x**2, x**2, evaluate=False)
 
 def test_S():
     assert repr(S) == 'S'

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -486,7 +486,7 @@ class BaseScalarField(AtomicExpr):
     # XXX Workaround for limitations on the content of args
     free_symbols = set()  # type: Set[Any]
 
-    def doit(self):
+    def doit(self, **hints):
         return self
 
 

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -81,7 +81,7 @@ class LeviCivita(Function):
         if has_dups(args):
             return S.Zero
 
-    def doit(self):
+    def doit(self, **hints):
         return eval_levicivita(*self.args)
 
 

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -444,7 +444,7 @@ def ArcCosh(a):
     return acosh(a)
 
 class Util_Coefficient(Function):
-    def doit(self, **hints):
+    def _eval_doit(self, **hints):
         if len(self.args) == 2:
             n = 1
         else:

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -444,7 +444,7 @@ def ArcCosh(a):
     return acosh(a)
 
 class Util_Coefficient(Function):
-    def doit(self):
+    def doit(self, **hints):
         if len(self.args) == 2:
             n = 1
         else:
@@ -6579,7 +6579,7 @@ def Cancel(expr):
     return cancel(expr)
 
 class Util_Part(Function):
-    def doit(self):
+    def doit(self, **hints):
         i = Simplify(self.args[0])
         if len(self.args) > 2 :
             lst = list(self.args[1:])

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -34,7 +34,7 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
-    def doit(self, expand=False):
+    def doit(self, expand=False, **hints):
         try:
             return self.arg._eval_determinant()
         except (AttributeError, NotImplementedError):

--- a/sympy/matrices/expressions/dotproduct.py
+++ b/sympy/matrices/expressions/dotproduct.py
@@ -42,7 +42,7 @@ class DotProduct(Expr):
 
         return Basic.__new__(cls, arg1, arg2)
 
-    def doit(self, expand=False):
+    def doit(self, expand=False, **hints):
         if self.args[0].shape == self.args[1].shape:
             if self.args[0].shape[0] == 1:
                 mul = self.args[0]*transpose(self.args[1])

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -76,7 +76,7 @@ class PermutationMatrix(MatrixExpr):
     def is_Identity(self):
         return self.args[0].is_Identity
 
-    def doit(self):
+    def doit(self, **hints):
         if self.is_Identity:
             return Identity(self.rows)
         return self
@@ -249,7 +249,7 @@ class MatrixPermute(MatrixExpr):
 
         return super(MatrixPermute, cls).__new__(cls, mat, perm, axis)
 
-    def doit(self, deep=True):
+    def doit(self, deep=True, **hints):
         mat, perm, axis = self.args
 
         if deep:

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -49,7 +49,7 @@ class XOp(HermitianOperator):
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
-    def _eval_commutator_PxOp(self, other):
+    def _eval_commutator_PxOp(self, other, **hints):
         return I*hbar
 
     def _apply_operator_XKet(self, ket):

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -109,10 +109,10 @@ class RaisingOp(SHOOp):
     def _eval_adjoint(self):
         return LoweringOp(*self.args)
 
-    def _eval_commutator_LoweringOp(self, other):
+    def _eval_commutator_LoweringOp(self, other, **hints):
         return Integer(-1)
 
-    def _eval_commutator_NumberOp(self, other):
+    def _eval_commutator_NumberOp(self, other, **hints):
         return Integer(-1)*self
 
     def _apply_operator_SHOKet(self, ket):
@@ -247,10 +247,10 @@ class LoweringOp(SHOOp):
     def _eval_adjoint(self):
         return RaisingOp(*self.args)
 
-    def _eval_commutator_RaisingOp(self, other):
+    def _eval_commutator_RaisingOp(self, other, **hints):
         return Integer(1)
 
-    def _eval_commutator_NumberOp(self, other):
+    def _eval_commutator_NumberOp(self, other, **hints):
         return Integer(1)*self
 
     def _apply_operator_SHOKet(self, ket):
@@ -371,13 +371,13 @@ class NumberOp(SHOOp):
     def _apply_operator_SHOKet(self, ket):
         return ket.n*ket
 
-    def _eval_commutator_Hamiltonian(self, other):
+    def _eval_commutator_Hamiltonian(self, other, **hints):
         return Integer(0)
 
-    def _eval_commutator_RaisingOp(self, other):
+    def _eval_commutator_RaisingOp(self, other, **hints):
         return other
 
-    def _eval_commutator_LoweringOp(self, other):
+    def _eval_commutator_LoweringOp(self, other, **hints):
         return Integer(-1)*other
 
     def _represent_default_basis(self, **options):
@@ -483,7 +483,7 @@ class Hamiltonian(SHOOp):
     def _apply_operator_SHOKet(self, ket):
         return (hbar*omega*(ket.n + Integer(1)/Integer(2)))*ket
 
-    def _eval_commutator_NumberOp(self, other):
+    def _eval_commutator_NumberOp(self, other, **hints):
         return Integer(0)
 
     def _represent_default_basis(self, **options):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -168,7 +168,7 @@ class JplusOp(SpinOpBase, Operator):
 
     basis = 'Jz'
 
-    def _eval_commutator_JminusOp(self, other):
+    def _eval_commutator_JminusOp(self, other, **hints):
         return 2*hbar*JzOp(self.name)
 
     def _apply_operator_JzKet(self, ket, **options):
@@ -253,10 +253,10 @@ class JxOp(SpinOpBase, HermitianOperator):
 
     basis = 'Jx'
 
-    def _eval_commutator_JyOp(self, other):
+    def _eval_commutator_JyOp(self, other, **hints):
         return I*hbar*JzOp(self.name)
 
-    def _eval_commutator_JzOp(self, other):
+    def _eval_commutator_JzOp(self, other, **hints):
         return -I*hbar*JyOp(self.name)
 
     def _apply_operator_JzKet(self, ket, **options):
@@ -288,10 +288,10 @@ class JyOp(SpinOpBase, HermitianOperator):
 
     basis = 'Jy'
 
-    def _eval_commutator_JzOp(self, other):
+    def _eval_commutator_JzOp(self, other, **hints):
         return I*hbar*JxOp(self.name)
 
-    def _eval_commutator_JxOp(self, other):
+    def _eval_commutator_JxOp(self, other, **hints):
         return -I*hbar*J2Op(self.name)
 
     def _apply_operator_JzKet(self, ket, **options):
@@ -323,16 +323,16 @@ class JzOp(SpinOpBase, HermitianOperator):
 
     basis = 'Jz'
 
-    def _eval_commutator_JxOp(self, other):
+    def _eval_commutator_JxOp(self, other, **hints):
         return I*hbar*JyOp(self.name)
 
-    def _eval_commutator_JyOp(self, other):
+    def _eval_commutator_JyOp(self, other, **hints):
         return -I*hbar*JxOp(self.name)
 
-    def _eval_commutator_JplusOp(self, other):
+    def _eval_commutator_JplusOp(self, other, **hints):
         return hbar*JplusOp(self.name)
 
-    def _eval_commutator_JminusOp(self, other):
+    def _eval_commutator_JminusOp(self, other, **hints):
         return -hbar*JminusOp(self.name)
 
     def matrix_element(self, j, m, jp, mp):
@@ -353,19 +353,19 @@ class J2Op(SpinOpBase, HermitianOperator):
 
     _coord = '2'
 
-    def _eval_commutator_JxOp(self, other):
+    def _eval_commutator_JxOp(self, other, **hints):
         return S.Zero
 
-    def _eval_commutator_JyOp(self, other):
+    def _eval_commutator_JyOp(self, other, **hints):
         return S.Zero
 
-    def _eval_commutator_JzOp(self, other):
+    def _eval_commutator_JzOp(self, other, **hints):
         return S.Zero
 
-    def _eval_commutator_JplusOp(self, other):
+    def _eval_commutator_JplusOp(self, other, **hints):
         return S.Zero
 
-    def _eval_commutator_JminusOp(self, other):
+    def _eval_commutator_JminusOp(self, other, **hints):
         return S.Zero
 
     def _apply_operator_JxKet(self, ket, **options):

--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -50,7 +50,7 @@ def test_commutator_dagger():
 
 class Foo(Operator):
 
-    def _eval_commutator_Bar(self, bar):
+    def _eval_commutator_Bar(self, bar, **hints):
         return Integer(0)
 
 
@@ -60,7 +60,7 @@ class Bar(Operator):
 
 class Tam(Operator):
 
-    def _eval_commutator_Foo(self, foo):
+    def _eval_commutator_Foo(self, foo, **hints):
         return Integer(1)
 
 

--- a/sympy/sandbox/indexed_integrals.py
+++ b/sympy/sandbox/indexed_integrals.py
@@ -44,7 +44,7 @@ class IndexedIntegral(Integral):
         obj._indexed_reverse_repl = dict((val, key) for key, val in repl.items())
         return obj
 
-    def doit(self):
+    def doit(self, **hints):
         res = super(IndexedIntegral, self).doit()
         return res.xreplace(self._indexed_reverse_repl)
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1490,7 +1490,7 @@ def reduce_order_meijer(func):
 
 def make_derivative_operator(M, z):
     """ Create a derivative operator, to be passed to Operator.apply. """
-    def doit(C):
+    def doit(C, **hints):
         r = z*C.diff(z) + C*M
         r = r.applyfunc(make_simp(z))
         return r

--- a/sympy/tensor/array/array_comprehension.py
+++ b/sympy/tensor/array/array_comprehension.py
@@ -247,7 +247,7 @@ class ArrayComprehension(Basic):
 
         return loop_size
 
-    def doit(self):
+    def doit(self, **hints):
         if not self.is_shape_numeric:
             return self
 

--- a/sympy/tensor/toperators.py
+++ b/sympy/tensor/toperators.py
@@ -84,7 +84,7 @@ class PartialDerivative(TensExpr):
 
         return args, indices, free, dum
 
-    def doit(self):
+    def doit(self, **hints):
         args, indices, free, dum = self._contract_indices_for_derivative(self.expr, self.variables)
 
         obj = self.func(*args)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #18837

#### Brief description of what is fixed or changed
`Basic._eval_doit` is introduced, which can be overridden to modify `doit` behavior of subclasses. All subclasses are now expected to define `_eval_doit` method, not `doit`. 
For 'evaluatable' classes (which take `evaluate` option, i.e. `Add`, `Mul`), `Basic._eval_doit_evaluatable` method is prepared.  
`properties` option in introduced to `doit`, which can specify the classes to be 'doit-ed'.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - `doit` now can take `properties` option, which specifies the classes that are to be affected.
    - `doit` now refers to `_eval_doit` method.
<!-- END RELEASE NOTES -->