### PR TITLE
Fix wrong computations of Fourier series

### DIFF
--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -583,33 +583,143 @@ class FiniteFourierSeries(FourierSeries):
 
 
 def fourier_series(f, limits=None, finite=True):
-    """Computes Fourier sine/cosine series expansion.
+    r"""Computes the Fourier trigonometric series expansion.
 
-    Returns a :class:`FourierSeries` object.
+    Explanation
+    ===========
+
+    Fourier trigonometric series is a series of trigonometric functions
+    uniformly converging to the given function in the given interval.
+
+    Fourier trigonometric series of $f(x)$ over the interval $(a, b)$
+    is defined as:
+
+    .. math::
+        a_0 + \sum_{n=1}^{\infty}
+        (a_n \cos(\frac{2n \pi x}{L}) + b_n \sin(\frac{2n \pi x}{L}))
+
+    where the coefficients are:
+
+    .. math::
+        L = b - a
+
+    .. math::
+        a_0 = \frac{1}{L} \int_{a}^{b}{f(x) dx}
+
+    .. math::
+        a_n = \frac{2}{L} \int_{a}^{b}{f(x) \cos(\frac{2n \pi x}{L}) dx}
+
+    .. math::
+        b_n = \frac{2}{L} \int_{a}^{b}{f(x) \sin(\frac{2n \pi x}{L}) dx}
+
+    The condition whether the function $f(x)$ given should be periodic
+    or not is more than necessary, because it is sufficient to consider
+    the series to be converging only in the given interval.
+
+    This also brings a lot of ease for the computation because
+    you don't necessarily have to think of make a function artificially
+    periodic by wrapping them with piecewise, modulo operations.
+
+    The examples of this property will be illustrated below.
+
+    Parameters
+    ==========
+
+    limits : (sym, start, end), optional
+        *sym* denotes the symbol the series is computed with respect to.
+
+        *start* and *end* denotes the start and the end of the interval
+        where the fourier series converges to the given function.
+
+        Default range is specified as $-\pi$ and $\pi$.
+
+    Returns
+    =======
+
+    FourierSeries
+        A symbolic object representing the Fourier trigonometric series.
 
     Examples
     ========
 
+    Computing the Fourier series of $f(x) = x^2$:
+
     >>> from sympy import fourier_series, pi, cos
     >>> from sympy.abc import x
 
-    >>> s = fourier_series(x**2, (x, -pi, pi))
-    >>> s.truncate(n=3)
+    >>> f = x**2
+    >>> s = fourier_series(f, (x, -pi, pi))
+    >>> s1 = s.truncate(n=3)
+    >>> s1
     -4*cos(x) + cos(2*x) + pi**2/3
 
-    Shifting
+    Shifting of the Fourier series:
 
     >>> s.shift(1).truncate()
     -4*cos(x) + cos(2*x) + 1 + pi**2/3
     >>> s.shiftx(1).truncate()
     -4*cos(x + 1) + cos(2*x + 2) + pi**2/3
 
-    Scaling
+    Shcaling of the Fourier series:
 
     >>> s.scale(2).truncate()
     -8*cos(x) + 2*cos(2*x) + 2*pi**2/3
     >>> s.scalex(2).truncate()
     -4*cos(2*x) + cos(4*x) + pi**2/3
+
+    Computing the Fourier series of $f(x) = x$:
+
+    This illustrates how truncating to the higher order gives better
+    convergence.
+
+    .. plot::
+        :context: reset
+        :format: doctest
+        :include-source: True
+
+        >>> from sympy import fourier_series, pi, plot
+        >>> from sympy.abc import x
+        >>> f = x
+        >>> s = fourier_series(f, (x, -pi, pi))
+        >>> s1 = s.truncate(n = 3)
+        >>> s2 = s.truncate(n = 5)
+        >>> s3 = s.truncate(n = 7)
+        >>> p = plot(f, s1, s2, s3, (x, -pi, pi), show=False, legend=True)
+
+        >>> p[0].line_color = (0, 0, 0)
+        >>> p[0].label = 'x'
+        >>> p[1].line_color = (0.7, 0.7, 0.7)
+        >>> p[1].label = 'n=3'
+        >>> p[2].line_color = (0.5, 0.5, 0.5)
+        >>> p[2].label = 'n=5'
+        >>> p[3].line_color = (0.3, 0.3, 0.3)
+        >>> p[3].label = 'n=7'
+
+        >>> p.show()
+
+    This illustrates how the series converges to different sawtooth
+    waves if the different ranges are specified.
+
+    .. plot::
+        :context: close-figs
+        :format: doctest
+        :include-source: True
+
+        >>> s1 = fourier_series(x, (x, -1, 1)).truncate(10)
+        >>> s2 = fourier_series(x, (x, -pi, pi)).truncate(10)
+        >>> s3 = fourier_series(x, (x, 0, 1)).truncate(10)
+        >>> p = plot(x, s1, s2, s3, (x, -5, 5), show=False, legend=True)
+
+        >>> p[0].line_color = (0, 0, 0)
+        >>> p[0].label = 'x'
+        >>> p[1].line_color = (0.7, 0.7, 0.7)
+        >>> p[1].label = '[-1, 1]'
+        >>> p[2].line_color = (0.5, 0.5, 0.5)
+        >>> p[2].label = '[-pi, pi]'
+        >>> p[3].line_color = (0.3, 0.3, 0.3)
+        >>> p[3].label = '[0, 1]'
+
+        >>> p.show()
 
     Notes
     =====
@@ -651,16 +761,18 @@ def fourier_series(f, limits=None, finite=True):
             return FiniteFourierSeries(f, limits, res_f)
 
     n = Dummy('n')
-    neg_f = f.subs(x, -x)
-    if f == neg_f:
-        a0, an = fourier_cos_seq(f, limits, n)
-        bn = SeqFormula(0, (1, oo))
-    elif f == -neg_f:
-        a0 = S.Zero
-        an = SeqFormula(0, (1, oo))
-        bn = fourier_sin_seq(f, limits, n)
-    else:
-        a0, an = fourier_cos_seq(f, limits, n)
-        bn = fourier_sin_seq(f, limits, n)
-
+    center = (limits[1] + limits[2]) / 2
+    if center.is_zero:
+        neg_f = f.subs(x, -x)
+        if f == neg_f:
+            a0, an = fourier_cos_seq(f, limits, n)
+            bn = SeqFormula(0, (1, oo))
+            return FourierSeries(f, limits, (a0, an, bn))
+        elif f == -neg_f:
+            a0 = S.Zero
+            an = SeqFormula(0, (1, oo))
+            bn = fourier_sin_seq(f, limits, n)
+            return FourierSeries(f, limits, (a0, an, bn))
+    a0, an = fourier_cos_seq(f, limits, n)
+    bn = fourier_sin_seq(f, limits, n)
     return FourierSeries(f, limits, (a0, an, bn))

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -661,7 +661,7 @@ def fourier_series(f, limits=None, finite=True):
     >>> s.shiftx(1).truncate()
     -4*cos(x + 1) + cos(2*x + 2) + pi**2/3
 
-    Shcaling of the Fourier series:
+    Scaling of the Fourier series:
 
     >>> s.scale(2).truncate()
     -8*cos(x) + 2*cos(2*x) + 2*pi**2/3

--- a/sympy/series/fourier.py
+++ b/sympy/series/fourier.py
@@ -588,14 +588,11 @@ def fourier_series(f, limits=None, finite=True):
     Explanation
     ===========
 
-    Fourier trigonometric series is a series of trigonometric functions
-    uniformly converging to the given function in the given interval.
-
     Fourier trigonometric series of $f(x)$ over the interval $(a, b)$
     is defined as:
 
     .. math::
-        a_0 + \sum_{n=1}^{\infty}
+        \frac{a_0}{2} + \sum_{n=1}^{\infty}
         (a_n \cos(\frac{2n \pi x}{L}) + b_n \sin(\frac{2n \pi x}{L}))
 
     where the coefficients are:
@@ -604,7 +601,7 @@ def fourier_series(f, limits=None, finite=True):
         L = b - a
 
     .. math::
-        a_0 = \frac{1}{L} \int_{a}^{b}{f(x) dx}
+        a_0 = \frac{2}{L} \int_{a}^{b}{f(x) dx}
 
     .. math::
         a_n = \frac{2}{L} \int_{a}^{b}{f(x) \cos(\frac{2n \pi x}{L}) dx}
@@ -614,13 +611,17 @@ def fourier_series(f, limits=None, finite=True):
 
     The condition whether the function $f(x)$ given should be periodic
     or not is more than necessary, because it is sufficient to consider
-    the series to be converging only in the given interval.
+    the series to be converging to $f(x)$ only in the given interval,
+    not throughout the whole real line.
 
     This also brings a lot of ease for the computation because
-    you don't necessarily have to think of make a function artificially
-    periodic by wrapping them with piecewise, modulo operations.
+    you don't have to make $f(x)$ artificially periodic by
+    wrapping it with piecewise, modulo operations,
+    but you can shape the function to look like the desired periodic
+    function only in the interval $(a, b)$, and the computed series will
+    automatically become the series of the periodic version of $f(x)$.
 
-    The examples of this property will be illustrated below.
+    This property is illustrated in the examples section below.
 
     Parameters
     ==========
@@ -744,7 +745,7 @@ def fourier_series(f, limits=None, finite=True):
     References
     ==========
 
-    .. [1] mathworld.wolfram.com/FourierSeries.html
+    .. [1] https://mathworld.wolfram.com/FourierSeries.html
     """
     f = sympify(f)
 

--- a/sympy/series/tests/test_fourier.py
+++ b/sympy/series/tests/test_fourier.py
@@ -72,7 +72,7 @@ def test_FourierSeries_2():
                             4*cos(pi*x / 2) / pi**2 + S.Half)
 
 
-def test_fourier_series_square_wave():
+def test_square_wave():
     """Test if fourier_series approximates discontinuous function correctly."""
     square_wave = Piecewise((1, x < pi), (-1, True))
     s = fourier_series(square_wave, (x, 0, 2*pi))
@@ -81,6 +81,15 @@ def test_fourier_series_square_wave():
         4 / (5 * pi) * sin(5 * x)
     assert s.sigma_approximation(4) == 4 / pi * sin(x) * sinc(pi / 4) + \
         4 / (3 * pi) * sin(3 * x) * sinc(3 * pi / 4)
+
+
+def test_sawtooth_wave():
+    s = fourier_series(x, (x, 0, pi))
+    assert s.truncate(4) == \
+        pi/2 - sin(2*x) - sin(4*x)/2 - sin(6*x)/3
+    s = fourier_series(x, (x, 0, 1))
+    assert s.truncate(4) == \
+        S.Half - sin(2*pi*x)/pi - sin(4*pi*x)/(2*pi) - sin(6*pi*x)/(3*pi)
 
 
 def test_FourierSeries__operations():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19375
Fixes #19044 


#### Brief description of what is fixed or changed

If the center of the integration limits are not origin, detecting whether the function is even or not is more complicated, and it may not even be worth testing it out because substituting `x` to some shifted values of `x` can have the issues of equality.

#### Other comments

I've also made the docs clear about the definitions because it was unclear how limits is supposed to do, and made some plotting examples for it.

![image](https://user-images.githubusercontent.com/34944973/82438764-88f93880-9ad4-11ea-8266-af5255d6daaf.png)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- series
  - Fixed wrong computations of `fourier_series` for even or odd functions with `limits` that are specified non-central.
<!-- END RELEASE NOTES -->