### PR TITLE
Fixed continuous_domain to account for nested fractions

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -91,7 +91,9 @@ def singularities(expression, symbol, domain=None):
     try:
         sings = S.EmptySet
         for i in expression.rewrite([sec, csc, cot, tan], cos).atoms(Pow):
-            if i.exp.is_negative and i.exp.is_finite:
+            if i.exp.is_infinite:
+                raise NotImplementedError
+            if i.exp.is_negative:
                 sings += solveset(i.base, symbol, domain)
         for i in expression.atoms(log):
             sings += solveset(i.args[0], symbol, domain)

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -8,7 +8,7 @@ from sympy.calculus.singularities import (
     is_monotonic
 )
 from sympy.sets import Interval, FiniteSet
-from sympy.testing.pytest import XFAIL, raises
+from sympy.testing.pytest import raises
 from sympy.abc import x, y
 
 
@@ -24,14 +24,9 @@ def test_singularities():
 
     x = Symbol('x', real=True)
     assert singularities(1/(x**2 + 1), x) == S.EmptySet
-
-
-@XFAIL
-def test_singularities_non_rational():
-    x = Symbol('x', real=True)
-
-    assert singularities(exp(1/x), x) == FiniteSet(0)
-    assert singularities(log((x - 2)**2), x) == FiniteSet(2)
+    assert singularities(exp(1/x), x, S.Reals) == FiniteSet(0)
+    assert singularities(exp(1/x), x, Interval(1, 2)) == S.EmptySet
+    assert singularities(log((x - 2)**2), x, Interval(1, 3)) == FiniteSet(2)
 
 
 def test_is_increasing():

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -27,6 +27,7 @@ def test_singularities():
     assert singularities(exp(1/x), x, S.Reals) == FiniteSet(0)
     assert singularities(exp(1/x), x, Interval(1, 2)) == S.EmptySet
     assert singularities(log((x - 2)**2), x, Interval(1, 3)) == FiniteSet(2)
+    raises(NotImplementedError, lambda: singularities(x**-oo, x))
 
 
 def test_is_increasing():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -67,6 +67,9 @@ def test_continuous_domain():
         Union(Interval.open(-oo, 0), Interval.open(0, oo))
     assert continuous_domain(1/(x**2 - 4) + 2, x, S.Reals) == \
         Union(Interval.open(-oo, -2), Interval.open(-2, 2), Interval.open(2, oo))
+    domain = continuous_domain(log(tan(x)**2 + 1), x, S.Reals)
+    assert not domain.contains(3*pi/2)
+    assert domain.contains(5)
 
 
 def test_not_empty_in():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -14,6 +14,7 @@ from sympy.sets.fancysets import ImageSet
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
 
+
 def continuous_domain(f, symbol, domain):
     """
     Returns the intervals in the given domain for which the function
@@ -62,8 +63,8 @@ def continuous_domain(f, symbol, domain):
 
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
-    from sympy.solvers.solveset import solveset, _has_rational_power
-    from sympy import sec, csc, cot, tan, cos
+    from sympy.solvers.solveset import _has_rational_power
+    from sympy.calculus.singularities import singularities
 
     if domain.is_subset(S.Reals):
         constrained_interval = domain
@@ -81,20 +82,8 @@ def continuous_domain(f, symbol, domain):
             constrained_interval = Intersection(constraint,
                                                 constrained_interval)
 
-        domain = constrained_interval
 
-    try:
-        sings = EmptySet()
-        for atom in f.rewrite([sec, csc, cot, tan], cos).atoms(Pow):
-            base, exponent = atom.as_base_exp()
-            if exponent.is_negative:
-                sings += solveset(base, symbol, domain)
-
-    except NotImplementedError:
-        raise NotImplementedError("Methods for determining the continuous domains"
-                                  " of this function have not been developed.")
-
-    return domain - sings
+    return constrained_interval - singularities(f, symbol, domain)
 
 
 def function_range(f, symbol, domain):

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -40,7 +40,7 @@ def _nsort(roots, separated=False):
     # get the real part of the evaluated real and imaginary parts of each root
     key = [[i.n(2).as_real_imag()[0] for i in r.as_real_imag()] for r in roots]
     # make sure the parts were computed with precision
-    if any(i._prec == 1 for k in key for i in k):
+    if len(roots) > 1 and any(i._prec == 1 for k in key for i in k):
         raise NotImplementedError("could not compute root with precision")
     # insert a key to indicate if the root has an imaginary part
     key = [(1 if i else 0, r, i) for r, i in key]

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -45,6 +45,9 @@ def test__nsort():
     assert len(_nsort(r, separated=True)[0]) == 0
     b, c, a = exp(-1000), exp(-999), exp(-1001)
     assert _nsort((b, c, a)) == [a, b, c]
+    # issue 12560
+    a = cos(1)**2 + sin(1)**2 - 1
+    assert _nsort([a]) == [a]
 
 
 def test__sort_gens():

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -66,13 +66,16 @@ def _set_function(f, x): # noqa:F811
     if not x.start.is_comparable or not x.end.is_comparable:
         return
 
-    # XXX: when non-rational functions are supported, remove this line.
-    if not expr.is_rational_function(var):
-        return
-
     try:
-        sing = [i for i in singularities(expr, var)
-            if i.is_real and i in x]
+        from sympy.polys.polyutils import _nsort
+        sing = singularities(expr, var, x)
+
+        if not (isinstance(sing, FiniteSet) or sing is EmptySet):
+            raise NotImplementedError()
+
+        sing = list(sing)
+        if len(sing) > 1:
+            sing = _nsort(sing)
     except NotImplementedError:
         return
 

--- a/sympy/sets/handlers/functions.py
+++ b/sympy/sets/handlers/functions.py
@@ -66,6 +66,10 @@ def _set_function(f, x): # noqa:F811
     if not x.start.is_comparable or not x.end.is_comparable:
         return
 
+    # XXX: when non-rational functions are supported, remove this line.
+    if not expr.is_rational_function(var):
+        return
+
     try:
         sing = [i for i in singularities(expr, var)
             if i.is_real and i in x]
@@ -82,7 +86,10 @@ def _set_function(f, x): # noqa:F811
         _end = f(x.end)
 
     if len(sing) == 0:
-        solns = list(solveset(diff(expr, var), var))
+        soln_expr = solveset(diff(expr, var), var)
+        if not (isinstance(soln_expr, FiniteSet) or soln_expr is EmptySet):
+            return
+        solns = list(soln_expr)
 
         extr = [_start, _end] + [f(i) for i in solns
                                  if i.is_real and i in x]

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1119,6 +1119,10 @@ def test_image_interval():
     assert imageset(Lambda(x, sin(cos(x))), Interval(0, 1)) == \
             ImageSet(Lambda(x, sin(cos(x))), Interval(0, 1))
 
+    # Assert these don't hang
+    imageset(x, 1/cos(x), S.Reals)
+    imageset(x, cos(x), S.Reals)
+
 
 def test_image_piecewise():
     f = Piecewise((x, x <= -1), (1/x**2, x <= 5), (x**3, True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #18857
Fixes #17018
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
I've refined the logic in continuous_domain to search out for nested fraction (i.e. `log(1/x)`) to count them as singularities. sec, csc, cot and tan are also expanded out in their fractional form, in terms of cos to enable this to be done better.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * fixed continuous_domain to account for nested fractions
<!-- END RELEASE NOTES -->