### PR TITLE
Improvement_of_dup_zz_mignotte_bound(f, K)

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -124,13 +124,29 @@ def dmp_trial_division(f, factors, u, K):
 
 
 def dup_zz_mignotte_bound(f, K):
-    """Mignotte bound for univariate polynomials in `K[x]`. """
-    a = dup_max_norm(f, K)
-    b = abs(dup_LC(f, K))
-    n = dup_degree(f)
+    """
+    The Knuth-Cohen variant of Mignotte bound for
+    univariate polynomials in `K[x]`.
 
-    return K.sqrt(K(n + 1))*2**n*a*b
+    Reference: John Abbott, Journal of Symbolic Computation 50 (2013) 532–563.
+    """
+    d = dup_degree(f)
+    delta = _ceil( d / 2 )
+    
+    # euclidean-norm
+    eucl_norm = K.sqrt( sum( [cf**2 for cf in f] ) )
 
+    # biggest values of binomial coefficients (p. 538 of reference)
+    t1 = binomial( delta - 1, _ceil( delta / 2 ) )
+    t2 = binomial( delta - 1, _ceil( delta / 2 ) - 1 )
+
+    lc = abs( dup_LC(f, K) )   # leading coefficient
+    
+    bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
+    
+    bound = _ceil( bound / 2 ) * 2   # round up to even integer
+    
+    return bound + dup_max_norm(f, K)  # add max_coeff for irreducible polys
 
 def dmp_zz_mignotte_bound(f, u, K):
     """Mignotte bound for multivariate polynomials in `K[X]`. """
@@ -1147,7 +1163,7 @@ def dmp_ext_factor(f, u, K):
         return lc, []
 
     f, F = dmp_sqf_part(f, u, K), f
-    s, g, r = dmp_sqf_norm(F, u, K)
+    s, g, r = dmp_sqf_norm(f, u, K)
 
     factors = dmp_factor_list_include(r, u, K.dom)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -130,12 +130,12 @@ def dup_zz_mignotte_bound(f, K):
 
     References
     ==========
-    
+
     ..[1] [Abbott2013]_
     
     """
     from sympy import binomial
-    
+
     d = dup_degree(f)
     delta = _ceil( d / 2 )
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1171,7 +1171,7 @@ def dmp_ext_factor(f, u, K):
         return lc, []
 
     f, F = dmp_sqf_part(f, u, K), f
-    s, g, r = dmp_sqf_norm(f, u, K)
+    s, g, r = dmp_sqf_norm(F, u, K)
 
     factors = dmp_factor_list_include(r, u, K.dom)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -73,7 +73,6 @@ from sympy.polys.polyerrors import (
 
 from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import subsets
-from sympy import binomial
 
 from math import ceil as _ceil, log as _log
 
@@ -135,6 +134,8 @@ def dup_zz_mignotte_bound(f, K):
     ..[1] [Abbott2013]_
     
     """
+    from sympy import binomial
+    
     d = dup_degree(f)
     delta = _ceil( d / 2 )
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -150,11 +150,9 @@ def dup_zz_mignotte_bound(f, K):
     Lastly,To see the difference between the new and the old Mignotte bound
     consider the irreducible polynomial::
 
-        f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
-
-        >>> f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
-        >>> R.dup_zz_mignotte_bound(f)
-        744
+    >>> f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
+    >>> R.dup_zz_mignotte_bound(f)
+    744
 
     The new Mignotte bound is 744 whereas the old one (SymPy 1.5.1) is 1937664.
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -147,11 +147,11 @@ def dup_zz_mignotte_bound(f, K):
     t2 = binomial( delta - 1, _ceil( delta / 2 ) - 1 )
 
     lc = abs( dup_LC(f, K) )   # leading coefficient
-    
+
     bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
-    
+
     bound = _ceil( bound / 2 ) * 2   # round up to even integer
-    
+
     return bound + dup_max_norm(f, K)  # add max_coeff for irreducible polys
 
 def dmp_zz_mignotte_bound(f, u, K):

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -129,7 +129,11 @@ def dup_zz_mignotte_bound(f, K):
     The Knuth-Cohen variant of Mignotte bound for
     univariate polynomials in `K[x]`.
 
-    Reference: John Abbott, Journal of Symbolic Computation 50 (2013) 532–563.
+    References
+    ==========
+    
+    ..[1] [Abbott2013]_
+    
     """
     d = dup_degree(f)
     delta = _ceil( d / 2 )

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -147,7 +147,7 @@ def dup_zz_mignotte_bound(f, K):
     >>> R.dup_zz_mignotte_bound(f)
     6
 
-    Lastly,To see the difference between the new and the old Mignotte bound 
+    Lastly,To see the difference between the new and the old Mignotte bound
     consider the irreducible polynomial::
 
         f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -147,6 +147,18 @@ def dup_zz_mignotte_bound(f, K):
     >>> R.dup_zz_mignotte_bound(f)
     6
 
+    Lastly,To see the difference between the new and the old Mignotte bound 
+    consider the irreducible polynomial::
+
+        f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
+
+        >>> f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
+        >>> R.dup_zz_mignotte_bound(f)
+        744
+
+    The new Mignotte bound is 744 whereas the old one (SymPy 1.5.1) is 1937664.
+
+
     References
     ==========
 
@@ -168,7 +180,7 @@ def dup_zz_mignotte_bound(f, K):
 
     lc = K.abs(dup_LC(f, K))   # leading coefficient
     bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
-    bound += dup_max_norm(f, K) #add max coeff for irreducible polys
+    bound += dup_max_norm(f, K) # add max coeff for irreducible polys
     bound = _ceil(bound / 2) * 2   # round up to even integer
 
     return bound

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -128,6 +128,25 @@ def dup_zz_mignotte_bound(f, K):
     The Knuth-Cohen variant of Mignotte bound for
     univariate polynomials in `K[x]`.
 
+    Examples
+    ========
+
+    >>> from sympy.polys import ring, ZZ
+    >>> R, x = ring("x", ZZ)
+
+    >>> f = x**3 + 14*x**2 + 56*x + 64
+    >>> R.dup_zz_mignotte_bound(f)
+    152
+
+    By checking `factor(f)` we can see that max coeff is 8
+
+    Also consider a case that `f` is irreducible for example `f = 2*x**2 + 3*x + 4`
+    To avoid a bug for these cases, we return the bound plus the max coefficient of `f`
+
+    >>> f = 2*x**2 + 3*x + 4
+    >>> R.dup_zz_mignotte_bound(f)
+    6
+
     References
     ==========
 
@@ -137,22 +156,20 @@ def dup_zz_mignotte_bound(f, K):
     from sympy import binomial
 
     d = dup_degree(f)
-    delta = _ceil( d / 2 )
+    delta = _ceil(d / 2)
+    delta2 = _ceil(delta / 2)
 
     # euclidean-norm
     eucl_norm = K.sqrt( sum( [cf**2 for cf in f] ) )
 
     # biggest values of binomial coefficients (p. 538 of reference)
-    t1 = binomial( delta - 1, _ceil( delta / 2 ) )
-    t2 = binomial( delta - 1, _ceil( delta / 2 ) - 1 )
+    t1 = binomial(delta - 1, delta2)
+    t2 = binomial(delta - 1, delta2 - 1)
 
-    lc = abs( dup_LC(f, K) )   # leading coefficient
-
+    lc = K.abs(dup_LC(f, K))   # leading coefficient
     bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
-
     bound += dup_max_norm(f, K) #add max coeff for irreducible polys
-
-    bound = _ceil( bound / 2 ) * 2   # round up to even integer
+    bound = _ceil(bound / 2) * 2   # round up to even integer
 
     return bound
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -73,6 +73,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import subsets
+from sympy import binomial
 
 from math import ceil as _ceil, log as _log
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -150,9 +150,11 @@ def dup_zz_mignotte_bound(f, K):
 
     bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
 
+    bound += dup_max_norm(f, K) #add max coeff for irreducible polys
+
     bound = _ceil( bound / 2 ) * 2   # round up to even integer
 
-    return bound + dup_max_norm(f, K)  # add max_coeff for irreducible polys
+    return bound
 
 def dmp_zz_mignotte_bound(f, u, K):
     """Mignotte bound for multivariate polynomials in `K[X]`. """

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -132,7 +132,7 @@ def dup_zz_mignotte_bound(f, K):
     ==========
 
     ..[1] [Abbott2013]_
-    
+
     """
     from sympy import binomial
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -133,7 +133,7 @@ def dup_zz_mignotte_bound(f, K):
     """
     d = dup_degree(f)
     delta = _ceil( d / 2 )
-    
+
     # euclidean-norm
     eucl_norm = K.sqrt( sum( [cf**2 for cf in f] ) )
 

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -28,6 +28,7 @@ def test_dmp_trial_division():
 def test_dup_zz_mignotte_bound():
     R, x = ring("x", ZZ)
     assert R.dup_zz_mignotte_bound(2*x**2 + 3*x + 4) == 6
+    assert R.dup_zz_mignotte_bound(x**3 + 14*x**2 + 56*x + 64) == 152
 
 
 def test_dmp_zz_mignotte_bound():

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -27,7 +27,7 @@ def test_dmp_trial_division():
 
 def test_dup_zz_mignotte_bound():
     R, x = ring("x", ZZ)
-    assert R.dup_zz_mignotte_bound(2*x**2 + 3*x + 4) == 32
+    assert R.dup_zz_mignotte_bound(2*x**2 + 3*x + 4) == 6
 
 
 def test_dmp_zz_mignotte_bound():


### PR DESCRIPTION
So, this is our change in the `dup_zz_mignotte_bound(f, K)` method. Also, we have replace the old value in the test_factortools.py file. If it is asked, we can cite our test_file with the comparison of the bounds. As it was mentioned, we have not create a new method but just change the code in the `dup_zz_mignotte_bound(f, K)`.


Fixes #19253 
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`dup_zz_mignotte_bound(f, K)` implemented with Knuth-Cohen

#### Other comments
As it was mentioned in the issue, `dmp_zz_mignotte_bound(f, u, K)` should also be cared of.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * improvement of `dup_zz_mignotte_bound(f, K)` by Knuth-Cohen bound
<!-- END RELEASE NOTES -->