### PR TITLE
Evaluate nested floor/ceiling.

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -68,6 +68,8 @@ class RoundFunction(Function):
             return ipart
         elif spart.is_imaginary or (S.ImaginaryUnit*spart).is_real:
             return ipart + cls(im(spart), evaluate=False)*S.ImaginaryUnit
+        elif isinstance(spart,cls):
+            return ipart + spart
         else:
             return ipart + cls(spart, evaluate=False)
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -68,7 +68,7 @@ class RoundFunction(Function):
             return ipart
         elif spart.is_imaginary or (S.ImaginaryUnit*spart).is_real:
             return ipart + cls(im(spart), evaluate=False)*S.ImaginaryUnit
-        elif isinstance(spart, floor) or isinstance(spart, ceiling):
+        elif isinstance(spart, (floor, ceiling)):
             return ipart + spart
         else:
             return ipart + cls(spart, evaluate=False)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -68,7 +68,7 @@ class RoundFunction(Function):
             return ipart
         elif spart.is_imaginary or (S.ImaginaryUnit*spart).is_real:
             return ipart + cls(im(spart), evaluate=False)*S.ImaginaryUnit
-        elif isinstance(spart,cls):
+        elif isinstance(spart, floor) or isinstance(spart, ceiling):
             return ipart + spart
         else:
             return ipart + cls(spart, evaluate=False)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -561,6 +561,10 @@ def test_nested_floor_ceiling():
     assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
     assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)
 
+def test_issue_18689():
+    assert floor(floor(floor(x)) + 3) == floor(x) + 3
+    assert ceiling(ceiling(ceiling(x)) + 1) == ceiling(x) + 1
+    assert ceiling(ceiling(floor(x)) + 3) == floor(x) + 3
 
 def test_issue_18421():
     assert floor(float(0)) is S.Zero


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18689 

#### Brief description of what is fixed or changed
evaluate nested floor and ceiling.
example-
```python
floor(floor(floor(x)) + 3) == floor(x) + 3
ceiling(ceiling(ceiling(x)) + 3) == ceiling(x) + 3
ceiling(ceiling(floor(x)) + 3) == floor(x) + 3
```
### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
    - Evaluate nested floor/ceiling.
<!-- END RELEASE NOTES -->