### PR TITLE
Fixed: srepr not printing dict and set properly

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -150,6 +150,8 @@ class ReprPrinter(Printer):
         return "{%s}" % sep.join(dict_kvs)
 
     def _print_set(self, expr):
+        if not expr:
+            return "set()"
         return "{%s}" % self.reprify(expr, ", ")
 
     def _print_MatrixBase(self, expr):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -144,6 +144,14 @@ class ReprPrinter(Printer):
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 
+    def _print_dict(self, expr):
+        sep = ", "
+        dict_kvs = ["%s: %s" % (self.doprint(key), self.doprint(value)) for key, value in expr.items()]
+        return "{%s}" % sep.join(dict_kvs)
+
+    def _print_set(self, expr):
+        return "{%s}" % self.reprify(expr, ", ")
+
     def _print_MatrixBase(self, expr):
         # special case for some empty matrices
         if (expr.rows == 0) ^ (expr.cols == 0):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -318,3 +318,23 @@ def test_diffgeom():
     assert srepr(rect) == "CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1'))"
     b = BaseScalarField(rect, 0)
     assert srepr(b) == "BaseScalarField(CoordSystem('rect', Patch('P', Manifold('M', 2)), ('rect_0', 'rect_1')), Integer(0))"
+
+def test_dict():
+    from sympy import srepr
+    from sympy.abc import x, y, z
+    d = {}
+    assert srepr(d) == "{}"
+    d = {x: y}
+    assert srepr(d) == "{Symbol('x'): Symbol('y')}"
+    d = {x: y, y: z}
+    assert srepr(d) == "{Symbol('x'): Symbol('y'), Symbol('y'): Symbol('z')}"
+    d = {x: {y: z}}
+    assert srepr(d) == "{Symbol('x'): {Symbol('y'): Symbol('z')}}"
+
+def test_set():
+    from sympy import srepr
+    from sympy.abc import x, y
+    s = {x}
+    assert srepr(s) == "{Symbol('x')}"
+    s = {x, y}
+    assert srepr(s) == "{Symbol('x'), Symbol('y')}"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -334,7 +334,7 @@ def test_dict():
 def test_set():
     from sympy import srepr
     from sympy.abc import x, y
-    s = {x}
-    assert srepr(s) == "{Symbol('x')}"
+    s = set()
+    assert srepr(s) == "set()"
     s = {x, y}
     assert srepr(s) == "{Symbol('x'), Symbol('y')}"

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -337,4 +337,4 @@ def test_set():
     s = set()
     assert srepr(s) == "set()"
     s = {x, y}
-    assert srepr(s) == "{Symbol('x'), Symbol('y')}"
+    assert srepr(s) in ("{Symbol('x'), Symbol('y')}", "{Symbol('y'), Symbol('x')}")

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -327,7 +327,10 @@ def test_dict():
     d = {x: y}
     assert srepr(d) == "{Symbol('x'): Symbol('y')}"
     d = {x: y, y: z}
-    assert srepr(d) == "{Symbol('x'): Symbol('y'), Symbol('y'): Symbol('z')}"
+    assert srepr(d) in (
+        "{Symbol('x'): Symbol('y'), Symbol('y'): Symbol('z')}",
+        "{Symbol('y'): Symbol('z'), Symbol('x'): Symbol('y')}",
+    )
     d = {x: {y: z}}
     assert srepr(d) == "{Symbol('x'): {Symbol('y'): Symbol('z')}}"
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19329


#### Brief description of what is fixed or changed
Added two methods `_print_dict` and `_print_set` to `ReprPrinter`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* printing
  * fixed a bug where `srepr` function would not print dictionary and set properly
<!-- END RELEASE NOTES -->