### PR TITLE
Raise nicer error when calling as_explicit() on symbolic-shaped matrix

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -342,8 +342,9 @@ class MatrixExpr(Expr):
         """
         if (not isinstance(self.rows, (SYMPY_INTS, Integer))
             or not isinstance(self.cols, (SYMPY_INTS, Integer))):
-            raise ValueError('Matrix with symbolic shape ' \
-                'cannot be represented explicitly')
+            raise ValueError(
+                'Matrix with symbolic shape '
+                'cannot be represented explicitly.')
         from sympy.matrices.immutable import ImmutableDenseMatrix
         return ImmutableDenseMatrix([[self[i, j]
                             for j in range(self.cols)]

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -340,8 +340,10 @@ class MatrixExpr(Expr):
         as_mutable: returns mutable Matrix type
 
         """
+        if not isinstance(self.rows, (SYMPY_INTS, Integer)) or not isinstance(self.cols, (SYMPY_INTS, Integer)):
+            raise ValueError('Matrix with symbolic shape cannot be represented explicitly')
         from sympy.matrices.immutable import ImmutableDenseMatrix
-        return ImmutableDenseMatrix([[    self[i, j]
+        return ImmutableDenseMatrix([[self[i, j]
                             for j in range(self.cols)]
                             for i in range(self.rows)])
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -340,8 +340,10 @@ class MatrixExpr(Expr):
         as_mutable: returns mutable Matrix type
 
         """
-        if not isinstance(self.rows, (SYMPY_INTS, Integer)) or not isinstance(self.cols, (SYMPY_INTS, Integer)):
-            raise ValueError('Matrix with symbolic shape cannot be represented explicitly')
+        if (not isinstance(self.rows, (SYMPY_INTS, Integer))
+            or not isinstance(self.cols, (SYMPY_INTS, Integer))):
+            raise ValueError('Matrix with symbolic shape ' \
+                'cannot be represented explicitly')
         from sympy.matrices.immutable import ImmutableDenseMatrix
         return ImmutableDenseMatrix([[self[i, j]
                             for j in range(self.cols)]

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -140,6 +140,8 @@ def test_ZeroMatrix():
     with raises(NonSquareMatrixError):
         Z**2
 
+    assert ZeroMatrix(3, 3).as_explicit() == ImmutableMatrix.zeros(3, 3)
+
 
 def test_ZeroMatrix_doit():
     Znn = ZeroMatrix(Add(n, n, evaluate=False), n)
@@ -223,6 +225,7 @@ def test_Identity():
             (0, True)
         )
     )
+    assert Identity(3).as_explicit() == ImmutableMatrix.eye(3)
 
 
 def test_Identity_doit():
@@ -653,3 +656,12 @@ def test_matrixsymbol_from_symbol():
     A_2 = A.subs(2, 3)
     assert A_1.args == A.args
     assert A_2.args[0] == A.args[0]
+
+
+def test_as_explicit():
+    Z = MatrixSymbol('Z', 2, 3)
+    assert Z.as_explicit() == ImmutableMatrix([
+        [Z[0, 0], Z[0, 1], Z[0, 2]],
+        [Z[1, 0], Z[1, 1], Z[1, 2]],
+    ])
+    raises(ValueError, lambda: A.as_explicit())


### PR DESCRIPTION
#### Brief description of what is fixed or changed
`MatrixSymbol('A', n, n).as_explicit()` now raises a nicer error to explain why it doesn't work. The previous `TypeError: 'Symbol' object cannot be interpreted as an integer` might be cryptic to some users.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->