### PR TITLE
Cleanup Printer.emptyPrinter

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2558,6 +2558,13 @@ class LatexPrinter(Printer):
                 (self._print(expr.args[0]), self._print(exp))
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
+    def emptyPrinter(self, expr):
+        # Checks what type of decimal separator to print.
+        expr = super().emptyPrinter(expr)
+        if self._settings['decimal_separator'] == 'comma':
+            expr = expr.replace('.', '{,}')
+        return expr
+
 def translate(s):
     r'''
     Check for a modifier ending the string.  If present, convert the

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -52,7 +52,9 @@ class PrettyPrinter(Printer):
             raise TypeError("'imaginary_unit' must a string, not {}".format(self._settings['imaginary_unit']))
         elif self._settings['imaginary_unit'] not in ["i", "j"]:
             raise ValueError("'imaginary_unit' must be either 'i' or 'j', not '{}'".format(self._settings['imaginary_unit']))
-        self.emptyPrinter = lambda x: prettyForm(xstr(x))
+
+    def emptyPrinter(self, expr):
+        return prettyForm(xstr(expr))
 
     @property
     def _use_unicode(self):

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -292,11 +292,7 @@ class Printer(object):
             self._print_level -= 1
 
     def emptyPrinter(self, expr):
-        # Checks what type of decimal separator to print.
-        expr = str(expr)
-        if self._settings.get('decimal_separator', None) == 'comma':
-            expr = expr.replace('.', '{,}')
-        return expr
+        return str(expr)
 
     def _as_ordered_terms(self, expr, order=None):
         """A compatibility function for ordering terms in Add. """

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -207,7 +207,6 @@ class Printer(object):
 
     _default_settings = {}  # type: Dict[str, Any]
 
-    emptyPrinter = str
     printmethod = None  # type: str
 
     def __init__(self, settings=None):
@@ -287,14 +286,17 @@ class Printer(object):
                 printmethod = '_print_' + cls.__name__
                 if hasattr(self, printmethod):
                     return getattr(self, printmethod)(expr, **kwargs)
-            # Unknown object, fall back to the emptyPrinter. Checks what type of
-            # decimal separator to print.
-            if (self.emptyPrinter == str) & \
-                (self._settings.get('decimal_separator', None) == 'comma'):
-                expr = str(expr).replace('.', '{,}')
+            # Unknown object, fall back to the emptyPrinter.
             return self.emptyPrinter(expr)
         finally:
             self._print_level -= 1
+
+    def emptyPrinter(self, expr):
+        # Checks what type of decimal separator to print.
+        expr = str(expr)
+        if self._settings.get('decimal_separator', None) == 'comma':
+            expr = expr.replace('.', '{,}')
+        return expr
 
     def _as_ordered_terms(self, expr, order=None):
         """A compatibility function for ordering terms in Add. """


### PR DESCRIPTION
cc @asmeurer, who brought this up in https://github.com/sympy/sympy/pull/16711#discussion_r426033855.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This moves the handling of `decimal_separator` from the printer base class to the latex printer.

The `decimal_separator` setting is part of only the latex printer, not part of all printers.
Furthermore, `{,}` is clearly latex syntax.

This probably still doesn't belong in `emptyPrinter` at all, but I'll leave fixing that to someone else in another patch.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->