### PR TITLE
Put brackets around python version for asv conf

### DIFF
--- a/asv.conf.travis.json
+++ b/asv.conf.travis.json
@@ -36,7 +36,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": "3.6",
+    "pythons": ["3.6"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I see setting the plain string argument fails with when combined with `"environment_type": "conda"`.

This can be an asv issue, but it could be a fragile feature because they have documented that it should be a *list* of strings
https://asv.readthedocs.io/en/stable/asv.conf.json.html#pythons

> If provided, it should be a list of strings. It may be one of the following:



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->