### PR TITLE
fix Mul.is_integer

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -7,7 +7,7 @@ from .basic import Basic
 from .singleton import S
 from .operations import AssocOp
 from .cache import cacheit
-from .logic import fuzzy_not, _fuzzy_group
+from .logic import fuzzy_not, _fuzzy_group, fuzzy_and
 from .compatibility import reduce
 from .expr import Expr
 from .parameters import global_parameters
@@ -1249,28 +1249,25 @@ class Mul(Expr, AssocOp):
 
     def _eval_is_integer(self):
         from sympy import fraction
+        from sympy.core.numbers import Float
 
         is_rational = self._eval_is_rational()
         if is_rational is False:
             return False
 
-        n, d = fraction(self)
+        # use exact=True to avoid recomputing num or den
+        n, d = fraction(self, exact=True)
         if is_rational:
             if d is S.One:
                 return True
-            elif d == S(2):
+        if d.is_even:
+            if d.is_prime:  # literal or symbolic 2
                 return n.is_even
-        # if d is even -- 0 or not -- the
-        # result is not an integer
-        if n.is_odd and d.is_even:
-            return False
-        if not is_rational:
-            if n.has(d):
-                _self = Mul(n, Pow(d, -1))
-                if _self != self:
-                    return _self.is_integer
-            elif n.is_rational is True and d == S.One:
-                return True
+            if n.is_odd:
+                return False  # true even if d = 0
+        if n == d:
+            return fuzzy_and([not bool(self.atoms(Float)),
+            fuzzy_not(d.is_zero)])
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1255,10 +1255,6 @@ class Mul(Expr, AssocOp):
             return False
 
         n, d = fraction(self)
-        if not is_rational:
-            _self = n/d
-            if _self != self:
-                return _self.is_integer
         if is_rational:
             if d is S.One:
                 return True
@@ -1268,6 +1264,13 @@ class Mul(Expr, AssocOp):
         # result is not an integer
         if n.is_odd and d.is_even:
             return False
+        if not is_rational:
+            if n.has(d):
+                _self = Mul(n, Pow(d, -1))
+                if _self != self:
+                    return _self.is_integer
+            elif n.is_rational is True and d == S.One:
+                return True
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -357,6 +357,33 @@ def test_Mul_doesnt_expand_exp():
     assert sqrt(2)*2**Rational(1, 4)*5**Rational(3, 4) == 10**Rational(3, 4)
     assert (x**(-log(5)/log(3))*x)/(x*x**( - log(5)/log(3))) == sympify(1)
 
+def test_Mul_is_integer():
+
+    k = Symbol('k', integer=True)
+    n = Symbol('n', integer=True)
+    nr = Symbol('nr', rational=False)
+    nz = Symbol('nz', integer=True, zero=False)
+    nze = Symbol('nze', even=True, zero=False)
+    e = Symbol('e', even=True)
+    o = Symbol('o', odd=True)
+    i2 = Symbol('2', prime=True, even=True)
+
+    assert (k/3).is_integer is None
+    assert (nz/3).is_integer is None
+    assert (nr/3).is_integer is False
+    assert (x*k*n).is_integer is None
+    assert (e/o).is_integer is None
+    assert (o/e).is_integer is False
+    assert (o/i2).is_integer is False
+    assert Mul(o, 1/o, evaluate=False).is_integer is True
+    assert Mul(k, 1/k, evaluate=False).is_integer is None
+    assert Mul(nze, 1/nze, evaluate=False).is_integer is True
+    assert Mul(2., S.Half, evaluate=False).is_integer is False
+
+    s = 2**2**2**Pow(2, 1000, evaluate=False)
+    m = Mul(s, s, evaluate=False)
+    assert m.is_integer
+
 
 def test_Add_Mul_is_integer():
     x = Symbol('x')
@@ -366,19 +393,11 @@ def test_Add_Mul_is_integer():
     nk = Symbol('nk', integer=False)
     nr = Symbol('nr', rational=False)
     nz = Symbol('nz', integer=True, zero=False)
-    e = Symbol('e', even=True)
-    o = Symbol('e', odd=True)
 
     assert (-nk).is_integer is None
     assert (-nr).is_integer is False
     assert (2*k).is_integer is True
     assert (-k).is_integer is True
-    assert (k/3).is_integer is None
-    assert (nz/3).is_integer is None
-    assert (nr/3).is_integer is False
-    assert (x*k*n).is_integer is None
-    assert (e/o).is_integer is None
-    assert (o/e).is_integer is False
 
     assert (k + nk).is_integer is False
     assert (k + n).is_integer is True
@@ -1501,9 +1520,12 @@ def test_Mul_is_irrational():
     expr = Mul(1, 2, 3, evaluate=False)
     assert expr.is_irrational is False
     expr = Mul(1, I, I, evaluate=False)
-    assert expr.is_rational is True # I * I = -1
+    assert expr.is_rational is None # I * I = -1 but *no evaluation allowed*
+    # sqrt(2) * I * I = -sqrt(2) is irrational but
+    # this can't be determined without evaluating the
+    # expression and the eval_is routines shouldn't do that
     expr = Mul(sqrt(2), I, I, evaluate=False)
-    assert expr.is_irrational is not True
+    assert expr.is_irrational is None
 
 
 def test_issue_3531():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This is just to check that no other tests fail in travis for a particular change made in 
d2cc97f 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19174 

#### Brief description of what is fixed or changed

`_eval_is_*` routines should not rebuild the arguments, they should only break apart the arguments in the most naive way and perform their analysis. For example `fraction(eq, exact=True)` is naive whereas `eq.as_numer_denom()` is not.

#### Other comments

Something like `Mul(I, I, evaluate=False)` could be evaluated as a negative integer but there is such a special case that it may not be worth adding it. But here is a possible way of handling it:
```python
        def get_I(a):
            i, d = sift(a, lambda x: x is S.ImaginaryUnit, binary=True)
            return len(i), d
        i_n, n = get_I(n)
        i_d, d = get_I(d)
        i_tot = i_n + i_d
        if i_tot:
            # 1/I -> -I so it still counts as a single I
            r = n/d
            if i_tot % 2 == 0:  # even number of I -> int
                return r.is_integer
            # integer if r is imaginary and floor(r) == r but not sure how to say this;
            # but if r is now an integer then I*int != integer unless r is zero
            if r.is_integer:
                return r.is_zero
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Mul.is_integer no longer rebuilds arguments into Mul
<!-- END RELEASE NOTES -->