### PR TITLE
Fix sphinx build on sympy master

### DIFF
--- a/doc/src/modules/crypto.rst
+++ b/doc/src/modules/crypto.rst
@@ -83,8 +83,6 @@ substitutions at different times in the message.
 
 .. autofunction:: decipher_bifid5
 
-.. autofunction:: bifid5_square
-
 .. autofunction:: encipher_bifid6
 
 .. autofunction:: decipher_bifid6
@@ -130,10 +128,6 @@ substitutions at different times in the message.
 .. autofunction:: dh_private_key
 
 .. autofunction:: dh_shared_key
-
-.. autofunction:: encipher_elgamal
-
-.. autofunction:: decipher_elgamal
 
 .. autofunction:: gm_public_key
 

--- a/doc/src/modules/polys/reference.rst
+++ b/doc/src/modules/polys/reference.rst
@@ -33,8 +33,6 @@ Basic polynomial manipulation functions
 .. autofunction:: subresultants
 .. autofunction:: resultant
 .. autofunction:: discriminant
-.. autofunction:: sympy.polys.dispersion.dispersion
-.. autofunction:: sympy.polys.dispersion.dispersionset
 .. autofunction:: terms_gcd
 .. autofunction:: cofactors
 .. autofunction:: gcd

--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -27,14 +27,6 @@ FiniteSet
 .. autoclass:: FiniteSet
    :members:
 
-ConditionSet
-^^^^^^^^^^^^
-.. module:: sympy.sets.conditionset
-    :noindex:
-
-.. autoclass:: ConditionSet
-    :members:
-
 Compound Sets
 -------------
 
@@ -174,4 +166,5 @@ Condition Sets
 ConditionSet
 ^^^^^^^^^^^^
 
-.. autofunction:: ConditionSet
+.. autoclass:: ConditionSet
+    :members:

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -122,8 +122,7 @@ class Tuple(Basic):
         return self.args.count(value)
 
     def index(self, value, start=None, stop=None):
-        """T.index(value, [start, [stop]]) -> integer -- return first index of value.
-           Raises ValueError if the value is not present."""
+        """Searches and returns the first index of the value."""
         # XXX: One would expect:
         #
         # return self.args.index(value, start, stop)
@@ -259,15 +258,16 @@ class Dict(Basic):
         return tuple(self.elements)
 
     def items(self):
-        '''D.items() -> list of D's (key, value) pairs, as 2-tuples'''
+        '''Returns a set-like object providing a view on dict's items.
+        '''
         return self._dict.items()
 
     def keys(self):
-        '''D.keys() -> list of D's keys'''
+        '''Returns the list of the dict's keys.'''
         return self._dict.keys()
 
     def values(self):
-        '''D.values() -> list of D's values'''
+        '''Returns the list of the dict's values.'''
         return self._dict.values()
 
     def __iter__(self):
@@ -279,7 +279,7 @@ class Dict(Basic):
         return self._dict.__len__()
 
     def get(self, key, default=None):
-        '''D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None.'''
+        '''Returns the value for key if the key is in the dictionary.'''
         return self._dict.get(sympify(key), default)
 
     def __contains__(self, key):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19084

#### Brief description of what is fixed or changed

Although the issue speculate the about the new matplotlib warnings, the warning rather comes from newer sphinx nitpicking about some duplicate docs in `crypto` and `polys`, and some formatting errors in `sympy.containers`. 
The problem is when you have `D.keys() -> list` in the summary, it can be parsed to override the signature in the docs, hence giving some errors when the notation is pseudo.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->