### PR TITLE
FIX: ensure autoscale_view gets called

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1230,9 +1230,11 @@ class MatplotlibBackend(BaseBackend):
                 "All numbers from ylim={} must be finite".format(ylim))
             ylim = (float(i) for i in ylim)
             ax.set_ylim(ylim)
+
         if not isinstance(ax, Axes3D):
-            ax.autoscale_view(scaley=ax.get_autoscalex_on(),
-                              scalex=ax.get_autoscaley_on())
+            ax.autoscale_view(
+                scalex=ax.get_autoscalex_on(),
+                scaley=ax.get_autoscaley_on())
 
 
     def process_series(self):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1231,7 +1231,8 @@ class MatplotlibBackend(BaseBackend):
             ylim = (float(i) for i in ylim)
             ax.set_ylim(ylim)
         if not isinstance(ax, Axes3D):
-            ax.autoscale_view()
+            ax.autoscale_view(scaley=ax.get_autoscalex_on(),
+                              scalex=ax.get_autoscaley_on())
 
 
     def process_series(self):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1230,7 +1230,9 @@ class MatplotlibBackend(BaseBackend):
                 "All numbers from ylim={} must be finite".format(ylim))
             ylim = (float(i) for i in ylim)
             ax.set_ylim(ylim)
-        ax.autoscale_view()
+        if not isinstance(ax, Axes3D):
+            ax.autoscale_view()
+
 
     def process_series(self):
         """

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1230,7 +1230,7 @@ class MatplotlibBackend(BaseBackend):
                 "All numbers from ylim={} must be finite".format(ylim))
             ylim = (float(i) for i in ylim)
             ax.set_ylim(ylim)
-
+        ax.autoscale_view()
 
     def process_series(self):
         """


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19051

Alternative to #19087

#### Brief description of what is fixed or changed

In mpl <=3.1 the view limits were implicitly and unconditionally
autoscaled as part of setting the scale.  It was by co-incident that
by unconditionally setting the x and y scales when plotting also
triggered the auto-scale logic.  In mpl 3.2+ the view limits are
only autoscaled if changing the scale would could change the
acceptable limits.  As in the default case sympy is changing from
linear -> linear, this autoscaling was no longer applied.

This adds an explicit call to autoscaling to sympy will ensure it
behaves as desired independent of Matplotlib version.



#### Other comments

It is still possible (but unlikely) that we will revert this change on the Matplotlib side.  I think it is best if sympy is explicit about autoscaling and does not rely on unexpected side-effects.


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->