### PR TITLE
Core: Fixes Incorrect Limit Evaluation

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1433,7 +1433,7 @@ class Pow(Expr):
         #     c_0*x**e_0 + c_1*x**e_1 + ... (finitely many terms)
         # where e_i are numbers (not necessarily integers) and c_i are
         # expressions involving only numbers, the log function, and log(x).
-        from sympy import ceiling, collect, exp, log, O, Order, powsimp
+        from sympy import ceiling, collect, exp, log, O, Order, powsimp, powdenest
         b, e = self.args
         if e.is_Integer:
             if e > 0:
@@ -1463,6 +1463,7 @@ class Pow(Expr):
                 while prefactor.is_Order:
                     nuse += 1
                     b = b_orig._eval_nseries(x, n=nuse, logx=logx)
+                    b = powdenest(b)
                     prefactor = b.as_leading_term(x)
 
                 # express "rest" as: rest = 1 + k*x**l + ... + O(x**n)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -612,6 +612,11 @@ def test_issue_14590():
     assert limit((x**3*((x + 1)/x)**x)/((x + 1)*(x + 2)*(x + 3)), x, oo) == exp(1)
 
 
+def test_issue_14393():
+    a, b = symbols('a b')
+    assert limit((x**b - y**b)/(x**a - y**a), x, y) == b*y**(-a)*y**b/a
+
+
 def test_issue_17431():
     assert limit(((n + 1) + 1) / (((n + 1) + 2) * factorial(n + 1)) *
                  (n + 2) * factorial(n) / (n + 1), n, oo) == 0


### PR DESCRIPTION
Fixes: #14393 

#### Brief description of what is fixed or changed
**Previously:**
```
a, b = symbols('a b')
limit((x**b - y**b)/(x**a - y**a), x, y) = 0
```
A bit of simplification was missing in `Pow._eval_nseries` which was causing incorrect evaluation.

**Now this evaluates correctly:**
```
a, b = symbols('a b')
limit((x**b - y**b)/(x**a - y**a), x, y) = b*y**(-a)*y**b/a
```



#### Other Comments
Regression Test has been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
  * Adds simplification to `Pow._eval_nseries` resolving incorrect limit evaluation
<!-- END RELEASE NOTES -->