### PR TITLE
[GSoC] Added Lomax and Bounded pareto distribution

### DIFF
--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -38,6 +38,7 @@ Continuous Types
 .. autofunction:: Beta
 .. autofunction:: BetaNoncentral
 .. autofunction:: BetaPrime
+.. autofunction:: BoundedPareto
 .. autofunction:: Cauchy
 .. autofunction:: Chi
 .. autofunction:: ChiNoncentral
@@ -59,6 +60,7 @@ Continuous Types
 .. autofunction:: Logistic
 .. autofunction:: LogLogistic
 .. autofunction:: LogNormal
+.. autofunction:: Lomax
 .. autofunction:: Maxwell
 .. autofunction:: Moyal
 .. autofunction:: Nakagami

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1335,6 +1335,9 @@ def test_sympy__stats__crv_types__BetaPrimeDistribution():
     from sympy.stats.crv_types import BetaPrimeDistribution
     assert _test_args(BetaPrimeDistribution(1, 1))
 
+def test_sympy__stats__crv_types__BoundedParetoDistribution():
+    from sympy.stats.crv_types import BoundedParetoDistribution
+    assert _test_args(BoundedParetoDistribution(1, 1, 2))
 
 def test_sympy__stats__crv_types__CauchyDistribution():
     from sympy.stats.crv_types import CauchyDistribution
@@ -1433,6 +1436,9 @@ def test_sympy__stats__crv_types__LogNormalDistribution():
     from sympy.stats.crv_types import LogNormalDistribution
     assert _test_args(LogNormalDistribution(0, 1))
 
+def test_sympy__stats__crv_types__LomaxDistribution():
+    from sympy.stats.crv_types import LomaxDistribution
+    assert _test_args(LomaxDistribution(1, 2))
 
 def test_sympy__stats__crv_types__MaxwellDistribution():
     from sympy.stats.crv_types import MaxwellDistribution

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -113,11 +113,11 @@ __all__ = [
     'FiniteDistributionHandmade',
 
     'ContinuousRV', 'Arcsin', 'Benini', 'Beta', 'BetaNoncentral', 'BetaPrime',
-    'Cauchy', 'Chi', 'ChiNoncentral', 'ChiSquared', 'Dagum', 'Erlang',
+    'BoundedPareto', 'Cauchy', 'Chi', 'ChiNoncentral', 'ChiSquared', 'Dagum', 'Erlang',
     'ExGaussian', 'Exponential', 'ExponentialPower', 'FDistribution',
     'FisherZ', 'Frechet', 'Gamma', 'GammaInverse', 'Gompertz', 'Gumbel',
-    'Kumaraswamy', 'Laplace', 'Levy', 'Logistic', 'LogLogistic', 'LogNormal', 'Moyal',
-    'Maxwell', 'Nakagami', 'Normal', 'GaussianInverse', 'Pareto', 'PowerFunction',
+    'Kumaraswamy', 'Laplace', 'Levy', 'Logistic', 'LogLogistic', 'LogNormal', 'Lomax',
+    'Moyal', 'Maxwell', 'Nakagami', 'Normal', 'GaussianInverse', 'Pareto', 'PowerFunction',
     'QuadraticU', 'RaisedCosine', 'Rayleigh','Reciprocal', 'StudentT', 'ShiftedGompertz',
     'Trapezoidal', 'Triangular', 'Uniform', 'UniformSum', 'VonMises', 'Wald',
     'Weibull', 'WignerSemicircle', 'ContinuousDistributionHandmade',
@@ -155,10 +155,10 @@ from .frv_types import (FiniteRV, DiscreteUniform, Die, Bernoulli, Coin,
         FiniteDistributionHandmade)
 
 from .crv_types import (ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral,
-        BetaPrime, Cauchy, Chi, ChiNoncentral, ChiSquared, Dagum, Erlang,
+        BetaPrime, BoundedPareto, Cauchy, Chi, ChiNoncentral, ChiSquared, Dagum, Erlang,
         ExGaussian, Exponential, ExponentialPower, FDistribution, FisherZ,
         Frechet, Gamma, GammaInverse, Gompertz, Gumbel, Kumaraswamy, Laplace,
-        Levy, Logistic, LogLogistic, LogNormal, Maxwell, Moyal, Nakagami, Normal,
+        Levy, Logistic, LogLogistic, LogNormal, Lomax, Maxwell, Moyal, Nakagami, Normal,
         GaussianInverse, Pareto, QuadraticU, RaisedCosine, Rayleigh, Reciprocal, StudentT,
         PowerFunction, ShiftedGompertz, Trapezoidal, Triangular, Uniform, UniformSum,
         VonMises, Wald, Weibull, WignerSemicircle, ContinuousDistributionHandmade)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -626,7 +626,7 @@ class BoundedParetoDistribution(SingleContinuousDistribution):
         return num/den
 
 def BoundedPareto(name, alpha, left, right):
-    """
+    r"""
     Create a continuous random variable with a Bounded Pareto distribution.
 
     The density of the Bounded Pareto distribution is given by
@@ -668,7 +668,6 @@ def BoundedPareto(name, alpha, left, right):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Pareto_distribution#Bounded_Pareto_distribution
-
 
     """
     return rv (name, BoundedParetoDistribution, (alpha, left, right))
@@ -2551,7 +2550,7 @@ class LomaxDistribution(SingleContinuousDistribution):
         return (alpha/lamba) * (S.One + x/lamba)**(-alpha-1)
 
 def Lomax(name, alpha, lamda):
-    """
+    r"""
     Create a continuous random variable with a Lomax distribution.
 
     The density of the Lomax distribution is given by
@@ -2593,7 +2592,6 @@ def Lomax(name, alpha, lamda):
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Lomax_distribution
-
 
     """
     return rv(name, LomaxDistribution, (alpha, lamda))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added lomax and bounded pareto distribution(CRV types)
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The PR aims at adding two continuous distributions under `crv_types.py`. For adding this distribution, we just need to add the `pdf`, `set`, and `check` to validate the parameters passed as the member functions of the classes. The `rv` is used to map random variables to these classes.
Therefore, to check the `pdf`, and `cdf` of the added RVs, please verify them from,
[https://en.wikipedia.org/wiki/Pareto_distribution#Bounded_Pareto_distribution](https://en.wikipedia.org/wiki/Pareto_distribution#Bounded_Pareto_distribution),
[https://en.wikipedia.org/wiki/Lomax_distribution](https://en.wikipedia.org/wiki/Lomax_distribution)


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
   * Added Lomax and Bounded pareto distribution
<!-- END RELEASE NOTES -->

ping @czgdp1807 @jmig5776 