### PR TITLE
Sample from a list instead of a set for python 3.9 compatibility

### DIFF
--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -1009,7 +1009,7 @@ def _modgcd_multivariate_p(f, g, p, degbound, contbound):
     d = 0
     evalpoints = []
     heval = []
-    points = set(range(p))
+    points = list(range(p))
 
     while points:
         a = random.sample(points, 1)[0]
@@ -1605,7 +1605,7 @@ def _func_field_modgcd_p(f, g, minpoly, p):
     evalpoints = []
     heval = []
     LMlist = []
-    points = set(range(p))
+    points = list(range(p))
 
     while points:
         a = random.sample(points, 1)[0]


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The Fedora project is rebuilding all of its python packages with the current alpha release of python 3.9 in order to find and fix problems prior to the release of 3.9.  The sympy package failed its tests due to the deprecation of sampling from a set.  See:

https://bugs.python.org/issue40325
https://github.com/python/cpython/commit/4fe002045fcf40823154b709fef0948b2bc5e934

This commit changes the sympy code to sample from a list instead.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->