### PR TITLE
Improve matrix slice printing

### DIFF
--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -106,7 +106,7 @@ def mat_slice_of_slice(parent, rowslice, colslice):
     >>> X[:, 1:5][5:8, :]
     X[5:8, 1:5]
     >>> X[1:9:2, 2:6][1:3, 2]
-    X[3:7:2, 4]
+    X[3:7:2, 4:5]
     """
     row = slice_of_slice(parent.rowslice, rowslice)
     col = slice_of_slice(parent.colslice, colslice)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1599,15 +1599,12 @@ class LatexPrinter(Printer):
     def _print_MatrixSlice(self, expr):
         def latexslice(x, dim):
             x = list(x)
-            if x[0] + 1 == x[1]:
-                x = [x[0]]
-            else:
-                if x[2] == 1:
-                    del x[2]
-                if x[0] == 0:
-                    x[0] = ''
-                if x[1] == dim:
-                    x[1] = ''
+            if x[2] == 1:
+                del x[2]
+            if x[0] == 0:
+                x[0] = ''
+            if x[1] == dim:
+                x[1] = ''
             return ':'.join(map(self._print, x))
         return (self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + r'\left[' +
                 latexslice(expr.rowslice, expr.parent.rows) + ', ' +

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1597,18 +1597,21 @@ class LatexPrinter(Printer):
             + '_{%s, %s}' % (self._print(expr.i), self._print(expr.j))
 
     def _print_MatrixSlice(self, expr):
-        def latexslice(x):
+        def latexslice(x, dim):
             x = list(x)
-            if x[2] == 1:
-                del x[2]
-            if x[1] == x[0] + 1:
-                del x[1]
-            if x[0] == 0:
-                x[0] = ''
+            if x[0] + 1 == x[1]:
+                x = [x[0]]
+            else:
+                if x[2] == 1:
+                    del x[2]
+                if x[0] == 0:
+                    x[0] = ''
+                if x[1] == dim:
+                    x[1] = ''
             return ':'.join(map(self._print, x))
-        return (self._print(expr.parent) + r'\left[' +
-                latexslice(expr.rowslice) + ', ' +
-                latexslice(expr.colslice) + r'\right]')
+        return (self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + r'\left[' +
+                latexslice(expr.rowslice, expr.parent.rows) + ', ' +
+                latexslice(expr.colslice, expr.parent.cols) + r'\right]')
 
     def _print_BlockMatrix(self, expr):
         return self._print(expr.blocks)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -816,15 +816,12 @@ class PrettyPrinter(Printer):
             prettyFunc = prettyForm(*prettyFunc.parens())
         def ppslice(x, dim):
             x = list(x)
-            if x[0] + 1 == x[1]:
-                x = [x[0]]
-            else:
-                if x[2] == 1:
-                    del x[2]
-                if x[0] == 0:
-                    x[0] = ''
-                if x[1] == dim:
-                    x[1] = ''
+            if x[2] == 1:
+                del x[2]
+            if x[0] == 0:
+                x[0] = ''
+            if x[1] == dim:
+                x[1] = ''
             return prettyForm(*self._print_seq(x, delimiter=':'))
         prettyArgs = self._print_seq((ppslice(m.rowslice, m.parent.rows),
             ppslice(m.colslice, m.parent.cols)), delimiter=', ').parens(left='[', right=']')[0]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -810,18 +810,24 @@ class PrettyPrinter(Printer):
 
     def _print_MatrixSlice(self, m):
         # XXX works only for applied functions
+        from sympy.matrices import MatrixSymbol
         prettyFunc = self._print(m.parent)
-        def ppslice(x):
+        if not isinstance(m.parent, MatrixSymbol):
+            prettyFunc = prettyForm(*prettyFunc.parens())
+        def ppslice(x, dim):
             x = list(x)
-            if x[2] == 1:
-                del x[2]
-            if x[1] == x[0] + 1:
-                del x[1]
-            if x[0] == 0:
-                x[0] = ''
+            if x[0] + 1 == x[1]:
+                x = [x[0]]
+            else:
+                if x[2] == 1:
+                    del x[2]
+                if x[0] == 0:
+                    x[0] = ''
+                if x[1] == dim:
+                    x[1] = ''
             return prettyForm(*self._print_seq(x, delimiter=':'))
-        prettyArgs = self._print_seq((ppslice(m.rowslice),
-            ppslice(m.colslice)), delimiter=', ').parens(left='[', right=']')[0]
+        prettyArgs = self._print_seq((ppslice(m.rowslice, m.parent.rows),
+            ppslice(m.colslice, m.parent.cols)), delimiter=', ').parens(left='[', right=']')[0]
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3176,9 +3176,9 @@ def test_MatrixSlice():
     expr = MatrixSlice(X, (None, None, None), (None, None, None))
     assert pretty(expr) == upretty(expr) == 'X[:, :]'
     expr = X[x:x + 1, y:y + 1]
-    assert pretty(expr) == upretty(expr) == 'X[x, y]'
+    assert pretty(expr) == upretty(expr) == 'X[x:x + 1, y:y + 1]'
     expr = X[x:x + 1:2, y:y + 1:2]
-    assert pretty(expr) == upretty(expr) == 'X[x, y]'
+    assert pretty(expr) == upretty(expr) == 'X[x:x + 1:2, y:y + 1:2]'
     expr = X[:x, y:]
     assert pretty(expr) == upretty(expr) == 'X[:x, y:]'
     expr = X[:x, y:]
@@ -3204,7 +3204,7 @@ def test_MatrixSlice():
     expr = MatrixSlice(X, (0, n, 2), (0, n, 2))
     assert pretty(expr) == upretty(expr) == 'X[::2, ::2]'
     expr = X[1:2:3, 4:5:6]
-    assert pretty(expr) == upretty(expr) == 'X[1, 4]'
+    assert pretty(expr) == upretty(expr) == 'X[1:2:3, 4:5:6]'
     expr = X[1:3:5, 4:6:8]
     assert pretty(expr) == upretty(expr) == 'X[1:3:5, 4:6:8]'
     expr = X[1:10:2]
@@ -3214,11 +3214,11 @@ def test_MatrixSlice():
     expr = Y[:5, 1:10:2]
     assert pretty(expr) == upretty(expr) == 'Y[:5, 1::2]'
     expr = Y[5, :5:2]
-    assert pretty(expr) == upretty(expr) == 'Y[5, :5:2]'
+    assert pretty(expr) == upretty(expr) == 'Y[5:6, :5:2]'
     expr = X[0:1, 0:1]
-    assert pretty(expr) == upretty(expr) == 'X[0, 0]'
+    assert pretty(expr) == upretty(expr) == 'X[:1, :1]'
     expr = X[0:1:2, 0:1:2]
-    assert pretty(expr) == upretty(expr) == 'X[0, 0]'
+    assert pretty(expr) == upretty(expr) == 'X[:1:2, :1:2]'
     expr = (Y + Z)[2:, 2:]
     assert pretty(expr) == upretty(expr) == '(Y + Z)[2:, 2:]'
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -9,7 +9,7 @@ from sympy import (
     SeqPer, SeqFormula, SeqAdd, SeqMul, fourier_series, fps, ITE,
     Complement, Interval, Intersection, Union, EulerGamma, GoldenRatio,
     LambertW, airyai, airybi, airyaiprime, airybiprime, fresnelc, fresnels,
-    Heaviside, dirichlet_eta, diag)
+    Heaviside, dirichlet_eta, diag, MatrixSlice)
 
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
     SubAugmentedAssignment, MulAugmentedAssignment, DivAugmentedAssignment, ModAugmentedAssignment)
@@ -3166,25 +3166,68 @@ tr⎜⎢    ⎥⎟ + tr⎜⎢    ⎥⎟
     assert upretty(Trace(X) + Trace(Y)) == ucode_str_2
 
 
+def test_MatrixSlice():
+    n = Symbol('n', integer=True)
+    x, y, z, w, t, = symbols('x y z w t')
+    X = MatrixSymbol('X', n, n)
+    Y = MatrixSymbol('Y', 10, 10)
+    Z = MatrixSymbol('Z', 10, 10)
+
+    expr = MatrixSlice(X, (None, None, None), (None, None, None))
+    assert pretty(expr) == upretty(expr) == 'X[:, :]'
+    expr = X[x:x + 1, y:y + 1]
+    assert pretty(expr) == upretty(expr) == 'X[x, y]'
+    expr = X[x:x + 1:2, y:y + 1:2]
+    assert pretty(expr) == upretty(expr) == 'X[x, y]'
+    expr = X[:x, y:]
+    assert pretty(expr) == upretty(expr) == 'X[:x, y:]'
+    expr = X[:x, y:]
+    assert pretty(expr) == upretty(expr) == 'X[:x, y:]'
+    expr = X[x:, :y]
+    assert pretty(expr) == upretty(expr) == 'X[x:, :y]'
+    expr = X[x:y, z:w]
+    assert pretty(expr) == upretty(expr) == 'X[x:y, z:w]'
+    expr = X[x:y:t, w:t:x]
+    assert pretty(expr) == upretty(expr) == 'X[x:y:t, w:t:x]'
+    expr = X[x::y, t::w]
+    assert pretty(expr) == upretty(expr) == 'X[x::y, t::w]'
+    expr = X[:x:y, :t:w]
+    assert pretty(expr) == upretty(expr) == 'X[:x:y, :t:w]'
+    expr = X[::x, ::y]
+    assert pretty(expr) == upretty(expr) == 'X[::x, ::y]'
+    expr = MatrixSlice(X, (0, None, None), (0, None, None))
+    assert pretty(expr) == upretty(expr) == 'X[:, :]'
+    expr = MatrixSlice(X, (None, n, None), (None, n, None))
+    assert pretty(expr) == upretty(expr) == 'X[:, :]'
+    expr = MatrixSlice(X, (0, n, None), (0, n, None))
+    assert pretty(expr) == upretty(expr) == 'X[:, :]'
+    expr = MatrixSlice(X, (0, n, 2), (0, n, 2))
+    assert pretty(expr) == upretty(expr) == 'X[::2, ::2]'
+    expr = X[1:2:3, 4:5:6]
+    assert pretty(expr) == upretty(expr) == 'X[1, 4]'
+    expr = X[1:3:5, 4:6:8]
+    assert pretty(expr) == upretty(expr) == 'X[1:3:5, 4:6:8]'
+    expr = X[1:10:2]
+    assert pretty(expr) == upretty(expr) == 'X[1:10:2, :]'
+    expr = Y[:5, 1:9:2]
+    assert pretty(expr) == upretty(expr) == 'Y[:5, 1:9:2]'
+    expr = Y[:5, 1:10:2]
+    assert pretty(expr) == upretty(expr) == 'Y[:5, 1::2]'
+    expr = Y[5, :5:2]
+    assert pretty(expr) == upretty(expr) == 'Y[5, :5:2]'
+    expr = X[0:1, 0:1]
+    assert pretty(expr) == upretty(expr) == 'X[0, 0]'
+    expr = X[0:1:2, 0:1:2]
+    assert pretty(expr) == upretty(expr) == 'X[0, 0]'
+    expr = (Y + Z)[2:, 2:]
+    assert pretty(expr) == upretty(expr) == '(Y + Z)[2:, 2:]'
+
+
 def test_MatrixExpressions():
     n = Symbol('n', integer=True)
     X = MatrixSymbol('X', n, n)
 
     assert pretty(X) == upretty(X) == "X"
-
-    Y = X[1:2:3, 4:5:6]
-
-    ascii_str = ucode_str = "X[1:3, 4:6]"
-
-    assert pretty(Y) == ascii_str
-    assert upretty(Y) == ucode_str
-
-    Z = X[1:10:2]
-
-    ascii_str = ucode_str = "X[1:10:2, :n]"
-
-    assert pretty(Z) == ascii_str
-    assert upretty(Z) == ucode_str
 
     # Apply function elementwise (`ElementwiseApplyFunc`):
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -257,15 +257,12 @@ class StrPrinter(Printer):
     def _print_MatrixSlice(self, expr):
         def strslice(x, dim):
             x = list(x)
-            if x[0] + 1 == x[1]:
-                x = [x[0]]
-            else:
-                if x[2] == 1:
-                    del x[2]
-                if x[0] == 0:
-                    x[0] = ''
-                if x[1] == dim:
-                    x[1] = ''
+            if x[2] == 1:
+                del x[2]
+            if x[0] == 0:
+                x[0] = ''
+            if x[1] == dim:
+                x[1] = ''
             return ':'.join(map(lambda arg: self._print(arg), x))
         return (self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '[' +
                 strslice(expr.rowslice, expr.parent.rows) + ', ' +

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -255,18 +255,21 @@ class StrPrinter(Printer):
             + '[%s, %s]' % (self._print(expr.i), self._print(expr.j))
 
     def _print_MatrixSlice(self, expr):
-        def strslice(x):
+        def strslice(x, dim):
             x = list(x)
-            if x[2] == 1:
-                del x[2]
-            if x[1] == x[0] + 1:
-                del x[1]
-            if x[0] == 0:
-                x[0] = ''
+            if x[0] + 1 == x[1]:
+                x = [x[0]]
+            else:
+                if x[2] == 1:
+                    del x[2]
+                if x[0] == 0:
+                    x[0] = ''
+                if x[1] == dim:
+                    x[1] = ''
             return ':'.join(map(lambda arg: self._print(arg), x))
-        return (self._print(expr.parent) + '[' +
-                strslice(expr.rowslice) + ', ' +
-                strslice(expr.colslice) + ']')
+        return (self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '[' +
+                strslice(expr.rowslice, expr.parent.rows) + ', ' +
+                strslice(expr.colslice, expr.parent.cols) + ']')
 
     def _print_DeferredVector(self, expr):
         return expr.name

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1599,8 +1599,8 @@ def test_latex_MatrixSlice():
     Z = MatrixSymbol('Z', 10, 10)
 
     assert latex(MatrixSlice(X, (None, None, None), (None, None, None))) == r'X\left[:, :\right]'
-    assert latex(X[x:x + 1, y:y + 1]) == r'X\left[x, y\right]'
-    assert latex(X[x:x + 1:2, y:y + 1:2]) == r'X\left[x, y\right]'
+    assert latex(X[x:x + 1, y:y + 1]) == r'X\left[x:x + 1, y:y + 1\right]'
+    assert latex(X[x:x + 1:2, y:y + 1:2]) == r'X\left[x:x + 1:2, y:y + 1:2\right]'
     assert latex(X[:x, y:]) == r'X\left[:x, y:\right]'
     assert latex(X[:x, y:]) == r'X\left[:x, y:\right]'
     assert latex(X[x:, :y]) == r'X\left[x:, :y\right]'
@@ -1613,14 +1613,14 @@ def test_latex_MatrixSlice():
     assert latex(MatrixSlice(X, (None, n, None), (None, n, None))) == r'X\left[:, :\right]'
     assert latex(MatrixSlice(X, (0, n, None), (0, n, None))) == r'X\left[:, :\right]'
     assert latex(MatrixSlice(X, (0, n, 2), (0, n, 2))) == r'X\left[::2, ::2\right]'
-    assert latex(X[1:2:3, 4:5:6]) == r'X\left[1, 4\right]'
+    assert latex(X[1:2:3, 4:5:6]) == r'X\left[1:2:3, 4:5:6\right]'
     assert latex(X[1:3:5, 4:6:8]) == r'X\left[1:3:5, 4:6:8\right]'
     assert latex(X[1:10:2]) == r'X\left[1:10:2, :\right]'
     assert latex(Y[:5, 1:9:2]) == r'Y\left[:5, 1:9:2\right]'
     assert latex(Y[:5, 1:10:2]) == r'Y\left[:5, 1::2\right]'
-    assert latex(Y[5, :5:2]) == r'Y\left[5, :5:2\right]'
-    assert latex(X[0:1, 0:1]) == r'X\left[0, 0\right]'
-    assert latex(X[0:1:2, 0:1:2]) == r'X\left[0, 0\right]'
+    assert latex(Y[5, :5:2]) == r'Y\left[5:6, :5:2\right]'
+    assert latex(X[0:1, 0:1]) == r'X\left[:1, :1\right]'
+    assert latex(X[0:1:2, 0:1:2]) == r'X\left[:1:2, :1:2\right]'
     assert latex((Y + Z)[2:, 2:]) == r'\left(Y + Z\right)\left[2:, 2:\right]'
 
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -16,7 +16,7 @@ from sympy import (
     meijerg, oo, polar_lift, polylog, re, root, sin, sqrt, symbols,
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
-    Contains, divisor_sigma, SeqPer, SeqFormula,
+    Contains, divisor_sigma, SeqPer, SeqFormula, MatrixSlice,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
     stieltjes, mathieuc, mathieus, mathieucprime, mathieusprime,
@@ -1592,11 +1592,36 @@ def test_matMul():
 
 
 def test_latex_MatrixSlice():
-    from sympy.matrices.expressions import MatrixSymbol
-    assert latex(MatrixSymbol('X', 10, 10)[:5, 1:9:2]) == \
-        r'X\left[:5, 1:9:2\right]'
-    assert latex(MatrixSymbol('X', 10, 10)[5, :5:2]) == \
-        r'X\left[5, :5:2\right]'
+    n = Symbol('n', integer=True)
+    x, y, z, w, t, = symbols('x y z w t')
+    X = MatrixSymbol('X', n, n)
+    Y = MatrixSymbol('Y', 10, 10)
+    Z = MatrixSymbol('Z', 10, 10)
+
+    assert latex(MatrixSlice(X, (None, None, None), (None, None, None))) == r'X\left[:, :\right]'
+    assert latex(X[x:x + 1, y:y + 1]) == r'X\left[x, y\right]'
+    assert latex(X[x:x + 1:2, y:y + 1:2]) == r'X\left[x, y\right]'
+    assert latex(X[:x, y:]) == r'X\left[:x, y:\right]'
+    assert latex(X[:x, y:]) == r'X\left[:x, y:\right]'
+    assert latex(X[x:, :y]) == r'X\left[x:, :y\right]'
+    assert latex(X[x:y, z:w]) == r'X\left[x:y, z:w\right]'
+    assert latex(X[x:y:t, w:t:x]) == r'X\left[x:y:t, w:t:x\right]'
+    assert latex(X[x::y, t::w]) == r'X\left[x::y, t::w\right]'
+    assert latex(X[:x:y, :t:w]) == r'X\left[:x:y, :t:w\right]'
+    assert latex(X[::x, ::y]) == r'X\left[::x, ::y\right]'
+    assert latex(MatrixSlice(X, (0, None, None), (0, None, None))) == r'X\left[:, :\right]'
+    assert latex(MatrixSlice(X, (None, n, None), (None, n, None))) == r'X\left[:, :\right]'
+    assert latex(MatrixSlice(X, (0, n, None), (0, n, None))) == r'X\left[:, :\right]'
+    assert latex(MatrixSlice(X, (0, n, 2), (0, n, 2))) == r'X\left[::2, ::2\right]'
+    assert latex(X[1:2:3, 4:5:6]) == r'X\left[1, 4\right]'
+    assert latex(X[1:3:5, 4:6:8]) == r'X\left[1:3:5, 4:6:8\right]'
+    assert latex(X[1:10:2]) == r'X\left[1:10:2, :\right]'
+    assert latex(Y[:5, 1:9:2]) == r'Y\left[:5, 1:9:2\right]'
+    assert latex(Y[:5, 1:10:2]) == r'Y\left[:5, 1::2\right]'
+    assert latex(Y[5, :5:2]) == r'Y\left[5, :5:2\right]'
+    assert latex(X[0:1, 0:1]) == r'X\left[0, 0\right]'
+    assert latex(X[0:1:2, 0:1:2]) == r'X\left[0, 0\right]'
+    assert latex((Y + Z)[2:, 2:]) == r'\left(Y + Z\right)\left[2:, 2:\right]'
 
 
 def test_latex_RandomDomain():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,7 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol)
+    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice)
 from sympy.core import Expr, Mul
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ, lex, grlex
@@ -777,9 +777,35 @@ def test_MatMul_MatAdd():
     assert str(-(1 + I)*X) == '(-1 - I)*X'
 
 def test_MatrixSlice():
-    from sympy.matrices.expressions import MatrixSymbol
-    assert str(MatrixSymbol('X', 10, 10)[:5, 1:9:2]) == 'X[:5, 1:9:2]'
-    assert str(MatrixSymbol('X', 10, 10)[5, :5:2]) == 'X[5, :5:2]'
+    n = Symbol('n', integer=True)
+    X = MatrixSymbol('X', n, n)
+    Y = MatrixSymbol('Y', 10, 10)
+    Z = MatrixSymbol('Z', 10, 10)
+
+    assert str(MatrixSlice(X, (None, None, None), (None, None, None))) == 'X[:, :]'
+    assert str(X[x:x + 1, y:y + 1]) == 'X[x, y]'
+    assert str(X[x:x + 1:2, y:y + 1:2]) == 'X[x, y]'
+    assert str(X[:x, y:]) == 'X[:x, y:]'
+    assert str(X[:x, y:]) == 'X[:x, y:]'
+    assert str(X[x:, :y]) == 'X[x:, :y]'
+    assert str(X[x:y, z:w]) == 'X[x:y, z:w]'
+    assert str(X[x:y:t, w:t:x]) == 'X[x:y:t, w:t:x]'
+    assert str(X[x::y, t::w]) == 'X[x::y, t::w]'
+    assert str(X[:x:y, :t:w]) == 'X[:x:y, :t:w]'
+    assert str(X[::x, ::y]) == 'X[::x, ::y]'
+    assert str(MatrixSlice(X, (0, None, None), (0, None, None))) == 'X[:, :]'
+    assert str(MatrixSlice(X, (None, n, None), (None, n, None))) == 'X[:, :]'
+    assert str(MatrixSlice(X, (0, n, None), (0, n, None))) == 'X[:, :]'
+    assert str(MatrixSlice(X, (0, n, 2), (0, n, 2))) == 'X[::2, ::2]'
+    assert str(X[1:2:3, 4:5:6]) == 'X[1, 4]'
+    assert str(X[1:3:5, 4:6:8]) == 'X[1:3:5, 4:6:8]'
+    assert str(X[1:10:2]) == 'X[1:10:2, :]'
+    assert str(Y[:5, 1:9:2]) == 'Y[:5, 1:9:2]'
+    assert str(Y[:5, 1:10:2]) == 'Y[:5, 1::2]'
+    assert str(Y[5, :5:2]) == 'Y[5, :5:2]'
+    assert str(X[0:1, 0:1]) == 'X[0, 0]'
+    assert str(X[0:1:2, 0:1:2]) == 'X[0, 0]'
+    assert str((Y + Z)[2:, 2:]) == '(Y + Z)[2:, 2:]'
 
 def test_true_false():
     assert str(true) == repr(true) == sstr(true) == "True"
@@ -833,14 +859,6 @@ def test_MatrixExpressions():
     X = MatrixSymbol('X', n, n)
 
     assert str(X) == "X"
-
-    Y = X[1:2:3, 4:5:6]
-
-    assert str(Y) == "X[1:3, 4:6]"
-
-    Z = X[1:10:2]
-
-    assert str(Z) == "X[1:10:2, :n]"
 
     # Apply function elementwise (`ElementwiseApplyFunc`):
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -783,8 +783,8 @@ def test_MatrixSlice():
     Z = MatrixSymbol('Z', 10, 10)
 
     assert str(MatrixSlice(X, (None, None, None), (None, None, None))) == 'X[:, :]'
-    assert str(X[x:x + 1, y:y + 1]) == 'X[x, y]'
-    assert str(X[x:x + 1:2, y:y + 1:2]) == 'X[x, y]'
+    assert str(X[x:x + 1, y:y + 1]) == 'X[x:x + 1, y:y + 1]'
+    assert str(X[x:x + 1:2, y:y + 1:2]) == 'X[x:x + 1:2, y:y + 1:2]'
     assert str(X[:x, y:]) == 'X[:x, y:]'
     assert str(X[:x, y:]) == 'X[:x, y:]'
     assert str(X[x:, :y]) == 'X[x:, :y]'
@@ -797,14 +797,14 @@ def test_MatrixSlice():
     assert str(MatrixSlice(X, (None, n, None), (None, n, None))) == 'X[:, :]'
     assert str(MatrixSlice(X, (0, n, None), (0, n, None))) == 'X[:, :]'
     assert str(MatrixSlice(X, (0, n, 2), (0, n, 2))) == 'X[::2, ::2]'
-    assert str(X[1:2:3, 4:5:6]) == 'X[1, 4]'
+    assert str(X[1:2:3, 4:5:6]) == 'X[1:2:3, 4:5:6]'
     assert str(X[1:3:5, 4:6:8]) == 'X[1:3:5, 4:6:8]'
     assert str(X[1:10:2]) == 'X[1:10:2, :]'
     assert str(Y[:5, 1:9:2]) == 'Y[:5, 1:9:2]'
     assert str(Y[:5, 1:10:2]) == 'Y[:5, 1::2]'
-    assert str(Y[5, :5:2]) == 'Y[5, :5:2]'
-    assert str(X[0:1, 0:1]) == 'X[0, 0]'
-    assert str(X[0:1:2, 0:1:2]) == 'X[0, 0]'
+    assert str(Y[5, :5:2]) == 'Y[5:6, :5:2]'
+    assert str(X[0:1, 0:1]) == 'X[:1, :1]'
+    assert str(X[0:1:2, 0:1:2]) == 'X[:1:2, :1:2]'
     assert str((Y + Z)[2:, 2:]) == '(Y + Z)[2:, 2:]'
 
 def test_true_false():


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #19148

#### Brief description of what is fixed or changed
- Fixes `A[:1, :1]` printing as `A[, ]` and `A[:1:2, :1:2]` printing as `A[:2, :2]`
- Always print using `:` notation, even if it's a 1x1 slice, to not have it be confused with matrix elements

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->