### PR TITLE
[GSoC] Fixes Sum.doit() with Randomindexed symbol

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -312,8 +312,10 @@ class RandomIndexedSymbol(RandomSymbol):
 
     @property
     def free_symbols(self):
-        if isinstance(self.key, Symbol):
-            return {self, self.key}
+        if self.key.free_symbols:
+            free_syms = self.key.free_symbols
+            free_syms.add(self)
+            return free_syms
         return {self}
 
 class RandomMatrixSymbol(MatrixSymbol):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -310,6 +310,12 @@ class RandomIndexedSymbol(RandomSymbol):
         elif isinstance(self.symbol, Function):
             return self.symbol.args[0]
 
+    @property
+    def free_symbols(self):
+        if isinstance(self.key, Symbol):
+            return {self, self.key}
+        return {self}
+
 class RandomMatrixSymbol(MatrixSymbol):
     def __new__(cls, symbol, n, m, pspace=None):
         n, m = _sympify(n), _sympify(m)

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -151,7 +151,7 @@ def test_BernoulliProcess():
     H, T = symbols("H,T")
     assert E(X[1]+X[2]*X[3]) == H**2/9 + 4*H*T/9 + H/3 + 4*T**2/9 + 2*T/3
 
-    t = symbols('t', positive=True, integer=True)
+    t, x = symbols('t, x', positive=True, integer=True)
     assert isinstance(B[t], RandomIndexedSymbol)
 
     raises(ValueError, lambda: BernoulliProcess("X", p=1.1, success=1, failure=0))
@@ -202,3 +202,6 @@ def test_BernoulliProcess():
     assert expr.doit() == B[0] + B[1] + B[2] + B[3] + B[4]
     assert expr2.doit() == Y
     assert expr3.doit() == B[1]**2 + B[2]**2 + B[3]**2
+    assert B[2*t].free_symbols == {B[2*t], t}
+    assert B[4].free_symbols == {B[4]}
+    assert B[x*t].free_symbols == {B[x*t], x, t}

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -1,5 +1,5 @@
 from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And,
-                   ImmutableMatrix, Ne, Lt, Gt, exp, Not, Rational, Lambda,
+                   ImmutableMatrix, Ne, Lt, Gt, exp, Not, Rational, Lambda, Sum,
                    Piecewise)
 from sympy.stats import (DiscreteMarkovChain, P, TransitionMatrixOf, E,
                          StochasticStateSpaceOf, variance, ContinuousMarkovChain,
@@ -194,3 +194,11 @@ def test_BernoulliProcess():
     assert P(B[5] > 0, B[5]) == BernoulliDistribution(0.6, 0, 1)
     raises(ValueError, lambda: P(3))
     raises(ValueError, lambda: P(B[3] > 0, 3))
+
+    # test issue 19456
+    expr = Sum(B[t], (t, 0, 4))
+    expr2 = Sum(B[t], (t, 1, 3))
+    expr3 = Sum(B[t]**2, (t, 1, 3))
+    assert expr.doit() == B[0] + B[1] + B[2] + B[3] + B[4]
+    assert expr2.doit() == Y
+    assert expr3.doit() == B[1]**2 + B[2]**2 + B[3]**2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19456 

#### Brief description of what is fixed or changed
Before fixing:

```python
>>> from sympy.stats import *
>>> from sympy import symbols, S, Eq, Sum
>>> B = BernoulliProcess('B', S(1)/2, 1, -1)
>>> t = symbols('t', positive=True, integer=True)
>>> expr = Sum(B[t], (t, 0, 5))
>>> expr.doit()  # this should not consider B[t] equal in all the cases as it is random variable
6*B[t]       # wrong result
```

After fixing:
```python
>>> from sympy.stats import *
>>> from sympy import symbols, S, Eq, Sum
>>> B = BernoulliProcess('B', S(1)/2, 1, -1)
>>> t = symbols('t', positive=True, integer=True)
>>> expr = Sum(B[t], (t, 0, 5))
>>> expr.doit()
B[0] + B[1] + B[2] + B[3] + B[4] + B[5]
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
   * FIxes free_symbols method of RandomIndexedSymbol
<!-- END RELEASE NOTES -->
ping @czgdp1807 @Upabjojr @jmig5776 