### PR TITLE
Fix handling of warnings in the test runner (onto 1.6 release branch)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1239,7 +1239,7 @@ class Basic(metaclass=ManagedProperties):
             return any(f.func == pattern or f == pattern
             for f in self.atoms(Function, UndefinedFunction))
 
-        pattern = sympify(pattern)
+        pattern = _sympify(pattern)
         if isinstance(pattern, BasicMeta):
             return any(isinstance(arg, pattern)
             for arg in preorder_traversal(self))

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -202,6 +202,7 @@ class Dict(Basic):
     cannot be changed afterwards.  Otherwise it behaves identically
     to the Python dict.
 
+    >>> from sympy import Symbol
     >>> from sympy.core.containers import Dict
 
     >>> D = Dict({1: 'one', 2: 'two'})
@@ -215,7 +216,7 @@ class Dict(Basic):
 
     >>> 1 in D
     True
-    >>> D.has('one') # searches keys and values
+    >>> D.has(Symbol('one')) # searches keys and values
     True
     >>> 'one' in D # not in the keys
     False

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -8,6 +8,7 @@ from sympy.core.basic import (Basic, Atom, preorder_traversal, as_Basic,
     _atomic, _aresame)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Symbol
+from sympy.core.sympify import SympifyError
 from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
@@ -102,6 +103,7 @@ def test_has():
     assert b21.has(Basic)
     assert not b1.has(b21, b3)
     assert not b21.has()
+    raises(SympifyError, lambda: Symbol("x").has("x"))
 
 
 def test_subs():

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -129,10 +129,7 @@ def sqrt(arg, evaluate=None):
     >>> sqrt(x).has(sqrt)
     Traceback (most recent call last):
       ...
-    sympy.core.sympify.SympifyError: Sympify of expression 'could not parse
-    '<function sqrt at 0x7f79ad860f80>'' failed, because of exception being
-    raised:
-    SyntaxError: invalid syntax
+    sympy.core.sympify.SympifyError: SympifyError: <function sqrt at 0x10e8900d0>
 
     To find ``sqrt`` look for ``Pow`` with an exponent of ``1/2``:
 

--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -96,7 +96,7 @@ class TableForm(object):
         Examples
         ========
 
-        >>> from sympy import TableForm, Matrix
+        >>> from sympy import TableForm, Symbol
         >>> TableForm([[5, 7], [4, 2], [10, 3]])
         5  7
         4  2
@@ -107,7 +107,7 @@ class TableForm(object):
         1 | .
         2 | . .
         3 | . . .
-        >>> TableForm([['.'*(j if not i%2 else 1) for i in range(3)]
+        >>> TableForm([[Symbol('.'*(j if not i%2 else 1)) for i in range(3)]
         ...            for j in range(4)], alignments='rcl')
             .
           . . .

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3003,8 +3003,8 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                             # list.
                             result.remove(res)
                     continue  # skip as it's independent of desired symbols
-                depen = (eq2.rewrite(Add)).as_independent(unsolved_syms)[0]
-                if depen.has(Abs) and solver == solveset_complex:
+                depen1, depen2 = (eq2.rewrite(Add)).as_independent(*unsolved_syms)
+                if (depen1.has(Abs) or depen2.has(Abs)) and solver == solveset_complex:
                     # Absolute values cannot be inverted in the
                     # complex domain
                     continue

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -32,13 +32,14 @@ import subprocess
 import signal
 import stat
 import tempfile
+import warnings
+from contextlib import contextmanager
 
 from sympy.core.cache import clear_cache
 from sympy.core.compatibility import (exec_, PY3, unwrap,
         unicode)
 from sympy.utilities.misc import find_executable
 from sympy.external import import_module
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 IS_WINDOWS = (os.name == 'nt')
 ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
@@ -155,6 +156,21 @@ def setup_pprint():
     # Prevent init_printing() in doctests from affecting other doctests
     interactive_printing.NO_GLOBAL = True
     return use_unicode_prev
+
+
+@contextmanager
+def raise_on_deprecated():
+    """Context manager to make DeprecationWarning raise an error
+
+    This is to catch SymPyDeprecationWarning from library code while running
+    tests and doctests. It is important to use this context manager around
+    each individual test/doctest in case some tests modify the warning
+    filters.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings('error', '.*', DeprecationWarning, module='sympy.*')
+        yield
+
 
 def run_in_subprocess_with_hash_randomization(
         function, function_args=(),
@@ -537,11 +553,6 @@ def _test(*paths, **kwargs):
                    fast_threshold=fast_threshold,
                    slow_threshold=slow_threshold)
 
-    # Show deprecation warnings
-    import warnings
-    warnings.simplefilter("error", SymPyDeprecationWarning)
-    warnings.filterwarnings('error', '.*', DeprecationWarning, module='sympy.*')
-
     test_files = t.get_test_files('sympy')
 
     not_blacklisted = [f for f in test_files
@@ -785,11 +796,6 @@ def _doctest(*paths, **kwargs):
     # Disable showing up of plots
     from sympy.plotting.plot import unset_show
     unset_show()
-
-    # Show deprecation warnings
-    import warnings
-    warnings.simplefilter("error", SymPyDeprecationWarning)
-    warnings.filterwarnings('error', '.*', DeprecationWarning, module='sympy.*')
 
     r = PyTestReporter(verbose, split=split, colors=colors,\
                        force_colors=force_colors)
@@ -1278,11 +1284,12 @@ class SymPyTests(object):
             try:
                 if getattr(f, '_slow', False) and not slow:
                     raise Skipped("Slow")
-                if timeout:
-                    self._timeout(f, timeout, fail_on_timeout)
-                else:
-                    random.seed(self._seed)
-                    f()
+                with raise_on_deprecated():
+                    if timeout:
+                        self._timeout(f, timeout, fail_on_timeout)
+                    else:
+                        random.seed(self._seed)
+                        f()
             except KeyboardInterrupt:
                 if getattr(f, '_slow', False):
                     reporter.test_skip("KeyboardInterrupt")
@@ -1828,15 +1835,17 @@ class SymPyDocTestRunner(DocTestRunner):
         self.save_linecache_getlines = pdoctest.linecache.getlines
         linecache.getlines = self.__patched_linecache_getlines
 
-        try:
-            test.globs['print_function'] = print_function
-            return self.__run(test, compileflags, out)
-        finally:
-            sys.stdout = save_stdout
-            pdb.set_trace = save_set_trace
-            linecache.getlines = self.save_linecache_getlines
-            if clear_globs:
-                test.globs.clear()
+        # Fail for deprecation warnings
+        with raise_on_deprecated():
+            try:
+                test.globs['print_function'] = print_function
+                return self.__run(test, compileflags, out)
+            finally:
+                sys.stdout = save_stdout
+                pdb.set_trace = save_set_trace
+                linecache.getlines = self.save_linecache_getlines
+                if clear_globs:
+                    test.globs.clear()
 
 
 # We have to override the name mangled methods.


### PR DESCRIPTION
See #19247

<!-- BEGIN RELEASE NOTES -->
* core
    * BREAKING CHANGE: Basic.has no longer accepts strings as input. For example in SymPy 1.5 you could do `Symbol('x').has('x')` and the string `'x'` passed to `has` would be sympified to a symbol so that the result would be `True`. In SymPy 1.6 this will raise an error because the string `'x'` can not be sympified using strict sympification.
<!-- END RELEASE NOTES -->