### PR TITLE
Order check condition moved to matches function of  SingleODESolver

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -186,10 +186,18 @@ class SingleODESolver:
     # Cache whether or not the equation has matched the method
     _matched = None  # type: Optional[bool]
 
+    # Subclasses should store in this attribute the list of order(s) of ODE
+    # that subclass can solve or leave it to None if not specific to any order
+    order = None  # type: None or list
+
     def __init__(self, ode_problem):
         self.ode_problem = ode_problem
 
     def matches(self) -> bool:
+        if self.order is not None and self.ode_problem.order not in self.order:
+            self._matched = False
+            return self._matched
+
         if self._matched is None:
             self._matched = self._matches()
         return self._matched
@@ -412,6 +420,7 @@ class FirstLinear(SinglePatternODESolver):
     """
     hint = '1st_linear'
     has_integral = True
+    order = [1]
 
     def _wilds(self, f, x, order):
         P = Wild('P', exclude=[f(x)])
@@ -482,6 +491,7 @@ class AlmostLinear(SinglePatternODESolver):
     """
     hint = "almost_linear"
     has_integral = True
+    order = [1]
 
     def _wilds(self, f, x, order):
         P = Wild('P', exclude=[f(x).diff(x)])
@@ -597,6 +607,7 @@ class Bernoulli(SinglePatternODESolver):
     """
     hint = "Bernoulli"
     has_integral = True
+    order = [1]
 
     def _wilds(self, f, x, order):
         P = Wild('P', exclude=[f(x)])
@@ -735,6 +746,7 @@ class RiccatiSpecial(SinglePatternODESolver):
     """
     hint = "Riccati_special_minus2"
     has_integral = False
+    order = [1]
 
     def _wilds(self, f, x, order):
         a = Wild('a', exclude=[x, f(x), f(x).diff(x), 0])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes: #18926 

#### Brief description of what is fixed or changed

Removed the condition that allowed only first-order ODE to be matched and solved from the _matches function of SinglePatternODESolver(base class).
The condition to check order has been added in the matches function of SingleODESolver and a class variable order has been added to all solver classes.
Removing this condition will now allow second or higher-order ODE solvers to be implemented.


#### Other comments
All further single ODE solvers must set `order` if specific to any order(s).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->