### PR TITLE
Update bin/test to use argparse

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -11,84 +11,72 @@ from __future__ import print_function
 
 import sys
 import os
-from optparse import OptionParser
+from argparse import ArgumentParser
 import re
 
 from get_sympy import path_hack
 path_hack()
 
-# callback to support variable length argument in optparse
-# docs.python.org/2/library/optparse.html#callback-example-6-variable-arguments
-def vararg_callback(option, opt_str, value, parser):
-    assert value is None
-    value = []
-
-    def floatable(str):
-        try:
-            float(str)
-            return True
-        except ValueError:
-            return False
-
-    for arg in parser.rargs:
-        # stop on --foo like options
-        if arg[:2] == "--" and len(arg) > 2:
-            break
-        # stop on -a, but not on -3 or -3.0
-        if arg[:1] == "-" and len(arg) > 1 and not floatable(arg):
-            break
-        value.append(arg)
-
-    del parser.rargs[:len(value)]
-    setattr(parser.values, option.dest, value)
-
-
-parser = OptionParser()
-parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
-        default=False)
-parser.add_option("--pdb", action="store_true", dest="pdb",
-        default=False, help="Run post mortem pdb on each failure")
-parser.add_option("--no-colors", action="store_false", dest="colors",
-        default=True, help="Do not report colored [OK] and [FAIL]")
-parser.add_option("--force-colors", action="store_true", dest="force_colors",
-        default=False, help="Always use colors, even if the output is not to a terminal.")
-parser.add_option("-k", dest="kw",
-        help="only run tests matching the given keyword expressions",
-        metavar="KEYWORDS", action="callback", callback=vararg_callback)
-parser.add_option("--tb", dest="tb",
-        help="traceback verboseness (short/no) [default: %default]",
-        metavar="TBSTYLE", default="short")
-parser.add_option("--random", action="store_false", dest="sort", default=True,
-        help="Run tests in random order instead of sorting them")
-parser.add_option("--seed", dest="seed", type="int",
-        help="use this seed for randomized tests",
-        metavar="SEED")
-parser.add_option('-t', '--types', dest='types', action='store',
-        default=None, choices=['gmpy', 'gmpy1', 'python'],
-        help='setup ground types: gmpy | gmpy1 | python')
-parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
-        default=True, help='disable caching mechanism')
-parser.add_option("--timeout", action="store", dest="timeout",
-        default=False, help="Set a timeout for the all functions, in seconds. By default there is no timeout.", type='int')
-parser.add_option("--slow", action="store_true", dest="slow",
-        default=False, help="Run only the slow functions.")
-parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
-                  default=True, help="Don't run the tests in a separate "
-                  "subprocess.  This may prevent hash randomization from being enabled.")
-parser.add_option("-E", "--enhance-asserts", action="store_true", dest="enhance_asserts",
-                  default=False, help="Rewrite assert statements to give more useful error messages.")
-parser.add_option('--split', action="store", type='str', default=None,
-    help="Only run part of the tests. Should be of the form a/b, e.g., 1/2")
-parser.add_option('--rerun', action="store", dest="rerun",
-                  default=0, help="Number of times to rerun the specified tests",
-                  type='int')
-parser.set_usage("test [options ...] [tests ...]")
-parser.epilog = """\
-"options" are any of the options above. "tests" are 0 or more glob strings of \
-tests to run. If no test arguments are given, all tests will be run.\
+epilog = """
+"options" are any of the options above.
+"tests" are 0 or more glob strings of tests to run.
+If no test arguments are given, all tests will be run.
 """
 
-options, args = parser.parse_args()
+parser = ArgumentParser(epilog=epilog)
+parser.add_argument(
+    "-v", "--verbose", action="store_true", dest="verbose", default=False)
+parser.add_argument(
+    "--pdb", action="store_true", dest="pdb", default=False,
+    help="Run post mortem pdb on each failure")
+parser.add_argument(
+    "--no-colors", action="store_false", dest="colors", default=True,
+    help="Do not report colored [OK] and [FAIL]")
+parser.add_argument(
+    "--force-colors", action="store_true", dest="force_colors", default=False,
+    help="Always use colors, even if the output is not to a terminal.")
+parser.add_argument(
+    "-k", dest="kw", metavar="KEYWORDS", action="store", nargs='*',
+    help="Only run tests matching the given keyword expressions")
+parser.add_argument(
+    "--tb", dest="tb", metavar="TBSTYLE", default="short",
+    help="Traceback verboseness (short/no)")
+parser.add_argument(
+    "--random", action="store_false", dest="sort", default=True,
+    help="Run tests in random order instead of sorting them.")
+parser.add_argument(
+    "--seed", dest="seed", type=int, metavar="SEED",
+    help="Use this seed for randomized tests.")
+parser.add_argument(
+    '-t', '--types', dest='types', action='store', default=None,
+    choices=['gmpy', 'gmpy1', 'python'],
+    help='Setup ground types.')
+parser.add_argument(
+    '-C', '--no-cache', dest='cache', action='store_false', default=True,
+    help='Disable caching mechanism.')
+parser.add_argument(
+    "--timeout", action="store", dest="timeout", default=False, type=int,
+    help="Set a timeout for the all functions, in seconds. "
+        "By default there is no timeout.")
+parser.add_argument(
+    "--slow", action="store_true", dest="slow", default=False,
+    help="Run only the slow functions.")
+parser.add_argument(
+    "--no-subprocess", action="store_false", dest="subprocess", default=True,
+    help="Don't run the tests in a separate subprocess. "
+        "This may prevent hash randomization from being enabled.")
+parser.add_argument(
+    "-E", "--enhance-asserts", action="store_true", dest="enhance_asserts",
+    default=False,
+    help="Rewrite assert statements to give more useful error messages.")
+parser.add_argument(
+    '--split', action="store", type=str, default=None,
+    help="Only run part of the tests. Should be of the form a/b, (e.g., 1/2)")
+parser.add_argument(
+    '--rerun', action="store", dest="rerun", default=0, type=int,
+    help="Number of times to rerun the specified tests.")
+
+options, args = parser.parse_known_args()
 
 # Check this again here to give a better error message
 if options.split:

--- a/bin/test
+++ b/bin/test
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 import sys
 import os
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import re
 
 from get_sympy import path_hack
@@ -23,7 +23,9 @@ epilog = """
 If no test arguments are given, all tests will be run.
 """
 
-parser = ArgumentParser(epilog=epilog)
+parser = ArgumentParser(
+    epilog=epilog,
+    formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument(
     "-v", "--verbose", action="store_true", dest="verbose", default=False)
 parser.add_argument(


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I've updated bin/test to use argparse.
The only notable change is that I have removed the callback function because the variable length arguments are supported after dropping python 2.
I've also removed some redundant help messages that are generated automatically.

```
usage: test [-h] [-v] [--pdb] [--no-colors] [--force-colors]
            [-k [KEYWORDS [KEYWORDS ...]]] [--tb TBSTYLE] [--random]
            [--seed SEED] [-t {gmpy,gmpy1,python}] [-C] [--timeout TIMEOUT]
            [--slow] [--no-subprocess] [-E] [--split SPLIT] [--rerun RERUN]

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  --pdb                 Run post mortem pdb on each failure
  --no-colors           Do not report colored [OK] and [FAIL]
  --force-colors        Always use colors, even if the output is not to a
                        terminal.
  -k [KEYWORDS [KEYWORDS ...]]
                        Only run tests matching the given keyword expressions
  --tb TBSTYLE          Traceback verboseness (short/no)
  --random              Run tests in random order instead of sorting them.
  --seed SEED           Use this seed for randomized tests.
  -t {gmpy,gmpy1,python}, --types {gmpy,gmpy1,python}
                        Setup ground types.
  -C, --no-cache        Disable caching mechanism.
  --timeout TIMEOUT     Set a timeout for the all functions, in seconds. By
                        default there is no timeout.
  --slow                Run only the slow functions.
  --no-subprocess       Don't run the tests in a separate subprocess. This may
                        prevent hash randomization from being enabled.
  -E, --enhance-asserts
                        Rewrite assert statements to give more useful error
                        messages.
  --split SPLIT         Only run part of the tests. Should be of the form a/b,
                        (e.g., 1/2)
  --rerun RERUN         Number of times to rerun the specified tests.

"options" are any of the options above. "tests" are 0 or more glob strings of
tests to run. If no test arguments are given, all tests will be run.
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->