### PR TITLE
Wrote test for issue 19358: KeyError from dsolve

### DIFF
--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1125,6 +1125,13 @@ def _get_examples_ode_sol_nth_linear_undetermined_coefficients():
         'sol': [Eq(f(x), C1 + x)],
         'slow': True,
     },
+
+    # https://github.com/sympy/sympy/issues/19358
+    'undet_29': {
+        'eq': f2 + f(x).diff(x) + exp(x-C1)
+        'sol': [Eq(f(x), C2 + C3*exp(-x) - exp(-C1 + x)/2)],
+        'slow': True,
+    },
     }
     }
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1128,7 +1128,7 @@ def _get_examples_ode_sol_nth_linear_undetermined_coefficients():
 
     # https://github.com/sympy/sympy/issues/19358
     'undet_29': {
-        'eq': f2 + f(x).diff(x) + exp(x-C1)
+        'eq': f2 + f(x).diff(x) + exp(x-C1),
         'sol': [Eq(f(x), C2 + C3*exp(-x) - exp(-C1 + x)/2)],
         'slow': True,
     },


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19358

#### Brief description of what is fixed or changed
Checks that dsolve doesn't produce a KeyError for a certain differential equation. 

#### Other comments
I tested that this test passes the current Sympy version (as from github), but I am not sure how to test that it fails the old version (1.5.1). I did test that the issue exists in 1.5.1, though.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->