### PR TITLE
mignotte bound applied in `dup_zz_zassenhaus(f, K)`

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -185,6 +185,10 @@ def dup_zz_mignotte_bound(f, K):
 
 def dmp_zz_mignotte_bound(f, u, K):
     """Mignotte bound for multivariate polynomials in `K[X]`. """
+
+    if u==0 :
+        return dup_zz_mignotte_bound(f, K)
+
     a = dmp_max_norm(f, u, K)
     b = abs(dmp_ground_LC(f, u, K))
     n = sum(dmp_degree_list(f, u))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
+    B = 4*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -73,7 +73,7 @@ from sympy.polys.polyerrors import (
 from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import subsets
 
-from math import ceil as _ceil, log as _log
+from math import ceil as _ceil, log as _log, sqrt as _sqrt
 
 
 def dup_trial_division(f, factors, K):
@@ -169,7 +169,7 @@ def dup_zz_mignotte_bound(f, K):
     delta2 = _ceil(delta / 2)
 
     # euclidean-norm
-    eucl_norm = K.sqrt( sum( [cf**2 for cf in f] ) )
+    eucl_norm = _sqrt( sum( [cf**2 for cf in f] ) )
 
     # biggest values of binomial coefficients (p. 538 of reference)
     t1 = binomial(delta - 1, delta2)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,11 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
+    if Poly(f).is_univariate:
+        B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
+    else:
+        B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
+
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = int(dup_zz_mignotte_bound(f, K))
+    B = int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 3*int(abs(dup_zz_mignotte_bound(f, K)))
+    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -147,6 +147,16 @@ def dup_zz_mignotte_bound(f, K):
     >>> R.dup_zz_mignotte_bound(f)
     6
 
+    Lastly,To see the difference between the new and the old Mignotte bound
+    consider the irreducible polynomial::
+
+    >>> f = 87*x**7 + 4*x**6 + 80*x**5 + 17*x**4 + 9*x**3 + 12*x**2 + 49*x + 26
+    >>> R.dup_zz_mignotte_bound(f)
+    744
+
+    The new Mignotte bound is 744 whereas the old one (SymPy 1.5.1) is 1937664.
+
+
     References
     ==========
 
@@ -168,7 +178,7 @@ def dup_zz_mignotte_bound(f, K):
 
     lc = K.abs(dup_LC(f, K))   # leading coefficient
     bound = t1 * eucl_norm + t2 * lc   # (p. 538 of reference)
-    bound += dup_max_norm(f, K) #add max coeff for irreducible polys
+    bound += dup_max_norm(f, K) # add max coeff for irreducible polys
     bound = _ceil(bound / 2) * 2   # round up to even integer
 
     return bound
@@ -313,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
+    B = int(dup_zz_mignotte_bound(f, K))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
+    B = 3*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -41,7 +41,6 @@ from sympy.polys.densearith import (
     dup_sub_mul, dmp_sub_mul,
     dup_lshift,
     dup_max_norm, dmp_max_norm,
-    dup_l1_norm,
     dup_mul_ground, dmp_mul_ground,
     dup_quo_ground, dmp_quo_ground)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -327,7 +327,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 4*int(abs(dup_zz_mignotte_bound(f, K)))
+    B = 5*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = int(abs(dup_zz_mignotte_bound(f, K)))
+    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -315,6 +315,11 @@ def _test_pl(fc, q, pl):
 
 def dup_zz_zassenhaus(f, K):
     """Factor primitive square-free polynomials in `Z[x]`. """
+    import sympy.polys
+
+    import mpmath
+    from mpmath.libmp.libhyper import NoConvergence
+
     n = dup_degree(f)
 
     if n == 1:

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,11 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    if Poly(f).is_univariate:
-        B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
-    else:
-        B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
-
+    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -315,11 +315,6 @@ def _test_pl(fc, q, pl):
 
 def dup_zz_zassenhaus(f, K):
     """Factor primitive square-free polynomials in `Z[x]`. """
-    import sympy.polys
-
-    import mpmath
-    from mpmath.libmp.libhyper import NoConvergence
-
     n = dup_degree(f)
 
     if n == 1:

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -323,7 +323,7 @@ def dup_zz_zassenhaus(f, K):
     fc = f[-1]
     A = dup_max_norm(f, K)
     b = dup_LC(f, K)
-    B = 2*int(abs(dup_zz_mignotte_bound(f, K)))
+    B = int((dup_zz_mignotte_bound(f, K)))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))
@@ -396,10 +396,10 @@ def dup_zz_zassenhaus(f, K):
 
             H = dup_trunc(H, pl, K)
 
-            G_norm = dup_l1_norm(G, K)
-            H_norm = dup_l1_norm(H, K)
+            G_norm = dup_max_norm(G, K)
+            H_norm = dup_max_norm(H, K)
 
-            if G_norm*H_norm <= B:
+            if G_norm <= B and H_norm <= B:
                 T = T_S
                 sorted_T = [i for i in sorted_T if i not in S]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Application of PR 19254

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19253 partially.

#### Brief description of what is fixed or changed
function `dup_zz_zassenhaus(f, K)` instead of calling `dup_zz_maignotte_bound(f, K)` calculates locally the old bound : `(abs(K.sqrt(K(n + 1))*2**n*A*b).`

#### Other comments
By changing the aforementioned line, there is an improvement on `factor(f)` to 10% on time. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
   * improvement of `dup_zz_zassenhaus(f, K)`
<!-- END RELEASE NOTES -->