### PR TITLE
Series: Resolves ValueError during limit evaluation

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -430,6 +430,7 @@ def limitinf(e, x, leadsimp=False):
         e = e.subs(x, p)
         x = p
     c0, e0 = mrv_leadterm(e, x)
+    e0 = e0.cancel()
     sig = sign(e0, x)
     if sig == 1:
         return S.Zero  # e0>0: lim f = 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -617,6 +617,10 @@ def test_issue_14393():
     assert limit((x**b - y**b)/(x**a - y**a), x, y) == b*y**(-a)*y**b/a
 
 
+def test_issue_14811():
+    assert limit(((1 + (Rational(2,3) ** (x + 1))) ** (2 ** x)) / (2 ** (Rational(4,3) ** (x - 1))), x, oo) is oo
+
+
 def test_issue_17431():
     assert limit(((n + 1) + 1) / (((n + 1) + 2) * factorial(n + 1)) *
                  (n + 2) * factorial(n) / (n + 1), n, oo) == 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -618,7 +618,7 @@ def test_issue_14393():
 
 
 def test_issue_14811():
-    assert limit(((1 + (Rational(2,3) ** (x + 1))) ** (2 ** x)) / (2 ** (Rational(4,3) ** (x - 1))), x, oo) is oo
+    assert limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) == oo
 
 
 def test_issue_17431():


### PR DESCRIPTION
Fixes: #14811 

First of all, it no longer raises any exception as mentioned in the issue.
But, the actual issue is that it is `returned unevaluated due to a ValueError.`

#### Brief description of what is fixed or changed
**Previously:**
```
In[1]: limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) 
Out[1]: Unevaluated, returned as it is
```
A bit of simplification was missing in `limitinf() function of gruntz.py` which was causing `ValueError `and thus, the result was an unevaluated form.

**Now this evaluates correctly:**
```
In[1]: limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) 
Out[1]: oo
```



#### Other Comments
Regression Test has been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Adds simplification to `limitinf() function of gruntz.py` resolving `ValueError` 
<!-- END RELEASE NOTES -->