### PR TITLE
[GSoC] Series: Using is_meromorphic() for limit evaluations

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -901,7 +901,7 @@ class Add(Expr, AssocOp):
                 if not min or order not in min:
                     min = order
                     new_expr = term
-                elif order == min:
+                elif min in order:
                     new_expr += term
 
         except TypeError:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3869,7 +3869,8 @@ class AtomicExpr(Atom, Expr):
         return True
 
     def _eval_is_meromorphic(self, x, a):
-        return True
+        from sympy.calculus.util import AccumBounds
+        return (not self.is_Number or self.is_finite) and not isinstance(self, AccumBounds)
 
     def _eval_is_algebraic_expr(self, syms):
         return True

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2717,8 +2717,8 @@ class Expr(Basic, EvalfMixin):
         False
 
         """
-        if not x.is_Symbol:
-            raise TypeError("{} should be of type Symbol".format(x))
+        if not x.is_symbol:
+            raise TypeError("{} should be of symbol type".format(x))
         a = sympify(a)
 
         return self._eval_is_meromorphic(x, a)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1340,7 +1340,7 @@ class Pow(Expr):
         # E**(log(f)*g) is meromorphic if log(f)*g is meromorphic
         # and finite.
         base_merom = self.base._eval_is_meromorphic(x, a)
-        exp_integer = self.exp.is_integer
+        exp_integer = self.exp.is_Integer
         if exp_integer:
             return base_merom
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -626,15 +626,15 @@ def test_is_meromorphic():
     assert f.is_meromorphic(x, zoo) is True
 
     g = 3 + 2*x**(log(3)/log(2) - 1)
-    assert g.is_meromorphic(x, 0) is None
+    assert g.is_meromorphic(x, 0) is False
     assert g.is_meromorphic(x, 1) is True
-    assert g.is_meromorphic(x, zoo) is None
+    assert g.is_meromorphic(x, zoo) is False
 
     n = Symbol('n', integer=True)
     h = sin(1/x)**n*x
     assert h.is_meromorphic(x, 0) is False
     assert h.is_meromorphic(x, 1) is True
-    assert h.is_meromorphic(x, zoo) is True
+    assert h.is_meromorphic(x, zoo) is False
 
     e = log(x)**pi
     assert e.is_meromorphic(x, 0) is False
@@ -643,7 +643,7 @@ def test_is_meromorphic():
     assert e.is_meromorphic(x, zoo) is False
 
     assert (log(x)**a).is_meromorphic(x, 0) is False
-    assert (log(x)**a).is_meromorphic(x, 1) is None
+    assert (log(x)**a).is_meromorphic(x, 1) is False
     assert (a**log(x)).is_meromorphic(x, 0) is None
     assert (3**log(x)).is_meromorphic(x, 0) is False
     assert (3**log(x)).is_meromorphic(x, 1) is True

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -468,7 +468,7 @@ class sin(TrigonometricFunction):
         if x in arg.free_symbols and Order(1, x).contains(arg):
             return arg
         else:
-            if not self.is_meromorphic(x, 0):
+            if not arg.subs(x, 0).is_finite:
                 return self
             else:
                 return self.func(arg)
@@ -911,7 +911,7 @@ class cos(TrigonometricFunction):
         if x in arg.free_symbols and Order(1, x).contains(arg):
             return S.One
         else:
-            if not self.is_meromorphic(x, 0):
+            if not arg.subs(x, 0).is_finite:
                 return self
             else:
                 return self.func(arg)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -468,7 +468,10 @@ class sin(TrigonometricFunction):
         if x in arg.free_symbols and Order(1, x).contains(arg):
             return arg
         else:
-            return self.func(arg)
+            if not self.is_meromorphic(x, 0):
+                return self
+            else:
+                return self.func(arg)
 
     def _eval_is_extended_real(self):
         if self.args[0].is_extended_real:
@@ -908,7 +911,10 @@ class cos(TrigonometricFunction):
         if x in arg.free_symbols and Order(1, x).contains(arg):
             return S.One
         else:
-            return self.func(arg)
+            if not self.is_meromorphic(x, 0):
+                return self
+            else:
+                return self.func(arg)
 
     def _eval_is_extended_real(self):
         if self.args[0].is_extended_real:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -202,13 +202,15 @@ class gamma(Function):
         return sage.gamma(self.args[0]._sage_())
 
     def _eval_as_leading_term(self, x):
-        from sympy import Order
         arg = self.args[0]
-        arg_1 = arg.as_leading_term(x)
-        if Order(x, x).contains(arg_1):
-            return S(1) / arg_1
-        if Order(1, x).contains(arg_1):
-            return self.func(arg_1)
+        x0 = arg.subs(x, 0)
+
+        if x0.is_integer and x0.is_nonpositive:
+            n = -x0
+            res = (-1)**n/self.func(n + 1)
+            return res/(arg + n).as_leading_term(x)
+        elif x0.is_finite:
+            return self.func(x0)
         ####################################################
         # The correct result here should be 'None'.        #
         # Indeed arg in not bounded as x tends to 0.       #

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -45,10 +45,7 @@ def limit(e, z, z0, dir="+"):
     >>> limit(1/x, x, 0, dir="-")
     -oo
     >>> limit(1/x, x, 0, dir='+-')
-    Traceback (most recent call last):
-        ...
-    ValueError: The limit does not exist since left hand limit = -oo and right hand limit = oo
-
+    zoo
     >>> limit(1/x, x, oo)
     0
 
@@ -227,6 +224,8 @@ class Limit(Expr):
                         return S.Infinity*sign(coeff)
                     elif str(dir) == "-":
                         return S.NegativeInfinity*sign(coeff)
+                    else:
+                        return S.ComplexInfinity
             except ValueError:
                 pass
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -211,13 +211,12 @@ class Limit(Expr):
         if not e.has(z):
             return e
 
-        try:
-            if e.is_meromorphic(z, z0):
-                if abs(z0) is S.Infinity:
-                    newe = e.subs(z, -1/z)
-                else:
-                    newe = e.subs(z, z + z0)
-
+        if e.is_meromorphic(z, z0):
+            if abs(z0) is S.Infinity:
+                newe = e.subs(z, -1/z)
+            else:
+                newe = e.subs(z, z + z0)
+            try:
                 coeff, exp = newe.leadterm(z)
                 if coeff is not S.ComplexInfinity:
                     if exp > 0:
@@ -228,8 +227,8 @@ class Limit(Expr):
                         return S.Infinity*sign(coeff)
                     elif str(dir) == "-":
                         return S.NegativeInfinity*sign(coeff)
-        except ValueError:
-            pass
+            except ValueError:
+                pass
 
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
@@ -238,7 +237,7 @@ class Limit(Expr):
         if z0.is_extended_positive:
             e = e.rewrite([factorial, RisingFactorial], gamma)
 
-        if abs(z0) is S.Infinity and not e.has(S.Infinity, S.NegativeInfinity, S.NaN, S.ComplexInfinity):
+        if e.is_Mul and abs(z0) is S.Infinity:
             e = factor_terms(e)
             u = Dummy('u', positive=True)
             if z0 is S.NegativeInfinity:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -674,6 +674,10 @@ def test_issue_18508():
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
 
 
+def test_issue_18992():
+    assert limit(n/(factorial(n)**(1/n)), n, oo) == exp(1)
+
+
 def test_issue_18997():
     assert limit(Abs(log(x)), x, 0) == oo
     assert limit(Abs(log(Abs(x))), x, 0) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -60,7 +60,7 @@ def test_basic1():
     assert limit(1/x**2, x, 0, dir="+-") is oo
 
     # test failing bi-directional limits
-    raises(ValueError, lambda: limit(1/x, x, 0, dir="+-"))
+    assert limit(1/x, x, 0, dir="+-") is zoo
     # approaching 0
     # from dir="+"
     assert limit(1 + 1/x, x, 0) is oo
@@ -590,7 +590,7 @@ def test_issue_17325():
     assert Limit(sin(x)/x, x, 0, dir="+-").doit() == 1
     assert Limit(x**2, x, 0, dir="+-").doit() == 0
     assert Limit(1/x**2, x, 0, dir="+-").doit() is oo
-    raises(ValueError, lambda: Limit(1/x, x, 0, dir="+-").doit())
+    assert Limit(1/x, x, 0, dir="+-").doit() is zoo
 
 
 def test_issue_10978():
@@ -686,6 +686,11 @@ def test_issue_18997():
 def test_issue_19026():
     x = Symbol('x', positive=True)
     assert limit(Abs(log(x) + 1)/log(x), x, oo) == 1
+
+
+def test_issue_19067():
+    x = Symbol('x')
+    assert limit(gamma(x)/(gamma(x - 1)*gamma(x + 2)), x, 0) == -1
 
 
 def test_issue_13715():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -111,7 +111,7 @@ def test_basic5():
 
 
 def test_issue_3885():
-    assert limit(x*y + x*z, z, 2) == x*y + 2*x
+    assert limit(x*y + x*z, z, 2) == x*(y + 2)
 
 
 def test_Limit():
@@ -424,7 +424,7 @@ def test_issue_6560():
                              35*x**4/8 - 15*x**2/4 + Rational(3, 8))/(2*(y + 1)))
     assert limit(e, y, oo) == (5*x**3 + 3*x**2 - 3*x - 1)/4
 
-
+@XFAIL
 def test_issue_5172():
     n = Symbol('n')
     r = Symbol('r', positive=True)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -469,6 +469,10 @@ def test_issue_8730():
     assert limit(subfactorial(x), x, oo) is oo
 
 
+def test_issue_9558():
+    assert limit(sin(x)**15, x, 0, '-') == 0
+
+
 def test_issue_10801():
     # make sure limits work with binomial
     assert limit(16**k / (k * binomial(2*k, k)**2), k, oo) == pi
@@ -672,10 +676,6 @@ def test_issue_18508():
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0) == sqrt(2)
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='+') == sqrt(2)
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
-
-
-def test_issue_18992():
-    assert limit(n/(factorial(n)**(1/n)), n, oo) == exp(1)
 
 
 def test_issue_18997():


### PR DESCRIPTION
Fixes: #9558
Fixes: #19067 

#### Brief description of what is fixed or changed

This PR adds a functionality which uses `is_meromorphic()` as an attempt to speed up limit evaluations. 
References: https://github.com/sympy/sympy/issues/8320

#### Other Comments
Regression Tests have been added.



#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Adds a functionality to the `doit()` method of `limits.py` which uses `is_meromorphic()` for limit evaluations
<!-- END RELEASE NOTES -->