### PR TITLE
Series: Removes XFAIL Test of Limit

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -429,8 +429,8 @@ def limitinf(e, x, leadsimp=False):
         p = Dummy('p', positive=True, finite=True)
         e = e.subs(x, p)
         x = p
+    e = powdenest(e)
     c0, e0 = mrv_leadterm(e, x)
-    e0 = e0.cancel()
     sig = sign(e0, x)
     if sig == 1:
         return S.Zero  # e0>0: lim f = 0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -617,12 +617,6 @@ def test_issue_14393():
     assert limit((x**b - y**b)/(x**a - y**a), x, y) == b*y**(-a)*y**b/a
 
 
-# Hangs intermittently on Python 3.5. Probably this is because a codepath
-# depends on dict-ordering which it perhaps should not but also the codepath
-# that hangs might be due to a bug somewhere.
-#
-# https://github.com/sympy/sympy/pull/18978
-@XFAIL
 def test_issue_14811():
     assert limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) == oo
 


### PR DESCRIPTION
Fixes: #14811 
References: #18978 
References: #18990 

First of all, the limit expression no longer raises any exception as mentioned in the issue.
But, the actual issue is that it is `returned unevaluated due to a ValueError.`

#### Brief description of what is fixed or changed
**Previously:**
```
In[1]: limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) 
Out[1]: Unevaluated, returned as it is
```
A bit of simplification was missing in `limitinf() function of gruntz.py` which was causing `ValueError `and thus, the result was an unevaluated form.

**Now this evaluates correctly:**
```
In[1]: limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) 
Out[1]: oo
```

But afterwards:
The test added was hanging intermittently on Python 3.5. Thus, a change in simplification strategy helps to remove the XFAIL test.


#### Other Comments
Regression Test has been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Adds simplification to `limitinf() function of gruntz.py` resolving `ValueError` 
<!-- END RELEASE NOTES -->