### PR TITLE
added perfect residuum method for permutation groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4872,7 +4872,7 @@ class PermutationGroup(Basic):
         if self.is_perfect:
             return self
         der = self.derived_series()
-        return der[-1];
+        return der[-1]
 
 def _orbit(degree, generators, alpha, action='tuples'):
     r"""Compute the orbit of alpha `\{g(\alpha) | g \in G\}` as a set.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4861,6 +4861,18 @@ class PermutationGroup(Basic):
 
         return PolycyclicGroup(pc_sequence, pc_series, relative_order, collector=None)
 
+    def perfect_residuum(self):
+        """
+        Returns the perfect residuum of a group G.
+
+        The perfect residuum of group G is the smallest normal subgroup of G
+        that has a solvable factor group.
+
+        """
+        if self.is_perfect:
+            return self
+        der = self.derived_series()
+        return der[-1];
 
 def _orbit(degree, generators, alpha, action='tuples'):
     r"""Compute the orbit of alpha `\{g(\alpha) | g \in G\}` as a set.

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1116,3 +1116,11 @@ def test_conjugacy_classes():
 
     assert len(expected) == len(computed)
     assert all(e in computed for e in expected)
+
+def test_perfect_residuum():
+    S = SymmetricGroup(4)
+    exp = PermutationGroup([(3)])
+    res = S.perfect_residuum()
+    assert res == exp
+    assert res.is_perfect
+    assert res.is_normal(S)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1119,7 +1119,7 @@ def test_conjugacy_classes():
 
 def test_perfect_residuum():
     S = SymmetricGroup(4)
-    exp = PermutationGroup([(3)])
+    exp = PermutationGroup([Permutation(3)])
     res = S.perfect_residuum()
     assert res == exp
     assert res.is_perfect


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
perfect residuum method is added for permutation groups.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
    - Added method `perfect_residuum` in `perm_groups.py`.
<!-- END RELEASE NOTES -->