### PR TITLE
Fix CSE to not construct invalid tree

### DIFF
--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -14,7 +14,8 @@ def sub_pre(e):
     """
     # replacing Add, A, from which -1 can be extracted with -1*-A
     adds = [a for a in e.atoms(Add) if a.could_extract_minus_sign()]
-    reps = dict((a, Mul._from_args([S.NegativeOne, -a])) for a in adds)
+    reps = dict((a, Mul(S.NegativeOne, -a, evaluate=False)) for a in adds)
+
     e = e.xreplace(reps)
 
     # repeat again for persisting Adds but mark these with a leading 1, -1
@@ -25,7 +26,7 @@ def sub_pre(e):
             if a in reps:
                 negs[a] = reps[a]
             elif a.could_extract_minus_sign():
-                negs[a] = Mul._from_args([S.One, S.NegativeOne, -a])
+                negs[a] = Mul(S.One, S.NegativeOne, -a, evaluate=False)
         e = e.xreplace(negs)
     return e
 
@@ -37,7 +38,7 @@ def sub_post(e):
     for node in preorder_traversal(e):
         if isinstance(node, Mul) and \
             node.args[0] is S.One and node.args[1] is S.NegativeOne:
-            replacements.append((node, -Mul._from_args(node.args[2:])))
+            replacements.append((node, -Mul(*node.args[2:], evaluate=False)))
     for node, replacement in replacements:
         e = e.xreplace({node: replacement})
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -5,7 +5,7 @@ from operator import add
 from sympy import (
     Add, Mul, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
     Matrix, S, cos, sin, Eq, Function, Tuple, CRootOf,
-    IndexedBase, Idx, Piecewise, O
+    IndexedBase, Idx, Piecewise, O, signsimp
 )
 from sympy.core.function import count_ops
 from sympy.simplify.cse_opts import sub_pre, sub_post
@@ -545,3 +545,7 @@ def test_issue_18203():
 def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
+
+def test_issue_18991():
+    A = MatrixSymbol('A', 2, 2)
+    assert signsimp(-A * A - A) == -A * A - A


### PR DESCRIPTION
Without executing Mul's post-processor, it might pack matrices inside.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #18991

#### Other comments
This raises the question whether maybe all `_from_args()` methods should themselves invoke the post processors instead, to avoid having to do that from all call sites. Existing code seems to call it after `_from_args()` though.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->