### PR TITLE
Inherit MatrixExpr for ImmutableSparseMatrix

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -42,8 +42,6 @@ class DenseMatrix(MatrixBase):
     _op_priority = 10.01
     _class_priority = 4
 
-    __hash__ = None
-
     def __eq__(self, other):
         other = sympify(other)
         self_shape = getattr(self, 'shape', None)
@@ -292,6 +290,8 @@ def _force_mutable(x):
 
 
 class MutableDenseMatrix(DenseMatrix, MatrixBase):
+    __hash__ = None
+
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -42,6 +42,8 @@ class DenseMatrix(MatrixBase):
     _op_priority = 10.01
     _class_priority = 4
 
+    __hash__ = None
+
     def __eq__(self, other):
         other = sympify(other)
         self_shape = getattr(self, 'shape', None)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -112,10 +112,14 @@ def test_subs():
     C = MatrixSymbol('C', m, l)
 
     assert A.subs(n, m).shape == (m, m)
-
     assert (A*B).subs(B, C) == A*C
-
     assert (A*B).subs(l, n).is_square
+
+    A = SparseMatrix([[1, 2], [3, 4]])
+    B = Matrix([[1, 2], [3, 4]])
+    C, D = MatrixSymbol('C', 2, 2), MatrixSymbol('D', 2, 2)
+
+    assert (C*D).subs({C: A, D: B}) == MatMul(A, B)
 
 
 def test_ZeroMatrix():

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -20,7 +20,7 @@ def sympify_mpmath_matrix(arg):
 sympify_converter[_matrix] = sympify_mpmath_matrix
 
 
-class ImmutableDenseMatrix(MatrixExpr, DenseMatrix):
+class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     """Create an immutable version of a matrix.
 
     Examples
@@ -47,6 +47,8 @@ class ImmutableDenseMatrix(MatrixExpr, DenseMatrix):
 
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
+
+    __hash__ = MatrixExpr.__hash__
 
     @classmethod
     def _new(cls, *args, **kwargs):
@@ -131,7 +133,7 @@ class ImmutableDenseMatrix(MatrixExpr, DenseMatrix):
 ImmutableMatrix = ImmutableDenseMatrix
 
 
-class ImmutableSparseMatrix(MatrixExpr, SparseMatrix):
+class ImmutableSparseMatrix(SparseMatrix, MatrixExpr):
     """Create an immutable version of a sparse matrix.
 
     Examples
@@ -158,6 +160,8 @@ class ImmutableSparseMatrix(MatrixExpr, SparseMatrix):
 
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
+
+    __hash__ = MatrixExpr.__hash__
 
     @classmethod
     def _new(cls, *args, **kwargs):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,4 +1,3 @@
-from typing import Callable
 from mpmath.matrices.matrices import _matrix
 
 from sympy.core import Basic, Dict, Integer, S, Tuple
@@ -21,7 +20,7 @@ def sympify_mpmath_matrix(arg):
 sympify_converter[_matrix] = sympify_mpmath_matrix
 
 
-class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
+class ImmutableDenseMatrix(MatrixExpr, DenseMatrix):
     """Create an immutable version of a matrix.
 
     Examples
@@ -49,8 +48,6 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
 
-    __hash__ = MatrixExpr.__hash__  # type: Callable[[MatrixExpr], int]
-
     @classmethod
     def _new(cls, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], ImmutableDenseMatrix):
@@ -62,19 +59,15 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
         else:
             rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
             flat_list = list(flat_list) # create a shallow copy
-        rows = Integer(rows)
-        cols = Integer(cols)
-        if not isinstance(flat_list, Tuple):
-            flat_list = Tuple(*flat_list)
 
-        return Basic.__new__(cls, rows, cols, flat_list)
-
-    @property
-    def _mat(self):
-        # self.args[2] is a Tuple.  Access to the elements
-        # of a tuple are significantly faster than Tuple,
-        # so return the internal tuple.
-        return self.args[2].args
+        obj = Basic.__new__(cls,
+            Integer(rows),
+            Integer(cols),
+            Tuple(*flat_list))
+        obj._rows = rows
+        obj._cols = cols
+        obj._mat = flat_list
+        return obj
 
     def _entry(self, i, j, **kwargs):
         return DenseMatrix.__getitem__(self, (i, j))
@@ -114,15 +107,15 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
 
     @property
     def cols(self):
-        return int(self.args[1])
+        return self._cols
 
     @property
     def rows(self):
-        return int(self.args[0])
+        return self._rows
 
     @property
     def shape(self):
-        return tuple(int(i) for i in self.args[:2])
+        return self._rows, self._cols
 
     def as_immutable(self):
         return self
@@ -138,7 +131,7 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr): # type: ignore
 ImmutableMatrix = ImmutableDenseMatrix
 
 
-class ImmutableSparseMatrix(SparseMatrix, Basic):
+class ImmutableSparseMatrix(MatrixExpr, SparseMatrix):
     """Create an immutable version of a sparse matrix.
 
     Examples
@@ -163,28 +156,38 @@ class ImmutableSparseMatrix(SparseMatrix, Basic):
     is_Matrix = True
     _class_priority = 9
 
+    def __new__(cls, *args, **kwargs):
+        return cls._new(*args, **kwargs)
+
     @classmethod
     def _new(cls, *args, **kwargs):
         s = MutableSparseMatrix(*args)
-        rows = Integer(s.rows)
-        cols = Integer(s.cols)
-        mat = Dict(s._smat)
-        obj = Basic.__new__(cls, rows, cols, mat)
-        obj.rows = s.rows
-        obj.cols = s.cols
-        obj._smat = s._smat
+        rows, cols, smat = s.rows, s.cols, s._smat
+        obj = Basic.__new__(cls, Integer(rows), Integer(cols), Dict(smat))
+        obj._rows = rows
+        obj._cols = cols
+        obj._smat = smat
         return obj
-
-    def __new__(cls, *args, **kwargs):
-        return cls._new(*args, **kwargs)
 
     def __setitem__(self, *args):
         raise TypeError("Cannot set values of ImmutableSparseMatrix")
 
-    def __hash__(self):
-        return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
+    def _entry(self, i, j, **kwargs):
+        return SparseMatrix.__getitem__(self, (i, j))
 
     _eval_Eq = ImmutableDenseMatrix._eval_Eq
+
+    @property
+    def cols(self):
+        return self._cols
+
+    @property
+    def rows(self):
+        return self._rows
+
+    @property
+    def shape(self):
+        return self._rows, self._cols
 
     def as_immutable(self):
         return self

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -768,9 +768,6 @@ class MatrixBase(MatrixDeprecated,
     zero = S.Zero
     one = S.One
 
-    # Mutable:
-    __hash__ = None  # type: ignore
-
     # Defined here the same as on Basic.
 
     # We don't define _repr_png_ here because it would add a large amount of

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1265,10 +1265,12 @@ class MatrixBase(MatrixDeprecated,
         multiply
         multiply_elementwise
         """
-        if not is_sequence(b):
+        from sympy.matrices.expressions.matexpr import MatrixExpr
+
+        if not isinstance(b, MatrixBase) and not isinstance(b, MatrixExpr):
             raise TypeError(
-                "`b` must be an ordered iterable or Matrix, not %s." %
-                type(b))
+                "{} must be a Matrix, not {}.".format(b, type(b)))
+
         if not (self.rows * self.cols == b.rows * b.cols == 3):
             raise ShapeError("Dimensions incorrect for cross product: %s x %s" %
                              ((self.rows, self.cols), (b.rows, b.cols)))

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -21,7 +21,8 @@ def test_creation():
 def test_immutability():
     with raises(TypeError):
         IM[2, 2] = 5
-        ISM[2, 2]
+    with raises(TypeError):
+        ISM[2, 2] = 5
 
 
 def test_slicing():

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,29 +1,34 @@
 from itertools import product
 
 from sympy import (ImmutableMatrix, Matrix, eye, zeros, S, Equality,
-        Unequality, ImmutableSparseMatrix, SparseMatrix, sympify,
-        integrate)
+        Unequality, SparseMatrix, sympify, integrate)
+from sympy.matrices.immutable import \
+    ImmutableDenseMatrix, ImmutableSparseMatrix
 from sympy.abc import x, y
 from sympy.testing.pytest import raises
 
-IM = ImmutableMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-ieye = ImmutableMatrix(eye(3))
+IM = ImmutableDenseMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+ISM = ImmutableSparseMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+ieye = ImmutableDenseMatrix(eye(3))
 
 
-def test_immutable_creation():
-    assert IM.shape == (3, 3)
-    assert IM[1, 2] == 6
-    assert IM[2, 2] == 9
+def test_creation():
+    assert IM.shape == ISM.shape == (3, 3)
+    assert IM[1, 2] == ISM[1, 2] == 6
+    assert IM[2, 2] == ISM[2, 2] == 9
 
 
 def test_immutability():
     with raises(TypeError):
         IM[2, 2] = 5
+        ISM[2, 2]
 
 
 def test_slicing():
-    assert IM[1, :] == ImmutableMatrix([[4, 5, 6]])
-    assert IM[:2, :2] == ImmutableMatrix([[1, 2], [4, 5]])
+    assert IM[1, :] == ImmutableDenseMatrix([[4, 5, 6]])
+    assert IM[:2, :2] == ImmutableDenseMatrix([[1, 2], [4, 5]])
+    assert ISM[1, :] == ImmutableSparseMatrix([[4, 5, 6]])
+    assert ISM[:2, :2] == ImmutableSparseMatrix([[1, 2], [4, 5]])
 
 
 def test_subs():
@@ -41,11 +46,13 @@ def test_subs():
 
 
 def test_as_immutable():
-    X = Matrix([[1, 2], [3, 4]])
-    assert sympify(X) == X.as_immutable() == ImmutableMatrix([[1, 2], [3, 4]])
-    X = SparseMatrix(5, 5, {})
-    assert sympify(X) == X.as_immutable() == ImmutableSparseMatrix(
-            [[0 for i in range(5)] for i in range(5)])
+    data = [[1, 2], [3, 4]]
+    X = Matrix(data)
+    assert sympify(X) == X.as_immutable() == ImmutableMatrix(data)
+
+    data = {(0, 0): 1, (0, 1): 2, (1, 0): 3, (1, 1): 4}
+    X = SparseMatrix(2, 2, data)
+    assert sympify(X) == X.as_immutable() == ImmutableSparseMatrix(2, 2, data)
 
 
 def test_function_return_types():

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -1,4 +1,6 @@
-from sympy import I, symbols, Matrix
+from sympy import I, symbols
+from sympy.core.expr import unchanged
+from sympy.matrices import Matrix, SparseMatrix
 
 from sympy.physics.quantum.commutator import Commutator as Comm
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -15,6 +17,11 @@ x = symbols('x')
 
 mat1 = Matrix([[1, 2*I], [1 + I, 3]])
 mat2 = Matrix([[2*I, 3], [4*I, 2]])
+
+
+def test_sparse_matrices():
+    spm = SparseMatrix.diag(1, 0)
+    assert unchanged(TensorProduct, spm, spm)
 
 
 def test_tensor_product_dagger():

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1588,9 +1588,9 @@ class LatexPrinter(Printer):
             out_str = r'\left' + left_delim + out_str + \
                       r'\right' + right_delim
         return out_str % r"\\".join(lines)
-    _print_ImmutableMatrix = _print_ImmutableDenseMatrix \
-                           = _print_Matrix \
-                           = _print_MatrixBase
+
+    _print_ImmutableDenseMatrix = _print_MatrixBase
+    _print_ImmutableSparseMatrix = _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
         return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True)\


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19227
#16800

#### Brief description of what is fixed or changed

The issue that ImmutableSparseMatrix is having different structure was reported in
https://groups.google.com/forum/#!searchin/sympy/ImmutableSparseMatrix%7Csort:date/sympy/K0k5JR7Tpqk/yTMwuLIkAgAJ
I think that this had caused a lot of side effects because immutable sparse matrix is not having some attributes that immutable dense matrix is supposed to have.
I've made them to have symmetrical class structures.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->