### PR TITLE
Remove expand_mul call in cholesky and LDLdecompisition

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -257,16 +257,15 @@ def _cholesky(M, hermitian=True):
     if not hermitian and not M.is_symmetric():
         raise ValueError("Matrix must be symmetric.")
 
-    dps = _get_intermediate_simp(expand_mul, expand_mul)
     L   = MutableDenseMatrix.zeros(M.rows, M.rows)
 
     if hermitian:
         for i in range(M.rows):
             for j in range(i):
-                L[i, j] = dps((1 / L[j, j])*(M[i, j] -
+                L[i, j] = ((1 / L[j, j])*(M[i, j] -
                     sum(L[i, k]*L[j, k].conjugate() for k in range(j))))
 
-            Lii2 = dps(M[i, i] -
+            Lii2 = (M[i, i] -
                 sum(L[i, k]*L[i, k].conjugate() for k in range(i)))
 
             if Lii2.is_positive is False:
@@ -278,11 +277,11 @@ def _cholesky(M, hermitian=True):
     else:
         for i in range(M.rows):
             for j in range(i):
-                L[i, j] = dps((1 / L[j, j])*(M[i, j] -
+                L[i, j] = ((1 / L[j, j])*(M[i, j] -
                     sum(L[i, k]*L[j, k] for k in range(j))))
 
-            L[i, i] = sqrt(dps(M[i, i] -
-                sum(L[i, k]**2 for k in range(i))))
+            L[i, i] = sqrt(M[i, i] -
+                sum(L[i, k]**2 for k in range(i)))
 
     return M._new(L)
 
@@ -460,17 +459,16 @@ def _LDLdecomposition(M, hermitian=True):
     if not hermitian and not M.is_symmetric():
         raise ValueError("Matrix must be symmetric.")
 
-    dps = _get_intermediate_simp(expand_mul, expand_mul)
     D   = MutableDenseMatrix.zeros(M.rows, M.rows)
     L   = MutableDenseMatrix.eye(M.rows)
 
     if hermitian:
         for i in range(M.rows):
             for j in range(i):
-                L[i, j] = dps((1 / D[j, j])*(M[i, j] - sum(
-                    L[i, k]*L[j, k].conjugate()*D[k, k] for k in range(j))))
+                L[i, j] = (1 / D[j, j])*(M[i, j] - sum(
+                    L[i, k]*L[j, k].conjugate()*D[k, k] for k in range(j)))
 
-            D[i, i] = dps(M[i, i] -
+            D[i, i] = (M[i, i] -
                 sum(L[i, k]*L[i, k].conjugate()*D[k, k] for k in range(i)))
 
             if D[i, i].is_positive is False:
@@ -480,10 +478,10 @@ def _LDLdecomposition(M, hermitian=True):
     else:
         for i in range(M.rows):
             for j in range(i):
-                L[i, j] = dps((1 / D[j, j])*(M[i, j] - sum(
-                    L[i, k]*L[j, k]*D[k, k] for k in range(j))))
+                L[i, j] = (1 / D[j, j])*(M[i, j] - sum(
+                    L[i, k]*L[j, k]*D[k, k] for k in range(j)))
 
-            D[i, i] = dps(M[i, i] - sum(L[i, k]**2*D[k, k] for k in range(i)))
+            D[i, i] = M[i, i] - sum(L[i, k]**2*D[k, k] for k in range(i))
 
     return M._new(L), M._new(D)
 

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -281,8 +281,8 @@ def test_LDLdecomposition():
     A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
     L, D = A.LDLdecomposition()
     assert expand_mul(L * D * L.H) == A
-    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S.Half - I/2, 0, 1)))
-    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
+    assert L.expand() == Matrix([[1, 0, 0], [I/2, 1, 0], [S.Half - I/2, 0, 1]])
+    assert D.expand() == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
 
     raises(NonSquareMatrixError, lambda: SparseMatrix((1, 2)).LDLdecomposition())
     raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).LDLdecomposition())

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1976,7 +1976,7 @@ def test_cholesky():
     assert L.is_lower
     assert L == Matrix([[5, 0, 0], [3, 3, 0], [-1, 1, 3]])
     A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
-    assert A.cholesky() == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
+    assert A.cholesky().expand() == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
 
     raises(NonSquareMatrixError, lambda: SparseMatrix((1, 2)).cholesky())
     raises(ValueError, lambda: SparseMatrix(((1, 2), (3, 4))).cholesky())


### PR DESCRIPTION
Both cholesky and LDLdecompisition used expand_mul to simplify some
calculations but this can lead to significant slowdowns in some cases.
This commit removes the calls to expand_mul from each of these
functions.

Fixes https://github.com/sympy/sympy/issues/19200

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->