### PR TITLE
Make classes in diffgeom module Atom

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -447,7 +447,7 @@ class Point(Basic):
         return self._coords.free_symbols
 
 
-class BaseScalarField(AtomicExpr):
+class BaseScalarField(Expr):
     """Base Scalar Field over a Manifold for a given Coordinate System.
 
     Explanation
@@ -542,7 +542,7 @@ class BaseScalarField(AtomicExpr):
         return self
 
 
-class BaseVectorField(AtomicExpr):
+class BaseVectorField(Expr):
     r"""Vector Field over a Manifold.
 
     Explanation

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -5,7 +5,7 @@ from itertools import permutations
 from sympy.combinatorics import Permutation
 from sympy.core import (
     AtomicExpr, Basic, Expr, Dummy, Function, sympify, diff,
-    Pow, Mul, Add, Symbol, symbols, Tuple, Atom
+    Pow, Mul, Add, Atom
 )
 from sympy.core.compatibility import reduce
 from sympy.core.numbers import Zero

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -4,11 +4,12 @@ from itertools import permutations
 
 from sympy.combinatorics import Permutation
 from sympy.core import (
-    AtomicExpr, Basic, Expr, Dummy, Function, sympify, diff,
+    AtomicExpr, Basic, Expr, Dummy, Function,  diff,
     Pow, Mul, Add, Atom
 )
 from sympy.core.compatibility import reduce
 from sympy.core.numbers import Zero
+from sympy.core.sympify import _sympify
 from sympy.functions import factorial
 from sympy.matrices import Matrix
 from sympy.simplify import simplify
@@ -512,13 +513,11 @@ class BaseScalarField(AtomicExpr):
     is_commutative = True
 
     def __new__(cls, coord_sys, index):
-        obj = super().__new__(cls)
+        index = _sympify(index)
+        obj = super().__new__(cls, coord_sys, index)
         obj._coord_sys = coord_sys
         obj._index = index
         return obj
-
-    def _hashable_content(self):
-        return self._coord_sys, self._index
 
     def __call__(self, *args):
         """Evaluating the field at a point or doing nothing.
@@ -616,13 +615,11 @@ class BaseVectorField(AtomicExpr):
     is_commutative = False
 
     def __new__(cls, coord_sys, index):
-        obj = super().__new__(cls)
+        index = _sympify(index)
+        obj = super().__new__(cls, coord_sys, index)
         obj._coord_sys = coord_sys
         obj._index = index
         return obj
-
-    def _hashable_content(self):
-        return self._coord_sys, self._index
 
     def __call__(self, scalar_field):
         """Apply on a scalar field.
@@ -1366,7 +1363,7 @@ def dummyfy(args, exprs):
     # TODO Is this a good idea?
     d_args = Matrix([s.as_dummy() for s in args])
     reps = dict(zip(args, d_args))
-    d_exprs = Matrix([sympify(expr).subs(reps) for expr in exprs])
+    d_exprs = Matrix([_sympify(expr).subs(reps) for expr in exprs])
     return d_args, d_exprs
 
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -4,7 +4,7 @@ from itertools import permutations
 
 from sympy.combinatorics import Permutation
 from sympy.core import (
-    AtomicExpr, Basic, Expr, Dummy, Function,  diff,
+    Basic, Expr, Dummy, Function,  diff,
     Pow, Mul, Add, Atom
 )
 from sympy.core.compatibility import reduce

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -43,6 +43,8 @@ class Manifold(Atom):
         # other Patch instance on the same manifold.
         return obj
 
+    def _hashable_content(self):
+        return self.name, self.dim
 
 class Patch(Atom):
     """Object representing a patch on a manifold.
@@ -83,6 +85,8 @@ class Patch(Atom):
     def dim(self):
         return self.manifold.dim
 
+    def _hashable_content(self):
+        return self.name, self.manifold
 
 class CoordSystem(Atom):
     """Contains all coordinate transformation logic.
@@ -183,7 +187,7 @@ class CoordSystem(Atom):
             names = ['%s_%d' % (name, i) for i in range(patch.dim)]
         obj = super().__new__(cls)
         obj.name = name
-        obj._names = [str(i) for i in names]
+        obj._names = tuple(str(i) for i in names)
         obj.patch = patch
         obj.patch.coord_systems.append(obj)
         obj.transforms = {}
@@ -201,6 +205,9 @@ class CoordSystem(Atom):
     @property
     def dim(self):
         return self.patch.dim
+
+    def _hashable_content(self):
+        return self.name, self.patch, self._names
 
     ##########################################################################
     # Coordinate transformations.

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -36,7 +36,7 @@ class Manifold(Atom):
     ==========
     name : str
         The name of the manifold.
-    
+
     dim : int
         The dimension of the manifold.
     """
@@ -71,7 +71,7 @@ class Patch(Atom):
     ==========
     name : string
         The name of the patch.
-    
+
     manifold : Manifold
         The manifold on which the patch is defined.
 
@@ -119,7 +119,7 @@ class CoordSystem(Atom):
 
     name : string
         The name of the coordinate system.
-    
+
     patch : Patch
         The patch where the coordinate system is defined.
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -32,6 +32,13 @@ class Manifold(Atom):
     defined on the manifold. It does not provide any means to study the
     topological characteristics of the manifold that it represents.
 
+    Parameters
+    ==========
+    name : str
+        The name of the manifold.
+    
+    dim : int
+        The dimension of the manifold.
     """
 
     def __new__(cls, name, dim):
@@ -47,7 +54,10 @@ class Manifold(Atom):
         return self.name, self.dim
 
 class Patch(Atom):
-    """Object representing a patch on a manifold.
+    """A patch on a manifold.
+
+    Explanation
+    ===========
 
     On a manifold one can have many patches that do not always include the
     whole manifold. On these patches coordinate charts can be defined that
@@ -56,6 +66,14 @@ class Patch(Atom):
 
     This object serves as a container/parent for all coordinate system charts
     that can be defined on the patch it represents.
+
+    Parameters
+    ==========
+    name : string
+        The name of the patch.
+    
+    manifold : Manifold
+        The manifold on which the patch is defined.
 
     Examples
     ========
@@ -89,7 +107,24 @@ class Patch(Atom):
         return self.name, self.manifold
 
 class CoordSystem(Atom):
-    """Contains all coordinate transformation logic.
+    """A coordinate system defined on the patch
+
+    Explanation
+    ===========
+
+    This class contains all coordinate transformation logic.
+
+    Parameters
+    ==========
+
+    name : string
+        The name of the coordinate system.
+    
+    patch : Patch
+        The patch where the coordinate system is defined.
+
+    names : list of strings, optional
+        Determines how base scalar fields will be printed.
 
     Examples
     ========
@@ -341,7 +376,10 @@ class CoordSystem(Atom):
     ##########################################################################
 
 class Point(Basic):
-    """Point in a Manifold object.
+    """Point defined in a coordinate system.
+
+    Explanation
+    ===========
 
     To define a point you must supply coordinates and a coordinate system.
 
@@ -349,6 +387,14 @@ class Point(Basic):
     coordinate system that was used in order to define it, however due to
     limitations in the simplification routines you can arrive at complicated
     expressions if you use inappropriate coordinate systems.
+
+    Parameters
+    ==========
+
+    coord_sys : CoordSystem
+
+    coords: list of sympy expressions
+        The coordinates of the point.
 
     Examples
     ========
@@ -403,6 +449,9 @@ class Point(Basic):
 class BaseScalarField(AtomicExpr):
     """Base Scalar Field over a Manifold for a given Coordinate System.
 
+    Explanation
+    ===========
+
     A scalar field takes a point as an argument and returns a scalar.
 
     A base scalar field of a coordinate system takes a point and returns one of
@@ -418,6 +467,13 @@ class BaseScalarField(AtomicExpr):
 
     You can build complicated scalar fields by just building up SymPy
     expressions containing ``BaseScalarField`` instances.
+
+    Parameters
+    ==========
+
+    coord_sys : CoordSystem
+
+    index : integer
 
     Examples
     ========
@@ -490,6 +546,9 @@ class BaseScalarField(AtomicExpr):
 class BaseVectorField(AtomicExpr):
     r"""Vector Field over a Manifold.
 
+    Explanation
+    ===========
+
     A vector field is an operator taking a scalar field and returning a
     directional derivative (which is also a scalar field).
 
@@ -503,6 +562,13 @@ class BaseVectorField(AtomicExpr):
     coordinate system in which it was defined, however due to limitations in the
     simplification routines you may arrive at more complicated expression if you
     use unappropriate coordinate systems.
+
+    Parameters
+    ==========
+
+    coord_sys : CoordSystem
+
+    index : integer
 
     Examples
     ========

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -698,7 +698,7 @@ class Commutator(Expr):
     Commutator(e_x, e_r)
 
     >>> simplify(c_xr(R2.y**2))
-    -2*y**2*cos(theta)/(x**2 + y**2)
+    -2*cos(theta)*y**2/(x**2 + y**2)
 
     """
     def __new__(cls, v1, v2):
@@ -1475,7 +1475,7 @@ def vectors_in_basis(expr, to_sys):
     >>> from sympy.diffgeom import vectors_in_basis
     >>> from sympy.diffgeom.rn import R2_r, R2_p
     >>> vectors_in_basis(R2_r.e_x, R2_p)
-    x*e_r/sqrt(x**2 + y**2) - y*e_theta/(x**2 + y**2)
+    -y*e_theta/(x**2 + y**2) + x*e_r/sqrt(x**2 + y**2)
     >>> vectors_in_basis(R2_p.e_r, R2_r)
     sin(theta)*e_y + cos(theta)*e_x
     """
@@ -1626,10 +1626,10 @@ def metric_to_Riemann_components(expr):
     >>> non_trivial_metric = exp(2*R2.r)*TP(R2.dr, R2.dr) + \
         R2.r**2*TP(R2.dtheta, R2.dtheta)
     >>> non_trivial_metric
-    r**2*TensorProduct(dtheta, dtheta) + exp(2*r)*TensorProduct(dr, dr)
+    exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
     >>> riemann = metric_to_Riemann_components(non_trivial_metric)
     >>> riemann[0, :, :, :]
-    [[[0, 0], [0, 0]], [[0, r*exp(-2*r)], [-r*exp(-2*r), 0]]]
+    [[[0, 0], [0, 0]], [[0, exp(-2*r)*r], [-exp(-2*r)*r, 0]]]
     >>> riemann[1, :, :, :]
     [[[0, -1/r], [1/r, 0]], [[0, 0], [0, 0]]]
 
@@ -1680,9 +1680,9 @@ def metric_to_Ricci_components(expr):
     >>> non_trivial_metric = exp(2*R2.r)*TP(R2.dr, R2.dr) + \
                              R2.r**2*TP(R2.dtheta, R2.dtheta)
     >>> non_trivial_metric
-    r**2*TensorProduct(dtheta, dtheta) + exp(2*r)*TensorProduct(dr, dr)
+    exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
     >>> metric_to_Ricci_components(non_trivial_metric)
-    [[1/r, 0], [0, r*exp(-2*r)]]
+    [[1/r, 0], [0, exp(-2*r)*r]]
 
     """
     riemann = metric_to_Riemann_components(expr)

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -20,10 +20,13 @@ def test_point():
     #TODO assert point.free_symbols == set([x, y])
 
 
-def test_rebuild():
-    assert s1 == s1.func(*s1.args)
-    assert v1 == v1.func(*v1.args)
-    assert f1 == f1.func(*f1.args)
+def test_atomicclass_args():
+    assert m.args == ()
+    assert p.args == ()
+    assert cs.args == ()
+    assert cs_noname.args == ()
+    assert s1.args == ()
+    assert v1.args == ()
 
 
 def test_subs():

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -26,7 +26,7 @@ def test_atomicclass_args():
     assert cs.args == ()
     assert cs_noname.args == ()
 
-def test_rebuild()
+def test_rebuild():
     assert s1 == s1.func(*s1.args)
     assert v1 == v1.func(*v1.args)
     assert f1 == f1.func(*f1.args)

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -21,10 +21,6 @@ def test_point():
 
 
 def test_rebuild():
-    assert m == m.func(*m.args)
-    assert p == p.func(*p.args)
-    assert cs == cs.func(*cs.args)
-    assert cs_noname == cs_noname.func(*cs_noname.args)
     assert s1 == s1.func(*s1.args)
     assert v1 == v1.func(*v1.args)
     assert f1 == f1.func(*f1.args)

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -25,9 +25,11 @@ def test_atomicclass_args():
     assert p.args == ()
     assert cs.args == ()
     assert cs_noname.args == ()
-    assert s1.args == ()
-    assert v1.args == ()
 
+def test_rebuild()
+    assert s1 == s1.func(*s1.args)
+    assert v1 == v1.func(*v1.args)
+    assert f1 == f1.func(*f1.args)
 
 def test_subs():
     assert s1.subs(s1, s2) == s2

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2478,6 +2478,20 @@ class LatexPrinter(Printer):
         return r"{{{}}} : {{{}}} \to {{{}}}".format(self._print(h._sympy_matrix()),
             self._print(h.domain), self._print(h.codomain))
 
+    def _print_Manifold(self, manifold):
+        return r'\text{%s}' % manifold.name
+
+    def _print_Patch(self, patch):
+        return r'\text{%s}_{\text{%s}}' % (patch.name, patch.manifold.name)
+
+    def _print_CoordSystem(self, coords):
+        return r'\text{%s}^{\text{%s}}_{\text{%s}}' % (
+            coords.name, coords.patch.name, coords.patch.manifold.name
+        )
+
+    def _print_CovarDerivativeOp(self, cvd):
+        return r'\mathbb{\nabla}_{%s}' % self._print(cvd._wrt)
+
     def _print_BaseScalarField(self, field):
         string = field._coord_sys._names[field._index]
         return r'\mathbf{{{}}}'.format(self._print(Symbol(string)))
@@ -2543,7 +2557,6 @@ class LatexPrinter(Printer):
             return r'\left(\Omega\left(%s\right)\right)^{%s}' % \
                 (self._print(expr.args[0]), self._print(exp))
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
-
 
 def translate(s):
     r'''

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2633,6 +2633,18 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*stringPict.next(l, op, r))
         return pform
 
+    def _print_Manifold(self, manifold):
+        return self._print(manifold.name)
+
+    def _print_Patch(self, patch):
+        return self._print(patch.name)
+
+    def _print_CoordSystem(self, coords):
+        return self._print(coords.name)
+
+    def _print_BaseScalarField(self, field):
+        string = field._coord_sys._names[field._index]
+        return self._print(string)
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2574,6 +2574,15 @@ class PrettyPrinter(Printer):
             ' %s> ' % hobj('-', 2), self._print(h.codomain)))
         return pform
 
+    def _print_Manifold(self, manifold):
+        return self._print(manifold.name)
+
+    def _print_Patch(self, patch):
+        return self._print(patch.name)
+
+    def _print_CoordSystem(self, coords):
+        return self._print(coords.name)
+
     def _print_BaseScalarField(self, field):
         string = field._coord_sys._names[field._index]
         return self._print(pretty_symbol(string))
@@ -2632,19 +2641,6 @@ class PrettyPrinter(Printer):
         r = self._print(e.rhs)
         pform = prettyForm(*stringPict.next(l, op, r))
         return pform
-
-    def _print_Manifold(self, manifold):
-        return self._print(manifold.name)
-
-    def _print_Patch(self, patch):
-        return self._print(patch.name)
-
-    def _print_CoordSystem(self, coords):
-        return self._print(coords.name)
-
-    def _print_BaseScalarField(self, field):
-        string = field._coord_sys._names[field._index]
-        return self._print(string)
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7003,3 +7003,14 @@ def test_issue_18272():
     '⎪                 ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
     '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
     '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
+
+def test_diffgeom():
+    from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
+    m = Manifold('M', 2)
+    assert pretty(m) == 'M'
+    p = Patch('P', m)
+    assert pretty(p) == "P"
+    rect = CoordSystem('rect', p)
+    assert pretty(rect) == "rect"
+    b = BaseScalarField(rect, 0)
+    assert pretty(b) == "rect_0"

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -315,6 +315,30 @@ class ReprPrinter(Printer):
         ext = self._print(f.ext)
         return "ExtElem(%s, %s)" % (rep, ext)
 
+    def _print_Manifold(self, manifold):
+        class_name = manifold.func.__name__
+        name = self._print(manifold.name)
+        dim = self._print(manifold.dim)
+        return "%s(%s, %s)" % (class_name, name, dim)
+
+    def _print_Patch(self, patch):
+        class_name = patch.func.__name__
+        name = self._print(patch.name)
+        manifold = self._print(patch.manifold)
+        return "%s(%s, %s)" % (class_name, name, manifold)
+
+    def _print_CoordSystem(self, coords):
+        class_name = coords.func.__name__
+        name = self._print(coords.name)
+        patch = self._print(coords.patch)
+        names = self._print(coords._names)
+        return "%s(%s, %s, %s)" % (class_name, name, patch, names)
+
+    def _print_BaseScalarField(self, bsf):
+        class_name = bsf.func.__name__
+        coords = self._print(bsf._coord_sys)
+        idx = self._print(bsf._index)
+        return "%s(%s, %s)" % (class_name, coords, idx)
 
 def srepr(expr, **settings):
     """return expr in repr form"""

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -880,6 +880,18 @@ class StrPrinter(Printer):
         #TODO : Handle indices
         return "%s(%s)" % ("Tr", self._print(expr.args[0]))
 
+    def _print_Manifold(self, manifold):
+        return manifold.name
+
+    def _print_Patch(self, patch):
+        return patch.name
+
+    def _print_CoordSystem(self, coords):
+        return coords.name
+
+    def _print_BaseScalarField(self, field):
+        string = field._coord_sys._names[field._index]
+        return string
 
 def sstr(expr, **settings):
     """Returns the expression as a string.

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -863,6 +863,15 @@ class StrPrinter(Printer):
     def _print_Category(self, category):
         return 'Category("%s")' % category.name
 
+    def _print_Manifold(self, manifold):
+        return manifold.name
+
+    def _print_Patch(self, patch):
+        return patch.name
+
+    def _print_CoordSystem(self, coords):
+        return coords.name
+
     def _print_BaseScalarField(self, field):
         return field._coord_sys._names[field._index]
 
@@ -879,19 +888,6 @@ class StrPrinter(Printer):
     def _print_Tr(self, expr):
         #TODO : Handle indices
         return "%s(%s)" % ("Tr", self._print(expr.args[0]))
-
-    def _print_Manifold(self, manifold):
-        return manifold.name
-
-    def _print_Patch(self, patch):
-        return patch.name
-
-    def _print_CoordSystem(self, coords):
-        return coords.name
-
-    def _print_BaseScalarField(self, field):
-        string = field._coord_sys._names[field._index]
-        return string
 
 def sstr(expr, **settings):
     """Returns the expression as a string.

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2528,7 +2528,7 @@ def test_text_re_im():
     assert latex(re(x), gothic_re_im=False) ==  r'\operatorname{re}{\left(x\right)}'
 
 
-def test_DiffGeomMethods():
+def test_latex_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField, Differential
     from sympy.diffgeom.rn import R2
     m = Manifold('M', 2)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -315,6 +315,6 @@ def test_diffgeom():
     p = Patch('P', m)
     assert srepr(p) == "Patch('P', Manifold('M', 2))"
     rect = CoordSystem('rect', p)
-    assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ['rect_0', 'rect_1'])"
+    assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'))"
     b = BaseScalarField(rect, 0)
-    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ['rect_0', 'rect_1']), 0)"
+    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1')), 0)"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -307,3 +307,14 @@ def test_Cycle():
 def test_Permutation():
     import_stmt = "from sympy.combinatorics import Permutation"
     sT(Permutation(1, 2), "Permutation(1, 2)", import_stmt)
+
+def test_diffgeom():
+    from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
+    m = Manifold('M', 2)
+    assert srepr(m) == "Manifold('M', 2)"
+    p = Patch('P', m)
+    assert srepr(p) == "Patch('P', Manifold('M', 2))"
+    rect = CoordSystem('rect', p)
+    assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ['rect_0', 'rect_1'])"
+    b = BaseScalarField(rect, 0)
+    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ['rect_0', 'rect_1']), 0)"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -317,4 +317,4 @@ def test_diffgeom():
     rect = CoordSystem('rect', p)
     assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'))"
     b = BaseScalarField(rect, 0)
-    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1')), 0)"
+    assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1')), Integer(0))"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -889,3 +889,14 @@ def test_str_special_matrices():
 
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
+
+def test_diffgeom():
+    from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
+    m = Manifold('M', 2)
+    assert str(m) == "M"
+    p = Patch('P', m)
+    assert str(p) == "P"
+    rect = CoordSystem('rect', p)
+    assert str(rect) == "rect"
+    b = BaseScalarField(rect, 0)
+    assert str(b) == "rect_0"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19300

#### Brief description of what is fixed or changed
`Manifold`, `Patch`, and `CoordSystem` in `diffgeom` module now inherit `Atom`. Also, their `.args` properties will return empty tuple.

#### Other comments
These classes' printing methods are moved to `printing` module as well.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- diffgeom
    - Now, `Manifold`, `Patch` and `CoordSystem` are atomic object. Their `args` attribute will return an empty tuple.
<!-- END RELEASE NOTES -->