### PR TITLE
be more specific when testing for T/F

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -369,6 +369,8 @@ def as_int(n, strict=True):
     """
     if strict:
         try:
+            if type(n) is bool:
+                raise TypeError
             return operator.index(n)
         except TypeError:
             raise ValueError('%s is not an integer' % (n,))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1389,12 +1389,15 @@ class Float(Number):
     __long__ = __int__
 
     def __eq__(self, other):
+        from sympy.logic.boolalg import Boolean
         try:
             other = _sympify(other)
         except SympifyError:
             return NotImplemented
         if not self:
             return not other
+        if isinstance(other, Boolean):
+            return False
         if other.is_NumberSymbol:
             if other.is_irrational:
                 return False

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -33,11 +33,10 @@ def _canonical(cond):
     # the tests so I've removed it...
 
 
-def _nonsym_Bool(side):
-    """return True if ``side`` is a non-Symbol Boolean"""
-    from sympy.core.symbol import Symbol
+def _nontriv_Bool(side):
+    """return True if ``side`` is a non-atomic Boolean"""
     from sympy.logic.boolalg import Boolean
-    return isinstance(side, Boolean) and not isinstance(side, Symbol)
+    return isinstance(side, Boolean) and not side.is_Atom
 
 
 class Relational(Boolean, EvalfMixin):
@@ -90,7 +89,7 @@ class Relational(Boolean, EvalfMixin):
             # other than Eq/Ne;
             # Note: Symbol is a subclass of Boolean but is considered
             # acceptable here.
-            if _nonsym_Bool(lhs) or _nonsym_Bool(rhs):
+            if _nontriv_Bool(lhs) or _nontriv_Bool(rhs):
                 from sympy.utilities.misc import filldedent
                 raise TypeError(filldedent('''
                     A Boolean argument can only be used in
@@ -495,9 +494,9 @@ class Equality(Relational):
 
         # sanitize 0/1 -> F/T if the other arg is a Boolean (other
         # than a Symbol), e.g. Eq(0, ~x) -> Eq(False, ~x)
-        if lhs in (True, False) and _nonsym_Bool(rhs):
+        if lhs in (True, False) and _nontriv_Bool(rhs):
             lhs = _sympify(bool(lhs))
-        elif rhs in (True, False) and _nonsym_Bool(lhs):
+        elif rhs in (True, False) and _nontriv_Bool(lhs):
             rhs = _sympify(bool(rhs))
 
         evaluate = options.pop('evaluate', global_parameters.evaluate)
@@ -732,9 +731,9 @@ class Unequality(Relational):
 
         # sanitize 0/1 -> F/T if the other arg is a Boolean (other
         # than a Symbol), e.g. Ne(0, ~x) -> Ne(False, ~x)
-        if lhs in (True, False) and _nonsym_Bool(rhs):
+        if lhs in (True, False) and _nontriv_Bool(rhs):
             lhs = _sympify(bool(lhs))
-        elif rhs in (True, False) and _nonsym_Bool(lhs):
+        elif rhs in (True, False) and _nontriv_Bool(lhs):
             rhs = _sympify(bool(rhs))
 
         evaluate = options.pop('evaluate', global_parameters.evaluate)

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -12,6 +12,7 @@ def test_default_sort_key():
 
 
 def test_as_int():
+    raises(ValueError, lambda : as_int(True))
     raises(ValueError, lambda : as_int(1.1))
     raises(ValueError, lambda : as_int([]))
     raises(ValueError, lambda : as_int(S.NaN))
@@ -25,6 +26,7 @@ def test_as_int():
     # integer. This is not -- by design -- as_ints role.
     raises(ValueError, lambda : as_int(1e23))
     raises(ValueError, lambda : as_int(S('1.'+'0'*20+'1')))
+    assert as_int(True, strict=False) == 1
 
 
 def test_iterable():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -114,7 +114,7 @@ def test_wrappers():
     assert Ne(y, x + x**2) == res
 
 
-def test_Eq():
+def test_Eq_Ne():
 
     assert Eq(x, x)  # issue 5719
 
@@ -126,9 +126,19 @@ def test_Eq():
     assert Eq(p, 0) is S.false
 
     # issue 13348; 19048
+    # SymPy is strict about 0 and 1 not being
+    # interpreted as Booleans
     assert Eq(True, 1) is S.false
+    assert Eq(False, 0) is S.false
+    assert Eq(~x, 0) is S.false
+    assert Eq(~x, 1) is S.false
+    assert Ne(True, 1) is S.true
+    assert Ne(False, 0) is S.true
+    assert Ne(~x, 0) is S.true
+    assert Ne(~x, 1) is S.true
 
     assert Eq((), 1) is S.false
+    assert Ne((), 1) is S.true
 
 
 def test_as_poly():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -989,10 +989,9 @@ def test_binary_symbols():
 
 
 def test_rel_args():
-    # can't have Boolean args; this is automatic with Python 3
-    # so this test and the __lt__, etc..., definitions in
-    # relational.py and boolalg.py which are marked with ///
-    # can be removed.
+    # can't have Boolean args; this is automatic for True/False
+    # with Python 3 and we confirm that SymPy does the same
+    # for true/false
     for op in ['<', '<=', '>', '>=']:
         for b in (S.true, x < 1, And(x, y)):
             for v in (0.1, 1, 2**32, t, S.One):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -126,7 +126,7 @@ def test_Eq():
     assert Eq(p, 0) is S.false
 
     # issue 13348; 19048
-    assert Eq(True, 1) is S.true
+    assert Eq(True, 1) is S.false
 
     assert Eq((), 1) is S.false
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -125,8 +125,8 @@ def test_Eq():
     p = Symbol('p', positive=True)
     assert Eq(p, 0) is S.false
 
-    # issue 13348
-    assert Eq(True, 1) is S.false
+    # issue 13348; 19048
+    assert Eq(True, 1) is S.true
 
     assert Eq((), 1) is S.false
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -436,7 +436,6 @@ class BooleanFunction(Application, Boolean):
         from sympy.simplify.simplify import simplify
         return simplify(self, **kwargs)
 
-    # /// drop when Py2 is no longer supported
     def __lt__(self, other):
         from sympy.utilities.misc import filldedent
         raise TypeError(filldedent('''
@@ -447,7 +446,6 @@ class BooleanFunction(Application, Boolean):
     __le__ = __lt__
     __ge__ = __lt__
     __gt__ = __lt__
-    # \\\
 
     @classmethod
     def binary_check_and_simplify(self, *args):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -383,11 +383,19 @@ def test_bool_symbol():
 
 
 def test_is_boolean():
-    assert true.is_Boolean
+    assert isinstance(True, Boolean) is False
+    assert isinstance(true, Boolean) is True
+    assert 1 == True
+    assert 1 != true
+    assert 0 == False
+    assert 0 != false
+    assert true.is_Boolean is True
     assert (A & B).is_Boolean
     assert (A | B).is_Boolean
     assert (~A).is_Boolean
     assert (A ^ B).is_Boolean
+    assert A.is_Boolean != isinstance(A, Boolean)
+    assert isinstance(A, Boolean)
 
 
 def test_subs():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -387,8 +387,10 @@ def test_is_boolean():
     assert isinstance(true, Boolean) is True
     assert 1 == True
     assert 1 != true
+    assert (1 == true) is False
     assert 0 == False
     assert 0 != false
+    assert (0 == false) is False
     assert true.is_Boolean is True
     assert (A & B).is_Boolean
     assert (A | B).is_Boolean

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -262,9 +262,9 @@ def checksol(f, symbol, sol=None, **flags):
         if f.rhs in (S.true, S.false):
             f = f.reversed
         B, E = f.args
-        if B in (S.true, S.false):
+        if isinstance(B, BooleanAtom):
             f = f.subs(sol)
-            if f not in (S.true, S.false):
+            if not f.is_Boolean:
                 return
         else:
             f = f.rewrite(Add, evaluate=False)
@@ -364,8 +364,6 @@ def checksol(f, symbol, sol=None, **flags):
         elif val.is_Rational:
             return val == 0
         if numerical and val.is_number:
-            if val in (S.true, S.false):
-                return bool(val)
             return (abs(val.n(18).n(12, chop=True)) < 1e-9) is S.true
         was = val
 
@@ -977,11 +975,10 @@ def solve(f, *symbols, **flags):
             if 'ImmutableDenseMatrix' in [type(a).__name__ for a in fi.args]:
                 fi = fi.lhs - fi.rhs
             else:
-                args = fi.args
-                if args[1] in (S.true, S.false):
-                    args = args[1], args[0]
-                L, R = args
-                if L in (S.false, S.true):
+                L, R = fi.args
+                if isinstance(R, BooleanAtom):
+                    L, R = R, L
+                if isinstance(L, BooleanAtom):
                     if isinstance(fi, Unequality):
                         L = ~L
                     if R.is_Relational:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -165,13 +165,15 @@ def test_solve_args():
     # - linear
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
     # When one or more args are Boolean
+    assert solve(Eq(x**2, 0.0)) == [0]  # issue 19048
     assert solve([True, Eq(x, 0)], [x], dict=True) == [{x: 0}]
     assert solve([Eq(x, x), Eq(x, 0), Eq(x, x+1)], [x], dict=True) == []
     assert not solve([Eq(x, x+1), x < 2], x)
     assert solve([Eq(x, 0), x+1<2]) == Eq(x, 0)
     assert solve([Eq(x, x), Eq(x, x+1)], x) == []
     assert solve(True, x) == []
-    assert solve([x-1, False], [x], set=True) == ([], set())
+    assert solve([x - 1, False], [x], set=True) == ([], set())
+
 
 def test_solve_polynomial1():
     assert solve(3*x - 2, x) == [Rational(2, 3)]
@@ -605,10 +607,15 @@ def test_solve_inequalities():
     assert solve(Eq(x < 1, True)) == (-oo < x) & (x < 1)
 
     assert solve(Eq(False, x)) == False
+    assert solve(Eq(0, x)) == [0]
     assert solve(Eq(True, x)) == True
+    assert solve(Eq(1, x)) == [1]
     assert solve(Eq(False, ~x)) == True
+    assert solve(Eq(0, ~x)) == True
     assert solve(Eq(True, ~x)) == False
+    assert solve(Eq(1, ~x)) == False
     assert solve(Ne(True, x)) == False
+    assert solve(Ne(1, x)) == (x > -oo) & (x < oo) & Ne(x, 1)
 
 
 def test_issue_4793():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -611,9 +611,7 @@ def test_solve_inequalities():
     assert solve(Eq(True, x)) == True
     assert solve(Eq(1, x)) == [1]
     assert solve(Eq(False, ~x)) == True
-    assert solve(Eq(0, ~x)) == True
     assert solve(Eq(True, ~x)) == False
-    assert solve(Eq(1, ~x)) == False
     assert solve(Ne(True, x)) == False
     assert solve(Ne(1, x)) == (x > -oo) & (x < oo) & Ne(x, 1)
 


### PR DESCRIPTION
When testing whether x is in (S.true, S.false) one
must be careful to consider whether 0 and 1 should
pass this test because that is the Python default.

SymPy can test more specifically, however, whether
x is a literal True or False. That is now being done
where failure to do so was previously causing an error.

But since SymPy lives in Python where 0/1 are short for T/F
still allow this but only when the context warrants it, i.e.
when the other argument in `Eq` or `Ne` is Boolean-related.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #19048

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * when `strict=True`, `as_int` will not convert True to 1
* solvers
    * no longer interpret 0./1. as bool when the other arg is not a Boolean
<!-- END RELEASE NOTES -->