### PR TITLE
Improve 2x2 block matrix inversion with off-diagonal invertible blocks

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -556,37 +556,70 @@ def blockinverse_1x1(expr):
         return BlockMatrix(mat)
     return expr
 
+
 def blockinverse_2x2(expr):
-    if isinstance(expr.arg, BlockMatrix) and expr.arg.blockshape == (2, 2) and expr.arg.blocks[0, 0].is_square:
-        # Cite: The Matrix Cookbook Section 9.1.3
+    if isinstance(expr.arg, BlockMatrix) and expr.arg.blockshape == (2, 2):
+        # See: Inverses of 2x2 Block Matrices, Tzon-Tzer Lu and Sheng-Hua Shiou
         [[A, B],
          [C, D]] = expr.arg.blocks.tolist()
 
-        # Use one or the other formula, depending on whether A or D is known to be invertible or at least not known
-        # to not be invertible.  Note that invertAbility of the other expressions M is not checked.
-        A_invertible = ask(Q.invertible(A))
-        D_invertible = ask(Q.invertible(D))
-        if A_invertible == True:
-            invert_A = True
-        elif D_invertible == True:
-            invert_A = False
-        elif A_invertible != False:
-            invert_A = True
-        elif D_invertible != False:
-            invert_A = False
-        else:
-            invert_A = True
+        formula = _choose_2x2_inversion_formula(A, B, C, D)
 
-        if invert_A:
+        if formula == 'A':
             AI = A.I
             MI = (D - C * AI * B).I
             return BlockMatrix([[AI + AI * B * MI * C * AI, -AI * B * MI], [-MI * C * AI, MI]])
-        else:
+        if formula == 'B':
+            BI = B.I
+            MI = (C - D * BI * A).I
+            return BlockMatrix([[-MI * D * BI, MI], [BI + BI * A * MI * D * BI, -BI * A * MI]])
+        if formula == 'C':
+            CI = C.I
+            MI = (B - A * CI * D).I
+            return BlockMatrix([[-CI * D * MI, CI + CI * D * MI * A * CI], [MI, -MI * A * CI]])
+        if formula == 'D':
             DI = D.I
             MI = (A - B * DI * C).I
             return BlockMatrix([[MI, -MI * B * DI], [-DI * C * MI, DI + DI * C * MI * B * DI]])
 
     return expr
+
+
+def _choose_2x2_inversion_formula(A, B, C, D):
+    """
+    Assuming [[A, B], [C, D]] would form a valid square block matrix, find
+    which of the classical 2x2 block matrix inversion formulas would be
+    best suited.
+
+    Returns 'A', 'B', 'C', 'D' to represent the algorithm involving inversion
+    of the given argument or None if the matrix cannot be inverted using
+    any of those formulas.
+    """
+    # Try to find a known invertible matrix.  Note that the Schur complement
+    # is currently not being considered for this
+    A_inv = ask(Q.invertible(A))
+    if A_inv == True:
+        return 'A'
+    B_inv = ask(Q.invertible(B))
+    if B_inv == True:
+        return 'B'
+    C_inv = ask(Q.invertible(C))
+    if C_inv == True:
+        return 'C'
+    D_inv = ask(Q.invertible(D))
+    if D_inv == True:
+        return 'D'
+    # Otherwise try to find a matrix that isn't known to be non-invertible
+    if A_inv != False:
+        return 'A'
+    if B_inv != False:
+        return 'B'
+    if C_inv != False:
+        return 'C'
+    if D_inv != False:
+        return 'D'
+    return None
+
 
 def deblock(B):
     """ Flatten a BlockMatrix of BlockMatrices """
@@ -609,15 +642,33 @@ def deblock(B):
         return B
 
 
-
-def reblock_2x2(B):
-    """ Reblock a BlockMatrix so that it has 2x2 blocks of block matrices """
-    if not isinstance(B, BlockMatrix) or not all(d > 2 for d in B.blocks.shape):
-        return B
+def reblock_2x2(expr):
+    """
+    Reblock a BlockMatrix so that it has 2x2 blocks of block matrices.  If
+    possible in such a way that the matrix continues to be invertible using the
+    classical 2x2 block inversion formulas.
+    """
+    if not isinstance(expr, BlockMatrix) or not all(d > 2 for d in expr.blockshape):
+        return expr
 
     BM = BlockMatrix  # for brevity's sake
-    return BM([[   B.blocks[0,  0],  BM(B.blocks[0,  1:])],
-               [BM(B.blocks[1:, 0]), BM(B.blocks[1:, 1:])]])
+    rowblocks, colblocks = expr.blockshape
+    blocks = expr.blocks
+    for i in range(1, rowblocks):
+        for j in range(1, colblocks):
+            # try to split rows at i and cols at j
+            A = bc_unpack(BM(blocks[:i, :j]))
+            B = bc_unpack(BM(blocks[:i, j:]))
+            C = bc_unpack(BM(blocks[i:, :j]))
+            D = bc_unpack(BM(blocks[i:, j:]))
+
+            formula = _choose_2x2_inversion_formula(A, B, C, D)
+            if formula is not None:
+                return BlockMatrix([[A, B], [C, D]])
+
+    # else: nothing worked, just split upper left corner
+    return BM([[blocks[0, 0], BM(blocks[0, 1:])],
+               [BM(blocks[1:, 0]), BM(blocks[1:, 1:])]])
 
 
 def bounds(sizes):

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -5,7 +5,7 @@ from sympy.matrices.expressions.blockmatrix import (
     BlockMatrix, bc_dist, bc_matadd, bc_transpose, bc_inverse,
     blockcut, reblock_2x2, deblock)
 from sympy.matrices.expressions import (MatrixSymbol, Identity,
-        Inverse, trace, Transpose, det, ZeroMatrix, OneMatrix)
+        Inverse, trace, Transpose, det, ZeroMatrix)
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.matrices import (
     Matrix, ImmutableMatrix, ImmutableSparseMatrix)


### PR DESCRIPTION
Implement all four 2x2 block matrix inversion formulas and attempt to reblock in a way to make larger block matrices also invertible.

#### Brief description of what is fixed or changed
My previous PR regarding 2x2 block matrix inversion only implemented the cases where the A or D block was invertible. This now implements the two remaining formulas for invertible B or C block.

Also the 2x2 reblocking code now attempts to reblock in such a way that keeps the matrix invertible, which improves the inversion of block matrices larger than 2x2.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->