### PR TITLE
Add simplifications involving OneMatrix

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1041,6 +1041,10 @@ class OneMatrix(MatrixExpr):
         cls._check_dim(m)
         cls._check_dim(n)
 
+        condition = Eq(m, 1) & Eq(n, 1)
+        if condition == True:
+            return Identity(1)
+
         obj = super(OneMatrix, cls).__new__(cls, m, n)
         return obj
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1036,14 +1036,15 @@ class OneMatrix(MatrixExpr):
     """
     Matrix whose all entries are ones.
     """
-    def __new__(cls, m, n):
+    def __new__(cls, m, n, evaluate=False):
         m, n = _sympify(m), _sympify(n)
         cls._check_dim(m)
         cls._check_dim(n)
 
-        condition = Eq(m, 1) & Eq(n, 1)
-        if condition == True:
-            return Identity(1)
+        if evaluate:
+            condition = Eq(m, 1) & Eq(n, 1)
+            if condition == True:
+                return Identity(1)
 
         obj = super(OneMatrix, cls).__new__(cls, m, n)
         return obj
@@ -1055,6 +1056,12 @@ class OneMatrix(MatrixExpr):
     def as_explicit(self):
         from sympy import ImmutableDenseMatrix
         return ImmutableDenseMatrix.ones(*self.shape)
+
+    def doit(self, **hints):
+        args = self.args
+        if hints.get('deep', True):
+            args = [a.doit(**hints) for a in args]
+        return self.func(*args, evaluate=True)
 
     def _eval_transpose(self):
         return OneMatrix(self.cols, self.rows)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -62,7 +62,7 @@ def test_zero_matrix_creation():
 def test_one_matrix_creation():
     assert OneMatrix(2, 2)
     assert OneMatrix(0, 0)
-    assert OneMatrix(1, 1) == Identity(1)
+    assert Eq(OneMatrix(1, 1), Identity(1))
     raises(ValueError, lambda: OneMatrix(-1, 2))
     raises(ValueError, lambda: OneMatrix(2.0, 2))
     raises(ValueError, lambda: OneMatrix(2j, 2))

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -62,6 +62,7 @@ def test_zero_matrix_creation():
 def test_one_matrix_creation():
     assert OneMatrix(2, 2)
     assert OneMatrix(0, 0)
+    assert OneMatrix(1, 1) == Identity(1)
     raises(ValueError, lambda: OneMatrix(-1, 2))
     raises(ValueError, lambda: OneMatrix(2.0, 2))
     raises(ValueError, lambda: OneMatrix(2j, 2))
@@ -175,6 +176,12 @@ def test_OneMatrix_doit():
     assert isinstance(Unn.rows, Add)
     assert Unn.doit() == OneMatrix(2 * n, n)
     assert isinstance(Unn.doit().rows, Mul)
+
+
+def test_OneMatrix_mul():
+    assert OneMatrix(n, m) * OneMatrix(m, k) == OneMatrix(n, k) * m
+    assert w * OneMatrix(1, 1) == w
+    assert OneMatrix(1, 1) * w.T == w.T
 
 
 def test_Identity():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Added additional simplification involving multiplications with `OneMatrix`.

#### Other comments
Specifically
- Successive `OneMatrix` in a `MatMul` are combined
- `OneMatrix(1, 1)` returns `Identity(1)` instead, allowing `.is_Identity` to be `True` and `A·𝟙` to be `A`

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Some expressions involving OneMatrix are now simplified.
<!-- END RELEASE NOTES -->