### PR TITLE
Deprecate sympify string fallback

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2045,7 +2045,7 @@ class preorder_traversal(object):
 def _make_find_query(query):
     """Convert the argument of Basic.find() into a callable"""
     try:
-        query = sympify(query)
+        query = _sympify(query)
     except SympifyError:
         pass
     if isinstance(query, type):

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -527,7 +527,7 @@ def default_sort_key(item, order=None):
     else:
         if not isinstance(item, str):
             try:
-                item = sympify(item)
+                item = sympify(item, strict=True)
             except SympifyError:
                 # e.g. lambda x: x
                 pass

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, MutableSet
-from sympy.core.sympify import sympify, converter
+from sympy.core.sympify import _sympify, converter
 from sympy.utilities.iterables import iterable
 
 
@@ -49,7 +49,7 @@ class Tuple(Basic):
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('sympify', True):
-            args = ( sympify(arg) for arg in args )
+            args = (_sympify(arg) for arg in args)
         obj = Basic.__new__(cls, *args)
         return obj
 

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, MutableSet
-from sympy.core.sympify import sympify, _sympify, converter
+from sympy.core.sympify import sympify, converter
 from sympy.utilities.iterables import iterable
 
 
@@ -49,7 +49,7 @@ class Tuple(Basic):
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('sympify', True):
-            args = (_sympify(arg) for arg in args)
+            args = (sympify(arg) for arg in args)
         obj = Basic.__new__(cls, *args)
         return obj
 

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from sympy.core import S
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, MutableSet
-from sympy.core.sympify import _sympify, converter
+from sympy.core.sympify import sympify, _sympify, converter
 from sympy.utilities.iterables import iterable
 
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -376,19 +376,18 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             # Not all iterables are rebuildable with their type.
             pass
 
-    # At this point we were given an arbitrary expression
-    # which does not inherit from Basic and doesn't implement
-    # _sympy_ (which is a canonical and robust way to convert
-    # anything to SymPy expression).
-    #
-    # As a last chance, we try to take "a"'s normal form via unicode()
-    # and try to parse it. If it fails, then we have no luck and
-    # return an exception
-    try:
-        from .compatibility import unicode
-        a = unicode(a)
-    except Exception as exc:
-        raise SympifyError(a, exc)
+    if not isinstance(a, str):
+        try:
+            a = str(a)
+        except Exception as exc:
+            raise SympifyError(a, exc)
+        from sympy.utilities.exceptions import SymPyDeprecationWarning
+        SymPyDeprecationWarning(
+            feature="String fallback in sympify",
+            useinstead='converter or _sympy_',
+            issue=18066,
+            deprecated_since_version='1.6'
+        ).warn()
 
     from sympy.parsing.sympy_parser import (parse_expr, TokenError,
                                             standard_transformations)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -384,7 +384,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         from sympy.utilities.exceptions import SymPyDeprecationWarning
         SymPyDeprecationWarning(
             feature="String fallback in sympify",
-            useinstead='converter or _sympy_',
+            useinstead= \
+                'sympify(str(obj)) or ' + \
+                'sympy.core.sympify.converter or obj._sympy_',
             issue=18066,
             deprecated_since_version='1.6'
         ).warn()

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -10,6 +10,12 @@ def test_default_sort_key():
     func = lambda x: x
     assert sorted([func, x, func], key=default_sort_key) == [func, func, x]
 
+    class C:
+        def __repr__(self):
+            return 'x.y'
+    func = C()
+    assert sorted([x, func], key=default_sort_key) == [func, x]
+
 
 def test_as_int():
     raises(ValueError, lambda : as_int(1.1))

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -8,6 +8,7 @@ from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.testing.pytest import raises, XFAIL, skip
 from sympy.utilities.decorator import conserve_mpmath_dps
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
@@ -273,6 +274,11 @@ def test_lambda_raises():
 
 def test_sympify_raises():
     raises(SympifyError, lambda: sympify("fx)"))
+
+    class A:
+        def __str__(self):
+            return 'x'
+    raises(SymPyDeprecationWarning, lambda: sympify(A()))
 
 
 def test__sympify():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -6,7 +6,7 @@ from sympy.core.sympify import (sympify, _sympify, SympifyError, kernS,
     CantSympify)
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
-from sympy.testing.pytest import raises, XFAIL, skip
+from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.geometry import Point, Line
@@ -278,7 +278,9 @@ def test_sympify_raises():
     class A:
         def __str__(self):
             return 'x'
-    raises(SymPyDeprecationWarning, lambda: sympify(A()))
+
+    with warns_deprecated_sympy():
+        assert sympify(A()) == Symbol('x')
 
 
 def test__sympify():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -8,7 +8,6 @@ from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.testing.pytest import raises, XFAIL, skip, warns_deprecated_sympy
 from sympy.utilities.decorator import conserve_mpmath_dps
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -24,7 +24,7 @@ if not sage:
 
 import sympy
 
-from sympy.testing.pytest import XFAIL
+from sympy.testing.pytest import XFAIL, warns_deprecated_sympy
 
 def is_trivially_equal(lhs, rhs):
     """
@@ -189,7 +189,8 @@ def test_functions():
     check_expression("Chi(x)", "x")
     check_expression("loggamma(x)", "x")
     check_expression("Ynm(n,m,x,y)", "n, m, x, y")
-    check_expression("hyper((n,m),(m,n),x)", "n, m, x")
+    with warns_deprecated_sympy():
+        check_expression("hyper((n,m),(m,n),x)", "n, m, x")
     check_expression("uppergamma(y, x)", "x, y")
 
 def test_issue_4023():

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -2,7 +2,7 @@ from sympy.core import symbols, Lambda
 from sympy.functions import KroneckerDelta
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import FunctionMatrix, MatrixExpr, Identity
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 def test_funcmatrix_creation():
@@ -18,7 +18,8 @@ def test_funcmatrix_creation():
     raises(ValueError, lambda: FunctionMatrix(0, 2j, Lambda((i, j), 0)))
 
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda(i, 0)))
-    raises(ValueError, lambda: FunctionMatrix(2, 2, lambda i, j: 0))
+    with warns_deprecated_sympy():
+        raises(ValueError, lambda: FunctionMatrix(2, 2, lambda i, j: 0))
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda((i,), 0)))
     raises(ValueError, lambda: FunctionMatrix(2, 2, Lambda((i, j, k), 0)))
     raises(ValueError, lambda: FunctionMatrix(2, 2, i+j))

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -150,8 +150,7 @@ class Domain(object):
         else: # TODO: remove this branch
             if not is_sequence(element):
                 try:
-                    element = sympify(element)
-
+                    element = sympify(element, strict=True)
                     if isinstance(element, Basic):
                         return self.from_sympy(element)
                 except (TypeError, ValueError):

--- a/sympy/polys/orderings.py
+++ b/sympy/polys/orderings.py
@@ -113,12 +113,12 @@ class ProductOrder(MonomialOrder):
         return tuple(O(lamda(monomial)) for (O, lamda) in self.args)
 
     def __repr__(self):
-        from sympy.core import Tuple
-        return self.__class__.__name__ + repr(Tuple(*[x[0] for x in self.args]))
+        contents = [repr(x[0]) for x in self.args]
+        return self.__class__.__name__ + '(' + ", ".join(contents) + ')'
 
     def __str__(self):
-        from sympy.core import Tuple
-        return self.__class__.__name__ + str(Tuple(*[x[0] for x in self.args]))
+        contents = [str(x[0]) for x in self.args]
+        return self.__class__.__name__ + '(' + ", ".join(contents) + ')'
 
     def __eq__(self, other):
         if not isinstance(other, ProductOrder):

--- a/sympy/tensor/array/tests/test_array_comprehension.py
+++ b/sympy/tensor/array/tests/test_array_comprehension.py
@@ -1,7 +1,7 @@
 from sympy.tensor.array.array_comprehension import ArrayComprehension, ArrayComprehensionMap
 from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.abc import i, j, k, l
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 from sympy.matrices import Matrix
 
 
@@ -73,5 +73,7 @@ def test_arraycomprehensionmap():
     # tests about lambda expression
     assert ArrayComprehensionMap(lambda: 3, (i, 1, 5)).doit().tolist() == [3, 3, 3, 3, 3]
     assert ArrayComprehensionMap(lambda i: i+1, (i, 1, 5)).doit().tolist() == [2, 3, 4, 5, 6]
-    raises(ValueError, lambda: ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5)).doit())
     raises(ValueError, lambda: ArrayComprehensionMap(i*j, (i, 1, 3), (j, 2, 4)))
+    with warns_deprecated_sympy():
+        a = ArrayComprehensionMap(lambda i, j: i+j, (i, 1, 5))
+        raises(ValueError, lambda: a.doit())


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18066
#18056

#### Brief description of what is fixed or changed

I've noticed that default_sort_key sympifies elements with string fallback.
And the issue #18056 still has problem in the master if it is about sorting
```python3
from sympy import *
from sympy.core.compatibility import default_sort_key

class C:
    def __repr__(self):
        return 'x.y'

a = Symbol('x')
b = C()

sorted([a, b], key=default_sort_key)
```
```
<string> in <module>

AttributeError: 'Symbol' object has no attribute 'y'
```

I think that default_sort_key still have to rely on `str` for ordering any external object with sympy, but it's better not to execute evaluate some nonsensical syntax that can cause problems

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Deprecated sympify automatically converting custom objects with `__str__` or `__repr__` implemented.
<!-- END RELEASE NOTES -->