### PR TITLE
Fix incorrect BlockMatrix indexing

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -234,6 +234,7 @@ class BlockMatrix(MatrixExpr):
 
     def _entry(self, i, j, **kwargs):
         # Find row entry
+        orig_i, orig_j = i, j
         for row_block, numrows in enumerate(self.rowblocksizes):
             cmp = i < numrows
             if cmp == True:
@@ -242,7 +243,7 @@ class BlockMatrix(MatrixExpr):
                 i -= numrows
             elif row_block < self.blockshape[0] - 1:
                 # Can't tell which block and it's not the last one, return unevaluated
-                return MatrixElement(self, i, j)
+                return MatrixElement(self, orig_i, orig_j)
         for col_block, numcols in enumerate(self.colblocksizes):
             cmp = j < numcols
             if cmp == True:
@@ -250,7 +251,7 @@ class BlockMatrix(MatrixExpr):
             elif cmp == False:
                 j -= numcols
             elif col_block < self.blockshape[1] - 1:
-                return MatrixElement(self, i, j)
+                return MatrixElement(self, orig_i, orig_j)
         return self.blocks[row_block, col_block][i, j]
 
     @property

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -7,7 +7,7 @@ from sympy.strategies.traverse import bottom_up
 from sympy.utilities import sift
 from sympy.utilities.misc import filldedent
 
-from sympy.matrices.expressions.matexpr import MatrixExpr, ZeroMatrix, Identity
+from sympy.matrices.expressions.matexpr import MatrixExpr, ZeroMatrix, Identity, MatrixElement
 from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.matadd import MatAdd
 from sympy.matrices.expressions.matpow import MatPow
@@ -235,15 +235,22 @@ class BlockMatrix(MatrixExpr):
     def _entry(self, i, j, **kwargs):
         # Find row entry
         for row_block, numrows in enumerate(self.rowblocksizes):
-            if (i < numrows) != False:
+            cmp = i < numrows
+            if cmp == True:
                 break
-            else:
+            elif cmp == False:
                 i -= numrows
+            elif row_block < self.blockshape[0] - 1:
+                # Can't tell which block and it's not the last one, return unevaluated
+                return MatrixElement(self, i, j)
         for col_block, numcols in enumerate(self.colblocksizes):
-            if (j < numcols) != False:
+            cmp = j < numcols
+            if cmp == True:
                 break
-            else:
+            elif cmp == False:
                 j -= numcols
+            elif col_block < self.blockshape[1] - 1:
+                return MatrixElement(self, i, j)
         return self.blocks[row_block, col_block][i, j]
 
     @property

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -192,7 +192,6 @@ def test_BlockDiagMatrix():
 def test_blockcut():
     A = MatrixSymbol('A', n, m)
     B = blockcut(A, (n/2, n/2), (m/2, m/2))
-    assert A[i, j] == B[i, j]
     assert B == BlockMatrix([[A[:n/2, :m/2], A[:n/2, m/2:]],
                              [A[n/2:, :m/2], A[n/2:, m/2:]]])
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -107,10 +107,10 @@ def test_block_index_symbolic_nonzero():
     # matrices have nonzero size and all indices are nonnegative
     k, l, m, n = symbols('k l m n', integer=True, positive=True)
     i, j = symbols('i j', integer=True, nonnegative=True)
-    A1 = MatrixSymbol('K1', n, k)
-    A2 = MatrixSymbol('K2', n, l)
-    A3 = MatrixSymbol('K3', m, k)
-    A4 = MatrixSymbol('K4', m, l)
+    A1 = MatrixSymbol('A1', n, k)
+    A2 = MatrixSymbol('A2', n, l)
+    A3 = MatrixSymbol('A3', m, k)
+    A4 = MatrixSymbol('A4', m, l)
     A = BlockMatrix([[A1, A2], [A3, A4]])
     assert A[0, 0] == A1[0, 0]
     assert A[n + m - 1, 0] == A3[m - 1, 0]
@@ -120,6 +120,22 @@ def test_block_index_symbolic_nonzero():
     assert A[n + i, k + j] == A4[i, j]
     assert A[n - i - 1, k - j - 1] == A1[n - i - 1, k - j - 1]
     assert A[2 * n, 2 * k] == A4[n, k]
+
+
+def test_block_index_large():
+    n, m, k = symbols('n m k', integer=True, positive=True)
+    i = symbols('i', integer=True, nonnegative=True)
+    A1 = MatrixSymbol('A1', n, n)
+    A2 = MatrixSymbol('A2', n, m)
+    A3 = MatrixSymbol('A3', n, k)
+    A4 = MatrixSymbol('A4', m, n)
+    A5 = MatrixSymbol('A5', m, m)
+    A6 = MatrixSymbol('A6', m, k)
+    A7 = MatrixSymbol('A7', k, n)
+    A8 = MatrixSymbol('A8', k, m)
+    A9 = MatrixSymbol('A9', k, k)
+    A = BlockMatrix([[A1, A2, A3], [A4, A5, A6], [A7, A8, A9]])
+    assert A[n + i, n + i] == MatrixElement(A, n + i, n + i)
 
 
 @XFAIL

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, MatrixSymbol, MatPow, BlockMatrix, KroneckerDelta,
         Identity, ZeroMatrix, ImmutableMatrix, eye, Sum, Dummy, trace,
         Symbol)
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, XFAIL
 from sympy.matrices.expressions.matexpr import MatrixElement, MatrixExpr
 
 k, l, m, n = symbols('k l m n', integer=True)
@@ -81,6 +81,56 @@ def test_block_index():
     BI = BlockMatrix([[I, Z], [Z, I]])
 
     assert BI.as_explicit().equals(eye(6))
+
+
+def test_block_index_symbolic():
+    # Note that these matrices may be zero-sized and indices may be negative, which causes
+    # all naive simplifications given in the comments to be invalid
+    A1 = MatrixSymbol('A1', n, k)
+    A2 = MatrixSymbol('A2', n, l)
+    A3 = MatrixSymbol('A3', m, k)
+    A4 = MatrixSymbol('A4', m, l)
+    A = BlockMatrix([[A1, A2], [A3, A4]])
+    assert A[0, 0] == MatrixElement(A, 0, 0)  # Cannot be A1[0, 0]
+    assert A[n - 1, k - 1] == A1[n - 1, k - 1]
+    assert A[n, k] == A4[0, 0]
+    assert A[n + m - 1, 0] == MatrixElement(A, n + m - 1, 0)  # Cannot be A3[m - 1, 0]
+    assert A[0, k + l - 1] == MatrixElement(A, 0, k + l - 1)  # Cannot be A2[0, l - 1]
+    assert A[n + m - 1, k + l - 1] == MatrixElement(A, n + m - 1, k + l - 1)  # Cannot be A4[m - 1, l - 1]
+    assert A[i, j] == MatrixElement(A, i, j)
+    assert A[n + i, k + j] == MatrixElement(A, n + i, k + j)  # Cannot be A4[i, j]
+    assert A[n - i - 1, k - j - 1] == MatrixElement(A, n - i - 1, k - j - 1)  # Cannot be A1[n - i - 1, k - j - 1]
+
+
+def test_block_index_symbolic_nonzero():
+    # All invalid simplifications from test_block_index_symbolic() that become valid if all
+    # matrices have nonzero size and all indices are nonnegative
+    k, l, m, n = symbols('k l m n', integer=True, positive=True)
+    i, j = symbols('i j', integer=True, nonnegative=True)
+    A1 = MatrixSymbol('K1', n, k)
+    A2 = MatrixSymbol('K2', n, l)
+    A3 = MatrixSymbol('K3', m, k)
+    A4 = MatrixSymbol('K4', m, l)
+    A = BlockMatrix([[A1, A2], [A3, A4]])
+    assert A[0, 0] == A1[0, 0]
+    assert A[n + m - 1, 0] == A3[m - 1, 0]
+    assert A[0, k + l - 1] == A2[0, l - 1]
+    assert A[n + m - 1, k + l - 1] == A4[m - 1, l - 1]
+    assert A[i, j] == MatrixElement(A, i, j)
+    assert A[n + i, k + j] == A4[i, j]
+    assert A[n - i - 1, k - j - 1] == A1[n - i - 1, k - j - 1]
+    assert A[2 * n, 2 * k] == A4[n, k]
+
+
+@XFAIL
+def test_block_index_symbolic_fail():
+    # To make this work, symbolic matrix dimensions would need to be somehow assumed nonnegative
+    # even if the symbols aren't specified as such.  Then 2 * n < n would correctly evaluate to
+    # False in BlockMatrix._entry()
+    A1 = MatrixSymbol('A1', n, 1)
+    A2 = MatrixSymbol('A2', m, 1)
+    A = BlockMatrix([[A1], [A2]])
+    assert A[2 * n, 0] == A2[n, 0]
 
 
 def test_slicing():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18996

#### Brief description of what is fixed or changed
Several types of indexing into BlockMatrix where either a matrix dimension or an index was symbolic returned wrong results, or should not have been evaluated altogether. This PR adds more tests for such situations.

#### Other comments
The one existing assertion that was removed was bogus to begin with. It previously passed not because the code was correct, but rather by chance.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Indexing BlockMatrix now more often produces correct results and remains unevaluated if a correct simplification is not possible.
<!-- END RELEASE NOTES -->