### PR TITLE
Apply connected components decomposition for computing eigenvalues

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -76,7 +76,9 @@ def _eigenvects_mpmath(M):
 
 
 # This functions is a candidate for caching if it gets implemented for matrices.
-def _eigenvals(M, error_when_incomplete=True, **flags):
+def _eigenvals(
+    M, error_when_incomplete=True, *, simplify=False, multiple=False,
+    rational=False, **flags):
     r"""Return eigenvalues using the Berkowitz agorithm to compute
     the characteristic polynomial.
 
@@ -148,14 +150,12 @@ def _eigenvals(M, error_when_incomplete=True, **flags):
     equation `\det(A - \lambda I) = 0`
     """
     if not M:
+        if multiple:
+            return []
         return {}
 
     if not M.is_square:
         raise NonSquareMatrixError("{} must be a square matrix.".format(M))
-
-    simplify = flags.pop('simplify', False)
-    multiple = flags.get('multiple', False)
-    rational = flags.pop('rational', True)
 
     if M.is_upper or M.is_lower:
         return _eigenvals_triangular(M, multiple=multiple)
@@ -167,32 +167,75 @@ def _eigenvals(M, error_when_incomplete=True, **flags):
         M = M.applyfunc(
             lambda x: nsimplify(x, rational=True) if x.has(Float) else x)
 
-    if isinstance(simplify, FunctionType):
-        eigs = roots(M.charpoly(simplify=simplify), **flags)
-    else:
-        eigs = roots(M.charpoly(), **flags)
+    if multiple:
+        return _eigenvals_list(
+            M, error_when_incomplete=error_when_incomplete, simplify=simplify,
+            **flags)
+    return _eigenvals_dict(
+        M, error_when_incomplete=error_when_incomplete, simplify=simplify,
+        **flags)
 
-    # make sure the algebraic multiplicity sums to the
-    # size of the matrix
-    if error_when_incomplete:
-        if not multiple and sum(eigs.values()) != M.rows or \
-            multiple and len(eigs) != M.cols:
-            raise MatrixError(
-                "Could not compute eigenvalues for {}".format(M))
 
-    # Since 'simplify' flag is unsupported in roots()
-    # simplify() function will be applied once at the end of the routine.
+def _eigenvals_list(
+    M, error_when_incomplete=True, simplify=False, **flags):
+    iblocks = M.connected_components()
+    all_eigs = []
+    for b in iblocks:
+        block = M[b, b]
+
+        if isinstance(simplify, FunctionType):
+            charpoly = block.charpoly(simplify=simplify)
+        else:
+            charpoly = block.charpoly()
+        eigs = roots(charpoly, multiple=True, **flags)
+
+        if error_when_incomplete:
+            if len(eigs) != block.rows:
+                raise MatrixError(
+                    "Could not compute eigenvalues for {}. if you see this "
+                    "error, please report to SymPy issue tracker."
+                    .format(block))
+
+        all_eigs += eigs
+
     if not simplify:
-        return eigs
+        return all_eigs
     if not isinstance(simplify, FunctionType):
         simplify = _simplify
+    return [simplify(value) for value in all_eigs]
 
-    # With 'multiple' flag set true, simplify() will be mapped for the list
-    # Otherwise, simplify() will be mapped for the keys of the dictionary
-    if not multiple:
-        return {simplify(key): value for key, value in eigs.items()}
-    else:
-        return [simplify(value) for value in eigs]
+
+def _eigenvals_dict(
+    M, error_when_incomplete=True, simplify=False, **flags):
+    iblocks = M.connected_components()
+    all_eigs = {}
+    for b in iblocks:
+        block = M[b, b]
+
+        if isinstance(simplify, FunctionType):
+            charpoly = block.charpoly(simplify=simplify)
+        else:
+            charpoly = block.charpoly()
+        eigs = roots(charpoly, multiple=False, **flags)
+
+        if error_when_incomplete:
+            if sum(eigs.values()) != block.rows:
+                raise MatrixError(
+                    "Could not compute eigenvalues for {}. if you see this "
+                    "error, please report to SymPy issue tracker."
+                    .format(block))
+
+        for k, v in eigs.items():
+            if k in all_eigs:
+                all_eigs[k] += v
+            else:
+                all_eigs[k] = v
+
+    if not simplify:
+        return all_eigs
+    if not isinstance(simplify, FunctionType):
+        simplify = _simplify
+    return {simplify(key): value for key, value in all_eigs.items()}
 
 
 def _eigenspace(M, eigenval, iszerofunc=_iszero, simplify=False):

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -2,8 +2,6 @@ from sympy import (
     Rational, Symbol, N, I, Abs, sqrt, exp, Float, sin,
     cos, symbols)
 from sympy.matrices import eye, Matrix
-from sympy.matrices.matrices import MatrixEigen
-from sympy.matrices.common import _MinimalMatrix, _CastableMatrix
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises, XFAIL
 from sympy.matrices.matrices import NonSquareMatrixError, MatrixError
@@ -11,9 +9,6 @@ from sympy.simplify.simplify import simplify
 from sympy.matrices.immutable import ImmutableMatrix
 from sympy.testing.pytest import slow
 
-
-class EigenOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixEigen):
-    pass
 
 def test_eigen():
     R = Rational
@@ -117,6 +112,7 @@ def test_eigen():
 
     # issue 10719
     assert Matrix([]).eigenvals() == {}
+    assert Matrix([]).eigenvals(multiple=True) == []
     assert Matrix([]).eigenvects() == []
 
     # issue 15119
@@ -195,9 +191,9 @@ def test_issue_8240():
     assert eigenvals.count(x) == 2
     assert eigenvals.count(y) == 1
 
-# EigenOnlyMatrix tests
+
 def test_eigenvals():
-    M = EigenOnlyMatrix([[0, 1, 1],
+    M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
     assert M.eigenvals() == {2*S.One: 1, -S.One: 1, S.Zero: 1}
@@ -213,7 +209,7 @@ def test_eigenvals():
 
 
 def test_eigenvects():
-    M = EigenOnlyMatrix([[0, 1, 1],
+    M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
     vecs = M.eigenvects()
@@ -223,7 +219,7 @@ def test_eigenvects():
 
 
 def test_left_eigenvects():
-    M = EigenOnlyMatrix([[0, 1, 1],
+    M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
     vecs = M.left_eigenvects()
@@ -371,7 +367,7 @@ def test_bidiagonalize():
 
 
 def test_diagonalize():
-    m = EigenOnlyMatrix(2, 2, [0, -1, 1, 0])
+    m = Matrix(2, 2, [0, -1, 1, 0])
     raises(MatrixError, lambda: m.diagonalize(reals_only=True))
     P, D = m.diagonalize()
     assert D.is_diagonal()
@@ -380,7 +376,7 @@ def test_diagonalize():
                  [ 0, I]])
 
     # make sure we use floats out if floats are passed in
-    m = EigenOnlyMatrix(2, 2, [0, .5, .5, 0])
+    m = Matrix(2, 2, [0, .5, .5, 0])
     P, D = m.diagonalize()
     assert all(isinstance(e, Float) for e in D.values())
     assert all(isinstance(e, Float) for e in P.values())
@@ -391,12 +387,12 @@ def test_diagonalize():
 
 def test_is_diagonalizable():
     a, b, c = symbols('a b c')
-    m = EigenOnlyMatrix(2, 2, [a, c, c, b])
+    m = Matrix(2, 2, [a, c, c, b])
     assert m.is_symmetric()
     assert m.is_diagonalizable()
-    assert not EigenOnlyMatrix(2, 2, [1, 1, 0, 1]).is_diagonalizable()
+    assert not Matrix(2, 2, [1, 1, 0, 1]).is_diagonalizable()
 
-    m = EigenOnlyMatrix(2, 2, [0, -1, 1, 0])
+    m = Matrix(2, 2, [0, -1, 1, 0])
     assert m.is_diagonalizable()
     assert not m.is_diagonalizable(reals_only=True)
 
@@ -410,7 +406,7 @@ def test_jordan_form():
     # *NOT* be determined  from algebraic and geometric multiplicity alone
     # This can be seen most easily when one lets compute the J.c.f. of a matrix that
     # is in J.c.f already.
-    m = EigenOnlyMatrix(4, 4, [2, 1, 0, 0,
+    m = Matrix(4, 4, [2, 1, 0, 0,
                     0, 2, 1, 0,
                     0, 0, 2, 0,
                     0, 0, 0, 2
@@ -418,7 +414,7 @@ def test_jordan_form():
     P, J = m.jordan_form()
     assert m == J
 
-    m = EigenOnlyMatrix(4, 4, [2, 1, 0, 0,
+    m = Matrix(4, 4, [2, 1, 0, 0,
                     0, 2, 0, 0,
                     0, 0, 2, 1,
                     0, 0, 0, 2
@@ -433,10 +429,8 @@ def test_jordan_form():
     P, J = A.jordan_form()
     assert simplify(P*J*P.inv()) == A
 
-    assert EigenOnlyMatrix(1, 1, [1]).jordan_form() == (
-        Matrix([1]), Matrix([1]))
-    assert EigenOnlyMatrix(1, 1, [1]).jordan_form(
-        calc_transform=False) == Matrix([1])
+    assert Matrix(1, 1, [1]).jordan_form() == (Matrix([1]), Matrix([1]))
+    assert Matrix(1, 1, [1]).jordan_form(calc_transform=False) == Matrix([1])
 
     # make sure if we cannot factor the characteristic polynomial, we raise an error
     m = Matrix([[3, 0, 0, 0, -3], [0, -3, -3, 0, 3], [0, 3, 0, 3, 0], [0, 0, 3, 0, 3], [3, 0, 0, 3, 0]])
@@ -454,7 +448,7 @@ def test_jordan_form():
 def test_singular_values():
     x = Symbol('x', real=True)
 
-    A = EigenOnlyMatrix([[0, 1*I], [2, 0]])
+    A = Matrix([[0, 1*I], [2, 0]])
     # if singular values can be sorted, they should be in decreasing order
     assert A.singular_values() == [2, 1]
 
@@ -465,11 +459,11 @@ def test_singular_values():
     # since Abs(x) cannot be sorted, test set equality
     assert set(vals) == {5, 1, Abs(x)}
 
-    A = EigenOnlyMatrix([[sin(x), cos(x)], [-cos(x), sin(x)]])
+    A = Matrix([[sin(x), cos(x)], [-cos(x), sin(x)]])
     vals = [sv.trigsimp() for sv in A.singular_values()]
     assert vals == [S.One, S.One]
 
-    A = EigenOnlyMatrix([
+    A = Matrix([
         [2, 4],
         [1, 3],
         [0, 0],
@@ -481,7 +475,7 @@ def test_singular_values():
         [sqrt(sqrt(221) + 15), sqrt(15 - sqrt(221)), 0, 0]
 
 def test___eq__():
-    assert (EigenOnlyMatrix(
+    assert (Matrix(
         [[0, 1, 1],
         [1, 0, 0],
         [1, 1, 1]]) == {}) is False


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I think that matrix eigenvalues computations should use connected component decomposition by default because this brings some advantage over polynomials that it can factor out some polynomial terms as much as in matrix form as possible.

However, the converse may not hold true because the companion matrix is connected as a whole, even if the polynomial can be factored.

I've also removed the usage of `EigenOnlyMatrix` because I think that such designs make it difficult to organize matrix methods in this way.

I've also expanded the eigenvalue computation routines to `_eigenvals_dict` and `_eigenvals_list`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `Matrix([]).eigenvals(multiple=True)` will give an empty list instead of an empty dict.
<!-- END RELEASE NOTES -->