### PR TITLE
Fix bc_block_plus_ident() losing unrelated summands

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -488,7 +488,8 @@ def bc_block_plus_ident(expr):
                and blocks[0].is_structurally_symmetric):
         block_id = BlockDiagMatrix(*[Identity(k)
                                         for k in blocks[0].rowblocksizes])
-        return MatAdd(block_id * len(idents), *blocks).doit()
+        rest = [arg for arg in expr.args if not arg.is_Identity and not isinstance(arg, BlockMatrix)]
+        return MatAdd(block_id * len(idents), *blocks, *rest).doit()
 
     return expr
 

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -47,8 +47,9 @@ def test_block_plus_ident():
     C = MatrixSymbol('C', m, n)
     D = MatrixSymbol('D', m, m)
     X = BlockMatrix([[A, B], [C, D]])
-    assert bc_block_plus_ident(X+Identity(m+n)) == \
-            BlockDiagMatrix(Identity(n), Identity(m)) + X
+    Z = MatrixSymbol('Z', n + m, n + m)
+    assert bc_block_plus_ident(X + Identity(m + n) + Z) == \
+            BlockDiagMatrix(Identity(n), Identity(m)) + X + Z
 
 def test_BlockMatrix():
     A = MatrixSymbol('A', n, m)


### PR DESCRIPTION
`bc_block_plus_ident()` was previously removing any summands that was neither an identity matrix nor a blockmatrix.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->