### PR TITLE
release: include autolev README and whitelist other files

### DIFF
--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -1039,6 +1039,7 @@ git_whitelist = {
     '.github/FUNDING.yml',
     '.editorconfig',
     '.coveragerc',
+    'asv.conf.travis.json',
     'coveragerc_travis',
     'codecov.yml',
     'pytest.ini',
@@ -1076,6 +1077,7 @@ git_whitelist = {
     'bin/test_import',
     'bin/test_import.py',
     'bin/test_isolated',
+    'bin/test_py2_import.py',
     'bin/test_setup.py',
     'bin/test_travis.sh',
     # The notebooks are not ready for shipping yet. They need to be cleaned

--- a/setup.py
+++ b/setup.py
@@ -432,6 +432,7 @@ if __name__ == '__main__':
                   '*.g4', 'test-examples/*.al', 'test-examples/*.py',
                   'test-examples/pydy-example-repo/*.al',
                   'test-examples/pydy-example-repo/*.py',
+                  'test-examples/README.txt',
                   ],
               'sympy.parsing.latex': ['*.txt', '*.g4'],
               'sympy.integrals.rubi.parsetools': ['header.py.txt'],


### PR DESCRIPTION
The README in autolev/test-examples is now included in the release
sdist. Two development files bin/test_py2_import.py and
asv.conf.travis.json are whitelisted as files that are not expected to
be included in the sdist.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/19193#issuecomment-625869641


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->