### PR TITLE
Add evaluate option to subs method

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -791,6 +791,9 @@ class Basic(metaclass=ManagedProperties):
         """
         Substitutes old for new in an expression after sympifying args.
 
+        Explanation
+        ===========
+
         `args` is either:
           - two arguments, e.g. foo.subs(old, new)
           - one iterable argument, e.g. foo.subs(iterable). The iterable may be
@@ -805,6 +808,8 @@ class Basic(metaclass=ManagedProperties):
 
         If the keyword ``simultaneous`` is True, the subexpressions will not be
         evaluated until all the substitutions have been made.
+
+        If the keyword ``evaluate`` is False, ``Subs`` instance will be returned.
 
         Examples
         ========
@@ -902,7 +907,7 @@ class Basic(metaclass=ManagedProperties):
         """
         from sympy.core.containers import Dict
         from sympy.utilities.iterables import sift
-        from sympy import Dummy, Symbol
+        from sympy import Dummy, Symbol, Subs
 
         unordered = False
         if len(args) == 1:
@@ -945,6 +950,9 @@ class Basic(metaclass=ManagedProperties):
                 lambda x: x.is_Atom, binary=True)
             sequence = [(k, sequence[k]) for k in
                 list(reversed(list(ordered(nonatoms)))) + list(ordered(atoms))]
+
+        if not kwargs.pop('evaluate', True):
+            return Subs(self, *zip(*sequence))
 
         if kwargs.pop('simultaneous', False):  # XXX should this be the default for dict subs?
             reps = {}

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -850,3 +850,8 @@ def test_issue_17823():
     expr = q1.diff().diff()**2*q1 + q1.diff()*q2.diff()
     reps={q1: a, q1.diff(): a*x*y, q1.diff().diff(): z}
     assert expr.subs(reps) == a*x*y*Derivative(q2, t) + a*z**2
+
+def test_unevaluated_subs():
+    expr = x+y+z
+    assert expr.subs({x:1, y:2}, evaluate=False) == Subs(expr, (x,y), (1,2))
+    assert expr.subs({x:1, y:2}, evaluate=False).doit() == expr.subs({x:1, y:2}, evaluate=True) == z+3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19371

#### Brief description of what is fixed or changed
keyword argument `evaluate` is added. If `evaluate=False`, `Subs` instance is returned.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- core
    - `evaluate` option is added to `Basic.subs`. When `evaluate=False` is passed, `Subs` instance is returned. This option is `True` by default.

<!-- END RELEASE NOTES -->