### PR TITLE
Implementation of class to represent a parametric region in space

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4923,7 +4923,7 @@ def test_sympy__vector__parametricregion__ParametricRegion():
     from sympy.vector.coordsysrect import CoordSys3D
     from sympy.vector.parametricregion import ParametricRegion
     C = CoordSys3D('C')
-    assert _test_args(ParametricRegion(C, t, t**2, (t, 0, 1)))
+    assert _test_args(ParametricRegion(t, t**2, (t, 0, 1), system=C))
 
 def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.scalar import BaseScalar

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4922,7 +4922,7 @@ def test_sympy__vector__orienters__QuaternionOrienter():
 def test_sympy__vector__parametricregion__ParametricRegion():
     from sympy.abc import t
     from sympy.vector.parametricregion import ParametricRegion
-    assert _test_args(ParametricRegion((t), (t, t**3), {t: (0, 2)}))
+    assert _test_args(ParametricRegion(t, (t, t**3), {t: (0, 2)}))
 
 
 def test_sympy__vector__scalar__BaseScalar():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4918,13 +4918,18 @@ def test_sympy__vector__orienters__QuaternionOrienter():
     a, b, c, d = symbols('a b c d')
     assert _test_args(QuaternionOrienter(a, b, c, d))
 
+def test_sympy__vector__parametricregion__ParametricRegion():
+    from sympy.abc import t
+    from sympy.vector.coordsysrect import CoordSys3D
+    from sympy.vector.parametricregion import ParametricRegion
+    C = CoordSys3D('C')
+    assert _test_args(ParametricRegion(C, t, t**2, (t, 0, 1)))
 
 def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.scalar import BaseScalar
     from sympy.vector.coordsysrect import CoordSys3D
     C = CoordSys3D('C')
     assert _test_args(BaseScalar(0, C, ' ', ' '))
-
 
 def test_sympy__physics__wigner__Wigner3j():
     from sympy.physics.wigner import Wigner3j

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4918,12 +4918,12 @@ def test_sympy__vector__orienters__QuaternionOrienter():
     a, b, c, d = symbols('a b c d')
     assert _test_args(QuaternionOrienter(a, b, c, d))
 
+
 def test_sympy__vector__parametricregion__ParametricRegion():
     from sympy.abc import t
-    from sympy.vector.coordsysrect import CoordSys3D
     from sympy.vector.parametricregion import ParametricRegion
-    C = CoordSys3D('C')
-    assert _test_args(ParametricRegion((t), (t, t**2), {t: (0, 1)}, system=C))
+    assert _test_args(ParametricRegion((t), (t, t**3), {t: (0, 2)}))
+
 
 def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.scalar import BaseScalar
@@ -4931,60 +4931,74 @@ def test_sympy__vector__scalar__BaseScalar():
     C = CoordSys3D('C')
     assert _test_args(BaseScalar(0, C, ' ', ' '))
 
+
 def test_sympy__physics__wigner__Wigner3j():
     from sympy.physics.wigner import Wigner3j
     assert _test_args(Wigner3j(0, 0, 0, 0, 0, 0))
 
+
 def test_sympy__integrals__rubi__symbol__matchpyWC():
     from sympy.integrals.rubi.symbol import matchpyWC
     assert _test_args(matchpyWC(1, True, 'a'))
+
 
 def test_sympy__integrals__rubi__utility_function__rubi_unevaluated_expr():
     from sympy.integrals.rubi.utility_function import rubi_unevaluated_expr
     a = symbols('a')
     assert _test_args(rubi_unevaluated_expr(a))
 
+
 def test_sympy__integrals__rubi__utility_function__rubi_exp():
     from sympy.integrals.rubi.utility_function import rubi_exp
     assert _test_args(rubi_exp(5))
+
 
 def test_sympy__integrals__rubi__utility_function__rubi_log():
     from sympy.integrals.rubi.utility_function import rubi_log
     assert _test_args(rubi_log(5))
 
+
 def test_sympy__integrals__rubi__utility_function__Int():
     from sympy.integrals.rubi.utility_function import Int
     assert _test_args(Int(5, x))
+
 
 def test_sympy__integrals__rubi__utility_function__Util_Coefficient():
     from sympy.integrals.rubi.utility_function import Util_Coefficient
     a, x = symbols('a x')
     assert _test_args(Util_Coefficient(a, x))
 
+
 def test_sympy__integrals__rubi__utility_function__Gamma():
     from sympy.integrals.rubi.utility_function import Gamma
     assert _test_args(Gamma(5))
+
 
 def test_sympy__integrals__rubi__utility_function__Util_Part():
     from sympy.integrals.rubi.utility_function import Util_Part
     a, b = symbols('a b')
     assert _test_args(Util_Part(a + b, 0))
 
+
 def test_sympy__integrals__rubi__utility_function__PolyGamma():
     from sympy.integrals.rubi.utility_function import PolyGamma
     assert _test_args(PolyGamma(1, 1))
+
 
 def test_sympy__integrals__rubi__utility_function__ProductLog():
     from sympy.integrals.rubi.utility_function import ProductLog
     assert _test_args(ProductLog(1))
 
+
 def test_sympy__combinatorics__schur_number__SchurNumber():
     from sympy.combinatorics.schur_number import SchurNumber
     assert _test_args(SchurNumber(1))
 
+
 def test_sympy__combinatorics__perm_groups__SymmetricPermutationGroup():
     from sympy.combinatorics.perm_groups import SymmetricPermutationGroup
     assert _test_args(SymmetricPermutationGroup(5))
+
 
 def test_sympy__combinatorics__perm_groups__Coset():
     from sympy.combinatorics.permutations import Permutation

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4923,7 +4923,7 @@ def test_sympy__vector__parametricregion__ParametricRegion():
     from sympy.vector.coordsysrect import CoordSys3D
     from sympy.vector.parametricregion import ParametricRegion
     C = CoordSys3D('C')
-    assert _test_args(ParametricRegion(t, t**2, (t, 0, 1), system=C))
+    assert _test_args(ParametricRegion((t), (t, t**2), {t: (0, 1)}, system=C))
 
 def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.scalar import BaseScalar

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -38,6 +38,6 @@ __all__ = [
 
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
     'divergence',
-    
+
     'ParametricRegion',
 ]

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -14,6 +14,7 @@ from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
 from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence
+from sympy.vector.parametricregion import ParametricRegion
 
 __all__ = [
     'Vector', 'VectorAdd', 'VectorMul', 'BaseVector', 'VectorZero', 'Cross',
@@ -37,4 +38,6 @@ __all__ = [
 
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
     'divergence',
+    
+    'ParametricRegion',
 ]

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -25,7 +25,7 @@ class ParametricRegion(Basic):
 
         for bound in bounds:
             if len(bound) != 3:
-                raise ValueError("Parameters should be specified in the form (paramteter, lower bound, upper bound)")
+                raise ValueError("Parameters should be specified in the form (parameter, lower bound, upper bound)")
 
         for elem in bounds:
             parameters.append(elem[0])

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -23,6 +23,10 @@ class ParametricRegion(Basic):
             else:
                 definition.append(arg)
 
+        for bound in bounds:
+            if len(bound) != 3:
+                raise ValueError("Parameters should be specified in the form (paramteter, lower bound, upper bound)")
+
         for elem in bounds:
             parameters.append(elem[0])
 

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -7,18 +7,21 @@ class ParametricRegion(Basic):
 
     Examples
     ========
-
     >>> from sympy import symbols, cos, sin, pi
+
     >>> from sympy.vector import ParametricRegion
 
     >>> r, theta = symbols("r theta")
-    >>> circle = ParametricRegion((r, theta), r*cos(theta), r*sin(theta), limits={theta: (0, pi)})
+    >>> circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), limits={theta: (0, pi)})
     """
-    def __new__(cls, parameters, definition, limits, system=None):
+    def __new__(cls, parameters, definition, limits=None, system=None):
         if not isinstance(parameters, tuple):
             parameters = (parameters,)
         if not isinstance(definition, tuple):
             definition = (definition,)
+
+        if limits is None:
+            limits = {}
 
         for parameter, bounds in limits.items():
             if parameter not in parameters:

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,5 +1,6 @@
 from sympy.core.basic import Basic
 from sympy.core.containers import Dict, Tuple
+from sympy.vector.coordsysrect import CoordSys3D
 
 class ParametricRegion(Basic):
     """
@@ -7,17 +8,49 @@ class ParametricRegion(Basic):
 
     Examples
     ========
-    >>> from sympy import symbols, cos, sin, pi
 
+    >>> from sympy import cos, sin, pi
+    >>> from sympy.abc import r, theta, t, a, b
     >>> from sympy.vector import ParametricRegion
 
-    >>> r, theta = symbols("r theta")
-    >>> circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), limits={theta: (0, pi)})
+    >>> ParametricRegion(t, (t, t**2), limits={t: (-1, 2)})
+    ParametricRegion((t,), (t, t**2), {t: (-1, 2)})
+    >>> ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {r: (-2, 2), theta: (0, pi)})
+    ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {r: (-2, 2), theta: (0, pi)})
+    >>> ParametricRegion(t, (a*cos(t), b*sin(t)))
+    ParametricRegion((t,), (a*cos(t), b*sin(t)), {})
+
+    >>> circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {theta: (0, pi)})
+    >>> circle.parameters
+    (r, theta)
+    >>> circle.definition
+    (r*cos(theta), r*sin(theta))
+    >>> circle.limits
+    {theta: (0, pi)}
+
+    Parameters
+    ==========
+
+    parameters_or_coordsys : parameter or a tuple of parameters or a CoordSys3d object.
+                        When a CoordSys3d object is passed, its base scalars are used as parameters.
+
+    definition : tuple to define base scalars in terms of parameters.
+
+    limits : dict to define bounds of each parameter.
+            Each Key of dictionary should be parameter and value
+            is a tuple to represent corresponding lower and upper bound.`
+
     """
-    def __new__(cls, parameters, definition, limits=None, system=None):
-        if not isinstance(parameters, tuple):
-            parameters = (parameters,)
-        if not isinstance(definition, tuple):
+    def __new__(cls, parameters_or_coordsys, definition, limits=None):
+
+        if isinstance(parameters_or_coordsys, CoordSys3D):
+            parameters = parameters_or_coordsys.base_scalars()
+        elif not (isinstance(parameters_or_coordsys, tuple) or isinstance(parameters_or_coordsys, Tuple)):
+            parameters = (parameters_or_coordsys,)
+        else:
+            parameters = parameters_or_coordsys
+
+        if not (isinstance(definition, tuple) or isinstance(definition, Tuple)):
             definition = (definition,)
 
         if limits is None:
@@ -30,7 +63,6 @@ class ParametricRegion(Basic):
                 raise ValueError("Bounds should be in the form (lower_bound, upper_bound)")
 
         obj = super().__new__(cls, Tuple(*parameters), Tuple(*definition), Dict(limits))
-        obj._system = system
         return obj
 
     @property
@@ -44,7 +76,3 @@ class ParametricRegion(Basic):
     @property
     def parameters(self):
         return self.args[0]
-
-    @property
-    def system(self):
-        return self._system

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -31,7 +31,6 @@ class ParametricRegion(Basic):
             parameters.append(elem[0])
 
         obj = super().__new__(cls, definition, bounds, parameters, system)
-        obj._system = system
 
         return obj
 
@@ -49,4 +48,4 @@ class ParametricRegion(Basic):
 
     @property
     def system(self):
-        return self._system
+        return self.args[3]

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -3,46 +3,46 @@ from sympy.core.basic import Basic
 class ParametricRegion(Basic):
     """
     Represents a parametric region in space.
-    """
-    def __init__(self, system, *args):
-        """
-        Examples
-        ========
 
-        >>> from sympy import symbols, cos, sin, pi
-        >>> from sympy.vector import CoordSys3D, ParametricRegion
-        >>> r, theta = symbols("r theta")
-        >>> C = CoordSys3D('C')
-        >>> circle = ParametricRegion(C, r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
-        """
-        self._definition = list()
-        self._bounds = list()
-        self._parameters = list()
-        self.system = system
+    Examples
+    ========
+
+    >>> from sympy import symbols, cos, sin, pi
+    >>> from sympy.vector import ParametricRegion
+    >>> r, theta = symbols("r theta")
+    >>> circle = ParametricRegion(r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
+    """
+    def __new__(cls, *args, system=None):
+        definition = list()
+        bounds = list()
+        parameters = list()
 
         for arg in args:
             if isinstance(arg, tuple):
-                self.bounds.append(arg)
+                bounds.append(arg)
             else:
-                self.definition.append(arg)
+                definition.append(arg)
 
-        if len(self.definition) > 3:
-            raise ValueError("Only 3-D regions are supported")
+        for elem in bounds:
+            parameters.append(elem[0])
 
-        if len(self.bounds) > 3:
-            raise ValueError("Only 3-D regions are supported")
+        obj = super().__new__(cls, definition, bounds, parameters, system)
+        obj._system = system
 
-        for elem in self.bounds:
-            self.parameters.append(elem[0])
-
-    @property
-    def definition(self):
-        return self._definition
+        return obj
 
     @property
     def bounds(self):
-        return self._bounds
+        return self.args[1]
+
+    @property
+    def definition(self):
+        return self.args[0]
 
     @property
     def parameters(self):
-        return self._parameters
+        return self.args[2]
+
+    @property
+    def system(self):
+        return self._system

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,0 +1,48 @@
+from sympy.core.basic import Basic
+
+class ParametricRegion(Basic):
+    """
+    Represents a parametric region in space.
+    """
+    def __init__(self, system, *args):
+        """
+        Examples
+        ========
+
+        >>> from sympy.abc import r, theta
+        >>> from sympy.vector import CoordSys3D, ParametricRegion
+        >>> from sympy import cos, sin
+        >>> C = CoordSys3D('C')
+        >>> circle = ParametricRegion(C, r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
+        """
+        self._definition = list()
+        self._bounds = list()
+        self._parameters = list()
+        self.system = system
+
+        for arg in args:
+            if isinstance(arg, tuple):
+                self.bounds.append(arg)
+            else:
+                self.definition.append(arg)
+
+        if len(self.definition) > 3:
+            raise ValueError("Only 3-D regions are supported")
+
+        if len(self.bounds) > 3:
+            raise ValueError("Only 3-D regions are supported")
+
+        for elem in self.bounds:
+            self.parameters.append(elem[0])
+
+    @property
+    def definition(self):
+        return self._definition
+
+    @property
+    def bounds(self):
+        return self._bounds
+
+    @property
+    def parameters(self):
+        return self._parameters

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -10,11 +10,13 @@ class ParametricRegion(Basic):
     ========
 
     >>> from sympy import cos, sin, pi
-    >>> from sympy.abc import r, theta, t, a, b
+    >>> from sympy.abc import r, theta, t, a, b, x, y
     >>> from sympy.vector import ParametricRegion
 
     >>> ParametricRegion(t, (t, t**2), limits={t: (-1, 2)})
     ParametricRegion((t,), (t, t**2), {t: (-1, 2)})
+    >>> ParametricRegion((x, y), (x, y), {x: (3, 4), y: (5, 6)})
+    ParametricRegion((x, y), (x, y), {x: (3, 4), y: (5, 6)})
     >>> ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {r: (-2, 2), theta: (0, pi)})
     ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {r: (-2, 2), theta: (0, pi)})
     >>> ParametricRegion(t, (a*cos(t), b*sin(t)))

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -9,9 +9,9 @@ class ParametricRegion(Basic):
         Examples
         ========
 
-        >>> from sympy.abc import r, theta
+        >>> from sympy import symbols, cos, sin, pi
         >>> from sympy.vector import CoordSys3D, ParametricRegion
-        >>> from sympy import cos, sin
+        >>> r, theta = symbols("r theta")
         >>> C = CoordSys3D('C')
         >>> circle = ParametricRegion(C, r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
         """

--- a/sympy/vector/tests/test_parametricregion.py
+++ b/sympy/vector/tests/test_parametricregion.py
@@ -1,10 +1,10 @@
-from sympy import sin, cos, pi, symbols
+from sympy import sin, cos, pi
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.parametricregion import ParametricRegion
 from sympy.testing.pytest import raises
+from sympy.abc import a, b, r, t, z, theta, phi
 
 C = CoordSys3D('C')
-r, theta, phi, a, b, t = symbols('r theta phi a b t')
 
 def test_parametricregion():
 
@@ -44,8 +44,8 @@ def test_parametricregion():
     assert ellipse.parameters == (t,)
     assert ellipse.limits == {t: (0, 8)}
 
-    cylinder = ParametricRegion((r, theta, C.z), (cos(theta), r*sin(theta), C.z), {theta: (0, 2*pi), C.z: (0, 4)})
-    assert cylinder.parameters == (r, theta, C.z)
+    cylinder = ParametricRegion((r, theta, z), (cos(theta), r*sin(theta), C.z), {theta: (0, 2*pi), z: (0, 4)})
+    assert cylinder.parameters == (r, theta, z)
 
     sphere = ParametricRegion((r, theta, phi), (r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi)),
                             {theta: ( 0, 2*pi), phi: ( 0, pi)})

--- a/sympy/vector/tests/test_parametricregion.py
+++ b/sympy/vector/tests/test_parametricregion.py
@@ -30,6 +30,10 @@ def test_parametricregion():
     assert p1.parameters == (a, b)
     assert p1.limits == {a: (0, 2), b: (-1, 5)}
 
+    p2 = ParametricRegion(t, (t, t**3))
+    assert p2.parameters == (t,)
+    assert p2.limits == {}
+
     circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {theta: (0, 2*pi)})
     assert circle.definition == (r*cos(theta), r*sin(theta))
     assert circle.system == None

--- a/sympy/vector/tests/test_parametricregion.py
+++ b/sympy/vector/tests/test_parametricregion.py
@@ -12,16 +12,14 @@ def test_parametricregion():
     assert point.definition == (3, 4)
     assert point.parameters == ()
     assert point.limits == {}
-    assert point.system == None
 
     # line x = y
-    line_xy = ParametricRegion((C.y), (C.y), limits={C.y: (-3, 3)}, system=C)
+    line_xy = ParametricRegion(C, (C.y), limits={C.y: (-3, 3)})
     assert line_xy .definition == (C.y,)
-    assert line_xy.parameters == (C.y,)
-    assert line_xy.system == C
+    assert line_xy.parameters == (C.x, C.y, C.z)
 
     # line y = z
-    line_yz = ParametricRegion((t), (C.x,t,t), limits={t: (1, 2)}, system=C)
+    line_yz = ParametricRegion((t), (C.x,t,t), limits={t: (1, 2)})
     assert line_yz.definition == (C.x,t,t)
     assert line_yz.parameters == (t,)
 
@@ -36,26 +34,23 @@ def test_parametricregion():
 
     circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {theta: (0, 2*pi)})
     assert circle.definition == (r*cos(theta), r*sin(theta))
-    assert circle.system == None
 
     halfdisc = ParametricRegion((r, theta), (r*cos(theta), r* sin(theta)), {r: (-2, 2), theta: (0, pi)})
     assert halfdisc.definition == (r*cos(theta), r*sin(theta))
     assert halfdisc.parameters == (r, theta)
     assert halfdisc.limits == {r: (-2, 2), theta: (0, pi)}
 
-    ellipse = ParametricRegion((t), (a*cos(t), b*sin(t)), {t: (0, 8)})
+    ellipse = ParametricRegion(t, (a*cos(t), b*sin(t)), {t: (0, 8)})
     assert ellipse.parameters == (t,)
     assert ellipse.limits == {t: (0, 8)}
 
-    cylinder = ParametricRegion((r, theta, C.z), (cos(theta), r*sin(theta), C.z), {theta: (0, 2*pi), C.z: (0, 4)},
-                                system=C)
-    assert cylinder.system == C
+    cylinder = ParametricRegion((r, theta, C.z), (cos(theta), r*sin(theta), C.z), {theta: (0, 2*pi), C.z: (0, 4)})
+    assert cylinder.parameters == (r, theta, C.z)
 
     sphere = ParametricRegion((r, theta, phi), (r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi)),
                             {theta: ( 0, 2*pi), phi: ( 0, pi)})
     assert sphere.definition == (r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi))
     assert sphere.parameters == (r, theta, phi)
-    assert sphere.system == None
 
     raises(ValueError, lambda: ParametricRegion((t), (a*t**2, 2*a*t), {a:  (-2, 2)}))
     raises(ValueError, lambda: ParametricRegion((a, b), (a**2, sin(b)), {a: (2, 4, 6)}))

--- a/sympy/vector/tests/test_parametricregion.py
+++ b/sympy/vector/tests/test_parametricregion.py
@@ -1,0 +1,50 @@
+from sympy import sin, cos, pi, symbols
+from sympy.vector.coordsysrect import CoordSys3D
+from sympy.vector.parametricregion import ParametricRegion
+
+C = CoordSys3D('C')
+r, theta, phi, a, b, t = symbols('r theta phi a b t')
+
+def test_parametricregion():
+
+    point = ParametricRegion(3, 4)
+    assert point.definition == [3, 4]
+    assert point.parameters == []
+    assert point.bounds == []
+    assert point.system == None
+
+    l = ParametricRegion(C.y, (C.y, -3, 3), system=C)
+    assert l.definition == [C.y]
+    assert l.parameters == [C.y]
+    assert l.system == C
+
+    p1 = ParametricRegion(9*a, -16*b, (a, 0, 3))
+    assert p1.definition == [9*a, -16*b]
+    assert p1.parameters == [a]
+    assert p1.bounds == [(a, 0, 3)]
+
+    circle = ParametricRegion(r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
+    assert circle.definition == [r*cos(theta), r*sin(theta)]
+    assert circle.system == None
+
+    halfdisc = ParametricRegion(r*cos(theta), r* sin(theta), (r, -2, 2), (theta, 0, pi))
+    assert halfdisc.definition == [r*cos(theta), r*sin(theta)]
+    assert halfdisc.parameters == [r, theta]
+    assert halfdisc.bounds == [(r, -2, 2), (theta, 0, pi)]
+
+    parabola = ParametricRegion(a*t**2, 2*a*t, (t, -2, 2))
+    assert parabola.definition == [a*t**2, 2*a*t]
+    assert parabola.parameters == [t]
+
+    ellipse = ParametricRegion(a*cos(t), b*sin(t), (t, 0, 8))
+    assert ellipse.parameters == [t]
+    assert ellipse.bounds == [(t, 0, 8)]
+
+    sphere = ParametricRegion(r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi), (theta, 0, 2*pi), (phi, 0, pi))
+    assert sphere.definition == [r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi)]
+    assert sphere.parameters == [theta, phi]
+    assert sphere.system == None
+
+    cylinder = ParametricRegion(r*cos(theta), r*sin(theta), C.z, (theta, 0, 2*pi), (C.z, 0, 4), system=C)
+    assert cylinder.parameters == [theta, C.z]
+    assert cylinder.system == C

--- a/sympy/vector/tests/test_parametricregion.py
+++ b/sympy/vector/tests/test_parametricregion.py
@@ -1,50 +1,57 @@
 from sympy import sin, cos, pi, symbols
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.parametricregion import ParametricRegion
+from sympy.testing.pytest import raises
 
 C = CoordSys3D('C')
 r, theta, phi, a, b, t = symbols('r theta phi a b t')
 
 def test_parametricregion():
 
-    point = ParametricRegion(3, 4)
-    assert point.definition == [3, 4]
-    assert point.parameters == []
-    assert point.bounds == []
+    point = ParametricRegion((), (3, 4), {})
+    assert point.definition == (3, 4)
+    assert point.parameters == ()
+    assert point.limits == {}
     assert point.system == None
 
-    l = ParametricRegion(C.y, (C.y, -3, 3), system=C)
-    assert l.definition == [C.y]
-    assert l.parameters == [C.y]
-    assert l.system == C
+    # line x = y
+    line_xy = ParametricRegion((C.y), (C.y), limits={C.y: (-3, 3)}, system=C)
+    assert line_xy .definition == (C.y,)
+    assert line_xy.parameters == (C.y,)
+    assert line_xy.system == C
 
-    p1 = ParametricRegion(9*a, -16*b, (a, 0, 3))
-    assert p1.definition == [9*a, -16*b]
-    assert p1.parameters == [a]
-    assert p1.bounds == [(a, 0, 3)]
+    # line y = z
+    line_yz = ParametricRegion((t), (C.x,t,t), limits={t: (1, 2)}, system=C)
+    assert line_yz.definition == (C.x,t,t)
+    assert line_yz.parameters == (t,)
 
-    circle = ParametricRegion(r*cos(theta), r*sin(theta), (theta, 0, 2*pi))
-    assert circle.definition == [r*cos(theta), r*sin(theta)]
+    p1 = ParametricRegion((a, b), (9*a, -16*b), limits={a: (0, 2), b: (-1, 5)})
+    assert p1.definition == (9*a, -16*b)
+    assert p1.parameters == (a, b)
+    assert p1.limits == {a: (0, 2), b: (-1, 5)}
+
+    circle = ParametricRegion((r, theta), (r*cos(theta), r*sin(theta)), {theta: (0, 2*pi)})
+    assert circle.definition == (r*cos(theta), r*sin(theta))
     assert circle.system == None
 
-    halfdisc = ParametricRegion(r*cos(theta), r* sin(theta), (r, -2, 2), (theta, 0, pi))
-    assert halfdisc.definition == [r*cos(theta), r*sin(theta)]
-    assert halfdisc.parameters == [r, theta]
-    assert halfdisc.bounds == [(r, -2, 2), (theta, 0, pi)]
+    halfdisc = ParametricRegion((r, theta), (r*cos(theta), r* sin(theta)), {r: (-2, 2), theta: (0, pi)})
+    assert halfdisc.definition == (r*cos(theta), r*sin(theta))
+    assert halfdisc.parameters == (r, theta)
+    assert halfdisc.limits == {r: (-2, 2), theta: (0, pi)}
 
-    parabola = ParametricRegion(a*t**2, 2*a*t, (t, -2, 2))
-    assert parabola.definition == [a*t**2, 2*a*t]
-    assert parabola.parameters == [t]
+    ellipse = ParametricRegion((t), (a*cos(t), b*sin(t)), {t: (0, 8)})
+    assert ellipse.parameters == (t,)
+    assert ellipse.limits == {t: (0, 8)}
 
-    ellipse = ParametricRegion(a*cos(t), b*sin(t), (t, 0, 8))
-    assert ellipse.parameters == [t]
-    assert ellipse.bounds == [(t, 0, 8)]
+    cylinder = ParametricRegion((r, theta, C.z), (cos(theta), r*sin(theta), C.z), {theta: (0, 2*pi), C.z: (0, 4)},
+                                system=C)
+    assert cylinder.system == C
 
-    sphere = ParametricRegion(r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi), (theta, 0, 2*pi), (phi, 0, pi))
-    assert sphere.definition == [r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi)]
-    assert sphere.parameters == [theta, phi]
+    sphere = ParametricRegion((r, theta, phi), (r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi)),
+                            {theta: ( 0, 2*pi), phi: ( 0, pi)})
+    assert sphere.definition == (r*sin(phi)*cos(theta),r*sin(phi)*sin(theta), r*cos(phi))
+    assert sphere.parameters == (r, theta, phi)
     assert sphere.system == None
 
-    cylinder = ParametricRegion(r*cos(theta), r*sin(theta), C.z, (theta, 0, 2*pi), (C.z, 0, 4), system=C)
-    assert cylinder.parameters == [theta, C.z]
-    assert cylinder.system == C
+    raises(ValueError, lambda: ParametricRegion((t), (a*t**2, 2*a*t), {a:  (-2, 2)}))
+    raises(ValueError, lambda: ParametricRegion((a, b), (a**2, sin(b)), {a: (2, 4, 6)}))


### PR DESCRIPTION
Added an implementation of ParamRegion class.
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19320 

#### Brief description of what is fixed or changed
An object of the ParametricRegion class should represent a parametric region in space. This object can then be used to perform scalar/vector integration over parametric regions.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
  * Added class to represent a parametric region in space.
<!-- END RELEASE NOTES -->