### PR TITLE
Giving `digits` a `bits` argument

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2981,6 +2981,7 @@ def test_issue_8207():
     assert d == b[0, 0]
     assert e == 0
 
+
 def test_func():
     from sympy.simplify.simplify import nthroot
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2981,7 +2981,6 @@ def test_issue_8207():
     assert d == b[0, 0]
     assert e == 0
 
-
 def test_func():
     from sympy.simplify.simplify import nthroot
 

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -25,8 +25,6 @@ def digits(n, b=10, digits=None):
     [-27, 5, 11, 16]
     >>> digits(35, 10)
     [10, 3, 5]
-    >>> digits(35, 10, 1)
-    [10, 3, 5]
     >>> digits(35, 10, 2)
     [10, 3, 5]
     >>> digits(35, 10, 3)
@@ -37,15 +35,15 @@ def digits(n, b=10, digits=None):
     Parameters
     ==========
 
-    n = integer
-    The number whose list of digits is computed
+    n: integer
+        The number whose list of digits is computed
 
-    b = integer
-    The base in which list of digits is computed
+    b: integer
+        The base in which list of digits is computed
 
-    digits = integer
-    indicates the number of digits to be return after the base;
-    leading zeros will be added if the number has too few digits
+    digits: integer
+        Indicates the number of digits to be return after the base;
+        leading zeros will be added if the number has too few digits
 
     """
 
@@ -64,8 +62,7 @@ def digits(n, b=10, digits=None):
         if digits is not None and len(y) - 1 < digits:
             if b**(digits - 1) <= n:
                 raise ValueError("b**(digits - 1) must be > n")
-            else:
-                y = [b] + [0]*(digits - len(y) + 1) + y[1:]
+            y = [b] + [0]*(digits - len(y) + 1) + y[1:]
         return y
 
 

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -6,7 +6,7 @@ from sympy.core.compatibility import as_int
 from sympy.utilities.iterables import multiset, is_palindromic as _palindromic
 
 
-def digits(n, b=10):
+def digits(n, b=10, digits=None):
     """
     Return a list of the digits of ``n`` in base ``b``. The first
     element in the list is ``b`` (or ``-b`` if ``n`` is negative).
@@ -21,8 +21,32 @@ def digits(n, b=10):
     [2, 1, 1, 0, 1, 1]
     >>> digits(65536, 256)
     [256, 1, 0, 0]
-    >>> digits(-3958, 27)
+    >>> digits(-3958, 27, 2)
     [-27, 5, 11, 16]
+    >>> digits(35, 10)
+    [10, 3, 5]
+    >>> digits(35, 10, 1)
+    [10, 3, 5]
+    >>> digits(35, 10, 2)
+    [10, 3, 5]
+    >>> digits(35, 10, 3)
+    [10, 0, 3, 5]
+    >>> digits(35, 10, 4)
+    [10, 0, 0, 3, 5]
+
+    Parameters
+    ==========
+
+    n = integer
+    The number whose list of digits is computed
+
+    b = integer
+    The base in which list of digits is computed
+
+    digits = integer
+    indicates the number of digits to be return after the base;
+    leading zeros will be added if the number has too few digits
+
     """
 
     b = as_int(b)
@@ -37,6 +61,11 @@ def digits(n, b=10):
         y.append(x)
         y.append(-b if n < 0 else b)
         y.reverse()
+        if digits is not None and len(y) - 1 < digits:
+            if b**(digits - 1) <= n:
+                raise ValueError("b**(digits - 1) must be > n")
+            else:
+                y = [b] + [0]*(digits - len(y) + 1) + y[1:]
         return y
 
 

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -64,7 +64,8 @@ def digits(n, b=10, digits=None):
         ndig = len(y) - 1
         if digits is not None:
             if ndig > digits:
-                raise ValueError("b**(digits - 1) must be > n")
+                raise ValueError(
+                    "For %s, at least %s digits are needed." % (n, ndig))
             elif ndig < digits:
                 y[1:1] = [0]*(digits - ndig)
         return y

--- a/sympy/ntheory/digits.py
+++ b/sympy/ntheory/digits.py
@@ -17,40 +17,42 @@ def digits(n, b=10, digits=None):
     >>> from sympy.ntheory.digits import digits
     >>> digits(35)
     [10, 3, 5]
-    >>> digits(27, 2)
+
+    If the number is negative, the negative sign will be placed on the
+    base (which is the first element in the returned list):
+
+    >>> digits(-35)
+    [-10, 3, 5]
+
+    Bases other than 10 (and greater than 1) can be selected with ``b``:
+
+    >>> digits(27, b=2)
     [2, 1, 1, 0, 1, 1]
-    >>> digits(65536, 256)
-    [256, 1, 0, 0]
-    >>> digits(-3958, 27, 2)
-    [-27, 5, 11, 16]
-    >>> digits(35, 10)
-    [10, 3, 5]
-    >>> digits(35, 10, 2)
-    [10, 3, 5]
-    >>> digits(35, 10, 3)
-    [10, 0, 3, 5]
-    >>> digits(35, 10, 4)
+
+    Use the ``digits`` keyword if a certain number of digits is desired:
+
+    >>> digits(35, digits=4)
     [10, 0, 0, 3, 5]
 
     Parameters
     ==========
 
     n: integer
-        The number whose list of digits is computed
+        The number whose digits are returned.
 
     b: integer
-        The base in which list of digits is computed
+        The base in which digits are computed.
 
-    digits: integer
-        Indicates the number of digits to be return after the base;
-        leading zeros will be added if the number has too few digits
+    digits: integer (or None for all digits)
+        The number of digits to be returned (padded with zeros, if
+        necessary).
 
     """
 
     b = as_int(b)
     n = as_int(n)
-    if b <= 1:
-        raise ValueError("b must be >= 2")
+    if b < 2:
+        raise ValueError("b must be greater than 1")
     else:
         x, y = abs(n), []
         while x >= b:
@@ -59,10 +61,12 @@ def digits(n, b=10, digits=None):
         y.append(x)
         y.append(-b if n < 0 else b)
         y.reverse()
-        if digits is not None and len(y) - 1 < digits:
-            if b**(digits - 1) <= n:
+        ndig = len(y) - 1
+        if digits is not None:
+            if ndig > digits:
                 raise ValueError("b**(digits - 1) must be > n")
-            y = [b] + [0]*(digits - len(y) + 1) + y[1:]
+            elif ndig < digits:
+                y[1:1] = [0]*(digits - ndig)
         return y
 
 

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -1,5 +1,7 @@
 from sympy.ntheory import count_digits, digits, is_palindromic
 
+from sympy.testing.pytest import raises
+
 
 def test_digits():
     assert all([digits(n, 2)[1:] == [int(d) for d in format(n, 'b')]
@@ -13,10 +15,9 @@ def test_digits():
     assert digits(93409, 10) == [10, 9, 3, 4, 0, 9]
     assert digits(-92838, 11) == [-11, 6, 3, 8, 2, 9]
     assert digits(35, 10) == [10, 3, 5]
-    assert digits(35, 10, 1) == ValueError("b**(digits - 1) must be > n")
-    assert digits(35, 10, 2) == [10, 3, 5]
     assert digits(35, 10, 3) == [10, 0, 3, 5]
-    assert digits(35, 10, 4) == [10, 0, 0, 3, 5]
+    assert digits(-35, 10, 4) == [-10, 0, 0, 3, 5]
+    raises(ValueError, lambda: digits(2, 2, 1))
 
 
 def test_count_digits():

--- a/sympy/ntheory/tests/test_digits.py
+++ b/sympy/ntheory/tests/test_digits.py
@@ -10,8 +10,13 @@ def test_digits():
                 for n in range(20)])
     assert digits(2345, 34) == [34, 2, 0, 33]
     assert digits(384753, 71) == [71, 1, 5, 23, 4]
-    assert digits(93409) == [10, 9, 3, 4, 0, 9]
+    assert digits(93409, 10) == [10, 9, 3, 4, 0, 9]
     assert digits(-92838, 11) == [-11, 6, 3, 8, 2, 9]
+    assert digits(35, 10) == [10, 3, 5]
+    assert digits(35, 10, 1) == ValueError("b**(digits - 1) must be > n")
+    assert digits(35, 10, 2) == [10, 3, 5]
+    assert digits(35, 10, 3) == [10, 0, 3, 5]
+    assert digits(35, 10, 4) == [10, 0, 0, 3, 5]
 
 
 def test_count_digits():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Giving `digits` a `bits` argument
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18959


#### Brief description of what is fixed or changed
Like ibin,  a bits argument is added to digits so the length would be padded with 0s if necessary to reach the given bit length.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
   *  the number of digits (like bit length) can now be specified for `digits`
<!-- END RELEASE NOTES -->