### PR TITLE
Various block matrix improvements

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -78,6 +78,8 @@ class AskSymmetricHandler(CommonHandler):
     def ZeroMatrix(expr, assumptions):
         return ask(Q.square(expr), assumptions)
 
+    OneMatrix = ZeroMatrix
+
     @staticmethod
     def Transpose(expr, assumptions):
         return ask(Q.symmetric(expr.arg), assumptions)
@@ -137,6 +139,10 @@ class AskInvertibleHandler(CommonHandler):
     Identity, Inverse = [staticmethod(CommonHandler.AlwaysTrue)]*2
 
     ZeroMatrix = staticmethod(CommonHandler.AlwaysFalse)
+
+    @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
 
     @staticmethod
     def Transpose(expr, assumptions):
@@ -287,6 +293,10 @@ class AskFullRankHandler(CommonHandler):
     ZeroMatrix = staticmethod(CommonHandler.AlwaysFalse)
 
     @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
+
+    @staticmethod
     def Transpose(expr, assumptions):
         return ask(Q.fullrank(expr.arg), assumptions)
 
@@ -338,6 +348,10 @@ class AskPositiveDefiniteHandler(CommonHandler):
     ZeroMatrix = staticmethod(CommonHandler.AlwaysFalse)
 
     @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
+
+    @staticmethod
     def Transpose(expr, assumptions):
         return ask(Q.positive_definite(expr.arg), assumptions)
 
@@ -385,6 +399,10 @@ class AskUpperTriangularHandler(CommonHandler):
             return True
 
     Identity, ZeroMatrix = [staticmethod(CommonHandler.AlwaysTrue)]*2
+
+    @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
 
     @staticmethod
     def Transpose(expr, assumptions):
@@ -438,6 +456,10 @@ class AskLowerTriangularHandler(CommonHandler):
             return True
 
     Identity, ZeroMatrix = [staticmethod(CommonHandler.AlwaysTrue)]*2
+
+    @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
 
     @staticmethod
     def Transpose(expr, assumptions):
@@ -501,6 +523,10 @@ class AskDiagonalHandler(CommonHandler):
     @staticmethod
     def ZeroMatrix(expr, assumptions):
         return True
+
+    @staticmethod
+    def OneMatrix(expr, assumptions):
+        return expr.shape[0] == 1 and expr.shape[1] == 1
 
     @staticmethod
     def Transpose(expr, assumptions):
@@ -567,7 +593,7 @@ class AskIntegerElementsHandler(CommonHandler):
 
     HadamardProduct, Determinant, Trace, Transpose = [MatAdd]*4
 
-    ZeroMatrix, Identity = [staticmethod(CommonHandler.AlwaysTrue)]*2
+    ZeroMatrix, OneMatrix, Identity = [staticmethod(CommonHandler.AlwaysTrue)]*3
 
     MatMul = staticmethod(partial(MatMul_elements, Q.integer_elements,
                                                    Q.integer))

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -1,6 +1,6 @@
 from sympy import Q, ask, Symbol, DiagMatrix, DiagonalMatrix
 from sympy.matrices.expressions import (MatrixSymbol, Identity, ZeroMatrix,
-        Trace, MatrixSlice, Determinant)
+        OneMatrix, Trace, MatrixSlice, Determinant)
 from sympy.matrices.expressions.factorizations import LofLU
 from sympy.testing.pytest import XFAIL
 
@@ -29,6 +29,8 @@ def test_invertible():
     assert ask(Q.invertible(X.I)) is True
     assert ask(Q.invertible(Identity(3))) is True
     assert ask(Q.invertible(ZeroMatrix(3, 3))) is False
+    assert ask(Q.invertible(OneMatrix(1, 1))) is True
+    assert ask(Q.invertible(OneMatrix(3, 3))) is False
     assert ask(Q.invertible(X), Q.fullrank(X) & Q.square(X))
 
 def test_singular():
@@ -58,6 +60,9 @@ def test_symmetric():
     assert ask(Q.symmetric(V1.T*(V1 + V2))) is True
     assert ask(Q.symmetric(V1.T*(V1 + V2) + A1x1)) is True
     assert ask(Q.symmetric(MatrixSlice(Y, (0, 1), (1, 2)))) is True
+    assert ask(Q.symmetric(Identity(3))) is True
+    assert ask(Q.symmetric(ZeroMatrix(3, 3))) is True
+    assert ask(Q.symmetric(OneMatrix(3, 3))) is True
 
 def _test_orthogonal_unitary(predicate):
     assert ask(predicate(X), predicate(X))
@@ -89,6 +94,8 @@ def test_fullrank():
     assert ask(Q.fullrank(X*Z), Q.fullrank(X) & Q.fullrank(Z)) is True
     assert ask(Q.fullrank(Identity(3))) is True
     assert ask(Q.fullrank(ZeroMatrix(3, 3))) is False
+    assert ask(Q.fullrank(OneMatrix(1, 1))) is True
+    assert ask(Q.fullrank(OneMatrix(3, 3))) is False
     assert ask(Q.invertible(X), ~Q.fullrank(X)) == False
 
 
@@ -107,6 +114,8 @@ def test_positive_definite():
     assert not ask(Q.positive_definite(Y.T*X*Y), Q.positive_definite(X))
     assert ask(Q.positive_definite(Identity(3))) is True
     assert ask(Q.positive_definite(ZeroMatrix(3, 3))) is False
+    assert ask(Q.positive_definite(OneMatrix(1, 1))) is True
+    assert ask(Q.positive_definite(OneMatrix(3, 3))) is False
     assert ask(Q.positive_definite(X + Z), Q.positive_definite(X) &
             Q.positive_definite(Z)) is True
     assert not ask(Q.positive_definite(-X), Q.positive_definite(X))
@@ -119,6 +128,11 @@ def test_triangular():
             Q.lower_triangular(Z)) is True
     assert ask(Q.lower_triangular(Identity(3))) is True
     assert ask(Q.lower_triangular(ZeroMatrix(3, 3))) is True
+    assert ask(Q.upper_triangular(ZeroMatrix(3, 3))) is True
+    assert ask(Q.lower_triangular(OneMatrix(1, 1))) is True
+    assert ask(Q.upper_triangular(OneMatrix(1, 1))) is True
+    assert ask(Q.lower_triangular(OneMatrix(3, 3))) is False
+    assert ask(Q.upper_triangular(OneMatrix(3, 3))) is False
     assert ask(Q.triangular(X), Q.unit_triangular(X))
     assert ask(Q.upper_triangular(X**3), Q.upper_triangular(X))
     assert ask(Q.lower_triangular(X**3), Q.lower_triangular(X))
@@ -128,6 +142,8 @@ def test_diagonal():
     assert ask(Q.diagonal(X + Z.T + Identity(2)), Q.diagonal(X) &
                Q.diagonal(Z)) is True
     assert ask(Q.diagonal(ZeroMatrix(3, 3)))
+    assert ask(Q.diagonal(OneMatrix(1, 1))) is True
+    assert ask(Q.diagonal(OneMatrix(3, 3))) is False
     assert ask(Q.lower_triangular(X) & Q.upper_triangular(X), Q.diagonal(X))
     assert ask(Q.diagonal(X), Q.lower_triangular(X) & Q.upper_triangular(X))
     assert ask(Q.symmetric(X), Q.diagonal(X))
@@ -214,6 +230,7 @@ def test_matrix_element_sets():
     assert ask(Q.complex(X[1, 2]), Q.complex_elements(X))
     assert ask(Q.integer_elements(Identity(3)))
     assert ask(Q.integer_elements(ZeroMatrix(3, 3)))
+    assert ask(Q.integer_elements(OneMatrix(3, 3)))
     from sympy.matrices.expressions.fourier import DFT
     assert ask(Q.complex_elements(DFT(3)))
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy import ask, Q
 from sympy.core import Basic, Add, Mul, S
+from sympy.core.sympify import _sympify
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.strategies import typed, exhaust, condition, do_one, unpack
 from sympy.strategies.traverse import bottom_up
@@ -17,7 +18,7 @@ from sympy.matrices.expressions.trace import trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
-from sympy.matrices import Matrix, ShapeError, MutableMatrix
+from sympy.matrices import Matrix, ShapeError
 from sympy.functions.elementary.complexes import re, im
 
 class BlockMatrix(MatrixExpr):
@@ -309,8 +310,7 @@ class BlockDiagMatrix(BlockMatrix):
     sympy.matrices.dense.diag
     """
     def __new__(cls, *mats):
-        mats = [m.as_immutable() if isinstance(m, MutableMatrix) else m for m in mats]
-        return Basic.__new__(BlockDiagMatrix, *mats)
+        return Basic.__new__(BlockDiagMatrix, *[_sympify(m) for m in mats])
 
     @property
     def diag(self):

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -544,7 +544,7 @@ def bc_transpose(expr):
 
 def bc_inverse(expr):
     if isinstance(expr.arg, BlockDiagMatrix):
-        return expr._eval_inverse()
+        return expr.inverse()
 
     expr2 = blockinverse_1x1(expr)
     if expr != expr2:

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -17,7 +17,7 @@ from sympy.matrices.expressions.trace import trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
-from sympy.matrices import Matrix, ShapeError
+from sympy.matrices import Matrix, ShapeError, MutableMatrix
 from sympy.functions.elementary.complexes import re, im
 
 class BlockMatrix(MatrixExpr):
@@ -309,6 +309,7 @@ class BlockDiagMatrix(BlockMatrix):
     sympy.matrices.dense.diag
     """
     def __new__(cls, *mats):
+        mats = [m.as_immutable() if isinstance(m, MutableMatrix) else m for m in mats]
         return Basic.__new__(BlockDiagMatrix, *mats)
 
     @property

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -12,7 +12,7 @@ from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.matadd import MatAdd
 from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.expressions.transpose import Transpose, transpose
-from sympy.matrices.expressions.trace import Trace
+from sympy.matrices.expressions.trace import trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
@@ -186,12 +186,14 @@ class BlockMatrix(MatrixExpr):
 
     def _eval_trace(self):
         if self.rowblocksizes == self.colblocksizes:
-            return Add(*[Trace(self.blocks[i, i])
+            return Add(*[trace(self.blocks[i, i])
                         for i in range(self.blockshape[0])])
         raise NotImplementedError(
             "Can't perform trace of irregular blockshape")
 
     def _eval_determinant(self):
+        if self.blockshape == (1, 1):
+            return det(self.blocks[0, 0])
         if self.blockshape == (2, 2):
             [[A, B],
              [C, D]] = self.blocks.tolist()

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Basic, Expr, S, sympify
-from .matexpr import ShapeError
+from sympy.matrices.common import NonSquareMatrixError
 
 
 class Determinant(Expr):
@@ -26,7 +26,7 @@ class Determinant(Expr):
             raise TypeError("Input to Determinant, %s, not a matrix" % str(mat))
 
         if not mat.is_square:
-            raise ShapeError("Det of a non-square matrix")
+            raise NonSquareMatrixError("Det of a non-square matrix")
 
         return Basic.__new__(cls, mat)
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,8 +1,9 @@
 from __future__ import print_function, division
 
 from sympy.core import Mul, sympify
+from sympy.matrices.common import ShapeError
 from sympy.matrices.expressions.matexpr import (
-    MatrixExpr, ShapeError, OneMatrix, ZeroMatrix
+    MatrixExpr, OneMatrix, ZeroMatrix
 )
 from sympy.strategies import (
     unpack, flatten, condition, exhaust, rm_id, sort

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.core.sympify import _sympify
 from sympy.core import S, Basic
 
-from sympy.matrices.expressions.matexpr import ShapeError
+from sympy.matrices.common import NonSquareMatrixError
 from sympy.matrices.expressions.matpow import MatPow
 
 
@@ -41,7 +41,7 @@ class Inverse(MatPow):
         if not mat.is_Matrix:
             raise TypeError("mat should be a matrix")
         if not mat.is_square:
-            raise ShapeError("Inverse of non-square matrix %s" % mat)
+            raise NonSquareMatrixError("Inverse of non-square matrix %s" % mat)
         return Basic.__new__(cls, mat, exp)
 
     @property

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -4,7 +4,8 @@ from __future__ import division, print_function
 
 from sympy.core import Mul, prod, sympify
 from sympy.functions import adjoint
-from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError, Identity
+from sympy.matrices.common import ShapeError
+from sympy.matrices.expressions.matexpr import MatrixExpr, Identity
 from sympy.matrices.expressions.transpose import transpose
 from sympy.matrices.matrices import MatrixBase
 from sympy.strategies import (

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -5,12 +5,13 @@ from operator import add
 
 from sympy.core import Add, Basic, sympify
 from sympy.functions import adjoint
+from sympy.matrices.common import ShapeError
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, flatten, sort, condition,
     exhaust, do_one, glom)
-from sympy.matrices.expressions.matexpr import (MatrixExpr, ShapeError,
-    ZeroMatrix, GenericZeroMatrix)
+from sympy.matrices.expressions.matexpr import (MatrixExpr, ZeroMatrix,
+    GenericZeroMatrix)
 from sympy.utilities import default_sort_key, sift
 
 # XXX: MatAdd should perhaps not subclass directly from Add

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -12,7 +12,7 @@ from sympy.core.compatibility import SYMPY_INTS, default_sort_key
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
-from sympy.matrices.common import ShapeError, NonSquareMatrixError, NonInvertibleMatrixError
+from sympy.matrices.common import NonSquareMatrixError, NonInvertibleMatrixError
 from sympy.simplify import simplify
 from sympy.utilities.misc import filldedent
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -12,7 +12,7 @@ from sympy.core.compatibility import SYMPY_INTS, default_sort_key
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
-from sympy.matrices import ShapeError
+from sympy.matrices.common import ShapeError, NonSquareMatrixError, NonInvertibleMatrixError
 from sympy.simplify import simplify
 from sympy.utilities.misc import filldedent
 
@@ -129,7 +129,7 @@ class MatrixExpr(Expr):
     @call_highest_priority('__rpow__')
     def __pow__(self, other):
         if not self.is_square:
-            raise ShapeError("Power of non-square matrix %s" % self)
+            raise NonSquareMatrixError("Power of non-square matrix %s" % self)
         elif self.is_Identity:
             return self
         elif other == S.Zero:
@@ -265,6 +265,8 @@ class MatrixExpr(Expr):
         return self.transpose()
 
     def inverse(self):
+        if not self.is_square:
+            raise NonSquareMatrixError('Inverse of non-square matrix')
         return self._eval_inverse()
 
     def inv(self):
@@ -969,11 +971,11 @@ class ZeroMatrix(MatrixExpr):
     @call_highest_priority('__rpow__')
     def __pow__(self, other):
         if other != 1 and not self.is_square:
-            raise ShapeError("Power of non-square matrix %s" % self)
+            raise NonSquareMatrixError("Power of non-square matrix %s" % self)
         if other == 0:
             return Identity(self.rows)
         if other < 1:
-            raise ValueError("Matrix det == 0; not invertible.")
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible")
         return self
 
     def _eval_transpose(self):
@@ -984,6 +986,9 @@ class ZeroMatrix(MatrixExpr):
 
     def _eval_determinant(self):
         return S.Zero
+
+    def _eval_inverse(self):
+        raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
 
     def conjugate(self):
         return self
@@ -1069,8 +1074,13 @@ class OneMatrix(MatrixExpr):
     def _eval_trace(self):
         return S.One*self.rows
 
+    def _is_1x1(self):
+        """Returns true if the matrix is known to be 1x1"""
+        shape = self.shape
+        return Eq(shape[0], 1) & Eq(shape[1], 1)
+
     def _eval_determinant(self):
-        condition = Eq(self.shape[0], 1) & Eq(self.shape[1], 1)
+        condition = self._is_1x1()
         if condition == True:
             return S.One
         elif condition == False:
@@ -1078,6 +1088,15 @@ class OneMatrix(MatrixExpr):
         else:
             from sympy import Determinant
             return Determinant(self)
+
+    def _eval_inverse(self):
+        condition = self._is_1x1()
+        if condition == True:
+            return Identity(1)
+        elif condition == False:
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
+        else:
+            return Inverse(self)
 
     def conjugate(self):
         return self

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -5,11 +5,12 @@ from sympy.core import Mul, Basic, sympify, S
 from sympy.functions import adjoint
 from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
         do_one, new)
+from sympy.matrices.common import ShapeError
 from sympy.matrices.matrices import MatrixBase
 
 from .inverse import Inverse
 from .matexpr import \
-    MatrixExpr, ShapeError, Identity, ZeroMatrix, OneMatrix, GenericIdentity
+    MatrixExpr, Identity, ZeroMatrix, OneMatrix, GenericIdentity
 from .matpow import MatPow
 from .transpose import transpose
 from .permutation import PermutationMatrix

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, division
 
-from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
+from sympy.matrices.common import NonSquareMatrixError
+from .matexpr import MatrixExpr, Identity, ZeroMatrix
 from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
+from sympy.matrices.common import NonInvertibleMatrixError
 
 from .permutation import PermutationMatrix
 
@@ -40,7 +42,7 @@ class MatPow(MatrixExpr):
         if isinstance(A, MatPow):
             # We still have a MatPow, make an explicit MatMul out of it.
             if not A.base.is_square:
-                raise ShapeError("Power of non-square matrix %s" % A.base)
+                raise NonSquareMatrixError("Power of non-square matrix %s" % A.base)
             elif A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
             #elif A.exp.is_Integer and self.exp.is_negative:
@@ -74,7 +76,7 @@ class MatPow(MatrixExpr):
                 return base.func(Identity(base.shape[0]))
             return Identity(base.shape[0])
         elif isinstance(base, ZeroMatrix) and exp.is_negative:
-            raise ValueError("Matrix determinant is 0, not invertible.")
+            raise NonInvertibleMatrixError("Matrix determinant is 0, not invertible")
         elif isinstance(base, (Identity, ZeroMatrix)):
             return base
         elif isinstance(base, PermutationMatrix):

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -119,6 +119,7 @@ def test_BlockMatrix_trace():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']
     X = BlockMatrix([[A, B], [C, D]])
     assert trace(X) == trace(A) + trace(D)
+    assert trace(BlockMatrix([ZeroMatrix(n, n)])) == 0
 
 def test_BlockMatrix_Determinant():
     A, B, C, D = [MatrixSymbol(s, 3, 3) for s in 'ABCD']
@@ -128,6 +129,8 @@ def test_BlockMatrix_Determinant():
         assert det(X) == det(A) * det(D - C*A.I*B)
 
     assert isinstance(det(X), Expr)
+    assert det(BlockMatrix([A])) == det(A)
+    assert det(BlockMatrix([ZeroMatrix(n, n)])) == 0
 
 def test_squareBlockMatrix():
     A = MatrixSymbol('A', n, n)

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -243,6 +243,11 @@ def test_BlockDiagMatrix_transpose():
     assert transpose(BlockDiagMatrix(A)) == BlockDiagMatrix(A.T)
     assert transpose(BlockDiagMatrix(A, B)) == BlockDiagMatrix(A.T, B.T)
 
+def test_issue_2460():
+    bdm1 = BlockDiagMatrix(Matrix([i]), Matrix([j]))
+    bdm2 = BlockDiagMatrix(Matrix([k]), Matrix([l]))
+    assert block_collapse(bdm1 + bdm2) == BlockDiagMatrix(Matrix([i + k]), Matrix([j + l]))
+
 def test_blockcut():
     A = MatrixSymbol('A', n, m)
     B = blockcut(A, (n/2, n/2), (m/2, m/2))

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -1,6 +1,7 @@
 from sympy.core import symbols, S
-from sympy.matrices.expressions import MatrixSymbol, Inverse, MatPow
-from sympy.matrices import eye, Identity, ShapeError
+from sympy.matrices.expressions import MatrixSymbol, Inverse, MatPow, ZeroMatrix, OneMatrix
+from sympy.matrices.common import NonSquareMatrixError, NonInvertibleMatrixError
+from sympy.matrices import eye, Identity
 from sympy.testing.pytest import raises
 from sympy import refine, Q
 
@@ -13,9 +14,6 @@ E = MatrixSymbol('E', m, n)
 
 
 def test_inverse():
-    raises(ShapeError, lambda: Inverse(A))
-    raises(ShapeError, lambda: Inverse(A*B))
-
     assert Inverse(C).args == (C, S.NegativeOne)
     assert Inverse(C).shape == (n, n)
     assert Inverse(A*E).shape == (n, n)
@@ -41,6 +39,16 @@ def test_inverse():
     assert Inverse(eye(3)).doit() == eye(3)
     assert Inverse(eye(3)).doit(deep=False) == eye(3)
 
+    assert OneMatrix(1, 1).I == Identity(1)
+    assert isinstance(OneMatrix(n, n).I, Inverse)
+
+def test_inverse_non_invertible():
+    raises(NonSquareMatrixError, lambda: Inverse(A))
+    raises(NonSquareMatrixError, lambda: Inverse(A*B))
+    raises(NonSquareMatrixError, lambda: ZeroMatrix(n, m).I)
+    raises(NonInvertibleMatrixError, lambda: ZeroMatrix(n, n).I)
+    raises(NonSquareMatrixError, lambda: OneMatrix(n, m).I)
+    raises(NonInvertibleMatrixError, lambda: OneMatrix(2, 2).I)
 
 def test_refine():
     assert refine(C.I, Q.orthogonal(C)) == C.T

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -2,7 +2,7 @@ from sympy.testing.pytest import raises
 from sympy.core import symbols, pi, S
 from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
-from sympy.matrices.expressions.matexpr import ShapeError
+from sympy.matrices.common import ShapeError
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy import Basic, Expr, sympify, S
 from sympy.matrices.matrices import MatrixBase
-from .matexpr import ShapeError
+from sympy.matrices.common import NonSquareMatrixError
 
 
 class Trace(Expr):
@@ -28,7 +28,7 @@ class Trace(Expr):
             raise TypeError("input to Trace, %s, is not a matrix" % str(mat))
 
         if not mat.is_square:
-            raise ShapeError("Trace of a non-square matrix")
+            raise NonSquareMatrixError("Trace of a non-square matrix")
 
         return Basic.__new__(cls, mat)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2141,7 +2141,7 @@ class MatrixBase(MatrixDeprecated,
 
         c = self.cols
         if c != self.rows:
-            raise ShapeError("Matrix must be square")
+            raise NonSquareMatrixError("Matrix must be square")
         if check_symmetry:
             self.simplify()
             if self != self.transpose():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -41,6 +41,7 @@ from sympy.simplify import (simplify, collect, powsimp, posify,  # type: ignore
     separatevars)
 from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1
+from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, factor, Poly, degree
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
@@ -2645,7 +2646,7 @@ def inv_quick(M):
     n = M.rows
     d = det(M)
     if d == S.Zero:
-        raise ValueError("Matrix det == 0; not invertible.")
+        raise NonInvertibleMatrixError("Matrix det == 0; not invertible")
     ret = zeros(n)
     s1 = -1
     for i in range(n):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -5,7 +5,7 @@ from sympy import (Matrix, MatrixSymbol, S, Indexed, Basic,
                    Lambda, Mul, Dummy, IndexedBase, Add,
                    linsolve, eye, Or, Not, Intersection,
                    Union, Expr, Function, exp, cacheit,
-                   Ge, Piecewise, Symbol)
+                   Ge, Piecewise, Symbol, NonSquareMatrixError)
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import Boolean
 from sympy.stats.joint_rv import JointDistributionHandmade, JointDistribution
@@ -80,7 +80,7 @@ def _matrix_checks(matrix):
         raise TypeError("Transition probabilities either should "
                             "be a Matrix or a MatrixSymbol.")
     if matrix.shape[0] != matrix.shape[1]:
-        raise ValueError("%s is not a square matrix"%(matrix))
+        raise NonSquareMatrixError("%s is not a square matrix"%(matrix))
     if isinstance(matrix, Matrix):
         matrix = ImmutableMatrix(matrix.tolist())
     return matrix


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #2460

#### Brief description of what is fixed or changed
Various improvements regarding BlockMatrix:
- Improve inversion of 2x2 block matrices
- Add assumption handlers for OneMatrix
- Raise more correct and more specific exceptions for matrices
- Allow creating BlockDiagMatrix from mutable matrices
- Improve evaluation of BlockMatrix trace/determinant
- Fix BlockDiagMatrix with non-square blocks

#### Other comments
Please let me know if smaller pull requests are better.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->