### PR TITLE
[GSoC] Series: Fixing incorrect limit evaluations caused due to bug in rewriting

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -628,7 +628,7 @@ def rewrite(e, Omega, x, wsym):
     # Some parts of sympy have difficulty computing series expansions with
     # non-integral exponents. The following heuristic improves the situation:
     exponent = reduce(ilcm, denominators, 1)
-    f = f.xreplace({wsym: wsym**exponent})
+    f = f.subs({wsym: wsym**exponent})
     logw /= exponent
 
     return f, logw

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -653,7 +653,7 @@ def test_issue_18306():
 
 
 def test_issue_18378():
-    assert limit(log(exp(3*x) + x)/log(exp(x) + x**100), x, oo).doit() == 3
+    assert limit(log(exp(3*x) + x)/log(exp(x) + x**100), x, oo) == 3
 
 
 def test_issue_18442():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -652,8 +652,16 @@ def test_issue_18306():
     assert limit(sin(sqrt(x))/sqrt(sin(x)), x, 0, '+') == 1
 
 
+def test_issue_18378():
+    assert limit(log(exp(3*x) + x)/log(exp(x) + x**100), x, oo).doit() == 3
+
+
 def test_issue_18442():
     assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == AccumBounds(-oo, oo)
+
+
+def test_issue_18482():
+    assert limit((2*exp(3*x)/(exp(2*x) + 1))**(1/x), x, oo) == exp(1)
 
 
 def test_issue_18501():


### PR DESCRIPTION
Fixes: #18378
Fixes: #18482 
Closes #18947

#### Brief description of what is fixed or changed

**Incorrect limit evaluation** takes place because of **bug in rewriting.**

The function `xreplace()` in the `rewrite()` function of `gruntz.py` is not substituting properly.
As a result, it has been replaced by the `subs()` function which resolves the issue.

#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Replaces `xreplace()` with `subs()` in `rewrite() function of gruntz.py` resolving incorrect limit evaluations 
<!-- END RELEASE NOTES -->