### PR TITLE
Fix latex printing for types implementing the _latex hook

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -166,9 +166,11 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
             elif isinstance(o, bool):
                 return False
-            # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
-            # to use here, than these explicit imports.
             elif isinstance(o, sympy_latex_types):
+                # types known to the printer
+                return True
+            elif hasattr(o, '_latex'):
+                # types which add support themselves
                 return True
             elif isinstance(o, (float, int)) and print_builtin:
                 return True

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -94,7 +94,7 @@ def test_print_builtin_option():
     # printer.
     app.run_cell("""\
     class WithOverload:
-        def _latex(self):
+        def _latex(self, printer):
             return r"\\LaTeX"
     """)
     app.run_cell("a = format((WithOverload(),))")

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -90,6 +90,21 @@ def test_print_builtin_option():
                     '{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}')
     assert latex == r'$\displaystyle \left\{ n_{i} : 3, \  \pi : 3.14\right\}$'
 
+    # Objects with an _latex overload should also be handled by our tuple
+    # printer.
+    app.run_cell("""\
+    class WithOverload:
+        def _latex(self):
+            return r"\\LaTeX"
+    """)
+    app.run_cell("a = format((WithOverload(),))")
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        latex = app.user_ns['a']['text/latex']
+    else:
+        latex = app.user_ns['a'][0]['text/latex']
+    assert latex == r'$\displaystyle \left( \LaTeX,\right)$'
+
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("init_printing(use_latex=True, print_builtin=False)")
     app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This is a simpler version of #17926, that avoids opening the can of worms that is the `emptyPrinter` (#19333).

#### Brief description of what is fixed or changed
Given an object like
```
class WithOverload:
    def _latex(self):
        return r"\LaTeX"

o = WithOverload()
```
An expression returning `[o]`, `(o,)`, `{x: o}`, etc is now shown in latex after `init_printing(use_latex=True)` is called.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * user types that implement `_latex` are now printed as LaTeX when embedded within builtin collections like ``list`` or ``dict``.
<!-- END RELEASE NOTES -->