### PR TITLE
added method exponent for permutation group

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4866,7 +4866,7 @@ class PermutationGroup(Basic):
             Returns the exponent of a group
 
             The exponent e of a group G is the lcm of the orders of its elements,
-            that is, e is the smallest integer such that g^e = 1 for all g ∈ G.
+            that is, e is the smallest integer such that g^e = 1 for all g belong to G.
         """
 
         def gcd(a, b):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4886,7 +4886,6 @@ class PermutationGroup(Basic):
 
         """
 
-        exp_p = 1
         exp = 1
         sylow_groups = {}
         P = factorint(self.order()).keys()

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4867,11 +4867,38 @@ class PermutationGroup(Basic):
 
             The exponent e of a group G is the lcm of the orders of its elements,
             that is, e is the smallest integer such that g^e = 1 for all g belong to G.
+            or the exponent of a group G is just the product of exponents of its sylow_subgroups.
+
+            Examples
+            ========
+
+            >>> from sympy.combinatorics import Permutation
+            >>> from sympy.combinatorics.perm_groups import PermutationGroup
+            >>> a = Permutation(1, 2)(2, 3)
+            >>> b = Permutation(1, 2, 3, 4)(2, 3, 4)(5, 6, 7)(8, 9)
+            >>> A = PermutationGroup([a, b])
+            >>> A.exponent()
+            12
+            >>> c = Permutation(1, 2, 3, 4, 5, 6)(2, 3, 4)(5, 6, 7)(8, 9)(10, 11, 12)
+            >>> A = PermutationGroup([a, b, c])
+            >>> A.exponent()
+            420
+
         """
-        elements = list(self.elements)
-        exp = elements[0].order()
-        for i in range(1, len(elements)):
-            exp = exp.lcm(elements[i].order())
+
+        exp_p = 1
+        exp = 1
+        sylow_groups = {}
+        P = factorint(self.order()).keys()
+        for p in P:
+            sylow_p_subgroup = self.sylow_subgroup(p)
+            if sylow_p_subgroup not in sylow_groups:
+                elements = list(sylow_p_subgroup.elements)
+                exp_p = elements[0].order()
+                for i in range(1, len(elements)):
+                    exp_p = exp_p.lcm(elements[i].order())
+                sylow_groups[sylow_p_subgroup] = exp_p
+            exp = exp * sylow_groups[sylow_p_subgroup]
         return exp
 
 def _orbit(degree, generators, alpha, action='tuples'):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4869,15 +4869,9 @@ class PermutationGroup(Basic):
             that is, e is the smallest integer such that g^e = 1 for all g belong to G.
         """
 
-        def gcd(a, b):
-            #Calculate the greatest common divisor
-            if b == 0:
-                return a
-            return gcd(b, a%b)
-
         exp = self[0].order()
         for i in range(1, len(self)):
-            exp = (self[i].order()*exp)/gcd(self[i].order(), exp)
+            exp = exp.lcm(self[i].order())
         return exp
 
 def _orbit(degree, generators, alpha, action='tuples'):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4868,10 +4868,10 @@ class PermutationGroup(Basic):
             The exponent e of a group G is the lcm of the orders of its elements,
             that is, e is the smallest integer such that g^e = 1 for all g belong to G.
         """
-
-        exp = self[0].order()
-        for i in range(1, len(self)):
-            exp = exp.lcm(self[i].order())
+        elements = list(self.elements)
+        exp = elements[0].order()
+        for i in range(1, len(elements)):
+            exp = exp.lcm(elements[i].order())
         return exp
 
 def _orbit(degree, generators, alpha, action='tuples'):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4861,6 +4861,24 @@ class PermutationGroup(Basic):
 
         return PolycyclicGroup(pc_sequence, pc_series, relative_order, collector=None)
 
+    def exponent(self):
+        """
+            Returns the exponent of a group
+
+            The exponent e of a group G is the lcm of the orders of its elements,
+            that is, e is the smallest integer such that g^e = 1 for all g ∈ G.
+        """
+
+        def gcd(a, b):
+            #Calculate the greatest common divisor
+            if b == 0:
+                return a
+            return gcd(b, a%b)
+
+        exp = self[0].order()
+        for i in range(1, len(self)):
+            exp = (self[i].order()*exp)/gcd(self[i].order(), exp)
+        return exp
 
 def _orbit(degree, generators, alpha, action='tuples'):
     r"""Compute the orbit of alpha `\{g(\alpha) | g \in G\}` as a set.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -18,7 +18,7 @@ from sympy.ntheory import sieve
 from sympy.utilities.iterables import has_variety, is_sequence, uniq
 from sympy.testing.randtest import _randrange
 from itertools import islice
-
+from sympy.core.numbers import Integer
 rmul = Permutation.rmul_with_af
 _af_new = Permutation._af_new
 
@@ -4895,7 +4895,7 @@ class PermutationGroup(Basic):
                 elements = list(sylow_p_subgroup.elements)
                 exp_p = elements[0].order()
                 for i in range(1, len(elements)):
-                    exp_p = exp_p.lcm(elements[i].order())
+                    exp_p = Integer(exp_p).lcm(elements[i].order())
                 sylow_groups[sylow_p_subgroup] = exp_p
             exp = exp * sylow_groups[sylow_p_subgroup]
         return exp

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1116,3 +1116,13 @@ def test_conjugacy_classes():
 
     assert len(expected) == len(computed)
     assert all(e in computed for e in expected)
+
+def test_exponent():
+    a = Permutation(1,2)(2,3)
+    b = Permutation(1,2,3,4)(2,3,4)(5,6,7)(8,9)
+    A = PermutationGroup([a,b])
+    assert A.exponent() == 12
+
+    c = Permutation(1,2,3,4,5,6)(2,3,4)(5,6,7)(8,9)(10,11,12)
+    A = PermutationGroup([a,b,c])
+    assert A.exponent() == 60

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1125,4 +1125,4 @@ def test_exponent():
 
     c = Permutation(1,2,3,4,5,6)(2,3,4)(5,6,7)(8,9)(10,11,12)
     A = PermutationGroup([a, b, c])
-    assert A.exponent() == 60
+    assert A.exponent() == 420

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1118,11 +1118,11 @@ def test_conjugacy_classes():
     assert all(e in computed for e in expected)
 
 def test_exponent():
-    a = Permutation(1,2)(2,3)
-    b = Permutation(1,2,3,4)(2,3,4)(5,6,7)(8,9)
-    A = PermutationGroup([a,b])
+    a = Permutation(1, 2)(2, 3)
+    b = Permutation(1, 2, 3, 4)(2, 3, 4)(5, 6, 7)(8, 9)
+    A = PermutationGroup([a, b])
     assert A.exponent() == 12
 
     c = Permutation(1,2,3,4,5,6)(2,3,4)(5,6,7)(8,9)(10,11,12)
-    A = PermutationGroup([a,b,c])
+    A = PermutationGroup([a, b, c])
     assert A.exponent() == 60


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
A method is added to calculate the exponent of a permutation group

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
    - Added method `exponent` in `perm_groups.py`.
<!-- END RELEASE NOTES -->