### PR TITLE
Add support for exp in LaTeX parsing

### DIFF
--- a/sympy/parsing/latex/LaTeX.g4
+++ b/sympy/parsing/latex/LaTeX.g4
@@ -40,6 +40,7 @@ FUNC_INT:  '\\int';
 FUNC_SUM:  '\\sum';
 FUNC_PROD: '\\prod';
 
+FUNC_EXP:  '\\exp';
 FUNC_LOG:  '\\log';
 FUNC_LN:   '\\ln';
 FUNC_SIN:  '\\sin';
@@ -197,7 +198,7 @@ binom:
     R_BRACE;
 
 func_normal:
-    FUNC_LOG | FUNC_LN
+    FUNC_EXP | FUNC_LOG | FUNC_LN
     | FUNC_SIN | FUNC_COS | FUNC_TAN
     | FUNC_CSC | FUNC_SEC | FUNC_COT
     | FUNC_ARCSIN | FUNC_ARCCOS | FUNC_ARCTAN

--- a/sympy/parsing/latex/_antlr/latexlexer.py
+++ b/sympy/parsing/latex/_antlr/latexlexer.py
@@ -19,7 +19,7 @@ import sys
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2")
-        buf.write(u">\u0205\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4")
+        buf.write(u"?\u020c\b\1\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4")
         buf.write(u"\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r")
         buf.write(u"\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22")
         buf.write(u"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4")
@@ -28,217 +28,219 @@ def serializedATN():
         buf.write(u"$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4,\t")
         buf.write(u",\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63")
         buf.write(u"\t\63\4\64\t\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\4")
-        buf.write(u"9\t9\4:\t:\4;\t;\4<\t<\4=\t=\4>\t>\4?\t?\3\2\3\2\3\3")
-        buf.write(u"\6\3\u0083\n\3\r\3\16\3\u0084\3\3\3\3\3\4\3\4\3\5\3\5")
-        buf.write(u"\3\6\3\6\3\7\3\7\3\b\3\b\3\t\3\t\3\n\3\n\3\13\3\13\3")
-        buf.write(u"\f\3\f\3\r\3\r\3\16\3\16\3\17\3\17\3\17\3\17\3\17\3\20")
+        buf.write(u"9\t9\4:\t:\4;\t;\4<\t<\4=\t=\4>\t>\4?\t?\4@\t@\3\2\3")
+        buf.write(u"\2\3\3\6\3\u0085\n\3\r\3\16\3\u0086\3\3\3\3\3\4\3\4\3")
+        buf.write(u"\5\3\5\3\6\3\6\3\7\3\7\3\b\3\b\3\t\3\t\3\n\3\n\3\13\3")
+        buf.write(u"\13\3\f\3\f\3\r\3\r\3\16\3\16\3\17\3\17\3\17\3\17\3\17")
         buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
         buf.write(u"\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20")
         buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
         buf.write(u"\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20")
         buf.write(u"\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3")
-        buf.write(u"\20\3\20\5\20\u00db\n\20\3\21\3\21\3\21\3\21\3\21\3\22")
-        buf.write(u"\3\22\3\22\3\22\3\22\3\23\3\23\3\23\3\23\3\23\3\23\3")
-        buf.write(u"\24\3\24\3\24\3\24\3\24\3\25\3\25\3\25\3\25\3\26\3\26")
-        buf.write(u"\3\26\3\26\3\26\3\27\3\27\3\27\3\27\3\27\3\30\3\30\3")
-        buf.write(u"\30\3\30\3\30\3\31\3\31\3\31\3\31\3\31\3\32\3\32\3\32")
-        buf.write(u"\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\34\3\34\3\34\3")
-        buf.write(u"\34\3\34\3\34\3\34\3\34\3\35\3\35\3\35\3\35\3\35\3\35")
-        buf.write(u"\3\35\3\35\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3")
-        buf.write(u"\37\3\37\3\37\3\37\3\37\3\37\3\37\3\37\3 \3 \3 \3 \3")
-        buf.write(u" \3 \3 \3 \3!\3!\3!\3!\3!\3!\3!\3!\3\"\3\"\3\"\3\"\3")
-        buf.write(u"\"\3\"\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\3$\3%\3%\3%\3")
-        buf.write(u"%\3%\3%\3%\3%\3&\3&\3&\3&\3&\3&\3&\3&\3\'\3\'\3\'\3\'")
-        buf.write(u"\3\'\3\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3)")
-        buf.write(u"\3)\3*\3*\3*\3*\3*\3*\3+\3+\3+\3+\3+\3,\3,\3,\3,\3,\3")
-        buf.write(u",\3-\3-\3-\3-\3-\3-\3-\3.\3.\3.\3.\3.\3.\3.\3.\3/\3/")
-        buf.write(u"\3/\3/\3/\3/\3/\3/\3\60\3\60\3\60\3\60\3\60\3\60\3\60")
-        buf.write(u"\3\60\3\61\3\61\3\62\3\62\3\63\3\63\3\64\3\64\3\65\3")
-        buf.write(u"\65\7\65\u01b5\n\65\f\65\16\65\u01b8\13\65\3\65\3\65")
-        buf.write(u"\3\65\6\65\u01bd\n\65\r\65\16\65\u01be\5\65\u01c1\n\65")
-        buf.write(u"\3\66\3\66\3\67\3\67\38\68\u01c8\n8\r8\168\u01c9\38\3")
-        buf.write(u"8\38\38\38\78\u01d1\n8\f8\168\u01d4\138\38\78\u01d7\n")
-        buf.write(u"8\f8\168\u01da\138\38\38\38\38\38\78\u01e1\n8\f8\168")
-        buf.write(u"\u01e4\138\38\38\68\u01e8\n8\r8\168\u01e9\58\u01ec\n")
-        buf.write(u"8\39\39\3:\3:\3;\3;\3;\3;\3;\3<\3<\3=\3=\3=\3=\3=\3>")
-        buf.write(u"\3>\3?\3?\6?\u0202\n?\r?\16?\u0203\3\u01b6\2@\3\3\5\4")
-        buf.write(u"\7\5\t\6\13\7\r\b\17\t\21\n\23\13\25\f\27\r\31\16\33")
-        buf.write(u"\17\35\20\37\21!\22#\23%\24\'\25)\26+\27-\30/\31\61\32")
-        buf.write(u"\63\33\65\34\67\359\36;\37= ?!A\"C#E$G%I&K\'M(O)Q*S+")
-        buf.write(u"U,W-Y.[/]\60_\61a\62c\63e\64g\2i\65k\66m\2o\67q8s9u:")
-        buf.write(u"w;y<{=}>\3\2\5\5\2\13\f\17\17\"\"\4\2C\\c|\3\2\62;\2")
-        buf.write(u"\u0211\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2")
-        buf.write(u"\2\2\13\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3\2\2\2")
-        buf.write(u"\2\23\3\2\2\2\2\25\3\2\2\2\2\27\3\2\2\2\2\31\3\2\2\2")
-        buf.write(u"\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2\2\2!\3\2\2\2\2")
-        buf.write(u"#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+\3\2\2")
-        buf.write(u"\2\2-\3\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2\2\2\2")
-        buf.write(u"\65\3\2\2\2\2\67\3\2\2\2\29\3\2\2\2\2;\3\2\2\2\2=\3\2")
-        buf.write(u"\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2\2E\3\2\2\2\2G\3")
-        buf.write(u"\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2\2\2\2")
-        buf.write(u"Q\3\2\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3\2\2\2")
-        buf.write(u"\2[\3\2\2\2\2]\3\2\2\2\2_\3\2\2\2\2a\3\2\2\2\2c\3\2\2")
-        buf.write(u"\2\2e\3\2\2\2\2i\3\2\2\2\2k\3\2\2\2\2o\3\2\2\2\2q\3\2")
-        buf.write(u"\2\2\2s\3\2\2\2\2u\3\2\2\2\2w\3\2\2\2\2y\3\2\2\2\2{\3")
-        buf.write(u"\2\2\2\2}\3\2\2\2\3\177\3\2\2\2\5\u0082\3\2\2\2\7\u0088")
-        buf.write(u"\3\2\2\2\t\u008a\3\2\2\2\13\u008c\3\2\2\2\r\u008e\3\2")
-        buf.write(u"\2\2\17\u0090\3\2\2\2\21\u0092\3\2\2\2\23\u0094\3\2\2")
-        buf.write(u"\2\25\u0096\3\2\2\2\27\u0098\3\2\2\2\31\u009a\3\2\2\2")
-        buf.write(u"\33\u009c\3\2\2\2\35\u009e\3\2\2\2\37\u00da\3\2\2\2!")
-        buf.write(u"\u00dc\3\2\2\2#\u00e1\3\2\2\2%\u00e6\3\2\2\2\'\u00ec")
-        buf.write(u"\3\2\2\2)\u00f1\3\2\2\2+\u00f5\3\2\2\2-\u00fa\3\2\2\2")
-        buf.write(u"/\u00ff\3\2\2\2\61\u0104\3\2\2\2\63\u0109\3\2\2\2\65")
-        buf.write(u"\u010e\3\2\2\2\67\u0113\3\2\2\29\u011b\3\2\2\2;\u0123")
-        buf.write(u"\3\2\2\2=\u012b\3\2\2\2?\u0133\3\2\2\2A\u013b\3\2\2\2")
-        buf.write(u"C\u0143\3\2\2\2E\u0149\3\2\2\2G\u014f\3\2\2\2I\u0155")
-        buf.write(u"\3\2\2\2K\u015d\3\2\2\2M\u0165\3\2\2\2O\u016d\3\2\2\2")
-        buf.write(u"Q\u0173\3\2\2\2S\u017a\3\2\2\2U\u0180\3\2\2\2W\u0185")
-        buf.write(u"\3\2\2\2Y\u018b\3\2\2\2[\u0192\3\2\2\2]\u019a\3\2\2\2")
-        buf.write(u"_\u01a2\3\2\2\2a\u01aa\3\2\2\2c\u01ac\3\2\2\2e\u01ae")
-        buf.write(u"\3\2\2\2g\u01b0\3\2\2\2i\u01b2\3\2\2\2k\u01c2\3\2\2\2")
-        buf.write(u"m\u01c4\3\2\2\2o\u01eb\3\2\2\2q\u01ed\3\2\2\2s\u01ef")
-        buf.write(u"\3\2\2\2u\u01f1\3\2\2\2w\u01f6\3\2\2\2y\u01f8\3\2\2\2")
-        buf.write(u"{\u01fd\3\2\2\2}\u01ff\3\2\2\2\177\u0080\7.\2\2\u0080")
-        buf.write(u"\4\3\2\2\2\u0081\u0083\t\2\2\2\u0082\u0081\3\2\2\2\u0083")
-        buf.write(u"\u0084\3\2\2\2\u0084\u0082\3\2\2\2\u0084\u0085\3\2\2")
-        buf.write(u"\2\u0085\u0086\3\2\2\2\u0086\u0087\b\3\2\2\u0087\6\3")
-        buf.write(u"\2\2\2\u0088\u0089\7-\2\2\u0089\b\3\2\2\2\u008a\u008b")
-        buf.write(u"\7/\2\2\u008b\n\3\2\2\2\u008c\u008d\7,\2\2\u008d\f\3")
-        buf.write(u"\2\2\2\u008e\u008f\7\61\2\2\u008f\16\3\2\2\2\u0090\u0091")
-        buf.write(u"\7*\2\2\u0091\20\3\2\2\2\u0092\u0093\7+\2\2\u0093\22")
-        buf.write(u"\3\2\2\2\u0094\u0095\7}\2\2\u0095\24\3\2\2\2\u0096\u0097")
-        buf.write(u"\7\177\2\2\u0097\26\3\2\2\2\u0098\u0099\7]\2\2\u0099")
-        buf.write(u"\30\3\2\2\2\u009a\u009b\7_\2\2\u009b\32\3\2\2\2\u009c")
-        buf.write(u"\u009d\7~\2\2\u009d\34\3\2\2\2\u009e\u009f\7^\2\2\u009f")
-        buf.write(u"\u00a0\7n\2\2\u00a0\u00a1\7k\2\2\u00a1\u00a2\7o\2\2\u00a2")
-        buf.write(u"\36\3\2\2\2\u00a3\u00a4\7^\2\2\u00a4\u00a5\7v\2\2\u00a5")
-        buf.write(u"\u00db\7q\2\2\u00a6\u00a7\7^\2\2\u00a7\u00a8\7t\2\2\u00a8")
-        buf.write(u"\u00a9\7k\2\2\u00a9\u00aa\7i\2\2\u00aa\u00ab\7j\2\2\u00ab")
-        buf.write(u"\u00ac\7v\2\2\u00ac\u00ad\7c\2\2\u00ad\u00ae\7t\2\2\u00ae")
-        buf.write(u"\u00af\7t\2\2\u00af\u00b0\7q\2\2\u00b0\u00db\7y\2\2\u00b1")
-        buf.write(u"\u00b2\7^\2\2\u00b2\u00b3\7T\2\2\u00b3\u00b4\7k\2\2\u00b4")
-        buf.write(u"\u00b5\7i\2\2\u00b5\u00b6\7j\2\2\u00b6\u00b7\7v\2\2\u00b7")
-        buf.write(u"\u00b8\7c\2\2\u00b8\u00b9\7t\2\2\u00b9\u00ba\7t\2\2\u00ba")
-        buf.write(u"\u00bb\7q\2\2\u00bb\u00db\7y\2\2\u00bc\u00bd\7^\2\2\u00bd")
-        buf.write(u"\u00be\7n\2\2\u00be\u00bf\7q\2\2\u00bf\u00c0\7p\2\2\u00c0")
-        buf.write(u"\u00c1\7i\2\2\u00c1\u00c2\7t\2\2\u00c2\u00c3\7k\2\2\u00c3")
-        buf.write(u"\u00c4\7i\2\2\u00c4\u00c5\7j\2\2\u00c5\u00c6\7v\2\2\u00c6")
-        buf.write(u"\u00c7\7c\2\2\u00c7\u00c8\7t\2\2\u00c8\u00c9\7t\2\2\u00c9")
-        buf.write(u"\u00ca\7q\2\2\u00ca\u00db\7y\2\2\u00cb\u00cc\7^\2\2\u00cc")
-        buf.write(u"\u00cd\7N\2\2\u00cd\u00ce\7q\2\2\u00ce\u00cf\7p\2\2\u00cf")
-        buf.write(u"\u00d0\7i\2\2\u00d0\u00d1\7t\2\2\u00d1\u00d2\7k\2\2\u00d2")
-        buf.write(u"\u00d3\7i\2\2\u00d3\u00d4\7j\2\2\u00d4\u00d5\7v\2\2\u00d5")
-        buf.write(u"\u00d6\7c\2\2\u00d6\u00d7\7t\2\2\u00d7\u00d8\7t\2\2\u00d8")
-        buf.write(u"\u00d9\7q\2\2\u00d9\u00db\7y\2\2\u00da\u00a3\3\2\2\2")
-        buf.write(u"\u00da\u00a6\3\2\2\2\u00da\u00b1\3\2\2\2\u00da\u00bc")
-        buf.write(u"\3\2\2\2\u00da\u00cb\3\2\2\2\u00db \3\2\2\2\u00dc\u00dd")
-        buf.write(u"\7^\2\2\u00dd\u00de\7k\2\2\u00de\u00df\7p\2\2\u00df\u00e0")
-        buf.write(u"\7v\2\2\u00e0\"\3\2\2\2\u00e1\u00e2\7^\2\2\u00e2\u00e3")
-        buf.write(u"\7u\2\2\u00e3\u00e4\7w\2\2\u00e4\u00e5\7o\2\2\u00e5$")
-        buf.write(u"\3\2\2\2\u00e6\u00e7\7^\2\2\u00e7\u00e8\7r\2\2\u00e8")
-        buf.write(u"\u00e9\7t\2\2\u00e9\u00ea\7q\2\2\u00ea\u00eb\7f\2\2\u00eb")
-        buf.write(u"&\3\2\2\2\u00ec\u00ed\7^\2\2\u00ed\u00ee\7n\2\2\u00ee")
-        buf.write(u"\u00ef\7q\2\2\u00ef\u00f0\7i\2\2\u00f0(\3\2\2\2\u00f1")
-        buf.write(u"\u00f2\7^\2\2\u00f2\u00f3\7n\2\2\u00f3\u00f4\7p\2\2\u00f4")
-        buf.write(u"*\3\2\2\2\u00f5\u00f6\7^\2\2\u00f6\u00f7\7u\2\2\u00f7")
-        buf.write(u"\u00f8\7k\2\2\u00f8\u00f9\7p\2\2\u00f9,\3\2\2\2\u00fa")
-        buf.write(u"\u00fb\7^\2\2\u00fb\u00fc\7e\2\2\u00fc\u00fd\7q\2\2\u00fd")
-        buf.write(u"\u00fe\7u\2\2\u00fe.\3\2\2\2\u00ff\u0100\7^\2\2\u0100")
-        buf.write(u"\u0101\7v\2\2\u0101\u0102\7c\2\2\u0102\u0103\7p\2\2\u0103")
-        buf.write(u"\60\3\2\2\2\u0104\u0105\7^\2\2\u0105\u0106\7e\2\2\u0106")
-        buf.write(u"\u0107\7u\2\2\u0107\u0108\7e\2\2\u0108\62\3\2\2\2\u0109")
-        buf.write(u"\u010a\7^\2\2\u010a\u010b\7u\2\2\u010b\u010c\7g\2\2\u010c")
-        buf.write(u"\u010d\7e\2\2\u010d\64\3\2\2\2\u010e\u010f\7^\2\2\u010f")
-        buf.write(u"\u0110\7e\2\2\u0110\u0111\7q\2\2\u0111\u0112\7v\2\2\u0112")
-        buf.write(u"\66\3\2\2\2\u0113\u0114\7^\2\2\u0114\u0115\7c\2\2\u0115")
-        buf.write(u"\u0116\7t\2\2\u0116\u0117\7e\2\2\u0117\u0118\7u\2\2\u0118")
-        buf.write(u"\u0119\7k\2\2\u0119\u011a\7p\2\2\u011a8\3\2\2\2\u011b")
-        buf.write(u"\u011c\7^\2\2\u011c\u011d\7c\2\2\u011d\u011e\7t\2\2\u011e")
-        buf.write(u"\u011f\7e\2\2\u011f\u0120\7e\2\2\u0120\u0121\7q\2\2\u0121")
-        buf.write(u"\u0122\7u\2\2\u0122:\3\2\2\2\u0123\u0124\7^\2\2\u0124")
-        buf.write(u"\u0125\7c\2\2\u0125\u0126\7t\2\2\u0126\u0127\7e\2\2\u0127")
-        buf.write(u"\u0128\7v\2\2\u0128\u0129\7c\2\2\u0129\u012a\7p\2\2\u012a")
-        buf.write(u"<\3\2\2\2\u012b\u012c\7^\2\2\u012c\u012d\7c\2\2\u012d")
-        buf.write(u"\u012e\7t\2\2\u012e\u012f\7e\2\2\u012f\u0130\7e\2\2\u0130")
-        buf.write(u"\u0131\7u\2\2\u0131\u0132\7e\2\2\u0132>\3\2\2\2\u0133")
-        buf.write(u"\u0134\7^\2\2\u0134\u0135\7c\2\2\u0135\u0136\7t\2\2\u0136")
-        buf.write(u"\u0137\7e\2\2\u0137\u0138\7u\2\2\u0138\u0139\7g\2\2\u0139")
-        buf.write(u"\u013a\7e\2\2\u013a@\3\2\2\2\u013b\u013c\7^\2\2\u013c")
-        buf.write(u"\u013d\7c\2\2\u013d\u013e\7t\2\2\u013e\u013f\7e\2\2\u013f")
-        buf.write(u"\u0140\7e\2\2\u0140\u0141\7q\2\2\u0141\u0142\7v\2\2\u0142")
-        buf.write(u"B\3\2\2\2\u0143\u0144\7^\2\2\u0144\u0145\7u\2\2\u0145")
-        buf.write(u"\u0146\7k\2\2\u0146\u0147\7p\2\2\u0147\u0148\7j\2\2\u0148")
-        buf.write(u"D\3\2\2\2\u0149\u014a\7^\2\2\u014a\u014b\7e\2\2\u014b")
-        buf.write(u"\u014c\7q\2\2\u014c\u014d\7u\2\2\u014d\u014e\7j\2\2\u014e")
-        buf.write(u"F\3\2\2\2\u014f\u0150\7^\2\2\u0150\u0151\7v\2\2\u0151")
-        buf.write(u"\u0152\7c\2\2\u0152\u0153\7p\2\2\u0153\u0154\7j\2\2\u0154")
-        buf.write(u"H\3\2\2\2\u0155\u0156\7^\2\2\u0156\u0157\7c\2\2\u0157")
-        buf.write(u"\u0158\7t\2\2\u0158\u0159\7u\2\2\u0159\u015a\7k\2\2\u015a")
-        buf.write(u"\u015b\7p\2\2\u015b\u015c\7j\2\2\u015cJ\3\2\2\2\u015d")
-        buf.write(u"\u015e\7^\2\2\u015e\u015f\7c\2\2\u015f\u0160\7t\2\2\u0160")
-        buf.write(u"\u0161\7e\2\2\u0161\u0162\7q\2\2\u0162\u0163\7u\2\2\u0163")
-        buf.write(u"\u0164\7j\2\2\u0164L\3\2\2\2\u0165\u0166\7^\2\2\u0166")
-        buf.write(u"\u0167\7c\2\2\u0167\u0168\7t\2\2\u0168\u0169\7v\2\2\u0169")
-        buf.write(u"\u016a\7c\2\2\u016a\u016b\7p\2\2\u016b\u016c\7j\2\2\u016c")
-        buf.write(u"N\3\2\2\2\u016d\u016e\7^\2\2\u016e\u016f\7u\2\2\u016f")
-        buf.write(u"\u0170\7s\2\2\u0170\u0171\7t\2\2\u0171\u0172\7v\2\2\u0172")
-        buf.write(u"P\3\2\2\2\u0173\u0174\7^\2\2\u0174\u0175\7v\2\2\u0175")
-        buf.write(u"\u0176\7k\2\2\u0176\u0177\7o\2\2\u0177\u0178\7g\2\2\u0178")
-        buf.write(u"\u0179\7u\2\2\u0179R\3\2\2\2\u017a\u017b\7^\2\2\u017b")
-        buf.write(u"\u017c\7e\2\2\u017c\u017d\7f\2\2\u017d\u017e\7q\2\2\u017e")
-        buf.write(u"\u017f\7v\2\2\u017fT\3\2\2\2\u0180\u0181\7^\2\2\u0181")
-        buf.write(u"\u0182\7f\2\2\u0182\u0183\7k\2\2\u0183\u0184\7x\2\2\u0184")
-        buf.write(u"V\3\2\2\2\u0185\u0186\7^\2\2\u0186\u0187\7h\2\2\u0187")
-        buf.write(u"\u0188\7t\2\2\u0188\u0189\7c\2\2\u0189\u018a\7e\2\2\u018a")
-        buf.write(u"X\3\2\2\2\u018b\u018c\7^\2\2\u018c\u018d\7d\2\2\u018d")
-        buf.write(u"\u018e\7k\2\2\u018e\u018f\7p\2\2\u018f\u0190\7q\2\2\u0190")
-        buf.write(u"\u0191\7o\2\2\u0191Z\3\2\2\2\u0192\u0193\7^\2\2\u0193")
-        buf.write(u"\u0194\7f\2\2\u0194\u0195\7d\2\2\u0195\u0196\7k\2\2\u0196")
-        buf.write(u"\u0197\7p\2\2\u0197\u0198\7q\2\2\u0198\u0199\7o\2\2\u0199")
-        buf.write(u"\\\3\2\2\2\u019a\u019b\7^\2\2\u019b\u019c\7v\2\2\u019c")
-        buf.write(u"\u019d\7d\2\2\u019d\u019e\7k\2\2\u019e\u019f\7p\2\2\u019f")
-        buf.write(u"\u01a0\7q\2\2\u01a0\u01a1\7o\2\2\u01a1^\3\2\2\2\u01a2")
-        buf.write(u"\u01a3\7^\2\2\u01a3\u01a4\7o\2\2\u01a4\u01a5\7c\2\2\u01a5")
-        buf.write(u"\u01a6\7v\2\2\u01a6\u01a7\7j\2\2\u01a7\u01a8\7k\2\2\u01a8")
-        buf.write(u"\u01a9\7v\2\2\u01a9`\3\2\2\2\u01aa\u01ab\7a\2\2\u01ab")
-        buf.write(u"b\3\2\2\2\u01ac\u01ad\7`\2\2\u01add\3\2\2\2\u01ae\u01af")
-        buf.write(u"\7<\2\2\u01aff\3\2\2\2\u01b0\u01b1\t\2\2\2\u01b1h\3\2")
-        buf.write(u"\2\2\u01b2\u01b6\7f\2\2\u01b3\u01b5\5g\64\2\u01b4\u01b3")
-        buf.write(u"\3\2\2\2\u01b5\u01b8\3\2\2\2\u01b6\u01b7\3\2\2\2\u01b6")
-        buf.write(u"\u01b4\3\2\2\2\u01b7\u01c0\3\2\2\2\u01b8\u01b6\3\2\2")
-        buf.write(u"\2\u01b9\u01c1\t\3\2\2\u01ba\u01bc\7^\2\2\u01bb\u01bd")
-        buf.write(u"\t\3\2\2\u01bc\u01bb\3\2\2\2\u01bd\u01be\3\2\2\2\u01be")
-        buf.write(u"\u01bc\3\2\2\2\u01be\u01bf\3\2\2\2\u01bf\u01c1\3\2\2")
-        buf.write(u"\2\u01c0\u01b9\3\2\2\2\u01c0\u01ba\3\2\2\2\u01c1j\3\2")
-        buf.write(u"\2\2\u01c2\u01c3\t\3\2\2\u01c3l\3\2\2\2\u01c4\u01c5\t")
-        buf.write(u"\4\2\2\u01c5n\3\2\2\2\u01c6\u01c8\5m\67\2\u01c7\u01c6")
-        buf.write(u"\3\2\2\2\u01c8\u01c9\3\2\2\2\u01c9\u01c7\3\2\2\2\u01c9")
-        buf.write(u"\u01ca\3\2\2\2\u01ca\u01d2\3\2\2\2\u01cb\u01cc\7.\2\2")
-        buf.write(u"\u01cc\u01cd\5m\67\2\u01cd\u01ce\5m\67\2\u01ce\u01cf")
-        buf.write(u"\5m\67\2\u01cf\u01d1\3\2\2\2\u01d0\u01cb\3\2\2\2\u01d1")
-        buf.write(u"\u01d4\3\2\2\2\u01d2\u01d0\3\2\2\2\u01d2\u01d3\3\2\2")
-        buf.write(u"\2\u01d3\u01ec\3\2\2\2\u01d4\u01d2\3\2\2\2\u01d5\u01d7")
-        buf.write(u"\5m\67\2\u01d6\u01d5\3\2\2\2\u01d7\u01da\3\2\2\2\u01d8")
-        buf.write(u"\u01d6\3\2\2\2\u01d8\u01d9\3\2\2\2\u01d9\u01e2\3\2\2")
-        buf.write(u"\2\u01da\u01d8\3\2\2\2\u01db\u01dc\7.\2\2\u01dc\u01dd")
-        buf.write(u"\5m\67\2\u01dd\u01de\5m\67\2\u01de\u01df\5m\67\2\u01df")
-        buf.write(u"\u01e1\3\2\2\2\u01e0\u01db\3\2\2\2\u01e1\u01e4\3\2\2")
-        buf.write(u"\2\u01e2\u01e0\3\2\2\2\u01e2\u01e3\3\2\2\2\u01e3\u01e5")
-        buf.write(u"\3\2\2\2\u01e4\u01e2\3\2\2\2\u01e5\u01e7\7\60\2\2\u01e6")
-        buf.write(u"\u01e8\5m\67\2\u01e7\u01e6\3\2\2\2\u01e8\u01e9\3\2\2")
-        buf.write(u"\2\u01e9\u01e7\3\2\2\2\u01e9\u01ea\3\2\2\2\u01ea\u01ec")
-        buf.write(u"\3\2\2\2\u01eb\u01c7\3\2\2\2\u01eb\u01d8\3\2\2\2\u01ec")
-        buf.write(u"p\3\2\2\2\u01ed\u01ee\7?\2\2\u01eer\3\2\2\2\u01ef\u01f0")
-        buf.write(u"\7>\2\2\u01f0t\3\2\2\2\u01f1\u01f2\7^\2\2\u01f2\u01f3")
-        buf.write(u"\7n\2\2\u01f3\u01f4\7g\2\2\u01f4\u01f5\7s\2\2\u01f5v")
-        buf.write(u"\3\2\2\2\u01f6\u01f7\7@\2\2\u01f7x\3\2\2\2\u01f8\u01f9")
-        buf.write(u"\7^\2\2\u01f9\u01fa\7i\2\2\u01fa\u01fb\7g\2\2\u01fb\u01fc")
-        buf.write(u"\7s\2\2\u01fcz\3\2\2\2\u01fd\u01fe\7#\2\2\u01fe|\3\2")
-        buf.write(u"\2\2\u01ff\u0201\7^\2\2\u0200\u0202\t\3\2\2\u0201\u0200")
-        buf.write(u"\3\2\2\2\u0202\u0203\3\2\2\2\u0203\u0201\3\2\2\2\u0203")
-        buf.write(u"\u0204\3\2\2\2\u0204~\3\2\2\2\17\2\u0084\u00da\u01b6")
-        buf.write(u"\u01be\u01c0\u01c9\u01d2\u01d8\u01e2\u01e9\u01eb\u0203")
-        buf.write(u"\3\b\2\2")
+        buf.write(u"\20\3\20\3\20\5\20\u00dd\n\20\3\21\3\21\3\21\3\21\3\21")
+        buf.write(u"\3\22\3\22\3\22\3\22\3\22\3\23\3\23\3\23\3\23\3\23\3")
+        buf.write(u"\23\3\24\3\24\3\24\3\24\3\24\3\25\3\25\3\25\3\25\3\25")
+        buf.write(u"\3\26\3\26\3\26\3\26\3\27\3\27\3\27\3\27\3\27\3\30\3")
+        buf.write(u"\30\3\30\3\30\3\30\3\31\3\31\3\31\3\31\3\31\3\32\3\32")
+        buf.write(u"\3\32\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\34\3\34\3")
+        buf.write(u"\34\3\34\3\34\3\35\3\35\3\35\3\35\3\35\3\35\3\35\3\35")
+        buf.write(u"\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\36\3\37\3\37\3")
+        buf.write(u"\37\3\37\3\37\3\37\3\37\3\37\3 \3 \3 \3 \3 \3 \3 \3 ")
+        buf.write(u"\3!\3!\3!\3!\3!\3!\3!\3!\3\"\3\"\3\"\3\"\3\"\3\"\3\"")
+        buf.write(u"\3\"\3#\3#\3#\3#\3#\3#\3$\3$\3$\3$\3$\3$\3%\3%\3%\3%")
+        buf.write(u"\3%\3%\3&\3&\3&\3&\3&\3&\3&\3&\3\'\3\'\3\'\3\'\3\'\3")
+        buf.write(u"\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3)")
+        buf.write(u"\3*\3*\3*\3*\3*\3*\3*\3+\3+\3+\3+\3+\3+\3,\3,\3,\3,\3")
+        buf.write(u",\3-\3-\3-\3-\3-\3-\3.\3.\3.\3.\3.\3.\3.\3/\3/\3/\3/")
+        buf.write(u"\3/\3/\3/\3/\3\60\3\60\3\60\3\60\3\60\3\60\3\60\3\60")
+        buf.write(u"\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\62\3\62\3")
+        buf.write(u"\63\3\63\3\64\3\64\3\65\3\65\3\66\3\66\7\66\u01bc\n\66")
+        buf.write(u"\f\66\16\66\u01bf\13\66\3\66\3\66\3\66\6\66\u01c4\n\66")
+        buf.write(u"\r\66\16\66\u01c5\5\66\u01c8\n\66\3\67\3\67\38\38\39")
+        buf.write(u"\69\u01cf\n9\r9\169\u01d0\39\39\39\39\39\79\u01d8\n9")
+        buf.write(u"\f9\169\u01db\139\39\79\u01de\n9\f9\169\u01e1\139\39")
+        buf.write(u"\39\39\39\39\79\u01e8\n9\f9\169\u01eb\139\39\39\69\u01ef")
+        buf.write(u"\n9\r9\169\u01f0\59\u01f3\n9\3:\3:\3;\3;\3<\3<\3<\3<")
+        buf.write(u"\3<\3=\3=\3>\3>\3>\3>\3>\3?\3?\3@\3@\6@\u0209\n@\r@\16")
+        buf.write(u"@\u020a\3\u01bd\2A\3\3\5\4\7\5\t\6\13\7\r\b\17\t\21\n")
+        buf.write(u"\23\13\25\f\27\r\31\16\33\17\35\20\37\21!\22#\23%\24")
+        buf.write(u"\'\25)\26+\27-\30/\31\61\32\63\33\65\34\67\359\36;\37")
+        buf.write(u"= ?!A\"C#E$G%I&K\'M(O)Q*S+U,W-Y.[/]\60_\61a\62c\63e\64")
+        buf.write(u"g\65i\2k\66m\67o\2q8s9u:w;y<{=}>\177?\3\2\5\5\2\13\f")
+        buf.write(u"\17\17\"\"\4\2C\\c|\3\2\62;\2\u0218\2\3\3\2\2\2\2\5\3")
+        buf.write(u"\2\2\2\2\7\3\2\2\2\2\t\3\2\2\2\2\13\3\2\2\2\2\r\3\2\2")
+        buf.write(u"\2\2\17\3\2\2\2\2\21\3\2\2\2\2\23\3\2\2\2\2\25\3\2\2")
+        buf.write(u"\2\2\27\3\2\2\2\2\31\3\2\2\2\2\33\3\2\2\2\2\35\3\2\2")
+        buf.write(u"\2\2\37\3\2\2\2\2!\3\2\2\2\2#\3\2\2\2\2%\3\2\2\2\2\'")
+        buf.write(u"\3\2\2\2\2)\3\2\2\2\2+\3\2\2\2\2-\3\2\2\2\2/\3\2\2\2")
+        buf.write(u"\2\61\3\2\2\2\2\63\3\2\2\2\2\65\3\2\2\2\2\67\3\2\2\2")
+        buf.write(u"\29\3\2\2\2\2;\3\2\2\2\2=\3\2\2\2\2?\3\2\2\2\2A\3\2\2")
+        buf.write(u"\2\2C\3\2\2\2\2E\3\2\2\2\2G\3\2\2\2\2I\3\2\2\2\2K\3\2")
+        buf.write(u"\2\2\2M\3\2\2\2\2O\3\2\2\2\2Q\3\2\2\2\2S\3\2\2\2\2U\3")
+        buf.write(u"\2\2\2\2W\3\2\2\2\2Y\3\2\2\2\2[\3\2\2\2\2]\3\2\2\2\2")
+        buf.write(u"_\3\2\2\2\2a\3\2\2\2\2c\3\2\2\2\2e\3\2\2\2\2g\3\2\2\2")
+        buf.write(u"\2k\3\2\2\2\2m\3\2\2\2\2q\3\2\2\2\2s\3\2\2\2\2u\3\2\2")
+        buf.write(u"\2\2w\3\2\2\2\2y\3\2\2\2\2{\3\2\2\2\2}\3\2\2\2\2\177")
+        buf.write(u"\3\2\2\2\3\u0081\3\2\2\2\5\u0084\3\2\2\2\7\u008a\3\2")
+        buf.write(u"\2\2\t\u008c\3\2\2\2\13\u008e\3\2\2\2\r\u0090\3\2\2\2")
+        buf.write(u"\17\u0092\3\2\2\2\21\u0094\3\2\2\2\23\u0096\3\2\2\2\25")
+        buf.write(u"\u0098\3\2\2\2\27\u009a\3\2\2\2\31\u009c\3\2\2\2\33\u009e")
+        buf.write(u"\3\2\2\2\35\u00a0\3\2\2\2\37\u00dc\3\2\2\2!\u00de\3\2")
+        buf.write(u"\2\2#\u00e3\3\2\2\2%\u00e8\3\2\2\2\'\u00ee\3\2\2\2)\u00f3")
+        buf.write(u"\3\2\2\2+\u00f8\3\2\2\2-\u00fc\3\2\2\2/\u0101\3\2\2\2")
+        buf.write(u"\61\u0106\3\2\2\2\63\u010b\3\2\2\2\65\u0110\3\2\2\2\67")
+        buf.write(u"\u0115\3\2\2\29\u011a\3\2\2\2;\u0122\3\2\2\2=\u012a\3")
+        buf.write(u"\2\2\2?\u0132\3\2\2\2A\u013a\3\2\2\2C\u0142\3\2\2\2E")
+        buf.write(u"\u014a\3\2\2\2G\u0150\3\2\2\2I\u0156\3\2\2\2K\u015c\3")
+        buf.write(u"\2\2\2M\u0164\3\2\2\2O\u016c\3\2\2\2Q\u0174\3\2\2\2S")
+        buf.write(u"\u017a\3\2\2\2U\u0181\3\2\2\2W\u0187\3\2\2\2Y\u018c\3")
+        buf.write(u"\2\2\2[\u0192\3\2\2\2]\u0199\3\2\2\2_\u01a1\3\2\2\2a")
+        buf.write(u"\u01a9\3\2\2\2c\u01b1\3\2\2\2e\u01b3\3\2\2\2g\u01b5\3")
+        buf.write(u"\2\2\2i\u01b7\3\2\2\2k\u01b9\3\2\2\2m\u01c9\3\2\2\2o")
+        buf.write(u"\u01cb\3\2\2\2q\u01f2\3\2\2\2s\u01f4\3\2\2\2u\u01f6\3")
+        buf.write(u"\2\2\2w\u01f8\3\2\2\2y\u01fd\3\2\2\2{\u01ff\3\2\2\2}")
+        buf.write(u"\u0204\3\2\2\2\177\u0206\3\2\2\2\u0081\u0082\7.\2\2\u0082")
+        buf.write(u"\4\3\2\2\2\u0083\u0085\t\2\2\2\u0084\u0083\3\2\2\2\u0085")
+        buf.write(u"\u0086\3\2\2\2\u0086\u0084\3\2\2\2\u0086\u0087\3\2\2")
+        buf.write(u"\2\u0087\u0088\3\2\2\2\u0088\u0089\b\3\2\2\u0089\6\3")
+        buf.write(u"\2\2\2\u008a\u008b\7-\2\2\u008b\b\3\2\2\2\u008c\u008d")
+        buf.write(u"\7/\2\2\u008d\n\3\2\2\2\u008e\u008f\7,\2\2\u008f\f\3")
+        buf.write(u"\2\2\2\u0090\u0091\7\61\2\2\u0091\16\3\2\2\2\u0092\u0093")
+        buf.write(u"\7*\2\2\u0093\20\3\2\2\2\u0094\u0095\7+\2\2\u0095\22")
+        buf.write(u"\3\2\2\2\u0096\u0097\7}\2\2\u0097\24\3\2\2\2\u0098\u0099")
+        buf.write(u"\7\177\2\2\u0099\26\3\2\2\2\u009a\u009b\7]\2\2\u009b")
+        buf.write(u"\30\3\2\2\2\u009c\u009d\7_\2\2\u009d\32\3\2\2\2\u009e")
+        buf.write(u"\u009f\7~\2\2\u009f\34\3\2\2\2\u00a0\u00a1\7^\2\2\u00a1")
+        buf.write(u"\u00a2\7n\2\2\u00a2\u00a3\7k\2\2\u00a3\u00a4\7o\2\2\u00a4")
+        buf.write(u"\36\3\2\2\2\u00a5\u00a6\7^\2\2\u00a6\u00a7\7v\2\2\u00a7")
+        buf.write(u"\u00dd\7q\2\2\u00a8\u00a9\7^\2\2\u00a9\u00aa\7t\2\2\u00aa")
+        buf.write(u"\u00ab\7k\2\2\u00ab\u00ac\7i\2\2\u00ac\u00ad\7j\2\2\u00ad")
+        buf.write(u"\u00ae\7v\2\2\u00ae\u00af\7c\2\2\u00af\u00b0\7t\2\2\u00b0")
+        buf.write(u"\u00b1\7t\2\2\u00b1\u00b2\7q\2\2\u00b2\u00dd\7y\2\2\u00b3")
+        buf.write(u"\u00b4\7^\2\2\u00b4\u00b5\7T\2\2\u00b5\u00b6\7k\2\2\u00b6")
+        buf.write(u"\u00b7\7i\2\2\u00b7\u00b8\7j\2\2\u00b8\u00b9\7v\2\2\u00b9")
+        buf.write(u"\u00ba\7c\2\2\u00ba\u00bb\7t\2\2\u00bb\u00bc\7t\2\2\u00bc")
+        buf.write(u"\u00bd\7q\2\2\u00bd\u00dd\7y\2\2\u00be\u00bf\7^\2\2\u00bf")
+        buf.write(u"\u00c0\7n\2\2\u00c0\u00c1\7q\2\2\u00c1\u00c2\7p\2\2\u00c2")
+        buf.write(u"\u00c3\7i\2\2\u00c3\u00c4\7t\2\2\u00c4\u00c5\7k\2\2\u00c5")
+        buf.write(u"\u00c6\7i\2\2\u00c6\u00c7\7j\2\2\u00c7\u00c8\7v\2\2\u00c8")
+        buf.write(u"\u00c9\7c\2\2\u00c9\u00ca\7t\2\2\u00ca\u00cb\7t\2\2\u00cb")
+        buf.write(u"\u00cc\7q\2\2\u00cc\u00dd\7y\2\2\u00cd\u00ce\7^\2\2\u00ce")
+        buf.write(u"\u00cf\7N\2\2\u00cf\u00d0\7q\2\2\u00d0\u00d1\7p\2\2\u00d1")
+        buf.write(u"\u00d2\7i\2\2\u00d2\u00d3\7t\2\2\u00d3\u00d4\7k\2\2\u00d4")
+        buf.write(u"\u00d5\7i\2\2\u00d5\u00d6\7j\2\2\u00d6\u00d7\7v\2\2\u00d7")
+        buf.write(u"\u00d8\7c\2\2\u00d8\u00d9\7t\2\2\u00d9\u00da\7t\2\2\u00da")
+        buf.write(u"\u00db\7q\2\2\u00db\u00dd\7y\2\2\u00dc\u00a5\3\2\2\2")
+        buf.write(u"\u00dc\u00a8\3\2\2\2\u00dc\u00b3\3\2\2\2\u00dc\u00be")
+        buf.write(u"\3\2\2\2\u00dc\u00cd\3\2\2\2\u00dd \3\2\2\2\u00de\u00df")
+        buf.write(u"\7^\2\2\u00df\u00e0\7k\2\2\u00e0\u00e1\7p\2\2\u00e1\u00e2")
+        buf.write(u"\7v\2\2\u00e2\"\3\2\2\2\u00e3\u00e4\7^\2\2\u00e4\u00e5")
+        buf.write(u"\7u\2\2\u00e5\u00e6\7w\2\2\u00e6\u00e7\7o\2\2\u00e7$")
+        buf.write(u"\3\2\2\2\u00e8\u00e9\7^\2\2\u00e9\u00ea\7r\2\2\u00ea")
+        buf.write(u"\u00eb\7t\2\2\u00eb\u00ec\7q\2\2\u00ec\u00ed\7f\2\2\u00ed")
+        buf.write(u"&\3\2\2\2\u00ee\u00ef\7^\2\2\u00ef\u00f0\7g\2\2\u00f0")
+        buf.write(u"\u00f1\7z\2\2\u00f1\u00f2\7r\2\2\u00f2(\3\2\2\2\u00f3")
+        buf.write(u"\u00f4\7^\2\2\u00f4\u00f5\7n\2\2\u00f5\u00f6\7q\2\2\u00f6")
+        buf.write(u"\u00f7\7i\2\2\u00f7*\3\2\2\2\u00f8\u00f9\7^\2\2\u00f9")
+        buf.write(u"\u00fa\7n\2\2\u00fa\u00fb\7p\2\2\u00fb,\3\2\2\2\u00fc")
+        buf.write(u"\u00fd\7^\2\2\u00fd\u00fe\7u\2\2\u00fe\u00ff\7k\2\2\u00ff")
+        buf.write(u"\u0100\7p\2\2\u0100.\3\2\2\2\u0101\u0102\7^\2\2\u0102")
+        buf.write(u"\u0103\7e\2\2\u0103\u0104\7q\2\2\u0104\u0105\7u\2\2\u0105")
+        buf.write(u"\60\3\2\2\2\u0106\u0107\7^\2\2\u0107\u0108\7v\2\2\u0108")
+        buf.write(u"\u0109\7c\2\2\u0109\u010a\7p\2\2\u010a\62\3\2\2\2\u010b")
+        buf.write(u"\u010c\7^\2\2\u010c\u010d\7e\2\2\u010d\u010e\7u\2\2\u010e")
+        buf.write(u"\u010f\7e\2\2\u010f\64\3\2\2\2\u0110\u0111\7^\2\2\u0111")
+        buf.write(u"\u0112\7u\2\2\u0112\u0113\7g\2\2\u0113\u0114\7e\2\2\u0114")
+        buf.write(u"\66\3\2\2\2\u0115\u0116\7^\2\2\u0116\u0117\7e\2\2\u0117")
+        buf.write(u"\u0118\7q\2\2\u0118\u0119\7v\2\2\u01198\3\2\2\2\u011a")
+        buf.write(u"\u011b\7^\2\2\u011b\u011c\7c\2\2\u011c\u011d\7t\2\2\u011d")
+        buf.write(u"\u011e\7e\2\2\u011e\u011f\7u\2\2\u011f\u0120\7k\2\2\u0120")
+        buf.write(u"\u0121\7p\2\2\u0121:\3\2\2\2\u0122\u0123\7^\2\2\u0123")
+        buf.write(u"\u0124\7c\2\2\u0124\u0125\7t\2\2\u0125\u0126\7e\2\2\u0126")
+        buf.write(u"\u0127\7e\2\2\u0127\u0128\7q\2\2\u0128\u0129\7u\2\2\u0129")
+        buf.write(u"<\3\2\2\2\u012a\u012b\7^\2\2\u012b\u012c\7c\2\2\u012c")
+        buf.write(u"\u012d\7t\2\2\u012d\u012e\7e\2\2\u012e\u012f\7v\2\2\u012f")
+        buf.write(u"\u0130\7c\2\2\u0130\u0131\7p\2\2\u0131>\3\2\2\2\u0132")
+        buf.write(u"\u0133\7^\2\2\u0133\u0134\7c\2\2\u0134\u0135\7t\2\2\u0135")
+        buf.write(u"\u0136\7e\2\2\u0136\u0137\7e\2\2\u0137\u0138\7u\2\2\u0138")
+        buf.write(u"\u0139\7e\2\2\u0139@\3\2\2\2\u013a\u013b\7^\2\2\u013b")
+        buf.write(u"\u013c\7c\2\2\u013c\u013d\7t\2\2\u013d\u013e\7e\2\2\u013e")
+        buf.write(u"\u013f\7u\2\2\u013f\u0140\7g\2\2\u0140\u0141\7e\2\2\u0141")
+        buf.write(u"B\3\2\2\2\u0142\u0143\7^\2\2\u0143\u0144\7c\2\2\u0144")
+        buf.write(u"\u0145\7t\2\2\u0145\u0146\7e\2\2\u0146\u0147\7e\2\2\u0147")
+        buf.write(u"\u0148\7q\2\2\u0148\u0149\7v\2\2\u0149D\3\2\2\2\u014a")
+        buf.write(u"\u014b\7^\2\2\u014b\u014c\7u\2\2\u014c\u014d\7k\2\2\u014d")
+        buf.write(u"\u014e\7p\2\2\u014e\u014f\7j\2\2\u014fF\3\2\2\2\u0150")
+        buf.write(u"\u0151\7^\2\2\u0151\u0152\7e\2\2\u0152\u0153\7q\2\2\u0153")
+        buf.write(u"\u0154\7u\2\2\u0154\u0155\7j\2\2\u0155H\3\2\2\2\u0156")
+        buf.write(u"\u0157\7^\2\2\u0157\u0158\7v\2\2\u0158\u0159\7c\2\2\u0159")
+        buf.write(u"\u015a\7p\2\2\u015a\u015b\7j\2\2\u015bJ\3\2\2\2\u015c")
+        buf.write(u"\u015d\7^\2\2\u015d\u015e\7c\2\2\u015e\u015f\7t\2\2\u015f")
+        buf.write(u"\u0160\7u\2\2\u0160\u0161\7k\2\2\u0161\u0162\7p\2\2\u0162")
+        buf.write(u"\u0163\7j\2\2\u0163L\3\2\2\2\u0164\u0165\7^\2\2\u0165")
+        buf.write(u"\u0166\7c\2\2\u0166\u0167\7t\2\2\u0167\u0168\7e\2\2\u0168")
+        buf.write(u"\u0169\7q\2\2\u0169\u016a\7u\2\2\u016a\u016b\7j\2\2\u016b")
+        buf.write(u"N\3\2\2\2\u016c\u016d\7^\2\2\u016d\u016e\7c\2\2\u016e")
+        buf.write(u"\u016f\7t\2\2\u016f\u0170\7v\2\2\u0170\u0171\7c\2\2\u0171")
+        buf.write(u"\u0172\7p\2\2\u0172\u0173\7j\2\2\u0173P\3\2\2\2\u0174")
+        buf.write(u"\u0175\7^\2\2\u0175\u0176\7u\2\2\u0176\u0177\7s\2\2\u0177")
+        buf.write(u"\u0178\7t\2\2\u0178\u0179\7v\2\2\u0179R\3\2\2\2\u017a")
+        buf.write(u"\u017b\7^\2\2\u017b\u017c\7v\2\2\u017c\u017d\7k\2\2\u017d")
+        buf.write(u"\u017e\7o\2\2\u017e\u017f\7g\2\2\u017f\u0180\7u\2\2\u0180")
+        buf.write(u"T\3\2\2\2\u0181\u0182\7^\2\2\u0182\u0183\7e\2\2\u0183")
+        buf.write(u"\u0184\7f\2\2\u0184\u0185\7q\2\2\u0185\u0186\7v\2\2\u0186")
+        buf.write(u"V\3\2\2\2\u0187\u0188\7^\2\2\u0188\u0189\7f\2\2\u0189")
+        buf.write(u"\u018a\7k\2\2\u018a\u018b\7x\2\2\u018bX\3\2\2\2\u018c")
+        buf.write(u"\u018d\7^\2\2\u018d\u018e\7h\2\2\u018e\u018f\7t\2\2\u018f")
+        buf.write(u"\u0190\7c\2\2\u0190\u0191\7e\2\2\u0191Z\3\2\2\2\u0192")
+        buf.write(u"\u0193\7^\2\2\u0193\u0194\7d\2\2\u0194\u0195\7k\2\2\u0195")
+        buf.write(u"\u0196\7p\2\2\u0196\u0197\7q\2\2\u0197\u0198\7o\2\2\u0198")
+        buf.write(u"\\\3\2\2\2\u0199\u019a\7^\2\2\u019a\u019b\7f\2\2\u019b")
+        buf.write(u"\u019c\7d\2\2\u019c\u019d\7k\2\2\u019d\u019e\7p\2\2\u019e")
+        buf.write(u"\u019f\7q\2\2\u019f\u01a0\7o\2\2\u01a0^\3\2\2\2\u01a1")
+        buf.write(u"\u01a2\7^\2\2\u01a2\u01a3\7v\2\2\u01a3\u01a4\7d\2\2\u01a4")
+        buf.write(u"\u01a5\7k\2\2\u01a5\u01a6\7p\2\2\u01a6\u01a7\7q\2\2\u01a7")
+        buf.write(u"\u01a8\7o\2\2\u01a8`\3\2\2\2\u01a9\u01aa\7^\2\2\u01aa")
+        buf.write(u"\u01ab\7o\2\2\u01ab\u01ac\7c\2\2\u01ac\u01ad\7v\2\2\u01ad")
+        buf.write(u"\u01ae\7j\2\2\u01ae\u01af\7k\2\2\u01af\u01b0\7v\2\2\u01b0")
+        buf.write(u"b\3\2\2\2\u01b1\u01b2\7a\2\2\u01b2d\3\2\2\2\u01b3\u01b4")
+        buf.write(u"\7`\2\2\u01b4f\3\2\2\2\u01b5\u01b6\7<\2\2\u01b6h\3\2")
+        buf.write(u"\2\2\u01b7\u01b8\t\2\2\2\u01b8j\3\2\2\2\u01b9\u01bd\7")
+        buf.write(u"f\2\2\u01ba\u01bc\5i\65\2\u01bb\u01ba\3\2\2\2\u01bc\u01bf")
+        buf.write(u"\3\2\2\2\u01bd\u01be\3\2\2\2\u01bd\u01bb\3\2\2\2\u01be")
+        buf.write(u"\u01c7\3\2\2\2\u01bf\u01bd\3\2\2\2\u01c0\u01c8\t\3\2")
+        buf.write(u"\2\u01c1\u01c3\7^\2\2\u01c2\u01c4\t\3\2\2\u01c3\u01c2")
+        buf.write(u"\3\2\2\2\u01c4\u01c5\3\2\2\2\u01c5\u01c3\3\2\2\2\u01c5")
+        buf.write(u"\u01c6\3\2\2\2\u01c6\u01c8\3\2\2\2\u01c7\u01c0\3\2\2")
+        buf.write(u"\2\u01c7\u01c1\3\2\2\2\u01c8l\3\2\2\2\u01c9\u01ca\t\3")
+        buf.write(u"\2\2\u01can\3\2\2\2\u01cb\u01cc\t\4\2\2\u01ccp\3\2\2")
+        buf.write(u"\2\u01cd\u01cf\5o8\2\u01ce\u01cd\3\2\2\2\u01cf\u01d0")
+        buf.write(u"\3\2\2\2\u01d0\u01ce\3\2\2\2\u01d0\u01d1\3\2\2\2\u01d1")
+        buf.write(u"\u01d9\3\2\2\2\u01d2\u01d3\7.\2\2\u01d3\u01d4\5o8\2\u01d4")
+        buf.write(u"\u01d5\5o8\2\u01d5\u01d6\5o8\2\u01d6\u01d8\3\2\2\2\u01d7")
+        buf.write(u"\u01d2\3\2\2\2\u01d8\u01db\3\2\2\2\u01d9\u01d7\3\2\2")
+        buf.write(u"\2\u01d9\u01da\3\2\2\2\u01da\u01f3\3\2\2\2\u01db\u01d9")
+        buf.write(u"\3\2\2\2\u01dc\u01de\5o8\2\u01dd\u01dc\3\2\2\2\u01de")
+        buf.write(u"\u01e1\3\2\2\2\u01df\u01dd\3\2\2\2\u01df\u01e0\3\2\2")
+        buf.write(u"\2\u01e0\u01e9\3\2\2\2\u01e1\u01df\3\2\2\2\u01e2\u01e3")
+        buf.write(u"\7.\2\2\u01e3\u01e4\5o8\2\u01e4\u01e5\5o8\2\u01e5\u01e6")
+        buf.write(u"\5o8\2\u01e6\u01e8\3\2\2\2\u01e7\u01e2\3\2\2\2\u01e8")
+        buf.write(u"\u01eb\3\2\2\2\u01e9\u01e7\3\2\2\2\u01e9\u01ea\3\2\2")
+        buf.write(u"\2\u01ea\u01ec\3\2\2\2\u01eb\u01e9\3\2\2\2\u01ec\u01ee")
+        buf.write(u"\7\60\2\2\u01ed\u01ef\5o8\2\u01ee\u01ed\3\2\2\2\u01ef")
+        buf.write(u"\u01f0\3\2\2\2\u01f0\u01ee\3\2\2\2\u01f0\u01f1\3\2\2")
+        buf.write(u"\2\u01f1\u01f3\3\2\2\2\u01f2\u01ce\3\2\2\2\u01f2\u01df")
+        buf.write(u"\3\2\2\2\u01f3r\3\2\2\2\u01f4\u01f5\7?\2\2\u01f5t\3\2")
+        buf.write(u"\2\2\u01f6\u01f7\7>\2\2\u01f7v\3\2\2\2\u01f8\u01f9\7")
+        buf.write(u"^\2\2\u01f9\u01fa\7n\2\2\u01fa\u01fb\7g\2\2\u01fb\u01fc")
+        buf.write(u"\7s\2\2\u01fcx\3\2\2\2\u01fd\u01fe\7@\2\2\u01fez\3\2")
+        buf.write(u"\2\2\u01ff\u0200\7^\2\2\u0200\u0201\7i\2\2\u0201\u0202")
+        buf.write(u"\7g\2\2\u0202\u0203\7s\2\2\u0203|\3\2\2\2\u0204\u0205")
+        buf.write(u"\7#\2\2\u0205~\3\2\2\2\u0206\u0208\7^\2\2\u0207\u0209")
+        buf.write(u"\t\3\2\2\u0208\u0207\3\2\2\2\u0209\u020a\3\2\2\2\u020a")
+        buf.write(u"\u0208\3\2\2\2\u020a\u020b\3\2\2\2\u020b\u0080\3\2\2")
+        buf.write(u"\2\17\2\u0086\u00dc\u01bd\u01c5\u01c7\u01d0\u01d9\u01df")
+        buf.write(u"\u01e9\u01f0\u01f2\u020a\3\b\2\2")
         return buf.getvalue()
 
 
@@ -266,48 +268,49 @@ class LaTeXLexer(Lexer):
     FUNC_INT = 16
     FUNC_SUM = 17
     FUNC_PROD = 18
-    FUNC_LOG = 19
-    FUNC_LN = 20
-    FUNC_SIN = 21
-    FUNC_COS = 22
-    FUNC_TAN = 23
-    FUNC_CSC = 24
-    FUNC_SEC = 25
-    FUNC_COT = 26
-    FUNC_ARCSIN = 27
-    FUNC_ARCCOS = 28
-    FUNC_ARCTAN = 29
-    FUNC_ARCCSC = 30
-    FUNC_ARCSEC = 31
-    FUNC_ARCCOT = 32
-    FUNC_SINH = 33
-    FUNC_COSH = 34
-    FUNC_TANH = 35
-    FUNC_ARSINH = 36
-    FUNC_ARCOSH = 37
-    FUNC_ARTANH = 38
-    FUNC_SQRT = 39
-    CMD_TIMES = 40
-    CMD_CDOT = 41
-    CMD_DIV = 42
-    CMD_FRAC = 43
-    CMD_BINOM = 44
-    CMD_DBINOM = 45
-    CMD_TBINOM = 46
-    CMD_MATHIT = 47
-    UNDERSCORE = 48
-    CARET = 49
-    COLON = 50
-    DIFFERENTIAL = 51
-    LETTER = 52
-    NUMBER = 53
-    EQUAL = 54
-    LT = 55
-    LTE = 56
-    GT = 57
-    GTE = 58
-    BANG = 59
-    SYMBOL = 60
+    FUNC_EXP = 19
+    FUNC_LOG = 20
+    FUNC_LN = 21
+    FUNC_SIN = 22
+    FUNC_COS = 23
+    FUNC_TAN = 24
+    FUNC_CSC = 25
+    FUNC_SEC = 26
+    FUNC_COT = 27
+    FUNC_ARCSIN = 28
+    FUNC_ARCCOS = 29
+    FUNC_ARCTAN = 30
+    FUNC_ARCCSC = 31
+    FUNC_ARCSEC = 32
+    FUNC_ARCCOT = 33
+    FUNC_SINH = 34
+    FUNC_COSH = 35
+    FUNC_TANH = 36
+    FUNC_ARSINH = 37
+    FUNC_ARCOSH = 38
+    FUNC_ARTANH = 39
+    FUNC_SQRT = 40
+    CMD_TIMES = 41
+    CMD_CDOT = 42
+    CMD_DIV = 43
+    CMD_FRAC = 44
+    CMD_BINOM = 45
+    CMD_DBINOM = 46
+    CMD_TBINOM = 47
+    CMD_MATHIT = 48
+    UNDERSCORE = 49
+    CARET = 50
+    COLON = 51
+    DIFFERENTIAL = 52
+    LETTER = 53
+    NUMBER = 54
+    EQUAL = 55
+    LT = 56
+    LTE = 57
+    GT = 58
+    GTE = 59
+    BANG = 60
+    SYMBOL = 61
 
     channelNames = [ u"DEFAULT_TOKEN_CHANNEL", u"HIDDEN" ]
 
@@ -316,42 +319,43 @@ class LaTeXLexer(Lexer):
     literalNames = [ u"<INVALID>",
             u"','", u"'+'", u"'-'", u"'*'", u"'/'", u"'('", u"')'", u"'{'",
             u"'}'", u"'['", u"']'", u"'|'", u"'\\lim'", u"'\\int'", u"'\\sum'",
-            u"'\\prod'", u"'\\log'", u"'\\ln'", u"'\\sin'", u"'\\cos'",
-            u"'\\tan'", u"'\\csc'", u"'\\sec'", u"'\\cot'", u"'\\arcsin'",
-            u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'", u"'\\arcsec'",
-            u"'\\arccot'", u"'\\sinh'", u"'\\cosh'", u"'\\tanh'", u"'\\arsinh'",
-            u"'\\arcosh'", u"'\\artanh'", u"'\\sqrt'", u"'\\times'", u"'\\cdot'",
-            u"'\\div'", u"'\\frac'", u"'\\binom'", u"'\\dbinom'", u"'\\tbinom'",
-            u"'\\mathit'", u"'_'", u"'^'", u"':'", u"'='", u"'<'", u"'\\leq'",
-            u"'>'", u"'\\geq'", u"'!'" ]
+            u"'\\prod'", u"'\\exp'", u"'\\log'", u"'\\ln'", u"'\\sin'",
+            u"'\\cos'", u"'\\tan'", u"'\\csc'", u"'\\sec'", u"'\\cot'",
+            u"'\\arcsin'", u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'",
+            u"'\\arcsec'", u"'\\arccot'", u"'\\sinh'", u"'\\cosh'", u"'\\tanh'",
+            u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'", u"'\\sqrt'", u"'\\times'",
+            u"'\\cdot'", u"'\\div'", u"'\\frac'", u"'\\binom'", u"'\\dbinom'",
+            u"'\\tbinom'", u"'\\mathit'", u"'_'", u"'^'", u"':'", u"'='",
+            u"'<'", u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
 
     symbolicNames = [ u"<INVALID>",
             u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN", u"R_PAREN",
             u"L_BRACE", u"R_BRACE", u"L_BRACKET", u"R_BRACKET", u"BAR",
             u"FUNC_LIM", u"LIM_APPROACH_SYM", u"FUNC_INT", u"FUNC_SUM",
-            u"FUNC_PROD", u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN", u"FUNC_COS",
-            u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT", u"FUNC_ARCSIN",
-            u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC", u"FUNC_ARCSEC",
-            u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH", u"FUNC_TANH", u"FUNC_ARSINH",
-            u"FUNC_ARCOSH", u"FUNC_ARTANH", u"FUNC_SQRT", u"CMD_TIMES",
-            u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM",
-            u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE", u"CARET", u"COLON",
-            u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL", u"LT", u"LTE",
-            u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+            u"FUNC_PROD", u"FUNC_EXP", u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN",
+            u"FUNC_COS", u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT",
+            u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC",
+            u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH",
+            u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH",
+            u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC",
+            u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE",
+            u"CARET", u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL",
+            u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
 
     ruleNames = [ u"T__0", u"WS", u"ADD", u"SUB", u"MUL", u"DIV", u"L_PAREN",
                   u"R_PAREN", u"L_BRACE", u"R_BRACE", u"L_BRACKET", u"R_BRACKET",
                   u"BAR", u"FUNC_LIM", u"LIM_APPROACH_SYM", u"FUNC_INT",
-                  u"FUNC_SUM", u"FUNC_PROD", u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN",
-                  u"FUNC_COS", u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT",
-                  u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC",
-                  u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH",
-                  u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH",
-                  u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV", u"CMD_FRAC",
-                  u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM", u"CMD_MATHIT",
-                  u"UNDERSCORE", u"CARET", u"COLON", u"WS_CHAR", u"DIFFERENTIAL",
-                  u"LETTER", u"DIGIT", u"NUMBER", u"EQUAL", u"LT", u"LTE",
-                  u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                  u"FUNC_SUM", u"FUNC_PROD", u"FUNC_EXP", u"FUNC_LOG", u"FUNC_LN",
+                  u"FUNC_SIN", u"FUNC_COS", u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC",
+                  u"FUNC_COT", u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN",
+                  u"FUNC_ARCCSC", u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH",
+                  u"FUNC_COSH", u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH",
+                  u"FUNC_ARTANH", u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT",
+                  u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM",
+                  u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE", u"CARET",
+                  u"COLON", u"WS_CHAR", u"DIFFERENTIAL", u"LETTER", u"DIGIT",
+                  u"NUMBER", u"EQUAL", u"LT", u"LTE", u"GT", u"GTE", u"BANG",
+                  u"SYMBOL" ]
 
     grammarFileName = u"LaTeX.g4"
 

--- a/sympy/parsing/latex/_antlr/latexparser.py
+++ b/sympy/parsing/latex/_antlr/latexparser.py
@@ -18,7 +18,7 @@ import sys
 def serializedATN():
     with StringIO() as buf:
         buf.write(u"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3")
-        buf.write(u">\u01ae\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t")
+        buf.write(u"?\u01ae\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t")
         buf.write(u"\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t\r")
         buf.write(u"\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22\4")
         buf.write(u"\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30")
@@ -62,8 +62,8 @@ def serializedATN():
         buf.write(u"!\3!\3\"\3\"\3\"\3\"\3\"\3\"\5\"\u019a\n\"\3#\3#\3#\3")
         buf.write(u"#\3#\3#\5#\u01a2\n#\3$\3$\3$\3$\3$\3%\3%\3%\3%\3%\3%")
         buf.write(u"\2\b\4\n\f\16 \"&\2\4\6\b\n\f\16\20\22\24\26\30\32\34")
-        buf.write(u"\36 \"$&(*,.\60\62\64\668:<>@BDFH\2\t\3\28<\3\2\5\6\5")
-        buf.write(u"\2\7\b*,\64\64\4\2\66\66>>\3\2.\60\3\2\25(\3\2\23\24")
+        buf.write(u"\36 \"$&(*,.\60\62\64\668:<>@BDFH\2\t\3\29=\3\2\5\6\5")
+        buf.write(u"\2\7\b+-\65\65\4\2\67\67??\3\2/\61\3\2\25)\3\2\23\24")
         buf.write(u"\2\u01c6\2J\3\2\2\2\4L\3\2\2\2\6W\3\2\2\2\b[\3\2\2\2")
         buf.write(u"\n]\3\2\2\2\fh\3\2\2\2\16s\3\2\2\2\20\u0085\3\2\2\2\22")
         buf.write(u"\u0090\3\2\2\2\24\u0092\3\2\2\2\26\u0099\3\2\2\2\30\u00a2")
@@ -77,7 +77,7 @@ def serializedATN():
         buf.write(u"H\u01a8\3\2\2\2JK\5\4\3\2K\3\3\2\2\2LM\b\3\1\2MN\5\b")
         buf.write(u"\5\2NT\3\2\2\2OP\f\4\2\2PQ\t\2\2\2QS\5\4\3\5RO\3\2\2")
         buf.write(u"\2SV\3\2\2\2TR\3\2\2\2TU\3\2\2\2U\5\3\2\2\2VT\3\2\2\2")
-        buf.write(u"WX\5\b\5\2XY\78\2\2YZ\5\b\5\2Z\7\3\2\2\2[\\\5\n\6\2\\")
+        buf.write(u"WX\5\b\5\2XY\79\2\2YZ\5\b\5\2Z\7\3\2\2\2[\\\5\n\6\2\\")
         buf.write(u"\t\3\2\2\2]^\b\6\1\2^_\5\f\7\2_e\3\2\2\2`a\f\4\2\2ab")
         buf.write(u"\t\3\2\2bd\5\n\6\5c`\3\2\2\2dg\3\2\2\2ec\3\2\2\2ef\3")
         buf.write(u"\2\2\2f\13\3\2\2\2ge\3\2\2\2hi\b\7\1\2ij\5\20\t\2jp\3")
@@ -100,20 +100,20 @@ def serializedATN():
         buf.write(u"\"\22\2\u009a\u009c\5\30\r\2\u009b\u009a\3\2\2\2\u009c")
         buf.write(u"\u009f\3\2\2\2\u009d\u009b\3\2\2\2\u009d\u009e\3\2\2")
         buf.write(u"\2\u009e\27\3\2\2\2\u009f\u009d\3\2\2\2\u00a0\u00a3\7")
-        buf.write(u"=\2\2\u00a1\u00a3\5\32\16\2\u00a2\u00a0\3\2\2\2\u00a2")
+        buf.write(u">\2\2\u00a1\u00a3\5\32\16\2\u00a2\u00a0\3\2\2\2\u00a2")
         buf.write(u"\u00a1\3\2\2\2\u00a3\31\3\2\2\2\u00a4\u00aa\7\17\2\2")
         buf.write(u"\u00a5\u00ab\5\36\20\2\u00a6\u00ab\5\34\17\2\u00a7\u00a8")
         buf.write(u"\5\36\20\2\u00a8\u00a9\5\34\17\2\u00a9\u00ab\3\2\2\2")
         buf.write(u"\u00aa\u00a5\3\2\2\2\u00aa\u00a6\3\2\2\2\u00aa\u00a7")
-        buf.write(u"\3\2\2\2\u00ab\33\3\2\2\2\u00ac\u00ad\7\62\2\2\u00ad")
+        buf.write(u"\3\2\2\2\u00ab\33\3\2\2\2\u00ac\u00ad\7\63\2\2\u00ad")
         buf.write(u"\u00b0\7\13\2\2\u00ae\u00b1\5\b\5\2\u00af\u00b1\5\6\4")
         buf.write(u"\2\u00b0\u00ae\3\2\2\2\u00b0\u00af\3\2\2\2\u00b1\u00b2")
         buf.write(u"\3\2\2\2\u00b2\u00b3\7\f\2\2\u00b3\35\3\2\2\2\u00b4\u00b5")
-        buf.write(u"\7\63\2\2\u00b5\u00b8\7\13\2\2\u00b6\u00b9\5\b\5\2\u00b7")
+        buf.write(u"\7\64\2\2\u00b5\u00b8\7\13\2\2\u00b6\u00b9\5\b\5\2\u00b7")
         buf.write(u"\u00b9\5\6\4\2\u00b8\u00b6\3\2\2\2\u00b8\u00b7\3\2\2")
         buf.write(u"\2\u00b9\u00ba\3\2\2\2\u00ba\u00bb\7\f\2\2\u00bb\37\3")
         buf.write(u"\2\2\2\u00bc\u00bd\b\21\1\2\u00bd\u00be\5$\23\2\u00be")
-        buf.write(u"\u00cd\3\2\2\2\u00bf\u00c0\f\4\2\2\u00c0\u00c6\7\63\2")
+        buf.write(u"\u00cd\3\2\2\2\u00bf\u00c0\f\4\2\2\u00c0\u00c6\7\64\2")
         buf.write(u"\2\u00c1\u00c7\5,\27\2\u00c2\u00c3\7\13\2\2\u00c3\u00c4")
         buf.write(u"\5\b\5\2\u00c4\u00c5\7\f\2\2\u00c5\u00c7\3\2\2\2\u00c6")
         buf.write(u"\u00c1\3\2\2\2\u00c6\u00c2\3\2\2\2\u00c7\u00c9\3\2\2")
@@ -122,7 +122,7 @@ def serializedATN():
         buf.write(u"\u00cf\3\2\2\2\u00cd\u00cb\3\2\2\2\u00cd\u00ce\3\2\2")
         buf.write(u"\2\u00ce!\3\2\2\2\u00cf\u00cd\3\2\2\2\u00d0\u00d1\b\22")
         buf.write(u"\1\2\u00d1\u00d2\5&\24\2\u00d2\u00e1\3\2\2\2\u00d3\u00d4")
-        buf.write(u"\f\4\2\2\u00d4\u00da\7\63\2\2\u00d5\u00db\5,\27\2\u00d6")
+        buf.write(u"\f\4\2\2\u00d4\u00da\7\64\2\2\u00d5\u00db\5,\27\2\u00d6")
         buf.write(u"\u00d7\7\13\2\2\u00d7\u00d8\5\b\5\2\u00d8\u00d9\7\f\2")
         buf.write(u"\2\u00d9\u00db\3\2\2\2\u00da\u00d5\3\2\2\2\u00da\u00d6")
         buf.write(u"\3\2\2\2\u00db\u00dd\3\2\2\2\u00dc\u00de\5B\"\2\u00dd")
@@ -147,14 +147,14 @@ def serializedATN():
         buf.write(u"\2\2\u0101\u0102\7\17\2\2\u0102\u0103\5\b\5\2\u0103\u0104")
         buf.write(u"\7\17\2\2\u0104+\3\2\2\2\u0105\u0107\t\5\2\2\u0106\u0108")
         buf.write(u"\5B\"\2\u0107\u0106\3\2\2\2\u0107\u0108\3\2\2\2\u0108")
-        buf.write(u"\u010d\3\2\2\2\u0109\u010d\7\67\2\2\u010a\u010d\7\65")
-        buf.write(u"\2\2\u010b\u010d\5.\30\2\u010c\u0105\3\2\2\2\u010c\u0109")
+        buf.write(u"\u010d\3\2\2\2\u0109\u010d\78\2\2\u010a\u010d\7\66\2")
+        buf.write(u"\2\u010b\u010d\5.\30\2\u010c\u0105\3\2\2\2\u010c\u0109")
         buf.write(u"\3\2\2\2\u010c\u010a\3\2\2\2\u010c\u010b\3\2\2\2\u010d")
-        buf.write(u"-\3\2\2\2\u010e\u010f\7\61\2\2\u010f\u0110\7\13\2\2\u0110")
+        buf.write(u"-\3\2\2\2\u010e\u010f\7\62\2\2\u010f\u0110\7\13\2\2\u0110")
         buf.write(u"\u0111\5\60\31\2\u0111\u0112\7\f\2\2\u0112/\3\2\2\2\u0113")
-        buf.write(u"\u0115\7\66\2\2\u0114\u0113\3\2\2\2\u0115\u0118\3\2\2")
+        buf.write(u"\u0115\7\67\2\2\u0114\u0113\3\2\2\2\u0115\u0118\3\2\2")
         buf.write(u"\2\u0116\u0114\3\2\2\2\u0116\u0117\3\2\2\2\u0117\61\3")
-        buf.write(u"\2\2\2\u0118\u0116\3\2\2\2\u0119\u011a\7-\2\2\u011a\u011b")
+        buf.write(u"\2\2\2\u0118\u0116\3\2\2\2\u0119\u011a\7.\2\2\u011a\u011b")
         buf.write(u"\7\13\2\2\u011b\u011c\5\b\5\2\u011c\u011d\7\f\2\2\u011d")
         buf.write(u"\u011e\7\13\2\2\u011e\u011f\5\b\5\2\u011f\u0120\7\f\2")
         buf.write(u"\2\u0120\63\3\2\2\2\u0121\u0122\t\6\2\2\u0122\u0123\7")
@@ -180,10 +180,10 @@ def serializedATN():
         buf.write(u"B\"\2\u014f\u0151\3\2\2\2\u0150\u014a\3\2\2\2\u0150\u014d")
         buf.write(u"\3\2\2\2\u0150\u0151\3\2\2\2\u0151\u0158\3\2\2\2\u0152")
         buf.write(u"\u0154\5\n\6\2\u0153\u0152\3\2\2\2\u0153\u0154\3\2\2")
-        buf.write(u"\2\u0154\u0155\3\2\2\2\u0155\u0159\7\65\2\2\u0156\u0159")
+        buf.write(u"\2\u0154\u0155\3\2\2\2\u0155\u0159\7\66\2\2\u0156\u0159")
         buf.write(u"\5\62\32\2\u0157\u0159\5\n\6\2\u0158\u0153\3\2\2\2\u0158")
         buf.write(u"\u0156\3\2\2\2\u0158\u0157\3\2\2\2\u0159\u0175\3\2\2")
-        buf.write(u"\2\u015a\u015f\7)\2\2\u015b\u015c\7\r\2\2\u015c\u015d")
+        buf.write(u"\2\u015a\u015f\7*\2\2\u015b\u015c\7\r\2\2\u015c\u015d")
         buf.write(u"\5\b\5\2\u015d\u015e\7\16\2\2\u015e\u0160\3\2\2\2\u015f")
         buf.write(u"\u015b\3\2\2\2\u015f\u0160\3\2\2\2\u0160\u0161\3\2\2")
         buf.write(u"\2\u0161\u0162\7\13\2\2\u0162\u0163\5\b\5\2\u0163\u0164")
@@ -198,25 +198,25 @@ def serializedATN():
         buf.write(u"\3\2\2\2\u0174\u0170\3\2\2\2\u01759\3\2\2\2\u0176\u0177")
         buf.write(u"\5\b\5\2\u0177\u0178\7\3\2\2\u0178\u0179\5:\36\2\u0179")
         buf.write(u"\u017c\3\2\2\2\u017a\u017c\5\b\5\2\u017b\u0176\3\2\2")
-        buf.write(u"\2\u017b\u017a\3\2\2\2\u017c;\3\2\2\2\u017d\u017e\7\62")
+        buf.write(u"\2\u017b\u017a\3\2\2\2\u017c;\3\2\2\2\u017d\u017e\7\63")
         buf.write(u"\2\2\u017e\u017f\7\13\2\2\u017f\u0180\t\5\2\2\u0180\u0181")
-        buf.write(u"\7\21\2\2\u0181\u0186\5\b\5\2\u0182\u0183\7\63\2\2\u0183")
+        buf.write(u"\7\21\2\2\u0181\u0186\5\b\5\2\u0182\u0183\7\64\2\2\u0183")
         buf.write(u"\u0184\7\13\2\2\u0184\u0185\t\3\2\2\u0185\u0187\7\f\2")
         buf.write(u"\2\u0186\u0182\3\2\2\2\u0186\u0187\3\2\2\2\u0187\u0188")
         buf.write(u"\3\2\2\2\u0188\u0189\7\f\2\2\u0189=\3\2\2\2\u018a\u0190")
         buf.write(u"\5\b\5\2\u018b\u018c\5\b\5\2\u018c\u018d\7\3\2\2\u018d")
         buf.write(u"\u018e\5> \2\u018e\u0190\3\2\2\2\u018f\u018a\3\2\2\2")
         buf.write(u"\u018f\u018b\3\2\2\2\u0190?\3\2\2\2\u0191\u0192\5\16")
-        buf.write(u"\b\2\u0192A\3\2\2\2\u0193\u0199\7\62\2\2\u0194\u019a")
+        buf.write(u"\b\2\u0192A\3\2\2\2\u0193\u0199\7\63\2\2\u0194\u019a")
         buf.write(u"\5,\27\2\u0195\u0196\7\13\2\2\u0196\u0197\5\b\5\2\u0197")
         buf.write(u"\u0198\7\f\2\2\u0198\u019a\3\2\2\2\u0199\u0194\3\2\2")
-        buf.write(u"\2\u0199\u0195\3\2\2\2\u019aC\3\2\2\2\u019b\u01a1\7\63")
+        buf.write(u"\2\u0199\u0195\3\2\2\2\u019aC\3\2\2\2\u019b\u01a1\7\64")
         buf.write(u"\2\2\u019c\u01a2\5,\27\2\u019d\u019e\7\13\2\2\u019e\u019f")
         buf.write(u"\5\b\5\2\u019f\u01a0\7\f\2\2\u01a0\u01a2\3\2\2\2\u01a1")
         buf.write(u"\u019c\3\2\2\2\u01a1\u019d\3\2\2\2\u01a2E\3\2\2\2\u01a3")
-        buf.write(u"\u01a4\7\62\2\2\u01a4\u01a5\7\13\2\2\u01a5\u01a6\5\6")
+        buf.write(u"\u01a4\7\63\2\2\u01a4\u01a5\7\13\2\2\u01a5\u01a6\5\6")
         buf.write(u"\4\2\u01a6\u01a7\7\f\2\2\u01a7G\3\2\2\2\u01a8\u01a9\7")
-        buf.write(u"\62\2\2\u01a9\u01aa\7\13\2\2\u01aa\u01ab\5\6\4\2\u01ab")
+        buf.write(u"\63\2\2\u01a9\u01aa\7\13\2\2\u01aa\u01ab\5\6\4\2\u01ab")
         buf.write(u"\u01ac\7\f\2\2\u01acI\3\2\2\2.Tep{\u0083\u0085\u008d")
         buf.write(u"\u0090\u0096\u009d\u00a2\u00aa\u00b0\u00b8\u00c6\u00c9")
         buf.write(u"\u00cd\u00da\u00dd\u00e1\u00ea\u00f1\u00ff\u0107\u010c")
@@ -239,31 +239,31 @@ class LaTeXParser ( Parser ):
     literalNames = [ u"<INVALID>", u"','", u"<INVALID>", u"'+'", u"'-'",
                      u"'*'", u"'/'", u"'('", u"')'", u"'{'", u"'}'", u"'['",
                      u"']'", u"'|'", u"'\\lim'", u"<INVALID>", u"'\\int'",
-                     u"'\\sum'", u"'\\prod'", u"'\\log'", u"'\\ln'", u"'\\sin'",
-                     u"'\\cos'", u"'\\tan'", u"'\\csc'", u"'\\sec'", u"'\\cot'",
-                     u"'\\arcsin'", u"'\\arccos'", u"'\\arctan'", u"'\\arccsc'",
-                     u"'\\arcsec'", u"'\\arccot'", u"'\\sinh'", u"'\\cosh'",
-                     u"'\\tanh'", u"'\\arsinh'", u"'\\arcosh'", u"'\\artanh'",
-                     u"'\\sqrt'", u"'\\times'", u"'\\cdot'", u"'\\div'",
-                     u"'\\frac'", u"'\\binom'", u"'\\dbinom'", u"'\\tbinom'",
-                     u"'\\mathit'", u"'_'", u"'^'", u"':'", u"<INVALID>",
-                     u"<INVALID>", u"<INVALID>", u"'='", u"'<'", u"'\\leq'",
-                     u"'>'", u"'\\geq'", u"'!'" ]
+                     u"'\\sum'", u"'\\prod'", u"'\\exp'", u"'\\log'", u"'\\ln'",
+                     u"'\\sin'", u"'\\cos'", u"'\\tan'", u"'\\csc'", u"'\\sec'",
+                     u"'\\cot'", u"'\\arcsin'", u"'\\arccos'", u"'\\arctan'",
+                     u"'\\arccsc'", u"'\\arcsec'", u"'\\arccot'", u"'\\sinh'",
+                     u"'\\cosh'", u"'\\tanh'", u"'\\arsinh'", u"'\\arcosh'",
+                     u"'\\artanh'", u"'\\sqrt'", u"'\\times'", u"'\\cdot'",
+                     u"'\\div'", u"'\\frac'", u"'\\binom'", u"'\\dbinom'",
+                     u"'\\tbinom'", u"'\\mathit'", u"'_'", u"'^'", u"':'",
+                     u"<INVALID>", u"<INVALID>", u"<INVALID>", u"'='", u"'<'",
+                     u"'\\leq'", u"'>'", u"'\\geq'", u"'!'" ]
 
     symbolicNames = [ u"<INVALID>", u"<INVALID>", u"WS", u"ADD", u"SUB",
                       u"MUL", u"DIV", u"L_PAREN", u"R_PAREN", u"L_BRACE",
                       u"R_BRACE", u"L_BRACKET", u"R_BRACKET", u"BAR", u"FUNC_LIM",
                       u"LIM_APPROACH_SYM", u"FUNC_INT", u"FUNC_SUM", u"FUNC_PROD",
-                      u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN", u"FUNC_COS",
-                      u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC", u"FUNC_COT",
-                      u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN", u"FUNC_ARCCSC",
-                      u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH", u"FUNC_COSH",
-                      u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH", u"FUNC_ARTANH",
-                      u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT", u"CMD_DIV",
-                      u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM", u"CMD_TBINOM",
-                      u"CMD_MATHIT", u"UNDERSCORE", u"CARET", u"COLON",
-                      u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL", u"LT",
-                      u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
+                      u"FUNC_EXP", u"FUNC_LOG", u"FUNC_LN", u"FUNC_SIN",
+                      u"FUNC_COS", u"FUNC_TAN", u"FUNC_CSC", u"FUNC_SEC",
+                      u"FUNC_COT", u"FUNC_ARCSIN", u"FUNC_ARCCOS", u"FUNC_ARCTAN",
+                      u"FUNC_ARCCSC", u"FUNC_ARCSEC", u"FUNC_ARCCOT", u"FUNC_SINH",
+                      u"FUNC_COSH", u"FUNC_TANH", u"FUNC_ARSINH", u"FUNC_ARCOSH",
+                      u"FUNC_ARTANH", u"FUNC_SQRT", u"CMD_TIMES", u"CMD_CDOT",
+                      u"CMD_DIV", u"CMD_FRAC", u"CMD_BINOM", u"CMD_DBINOM",
+                      u"CMD_TBINOM", u"CMD_MATHIT", u"UNDERSCORE", u"CARET",
+                      u"COLON", u"DIFFERENTIAL", u"LETTER", u"NUMBER", u"EQUAL",
+                      u"LT", u"LTE", u"GT", u"GTE", u"BANG", u"SYMBOL" ]
 
     RULE_math = 0
     RULE_relation = 1
@@ -330,48 +330,49 @@ class LaTeXParser ( Parser ):
     FUNC_INT=16
     FUNC_SUM=17
     FUNC_PROD=18
-    FUNC_LOG=19
-    FUNC_LN=20
-    FUNC_SIN=21
-    FUNC_COS=22
-    FUNC_TAN=23
-    FUNC_CSC=24
-    FUNC_SEC=25
-    FUNC_COT=26
-    FUNC_ARCSIN=27
-    FUNC_ARCCOS=28
-    FUNC_ARCTAN=29
-    FUNC_ARCCSC=30
-    FUNC_ARCSEC=31
-    FUNC_ARCCOT=32
-    FUNC_SINH=33
-    FUNC_COSH=34
-    FUNC_TANH=35
-    FUNC_ARSINH=36
-    FUNC_ARCOSH=37
-    FUNC_ARTANH=38
-    FUNC_SQRT=39
-    CMD_TIMES=40
-    CMD_CDOT=41
-    CMD_DIV=42
-    CMD_FRAC=43
-    CMD_BINOM=44
-    CMD_DBINOM=45
-    CMD_TBINOM=46
-    CMD_MATHIT=47
-    UNDERSCORE=48
-    CARET=49
-    COLON=50
-    DIFFERENTIAL=51
-    LETTER=52
-    NUMBER=53
-    EQUAL=54
-    LT=55
-    LTE=56
-    GT=57
-    GTE=58
-    BANG=59
-    SYMBOL=60
+    FUNC_EXP=19
+    FUNC_LOG=20
+    FUNC_LN=21
+    FUNC_SIN=22
+    FUNC_COS=23
+    FUNC_TAN=24
+    FUNC_CSC=25
+    FUNC_SEC=26
+    FUNC_COT=27
+    FUNC_ARCSIN=28
+    FUNC_ARCCOS=29
+    FUNC_ARCTAN=30
+    FUNC_ARCCSC=31
+    FUNC_ARCSEC=32
+    FUNC_ARCCOT=33
+    FUNC_SINH=34
+    FUNC_COSH=35
+    FUNC_TANH=36
+    FUNC_ARSINH=37
+    FUNC_ARCOSH=38
+    FUNC_ARTANH=39
+    FUNC_SQRT=40
+    CMD_TIMES=41
+    CMD_CDOT=42
+    CMD_DIV=43
+    CMD_FRAC=44
+    CMD_BINOM=45
+    CMD_DBINOM=46
+    CMD_TBINOM=47
+    CMD_MATHIT=48
+    UNDERSCORE=49
+    CARET=50
+    COLON=51
+    DIFFERENTIAL=52
+    LETTER=53
+    NUMBER=54
+    EQUAL=55
+    LT=56
+    LTE=57
+    GT=58
+    GTE=59
+    BANG=60
+    SYMBOL=61
 
     def __init__(self, input, output=sys.stdout):
         super(LaTeXParser, self).__init__(input, output=output)
@@ -874,7 +875,7 @@ class LaTeXParser ( Parser ):
                 self.state = 125
                 self.unary()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_EXP, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 127
                 self._errHandler.sync(self)
@@ -956,7 +957,7 @@ class LaTeXParser ( Parser ):
                 self.state = 134
                 self.unary_nofunc()
                 pass
-            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+            elif token in [LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_EXP, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                 self.enterOuterAlt(localctx, 2)
                 self.state = 135
                 self.postfix()
@@ -2137,6 +2138,9 @@ class LaTeXParser ( Parser ):
             super(LaTeXParser.Func_normalContext, self).__init__(parent, invokingState)
             self.parser = parser
 
+        def FUNC_EXP(self):
+            return self.getToken(LaTeXParser.FUNC_EXP, 0)
+
         def FUNC_LOG(self):
             return self.getToken(LaTeXParser.FUNC_LOG, 0)
 
@@ -2212,7 +2216,7 @@ class LaTeXParser ( Parser ):
             self.enterOuterAlt(localctx, 1)
             self.state = 295
             _la = self._input.LA(1)
-            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH))) != 0)):
+            if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << LaTeXParser.FUNC_EXP) | (1 << LaTeXParser.FUNC_LOG) | (1 << LaTeXParser.FUNC_LN) | (1 << LaTeXParser.FUNC_SIN) | (1 << LaTeXParser.FUNC_COS) | (1 << LaTeXParser.FUNC_TAN) | (1 << LaTeXParser.FUNC_CSC) | (1 << LaTeXParser.FUNC_SEC) | (1 << LaTeXParser.FUNC_COT) | (1 << LaTeXParser.FUNC_ARCSIN) | (1 << LaTeXParser.FUNC_ARCCOS) | (1 << LaTeXParser.FUNC_ARCTAN) | (1 << LaTeXParser.FUNC_ARCCSC) | (1 << LaTeXParser.FUNC_ARCSEC) | (1 << LaTeXParser.FUNC_ARCCOT) | (1 << LaTeXParser.FUNC_SINH) | (1 << LaTeXParser.FUNC_COSH) | (1 << LaTeXParser.FUNC_TANH) | (1 << LaTeXParser.FUNC_ARSINH) | (1 << LaTeXParser.FUNC_ARCOSH) | (1 << LaTeXParser.FUNC_ARTANH))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
@@ -2341,7 +2345,7 @@ class LaTeXParser ( Parser ):
             self.state = 370
             self._errHandler.sync(self)
             token = self._input.LA(1)
-            if token in [LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH]:
+            if token in [LaTeXParser.FUNC_EXP, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH]:
                 self.enterOuterAlt(localctx, 1)
                 self.state = 297
                 self.func_normal()
@@ -2449,7 +2453,7 @@ class LaTeXParser ( Parser ):
                     self.state = 332
                     self.subexpr()
                     pass
-                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
+                elif token in [LaTeXParser.ADD, LaTeXParser.SUB, LaTeXParser.L_PAREN, LaTeXParser.L_BRACE, LaTeXParser.L_BRACKET, LaTeXParser.BAR, LaTeXParser.FUNC_LIM, LaTeXParser.FUNC_INT, LaTeXParser.FUNC_SUM, LaTeXParser.FUNC_PROD, LaTeXParser.FUNC_EXP, LaTeXParser.FUNC_LOG, LaTeXParser.FUNC_LN, LaTeXParser.FUNC_SIN, LaTeXParser.FUNC_COS, LaTeXParser.FUNC_TAN, LaTeXParser.FUNC_CSC, LaTeXParser.FUNC_SEC, LaTeXParser.FUNC_COT, LaTeXParser.FUNC_ARCSIN, LaTeXParser.FUNC_ARCCOS, LaTeXParser.FUNC_ARCTAN, LaTeXParser.FUNC_ARCCSC, LaTeXParser.FUNC_ARCSEC, LaTeXParser.FUNC_ARCCOT, LaTeXParser.FUNC_SINH, LaTeXParser.FUNC_COSH, LaTeXParser.FUNC_TANH, LaTeXParser.FUNC_ARSINH, LaTeXParser.FUNC_ARCOSH, LaTeXParser.FUNC_ARTANH, LaTeXParser.FUNC_SQRT, LaTeXParser.CMD_FRAC, LaTeXParser.CMD_BINOM, LaTeXParser.CMD_DBINOM, LaTeXParser.CMD_TBINOM, LaTeXParser.CMD_MATHIT, LaTeXParser.DIFFERENTIAL, LaTeXParser.LETTER, LaTeXParser.NUMBER, LaTeXParser.SYMBOL]:
                     pass
                 else:
                     pass

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -393,6 +393,9 @@ def convert_func(func):
             name = "a" + name[2:]
             expr = getattr(sympy.functions, name)(arg, evaluate=False)
 
+        if name == "exp":
+            expr = sympy.exp(arg, evaluate=False)
+
         if (name == "log" or name == "ln"):
             if func.subexpr():
                 base = convert_expr(func.subexpr().expr())

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -5,7 +5,7 @@ from sympy import (
     Symbol, Mul, Add, Eq, Abs, sin, asin, cos, Pow,
     csc, sec, Limit, oo, Derivative, Integral, factorial,
     sqrt, root, StrictLessThan, LessThan, StrictGreaterThan,
-    GreaterThan, Sum, Product, E, log, tan, Function, binomial
+    GreaterThan, Sum, Product, E, log, tan, Function, binomial, exp,
 )
 from sympy.abc import x, y, z, a, b, c, t, k, n
 antlr4 = import_module("antlr4")
@@ -39,8 +39,13 @@ def _factorial(a):
     return factorial(a, evaluate=False)
 
 
+def _exp(a):
+    return exp(a, evaluate=False)
+
+
 def _log(a, b):
     return log(a, b, evaluate=False)
+
 
 def _binomial(n, k):
     return binomial(n, k, evaluate=False)
@@ -167,6 +172,8 @@ GOOD_PAIRS = [
     ("\\prod_{a = b}^c x", Product(x, (a, b, c))),
     ("\\prod^{c}_{a = b} x", Product(x, (a, b, c))),
     ("\\prod^c_{a = b} x", Product(x, (a, b, c))),
+    ("\\exp x", _exp(x)),
+    ("\\exp(x)", _exp(x)),
     ("\\ln x", _log(x, E)),
     ("\\ln xy", _log(x*y, E)),
     ("\\log x", _log(x, 10)),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#15604

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
  - Added parsing of `\exp` in `parse_latex`.
<!-- END RELEASE NOTES -->