### PR TITLE
Quartenion: added tests to increase test coverage

### DIFF
--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -176,9 +176,8 @@ def test_quaternion_multiplication():
 
 def test_issue_16318():
     #for rtruediv
-    q1 = Quaternion(1, 2, 3, 4)
     q0 = Quaternion(0, 0, 0, 0)
-    raises(ValueError, lambda: q0.__rtruediv__(q1))
+    raises(ValueError, lambda: 1/q0)
     #for rotate_point
     q = Quaternion(1, 2, 3, 4)
     (axis, angle) = q.to_axis_angle()

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -176,7 +176,7 @@ def test_quaternion_multiplication():
 
 def test__rtruediv__iss16318():
     q1 = Quaternion(1, 2, 3, 4)
-    q0 = Quaternion(0,0,0,0)
+    q0 = Quaternion(0, 0, 0, 0)
     raises(ValueError, lambda: q0.__rtruediv__(q1))
 
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -172,3 +172,15 @@ def test_quaternion_multiplication():
 
     assert z * q == z_quat * q
     assert q * z == q * z_quat
+
+
+def test__rtruediv__iss16318():
+    q1 = Quaternion(1, 2, 3, 4)
+    q0 = Quaternion(0,0,0,0)
+    raises(ValueError, lambda: q0.__rtruediv__(q1))
+
+
+def test__rotate_point_iss16138():
+    q = Quaternion(1, 2, 3, 4)
+    (axis, angle) = q.to_axis_angle()
+    assert Quaternion.rotate_point((1, 1, 1), (axis, angle)) == (S.One / 5, 1, S(7) / 5)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -182,3 +182,8 @@ def test_issue_16318():
     q = Quaternion(1, 2, 3, 4)
     (axis, angle) = q.to_axis_angle()
     assert Quaternion.rotate_point((1, 1, 1), (axis, angle)) == (S.One / 5, 1, S(7) / 5)
+    #test for to_axis_angle
+    q = Quaternion(-1, 1, 1, 1)
+    axis = (-sqrt(3)/3, -sqrt(3)/3, -sqrt(3)/3)
+    angle = 2*pi/3
+    assert (axis, angle) == q.to_axis_angle()

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -174,13 +174,12 @@ def test_quaternion_multiplication():
     assert q * z == q * z_quat
 
 
-def test__rtruediv__iss16318():
+def test_issue_16318():
+    #for rtruediv
     q1 = Quaternion(1, 2, 3, 4)
     q0 = Quaternion(0, 0, 0, 0)
     raises(ValueError, lambda: q0.__rtruediv__(q1))
-
-
-def test__rotate_point_iss16138():
+    #for rotate_point
     q = Quaternion(1, 2, 3, 4)
     (axis, angle) = q.to_axis_angle()
     assert Quaternion.rotate_point((1, 1, 1), (axis, angle)) == (S.One / 5, 1, S(7) / 5)


### PR DESCRIPTION
 On branch iss_16318
 Changes to be committed:
	modified:   sympy/algebras/tests/test_quaternion.py


#### References to other Issues or PRs 
Related to issue #16318



#### Brief description of what is fixed or changed 
Added two tests to test_quaternion.py to increase the test coverage, as reported from Codecov. 
1. for the rtruediv() to raise ValueError when dividing by a quaternion with zero norm.
2. for the rotate_point(pin,r) to assert that the result is correct, when r is of the form (vector, angle).



#### Release Notes 
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->