### PR TITLE
maint(release): update python versions in release script

### DIFF
--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -37,14 +37,14 @@ $ACTIVITIES = [
     'build_docs',
     'copy_release_files',
     'compare_tar_against_git',
-    'test_tarball27',
     'test_tarball35',
     'test_tarball36',
     'test_tarball37',
-    'test_wheel27',
+    'test_tarball38',
     'test_wheel35',
     'test_wheel36',
     'test_wheel37',
+    'test_wheel38',
     'print_authors',
     'sha256',
     # 'tag',
@@ -125,10 +125,6 @@ def copy_release_files():
     cp dist/* /root/release/
 
 @activity(deps={'source_tarball'})
-def test_tarball27():
-    test_tarball('2.7')
-
-@activity(deps={'source_tarball'})
 def test_tarball35():
     test_tarball('3.5')
 
@@ -140,9 +136,9 @@ def test_tarball36():
 def test_tarball37():
     test_tarball('3.7')
 
-@activity(deps={'wheel'})
-def test_wheel27():
-    test_wheel('2.7')
+@activity(deps={'source_tarball'})
+def test_tarball38():
+    test_tarball('3.8')
 
 @activity(deps={'wheel'})
 def test_wheel35():
@@ -155,6 +151,10 @@ def test_wheel36():
 @activity(deps={'wheel'})
 def test_wheel37():
     test_wheel('3.7')
+
+@activity(deps={'wheel'})
+def test_wheel38():
+    test_wheel('3.8')
 
 @activity(deps={'source_tarball'})
 def compare_tar_against_git():
@@ -245,10 +245,9 @@ def _sha256(print_=True, local=False):
 
 @activity(deps={'mailmap_update', 'sha256', 'print_authors',
                 'source_tarball', 'wheel', 'build_docs',
-                'compare_tar_against_git', 'test_tarball27',
-                'test_tarball35', 'test_tarball36', 'test_wheel27',
-                'test_wheel35', 'test_wheel36',
-                'test_wheel37', 'test_sympy'})
+                'compare_tar_against_git', 'test_tarball35', 'test_tarball36',
+                'test_tarball37', 'test_tarball38', 'test_wheel35',
+                'test_wheel36', 'test_wheel37', 'test_wheel38', 'test_sympy'})
 def release():
     pass
 
@@ -282,8 +281,8 @@ def test_tarball(py_version):
     Test that the tarball can be unpacked and installed, and that sympy
     imports in the install.
     """
-    if py_version not in {'2.7', '3.5', '3.6', '3.7'}: # TODO: Add win32
-        raise ValueError("release must be one of 2.7, 3.5, 3.6, or 3.7 not %s" % py_version)
+    if py_version not in {'3.5', '3.6', '3.7', '3.8'}: # TODO: Add win32
+        raise ValueError("release must be one of 3.5, 3.6, 3.7 or 3.8 not %s" % py_version)
 
 
     with run_in_conda_env(['python=%s' % py_version], 'test-install-%s' % py_version):
@@ -300,8 +299,8 @@ def test_wheel(py_version):
     """
     Test that the wheel can be installed, and that sympy imports in the install.
     """
-    if py_version not in {'2.7', '3.4', '3.5', '3.6', '3.7'}: # TODO: Add win32
-        raise ValueError("release must be one of 2.7, 3.4, 3.5, 3.6, or 3.7 not %s" % py_version)
+    if py_version not in {'3.5', '3.6', '3.7', '3.8'}: # TODO: Add win32
+        raise ValueError("release must be one of 3.5, 3.6, 3.7 or 3.8 not %s" % py_version)
 
 
     with run_in_conda_env(['python=%s' % py_version], 'test-install-%s' % py_version):
@@ -344,7 +343,7 @@ def get_tarball_name(file):
     elif file == 'pdf-orig':
         name = "sympy-{version}.pdf"
     elif file == 'wheel':
-        name = 'sympy-{version}-py2.py3-none-any.whl'
+        name = 'sympy-{version}-py3-none-any.whl'
     else:
         raise ValueError(file + " is not a recognized argument")
 


### PR DESCRIPTION
Remove Python 2.7 and add Python 3.8 in the release script. Sympy 1.6 is
the first version that no longer supports Python 2.7.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See #19193 


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->