### PR TITLE
Fix LaTeX printing of base-n logarithm

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1071,10 +1071,15 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_log(self, expr, exp=None):
-        if not self._settings["ln_notation"]:
-            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
+        args = expr.args
+        if len(args) == 1:
+            if self._settings["ln_notation"]:
+                tex = r"\ln{%s}" % self._add_parens(args[0])
+            else:
+                tex = r"\log{%s}" % self._add_parens(args[0])
         else:
-            tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
+            tex = r"\log_{%s}{%s}" % \
+                (self._print(args[1]), self._add_parens(args[0]))
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
@@ -2950,7 +2955,8 @@ def latex(expr, **settings):
         Specifies if itex-specific syntax is used, including emitting
         ``$$...$$``.
     ln_notation : boolean, optional
-        If set to ``True``, ``\ln`` is used instead of default ``\log``.
+        If set to ``True``, ``\ln`` is used instead of default ``\log``
+        when the base is the exponential constant :math:`e`.
     long_frac_ratio : float or None, optional
         The allowed ratio of the width of the numerator to the width of the
         denominator before the printer breaks off long fractions. If ``None``
@@ -3114,9 +3120,9 @@ def latex(expr, **settings):
     Logarithms:
 
     >>> print(latex(log(10)))
-    \log{\left(10 \right)}
+    \log{\left(10\right)}
     >>> print(latex(log(10), ln_notation=True))
-    \ln{\left(10 \right)}
+    \ln{\left(10\right)}
 
     ``latex()`` also supports the builtin container types :class:`list`,
     :class:`tuple`, and :class:`dict`:
@@ -3182,21 +3188,21 @@ def multiline_latex(lhs, rhs, terms_per_line=1, environment="align*", use_dots=F
     \begin{align*}
     x = & e^{i \alpha} \\
     & + \sin{\left(\alpha y \right)} \\
-    & - \cos{\left(\log{\left(y \right)} \right)}
+    & - \cos{\left(\log{\left(y\right)} \right)}
     \end{align*}
 
     Using at most two terms per line:
     >>> print(multiline_latex(x, expr, 2))
     \begin{align*}
     x = & e^{i \alpha} + \sin{\left(\alpha y \right)} \\
-    & - \cos{\left(\log{\left(y \right)} \right)}
+    & - \cos{\left(\log{\left(y\right)} \right)}
     \end{align*}
 
     Using ``eqnarray`` and dots:
     >>> print(multiline_latex(x, expr, terms_per_line=2, environment="eqnarray", use_dots=True))
     \begin{eqnarray}
     x & = & e^{i \alpha} + \sin{\left(\alpha y \right)} \dots\nonumber\\
-    & & - \cos{\left(\log{\left(y \right)} \right)}
+    & & - \cos{\left(\log{\left(y\right)} \right)}
     \end{eqnarray}
 
     Using ``IEEEeqnarray``:
@@ -3204,7 +3210,7 @@ def multiline_latex(lhs, rhs, terms_per_line=1, environment="align*", use_dots=F
     \begin{IEEEeqnarray}{rCl}
     x & = & e^{i \alpha} \nonumber\\
     & & + \sin{\left(\alpha y \right)} \nonumber\\
-    & & - \cos{\left(\log{\left(y \right)} \right)}
+    & & - \cos{\left(\log{\left(y\right)} \right)}
     \end{IEEEeqnarray}
 
     Notes

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -256,7 +256,7 @@ def test_latex_basic():
 
 
     p = Symbol('p', positive=True)
-    assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left(p \right)}"
+    assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left(p\right)}"
 
 
 def test_latex_builtins():
@@ -938,7 +938,7 @@ def test_latex_subs():
 
 
 def test_latex_integrals():
-    assert latex(Integral(log(x), x)) == r"\int \log{\left(x \right)}\, dx"
+    assert latex(Integral(log(x), x)) == r"\int \log{\left(x\right)}\, dx"
     assert latex(Integral(x**2, (x, 0, 1))) == \
         r"\int\limits_{0}^{1} x^{2}\, dx"
     assert latex(Integral(x**2, (x, 10, 20))) == \
@@ -1388,15 +1388,21 @@ def test_latex_limits():
 
 
 def test_latex_log():
-    assert latex(log(x)) == r"\log{\left(x \right)}"
-    assert latex(log(x), ln_notation=True) == r"\ln{\left(x \right)}"
+    assert latex(log(x)) == r"\log{\left(x\right)}"
+    assert latex(log(x), ln_notation=True) == r"\ln{\left(x\right)}"
     assert latex(log(x) + log(y)) == \
-        r"\log{\left(x \right)} + \log{\left(y \right)}"
+        r"\log{\left(x\right)} + \log{\left(y\right)}"
     assert latex(log(x) + log(y), ln_notation=True) == \
-        r"\ln{\left(x \right)} + \ln{\left(y \right)}"
-    assert latex(pow(log(x), x)) == r"\log{\left(x \right)}^{x}"
+        r"\ln{\left(x\right)} + \ln{\left(y\right)}"
+    assert latex(pow(log(x), x)) == r"\log{\left(x\right)}^{x}"
     assert latex(pow(log(x), x), ln_notation=True) == \
-        r"\ln{\left(x \right)}^{x}"
+        r"\ln{\left(x\right)}^{x}"
+    assert latex(log(x, 10, evaluate=False), ln_notation=False) == \
+        latex(log(x, 10, evaluate=False), ln_notation=True) == \
+        r'\log_{10}{\left(x\right)}'
+    expr = log(x, 10, evaluate=False) + log(x)
+    assert latex(expr, ln_notation=True) == \
+        r'\ln{\left(x\right)} + \log_{10}{\left(x\right)}'
 
 
 def test_issue_3568():
@@ -1630,8 +1636,8 @@ def test_latex_mul_symbol():
 
 def test_latex_issue_4381():
     y = 4*4**log(2)
-    assert latex(y) == r'4 \cdot 4^{\log{\left(2 \right)}}'
-    assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left(2 \right)}}}'
+    assert latex(y) == r'4 \cdot 4^{\log{\left(2\right)}}'
+    assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left(2\right)}}}'
 
 
 def test_latex_issue_4576():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - LaTeX printers will print the base for unevaluated base-n logarithm. For example, `log(3, 10, evaluate=False)`.
<!-- END RELEASE NOTES -->