### PR TITLE
fix(core): deprecate non-Expr args in Add/Mul/Pow

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -73,6 +73,8 @@ class Add(Expr, AssocOp):
 
     is_Add = True
 
+    _args_type = Expr
+
     @classmethod
     def flatten(cls, seq):
         """

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1282,7 +1282,7 @@ def _mask_nc(eq, name=None):
     ========
 
     >>> from sympy.physics.secondquant import Commutator, NO, F, Fd
-    >>> from sympy import symbols, Mul
+    >>> from sympy import symbols
     >>> from sympy.core.exprtools import _mask_nc
     >>> from sympy.abc import x, y
     >>> A, B, C = symbols('A,B,C', commutative=False)
@@ -1315,22 +1315,6 @@ def _mask_nc(eq, name=None):
     >>> eq = A*Commutator(A, B) + B*Commutator(A, C)
     >>> _mask_nc(eq, 'd')
     (A*_d0 + B*_d1, {_d0: Commutator(A, B), _d1: Commutator(A, C)}, [_d0, _d1, A, B])
-
-    If there is an object that:
-
-        - doesn't contain nc-symbols
-        - but has arguments which derive from Basic, not Expr
-        - and doesn't define an _eval_is_commutative routine
-
-    then it will give False (or None?) for the is_commutative test. Such
-    objects are also removed by this routine:
-
-    >>> from sympy import Basic
-    >>> eq = (1 + Mul(Basic(), Basic(), evaluate=False))
-    >>> eq.is_commutative
-    False
-    >>> _mask_nc(eq, 'd')
-    (_d0**2 + 1, {_d0: Basic()}, [])
 
     """
     name = name or 'mask'

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -92,6 +92,8 @@ class Mul(Expr, AssocOp):
 
     is_Mul = True
 
+    _args_type = Expr
+
     def __neg__(self):
         c, args = self.as_coeff_mul()
         c = -c

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,6 +11,7 @@ from .logic import fuzzy_bool, fuzzy_not, fuzzy_and
 from .compatibility import as_int, HAS_GMPY, gmpy
 from .parameters import global_parameters
 from sympy.utilities.iterables import sift
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from mpmath.libmp import sqrtrem as mpmath_sqrtrem
 
@@ -273,10 +274,20 @@ class Pow(Expr):
         b = _sympify(b)
         e = _sympify(e)
 
-        # XXX: Maybe only Expr should be allowed...
+        # XXX: This can be removed when non-Expr args are disallowed rather
+        # than deprecated.
         from sympy.core.relational import Relational
         if isinstance(b, Relational) or isinstance(e, Relational):
             raise TypeError('Relational can not be used in Pow')
+
+        # XXX: This should raise TypeError once deprecation period is over:
+        if not (isinstance(b, Expr) and isinstance(e, Expr)):
+            SymPyDeprecationWarning(
+                feature="Pow with non-Expr args",
+                useinstead="Expr args",
+                issue=19445,
+                deprecated_since_version="1.7"
+            ).warn()
 
         if evaluate:
             if e is S.ComplexInfinity:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,11 +1,12 @@
 from sympy import (Basic, Symbol, sin, cos, atan, exp, sqrt, Rational,
         Float, re, pi, sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols,
-        oo, zoo, Integer, sign, im, nan, Dummy, factorial, comp, floor
+        oo, zoo, Integer, sign, im, nan, Dummy, factorial, comp, floor, Poly,
+        FiniteSet
 )
 from sympy.core.parameters import distribute
 from sympy.core.expr import unchanged
 from sympy.utilities.iterables import cartes
-from sympy.testing.pytest import XFAIL, raises
+from sympy.testing.pytest import XFAIL, raises, warns_deprecated_sympy
 from sympy.testing.randtest import verify_numerically
 
 
@@ -1577,6 +1578,7 @@ def test_suppressed_evaluation():
     assert c.func is Pow
     assert c.args == (3, 2)
 
+
 def test_AssocOp_doit():
     a = Add(x,x, evaluate=False)
     b = Mul(y,y, evaluate=False)
@@ -1590,6 +1592,15 @@ def test_AssocOp_doit():
     assert d.doit(deep=False).args == (a, 2*S.One)
     assert d.doit().func == Mul
     assert d.doit().args == (4*S.One, Pow(x,2))
+
+
+def test_Add_Mul_Expr_args():
+    nonexpr = [Basic(), Poly(x, x), FiniteSet(x)]
+    for typ in [Add, Mul]:
+        for obj in nonexpr:
+            with warns_deprecated_sympy():
+                typ(obj, 1)
+
 
 def test_Add_as_coeff_mul():
     # issue 5524.  These should all be (1, self)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -1,6 +1,6 @@
 from sympy.core import (
-    Rational, Symbol, S, Float, Integer, Mul, Number, Pow,
-    Basic, I, nan, pi, symbols, oo, zoo, N)
+    Basic, Rational, Symbol, S, Float, Integer, Mul, Number, Pow,
+    Expr, I, nan, pi, symbols, oo, zoo, N)
 from sympy.core.tests.test_evalf import NS
 from sympy.core.function import expand_multinomial
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt
@@ -8,8 +8,12 @@ from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.special.error_functions import erf
 from sympy.functions.elementary.trigonometric import (
     sin, cos, tan, sec, csc, sinh, cosh, tanh, atan)
+from sympy.polys import Poly
 from sympy.series.order import O
+from sympy.sets import FiniteSet
 from sympy.core.expr import unchanged
+
+from sympy.testing.pytest import warns_deprecated_sympy
 
 
 def test_rational():
@@ -190,6 +194,14 @@ def test_issue_4362():
     assert ((1 + x/y)**i).as_numer_denom() == ((x + y)**i, y**i)
 
 
+def test_Pow_Expr_args():
+    x = Symbol('x')
+    bases = [Basic(), Poly(x, x), FiniteSet(x)]
+    for base in bases:
+        with warns_deprecated_sympy():
+            Pow(base, S.One)
+
+
 def test_Pow_signs():
     """Cf. issues 4595 and 5250"""
     x = Symbol('x')
@@ -277,7 +289,7 @@ def test_issue_6100_12942_4473():
     # Pow != Symbol
     assert (x**1.0)**1.0 != x
     assert (x**1.0)**2.0 != x**2
-    b = Basic()
+    b = Expr()
     assert Pow(b, 1.0, evaluate=False) != b
     # if the following gets distributed as a Mul (x**1.0*y**1.0 then
     # __eq__ methods could be added to Symbol and Pow to detect the

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1933,8 +1933,7 @@ class PrettyPrinter(Printer):
 
     def _print_ProductSet(self, p):
         if len(p.sets) >= 1 and not has_variety(p.sets):
-            from sympy import Pow
-            return self._print(Pow(p.sets[0], len(p.sets), evaluate=False))
+            return self._print(p.sets[0]) ** self._print(len(p.sets))
         else:
             prod_char = u"\N{MULTIPLICATION SIGN}" if self._use_unicode else 'x'
             return self._print_seq(p.sets, None, None, ' %s ' % prod_char,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -162,8 +162,9 @@ def denoms(eq, *symbols):
     pot = preorder_traversal(eq)
     dens = set()
     for p in pot:
-        # lhs and rhs will be traversed after anyway
-        if isinstance(p, Relational):
+        # Here p might be Tuple or Relational
+        # Expr subtrees (e.g. lhs and rhs) will be traversed after by pot
+        if not isinstance(p, Expr):
             continue
         den = denom(p)
         if den is S.One:


### PR DESCRIPTION
Deprecates creating an Add, Mul or Pow with non-expr args e.g.:

    Add(Tuple(1, 2), FiniteSet(2), S.true, 0)

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related issues and PRs #19429, #5031, #18053, #18613

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * **DEPRECATION**: Using non-Expr args in Add, Mul or Pow is now deprecated
<!-- END RELEASE NOTES -->