### PR TITLE
Overflow condition and negative argument for 'ibin'

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -477,7 +477,7 @@ def interactive_traversal(expr):
     return _interactive_traversal(expr, 0)
 
 
-def ibin(n, bits=0, str=False):
+def ibin(n, bits=None, str=False):
     """Return a list of length ``bits`` corresponding to the binary value
     of ``n`` with small bits to the right (last). If bits is omitted, the
     length will be the number required to represent ``n``. If the bits are
@@ -497,8 +497,6 @@ def ibin(n, bits=0, str=False):
     [1, 0]
     >>> ibin(2, 4)
     [0, 0, 1, 0]
-    >>> ibin(2, 4)[::-1]
-    [0, 1, 0, 0]
 
     If all lists corresponding to 0 to 2**n - 1, pass a non-integer
     for bits:
@@ -523,17 +521,31 @@ def ibin(n, bits=0, str=False):
     ['000', '001', '010', '011', '100', '101', '110', '111']
 
     """
-    if not str:
-        try:
-            bits = as_int(bits)
-            return [1 if i == "1" else 0 for i in bin(n)[2:].rjust(bits, "0")]
-        except ValueError:
-            return variations(list(range(2)), n, repetition=True)
+    if n < 0:
+        raise ValueError("negative numbers are not allowed")
+    n = as_int(n)
+
+    if bits is None:
+        bits = 0
     else:
         try:
-            bits = as_int(bits)
-            return bin(n)[2:].rjust(bits, "0")
+             bits = as_int(bits)
         except ValueError:
+            bits = -1
+        else:
+            if n.bit_length() > bits:
+                raise ValueError(
+                    "`bits` must be >= {}".format(n.bit_length()))
+
+    if not str:
+        if bits >= 0:
+            return [1 if i == "1" else 0 for i in bin(n)[2:].rjust(bits, "0")]
+        else:
+            return variations(list(range(2)), n, repetition=True)
+    else:
+        if bits >= 0:
+            return bin(n)[2:].rjust(bits, "0")
+        else:
             return (bin(i)[2:].rjust(n, "0") for i in range(2**n))
 
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -207,10 +207,12 @@ def test_cartes():
     assert list(cartes('a', repeat=2)) == [('a', 'a')]
     assert list(cartes(list(range(2)))) == [(0,), (1,)]
 
+
 def test_filter_symbols():
     s = numbered_symbols()
     filtered = filter_symbols(s, symbols("x0 x2 x3"))
     assert take(filtered, 3) == list(symbols("x1 x4 x5"))
+
 
 def test_numbered_symbols():
     s = numbered_symbols(cls=Dummy)
@@ -397,6 +399,7 @@ def test_multiset_partitions():
     assert list(factoring_visitor(p, [2,3]) for
                 p in multiset_partitions_taocp([3, 1])) == factorings
 
+
 def test_multiset_combinations():
     ans = ['iii', 'iim', 'iip', 'iis', 'imp', 'ims', 'ipp', 'ips',
            'iss', 'mpp', 'mps', 'mss', 'pps', 'pss', 'sss']
@@ -512,6 +515,7 @@ def test_partitions():
             i += 1
         assert i == RGS_enum(n)
 
+
 def test_binary_partitions():
     assert [i[:] for i in binary_partitions(10)] == [[8, 2], [8, 1, 1],
         [4, 4, 2], [4, 4, 1, 1], [4, 2, 2, 2], [4, 2, 2, 1, 1],
@@ -577,6 +581,7 @@ def test_necklaces():
         [5,   8,   8,  39],
         [6,  14,  13,  92],
         [7,  20,  18, 198]])
+
 
 def test_bracelets():
     bc = [i for i in bracelets(2, 4)]
@@ -691,6 +696,7 @@ def test_reshape():
         [[0, 1, [2, 3, 4], {5, 6}, (7, (8, 9, 10), 11)]]
     raises(ValueError, lambda: reshape([0, 1], [-1]))
     raises(ValueError, lambda: reshape([0, 1], [3]))
+
 
 def test_uniq():
     assert list(uniq(p.copy() for p in partitions(4))) == \
@@ -827,4 +833,6 @@ def test_ibin():
     assert ibin(3, str=True) == '11'
     assert ibin(3, 3, str=True) == '011'
     assert list(ibin(2, 'all')) == [(0, 0), (0, 1), (1, 0), (1, 1)]
-    assert list(ibin(2, 'all', str=True)) == ['00', '01', '10', '11']
+    assert list(ibin(2, '', str=True)) == ['00', '01', '10', '11']
+    raises(ValueError, lambda: ibin(-.5))
+    raises(ValueError, lambda: ibin(2, 1))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Overflow condition and negative argument for 'ibin'
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18963 

#### Brief description of what is fixed or changed
Currently, sympy.utilitities.iterables.ibin passes silently, returning all bits of a number even if the requested bit length is too small. The user can omit the bits argument to get all bits; they should be warned if they request a certain length and the number has more than that many bits since this could indicate a logical error in their code. e.g. 3 bits are required but the user-specified 2 bits
Also, a negative argument is given error condition
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Overflow condition and negative argument for 'ibin' added
<!-- END RELEASE NOTES -->