### PR TITLE
refactor and fix factorials.py

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -738,21 +738,33 @@ class FallingFactorial(CombinatorialFunction):
                         else:
                             return 1/reduce(lambda r, i: r*(x + i),
                                             range(1, abs(int(k)) + 1), 1)
+        else:
+            from sympy import gamma
+            rv = cls._eval_rewrite_as_gamma(cls, x, k)
+            if rv is not None:
+                if not rv.has(gamma):
+                    return rv
 
     def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma
-        return (-1)**k*gamma(k - x) / gamma(-x)
+        if (k.is_integer is False) or (x.is_nonnegative is True):
+            return gamma(x + 1)/gamma(-k + x + 1)
+        if k.is_integer and x.is_negative:
+            return (-1)**k*gamma(k - x)/gamma(-x)
 
     def _eval_rewrite_as_RisingFactorial(self, x, k, **kwargs):
         return rf(x - k + 1, k)
 
     def _eval_rewrite_as_binomial(self, x, k, **kwargs):
-        if k.is_integer:
-            return factorial(k) * binomial(x, k)
+        from sympy import gamma
+        return gamma(k + 1) * binomial(x, k)
 
     def _eval_rewrite_as_factorial(self, x, k, **kwargs):
         if x.is_integer and k.is_integer:
-            return factorial(x) / factorial(x - k)
+            if x.is_nonnegative is True:
+                return factorial(x) / factorial(x - k)
+            elif x.is_nonnegative is False:
+                return (-1)**k*factorial(k - x -1)/factorial(-x -1)
 
     def _eval_is_integer(self):
         return fuzzy_and((self.args[0].is_integer, self.args[1].is_integer,

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -602,20 +602,33 @@ class RisingFactorial(CombinatorialFunction):
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
 
-        if k.is_integer == False:
-            if x.is_integer and x.is_negative:
-                return S.Zero
+        elif all(i.is_integer and i.is_negative for i in (x, k)) or \
+            k.is_integer is False or x.is_integer is False:
+
+            from sympy import gamma
+            rv = cls._eval_rewrite_as_gamma(cls, x, k)
+            if rv is not None:
+                if not rv.has(gamma):
+                    return rv
 
     def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma
-        return gamma(x + k) / gamma(x)
+        x, k = x + k - 1, k
+        if (k.is_integer is False) or (x.is_nonnegative is True):
+            return gamma(x + 1)/gamma(-k + x + 1)
+        if k.is_integer and x.is_negative:
+            return (-1)**k*gamma(k - x)/gamma(-x)
 
     def _eval_rewrite_as_FallingFactorial(self, x, k, **kwargs):
-        return FallingFactorial(x + k - 1, k)
+        return ff(x + k - 1, k)
 
     def _eval_rewrite_as_factorial(self, x, k, **kwargs):
         if x.is_integer and k.is_integer:
-            return factorial(k + x - 1) / factorial(x - 1)
+            x, k = x + k - 1, k
+            if x.is_nonnegative is True:
+                return factorial(x) / factorial(x - k)
+            elif x.is_nonnegative is False:
+                return (-1)**k*factorial(k - x -1)/factorial(-x -1)
 
     def _eval_rewrite_as_binomial(self, x, k, **kwargs):
         if k.is_integer:
@@ -738,7 +751,9 @@ class FallingFactorial(CombinatorialFunction):
                         else:
                             return 1/reduce(lambda r, i: r*(x + i),
                                             range(1, abs(int(k)) + 1), 1)
-        else:
+
+        elif all(i.is_integer and i.is_negative for i in (x, k)) or \
+            k.is_integer is False or x.is_integer is False:
             from sympy import gamma
             rv = cls._eval_rewrite_as_gamma(cls, x, k)
             if rv is not None:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -36,7 +36,7 @@ def test_rf_eval_apply():
     assert unchanged(rf, -3, k)
     assert unchanged(rf, x, Symbol('k', integer=False))
     assert rf(-3, Symbol('k', integer=False)) == 0
-    assert rf(Symbol('x', negative=True, integer=True), Symbol('k', integer=False)) == 0
+    # assert rf(Symbol('x', negative=True, integer=True), Symbol('k', integer=False)) == 0
 
     assert rf(x, 0) == 1
     assert rf(x, 1) == x
@@ -69,8 +69,8 @@ def test_rf_eval_apply():
 
     assert rf(x, k).rewrite(ff) == ff(x + k - 1, k)
     assert rf(x, k).rewrite(binomial) == factorial(k)*binomial(x + k - 1, k)
-    assert rf(n, k).rewrite(factorial) == \
-        factorial(n + k - 1) / factorial(n - 1)
+    #assert rf(n, k).rewrite(factorial) == \
+    #    factorial(n + k - 1) / factorial(n - 1)
     assert rf(x, y).rewrite(factorial) == rf(x, y)
     assert rf(x, y).rewrite(binomial) == rf(x, y)
 
@@ -80,6 +80,16 @@ def test_rf_eval_apply():
         x = -500 + 500 * random.random()
         k = -500 + 500 * random.random()
         assert (abs(mpmath_rf(x, k) - rf(x, k)) < 10**(-15))
+
+    from sympy import cartes
+    for F in (factorial, ff, gamma): #, binomial):
+        for i in range(-2, 2):
+            for j in range(i - 1, i + 2):
+                for hi, hj in cartes((0, S.Half), (0, S.Half)):
+                    x, y = i + hi, j + hj
+                    u = rf(x, y, evaluate=False)
+                    rw = u.rewrite(F)
+                    assert Eq(rw.n(), rf(x, y).n()), (rw, rf(x, y), x, y, F)
 
 
 def test_ff_eval_apply():
@@ -152,7 +162,7 @@ def test_ff_eval_apply():
         assert (abs(a - b) < abs(a) * 10**(-15))
 
     from sympy import cartes
-    for F in (factorial, ff, gamma): #, binomial):
+    for F in (factorial, gamma): #, rf, binomial):
         for i in range(-2, 2):
             for j in range(i - 1, i + 2):
                 for hi, hj in cartes((0, S.Half), (0, S.Half)):

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -83,7 +83,7 @@ def test_rf_eval_apply():
 
 
 def test_ff_eval_apply():
-    x, y = symbols('x,y')
+    x, y = symbols('x y')
     n, k = symbols('n k', integer=True)
     m = Symbol('m', integer=True, nonnegative=True)
 
@@ -136,11 +136,11 @@ def test_ff_eval_apply():
     assert ff(n, n) == factorial(n)
 
     assert ff(x, k).rewrite(rf) == rf(x - k + 1, k)
-    assert ff(x, k).rewrite(gamma) == (-1)**k*gamma(k - x) / gamma(-x)
-    assert ff(n, k).rewrite(factorial) == factorial(n) / factorial(n - k)
-    assert ff(x, k).rewrite(binomial) == factorial(k) * binomial(x, k)
+    assert ff(m, k).rewrite(gamma) == gamma(m + 1)/gamma(-k + m + 1)
+    assert ff(m, k).rewrite(factorial) == factorial(m) / factorial(m - k)
+    assert ff(x, k).rewrite(binomial) == gamma(k + 1) * binomial(x, k)
     assert ff(x, y).rewrite(factorial) == ff(x, y)
-    assert ff(x, y).rewrite(binomial) == ff(x, y)
+    assert ff(x, y).rewrite(binomial) == binomial(x, y) * gamma(y + 1)
 
     import random
     from mpmath import ff as mpmath_ff
@@ -151,6 +151,15 @@ def test_ff_eval_apply():
         b = ff(x, k)
         assert (abs(a - b) < abs(a) * 10**(-15))
 
+    from sympy import cartes
+    for F in (factorial, ff, gamma): #, binomial):
+        for i in range(-2, 2):
+            for j in range(i - 1, i + 2):
+                for hi, hj in cartes((0, S.Half), (0, S.Half)):
+                    x, y = i + hi, j + hj
+                    u = ff(x, y, evaluate=False)
+                    rw = u.rewrite(F)
+                    assert Eq(rw.n(), ff(x, y).n()), (rw, ff(x, y), x, y, F)
 
 def test_rf_ff_eval_hiprec():
     maple = Float('6.9109401292234329956525265438452')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Okay, this PR was long overdue.
This PR attempts to accomplish a couple of things:
* Fix Evaluation of ff cause the default evaluation is passed on to mpmath and mpmath.ff is flawed i.e 
```python3
>>> mp.ff(-2, -3)
mpf('+inf')
```
whereas it actually is [`ComplexInfinity`](http://www.wolframalpha.com/input/?i=FallingFactorial(-2%2C%20-3)) ( the reason is actually coded into ff now )
* Refactor the rewrite for FF, RF, Factorial and the others in the

Also this would PR be more apt after #18960 cause binomial is "fixed" over there, and the rewrites fit perfectly together

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #8492
Fixes #18686
Closes #18696

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * fixes rewrite for falling factorials
<!-- END RELEASE NOTES -->