### PR TITLE
Clean up of MatPow code, forbid non-square matrix powers

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2484,8 +2484,6 @@ class MatrixArithmetic(MatrixRequired):
 
         if method is not None and method not in ['multiply', 'mulsimp', 'jordan', 'cayley']:
             raise TypeError('No such method')
-        if exp == S.One:
-            return self
         if self.rows != self.cols:
             raise NonSquareMatrixError()
         a = self

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2484,6 +2484,8 @@ class MatrixArithmetic(MatrixRequired):
 
         if method is not None and method not in ['multiply', 'mulsimp', 'jordan', 'cayley']:
             raise TypeError('No such method')
+        if exp == S.One:
+            return self
         if self.rows != self.cols:
             raise NonSquareMatrixError()
         a = self

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -67,10 +67,7 @@ class Inverse(MatPow):
         if hints.get('deep', True):
             arg = arg.doit(**hints)
 
-        if isinstance(arg, MatPow):
-            return MatPow(arg.base, self.exp * arg.exp)
         return arg.inverse()
-
 
     def _eval_derivative_matrix_lines(self, x):
         arg = self.args[0]

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -391,7 +391,7 @@ def kronecker_mat_mul(expr):
 
 
 def kronecker_mat_pow(expr):
-    if isinstance(expr.base, KroneckerProduct):
+    if isinstance(expr.base, KroneckerProduct) and all(a.is_square for a in expr.base.args):
         return KroneckerProduct(*[MatPow(a, expr.exp) for a in expr.base.args])
     else:
         return expr
@@ -415,8 +415,10 @@ def combine_kronecker(expr):
     KroneckerProduct(A*B, B*A)
     >>> combine_kronecker(KroneckerProduct(A, B)+KroneckerProduct(B.T, A.T))
     KroneckerProduct(A + B.T, B + A.T)
-    >>> combine_kronecker(KroneckerProduct(A, B)**m)
-    KroneckerProduct(A**m, B**m)
+    >>> C = MatrixSymbol('C', n, n)
+    >>> D = MatrixSymbol('D', m, m)
+    >>> combine_kronecker(KroneckerProduct(C, D)**m)
+    KroneckerProduct(C**m, D**m)
     """
     def haskron(expr):
         return isinstance(expr, MatrixExpr) and expr.has(KroneckerProduct)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -129,10 +129,6 @@ class MatrixExpr(Expr):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rpow__')
     def __pow__(self, other):
-        # Note: A ** 0 and A ** 1 are not allowed for non-square A, whereas MatPow(A, 0) and MatPow(A, 1) are
-        # allowed but remain unevaluated.
-        if not self.is_square:
-            raise NonSquareMatrixError("Power of non-square matrix %s" % self)
         return MatPow(self, other).doit()
 
     @_sympifyit('other', NotImplemented)
@@ -186,8 +182,8 @@ class MatrixExpr(Expr):
 
     def _eval_power(self, exp):
         """
-        Override this in sub-classes to implement simplification of powers.  The cases where the base is non-square or
-        where exp is -1, 0, 1 are already covered in MatPow.doit(), so implementations can exclude these cases.
+        Override this in sub-classes to implement simplification of powers.  The cases where the exponent
+        is -1, 0, 1 are already covered in MatPow.doit(), so implementations can exclude these cases.
         """
         return MatPow(self, exp)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -337,12 +337,12 @@ def combine_powers(mul):
         elif not isinstance(B_base, MatrixBase):
             try:
                 B_base_inv = B_base.inverse()
-                if A_base == B_base_inv:
-                    new_exp = A_exp - B_exp
-                    new_args[-1] = MatPow(A_base, new_exp).doit(deep=False)
-                    continue
             except NonInvertibleMatrixError:
-                pass
+                B_base_inv = None
+            if B_base_inv is not None and A_base == B_base_inv:
+                new_exp = A_exp - B_exp
+                new_args[-1] = MatPow(A_base, new_exp).doit(deep=False)
+                continue
         new_args.append(B)
 
     return newmul(factor, *new_args)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -13,10 +13,10 @@ class MatPow(MatrixExpr):
         base = _sympify(base)
         if not base.is_Matrix:
             raise TypeError("MatPow base should be a matrix")
-        exp = _sympify(exp)
-        if not base.is_square and exp not in [S.Zero, S.One]:
+        if not base.is_square:
             raise NonSquareMatrixError("Power of non-square matrix %s" % base)
 
+        exp = _sympify(exp)
         obj = Basic.__new__(cls, base, exp)
 
         if evaluate:
@@ -41,7 +41,7 @@ class MatPow(MatrixExpr):
         A = self.doit()
         if isinstance(A, MatPow):
             # We still have a MatPow, make an explicit MatMul out of it.
-            if A.base.is_square and A.exp.is_Integer and A.exp.is_positive:
+            if A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
             #elif A.exp.is_Integer and self.exp.is_negative:
             # Note: possible future improvement: in principle we can take
@@ -66,11 +66,6 @@ class MatPow(MatrixExpr):
             exp *= base.args[1]
             base = base.args[0]
 
-        if not base.is_square:
-            if exp in [S.Zero, S.One]:
-                return self
-            raise NonSquareMatrixError("Power of non-square matrix %s" % base)
-
         if isinstance(base, MatrixBase):
             # Delegate
             return base ** exp
@@ -91,8 +86,6 @@ class MatPow(MatrixExpr):
         return MatPow(base, exp)
 
     def as_explicit(self):
-        if not self.base.is_square:
-            raise NonSquareMatrixError("Non-square matrix power cannot be converted to explicit matrix")
         return super().as_explicit()
 
     def _eval_transpose(self):

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -85,9 +85,6 @@ class MatPow(MatrixExpr):
 
         return MatPow(base, exp)
 
-    def as_explicit(self):
-        return super().as_explicit()
-
     def _eval_transpose(self):
         base, exp = self.args
         return MatPow(base.T, exp)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -144,3 +144,6 @@ class MatPow(MatrixExpr):
         else:
             raise NotImplementedError("cannot evaluate %s derived by %s" % (self, x))
         return newexpr._eval_derivative_matrix_lines(x)
+
+    def _eval_inverse(self):
+        return MatPow(self.base, -self.exp)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,13 +1,10 @@
 from __future__ import print_function, division
 
 from sympy.matrices.common import NonSquareMatrixError
-from .matexpr import MatrixExpr, Identity, ZeroMatrix
-from sympy.core import S
+from .matexpr import MatrixExpr, Identity
+from sympy.core import S, Basic
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
-from sympy.matrices.common import NonInvertibleMatrixError
-
-from .permutation import PermutationMatrix
 
 
 class MatPow(MatrixExpr):
@@ -15,10 +12,13 @@ class MatPow(MatrixExpr):
     def __new__(cls, base, exp, evaluate=False, **options):
         base = _sympify(base)
         if not base.is_Matrix:
-            raise TypeError("Function parameter should be a matrix")
+            raise TypeError("MatPow base should be a matrix")
         exp = _sympify(exp)
+        if not base.is_square and exp not in [S.Zero, S.One]:
+            raise NonSquareMatrixError("Power of non-square matrix %s" % base)
 
-        obj = super(MatPow, cls).__new__(cls, base, exp)
+        obj = Basic.__new__(cls, base, exp)
+
         if evaluate:
             obj = obj.doit(deep=False)
 
@@ -41,9 +41,7 @@ class MatPow(MatrixExpr):
         A = self.doit()
         if isinstance(A, MatPow):
             # We still have a MatPow, make an explicit MatMul out of it.
-            if not A.base.is_square:
-                raise NonSquareMatrixError("Power of non-square matrix %s" % A.base)
-            elif A.exp.is_Integer and A.exp.is_positive:
+            if A.base.is_square and A.exp.is_Integer and A.exp.is_positive:
                 A = MatMul(*[A.base for k in range(A.exp)])
             #elif A.exp.is_Integer and self.exp.is_negative:
             # Note: possible future improvement: in principle we can take
@@ -55,43 +53,47 @@ class MatPow(MatrixExpr):
                 # Leave the expression unevaluated:
                 from sympy.matrices.expressions.matexpr import MatrixElement
                 return MatrixElement(self, i, j)
-        return A._entry(i, j)
+        return A[i, j]
 
     def doit(self, **kwargs):
-        from sympy.matrices.expressions import Inverse
-        deep = kwargs.get('deep', True)
-        if deep:
-            args = [arg.doit(**kwargs) for arg in self.args]
+        if kwargs.get('deep', True):
+            base, exp = [arg.doit(**kwargs) for arg in self.args]
         else:
-            args = self.args
+            base, exp = self.args
 
-        base, exp = args
-        # combine all powers, e.g. (A**2)**3 = A**6
+        # combine all powers, e.g. (A ** 2) ** 3 -> A ** 6
         while isinstance(base, MatPow):
-            exp = exp*base.args[1]
+            exp *= base.args[1]
             base = base.args[0]
 
-        if exp.is_zero and base.is_square:
-            if isinstance(base, MatrixBase):
-                return base.func(Identity(base.shape[0]))
-            return Identity(base.shape[0])
-        elif isinstance(base, ZeroMatrix) and exp.is_negative:
-            raise NonInvertibleMatrixError("Matrix determinant is 0, not invertible")
-        elif isinstance(base, (Identity, ZeroMatrix)):
+        if not base.is_square:
+            if exp in [S.Zero, S.One]:
+                return self
+            raise NonSquareMatrixError("Power of non-square matrix %s" % base)
+
+        if isinstance(base, MatrixBase):
+            # Delegate
+            return base ** exp
+
+        # Handle simple cases so that _eval_power() in MatrixExpr sub-classes can ignore them
+        if exp == S.One:
             return base
-        elif isinstance(base, PermutationMatrix):
-            return PermutationMatrix(base.args[0] ** exp).doit()
-        elif isinstance(base, MatrixBase):
-            if exp is S.One:
-                return base
-            return base**exp
-        # Note: just evaluate cases we know, return unevaluated on others.
-        # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
-        elif exp is S.NegativeOne and base.is_square:
+        if exp == S.Zero:
+            return Identity(base.rows)
+        if exp == S.NegativeOne:
+            from sympy.matrices.expressions import Inverse
             return Inverse(base).doit(**kwargs)
-        elif exp is S.One:
-            return base
+
+        eval_power = getattr(base, '_eval_power', None)
+        if eval_power is not None:
+            return eval_power(exp)
+
         return MatPow(base, exp)
+
+    def as_explicit(self):
+        if not self.base.is_square:
+            raise NonSquareMatrixError("Non-square matrix power cannot be converted to explicit matrix")
+        return super().as_explicit()
 
     def _eval_transpose(self):
         base, exp = self.args

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.matrices.common import NonSquareMatrixError
 from .matexpr import MatrixExpr, Identity
-from sympy.core import S, Basic
+from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase
 
@@ -17,7 +17,7 @@ class MatPow(MatrixExpr):
             raise NonSquareMatrixError("Power of non-square matrix %s" % base)
 
         exp = _sympify(exp)
-        obj = Basic.__new__(cls, base, exp)
+        obj = super().__new__(cls, base, exp)
 
         if evaluate:
             obj = obj.doit(deep=False)

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -85,6 +85,9 @@ class PermutationMatrix(MatrixExpr):
         perm = self.args[0]
         return KroneckerDelta(perm.apply(i), j)
 
+    def _eval_power(self, exp):
+        return PermutationMatrix(self.args[0] ** exp).doit()
+
     def _eval_inverse(self):
         return PermutationMatrix(self.args[0] ** -1)
 

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -19,6 +19,7 @@ def test_inverse():
     assert Inverse(A*E).shape == (n, n)
     assert Inverse(E*A).shape == (m, m)
     assert Inverse(C).inverse() == C
+    assert Inverse(Inverse(C)).doit() == C
     assert isinstance(Inverse(Inverse(C)), Inverse)
 
     assert Inverse(*Inverse(E*A).args) == Inverse(E*A)

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -127,6 +127,8 @@ def test_KroneckerProduct_combine_pow():
                              ** 2) == x * KroneckerProduct(X**2, Y**2)
     assert combine_kronecker(
         x * (KroneckerProduct(X, Y)**2) * KroneckerProduct(A, B)) == x * KroneckerProduct(X**2 * A, Y**2 * B)
+    # cannot simplify because of non-square arguments to kronecker product:
+    assert combine_kronecker(KroneckerProduct(A, B.T) ** m) == KroneckerProduct(A, B.T) ** m
 
 
 def test_KroneckerProduct_expand():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -7,7 +7,7 @@ from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
-        SparseMatrix, Transpose, Adjoint)
+        SparseMatrix, Transpose, Adjoint, NonSquareMatrixError)
 from sympy.matrices.expressions.matexpr import (MatrixElement,
                                                 GenericZeroMatrix, GenericIdentity, OneMatrix)
 from sympy.testing.pytest import raises, XFAIL
@@ -133,9 +133,11 @@ def test_ZeroMatrix():
     assert Z.conjugate() == Z
 
     assert ZeroMatrix(n, n)**0 == Identity(n)
-    with raises(ShapeError):
+    with raises(NonSquareMatrixError):
         Z**0
-    with raises(ShapeError):
+    with raises(NonSquareMatrixError):
+        Z**1
+    with raises(NonSquareMatrixError):
         Z**2
 
 
@@ -157,9 +159,11 @@ def test_OneMatrix():
     assert U.conjugate() == U
 
     assert OneMatrix(n, n) ** 0 == Identity(n)
-    with raises(ShapeError):
+    with raises(NonSquareMatrixError):
         U ** 0
-    with raises(ShapeError):
+    with raises(NonSquareMatrixError):
+        U ** 1
+    with raises(NonSquareMatrixError):
         U ** 2
     with raises(ShapeError):
         a + U
@@ -290,7 +294,7 @@ def test_MatPow():
     assert (A**2)**3 == A**6
     assert A**S.Half == sqrt(A)
     assert A**Rational(1, 3) == cbrt(A)
-    raises(ShapeError, lambda: MatrixSymbol('B', 3, 2)**2)
+    raises(NonSquareMatrixError, lambda: MatrixSymbol('B', 3, 2)**2)
 
 
 def test_MatrixSymbol():

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -15,7 +15,7 @@ D = MatrixSymbol('D', n, n)
 E = MatrixSymbol('E', m, n)
 
 
-def test_entry_square_matrix():
+def test_entry_matrix():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(X, 0)[0, 0] == 1
     assert MatPow(X, 0)[0, 1] == 0
@@ -24,7 +24,7 @@ def test_entry_square_matrix():
     assert MatPow(X, 2)[0, 0] == 7
 
 
-def test_entry_square_symbol():
+def test_entry_symbol():
     from sympy.concrete import Sum
     assert MatPow(C, 0)[0, 0] == 1
     assert MatPow(C, 0)[0, 1] == 0
@@ -33,22 +33,7 @@ def test_entry_square_symbol():
     assert isinstance(MatPow(C, n)[0, 0], MatrixElement)
 
 
-def test_entry_nonsquare_matrix():
-    X = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
-    assert isinstance(MatPow(X, 0)[0, 0], MatrixElement)
-    assert isinstance(MatPow(X, 1)[0, 0], MatrixElement)
-    for r in [-1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(X, r)[0, 0])
-
-
-def test_entry_nonsquare_symbol():
-    assert isinstance(MatPow(A, 0)[0, 0], MatrixElement)
-    assert isinstance(MatPow(A, 1)[0, 0], MatrixElement)
-    for r in [-1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(A, r)[0, 0])
-
-
-def test_as_explicit_square_symbol():
+def test_as_explicit_symbol():
     X = MatrixSymbol('X', 2, 2)
     assert MatPow(X, 0).as_explicit() == ImmutableMatrix(Identity(2))
     assert MatPow(X, 1).as_explicit() == X.as_explicit()
@@ -59,13 +44,7 @@ def test_as_explicit_square_symbol():
     ])
 
 
-def test_as_explicit_nonsquare_symbol():
-    X = MatrixSymbol('X', 2, 3)
-    for r in [-1, 0, 1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(X, r).as_explicit())
-
-
-def test_as_explicit_square_matrix():
+def test_as_explicit_matrix():
     A = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(A, 0).as_explicit() == ImmutableMatrix(Identity(2))
     assert MatPow(A, 1).as_explicit() == A
@@ -77,13 +56,7 @@ def test_as_explicit_square_matrix():
     assert MatPow(A, S.Half).as_explicit() == A**S.Half
 
 
-def test_as_explicit_nonsquare_matrix():
-    A = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
-    for r in [-1, 0, 1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(A, r).as_explicit())
-
-
-def test_doit_square_symbol():
+def test_doit_symbol():
     assert MatPow(C, 0).doit() == Identity(n)
     assert MatPow(C, 1).doit() == C
     assert MatPow(C, -1).doit() == C.I
@@ -91,14 +64,7 @@ def test_doit_square_symbol():
         assert MatPow(C, r).doit() == MatPow(C, r)
 
 
-def test_doit_nonsquare_symbol():
-    assert MatPow(A, 0).doit() == MatPow(A, 0)
-    assert MatPow(A, 1).doit() == MatPow(A, 1)
-    for r in [-1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(A, r).doit())
-
-
-def test_doit_square_matrix():
+def test_doit_matrix():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(X, 0).doit() == ImmutableMatrix(Identity(2))
     assert MatPow(X, 1).doit() == X
@@ -112,12 +78,12 @@ def test_doit_square_matrix():
     raises(ValueError, lambda: MatPow(X,-2).doit())
 
 
-def test_doit_nonsquare_matrix():
-    X = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
-    assert MatPow(X, 0).doit() == MatPow(X, 0)
-    assert MatPow(X, 1).doit() == MatPow(X, 1)
-    for r in [-1, 2, S.Half, S.Pi, n]:
-        raises(NonSquareMatrixError, lambda: MatPow(X, r).doit())
+def test_nonsquare():
+    A = MatrixSymbol('A', 2, 3)
+    B = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
+    for r in [-1, 0, 1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(A, r))
+        raises(NonSquareMatrixError, lambda: MatPow(B, r))
 
 
 def test_doit_equals_pow(): #17179

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,5 +1,6 @@
-from sympy.simplify import simplify
+from sympy.simplify.powsimp import powsimp
 from sympy.testing.pytest import raises
+from sympy.core.expr import unchanged
 from sympy.core import symbols, S
 from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix, OneMatrix
 from sympy.matrices.common import NonSquareMatrixError
@@ -134,8 +135,8 @@ def test_OneMatrix_power():
 
     o = OneMatrix(n, n)
     assert o * o == o ** 2 == n * o
-    # simplify currently necessary as n ** (n - 2) * n does not produce n ** (n - 1)
-    assert simplify(o ** (n - 1) * o) == o ** n == n ** (n - 1) * o
+    # powsimp necessary as n ** (n - 2) * n does not produce n ** (n - 1)
+    assert powsimp(o ** (n - 1) * o) == o ** n == n ** (n - 1) * o
 
 
 def test_transpose_power():
@@ -174,3 +175,12 @@ def test_combine_powers():
     assert (C ** -1) ** -1 == C
     assert (((C ** 2) ** 3) ** 4) ** 5 == MatPow(C, 120)
     assert (C ** n) ** n == C ** (n ** 2)
+
+
+def test_unchanged():
+    assert unchanged(MatPow, C, 0)
+    assert unchanged(MatPow, C, 1)
+    assert unchanged(MatPow, Inverse(C), -1)
+    assert unchanged(Inverse, MatPow(C, -1), -1)
+    assert unchanged(MatPow, MatPow(C, -1), -1)
+    assert unchanged(MatPow, MatPow(C, 1), 1)

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,8 +1,11 @@
+from sympy.simplify import simplify
 from sympy.testing.pytest import raises
-from sympy.core import symbols, pi, S
-from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix
+from sympy.core import symbols, S
+from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix, OneMatrix
+from sympy.matrices.common import NonSquareMatrixError
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
-from sympy.matrices.common import ShapeError
+from sympy.matrices.expressions.inverse import Inverse
+from sympy.matrices.expressions.matexpr import MatrixElement
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)
@@ -12,29 +15,57 @@ D = MatrixSymbol('D', n, n)
 E = MatrixSymbol('E', m, n)
 
 
-def test_entry():
+def test_entry_square_matrix():
+    X = ImmutableMatrix([[1, 2], [3, 4]])
+    assert MatPow(X, 0)[0, 0] == 1
+    assert MatPow(X, 0)[0, 1] == 0
+    assert MatPow(X, 1)[0, 0] == 1
+    assert MatPow(X, 1)[0, 1] == 2
+    assert MatPow(X, 2)[0, 0] == 7
+
+
+def test_entry_square_symbol():
     from sympy.concrete import Sum
-    assert MatPow(A, 1)[0, 0] == A[0, 0]
     assert MatPow(C, 0)[0, 0] == 1
     assert MatPow(C, 0)[0, 1] == 0
+    assert MatPow(C, 1)[0, 0] == C[0, 0]
     assert isinstance(MatPow(C, 2)[0, 0], Sum)
+    assert isinstance(MatPow(C, n)[0, 0], MatrixElement)
 
 
-def test_as_explicit_symbol():
+def test_entry_nonsquare_matrix():
+    X = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
+    assert isinstance(MatPow(X, 0)[0, 0], MatrixElement)
+    assert isinstance(MatPow(X, 1)[0, 0], MatrixElement)
+    for r in [-1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(X, r)[0, 0])
+
+
+def test_entry_nonsquare_symbol():
+    assert isinstance(MatPow(A, 0)[0, 0], MatrixElement)
+    assert isinstance(MatPow(A, 1)[0, 0], MatrixElement)
+    for r in [-1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(A, r)[0, 0])
+
+
+def test_as_explicit_square_symbol():
     X = MatrixSymbol('X', 2, 2)
     assert MatPow(X, 0).as_explicit() == ImmutableMatrix(Identity(2))
     assert MatPow(X, 1).as_explicit() == X.as_explicit()
     assert MatPow(X, 2).as_explicit() == (X.as_explicit())**2
+    assert MatPow(X, n).as_explicit() == ImmutableMatrix([
+        [(X ** n)[0, 0], (X ** n)[0, 1]],
+        [(X ** n)[1, 0], (X ** n)[1, 1]],
+    ])
 
 
 def test_as_explicit_nonsquare_symbol():
     X = MatrixSymbol('X', 2, 3)
-    assert MatPow(X, 1).as_explicit() == X.as_explicit()
-    for r in [0, 2, S.Half, S.Pi]:
-        raises(ShapeError, lambda: MatPow(X, r).as_explicit())
+    for r in [-1, 0, 1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(X, r).as_explicit())
 
 
-def test_as_explicit():
+def test_as_explicit_square_matrix():
     A = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(A, 0).as_explicit() == ImmutableMatrix(Identity(2))
     assert MatPow(A, 1).as_explicit() == A
@@ -42,33 +73,32 @@ def test_as_explicit():
     assert MatPow(A, -1).as_explicit() == A.inv()
     assert MatPow(A, -2).as_explicit() == (A.inv())**2
     # less expensive than testing on a 2x2
-    A = ImmutableMatrix([4]);
+    A = ImmutableMatrix([4])
     assert MatPow(A, S.Half).as_explicit() == A**S.Half
 
 
-def test_as_explicit_nonsquare():
+def test_as_explicit_nonsquare_matrix():
     A = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
-    assert MatPow(A, 1).as_explicit() == A
-    raises(ShapeError, lambda: MatPow(A, 0).as_explicit())
-    raises(ShapeError, lambda: MatPow(A, 2).as_explicit())
-    raises(ShapeError, lambda: MatPow(A, -1).as_explicit())
-    raises(ValueError, lambda: MatPow(A, pi).as_explicit())
+    for r in [-1, 0, 1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(A, r).as_explicit())
 
 
-def test_doit_nonsquare_MatrixSymbol():
-    assert MatPow(A, 1).doit() == A
-    for r in [0, 2, -1, pi]:
-        assert MatPow(A, r).doit() == MatPow(A, r)
-
-
-def test_doit_square_MatrixSymbol_symsize():
+def test_doit_square_symbol():
     assert MatPow(C, 0).doit() == Identity(n)
     assert MatPow(C, 1).doit() == C
-    for r in [2, pi]:
+    assert MatPow(C, -1).doit() == C.I
+    for r in [2, S.Half, S.Pi, n]:
         assert MatPow(C, r).doit() == MatPow(C, r)
 
 
-def test_doit_with_MatrixBase():
+def test_doit_nonsquare_symbol():
+    assert MatPow(A, 0).doit() == MatPow(A, 0)
+    assert MatPow(A, 1).doit() == MatPow(A, 1)
+    for r in [-1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(A, r).doit())
+
+
+def test_doit_square_matrix():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(X, 0).doit() == ImmutableMatrix(Identity(2))
     assert MatPow(X, 1).doit() == X
@@ -82,13 +112,12 @@ def test_doit_with_MatrixBase():
     raises(ValueError, lambda: MatPow(X,-2).doit())
 
 
-def test_doit_nonsquare():
+def test_doit_nonsquare_matrix():
     X = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
-    assert MatPow(X, 1).doit() == X
-    raises(ShapeError, lambda: MatPow(X, 0).doit())
-    raises(ShapeError, lambda: MatPow(X, 2).doit())
-    raises(ShapeError, lambda: MatPow(X, -1).doit())
-    raises(ShapeError, lambda: MatPow(X, pi).doit())
+    assert MatPow(X, 0).doit() == MatPow(X, 0)
+    assert MatPow(X, 1).doit() == MatPow(X, 1)
+    for r in [-1, 2, S.Half, S.Pi, n]:
+        raises(NonSquareMatrixError, lambda: MatPow(X, r).doit())
 
 
 def test_doit_equals_pow(): #17179
@@ -130,6 +159,19 @@ def test_zero_power():
     raises(ValueError, lambda:MatPow(z2, -1).doit())
 
 
+def test_OneMatrix_power():
+    o = OneMatrix(3, 3)
+    assert o ** 0 == Identity(3)
+    assert o ** 1 == o
+    assert o * o == o ** 2 == 3 * o
+    assert o * o * o == o ** 3 == 9 * o
+
+    o = OneMatrix(n, n)
+    assert o * o == o ** 2 == n * o
+    # simplify currently necessary as n ** (n - 2) * n does not produce n ** (n - 1)
+    assert simplify(o ** (n - 1) * o) == o ** n == n ** (n - 1) * o
+
+
 def test_transpose_power():
     from sympy.matrices.expressions.transpose import Transpose as TP
 
@@ -145,3 +187,24 @@ def test_transpose_power():
 
     assert ((D*C)**-5).T**-5 == ((D*C)**25).T
     assert (((D*C)**l).T**k).T == (D*C)**(l*k)
+
+
+def test_Inverse():
+    assert Inverse(MatPow(C, 0)).doit() == Identity(n)
+    assert Inverse(MatPow(C, 1)).doit() == Inverse(C)
+    assert Inverse(MatPow(C, 2)).doit() == MatPow(C, -2)
+    assert Inverse(MatPow(C, -1)).doit() == C
+
+    assert MatPow(Inverse(C), 0).doit() == Identity(n)
+    assert MatPow(Inverse(C), 1).doit() == Inverse(C)
+    assert MatPow(Inverse(C), 2).doit() == MatPow(C, -2)
+    assert MatPow(Inverse(C), -1).doit() == C
+
+
+def test_combine_powers():
+    assert (C ** 1) ** 1 == C
+    assert (C ** 2) ** 3 == MatPow(C, 6)
+    assert (C ** -2) ** -3 == MatPow(C, 6)
+    assert (C ** -1) ** -1 == C
+    assert (((C ** 2) ** 3) ** 4) ** 5 == MatPow(C, 120)
+    assert (C ** n) ** n == C ** (n ** 2)


### PR DESCRIPTION
Completely forbid matrix powers with non-square bases. Further this moves responsibility of evaluating matrix powers to the respective sub-classes via _eval_power().

#### Other comments
Also includes a fix for Inverse(Inverse(C)).doit()

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Powers of non-square matrices now always raise an error, even when constructed using `MatPow(...)`.
<!-- END RELEASE NOTES -->