### PR TITLE
Fix validation of BlockMatrix

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -99,12 +99,13 @@ class BlockMatrix(MatrixExpr):
                     if not ok:
                         break
                 blocky = ok
-                # same number of cols for each matrix in each col
-                for c in range(len(rows[0])):
-                    ok = len(set([rows[i][c].cols
-                        for i in range(len(rows))])) == 1
-                    if not ok:
-                        break
+                if ok:
+                    # same number of cols for each matrix in each col
+                    for c in range(len(rows[0])):
+                        ok = len(set([rows[i][c].cols
+                            for i in range(len(rows))])) == 1
+                        if not ok:
+                            break
             if not ok:
                 # same total cols in each row
                 ok = len(set([

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -1,3 +1,4 @@
+from sympy.testing.pytest import raises
 from sympy.matrices.expressions.blockmatrix import (
     block_collapse, bc_matmul, bc_block_plus_ident, BlockDiagMatrix,
     BlockMatrix, bc_dist, bc_matadd, bc_transpose, bc_inverse,
@@ -232,3 +233,19 @@ def test_block_collapse_type():
     assert block_collapse(Transpose(bm1)).__class__ == BlockDiagMatrix
     assert bc_transpose(Transpose(bm1)).__class__ == BlockDiagMatrix
     assert bc_inverse(Inverse(bm1)).__class__ == BlockDiagMatrix
+
+def test_invalid_block_matrix():
+    raises(ValueError, lambda: BlockMatrix([
+        [Identity(2), Identity(5)],
+    ]))
+    raises(ValueError, lambda: BlockMatrix([
+        [Identity(n), Identity(m)],
+    ]))
+    raises(ValueError, lambda: BlockMatrix([
+        [ZeroMatrix(n, n), ZeroMatrix(n, n)],
+        [ZeroMatrix(n, n - 1), ZeroMatrix(n, n + 1)],
+    ]))
+    raises(ValueError, lambda: BlockMatrix([
+        [ZeroMatrix(n - 1, n), ZeroMatrix(n, n)],
+        [ZeroMatrix(n + 1, n), ZeroMatrix(n, n)],
+    ]))


### PR DESCRIPTION
#### Brief description of what is fixed or changed
It now rejects some invalid shape combinations, for example:
```
BlockMatrix([[Identity(2), Identity(5)]])

BlockMatrix([
    [ZeroMatrix(n - 1, n), ZeroMatrix(n, n)],
    [ZeroMatrix(n + 1, n), ZeroMatrix(n, n)],
])
```
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->