### PR TITLE
parsing(c_parser): added support for major data types and shorthand operators

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -46,8 +46,8 @@ if cin:
     from sympy.codegen.ast import (Variable, IntBaseType,
         FloatBaseType, String, Integer, Float, FunctionPrototype,
         FunctionDefinition, FunctionCall, none, Return, Assignment,
-        Type, int8, int16, int32, int64, uint8, uint16, uint32, uint64,
-        float16, float32, float64, float80, aug_assign)
+        Type, int8, int16, int64, uint8, uint16, uint32, uint64,
+        float64, float80, aug_assign)
     from sympy.codegen.cnodes import (PreDecrement, PostDecrement,
         PreIncrement, PostIncrement)
     from sympy.core import Add, Mod, Mul, Pow, Rel

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -313,9 +313,9 @@ if cin:
                 elif child.kind == cin.CursorKind.CALL_EXPR:
                     return Variable(
                         node.spelling
-                    ).as_Declaration(
-                        value = val
-                    )
+                        ).as_Declaration(
+                            value = val
+                        )
 
                 else:
                     raise NotImplementedError("Given "

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -236,8 +236,7 @@ if cin:
             Returns
             =======
 
-            A variable node as Declaration, with the given value or 0 if the
-            value is not provided
+            A variable node as Declaration, with the initial value if given
 
             Raises
             ======
@@ -248,8 +247,23 @@ if cin:
             Notes
             =====
 
-            This function currently only supports basic Integer and Float data
-            types
+            The function currently supports following data types:
+
+            Boolean:
+                bool, _Bool
+
+            Integer:
+                8-bit: signed char and unsigned char
+                16-bit: short, short int, signed short,
+                    signed short int, unsigned short, unsigned short int
+                32-bit: int, signed int, unsigned int
+                64-bit: long, long int, signed long,
+                    signed long int, unsigned long, unsigned long int
+
+            Floating point:
+                Single Precision: float
+                Double Precision: double
+                Extended Precision: long double
 
             """
             if node.type.kind in self._data_types["int"]:

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -252,6 +252,15 @@ if cin:
             types
 
             """
+            if node.type.kind in self._data_types["int"]:
+                type = self._data_types["int"][node.type.kind]
+            elif node.type.kind in self._data_types["float"]:
+                type = self._data_types["float"][node.type.kind]
+            elif node.type.kind in self._data_types["bool"]:
+                type = self._data_types["bool"][node.type.kind]
+            else:
+                raise NotImplementedError("Only bool, int "
+                    "and float are supported")
             try:
                 children = node.get_children()
                 child = next(children)
@@ -270,8 +279,6 @@ if cin:
                     or child.kind == cin.CursorKind.UNEXPOSED_EXPR):
 
                     if node.type.kind in self._data_types["int"]:
-                        type = self._data_types["int"][node.type.kind]
-
                         # when only one decl_ref_expr is assigned
                         # e.g., int b = a;
                         if isinstance(val, str):
@@ -290,8 +297,6 @@ if cin:
                             value = val
 
                     elif node.type.kind in self._data_types["float"]:
-                        type = self._data_types["float"][node.type.kind]
-
                         # e.g., float b = a;
                         if isinstance(val, str):
                             value = Symbol(val)
@@ -306,7 +311,6 @@ if cin:
                             value = val
 
                     elif node.type.kind in self._data_types["bool"]:
-                        type = self._data_types["bool"][node.type.kind]
                         # e.g., bool b = a;
                         if isinstance(val, str):
                             value = Symbol(val)
@@ -316,10 +320,6 @@ if cin:
                         # e.g., bool b = a * 1;
                         else:
                             value = val
-
-                    else:
-                        raise NotImplementedError("Only bool, int "
-                            "and float are supported")
 
                 elif (child.kind == cin.CursorKind.CALL_EXPR):
                     return Variable(
@@ -337,15 +337,6 @@ if cin:
                     or child.kind == cin.CursorKind.PAREN_EXPR
                     or child.kind == cin.CursorKind.UNARY_OPERATOR
                     or child.kind == cin.CursorKind.CXX_BOOL_LITERAL_EXPR):
-                    if node.type.kind in self._data_types["int"]:
-                        type = self._data_types["int"][node.type.kind]
-                    elif node.type.kind in self._data_types["float"]:
-                        type = self._data_types["float"][node.type.kind]
-                    elif node.type.kind in self._data_types["bool"]:
-                        type = self._data_types["bool"][node.type.kind]
-                    else:
-                        raise NotImplementedError("Only bool, int "
-                            "and float are supported")
                     value = val
 
                 else:
@@ -358,31 +349,14 @@ if cin:
                         ))
 
             except StopIteration:
-
-                if node.type.kind in self._data_types["int"]:
-                    type = self._data_types["int"][node.type.kind]
-                elif node.type.kind in self._data_types["float"]:
-                    type = self._data_types["float"][node.type.kind]
-                elif node.type.kind in self._data_types["bool"]:
-                    type = self._data_types["bool"][node.type.kind]
-                else:
-                    raise NotImplementedError("Only bool, int "
-                        "and float are supported")
                 value = None
 
-            if value == None:
-                return Variable(
-                    node.spelling
-                ).as_Declaration(
-                    type = type
-                )
-            else:
-                return Variable(
-                    node.spelling
-                ).as_Declaration(
-                    type = type,
-                    value = value
-                )
+            return Variable(
+                node.spelling
+            ).as_Declaration(
+                type = type,
+                value = value
+            )
 
         def transform_function_decl(self, node):
             """Transformation Function For Function Declaration

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -349,14 +349,18 @@ if cin:
                         ))
 
             except StopIteration:
-                value = None
+                return Variable(
+                node.spelling
+                ).as_Declaration(
+                    type = type
+                )
 
             return Variable(
                 node.spelling
-            ).as_Declaration(
-                type = type,
-                value = value
-            )
+                ).as_Declaration(
+                    type = type,
+                    value = value
+                )
 
         def transform_function_decl(self, node):
             """Transformation Function For Function Declaration

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -522,7 +522,7 @@ if cin:
                 )
 
             try:
-                value = self.transform(next(children))
+                self.transform(next(children))
                 raise ValueError("Can't handle multiple children on parameter")
             except StopIteration:
                 pass

--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -402,22 +402,28 @@ if cin:
                 curr_ret_type += spelling + ' '
 
             ret_types = {
-            'void': none,
-            'bool': bool_,
-            'unsigned char': int8,
-            'short' : int16,
-            'short int' : int16,
-            'signed short': int16,
-            'signed short int': int16,
-            'int': intc,
-            'signed int': intc,
-            'long': int64,
-            'long int': int64,
-            'signed long': int64,
-            'signed long int': int64,
-            'float': float32,
-            'double': float64,
-            'long double': float80
+                'void': none,
+                'bool': bool_,
+                'signed char': int8,
+                'unsigned char': uint8,
+                'short' : int16,
+                'short int' : int16,
+                'signed short': int16,
+                'signed short int': int16,
+                'unsigned short': uint16,
+                'unsigned short int': uint16,
+                'int': intc,
+                'signed int': intc,
+                'unsigned int': uint32,
+                'long': int64,
+                'long int': int64,
+                'signed long': int64,
+                'signed long int': int64,
+                'unsigned long': uint64,
+                'unsigned long int': uint64,
+                'float': float32,
+                'double': float64,
+                'long double': float80
             }
 
             if curr_ret_type in ret_types:

--- a/sympy/parsing/sym_expr.py
+++ b/sympy/parsing/sym_expr.py
@@ -47,10 +47,10 @@ class SymPyExpression(object):  # type: ignore
     ... '''
     >>> a = SymPyExpression(src, 'c')
     >>> a.return_expr()
-    [Declaration(Variable(a, type=integer, value=0)),
-    Declaration(Variable(b, type=integer, value=0)),
-    Declaration(Variable(c, type=real, value=2.0)),
-    Declaration(Variable(d, type=real, value=4.0))]
+    [Declaration(Variable(a, type=intc)),
+    Declaration(Variable(b, type=intc)),
+    Declaration(Variable(c, type=float32, value=2.0)),
+    Declaration(Variable(d, type=float32, value=4.0))]
 
     An example of variable definiton:
 

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -200,6 +200,8 @@ if cin:
         res_type4 = SymPyExpression(c_src_type4, 'c').return_expr()
         res_type5 = SymPyExpression(c_src_type5, 'c').return_expr()
         res_type6 = SymPyExpression(c_src_type6, 'c').return_expr()
+        res_type7 = SymPyExpression(c_src_type7, 'c').return_expr()
+        res_type8 = SymPyExpression(c_src_type8, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -535,6 +537,72 @@ if cin:
                 type=UnsignedIntType(
                     String('uint16'),
                     nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type7[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=UnsignedIntType(
+                    String('uint32'),
+                    nbits=Integer(32)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type7[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=UnsignedIntType(
+                    String('uint32'),
+                    nbits=Integer(32)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type8[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=UnsignedIntType(
+                    String('uint64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type8[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=UnsignedIntType(
+                    String('uint64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type8[2] == Declaration(
+            Variable(
+                Symbol('c'),
+                type=UnsignedIntType(
+                    String('uint64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type8[3] == Declaration(
+            Variable(
+                Symbol('d'),
+                type=UnsignedIntType(
+                    String('uint64'),
+                    nbits=Integer(64)
                     ),
                 value=Integer(5)
                 )

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -48,16 +48,14 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
 
         assert res1[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
 
@@ -69,8 +67,7 @@ if cin:
                     nbits=Integer(32),
                     nmant=Integer(23),
                     nexp=Integer(8)
-                    ),
-                value=Float('0.0', precision=53)
+                    )
             )
         )
         assert res2[1] == Declaration(
@@ -81,16 +78,14 @@ if cin:
                     nbits=Integer(32),
                     nmant=Integer(23),
                     nexp=Integer(8)
-                    ),
-                value=Float('0.0', precision=53)
+                    )
             )
         )
 
         assert res3[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
 
@@ -102,16 +97,14 @@ if cin:
                     nbits=Integer(32),
                     nmant=Integer(23),
                     nexp=Integer(8)
-                    ),
-                value=Float('0.0', precision=53)
+                    )
             )
         )
 
         assert res3[2] == Declaration(
             Variable(
                 Symbol('c'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
 
@@ -981,8 +974,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                     )
                 )
             )
@@ -996,8 +988,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                     )
                 ),
                 Return('a')
@@ -1022,8 +1013,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                     )
                 ),
                 Return('b')
@@ -1074,16 +1064,14 @@ if cin:
             parameters=(
                 Variable(
                     Symbol('a'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                 ),
             ),
             body=CodeBlock(
                 Declaration(
                     Variable(
                         Symbol('i'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                     )
                 )
             )
@@ -1100,8 +1088,7 @@ if cin:
                         nbits=Integer(32),
                         nmant=Integer(23),
                         nexp=Integer(8)
-                        ),
-                    value=Float('0.0', precision=53)
+                        )
                 ),
                 Variable(
                     Symbol('y'),
@@ -1110,16 +1097,14 @@ if cin:
                         nbits=Integer(32),
                         nmant=Integer(23),
                         nexp=Integer(8)
-                        ),
-                    value=Float('0.0', precision=53)
+                        )
                 )
             ),
             body=CodeBlock(
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                     )
                 ),
                 Return('a')
@@ -1137,8 +1122,7 @@ if cin:
             parameters=(
                 Variable(
                     Symbol('p'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                 ),
                 Variable(
                     Symbol('q'),
@@ -1147,13 +1131,11 @@ if cin:
                         nbits=Integer(32),
                         nmant=Integer(23),
                         nexp=Integer(8)
-                        ),
-                    value=Float('0.0', precision=53)
+                        )
                 ),
                 Variable(
                     Symbol('r'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                 )
             ),
             body=CodeBlock(
@@ -1165,8 +1147,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                     )
                 ),
                 Return('b')
@@ -1247,8 +1228,7 @@ if cin:
             IntBaseType(String('intc')),
             name=String('fun1'),
             parameters=(Variable(Symbol('x'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
                 ),
             ),
             body=CodeBlock(
@@ -1277,15 +1257,13 @@ if cin:
             IntBaseType(String('intc')),
             name=String('fun2'),
             parameters=(Variable(Symbol('a'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
                 ),
             Variable(Symbol('b'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)),
+                type=IntBaseType(String('intc'))
+                ),
             Variable(Symbol('c'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
                 )
             ),
             body=CodeBlock(
@@ -1318,16 +1296,13 @@ if cin:
             name=String('fun3'),
             parameters=(
                 Variable(Symbol('a'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                     ),
                 Variable(Symbol('b'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                     ),
                 Variable(Symbol('c'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0)
+                    type=IntBaseType(String('intc'))
                     )
                 ),
             body=CodeBlock(
@@ -1342,20 +1317,17 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('p'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('q'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('r'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
@@ -1382,19 +1354,18 @@ if cin:
                     nbits=Integer(32),
                     nmant=Integer(23),
                     nexp=Integer(8)
-                    ),
-                value=Float('0.0', precision=53)),
+                    )
+                ),
             Variable(Symbol('b'),
                 type=FloatType(
                     String('float32'),
                     nbits=Integer(32),
                     nmant=Integer(23),
                     nexp=Integer(8)
-                    ),
-                value=Float('0.0', precision=53)),
+                    )
+                ),
             Variable(Symbol('c'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
                 )
             ),
             body=CodeBlock(
@@ -1414,8 +1385,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Declaration(
@@ -1425,14 +1395,12 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Declaration(
                     Variable(Symbol('z'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
@@ -1504,15 +1472,13 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
         assert res1[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('intc')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
         assert res2[0] == FunctionDefinition(
@@ -1523,8 +1489,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                     )
                 )
             )
@@ -2000,8 +1965,9 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                    type=IntBaseType(String('intc')),
-                    value=Integer(0))),
+                        type=IntBaseType(String('intc'))
+                        )
+                    ),
                 Assignment(Variable(Symbol('a')), Integer(1))
                 )
             )
@@ -2059,12 +2025,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0))),
+                        type=IntBaseType(String('intc'))
+                        )
+                    ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2095,26 +2061,22 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2159,26 +2121,22 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2232,8 +2190,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Assignment(
@@ -2255,8 +2212,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Assignment(
@@ -2278,8 +2234,9 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53))),
+                            )
+                        )
+                    ),
                 Assignment(
                     Variable(Symbol('a')),
                     Float('4.0', precision=53)
@@ -2294,8 +2251,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2312,8 +2268,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2330,8 +2285,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2348,14 +2302,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
@@ -2365,8 +2317,7 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Assignment(
@@ -2407,8 +2358,7 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('s'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2441,8 +2391,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2465,8 +2414,7 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2498,8 +2446,7 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2537,8 +2484,7 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2586,8 +2532,7 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Assignment(
@@ -2618,14 +2563,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -2646,26 +2589,22 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -2706,50 +2645,42 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c7'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c8'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -2830,38 +2761,32 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -2921,32 +2846,27 @@ if cin:
                             nbits=Integer(32),
                             nmant=Integer(23),
                             nexp=Integer(8)
-                            ),
-                        value=Float('0.0', precision=53)
+                            )
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -2996,39 +2916,33 @@ if cin:
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
                         type=Type(String('bool')
-                            ),
-                        value=false
+                            )
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3082,38 +2996,32 @@ if cin:
             parameters=(), body=CodeBlock(
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3150,38 +3058,32 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3217,32 +3119,27 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3271,30 +3168,27 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0))),
+                        type=IntBaseType(String('intc'))
+                        )
+                    ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3323,62 +3217,52 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('intc')),
-                        value=Integer(0)
+                        type=IntBaseType(String('intc'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c1'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c2'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c3'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c4'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c5'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c6'),
-                        type=Type(String('bool')),
-                        value=false
+                        type=Type(String('bool'))
                         )
                     ),
                 Assignment(
@@ -3514,8 +3398,8 @@ if cin:
         )
 
         c_src15 = (
-            'int a;' + '\n' +
-            'int b;' + '\n' +
+            'int a = 4;' + '\n' +
+            'int b = 2;' + '\n' +
             'float c = b/a;' + '\n'
         )
 
@@ -3633,7 +3517,7 @@ if cin:
         )
 
         c_src30 = (
-            'bool a;' + '\n' +
+            'bool a = false;' + '\n' +
 
             'bool c1 = a && true;' + '\n' +
             'bool c2 = false && a;' + '\n' +
@@ -3643,7 +3527,7 @@ if cin:
         )
 
         c_src31 = (
-            'int a;' + '\n' +
+            'int a = 1;' + '\n' +
 
             'bool c1 = a && 1;' + '\n' +
             'bool c2 = a && 0;' + '\n' +
@@ -3653,8 +3537,8 @@ if cin:
         )
 
         c_src32 = (
-            'int a, b;' + '\n' +
-            'bool c, d;'+ '\n' +
+            'int a = 1, b = 0;' + '\n' +
+            'bool c = false, d = true;'+ '\n' +
 
             'bool c1 = a && b;' + '\n' +
             'bool c2 = a && c;' + '\n' +
@@ -4066,14 +3950,14 @@ if cin:
         assert res15[0] == Declaration(
             Variable(Symbol('a'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(4)
                 )
             )
 
         assert res15[1] == Declaration(
             Variable(Symbol('b'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(2)
                 )
             )
 
@@ -4748,7 +4632,7 @@ if cin:
         assert res31[0] == Declaration(
             Variable(Symbol('a'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(1)
                 )
             )
 
@@ -4783,7 +4667,7 @@ if cin:
         assert res32[0] == Declaration(
             Variable(Symbol('a'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(1)
                 )
             )
 
@@ -4804,7 +4688,7 @@ if cin:
         assert res32[3] == Declaration(
             Variable(Symbol('d'),
                 type=Type(String('bool')),
-                value=false
+                value=true
                 )
             )
 
@@ -4879,7 +4763,7 @@ if cin:
         )
 
         c_src2 = (
-            'int a, b, c;'
+            'int a = 1, b = 2, c = 3;'
             'int d = (a);'
             'int e = (a + 1);'
             'int f = (a + b * c - d / e);'
@@ -4905,21 +4789,21 @@ if cin:
         assert res2[0] == Declaration(
             Variable(Symbol('a'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(1)
                 )
             )
 
         assert res2[1] == Declaration(
             Variable(Symbol('b'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(2)
                 )
             )
 
         assert res2[2] == Declaration(
             Variable(Symbol('c'),
                 type=IntBaseType(String('intc')),
-                value=Integer(0)
+                value=Integer(3)
                 )
             )
 

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -3550,12 +3550,11 @@ if cin:
         )
 
         c_src_raise1 = (
-            'int a = (int) 1.0;'
+            "char a = 'b';"
         )
 
         c_src_raise2 = (
-            'int a = 10;'
-            'int b = (a!=10)?(a):(0);'
+            'int a[] = {10, 20};'
         )
 
         res1 = SymPyExpression(c_src1, 'c').return_expr()

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -5,15 +5,18 @@ from sympy.external import import_module
 cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
 
 if cin:
-    from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
-                                   Return, FunctionDefinition, Integer, Float,
-                                   Declaration, CodeBlock, FunctionPrototype,
-                                   FunctionCall, NoneToken, Assignment, Type)
+    from sympy.codegen.ast import (Variable, IntBaseType,
+        FloatBaseType, String, Return, FunctionDefinition, Integer,
+        Float, Declaration, CodeBlock, FunctionPrototype, FunctionCall,
+        NoneToken, Assignment, Type, SignedIntType, UnsignedIntType,
+        FloatType, AddAugmentedAssignment, SubAugmentedAssignment,
+        MulAugmentedAssignment, DivAugmentedAssignment,
+        ModAugmentedAssignment)
     from sympy.codegen.cnodes import (PreDecrement, PostDecrement,
         PreIncrement, PostIncrement)
-    from sympy.core import (Add, Mul, Mod, Pow, Rational, StrictLessThan,
-                            LessThan, StrictGreaterThan, GreaterThan,
-                            Equality, Unequality)
+    from sympy.core import (Add, Mul, Mod, Pow, Rational,
+        StrictLessThan, LessThan, StrictGreaterThan, GreaterThan,
+        Equality, Unequality)
     from sympy.logic.boolalg import And, Not, Or
     from sympy import Symbol, true, false
     import os
@@ -141,12 +144,64 @@ if cin:
         c_src5 = "int x = '0', y = 'a';"
         c_src6 = "int r = true, s = false;"
 
+        # cin.TypeKind.UCHAR
+        c_src_type1 = (
+            "signed char a = 1, b = 5.1;"
+            )
+
+        # cin.TypeKind.SHORT
+        c_src_type2 = (
+            "short a = 1, b = 5.1;"
+            "signed short c = 1, d = 5.1;"
+            "short int e = 1, f = 5.1;"
+            "signed short int g = 1, h = 5.1;"
+            )
+
+        # cin.TypeKind.INT
+        c_src_type3 = (
+            "signed int a = 1, b = 5.1;"
+            "int c = 1, d = 5.1;"
+            )
+
+        # cin.TypeKind.LONG
+        c_src_type4 = (
+            "long a = 1, b = 5.1;"
+            "long int c = 1, d = 5.1;"
+            )
+
+        # cin.TypeKind.UCHAR
+        c_src_type5 = "unsigned char a = 1, b = 5.1;"
+
+        # cin.TypeKind.USHORT
+        c_src_type6 = (
+            "unsigned short a = 1, b = 5.1;"
+            "unsigned short int c = 1, d = 5.1;"
+            )
+
+        # cin.TypeKind.UINT
+        c_src_type7 = "unsigned int a = 1, b = 5.1;"
+
+        # cin.TypeKind.ULONG
+        c_src_type8 = (
+            "unsigned long a = 1, b = 5.1;"
+            "unsigned long int c = 1, d = 5.1;"
+            )
+
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
         res3 = SymPyExpression(c_src3, 'c').return_expr()
         res4 = SymPyExpression(c_src4, 'c').return_expr()
         res5 = SymPyExpression(c_src5, 'c').return_expr()
         res6 = SymPyExpression(c_src6, 'c').return_expr()
+
+        res_type1 = SymPyExpression(c_src_type1, 'c').return_expr()
+        res_type2 = SymPyExpression(c_src_type2, 'c').return_expr()
+        res_type3 = SymPyExpression(c_src_type3, 'c').return_expr()
+        res_type4 = SymPyExpression(c_src_type4, 'c').return_expr()
+        res_type5 = SymPyExpression(c_src_type5, 'c').return_expr()
+        res_type6 = SymPyExpression(c_src_type6, 'c').return_expr()
+        res_type7 = SymPyExpression(c_src_type7, 'c').return_expr()
+        res_type8 = SymPyExpression(c_src_type8, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -236,6 +291,257 @@ if cin:
             )
         )
 
+        assert res_type1[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=SignedIntType(
+                    String('int8'),
+                    nbits=Integer(8)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type1[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=SignedIntType(
+                    String('int8'),
+                    nbits=Integer(8)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type2[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type2[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type2[2] == Declaration(
+            Variable(Symbol('c'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type2[3] == Declaration(
+            Variable(
+                Symbol('d'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type2[4] == Declaration(
+            Variable(
+                Symbol('e'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type2[5] == Declaration(
+            Variable(
+                Symbol('f'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type2[6] == Declaration(
+            Variable(
+                Symbol('g'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type2[7] == Declaration(
+            Variable(
+                Symbol('h'),
+                type=SignedIntType(
+                    String('int16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type3[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=IntBaseType(String('integer')),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type3[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=IntBaseType(String('integer')),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type3[2] == Declaration(
+            Variable(
+                Symbol('c'),
+                type=IntBaseType(String('integer')),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type3[3] == Declaration(
+            Variable(
+                Symbol('d'),
+                type=IntBaseType(String('integer')),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type4[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=SignedIntType(
+                    String('int64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type4[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=SignedIntType(
+                    String('int64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type4[2] == Declaration(
+            Variable(
+                Symbol('c'),
+                type=SignedIntType(
+                    String('int64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type4[3] == Declaration(
+            Variable(
+                Symbol('d'),
+                type=SignedIntType(
+                    String('int64'),
+                    nbits=Integer(64)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type5[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=UnsignedIntType(
+                    String('uint8'),
+                    nbits=Integer(8)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type5[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=UnsignedIntType(
+                    String('uint8'),
+                    nbits=Integer(8)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type6[0] == Declaration(
+            Variable(
+                Symbol('a'),
+                type=UnsignedIntType(
+                    String('uint16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type6[1] == Declaration(
+            Variable(
+                Symbol('b'),
+                type=UnsignedIntType(
+                    String('uint16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
+        assert res_type6[2] == Declaration(
+            Variable(
+                Symbol('c'),
+                type=UnsignedIntType(
+                    String('uint16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(1)
+                )
+            )
+
+        assert res_type6[3] == Declaration(
+            Variable(
+                Symbol('d'),
+                type=UnsignedIntType(
+                    String('uint16'),
+                    nbits=Integer(16)
+                    ),
+                value=Integer(5)
+                )
+            )
+
 
     def test_float():
         c_src1 = 'float a = 1.0;'
@@ -247,11 +553,24 @@ if cin:
         c_src4 = 'float p = 5, e = 7.89;'
         c_src5 = 'float r = true, s = false;'
 
+        # cin.TypeKind.FLOAT
+        c_src_type1 = 'float x = 1, y = 2.5;'
+
+        # cin.TypeKind.DOUBLE
+        c_src_type2 = 'double x = 1, y = 2.5;'
+
+        # cin.TypeKind.LONGDOUBLE
+        c_src_type3 = 'long double x = 1, y = 2.5;'
+
         res1 = SymPyExpression(c_src1, 'c').return_expr()
         res2 = SymPyExpression(c_src2, 'c').return_expr()
         res3 = SymPyExpression(c_src3, 'c').return_expr()
         res4 = SymPyExpression(c_src4, 'c').return_expr()
         res5 = SymPyExpression(c_src5, 'c').return_expr()
+
+        res_type1 = SymPyExpression(c_src_type1, 'c').return_expr()
+        res_type2 = SymPyExpression(c_src_type2, 'c').return_expr()
+        res_type3 = SymPyExpression(c_src_type3, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(
@@ -324,6 +643,73 @@ if cin:
                 value=Float('0.0', precision=53)
             )
         )
+
+        assert res_type1[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=FloatBaseType(String('real')),
+                value=Float('1.0', precision=53)
+                )
+            )
+
+        assert res_type1[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=FloatBaseType(String('real')),
+                value=Float('2.5', precision=53)
+                )
+            )
+        assert res_type2[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=FloatType(
+                    String('float64'),
+                    nbits=Integer(64),
+                    nmant=Integer(52),
+                    nexp=Integer(11)
+                    ),
+                value=Float('1.0', precision=53)
+                )
+            )
+
+        assert res_type2[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=FloatType(
+                    String('float64'),
+                    nbits=Integer(64),
+                    nmant=Integer(52),
+                    nexp=Integer(11)
+                    ),
+                value=Float('2.5', precision=53)
+                )
+            )
+
+        assert res_type3[0] == Declaration(
+            Variable(
+                Symbol('x'),
+                type=FloatType(
+                    String('float80'),
+                    nbits=Integer(80),
+                    nmant=Integer(63),
+                    nexp=Integer(15)
+                    ),
+                value=Float('1.0', precision=53)
+                )
+            )
+
+        assert res_type3[1] == Declaration(
+            Variable(
+                Symbol('y'),
+                type=FloatType(
+                    String('float80'),
+                    nbits=Integer(80),
+                    nmant=Integer(63),
+                    nexp=Integer(15)
+                    ),
+                value=Float('2.5', precision=53)
+                )
+            )
 
 
     def  test_bool():
@@ -3038,18 +3424,10 @@ if cin:
         )
 
         c_src_raise1 = (
-            'double a;'
-        )
-
-        c_src_raise2 = (
-            'long a = 1;'
-        )
-
-        c_src_raise3 = (
             'int a = (int) 1.0;'
         )
 
-        c_src_raise4 = (
+        c_src_raise2 = (
             'int a = 10;'
             'int b = (a!=10)?(a):(0);'
         )
@@ -4195,8 +4573,6 @@ if cin:
 
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise1, 'c'))
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise2, 'c'))
-        raises(NotImplementedError, lambda: SymPyExpression(c_src_raise3, 'c'))
-        raises(NotImplementedError, lambda: SymPyExpression(c_src_raise4, 'c'))
 
 
     def test_paren_expr():
@@ -4438,6 +4814,57 @@ if cin:
 
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise1, 'c'))
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise2, 'c'))
+
+
+    def test_compound_assignment_operator():
+        c_src = (
+            'void func()'+
+            '{' + '\n' +
+                'int a = 100;' + '\n' +
+                'a += 10;' + '\n' +
+                'a -= 10;' + '\n' +
+                'a *= 10;' + '\n' +
+                'a /= 10;' + '\n' +
+                'a %= 10;' + '\n' +
+            '}'
+        )
+
+        res = SymPyExpression(c_src, 'c').return_expr()
+
+        assert res[0] == FunctionDefinition(
+            NoneToken(),
+            name=String('func'),
+            parameters=(),
+            body=CodeBlock(
+                Declaration(
+                    Variable(
+                        Symbol('a'),
+                        type=IntBaseType(String('integer')),
+                        value=Integer(100)
+                        )
+                    ),
+                AddAugmentedAssignment(
+                    Variable(Symbol('a')),
+                    Integer(10)
+                    ),
+                SubAugmentedAssignment(
+                    Variable(Symbol('a')),
+                    Integer(10)
+                    ),
+                MulAugmentedAssignment(
+                    Variable(Symbol('a')),
+                    Integer(10)
+                    ),
+                DivAugmentedAssignment(
+                    Variable(Symbol('a')),
+                    Integer(10)
+                    ),
+                ModAugmentedAssignment(
+                    Variable(Symbol('a')),
+                    Integer(10)
+                    )
+                )
+            )
 
 else:
     def test_raise():

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -200,8 +200,6 @@ if cin:
         res_type4 = SymPyExpression(c_src_type4, 'c').return_expr()
         res_type5 = SymPyExpression(c_src_type5, 'c').return_expr()
         res_type6 = SymPyExpression(c_src_type6, 'c').return_expr()
-        res_type7 = SymPyExpression(c_src_type7, 'c').return_expr()
-        res_type8 = SymPyExpression(c_src_type8, 'c').return_expr()
 
         assert res1[0] == Declaration(
             Variable(

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -5,11 +5,11 @@ from sympy.external import import_module
 cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
 
 if cin:
-    from sympy.codegen.ast import (Variable, IntBaseType,
-        FloatBaseType, String, Return, FunctionDefinition, Integer,
-        Float, Declaration, CodeBlock, FunctionPrototype, FunctionCall,
-        NoneToken, Assignment, Type, SignedIntType, UnsignedIntType,
-        FloatType, AddAugmentedAssignment, SubAugmentedAssignment,
+    from sympy.codegen.ast import (Variable, String, Return,
+        FunctionDefinition, Integer, Float, Declaration, CodeBlock,
+        FunctionPrototype, FunctionCall, NoneToken, Assignment, Type,
+        IntBaseType, SignedIntType, UnsignedIntType, FloatType,
+        AddAugmentedAssignment, SubAugmentedAssignment,
         MulAugmentedAssignment, DivAugmentedAssignment,
         ModAugmentedAssignment)
     from sympy.codegen.cnodes import (PreDecrement, PostDecrement,
@@ -48,7 +48,7 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -56,7 +56,7 @@ if cin:
         assert res1[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -64,14 +64,24 @@ if cin:
         assert res2[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)
             )
         )
         assert res2[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)
             )
         )
@@ -79,7 +89,7 @@ if cin:
         assert res3[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -87,7 +97,12 @@ if cin:
         assert res3[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)
             )
         )
@@ -95,7 +110,7 @@ if cin:
         assert res3[2] == Declaration(
             Variable(
                 Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -103,7 +118,7 @@ if cin:
         assert res4[0] == Declaration(
             Variable(
                 Symbol('x'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
             )
         )
@@ -111,7 +126,7 @@ if cin:
         assert res4[1] == Declaration(
             Variable(
                 Symbol('y'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(6)
             )
         )
@@ -119,7 +134,12 @@ if cin:
         assert res4[2] == Declaration(
             Variable(
                 Symbol('p'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.0', precision=53)
             )
         )
@@ -127,7 +147,12 @@ if cin:
         assert res4[3] == Declaration(
             Variable(
                 Symbol('q'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('9.67', precision=53)
             )
         )
@@ -206,7 +231,7 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
             )
         )
@@ -214,7 +239,7 @@ if cin:
         assert res2[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
             )
         )
@@ -222,7 +247,7 @@ if cin:
         assert res2[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
             )
         )
@@ -230,7 +255,7 @@ if cin:
         assert res3[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
             )
         )
@@ -238,7 +263,7 @@ if cin:
         assert res3[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(5)
             )
         )
@@ -246,7 +271,7 @@ if cin:
         assert res4[0] == Declaration(
             Variable(
                 Symbol('p'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(6)
             )
         )
@@ -254,7 +279,7 @@ if cin:
         assert res4[1] == Declaration(
             Variable(
                 Symbol('q'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(23)
             )
         )
@@ -262,7 +287,7 @@ if cin:
         assert res5[0] == Declaration(
             Variable(
                 Symbol('x'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(48)
             )
         )
@@ -270,7 +295,7 @@ if cin:
         assert res5[1] == Declaration(
             Variable(
                 Symbol('y'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(97)
             )
         )
@@ -278,7 +303,7 @@ if cin:
         assert res6[0] == Declaration(
             Variable(
                 Symbol('r'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
             )
         )
@@ -286,7 +311,7 @@ if cin:
         assert res6[1] == Declaration(
             Variable(
                 Symbol('s'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -403,7 +428,7 @@ if cin:
         assert res_type3[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
@@ -411,7 +436,7 @@ if cin:
         assert res_type3[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(5)
                 )
             )
@@ -419,7 +444,7 @@ if cin:
         assert res_type3[2] == Declaration(
             Variable(
                 Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
@@ -427,7 +452,7 @@ if cin:
         assert res_type3[3] == Declaration(
             Variable(
                 Symbol('d'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(5)
                 )
             )
@@ -641,7 +666,12 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.0', precision=53)
                 )
             )
@@ -649,7 +679,12 @@ if cin:
         assert res2[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.25', precision=53)
             )
         )
@@ -657,7 +692,12 @@ if cin:
         assert res2[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.3900000000000001', precision=53)
             )
         )
@@ -665,7 +705,12 @@ if cin:
         assert res3[0] == Declaration(
             Variable(
                 Symbol('x'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.0', precision=53)
             )
         )
@@ -673,7 +718,12 @@ if cin:
         assert res3[1] == Declaration(
             Variable(
                 Symbol('y'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.0', precision=53)
             )
         )
@@ -681,7 +731,12 @@ if cin:
         assert res4[0] == Declaration(
             Variable(
                 Symbol('p'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                ),
                 value=Float('5.0', precision=53)
             )
         )
@@ -689,7 +744,12 @@ if cin:
         assert res4[1] == Declaration(
             Variable(
                 Symbol('e'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('7.89', precision=53)
             )
         )
@@ -697,7 +757,12 @@ if cin:
         assert res5[0] == Declaration(
             Variable(
                 Symbol('r'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.0', precision=53)
             )
         )
@@ -705,7 +770,12 @@ if cin:
         assert res5[1] == Declaration(
             Variable(
                 Symbol('s'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)
             )
         )
@@ -713,7 +783,12 @@ if cin:
         assert res_type1[0] == Declaration(
             Variable(
                 Symbol('x'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.0', precision=53)
                 )
             )
@@ -721,7 +796,12 @@ if cin:
         assert res_type1[1] == Declaration(
             Variable(
                 Symbol('y'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.5', precision=53)
                 )
             )
@@ -901,7 +981,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                     )
                 )
@@ -909,14 +989,14 @@ if cin:
         )
 
         assert res2[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun2'),
             parameters=(),
             body=CodeBlock(
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                     )
                 ),
@@ -925,14 +1005,24 @@ if cin:
         )
 
         assert res3[0] == FunctionDefinition(
-            FloatBaseType(String('real')),
+            FloatType(
+                String('float32'),
+                nbits=Integer(32),
+                nmant=Integer(23),
+                nexp=Integer(8)
+                ),
             name=String('fun3'),
             parameters=(),
             body=CodeBlock(
                 Declaration(
                     Variable(
                         Symbol('b'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                     )
                 ),
@@ -941,7 +1031,12 @@ if cin:
         )
 
         assert res4[0] == FunctionPrototype(
-            FloatBaseType(String('real')),
+            FloatType(
+                String('float32'),
+                nbits=Integer(32),
+                nmant=Integer(23),
+                nexp=Integer(8)
+                ),
             name=String('fun4'),
             parameters=()
         )
@@ -979,7 +1074,7 @@ if cin:
             parameters=(
                 Variable(
                     Symbol('a'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                 ),
             ),
@@ -987,7 +1082,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('i'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                     )
                 )
@@ -995,17 +1090,27 @@ if cin:
         )
 
         assert res2[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun2'),
             parameters=(
                 Variable(
                     Symbol('x'),
-                    type=FloatBaseType(String('real')),
+                    type=FloatType(
+                        String('float32'),
+                        nbits=Integer(32),
+                        nmant=Integer(23),
+                        nexp=Integer(8)
+                        ),
                     value=Float('0.0', precision=53)
                 ),
                 Variable(
                     Symbol('y'),
-                    type=FloatBaseType(String('real')),
+                    type=FloatType(
+                        String('float32'),
+                        nbits=Integer(32),
+                        nmant=Integer(23),
+                        nexp=Integer(8)
+                        ),
                     value=Float('0.0', precision=53)
                 )
             ),
@@ -1013,7 +1118,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                     )
                 ),
@@ -1022,21 +1127,32 @@ if cin:
         )
 
         assert res3[0] == FunctionDefinition(
-            FloatBaseType(String('real')), name=String('fun3'),
+            FloatType(
+                String('float32'),
+                nbits=Integer(32),
+                nmant=Integer(23),
+                nexp=Integer(8)
+                ),
+            name=String('fun3'),
             parameters=(
                 Variable(
                     Symbol('p'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                 ),
                 Variable(
                     Symbol('q'),
-                    type=FloatBaseType(String('real')),
+                    type=FloatType(
+                        String('float32'),
+                        nbits=Integer(32),
+                        nmant=Integer(23),
+                        nexp=Integer(8)
+                        ),
                     value=Float('0.0', precision=53)
                 ),
                 Variable(
                     Symbol('r'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                 )
             ),
@@ -1044,7 +1160,12 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('b'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                     )
                 ),
@@ -1123,10 +1244,10 @@ if cin:
 
 
         assert res1[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun1'),
             parameters=(Variable(Symbol('x'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 ),
             ),
@@ -1153,17 +1274,17 @@ if cin:
             )
 
         assert res2[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun2'),
             parameters=(Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 ),
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)),
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             ),
@@ -1193,19 +1314,19 @@ if cin:
             )
 
         assert res3[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun3'),
             parameters=(
                 Variable(Symbol('a'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                     ),
                 Variable(Symbol('b'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                     ),
                 Variable(Symbol('c'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0)
                     )
                 ),
@@ -1221,19 +1342,19 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('p'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('q'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('r'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -1253,16 +1374,26 @@ if cin:
             )
 
         assert res4[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun4'),
             parameters=(Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)),
             Variable(Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('0.0', precision=53)),
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             ),
@@ -1278,19 +1409,29 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('x'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('y'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('z'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -1309,7 +1450,7 @@ if cin:
             )
 
         assert res5[0] == FunctionDefinition(
-            IntBaseType(String('integer')),
+            IntBaseType(String('intc')),
             name=String('fun'),
             parameters=(),
             body=CodeBlock(
@@ -1363,14 +1504,14 @@ if cin:
         assert res1[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
         assert res1[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
             )
         )
@@ -1382,7 +1523,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                     )
                 )
@@ -1859,7 +2000,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0))),
                 Assignment(Variable(Symbol('a')), Integer(1))
                 )
@@ -1872,7 +2013,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                    type=IntBaseType(String('integer')),
+                    type=IntBaseType(String('intc')),
                     value=Integer(0))),
                 Assignment(
                     Variable(Symbol('a')),
@@ -1897,7 +2038,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(10)
                         )
                     ),
@@ -1918,11 +2059,11 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0))),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -1954,25 +2095,25 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2018,25 +2159,25 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2086,7 +2227,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
@@ -2104,7 +2250,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
@@ -2122,7 +2273,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53))),
                 Assignment(
                     Variable(Symbol('a')),
@@ -2138,7 +2294,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2156,7 +2312,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2174,7 +2330,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2192,19 +2348,24 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
@@ -2228,25 +2389,25 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(2)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(5)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('n'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(10)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('s'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2280,7 +2441,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2298,13 +2459,13 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(2)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2325,19 +2486,19 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(100)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(3)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2358,25 +2519,25 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(100)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(3)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('mod'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(1000000007)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2407,25 +2568,25 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(100)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(3)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('mod'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(1000000007)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -2533,13 +2694,13 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(1)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(2)
                         )
                     ),
@@ -2657,13 +2818,13 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(3)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(4)
                         )
                     ),
@@ -2755,7 +2916,12 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('0.0', precision=53)
                         )
                     ),
@@ -2808,13 +2974,23 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('1.25', precision=53)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=FloatBaseType(String('real')),
+                        type=FloatType(
+                            String('float32'),
+                            nbits=Integer(32),
+                            nmant=Integer(23),
+                            nexp=Integer(8)
+                            ),
                         value=Float('2.5', precision=53)
                         )
                     ),
@@ -3095,7 +3271,7 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0))),
                 Declaration(
                     Variable(Symbol('c1'),
@@ -3147,13 +3323,13 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(0)
                         )
                     ),
@@ -3533,27 +3709,27 @@ if cin:
 
         assert res1[0] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(100)
                 )
             )
 
         assert res1[1] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Symbol('b')
                 )
             )
 
         assert res2[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res2[1] == Declaration(Variable(Symbol('b'),
-            type=IntBaseType(String('integer')),
+            type=IntBaseType(String('intc')),
             value=Add(
                 Symbol('a'),
                 Integer(1)
@@ -3563,14 +3739,24 @@ if cin:
 
         assert res3[0] == Declaration(
             Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('12.5', precision=53)
                 )
             )
 
         assert res3[1] == Declaration(
             Variable(Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Mul(
                     Float('20.0', precision=53),
                     Symbol('a')
@@ -3580,35 +3766,35 @@ if cin:
 
         assert res4[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(83)
                 )
             )
 
         assert res5[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(-4836)
                 )
             )
 
         assert res6[0] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
                 )
             )
 
         assert res6[1] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(3)
                 )
             )
 
         assert res6[2] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Symbol('b'),
                     Mul(
@@ -3621,14 +3807,14 @@ if cin:
 
         assert res7[0] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res7[1] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Symbol('b'),
                     Integer(2)
@@ -3638,7 +3824,7 @@ if cin:
 
         assert res7[2] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mul(
                     Integer(10),
                     Pow(
@@ -3657,19 +3843,19 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(1)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(2)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('temp'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Symbol('a')
                         )
                     ),
@@ -3686,28 +3872,28 @@ if cin:
 
         assert res9[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res9[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
                 )
             )
 
         assert res9[2] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Symbol('a')
                 )
             )
 
         assert res9[3] == Declaration(
             Variable(Symbol('d'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Symbol('a'),
                     Symbol('b'),
@@ -3718,7 +3904,7 @@ if cin:
 
         assert res9[4] == Declaration(
             Variable(Symbol('e'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Pow(
                         Symbol('a'),
@@ -3750,7 +3936,7 @@ if cin:
 
         assert res9[5] == Declaration(
             Variable(Symbol('f'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mul(
                     Add(
                         Symbol('a'),
@@ -3771,7 +3957,7 @@ if cin:
 
         assert res9[6] == Declaration(
             Variable(Symbol('g'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mul(
                     Symbol('a'),
                     Add(
@@ -3796,21 +3982,36 @@ if cin:
 
         assert res10[0] == Declaration(
             Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('10.0', precision=53)
                 )
             )
 
         assert res10[1] == Declaration(
             Variable(Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.5', precision=53)
                 )
             )
 
         assert res10[2] == Declaration(
             Variable(Symbol('c'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Add(
                     Pow(
                         Symbol('a'),
@@ -3831,49 +4032,59 @@ if cin:
 
         assert res11[0] == Declaration(
             Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('4.0', precision=53)
                 )
             )
 
         assert res12[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(25)
                 )
             )
 
         assert res13[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(-95)
                 )
             )
 
         assert res14[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(-300)
                 )
             )
 
         assert res15[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res15[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res15[2] == Declaration(
             Variable(Symbol('c'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Mul(
                     Pow(
                         Symbol('a'),
@@ -3886,28 +4097,28 @@ if cin:
 
         assert res16[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
                 )
             )
 
         assert res16[1] == Declaration(
             Variable(Symbol('d'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(5)
                 )
             )
 
         assert res16[2] == Declaration(
             Variable(Symbol('n'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(10)
                 )
             )
 
         assert res16[3] == Declaration(
             Variable(Symbol('s'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mul(
                     Rational(1, 2),
                     Symbol('a'),
@@ -3930,21 +4141,21 @@ if cin:
 
         assert res17[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res18[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
                 )
             )
 
         assert res18[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mod(
                     Symbol('a'),
                     Integer(3)
@@ -3954,20 +4165,20 @@ if cin:
 
         assert res19[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(100)
                 )
             )
         assert res19[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(3)
                 )
             )
 
         assert res19[2] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mod(
                     Symbol('a'),
                     Symbol('b')
@@ -3977,28 +4188,28 @@ if cin:
 
         assert res20[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(100)
                 )
             )
 
         assert res20[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(3)
                 )
             )
 
         assert res20[2] == Declaration(
             Variable(Symbol('mod'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1000000007)
                 )
             )
 
         assert res20[3] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mod(
                     Add(
                         Symbol('a'),
@@ -4018,28 +4229,28 @@ if cin:
 
         assert res21[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(100)
                 )
             )
 
         assert res21[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(3)
                 )
             )
 
         assert res21[2] == Declaration(
             Variable(Symbol('mod'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1000000007)
                 )
             )
 
         assert res21[3] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Mod(
                     Mul(
                         Add(
@@ -4103,14 +4314,14 @@ if cin:
 
         assert res24[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res24[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(2)
                 )
             )
@@ -4196,14 +4407,14 @@ if cin:
 
         assert res25[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(3)
                 )
             )
 
         assert res25[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(4)
                 )
             )
@@ -4269,14 +4480,24 @@ if cin:
 
         assert res26[0] == Declaration(
             Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.25', precision=53)
                 )
             )
 
         assert res26[1] == Declaration(
             Variable(Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.5', precision=53)
                 )
             )
@@ -4323,14 +4544,24 @@ if cin:
 
         assert res27[0] == Declaration(
             Variable(Symbol('a'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('1.25', precision=53)
                 )
             )
 
         assert res27[1] == Declaration(
             Variable(Symbol('b'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.5', precision=53)
                 )
             )
@@ -4516,7 +4747,7 @@ if cin:
 
         assert res31[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
@@ -4551,14 +4782,14 @@ if cin:
 
         assert res32[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res32[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
@@ -4659,49 +4890,49 @@ if cin:
 
         assert res1[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(1)
                 )
             )
 
         assert res1[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(7)
                 )
             )
 
         assert res2[0] == Declaration(
             Variable(Symbol('a'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res2[1] == Declaration(
             Variable(Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res2[2] == Declaration(
             Variable(Symbol('c'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(0)
                 )
             )
 
         assert res2[3] == Declaration(
             Variable(Symbol('d'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Symbol('a')
                 )
             )
 
         assert res2[4] == Declaration(
             Variable(Symbol('e'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Symbol('a'),
                     Integer(1)
@@ -4711,7 +4942,7 @@ if cin:
 
         assert res2[5] == Declaration(
             Variable(Symbol('f'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Add(
                     Symbol('a'),
                     Mul(
@@ -4787,13 +5018,13 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(10)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(20)
                         )
                     ),
@@ -4811,43 +5042,43 @@ if cin:
             body=CodeBlock(
                 Declaration(
                     Variable(Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(10)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('b'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(-100)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('c'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(19)
                         )
                     ),
                 Declaration(
                     Variable(Symbol('d'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=PreIncrement(Symbol('a'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('e'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=PreDecrement(Symbol('b'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('f'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=PostIncrement(Symbol('a'))
                         )
                     ),
                 Declaration(
                     Variable(Symbol('g'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=PostDecrement(Symbol('b'))
                         )
                     ),
@@ -4905,7 +5136,7 @@ if cin:
                 Declaration(
                     Variable(
                         Symbol('a'),
-                        type=IntBaseType(String('integer')),
+                        type=IntBaseType(String('intc')),
                         value=Integer(100)
                         )
                     ),

--- a/sympy/parsing/tests/test_sym_expr.py
+++ b/sympy/parsing/tests/test_sym_expr.py
@@ -7,7 +7,7 @@ cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
 
 if lfortran and cin:
     from sympy.codegen.ast import (Variable, IntBaseType, FloatBaseType, String,
-                                   Declaration,)
+                                   Declaration, FloatType)
     from sympy.core import Integer, Float
     from sympy import Symbol
 
@@ -28,28 +28,36 @@ if lfortran and cin:
         assert ls[0] == Declaration(
             Variable(
                 Symbol('a'),
-                type=IntBaseType(String('integer')),
-                value=Integer(0)
+                type=IntBaseType(String('intc'))
             )
         )
         assert ls[1] == Declaration(
             Variable(
                 Symbol('b'),
-                type=IntBaseType(String('integer')),
+                type=IntBaseType(String('intc')),
                 value=Integer(4)
             )
         )
         assert ls[2] == Declaration(
             Variable(
                 Symbol('c'),
-                type=FloatBaseType(String('real')),
-                value=Float('0.0', precision=53)
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    )
             )
         )
         assert ls[3] == Declaration(
             Variable(
                 Symbol('d'),
-                type=FloatBaseType(String('real')),
+                type=FloatType(
+                    String('float32'),
+                    nbits=Integer(32),
+                    nmant=Integer(23),
+                    nexp=Integer(8)
+                    ),
                 value=Float('2.3999999999999999', precision=53)
             )
         )


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Added support for data types in C parser:
    - `int` data types:
        - `signed char`(8-bit integer)
        - `unsigned char`(8-bit integer, unsigned)
        - `short` (16-bit integer)
        - `short int` (16-bit integer)
        - `signed short` (16-bit integer)
        - `signed short int` (16-bit integer)
        - `unsigned short` (16-bit integer, unsigned)
        - `unsigned short int` (16-bit integer, unsigned)
        - `unsigned int` (32-bit integer, unsigned)
        - `long` (64-bit integer)
        - `long int` (64-bit integer)
        - `signed long` (64-bit integer)
        - `signed long int` (64-bit integer)
        - `unsigned long` (64-bit integer, unsigned)
        - `unsigned long int` (64-bit integer, unsigned)

    - `float` data types:
        - `double` (double precision floating point)
        - `long double` (extended precision floating point)
- Added support for shorthand operators in C parser:
    - `+=`, `-=`, `*=`, `/=` and `%=`
 - Removed the assumption of value of a variable, if it is not initialized while variable declaration. Also, removed the assumption of default value of formal parameters while parameter declaration in function definition or function prototype

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
    - Added support for more data types in C parser: `signed char`, `unsigned char`, `short`, `short int`, `signed short`, `signed short int`, `unsigned short`, `unsigned short int`, `unsigned int`, `long`, `long int`, `signed long`, `signed long int`, `unsigned long`, `unsigned long int`, `double`, `long double`. Also, modified the data type for `int` and `float` to `intc` and `float32` respectively, replacing `integer` and `real`
    - Added support for shorthand operators in C parser: `+=`, `-=`, `*=`, `/=` and `%=`
    - Removed the assumption of value of a variable, if it is not initialized while variable declaration(e.g.; in case of `int a;`, the value of `a` was assumed to be `Integer(0)`, in case of `float b;`, the value of `b` was assumed to be `Float(0.0)` and in case of `bool c;`, the value of `c` was assumed to be `S.false`). Also, removed the assumption of default value of formal parameters while parameter declaration in function definition or function prototype (e.g.; in case of function definition `void func(int a, float b) { //some code }`, default value of formal parameters`a` and `b` were assumed to be `Integer(0)` and `Float(0.0)` respectively)
 
<!-- END RELEASE NOTES -->