### PR TITLE
[GSoC] Rename doit to expand in symbolic_probability.py

### DIFF
--- a/sympy/stats/error_prop.py
+++ b/sympy/stats/error_prop.py
@@ -71,14 +71,14 @@ def variance_prop(expr, consts=(), include_covar=False):
     if isinstance(expr, Add):
         var_expr = Add(*var_args)
         if include_covar:
-            terms = [2 * Covariance(_arg0_or_var(x), _arg0_or_var(y)).doit() \
+            terms = [2 * Covariance(_arg0_or_var(x), _arg0_or_var(y)).expand() \
                      for x, y in combinations(var_args, 2)]
             var_expr += Add(*terms)
     elif isinstance(expr, Mul):
         terms = [v/a**2 for a, v in zip(args, var_args)]
         var_expr = simplify(expr**2 * Add(*terms))
         if include_covar:
-            terms = [2*Covariance(_arg0_or_var(x), _arg0_or_var(y)).doit()/(a*b) \
+            terms = [2*Covariance(_arg0_or_var(x), _arg0_or_var(y)).expand()/(a*b) \
                      for (a, b), (x, y) in zip(combinations(args, 2),
                                                combinations(var_args, 2))]
             var_expr += Add(*terms)

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -89,11 +89,11 @@ class Expectation(Expr):
     >>> Expectation(X + Y)
     Expectation(X + Y)
 
-    To expand the ``Expectation`` into its expression, use ``doit()``:
+    To expand the ``Expectation`` into its expression, use ``expand()``:
 
-    >>> Expectation(X + Y).doit()
+    >>> Expectation(X + Y).expand()
     Expectation(X) + Expectation(Y)
-    >>> Expectation(a*X + Y).doit()
+    >>> Expectation(a*X + Y).expand()
     a*Expectation(X) + Expectation(Y)
     >>> Expectation(a*X + Y)
     Expectation(a*X + Y)
@@ -111,7 +111,7 @@ class Expectation(Expr):
         obj._condition = condition
         return obj
 
-    def doit(self, **hints):
+    def expand(self, **hints):
         expr = self.args[0]
         condition = self._condition
 
@@ -119,7 +119,7 @@ class Expectation(Expr):
             return expr
 
         if isinstance(expr, Add):
-            return Add(*[Expectation(a, condition=condition).doit() for a in expr.args])
+            return Add(*[Expectation(a, condition=condition).expand() for a in expr.args])
         elif isinstance(expr, Mul):
             rv = []
             nonrv = []
@@ -205,13 +205,13 @@ class Variance(Expr):
     >>> Variance(a*X)
     Variance(a*X)
 
-    To expand the variance in its expression, use ``doit()``:
+    To expand the variance in its expression, use ``expand()``:
 
-    >>> Variance(a*X).doit()
+    >>> Variance(a*X).expand()
     a**2*Variance(X)
     >>> Variance(X + Y)
     Variance(X + Y)
-    >>> Variance(X + Y).doit()
+    >>> Variance(X + Y).expand()
     2*Covariance(X, Y) + Variance(X) + Variance(Y)
 
     """
@@ -225,7 +225,7 @@ class Variance(Expr):
         obj._condition = condition
         return obj
 
-    def doit(self, **hints):
+    def expand(self, **hints):
         arg = self.args[0]
         condition = self._condition
 
@@ -239,8 +239,8 @@ class Variance(Expr):
             for a in arg.args:
                 if a.has(RandomSymbol):
                     rv.append(a)
-            variances = Add(*map(lambda xv: Variance(xv, condition).doit(), rv))
-            map_to_covar = lambda x: 2*Covariance(*x, condition=condition).doit()
+            variances = Add(*map(lambda xv: Variance(xv, condition).expand(), rv))
+            map_to_covar = lambda x: 2*Covariance(*x, condition=condition).expand()
             covariances = Add(*map(map_to_covar, itertools.combinations(rv, 2)))
             return variances + covariances
         elif isinstance(arg, Mul):
@@ -304,19 +304,19 @@ class Covariance(Expr):
     >>> cexpr.rewrite(Expectation)
     Expectation(X*Y) - Expectation(X)*Expectation(Y)
 
-    In order to expand the argument, use ``doit()``:
+    In order to expand the argument, use ``expand()``:
 
     >>> from sympy.abc import a, b, c, d
     >>> Covariance(a*X + b*Y, c*Z + d*W)
     Covariance(a*X + b*Y, c*Z + d*W)
-    >>> Covariance(a*X + b*Y, c*Z + d*W).doit()
+    >>> Covariance(a*X + b*Y, c*Z + d*W).expand()
     a*c*Covariance(X, Z) + a*d*Covariance(W, X) + b*c*Covariance(Y, Z) + b*d*Covariance(W, Y)
 
     This class is aware of some properties of the covariance:
 
-    >>> Covariance(X, X).doit()
+    >>> Covariance(X, X).expand()
     Variance(X)
-    >>> Covariance(a*X, b*Y).doit()
+    >>> Covariance(a*X, b*Y).expand()
     a*b*Covariance(X, Y)
     """
 
@@ -335,13 +335,13 @@ class Covariance(Expr):
         obj._condition = condition
         return obj
 
-    def doit(self, **hints):
+    def expand(self, **hints):
         arg1 = self.args[0]
         arg2 = self.args[1]
         condition = self._condition
 
         if arg1 == arg2:
-            return Variance(arg1, condition).doit()
+            return Variance(arg1, condition).expand()
 
         if not arg1.has(RandomSymbol):
             return S.Zero

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -61,7 +61,7 @@ def test_literal_probability():
     assert Covariance(X + Y, Z + W).expand() == Covariance(W, X) + Covariance(W, Y) + Covariance(X, Z) + Covariance(Y, Z)
     assert Covariance(x*X + y*Y, z*Z + w*W).expand() == (x*w*Covariance(W, X) + w*y*Covariance(W, Y) +
                                                 x*z*Covariance(X, Z) + y*z*Covariance(Y, Z))
-    assert Covariance(x*X**2 + y*sin(Y), z*Y*Z**2 + w*W).doit() == (w*x*Covariance(W, X**2) + w*y*Covariance(sin(Y), W) +
+    assert Covariance(x*X**2 + y*sin(Y), z*Y*Z**2 + w*W).expand() == (w*x*Covariance(W, X**2) + w*y*Covariance(sin(Y), W) +
                                                         x*z*Covariance(Y*Z**2, X**2) + y*z*Covariance(Y*Z**2, sin(Y)))
     assert Covariance(X, X**2).expand() == Covariance(X, X**2)
     assert Covariance(X, sin(X)).expand() == Covariance(sin(X), X)

--- a/sympy/stats/tests/test_symbolic_probability.py
+++ b/sympy/stats/tests/test_symbolic_probability.py
@@ -22,50 +22,50 @@ def test_literal_probability():
     assert Expectation(X).rewrite(Integral).doit() == expectation(X)
     assert Expectation(X**2).evaluate_integral() == expectation(X**2)
     assert Expectation(x*X).args == (x*X,)
-    assert Expectation(x*X).doit() == x*Expectation(X)
-    assert Expectation(2*X + 3*Y + z*X*Y).doit() == 2*Expectation(X) + 3*Expectation(Y) + z*Expectation(X*Y)
+    assert Expectation(x*X).expand() == x*Expectation(X)
+    assert Expectation(2*X + 3*Y + z*X*Y).expand() == 2*Expectation(X) + 3*Expectation(Y) + z*Expectation(X*Y)
     assert Expectation(2*X + 3*Y + z*X*Y).args == (2*X + 3*Y + z*X*Y,)
-    assert Expectation(sin(X)) == Expectation(sin(X)).doit()
-    assert Expectation(2*x*sin(X)*Y + y*X**2 + z*X*Y).doit() == 2*x*Expectation(sin(X)*Y) + y*Expectation(X**2) + z*Expectation(X*Y)
+    assert Expectation(sin(X)) == Expectation(sin(X)).expand()
+    assert Expectation(2*x*sin(X)*Y + y*X**2 + z*X*Y).expand() == 2*x*Expectation(sin(X)*Y) + y*Expectation(X**2) + z*Expectation(X*Y)
 
     assert Variance(w).args == (w,)
-    assert Variance(w).doit() == 0
+    assert Variance(w).expand() == 0
     assert Variance(X).evaluate_integral() == Variance(X).rewrite(Integral).doit() == variance(X)
     assert Variance(X + z).args == (X + z,)
-    assert Variance(X + z).doit() == Variance(X)
+    assert Variance(X + z).expand() == Variance(X)
     assert Variance(X*Y).args == (Mul(X, Y),)
     assert type(Variance(X*Y)) == Variance
-    assert Variance(z*X).doit() == z**2*Variance(X)
-    assert Variance(X + Y).doit() == Variance(X) + Variance(Y) + 2*Covariance(X, Y)
-    assert Variance(X + Y + Z + W).doit() == (Variance(X) + Variance(Y) + Variance(Z) + Variance(W) +
+    assert Variance(z*X).expand() == z**2*Variance(X)
+    assert Variance(X + Y).expand() == Variance(X) + Variance(Y) + 2*Covariance(X, Y)
+    assert Variance(X + Y + Z + W).expand() == (Variance(X) + Variance(Y) + Variance(Z) + Variance(W) +
                                        2 * Covariance(X, Y) + 2 * Covariance(X, Z) + 2 * Covariance(X, W) +
                                        2 * Covariance(Y, Z) + 2 * Covariance(Y, W) + 2 * Covariance(W, Z))
     assert Variance(X**2).evaluate_integral() == variance(X**2)
     assert unchanged(Variance, X**2)
-    assert Variance(x*X**2).doit() == x**2*Variance(X**2)
+    assert Variance(x*X**2).expand() == x**2*Variance(X**2)
     assert Variance(sin(X)).args == (sin(X),)
-    assert Variance(sin(X)).doit() == Variance(sin(X))
-    assert Variance(x*sin(X)).doit() == x**2*Variance(sin(X))
+    assert Variance(sin(X)).expand() == Variance(sin(X))
+    assert Variance(x*sin(X)).expand() == x**2*Variance(sin(X))
 
     assert Covariance(w, z).args == (w, z)
-    assert Covariance(w, z).doit() == 0
-    assert Covariance(X, w).doit() == 0
-    assert Covariance(w, X).doit() == 0
+    assert Covariance(w, z).expand() == 0
+    assert Covariance(X, w).expand() == 0
+    assert Covariance(w, X).expand() == 0
     assert Covariance(X, Y).args == (X, Y)
     assert type(Covariance(X, Y)) == Covariance
-    assert Covariance(z*X + 3, Y).doit() == z*Covariance(X, Y)
+    assert Covariance(z*X + 3, Y).expand() == z*Covariance(X, Y)
     assert Covariance(X, X).args == (X, X)
-    assert Covariance(X, X).doit() == Variance(X)
-    assert Covariance(z*X + 3, w*Y + 4).doit() == w*z*Covariance(X,Y)
+    assert Covariance(X, X).expand() == Variance(X)
+    assert Covariance(z*X + 3, w*Y + 4).expand() == w*z*Covariance(X,Y)
     assert Covariance(X, Y) == Covariance(Y, X)
-    assert Covariance(X + Y, Z + W).doit() == Covariance(W, X) + Covariance(W, Y) + Covariance(X, Z) + Covariance(Y, Z)
-    assert Covariance(x*X + y*Y, z*Z + w*W).doit() == (x*w*Covariance(W, X) + w*y*Covariance(W, Y) +
+    assert Covariance(X + Y, Z + W).expand() == Covariance(W, X) + Covariance(W, Y) + Covariance(X, Z) + Covariance(Y, Z)
+    assert Covariance(x*X + y*Y, z*Z + w*W).expand() == (x*w*Covariance(W, X) + w*y*Covariance(W, Y) +
                                                 x*z*Covariance(X, Z) + y*z*Covariance(Y, Z))
     assert Covariance(x*X**2 + y*sin(Y), z*Y*Z**2 + w*W).doit() == (w*x*Covariance(W, X**2) + w*y*Covariance(sin(Y), W) +
                                                         x*z*Covariance(Y*Z**2, X**2) + y*z*Covariance(Y*Z**2, sin(Y)))
-    assert Covariance(X, X**2).doit() == Covariance(X, X**2)
-    assert Covariance(X, sin(X)).doit() == Covariance(sin(X), X)
-    assert Covariance(X**2, sin(X)*Y).doit() == Covariance(sin(X)*Y, X**2)
+    assert Covariance(X, X**2).expand() == Covariance(X, X**2)
+    assert Covariance(X, sin(X)).expand() == Covariance(sin(X), X)
+    assert Covariance(X**2, sin(X)*Y).expand() == Covariance(sin(X)*Y, X**2)
     assert Covariance(w, X).evaluate_integral() == 0
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Rename doit to expand in symbolic_probability.py
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to discussions in #19267 

#### Brief description of what is fixed or changed
Following the discussions and the documentation, the current `doit` is performing the `expand` and hence rename it to `expand`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
   * `expand` added in `sympy.stats.symbolic_rv` API.
<!-- END RELEASE NOTES -->
ping @czgdp1807 @Upabjojr @jmig5776 