### PR TITLE
Add examples of rank deficient QR decomposition

### DIFF
--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1225,10 +1225,9 @@ def _QRdecomposition(M):
     decomposition, you should augment $Q$ with an another orthogonal
     column.
 
-    But if you know the Gram-Schmidt process, you are able to append an
-    arbitrary standard basis that are linearly independent to every
-    other columns and run the Gram-Schmidt process again to make them
-    orthogonal again.
+    You are able to append an arbitrary standard basis that are linearly
+    independent to every other columns and you can run the Gram-Schmidt
+    process to make them augmented as orthogonal basis.
 
     >>> Q_aug = Q.row_join(Matrix([0, 0, 1]))
     >>> Q_aug = Q_aug.QRdecomposition()[0]

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1124,12 +1124,42 @@ def _LUdecompositionFF(M):
 
 
 def _QRdecomposition(M):
-    """Return Q, R where A = Q*R, Q is orthogonal and R is upper triangular.
+    r"""Returns a QR decomposition.
+
+    Explanation
+    ===========
+
+    A QR decomposition is a decomposition in the form $A = Q R$
+    where
+
+    - $Q$ is a column orthogonal matrix.
+    - $R$ is a upper triangular (trapezoidal) matrix.
+
+    A column orthogonal matrix satisfies
+    $\mathbb{I} = Q^H Q$ while a full orthogonal matrix satisfies
+    relation $\mathbb{I} = Q Q^H = Q^H Q$ where $I$ is an identity
+    matrix with matching dimensions.
+
+    For matrices which are not square or are rank-deficient, it is
+    sufficient to return a column orthogonal matrix because augmenting
+    them may introduce redundant computations.
+    And an another advantage of this is that you can easily inspect the
+    matrix rank by counting the number of columns of $Q$.
+
+    If you want to augment the results to return a full orthogonal
+    decomposition, you should use the following procedures.
+
+    - Augment the $Q$ matrix with columns that are orthogonal to every
+      other columns and make it square.
+    - Augument the $R$ matrix with zero rows to make it have the same
+      shape as the original matrix.
+
+    The procedure will be illustrated in the examples section.
 
     Examples
     ========
 
-    This is the example from wikipedia:
+    A full rank matrix example:
 
     >>> from sympy import Matrix
     >>> A = Matrix([[12, -51, 4], [6, 167, -68], [-4, 24, -41]])
@@ -1144,23 +1174,129 @@ def _QRdecomposition(M):
     [14,  21, -14],
     [ 0, 175, -70],
     [ 0,   0,  35]])
+
+    If the matrix is square and full rank, the $Q$ matrix becomes
+    orthogonal in both directions, and needs no augmentation.
+
+    >>> Q * Q.H
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+    >>> Q.H * Q
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
     >>> A == Q*R
     True
 
-    QR factorization of an identity matrix:
+    A rank deficient matrix example:
 
-    >>> A = Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    >>> A = Matrix([[12, -51, 0], [6, 167, 0], [-4, 24, 0]])
     >>> Q, R = A.QRdecomposition()
     >>> Q
     Matrix([
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, 1]])
+    [ 6/7, -69/175],
+    [ 3/7, 158/175],
+    [-2/7,    6/35]])
     >>> R
+    Matrix([
+    [14,  21, 0],
+    [ 0, 175, 0]])
+
+    It may return a $Q$ matrix which is orthogonal in only one way
+    around ($\mathbb{I} = Q^H Q$).
+
+    >>> Q.H * Q
+    Matrix([
+    [1, 0],
+    [0, 1]])
+    >>> Q * Q.H
+    Matrix([
+    [27261/30625,   348/30625, -1914/6125],
+    [  348/30625, 30589/30625,   198/6125],
+    [ -1914/6125,    198/6125,   136/1225]])
+
+    If you want to augment the results to be a full orthogonal
+    decomposition, you should augment $Q$ with an another orthogonal
+    column. It may not look easy at the first place.
+
+    But if you know the Gram–Schmidt process, you are able to append an
+    arbitrary standard basis that are linearlly independent to every
+    other columns and run the Gram–Schmidt process again to make them
+    orthogonal again.
+
+    >>> Q_aug = Q.row_join(Matrix([0, 0, 1]))
+    >>> Q_aug = Q_aug.QRdecomposition()[0]
+    >>> Q_aug
+    Matrix([
+    [ 6/7, -69/175, 58/175],
+    [ 3/7, 158/175, -6/175],
+    [-2/7,    6/35,  33/35]])
+    >>> Q_aug.H * Q_aug
     Matrix([
     [1, 0, 0],
     [0, 1, 0],
     [0, 0, 1]])
+    >>> Q_aug * Q_aug.H
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+
+    Augmenting the $R$ matrix with zero row is straightforward.
+
+    >>> R_aug = R.col_join(Matrix([[0, 0, 0]]))
+    >>> R_aug
+    Matrix([
+    [14,  21, 0],
+    [ 0, 175, 0],
+    [ 0,   0, 0]])
+    >>> Q_aug * R_aug == A
+    True
+
+    A zero matrix example"
+
+    >>> from sympy import Matrix
+    >>> A = Matrix.zeros(3, 4)
+    >>> Q, R = A.QRdecomposition()
+
+    They may return matrices with zero rows and columns.
+
+    >>> Q
+    Matrix(3, 0, [])
+    >>> R
+    Matrix(0, 4, [])
+
+    However, if you know the algebra of matrices with zero rows or
+    columns they are also valid decomposition results.
+
+    >>> Q*R
+    Matrix([
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0]])
+
+    As the same augmentation rule described above, $Q$ can be augmented
+    with columns of an identity matrix and $R$ can be augmented with
+    rows of a zero matrix.
+
+    >>> Q_aug = Q.row_join(Matrix.eye(3))
+    >>> R_aug = R.col_join(Matrix.zeros(3, 4))
+    >>> Q_aug * Q_aug.T
+    Matrix([
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]])
+    >>> R_aug
+    Matrix([
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0]])
+    >>> Q_aug * R_aug == A
+    True
 
     See Also
     ========
@@ -1172,7 +1308,6 @@ def _QRdecomposition(M):
     """
 
     dps    = _get_intermediate_simp(expand_mul, expand_mul)
-    cls    = M.__class__
     mat    = M.as_mutable()
     n      = mat.rows
     m      = mat.cols
@@ -1206,16 +1341,6 @@ def _QRdecomposition(M):
             ranked.append(j)
             Q[:, j] = tmp / R[j, j]
 
-
-    if len(ranked) != 0:
-        return (cls(Q.extract(range(nOrig), ranked)),
-                cls(R.extract(ranked, range(R.cols))))
-
-    else:
-        # Trivial case handling for zero-rank matrix
-        # Force Q as matrix containing standard basis vectors
-        for i in range(Min(nOrig, m)):
-            Q[i, i] = 1
-
-        return (cls(Q.extract(range(nOrig), range(Min(nOrig, m)))),
-                cls(R.extract(range(Min(nOrig, m)), range(R.cols))))
+    Q = Q.extract(range(nOrig), ranked)
+    R = R.extract(ranked, range(R.cols))
+    return M.__class__(Q), M.__class__(R)

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1257,7 +1257,7 @@ def _QRdecomposition(M):
     >>> Q_aug * R_aug == A
     True
 
-    A zero matrix example"
+    A zero matrix example:
 
     >>> from sympy import Matrix
     >>> A = Matrix.zeros(3, 4)

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1223,9 +1223,9 @@ def _QRdecomposition(M):
     decomposition, you should augment $Q$ with an another orthogonal
     column. It may not look easy at the first place.
 
-    But if you know the Gram–Schmidt process, you are able to append an
+    But if you know the Gram-Schmidt process, you are able to append an
     arbitrary standard basis that are linearlly independent to every
-    other columns and run the Gram–Schmidt process again to make them
+    other columns and run the Gram-Schmidt process again to make them
     orthogonal again.
 
     >>> Q_aug = Q.row_join(Matrix([0, 0, 1]))

--- a/sympy/matrices/decompositions.py
+++ b/sympy/matrices/decompositions.py
@@ -1206,8 +1206,10 @@ def _QRdecomposition(M):
     [14,  21, 0],
     [ 0, 175, 0]])
 
-    It may return a $Q$ matrix which is orthogonal in only one way
-    around ($\mathbb{I} = Q^H Q$).
+    QRdecomposition might return a matrix Q that is rectangular.
+    In this case the orthogonality condition might be satisfied as
+    $\mathbb{I} = Q.H*Q$ but not in the reversed product
+    $\mathbb{I} = Q * Q.H$.
 
     >>> Q.H * Q
     Matrix([
@@ -1221,10 +1223,10 @@ def _QRdecomposition(M):
 
     If you want to augment the results to be a full orthogonal
     decomposition, you should augment $Q$ with an another orthogonal
-    column. It may not look easy at the first place.
+    column.
 
     But if you know the Gram-Schmidt process, you are able to append an
-    arbitrary standard basis that are linearlly independent to every
+    arbitrary standard basis that are linearly independent to every
     other columns and run the Gram-Schmidt process again to make them
     orthogonal again.
 
@@ -1269,10 +1271,6 @@ def _QRdecomposition(M):
     Matrix(3, 0, [])
     >>> R
     Matrix(0, 4, [])
-
-    However, if you know the algebra of matrices with zero rows or
-    columns they are also valid decomposition results.
-
     >>> Q*R
     Matrix([
     [0, 0, 0, 0],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19017

#### Brief description of what is fixed or changed

There were multiple questions about QR decomposition in #19017 and https://github.com/sympy/sympy/pull/18841#discussion_r393762660 because lots of people were not used to why `Q` can be non square and it is a good idea to leave it nonsquare. So I have added detailed documentation about how to deal with the decomposition in the rank deficient cases and made the glossaries more clear.

![image](https://user-images.githubusercontent.com/34944973/82014183-109b0d80-96b7-11ea-8d96-f3caee4433a1.png)

I've also made `Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]]).QRdecomposition()` to return `Matrix(3, 0, [])` and `Matrix(0, 3, [])` which can look more weird at the first place, but I think that it's a more consistent idea that the number of columns of `Q` can reveal information about the rank of the matrix. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `QRdecomposition` will return matrices with zero rows and columns for zero rank matrices. e.g. `Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])` will be decomposed with `Matrix(3, 0, [])` and `Matrix(0, 3, [])`
<!-- END RELEASE NOTES -->