### PR TITLE
Added simplify before plotting of expression

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1541,7 +1541,7 @@ def plot(*args, **kwargs):
 
     """
     args = list(map(sympify, args))
-    args[0]=args[0].simplify()
+    if(len(args)): args[0]=args[0].simplify()
     free = set()
     for a in args:
         if isinstance(a, Expr):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1541,6 +1541,7 @@ def plot(*args, **kwargs):
 
     """
     args = list(map(sympify, args))
+    args[0]=args[0].simplify()
     free = set()
     for a in args:
         if isinstance(a, Expr):


### PR DESCRIPTION
#### Fixes #19013
Issue: Error in plot of trigonometric expressions, shows incorrect plot of expressions which reduce to a constant like `csc(x)**2 - cot(x)**2`


#### Brief description of what is fixed or changed
Added simplify the expression before plotting
Fixes both the problems discussed in #19013

The plot of `exp = csc(x)**2 - cot(x)**2`:
Previously:
![Figure_3](https://user-images.githubusercontent.com/20184115/77894016-52503000-7292-11ea-9661-3dc73b288545.png)
Now:
![Figure_2](https://user-images.githubusercontent.com/20184115/77893888-2765dc00-7292-11ea-9ae0-59e6d42d124f.png)


#### Other comments
Still there is a issue with plotting constants as discussed in #18901

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->