### PR TITLE
Use Python 3 syntax in vector module

### DIFF
--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -214,8 +214,7 @@ class BasisDependentAdd(BasisDependent, Add):
 
         # Build object
         newargs = [x * components[x] for x in components]
-        obj = super(BasisDependentAdd, cls).__new__(cls,
-                                                    *newargs, **options)
+        obj = super().__new__(cls, *newargs, **options)
         if isinstance(obj, Mul):
             return cls._mul_func(*obj.args)
         assumptions = {'commutative': True}
@@ -274,10 +273,10 @@ class BasisDependentMul(BasisDependent, Mul):
                        x in expr.args]
             return cls._add_func(*newargs)
 
-        obj = super(BasisDependentMul, cls).__new__(cls, measure_number,
-                                                    expr._base_instance,
-                                                    *extra_args,
-                                                    **options)
+        obj = super().__new__(cls, measure_number,
+                              expr._base_instance,
+                              *extra_args,
+                              **options)
         if isinstance(obj, Add):
             return cls._add_func(*obj.args)
         obj._base_instance = expr._base_instance
@@ -309,7 +308,7 @@ class BasisDependentZero(BasisDependent):
     components = {}  # type: Dict[Any, Expr]
 
     def __new__(cls):
-        obj = super(BasisDependentZero, cls).__new__(cls)
+        obj = super().__new__(cls)
         # Pre-compute a specific hash value for the zero vector
         # Use the same one always
         obj._hash = tuple([S.Zero, cls]).__hash__()

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -92,7 +92,7 @@ class CoordSys3D(Basic):
                 pass
             else:
                 raise TypeError("transformation: "
-                                "wrong type {0}".format(type(transformation)))
+                                "wrong type {}".format(type(transformation)))
 
         # If orientation information has been provided, store
         # the rotation matrix accordingly
@@ -187,10 +187,10 @@ class CoordSys3D(Basic):
         # positioned/oriented wrt different parents, even though
         # they may actually be 'coincident' wrt the root system.
         if parent is not None:
-            obj = super(CoordSys3D, cls).__new__(
+            obj = super().__new__(
                 cls, Symbol(name), transformation, parent)
         else:
-            obj = super(CoordSys3D, cls).__new__(
+            obj = super().__new__(
                 cls, Symbol(name), transformation)
         obj._name = name
         # Initialize the base vectors

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -17,7 +17,7 @@ class Del(Basic):
                 deprecated_since_version="1.1",
                 issue=12866,
             ).warn()
-        obj = super(Del, cls).__new__(cls)
+        obj = super().__new__(cls)
         obj._name = "delop"
         return obj
 

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -209,12 +209,12 @@ class BaseDyadic(Dyadic, AtomicExpr):
         elif vector1 == Vector.zero or vector2 == Vector.zero:
             return Dyadic.zero
         # Initialize instance
-        obj = super(BaseDyadic, cls).__new__(cls, vector1, vector2)
+        obj = super().__new__(cls, vector1, vector2)
         obj._base_instance = obj
         obj._measure_number = 1
         obj._components = {obj: S.One}
         obj._sys = vector1._sys
-        obj._pretty_form = (u'(' + vector1._pretty_form + '|' +
+        obj._pretty_form = ('(' + vector1._pretty_form + '|' +
                              vector2._pretty_form + ')')
         obj._latex_form = ('(' + vector1._latex_form + "{|}" +
                            vector2._latex_form + ')')
@@ -274,7 +274,7 @@ class DyadicZero(BasisDependentZero, Dyadic):
     """
 
     _op_priority = 13.1
-    _pretty_form = u'(0|0)'
+    _pretty_form = '(0|0)'
     _latex_form = r'(\mathbf{\hat{0}}|\mathbf{\hat{0}})'
 
     def __new__(cls):

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -112,7 +112,7 @@ def express(expr, system, system2=None, variables=False):
                                 Vectors")
         if variables:
             # Given expr is a scalar field
-            system_set = set([])
+            system_set = set()
             expr = sympify(expr)
             # Substitute all the coordinate variables
             for x in expr.atoms(BaseScalar):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -11,7 +11,7 @@ from sympy import Add, Mul
 
 def _get_coord_systems(expr):
     g = preorder_traversal(expr)
-    ret = set([])
+    ret = set()
     for i in g:
         if isinstance(i, CoordSys3D):
             ret.add(i)

--- a/sympy/vector/orienters.py
+++ b/sympy/vector/orienters.py
@@ -28,8 +28,7 @@ class AxisOrienter(Orienter):
             raise TypeError("axis should be a Vector")
         angle = sympify(angle)
 
-        obj = super(AxisOrienter, cls).__new__(cls, angle,
-                                               axis)
+        obj = super().__new__(cls, angle, axis)
         obj._angle = angle
         obj._axis = axis
 
@@ -137,7 +136,7 @@ class ThreeAngleOrienter(Orienter):
                              _rot(a1, angle1))
         parent_orient = parent_orient.T
 
-        obj = super(ThreeAngleOrienter, cls).__new__(
+        obj = super().__new__(
             cls, angle1, angle2, angle3, Symbol(rot_order))
         obj._angle1 = angle1
         obj._angle2 = angle2
@@ -321,7 +320,7 @@ class QuaternionOrienter(Orienter):
                                   q2 ** 2 + q3 ** 2]]))
         parent_orient = parent_orient.T
 
-        obj = super(QuaternionOrienter, cls).__new__(cls, q0, q1, q2, q3)
+        obj = super().__new__(cls, q0, q1, q2, q3)
         obj._q0 = q0
         obj._q1 = q1
         obj._q2 = q2

--- a/sympy/vector/point.py
+++ b/sympy/vector/point.py
@@ -25,10 +25,9 @@ class Point(Basic):
                     parent_point))
         # Super class construction
         if parent_point is None:
-            obj = super(Point, cls).__new__(cls, Symbol(name), position)
+            obj = super().__new__(cls, Symbol(name), position)
         else:
-            obj = super(Point, cls).__new__(cls, Symbol(name),
-                                            position, parent_point)
+            obj = super().__new__(cls, Symbol(name), position, parent_point)
         # Decide the object parameters
         obj._name = name
         obj._pos = position

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -17,17 +17,17 @@ class BaseScalar(AtomicExpr):
     def __new__(cls, index, system, pretty_str=None, latex_str=None):
         from sympy.vector.coordsysrect import CoordSys3D
         if pretty_str is None:
-            pretty_str = "x{0}".format(index)
+            pretty_str = "x{}".format(index)
         elif isinstance(pretty_str, Symbol):
             pretty_str = pretty_str.name
         if latex_str is None:
-            latex_str = "x_{0}".format(index)
+            latex_str = "x_{}".format(index)
         elif isinstance(latex_str, Symbol):
             latex_str = latex_str.name
 
         index = _sympify(index)
         system = _sympify(system)
-        obj = super(BaseScalar, cls).__new__(cls, index, system)
+        obj = super().__new__(cls, index, system)
         if not isinstance(system, CoordSys3D):
             raise TypeError("system should be a CoordSys3D")
         if index not in range(0, 3):
@@ -35,7 +35,7 @@ class BaseScalar(AtomicExpr):
         # The _id is used for equating purposes, and for hashing
         obj._id = (index, system)
         obj._name = obj.name = system._name + '.' + system._variable_names[index]
-        obj._pretty_form = u'' + pretty_str
+        obj._pretty_form = '' + pretty_str
         obj._latex_form = latex_str
         obj._system = system
 

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -290,7 +290,7 @@ def test_mixed_coordinates():
     b = CoordSys3D('b')
     c = CoordSys3D('c')
     assert gradient(a.x*b.y) == b.y*a.i + a.x*b.j
-    assert gradient(3*cos(q)*a.x*b.x+a.y*(a.x+((cos(q)+b.x)))) ==\
+    assert gradient(3*cos(q)*a.x*b.x+a.y*(a.x+(cos(q)+b.x))) ==\
            (a.y + 3*b.x*cos(q))*a.i + (a.x + b.x + cos(q))*a.j + (3*a.x*cos(q) + a.y)*b.i
     # Some tests need further work:
     # assert gradient(a.x*(cos(a.x+b.x))) == (cos(a.x + b.x))*a.i + a.x*Gradient(cos(a.x + b.x))

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -113,33 +113,33 @@ def test_str_printing():
 
 @XFAIL
 def test_pretty_printing_ascii():
-    assert pretty(v[0]) == u'0'
-    assert pretty(v[1]) == u'i_N'
-    assert pretty(v[5]) == u'(a) i_N + (-b) j_N'
+    assert pretty(v[0]) == '0'
+    assert pretty(v[1]) == 'i_N'
+    assert pretty(v[5]) == '(a) i_N + (-b) j_N'
     assert pretty(v[8]) == pretty_v_8
-    assert pretty(v[2]) == u'(-1) i_N'
+    assert pretty(v[2]) == '(-1) i_N'
     assert pretty(v[11]) == pretty_v_11
     assert pretty(s) == pretty_s
-    assert pretty(d[0]) == u'(0|0)'
-    assert pretty(d[5]) == u'(a) (i_N|k_N) + (-b) (j_N|k_N)'
+    assert pretty(d[0]) == '(0|0)'
+    assert pretty(d[5]) == '(a) (i_N|k_N) + (-b) (j_N|k_N)'
     assert pretty(d[7]) == pretty_d_7
-    assert pretty(d[10]) == u'(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
+    assert pretty(d[10]) == '(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
 
 
 def test_pretty_print_unicode_v():
-    assert upretty(v[0]) == u'0'
-    assert upretty(v[1]) == u'i_N'
-    assert upretty(v[5]) == u'(a) i_N + (-b) j_N'
+    assert upretty(v[0]) == '0'
+    assert upretty(v[1]) == 'i_N'
+    assert upretty(v[5]) == '(a) i_N + (-b) j_N'
     # Make sure the printing works in other objects
-    assert upretty(v[5].args) == u'((a) i_N, (-b) j_N)'
+    assert upretty(v[5].args) == '((a) i_N, (-b) j_N)'
     assert upretty(v[8]) == upretty_v_8
-    assert upretty(v[2]) == u'(-1) i_N'
+    assert upretty(v[2]) == '(-1) i_N'
     assert upretty(v[11]) == upretty_v_11
     assert upretty(s) == upretty_s
-    assert upretty(d[0]) == u'(0|0)'
-    assert upretty(d[5]) == u'(a) (i_N|k_N) + (-b) (j_N|k_N)'
+    assert upretty(d[0]) == '(0|0)'
+    assert upretty(d[5]) == '(a) (i_N|k_N) + (-b) (j_N|k_N)'
     assert upretty(d[7]) == upretty_d_7
-    assert upretty(d[10]) == u'(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
+    assert upretty(d[10]) == '(cos(a)) (i_C|k_N) + (-sin(a)) (j_C|k_N)'
 
 
 def test_latex_printing():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -352,9 +352,9 @@ class BaseVector(Vector, AtomicExpr):
 
     def __new__(cls, index, system, pretty_str=None, latex_str=None):
         if pretty_str is None:
-            pretty_str = "x{0}".format(index)
+            pretty_str = "x{}".format(index)
         if latex_str is None:
-            latex_str = "x_{0}".format(index)
+            latex_str = "x_{}".format(index)
         pretty_str = str(pretty_str)
         latex_str = str(latex_str)
         # Verify arguments
@@ -364,13 +364,13 @@ class BaseVector(Vector, AtomicExpr):
             raise TypeError("system should be a CoordSys3D")
         name = system._vector_names[index]
         # Initialize an object
-        obj = super(BaseVector, cls).__new__(cls, S(index), system)
+        obj = super().__new__(cls, S(index), system)
         # Assign important attributes
         obj._base_instance = obj
         obj._components = {obj: S.One}
         obj._measure_number = S.One
         obj._name = system._name + '.' + name
-        obj._pretty_form = u'' + pretty_str
+        obj._pretty_form = '' + pretty_str
         obj._latex_form = latex_str
         obj._system = system
         # The _id is used for printing purposes
@@ -453,7 +453,7 @@ class VectorZero(BasisDependentZero, Vector):
     """
 
     _op_priority = 12.1
-    _pretty_form = u'0'
+    _pretty_form = '0'
     _latex_form = r'\mathbf{\hat{0}}'
 
     def __new__(cls):


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
* See also: https://github.com/sympy/sympy/pull/18825/files

#### Brief description of what is fixed or changed

Changed Python 2 syntax to Python 3 syntax

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->