### PR TITLE
ZeroMatrix should not return False.

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -996,12 +996,6 @@ class ZeroMatrix(MatrixExpr):
     def _entry(self, i, j, **kwargs):
         return S.Zero
 
-    def __nonzero__(self):
-        return False
-
-    __bool__ = __nonzero__
-
-
 class GenericZeroMatrix(ZeroMatrix):
     """
     A zero matrix without a specified shape

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -127,7 +127,7 @@ def test_ZeroMatrix():
     assert Z*A.T == ZeroMatrix(n, n)
     assert A - A == ZeroMatrix(*A.shape)
 
-    assert not Z
+    assert Z
 
     assert transpose(Z) == ZeroMatrix(m, n)
     assert Z.conjugate() == Z


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #19109

#### Brief description of what is fixed or changed
removed `__nonzero__` and `__bool__`

### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
    - ZeroMatrix will not be logically `False`.
<!-- END RELEASE NOTES -->