### PR TITLE
tweaking of canonical-related items

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -409,7 +409,7 @@ class Basic(metaclass=ManagedProperties):
 
         tmp = dummy.__class__()
 
-        return s.subs(dummy, tmp) == o.subs(symbol, tmp)
+        return s.xreplace({dummy: tmp}) == o.xreplace({symbol: tmp})
 
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting.  See issue 5487.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -895,8 +895,8 @@ class Basic(metaclass=ManagedProperties):
         sympy.core.evalf.EvalfMixin.evalf: calculates the given formula to a desired level of precision
 
         """
+        from sympy.core.compatibility import _nodes, default_sort_key
         from sympy.core.containers import Dict
-        from sympy.utilities.iterables import sift
         from sympy import Dummy, Symbol
 
         unordered = False
@@ -936,10 +936,17 @@ class Basic(metaclass=ManagedProperties):
 
         if unordered:
             sequence = dict(sequence)
-            atoms, nonatoms = sift(list(sequence),
-                lambda x: x.is_Atom, binary=True)
-            sequence = [(k, sequence[k]) for k in
-                list(reversed(list(ordered(nonatoms)))) + list(ordered(atoms))]
+            # order so more complex items are first and items
+            # of identical complexity are ordered so
+            # f(x) < f(y) < x < y
+            # \___ 2 __/    \_1_/  <- number of nodes
+            #
+            # For more complex ordering use an unordered sequence.
+            k = list(ordered(sequence, default=False, keys=(
+                lambda x: -_nodes(x),
+                lambda x: default_sort_key(x),
+                )))
+            sequence = [(k, sequence[k]) for k in k]
 
         if kwargs.pop('simultaneous', False):  # XXX should this be the default for dict subs?
             reps = {}

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -553,8 +553,11 @@ def _nodes(e):
     for which the sum of nodes is returned).
     """
     from .basic import Basic
+    from .function import Derivative
 
     if isinstance(e, Basic):
+        if isinstance(e, Derivative):
+            return _nodes(e.expr) + len(e.variables)
         return e.count(Basic)
     elif iterable(e):
         return 1 + sum(_nodes(ei) for ei in e)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -3061,7 +3061,7 @@ def count_ops(expr, visual=False):
     2*ADD + SIN
 
     """
-    from sympy import Integral, Symbol
+    from sympy import Integral, Sum, Symbol
     from sympy.core.relational import Relational
     from sympy.simplify.radsimp import fraction
     from sympy.logic.boolalg import BooleanFunction
@@ -3129,18 +3129,22 @@ def count_ops(expr, visual=False):
                 ops.append(DIV)
                 args.append(a.base)  # won't be -Mul but could be Add
                 continue
-            if (a.is_Mul or
-                a.is_Pow or
-                a.is_Function or
-                isinstance(a, Derivative) or
-                    isinstance(a, Integral)):
-
+            if a.is_Mul or isinstance(a, LatticeOp):
                 o = Symbol(a.func.__name__.upper())
                 # count the args
-                if (a.is_Mul or isinstance(a, LatticeOp)):
-                    ops.append(o*(len(a.args) - 1))
-                else:
-                    ops.append(o)
+                ops.append(o*(len(a.args) - 1))
+            elif a.args and (
+                    a.is_Pow or
+                    a.is_Function or
+                    isinstance(a, Derivative) or
+                    isinstance(a, Integral) or
+                    isinstance(a, Sum)):
+                # if it's not in the list above we don't
+                # consider a.func something to count, e.g.
+                # Tuple, MatrixSymbol, etc...
+                o = Symbol(a.func.__name__.upper())
+                ops.append(o)
+
             if not a.is_Symbol:
                 args.extend(a.args)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1891,6 +1891,9 @@ class Lambda(Expr):
     'lambda x: expr'. A function of several variables is written as
     Lambda((x, y, ...), expr).
 
+    Examples
+    ========
+
     A simple example:
 
     >>> from sympy import Lambda

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -273,7 +273,7 @@ class Symbol(AtomicExpr, Boolean):
         return self.class_key(), (1, (self.name,)), S.One.sort_key(), S.One
 
     def as_dummy(self):
-        return Dummy(self.name)
+        return Dummy(self.name, commutative=self.is_commutative)
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import im, re

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -281,12 +281,21 @@ def test_as_dummy():
     u, v, x, y, z, _0, _1 = symbols('u v x y z _0 _1')
     assert Lambda(x, x + 1).as_dummy() == Lambda(_0, _0 + 1)
     assert Lambda(x, x + _0).as_dummy() == Lambda(_1, _0 + _1)
-    assert (1 + Sum(x, (x, 1, x))).as_dummy() == 1 + Sum(_0, (_0, 1, x))
+    eq = (1 + Sum(x, (x, 1, x)))
+    ans = 1 + Sum(_0, (_0, 1, x))
+    once = eq.as_dummy()
+    assert once == ans
+    twice = once.as_dummy()
+    assert twice == ans
+    assert Integral(x + _0, (x, x + 1), (_0, 1, 2)
+        ).as_dummy() == Integral(_0 + _1, (_0, x + 1), (_1, 1, 2))
 
 
 def test_canonical_variables():
     x, i0, i1 = symbols('x _:2')
     assert Integral(x, (x, x + 1)).canonical_variables == {x: i0}
+    assert Integral(x, (x, x + 1), (i0, 1, 2)).canonical_variables == {
+        x: i0, i0: i1}
     assert Integral(x, (x, x + i0)).canonical_variables == {x: i1}
 
 

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,6 +1,6 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor, Nand, Nor, Implies, \
-    Equivalent, MatrixSymbol, Symbol, ITE, Rel, Rational
+    Equivalent, MatrixSymbol, Symbol, ITE, Rel, Rational, Sum
 from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
@@ -30,8 +30,8 @@ def test_count_ops_non_visual():
 
 
 def test_count_ops_visual():
-    ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
-        'Add Mul Pow sin cos exp And Derivative Integral'.upper())
+    ADD, MUL, POW, SIN, COS, EXP, AND, D, G, M = symbols(
+        'Add Mul Pow sin cos exp And Derivative Integral Sum'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
     LT, LE, GT, GE, EQ, NE = symbols('LT LE GT GE EQ NE')
     NOT, OR, AND, XOR, IMPLIES, EQUIVALENT, _ITE, BASIC, TUPLE = symbols(
@@ -88,6 +88,7 @@ def test_count_ops_visual():
 
     assert count(Derivative(x, x)) == D
     assert count(Integral(x, x) + 2*x/(1 + x)) == G + DIV + MUL + 2*ADD
+    assert count(Sum(x, (x, 1, x + 1)) + 2*x/(1 + x)) == M + DIV + MUL + 3*ADD
     assert count(Basic()) is S.Zero
 
     assert count({x + 1: sin(x)}) == ADD + SIN

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -850,3 +850,8 @@ def test_issue_17823():
     expr = q1.diff().diff()**2*q1 + q1.diff()*q2.diff()
     reps={q1: a, q1.diff(): a*x*y, q1.diff().diff(): z}
     assert expr.subs(reps) == a*x*y*Derivative(q2, t) + a*z**2
+
+
+def test_issue_19326():
+    x, y = [i(t) for i in map(Function, 'xy')]
+    assert (x*y).subs({x: 1 + x, y: x}) == (1 + x)*x

--- a/sympy/matrices/expressions/applyfunc.py
+++ b/sympy/matrices/expressions/applyfunc.py
@@ -49,7 +49,7 @@ class ElementwiseApplyFunction(MatrixExpr):
         if not expr.is_Matrix:
             raise ValueError("{} must be a matrix instance.".format(expr))
 
-        if not isinstance(function, FunctionClass):
+        if not isinstance(function, (FunctionClass, Lambda)):
             d = Dummy('d')
             function = Lambda(d, function(d))
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3248,13 +3248,13 @@ def test_MatrixExpressions():
     expr = (n*X).applyfunc(lamda)
     ascii_str = """\
 /     1\\      \n\
-|d -> -|.(n*X)\n\
-\\     d/      \
+|x -> -|.(n*X)\n\
+\\     x/      \
 """
     ucode_str = u("""\
 ⎛    1⎞      \n\
-⎜d ↦ ─⎟˳(n⋅X)\n\
-⎝    d⎠      \
+⎜x ↦ ─⎟˳(n⋅X)\n\
+⎝    x⎠      \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1866,7 +1866,7 @@ def test_ElementwiseApplyFunction():
     expr = (X.T*X).applyfunc(sin)
     assert latex(expr) == r"{\left( d \mapsto \sin{\left(d \right)} \right)}_{\circ}\left({X^{T} X}\right)"
     expr = X.applyfunc(Lambda(x, 1/x))
-    assert latex(expr) == r'{\left( d \mapsto \frac{1}{d} \right)}_{\circ}\left({X}\right)'
+    assert latex(expr) == r'{\left( x \mapsto \frac{1}{x} \right)}_{\circ}\left({X}\right)'
 
 
 def test_ZeroMatrix():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -185,7 +185,7 @@ def test_Dummy_from_Symbol():
     n = Symbol('n', integer=True)
     d = n.as_dummy()
     assert srepr(d
-        ) == "Dummy('n', dummy_index=%s)" % str(d.dummy_index)
+        ) == "Dummy('n', commutative=True, dummy_index=%s)" % str(d.dummy_index)
 
 
 def test_tuple():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -867,7 +867,7 @@ def test_MatrixExpressions():
 
     lamda = Lambda(x, 1/x)
     expr = (n*X).applyfunc(lamda)
-    assert str(expr) == 'Lambda(_d, 1/_d).(n*X)'
+    assert str(expr) == 'Lambda(x, 1/x).(n*X)'
 
 
 def test_Subs_printing():

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1770,7 +1770,18 @@ class FiniteSet(Set, EvalfMixin):
         else:
             args = list(map(sympify, args))
 
-        _args_set = set(args)
+        # keep the form of the first canonical arg
+        dargs = {}
+        for i in reversed(list(ordered(args))):
+            if i.is_Symbol:
+                dargs[i] = i
+            else:
+                try:
+                    dargs[i.as_dummy()] = i
+                except TypeError:
+                    # e.g. i = class without args like `Interval`
+                    dargs[i] = i
+        _args_set = set(dargs.values())
         args = list(ordered(_args_set, Set._infimum_key))
         obj = Basic.__new__(cls, *args)
         obj._args_set = _args_set


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#### Brief description of what is fixed or changed

- anticipate Lambda(x,x+1) != Lambda(y,y+1)
These changes are not necessary yet, but they anticipate the removal of the equality behavior that makes Lambdas with different variables compare the same. A visible change is that matrix expressions `applyfunc` will no longer create a new Lambda with Dummy symbols when applying a Lambda.
- as_dummy copies symbol commutativity
This keeps the important commutativity attribute of the dummy intact.
- make canonical_variables more canonical
Calling `as_dummy` on an expression should return a canonical expression regardless of
whether clashing symbols are already used. Most importantly, calling the method twice
on the same object will not return a different object than when calling it once.
- Sum shows in count_ops
Sum, unlike Integral, did not appear in visual count_ops expressions. Now it does.

before:
```python
>>> Sum(x, (x, 1, 2)).count_ops()
0
```
now:
```python
    >>> Sum(x, (x, 1, 2)).count_ops(visual=1)  # output is 1 if not visual
    SUM
```
- use xreplace in dummy_eq
This is a small optimization that can be used safely in the function.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  - `as_dummy` is now indempotent and should return a more canonical result
  - `Symbol.as_dummy` copies the commutativity of the Symbol
  - `count_ops` will now count/show `Sum` in expressions
  - higher order derivatives will now have a higher value from the `_node` function
<!-- END RELEASE NOTES -->