### PR TITLE
STY: Remove trailing whitespace

### DIFF
--- a/doc/man/isympy.1
+++ b/doc/man/isympy.1
@@ -28,7 +28,7 @@ isympy \- interactive shell for SymPy
 'in \n(.iu+\nxu
 [
 {\fB-h\fR | \fB--help\fR}
-| 
+|
 {\fB-v\fR | \fB--version\fR}
 ]
 'in \n(.iu-\nxu
@@ -54,7 +54,7 @@ experimentation with SymPy. For more complicated programs, it is recommended
 to write a script and import things explicitly (using the "from sympy
 import sin, log, Symbol, ..." idiom).
 .SH OPTIONS
-.TP 
+.TP
 \*(T<\fB\-c \fR\*(T>\fISHELL\fR, \*(T<\fB\-\-console=\fR\*(T>\fISHELL\fR
 Use the specified shell (python or ipython) as
 console backend instead of the default one (ipython
@@ -64,7 +64,7 @@ Example: isympy -c python
 
 \fISHELL\fR could be either
 \&'ipython' or 'python'
-.TP 
+.TP
 \*(T<\fB\-p \fR\*(T>\fIENCODING\fR, \*(T<\fB\-\-pretty=\fR\*(T>\fIENCODING\fR
 Setup pretty printing in SymPy. By default, the most pretty, unicode
 printing is enabled (if the terminal supports it). You can use less
@@ -74,7 +74,7 @@ Example: isympy -p no
 
 \fIENCODING\fR must be one of 'unicode',
 \&'ascii' or 'no'.
-.TP 
+.TP
 \*(T<\fB\-t \fR\*(T>\fITYPE\fR, \*(T<\fB\-\-types=\fR\*(T>\fITYPE\fR
 Setup the ground types for the polys. By default, gmpy ground types
 are used if gmpy2 or gmpy is installed, otherwise it falls back to python
@@ -98,7 +98,7 @@ Example: isympy -t python
 
 \fITYPE\fR must be one of 'gmpy',
 \&'gmpy1' or 'python'.
-.TP 
+.TP
 \*(T<\fB\-o \fR\*(T>\fIORDER\fR, \*(T<\fB\-\-order=\fR\*(T>\fIORDER\fR
 Setup the ordering of terms for printing. The default is lex, which
 orders terms lexicographically (e.g., x**2 + x + 1). You can choose
@@ -113,14 +113,14 @@ Example: isympy -o rev-lax
 
 \fIORDER\fR must be one of 'lex', 'rev-lex', 'grlex',
 \&'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.
-.TP 
+.TP
 \*(T<\fB\-q\fR\*(T>, \*(T<\fB\-\-quiet\fR\*(T>
 Print only Python's and SymPy's versions to stdout at startup, and nothing else.
-.TP 
+.TP
 \*(T<\fB\-d\fR\*(T>, \*(T<\fB\-\-doctest\fR\*(T>
 Use the same format that should be used for doctests. This is
 equivalent to '\fIisympy -c python -p no\fR'.
-.TP 
+.TP
 \*(T<\fB\-C\fR\*(T>, \*(T<\fB\-\-no\-cache\fR\*(T>
 Disable the caching mechanism. Disabling the cache may slow certain
 operations down considerably. This is useful for testing the cache,
@@ -128,7 +128,7 @@ or for benchmarking, as the cache can result in deceptive benchmark timings.
 
 This is the same as setting the environment variable SYMPY_USE_CACHE
 to 'no'.
-.TP 
+.TP
 \*(T<\fB\-a\fR\*(T>, \*(T<\fB\-\-auto\fR\*(T>
 Automatically create missing symbols. Normally, typing a name of a
 Symbol that has not been instantiated first would raise NameError,
@@ -153,12 +153,12 @@ using symbols() or var().
 Finally, this only works in the top level namespace. So, for
 example, if you define a function in isympy with an undefined
 Symbol, it will not work.
-.TP 
+.TP
 \*(T<\fB\-D\fR\*(T>, \*(T<\fB\-\-debug\fR\*(T>
 Enable debugging output. This is the same as setting the
 environment variable SYMPY_DEBUG to 'True'. The debug status is set
 in the variable SYMPY_DEBUG within isympy.
-.TP 
+.TP
 -- \fIPYTHONOPTIONS\fR
 These options will be passed on to \fIipython (1)\fR shell.
 Only supported when ipython is being used (standard python shell not supported).
@@ -169,14 +169,14 @@ from the other isympy options.
 For example, to run iSymPy without startup banner and colors:
 
 isympy -q -c ipython -- --colors=NoColor
-.TP 
+.TP
 \*(T<\fB\-h\fR\*(T>, \*(T<\fB\-\-help\fR\*(T>
 Print help output and exit.
-.TP 
+.TP
 \*(T<\fB\-v\fR\*(T>, \*(T<\fB\-\-version\fR\*(T>
 Print isympy version information and exit.
 .SH FILES
-.TP 
+.TP
 \*(T<\fI${HOME}/.sympy\-history\fR\*(T>
 Saves the history of commands when using the python
 shell as backend.

--- a/doc/src/modules/combinatorics/pc_groups.rst
+++ b/doc/src/modules/combinatorics/pc_groups.rst
@@ -40,7 +40,7 @@ relative order.
 Attributes of PolycyclicGroup
 `````````````````````````````
 
-* ``pc_sequence`` : Polycyclic sequence is formed by collecting all the missing 
+* ``pc_sequence`` : Polycyclic sequence is formed by collecting all the missing
   generators between the adjacent groups in the derived series of given
   permutation group.
 
@@ -251,7 +251,7 @@ polycyclic generating sequence. Hence, the length of exponent vector is equal to
 the length of the pcgs.
 
 A given generator ``g`` of the polycyclic group, can be represented as
-`g = x_1^{e_1} \ldots x_n^{e_n}`, where `x_i` represents polycyclic generators 
+`g = x_1^{e_1} \ldots x_n^{e_n}`, where `x_i` represents polycyclic generators
 and ``n`` is the number of generators in the free_group equal to the length of pcgs.
 
 >>> from sympy.combinatorics.named_groups import SymmetricGroup

--- a/doc/src/modules/physics/mechanics/autolev_parser.rst
+++ b/doc/src/modules/physics/mechanics/autolev_parser.rst
@@ -146,7 +146,7 @@ Note that we need to use SymPy functions like ``.ang_vel_in()``, ``.dcm()``
 etc in many cases unlike directly printing out the variables like ``zero``.
 If you are completely new to SymPy mechanics, the :ref:`SymPy Mechanics for Autolev Users guide <sympy_mechanics_for_autolev_users>`
 guide should help. You might also have to use basic SymPy simplifications
-and manipulations like ``trigsimp()``, ``expand()``, ``evalf()`` etc for 
+and manipulations like ``trigsimp()``, ``expand()``, ``evalf()`` etc for
 getting outputs similar to Autolev.
 Refer to the `SymPy Tutorial <https://docs.sympy.org/latest/tutorial/index.html>`_
 to know more about these.
@@ -206,7 +206,7 @@ Gotchas
 - When dealing with Matrices returned by functions, one must check the
   order of the values as they may not be the same as in Autolev. This is
   especially the case for eigenvalues and eigenvectors.
-  
+
   .. code-block:: none
 
      %Autolev Code
@@ -219,7 +219,7 @@ Gotchas
   .. code-block:: python
 
      #SymPy Code
-     #---------- 
+     #----------
      e1 = sm.Matrix([i.evalf() for i in m.eigenvals().keys()])
      # sm.Matrix([5;13;14]) different order
      e2 = sm.Matrix([i[2][0].evalf() for i in m.eigenvects()]).reshape(m.shape[0], m.shape[1])
@@ -229,15 +229,15 @@ Gotchas
 
 ------------------------------------------------------------------------
 
-- When using ``EVALUATE``, use something like ``90*UNITS(deg,rad)`` for 
+- When using ``EVALUATE``, use something like ``90*UNITS(deg,rad)`` for
   angle substitutions as radians are the default in SymPy.
   You could also add ``np.deg2rad()`` directly in the SymPy code.
-  
+
   This need not be done for the output code (generated on parsing the
   ``CODE`` commands) as the parser takes care of this when ``deg`` units
-  are given in the ``INPUT`` declarations. 
-  
-  The ``DEGREES`` setting, on the other hand, works only in some cases like 
+  are given in the ``INPUT`` declarations.
+
+  The ``DEGREES`` setting, on the other hand, works only in some cases like
   in ``SIMPROT`` where an angle is expected.
 
   .. code-block:: none
@@ -248,7 +248,7 @@ Gotchas
      B> = EVALUATE(A>, Q1:30*UNITS(DEG,RAD))
 
   .. code-block:: python
-  
+
      #SymPy Code
      #----------
      a = q1*a.frame_a.x + q2*frame_a.y
@@ -285,7 +285,7 @@ Gotchas
   ``M=COEF([E1;E2],[U1,U2,U3])``
 
   This would compute the coefficients of ``U1``, ``U2`` and ``U3`` in ``E1``
-  and ``E2``. It is preferable to manually construct a Matrix using the 
+  and ``E2``. It is preferable to manually construct a Matrix using the
   regular versions of these commands.
 
   .. code-block:: none
@@ -294,7 +294,7 @@ Gotchas
      %------------
      % COEF([E1;E2],[U1,U2,U3])
      M = [COEF(E1,U1),COEF(E1,U2),COEF(E1,U3) &
-         ;COEF(E2,U1),COEF(E2,U2),COEF(E2,U3)]    
+         ;COEF(E2,U1),COEF(E2,U2),COEF(E2,U3)]
 
 ------------------------------------------------------------------------
 
@@ -303,13 +303,13 @@ Gotchas
   ``VARIABLE`` declarations.
   The parser requires this to distinguish between them to pass the correct
   parameters to the Kane's method object.
-  
+
   It is also preferred to always declare the speeds corresponding to the
   coordinates and to pass in the kinematic differential equations.
   The parser is able to handle some cases where this isn't the case by
   introducing some dummy variables of its own but SymPy on its own
   does require them.
-  
+
   Also note that older Autolev declarations like ``VARIABLES U{3}'`` are not
   supported either.
 
@@ -330,9 +330,9 @@ Gotchas
      #----------
      q1, q2, u1, u2 = me.dynamicsymbols('q1 q2 u1 u2')
      q1d, q2d, u1d, u2d = me.dynamicsymbols('q1 q2 u1 u2', 1)
-     
+
      # ------- other lines -------
-     
+
      kd_eqs = [q1d - u1, q2d - u2]
      kane = me.KanesMethod(frame_n, q_ind=[q1,q2], u_ind=[u1, u2], kd_eqs = kd_eqs)
      fr, frstar = kane.kanes_equations([particle_p, particle_r], forceList)
@@ -345,12 +345,12 @@ Gotchas
   line 10 of this `spring damper example <https://github.com/sympy/sympy/blob/master/sympy/parsing/autolev/test_examples/mass_spring_damper.py>`_.
   This equation is used in forming the Kane's equations so we need to
   change ``me.dynamicsymbols._t`` to ``me.dynamicsymbols('t')`` in this case.
-  
+
   The main reason that this needs to be done is because PyDy
   requires time dependent specifieds to be explicitly laid out while
   Autolev simply takes care of the stray time variables in the equations
   by itself.
-  
+
   The problem is that PyDy's System class does not accept
   ``dynamicsymbols._t`` as a specified. Refer to issue `#396 <https://github.com/pydy/pydy/issues/396>`_.
   This change is not actually ideal so a better solution should be figured
@@ -360,16 +360,16 @@ Gotchas
 
 - The parser creates SymPy ``symbols`` and ``dynamicsymbols`` by parsing
   variable declarations in the Autolev Code.
-  
+
   For intermediate expressions which are directly initialized the parser
   does not create SymPy symbols. It just assigns them to the expression.
-  
+
   On the other hand, when a declared variable is assigned to an expression,
-  the parser stores the expression against the variable in a dictionary so 
-  as to not reassign it to a completely different entity. This constraint 
+  the parser stores the expression against the variable in a dictionary so
+  as to not reassign it to a completely different entity. This constraint
   is due to the inherent nature of Python and how it differs from a language
   like Autolev.
-  
+
   Also, Autolev seems to be able to assume whether to use a variable or the
   rhs expression that variable has been assigned to in equations even
   without an explicit ``RHS()`` call in some cases.
@@ -383,13 +383,13 @@ Gotchas
      VARIABLES X, Y
      E = X + Y
      X = 2*Y
-     
+
      RHS_X = RHS(X)
-     
+
      I1 = X
      I2 = Y
      I3 = X + Y
-     
+
      INERTIA B,I1,I2,I3
      % -> I_B_BO>> = I1*B1>*B1> + I2*B2>*B2> + I3*B3>*B3>
 
@@ -399,22 +399,22 @@ Gotchas
      #----------
      x,y = me.dynamicsymbols('x y')
      e = x + y  # No symbol is made out of 'e'
-     
+
      # an entry like {x:2*y} is stored in an rhs dictionary
-     
+
      rhs_x = 2*y
-     
+
      i1 = x  # again these are not made into SymPy symbols
      i2 = y
      i3 = x + y
-     
+
      body_b.inertia = (me.inertia(body_b_f, i1, i2, i3), b_cm)
      # This prints as:
      # x*b_f.x*b_f.x + y*b_f.y*b_f.y + (x+y)*b_f.z*b_f.z
      # while Autolev's output has I1,I2 and I3 in it.
      # Autolev however seems to know when to use the RHS of I1,I2 and I3
      # based on the context.
-  
+
 ------------------------------------------------------------------------
 
 - This is how the ``SOLVE`` command is parsed:
@@ -434,10 +434,10 @@ Gotchas
      # Behind the scenes the rhs of x
      # is set to sm.solve(zero,x,y)[x].
      a = sm.solve(zero,x,y)[x]*2 + sm.solve(zero,x,y)[y]
-     
+
   The indexing like ``[x]`` and ``[y]`` doesn't always work so you might want to
   look at the underlying dictionary that solve returns and index it correctly.
-  
+
 ------------------------------------------------------------------------
 
 - Inertia declarations and Inertia functions work somewhat differently in
@@ -447,11 +447,11 @@ Gotchas
 
   1. Inertia declarations (``INERTIA B,I1,I2,I3``) set the inertias of rigid
   bodies.
-  
+
   2. Inertia setters of the form ``I_C_D>> = expr`` however, set the inertias
   only when C is a body. If C is a particle then ``I_C_D>> = expr``
   simply parses to ``i_c_d = expr`` and ``i_c_d`` acts like a regular variable.
-  
+
   3. When it comes to inertia getters (``I_C_D>>`` used in an expression or
   ``INERTIA`` commands), these MUST be used with the ``EXPRESS`` command
   to specify the frame as SymPy needs this information to compute the
@@ -464,21 +464,21 @@ Gotchas
      INERTIA B,I1,I2,I3
      I_B_BO>> = X*A1>*A1> + Y*A2>*A2>  % Parser will set the inertia of B
      I_P_Q>> = X*A1>*A1> + Y^2*A2>*A2> % Parser just parses it as i_p_q = expr
-     
+
      E1 = 2*EXPRESS(I_B_O>>,A)
      E2 =  I_P_Q>>
      E3 = EXPRESS(I_P_O>>,A)
      E4 = EXPRESS(INERTIA(O),A)
-     
+
      % In E1 we are using the EXPRESS command with I_B_O>> which makes
      % the parser and SymPy compute the inertia of Body B about point O.
-     
+
      % In E2 we are just using the dyadic object I_P_Q>> (as I_P_Q>> = expr
-     % doesn't act as a setter) defined above and not asking the parser 
+     % doesn't act as a setter) defined above and not asking the parser
      % or SymPy to compute anything.
-     
+
      % E3 asks the parser to compute the inertia of P about point O.
-     
+
      % E4 asks the parser to compute the inertias of all bodies wrt about O.
 
 ------------------------------------------------------------------------
@@ -518,7 +518,7 @@ Limitations and Issues
   - Settings aren't parsed.
   - symbols and rhs expressions work very differently in Python which might
     cause undesirable results.
-  - Dictionary indexing for the parsed code of the ``SOLVE`` command is 
+  - Dictionary indexing for the parsed code of the ``SOLVE`` command is
     not proper in many cases.
   - Need to change ``dynamicsymbols._t`` to ``dynamicsymbols('t')`` for the
     PyDy simulation code to work properly.
@@ -572,7 +572,7 @@ to make sure the codes parsed well.
 
 The parsed codes of these are available on GitLab `here <https://gitlab.com/sympy/autolev-test-examples>`_.
 The repo is private so access needs to be requested.
-As of now, most codes till Chapter 4 of *Dynamics Online* have been parsed. 
+As of now, most codes till Chapter 4 of *Dynamics Online* have been parsed.
 
 Completing all the remaining codes of the book (namely, *2-10*, *2-11*, *rest
 of Ch4*, *Ch5* and *Ch6* (less important) ) would make the parser more complete.
@@ -580,8 +580,8 @@ of Ch4*, *Ch5* and *Ch6* (less important) ) would make the parser more complete.
 
 2. Fixing Issues
 ----------------
-The second thing to do would be to go about fixing the problems described 
-above in the :ref:`Gotchas <gotchas_autolev>` and :ref:`Limitations and Issues <issues>` 
+The second thing to do would be to go about fixing the problems described
+above in the :ref:`Gotchas <gotchas_autolev>` and :ref:`Limitations and Issues <issues>`
 sections in order of priority and ease. Many of these require changes
 in the parser code while some of these are better fixed by adding some
 functionality to SymPy.
@@ -589,7 +589,7 @@ functionality to SymPy.
 
 3. Switching to an AST
 ----------------------
-The parser is currently built using a kind of Concrete Syntax Tree (CST) 
+The parser is currently built using a kind of Concrete Syntax Tree (CST)
 using the `ANTLR <http://www.antlr.org/>`_ framework. It would be ideal to switch from a CST to an
 Abstract Syntax Tree (AST). This way, the parser code will be independent
 of the ANTLR grammar which makes it a lot more flexible. It would also be

--- a/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
+++ b/doc/src/modules/physics/mechanics/sympy_mechanics_for_autolev_users.rst
@@ -9,7 +9,7 @@ Introduction
 
 Autolev (now superseded by MotionGenesis) is a domain specific programming
 language which is used for symbolic multibody dynamics. The SymPy mechanics
-module now has enough power and functionality to be a fully featured symbolic 
+module now has enough power and functionality to be a fully featured symbolic
 dynamics module. The PyDy package extends the SymPy output to the numerical
 domain for simulation, analyses and visualization. Autolev and SymPy Mechanics have
 a lot in common but there are also many differences between them.
@@ -26,15 +26,15 @@ For an introduction to Multibody dynamics in Python, `this <https://www.youtube.
 lecture is very helpful.
 
 You might also find the :ref:`Autolev Parser <autolev_parser>` which is
-a part of SymPy to be helpful. 
+a part of SymPy to be helpful.
 
 Some Key Differences
 ------------------------
 
 +-----------------------------------+-----------------------------------+
-|          **Autolev**              |         **SymPy Mechanics**       |            
+|          **Autolev**              |         **SymPy Mechanics**       |
 +===================================+===================================+
-||                                  ||                                  | 
+||                                  ||                                  |
 | Autolev is a domain specific      | SymPy is a library written in the |
 | programming language designed to  | general purpose language Python.  |
 | perform multibody dynamics. Since | Although Autolev's code is more   |
@@ -42,7 +42,7 @@ Some Key Differences
 | has a very rigid language         | an add on to Python) is more      |
 | specification. It predefines,     | flexible. The users have more     |
 | assumes and computes              | control over what they can do. For|
-| many things based on the          | example, one can create a class in| 
+| many things based on the          | example, one can create a class in|
 | input code. Its code is a lot     | their code for let's say a type of|
 | cleaner and concise as a result of| rigibodies with common            |
 | this.                             | properties.                       |
@@ -117,8 +117,8 @@ Mathematical Equivalents
 +-----------------------+-----------------------+-----------------------+
 ||                      ||                      ||                      |
 | ``Constants C+``      | ``c = sm.symbols(‘c’, | Refer to SymPy        |
-|                       | real=True,            | :ref:`assumptions     | 
-|                       | nonnegative=True)``   | <assumptions_module>` |            
+|                       | real=True,            | :ref:`assumptions     |
+|                       | nonnegative=True)``   | <assumptions_module>` |
 |                       |                       | for more information. |
 +-----------------------+-----------------------+-----------------------+
 ||                      ||                      ||                      |
@@ -142,9 +142,9 @@ Mathematical Equivalents
 |                       | b21 b22', real=True)``|                       |
 +-----------------------+-----------------------+-----------------------+
 ||                      ||                      ||                      |
-| ``Specified Phi``     | ``phi =               |                       | 
+| ``Specified Phi``     | ``phi =               |                       |
 |                       | me.dynamicsymbols(‘phi|                       |
-|                       | ')``                  |                       |       
+|                       | ')``                  |                       |
 +-----------------------+-----------------------+-----------------------+
 ||                      ||                      ||                      |
 | ``Variables q, s``    | ``q, s =              |                       |
@@ -269,7 +269,7 @@ Mathematical Equivalents
 |                       | ``.evalf()``          |                       |
 |                       |                       |                       |
 |                       | ``E.evalf((a +        |                       |
-|                       | sm.pi).subs({a: 3}))``|                       |                  
+|                       | sm.pi).subs({a: 3}))``|                       |
 +-----------------------+-----------------------+-----------------------+
 | ``P = Polynomial([a,  | ``p =                 | For more information  |
 | b, c], x)``           | sm.Poly(sm.Matrix([a, | refer to              |
@@ -285,13 +285,13 @@ Mathematical Equivalents
 |                       | reshape(3, 1), x),    | to polynomials and    |
 |                       | x)``                  | roots refer to        |
 |                       |                       | `mpmath/calculus. <htt|
-|                       |                       | p://docs.s            | 
+|                       |                       | p://docs.s            |
 |                       |                       | ympy.org/0.7.6/module |
 |                       |                       | s/mpmath/calculus/pol |
 |                       |                       | ynomials.html>`_      |
 +-----------------------+-----------------------+-----------------------+
 | ``Solve(A, x1, x2)``  | ``sm.linsolve(A,      | For more information  |
-|                       | (x1, x2))``           | refer to              |   
+|                       | (x1, x2))``           | refer to              |
 |                       |                       | :ref:`                |
 | where A is an         | where A is an         | solvers/solveset.     |
 | augmented matrix that | augmented matrix      | <solveset>`           |
@@ -307,10 +307,10 @@ Mathematical Equivalents
 | ``RowMatrix = [1, 2,  | ``row_matrix =        | For more information  |
 | 3, 4]``               | sm.Matrix([[1],[2],   | refer to              |
 |                       | [3],[4]])``           | :ref:`matrices.       |
-|                       |                       | <matrices>`           |            
-| ``ColMatrix = [1; 2;  | ``col_matrix =        |                       |                     
-| 3; 4]``               | sm.Matrix([1, 2, 3,   |                       |       
-|                       | 4])``                 |                       |           
+|                       |                       | <matrices>`           |
+| ``ColMatrix = [1; 2;  | ``col_matrix =        |                       |
+| 3; 4]``               | sm.Matrix([1, 2, 3,   |                       |
+|                       | 4])``                 |                       |
 |                       |                       |                       |
 | ``MO = [a, b; c, 0]`` | ``MO = sm.Matrix([[a, |                       |
 |                       | b], [c, 0]])``        |                       |
@@ -342,10 +342,10 @@ Mathematical Equivalents
 | ``Eig(A)``            | ``A.eigenvals()``     |                       |
 |                       |                       |                       |
 | ``Eig(A, EigVal,      | ``eigval =            |                       |
-| EigVec)``             | A.eigenvals()``       |                       |   
+| EigVec)``             | A.eigenvals()``       |                       |
 |                       |                       |                       |
 |                       | ``eigvec =            |                       |
-|                       | A.eigenvects()``      |                       |  
+|                       | A.eigenvects()``      |                       |
 +-----------------------+-----------------------+-----------------------+
 
 
@@ -418,8 +418,8 @@ Physical Equivalents
 | ``Inertia B, I1, I2,  | ``I = me.inertia(Bf,  | For more information  |
 | I3, I12, I23, I31``   | i1, i2, i3, i12, i23, | refer to the          |
 |                       | i31)``                | :ref:`mechanics api.  |
-|                       |                       | <part_bod>`           |                       
-|                       | ``B.inertia = (I, P)``|                       |                      
+|                       |                       | <part_bod>`           |
+|                       | ``B.inertia = (I, P)``|                       |
 |                       | where B is a          |                       |
 |                       | rigidbody, Bf is the  |                       |
 |                       | related frame and P is|                       |
@@ -433,7 +433,7 @@ Physical Equivalents
 |                       | ``I =                 |                       |
 |                       | me.outer(N.x, N.x)``  |                       |
 +-----------------------+-----------------------+-----------------------+
-| ``vec> = P_O_Q>/L``   | ``vec  =              | For more information  |                
+| ``vec> = P_O_Q>/L``   | ``vec  =              | For more information  |
 |                       | (Qo.pos_from(O))/L``  | refer to              |
 | ``vec> =              |                       | :ref:`physics/vectors.|
 | u1*N1> + u2*N2>``     | ``vec =               | <physics_vector>`     |
@@ -449,19 +449,19 @@ Physical Equivalents
 |                       |                       |                       |
 | ``DYAD>> = 3*A1>*A1> +| ``dyad =              |                       |
 | A2>*A2> + 2*A3>*A3>`` | 3*me.outer(a.x        |                       |
-|                       | ,a.x) + me.outer(a.y, |                       | 
+|                       | ,a.x) + me.outer(a.y, |                       |
 |                       | a.y) + 2*me.outer(a.z |                       |
 |                       | ,a.z)``               |                       |
 +-----------------------+-----------------------+-----------------------+
 | ``P_O_Q> = LA*A1>``   | ``Q.point =           | For more information  |
-|                       | O.locatenew(‘Qo’,     | refer to the          | 
+|                       | O.locatenew(‘Qo’,     | refer to the          |
 |                       | LA*A.x)``             | :ref:`kinematics api. |
 |                       |                       | <kinematics>`         |
 | ``P_P_Q> = LA*A1>``   | where A is a          |                       |
 |                       | reference frame.      |                       |
 |                       |                       |                       |
-|                       | ``Q.point =           |                       |   
-|                       | P.point.locatenew(‘Qo | All these vector and  | 
+|                       | ``Q.point =           |                       |
+|                       | P.point.locatenew(‘Qo | All these vector and  |
 |                       | ’,                    | kinematic functions   |
 |                       | LA*A.x)``             | are to be used on     |
 |                       |                       | ``Point`` objects and |
@@ -514,7 +514,7 @@ Physical Equivalents
 | where M is a matrix   | M)`` where M is a     |                       |
 | and A, B are frames.  | SymPy Matrix.         |                       |
 |                       |                       |                       |
-| ``D = A_B*2 + 1``     | ``D = A.dcm(B)*2 + 1``|                       | 
+| ``D = A_B*2 + 1``     | ``D = A.dcm(B)*2 + 1``|                       |
 +-----------------------+-----------------------+-----------------------+
 | ``CM(B)``             | ``B.masscenter``      |                       |
 +-----------------------+-----------------------+-----------------------+
@@ -651,7 +651,7 @@ on how it is done::
     plt.legend((str(position), str(speed)))
     plt.show()
 
-For information on all the things PyDy can accomplish refer to the 
+For information on all the things PyDy can accomplish refer to the
 `PyDy Documentation <https://www.pydy.org/documentation.html>`_.
 
 The tools in the PyDy workflow are :

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -125,18 +125,18 @@ between coordinates and speeds. ::
 Now the equations of motion instances can be created using the above mentioned
 equations of motion formats. ::
 
-    >>> symsystem1 = system.SymbolicSystem(states, comb_explicit_rhs, 
-    ...                                    alg_con=alg_con_full, bodies=bodies, 
+    >>> symsystem1 = system.SymbolicSystem(states, comb_explicit_rhs,
+    ...                                    alg_con=alg_con_full, bodies=bodies,
     ...                                    loads=loads)
-    >>> symsystem2 = system.SymbolicSystem(states, comb_implicit_rhs, 
+    >>> symsystem2 = system.SymbolicSystem(states, comb_implicit_rhs,
     ...                                    mass_matrix=comb_implicit_mat,
     ...                                    alg_con=alg_con_full,
     ...                                    coord_idxs=coord_idxs)
-    >>> symsystem3 = system.SymbolicSystem(states, dyn_implicit_rhs, 
+    >>> symsystem3 = system.SymbolicSystem(states, dyn_implicit_rhs,
     ...                                    mass_matrix=dyn_implicit_mat,
     ...                                    coordinate_derivatives=kin_explicit_rhs,
-    ...                                    alg_con=alg_con, 
-    ...                                    coord_idxs=coord_idxs, 
+    ...                                    alg_con=alg_con,
+    ...                                    coord_idxs=coord_idxs,
     ...                                    speed_idxs=speed_idxs)
 
  Like coordinates and speeds, the bodies and loads attributes can only be

--- a/doc/src/modules/polys/literature.rst
+++ b/doc/src/modules/polys/literature.rst
@@ -134,7 +134,7 @@ a theoretical foundation for implementing polynomials manipulation module.
     2008, Springer,
     https://www.researchgate.net/publication/225607735_Dixon_resultant's_solution_of_systems_of_geodetic_polynomial_equations.
 
-.. [Bruce97] Bruce Randall Donald, Deepak Kapur, and Joseph L. Mundy (Eds.). 
+.. [Bruce97] Bruce Randall Donald, Deepak Kapur, and Joseph L. Mundy (Eds.).
     "Symbolic and Numerical Computation for Artificial Intelligence",
     Chapter 2, Academic Press, Inc., Orlando, FL, USA, 1997,
     https://www2.cs.duke.edu/donaldlab/Books/SymbolicNumericalComputation/045-087.pdf.

--- a/doc/src/tutorial/manipulation.rst
+++ b/doc/src/tutorial/manipulation.rst
@@ -470,7 +470,7 @@ traversals easy.  We could have also written our algorithm as
 Prevent expression evaluation
 =============================
 
-There are generally two ways to prevent the evaluation, either pass an 
+There are generally two ways to prevent the evaluation, either pass an
 ``evaluate=False`` parameter while constructing the expression, or create
 an evaluation stopper by wrapping the expression with ``UnevaluatedExpr``.
 

--- a/sympy/parsing/autolev/Autolev.g4
+++ b/sympy/parsing/autolev/Autolev.g4
@@ -13,7 +13,7 @@ stat:   varDecl
 
 assignment:   vec equals expr #vecAssign
           |   ID '[' index ']' equals expr #indexAssign
-          |   ID diff? equals expr #regularAssign; 
+          |   ID diff? equals expr #regularAssign;
 
 equals:   ('='|'+='|'-='|':='|'*='|'/='|'^=');
 
@@ -22,7 +22,7 @@ index:   expr (',' expr)* ;
 diff:   ('\'')+;
 
 functionCall:   ID '(' (expr (',' expr)*)? ')'
-            |   (Mass|Inertia) '(' (ID (',' ID)*)? ')'; 
+            |   (Mass|Inertia) '(' (ID (',' ID)*)? ')';
 
 varDecl:   varType varDecl2 (',' varDecl2)*;
 
@@ -76,7 +76,7 @@ expr:   expr '^'<assoc=right> expr  # Exponent
     |   vec                         # VectorOrDyadic
     |   ID '['expr (',' expr)* ']'  # Indexing
     |   functionCall                # function
-    |   matrix                      # matrices  
+    |   matrix                      # matrices
     |   '(' expr ')'                # parens
     |   expr '=' expr               # idEqualsExpr
     |   expr ':' expr               # colon
@@ -110,5 +110,5 @@ FLOAT:  DIGIT+ '.' DIGIT*
 EXP:   FLOAT 'E' INT
 |      FLOAT 'E' '-' INT;
 LINE_COMMENT : '%' .*? '\r'? '\n' -> skip ;
-ID:   [a-zA-Z][a-zA-Z0-9_]*;     
+ID:   [a-zA-Z][a-zA-Z0-9_]*;
 WS:   [ \t\r\n&]+ -> skip ; // toss out whitespace

--- a/sympy/utilities/mathml/data/mmltex.xsl
+++ b/sympy/utilities/mathml/data/mmltex.xsl
@@ -117,7 +117,7 @@ Modified Fabian Seoane 2007 for sympy
 <xsl:template match="m:interval[*[2]]">
 	<xsl:choose>
 		<xsl:when test="@closure='open' or @closure='open-closed'">
-			<xsl:text>\left(</xsl:text>		
+			<xsl:text>\left(</xsl:text>
 		</xsl:when>
 		<xsl:otherwise><xsl:text>\left[</xsl:text></xsl:otherwise>
 	</xsl:choose>
@@ -126,7 +126,7 @@ Modified Fabian Seoane 2007 for sympy
 	<xsl:apply-templates select="*[2]"/>
 	<xsl:choose>
 		<xsl:when test="@closure='open' or @closure='closed-open'">
-			<xsl:text>\right)</xsl:text>		
+			<xsl:text>\right)</xsl:text>
 		</xsl:when>
 		<xsl:otherwise><xsl:text>\right]</xsl:text></xsl:otherwise>
 	</xsl:choose>
@@ -822,7 +822,7 @@ priority="2">
 <xsl:template match="m:apply[*[1][self::m:product]]">
 	<xsl:text>\prod</xsl:text><xsl:call-template name="series"/>
 </xsl:template>
-	
+
 <xsl:template name="series">
 	<xsl:if test="m:lowlimit/*|m:interval/*[1]|m:condition/*">
 		<xsl:text>_{</xsl:text>
@@ -1068,7 +1068,7 @@ priority="2">
 
 <!-- 4.4.12.6 primes -->
 <xsl:template match="m:primes"><xsl:text>\mathbb{P}</xsl:text></xsl:template>
-	
+
 <!-- 4.4.12.7 exponentiale -->
 <xsl:template match="m:exponentiale"><xsl:text>e</xsl:text></xsl:template>
 
@@ -1147,7 +1147,7 @@ priority="2">
 	Greek
 	Range: 0370-03FF
 	http://www.unicode.org/charts/PDF/U0370.pdf	                    -->
-<!-- ====================================================================== -->	
+<!-- ====================================================================== -->
 		<xsl:when test="starts-with($content,'&#x00393;')"><xsl:value-of select="'\Gamma '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x00393;')"/></xsl:call-template></xsl:when>	<!--/Gamma capital Gamma, Greek -->
 		<xsl:when test="starts-with($content,'&#x00394;')"><xsl:value-of select="'\Delta '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x00394;')"/></xsl:call-template></xsl:when>	<!--/Delta capital Delta, Greek -->
 		<xsl:when test="starts-with($content,'&#x00398;')"><xsl:value-of select="'\Theta '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x00398;')"/></xsl:call-template></xsl:when>	<!--/Theta capital Theta, Greek -->
@@ -1188,7 +1188,7 @@ priority="2">
 		<xsl:when test="starts-with($content,'&#x003D6;')"><xsl:value-of select="'\varpi '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x003D6;')"/></xsl:call-template></xsl:when>		<!--/varpi -->
 		<xsl:when test="starts-with($content,'&#x003F0;')"><xsl:value-of select="'\varkappa '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x003F0;')"/></xsl:call-template></xsl:when>	<!--/varkappa -->
 		<xsl:when test="starts-with($content,'&#x003F1;')"><xsl:value-of select="'\varrho '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x003F1;')"/></xsl:call-template></xsl:when>	<!--/varrho -->
-		
+
 <!-- ====================================================================== -->
 		<xsl:when test="starts-with($content,'&#x0200B;')"><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0200B;')"/></xsl:call-template></xsl:when>						<!--short form of  &InvisibleComma; -->
 		<xsl:when test="starts-with($content,'&#x02026;')"><xsl:value-of select="'\dots '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02026;')"/></xsl:call-template></xsl:when>
@@ -1219,13 +1219,13 @@ priority="2">
 
 <!-- ====================================================================== -->
 		<xsl:when test="starts-with($content,'&#x02192;')"><xsl:value-of select="'\to '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02192;')"/></xsl:call-template></xsl:when>		<!--/rightarrow /to A: =rightward arrow -->
-		
+
 <!-- ====================================================================== -->
 <!-- 	Unicode 3.2
 	Mathematical Operators
 	Range: 2200-22FF
 	http://www.unicode.org/charts/PDF/U2200.pdf                         -->
-<!-- ====================================================================== -->	
+<!-- ====================================================================== -->
 		<xsl:when test="starts-with($content,'&#x02200;')"><xsl:value-of select="'\forall '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02200;')"/></xsl:call-template></xsl:when>	<!--/forall for all -->
 		<xsl:when test="starts-with($content,'&#x02201;')"><xsl:value-of select="'\complement '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02201;')"/></xsl:call-template></xsl:when>	<!--/complement - complement sign --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02202;')"><xsl:value-of select="'\partial '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02202;')"/></xsl:call-template></xsl:when>	<!--/partial partial differential -->
@@ -1242,7 +1242,7 @@ priority="2">
 		<xsl:when test="starts-with($content,'&#x0220F;')"><xsl:value-of select="'\prod '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0220F;')"/></xsl:call-template></xsl:when>		<!--/prod L: product operator -->
 		<xsl:when test="starts-with($content,'&#x02210;')"><xsl:value-of select="'\coprod '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02210;')"/></xsl:call-template></xsl:when>	<!--/coprod L: coproduct operator -->
 		<xsl:when test="starts-with($content,'&#x02211;')"><xsl:value-of select="'\sum '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02211;')"/></xsl:call-template></xsl:when>		<!--/sum L: summation operator -->
-		<xsl:when test="starts-with($content,'&#x02212;')"><xsl:value-of select="'-'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02212;')"/></xsl:call-template></xsl:when>		<!--B: minus sign -->		
+		<xsl:when test="starts-with($content,'&#x02212;')"><xsl:value-of select="'-'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02212;')"/></xsl:call-template></xsl:when>		<!--B: minus sign -->
 		<xsl:when test="starts-with($content,'&#x02213;')"><xsl:value-of select="'\mp '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02213;')"/></xsl:call-template></xsl:when>		<!--/mp B: minus-or-plus sign -->
 		<xsl:when test="starts-with($content,'&#x02214;')"><xsl:value-of select="'\dotplus '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02214;')"/></xsl:call-template></xsl:when>	<!--/dotplus B: plus sign, dot above --> <!-- Required amssymb -->
 <!--		<xsl:when test="starts-with($content,'&#x02215;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02215;')"/></xsl:call-template></xsl:when>-->
@@ -1266,7 +1266,7 @@ priority="2">
 		<xsl:when test="starts-with($content,'&#x02227;')"><xsl:value-of select="'\wedge '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02227;')"/></xsl:call-template></xsl:when>		<!--/wedge /land B: logical and -->
 		<xsl:when test="starts-with($content,'&#x02228;')"><xsl:value-of select="'\vee '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02228;')"/></xsl:call-template></xsl:when>		<!--/vee /lor B: logical or -->
 		<xsl:when test="starts-with($content,'&#x02229;')"><xsl:value-of select="'\cap '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02229;')"/></xsl:call-template></xsl:when>		<!--/cap B: intersection -->
-		<xsl:when test="starts-with($content,'&#x0222A;')"><xsl:value-of select="'\cup '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0222A;')"/></xsl:call-template></xsl:when>		<!--/cup B: union or logical sum -->		
+		<xsl:when test="starts-with($content,'&#x0222A;')"><xsl:value-of select="'\cup '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0222A;')"/></xsl:call-template></xsl:when>		<!--/cup B: union or logical sum -->
 		<xsl:when test="starts-with($content,'&#x0222B;')"><xsl:value-of select="'\int '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0222B;')"/></xsl:call-template></xsl:when>		<!--/int L: integral operator -->
 		<xsl:when test="starts-with($content,'&#x0222C;')"><xsl:value-of select="'\iint '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0222C;')"/></xsl:call-template></xsl:when>		<!--double integral operator --> <!-- Required amsmath -->
 		<xsl:when test="starts-with($content,'&#x0222D;')"><xsl:value-of select="'\iiint '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0222D;')"/></xsl:call-template></xsl:when>		<!--/iiint triple integral operator -->	<!-- Required amsmath -->
@@ -1282,7 +1282,7 @@ priority="2">
 <!-- ? -->	<xsl:when test="starts-with($content,'&#x02237;')"><xsl:value-of select="'\colon\colon '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02237;')"/></xsl:call-template></xsl:when>	<!--/Colon, two colons -->
 <!-- ? -->	<xsl:when test="starts-with($content,'&#x02238;')"><xsl:value-of select="'\dot{-}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02238;')"/></xsl:call-template></xsl:when>		<!--/dotminus B: minus sign, dot above -->
 <!--		<xsl:when test="starts-with($content,'&#x02239;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02239;')"/></xsl:call-template></xsl:when>		-->
-<!--		<xsl:when test="starts-with($content,'&#x0223A;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0223A;')"/></xsl:call-template></xsl:when>		minus with four dots, geometric properties -->		
+<!--		<xsl:when test="starts-with($content,'&#x0223A;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0223A;')"/></xsl:call-template></xsl:when>		minus with four dots, geometric properties -->
 <!--		<xsl:when test="starts-with($content,'&#x0223B;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0223B;')"/></xsl:call-template></xsl:when>		homothetic -->
 		<xsl:when test="starts-with($content,'&#x0223C;')"><xsl:value-of select="'\sim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0223C;')"/></xsl:call-template></xsl:when>		<!--/sim R: similar -->
 		<xsl:when test="starts-with($content,'&#x0223D;')"><xsl:value-of select="'\backsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0223D;')"/></xsl:call-template></xsl:when>	<!--/backsim R: reverse similar --> <!-- Required amssymb -->
@@ -1319,7 +1319,7 @@ priority="2">
 <!-- ? -->	<xsl:when test="starts-with($content,'&#x0225B;')"><xsl:value-of select="'\stackrel{\star}{=}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225B;')"/></xsl:call-template></xsl:when>	<!--equal, asterisk above -->
 		<xsl:when test="starts-with($content,'&#x0225C;')"><xsl:value-of select="'\triangleq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225C;')"/></xsl:call-template></xsl:when>	<!--/triangleq R: triangle, equals --> <!-- Required amssymb -->
 <!-- ? -->	<xsl:when test="starts-with($content,'&#x0225D;')"><xsl:value-of select="'\stackrel{\scriptscriptstyle\mathrm{def}}{=}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225D;')"/></xsl:call-template></xsl:when>
-<!-- ? -->	<xsl:when test="starts-with($content,'&#x0225E;')"><xsl:value-of select="'\stackrel{\scriptscriptstyle\mathrm{m}}{=}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225E;')"/></xsl:call-template></xsl:when>	
+<!-- ? -->	<xsl:when test="starts-with($content,'&#x0225E;')"><xsl:value-of select="'\stackrel{\scriptscriptstyle\mathrm{m}}{=}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225E;')"/></xsl:call-template></xsl:when>
 <!-- ? -->	<xsl:when test="starts-with($content,'&#x0225F;')"><xsl:value-of select="'\stackrel{?}{=}'" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0225F;')"/></xsl:call-template></xsl:when>	<!--/questeq R: equal with questionmark -->
 <!--		<xsl:when test="starts-with($content,'&#x02260;&#x0FE00;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02260;&#x0FE00;')"/></xsl:call-template></xsl:when>	not equal, dot -->
 		<xsl:when test="starts-with($content,'&#x02260;')"><xsl:value-of select="'\ne '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02260;')"/></xsl:call-template></xsl:when>		<!--/ne /neq R: not equal -->
@@ -1348,7 +1348,7 @@ priority="2">
 		<xsl:when test="starts-with($content,'&#x02271;&#x020E5;')"><xsl:value-of select="'\ngeq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02271;&#x020E5;')"/></xsl:call-template></xsl:when>	<!--/ngeq N: not greater-than-or-equal --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02271;')"><xsl:value-of select="'\ngeqq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02271;')"/></xsl:call-template></xsl:when>		<!--/ngeqq N: not greater, dbl equals --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02272;')"><xsl:value-of select="'\lesssim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02272;')"/></xsl:call-template></xsl:when>	<!--/lesssim R: less, similar --> <!-- Required amssymb -->
-		<xsl:when test="starts-with($content,'&#x02273;')"><xsl:value-of select="'\gtrsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02273;')"/></xsl:call-template></xsl:when>	<!--/gtrsim R: greater, similar --> <!-- Required amssymb -->		
+		<xsl:when test="starts-with($content,'&#x02273;')"><xsl:value-of select="'\gtrsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02273;')"/></xsl:call-template></xsl:when>	<!--/gtrsim R: greater, similar --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02274;')"><xsl:value-of select="'\not\lesssim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02274;')"/></xsl:call-template></xsl:when>	<!--not less, similar --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02275;')"><xsl:value-of select="'\not\gtrsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02275;')"/></xsl:call-template></xsl:when>	<!--not greater, similar --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x02276;')"><xsl:value-of select="'\lessgtr '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02276;')"/></xsl:call-template></xsl:when>	<!--/lessgtr R: less, greater --> <!-- Required amssymb -->
@@ -1357,7 +1357,7 @@ priority="2">
 		<xsl:when test="starts-with($content,'&#x02279;')"><xsl:value-of select="'\not\gtrless '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x02279;')"/></xsl:call-template></xsl:when>	<!--not greater, less --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x0227A;')"><xsl:value-of select="'\prec '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227A;')"/></xsl:call-template></xsl:when>		<!--/prec R: precedes -->
 		<xsl:when test="starts-with($content,'&#x0227B;')"><xsl:value-of select="'\succ '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227B;')"/></xsl:call-template></xsl:when>		<!--/succ R: succeeds -->
-		<xsl:when test="starts-with($content,'&#x0227C;')"><xsl:value-of select="'\preccurlyeq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227C;')"/></xsl:call-template></xsl:when>	<!--/preccurlyeq R: precedes, curly eq --> <!-- Required amssymb -->		
+		<xsl:when test="starts-with($content,'&#x0227C;')"><xsl:value-of select="'\preccurlyeq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227C;')"/></xsl:call-template></xsl:when>	<!--/preccurlyeq R: precedes, curly eq --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x0227D;')"><xsl:value-of select="'\succcurlyeq '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227D;')"/></xsl:call-template></xsl:when>	<!--/succcurlyeq R: succeeds, curly eq --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x0227E;')"><xsl:value-of select="'\precsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227E;')"/></xsl:call-template></xsl:when>	<!--/precsim R: precedes, similar --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x0227F;')"><xsl:value-of select="'\succsim '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x0227F;')"/></xsl:call-template></xsl:when>	<!--/succsim R: succeeds, similar --> <!-- Required amssymb -->
@@ -1398,10 +1398,10 @@ priority="2">
 <!--		<xsl:when test="starts-with($content,'&#x022F0;')"><xsl:value-of select="' '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x022F0;')"/></xsl:call-template></xsl:when>		three dots, ascending -->
 		<xsl:when test="starts-with($content,'&#x022F1;')"><xsl:value-of select="'\ddots '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x022F1;')"/></xsl:call-template></xsl:when>		<!--/ddots, three dots, descending -->
 
-<!-- ====================================================================== -->		
+<!-- ====================================================================== -->
 		<xsl:when test="starts-with($content,'&#x025A1;')"><xsl:value-of select="'\square '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x025A1;')"/></xsl:call-template></xsl:when>	<!--/square, square --> <!-- Required amssymb -->
 		<xsl:when test="starts-with($content,'&#x025AA;')"><xsl:value-of select="'\blacksquare '" /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '&#x025AA;')"/></xsl:call-template></xsl:when>	<!--/blacksquare, square, filled  --> <!-- Required amssymb -->
-		
+
 		<xsl:when test='starts-with($content,"&apos;")'><xsl:value-of select='"\text{&apos;}"' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select='substring-after($content, "&apos;")'/></xsl:call-template></xsl:when><!-- \text required amslatex -->
 		<xsl:when test='starts-with($content,"(")'><xsl:value-of select='"\left("' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '(')"/></xsl:call-template></xsl:when>
 		<xsl:when test='starts-with($content,")")'><xsl:value-of select='"\right)"' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, ')')"/></xsl:call-template></xsl:when>
@@ -1409,7 +1409,7 @@ priority="2">
 		<xsl:when test='starts-with($content,"]")'><xsl:value-of select='"\right]"' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, ']')"/></xsl:call-template></xsl:when>
 		<xsl:when test='starts-with($content,"{")'><xsl:value-of select='"\left\{"' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '{')"/></xsl:call-template></xsl:when>
 		<xsl:when test='starts-with($content,"}")'><xsl:value-of select='"\right\}"' /><xsl:call-template name="replaceEntities"><xsl:with-param name="content" select="substring-after($content, '}')"/></xsl:call-template></xsl:when>
-		
+
 
 		<xsl:otherwise>
 			<xsl:value-of select="substring($content,1,1)"/>
@@ -1588,7 +1588,7 @@ priority="2">
 			<xsl:with-param name="symbol" select="./*[3]"/>
 		</xsl:call-template>
 	</xsl:variable>
-	
+
 	<xsl:choose>
 		<xsl:when test="$over='&#x000AF;'">	<!-- OverBar - over bar -->
 			<xsl:text>\overline{</xsl:text>
@@ -1722,7 +1722,7 @@ priority="2">
 			<!--
 			<xsl:text>\overset{</xsl:text>
 			<xsl:apply-templates select="./*[$pos_over]"/>
-			<xsl:text>}{</xsl:text>	
+			<xsl:text>}{</xsl:text>
 			<xsl:apply-templates select="./*[1]"/>
 			<xsl:text>}</xsl:text>-->
 		</xsl:otherwise>
@@ -1761,66 +1761,66 @@ priority="2">
 		<xsl:otherwise>
 			<xsl:text>\underset{</xsl:text>		<!-- Required AmsMath package -->
 			<xsl:apply-templates select="./*[2]"/>
-			<xsl:text>}{</xsl:text>	
+			<xsl:text>}{</xsl:text>
 			<xsl:apply-templates select="./*[1]"/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
 
 <xsl:template match="m:msubsup">
-	<xsl:text>{</xsl:text>	
+	<xsl:text>{</xsl:text>
 	<xsl:apply-templates select="./*[1]"/>
 	<xsl:text>}_{</xsl:text>
 	<xsl:apply-templates select="./*[2]"/>
-	<xsl:text>}^{</xsl:text>	
+	<xsl:text>}^{</xsl:text>
 	<xsl:apply-templates select="./*[3]"/>
-	<xsl:text>}</xsl:text>	
+	<xsl:text>}</xsl:text>
 </xsl:template>
 
 <xsl:template match="m:msup">
-	<xsl:text>{</xsl:text>	
+	<xsl:text>{</xsl:text>
 	<xsl:apply-templates select="./*[1]"/>
-	<xsl:text>}^{</xsl:text>	
+	<xsl:text>}^{</xsl:text>
 	<xsl:apply-templates select="./*[2]"/>
-	<xsl:text>}</xsl:text>	
+	<xsl:text>}</xsl:text>
 </xsl:template>
 
 <xsl:template match="m:msub">
-	<xsl:text>{</xsl:text>	
+	<xsl:text>{</xsl:text>
 	<xsl:apply-templates select="./*[1]"/>
-	<xsl:text>}_{</xsl:text>	
+	<xsl:text>}_{</xsl:text>
 	<xsl:apply-templates select="./*[2]"/>
-	<xsl:text>}</xsl:text>	
+	<xsl:text>}</xsl:text>
 </xsl:template>
 
 <xsl:template match="m:mmultiscripts" mode="mprescripts">
 	<xsl:for-each select="m:mprescripts/following-sibling::*">
 		<xsl:if test="position() mod 2 and local-name(.)!='none'">
-			<xsl:text>{}_{</xsl:text>	
+			<xsl:text>{}_{</xsl:text>
 			<xsl:apply-templates select="."/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:if>
 		<xsl:if test="not(position() mod 2) and local-name(.)!='none'">
-			<xsl:text>{}^{</xsl:text>	
+			<xsl:text>{}^{</xsl:text>
 			<xsl:apply-templates select="."/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:if>
 	</xsl:for-each>
 	<xsl:apply-templates select="./*[1]"/>
 	<xsl:for-each select="m:mprescripts/preceding-sibling::*[position()!=last()]">
 		<xsl:if test="position()>2 and local-name(.)!='none'">
-			<xsl:text>{}</xsl:text>	
+			<xsl:text>{}</xsl:text>
 		</xsl:if>
 		<xsl:if test="position() mod 2 and local-name(.)!='none'">
-			<xsl:text>_{</xsl:text>	
+			<xsl:text>_{</xsl:text>
 			<xsl:apply-templates select="."/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:if>
 		<xsl:if test="not(position() mod 2) and local-name(.)!='none'">
-			<xsl:text>^{</xsl:text>	
+			<xsl:text>^{</xsl:text>
 			<xsl:apply-templates select="."/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:if>
 	</xsl:for-each>
 </xsl:template>
@@ -1834,17 +1834,17 @@ priority="2">
 			<xsl:apply-templates select="./*[1]"/>
 			<xsl:for-each select="*[position()>1]">
 				<xsl:if test="position()>2 and local-name(.)!='none'">
-					<xsl:text>{}</xsl:text>	
+					<xsl:text>{}</xsl:text>
 				</xsl:if>
 				<xsl:if test="position() mod 2 and local-name(.)!='none'">
-					<xsl:text>_{</xsl:text>	
+					<xsl:text>_{</xsl:text>
 					<xsl:apply-templates select="."/>
-					<xsl:text>}</xsl:text>	
+					<xsl:text>}</xsl:text>
 				</xsl:if>
 				<xsl:if test="not(position() mod 2) and local-name(.)!='none'">
-					<xsl:text>^{</xsl:text>	
+					<xsl:text>^{</xsl:text>
 					<xsl:apply-templates select="."/>
-					<xsl:text>}</xsl:text>	
+					<xsl:text>}</xsl:text>
 				</xsl:if>
 			</xsl:for-each>
 		</xsl:otherwise>
@@ -1899,7 +1899,7 @@ priority="2">
 	<xsl:if test="@numalign='left'">
 		<xsl:text>\hfill </xsl:text>
 	</xsl:if>
-	<xsl:text>}{</xsl:text>	
+	<xsl:text>}{</xsl:text>
 	<xsl:if test="@denomalign='right'">
 		<xsl:text>\hfill </xsl:text>
 	</xsl:if>
@@ -1915,9 +1915,9 @@ priority="2">
 		<xsl:when test="count(./*)=2">
 			<xsl:text>\sqrt[</xsl:text>
 			<xsl:apply-templates select="./*[2]"/>
-			<xsl:text>]{</xsl:text>	
+			<xsl:text>]{</xsl:text>
 			<xsl:apply-templates select="./*[1]"/>
-			<xsl:text>}</xsl:text>	
+			<xsl:text>}</xsl:text>
 		</xsl:when>
 		<xsl:otherwise>
 		<!-- number of argumnets is not 2 - code 25 -->
@@ -1983,11 +1983,11 @@ priority="2">
 			</xsl:if>
 			<xsl:if test="@open='{' or @open='}'">
 				<xsl:text>\</xsl:text>
-			</xsl:if>		
+			</xsl:if>
 			<xsl:value-of select="@close"/>
 		</xsl:when>
 		<xsl:otherwise><xsl:text>\right)</xsl:text></xsl:otherwise>
-	</xsl:choose>	
+	</xsl:choose>
 </xsl:template>
 
 <xsl:template match="m:mphantom">
@@ -2048,9 +2048,9 @@ priority="2">
 <xsl:template match="m:mstyle">
 	<xsl:if test="@displaystyle='true'">
 		<xsl:text>{\displaystyle</xsl:text>
-	</xsl:if>			
+	</xsl:if>
 	<xsl:if test="@scriptlevel=2">
-		<xsl:text>{\scriptscriptstyle</xsl:text>	
+		<xsl:text>{\scriptscriptstyle</xsl:text>
 	</xsl:if>
 	<xsl:apply-templates/>
 	<xsl:if test="@scriptlevel=2">


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17287 

#### Brief description of what is fixed or changed

All trailing whitespaces were removed from the codebase
#### Other comments
It was done with the following `.pre-commit-config.yaml`:

```
repos:
-   repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v2.3.0
    hooks:
    -   id: trailing-whitespace
        exclude: ^sympy/parsing/latex/_antlr/|^sympy/parsing/autolev/_antlr/|^sympy/integrals/rubi/
```
by running `pre-commit run --all-files`. No other change was done.
#### Release Notes 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->