### PR TITLE
Define multiplication between Permutation and PermutationGroup

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -266,6 +266,8 @@ class PermutationGroup(Basic):
         25
 
         """
+        if isinstance(other, Permutation):
+            return Coset(other, self, dir = "+")
         gens1 = [perm._array_form for perm in self.generators]
         gens2 = [perm._array_form for perm in other.generators]
         n1 = self._degree

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -267,7 +267,7 @@ class PermutationGroup(Basic):
 
         """
         if isinstance(other, Permutation):
-            return Coset(other, self, dir = "+")
+            return Coset(other, self, dir='+')
         gens1 = [perm._array_form for perm in self.generators]
         gens2 = [perm._array_form for perm in other.generators]
         n1 = self._degree

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1306,7 +1306,7 @@ class Permutation(Atom):
         """
         from sympy.combinatorics.perm_groups import PermutationGroup, Coset
         if isinstance(other, PermutationGroup):
-            return Coset(self, other, dir = "-")
+            return Coset(self, other, dir='-')
         a = self.array_form
         # __rmul__ makes sure the other is a Permutation
         b = other.array_form

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1304,6 +1304,9 @@ class Permutation(Atom):
         (1 3 2)
 
         """
+        from sympy.combinatorics.perm_groups import PermutationGroup, Coset
+        if isinstance(other, PermutationGroup):
+            return Coset(self, other, dir = "-")
         a = self.array_form
         # __rmul__ makes sure the other is a Permutation
         b = other.array_form

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1122,7 +1122,7 @@ def test_coset_class():
     b = Permutation(0, 1)
     G = PermutationGroup([a, b])
     #Creating right coset
-    rht_coset = Coset(a, G, dir='+')
+    rht_coset = G*a
     #Checking whether it is left coset or right coset
     assert rht_coset.is_right_coset
     assert not rht_coset.is_left_coset
@@ -1132,7 +1132,7 @@ def test_coset_class():
     for ele in list_repr:
         assert ele in expected
     #Creating left coset
-    left_coset = Coset(a, G, dir='-')
+    left_coset = a*G
     #Checking whether it is left coset or right coset
     assert not left_coset.is_right_coset
     assert left_coset.is_left_coset


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #7127 

#### Brief description of what is fixed or changed
Now `Permutation * PermutationGroup` and `PermutationGroup * Permutation` return Coset.
```
>>> a = Permutation(1, 2)
>>> b = Permutation(0, 1)
>>> G = PermutationGroup([a, b])
>>> G*a
Coset((1 2), PermutationGroup([
    (1 2),
    (2)(0 1)]), SymmetricPermutationGroup(3), +)
>>> a*G
Coset((1 2), PermutationGroup([
    (1 2),
    (2)(0 1)]), SymmetricPermutationGroup(3), -)
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
    - `Permutation * PermutationGroup` and `PermutationGroup * Permutation` return Coset.
<!-- END RELEASE NOTES --> 