### PR TITLE
physics.quantum: Respect local printer settings in `_sympystr`.

### DIFF
--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -130,7 +130,8 @@ class AntiCommutator(Expr):
         )
 
     def _sympystr(self, printer, *args):
-        return "{%s,%s}" % (self.args[0], self.args[1])
+        return "{%s,%s}" % (
+            printer._print(self.args[0]), printer._print(self.args[1]))
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -219,7 +219,8 @@ class Commutator(Expr):
         )
 
     def _sympystr(self, printer, *args):
-        return "[%s,%s]" % (self.args[0], self.args[1])
+        return "[%s,%s]" % (
+            printer._print(self.args[0]), printer._print(self.args[1]))
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)

--- a/sympy/physics/quantum/innerproduct.py
+++ b/sympy/physics/quantum/innerproduct.py
@@ -98,8 +98,8 @@ class InnerProduct(Expr):
             printer._print(self.bra, *args), printer._print(self.ket, *args))
 
     def _sympystr(self, printer, *args):
-        sbra = str(self.bra)
-        sket = str(self.ket)
+        sbra = printer._print(self.bra)
+        sket = printer._print(self.ket)
         return '%s|%s' % (sbra[:-1], sket[1:])
 
     def _pretty(self, printer, *args):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -458,7 +458,7 @@ class OuterProduct(Operator):
         return OuterProduct(Dagger(self.bra), Dagger(self.ket))
 
     def _sympystr(self, printer, *args):
-        return str(self.ket) + str(self.bra)
+        return printer._print(self.ket) + printer._print(self.bra)
 
     def _sympyrepr(self, printer, *args):
         return '%s(%s,%s)' % (self.__class__.__name__,

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -149,13 +149,12 @@ class TensorProduct(Expr):
         return TensorProduct(*terms).expand(tensorproduct=True)
 
     def _sympystr(self, printer, *args):
-        from sympy.printing.str import sstr
         length = len(self.args)
         s = ''
         for i in range(length):
             if isinstance(self.args[i], (Add, Pow, Mul)):
                 s = s + '('
-            s = s + sstr(self.args[i])
+            s = s + printer._print(self.args[i])
             if isinstance(self.args[i], (Add, Pow, Mul)):
                 s = s + ')'
             if i != length - 1:


### PR DESCRIPTION
Calling `sstr`, `str`, or `"%s" %` inside `_sympystr` discards local printer settings and uses the global ones.
It also means subclasses of `sympy.printing.str.StrPrinter` are ignored.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
  * When printing, `Commutator`, `Anticommutator`, `InnerProduct`, `TensorProduct`, and `OuterProduct` now respect keyword-arguments to `sstr`.
<!-- END RELEASE NOTES -->