### PR TITLE
Added import guard for importing ClassVar

### DIFF
--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1,8 +1,11 @@
 #
 # This is the module for ODE solver classes for single ODEs.
 #
+import typing
 
-from typing import ClassVar, Dict, Iterable, List, Optional, Type
+if typing.TYPE_CHECKING:
+    from typing import ClassVar
+from typing import Dict, Iterable, List, Optional, Type
 
 from sympy.core import S
 from sympy.core.exprtools import factor_terms


### PR DESCRIPTION
removed an error, so sympy now supports 3.5.0

#### References to other Issues or PRs
Fixes #18970


#### Brief description of what is fixed or changed
Added an import guard for importing ClassVar in solvers/ode/single.py

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->