### PR TITLE
for 90 degree rotation of matrix elements

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2019,48 +2019,74 @@ class MatrixOperations(MatrixRequired):
         return self.applyfunc(
             lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
     
-    def rot90(self, anticlockwise = False):
+    def rot90(self, k = 0):
         """Rotates Matrix by 90 degrees
 
         Examples
         ========
 
-        >>> from sympy import Matrix
-        >>> M = Matrix(2, 2, lambda i, j: i+j)
-        >>> M
+        >>> from sympy import MatrixSymbol
+        >>> A = MatrixSymbol('A', 2, 2).as_explicit()
+        >>> A
         Matrix([
-        [0, 1],
-        [1, 2]])
-        >>> M.rot90()
+        [A[0, 0], A[0, 1]],
+        [A[1, 0], A[1, 1]]])
+        >>> A.rot90(k = 0)
         Matrix([
-        [1, 2],
-        [0, 1]])
-        >>> M.r90
+        [A[0, 0], A[0, 1]],
+        [A[1, 0], A[1, 1]]])
+        >>> A.rot90(k = 1)
         Matrix([
-        [1, 2],
-        [0, 1]])
-        >>> M.rot90(anticlockwise = True)
+        [A[1, 0], A[0, 0]],
+        [A[1, 1], A[0, 1]]])
+        >>> A.r90
         Matrix([
-        [1, 0],
-        [2, 1]])
-        >>> M.r90a
+        [A[1, 0], A[0, 0]],
+        [A[1, 1], A[0, 1]]])
+        >>> A.rot90(k = -1)
         Matrix([
-        [1, 0],
-        [2, 1]])  
+        [A[0, 1], A[1, 1]],
+        [A[0, 0], A[1, 0]]])
+        >>> A.r90a
+        Matrix([
+        [A[0, 1], A[1, 1]],
+        [A[0, 0], A[1, 0]]])
+        >>> A.rot90(k = 2)
+        Matrix([
+        [A[1, 1], A[1, 0]],
+        [A[0, 1], A[0, 0]]])
+        >>> A.rot90(k = -2)
+        Matrix([
+        [A[1, 1], A[1, 0]],
+        [A[0, 1], A[0, 0]]])
+        >>> A.rot90(k = 3)
+        Matrix([
+        [A[0, 1], A[1, 1]],
+        [A[0, 0], A[1, 0]]])
+        >>> A.rot90(k = -3)
+        Matrix([
+        [A[1, 0], A[0, 0]],
+        [A[1, 1], A[0, 1]]])
         """
-        if(anticlockwise):
+
+        mod = k%4
+        if(mod == 0):
+            return self
+        if(mod == 1):
             return self[::-1, ::].T
-        else:
+        if(mod == 2):
+            return self[::-1, ::-1]
+        if(mod == 3):
             return self[::, ::-1].T
     
     @property
     def r90(self):
         '''Matrix transposition clockwise'''
-        return self.rot90()
+        return self.rot90(k = 1)
     @property
     def r90a(self):
         '''Matrix transposition anticlockwise'''
-        return self.rot90(anticlockwise=True)
+        return self.rot90(k = -1)
 
     def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2062,13 +2062,13 @@ class MatrixOperations(MatrixRequired):
         """
 
         mod = k%4
-        if mod == 0 :
+        if mod == 0:
             return self
-        if mod == 1 :
+        if mod == 1:
             return self[::-1, ::].T
-        if mod == 2 :
+        if mod == 2:
             return self[::-1, ::-1]
-        if mod == 3 :
+        if mod == 3:
             return self[::, ::-1].T
     
     def simplify(self, **kwargs):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2062,13 +2062,13 @@ class MatrixOperations(MatrixRequired):
         """
 
         mod = k%4
-        if(mod == 0):
+        if mod == 0 :
             return self
-        if(mod == 1):
+        if mod == 1 :
             return self[::-1, ::].T
-        if(mod == 2):
+        if mod == 2 :
             return self[::-1, ::-1]
-        if(mod == 3):
+        if mod == 3 :
             return self[::, ::-1].T
     
     def simplify(self, **kwargs):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2030,11 +2030,11 @@ class MatrixOperations(MatrixRequired):
             k is 0 when the Matrix is not rotated
             k is +ve when the Matrix is rotated Clockwise
             k is -ve when the Matrix is rotated Anti-Clockwise
-            |k| > 1 represent iterative rotations 
-            i.e. 
+            |k| > 1 represent iterative rotations
+            i.e.
             2 --> Clockwise x 2
             -2 --> Anti-Clockwise x 2
-        
+
         Examples
         ========
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2021,7 +2021,16 @@ class MatrixOperations(MatrixRequired):
 
     def rot90(self, k=1):
         """Rotates Matrix by 90 degrees
-
+   
+        Parameter k specifies the rotation
+        k is 0 when the Matrix is not rotated
+        k is +ve when the Matrix is rotated Clockwise
+        k is -ve when the Matrix is rotated Anti-Clockwise
+        |k| > 1 represent iterative rotations 
+        i.e. 
+        2 --> Clockwise x 2
+        - 2 --> Anti-Clockwise x 2
+        
         Examples
         ========
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2018,7 +2018,59 @@ class MatrixOperations(MatrixRequired):
         """
         return self.applyfunc(
             lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
+    
+    def rot90(self, k=1):
+        """Rotates Matrix by 90 degrees
 
+        Examples
+        ========
+
+        >>> from sympy import MatrixSymbol
+        >>> A = MatrixSymbol('A', 2, 2).as_explicit()
+        >>> A
+        Matrix([
+        [A[0, 0], A[0, 1]],
+        [A[1, 0], A[1, 1]]])
+        >>> A.rot90(k = 0)
+        Matrix([
+        [A[0, 0], A[0, 1]],
+        [A[1, 0], A[1, 1]]])
+        >>> A.rot90(k = 1)
+        Matrix([
+        [A[1, 0], A[0, 0]],
+        [A[1, 1], A[0, 1]]])
+        >>> A.rot90(k = -1)
+        Matrix([
+        [A[0, 1], A[1, 1]],
+        [A[0, 0], A[1, 0]]])
+        >>> A.rot90(k = 2)
+        Matrix([
+        [A[1, 1], A[1, 0]],
+        [A[0, 1], A[0, 0]]])
+        >>> A.rot90(k = -2)
+        Matrix([
+        [A[1, 1], A[1, 0]],
+        [A[0, 1], A[0, 0]]])
+        >>> A.rot90(k = 3)
+        Matrix([
+        [A[0, 1], A[1, 1]],
+        [A[0, 0], A[1, 0]]])
+        >>> A.rot90(k = -3)
+        Matrix([
+        [A[1, 0], A[0, 0]],
+        [A[1, 1], A[0, 1]]])
+        """
+
+        mod = k%4
+        if mod == 0:
+            return self
+        if mod == 1:
+            return self[::-1, ::].T
+        if mod == 2:
+            return self[::-1, ::-1]
+        if mod == 3:
+            return self[::, ::-1].T
+    
     def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2039,15 +2039,7 @@ class MatrixOperations(MatrixRequired):
         Matrix([
         [A[1, 0], A[0, 0]],
         [A[1, 1], A[0, 1]]])
-        >>> A.r90
-        Matrix([
-        [A[1, 0], A[0, 0]],
-        [A[1, 1], A[0, 1]]])
         >>> A.rot90(k = -1)
-        Matrix([
-        [A[0, 1], A[1, 1]],
-        [A[0, 0], A[1, 0]]])
-        >>> A.r90a
         Matrix([
         [A[0, 1], A[1, 1]],
         [A[0, 0], A[1, 0]]])

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2018,6 +2018,49 @@ class MatrixOperations(MatrixRequired):
         """
         return self.applyfunc(
             lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
+    
+    def rot90(self, anticlockwise = False):
+        """Rotates Matrix by 90 degrees
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> M = Matrix(2, 2, lambda i, j: i+j)
+        >>> M
+        Matrix([
+        [0, 1],
+        [1, 2]])
+        >>> M.rot90()
+        Matrix([
+        [1, 2],
+        [0, 1]])
+        >>> M.r90
+        Matrix([
+        [1, 2],
+        [0, 1]])
+        >>> M.rot90(anticlockwise = True)
+        Matrix([
+        [1, 0],
+        [2, 1]])
+        >>> M.r90a
+        Matrix([
+        [1, 0],
+        [2, 1]])  
+        """
+        if(anticlockwise):
+            return self[::-1, ::].T
+        else:
+            return self[::, ::-1].T
+    
+    @property
+    def r90(self):
+        '''Matrix transposition clockwise'''
+        return self.rot90()
+    @property
+    def r90a(self):
+        '''Matrix transposition anticlockwise'''
+        return self.rot90(anticlockwise=True)
 
     def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2018,7 +2018,7 @@ class MatrixOperations(MatrixRequired):
         """
         return self.applyfunc(
             lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
-    
+
     def rot90(self, k=1):
         """Rotates Matrix by 90 degrees
 
@@ -2031,31 +2031,31 @@ class MatrixOperations(MatrixRequired):
         Matrix([
         [A[0, 0], A[0, 1]],
         [A[1, 0], A[1, 1]]])
-        >>> A.rot90(k = 0)
+        >>> A.rot90(k=0)
         Matrix([
         [A[0, 0], A[0, 1]],
         [A[1, 0], A[1, 1]]])
-        >>> A.rot90(k = 1)
+        >>> A.rot90(k=1)
         Matrix([
         [A[1, 0], A[0, 0]],
         [A[1, 1], A[0, 1]]])
-        >>> A.rot90(k = -1)
+        >>> A.rot90(k=-1)
         Matrix([
         [A[0, 1], A[1, 1]],
         [A[0, 0], A[1, 0]]])
-        >>> A.rot90(k = 2)
+        >>> A.rot90(k=2)
         Matrix([
         [A[1, 1], A[1, 0]],
         [A[0, 1], A[0, 0]]])
-        >>> A.rot90(k = -2)
+        >>> A.rot90(k=-2)
         Matrix([
         [A[1, 1], A[1, 0]],
         [A[0, 1], A[0, 0]]])
-        >>> A.rot90(k = 3)
+        >>> A.rot90(k=3)
         Matrix([
         [A[0, 1], A[1, 1]],
         [A[0, 0], A[1, 0]]])
-        >>> A.rot90(k = -3)
+        >>> A.rot90(k=-3)
         Matrix([
         [A[1, 0], A[0, 0]],
         [A[1, 1], A[0, 1]]])
@@ -2070,7 +2070,7 @@ class MatrixOperations(MatrixRequired):
             return self[::-1, ::-1]
         if mod == 3:
             return self[::, ::-1].T
-    
+
     def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2021,15 +2021,19 @@ class MatrixOperations(MatrixRequired):
 
     def rot90(self, k=1):
         """Rotates Matrix by 90 degrees
-   
-        Parameter k specifies the rotation
-        k is 0 when the Matrix is not rotated
-        k is +ve when the Matrix is rotated Clockwise
-        k is -ve when the Matrix is rotated Anti-Clockwise
-        |k| > 1 represent iterative rotations 
-        i.e. 
-        2 --> Clockwise x 2
-        - 2 --> Anti-Clockwise x 2
+
+        Parameters
+        ==========
+
+        k : int
+            Parameter k specifies the rotation
+            k is 0 when the Matrix is not rotated
+            k is +ve when the Matrix is rotated Clockwise
+            k is -ve when the Matrix is rotated Anti-Clockwise
+            |k| > 1 represent iterative rotations 
+            i.e. 
+            2 --> Clockwise x 2
+            -2 --> Anti-Clockwise x 2
         
         Examples
         ========

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2079,15 +2079,6 @@ class MatrixOperations(MatrixRequired):
         if(mod == 3):
             return self[::, ::-1].T
     
-    @property
-    def r90(self):
-        '''Matrix transposition clockwise'''
-        return self.rot90(k = 1)
-    @property
-    def r90a(self):
-        '''Matrix transposition anticlockwise'''
-        return self.rot90(k = -1)
-
     def simplify(self, **kwargs):
         """Apply simplify to each element of the matrix.
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2019,7 +2019,7 @@ class MatrixOperations(MatrixRequired):
         return self.applyfunc(
             lambda x: x.replace(F, G, map=map, simultaneous=simultaneous, exact=exact))
     
-    def rot90(self, k = 0):
+    def rot90(self, k=1):
         """Rotates Matrix by 90 degrees
 
         Examples

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -522,17 +522,7 @@ def test_replace_map():
     assert N == K
 
 def test_rot90():
-    """
-    Parameter k specifies the rotation
-    k is 0 when the Matrix is not rotated
-    k is +ve when the Matrix is rotated Clockwise
-    k is -ve when the Matrix is rotated Anti-Clockwise
-    |k| > 1 represent iterative rotations 
-    i.e. 
-    2 --> Clockwise x 2
-    - 2 --> Anti-Clockwise x 2
-    """
-    A = MatrixSymbol('A', 2, 2).as_explicit()
+    A = Matrix([[1,2],[3,4]])
     assert A == A.rot90(k=0)
     assert A.rot90(k=1) == A.rot90(k=-3)
     assert A.rot90(k=2) == A.rot90(k=-2)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -521,6 +521,22 @@ def test_replace_map():
     N = M.replace(F, G, True)
     assert N == K
 
+def test_rot90():
+    """
+    Parameter k specifies the rotation
+    k is 0 when the Matrix is not rotated
+    k is +ve when the Matrix is rotated Clockwise
+    k is -ve when the Matrix is rotated Anti-Clockwise
+    |k| > 1 represent iterative rotations 
+    i.e. 
+    2 --> Clockwise x 2
+    - 2 --> Anti-Clockwise x 2
+    """
+    A = MatrixSymbol('A', 2, 2).as_explicit()
+    assert A == A.rot90(k=0)
+    assert A.rot90(k=1) == A.rot90(k=-3)
+    assert A.rot90(k=2) == A.rot90(k=-2)
+    assert A.rot90(k=3) == A.rot90(k=-1)
 
 def test_simplify():
     n = Symbol('n')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18948

#### Brief description of what is fixed or changed
I've Implemented a function called rot90 that returns the matrix rotated by 90 degrees with the ability to also rotate it anticlockwise ... and also two properties called r90 and r90a which do the same 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added a function that rotates matrices by 90 degrees
<!-- END RELEASE NOTES -->