### PR TITLE
[GSoC] Functions: Corrects the _eval_as_leading_term() method of tan and sec functions

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1230,13 +1230,13 @@ class tan(TrigonometricFunction):
         return y
 
     def _eval_as_leading_term(self, x):
-        from sympy import Order
-        arg = self.args[0].as_leading_term(x)
-
-        if x in arg.free_symbols and Order(1, x).contains(arg):
-            return arg
-        else:
-            return self.func(arg)
+        arg = self.args[0]
+        x0 = arg.subs(x, 0)
+        n = x0/S.Pi
+        if n.is_integer:
+            lt = (arg - n*S.Pi).as_leading_term(x)
+            return lt if n.is_even else -1/lt
+        return self.func(arg)
 
     def _eval_is_extended_real(self):
         # FIXME: currently tan(pi/2) return zoo
@@ -1782,6 +1782,14 @@ class sec(ReciprocalTrigonometricFunction):
             k = n//2
             return (-1)**k*euler(2*k)/factorial(2*k)*x**(2*k)
 
+    def _eval_as_leading_term(self, x):
+        arg = self.args[0]
+        x0 = arg.subs(x, 0).cancel()
+        n = (x0 + S.Pi/2)/S.Pi
+        if n.is_integer:
+            lt = (arg - n*S.Pi + S.Pi/2).as_leading_term(x)
+            return ((-1)**n)/lt
+        return self.func(x0)
 
 class csc(ReciprocalTrigonometricFunction):
     """

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -215,19 +215,19 @@ class Limit(Expr):
                 newe = e.subs(z, z + z0)
             try:
                 coeff, exp = newe.leadterm(z)
-                if coeff is not S.ComplexInfinity:
-                    if exp > 0:
-                        return S.Zero
-                    elif exp == 0:
-                        return coeff
-                    if str(dir) == "+" or not(int(exp) & 1):
-                        return S.Infinity*sign(coeff)
-                    elif str(dir) == "-":
-                        return S.NegativeInfinity*sign(coeff)
-                    else:
-                        return S.ComplexInfinity
             except ValueError:
                 pass
+            else:
+                if exp > 0:
+                    return S.Zero
+                elif exp == 0:
+                    return coeff
+                if str(dir) == "+" or not(int(exp) & 1):
+                    return S.Infinity*sign(coeff)
+                elif str(dir) == "-":
+                    return S.NegativeInfinity*sign(coeff)
+                else:
+                    return S.ComplexInfinity
 
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -696,7 +696,7 @@ def test_issue_19067():
 def test_issue_13715():
     n = Symbol('n')
     p = Symbol('p', zero=True)
-    assert limit(n + p, n, 0) == 0
+    assert limit(n + p, n, 0) == p
 
 
 def test_issue_15055():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
This PR corrects the `_eval_as_leading_term()` method of `tan` and `sec` functions.

It also removes the check: `if coeff is S.ComplexInfinity` added in this PR: https://github.com/sympy/sympy/pull/19432, by handling the cases which returned `zoo` and correcting them.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* functions
  * Corrects the `_eval_as_leading_term()` method of `tan` and `sec` functions
<!-- END RELEASE NOTES -->