### PR TITLE
add 2 rules in mathematica parser

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -428,3 +428,20 @@ class MathematicaParser(object):
 #        s = cls._replace(s, '}')
 
         return s
+
+if __name__ == "__main__":
+    testlist = [
+        'Sqrt[x]',
+        'Exp[x]',
+        'Log[x]',
+        'Log[x,y]',
+        'Log2[x]',
+        'Log10[x]',
+        'Mod[x,y]',
+        'Max[x,y,z]',
+        'Min[x,y,z]',
+        'Pochhammer[x,y]',
+        'ArcTan[x,y]'
+    ]
+    for i in testlist:
+        print(mathematica(i))

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -48,7 +48,8 @@ class MathematicaParser(object):
         'Mod[x,y]': 'Mod(x,y)',
         'Max[*x]': 'Max(*x)',
         'Min[*x]': 'Min(*x)',
-        'Pochhammer[x,y]':'rf(x,y)'
+        'Pochhammer[x,y]':'rf(x,y)',
+        'ArcTan[x,y]':'atan2(y,x)'
     }
 
     # trigonometric, e.t.c.

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -48,6 +48,7 @@ class MathematicaParser(object):
         'Mod[x,y]': 'Mod(x,y)',
         'Max[*x]': 'Max(*x)',
         'Min[*x]': 'Min(*x)',
+        'Pochhammer[x,y]':'rf(x,y)'
     }
 
     # trigonometric, e.t.c.

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -428,20 +428,3 @@ class MathematicaParser(object):
 #        s = cls._replace(s, '}')
 
         return s
-
-if __name__ == "__main__":
-    testlist = [
-        'Sqrt[x]',
-        'Exp[x]',
-        'Log[x]',
-        'Log[x,y]',
-        'Log2[x]',
-        'Log10[x]',
-        'Mod[x,y]',
-        'Max[x,y,z]',
-        'Min[x,y,z]',
-        'Pochhammer[x,y]',
-        'ArcTan[x,y]'
-    ]
-    for i in testlist:
-        print(mathematica(i))

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -47,6 +47,8 @@ def test_mathematica():
         'Max[1,-2,3,-4]': 'Max(1,-2,3,-4)',
         'Min[1,-2,3]': 'Min(1,-2,3)',
         'Exp[I Pi/2]': 'exp(I*pi/2)',
+        'ArcTan[x,y]': 'atan2(y,x)',
+        'Pochhammer[x,y]': 'rf(x,y)'
         }
 
     for e in d:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

add two rules

```
ArcTan[x,y] -> atan2(y,x)
Pochhammer[x,y] -> rf(x,y)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added 2 new rules for mathematica parser.
<!-- END RELEASE NOTES -->