### PR TITLE
Fix IdentityFunction for LaTeX printing

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -936,7 +936,7 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_IdentityFunction(self, expr):
-        return r"\left( x \mapsto x + 1 \right)"
+        return r"\left( x \mapsto x \right)"
 
     def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -935,6 +935,9 @@ class LatexPrinter(Printer):
 
         return tex
 
+    def _print_IdentityFunction(self, expr):
+        return r"\left( x \mapsto x + 1 \right)"
+
     def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1426,7 +1426,7 @@ def test_latex_Lambda():
     assert latex(Lambda((x, y), x + 1)) == \
         r"\left( \left( x, \  y\right) \mapsto x + 1 \right)"
     assert latex(Lambda(x, x)) == \
-        r"\left( x \mapsto x + 1 \right)"
+        r"\left( x \mapsto x \right)"
 
 def test_latex_PolyElement():
     Ruv, u, v = ring("u,v", ZZ)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1425,7 +1425,8 @@ def test_latex_Lambda():
         r"\left( x \mapsto x + 1 \right)"
     assert latex(Lambda((x, y), x + 1)) == \
         r"\left( \left( x, \  y\right) \mapsto x + 1 \right)"
-
+    assert latex(Lambda(x, x)) == \
+        r"\left( x \mapsto x + 1 \right)"
 
 def test_latex_PolyElement():
     Ruv, u, v = ring("u,v", ZZ)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

IdentityFunction is inherited from Lambda, but printing is not done properly

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed IdentityFunction printing for LaTeX.
<!-- END RELEASE NOTES -->