### PR TITLE
Define Is meromorphic

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -514,6 +514,10 @@ class Add(Expr, AssocOp):
     def _eval_is_rational_function(self, syms):
         return all(term._eval_is_rational_function(syms) for term in self.args)
 
+    def _eval_is_meromorphic(self, x, a):
+        return _fuzzy_group((arg.is_meromorphic(x, a) for arg in self.args),
+                            quick_exit=True)
+
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2674,7 +2674,7 @@ class Expr(Basic, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy import zoo, log, sin
+        >>> from sympy import zoo, log, sin, sqrt
         >>> from sympy.abc import x
 
         >>> f = 1/x**2 + 1 - 2*x**3
@@ -2701,7 +2701,20 @@ class Expr(Basic, EvalfMixin):
         >>> h.is_meromorphic(x, zoo)
         True
 
+        Multivalued functions are considered meromorphic when their
+        branches are meromorphic. Thus most functions are meromorphic
+        everywhere except at essential singularities and branch points.
+        In particular, they will be meromorphic also on branch cuts
+        except at their endpoints.
 
+        >>> log(x).is_meromorphic(x, -1)
+        True
+        >>> log(x).is_meromorphic(x, 0)
+        False
+        >>> sqrt(x).is_meromorphic(x, -1)
+        True
+        >>> sqrt(x).is_meromorphic(x, 0)
+        False
 
         """
         if not x.is_Symbol:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2658,6 +2658,58 @@ class Expr(Basic, EvalfMixin):
         else:
             return self._eval_is_rational_function(syms)
 
+    def _eval_is_meromorphic(self, x, a):
+        # Default implementation, return True for constants.
+        return None if self.has(x) else True
+
+    def is_meromorphic(self, x, a):
+        """
+        This tests whether an expression is meromorphic as
+        a function of the given symbol ``x`` at the point ``a``.
+
+        This method is intended as a quick test that will return
+        None if no decision can be made without simplification or
+        more detailed analysis.
+
+        Examples
+        ========
+
+        >>> from sympy import zoo, log, sin
+        >>> from sympy.abc import x
+
+        >>> f = 1/x**2 + 1 - 2*x**3
+        >>> f.is_meromorphic(x, 0)
+        True
+        >>> f.is_meromorphic(x, 1)
+        True
+        >>> f.is_meromorphic(x, zoo)
+        True
+
+        >>> g = x**log(3)
+        >>> g.is_meromorphic(x, 0)
+        False
+        >>> g.is_meromorphic(x, 1)
+        True
+        >>> g.is_meromorphic(x, zoo)
+        False
+
+        >>> h = sin(1/x)*x**2
+        >>> h.is_meromorphic(x, 0)
+        False
+        >>> h.is_meromorphic(x, 1)
+        True
+        >>> h.is_meromorphic(x, zoo)
+        True
+
+
+
+        """
+        if not x.is_Symbol:
+            raise TypeError("{} should be of type Symbol".format(x))
+        a = sympify(a)
+
+        return self._eval_is_meromorphic(x, a)
+
     def _eval_is_algebraic_expr(self, syms):
         if self.free_symbols.intersection(syms) == set():
             return True
@@ -3797,6 +3849,9 @@ class AtomicExpr(Atom, Expr):
         return True
 
     def _eval_is_rational_function(self, syms):
+        return True
+
+    def _eval_is_meromorphic(self, x, a):
         return True
 
     def _eval_is_algebraic_expr(self, syms):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1186,6 +1186,10 @@ class Mul(Expr, AssocOp):
     def _eval_is_rational_function(self, syms):
         return all(term._eval_is_rational_function(syms) for term in self.args)
 
+    def _eval_is_meromorphic(self, x, a):
+        return _fuzzy_group((arg.is_meromorphic(x, a) for arg in self.args),
+                            quick_exit=True)
+
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -619,6 +619,34 @@ def test_is_rational_function():
     assert (S.NegativeInfinity).is_rational_function() is False
     assert (S.ComplexInfinity).is_rational_function() is False
 
+def test_is_meromorphic():
+    f = a/x**2 + b + x + c*x**2
+    assert f.is_meromorphic(x, 0) is True
+    assert f.is_meromorphic(x, 1) is True
+    assert f.is_meromorphic(x, zoo) is True
+
+    g = 3 + 2*x**(log(3)/log(2) - 1)
+    assert g.is_meromorphic(x, 0) is None
+    assert g.is_meromorphic(x, 1) is True
+    assert g.is_meromorphic(x, zoo) is None
+
+    n = Symbol('n', integer=True)
+    h = sin(1/x)**n*x
+    assert h.is_meromorphic(x, 0) is False
+    assert h.is_meromorphic(x, 1) is True
+    assert h.is_meromorphic(x, zoo) is True
+
+    e = log(x)**pi
+    assert e.is_meromorphic(x, 0) is False
+    assert e.is_meromorphic(x, 1) is False
+    assert e.is_meromorphic(x, 2) is True
+    assert e.is_meromorphic(x, zoo) is False
+
+    assert (log(x)**a).is_meromorphic(x, 0) is False
+    assert (log(x)**a).is_meromorphic(x, 1) is None
+    assert (a**log(x)).is_meromorphic(x, 0) is None
+    assert (3**log(x)).is_meromorphic(x, 0) is False
+    assert (3**log(x)).is_meromorphic(x, 1) is True
 
 def test_is_algebraic_expr():
     assert sqrt(3).is_algebraic_expr(x) is True

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -46,6 +46,7 @@ class re(Function):
 
     is_extended_real = True
     unbranched = True  # implicitly works on the projection to C
+    _singularities = True  # non-holomorphic
 
     @classmethod
     def eval(cls, arg):
@@ -154,6 +155,7 @@ class im(Function):
 
     is_extended_real = True
     unbranched = True  # implicitly works on the projection to C
+    _singularities = True  # non-holomorphic
 
     @classmethod
     def eval(cls, arg):
@@ -283,6 +285,7 @@ class sign(Function):
     """
 
     is_complex = True
+    _singularities = True
 
     def doit(self, **hints):
         if self.args[0].is_zero is False:
@@ -437,6 +440,7 @@ class Abs(Function):
     is_extended_negative = False
     is_extended_nonnegative = True
     unbranched = True
+    _singularities = True  # non-holomorphic
 
     def fdiff(self, argindex=1):
         """
@@ -653,6 +657,7 @@ class arg(Function):
     is_extended_real = True
     is_real = True
     is_finite = True
+    _singularities = True  # non-holomorphic
 
     @classmethod
     def eval(cls, arg):
@@ -713,6 +718,7 @@ class conjugate(Function):
 
     .. [1] https://en.wikipedia.org/wiki/Complex_conjugation
     """
+    _singularities = True  # non-holomorphic
 
     @classmethod
     def eval(cls, arg):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -28,6 +28,7 @@ from sympy.ntheory import multiplicity, perfect_power
 class ExpBase(Function):
 
     unbranched = True
+    _singularities = (S.ComplexInfinity,)
 
     def inverse(self, argindex=1):
         """
@@ -572,6 +573,7 @@ class log(Function):
     exp
 
     """
+    _singularities = (S.Zero, S.ComplexInfinity)
 
     def fdiff(self, argindex=1):
         """

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -25,6 +25,7 @@ class TrigonometricFunction(Function):
     """Base class for trigonometric functions. """
 
     unbranched = True
+    _singularities = (S.ComplexInfinity,)
 
     def _eval_is_rational(self):
         s = self.func(*self.args)
@@ -1573,6 +1574,7 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
     """Base class for reciprocal functions of trigonometric functions. """
 
     _reciprocal_of = None       # mandatory, to be defined in subclass
+    _singularities = (S.ComplexInfinity,)
 
     # _is_even and _is_odd are used for correct evaluation of csc(-x), sec(-x)
     # TODO refactor into TrigonometricFunction common parts of
@@ -1910,6 +1912,7 @@ class sinc(Function):
     .. [1] https://en.wikipedia.org/wiki/Sinc_function
 
     """
+    _singularities = (S.ComplexInfinity,)
 
     def fdiff(self, argindex=1):
         x = self.args[0]
@@ -1961,6 +1964,7 @@ class sinc(Function):
 
 class InverseTrigonometricFunction(Function):
     """Base class for inverse trigonometric functions."""
+    _singularities = (1, -1, 0, S.ComplexInfinity)
 
     @staticmethod
     def _asin_table():
@@ -2413,6 +2417,7 @@ class atan(InverseTrigonometricFunction):
     .. [3] http://functions.wolfram.com/ElementaryFunctions/ArcTan
 
     """
+    _singularities = (S.ImaginaryUnit, -S.ImaginaryUnit)
 
     def fdiff(self, argindex=1):
         if argindex == 1:
@@ -2586,6 +2591,7 @@ class acot(InverseTrigonometricFunction):
     .. [2] http://functions.wolfram.com/ElementaryFunctions/ArcCot
 
     """
+    _singularities = (S.ImaginaryUnit, -S.ImaginaryUnit)
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -103,6 +103,7 @@ class gamma(Function):
     """
 
     unbranched = True
+    _singularities = (S.ComplexInfinity,)
 
     def fdiff(self, argindex=1):
         if argindex == 1:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
See #8320

#### Brief description of what is fixed or changed
Added a new method, `.is_meromorphic(x, a)` to check whether an expression is a
meromorphic function of `x` at `a`.


#### Other comments
Limits of meromorphic functions can be easily found from the leading terms of their Laurent
series expansions. There is some heuristic in `Limit.doit()` for that purpose (`if all(ok(w) ...)`)
but in most cases the limit will be handled by `gruntz`. That will make a change of variables
introducing an essential singularity and consequently increasing the difficulty of finding a limit.

This method can be used to cover most cases where the limit can be found from the leading
term.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * expr: A new method `is_meromorphic` is added.
<!-- END RELEASE NOTES -->