### PR TITLE
Matrix connected components decomposition

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -175,6 +175,16 @@ class MatrixShaping(MatrixRequired):
     def _eval_tolist(self):
         return [list(self[i,:]) for i in range(self.rows)]
 
+    def _eval_todok(self):
+        dok = {}
+        rows, cols = self.shape
+        for i in range(rows):
+            for j in range(cols):
+                val = self[i, j]
+                if val != self.zero:
+                    dok[i, j] = val
+        return dok
+
     def _eval_vec(self):
         rows = self.rows
 
@@ -590,6 +600,19 @@ class MatrixShaping(MatrixRequired):
         3
         """
         return (self.rows, self.cols)
+
+    def todok(self):
+        """Return the matrix as dictionary of keys.
+
+        Example
+        =======
+
+        >>> from sympy import Matrix, SparseMatrix
+        >>> M = Matrix.eye(3)
+        >>> M.todok()
+        {(0, 0): 1, (1, 1): 1, (2, 2): 1}
+        """
+        return self._eval_todok()
 
     def tolist(self):
         """Return the Matrix as a nested Python list.

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -604,8 +604,8 @@ class MatrixShaping(MatrixRequired):
     def todok(self):
         """Return the matrix as dictionary of keys.
 
-        Example
-        =======
+        Examples
+        ========
 
         >>> from sympy import Matrix, SparseMatrix
         >>> M = Matrix.eye(3)

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -297,7 +297,7 @@ class BlockDiagMatrix(BlockMatrix):
     =====
 
     If you want to get the individual diagonal blocks, use
-    :meth:`get_diagonal_blocks`.
+    :meth:`get_diag_blocks`.
 
     See Also
     ========

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -279,8 +279,10 @@ class BlockMatrix(MatrixExpr):
 
 
 class BlockDiagMatrix(BlockMatrix):
-    """
-    A BlockDiagMatrix is a BlockMatrix with matrices only along the diagonal
+    """A sparse matrix with block matrices along its diagonals
+
+    Examples
+    ========
 
     >>> from sympy import MatrixSymbol, BlockDiagMatrix, symbols, Identity
     >>> n, m, l = symbols('n m l')
@@ -291,8 +293,15 @@ class BlockDiagMatrix(BlockMatrix):
     [X, 0],
     [0, Y]])
 
+    Notes
+    =====
+
+    If you want to get the individual diagonal blocks, use
+    :meth:`get_diagonal_blocks`.
+
     See Also
     ========
+
     sympy.matrices.dense.diag
     """
     def __new__(cls, *mats):
@@ -350,6 +359,32 @@ class BlockDiagMatrix(BlockMatrix):
             return BlockDiagMatrix(*[a + b for a, b in zip(self.args, other.args)])
         else:
             return BlockMatrix._blockadd(self, other)
+
+    def get_diag_blocks(self):
+        """Return the list of diagonal blocks of the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import BlockDiagMatrix, Matrix
+
+        >>> A = Matrix([[1, 2], [3, 4]])
+        >>> B = Matrix([[5, 6], [7, 8]])
+        >>> M = BlockDiagMatrix(A, B)
+
+        How to get diagonal blocks from the block diagonal matrix:
+
+        >>> diag_blocks = M.get_diag_blocks()
+        >>> diag_blocks[0]
+        Matrix([
+        [1, 2],
+        [3, 4]])
+        >>> diag_blocks[1]
+        Matrix([
+        [5, 6],
+        [7, 8]])
+        """
+        return self.args
 
 
 def block_collapse(expr):

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -172,6 +172,7 @@ def test_BlockDiagMatrix():
     assert all(X.blocks[i, j].is_ZeroMatrix if i != j else X.blocks[i, j] in [A, B, C]
             for i in range(3) for j in range(3))
     assert X.__class__(*X.args) == X
+    assert X.get_diag_blocks() == (A, B, C)
 
     assert isinstance(block_collapse(X.I * X), Identity)
 

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -55,6 +55,10 @@ def _connected_components_decomposition(M):
         as in the explanation. And *B* is the block diagonal matrix of
         the result of the permutation.
 
+        If you would like to get the diagonal blocks from the
+        BlockDiagMatrix, see
+        :meth:`~sympy.matrices.expressions.blockmatrix.BlockDiagMatrix.get_diag_blocks`.
+
     Examples
     ========
 
@@ -83,7 +87,7 @@ def _connected_components_decomposition(M):
     [c, d, 0, 0],
     [0, 0, e, f],
     [0, 0, g, h]])
-    >>> P * B * P.inv()
+    >>> P * B * P_inv
     Matrix([
     [a, 0, b, 0],
     [0, e, 0, f],

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -29,8 +29,6 @@ def _connected_components(M):
     structural aspect of the matrix, so they will considered to be
     nonzero.
     """
-    from .sparse import SparseMatrix
-
     if not M.is_square:
         raise NonSquareMatrixError
 

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -1,5 +1,5 @@
 from sympy.utilities.iterables import \
-    flatten, strongly_connected_components
+    flatten, connected_components
 
 from .common import NonSquareMatrixError
 
@@ -32,19 +32,7 @@ def _connected_components(M):
     if not M.is_square:
         raise NonSquareMatrixError
 
-    N = M.shape[0]
-    V = list(range(N))
-
-    E = set()
-    for i, j in M.todok().keys():
-        if i == j:
-            E.add((i, j))
-        else:
-            E.add((i, j))
-            E.add((j, i))
-    E = list(E)
-
-    return strongly_connected_components((V, E))
+    return connected_components((range(M.rows), M.todok()))
 
 
 def _connected_components_decomposition(M):

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -37,25 +37,14 @@ def _connected_components(M):
     N = M.shape[0]
     V = list(range(N))
 
-    if isinstance(M, SparseMatrix):
-        E = set()
-        for i, j in M._smat.keys():
-            if i == j:
-                E.add((i, j))
-            else:
-                E.add((i, j))
-                E.add((j, i))
-        E = list(E)
-    else:
-        E = list()
-        for i in range(N):
-            for j in range(i):
-                if M[i, j] is M.zero and M[j, i] is M.zero:
-                    continue
-                E.append((i, j))
-                E.append((j, i))
-            if M[i, i] is M.zero:
-                E.append((i, i))
+    E = set()
+    for i, j in M.todok().keys():
+        if i == j:
+            E.add((i, j))
+        else:
+            E.add((i, j))
+            E.add((j, i))
+    E = list(E)
 
     return strongly_connected_components((V, E))
 

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -1,0 +1,135 @@
+from sympy.utilities.iterables import \
+    flatten, strongly_connected_components
+
+from .common import NonSquareMatrixError
+
+
+def _connected_components(M):
+    """Returns the list of connected vertices of the graph when
+    a square matrix is viewed as a weighted graph.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, Matrix
+    >>> a, b, c, d, e, f, g, h = symbols('a:h')
+    >>> A = Matrix([
+    ...     [a, 0, b, 0],
+    ...     [0, e, 0, f],
+    ...     [c, 0, d, 0],
+    ...     [0, g, 0, h]])
+    >>> A.connected_components()
+    [[0, 2], [1, 3]]
+
+    Notes
+    =====
+
+    Even if any symbolic elements of the matrix can be indeterminate
+    to be zero mathematically, this only takes the account of the
+    structural aspect of the matrix, so they will considered to be
+    nonzero.
+    """
+    from .sparse import SparseMatrix
+
+    if not M.is_square:
+        raise NonSquareMatrixError
+
+    N = M.shape[0]
+    V = list(range(N))
+
+    if isinstance(M, SparseMatrix):
+        E = set()
+        for i, j in M._smat.keys():
+            if i == j:
+                E.add((i, j))
+            else:
+                E.add((i, j))
+                E.add((j, i))
+        E = list(E)
+    else:
+        E = list()
+        for i in range(N):
+            for j in range(i):
+                if M[i, j] is M.zero and M[j, i] is M.zero:
+                    continue
+                E.append((i, j))
+                E.append((j, i))
+            if M[i, i] is M.zero:
+                E.append((i, i))
+
+    return strongly_connected_components((V, E))
+
+
+def _connected_components_decomposition(M):
+    """Decomposes a square matrix into block diagonal form only
+    using the permutations.
+
+    Explanation
+    ===========
+
+    The decomposition is in a form of $A = P B P^{-1}$ where $P$ is a
+    permutation matrix and $B$ is a block diagonal matrix.
+
+    Returns
+    =======
+
+    P, B : PermutationMatrix, BlockDiagMatrix
+        *P* is a permutation matrix for the similarity transform
+        as in the explanation. And *B* is the block diagonal matrix of
+        the result of the permutation.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, Matrix
+    >>> a, b, c, d, e, f, g, h = symbols('a:h')
+    >>> A = Matrix([
+    ...     [a, 0, b, 0],
+    ...     [0, e, 0, f],
+    ...     [c, 0, d, 0],
+    ...     [0, g, 0, h]])
+
+    >>> P, B = A.connected_components_decomposition()
+    >>> P = P.as_explicit()
+    >>> P_inv = P.inv().as_explicit()
+    >>> B = B.as_explicit()
+
+    >>> P
+    Matrix([
+    [1, 0, 0, 0],
+    [0, 0, 1, 0],
+    [0, 1, 0, 0],
+    [0, 0, 0, 1]])
+    >>> B
+    Matrix([
+    [a, b, 0, 0],
+    [c, d, 0, 0],
+    [0, 0, e, f],
+    [0, 0, g, h]])
+    >>> P * B * P.inv()
+    Matrix([
+    [a, 0, b, 0],
+    [0, e, 0, f],
+    [c, 0, d, 0],
+    [0, g, 0, h]])
+
+    Notes
+    =====
+
+    This problem corresponds to the finding of the connected components
+    of a graph, when a matrix is viewed as a weighted graph.
+    """
+    from sympy.combinatorics.permutations import Permutation
+    from sympy.matrices.expressions.blockmatrix import BlockDiagMatrix
+    from sympy.matrices.expressions.permutation import PermutationMatrix
+
+    iblocks = M.connected_components()
+
+    p = Permutation(flatten(iblocks))
+    P = PermutationMatrix(p)
+
+    blocks = []
+    for b in iblocks:
+        blocks.append(M[b, b])
+    B = BlockDiagMatrix(*blocks)
+    return P, B

--- a/sympy/matrices/graph.py
+++ b/sympy/matrices/graph.py
@@ -32,7 +32,9 @@ def _connected_components(M):
     if not M.is_square:
         raise NonSquareMatrixError
 
-    return connected_components((range(M.rows), M.todok()))
+    V = range(M.rows)
+    E = sorted(M.todok().keys())
+    return connected_components((V, E))
 
 
 def _connected_components_decomposition(M):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -51,6 +51,8 @@ from .decompositions import (
     _LUdecomposition, _LUdecomposition_Simple, _LUdecompositionFF,
     _QRdecomposition)
 
+from .graph import _connected_components, _connected_components_decomposition
+
 from .solvers import (
     _diagonal_solve, _lower_triangular_solve, _upper_triangular_solve,
     _cholesky_solve, _LDLsolve, _LUsolve, _QRsolve, _gauss_jordan_solve,
@@ -2249,6 +2251,12 @@ class MatrixBase(MatrixDeprecated,
     def inv(self, method=None, iszerofunc=_iszero, try_block_diag=False):
         return _inv(self, method=method, iszerofunc=iszerofunc,
                 try_block_diag=try_block_diag)
+
+    def connected_components(self):
+        return _connected_components(self)
+
+    def connected_components_decomposition(self):
+        return _connected_components_decomposition(self)
 
     rank_decomposition.__doc__     = _rank_decomposition.__doc__
     cholesky.__doc__               = _cholesky.__doc__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2289,6 +2289,10 @@ class MatrixBase(MatrixDeprecated,
     inverse_BLOCK.__doc__          = _inv_block.__doc__
     inv.__doc__                    = _inv.__doc__
 
+    connected_components.__doc__   = _connected_components.__doc__
+    connected_components_decomposition.__doc__ = \
+        _connected_components_decomposition.__doc__
+
 
 @deprecated(
     issue=15109,

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -427,6 +427,9 @@ class SparseMatrix(MatrixBase):
     def _eval_scalar_rmul(self, other):
         return self.applyfunc(lambda x: other*x)
 
+    def _eval_todok(self):
+        return self._smat.copy()
+
     def _eval_transpose(self):
         """Returns the transposed SparseMatrix of this SparseMatrix.
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -13,7 +13,9 @@ from sympy.matrices.common import (ShapeError, NonSquareMatrixError,
     MatrixOperations, MatrixArithmetic, MatrixSpecial)
 from sympy.matrices.matrices import MatrixCalculus
 from sympy.matrices import (Matrix, diag, eye,
-    matrix_multiply_elementwise, ones, zeros, SparseMatrix, banded)
+    matrix_multiply_elementwise, ones, zeros, SparseMatrix, banded,
+    MutableDenseMatrix, MutableSparseMatrix, ImmutableDenseMatrix,
+    ImmutableSparseMatrix)
 from sympy.utilities.iterables import flatten
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
@@ -102,6 +104,16 @@ def test_vec():
     assert m_vec.cols == 1
     for i in range(4):
         assert m_vec[i] == i + 1
+
+
+def test_todok():
+    a, b, c, d = symbols('a:d')
+    m1 = MutableDenseMatrix([[a, b], [c, d]])
+    m2 = ImmutableDenseMatrix([[a, b], [c, d]])
+    m3 = MutableSparseMatrix([[a, b], [c, d]])
+    m4 = ImmutableSparseMatrix([[a, b], [c, d]])
+    assert m1.todok() == m2.todok() == m3.todok() == m4.todok() == \
+        {(0, 0): a, (0, 1): b, (1, 0): c, (1, 1): d}
 
 
 def test_tolist():

--- a/sympy/matrices/tests/test_graph.py
+++ b/sympy/matrices/tests/test_graph.py
@@ -1,0 +1,49 @@
+from sympy.combinatorics import Permutation
+from sympy.core.symbol import Symbol, symbols
+from sympy.matrices import Matrix
+from sympy.matrices.expressions import PermutationMatrix, BlockDiagMatrix
+
+
+def test_connected_components():
+    kp, ki, kd = symbols('kp ki kd')
+    Ix, Iy, Iz = symbols('Ix Iy Iz')
+    d = Symbol('d')
+
+    M = Matrix([
+        [1 + d*kd/Ix,           0,           0, 0, d*kp/Ix,       0,       0, 0, 0, 0, d*ki/Ix,       0,       0],
+        [          0, 1 + d*kd/Iy,           0, 0,       0, d*kp/Iy,       0, 0, 0, 0,       0, d*ki/Iy,       0],
+        [          0,           0, 1 + d*kd/Iz, 0,       0,       0, d*kp/Iz, 0, 0, 0,       0,       0, d*ki/Iz],
+        [          0,           0,           0, 1,       0,       0,       0, 0, 0, 0,       0,       0,       0],
+        [        d/2,           0,           0, 0,       1,       0,       0, 0, 0, 0,       0,       0,       0],
+        [          0,         d/2,           0, 0,       0,       1,       0, 0, 0, 0,       0,       0,       0],
+        [          0,           0,         d/2, 0,       0,       0,       1, 0, 0, 0,       0,       0,       0],
+        [      -d*kd,           0,           0, 0,   -d*kp,       0,       0, 1, 0, 0,   -d*ki,       0,       0],
+        [          0,       -d*kd,           0, 0,       0,   -d*kp,       0, 0, 1, 0,       0,   -d*ki,       0],
+        [          0,           0,       -d*kd, 0,       0,       0,   -d*kp, 0, 0, 1,       0,       0,   -d*ki],
+        [          0,           0,           0, 0,       d,       0,       0, 0, 0, 0,       1,       0,       0],
+        [          0,           0,           0, 0,       0,       d,       0, 0, 0, 0,       0,       1,       0],
+        [          0,           0,           0, 0,       0,       0,       d, 0, 0, 0,       0,       0,       1]])
+    cc = M.connected_components()
+    assert cc == [[0, 4, 7, 10], [1, 5, 8, 11], [2, 6, 9, 12], [3]]
+
+    P, B = M.connected_components_decomposition()
+    p = Permutation([0, 4, 7, 10, 1, 5, 8, 11, 2, 6, 9, 12, 3])
+    assert P == PermutationMatrix(p)
+
+    B0 = Matrix([
+        [1 + d*kd/Ix, d*kp/Ix, 0, d*ki/Ix],
+        [        d/2,       1, 0,       0],
+        [      -d*kd,   -d*kp, 1,   -d*ki],
+        [          0,       d, 0,       1]])
+    B1 = Matrix([
+        [1 + d*kd/Iy, d*kp/Iy, 0, d*ki/Iy],
+        [        d/2,       1, 0,       0],
+        [      -d*kd,   -d*kp, 1,   -d*ki],
+        [          0,       d, 0,       1]])
+    B2 = Matrix([
+        [1 + d*kd/Iz, d*kp/Iz, 0, d*ki/Iz],
+        [        d/2,       1, 0,       0],
+        [      -d*kd,   -d*kp, 1,   -d*ki],
+        [          0,       d, 0,       1]])
+    B3 = Matrix([[1]])
+    assert B == BlockDiagMatrix(B0, B1, B2, B3)

--- a/sympy/matrices/tests/test_graph.py
+++ b/sympy/matrices/tests/test_graph.py
@@ -1,28 +1,26 @@
 from sympy.combinatorics import Permutation
-from sympy.core.symbol import Symbol, symbols
+from sympy.core.symbol import symbols
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import PermutationMatrix, BlockDiagMatrix
 
 
 def test_connected_components():
-    kp, ki, kd = symbols('kp ki kd')
-    Ix, Iy, Iz = symbols('Ix Iy Iz')
-    d = Symbol('d')
+    a, b, c, d, e, f, g, h, i, j, k, l, m = symbols('a:m')
 
     M = Matrix([
-        [1 + d*kd/Ix,           0,           0, 0, d*kp/Ix,       0,       0, 0, 0, 0, d*ki/Ix,       0,       0],
-        [          0, 1 + d*kd/Iy,           0, 0,       0, d*kp/Iy,       0, 0, 0, 0,       0, d*ki/Iy,       0],
-        [          0,           0, 1 + d*kd/Iz, 0,       0,       0, d*kp/Iz, 0, 0, 0,       0,       0, d*ki/Iz],
-        [          0,           0,           0, 1,       0,       0,       0, 0, 0, 0,       0,       0,       0],
-        [        d/2,           0,           0, 0,       1,       0,       0, 0, 0, 0,       0,       0,       0],
-        [          0,         d/2,           0, 0,       0,       1,       0, 0, 0, 0,       0,       0,       0],
-        [          0,           0,         d/2, 0,       0,       0,       1, 0, 0, 0,       0,       0,       0],
-        [      -d*kd,           0,           0, 0,   -d*kp,       0,       0, 1, 0, 0,   -d*ki,       0,       0],
-        [          0,       -d*kd,           0, 0,       0,   -d*kp,       0, 0, 1, 0,       0,   -d*ki,       0],
-        [          0,           0,       -d*kd, 0,       0,       0,   -d*kp, 0, 0, 1,       0,       0,   -d*ki],
-        [          0,           0,           0, 0,       d,       0,       0, 0, 0, 0,       1,       0,       0],
-        [          0,           0,           0, 0,       0,       d,       0, 0, 0, 0,       0,       1,       0],
-        [          0,           0,           0, 0,       0,       0,       d, 0, 0, 0,       0,       0,       1]])
+        [a, 0, 0, 0, b, 0, 0, 0, 0, 0, c, 0, 0],
+        [0, d, 0, 0, 0, e, 0, 0, 0, 0, 0, f, 0],
+        [0, 0, g, 0, 0, 0, h, 0, 0, 0, 0, 0, i],
+        [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [m, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, m, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, m, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+        [j, 0, 0, 0, k, 0, 0, 1, 0, 0, l, 0, 0],
+        [0, j, 0, 0, 0, k, 0, 0, 1, 0, 0, l, 0],
+        [0, 0, j, 0, 0, 0, k, 0, 0, 1, 0, 0, l],
+        [0, 0, 0, 0, d, 0, 0, 0, 0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0, d, 0, 0, 0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 0, 0, d, 0, 0, 0, 0, 0, 1]])
     cc = M.connected_components()
     assert cc == [[0, 4, 7, 10], [1, 5, 8, 11], [2, 6, 9, 12], [3]]
 
@@ -31,19 +29,19 @@ def test_connected_components():
     assert P == PermutationMatrix(p)
 
     B0 = Matrix([
-        [1 + d*kd/Ix, d*kp/Ix, 0, d*ki/Ix],
-        [        d/2,       1, 0,       0],
-        [      -d*kd,   -d*kp, 1,   -d*ki],
-        [          0,       d, 0,       1]])
+        [a, b, 0, c],
+        [m, 1, 0, 0],
+        [j, k, 1, l],
+        [0, d, 0, 1]])
     B1 = Matrix([
-        [1 + d*kd/Iy, d*kp/Iy, 0, d*ki/Iy],
-        [        d/2,       1, 0,       0],
-        [      -d*kd,   -d*kp, 1,   -d*ki],
-        [          0,       d, 0,       1]])
+        [d, e, 0, f],
+        [m, 1, 0, 0],
+        [j, k, 1, l],
+        [0, d, 0, 1]])
     B2 = Matrix([
-        [1 + d*kd/Iz, d*kp/Iz, 0, d*ki/Iz],
-        [        d/2,       1, 0,       0],
-        [      -d*kd,   -d*kp, 1,   -d*ki],
-        [          0,       d, 0,       1]])
+        [g, h, 0, i],
+        [m, 1, 0, 0],
+        [j, k, 1, l],
+        [0, d, 0, 1]])
     B3 = Matrix([[1]])
     assert B == BlockDiagMatrix(B0, B1, B2, B3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#16207

#### Brief description of what is fixed or changed

I see there were some needs of using `connected_components`.
So I wrap two APIs for this first for finding connected components and second for finding a similar matrix which is block diagonal.

I would also wrap most of the new decomposition methods using the most economical structure possible (with block diagonal matrix and permutation matrix) because
1. It is the most economical representation.
2. It loses a lot of usefulness after people start to run some search algorithms to find block structures or permutation from the explicit result, and it poorly utilizes some intermediate results. (I saw this was done poorly in jordan-decomposition related methods)

But someone would find these stuff unintuitive or difficult to use since I don't think that matrix expressions API is more famous than `Matrix`.
In the examples, I have just used `as_explicit` because it prints block diagonal matrix into some awkward forms.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Added `connected_components` and `connected_components_decomposition` for matrix which decomposes a matrix into a block diagonal form.
  - Added `todok` function to find dictionary of keys format from any dense or sparse matrices.
  - Added `BlockDiagMatrix.get_diag_blocks` to provide an user API to get diagonal blocks from the matrix.
<!-- END RELEASE NOTES -->