### PR TITLE
Make Determinant commutative

### DIFF
--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -17,6 +17,7 @@ class Determinant(Expr):
     >>> Determinant(eye(3)).doit()
     1
     """
+    is_commutative = True
 
     def __new__(cls, mat):
         mat = sympify(mat)

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -38,3 +38,9 @@ def test_eval_determinant():
 def test_refine():
     assert refine(det(A), Q.orthogonal(A)) == 1
     assert refine(det(A), Q.singular(A)) == 0
+
+
+def test_commutative():
+    det_a = Determinant(A)
+    det_b = Determinant(B)
+    assert det_a * det_b == det_b * det_a

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -43,4 +43,6 @@ def test_refine():
 def test_commutative():
     det_a = Determinant(A)
     det_b = Determinant(B)
+    assert det_a.is_commutative
+    assert det_b.is_commutative
     assert det_a * det_b == det_b * det_a


### PR DESCRIPTION
This brings it in line with sympy.matrices.expressions.Trace, which is also marked commutative.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #19308. Note that after this change, `Determinant` will inherit the same bug that `Trace` has, namely #19353. Dealing with that seems out of scope for this PR.

#### Brief description of what is fixed or changed
```python
>>> Determinant.is_commutative
True  # previously None
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * `Determinant` is now considered commutative.
<!-- END RELEASE NOTES -->