### PR TITLE
Put the doctr environment variable only in the build that needs it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   - SPLIT="1/2" TEST_SYMPY="true"
   - SPLIT="2/2" TEST_SYMPY="true"
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_EXAMPLES="true"
-  global:
-    - secure: "YIEZal9EBTL+fg2YmoZoS8Bvt3eAVUOZjb38CtqpzR2CCSXWoUk35KG23m2NknlY1iKfYJyt7XWBszT/VKOQEbWQq7PIakV4vIByrWacgBxy1x3WC+rZoW7TX+JJiL+y942qIYbMoNMMB8xFpE5RDLSjSecMpFhJJXoafVTvju8="
 dist: trusty
 
 python:
@@ -98,6 +96,7 @@ matrix:
       env:
         - TEST_SPHINX="true"
         - FASTCACHE="false"
+        - secure: "YIEZal9EBTL+fg2YmoZoS8Bvt3eAVUOZjb38CtqpzR2CCSXWoUk35KG23m2NknlY1iKfYJyt7XWBszT/VKOQEbWQq7PIakV4vIByrWacgBxy1x3WC+rZoW7TX+JJiL+y942qIYbMoNMMB8xFpE5RDLSjSecMpFhJJXoafVTvju8="
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ stages:
 
 env:
   matrix:
-  - SPLIT="1/2" TEST_SYMPY="true"
-  - SPLIT="2/2" TEST_SYMPY="true"
+  - TEST_SYMPY="true" SPLIT="1/2"
+  - TEST_SYMPY="true" SPLIT="2/2"
   - TEST_DOCTESTS="true" FASTCACHE="false" TEST_SETUP="true" TEST_EXAMPLES="true"
 dist: trusty
 
@@ -41,12 +41,12 @@ matrix:
       dist: xenial
       sudo: true
       env:
-        - SPLIT="1/2" TEST_SYMPY="true"
+        - TEST_SYMPY="true" SPLIT="1/2"
     - python: 3.8
       dist: xenial
       sudo: true
       env:
-        - SPLIT="2/2" TEST_SYMPY="true"
+        - TEST_SYMPY="true" SPLIT="2/2"
     - python: 3.7
       dist: xenial
       # At the time of writing this is Python 3.7 but it will become 3.8 when
@@ -79,11 +79,11 @@ matrix:
     - python: 3.7
       dist: xenial
       env:
-        - SPLIT="1/2" TEST_SYMPY="true"
+        - TEST_SYMPY="true" SPLIT="1/2"
     - python: 3.7
       dist: xenial
       env:
-        - SPLIT="2/2" TEST_SYMPY="true"
+        - TEST_SYMPY="true" SPLIT="2/2"
 
     # Tensorflow 1 support
     - python: 3.6
@@ -128,26 +128,26 @@ matrix:
       dist: xenial
       env:
         - TEST_SYMPY="true"
-        - TEST_COVERAGE="true"
         - SPLIT="1/4"
+        - TEST_COVERAGE="true"
     - python: 3.6
       dist: xenial
       env:
         - TEST_SYMPY="true"
-        - TEST_COVERAGE="true"
         - SPLIT="2/4"
+        - TEST_COVERAGE="true"
     - python: 3.6
       dist: xenial
       env:
         - TEST_SYMPY="true"
-        - TEST_COVERAGE="true"
         - SPLIT="3/4"
+        - TEST_COVERAGE="true"
     - python: 3.6
       dist: xenial
       env:
         - TEST_SYMPY="true"
-        - TEST_COVERAGE="true"
         - SPLIT="4/4"
+        - TEST_COVERAGE="true"
 
     # PyPy randomly fails because of some PyPy bugs
     # (Fatal RPython error: AssertionError)


### PR DESCRIPTION
Aside from being more secure, this fixes the environment variable listing on
the Travis site from showing DOCTR_DEPLOY_ENCRYPTION_KEY=[secure] as the first
thing for every build.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->