### PR TITLE
Make custom function able to define its name

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -180,6 +180,9 @@ class FunctionClass(ManagedProperties):
             nargs = (as_int(nargs),)
         cls._nargs = nargs
 
+        name = kwargs.pop('name', cls.__dict__.get('name', cls.__name__))
+        cls.name = name
+
         super(FunctionClass, cls).__init__(*args, **kwargs)
 
     @property
@@ -250,7 +253,7 @@ class FunctionClass(ManagedProperties):
         return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
     def __repr__(cls):
-        return cls.__name__
+        return cls.name
 
 
 class Application(Basic, metaclass=FunctionClass):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1355,3 +1355,11 @@ def test_Derivative_free_symbols():
 def test_issue_10503():
     f = exp(x**3)*cos(x**6)
     assert f.series(x, 0, 14) == 1 + x**3 + x**6/2 + x**9/6 - 11*x**12/24 + O(x**14)
+
+def test_function_name():
+    class F1(Function):
+        name = 'F'
+    class F2(Function):
+        pass
+    assert F1.name == 'F'
+    assert F2.name == 'F2'

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -86,4 +86,5 @@ class Dagger(adjoint):
         return Expr.__new__(cls, arg)
 
 adjoint.__name__ = "Dagger"
+adjoint.name = "Dagger"
 adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -832,8 +832,7 @@ class LatexPrinter(Printer):
         expr is the expression involving the function
         exp is an exponent
         '''
-        clsname = expr.func.__name__
-        func = getattr(expr.func, 'name', clsname)
+        func = expr.func.name
         if hasattr(self, '_print_' + func) and \
                 not isinstance(expr, AppliedUndef):
             return getattr(self, '_print_' + func)(expr, exp)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -832,7 +832,8 @@ class LatexPrinter(Printer):
         expr is the expression involving the function
         exp is an exponent
         '''
-        func = expr.func.__name__
+        clsname = expr.func.__name__
+        func = getattr(expr.func, 'name', clsname)
         if hasattr(self, '_print_' + func) and \
                 not isinstance(expr, AppliedUndef):
             return getattr(self, '_print_' + func)(expr, exp)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1422,8 +1422,6 @@ class PrettyPrinter(Printer):
     def _print_Function(self, e, sort=False, func_name=None):
         # optional argument func_name for supplying custom names
         # XXX works only for applied functions
-        if not func_name and hasattr(e, 'name'):
-            func_name = e.name
         return self._helper_print_function(e.func, e.args, sort=sort, func_name=func_name)
 
     def _print_mathieuc(self, e):
@@ -1442,8 +1440,11 @@ class PrettyPrinter(Printer):
         if sort:
             args = sorted(args, key=default_sort_key)
 
-        if not func_name and hasattr(func, "__name__"):
-            func_name = func.__name__
+        if not func_name:
+            if hasattr(func, 'name'):
+                func_name = func.name
+            elif hasattr(func, '__name__'):
+                func_name = func.__name__
 
         if func_name:
             prettyFunc = self._print(Symbol(func_name))
@@ -1501,8 +1502,7 @@ class PrettyPrinter(Printer):
                     return prettyForm(self._special_function_classes[cls][0])
                 else:
                     return prettyForm(self._special_function_classes[cls][1])
-        clsname = expr.__name__
-        func_name = getattr(expr, 'name', clsname)
+        func_name = expr.name
         return prettyForm(pretty_symbol(func_name))
 
     def _print_GeometryEntity(self, expr):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1422,6 +1422,8 @@ class PrettyPrinter(Printer):
     def _print_Function(self, e, sort=False, func_name=None):
         # optional argument func_name for supplying custom names
         # XXX works only for applied functions
+        if not func_name and hasattr(e, 'name'):
+            func_name = e.name
         return self._helper_print_function(e.func, e.args, sort=sort, func_name=func_name)
 
     def _print_mathieuc(self, e):
@@ -1499,7 +1501,8 @@ class PrettyPrinter(Printer):
                     return prettyForm(self._special_function_classes[cls][0])
                 else:
                     return prettyForm(self._special_function_classes[cls][1])
-        func_name = expr.__name__
+        clsname = expr.__name__
+        func_name = getattr(expr, 'name', clsname)
         return prettyForm(pretty_symbol(func_name))
 
     def _print_GeometryEntity(self, expr):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6960,3 +6960,10 @@ def test_issue_18272():
     '⎪                 ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
     '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
     '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
+
+def test_pretty_customfunction():
+    f_star1 = Function('f^*')
+    class f_star2(Function):
+        name = 'f^*'
+    assert pretty(f_star1) == pretty(f_star2)
+    assert pretty(f_star1(x)) == pretty(f_star2(x))

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -151,7 +151,7 @@ class StrPrinter(Printer):
         return '(%s, %s)' % (self._print(expr.expr), self._print(expr.cond))
 
     def _print_Function(self, expr):
-        clsname = expr.func.__name__
+        clsname = expr.func.name
         func = getattr(expr.func, 'name', clsname)
         return func + "(%s)" % self.stringify(expr.args, ", ")
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -151,7 +151,9 @@ class StrPrinter(Printer):
         return '(%s, %s)' % (self._print(expr.expr), self._print(expr.cond))
 
     def _print_Function(self, expr):
-        return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")
+        clsname = expr.func.__name__
+        func = getattr(expr.func, 'name', clsname)
+        return func + "(%s)" % self.stringify(expr.args, ", ")
 
     def _print_GoldenRatio(self, expr):
         return 'GoldenRatio'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2565,3 +2565,9 @@ def test_latex_decimal_separator():
     raises(ValueError, lambda: latex([1,2.3,4.5], decimal_separator='non_existing_decimal_separator_in_list'))
     raises(ValueError, lambda: latex(FiniteSet(1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_set'))
     raises(ValueError, lambda: latex((1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_tuple'))
+
+def test_latex_customfunction():
+    f_star1 = Function('f^*')
+    class f_star2(Function):
+        name = 'f^*'
+    assert latex(f_star1(x)) == latex(f_star2(x))

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -869,5 +869,11 @@ def test_str_special_matrices():
     assert str(OneMatrix(2, 2)) == '1'
 
 
-def test_issue_14567():
+def test_str_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
+
+def test_latex_customfunction():
+    f_star1 = Function('f^*')
+    class f_star2(Function):
+        name = 'f^*'
+    assert str(f_star1(x)) == str(f_star2(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Just like `Function('f^*').name` (=`'f^*'`) is used in printing, making subclass of `Function` with class attribute `name` makes it printed with the name.

#### Other comments

Previously,
```python
>>> from sympy import Function, latex
>>> from sympy.abc import x
>>> class f_star(Function):
...     name = 'f^*'
>>> latex(f_star(x))
'\\operatorname{f_{star}}{\\left(x \\right)}'
```

Now,
```python
>>> from sympy import Function, latex
>>> from sympy.abc import x
>>> class f_star(Function):
...     name = 'f^*'
>>> latex(f_star(x))
'\\operatorname{f^{*}}{\\left(x \\right)}'
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - Every `Function` now have `name` attribute.

- printing
    - Making custom function with class attribute `name` now makes it printed using the name.
<!-- END RELEASE NOTES -->