### PR TITLE
add `force` to `to_cnf` and `to_dnf`; `is_literal` made more general

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1910,22 +1910,14 @@ def _is_form(expr, function1, function2):
     """
     expr = sympify(expr)
 
-    def is_a_literal(lit):
-        if isinstance(lit, Not) \
-                and lit.args[0].is_Atom:
-            return True
-        elif lit.is_Atom:
-            return True
-        return False
-
     vals = function1.make_args(expr) if isinstance(expr, function1) else [expr]
     for lit in vals:
         if isinstance(lit, function2):
             vals2 = function2.make_args(lit) if isinstance(lit, function2) else [lit]
             for l in vals2:
-                if is_a_literal(l) is False:
+                if is_literal(l) is False:
                     return False
-        elif is_a_literal(lit) is False:
+        elif is_literal(lit) is False:
             return False
 
     return True
@@ -1977,9 +1969,12 @@ def is_literal(expr):
 
     """
     if isinstance(expr, Not):
-        return not isinstance(expr.args[0], BooleanFunction)
-    else:
-        return not isinstance(expr, BooleanFunction)
+        return expr.args[0].is_Atom
+    elif expr in (True, False) or expr.is_Atom:
+        return True
+    elif expr.is_Relational and all(map(is_literal, expr.args)):
+        return True
+    return False
 
 
 def to_int_repr(clauses, symbols):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1983,11 +1983,11 @@ def is_literal(expr):
 
     """
     if isinstance(expr, Not):
-        return expr.args[0].is_Atom
+        return is_literal(expr.args[0])
     elif expr in (True, False) or expr.is_Atom:
         return True
     elif not isinstance(expr, BooleanFunction) and all(
-            map(is_literal, expr.args)):
+            a.is_Atom for a in expr.args):
         return True
     return False
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1960,12 +1960,9 @@ def eliminate_implications(expr):
     return to_nnf(expr, simplify=False)
 
 
-def is_literal(expr, literal_Not=True):
+def is_literal(expr):
     """
-    Returns True if expr is a literal, else False. When a
-    ``Not`` is encountered it is considered a literal
-    by default if its argument is literal. It can be
-    treated as non-literal by setting the ``literal_Not`` to False.
+    Returns True if expr is a literal, else False.
 
     Examples
     ========
@@ -2803,7 +2800,7 @@ def simplify_logic(expr, form=None, deep=True, force=False):
     form_ok = (
         isc and form == 'cnf' or
         isd and form == 'dnf')
-    if form_ok and all(is_literal(a, literal_Not=False)
+    if form_ok and all(is_literal(a)
             for a in expr.args):
         return expr
     if deep:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1983,7 +1983,7 @@ def is_literal(expr):
 
     """
     if isinstance(expr, Not):
-        return literal_Not and expr.args[0].is_Atom
+        return expr.args[0].is_Atom
     elif expr in (True, False) or expr.is_Atom:
         return True
     elif not isinstance(expr, BooleanFunction) and all(

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1986,7 +1986,8 @@ def is_literal(expr):
         return expr.args[0].is_Atom
     elif expr in (True, False) or expr.is_Atom:
         return True
-    elif expr.is_Relational and all(map(is_literal, expr.args)):
+    elif not isinstance(expr, BooleanFunction) and all(
+            map(is_literal, expr.args)):
         return True
     return False
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -528,6 +528,11 @@ def test_to_cnf():
         And(Or(Not(B), A), Or(Not(C), A), Or(B, C, Not(A)))
     assert to_cnf(A + 1) == A + 1
 
+
+def test_issue_9949():
+    assert is_cnf(to_cnf((b > -5) | (a > 2) & (a < 4)))
+
+
 def test_to_CNF():
     assert CNF.CNF_to_cnf(CNF.to_CNF(~(B | C))) == to_cnf(~(B | C))
     assert CNF.CNF_to_cnf(CNF.to_CNF((A & B) | C)) == to_cnf((A & B) | C)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -683,6 +683,8 @@ def test_is_literal():
     assert is_literal(Not(Q.zero(A))) is True
     assert is_literal(Or(A, B)) is False
     assert is_literal(And(Q.zero(A), Q.zero(B))) is False
+    assert is_literal(Not(a))
+    assert not is_literal(Not(a), literal_Not=False)
 
 
 def test_operators():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -529,6 +529,19 @@ def test_to_cnf():
     assert to_cnf(A + 1) == A + 1
 
 
+def test_issue_18904():
+    x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 = symbols('x1:16')
+    eq = (( x1 & x2 & x3 & x4 & x5 & x6 & x7 & x8 & x9 )  |
+        ( x1 & x2 & x3 & x4 & x5 & x6 & x7 & x10 & x9 )  |
+        ( x1 & x11 & x3 & x12 & x5 & x13 & x14 & x15 & x9 ))
+    assert is_cnf(to_cnf(eq))
+    raises(ValueError, lambda: to_cnf(eq, simplify=True))
+    for f, t in zip((And, Or), (to_cnf, to_dnf)):
+        eq = f(x1, x2, x3, x4, x5, x6, x7, x8, x9)
+        raises(ValueError, lambda: to_cnf(eq, simplify=True))
+        assert t(eq, simplify=True, force=True) == eq
+
+
 def test_issue_9949():
     assert is_cnf(to_cnf((b > -5) | (a > 2) & (a < 4)))
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -683,6 +683,8 @@ def test_is_literal():
     assert is_literal(Not(Q.zero(A))) is True
     assert is_literal(Or(A, B)) is False
     assert is_literal(And(Q.zero(A), Q.zero(B))) is False
+    assert is_literal(x < 3)
+    assert not is_literal(x + y < 3)
 
 
 def test_operators():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -683,8 +683,6 @@ def test_is_literal():
     assert is_literal(Not(Q.zero(A))) is True
     assert is_literal(Or(A, B)) is False
     assert is_literal(And(Q.zero(A), Q.zero(B))) is False
-    assert is_literal(Not(a))
-    assert not is_literal(Not(a), literal_Not=False)
 
 
 def test_operators():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #9949
fixes #18904

#### Brief description of what is fixed or changed

When `to_cnf` is given an expression with more than 8 variables and `simplify=True` it will not simplify the expression -- and may not return it in cnf form and does so silently. Now, a ValueError is raised if simplification is requested and `force` is not True. The user has the option to not use `simplify` or to use `force`.

In addition, `is_literal` and `is_a_literal` were combined and made to recognize that things like `x < 2` can be treated like a literal. This fixes issue 9949.

Finally, a quick-exit is given to `simplify_logic` to deal with trivial cases that don't need simplification and are already in the correct, most implified form.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
    * boolalg
        * `to_cnf`/`to_dnf` (when `simplify=True) require `force=True` if there are more than 8 variables
        * `simplify_logic` recognizes trivial simplified cases
        * `is_literal` can treat `Not` as literal or not by using the `literal_Not` flag
<!-- END RELEASE NOTES -->