### PR TITLE
matrices typo and banded reference

### DIFF
--- a/doc/src/modules/matrices/index.rst
+++ b/doc/src/modules/matrices/index.rst
@@ -15,5 +15,6 @@ Contents:
    common.rst
    dense.rst
    sparse.rst
+   sparsetools.rst
    immutablematrices.rst
    expressions.rst

--- a/doc/src/modules/matrices/sparsetools.rst
+++ b/doc/src/modules/matrices/sparsetools.rst
@@ -1,0 +1,12 @@
+.. _matrices-sparsetools:
+
+Sparse Tools
+============
+
+.. module:: sympy.matrices.sparsetools
+
+.. automethod:: sympy.matrices.sparsetools._doktocsr
+
+.. automethod:: sympy.matrices.sparsetools._csrtodok
+
+.. automethod:: sympy.matrices.sparsetools.banded

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -760,7 +760,7 @@ class MatrixSpecial(MatrixRequired):
 
         When more than one element is passed, each is interpreted as
         something to put on the diagonal. Lists are converted to
-        matricecs. Filling of the diagonal always continues from
+        matrices. Filling of the diagonal always continues from
         the bottom right hand corner of the previous item: this
         will create a block-diagonal matrix whether the matrices
         are square or not.
@@ -808,6 +808,7 @@ class MatrixSpecial(MatrixRequired):
         diagonal - to extract a diagonal
         .dense.diag
         .expressions.blockmatrix.BlockMatrix
+        .sparsetools.banded - to create multi-diagonal matrices
        """
         from sympy.matrices.matrices import MatrixBase
         from sympy.matrices.dense import Matrix

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -69,9 +69,13 @@ def banded(*args, **kwargs):
     the diagonals of the matrix. The keys are positive for upper
     diagonals and negative for those below the main diagonal. The
     values may be:
-        * expressions or single-argument functions,
-        * lists or tuples of values,
-        * matrices
+
+    * expressions or single-argument functions,
+
+    * lists or tuples of values,
+
+    * matrices
+
     Unless dimensions are given, the size of the returned matrix will
     be large enough to contain the largest non-zero value provided.
 

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -4,7 +4,7 @@ from sympy.core.compatibility import as_int
 from sympy.utilities.iterables import is_sequence
 from sympy.utilities.misc import filldedent
 
-from .sparse import SparseMatrix
+from .sparse import MutableSparseMatrix
 
 
 def _doktocsr(dok):
@@ -19,6 +19,17 @@ def _doktocsr(dok):
         of row[i]. Thus IA[i+1] - IA[i] gives number of non-zero
         elements row[i]. The length of IA is always 1 more than the
         number of rows in the matrix.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.sparsetools import _doktocsr
+    >>> from sympy import SparseMatrix, diag
+    >>> m = SparseMatrix(diag(1, 2, 3))
+    >>> m[2, 0] = -1
+    >>> _doktocsr(m)
+    [[1, 2, -1, 3], [0, 1, 0, 2], [0, 1, 2, 4], [3, 3]]
+
     """
     row, JA, A = [list(i) for i in zip(*dok.row_list())]
     IA = [0]*((row[0] if row else 0) + 1)
@@ -30,14 +41,27 @@ def _doktocsr(dok):
 
 
 def _csrtodok(csr):
-    """Converts a CSR representation to DOK representation"""
+    """Converts a CSR representation to DOK representation.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.sparsetools import _csrtodok
+    >>> _csrtodok([[5, 8, 3, 6], [0, 1, 2, 1], [0, 0, 2, 3, 4], [4, 3]])
+    Matrix([
+    [0, 0, 0],
+    [5, 8, 0],
+    [0, 0, 3],
+    [0, 6, 0]])
+
+    """
     smat = {}
     A, JA, IA, shape = csr
     for i in range(len(IA) - 1):
         indices = slice(IA[i], IA[i + 1])
         for l, m in zip(A[indices], JA[indices]):
             smat[i, m] = l
-    return SparseMatrix(*(shape + [smat]))
+    return MutableSparseMatrix(*shape, smat)
 
 
 def banded(*args, **kwargs):

--- a/sympy/matrices/tests/test_sparsetools.py
+++ b/sympy/matrices/tests/test_sparsetools.py
@@ -29,7 +29,9 @@ def test_csrtodok():
     i = [[1, 3, 12], [0, 2, 4], [0, 2, 3], [2, 5]]
     j = [[11, 15, 12, 15], [2, 4, 1, 2], [0, 1, 1, 2, 3, 4], [5, 8]]
     k = [[1, 3], [2, 1], [0, 1, 1, 2], [3, 3]]
-    assert _csrtodok(h) == SparseMatrix(3, 4,
+    m = _csrtodok(h)
+    assert isinstance(m, SparseMatrix)
+    assert m == SparseMatrix(3, 4,
         {(0, 2): 5, (2, 1): 7, (2, 3): 5})
     assert _csrtodok(g) == SparseMatrix(3, 7,
         {(0, 2): 12, (1, 4): 5, (2, 2): 4})


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

* fixed a typo
* added a See Also entry to `diag`
* `_csrtodok` now returns MutableSparseMatrix instead of superclass SparseMatrix


#### Other comments

Testing of the return value of `_doktocsr` did not catch that the matrix couldn't be printed because it imported the superclass SparseMatrix. Although such a matrix can be created, it doesn't have the same behavior as the subclass MutableSparseMatrix.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * sparsetools - `_doktocsr` now returns a MutableSparseMatrix
<!-- END RELEASE NOTES -->