### PR TITLE
Added missing test for the linrec function in the discrete/recurrences.py 

### DIFF
--- a/sympy/discrete/tests/test_recurrences.py
+++ b/sympy/discrete/tests/test_recurrences.py
@@ -55,3 +55,4 @@ def test_linrec():
     assert linrec(coeffs=[0]*50 + [1, 2, 3], init=[x, y, z], n=1000) == \
         11477135884896*x + 25999077948732*y + 41975630244216*z
     assert linrec(coeffs=[], init=[1, 1], n=20) == 0
+    assert linrec(coeffs=[x, y, z], init=[1, 2, 3], n=2) == 3


### PR DESCRIPTION

#### References to other Issues or PRs
Related to issue #16318


#### Brief description of what is fixed or changed
Test to make the recurrences module 100% covered.
Checks the case that n < k, with n=point of evaluation for the recurrence
and  k=the order of recurrence.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->