### PR TITLE
[WIP] Add Min Max and Abs to Latex capability

### DIFF
--- a/sympy/parsing/latex/LaTeX.g4
+++ b/sympy/parsing/latex/LaTeX.g4
@@ -64,6 +64,7 @@ FUNC_ARCOSH: '\\arcosh';
 FUNC_ARTANH: '\\artanh';
 
 FUNC_SQRT: '\\sqrt';
+FUNC_MAX:  '\\max';
 
 CMD_TIMES: '\\times';
 CMD_CDOT:  '\\cdot';
@@ -191,7 +192,8 @@ func_normal:
     | FUNC_ARCSIN | FUNC_ARCCOS | FUNC_ARCTAN
     | FUNC_ARCCSC | FUNC_ARCSEC | FUNC_ARCCOT
     | FUNC_SINH | FUNC_COSH | FUNC_TANH
-    | FUNC_ARSINH | FUNC_ARCOSH | FUNC_ARTANH;
+    | FUNC_ARSINH | FUNC_ARCOSH | FUNC_ARTANH
+    | FUNC_MAX;
 
 func:
     func_normal

--- a/sympy/parsing/latex/_antlr/latexlexer.py
+++ b/sympy/parsing/latex/_antlr/latexlexer.py
@@ -293,6 +293,7 @@ class LaTeXLexer(Lexer):
     GTE = 55
     BANG = 56
     SYMBOL = 57
+    MAX = 58
 
     channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
 
@@ -307,7 +308,7 @@ class LaTeXLexer(Lexer):
             u"'\\arccot'", u"'\\sinh'", u"'\\cosh'", u"'\\tanh'", u"'\\arsinh'",
             u"'\\arcosh'", u"'\\artanh'", u"'\\sqrt'", u"'\\times'", u"'\\cdot'",
             u"'\\div'", u"'\\frac'", u"'\\mathit'", u"'_'", u"'^'", u"':'",
-            u"'='", u"'<'", u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
+            u"'='", u"'<'", u"'\\leq'", u"'>'", u"'\\geq'", u"'!'", u"'\\max'" ]
 
     symbolicNames = [ u"<INVALID>",
             u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN", u"R_PAREN",
@@ -320,7 +321,7 @@ class LaTeXLexer(Lexer):
             u"FUNC_ARCOSH", u"FUNC_ARTANH", u"FUNC_SQRT", u"CMD_TIMES",
             u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC", u"CMD_MATHIT", u"UNDERSCORE",
             u"CARET", u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL",
-            u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+            u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL", u"FUNC_MAX" ]
 
     ruleNames = [ u"T__0", u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN",
                   u"R_PAREN", u"L_BRACE", u"R_BRACE", u"L_BRACKET", u"R_BRACKET",
@@ -333,7 +334,7 @@ class LaTeXLexer(Lexer):
                   u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC",
                   u"CMD_MATHIT", u"UNDERSCORE", u"CARET", u"COLON", u"WS_CHAR",
                   u"DIFFERENTIAL", u"LETTER", u"DIGIT", u"NUMBER", u"EQUAL",
-                  u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                  u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL", u"FUNC_MAX" ]
 
     grammarFileName = u"LaTeX.g4"
 

--- a/sympy/parsing/latex/_antlr/latexparser.py
+++ b/sympy/parsing/latex/_antlr/latexparser.py
@@ -237,10 +237,11 @@ class LaTeXParser ( Parser ):
                      u"'\\arcsin'", u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'",
                      u"'\\arcsec'", u"'\\arccot'", u"'\\sinh'", u"'\\cosh'",
                      u"'\\tanh'", u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'",
-                     u"'\\sqrt'", u"'\\times'", u"'\\cdot'", u"'\\div'",
-                     u"'\\frac'", u"'\\mathit'", u"'_'", u"'^'", u"':'",
-                     u"<INVALID>", u"<INVALID>", u"<INVALID>", u"'='", u"'<'",
-                     u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
+                     u"'\\sqrt'", u"'\\times'",
+                     u"'\\cdot'", u"'\\div'", u"'\\frac'", u"'\\mathit'",
+                     u"'_'", u"'^'", u"':'", u"<INVALID>", u"<INVALID>",
+                     u"<INVALID>", u"'='", u"'<'", u"'\\leq'", u"'>'",
+                     u"'\\geq'", u"'!'", u"'\\max'" ]
 
     symbolicNames = [ u"<INVALID>", u"<INVALID>", u"WS", u"ADD", u"SUB",
                       u"MUL", u"DIV", u"L_PAREN", u"R_PAREN", u"L_BRACE",
@@ -254,7 +255,7 @@ class LaTeXParser ( Parser ):
                       u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV",
                       u"CMD_FRAC", u"CMD_MATHIT", u"UNDERSCORE", u"CARET",
                       u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL",
-                      u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                      u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL", u"FUNC_MAX" ]
 
     RULE_math = 0
     RULE_relation = 1
@@ -359,6 +360,7 @@ class LaTeXParser ( Parser ):
     GTE=55
     BANG=56
     SYMBOL=57
+    FUNC_MAX=58
 
     def __init__(self, input, output=sys.stdout):
         super(LaTeXParser, self).__init__(input, output=output)
@@ -861,7 +863,7 @@ class LaTeXParser ( Parser ):
                 self.state = 123
                 self.unary()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL, LaTeXParser.FUNC_MAX]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 125
                 self._errHandler.sync(self)
@@ -943,7 +945,7 @@ class LaTeXParser ( Parser ):
                 self.state = 132
                 self.unary_nofunc()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL, LaTeXParser.FUNC_MAX]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 133
                 self.postfix()
@@ -2030,9 +2032,11 @@ class LaTeXParser ( Parser ):
             self.parser = parser
 
         def FUNC_LOG(self):
+            print("log")
             return self.getToken(LaTeXParser.FUNC_LOG, 0)
 
         def FUNC_LN(self):
+            print("log")
             return self.getToken(LaTeXParser.FUNC_LN, 0)
 
         def FUNC_SIN(self):
@@ -2088,6 +2092,10 @@ class LaTeXParser ( Parser ):
 
         def FUNC_ARTANH(self):
             return self.getToken(LaTeXParser.FUNC_ARTANH, 0)
+        
+        def FUNC_MAX(self):
+            print("func max")
+            return self.getToken(LaTeXParser.FUNC_MAX, 0)
 
         def getRuleIndex(self):
             return LaTeXParser.RULE_func_normal
@@ -2104,7 +2112,7 @@ class LaTeXParser ( Parser ):
             self.enterOuterAlt(localctx, 1)
             self.state = 283
             _la = self._input.LA(1)
-            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH))) != 0)):
+            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH) | (1 << LaTeXParser.FUNC_MAX))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
@@ -2233,7 +2241,7 @@ class LaTeXParser ( Parser ):
             self.state = 358
             self._errHandler.sync(self)
             token = self._input.LA(1)
-            if token in [LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH]:
+            if token in [LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_MAX]:
                 self.enterOuterAlt(localctx, 1)
                 self.state = 285
                 self.func_normal()
@@ -2341,7 +2349,7 @@ class LaTeXParser ( Parser ):
                     self.state = 320
                     self.subexpr()
                     pass
-                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL, LaTeXParser.FUNC_MAX]:
                     pass
                 else:
                     pass

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -369,6 +369,7 @@ def convert_frac(frac):
 
 
 def convert_func(func):
+    print("convert func: ", func.func_normal().start.text)
     if func.func_normal():
         if func.L_PAREN():  # function called with parenthesis
             arg = convert_func_arg(func.func_arg())
@@ -388,6 +389,7 @@ def convert_func(func):
             expr = getattr(sympy.functions, name)(arg, evaluate=False)
 
         if (name == "log" or name == "ln"):
+            print("_parse_latex_antlr_log")
             if func.subexpr():
                 base = convert_expr(func.subexpr().expr())
             elif name == "log":
@@ -395,6 +397,10 @@ def convert_func(func):
             elif name == "ln":
                 base = sympy.E
             expr = sympy.log(arg, base, evaluate=False)
+        
+        if name == "max":
+            print("_parse_latex_antlr_max")
+            expr = sympy.Max(arg, evaluate=False)
 
         func_pow = None
         should_pow = True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19127

#### Brief description of what is fixed or changed
I have added the lexer and parser for latex `\max`. But I am not getting the result. I think the possible reason I have not updated:
```python
def serializedATN():
    with StringIO() as buf:
        buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2")
        buf.write(u";\u01e8\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4")
        buf.write(u"\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r")
        buf.write(u"\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22")
        buf.write(u"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4")
```
in `sympy/parsing/latex/_antlr/latexlexer.py`. Could anyone please suggest how to update this.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->