### PR TITLE
parsing(c_parser): Added parsing code to handle the assignment case where character is assigned to integer

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -256,6 +256,17 @@ if cin:
                     ).as_Declaration(
                         value = val
                     )
+                #case where a character is assigned to an integer type variable
+                elif (child.kind == cin.CursorKind.CHARACTER_LITERAL
+                    and node.type.kind == cin.TypeKind.INT):
+                    type = IntBaseType(String('integer'))
+                    value = Integer(ord(val))
+                    return Variable(
+                        node.spelling
+                    ).as_Declaration(
+                        type = type,
+                        value = value
+                    )
                 else:
                     raise NotImplementedError()
 
@@ -478,16 +489,29 @@ if cin:
             pass
 
         def transform_character_literal(self, node):
-            #TODO: No string Type in AST
-            #type =
-            #try:
-            #    value = next(node.get_tokens()).spelling
-            #except (StopIteration, ValueError):
+            """Transformation function for character literal
+
+            Used to get the value of the given character literal.
+
+            Returns
+            =======
+
+            val : str
+                val contains the string value stored in the variable
+
+            Notes
+            =====
+
+            Only for cases where character is assigned to a integer value,
+            since character literal is not in sympy AST
+
+            """
+            try:
+               value = next(node.get_tokens()).spelling
+            except (StopIteration, ValueError):
                 # No tokens
-            #    value = node.literal
-            #val = [type, value]
-            #return val
-            pass
+               value = node.literal
+            return str(value[1])
 
         def transform_unexposed_decl(self,node):
             """Transformation function for unexposed declarations"""

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -132,11 +132,13 @@ if cin:
         )
         c_src3 = 'int a = 2.345, b = 5.67;'
         c_src4 = 'int p = 6, q = 23.45;'
+        c_src5 = "int x = '0', y = 'a';"
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
         res3 = SymPyExpression(c_src3, 'c').return_expr()
         res4 = SymPyExpression(c_src4, 'c').return_expr()
+        res5 = SymPyExpression(c_src5, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -191,6 +193,22 @@ if cin:
                 Symbol('q'),
                 type=IntBaseType(String('integer')),
                 value=Integer(23)
+            )
+        )
+
+        assert res5[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=IntBaseType(String('integer')),
+                value=Integer(48)
+            )
+        )
+
+        assert res5[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=IntBaseType(String('integer')),
+                value=Integer(97)
             )
         )
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added the case where character is assigned to an integer
- Added code in the function transform_character_literal() to return appropriate string
- Handled the AST clang nodes in transform_var_decl()
-  Added tests for the same.

#### Other comments
Consider the following case :
<pre>
In [1]: from sympy.parsing.sym_expr import SymPyExpression                      

In [2]: src = """ 
   ...: int a='1', b='d'; 
   ...: """                                                                     

In [3]: a=SymPyExpression(src, 'c')                                             

In [4]: a.return_expr()                                                         
Out[4]: 
[Declaration(Variable(a, type=integer, value=49)), Declaration(Variable(b, typ
e=integer, value=100))]

</pre>

Before: Raised NotImplementedError
Now: Assigns correct ascii value to the integer value as expected in C and successfully gets parsed to sympy expression as shown above.

#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
    - Added the assignment case where character is assigned to an integer in C parser
<!-- END RELEASE NOTES -->