### PR TITLE
perm_groups.py: Add Coset class

### DIFF
--- a/sympy/combinatorics/__init__.py
+++ b/sympy/combinatorics/__init__.py
@@ -6,7 +6,7 @@ from sympy.combinatorics.partitions import (Partition, IntegerPartition,
     RGS_rank, RGS_unrank, RGS_enum)
 from sympy.combinatorics.polyhedron import (Polyhedron, tetrahedron, cube,
     octahedron, dodecahedron, icosahedron)
-from sympy.combinatorics.perm_groups import PermutationGroup
+from sympy.combinatorics.perm_groups import PermutationGroup, Coset, SymmetricPermutationGroup
 from sympy.combinatorics.group_constructs import DirectProduct
 from sympy.combinatorics.graycode import GrayCode
 from sympy.combinatorics.named_groups import (SymmetricGroup, DihedralGroup,
@@ -27,7 +27,7 @@ __all__ = [
     'Polyhedron', 'tetrahedron', 'cube', 'octahedron', 'dodecahedron',
     'icosahedron',
 
-    'PermutationGroup',
+    'PermutationGroup', 'Coset', 'SymmetricPermutationGroup',
 
     'DirectProduct',
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1702,6 +1702,10 @@ class PermutationGroup(Basic):
         """
         if not isinstance(g, Permutation):
             return False
+        if isinstance(G, SymmetricPermutationGroup):
+            if g.size() == G.degree:
+                return True
+            return False
         if g.size != self.degree:
             if strict:
                 return False
@@ -2301,6 +2305,10 @@ class PermutationGroup(Basic):
         False
 
         """
+        if isinstance(G, SymmetricPermutationGroup):
+            if self.degree != G.degree:
+                return False
+            return True
         if not isinstance(G, PermutationGroup):
             return False
         if self == G or self.generators[0]==Permutation():
@@ -5081,6 +5089,7 @@ class SymmetricPermutationGroup(Basic):
     The class defining the lazy form of SymmetricGroup
 
     deg : int
+
     """
 
     def __new__(cls, deg):
@@ -5089,6 +5098,14 @@ class SymmetricPermutationGroup(Basic):
         obj._deg = deg
         obj._order = None
         return obj
+
+    def __contains__(self, i):
+        """Return ``True`` if *i* is contained in SymmetricPermutationGroup.
+        """
+        if not isinstance(i, Permutation):
+            raise TypeError("A SymmetricPermutationGroup contains only Permutations as "
+                            "elements, not elements of type %s" % type(i))
+        return i.size == self.degree
 
     def order(self):
         """
@@ -5115,6 +5132,7 @@ class SymmetricPermutationGroup(Basic):
         '''
         return _af_new(list(range(self._deg)))
 
+
 class Coset(Basic):
     """A left coset of a permutation group with respect to an element.
 
@@ -5138,6 +5156,7 @@ class Coset(Basic):
         ``SymmetricPermutationGroup(H.degree)`` if ``g.size`` and ``H.degree``
         are matching.``SymmetricPermutationGroup`` is a lazy form of SymmetricGroup
         used for representation purpose.
+        
     """
 
     def __new__(cls, g, H, G=None, dir = "+"):
@@ -5153,22 +5172,10 @@ class Coset(Basic):
             G = _sympify(G)
             if not isinstance(G, PermutationGroup) and not isinstance(G, SymmetricPermutationGroup):
                 raise NotImplementedError
-            if isinstance(G, PermutationGroup):
-                if not H.is_subgroup(G):
-                    raise ValueError("{} must be a subgroup of {}.".format(H, G))
-                if g not in G:
-                    raise ValueError("{} must be an element of {}.".format(g, G))
-            else:
-                g_size = g.size
-                h_degree = H.degree
-                if g_size != h_degree:
-                    raise ValueError(
-                        "When using SymmetricPermutationGroup the size of the permutation {} and the degree of "
-                        "the permutation group {} should be matching "
-                        .format(g, H))
-                if G.degree != g.size:
-                    raise ValueError("{} is expected but {} was given".format(SymmetricPermutationGroup(g.size), G))
-
+            if not H.is_subgroup(G):
+                raise ValueError("{} must be a subgroup of {}.".format(H, G))
+            if g not in G:
+                raise ValueError("{} must be an element of {}.".format(g, G))
         else:
             g_size = g.size
             h_degree = H.degree

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5087,20 +5087,21 @@ class SymmetricPermutationGroup(Basic):
         deg = sympify(deg)
         obj = Basic.__new__(cls, deg)
         obj.deg = deg
-        obj.order = None
+        obj._order = None
         return obj
 
     def order(self):
         """
         Return the order of the permutation group.
         """
-        if self.order == None:
-            n = self.deg
-            self.order = factorial(n)
-        return self.order
+        if self._order is not None:
+            return self._order
+        n = self.deg
+        self._order = factorial(n)
+        return self._order
 
     @property
-    def degree():
+    def degree(self):
         """
         Return the degree of the permutation group.
         """
@@ -5112,7 +5113,7 @@ class SymmetricPermutationGroup(Basic):
         Return the identity element of the permutation group.
 
         '''
-        return _af_new(list(range(self.degree)))
+        return _af_new(list(range(self.deg)))
 
 class Coset(Basic):
     """A left coset of a permutation group with respect to an element.
@@ -5140,7 +5141,6 @@ class Coset(Basic):
     """
 
     def __new__(cls, g, H, G=None, dir = "+"):
-        from sympy.combinatorics.named_groups import SymmetricGroup
         g = sympify(g)
         if not isinstance(g, Permutation):
             raise NotImplementedError

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from random import randrange, choice
 from math import log
 from sympy.ntheory import primefactors
-from sympy import multiplicity, factorint, sympify, Symbol
+from sympy import multiplicity, factorint, Symbol
 
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
@@ -18,7 +18,7 @@ from sympy.ntheory import sieve
 from sympy.utilities.iterables import has_variety, is_sequence, uniq
 from sympy.testing.randtest import _randrange
 from itertools import islice
-
+from sympy.core.sympify import _sympify
 rmul = Permutation.rmul_with_af
 _af_new = Permutation._af_new
 
@@ -5084,7 +5084,7 @@ class SymmetricPermutationGroup(Basic):
     """
 
     def __new__(cls, deg):
-        deg = sympify(deg)
+        deg = _sympify(deg)
         obj = Basic.__new__(cls, deg)
         obj.deg = deg
         obj._order = None
@@ -5141,16 +5141,16 @@ class Coset(Basic):
     """
 
     def __new__(cls, g, H, G=None, dir = "+"):
-        g = sympify(g)
+        g = _sympify(g)
         if not isinstance(g, Permutation):
             raise NotImplementedError
 
-        H = sympify(H)
+        H = _sympify(H)
         if not isinstance(H, PermutationGroup):
             raise NotImplementedError
 
         if G is not None:
-            G = sympify(G)
+            G = _sympify(G)
             if not isinstance(G, PermutationGroup):
                 raise NotImplementedError
             if not H.is_subgroup(G):
@@ -5168,11 +5168,7 @@ class Coset(Basic):
             G = SymmetricPermutationGroup(g.size)
 
         dir = Symbol(dir)
-        if str(dir) ==  '+':
-            type = "RightCoset"
-        else:
-            type = "LeftCoset"
-        obj = Basic.__new__(cls, g, H, G, type)
+        obj = Basic.__new__(cls, g, H, G, dir)
         obj._dir = dir
         return obj
 
@@ -5190,7 +5186,7 @@ class Coset(Basic):
         """
         return str(self._dir) == '+'
 
-    def aslist(self):
+    def as_list(self):
         """
         Return all the elements of coset in the form of list.
         """

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1702,10 +1702,6 @@ class PermutationGroup(Basic):
         """
         if not isinstance(g, Permutation):
             return False
-        if isinstance(G, SymmetricPermutationGroup):
-            if g.size() == G.degree:
-                return True
-            return False
         if g.size != self.degree:
             if strict:
                 return False
@@ -5086,7 +5082,7 @@ PermGroup = PermutationGroup
 
 class SymmetricPermutationGroup(Basic):
     """
-    The class defining the lazy form of SymmetricGroup
+    The class defining the lazy form of SymmetricGroup.
 
     deg : int
 
@@ -5101,6 +5097,15 @@ class SymmetricPermutationGroup(Basic):
 
     def __contains__(self, i):
         """Return ``True`` if *i* is contained in SymmetricPermutationGroup.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
+        >>> G = SymmetricPermutationGroup(4)
+        >>> Permutation(1, 2, 3) in G
+        True
+
         """
         if not isinstance(i, Permutation):
             raise TypeError("A SymmetricPermutationGroup contains only Permutations as "
@@ -5109,7 +5114,15 @@ class SymmetricPermutationGroup(Basic):
 
     def order(self):
         """
-        Return the order of the permutation group.
+        Return the order of the SymmetricPermutationGroup.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
+        >>> G = SymmetricPermutationGroup(4)
+        >>> G.order()
+
         """
         if self._order is not None:
             return self._order
@@ -5120,14 +5133,30 @@ class SymmetricPermutationGroup(Basic):
     @property
     def degree(self):
         """
-        Return the degree of the permutation group.
+        Return the degree of the SymmetricPermutationGroup.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
+        >>> G = SymmetricPermutationGroup(4)
+        >>> G.degree
+
         """
         return self._deg
 
     @property
     def identity(self):
         '''
-        Return the identity element of the permutation group.
+        Return the identity element of the SymmetricPermutationGroup.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
+        >>> G = SymmetricPermutationGroup(4)
+        >>> G.identity()
+        Permutation(3)
 
         '''
         return _af_new(list(range(self._deg)))
@@ -5156,7 +5185,7 @@ class Coset(Basic):
         ``SymmetricPermutationGroup(H.degree)`` if ``g.size`` and ``H.degree``
         are matching.``SymmetricPermutationGroup`` is a lazy form of SymmetricGroup
         used for representation purpose.
-        
+
     """
 
     def __new__(cls, g, H, G=None, dir = "+"):
@@ -5196,6 +5225,18 @@ class Coset(Basic):
     def is_left_coset(self):
         """
         Check if the coset is left coset that is ``gH``.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, PermutationGroup, Coset
+        >>> a = Permutation(1, 2)
+        >>> b = Permutation(0, 1)
+        >>> G = PermutationGroup([a, b])
+        >>> cst = Coset(a, G, dir = "-")
+        >>> cst.is_left_coset
+        True
+
         """
         return str(self._dir) == '-'
 
@@ -5203,6 +5244,18 @@ class Coset(Basic):
     def is_right_coset(self):
         """
         Check if the coset is right coset that is ``Hg``.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import Permutation, PermutationGroup, Coset
+        >>> a = Permutation(1, 2)
+        >>> b = Permutation(0, 1)
+        >>> G = PermutationGroup([a, b])
+        >>> cst = Coset(a, G, dir = "+")
+        >>> cst.is_right_coset
+        True
+
         """
         return str(self._dir) == '+'
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5122,7 +5122,7 @@ class SymmetricPermutationGroup(Basic):
         >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
         >>> G = SymmetricPermutationGroup(4)
         >>> G.order()
-
+        24
         """
         if self._order is not None:
             return self._order
@@ -5141,6 +5141,7 @@ class SymmetricPermutationGroup(Basic):
         >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
         >>> G = SymmetricPermutationGroup(4)
         >>> G.degree
+        4
 
         """
         return self._deg
@@ -5156,7 +5157,7 @@ class SymmetricPermutationGroup(Basic):
         >>> from sympy.combinatorics import Permutation, SymmetricPermutationGroup
         >>> G = SymmetricPermutationGroup(4)
         >>> G.identity()
-        Permutation(3)
+        (3)
 
         '''
         return _af_new(list(range(self._deg)))

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5189,7 +5189,7 @@ class Coset(Basic):
 
     """
 
-    def __new__(cls, g, H, G=None, dir = "+"):
+    def __new__(cls, g, H, G=None, dir="+"):
         g = _sympify(g)
         if not isinstance(g, Permutation):
             raise NotImplementedError
@@ -5239,7 +5239,7 @@ class Coset(Basic):
         >>> a = Permutation(1, 2)
         >>> b = Permutation(0, 1)
         >>> G = PermutationGroup([a, b])
-        >>> cst = Coset(a, G, dir = "-")
+        >>> cst = Coset(a, G, dir="-")
         >>> cst.is_left_coset
         True
 
@@ -5258,7 +5258,7 @@ class Coset(Basic):
         >>> a = Permutation(1, 2)
         >>> b = Permutation(0, 1)
         >>> G = PermutationGroup([a, b])
-        >>> cst = Coset(a, G, dir = "+")
+        >>> cst = Coset(a, G, dir="+")
         >>> cst.is_right_coset
         True
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5216,8 +5216,13 @@ class Coset(Basic):
                     .format(g, H))
             G = SymmetricPermutationGroup(g.size)
 
-        if not isinstance(dir, Symbol):
+        if isinstance(dir, str):
             dir = Symbol(dir)
+        elif not isinstance(dir, Symbol):
+            raise TypeError("dir must be of type basestring or "
+                    "Symbol, not %s" % type(dir))
+        if str(dir) not in ('+', '-'):
+            raise ValueError("dir must be one of '+' or '-' not %s" % dir)
         obj = Basic.__new__(cls, g, H, G, dir)
         obj._dir = dir
         return obj

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5151,12 +5151,24 @@ class Coset(Basic):
 
         if G is not None:
             G = _sympify(G)
-            if not isinstance(G, PermutationGroup):
+            if not isinstance(G, PermutationGroup) and not isinstance(G, SymmetricPermutationGroup):
                 raise NotImplementedError
-            if not H.is_subgroup(G):
-                raise ValueError("{} must be a subgroup of {}.".format(H, G))
-            if g not in G:
-                raise ValueError("{} must be an element of {}.".format(g, G))
+            if isinstance(G, PermutationGroup):
+                if not H.is_subgroup(G):
+                    raise ValueError("{} must be a subgroup of {}.".format(H, G))
+                if g not in G:
+                    raise ValueError("{} must be an element of {}.".format(g, G))
+            else:
+                g_size = g.size
+                h_degree = H.degree
+                if g_size != h_degree:
+                    raise ValueError(
+                        "When using SymmetricPermutationGroup the size of the permutation {} and the degree of "
+                        "the permutation group {} should be matching "
+                        .format(g, H))
+                if G.degree != g.size:
+                    raise ValueError("{} is expected but {} was given".format(SymmetricPermutationGroup(g.size), G))
+
         else:
             g_size = g.size
             h_degree = H.degree

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5086,7 +5086,7 @@ class SymmetricPermutationGroup(Basic):
     def __new__(cls, deg):
         deg = _sympify(deg)
         obj = Basic.__new__(cls, deg)
-        obj.deg = deg
+        obj._deg = deg
         obj._order = None
         return obj
 
@@ -5096,7 +5096,7 @@ class SymmetricPermutationGroup(Basic):
         """
         if self._order is not None:
             return self._order
-        n = self.deg
+        n = self._deg
         self._order = factorial(n)
         return self._order
 
@@ -5105,7 +5105,7 @@ class SymmetricPermutationGroup(Basic):
         """
         Return the degree of the permutation group.
         """
-        return self.deg
+        return self._deg
 
     @property
     def identity(self):
@@ -5113,7 +5113,7 @@ class SymmetricPermutationGroup(Basic):
         Return the identity element of the permutation group.
 
         '''
-        return _af_new(list(range(self.deg)))
+        return _af_new(list(range(self._deg)))
 
 class Coset(Basic):
     """A left coset of a permutation group with respect to an element.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -5179,7 +5179,8 @@ class Coset(Basic):
                     .format(g, H))
             G = SymmetricPermutationGroup(g.size)
 
-        dir = Symbol(dir)
+        if not isinstance(dir, Symbol):
+            dir = Symbol(dir)
         obj = Basic.__new__(cls, g, H, G, dir)
         obj._dir = dir
         return obj

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1153,3 +1153,9 @@ def test_coset_class():
     Permutation(1, 4, 3, 2)]
     for ele in list_repr:
         assert ele in expected
+
+def test_symmetricpermutationgroup():
+    a = SymmetricPermutationGroup(5)
+    assert a.degree == 5
+    assert a.order() == 120
+    assert a.identity() == Permutation(4)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1,5 +1,5 @@
 from sympy.combinatorics.perm_groups import (PermutationGroup,
-    _orbit_transversal)
+    _orbit_transversal, Coset, SymmetricPermutationGroup)
 from sympy.combinatorics.named_groups import SymmetricGroup, CyclicGroup,\
     DihedralGroup, AlternatingGroup, AbelianGroup, RubikGroup
 from sympy.combinatorics.permutations import Permutation
@@ -1116,3 +1116,40 @@ def test_conjugacy_classes():
 
     assert len(expected) == len(computed)
     assert all(e in computed for e in expected)
+
+def test_coset_class():
+    a = Permutation(1, 2)
+    b = Permutation(0, 1)
+    G = PermutationGroup([a, b])
+    #Creating right coset
+    rht_coset = Coset(a, G, dir = '+')
+    #Checking whether it is left coset or right coset
+    assert rht_coset.is_right_coset
+    assert not rht_coset.is_left_coset
+    #Creating list representation of coset
+    list_repr = rht_coset.as_list()
+    expected = [Permutation(0, 2), Permutation(0, 2, 1), Permutation(1, 2), Permutation(2), Permutation(2)(0, 1), Permutation(0, 1, 2)]
+    for ele in list_repr:
+        assert ele in expected
+    #Creating left coset
+    left_coset = Coset(a, G, dir = '-')
+    #Checking whether it is left coset or right coset
+    assert not left_coset.is_right_coset
+    assert left_coset.is_left_coset
+    #Creating list representation of Coset
+    list_repr = left_coset.as_list()
+    expected = [Permutation(2)(0, 1), Permutation(0, 1, 2), Permutation(1, 2),
+    Permutation(2), Permutation(0, 2), Permutation(0, 2, 1)]
+    for ele in list_repr:
+        assert ele in expected
+
+    G = PermutationGroup(Permutation(1, 2, 3, 4), Permutation(2, 3, 4))
+    H = PermutationGroup(Permutation(1, 2, 3, 4))
+    g = Permutation(1, 3)(2, 4)
+    rht_coset = Coset(g, H, G, dir = '+')
+    assert rht_coset.is_right_coset
+    list_repr = rht_coset.as_list()
+    expected = [Permutation(1, 2, 3, 4), Permutation(4), Permutation(1, 3)(2, 4),
+    Permutation(1, 4, 3, 2)]
+    for ele in list_repr:
+        assert ele in expected

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1122,7 +1122,7 @@ def test_coset_class():
     b = Permutation(0, 1)
     G = PermutationGroup([a, b])
     #Creating right coset
-    rht_coset = Coset(a, G, dir = '+')
+    rht_coset = Coset(a, G, dir='+')
     #Checking whether it is left coset or right coset
     assert rht_coset.is_right_coset
     assert not rht_coset.is_left_coset
@@ -1132,7 +1132,7 @@ def test_coset_class():
     for ele in list_repr:
         assert ele in expected
     #Creating left coset
-    left_coset = Coset(a, G, dir = '-')
+    left_coset = Coset(a, G, dir='-')
     #Checking whether it is left coset or right coset
     assert not left_coset.is_right_coset
     assert left_coset.is_left_coset
@@ -1146,7 +1146,7 @@ def test_coset_class():
     G = PermutationGroup(Permutation(1, 2, 3, 4), Permutation(2, 3, 4))
     H = PermutationGroup(Permutation(1, 2, 3, 4))
     g = Permutation(1, 3)(2, 4)
-    rht_coset = Coset(g, H, G, dir = '+')
+    rht_coset = Coset(g, H, G, dir='+')
     assert rht_coset.is_right_coset
     list_repr = rht_coset.as_list()
     expected = [Permutation(1, 2, 3, 4), Permutation(4), Permutation(1, 3)(2, 4),

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4958,3 +4958,15 @@ def test_sympy__integrals__rubi__utility_function__ProductLog():
 def test_sympy__combinatorics__schur_number__SchurNumber():
     from sympy.combinatorics.schur_number import SchurNumber
     assert _test_args(SchurNumber(1))
+
+def test_sympy__combinatorics__perm_groups__SymmetricPermutationGroup():
+    from sympy.combinatorics.perm_groups import SymmetricPermutationGroup
+    assert _test_args(SymmetricPermutationGroup(5))
+
+def test_sympy__combinatorics__perm_groups__Coset():
+    from sympy.combinatorics.permutations import Permutation
+    from sympy.combinatorics.perm_groups import PermutationGroup, Coset
+    a = Permutation(1, 2)
+    b = Permutation(0, 1)
+    G = PermutationGroup([a, b])
+    assert _test_args(Coset(a, G))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #7127


#### Brief description of what is fixed or changed

- [x] Add Coset Class.

- [x] Add SymmetricPermutationGroup Class to represent lazy form of Symmetric Group.

- [x] Add documentation and good amount of test.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
    - Added Coset Class.
    - Added SymmetricPermutationGroup Class. 

<!-- END RELEASE NOTES -->
