### PR TITLE
Introduce general add, mul, and pow function

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -5,7 +5,7 @@ from .compatibility import reduce, is_sequence
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
-from .operations import AssocOp
+from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
@@ -65,7 +65,6 @@ def _unevaluated_Add(*args):
     if co:
         newargs.insert(0, co)
     return Add._from_args(newargs)
-
 
 class Add(Expr, AssocOp):
 
@@ -1127,6 +1126,7 @@ class Add(Expr, AssocOp):
             return super().__neg__()
         return Add(*[-i for i in self.args])
 
+add = AssocOpDispatcher('add')
 
 from .mul import Mul, _keep_coeff, prod
 from sympy.core.numbers import Rational

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1126,8 +1126,6 @@ class Add(Expr, AssocOp):
             return super().__neg__()
         return Add(*[-i for i in self.args])
 
-Expr._add_handler = Add
-
 add = AssocOpDispatcher('add')
 
 from .mul import Mul, _keep_coeff, prod

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1126,6 +1126,8 @@ class Add(Expr, AssocOp):
             return super().__neg__()
         return Add(*[-i for i in self.args])
 
+Expr._add_handler = Add
+
 add = AssocOpDispatcher('add')
 
 from .mul import Mul, _keep_coeff, prod

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -163,6 +163,18 @@ class Expr(Basic, EvalfMixin):
     # something better and more powerful.  See issue 5510.
     _op_priority = 10.0
 
+    # Handler methods for dispatching
+    # See operations.AssocOpDispatcher
+    @staticmethod
+    def _add_handler(*args, **kwargs):
+        from .add import Add
+        return Add(*args, **kwargs)
+
+    @staticmethod
+    def _mul_handler(*args, **kwargs):
+        from .mul import Mul
+        return Mul(*args, **kwargs)
+
     def __pos__(self):
         return self
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -163,6 +163,14 @@ class Expr(Basic, EvalfMixin):
     # something better and more powerful.  See issue 5510.
     _op_priority = 10.0
 
+    @property
+    def _add_handler(self):
+        return Add
+
+    @property
+    def _mul_handler(self):
+        return Mul
+
     def __pos__(self):
         return self
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -163,18 +163,6 @@ class Expr(Basic, EvalfMixin):
     # something better and more powerful.  See issue 5510.
     _op_priority = 10.0
 
-    # Handler methods for dispatching
-    # See operations.AssocOpDispatcher
-    @staticmethod
-    def _add_handler(*args, **kwargs):
-        from .add import Add
-        return Add(*args, **kwargs)
-
-    @staticmethod
-    def _mul_handler(*args, **kwargs):
-        from .mul import Mul
-        return Mul(*args, **kwargs)
-
     def __pos__(self):
         return self
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -5,7 +5,7 @@ import operator
 from .sympify import sympify
 from .basic import Basic
 from .singleton import S
-from .operations import AssocOp
+from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group, fuzzy_and
 from .compatibility import reduce
@@ -1901,6 +1901,7 @@ class Mul(Expr, AssocOp):
     def _sorted_args(self):
         return tuple(self.as_ordered_factors())
 
+mul = AssocOpDispatcher('mul')
 
 def prod(a, start=1):
     """Return product of elements of a. Start with int 1 so if only

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1901,8 +1901,6 @@ class Mul(Expr, AssocOp):
     def _sorted_args(self):
         return tuple(self.as_ordered_factors())
 
-Expr._mul_handler = Mul
-
 mul = AssocOpDispatcher('mul')
 
 def prod(a, start=1):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1901,6 +1901,8 @@ class Mul(Expr, AssocOp):
     def _sorted_args(self):
         return tuple(self.as_ordered_factors())
 
+Expr._mul_handler = Mul
+
 mul = AssocOpDispatcher('mul')
 
 def prod(a, start=1):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -13,7 +13,7 @@ from sympy.core.parameters import global_parameters
 from sympy.utilities.iterables import sift
 from sympy.multipledispatch.dispatcher import (Dispatcher,
     ambiguity_register_error_ignore_dup,
-    str_signature, raise_NotImplementedError)
+    str_signature, RaiseNotImplementedError)
 
 
 class AssocOp(Basic):
@@ -669,7 +669,7 @@ class AssocOpDispatcher:
 
             sigs_str = ', '.join('<%s>' % str_signature(sig) for sig in sigs)
 
-            if typ is raise_NotImplementedError:
+            if isinstance(typ, RaiseNotImplementedError):
                 amb_sigs.append(sigs_str)
                 continue
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -11,7 +11,8 @@ from sympy.core.compatibility import ordered
 from sympy.core.logic import fuzzy_and
 from sympy.core.parameters import global_parameters
 from sympy.utilities.iterables import sift
-from sympy.multipledispatch.dispatcher import (Dispatcher, ambiguity_register_error,
+from sympy.multipledispatch.dispatcher import (Dispatcher,
+    ambiguity_register_error_ignore_dup,
     str_signature, raise_NotImplementedError)
 
 
@@ -571,7 +572,7 @@ class AssocOpDispatcher:
     def __repr__(self):
         return "<dispatched %s>" % self.name
 
-    def register_handlerclass(self, classes, typ, on_ambiguity=ambiguity_register_error):
+    def register_handlerclass(self, classes, typ, on_ambiguity=ambiguity_register_error_ignore_dup):
         """
         Register the handler class for two classes, in both straight and reversed order.
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -10,7 +10,7 @@ from sympy.core.cache import cacheit
 from sympy.core.compatibility import ordered
 from sympy.core.logic import fuzzy_and
 from sympy.core.parameters import global_parameters
-from sympy.utilities.iterables import sift, tied_max
+from sympy.utilities.iterables import sift
 from sympy.multipledispatch.dispatcher import (Dispatcher, ambiguity_register_error,
     str_signature)
 
@@ -537,9 +537,8 @@ class AssocOpDispatcher:
     Explanation
     ===========
 
-    If arguments of different kind are passed, their ``_op_priority`` are compared to
-    choose the type with the highest priority. If this is ambiguous, priority relations
-    which are registered by ``register_priority`` method are referred to.
+    If arguments of different kind are passed, priority relations which are registered by
+    ``register_priority`` method are referred to.
     Once a type is selected, handler method of the type, which is a static method, is used
     to perform the operation.
 
@@ -646,19 +645,8 @@ class AssocOpDispatcher:
             h, = handlers
             return h
 
-        # Sieve the types with low op_priority or no handler
-        # This makes it faster than using dispatcher on every types.
-        sieved_data = tied_max(
-            types, key=lambda typ: getattr(typ, '_op_priority', 0)
-        )
-
-        # Only one type remains
-        if len(sieved_data) == 1:
-            typ, = sieved_data
-            return self._handlergetter(typ)
-
         # Recursively select with registered binary priority
-        for i, typ in enumerate(sieved_data):
+        for i, typ in enumerate(types):
             if i == 0:
                 result_type = typ
             else:
@@ -680,7 +668,7 @@ class AssocOpDispatcher:
 
                 result_type = selected_type
 
-        # return handler method of selected argument
+        # return handler method of selected type
         return handler
 
     @property

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -1,6 +1,6 @@
-import itertools
 from operator import attrgetter
 from typing import Tuple
+from collections import defaultdict
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -665,7 +665,13 @@ class AssocOpDispatcher:
         docs.append(s)
 
         amb_sigs = []
-        for typ, sigs in itertools.groupby(self._dispatcher.ordering[::-1], lambda sig: self._dispatcher.funcs[sig]):
+
+        typ_sigs = defaultdict(list)
+        for sigs in self._dispatcher.ordering[::-1]:
+            key = self._dispatcher.funcs[sigs]
+            typ_sigs[key].append(sigs)
+
+        for typ, sigs in typ_sigs.items():
 
             sigs_str = ', '.join('<%s>' % str_signature(sig) for sig in sigs)
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -614,10 +614,16 @@ class AssocOpDispatcher:
         # Quick exit for the case where all handlers are same
         if len(handlers) == 1:
             h, = handlers
+            if not isinstance(h, type):
+                raise RuntimeError("Handler {!r} is not a type.".format(h))
             return h
 
         # Recursively select with registered binary priority
         for i, typ in enumerate(handlers):
+
+            if not isinstance(typ, type):
+                raise RuntimeError("Handler {!r} is not a type.".format(typ))
+
             if i == 0:
                 handler = typ
             else:

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -31,13 +31,8 @@ class AssocOp(Basic):
 
     *args : Arguments which are operated
 
-    sympify : bool, optional
-        Default is ``True``. ``False`` may be passed only when all arguments are
-            already sympified, for faster processing.
-
     evaluate : bool, optional
         Default is ``True``. If ``False``, do not evaluate the operation.
-
     """
 
     # for performance reason, we don't let is_commutative go to assumptions,
@@ -47,12 +42,12 @@ class AssocOp(Basic):
     _args_type = None
 
     @cacheit
-    def __new__(cls, *args, sympify=True, **options):
+    def __new__(cls, *args, **options):
         from sympy import Order
 
-        # Allow faster processing by passing ``sympify=False``, if all arguments
+        # Allow faster processing by passing ``_sympify=False``, if all arguments
         # are already sympified.
-        if sympify:
+        if options.get('_sympify', True):
             args = list(map(_sympify, args))
 
         # Disallow non-Expr args in Add/Mul
@@ -613,24 +608,21 @@ class AssocOpDispatcher:
         return _
 
     @cacheit
-    def __call__(self, *args, sympify=True, **kwargs):
+    def __call__(self, *args, **kwargs):
         """
         Parameters
         ==========
 
         *args : Arguments which are operated
-
-        sympify : bool, optional
-            Default is ``True``. ``False`` may be passed only when all arguments are
-            already sympified, for faster processing.
         """
-        if sympify:
+        if kwargs.get('_sympify', True):
             args = tuple(map(_sympify, args))
         types = frozenset(map(type, args))
 
-        # If sympify=True was passed, no need to sympify again so pass sympify=False.
-        # If sympify=False was passed, all args are already sympified so pass sympify=False.
-        return self.dispatch(types)(*args, sympify=False, **kwargs)
+        # If _sympify=True was passed, no need to sympify again so pass _sympify=False.
+        # If _sympify=False was passed, all args are already sympified so pass _sympify=False.
+        kwargs.update(_sympify=False)
+        return self.dispatch(types)(*args, **kwargs)
 
     @cacheit
     def dispatch(self, types):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -677,7 +677,6 @@ class AssocOpDispatcher:
 
         docs.append("Registered handler classes are as follows:")
 
-        other = []
         for typ, sigs in itertools.groupby(self._dispatcher.ordering[::-1], lambda sig: self._dispatcher.funcs[sig]):
             s = 'Inputs: %s\n' % ', '.join('<%s>' % str_signature(sig) for sig in sigs)
             s += '-' * len(s) + '\n'

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -29,7 +29,8 @@ class AssocOp(Basic):
     Parameters
     ==========
 
-    *args : Arguments which are operated
+    *args :
+        Arguments which are operated
 
     sympify : bool, optional
         Default is ``True``. ``False`` may be passed only when all arguments are
@@ -619,7 +620,8 @@ class AssocOpDispatcher:
         Parameters
         ==========
 
-        *args : Arguments which are operated
+        *args :
+            Arguments which are operated
 
         sympify : bool, optional
             Default is ``True``. ``False`` may be passed only when all arguments are

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -12,6 +12,7 @@ from .compatibility import as_int, HAS_GMPY, gmpy
 from .parameters import global_parameters
 from sympy.utilities.iterables import sift
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.multipledispatch import Dispatcher
 
 from mpmath.libmp import sqrtrem as mpmath_sqrtrem
 
@@ -1732,6 +1733,8 @@ class Pow(Expr):
             new_e = e.subs(n, n + step)
             return (b**(new_e - e) - 1) * self
 
+power = Dispatcher('power')
+power.add((object, object), Pow)
 
 from .add import Add
 from .numbers import Integer

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -69,41 +69,37 @@ def test_AssocOp_flatten():
 
 def test_add_dispatcher():
 
-    class NewBase1(Expr):
-        @staticmethod
-        def _add_handler(*args, **kwargs):
-            return NewAdd1(*args, **kwargs)
-    class NewAdd1(NewBase1, Add):
+    class NewBase(Expr):
         pass
-    add.register_handlerclass((Expr, NewBase1), NewBase1)
-    add.register_handlerclass((NewBase1, NewBase1), NewBase1)
+    class NewAdd(NewBase, Add):
+        pass
+    NewBase._add_handler = NewAdd
+    add.register_handlerclass((Add, NewAdd), NewAdd)
 
-    a, b = Symbol('a'), NewBase1()
+    a, b = Symbol('a'), NewBase()
 
     # Add called as fallback
     assert add(1, 2) == Add(1, 2)
     assert add(a, a) == Add(a, a)
 
     # selection by registered priority
-    assert add(a,b,a) == NewAdd1(2*a, b)
+    assert add(a,b,a) == NewAdd(2*a, b)
 
 
 def test_mul_dispatcher():
 
-    class NewBase1(Expr):
-        @staticmethod
-        def _mul_handler(*args, **kwargs):
-            return NewMul1(*args, **kwargs)
-    class NewMul1(NewBase1, Mul):
+    class NewBase(Expr):
         pass
-    mul.register_handlerclass((Expr, NewBase1), NewBase1)
-    mul.register_handlerclass((NewBase1, NewBase1), NewBase1)
+    class NewMul(NewBase, Mul):
+        pass
+    NewBase._mul_handler = NewMul
+    mul.register_handlerclass((Mul, NewMul), NewMul)
 
-    a, b = Symbol('a'), NewBase1()
+    a, b = Symbol('a'), NewBase()
 
     # Mul called as fallback
     assert mul(1, 2) == Mul(1, 2)
     assert mul(a, a) == Mul(a, a)
 
     # selection by registered priority
-    assert mul(a,b,a) == NewMul1(a**2, b)
+    assert mul(a,b,a) == NewMul(a**2, b)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -75,13 +75,10 @@ def test_add_dispatcher():
             return NewAdd1(*args, **kwargs)
     class NewAdd1(NewBase1, Add):
         pass
+    add.register_handlerclass((Expr, NewBase1), NewBase1)
+    add.register_handlerclass((NewBase1, NewBase1), NewBase1)
 
     a, b = Symbol('a'), NewBase1()
-
-    @add.register_priority(Expr, NewBase1)
-    @add.register_priority(NewBase1, NewBase1)
-    def _(_1, _2):
-        return NewBase1
 
     # Add called as fallback
     assert add(1, 2) == Add(1, 2)
@@ -99,13 +96,10 @@ def test_mul_dispatcher():
             return NewMul1(*args, **kwargs)
     class NewMul1(NewBase1, Mul):
         pass
+    mul.register_handlerclass((Expr, NewBase1), NewBase1)
+    mul.register_handlerclass((NewBase1, NewBase1), NewBase1)
 
     a, b = Symbol('a'), NewBase1()
-
-    @mul.register_priority(Expr, NewBase1)
-    @mul.register_priority(NewBase1, NewBase1)
-    def _(_1, _2):
-        return NewBase1
 
     # Mul called as fallback
     assert mul(1, 2) == Mul(1, 2)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -66,6 +66,7 @@ def test_AssocOp_flatten():
     # like Add, any unevaluated outer call will flatten inner args
     assert MyAssoc(a, v).args == (a, b, c, d)
 
+
 def test_add_dispatcher():
 
     class NewBase1(Expr):
@@ -74,14 +75,8 @@ def test_add_dispatcher():
             return NewAdd1(*args, **kwargs)
     class NewAdd1(NewBase1, Add):
         pass
-    class NewBase2(Expr):
-        _op_priority = 11
-        @staticmethod
-        def _add_handler(*args, **kwargs):
-            return NewAdd2(*args, **kwargs)
-    class NewAdd2(NewBase2, Add):
-        pass
-    a, b, c = Symbol('a'), NewBase1(), NewBase2()
+
+    a, b = Symbol('a'), NewBase1()
 
     @add.register_priority(Expr, NewBase1)
     @add.register_priority(NewBase1, NewBase1)
@@ -95,9 +90,6 @@ def test_add_dispatcher():
     # selection by registered priority
     assert add(a,b,a) == NewAdd1(2*a, b)
 
-    # selection by _op_priority
-    assert add(a,c,a) == NewAdd2(2*a, c)
-    assert add(a,b,c) == NewAdd2(a,b,c)
 
 def test_mul_dispatcher():
 
@@ -107,14 +99,8 @@ def test_mul_dispatcher():
             return NewMul1(*args, **kwargs)
     class NewMul1(NewBase1, Mul):
         pass
-    class NewBase2(Expr):
-        _op_priority = 11
-        @staticmethod
-        def _mul_handler(*args, **kwargs):
-            return NewMul2(*args, **kwargs)
-    class NewMul2(NewBase2, Mul):
-        pass
-    a, b, c = Symbol('a'), NewBase1(), NewBase2()
+
+    a, b = Symbol('a'), NewBase1()
 
     @mul.register_priority(Expr, NewBase1)
     @mul.register_priority(NewBase1, NewBase1)
@@ -127,7 +113,3 @@ def test_mul_dispatcher():
 
     # selection by registered priority
     assert mul(a,b,a) == NewMul1(a**2, b)
-
-    # selection by _op_priority
-    assert mul(a,c,a) == NewMul2(a**2, c)
-    assert mul(a,b,c) == NewMul2(a,b,c)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -70,10 +70,11 @@ def test_AssocOp_flatten():
 def test_add_dispatcher():
 
     class NewBase(Expr):
-        pass
+        @property
+        def _add_handler(self):
+            return NewAdd
     class NewAdd(NewBase, Add):
         pass
-    NewBase._add_handler = NewAdd
     add.register_handlerclass((Add, NewAdd), NewAdd)
 
     a, b = Symbol('a'), NewBase()
@@ -89,10 +90,11 @@ def test_add_dispatcher():
 def test_mul_dispatcher():
 
     class NewBase(Expr):
-        pass
+        @property
+        def _mul_handler(self):
+            return NewMul
     class NewMul(NewBase, Mul):
         pass
-    NewBase._mul_handler = NewMul
     mul.register_handlerclass((Mul, NewMul), NewMul)
 
     a, b = Symbol('a'), NewBase()

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -12,7 +12,7 @@ from sympy.polys import Poly
 from sympy.series.order import O
 from sympy.sets import FiniteSet
 from sympy.core.expr import unchanged
-
+from sympy.core.power import power
 from sympy.testing.pytest import warns_deprecated_sympy
 
 
@@ -555,3 +555,27 @@ def test_issue_18762():
     e, p = symbols('e p')
     g0 = sqrt(1 + e**2 - 2*e*cos(p))
     assert len(g0.series(e, 1, 3).args) == 4
+
+def test_power_dispatcher():
+
+    class NewBase(Expr):
+        pass
+    class NewPow(NewBase, Pow):
+        pass
+    a, b = Symbol('a'), NewBase()
+
+    @power.register(Expr, NewBase)
+    @power.register(NewBase, Expr)
+    @power.register(NewBase, NewBase)
+    def _(a, b):
+        return NewPow(a, b)
+
+    # Pow called as fallback
+    assert power(2, 3) == 8*S.One
+    assert power(a, 2) == Pow(a, 2)
+    assert power(a, a) == Pow(a, a)
+
+    # NewPow called by dispatch
+    assert power(a, b) == NewPow(a, b)
+    assert power(b, a) == NewPow(b, a)
+    assert power(b, b) == NewPow(b, b)

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -86,8 +86,8 @@ class MatAdd(MatrixExpr, Add):
         add_lines = [arg._eval_derivative_matrix_lines(x) for arg in self.args]
         return [j for i in add_lines for j in i]
 
-MatrixExpr._add_handler = MatAdd
 add.register_handlerclass((Add, MatAdd), MatAdd)
+add.register_handlerclass((MatAdd, MatAdd), MatAdd)
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -1,7 +1,8 @@
 from sympy.core.compatibility import reduce
-from operator import add
+import operator
 
 from sympy.core import Add, Basic, sympify
+from sympy.core.add import add
 from sympy.functions import adjoint
 from sympy.matrices.common import ShapeError
 from sympy.matrices.matrices import MatrixBase
@@ -85,6 +86,8 @@ class MatAdd(MatrixExpr, Add):
         add_lines = [arg._eval_derivative_matrix_lines(x) for arg in self.args]
         return [j for i in add_lines for j in i]
 
+MatrixExpr._add_handler = MatAdd
+add.register_handlerclass((Add, MatAdd), MatAdd)
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):
@@ -127,7 +130,7 @@ def merge_explicit(matadd):
     """
     groups = sift(matadd.args, lambda arg: isinstance(arg, MatrixBase))
     if len(groups[True]) > 1:
-        return MatAdd(*(groups[False] + [reduce(add, groups[True])]))
+        return MatAdd(*(groups[False] + [reduce(operator.add, groups[True])]))
     else:
         return matadd
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -87,7 +87,6 @@ class MatAdd(MatrixExpr, Add):
         return [j for i in add_lines for j in i]
 
 add.register_handlerclass((Add, MatAdd), MatAdd)
-add.register_handlerclass((MatAdd, MatAdd), MatAdd)
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -78,6 +78,15 @@ class MatrixExpr(Expr):
         return Basic.__new__(cls, *args, **kwargs)
 
     # The following is adapted from the core Expr object
+
+    @property
+    def _add_handler(self):
+        return MatAdd
+
+    @property
+    def _mul_handler(self):
+        return MatMul
+
     def __neg__(self):
         return MatMul(S.NegativeOne, self).doit()
 
@@ -647,6 +656,7 @@ Basic._constructor_postprocessor_mapping[MatrixExpr] = {
     "Mul": [get_postprocessor(Mul)],
     "Add": [get_postprocessor(Add)],
 }
+
 
 def _matrix_derivative(expr, x):
     from sympy import Derivative

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -595,14 +595,6 @@ class MatrixExpr(Expr):
         from .applyfunc import ElementwiseApplyFunction
         return ElementwiseApplyFunction(func, self)
 
-    @staticmethod
-    def _add_handler(*args, **kwargs):
-        return MatAdd(*args, **kwargs)
-
-    @staticmethod
-    def _mul_handler(*args, **kwargs):
-        return MatMul(*args, **kwargs)
-
 @dispatch(MatrixExpr, Expr)
 def _eval_is_eq(lhs, rhs): # noqa:F811
     return False
@@ -657,11 +649,6 @@ Basic._constructor_postprocessor_mapping[MatrixExpr] = {
     "Mul": [get_postprocessor(Mul)],
     "Add": [get_postprocessor(Add)],
 }
-
-add.register_handlerclass((Expr, MatrixExpr), MatrixExpr)
-add.register_handlerclass((MatrixExpr, MatrixExpr), MatrixExpr)
-mul.register_handlerclass((Expr, MatrixExpr), MatrixExpr)
-mul.register_handlerclass((MatrixExpr, MatrixExpr), MatrixExpr)
 
 def _matrix_derivative(expr, x):
     from sympy import Derivative

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -658,13 +658,10 @@ Basic._constructor_postprocessor_mapping[MatrixExpr] = {
     "Add": [get_postprocessor(Add)],
 }
 
-@add.register_priority(Expr, MatrixExpr)
-@add.register_priority(MatrixExpr, MatrixExpr)
-@mul.register_priority(Expr, MatrixExpr)
-@mul.register_priority(MatrixExpr, MatrixExpr)
-def _(_1, _2):
-    "Use MatrixExpr's handler method."
-    return MatrixExpr
+add.register_handlerclass((Expr, MatrixExpr), MatrixExpr)
+add.register_handlerclass((MatrixExpr, MatrixExpr), MatrixExpr)
+mul.register_handlerclass((Expr, MatrixExpr), MatrixExpr)
+mul.register_handlerclass((MatrixExpr, MatrixExpr), MatrixExpr)
 
 def _matrix_derivative(expr, x):
     from sympy import Derivative

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -5,8 +5,6 @@ from functools import wraps, reduce
 import collections
 
 from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Mul, Add
-from sympy.core.add import add
-from sympy.core.mul import mul
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import SYMPY_INTS, default_sort_key
 from sympy.core.sympify import SympifyError, _sympify

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -208,8 +208,8 @@ class MatMul(MatrixExpr, Mul):
 
         return lines
 
-MatrixExpr._mul_handler = MatMul
 mul.register_handlerclass((Mul, MatMul), MatMul)
+mul.register_handlerclass((MatMul, MatMul), MatMul)
 
 def validate(*matrices):
     """ Checks for valid shapes for args of MatMul """

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -1,5 +1,6 @@
 from sympy import Number
 from sympy.core import Mul, Basic, sympify, S
+from sympy.core.mul import mul
 from sympy.functions import adjoint
 from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
         do_one, new)
@@ -207,6 +208,8 @@ class MatMul(MatrixExpr, Mul):
 
         return lines
 
+MatrixExpr._mul_handler = MatMul
+mul.register_handlerclass((Mul, MatMul), MatMul)
 
 def validate(*matrices):
     """ Checks for valid shapes for args of MatMul """

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -209,7 +209,6 @@ class MatMul(MatrixExpr, Mul):
         return lines
 
 mul.register_handlerclass((Mul, MatMul), MatMul)
-mul.register_handlerclass((MatMul, MatMul), MatMul)
 
 def validate(*matrices):
     """ Checks for valid shapes for args of MatMul """

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -2,24 +2,27 @@ from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
 from sympy.matrices.expressions.special import GenericZeroMatrix, ZeroMatrix
 from sympy.matrices import eye, ImmutableMatrix
 from sympy.core import Add, Basic, S
+from sympy.core.add import add
 from sympy.testing.pytest import XFAIL, raises
 
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 2)
 
 def test_evaluate():
-    assert MatAdd(X, X, evaluate=True) == MatAdd(X, X).doit()
+    assert MatAdd(X, X, evaluate=True) == add(X, X, evaluate=True) == MatAdd(X, X).doit()
 
 def test_sort_key():
-    assert MatAdd(Y, X).doit().args == (X, Y)
+    assert MatAdd(Y, X).doit().args == add(Y, X).doit().args == (X, Y)
 
 
 def test_matadd_sympify():
     assert isinstance(MatAdd(eye(1), eye(1)).args[0], Basic)
+    assert isinstance(add(eye(1), eye(1)).args[0], Basic)
 
 
 def test_matadd_of_matrices():
     assert MatAdd(eye(2), 4*eye(2), eye(2)).doit() == ImmutableMatrix(6*eye(2))
+    assert add(eye(2), 4*eye(2), eye(2)).doit() == ImmutableMatrix(6*eye(2))
 
 
 def test_doit_args():
@@ -28,7 +31,8 @@ def test_doit_args():
     assert MatAdd(A, MatPow(B, 2)).doit() == A + B**2
     assert MatAdd(A, MatMul(A, B)).doit() == A + A*B
     assert (MatAdd(A, X, MatMul(A, B), Y, MatAdd(2*A, B)).doit() ==
-            MatAdd(3*A + A*B + B, X, Y))
+    add(A, X, MatMul(A, B), Y, add(2*A, B)).doit() ==
+    MatAdd(3*A + A*B + B, X, Y))
 
 
 def test_generic_identity():
@@ -40,5 +44,5 @@ def test_zero_matrix_add():
     assert Add(ZeroMatrix(2, 2), ZeroMatrix(2, 2)) == ZeroMatrix(2, 2)
 
 @XFAIL
-def test_matrix_add_with_scalar():
+def test_matrix_Add_with_scalar():
     raises(TypeError, lambda: Add(0, ZeroMatrix(2, 2)))

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -1,4 +1,5 @@
 from sympy.core import I, symbols, Basic, Mul, S
+from sympy.core.mul import mul
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
@@ -152,6 +153,11 @@ def test_issue_12950():
 def test_construction_with_Mul():
     assert Mul(C, D) == MatMul(C, D)
     assert Mul(D, C) == MatMul(D, C)
+
+def test_construction_with_mul():
+    assert mul(C, D) == MatMul(C, D)
+    assert mul(D, C) == MatMul(D, C)
+    assert mul(C, D) != MatMul(D, C)
 
 def test_generic_identity():
     assert MatMul.identity == GenericIdentity()

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -11,6 +11,8 @@ class MDNotImplementedError(NotImplementedError):
     """ A NotImplementedError for multiple dispatch """
 
 
+### Functions for on_ambiguity
+
 def ambiguity_warn(dispatcher, ambiguities):
     """ Raise warning when ambiguity is detected
 
@@ -30,8 +32,8 @@ def ambiguity_warn(dispatcher, ambiguities):
 
 def ambiguity_register_error(dispatcher, ambiguities):
     """
-    Automatically register function which raises error when ambiguous types
-    are registered.
+    When ambiguity is detected, automatically register
+    ``raise_NotImplementedError``, which raises error when arguments are passed.
 
     Parameters
     ----------
@@ -45,15 +47,21 @@ def ambiguity_register_error(dispatcher, ambiguities):
         ambiguity_warn
     """
     for amb in ambiguities:
-        @dispatcher.register(*super_signature(amb), on_ambiguity=ambiguity_register_error)
-        def _(*args, **kwargs):
-            """ Unimplemented handler """
-            types = tuple(type(a) for a in args)
-            raise NotImplementedError(
-                "Ambiguous signature for %s: <%s>" % (
-                    dispatcher.name, str_signature(types)
-                )
-            )
+        signature = tuple(super_signature(amb))
+        dispatcher.add(
+            signature, raise_NotImplementedError, on_ambiguity=ambiguity_register_error
+        )
+
+def raise_NotImplementedError(*args, **kwargs):
+    """Raise ``NotImplementedError``."""
+    types = tuple(type(a) for a in args)
+    raise NotImplementedError(
+        "Ambiguous signature for %s: <%s>" % (
+            dispatcher.name, str_signature(types)
+        )
+    )
+
+###
 
 
 _unresolved_dispatchers = set() # type: Set[Dispatcher]

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -32,7 +32,7 @@ def ambiguity_warn(dispatcher, ambiguities):
 
 def ambiguity_register_error(dispatcher, ambiguities):
     """
-    Register ``raise_NotImplementedError`` for ambiguous types.
+    Register instance of ``RaiseNotImplementedError`` for ambiguous types.
 
     Parameters
     ----------
@@ -48,22 +48,27 @@ def ambiguity_register_error(dispatcher, ambiguities):
     for amb in ambiguities:
         signature = tuple(super_signature(amb))
         dispatcher.add(
-            signature, raise_NotImplementedError, on_ambiguity=ambiguity_register_error
+            signature, RaiseNotImplementedError(dispatcher), on_ambiguity=ambiguity_register_error
         )
 
-def raise_NotImplementedError(*args, **kwargs):
-    """Raise ``NotImplementedError``."""
-    types = tuple(type(a) for a in args)
-    raise NotImplementedError(
-        "Ambiguous signature for %s: <%s>" % (
-        dispatcher.name, str_signature(types)
-    ))
+class RaiseNotImplementedError:
+    """Raise ``NotImplementedError`` when called."""
+
+    def __init__(self, dispatcher):
+        self.dispatcher = dispatcher
+
+    def __call__(self, *args, **kwargs):
+        types = tuple(type(a) for a in args)
+        raise NotImplementedError(
+            "Ambiguous signature for %s: <%s>" % (
+            self.dispatcher.name, str_signature(types)
+        ))
 
 
 def ambiguity_register_error_ignore_dup(dispatcher, ambiguities):
     """
     If super signature for ambiguous types is duplicate types, ignore it.
-    Else, register ``raise_NotImplementedError`` for ambiguous types.
+    Else, register instance of ``RaiseNotImplementedError`` for ambiguous types.
 
     Parameters
     ----------
@@ -81,8 +86,8 @@ def ambiguity_register_error_ignore_dup(dispatcher, ambiguities):
         if len(set(signature)) == 1:
             continue
         dispatcher.add(
-            signature, raise_NotImplementedError,
-            on_ambiguity=ambiguity_register_error
+            signature, RaiseNotImplementedError(dispatcher),
+            on_ambiguity=ambiguity_register_error_ignore_dup
         )
 
 ###

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -30,27 +30,6 @@ def ambiguity_warn(dispatcher, ambiguities):
     warn(warning_text(dispatcher.name, ambiguities), AmbiguityWarning)
 
 
-def ambiguity_register_error(dispatcher, ambiguities):
-    """
-    Register instance of ``RaiseNotImplementedError`` for ambiguous types.
-
-    Parameters
-    ----------
-    dispatcher : Dispatcher
-        The dispatcher on which the ambiguity was detected
-    ambiguities : set
-        Set of type signature pairs that are ambiguous within this dispatcher
-
-    See Also:
-        Dispatcher.add
-        ambiguity_warn
-    """
-    for amb in ambiguities:
-        signature = tuple(super_signature(amb))
-        dispatcher.add(
-            signature, RaiseNotImplementedError(dispatcher), on_ambiguity=ambiguity_register_error
-        )
-
 class RaiseNotImplementedError:
     """Raise ``NotImplementedError`` when called."""
 
@@ -63,7 +42,6 @@ class RaiseNotImplementedError:
             "Ambiguous signature for %s: <%s>" % (
             self.dispatcher.name, str_signature(types)
         ))
-
 
 def ambiguity_register_error_ignore_dup(dispatcher, ambiguities):
     """

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -28,6 +28,34 @@ def ambiguity_warn(dispatcher, ambiguities):
     warn(warning_text(dispatcher.name, ambiguities), AmbiguityWarning)
 
 
+def ambiguity_register_error(dispatcher, ambiguities):
+    """
+    Automatically register function which raises error when ambiguous types
+    are registered.
+
+    Parameters
+    ----------
+    dispatcher : Dispatcher
+        The dispatcher on which the ambiguity was detected
+    ambiguities : set
+        Set of type signature pairs that are ambiguous within this dispatcher
+
+    See Also:
+        Dispatcher.add
+        ambiguity_warn
+    """
+    for amb in ambiguities:
+        @dispatcher.register(*super_signature(amb))
+        def _(*args, **kwargs):
+            """ Unimplemented handler """
+            types = tuple(type(a) for a in args)
+            raise NotImplementedError(
+                "Ambiguous signature for %s: <%s>" % (
+                    dispatcher.name, str_signature(types)
+                )
+            )
+
+
 _unresolved_dispatchers = set() # type: Set[Dispatcher]
 _resolve = [True]
 

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -45,7 +45,7 @@ def ambiguity_register_error(dispatcher, ambiguities):
         ambiguity_warn
     """
     for amb in ambiguities:
-        @dispatcher.register(*super_signature(amb))
+        @dispatcher.register(*super_signature(amb), on_ambiguity=ambiguity_register_error)
         def _(*args, **kwargs):
             """ Unimplemented handler """
             types = tuple(type(a) for a in args)

--- a/sympy/multipledispatch/dispatcher.py
+++ b/sympy/multipledispatch/dispatcher.py
@@ -32,8 +32,7 @@ def ambiguity_warn(dispatcher, ambiguities):
 
 def ambiguity_register_error(dispatcher, ambiguities):
     """
-    When ambiguity is detected, automatically register
-    ``raise_NotImplementedError``, which raises error when arguments are passed.
+    Register ``raise_NotImplementedError`` for ambiguous types.
 
     Parameters
     ----------
@@ -57,9 +56,34 @@ def raise_NotImplementedError(*args, **kwargs):
     types = tuple(type(a) for a in args)
     raise NotImplementedError(
         "Ambiguous signature for %s: <%s>" % (
-            dispatcher.name, str_signature(types)
+        dispatcher.name, str_signature(types)
+    ))
+
+
+def ambiguity_register_error_ignore_dup(dispatcher, ambiguities):
+    """
+    If super signature for ambiguous types is duplicate types, ignore it.
+    Else, register ``raise_NotImplementedError`` for ambiguous types.
+
+    Parameters
+    ----------
+    dispatcher : Dispatcher
+        The dispatcher on which the ambiguity was detected
+    ambiguities : set
+        Set of type signature pairs that are ambiguous within this dispatcher
+
+    See Also:
+        Dispatcher.add
+        ambiguity_warn
+    """
+    for amb in ambiguities:
+        signature = tuple(super_signature(amb))
+        if len(set(signature)) == 1:
+            continue
+        dispatcher.add(
+            signature, raise_NotImplementedError,
+            on_ambiguity=ambiguity_register_error
         )
-    )
 
 ###
 

--- a/sympy/multipledispatch/tests/test_dispatcher.py
+++ b/sympy/multipledispatch/tests/test_dispatcher.py
@@ -1,7 +1,7 @@
 from sympy.multipledispatch.dispatcher import (Dispatcher, MDNotImplementedError,
                                          MethodDispatcher, halt_ordering,
                                          restart_ordering,
-                                         ambiguity_register_error)
+                                         ambiguity_register_error_ignore_dup)
 from sympy.testing.pytest import raises, warns
 
 
@@ -264,12 +264,21 @@ def test_not_implemented_error():
 
     assert raises(NotImplementedError, lambda: f(1.0))
 
-def test_ambiguity_register_error():
-    f = Dispatcher('add')
+def test_ambiguity_register_error_ignore_dup():
+    f = Dispatcher('f')
+
+    class A:
+        pass
+    class B(A):
+        pass
+    class C(A):
+        pass
 
     # suppress warning for registering ambiguous signal
-    f.add((int, object), lambda x,y: x+y, ambiguity_register_error)
-    f.add((object, int), lambda x,y: x+y, ambiguity_register_error)
+    f.add((A, B), lambda x,y: None, ambiguity_register_error_ignore_dup)
+    f.add((B, A), lambda x,y: None, ambiguity_register_error_ignore_dup)
+    f.add((A, C), lambda x,y: None, ambiguity_register_error_ignore_dup)
+    f.add((C, A), lambda x,y: None, ambiguity_register_error_ignore_dup)
 
     # raises error if ambiguous signal is passed
-    assert raises(NotImplementedError, lambda: f(1,2))
+    assert raises(NotImplementedError, lambda: f(B(), C()))

--- a/sympy/multipledispatch/tests/test_dispatcher.py
+++ b/sympy/multipledispatch/tests/test_dispatcher.py
@@ -1,6 +1,7 @@
 from sympy.multipledispatch.dispatcher import (Dispatcher, MDNotImplementedError,
                                          MethodDispatcher, halt_ordering,
-                                         restart_ordering)
+                                         restart_ordering,
+                                         ambiguity_register_error)
 from sympy.testing.pytest import raises, warns
 
 
@@ -262,3 +263,13 @@ def test_not_implemented_error():
         raise MDNotImplementedError()
 
     assert raises(NotImplementedError, lambda: f(1.0))
+
+def test_ambiguity_register_error():
+    f = Dispatcher('add')
+
+    # suppress warning for registering ambiguous signal
+    f.add((int, object), lambda x,y: x+y, ambiguity_register_error)
+    f.add((object, int), lambda x,y: x+y, ambiguity_register_error)
+
+    # raises error if ambiguous signal is passed
+    assert raises(NotImplementedError, lambda: f(1,2))

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -819,37 +819,6 @@ def sift(seq, keyfunc, binary=False):
     return T, F
 
 
-def tied_max(iterable, *, key):
-    """
-    Return the list of items from *iterable* which returns
-    highest value when *key* is applied.
-
-    Examples
-    ========
-
-    >>> from sympy.utilities.iterables import tied_max
-    >>> iterable = ['abc', 'de', 'fgh', 'i']
-    >>> tied_max(iterable, key=len)
-    ['abc', 'fgh']
-
-    """
-    it = iter(iterable)
-    try:
-        first = next(it)
-    except StopIteration:
-        return []
-    max_key = key(first)
-    max_vals = [first]
-    for val in it:
-        k = key(val)
-        if k == max_key:
-            max_vals.append(val)
-        elif k > max_key:
-            max_key = k
-            max_vals = [val]
-    return max_vals
-
-
 def take(iter, n):
     """Return ``n`` items from ``iter`` iterator. """
     return [ value for _, value in zip(range(n), iter) ]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -819,6 +819,37 @@ def sift(seq, keyfunc, binary=False):
     return T, F
 
 
+def tied_max(iterable, *, key):
+    """
+    Return the list of items from *iterable* which returns
+    highest value when *key* is applied.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import tied_max
+    >>> iterable = ['abc', 'de', 'fgh', 'i']
+    >>> tied_max(iterable, key=len)
+    ['abc', 'fgh']
+
+    """
+    it = iter(iterable)
+    try:
+        first = next(it)
+    except StopIteration:
+        return []
+    max_key = key(first)
+    max_vals = [first]
+    for val in it:
+        k = key(val)
+        if k == max_key:
+            max_vals.append(val)
+        elif k > max_key:
+            max_key = k
+            max_vals = [val]
+    return max_vals
+
+
 def take(iter, n):
     """Return ``n`` items from ``iter`` iterator. """
     return [ value for _, value in zip(range(n), iter) ]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #18769
Fixes #18768

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - Extensible `add`, `mul` and `power` functions are introduced to allow sympy objects to define what classes should be used for them in place of `Add`, `Mul` and `Pow` (e.g. matrices use `MatAdd`). This is an experimental approach aimed at enabling the behaviour of core routines (expand, collect, etc) to be customised by user-defined types (e.g. `MatAdd` rather than `Add`). This mechanism is still experimental, is not fully implemented across the core and might be changed or removed in a future release of sympy.
<!-- END RELEASE NOTES -->