### PR TITLE
Basic free group

### DIFF
--- a/doc/src/modules/combinatorics/pc_groups.rst
+++ b/doc/src/modules/combinatorics/pc_groups.rst
@@ -40,7 +40,7 @@ relative order.
 Attributes of PolycyclicGroup
 `````````````````````````````
 
-* ``pc_sequence`` : Polycyclic sequence is formed by collecting all the missing 
+* ``pc_sequence`` : Polycyclic sequence is formed by collecting all the missing
   generators between the adjacent groups in the derived series of given
   permutation group.
 
@@ -156,7 +156,7 @@ represents the respective relative order.
 >>> collected_word = collector.collected_word(word)
 >>> free_to_perm = {}
 >>> free_group = collector.free_group
->>> for sym, gen in zip(free_group.symbols, collector.pcgs):
+>>> for sym, gen in zip(free_group.generators, collector.pcgs):
 ...     free_to_perm[sym] = gen
 >>> G1 = PermutationGroup()
 >>> for w in word:
@@ -251,7 +251,7 @@ polycyclic generating sequence. Hence, the length of exponent vector is equal to
 the length of the pcgs.
 
 A given generator ``g`` of the polycyclic group, can be represented as
-`g = x_1^{e_1} \ldots x_n^{e_n}`, where `x_i` represents polycyclic generators 
+`g = x_1^{e_1} \ldots x_n^{e_n}`, where `x_i` represents polycyclic generators
 and ``n`` is the number of generators in the free_group equal to the length of pcgs.
 
 >>> from sympy.combinatorics.named_groups import SymmetricGroup

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -4,11 +4,10 @@ from typing import List
 
 from sympy.core import S
 from sympy.core.basic import Basic
-from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import is_sequence, as_int
 from sympy.core.expr import Expr
-from sympy.core.symbol import Symbol, symbols as _symbols
+from sympy.core.symbol import symbols as _symbols
 from sympy.core.sympify import _sympify
 from sympy.utilities import public
 from sympy.utilities.iterables import flatten

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -4,6 +4,7 @@ from typing import List
 
 from sympy.core import S
 from sympy.core.basic import Basic
+from sympy.core.cache import cacheit
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import is_sequence, as_int
 from sympy.core.expr import Expr
@@ -140,14 +141,7 @@ class FreeGroup(Basic):
     def __new__(cls, symbols):
         symbols = tuple(_parse_symbols(symbols))
         obj = super().__new__(cls, Tuple(*symbols))
-        obj._symbols = symbols
         obj._generators = None
-        for symbol, generator in zip(obj.symbols, obj.generators):
-            if isinstance(symbol, Symbol):
-                name = symbol.name
-                if hasattr(obj, name):
-                    setattr(obj, name, generator)
-
         return obj
 
     def dtype(self, arg):
@@ -156,7 +150,7 @@ class FreeGroup(Basic):
 
     @property
     def symbols(self):
-        return self._symbols
+        return self.args[0].args
 
     @property
     def generators(self):

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -213,10 +213,11 @@ class FreeGroup(Basic):
         0
 
         """
-        if isinstance(gen, self.dtype):
+        gen = _sympify(gen)
+        if isinstance(gen, FreeGroupElement) and self == gen.group:
             return self.generators.index(gen)
-        else:
-            raise ValueError("expected a generator of Free Group %s, got %s" % (self, gen))
+        raise ValueError(
+            "expected a generator of Free Group %s, got %s" % (self, gen))
 
     def order(self):
         """Return the order of the free group.

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -139,12 +139,9 @@ class FreeGroup(Basic):
     relators = []  # type: List[Expr]
 
     def __new__(cls, symbols):
-        if isinstance(symbols, str):
-            symbols = tuple(_parse_symbols(symbols))
-        elif isinstance(symbols, Symbol):
-            symbols = (symbols,)
-
+        symbols = tuple(_parse_symbols(symbols))
         obj = super().__new__(cls, Tuple(*symbols))
+        obj._symbols = symbols
         obj._generators = None
         for symbol, generator in zip(obj.symbols, obj.generators):
             if isinstance(symbol, Symbol):
@@ -160,7 +157,7 @@ class FreeGroup(Basic):
 
     @property
     def symbols(self):
-        return self.args[0]
+        return self._symbols
 
     @property
     def generators(self):

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -1,11 +1,10 @@
 from __future__ import print_function, division
 
-from typing import Dict, List
+from typing import List
 
 from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
-from sympy.core.numbers import Integer
 from sympy.core.compatibility import is_sequence, as_int
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols

--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -348,7 +348,6 @@ class Collector(DefaultPrinting):
                 s2 = free_group.dtype(s2)
                 word_ = self.map_relation(free_group.dtype(w))
                 word_ = s2*word_**e1
-                word_ = free_group.dtype(word_)
                 word = word.substituted_word(low, high, word_)
 
             elif len(w) == 2 and w[1][1] < 0:
@@ -357,7 +356,6 @@ class Collector(DefaultPrinting):
                 s2 = free_group.dtype(s2)
                 word_ = self.map_relation(free_group.dtype(w))
                 word_ = s2**-1*word_**e1
-                word_ = free_group.dtype(word_)
                 word = word.substituted_word(low, high, word_)
 
         return word

--- a/sympy/combinatorics/pc_groups.py
+++ b/sympy/combinatorics/pc_groups.py
@@ -256,8 +256,7 @@ class Collector(DefaultPrinting):
 
 
     def collected_word(self, word):
-        r"""
-        Return the collected form of a word.
+        r"""Return the collected form of a word.
 
         A word ``w`` is called collected, if `w = {x_{i_1}}^{a_1} * \ldots *
         {x_{i_r}}^{a_r}` with `i_1 < i_2< \ldots < i_r` and `a_j` is in
@@ -278,34 +277,6 @@ class Collector(DefaultPrinting):
             A collected word of form `w = {x_{i_1}}^{a_1}, \ldots,
             {x_{i_r}}^{a_r}` with `i_1, i_2, \ldots, i_r` and `a_j \in
             \{1, \ldots, {s_j}-1\}`.
-
-        Examples
-        ========
-        >>> from sympy.combinatorics.named_groups import SymmetricGroup
-        >>> from sympy.combinatorics.perm_groups import PermutationGroup
-        >>> from sympy.combinatorics.free_groups import free_group
-        >>> G = SymmetricGroup(4)
-        >>> PcGroup = G.polycyclic_group()
-        >>> collector = PcGroup.collector
-        >>> F, x0, x1, x2, x3 = free_group("x0, x1, x2, x3")
-        >>> word = x3*x2*x1*x0
-        >>> collected_word = collector.collected_word(word)
-        >>> free_to_perm = {}
-        >>> free_group = collector.free_group
-        >>> for sym, gen in zip(free_group.symbols, collector.pcgs):
-        ...     free_to_perm[sym] = gen
-        >>> G1 = PermutationGroup()
-        >>> for w in word:
-        ...     sym = w[0]
-        ...     perm = free_to_perm[sym]
-        ...     G1 = PermutationGroup([perm] + G1.generators)
-        >>> G2 = PermutationGroup()
-        >>> for w in collected_word:
-        ...     sym = w[0]
-        ...     perm = free_to_perm[sym]
-        ...     G2 = PermutationGroup([perm] + G2.generators)
-        >>> G1 == G2
-        True
 
         See Also
         ========

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -44,7 +44,6 @@ def test_FreeGroup__hash__():
 
 def test_FreeGroup__eq__():
     assert free_group("x, y, z")[0] == free_group("x, y, z")[0]
-    assert free_group("x, y, z")[0] is free_group("x, y, z")[0]
 
     assert free_group("x, y, z")[0] != free_group("a, x, y")[0]
     assert free_group("x, y, z")[0] is not free_group("a, x, y")[0]

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -467,6 +467,17 @@ def test_sympy__combinatorics__subsets__Subset():
     assert _test_args(Subset(['c', 'd'], ['a', 'b', 'c', 'd']))
 
 
+def test_sympy__combinatorics__free_groups__FreeGroup():
+    from sympy.combinatorics.free_groups import FreeGroup
+    assert _test_args(FreeGroup('x y z'))
+
+
+def test_sympy__combinatorics__free_groups__FreeGroupElement():
+    from sympy.combinatorics.free_groups import free_group, FreeGroupElement
+    G, x, y, z = free_group('x y z')
+    assert _test_args(FreeGroupElement(((x, 1), (y, 2), (z, -1)), G))
+
+
 def test_sympy__combinatorics__permutations__Permutation():
     from sympy.combinatorics.permutations import Permutation
     assert _test_args(Permutation([0, 1, 2, 3]))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -414,6 +414,20 @@ class LatexPrinter(Printer):
         perm, var = expr.args
         return r"\sigma_{%s}(%s)" % (self._print(perm), self._print(var))
 
+    def _print_FreeGroupElement(self, expr):
+        if expr.is_identity:
+            return "1"
+
+        terms = []
+        for base, exp in expr.array_form:
+            if exp == 1:
+                terms.append(self._print(base))
+            else:
+                terms.append(
+                    "{}^{}".format(self._print(base), self._print(exp)))
+
+        return " ".join(terms)
+
     def _print_Float(self, expr):
         # Based off of that in StrPrinter
         dps = prec_to_dps(expr._prec)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -424,7 +424,7 @@ class LatexPrinter(Printer):
                 terms.append(self._print(base))
             else:
                 terms.append(
-                    "{}^{}".format(self._print(base), self._print(exp)))
+                    r"{%s}^{%s}" % (self._print(base), self._print(exp)))
 
         return " ".join(terms)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -409,6 +409,28 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
+    def _print_FreeGroup(self, expr):
+        if expr.rank > 30:
+            str_form = "<free group with %s generators>" % expr.rank
+        else:
+            str_form = "<free group on the generators "
+            gens = expr.generators
+            str_form += self._print(gens) + ">"
+        return str_form
+
+    def _print_FreeGroupElement(self, expr):
+        if expr.is_identity:
+            return "<identity>"
+
+        terms = []
+        for base, exp in expr.array_form:
+            if exp == 1:
+                terms.append(self._print(base))
+            else:
+                terms.append(self._print(base) + "**" + self._print(exp))
+
+        return "*".join(terms)
+
     def _print_Subs(self, obj):
         expr, old, new = obj.args
         if len(obj.point) == 1:
@@ -452,9 +474,6 @@ class StrPrinter(Printer):
         return "Rational function field in %s over %s with %s order" % \
             (", ".join(map(lambda fs: self._print(fs), field.symbols)),
             self._print(field.domain), self._print(field.order))
-
-    def _print_FreeGroupElement(self, elm):
-        return elm.__str__()
 
     def _print_PolyElement(self, poly):
         return poly.str(self, PRECEDENCE, "%s**%s", "*")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#17731

#### Brief description of what is fixed or changed

I have removed `free_group_cache` and removed overriding of `__eq__`, `__hash__` for more clean design.

Now, the standard structure of the classes should be like below

- `FreeGroup((x, y, z))` where `x, y, z` are symbols
- `FreeGroupElement(((x, 1), (y, 2), ...), G)` where `(x, 1), (y, 2)` are base-exp pairs and `G` is the parent free group.

I've also moved most of the printings to printer classes and added LaTeX printing for `FreeGroupElement`.

#### Other comments

I think that the `args` structure can be flattened to use `FreeGroup(x, y, z)` rather than `FreeGroup((x, y, z))`. But kept only for some backward compatibility. 
But I think that this can be changed abruptly because I see that the classes were not decorated as public methods.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- combinatorics
  - Made `FreeGroup` and `FreeGroupElement` instances of `Basic`.
- printing
  - Added LaTeX printing support for `FreeGroupElement`.

<!-- END RELEASE NOTES -->