### PR TITLE
adding to and moving assumption helpers

### DIFF
--- a/doc/src/modules/solvers/solvers.rst
+++ b/doc/src/modules/solvers/solvers.rst
@@ -43,10 +43,6 @@ is the symbol that we want to solve the equation for.
 
 .. autofunction:: sympy.solvers.solvers.nsolve
 
-.. autofunction:: sympy.solvers.solvers.check_assumptions
-
-.. autofunction:: sympy.solvers.solvers.failing_assumptions
-
 .. autofunction:: sympy.solvers.solvers.checksol
 
 .. autofunction:: sympy.solvers.solvers.unrad

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1314,10 +1314,11 @@ def _eval_matrix_sum(expression):
 
 def _dummy_with_inherited_properties_concrete(limits):
     """
-    Return a Dummy symbol that inherits as much assumptions based on the
-    provided symbol and limits as possible.
+    Return a Dummy symbol that inherits as many assumptions as possible
+    from the provided symbol and limits.
 
-    If the symbol already has all possible assumptions, return None.
+    If the symbol already has all True assumption shared by the limits
+    then return None.
     """
     x, a, b = limits
     l = [a, b]
@@ -1340,5 +1341,3 @@ def _dummy_with_inherited_properties_concrete(limits):
     if assumptions_to_add:
         assumptions_to_keep.update(assumptions_to_add)
         return Dummy('d', **assumptions_to_keep)
-    else:
-        return None

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -8,6 +8,7 @@ from sympy import (
 from sympy.abc import a, b, c, d, k, m, x, y, z
 from sympy.concrete.summations import telescopic, _dummy_with_inherited_properties_concrete
 from sympy.concrete.expr_with_intlimits import ReorderError
+from sympy.core.facts import InconsistentAssumptions
 from sympy.testing.pytest import XFAIL, raises, slow
 from sympy.matrices import \
     Matrix, SparseMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
@@ -1370,7 +1371,6 @@ def test__dummy_with_inherited_properties_concrete():
     d = _dummy_with_inherited_properties_concrete(Tuple(N, 2, 4))
     assert d is None
 
-    from sympy.core.facts import InconsistentAssumptions
     x = Symbol('x', negative=True)
     raises(InconsistentAssumptions,
            lambda: _dummy_with_inherited_properties_concrete(Tuple(x, 1, 5)))

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -3,6 +3,7 @@
 
 from .sympify import sympify, SympifyError
 from .cache import cacheit
+from .assumptions import assumptions, check_assumptions, failing_assumptions, common_assumptions
 from .basic import Basic, Atom, preorder_traversal
 from .singleton import S
 from .expr import Expr, AtomicExpr, UnevaluatedExpr
@@ -38,6 +39,9 @@ __all__ = [
     'sympify', 'SympifyError',
 
     'cacheit',
+
+    'assumptions', 'check_assumptions', 'failing_assumptions',
+    'common_assumptions',
 
     'Basic', 'Atom', 'preorder_traversal',
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -153,6 +153,7 @@ References
 
 from sympy.core.facts import FactRules, FactKB
 from sympy.core.core import BasicMeta
+from sympy.core.sympify import sympify
 
 from random import shuffle
 
@@ -221,8 +222,160 @@ _assume_defined.add('polar')
 _assume_defined = frozenset(_assume_defined)
 
 
+def assumptions(expr, _check=None):
+    """return the T/F assumptions of ``expr``"""
+    n = sympify(expr)
+    if n.is_Symbol:
+        rv = n.assumptions0  # are any important ones missing?
+        if _check is not None:
+            rv = {k: rv[k] for k in set(rv) & set(_check)}
+        return rv
+    rv = {}
+    for k in _assume_defined if _check is None else _check:
+        v = getattr(n, 'is_{}'.format(k))
+        if v is not None:
+            rv[k] = v
+    return rv
+
+
+def common_assumptions(exprs, check=None):
+    """return those assumptions which have the same True or False
+    value for all the given expressions.
+
+    Examples
+    ========
+
+    >>> from sympy.core.assumptions import common_assumptions
+    >>> from sympy import oo, pi, sqrt
+    >>> common_assumptions([-4, 0, sqrt(2), 2, pi, oo])
+    {'commutative': True, 'composite': False,
+    'extended_real': True, 'imaginary': False, 'odd': False}
+
+    By default, all assumptions are tested; pass an iterable of the
+    assumptions to limit those that are reported:
+
+    >>> common_assumptions([0, 1, 2], ['positive', 'integer'])
+    {'integer': True}
+    """
+    check = _assume_defined if check is None else set(check)
+    if not check or not exprs:
+        return {}
+
+    # get all assumptions for each
+    assume = [assumptions(i, _check=check) for i in sympify(exprs)]
+    # focus on those of interest that are True
+    for i, e in enumerate(assume):
+        assume[i] = {k: e[k] for k in set(e) & check}
+    # what assumptions are in common?
+    common = set.intersection(*[set(i) for i in assume])
+    # which ones hold the same value
+    a = assume[0]
+    return {k: a[k] for k in common if all(a[k] == b[k]
+        for b in assume)}
+
+
+def failing_assumptions(expr, **assumptions):
+    """
+    Return a dictionary containing assumptions with values not
+    matching those of the passed assumptions.
+
+    Examples
+    ========
+
+    >>> from sympy import failing_assumptions, Symbol
+
+    >>> x = Symbol('x', real=True, positive=True)
+    >>> y = Symbol('y')
+    >>> failing_assumptions(6*x + y, real=True, positive=True)
+    {'positive': None, 'real': None}
+
+    >>> failing_assumptions(x**2 - 1, positive=True)
+    {'positive': None}
+
+    If *expr* satisfies all of the assumptions, an empty dictionary is returned.
+
+    >>> failing_assumptions(x**2, positive=True)
+    {}
+
+    """
+    expr = sympify(expr)
+    failed = {}
+    for k in assumptions:
+        test = getattr(expr, 'is_%s' % k, None)
+        if test is not assumptions[k]:
+            failed[k] = test
+    return failed  # {} or {assumption: value != desired}
+
+
+def check_assumptions(expr, against=None, **assume):
+    """
+    Checks whether assumptions of ``expr`` match the T/F assumptions
+    given (or possessed by ``against``). True is returned if all
+    assumptions match; False is returned if there is a mismatch and
+    the assumption in ``expr`` is not None; else None is returned.
+
+    Explanation
+    ===========
+
+    *assume* is a dict of assumptions with True or False values
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, pi, I, exp, check_assumptions
+    >>> check_assumptions(-5, integer=True)
+    True
+    >>> check_assumptions(pi, real=True, integer=False)
+    True
+    >>> check_assumptions(pi, real=True, negative=True)
+    False
+    >>> check_assumptions(exp(I*pi/7), real=False)
+    True
+    >>> x = Symbol('x', real=True, positive=True)
+    >>> check_assumptions(2*x + 1, real=True, positive=True)
+    True
+    >>> check_assumptions(-2*x - 5, real=True, positive=True)
+    False
+
+    To check assumptions of *expr* against another variable or expression,
+    pass the expression or variable as ``against``.
+
+    >>> check_assumptions(2*x + 1, x)
+    True
+
+    ``None`` is returned if ``check_assumptions()`` could not conclude.
+
+    >>> check_assumptions(2*x - 1, x)
+
+    >>> z = Symbol('z')
+    >>> check_assumptions(z, real=True)
+
+    See Also
+    ========
+
+    failing_assumptions
+
+    """
+    expr = sympify(expr)
+    if against:
+        if against is not None and assume:
+            raise ValueError(
+                'Expecting `against` or `assume`, not both.')
+        assume = assumptions(against)
+    known = True
+    for k, v in assume.items():
+        if v is None:
+            continue
+        e = getattr(expr, 'is_' + k, None)
+        if e is None:
+            known = None
+        elif v != e:
+            return False
+    return known
+
+
 class StdFactKB(FactKB):
-    """A FactKB specialised for the built-in rules
+    """A FactKB specialized for the built-in rules
 
     This is the only kind of FactKB that Basic objects should use.
     """

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -129,9 +129,51 @@ See Also
 Notes
 =====
 
-Assumption values are stored in obj._assumptions dictionary or
-are returned by getter methods (with property decorators) or are
-attributes of objects/classes.
+The fully-resolved assumptions for any SymPy expression
+can be obtained as follows:
+
+    >>> from sympy.core.assumptions import assumptions
+    >>> x = Symbol('x',positive=True)
+    >>> assumptions(x + I)
+    {'commutative': True, 'complex': True, 'composite': False, 'even':
+    False, 'extended_negative': False, 'extended_nonnegative': False,
+    'extended_nonpositive': False, 'extended_nonzero': False,
+    'extended_positive': False, 'extended_real': False, 'finite': True,
+    'imaginary': False, 'infinite': False, 'integer': False, 'irrational':
+    False, 'negative': False, 'noninteger': False, 'nonnegative': False,
+    'nonpositive': False, 'nonzero': False, 'odd': False, 'positive':
+    False, 'prime': False, 'rational': False, 'real': False, 'zero':
+    False}
+
+Developers Notes
+================
+
+The current (and possibly incomplete) values are stored
+in the ``obj._assumptions dictionary``; queries to getter methods
+(with property decorators) or attributes of objects/classes
+will return values and update the dictionary.
+
+    >>> eq = x**2 + I
+    >>> eq._assumptions
+    {}
+    >>> eq.is_finite
+    True
+    >>> eq._assumptions
+    {'finite': True, 'infinite': False}
+
+For a Symbol, there are two locations for assumptions that may
+be of interest. The ``assumptions0`` attribute gives the full set of
+assumptions derived from a given set of initial assumptions. The
+latter assumptions are stored as ``Symbol._assumptions.generator``
+
+    >>> Symbol('x', prime=True, even=True)._assumptions.generator
+    {'even': True, 'prime': True}
+
+The ``generator`` is not necessarily canonical nor is it filtered
+in any way: it records the assumptions used to instantiate a Symbol
+and (for storage purposes) represents a more compact representation
+of the assumptions needed to recreate the full set in
+`Symbol.assumptions0`.
 
 
 References

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -629,10 +629,10 @@ class Mul(Expr, AssocOp):
 
         return c_part, nc_part, order_symbols
 
-    def _eval_power(b, e):
+    def _eval_power(self, e):
 
         # don't break up NC terms: (A*B)**3 != A**3*B**3, it is A*B*A*B*A*B
-        cargs, nc = b.args_cnc(split_1=False)
+        cargs, nc = self.args_cnc(split_1=False)
 
         if e.is_Integer:
             return Mul(*[Pow(b, e, evaluate=False) for b in cargs]) * \
@@ -640,8 +640,8 @@ class Mul(Expr, AssocOp):
         if e.is_Rational and e.q == 2:
             from sympy.core.power import integer_nthroot
             from sympy.functions.elementary.complexes import sign
-            if b.is_imaginary:
-                a = b.as_real_imag()[1]
+            if self.is_imaginary:
+                a = self.as_real_imag()[1]
                 if a.is_Rational:
                     n, d = abs(a/2).as_numer_denom()
                     n, t = integer_nthroot(n, 2)
@@ -651,7 +651,7 @@ class Mul(Expr, AssocOp):
                             r = sympify(n)/d
                             return _unevaluated_Mul(r**e.p, (1 + sign(a)*S.ImaginaryUnit)**e.p)
 
-        p = Pow(b, e, evaluate=False)
+        p = Pow(self, e, evaluate=False)
 
         if e.is_Rational or e.is_Float:
             return p._eval_expand_power_base()

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1248,15 +1248,25 @@ class Mul(Expr, AssocOp):
         return zero
 
     def _eval_is_integer(self):
-        is_rational = self.is_rational
+        from sympy import fraction
 
+        is_rational = self._eval_is_rational()
+        if is_rational is False:
+            return False
+
+        n, d = fraction(self)
+        if not is_rational:
+            _self = n/d
+            if _self != self:
+                return _self.is_integer
         if is_rational:
-            n, d = self.as_numer_denom()
             if d is S.One:
                 return True
             elif d == S(2):
                 return n.is_even
-        elif is_rational is False:
+        # if d is even -- 0 or not -- the
+        # result is not an integer
+        if n.is_odd and d.is_even:
             return False
 
     def _eval_is_polar(self):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -590,6 +590,10 @@ class Pow(Expr):
         if b.is_Number and e.is_Number:
             check = self.func(*self.args)
             return check.is_Integer
+        if e.is_negative and b.is_positive and (b - 1).is_positive:
+            return False
+        if e.is_negative and b.is_negative and (b + 1).is_negative:
+            return False
 
     def _eval_is_extended_real(self):
         from sympy import arg, exp, log, Mul

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -27,6 +27,7 @@ def _filter_assumptions(kwargs):
     Symbol._sanitize(assumptions)
     return assumptions, nonassumptions
 
+
 def _symbol(s, matching_symbol=None, **assumptions):
     """Return s if s is a Symbol, else if s is a string, return either
     the matching_symbol if the names are the same or else a new symbol

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -995,8 +995,14 @@ def test_Pow_is_integer():
 
     assert ((-1)**k).is_integer
 
+    # issue 8641
     x = Symbol('x', real=True, integer=False)
-    assert (x**2).is_integer is None  # issue 8641
+    assert (x**2).is_integer is None
+
+    # issue 10458
+    x = Symbol('x', positive=True)
+    assert (1/(x + 1)).is_integer is False
+    assert (1/(-x - 1)).is_integer is False
 
 
 def test_Pow_is_real():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -363,16 +363,30 @@ def test_Add_Mul_is_integer():
 
     k = Symbol('k', integer=True)
     n = Symbol('n', integer=True)
+    nk = Symbol('nk', integer=False)
+    nr = Symbol('nr', rational=False)
+    nz = Symbol('nz', integer=True, zero=False)
+    e = Symbol('e', even=True)
+    o = Symbol('e', odd=True)
 
+    assert (-nk).is_integer is None
+    assert (-nr).is_integer is False
     assert (2*k).is_integer is True
     assert (-k).is_integer is True
     assert (k/3).is_integer is None
+    assert (nz/3).is_integer is None
+    assert (nr/3).is_integer is False
     assert (x*k*n).is_integer is None
+    assert (e/o).is_integer is None
+    assert (o/e).is_integer is False
 
+    assert (k + nk).is_integer is False
     assert (k + n).is_integer is True
     assert (k + x).is_integer is None
     assert (k + n*x).is_integer is None
     assert (k + n/3).is_integer is None
+    assert (k + nz/3).is_integer is None
+    assert (k + nr/3).is_integer is False
 
     assert ((1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
     assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
@@ -1481,7 +1495,7 @@ def test_Mul_is_irrational():
     expr = Mul(1, 2, 3, evaluate=False)
     assert expr.is_irrational is False
     expr = Mul(1, I, I, evaluate=False)
-    assert expr.is_irrational is not False
+    assert expr.is_rational is True # I * I = -1
     expr = Mul(sqrt(2), I, I, evaluate=False)
     assert expr.is_irrational is not True
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -230,7 +230,7 @@ class MatrixExpr(Expr):
     @classmethod
     def _check_dim(cls, dim):
         """Helper function to check invalid matrix dimensions"""
-        from sympy.solvers.solvers import check_assumptions
+        from sympy.core.assumptions import check_assumptions
         ok = check_assumptions(dim, integer=True, nonnegative=True)
         if ok is False:
             raise ValueError(

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -8,9 +8,11 @@
     >>> solve(x**5+5*x**4+10*x**3+10*x**2+5*x+1,x)
     [-1]
 """
+from sympy.core.assumptions import check_assumptions, failing_assumptions
+
 from .solvers import solve, solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs, nsolve, solve_linear, checksol, \
-    det_quick, inv_quick, check_assumptions, failing_assumptions
+    det_quick, inv_quick
 
 from .diophantine import diophantine
 

--- a/sympy/solvers/diophantine/diophantine.py
+++ b/sympy/solvers/diophantine/diophantine.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.add import Add
+from sympy.core.assumptions import check_assumptions
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import as_int, is_sequence, ordered
 from sympy.core.exprtools import factor_terms
@@ -25,7 +26,6 @@ from sympy.ntheory.residue_ntheory import sqrt_mod
 from sympy.polys.polyerrors import GeneratorsNeeded
 from sympy.polys.polytools import Poly, factor_list
 from sympy.simplify.simplify import signsimp
-from sympy.solvers.solvers import check_assumptions
 from sympy.solvers.solveset import solveset_real
 from sympy.utilities import default_sort_key, numbered_symbols
 from sympy.utilities.misc import filldedent

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -15,6 +15,7 @@ This module contain solvers for all kinds of equations:
 from __future__ import print_function, division
 
 from sympy import divisors, binomial, expand_func
+from sympy.core.assumptions import check_assumptions
 from sympy.core.compatibility import (iterable, is_sequence, ordered,
     default_sort_key)
 from sympy.core.sympify import sympify
@@ -27,7 +28,7 @@ from sympy.core.function import (expand_mul, expand_log,
 from sympy.integrals.integrals import Integral
 from sympy.core.numbers import ilcm, Float, Rational
 from sympy.core.relational import Relational
-from sympy.core.logic import fuzzy_not, fuzzy_and
+from sympy.core.logic import fuzzy_not
 from sympy.core.power import integer_log
 from sympy.logic.boolalg import And, Or, BooleanAtom
 from sympy.core.basic import preorder_traversal
@@ -372,100 +373,6 @@ def checksol(f, symbol, sol=None, **flags):
         warnings.warn("\n\tWarning: could not verify solution %s." % sol)
     # returns None if it can't conclude
     # TODO: improve solution testing
-
-
-def failing_assumptions(expr, **assumptions):
-    """
-    Return a dictionary containing assumptions with values not
-    matching those of the passed assumptions.
-
-    Examples
-    ========
-
-    >>> from sympy import failing_assumptions, Symbol
-
-    >>> x = Symbol('x', real=True, positive=True)
-    >>> y = Symbol('y')
-    >>> failing_assumptions(6*x + y, real=True, positive=True)
-    {'positive': None, 'real': None}
-
-    >>> failing_assumptions(x**2 - 1, positive=True)
-    {'positive': None}
-
-    If *expr* satisfies all of the assumptions, an empty dictionary is returned.
-
-    >>> failing_assumptions(x**2, positive=True)
-    {}
-
-    """
-    expr = sympify(expr)
-    failed = {}
-    for key in list(assumptions.keys()):
-        test = getattr(expr, 'is_%s' % key, None)
-        if test is not assumptions[key]:
-            failed[key] = test
-    return failed  # {} or {assumption: value != desired}
-
-
-def check_assumptions(expr, against=None, **assumptions):
-    """
-    Checks whether expression *expr* satisfies all assumptions.
-
-    Explanation
-    ===========
-
-    *assumptions* is a dict of assumptions: {'assumption': True|False, ...}.
-
-    Examples
-    ========
-
-       >>> from sympy import Symbol, pi, I, exp, check_assumptions
-
-       >>> check_assumptions(-5, integer=True)
-       True
-       >>> check_assumptions(pi, real=True, integer=False)
-       True
-       >>> check_assumptions(pi, real=True, negative=True)
-       False
-       >>> check_assumptions(exp(I*pi/7), real=False)
-       True
-
-       >>> x = Symbol('x', real=True, positive=True)
-       >>> check_assumptions(2*x + 1, real=True, positive=True)
-       True
-       >>> check_assumptions(-2*x - 5, real=True, positive=True)
-       False
-
-       To check assumptions of *expr* against another variable or expression,
-       pass the expression or variable as ``against``.
-
-       >>> check_assumptions(2*x + 1, x)
-       True
-
-       ``None`` is returned if ``check_assumptions()`` could not conclude.
-
-       >>> check_assumptions(2*x - 1, real=True, positive=True)
-       >>> z = Symbol('z')
-       >>> check_assumptions(z, real=True)
-
-    See Also
-    ========
-
-    failing_assumptions
-
-    """
-    expr = sympify(expr)
-    if against:
-        if not isinstance(against, Symbol):
-            raise TypeError('against should be of type Symbol')
-        if assumptions:
-            raise AssertionError('No assumptions should be specified')
-        assumptions = against.assumptions0
-    def _test(key):
-        v = getattr(expr, 'is_' + key, None)
-        if v is not None:
-            return assumptions[key] is v
-    return fuzzy_and(_test(key) for key in assumptions)
 
 
 def solve(f, *symbols, **flags):

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -12,8 +12,7 @@ from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs
 from sympy.solvers.bivariate import _filtered_gens, _solve_lambert, _lambert
 from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow, \
-    det_quick, det_perm, det_minor, _simple_dens, check_assumptions, denoms, \
-    failing_assumptions
+    det_quick, det_perm, det_minor, _simple_dens, denoms
 
 from sympy.physics.units import cm
 from sympy.polys.rootoftools import CRootOf
@@ -1355,21 +1354,6 @@ def test_float_handling():
 def test_check_assumptions():
     x = symbols('x', positive=True)
     assert solve(x**2 - 1) == [1]
-    assert check_assumptions(1, x) == True
-    raises(AssertionError, lambda: check_assumptions(2*x, x, positive=True))
-    raises(TypeError, lambda: check_assumptions(1, 1))
-
-
-def test_failing_assumptions():
-    x = Symbol('x', real=True, positive=True)
-    y = Symbol('y')
-    assert failing_assumptions(6*x + y, **x.assumptions0) == \
-    {'real': None, 'imaginary': None, 'complex': None, 'hermitian': None,
-    'positive': None, 'nonpositive': None, 'nonnegative': None, 'nonzero': None,
-    'negative': None, 'zero': None, 'extended_real': None, 'finite': None,
-    'infinite': None, 'extended_negative': None, 'extended_nonnegative': None,
-    'extended_nonpositive': None, 'extended_nonzero': None,
-    'extended_positive': None }
 
 
 def test_issue_6056():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

fixes #19145
issue #10458 is not fixed but
```python
>>> x = var('x', positive=1, integer=1)
>>> together(1/x - 1).is_nonpositive
True
```
Without the `together` this does not evaluate and I'm not sure that `together` should be used in general except maybe for the 2-arg Add that is rational.

#### Brief description of what is fixed or changed

Work extracted from #18960.

* Mul can be evaluated as a non-integer in more cases
* `assumptions` and `common_assumptions` were added

#### Other comments

The following was not added but might be something to consider as an addition to symbol.py. (I was not able to import Symbol in assumptions and don't know how to run assumption resolution without Symbol.)
```python
def canonical_assumptions(assumptions_dict, verify=True):
    """return a canonical set of assumptions that gives the same
    assumptions as those implied by the assumptions passed.

    Verification is not necessary if the assumptions are those
    obtained from a Symbol's ``assumptions0`` attribute.

    Examples
    ========

    >>> from sympy.core.symbol import canonical_assumptions, Symbol
    >>> assume = dict(integer=1, zero=False, odd=False, prime=True)
    >>> canonical_assumptions(assume)
    {'odd': False, 'prime': True}

    >>> from sympy.core.assumptions import common_assumptions
    >>> common_assumptions([-2, 0, 2])
    {'algebraic': True, 'commutative': True, 'complex': True,
    'composite': False, 'even': True, 'extended_real': True,
    'finite': True, 'hermitian': True, 'imaginary': False,
    'infinite': False, 'integer': True, 'irrational': False,
    'noninteger': False, 'odd': False, 'rational': True, 'real': True,
    'transcendental': False}

    >>> canonical_assumptions(_)
    {'composite': False, 'even': True}

    To obtain the set of assumptions that were used to create
    a Symbol -- not the canonical set -- it can be obtained
    from the assumptions generator:

    >>> Symbol('x', prime=True, even=True)._assumptions.generator
    {'even': True, 'prime': True}
    >>> canonical_assumptions(_)
    {'odd': False, 'prime': True}

    All assumptions derived from a given subset of assumptions can
    be found with Symbol's ``assumptions0`` attribute:

    >>> len(Symbol('x', **_).assumptions0)
    29

    """
    assumptions = Symbol('', **assumptions_dict
        ).assumptions0 if verify else assumptions_dict
    for ai in subsets(sorted(assumptions.items(),
            key=lambda i:(len(i[0]), i[0]))):
        if Symbol('', **dict(ai)).assumptions0 == assumptions:
            return dict(ai)

def test_canonical_assumptions():
    assert canonical_assumptions(common_assumptions([0, 1, 2])
        ) == {'integer': True, 'negative': False, 'composite': False}
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
    * `assumptions` will give the T/F assumptions of a symbol or expression
    * `common_assumptions` returns the T/F assumptions in common amongst the given expressions
* core
    * Add with 2 args can evaluate as integer in more cases
    * Mul with odd numerator and even denominator is recognized as rational but not integer
<!-- END RELEASE NOTES -->