### PR TITLE
[GSoC] Series: Correcting incorrect limit evaluations based on different assumptions of the limit variable

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -422,10 +422,10 @@ def limitinf(e, x, leadsimp=False):
     if e.has(Order):
         e = e.expand().removeO()
     if not x.is_positive or x.is_integer:
-        # We make sure that x.is_positive is True and x.is_integer is False
+        # We make sure that x.is_positive is True and x.is_integer is None
         # so we get all the correct mathematical behavior from the expression.
         # We need a fresh variable.
-        p = Dummy('p', positive=True, finite=True)
+        p = Dummy('p', positive=True)
         e = e.subs(x, p)
         x = p
     e = e.rewrite('tractable', deep=True)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -416,19 +416,19 @@ def limitinf(e, x, leadsimp=False):
     ``e`` cannot be simplified.
     """
     # rewrite e in terms of tractable functions only
-    e = e.rewrite('tractable', deep=True)
 
     if not e.has(x):
         return e  # e is a constant
     if e.has(Order):
         e = e.expand().removeO()
-    if not x.is_positive:
-        # We make sure that x.is_positive is True so we
-        # get all the correct mathematical behavior from the expression.
+    if not x.is_positive or x.is_integer:
+        # We make sure that x.is_positive is True and x.is_integer is False
+        # so we get all the correct mathematical behavior from the expression.
         # We need a fresh variable.
         p = Dummy('p', positive=True, finite=True)
         e = e.subs(x, p)
         x = p
+    e = e.rewrite('tractable', deep=True)
     e = powdenest(e)
     c0, e0 = mrv_leadterm(e, x)
     sig = sign(e0, x)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -646,7 +646,7 @@ def test_issue_17671():
 
 
 def test_issue_17792():
-    assert limit(factorial(n)/sqrt(n)*(E/n)**n, n, oo) == sqrt(2)*sqrt(pi)
+    assert limit(factorial(n)/sqrt(n)*(exp(1)/n)**n, n, oo) == sqrt(2)*sqrt(pi)
 
 
 def test_issue_18306():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -617,8 +617,20 @@ def test_issue_14393():
     assert limit((x**b - y**b)/(x**a - y**a), x, y) == b*y**(-a)*y**b/a
 
 
+def test_issue_14556():
+    a = Symbol('a')
+    assert limit(factorial(n + 1)**(1/(n + 1)) - factorial(n)**(1/n), n, oo) == exp(-1)
+
+
 def test_issue_14811():
     assert limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) == oo
+
+
+def test_issue_16722():
+    z = symbols('z', positive=True)
+    assert limit(binomial(n + z, n)*n**-z, n, oo) == 1/gamma(z + 1)
+    z = symbols('z', positive=True, integer=True)
+    assert limit(binomial(n + z, n)*n**-z, n, oo) == 1/gamma(z + 1)
 
 
 def test_issue_17431():
@@ -631,6 +643,10 @@ def test_issue_17431():
 
 def test_issue_17671():
     assert limit(Ei(-log(x)) - log(log(x))/x, x, 1) == EulerGamma
+
+
+def test_issue_17792():
+    assert limit(factorial(n)/sqrt(n)*(E/n)**n, n, oo) == sqrt(2)*sqrt(pi)
 
 
 def test_issue_18306():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -618,7 +618,6 @@ def test_issue_14393():
 
 
 def test_issue_14556():
-    a = Symbol('a')
     assert limit(factorial(n + 1)**(1/(n + 1)) - factorial(n)**(1/n), n, oo) == exp(-1)
 
 


### PR DESCRIPTION
Fixes: #8481
Fixes: #9041 
Fixes: #14556
Fixes: #16722 
Fixes: #17792
Fixes: #18992 

#### Brief description of what is fixed or changed

**Incorrect limit evaluation** takes place based on **different assumptions** of the variable in the limit expression.

The assumption `integer = True` is causing these issues.

As we know, Gruntz algorithm changes a variable to a dummy with `positive=True` if the variable does not possess that property. We can make it define a dummy, if the limit variable has `integer=True` property. 
So, Gruntz algorithm would not need to work with variables having `integer=True` property and thus this issue won’t occur. 
The rewrite line can come later, after the dummy variable has been substituted.

Now the limit evaluations take place correctly:

```
In [6]: b = Symbol('b', positive=True, integer=True)
In [7]: limit(factorial(b+1)**(1/(b+1)) - factorial(b)**(1/b), b, oo)
Out[7]:  
 -1
e

In [8]: n = Symbol('n',positive=True,integer=True)

In [9]: limit(factorial(n)/sqrt(n)*(E/n)**n,n,oo)
Out[9]:
  ___   ____
\/ 2 *\/ pi


In [10]: z = symbols('z', positive=True)

In [11]: limit(binomial(n + z, n)*n**-z, n, oo)
Out[11]: 1/gamma(z + 1)

In [12]: z = symbols('z', positive=True, integer=True)

In [13]: limit(binomial(n + z, n)*n**-z, n, oo)
Out[13]: 1/gamma(z + 1)
```

#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Adds a condition to `limitinf() function of gruntz.py` resolving incorrect limit evaluations 
<!-- END RELEASE NOTES -->