### PR TITLE
Fix creation of matrix with list of ndarray

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1077,8 +1077,8 @@ class MatrixBase(MatrixDeprecated,
                             r, c, flatT = cls._handle_creation_inputs(
                                 [i.T for i in row])
                             T = reshape(flatT, [c])
-                            flat = [T[i][j] for j in range(c) for i
-                            in range(r)]
+                            flat = \
+                                [T[i][j] for j in range(c) for i in range(r)]
                             r, c = c, r
                         else:
                             r = 1

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1069,7 +1069,6 @@ class MatrixBase(MatrixDeprecated,
                         if hasattr(row, '__array__'):
                             if 0 in row.shape:
                                 continue
-                            r, c, flat = cls._handle_ndarray(row)
                         elif not row:
                             continue
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2601,8 +2601,11 @@ def test_from_ndarray():
     assert Matrix(array([[1, 2, 3], [4, 5, 6]])) == \
         Matrix([[1, 2, 3], [4, 5, 6]])
     assert Matrix(array([x, y, z])) == Matrix([x, y, z])
-    raises(NotImplementedError, lambda: Matrix(array([[
-        [1, 2], [3, 4]], [[5, 6], [7, 8]]])))
+    raises(NotImplementedError,
+        lambda: Matrix(array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])))
+    assert Matrix([array([1, 2]), array([3, 4])]) == Matrix([[1, 2], [3, 4]])
+    assert Matrix([array([1, 2]), [3, 4]]) == Matrix([[1, 2], [3, 4]])
+    assert Matrix([array([]), array([])]) == Matrix([])
 
 def test_17522_numpy():
     from sympy.matrices.common import _matrixify


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18268

#### Brief description of what is fixed or changed

`not np.array([])` or `not np.array([1, 2])` does not work as intended.
Though they recommend the usage of `ndarray.any` or `ndarray.all`, however, I find that this is not a valid way to test out the empty array because they are used for testing the zero array.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed matrix creation from the list containg numpy ndarray. (e.g. `Matrix([np.array([1, 2]), np.array([1, 2])])`)
<!-- END RELEASE NOTES -->