### PR TITLE
codegen(cnodes): Improved and extended cnodes

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -336,7 +336,7 @@ class BreakToken(Token):
     >>> from sympy.printing import ccode, fcode
     >>> from sympy.codegen.ast import break_
     >>> ccode(break_)
-    'break'
+    'break;'
     >>> fcode(break_, source_format='free')
     'exit'
     """
@@ -355,7 +355,7 @@ class ContinueToken(Token):
     >>> from sympy.printing import ccode, fcode
     >>> from sympy.codegen.ast import continue_
     >>> ccode(continue_)
-    'continue'
+    'continue;'
     >>> fcode(continue_, source_format='free')
     'cycle'
     """

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -47,13 +47,14 @@ class Label(Node):
     Examples
     ========
 
+    >>> from sympy import Symbol
     >>> from sympy.codegen.cnodes import Label, PreIncrement
     >>> from sympy.printing.ccode import ccode
     >>> print(ccode(Label('foo')))
     foo:
     >>> print(ccode(Label('bar', [PreIncrement(Symbol('a'))])))
     bar:
-    ++(a)
+    ++(a);
 
     """
     __slots__ = ('name', 'body')

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -2,7 +2,8 @@
 AST nodes specific to the C family of languages
 """
 
-from sympy.codegen.ast import Attribute, Declaration, Node, String, Token, Type, none, FunctionCall
+from sympy.codegen.ast import (Attribute, Declaration, Node, String,
+    Token, Type, none, FunctionCall, CodeBlock)
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.sympify import sympify
@@ -40,18 +41,32 @@ class CommaOperator(Basic):
         return Basic.__new__(cls, *[sympify(arg) for arg in args])
 
 
-class Label(String):
+class Label(Node):
     """ Label for use with e.g. goto statement.
 
     Examples
     ========
 
-    >>> from sympy.codegen.cnodes import Label
+    >>> from sympy.codegen.cnodes import Label, PreIncrement
     >>> from sympy.printing.ccode import ccode
     >>> print(ccode(Label('foo')))
     foo:
+    >>> print(ccode(Label('bar', [PreIncrement(Symbol('a'))])))
+    bar:
+    ++(a)
 
     """
+    __slots__ = ('name', 'body')
+    defaults = {'body': none}
+    _construct_name = String
+
+    @classmethod
+    def _construct_body(cls, itr):
+        if isinstance(itr, CodeBlock):
+            return itr
+        else:
+            return CodeBlock(*itr)
+
 
 class goto(Token):
     """ Represents goto in C """
@@ -103,3 +118,7 @@ class struct(Node):
 
 class union(struct):
     """ Represents a union in C """
+
+class NullStatement(Basic):
+    """ Represents the null statement in C """
+

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -119,6 +119,3 @@ class struct(Node):
 
 class union(struct):
     """ Represents a union in C """
-
-class NullStatement(Basic):
-    """ Represents the null statement in C """

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -122,4 +122,3 @@ class union(struct):
 
 class NullStatement(Basic):
     """ Represents the null statement in C """
-

--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -41,6 +41,13 @@ def test_goto_Label():
     assert ccode(l2) == ("early_exit:\n"
         "++(x);")
 
+    body = [PreIncrement(x), PreDecrement(y)]
+    l2 = Label(s, body)
+    assert l2.name == String("early_exit")
+    assert l2.body == CodeBlock(*body)
+    assert ccode(l2) == ("early_exit:\n"
+        "{\n   ++(x);\n   --(y);\n}")
+
 
 def test_PreDecrement():
     p = PreDecrement(x)

--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -1,6 +1,7 @@
 from sympy.core.symbol import symbols
 from sympy.printing.ccode import ccode
-from sympy.codegen.ast import Declaration, Variable, float64, int64, String
+from sympy.codegen.ast import (Declaration, Variable, float64, int64,
+    String, CodeBlock)
 from sympy.codegen.cnodes import (
     alignof, CommaOperator, goto, Label, PreDecrement, PostDecrement, PreIncrement, PostIncrement,
     sizeof, union, struct
@@ -26,14 +27,19 @@ def test_goto_Label():
     g = goto(s)
     assert g.func(*g.args) == g
     assert g != goto('foobar')
-    assert ccode(g) == 'goto early_exit'
+    assert ccode(g) == 'goto early_exit;'
 
-    l = Label(s)
-    assert l.is_Atom
-    assert ccode(l) == 'early_exit:'
-    assert g.label == l
-    assert l == Label(s)
-    assert l != Label('foobar')
+    l1 = Label(s)
+    assert ccode(l1) == 'early_exit:'
+    assert l1 == Label(s)
+    assert l1 != Label('foobar')
+
+    body = [PreIncrement(x)]
+    l2 = Label(s, body)
+    assert l2.name == String("early_exit")
+    assert l2.body == CodeBlock(*body)
+    assert ccode(l2) == ("early_exit:\n"
+        "++(x);")
 
 
 def test_PreDecrement():

--- a/sympy/codegen/tests/test_cnodes.py
+++ b/sympy/codegen/tests/test_cnodes.py
@@ -31,20 +31,20 @@ def test_goto_Label():
 
     l1 = Label(s)
     assert ccode(l1) == 'early_exit:'
-    assert l1 == Label(s)
+    assert l1 == Label('early_exit')
     assert l1 != Label('foobar')
 
     body = [PreIncrement(x)]
     l2 = Label(s, body)
     assert l2.name == String("early_exit")
-    assert l2.body == CodeBlock(*body)
+    assert l2.body == CodeBlock(PreIncrement(x))
     assert ccode(l2) == ("early_exit:\n"
         "++(x);")
 
     body = [PreIncrement(x), PreDecrement(y)]
     l2 = Label(s, body)
     assert l2.name == String("early_exit")
-    assert l2.body == CodeBlock(*body)
+    assert l2.body == CodeBlock(PreIncrement(x), PreDecrement(y))
     assert ccode(l2) == ("early_exit:\n"
         "{\n   ++(x);\n   --(y);\n}")
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -584,10 +584,10 @@ class C89CodePrinter(CodePrinter):
         return '(%s)' % ', '.join(map(lambda arg: self._print(arg), expr.args))
 
     def _print_Label(self, expr):
-        return '%s:' % str(expr)
+        return '%s: \n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
 
     def _print_goto(self, expr):
-        return 'goto %s' % expr.label
+        return 'goto %s;' % expr.label.name
 
     def _print_PreIncrement(self, expr):
         arg, = expr.args
@@ -612,10 +612,13 @@ class C89CodePrinter(CodePrinter):
         )
 
     def _print_BreakToken(self, _):
-        return 'break'
+        return 'break;'
 
     def _print_ContinueToken(self, _):
-        return 'continue'
+        return 'continue;'
+
+    def _print_NullStatement(self, _):
+        return ';'
 
     _print_union = _print_struct
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -620,9 +620,6 @@ class C89CodePrinter(CodePrinter):
     def _print_ContinueToken(self, _):
         return 'continue;'
 
-    def _print_NullStatement(self, _):
-        return ';'
-
     _print_union = _print_struct
 
 class C99CodePrinter(C89CodePrinter):

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -23,7 +23,8 @@ from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
     complex64, complex128, intc, value_const, pointer_const,
-    int8, int16, int32, int64, uint8, uint16, uint32, uint64, untyped
+    int8, int16, int32, int64, uint8, uint16, uint32, uint64, untyped,
+    none
 )
 from sympy.printing.codeprinter import CodePrinter, requires
 from sympy.printing.precedence import precedence, PRECEDENCE
@@ -584,7 +585,9 @@ class C89CodePrinter(CodePrinter):
         return '(%s)' % ', '.join(map(lambda arg: self._print(arg), expr.args))
 
     def _print_Label(self, expr):
-        return '%s: \n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
+        if expr.body == none:
+            return '%s:' % str(expr.name)
+        return '%s:\n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
 
     def _print_goto(self, expr):
         return 'goto %s;' % expr.label.name

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -587,7 +587,10 @@ class C89CodePrinter(CodePrinter):
     def _print_Label(self, expr):
         if expr.body == none:
             return '%s:' % str(expr.name)
-        return '%s:\n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
+        if len(expr.body.args) == 1:
+            return '%s:\n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
+        return '%s:\n{\n%s\n}' % (str(expr.name), self._print_CodeBlock(expr.body))
+
 
     def _print_goto(self, expr):
         return 'goto %s;' % expr.label.name


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Added `name` and `body` to `Label` class in cnodes
  (Label was not able to store its child or body. While trying to implement loops in C parser, I came across this issue of label)
- Modified printing of `Label`, `goto`, `break`, `continue`
~Added `NullStatement` class~
Not needed since it is okay to write blank block (`{ }`) instead of null statement (`;`)
- Added corresponding tests

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->