### PR TITLE
Adding parameters list and examples to specials submodule

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -984,6 +984,16 @@ def jn_zeros(n, k, method="sympy", dps=15):
 
     jn, yn, besselj, besselk, bessely
 
+    Parameters
+    ==========
+
+    n : integer
+        order of Bessel function
+
+    k : integer
+        number of zeros to return
+
+
     """
     from math import pi
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -137,6 +137,20 @@ def bspline_basis(d, knots, n, x):
         >>> f = lambdify(x, b0)
         >>> y = f(0.5)
 
+    Parameters
+    ==========
+
+    d : integer
+        degree of bspline
+
+    knots : list of integer values
+        list of knots points of bspline
+
+    n : integer
+        $n$-th B-spline
+
+    x : symbol
+
     See Also
     ========
 
@@ -218,6 +232,17 @@ def bspline_basis_set(d, knots, x):
               (x**2/2 - 4*x + 8, (x >= 3) & (x <= 4)),
               (0, True))]
 
+    Parameters
+    ==========
+
+    d : integer
+        degree of bspline
+
+    knots : list of integers
+        list of knots points of bspline
+
+    x : symbol
+
     See Also
     ========
 
@@ -253,6 +278,20 @@ def interpolating_spline(d, x, X, Y):
     >>> interpolating_spline(3, x, [-2, 0, 1, 3, 4], [4, 2, 1, 1, 3])
     Piecewise((7*x**3/117 + 7*x**2/117 - 131*x/117 + 2, (x >= -2) & (x <= 1)),
             (10*x**3/117 - 2*x**2/117 - 122*x/117 + 77/39, (x >= 1) & (x <= 4)))
+
+    Parameters
+    ==========
+
+    d : integer
+        Degree of Bspline strictly greater than equal to one
+
+    x : symbol
+
+    X : list of strictly increasing integer values
+        list of X coordinates through which the spline passes
+
+    Y : list of strictly increasing integer values
+        list of Y coordinates through which the spline passes
 
     See Also
     ========

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -132,6 +132,12 @@ class DiracDelta(Function):
         >>> diff(DiracDelta(x, 1)).fdiff()
         DiracDelta(x, 3)
 
+        Parameters
+        ==========
+
+        argindex : integer
+            degree of derivative
+
         """
         if argindex == 1:
             #I didn't know if there is a better way to handle default arguments
@@ -192,6 +198,14 @@ class DiracDelta(Function):
 
         >>> DiracDelta(x - 100).subs(x, 100)
         DiracDelta(0)
+
+        Parameters
+        ==========
+
+        k : integer
+            order of derivative
+
+        arg : argument passed to DiracDelta
 
         """
         k = sympify(k)
@@ -465,6 +479,12 @@ class Heaviside(Function):
         >>> diff(Heaviside(x)).fdiff()
         DiracDelta(x, 1)
 
+        Parameters
+        ==========
+
+        argindex : integer
+            order of derivative
+
         """
         if argindex == 1:
             # property number 1
@@ -527,6 +547,12 @@ class Heaviside(Function):
 
         >>> Heaviside(x - 100).subs(x, 105)
         1
+
+        Parameters
+        ==========
+
+        arg : argument passed by HeaviSide object
+        HO : boolean flag for HeaviSide Object is set to True
 
         """
         H0 = sympify(H0)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1350,6 +1350,16 @@ def E1(z):
 
     This is equivalent to ``expint(1, z)``.
 
+    Examples
+    ========
+
+    >>> from sympy import E1
+    >>> E1(0)
+    expint(1, 0)
+
+    >>> E1(5)
+    expint(1, 5)
+
     See Also
     ========
 
@@ -1399,6 +1409,12 @@ class li(Function):
     1/log(z)
 
     Defining the ``li`` function via an integral:
+    >>> from sympy import integrate
+    >>> integrate(li(z))
+    z*li(z) - Ei(2*log(z))
+
+    >>> integrate(li(z),z)
+    z*li(z) - Ei(2*log(z))
 
 
     The logarithmic integral can also be defined in terms of ``Ei``:

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -243,6 +243,17 @@ def jacobi_normalized(n, a, b, x):
     >>> jacobi_normalized(n, a, b, x)
     jacobi(n, a, b, x)/sqrt(2**(a + b + 1)*gamma(a + n + 1)*gamma(b + n + 1)/((a + b + 2*n + 1)*factorial(n)*gamma(a + b + n + 1)))
 
+    Parameters
+    ==========
+
+    n : integer degree of polynomial
+
+    a : alpha value
+
+    b : beta value
+
+    x : symbol
+
     See Also
     ========
 

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -237,6 +237,26 @@ def Ynm_c(n, m, theta, phi):
     .. math::
         \overline{Y_n^m(\theta, \varphi)} := (-1)^m Y_n^{-m}(\theta, \varphi).
 
+    Examples
+    ========
+
+    >>> from sympy import Ynm_c, Symbol, simplify
+    >>> from sympy.abc import n,m
+    >>> theta = Symbol("theta")
+    >>> phi = Symbol("phi")
+    >>> Ynm_c(n, m, theta, phi)
+    (-1)**(2*m)*exp(-2*I*m*phi)*Ynm(n, m, theta, phi)
+    >>> Ynm_c(n, m, -theta, phi)
+    (-1)**(2*m)*exp(-2*I*m*phi)*Ynm(n, m, theta, phi)
+
+    For specific integers $n$ and $m$ we can evaluate the harmonics
+    to more useful expressions:
+
+    >>> simplify(Ynm_c(0, 0, theta, phi).expand(func=True))
+    1/(2*sqrt(pi))
+    >>> simplify(Ynm_c(1, -1, theta, phi).expand(func=True))
+    sqrt(6)*exp(I*(-phi + 2*conjugate(phi)))*sin(theta)/(4*sqrt(pi))
+
     See Also
     ========
 


### PR DESCRIPTION
<!-- Updated docstrings. Added parameter lists
and Examples section to functions in Special submodule of functions module -->

#### References to other Issues or PRs
<!-- Fixes #17887 -->


#### Brief description of what is fixed or changed

- Added parameters section to docstring jn_zeros function.
- Added parameters section to Bspline_basis, bspline_basis_set.
- Added parameters section to Interpolating_spline
- Added parameters section to Fdiff, eval (under DiracDelta)
- Added parameters section to Fdiff, eval (under Heaviside)
- Added parameters section to Fdiff, eval (under Heaviside)
- Added the example for under the text “Defining the li function via an integral:” in error_functions
- Added parameters section in Jacobi_normalized docstring
- Added examples in Ynm_c in spherical_harmonics
- Fixed and improved indentations for Parameters list
- Fixed trailing whitespaces

#### Other comments



#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->