### PR TITLE
Fixed tensor contraction problem

### DIFF
--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1910,6 +1910,13 @@ def test_tensor_replacement():
     repl = {H(i, -i): 42}
     assert expr._extract_data(repl) == ([], 42)
 
+    expr = H(i, -i)
+    repl = {
+        H(-i, -j): Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
+        L: Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
+    }
+    assert expr._extract_data(repl) == ([], 4)
+
     # Replace with array, raise exception if indices are not compatible:
     expr = A(i)*A(j)
     repl = {A(i): [1, 2]}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18465 


#### Brief description of what is fixed or changed

Tensor contractions using `replace_with_arrays` would prematurely contract the data arrays before applying the metric—yielding incorrect results. The solution implemented here is a rather trivial one in that it simply separates out an existing function for doing matrix multiplication with an existing data array with the metric and utilizes it in `Tensor._extract_data` to apply the metric before dummy indices are contracted.

#### Other comments

This is my first pull request with Sympy. Let me know if I should make any adjustments to my code.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixed a bug where tensor contractions in calls to `replace_with_arrays` would fail to apply the metric.
<!-- END RELEASE NOTES -->