### PR TITLE
Add companion matrix

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -54,6 +54,8 @@ Matrix Expressions Core Reference
    :members:
 .. autoclass:: ZeroMatrix
    :members:
+.. autoclass:: CompanionMatrix
+   :members:
 
 Block Matrices
 --------------

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3099,6 +3099,15 @@ def test_sympy__matrices__expressions__permutation__MatrixPermute():
     A = MatrixSymbol('A', 3, 3)
     assert _test_args(MatrixPermute(A, Permutation([2, 0, 1])))
 
+def test_sympy__matrices__expressions__companion__CompanionMatrix():
+    from sympy.core.symbol import Symbol
+    from sympy.matrices.expressions.companion import CompanionMatrix
+    from sympy.polys.polytools import Poly
+
+    x = Symbol('x')
+    p = Poly([1, 2, 3], x)
+    assert _test_args(CompanionMatrix(p))
+
 def test_sympy__physics__vector__frame__CoordinateSym():
     from sympy.physics.vector import CoordinateSym
     from sympy.physics.vector import ReferenceFrame

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -20,6 +20,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.functions import Abs
+from sympy.polys.polytools import Poly
 from sympy.simplify import simplify as _simplify
 from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -1105,6 +1106,48 @@ class MatrixSpecial(MatrixRequired):
         rows, cols = as_int(rows), as_int(cols)
 
         return klass._eval_zeros(rows, cols)
+
+    @classmethod
+    def companion(kls, poly):
+        """Returns a companion matrix of a polynomial.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix, Poly, Symbol, symbols
+        >>> x = Symbol('x')
+        >>> c0, c1, c2, c3, c4 = symbols('c0:5')
+        >>> p = Poly(c0 + c1*x + c2*x**2 + c3*x**3 + c4*x**4 + x**5, x)
+        >>> Matrix.companion(p)
+        Matrix([
+        [0, 0, 0, 0, -c0],
+        [1, 0, 0, 0, -c1],
+        [0, 1, 0, 0, -c2],
+        [0, 0, 1, 0, -c3],
+        [0, 0, 0, 1, -c4]])
+        """
+        poly = kls._sympify(poly)
+        if not isinstance(poly, Poly):
+            raise ValueError("{} must be a Poly instance.".format(poly))
+        if not poly.is_monic:
+            raise ValueError("{} must be a monic polynomial.".format(poly))
+        if not poly.is_univariate:
+            raise ValueError(
+                "{} must be a univariate polynomial.".format(poly))
+
+        size = poly.degree()
+        if not size >= 1:
+            raise ValueError(
+                "{} must have degree not less than 1.".format(poly))
+
+        coeffs = poly.all_coeffs()
+        def entry(i, j):
+            if j == size - 1:
+                return -coeffs[-1 - i]
+            elif i == j + 1:
+                return kls.one
+            return kls.zero
+        return kls._new(size, size, entry)
 
 
 class MatrixProperties(MatrixRequired):

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -2,6 +2,7 @@
 
 from .slice import MatrixSlice
 from .blockmatrix import BlockMatrix, BlockDiagMatrix, block_collapse, blockcut
+from .companion import CompanionMatrix
 from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
@@ -24,6 +25,8 @@ __all__ = [
 
     'BlockMatrix', 'BlockDiagMatrix', 'block_collapse', 'blockcut',
     'FunctionMatrix',
+
+    'CompanionMatrix',
 
     'Inverse',
 

--- a/sympy/matrices/expressions/companion.py
+++ b/sympy/matrices/expressions/companion.py
@@ -1,0 +1,56 @@
+from sympy.core.singleton import S
+from sympy.core.sympify import _sympify
+from sympy.polys.polytools import Poly
+
+from .matexpr import MatrixExpr
+
+
+class CompanionMatrix(MatrixExpr):
+    """A symbolic companion matrix of a polynomial.
+
+    Examples
+    ========
+
+    >>> from sympy import Poly, Symbol, symbols
+    >>> from sympy.matrices.expressions import CompanionMatrix
+    >>> x = Symbol('x')
+    >>> c0, c1, c2, c3, c4 = symbols('c0:5')
+    >>> p = Poly(c0 + c1*x + c2*x**2 + c3*x**3 + c4*x**4 + x**5, x)
+    >>> CompanionMatrix(p)
+    CompanionMatrix(Poly(x**5 + c4*x**4 + c3*x**3 + c2*x**2 + c1*x + c0,
+    x, domain='ZZ[c0,c1,c2,c3,c4]'))
+    """
+    def __new__(cls, poly):
+        poly = _sympify(poly)
+        if not isinstance(poly, Poly):
+            raise ValueError("{} must be a Poly instance.".format(poly))
+        if not poly.is_monic:
+            raise ValueError("{} must be a monic polynomial.".format(poly))
+        if not poly.is_univariate:
+            raise ValueError(
+                "{} must be a univariate polynomial.".format(poly))
+        if not poly.degree() >= 1:
+            raise ValueError(
+                "{} must have degree not less than 1.".format(poly))
+
+        return super().__new__(cls, poly)
+
+
+    @property
+    def shape(self):
+        poly = self.args[0]
+        size = poly.degree()
+        return size, size
+
+
+    def _entry(self, i, j):
+        if j == self.cols - 1:
+            return -self.args[0].all_coeffs()[-1 - i]
+        elif i == j + 1:
+            return S.One
+        return S.Zero
+
+
+    def as_explicit(self):
+        from sympy.matrices.immutable import ImmutableDenseMatrix
+        return ImmutableDenseMatrix.companion(self.args[0])

--- a/sympy/matrices/expressions/tests/test_companion.py
+++ b/sympy/matrices/expressions/tests/test_companion.py
@@ -1,0 +1,48 @@
+from sympy.core.expr import unchanged
+from sympy.core.symbol import Symbol, symbols
+from sympy.matrices.immutable import ImmutableDenseMatrix
+from sympy.matrices.expressions.companion import CompanionMatrix
+from sympy.polys.polytools import Poly
+from sympy.testing.pytest import raises
+
+
+def test_creation():
+    x = Symbol('x')
+    y = Symbol('y')
+    raises(ValueError, lambda: CompanionMatrix(1))
+    raises(ValueError, lambda: CompanionMatrix(Poly([1], x)))
+    raises(ValueError, lambda: CompanionMatrix(Poly([2, 1], x)))
+    raises(ValueError, lambda: CompanionMatrix(Poly(x*y, [x, y])))
+    unchanged(CompanionMatrix, Poly([1, 2, 3], x))
+
+
+def test_shape():
+    c0, c1, c2 = symbols('c0:3')
+    x = Symbol('x')
+    assert CompanionMatrix(Poly([1, c0], x)).shape == (1, 1)
+    assert CompanionMatrix(Poly([1, c1, c0], x)).shape == (2, 2)
+    assert CompanionMatrix(Poly([1, c2, c1, c0], x)).shape == (3, 3)
+
+
+def test_entry():
+    c0, c1, c2 = symbols('c0:3')
+    x = Symbol('x')
+    A = CompanionMatrix(Poly([1, c2, c1, c0], x))
+    assert A[0, 0] == 0
+    assert A[1, 0] == 1
+    assert A[1, 1] == 0
+    assert A[2, 1] == 1
+    assert A[0, 2] == -c0
+    assert A[1, 2] == -c1
+    assert A[2, 2] == -c2
+
+
+def test_as_explicit():
+    c0, c1, c2 = symbols('c0:3')
+    x = Symbol('x')
+    assert CompanionMatrix(Poly([1, c0], x)).as_explicit() == \
+        ImmutableDenseMatrix([-c0])
+    assert CompanionMatrix(Poly([1, c1, c0], x)).as_explicit() == \
+        ImmutableDenseMatrix([[0, -c0], [1, -c1]])
+    assert CompanionMatrix(Poly([1, c2, c1, c0], x)).as_explicit() == \
+        ImmutableDenseMatrix([[0, 0, -c0], [1, 0, -c1], [0, 1, -c2]])

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -16,6 +16,7 @@ from sympy.matrices import (Matrix, diag, eye,
     matrix_multiply_elementwise, ones, zeros, SparseMatrix, banded,
     MutableDenseMatrix, MutableSparseMatrix, ImmutableDenseMatrix,
     ImmutableSparseMatrix)
+from sympy.polys.polytools import Poly
 from sympy.utilities.iterables import flatten
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 
@@ -1002,3 +1003,19 @@ def test_issue_13774():
     v = [1, 1, 1]
     raises(TypeError, lambda: M*v)
     raises(TypeError, lambda: v*M)
+
+
+def test_companion():
+    x = Symbol('x')
+    y = Symbol('y')
+    raises(ValueError, lambda: Matrix.companion(1))
+    raises(ValueError, lambda: Matrix.companion(Poly([1], x)))
+    raises(ValueError, lambda: Matrix.companion(Poly([2, 1], x)))
+    raises(ValueError, lambda: Matrix.companion(Poly(x*y, [x, y])))
+
+    c0, c1, c2 = symbols('c0:3')
+    assert Matrix.companion(Poly([1, c0], x)) == Matrix([-c0])
+    assert Matrix.companion(Poly([1, c1, c0], x)) == \
+        Matrix([[0, -c0], [1, -c1]])
+    assert Matrix.companion(Poly([1, c2, c1, c0], x)) == \
+        Matrix([[0, 0, -c0], [1, 0, -c1], [0, 1, -c2]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19335

#### Brief description of what is fixed or changed

I've added two public API for companion matrix, one for explicit matrix and the other for matrix expressions.
Regarding whether the transposed definition should be default, I have followed what other de-facto math libraries are using.
https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.companion.html
https://mathworks.com/help/matlab/ref/compan.html
https://www.maplesoft.com/support/help/Maple/view.aspx?path=LinearAlgebra%2FCompanionMatrix

I have not implemented any feature about converting `Expr` to `Poly` or normalizing the coefficients of non-monic polynomials.

#### Other comments

![Screen Shot 2020-05-17 at 14 31 10](https://user-images.githubusercontent.com/34944973/82136725-76200300-984b-11ea-9973-6c8eacbb627a.png)
![Screen Shot 2020-05-17 at 14 30 28](https://user-images.githubusercontent.com/34944973/82136726-77e9c680-984b-11ea-9cd8-ee36a2583416.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added `Matrix.companion` for creating dense companion matrix.
  - Added `CompanionMatrix` for creating a symbolic companion matrix.
<!-- END RELEASE NOTES -->