### PR TITLE
Change deprecated sphinx from sympylive

### DIFF
--- a/doc/ext/sympylive.py
+++ b/doc/ext/sympylive.py
@@ -15,18 +15,17 @@ def builder_inited(app):
         raise ExtensionError('sympylive_url config value must be set'
                              ' for the sympylive extension to work')
 
-    app.add_javascript(app.config.sympylive_url + '/static/utilities.js')
-    app.add_javascript(app.config.sympylive_url + '/static/external/classy.js')
+    app.add_js_file(app.config.sympylive_url + '/static/utilities.js')
+    app.add_js_file(app.config.sympylive_url + '/static/external/classy.js')
 
-    app.add_stylesheet(app.config.sympylive_url + '/static/live-core.css')
-    app.add_stylesheet(app.config.sympylive_url +
-                       '/static/live-autocomplete.css')
-    app.add_stylesheet(app.config.sympylive_url + '/static/live-sphinx.css')
+    app.add_css_file(app.config.sympylive_url + '/static/live-core.css')
+    app.add_css_file(app.config.sympylive_url +
+                     '/static/live-autocomplete.css')
+    app.add_css_file(app.config.sympylive_url + '/static/live-sphinx.css')
 
-    app.add_javascript(app.config.sympylive_url + '/static/live-core.js')
-    app.add_javascript(app.config.sympylive_url +
-                       '/static/live-autocomplete.js')
-    app.add_javascript(app.config.sympylive_url + '/static/live-sphinx.js')
+    app.add_js_file(app.config.sympylive_url + '/static/live-core.js')
+    app.add_js_file(app.config.sympylive_url + '/static/live-autocomplete.js')
+    app.add_js_file(app.config.sympylive_url + '/static/live-sphinx.js')
 
 
 def setup(app):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

```
ext/sympylive.py:18: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.sympylive_url + '/static/utilities.js')
ext/sympylive.py:19: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.sympylive_url + '/static/external/classy.js')
ext/sympylive.py:21: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet(app.config.sympylive_url + '/static/live-core.css')
ext/sympylive.py:23: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  '/static/live-autocomplete.css')
ext/sympylive.py:24: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet(app.config.sympylive_url + '/static/live-sphinx.css')
ext/sympylive.py:26: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.sympylive_url + '/static/live-core.js')
ext/sympylive.py:28: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  '/static/live-autocomplete.js')
ext/sympylive.py:29: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.sympylive_url + '/static/live-sphinx.js')
```

Now they had renamed add_javascript to add_js_file.
https://www.sphinx-doc.org/en/master/extdev/appapi.html


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->