### PR TITLE
binomial(n,k<0) is no longer always 0

### DIFF
--- a/doc/src/modules/concrete.rst
+++ b/doc/src/modules/concrete.rst
@@ -15,7 +15,7 @@ method which is available in Basic class. Here is simple example involving a
 polynomial:
 
     >>> from sympy import *
-    >>> n, k = symbols('n,k')
+    >>> n, k = symbols('n,k', nonnegative=True)
     >>> (n**2 + 1).is_hypergeometric(n)
     True
 

--- a/doc/src/modules/concrete.rst
+++ b/doc/src/modules/concrete.rst
@@ -15,7 +15,7 @@ method which is available in Basic class. Here is simple example involving a
 polynomial:
 
     >>> from sympy import *
-    >>> n, k = symbols('n,k', nonnegative=True)
+    >>> n, k = symbols('n,k', nonnegative=True, integer=True)
     >>> (n**2 + 1).is_hypergeometric(n)
     True
 

--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -1,10 +1,11 @@
 """Tests for Gosper's algorithm for hypergeometric summation. """
 
 from sympy import binomial, factorial, gamma, Poly, S, simplify, sqrt, exp, \
-    log, Symbol, pi, Rational
-from sympy.abc import a, b, j, k, m, n, r, x
+    log, Symbol, pi, Rational, symbols
+from sympy.abc import a, b, m, x
 from sympy.concrete.gosper import gosper_normal, gosper_sum, gosper_term
 
+n, k = symbols('n k', nonnegative=True)
 
 def test_gosper_normal():
     eq = 4*n + 5, 2*(4*n + 1)*(2*n + 3), n
@@ -63,9 +64,10 @@ def test_gosper_sum_indefinite():
 
 
 def test_gosper_sum_parametric():
-    assert gosper_sum(binomial(S.Half, m - j + 1)*binomial(S.Half, m + j), (j, 1, n)) == \
-        n*(1 + m - n)*(-1 + 2*m + 2*n)*binomial(S.Half, 1 + m - n)* \
-        binomial(S.Half, m + n)/(m*(1 + 2*m))
+    n, k = symbols('n k')
+    assert gosper_sum(binomial(S.Half, n - k + 1)*binomial(S.Half, n + k), (k, 1, n)) == \
+        n*(1 + n - n)*(-1 + 2*n + 2*n)*binomial(S.Half, 1 + n - n)* \
+        binomial(S.Half, n + n)/(n*(1 + 2*n))
 
 
 def test_gosper_sum_algebraic():
@@ -133,21 +135,21 @@ def test_gosper_sum_AeqB_part1():
 
 def test_gosper_sum_AeqB_part2():
     f2a = n**2*a**n
-    f2b = (n - r/2)*binomial(r, n)
+    f2b = (n - k/2)*binomial(k, n)
     f2c = factorial(n - 1)**2/(factorial(n - x)*factorial(n + x))
 
     g2a = -a*(a + 1)/(a - 1)**3 + a**(
-        m + 1)*(a**2*m**2 - 2*a*m**2 + m**2 - 2*a*m + 2*m + a + 1)/(a - 1)**3
-    g2b = (m - r)*binomial(r, m)/2
+        n + 1)*(a**2*n**2 - 2*a*n**2 + n**2 - 2*a*n + 2*n + a + 1)/(a - 1)**3
+    g2b = (n - k)*binomial(k, n)/2
     ff = factorial(1 - x)*factorial(1 + x)
     g2c = 1/ff*(
-        1 - 1/x**2) + factorial(m)**2/(x**2*factorial(m - x)*factorial(m + x))
+        1 - 1/x**2) + factorial(n)**2/(x**2*factorial(n - x)*factorial(n + x))
 
-    g = gosper_sum(f2a, (n, 0, m))
+    g = gosper_sum(f2a, (n, 0, n))
     assert g is not None and simplify(g - g2a) == 0
-    g = gosper_sum(f2b, (n, 0, m))
+    g = gosper_sum(f2b, (n, 0, n))
     assert g is not None and simplify(g - g2b) == 0
-    g = gosper_sum(f2c, (n, 1, m))
+    g = gosper_sum(f2c, (n, 1, n))
     assert g is not None and simplify(g - g2c) == 0
 
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1134,10 +1134,11 @@ def test_issue_14640():
 
 def test_issue_15943():
     n, k = symbols('n k', integer=True, nonnegative=True)
-    s = Sum(binomial(n, k)*factorial(n - k), (k, 0, n)).doit().rewrite(gamma)
-    assert s == -E*(n + 1)*gamma(n + 1)*lowergamma(n + 1, 1)/gamma(n + 2
-        ) + E*gamma(n + 1)
-    assert s.simplify() == E*(factorial(n) - lowergamma(n + 1, 1))
+    s = Sum(binomial(n, k)*factorial(n - k), (k, 0, n))
+    d = s.doit()
+    assert d == (-E*(n + 1)*lowergamma(n + 1, 1
+        )/factorial(n + 1) + E)*gamma(n + 1)
+    assert d.simplify() == E*(factorial(n) - lowergamma(n + 1, 1))
 
 
 def test_Sum_dummy_eq():
@@ -1304,7 +1305,10 @@ def test_empty_sequence():
     assert Sum(x, (y, 1, 0), (x, -oo, oo)).doit() == 0
 
 
+@XFAIL
 def test_issue_8016():
+    # rewriting fails because n - k is not recognized
+    # as being nonnegative
     k = Symbol('k', integer=True, nonnegative=True)
     n, m = symbols('n m', integer=True, positive=True)
     s = Sum(binomial(m, k)*binomial(m, n - k)*(-1)**k, (k, 0, n))

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -314,6 +314,7 @@ def test_composite_sums():
 
 
 def test_hypergeometric_sums():
+    n, k = symbols('n k', integer=True, nonnegative=True)
     assert summation(
         binomial(2*k, k)/4**k, (k, 0, n)) == (1 + 2*n)*binomial(2*n, n)/4**n
     assert summation(binomial(2*k, k)/5**k, (k, -oo, oo)) == sqrt(5)
@@ -1132,6 +1133,7 @@ def test_issue_14640():
 
 
 def test_issue_15943():
+    n, k = symbols('n k', integer=True, nonnegative=True)
     s = Sum(binomial(n, k)*factorial(n - k), (k, 0, n)).doit().rewrite(gamma)
     assert s == -E*(n + 1)*gamma(n + 1)*lowergamma(n + 1, 1)/gamma(n + 2
         ) + E*gamma(n + 1)
@@ -1303,12 +1305,11 @@ def test_empty_sequence():
 
 
 def test_issue_8016():
-    k = Symbol('k', integer=True)
-    n, m = symbols('n, m', integer=True, positive=True)
+    k = Symbol('k', integer=True, nonnegative=True)
+    n, m = symbols('n m', integer=True, positive=True)
     s = Sum(binomial(m, k)*binomial(m, n - k)*(-1)**k, (k, 0, n))
-    assert s.doit().simplify() == \
-        cos(pi*n/2)*gamma(m + 1)/gamma(n/2 + 1)/gamma(m - n/2 + 1)
-
+    assert s.doit().simplify(
+        ) == cos(pi*n/2)*gamma(m + 1)/gamma(n/2 + 1)/gamma(m - n/2 + 1)
 
 @XFAIL
 def test_issue_14313():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -542,6 +542,14 @@ def test_Mul_is_rational():
     assert (z*i).is_rational is True
     bi = Symbol('i', imaginary=True, finite=True)
     assert (z*bi).is_zero is True
+    # I * I = -1 is rational but
+    # this can't be determined without evaluating the
+    # expression and the eval_is routines shouldn't do that;
+    # it could be resolved by counting literal I but that
+    # seems to be a pretty small corner case and would make
+    # the routine slower for all non-corner cases
+    expr = Mul(I, I, evaluate=False)
+    assert expr.is_rational is None
 
 
 def test_Add_is_rational():
@@ -1519,13 +1527,17 @@ def test_Add_is_irrational():
 def test_Mul_is_irrational():
     expr = Mul(1, 2, 3, evaluate=False)
     assert expr.is_irrational is False
-    expr = Mul(1, I, I, evaluate=False)
-    assert expr.is_rational is None # I * I = -1 but *no evaluation allowed*
     # sqrt(2) * I * I = -sqrt(2) is irrational but
     # this can't be determined without evaluating the
-    # expression and the eval_is routines shouldn't do that
+    # expression and the eval_is routines shouldn't do that;
+    # it could be resolved by counting literal I but that
+    # seems to be a pretty small corner case and would make
+    # the routine slower for all non-corner cases
     expr = Mul(sqrt(2), I, I, evaluate=False)
     assert expr.is_irrational is None
+    nk = Symbol('nk', integer=False)
+    nr = Symbol('nr', rational=False)
+    assert (nk*nr).is_rational is None
 
 
 def test_issue_3531():

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -2,9 +2,9 @@ from typing import List
 
 from sympy.core import S, sympify, Mod
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import reduce, HAS_GMPY, ordered, as_int
+from sympy.core.compatibility import reduce, HAS_GMPY, as_int
 from sympy.core.function import Function, ArgumentIndexError, _mexpand
-from sympy.core.logic import fuzzy_and, fuzzy_or
+from sympy.core.logic import fuzzy_and
 from sympy.core.mul import Mul
 from sympy.core.numbers import Float, Integer, pi
 from sympy.core.relational import Eq

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -949,19 +949,15 @@ class binomial(CombinatorialFunction):
     def eval(cls, n, k):
         from sympy import Min
         n, k = map(sympify, (n, k))
-        if n.is_zero:   #
-            n = S.Zero  # XXX is this anti-SymPy?
-        if k.is_zero:   #
-            k = S.Zero  #
-        n_k = n - k
         if k == 1:
-            return k*n          #
-        if n_k == 1:            #
-            return n_k*n        # written to
-        if k.is_zero:           # retain Float
-            return S.One + k    # when present
-        if n_k.is_zero:         #
-            return S.One + n_k  #
+            return n
+        n_k = n - k
+        if n_k == 1:
+            return n
+        if k.is_zero:
+            return S.One
+        if n_k.is_zero:
+            return S.One
         if -1 in (k, n_k):
             if (n + 1).is_zero is False:
                 # includes n.is_integer=False, too

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -412,7 +412,7 @@ def test_binomial():
     kn = Symbol('kn', integer=True, negative=True)
     kne = Symbol('kn', integer=True, negative=True, even=True)
     nt, kt = symbols('nt kt', integer=False)
-    ntr = symbols('ntr', rational=False, real=True)
+    nr = symbols('nr', rational=False, real=True)
     a, b = symbols('a b', integer=True, nonnegative=True)
     u = Symbol('u', negative=True)
     v = Symbol('v', nonnegative=True)
@@ -470,7 +470,7 @@ def test_binomial():
     assert binomial(n, k).is_integer
     assert binomial(nt, k).is_integer is None
     assert binomial(k, nt).is_integer is None
-    assert binomial(k, ntr).is_integer is False
+    assert binomial(k, nr).is_integer is False
     assert binomial(x, nt).is_integer is None  # see next,
     assert binomial(S.Half, S.Half*3) == 0     #<--------+
     assert binomial(n, a).is_integer
@@ -524,17 +524,19 @@ def test_binomial():
     assert binomial(kn, kt) is zoo
 
     assert binomial(nt, kt).func == binomial
-    assert unchanged(binomial, nt, Rational(15, 6))
+    assert unchanged(binomial, nt, Rational(5, 2))
     assert binomial(kn - 3, kn - 1, evaluate=False).rewrite(gamma) == 0
-    assert binomial(nt, Rational(15, 6)).rewrite(gamma
-        ) == 8*gamma(nt + 1)/(15*sqrt(pi)*gamma(nt - Rational(3, 2)))
-    assert binomial(Rational(20, 3), Rational(-10, 8)
+    b = binomial(nt, Rational(5, 2))
+    assert b.rewrite(gamma) == b  # nt could be 3/2
+    assert binomial(nr, Rational(5, 2)).rewrite(gamma
+        ) == 8*gamma(nr + 1)/(15*sqrt(pi)*gamma(nr - Rational(3, 2)))
+    assert binomial(Rational(20, 3), Rational(-5, 4)
         ).rewrite(gamma) == gamma(Rational(23, 3)
         )/(gamma(Rational(-1, 4))*gamma(Rational(107, 12)))
     assert binomial(Rational(19, 2), Rational(-7, 2)
         ).rewrite(gamma) == Rational(-1615, 8388608)
     assert binomial(Rational(-13, 5), Rational(-7, 8)
-        ).rewrite(gamma) == gamma(Rational(-8, 5))/(gamma(Rational(-29, 40))*gamma(Rational(1,8)))
+        ).rewrite(gamma) == gamma(Rational(-8, 5))/(gamma(Rational(-29, 40))*gamma(Rational(1, 8)))
     assert binomial(Rational(-19, 8), Rational(-13, 5)
         ).rewrite(gamma) == gamma(Rational(-11, 8)
         )/(gamma(Rational(-8, 5))*gamma(Rational(49, 40)))
@@ -732,7 +734,6 @@ def test_binomial_rewrite():
                     else:
                         rw = u.rewrite(F)
                     assert Eq(rw, binomial(x, y)), (x, y, F)
-
 
 
 @XFAIL

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -440,7 +440,7 @@ def test_binomial():
     # issues 14529 and 14625
     assert binomial(x, z) == binomial(x, x) == 1
     assert binomial(x, 1) == binomial(x, x - 1) == x
-    assert binomial(x, 1.) == binomial(x, x - 1.) == 1.*x
+    assert binomial(x, 1.) == binomial(x, x - 1.) == x
     assert binomial(x + 1, x) == x + 1
 
     assert unchanged(binomial, x, -1)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,4 +1,4 @@
-from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
+from sympy import (symbols, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
                    airyai, acos, acosh, gamma, erf, asech, Add, Mul,
                    integrate)
@@ -16,7 +16,7 @@ f, r = Function('f'), Function('r')
 def test_rational_algorithm():
     f = 1 / ((x - 1)**2 * (x - 2))
     assert rational_algorithm(f, x, k) == \
-        (-2**(-k - 1) + 1 - (factorial(k + 1) / factorial(k)), 0, 0)
+        (-2**(-k - 1) - k, 0, 0)
 
     f = (1 + x + x**2 + x**3) / ((x - 1) * (x - 2))
     assert rational_algorithm(f, x, k) == \

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -471,6 +471,7 @@ def test_issue_8730():
 
 def test_issue_10801():
     # make sure limits work with binomial
+    k = symbols('k', nonnegative=True)
     assert limit(16**k / (k * binomial(2*k, k)**2), k, oo) == pi
 
 

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -1,5 +1,5 @@
 from sympy import (
-    Rational, gammasimp, factorial, gamma, binomial, multinomial, pi, S,
+    Rational, gammasimp, factorial, gamma, binomial, pi, S,
     sin, exp, powsimp, sqrt, simplify, symbols, cos, rf)
 
 from sympy.abc import x, y
@@ -32,8 +32,6 @@ def test_gammasimp():
     assert gammasimp(factorial(n + 2)) == gamma(n + 3)
     assert gammasimp(binomial(n, k)) == \
         gamma(n + 1)/(gamma(k + 1)*gamma(-k + n + 1))
-    assert gammasimp(multinomial(n, k, k)) == \
-        gamma(2*k + n + 1)/(gamma(k + 1)**2*gamma(n + 1))
     assert powsimp(gammasimp(
         gamma(x)*gamma(x + S.Half)*gamma(y)/gamma(x + y))) == \
         2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -1,12 +1,13 @@
 from sympy import (
-    Rational, gammasimp, factorial, gamma, binomial, pi, S,
+    Rational, gammasimp, factorial, gamma, binomial, multinomial, pi, S,
     sin, exp, powsimp, sqrt, simplify, symbols, cos, rf)
 
-from sympy.abc import x, y, n, k
+from sympy.abc import x, y
 
 
 def test_gammasimp():
     R = Rational
+    n, k = symbols('n k', nonnegative=True)
 
     # was part of test_combsimp_gamma() in test_combsimp.py
     assert gammasimp(gamma(x)) == gamma(x)
@@ -31,7 +32,8 @@ def test_gammasimp():
     assert gammasimp(factorial(n + 2)) == gamma(n + 3)
     assert gammasimp(binomial(n, k)) == \
         gamma(n + 1)/(gamma(k + 1)*gamma(-k + n + 1))
-
+    assert gammasimp(multinomial(n, k, k)) == \
+        gamma(2*k + n + 1)/(gamma(k + 1)**2*gamma(n + 1))
     assert powsimp(gammasimp(
         gamma(x)*gamma(x + S.Half)*gamma(y)/gamma(x + y))) == \
         2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
@@ -86,7 +88,7 @@ def test_gammasimp():
         gamma(n + 3)/(gamma(k + 3.0)*gamma(-k + n + 1))
 
     # issue 11548
-    assert gammasimp(binomial(0, x)) == sin(pi*x)/(pi*x)
+    assert gammasimp(binomial(0, k)) == sin(pi*k)/(pi*k)
 
     e = gamma(n + Rational(1, 3))*gamma(n + R(2, 3))
     assert gammasimp(e) == e

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -324,7 +324,7 @@ def test_separatevars_advanced_factor():
 
 
 def test_hypersimp():
-    n, k = symbols('n,k', integer=True)
+    n, k = symbols('n,k', integer=True, nonnegative=True)
 
     assert hypersimp(factorial(k), k) == k + 1
     assert hypersimp(factorial(k**2), k) is None

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -5,7 +5,7 @@ from sympy.testing.pytest import raises, slow
 from sympy.abc import a, b
 
 y = Function('y')
-n, k = symbols('n,k', integer=True)
+n, k = symbols('n,k', integer=True, nonnegative=True)
 C0, C1, C2 = symbols('C0,C1,C2')
 
 

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -986,6 +986,7 @@ def test_M23():
 
 def test_M24():
     # TODO: Replace solve with solveset, as of now test fails for solveset
+    m = symbols('m', nonnegative=True)
     solution = solve(1 - binomial(m, 2)*2**k, k)
     answer = log(2/(m*(m - 1)), 2)
     assert solution[0].expand() == answer.expand()


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19082
Fixes #19030
Fixes #14577
Fixes #14612
work of #18960 continues from this by defining `multinomial` for arbitrary input.


#### Brief description of what is fixed or changed

A new branch of behavior has been opened up for binomial(n,k).

The former behavior was to return 0 whenever k was negative. Now

`(n, k) == (n, n - k)` for all `n` and `k` but the identity `(n, k) = (n-1, k-1) + (n-1, k)` no longer holds for (0,0).
```python
>>> binomial(0,0)
1
>>> binomial(-1,-1),binomial(-1,0)
(1, 1)
```
In addition, all rewriting now has to check that the sign of
the arguments will produce a rewrite value that is true for
all values matching the assumptions of the arguments. As a case
in point, consider the Piecewise form for binomial(x,y)
```python
    def _eval_rewrite_as_Piecewise(self, n, k, **kwargs):
        from sympy import gamma, Abs, Lt
        isint = lambda x: Eq(x, floor(x))
        nneg = lambda x: Or(Eq(x, 0), Eq(x/Abs(x), 1))
        for i in igen():
            if not n.has(i) and not k.has(i):
                break
        return Piecewise(
            (factorial(n)/factorial(k)/factorial(n - k),
                And(isint(n), isint(k),
                nneg(n), nneg(k), nneg(n - k))),
            (ff(n, k)/factorial(k),
                And(isint(k), nneg(k))),
            (ff(n, n - k)/factorial(n - k),
                And(isint(n - k), nneg(n - k))),
            (0, And(*[i for x in (n, k, n - k)
                for i in [isint(x), Lt(x, 0)]])),
            (gamma(n + 1)/gamma(k + 1)/gamma(n - k + 1),
                True))
```
The checks for non-negative values are in place to guarantee that
the given expression will be true for arguments with matching
assumptions. The 4th condition (x, y and x - y all negative integers)
is there to guard from returning gamma for that case which would give
nan when the actual answer is 0.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * binomial(n,k) no longer gives 0 for negative values of k
  * binomial can now be rewritten as Piecewise and all other rewrites respect assumptions on args parsing

<!-- END RELEASE NOTES -->