### PR TITLE
Fix numpy printing of unevaluated pow

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -765,8 +765,9 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_Pow(self, expr, rational=False):
         # XXX Workaround for negative integer power error
+        from sympy.core.power import Pow
         if expr.exp.is_integer and expr.exp.is_negative:
-            expr = expr.base ** expr.exp.evalf()
+            expr = Pow(expr.base, expr.exp.evalf(), evaluate=False)
         return self._hprint_Pow(expr, rational=rational, sqrt='numpy.sqrt')
 
     def _print_Min(self, expr):

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -4,6 +4,7 @@ from sympy import (
 )
 from sympy import eye
 from sympy.abc import x, i, j, a, b, c, d
+from sympy.core import Pow
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Sqrt
 from sympy.codegen.array_utils import (CodegenArrayContraction,
@@ -180,6 +181,15 @@ def test_mod():
     a_ = np.array([2, 3, 4, 5])
     b_ = np.array([2, 3, 4, 5])
     assert np.array_equal(f(a_, b_), [0, 0, 0, 0])
+
+
+def test_pow():
+    if not np:
+        skip('NumPy not installed')
+
+    expr = Pow(2, -1, evaluate=False)
+    f = lambdify([], expr, 'numpy')
+    assert f() == 0.5
 
 
 def test_expm1():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sympy.codegen import Assignment
 from sympy.codegen.ast import none
 from sympy.codegen.matrix_nodes import MatrixSolve
-from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational
+from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
 from sympy.core.singleton import S
 from sympy.functions import acos, KroneckerDelta, Piecewise, sign, sqrt
@@ -111,6 +111,9 @@ def test_NumPyPrinter():
     # Workaround for numpy negative integer power errors
     assert p.doprint(x**-1) == 'x**(-1.0)'
     assert p.doprint(x**-2) == 'x**(-2.0)'
+
+    expr = Pow(2, -1, evaluate=False)
+    assert p.doprint(expr) == "2**(-1.0)"
 
     assert p.doprint(S.Exp1) == 'numpy.e'
     assert p.doprint(S.Pi) == 'numpy.pi'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19168

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fixed numpy printer raising error for unevaluated numeric power.
<!-- END RELEASE NOTES -->