### PR TITLE
Use Python 3 syntax in utilities

### DIFF
--- a/sympy/utilities/_compilation/__init__.py
+++ b/sympy/utilities/_compilation/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
 """ This sub-module is private, i.e. external code should not depend on it.
 
 These functions are used by tests run as part of continuous integration.

--- a/sympy/utilities/_compilation/availability.py
+++ b/sympy/utilities/_compilation/availability.py
@@ -1,4 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
 import os
 from .compilation import compile_run_strings
 from .util import CompilerNotFoundError

--- a/sympy/utilities/_compilation/compilation.py
+++ b/sympy/utilities/_compilation/compilation.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-
 import glob
 import os
 import shutil
@@ -74,7 +72,7 @@ def compile_sources(files, Runner=None, destdir=None, cwd=None, keep_dir_struct=
     destdir = destdir or '.'
     if not os.path.isdir(destdir):
         if os.path.exists(destdir):
-            raise IOError("{} is not a directory".format(destdir))
+            raise OSError("{} is not a directory".format(destdir))
         else:
             make_dirs(destdir)
     if cwd is None:
@@ -544,7 +542,7 @@ def _write_sources_to_build_dir(sources, build_dir):
         sha256_in_mem = sha256_of_string(src.encode('utf-8')).hexdigest()
         if os.path.exists(dest):
             if os.path.exists(dest + '.sha256'):
-                sha256_on_disk = open(dest + '.sha256', 'rt').read()
+                sha256_on_disk = open(dest + '.sha256').read()
             else:
                 sha256_on_disk = sha256_of_file(dest).hexdigest()
 

--- a/sympy/utilities/_compilation/runners.py
+++ b/sympy/utilities/_compilation/runners.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from typing import Callable, Dict, Optional, Tuple, Union
 
 from collections import OrderedDict
@@ -14,7 +12,7 @@ from .util import (
 )
 
 
-class CompilerRunner(object):
+class CompilerRunner:
     """ CompilerRunner base class.
 
     Parameters
@@ -83,7 +81,7 @@ class CompilerRunner(object):
                 preferred_vendor = os.environ.get('SYMPY_COMPILER_VENDOR', None)
             self.compiler_name, self.compiler_binary, self.compiler_vendor = self.find_compiler(preferred_vendor)
             if self.compiler_binary is None:
-                raise ValueError("No compiler found (searched: {0})".format(', '.join(self.compiler_dict.values())))
+                raise ValueError("No compiler found (searched: {})".format(', '.join(self.compiler_dict.values())))
         self.define = define or []
         self.undef = undef or []
         self.include_dirs = include_dirs or []
@@ -189,7 +187,7 @@ class CompilerRunner(object):
 
         # Error handling
         if self.cmd_returncode != 0:
-            msg = "Error executing '{0}' in {1} (exited status {2}):\n {3}\n".format(
+            msg = "Error executing '{}' in {} (exited status {}):\n {}\n".format(
                 ' '.join(self.cmd()), self.cwd, str(self.cmd_returncode), self.cmd_outerr
             )
             raise CompileError(msg)

--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import shutil
 from sympy.external import import_module
 from sympy.testing.pytest import skip

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
-
 from collections import namedtuple
 from hashlib import sha256
 import os
@@ -25,7 +23,7 @@ if sys.version_info[0] == 2:
     class FileNotFoundError(IOError):
         pass
 
-    class TemporaryDirectory(object):
+    class TemporaryDirectory:
         def __init__(self):
             self.path = tempfile.mkdtemp()
         def __enter__(self):
@@ -208,7 +206,7 @@ def pyx_is_cplus(path):
 
     Returns True if such a file is present in the file, else False.
     """
-    for line in open(path, 'rt'):
+    for line in open(path):
         if line.startswith('#') and '=' in line:
             splitted = line.split('=')
             if len(splitted) != 2:

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -65,8 +65,6 @@ When is this module NOT the best approach?
 
 """
 
-from __future__ import print_function, division
-
 import sys
 import os
 import shutil
@@ -96,7 +94,7 @@ class CodeWrapError(Exception):
     pass
 
 
-class CodeWrapper(object):
+class CodeWrapper:
     """Base Class for code wrappers"""
     _filename = "wrapped_code"
     _module_basename = "wrapper_module"
@@ -300,7 +298,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
 
         self._need_numpy = False
 
-        super(CythonCodeWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def command(self):
@@ -379,8 +377,8 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
             for arg, val in py_inf.items():
                 proto = self._prototype_arg(arg)
                 mat, ind = [self._string_var(v) for v in val]
-                local_decs.append("    cdef {0} = {1}.shape[{2}]".format(proto, mat, ind))
-            local_decs.extend(["    cdef {0}".format(self._declare_arg(a)) for a in py_loc])
+                local_decs.append("    cdef {} = {}.shape[{}]".format(proto, mat, ind))
+            local_decs.extend(["    cdef {}".format(self._declare_arg(a)) for a in py_loc])
             declarations = "\n".join(local_decs)
             if declarations:
                 declarations = declarations + "\n"
@@ -460,9 +458,9 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
     def _call_arg(self, arg):
         if arg.dimensions:
             t = arg.get_datatype('c')
-            return "<{0}*> {1}.data".format(t, self._string_var(arg.name))
+            return "<{}*> {}.data".format(t, self._string_var(arg.name))
         elif isinstance(arg, ResultBase):
-            return "&{0}".format(self._string_var(arg.name))
+            return "&{}".format(self._string_var(arg.name))
         else:
             return self._string_var(arg.name)
 
@@ -486,7 +484,7 @@ class F2PyCodeWrapper(CodeWrapper):
                 warn(msg.format(k))
             kwargs.pop(k, None)
 
-        super(F2PyCodeWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def command(self):
@@ -526,7 +524,7 @@ def _validate_backend_language(backend, language):
     if not langs:
         raise ValueError("Unrecognized backend: " + backend)
     if language.upper() not in langs:
-        raise ValueError(("Backend {0} and language {1} are "
+        raise ValueError(("Backend {} and language {} are "
                           "incompatible").format(backend, language))
 
 
@@ -801,7 +799,7 @@ class UfuncifyCodeWrapper(CodeWrapper):
                 warn(msg.format(k))
             kwargs.pop(k, None)
 
-        super(UfuncifyCodeWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def command(self):
@@ -893,7 +891,7 @@ class UfuncifyCodeWrapper(CodeWrapper):
         function_creation = []
         ufunc_init = []
         module = self.module_name
-        include_file = "\"{0}.h\"".format(prefix)
+        include_file = "\"{}.h\"".format(prefix)
         top = _ufunc_top.substitute(include_file=include_file, module=module)
 
         name = funcname
@@ -935,7 +933,7 @@ class UfuncifyCodeWrapper(CodeWrapper):
         docstring = '"Created in SymPy with Ufuncify"'
 
         # Function Creation
-        function_creation.append("PyObject *ufunc{0};".format(r_index))
+        function_creation.append("PyObject *ufunc{};".format(r_index))
 
         # Ufunc initialization
         init_form = _ufunc_init_form.substitute(module=module,

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -79,8 +79,6 @@ unsurmountable issues that can only be tackled with dedicated code generator:
 
 """
 
-from __future__ import print_function, division
-
 import os
 import textwrap
 
@@ -115,7 +113,7 @@ __all__ = [
 #
 
 
-class Routine(object):
+class Routine:
     """Generic description of evaluation routine for set of expressions.
 
     A CodeGen class can translate instances of this class into code in a
@@ -160,8 +158,8 @@ class Routine(object):
         """
 
         # extract all input symbols and all symbols appearing in an expression
-        input_symbols = set([])
-        symbols = set([])
+        input_symbols = set()
+        symbols = set()
         for arg in arguments:
             if isinstance(arg, OutputArgument):
                 symbols.update(arg.expr.free_symbols - arg.expr.atoms(Indexed))
@@ -186,14 +184,14 @@ class Routine(object):
             else:
                 local_symbols.add(r)
 
-        symbols = set([s.label if isinstance(s, Idx) else s for s in symbols])
+        symbols = {s.label if isinstance(s, Idx) else s for s in symbols}
 
         # Check that all symbols in the expressions are covered by
         # InputArguments/InOutArguments---subset because user could
         # specify additional (unused) InputArguments or local_vars.
         notcovered = symbols.difference(
             input_symbols.union(local_symbols).union(global_vars))
-        if notcovered != set([]):
+        if notcovered != set():
             raise ValueError("Symbols needed for output are not in input " +
                              ", ".join([str(x) for x in notcovered]))
 
@@ -235,7 +233,7 @@ class Routine(object):
         return args
 
 
-class DataType(object):
+class DataType:
     """Holds strings for a certain datatype in different languages."""
     def __init__(self, cname, fname, pyname, jlname, octname, rsname):
         self.cname = cname
@@ -283,7 +281,7 @@ def get_default_datatype(expr, complex_allowed=None):
         return default_datatypes[final_dtype]
 
 
-class Variable(object):
+class Variable:
     """Represents a typed variable."""
 
     def __init__(self, name, datatype=None, dimensions=None, precision=None):
@@ -374,7 +372,7 @@ class InputArgument(Argument):
     pass
 
 
-class ResultBase(object):
+class ResultBase:
     """Base class for all "outgoing" information from a routine.
 
     Objects of this class stores a sympy expression, and a sympy object
@@ -536,7 +534,7 @@ class Result(Variable, ResultBase):
 # Transformation of routine objects into code
 #
 
-class CodeGen(object):
+class CodeGen:
     """Abstract class for the code generators."""
 
     printer = None  # will be set to an instance of a CodePrinter subclass
@@ -616,7 +614,7 @@ class CodeGen(object):
                     expr = simplified
 
             local_vars = [Result(b,a) for a,b in common]
-            local_symbols = set([a for a,_ in common])
+            local_symbols = {a for a,_ in common}
             local_expressions = Tuple(*[b for _,b in common])
         else:
             local_expressions = Tuple()
@@ -641,7 +639,7 @@ class CodeGen(object):
 
         # symbols that should be arguments
         symbols = (expressions.free_symbols | local_expressions.free_symbols) - local_symbols - global_vars
-        new_symbols = set([])
+        new_symbols = set()
         new_symbols.update(symbols)
 
         for symbol in symbols:
@@ -879,7 +877,7 @@ class CCodeGen(CodeGen):
 
     def __init__(self, project="project", printer=None,
                  preprocessor_statements=None, cse=False):
-        super(CCodeGen, self).__init__(project=project, cse=cse)
+        super().__init__(project=project, cse=cse)
         self.printer = printer or c_code_printers[self.standard.lower()]()
 
         self.preprocessor_statements = preprocessor_statements
@@ -968,10 +966,10 @@ class CCodeGen(CodeGen):
                 dims = result.expr.shape
                 if dims[1] != 1:
                     raise CodeGenError("Only column vectors are supported in local variabels. Local result {} has dimensions {}".format(result, dims))
-                code_lines.append("{0} {1}[{2}];\n".format(t, str(assign_to), dims[0]))
+                code_lines.append("{} {}[{}];\n".format(t, str(assign_to), dims[0]))
                 prefix = ""
             else:
-                prefix = "const {0} ".format(t)
+                prefix = "const {} ".format(t)
 
             constants, not_c, c_expr = self._printer_method_with_settings(
                 'doprint', dict(human=False, dereference=dereference),
@@ -1000,7 +998,7 @@ class CCodeGen(CodeGen):
             if isinstance(result, Result):
                 assign_to = routine.name + "_result"
                 t = result.get_datatype('c')
-                code_lines.append("{0} {1};\n".format(t, str(assign_to)))
+                code_lines.append("{} {};\n".format(t, str(assign_to)))
                 return_val = assign_to
             else:
                 assign_to = result.result_var
@@ -1105,7 +1103,7 @@ class FCodeGen(CodeGen):
     interface_extension = "h"
 
     def __init__(self, project='project', printer=None):
-        super(FCodeGen, self).__init__(project)
+        super().__init__(project)
         self.printer = printer or FCodePrinter()
 
     def _get_header(self):
@@ -1138,7 +1136,7 @@ class FCodeGen(CodeGen):
         args = ", ".join("%s" % self._get_symbol(arg.name)
                         for arg in routine.arguments)
 
-        call_sig = "{0}({1})\n".format(routine.name, args)
+        call_sig = "{}({})\n".format(routine.name, args)
         # Fortran 95 requires all lines be less than 132 characters, so wrap
         # this line before appending.
         call_sig = ' &\n'.join(textwrap.wrap(call_sig,
@@ -1319,7 +1317,7 @@ class JuliaCodeGen(CodeGen):
     code_extension = "jl"
 
     def __init__(self, project='project', printer=None):
-        super(JuliaCodeGen, self).__init__(project)
+        super().__init__(project)
         self.printer = printer or JuliaCodePrinter()
 
     def routine(self, name, expr, argument_sequence, global_vars):
@@ -1340,7 +1338,7 @@ class JuliaCodeGen(CodeGen):
 
         # symbols that should be arguments
         old_symbols = expressions.free_symbols - local_vars - global_vars
-        symbols = set([])
+        symbols = set()
         for s in old_symbols:
             if isinstance(s, Idx):
                 symbols.update(s.args[1].free_symbols)
@@ -1528,7 +1526,7 @@ class OctaveCodeGen(CodeGen):
     code_extension = "m"
 
     def __init__(self, project='project', printer=None):
-        super(OctaveCodeGen, self).__init__(project)
+        super().__init__(project)
         self.printer = printer or OctaveCodePrinter()
 
     def routine(self, name, expr, argument_sequence, global_vars):
@@ -1552,7 +1550,7 @@ class OctaveCodeGen(CodeGen):
 
         # symbols that should be arguments
         old_symbols = expressions.free_symbols - local_vars - global_vars
-        symbols = set([])
+        symbols = set()
         for s in old_symbols:
             if isinstance(s, Idx):
                 symbols.update(s.args[1].free_symbols)
@@ -1764,7 +1762,7 @@ class RustCodeGen(CodeGen):
     code_extension = "rs"
 
     def __init__(self, project="project", printer=None):
-        super(RustCodeGen, self).__init__(project=project)
+        super().__init__(project=project)
         self.printer = printer or RustCodePrinter()
 
     def routine(self, name, expr, argument_sequence, global_vars):
@@ -1778,7 +1776,7 @@ class RustCodeGen(CodeGen):
             expressions = Tuple(expr)
 
         # local variables
-        local_vars = set([i.label for i in expressions.atoms(Idx)])
+        local_vars = {i.label for i in expressions.atoms(Idx)}
 
         # global variables
         global_vars = set() if global_vars is None else set(global_vars)

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -1,7 +1,5 @@
 """Useful utility decorators. """
 
-from __future__ import print_function, division
-
 import sys
 import types
 import inspect
@@ -95,7 +93,7 @@ def conserve_mpmath_dps(func):
     return func_wrapper
 
 
-class no_attrs_in_subclass(object):
+class no_attrs_in_subclass:
     """Don't 'inherit' certain attributes from a base class
 
     >>> from sympy.utilities.decorator import no_attrs_in_subclass

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 """
 Algorithms and classes to support enumerative combinatorics.
 
@@ -91,7 +89,7 @@ time that would be spent skipping over zeros.
 
 """
 
-class PartComponent(object):
+class PartComponent:
     """Internal class used in support of the multiset partitions
     enumerators and the associated visitor functions.
 

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -2,8 +2,6 @@
 General SymPy exceptions and warnings.
 """
 
-from __future__ import print_function, division
-
 import warnings
 
 from sympy.utilities.misc import filldedent

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from collections import defaultdict, OrderedDict
 from itertools import (
     combinations, combinations_with_replacement, permutations,
@@ -294,8 +292,7 @@ def iproduct(*iterables):
         for e in iterables[0]:
             yield (e,)
     elif len(iterables) == 2:
-        for e12 in _iproduct2(*iterables):
-            yield e12
+        yield from _iproduct2(*iterables)
     else:
         first, others = iterables[0], iterables[1:]
         for ef, eo in _iproduct2(first, iproduct(*others)):
@@ -375,12 +372,10 @@ def postorder_traversal(node, keys=None):
             else:
                 args = ordered(args)
         for arg in args:
-            for subtree in postorder_traversal(arg, keys):
-                yield subtree
+            yield from postorder_traversal(arg, keys)
     elif iterable(node):
         for item in node:
-            for subtree in postorder_traversal(item, keys):
-                yield subtree
+            yield from postorder_traversal(item, keys)
     yield node
 
 
@@ -586,14 +581,12 @@ def variations(seq, n, repetition=False):
         seq = tuple(seq)
         if len(seq) < n:
             return
-        for i in permutations(seq, n):
-            yield i
+        yield from permutations(seq, n)
     else:
         if n == 0:
             yield ()
         else:
-            for i in product(seq, repeat=n):
-                yield i
+            yield from product(seq, repeat=n)
 
 
 def subsets(seq, k=None, repetition=False):
@@ -638,15 +631,12 @@ def subsets(seq, k=None, repetition=False):
     """
     if k is None:
         for k in range(len(seq) + 1):
-            for i in subsets(seq, k, repetition):
-                yield i
+            yield from subsets(seq, k, repetition)
     else:
         if not repetition:
-            for i in combinations(seq, k):
-                yield i
+            yield from combinations(seq, k)
         else:
-            for i in combinations_with_replacement(seq, k):
-                yield i
+            yield from combinations_with_replacement(seq, k)
 
 
 def filter_symbols(iterator, exclude):
@@ -2146,11 +2136,9 @@ def uniq(seq, result=None):
             check()
             result.append(s)
         if hasattr(seq, '__getitem__'):
-            for s in uniq(seq[i + 1:], result):
-                yield s
+            yield from uniq(seq[i + 1:], result)
         else:
-            for s in uniq(seq, result):
-                yield s
+            yield from uniq(seq, result)
 
 
 def generate_bell(n):
@@ -2227,8 +2215,7 @@ def generate_bell(n):
         yield (0, 1)
         yield (1, 0)
     elif n == 3:
-        for li in [(0, 1, 2), (0, 2, 1), (2, 0, 1), (2, 1, 0), (1, 2, 0), (1, 0, 2)]:
-            yield li
+        yield from [(0, 1, 2), (0, 2, 1), (2, 0, 1), (2, 1, 0), (1, 2, 0), (1, 0, 2)]
     else:
         m = n - 1
         op = [0] + [-1]*m
@@ -2637,16 +2624,13 @@ def kbins(l, k, ordered=None):
                         yield [lista[:i]] + part
 
     if ordered is None:
-        for p in partition(l, k):
-            yield p
+        yield from partition(l, k)
     elif ordered == 11:
         for pl in multiset_permutations(l):
             pl = list(pl)
-            for p in partition(pl, k):
-                yield p
+            yield from partition(pl, k)
     elif ordered == 00:
-        for p in multiset_partitions(l, k):
-            yield p
+        yield from multiset_partitions(l, k)
     elif ordered == 10:
         for p in multiset_partitions(l, k):
             for perm in permutations(p):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -3,8 +3,6 @@ This module provides convenient functions to transform sympy expressions to
 lambda functions which can be used to calculate numerical values very fast.
 """
 
-from __future__ import print_function, division
-
 from typing import Any, Dict
 
 import inspect
@@ -858,7 +856,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     func = funclocals[funcname]
 
     # Apply the docstring
-    sig = "func({0})".format(", ".join(str(i) for i in names))
+    sig = "func({})".format(", ".join(str(i) for i in names))
     sig = textwrap.fill(sig, subsequent_indent=' '*8)
     expr_str = str(expr)
     if len(expr_str) > 78:
@@ -1012,7 +1010,7 @@ def lambdastr(args, expr, printer=None, dummify=None):
     expr = lambdarepr(expr)
     return "lambda %s: (%s)" % (args, expr)
 
-class _EvaluatorPrinter(object):
+class _EvaluatorPrinter:
     def __init__(self, printer=None, dummify=False):
         self._dummify = dummify
 

--- a/sympy/utilities/magic.py
+++ b/sympy/utilities/magic.py
@@ -1,7 +1,5 @@
 """Functions that involve magic. """
 
-from __future__ import print_function, division
-
 def pollute(names, objects):
     """Pollute the global namespace with symbols -> objects mapping. """
     from inspect import currentframe

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy.core.decorators import wraps
 
 

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,7 +1,5 @@
 """Miscellaneous stuff that doesn't really fit anywhere else."""
 
-from __future__ import print_function, division
-
 from typing import List
 
 import sys
@@ -229,7 +227,7 @@ def debug_decorator(func):
         _debug_tmp = oldtmp
         _debug_tmp.append(s)
         if _debug_iter == 0:
-            print((_debug_tmp[0]))
+            print(_debug_tmp[0])
             _debug_tmp = []
         return r
 

--- a/sympy/utilities/pkgdata.py
+++ b/sympy/utilities/pkgdata.py
@@ -17,8 +17,6 @@ getResource to its get_data implementation and return it as a file-like
 object (such as StringIO).
 """
 
-from __future__ import print_function, division
-
 import sys
 import os
 from sympy.core.compatibility import cStringIO as StringIO
@@ -45,13 +43,13 @@ def get_resource(identifier, pkgname=__name__):
     mod = sys.modules[pkgname]
     fn = getattr(mod, '__file__', None)
     if fn is None:
-        raise IOError("%r has no __file__!")
+        raise OSError("%r has no __file__!")
     path = os.path.join(os.path.dirname(fn), identifier)
     loader = getattr(mod, '__loader__', None)
     if loader is not None:
         try:
             data = loader.get_data(path)
-        except (IOError,AttributeError):
+        except (OSError, AttributeError):
             pass
         else:
             return StringIO(data.decode('utf-8'))

--- a/sympy/utilities/source.py
+++ b/sympy/utilities/source.py
@@ -2,7 +2,6 @@
 This module adds several functions for interactive source code inspection.
 """
 
-from __future__ import print_function, division
 from sympy.core.decorators import deprecated
 
 import inspect

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from textwrap import dedent
 from itertools import islice, product
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -730,7 +730,7 @@ def test_namespace_type():
     # lambdify had a bug where it would reject modules of type unicode
     # on Python 2.
     x = sympy.Symbol('x')
-    lambdify(x, x, modules=u'math')
+    lambdify(x, x, modules='math')
 
 
 def test_imps():

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -1,4 +1,3 @@
-import sys
 import inspect
 import copy
 import pickle
@@ -31,21 +30,17 @@ from sympy import symbols, S
 from sympy.external import import_module
 cloudpickle = import_module('cloudpickle')
 
-excluded_attrs = set([
+excluded_attrs = {
     '_assumptions',  # This is a local cache that isn't automatically filled on creation
     '_mhash',   # Cached after __hash__ is called but set to None after creation
-    'message',   # This is an exception attribute that is present but deprecated in Py2 (can be removed when Py2 support is dropped
     'is_EmptySet',  # Deprecated from SymPy 1.5. This can be removed when is_EmptySet is removed.
-    ])
+    }
 
 
 def check(a, exclude=[], check_attr=True):
     """ Check that pickling and copying round-trips.
     """
-    protocols = [0, 1, 2, copy.copy, copy.deepcopy]
-    # Python 2.x doesn't support the third pickling protocol
-    if sys.version_info >= (3,):
-        protocols.extend([3, 4])
+    protocols = [0, 1, 2, copy.copy, copy.deepcopy, 3, 4]
     if cloudpickle:
         protocols.extend([cloudpickle])
 
@@ -180,9 +175,7 @@ def test_core_multidimensional():
 
 
 def test_Singletons():
-    protocols = [0, 1, 2]
-    if sys.version_info >= (3,):
-        protocols.extend([3, 4])
+    protocols = [0, 1, 2, 3, 4]
     copiers = [copy.copy, copy.deepcopy]
     copiers += [lambda x: pickle.loads(pickle.dumps(x, proto))
             for proto in protocols]

--- a/sympy/utilities/tests/test_source.py
+++ b/sympy/utilities/tests/test_source.py
@@ -6,7 +6,7 @@ from sympy.geometry import point
 
 def test_source():
     # Dummy stdout
-    class StdOut(object):
+    class StdOut:
         def write(self, x):
             pass
 

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -306,7 +306,7 @@ def test_F3():
 
 @XFAIL
 def test_F4():
-    assert combsimp((2**n * factorial(n) * product(2*k - 1, (k, 1, n)))) == factorial(2*n)
+    assert combsimp(2**n * factorial(n) * product(2*k - 1, (k, 1, n))) == factorial(2*n)
 
 
 @XFAIL
@@ -479,7 +479,7 @@ def test_H14():
 
 
 def test_H15():
-    assert simplify((Mul(*[x - r for r in solveset(x**3 + x**2 - 7)]))) == x**3 + x**2 - 7
+    assert simplify(Mul(*[x - r for r in solveset(x**3 + x**2 - 7)])) == x**3 + x**2 - 7
 
 
 def test_H16():

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -1,13 +1,12 @@
 """Simple tools for timing functions' execution, when IPython is not available. """
 
-from __future__ import print_function, division
 
 import timeit
 import math
 
 
 _scales = [1e0, 1e3, 1e6, 1e9]
-_units = [u's', u'ms', u'\N{GREEK SMALL LETTER MU}s', u'ns']
+_units = ['s', 'ms', '\N{GREEK SMALL LETTER MU}s', 'ns']
 
 
 def timed(func, setup="pass", limit=None):


### PR DESCRIPTION
#### References to other Issues or PRs

* https://github.com/sympy/sympy/issues/18816
* https://github.com/sympy/sympy/pull/19194


#### Brief description of what is fixed or changed

Changed Python 2 syntax to Python 3 syntax:

* IOError -> OSError: https://stackoverflow.com/a/29347946/562769
* Remove __future__ imports
* Remove explicit inheritance from object
* super(SomeClass, self) -> super()
* String Formatting
    * Percentage to format
    * {0} -> {}
* set([]) -> set()
* Use `yield from`

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->