### PR TITLE
add _eval_adjoint and _eval_transpose to ExpBase

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -74,8 +74,14 @@ class ExpBase(Function):
         """
         return self.func(1), Mul(*self.args)
 
+    def _eval_adjoint(self):
+        return self.func(self.args[0].adjoint())
+
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
+
+    def _eval_transpose(self):
+        return self.func(self.args[0].transpose())
 
     def _eval_is_finite(self):
         arg = self.args[0]

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,6 +1,7 @@
 from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
-    LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
+    LambertW, sqrt, Rational, expand_log, S, sign,
+    adjoint, conjugate, transpose, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, simplify,
     AccumBounds, MatrixSymbol, Pow, gcd, Sum, Product)
 from sympy.functions.elementary.exponential import match_real_imag
@@ -131,8 +132,16 @@ def test_exp_subs():
     assert exp(3).subs(E, sin) == sin(3)
 
 
+def test_exp_adjoint():
+    assert adjoint(exp(x)) == exp(adjoint(x))
+
+
 def test_exp_conjugate():
     assert conjugate(exp(x)) == exp(conjugate(x))
+
+
+def test_exp_transpose():
+    assert transpose(exp(x)) == exp(transpose(x))
 
 
 def test_exp_rewrite():

--- a/sympy/physics/quantum/tests/test_boson.py
+++ b/sympy/physics/quantum/tests/test_boson.py
@@ -23,6 +23,8 @@ def test_bosonoperator():
 
     assert Commutator(a, Dagger(b)).doit() == a * Dagger(b) - Dagger(b) * a
 
+    assert Dagger(exp(a)) == exp(Dagger(a))
+
 
 def test_boson_states():
     a = BosonOp("a")


### PR DESCRIPTION
Current behavior for adjoint and transpose of an exponential function:
```
>>> a = Symbol("a")
>>> adjoint(exp(a))
transpose(exp(conjugate(a)))
>>> transpose(exp(a))
transpose(exp(a))
```
The expected behavior is for those operations to be [applied to the exponential function's argument ](https://en.wikipedia.org/wiki/Matrix_exponential#Elementary_properties) which this PR fixes:
```
>>> adjoint(exp(a))
exp(adjoint(a))
>>> transpose(exp(a))
exp(transpose(a))
```

This is especially relevant when applying `Dagger` from `sympy.physics.quantum` to a `QExpr` such as `BosonOp` . Previous behavior:
```
>>> a = BosonOp("a")
>>> Dagger(exp(a))
transpose(exp(conjugate(a)))
```
Fixed behavior:
```
>>> Dagger(exp(a))
exp(Dagger(a))
```

<!-- BEGIN RELEASE NOTES -->
* functions
  * Adjoint of `exp` and transpose of `exp` now work as expected.
<!-- END RELEASE NOTES -->