### PR TITLE
parsing(c_parser): redundant parameter "name" has been removed

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -80,7 +80,7 @@ if cin:
         converts them to SymPy Expressions.
         """
 
-        def __init__(self, name):
+        def __init__(self):
             """Initializes the code converter"""
             super(CCodeConverter, self).__init__()
             self._py_nodes = []
@@ -650,7 +650,7 @@ def parse_c(source):
         List of Python expression strings
 
     """
-    converter = CCodeConverter('output')
+    converter = CCodeConverter()
     if os.path.exists(source):
         src = converter.parse(source, flags = [])
     else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18906 

#### Brief description of what is fixed or changed
Parmeterized  constructor of CCodeConverter class in `sympy/parsing/c_parser.py` possesses a redundant parameter "name", which was not used anywhere in the instance variables or methods. So, it has been removed from its definition as well as from its reference.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->