### PR TITLE
[GSoC] Core: Fixes _eval_nseries() of Power

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3198,7 +3198,6 @@ class Expr(Basic, EvalfMixin):
         # we are calculating the series over and over again. Subclasses should
         # override this method and implement much more efficient yielding of
         # terms.
-        from sympy import LM
         n = 0
         series = self._eval_nseries(x, n=n, logx=logx)
         if not series.is_Order:
@@ -3217,15 +3216,8 @@ class Expr(Basic, EvalfMixin):
             series = self._eval_nseries(x, n=n, logx=logx)
         e = series.removeO()
         yield e
-
-        brk_cnt = S.Zero
-        self = self.cancel()
-        if self.is_polynomial():
-            brk_cnt += S.One
-            if self.is_zero:
-                exp = S.Zero
-            else:
-                _, exp = LM(self).leadterm(x)
+        if e.is_zero:
+            return
 
         while 1:
             while 1:
@@ -3233,14 +3225,10 @@ class Expr(Basic, EvalfMixin):
                 series = self._eval_nseries(x, n=n, logx=logx).removeO()
                 if e != series:
                     break
-                if brk_cnt == S.One and n > (exp + S.One):
-                    brk_cnt += S.One
-                    break
-            if brk_cnt != 2:
-                yield series - e
-                e = series
-            else:
-                break
+                if (series - self).cancel() is S.Zero:
+                    return
+            yield series - e
+            e = series
 
     def nseries(self, x=None, x0=0, n=6, dir='+', logx=None):
         """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3217,10 +3217,15 @@ class Expr(Basic, EvalfMixin):
             series = self._eval_nseries(x, n=n, logx=logx)
         e = series.removeO()
         yield e
+
         brk_cnt = S.Zero
+        self = self.cancel()
         if self.is_polynomial():
             brk_cnt += S.One
-            _, exp = LM(self).leadterm(x)
+            if self.is_zero:
+                exp = S.Zero
+            else:
+                _, exp = LM(self).leadterm(x)
 
         while 1:
             while 1:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1803,7 +1803,7 @@ class Mul(Expr, AssocOp):
             if power < n:
                 res += Mul(*coeffs)*(x**power)
 
-        if res != self:
+        if (res - self).cancel() is not S.Zero:
             res += Order(x**n, x)
         return res
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1778,7 +1778,7 @@ class Mul(Expr, AssocOp):
         try:
             for t in self.args:
                 coeff, exp = t.leadterm(x)
-                if isinstance(coeff, Integer) or isinstance(coeff, Rational):
+                if not coeff.has(x):
                     ords.append((t, exp))
                 else:
                     raise ValueError
@@ -1803,7 +1803,8 @@ class Mul(Expr, AssocOp):
             if power < n:
                 res += Mul(*coeffs)*(x**power)
 
-        res += Order(x**n, x)
+        if res != self:
+            res += Order(x**n, x)
         return res
 
     def _eval_as_leading_term(self, x):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1759,7 +1759,7 @@ class Mul(Expr, AssocOp):
         return co_residual*self2.func(*margs)*self2.func(*nc)
 
     def _eval_nseries(self, x, n, logx):
-        from sympy import Integer, Mul, Order, ceiling, powsimp
+        from sympy import Mul, Order, ceiling, powsimp
         from itertools import product
 
         def coeff_exp(term, x):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1569,8 +1569,7 @@ class Pow(Expr):
 
         for e1 in terms:
             ex = e1 + inex
-            if ex < n:
-                res += terms[e1]*inco*x**(ex)
+            res += terms[e1]*inco*x**(ex)
 
         if (res - self).cancel() == S.Zero:
             return res

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1574,7 +1574,7 @@ class Pow(Expr):
             if ex < n:
                 res += fac[e1]*inco*x**(ex)
 
-        if res == self:
+        if (res - self).cancel() == S.Zero:
             return res
 
         return res + O(x**n, x)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -541,15 +541,16 @@ def test_function__eval_nseries():
     assert polygamma(n, x + 1)._eval_nseries(x, 2, None) == \
         polygamma(n, 1) + polygamma(n + 1, 1)*x + O(x**2)
     raises(PoleError, lambda: sin(1/x)._eval_nseries(x, 2, None))
-    assert acos(1 - x)._eval_nseries(x, 2, None) == sqrt(2)*sqrt(x) + O(x)
-    assert acos(1 + x)._eval_nseries(x, 2, None) == sqrt(2)*I*sqrt(x) + O(x)  # XXX: wrong, branch cuts
+    assert acos(1 - x)._eval_nseries(x, 2, None) == sqrt(2)*sqrt(x) + sqrt(2)*x**(S(3)/2)/12 + O(x**2)
+    assert acos(1 + x)._eval_nseries(x, 2, None) == sqrt(2)*I*sqrt(x) - sqrt(2)*I*x**(S(3)/2)/12 + O(x**2)  # XXX: wrong, branch cuts
     assert loggamma(1/x)._eval_nseries(x, 0, None) == \
         log(x)/2 - log(x)/x - 1/x + O(1, x)
     assert loggamma(log(1/x)).nseries(x, n=1, logx=y) == loggamma(-y)
 
     # issue 6725:
     assert expint(Rational(3, 2), -x)._eval_nseries(x, 5, None) == \
-        2 - 2*sqrt(pi)*I*sqrt(x) - 2*x - x**2/3 - x**3/15 - x**4/84 + O(x**5)
+        2 - 2*sqrt(pi)*sqrt(-x) - 2*x + x**2 + x**3/3 + x**4/12 + 4*I*x**(S(3)/2)*sqrt(-x)/3 + \
+        2*I*x**(S(5)/2)*sqrt(-x)/5 + 2*I*x**(S(7)/2)*sqrt(-x)/21 + O(x**5)
     assert sin(sqrt(x))._eval_nseries(x, 3, None) == \
         sqrt(x) - x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + O(x**3)
 

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -302,8 +302,7 @@ def test_issue_6990():
     a = Symbol('a')
     b = Symbol('b')
     assert (sqrt(a + b*x + x**2)).series(x, 0, 3).removeO() == \
-        b*x/(2*sqrt(a)) + x**2*(1/(2*sqrt(a)) - \
-        b**2/(8*a**Rational(3, 2))) + sqrt(a)
+        sqrt(a)*x**2*(1/(2*a) - b**2/(8*a**2)) + sqrt(a) + b*x/(2*sqrt(a))
 
 
 def test_issue_6068():

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -914,7 +914,7 @@ class loggamma(Function):
     Series expansion is also supported:
 
     >>> from sympy import series
-    >>> series(loggamma(x), x, 0, 4).simplify()
+    >>> series(loggamma(x), x, 0, 4).cancel()
     -log(x) - EulerGamma*x + pi**2*x**2/12 + x**3*polygamma(2, 1)/6 + O(x**4)
 
     We can numerically evaluate the ``gamma`` function to arbitrary precision

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -688,7 +688,7 @@ class polygamma(Function):
                 m = ceiling((n + 1)//2)
                 l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
                 r -= Add(*l)
-                o = Order(1/z**(2*m), x)
+                o = Order(1/z**n, x)
             return r._eval_nseries(x, n, logx) + o
         else:
             # proper polygamma function
@@ -914,7 +914,7 @@ class loggamma(Function):
     Series expansion is also supported:
 
     >>> from sympy import series
-    >>> series(loggamma(x), x, 0, 4)
+    >>> series(loggamma(x), x, 0, 4).simplify()
     -log(x) - EulerGamma*x + pi**2*x**2/12 + x**3*polygamma(2, 1)/6 + O(x**4)
 
     We can numerically evaluate the ``gamma`` function to arbitrary precision
@@ -1001,14 +1001,13 @@ class loggamma(Function):
         if args0[0] != oo:
             return super()._eval_aseries(n, args0, x, logx)
         z = self.args[0]
-        m = min(n, ceiling((n + S.One)/2))
         r = log(z)*(z - S.Half) - z + log(2*pi)/2
-        l = [bernoulli(2*k) / (2*k*(2*k - 1)*z**(2*k - 1)) for k in range(1, m)]
+        l = [bernoulli(2*k) / (2*k*(2*k - 1)*z**(2*k - 1)) for k in range(1, n)]
         o = None
-        if m == 0:
+        if n == 0:
             o = Order(1, x)
         else:
-            o = Order(1/z**(2*m - 1), x)
+            o = Order(1/z**n, x)
         # It is very inefficient to first add the order and then do the nseries
         return (r + Add(*l))._eval_nseries(x, n, logx) + o
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -546,10 +546,10 @@ def test_loggamma():
 
     assert loggamma(x).rewrite('intractable') == log(gamma(x))
 
-    s1 = loggamma(x).series(x).simplify()
+    s1 = loggamma(x).series(x).cancel()
     assert s1 == -log(x) - EulerGamma*x + pi**2*x**2/12 + x**3*polygamma(2, 1)/6 + \
         pi**4*x**4/360 + x**5*polygamma(4, 1)/120 + O(x**6)
-    assert s1 == loggamma(x).rewrite('intractable').series(x).simplify()
+    assert s1 == loggamma(x).rewrite('intractable').series(x).cancel()
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
     assert conjugate(loggamma(0)) is oo

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -546,10 +546,10 @@ def test_loggamma():
 
     assert loggamma(x).rewrite('intractable') == log(gamma(x))
 
-    s1 = loggamma(x).series(x)
+    s1 = loggamma(x).series(x).simplify()
     assert s1 == -log(x) - EulerGamma*x + pi**2*x**2/12 + x**3*polygamma(2, 1)/6 + \
         pi**4*x**4/360 + x**5*polygamma(4, 1)/120 + O(x**6)
-    assert s1 == loggamma(x).rewrite('intractable').series(x)
+    assert s1 == loggamma(x).rewrite('intractable').series(x).simplify()
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
     assert conjugate(loggamma(0)) is oo

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -296,7 +296,7 @@ def test_series():
     assert expr_to_holonomic((2*x - 3*x**2)**Rational(1, 3)).series() == ((2*x - 3*x**2)**Rational(1, 3)).series()
     assert  expr_to_holonomic(sqrt(x**2-x)).series() == (sqrt(x**2-x)).series()
     assert expr_to_holonomic(cos(x)**2/x**2, y0={-2: [1, 0, -1]}).series(n=10) == (cos(x)**2/x**2).series(n=10)
-    assert expr_to_holonomic(cos(x)**2/x**2, x0=1).series(n=10) == (cos(x)**2/x**2).series(n=10, x0=1)
+    assert expr_to_holonomic(cos(x)**2/x**2, x0=1).series(n=10).simplify() == (cos(x)**2/x**2).series(n=10, x0=1).simplify()
     assert expr_to_holonomic(cos(x-1)**2/(x-1)**2, x0=1, y0={-2: [1, 0, -1]}).series(n=10) \
         == (cos(x-1)**2/(x-1)**2).series(x0=1, n=10)
 

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -296,7 +296,7 @@ def test_series():
     assert expr_to_holonomic((2*x - 3*x**2)**Rational(1, 3)).series() == ((2*x - 3*x**2)**Rational(1, 3)).series()
     assert  expr_to_holonomic(sqrt(x**2-x)).series() == (sqrt(x**2-x)).series()
     assert expr_to_holonomic(cos(x)**2/x**2, y0={-2: [1, 0, -1]}).series(n=10) == (cos(x)**2/x**2).series(n=10)
-    assert expr_to_holonomic(cos(x)**2/x**2, x0=1).series(n=10).simplify() == (cos(x)**2/x**2).series(n=10, x0=1).simplify()
+    assert expr_to_holonomic(cos(x)**2/x**2, x0=1).series(n=10).together() == (cos(x)**2/x**2).series(n=10, x0=1).together()
     assert expr_to_holonomic(cos(x-1)**2/(x-1)**2, x0=1, y0={-2: [1, 0, -1]}).series(n=10) \
         == (cos(x-1)**2/(x-1)**2).series(x0=1, n=10)
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -33,8 +33,8 @@ def test_basic1():
     assert limit(x + 1/x, x, oo) is oo
     assert limit(x - x**2, x, oo) is -oo
     assert limit((1 + x)**(1 + sqrt(2)), x, 0) == 1
-    assert limit((1 + x)**oo, x, 0) is oo
-    assert limit((1 + x)**oo, x, 0, dir='-') == 0
+    assert limit((1 + x)**oo, x, 0) == Limit((x + 1)**oo, x, 0)
+    assert limit((1 + x)**oo, x, 0, dir='-') == Limit((x + 1)**oo, x, 0, dir='-')
     assert limit((1 + x + y)**oo, x, 0, dir='-') == (1 + y)**(oo)
     assert limit(y/x/log(x), x, 0) == -oo*sign(y)
     assert limit(cos(x + y)/x, x, 0) == sign(cos(y))*oo
@@ -524,6 +524,18 @@ def test_issue_12555():
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) is oo
 
 
+def test_issue_12769():
+    r, z, x = symbols('r z x', real=True)
+    a, b, s0, K, F0, s, T = symbols('a b s0 K F0 s T', positive=True, real=True)
+    fx = (F0**b*K**b*r*s0 - sqrt((F0**2*K**(2*b)*a**2*(b - 1) + \
+        F0**(2*b)*K**2*a**2*(b - 1) + F0**(2*b)*K**(2*b)*s0**2*(b - 1)*(b**2 - 2*b + 1) - \
+        2*F0**(2*b)*K**(b + 1)*a*r*s0*(b**2 - 2*b +  1) + \
+        2*F0**(b + 1)*K**(2*b)*a*r*s0*(b**2 - 2*b + 1) - \
+        2*F0**(b + 1)*K**(b + 1)*a**2*(b - 1))/((b - 1)*(b**2 - 2*b + 1))))*(b*r -  b - r + 1)
+
+    assert fx.subs(K, F0).cancel().together() == limit(fx, K, F0).together()
+
+
 def test_issue_13332():
     assert limit(sqrt(30)*5**(-5*x - 1)*(46656*x)**x*(5*x + 2)**(5*x + 5*S.Half) *
                 (6*x + 2)**(-6*x - 5*S.Half), x, oo) == Rational(25, 36)
@@ -658,6 +670,11 @@ def test_issue_17671():
     assert limit(Ei(-log(x)) - log(log(x))/x, x, 1) == EulerGamma
 
 
+def test_issue_17751():
+    a, b, c, x = symbols('a b c x', positive=True)
+    assert limit((a + 1)*x - sqrt((a + 1)**2*x**2 + b*x + c), x, oo) == -b/(2*a + 2)
+
+
 def test_issue_17792():
     assert limit(factorial(n)/sqrt(n)*(exp(1)/n)**n, n, oo) == sqrt(2)*sqrt(pi)
 
@@ -671,7 +688,7 @@ def test_issue_18378():
 
 
 def test_issue_18442():
-    assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == AccumBounds(-oo, oo)
+    assert limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-') == Limit(tan(x)**(2**(sqrt(pi))), x, oo, dir='-')
 
 
 def test_issue_18482():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -5,7 +5,7 @@ from sympy import (
     atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
-    acos, erfi, LambertW, factorial, Ei, EulerGamma)
+    acos, erfi, LambertW, factorial, digamma, Ei, EulerGamma)
 
 from sympy.calculus.util import AccumBounds
 from sympy.core.add import Add
@@ -590,6 +590,12 @@ def test_issue_10102():
 
 def test_issue_14377():
     raises(NotImplementedError, lambda: limit(exp(I*x)*sin(pi*x), x, oo))
+
+
+def test_issue_15146():
+    e = (x/2) * (-2*x**3 - 2*(x**3 - 1) * x**2 * digamma(x**3 + 1) + \
+        2*(x**3 - 1) * x**2 * digamma(x**3 + x + 1) + x + 3)
+    assert limit(e, x, oo) == S(1)/3
 
 
 def test_issue_15984():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -238,7 +238,7 @@ def test_expbug4():
         log(sin(2*x)/x)*(1 + x)).series(x, 0, 2) == 2 + 2*x*log(2) + O(x**2)
 
     assert exp(log(2) + O(x)).nseries(x, 0, 2) == 2 + O(x)
-    assert ((2 + O(x))**(1 + x)).nseries(x, 0, 2) == 2 + 2*x*log(2) + O(x**2)
+    assert ((2 + O(x))**(1 + x)).nseries(x, 0, 2) == 2 + O(x)
 
 
 def test_logbug4():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -35,7 +35,7 @@ def test_pow_0():
 
 
 def test_pow_1():
-    assert ((1 + x)**2).nseries(x, n=5) == 1 + 2*x + x**2 + O(x**5)
+    assert ((1 + x)**2).nseries(x, n=5) == x**2 + 2*x + 1
 
 
 def test_geometric_1():
@@ -134,13 +134,13 @@ def test_series2x():
     assert ((x + 1)**(-1)).nseries(x, 0, 4) == 1 - x + x**2 - x**3 + O(x**4, x)
     assert ((x + 1)**0).nseries(x, 0, 3) == 1
     assert ((x + 1)**1).nseries(x, 0, 3) == 1 + x
-    assert ((x + 1)**2).nseries(x, 0, 3) == 1 + 2*x + x**2 + O(x**3)
+    assert ((x + 1)**2).nseries(x, 0, 3) == x**2 + 2*x + 1
     assert ((x + 1)**3).nseries(x, 0, 3) == 1 + 3*x + 3*x**2 + O(x**3)
 
     assert (1/(1 + x)).nseries(x, 0, 4) == 1 - x + x**2 - x**3 + O(x**4, x)
     assert (x + 3/(1 + 2*x)).nseries(x, 0, 4) == 3 - 5*x + 12*x**2 - 24*x**3 + O(x**4, x)
 
-    assert ((1/x + 1)**3).nseries(x, 0, 3) == x**(-3) + 3/x**2 + 3/x + 1 + O(x**3)
+    assert ((1/x + 1)**3).nseries(x, 0, 3) == 1 + 3/x + 3/x**2 + x**(-3)
     assert (1/(1 + 1/x)).nseries(x, 0, 4) == x - x**2 + x**3 - O(x**4, x)
     assert (1/(1 + 1/x**2)).nseries(x, 0, 6) == x**2 - x**4 + O(x**6, x)
 
@@ -492,7 +492,7 @@ def test_issue_4329():
 def test_issue_5183():
     assert abs(x + x**2).series(n=1) == O(x)
     assert abs(x + x**2).series(n=2) == x + O(x**2)
-    assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2 + O(x**6)
+    assert ((1 + x)**2).series(x, n=6) == x**2 + 2*x + 1
     assert (1 + 1/x).series() == 1 + 1/x
     assert Derivative(exp(x).series(), x).doit() == \
         1 + x + x**2/2 + x**3/6 + x**4/24 + O(x**5)

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -35,7 +35,7 @@ def test_pow_0():
 
 
 def test_pow_1():
-    assert ((1 + x)**2).nseries(x, n=5) == 1 + 2*x + x**2
+    assert ((1 + x)**2).nseries(x, n=5) == 1 + 2*x + x**2 + O(x**5)
 
 
 def test_geometric_1():
@@ -83,7 +83,7 @@ def test_log_singular1():
 
 def test_log_power1():
     e = 1 / (1/x + x ** (log(3)/log(2)))
-    assert e.nseries(x, n=5) == x - x**(2 + log(3)/log(2)) + O(x**5)
+    assert e.nseries(x, n=5) == -x**(log(3)/log(2) + 2) + x + O(x**5)
 
 
 def test_log_series():
@@ -134,14 +134,13 @@ def test_series2x():
     assert ((x + 1)**(-1)).nseries(x, 0, 4) == 1 - x + x**2 - x**3 + O(x**4, x)
     assert ((x + 1)**0).nseries(x, 0, 3) == 1
     assert ((x + 1)**1).nseries(x, 0, 3) == 1 + x
-    assert ((x + 1)**2).nseries(x, 0, 3) == 1 + 2*x + x**2
-    assert ((x + 1)**3).nseries(
-        x, 0, 3) == 1 + 3*x + 3*x**2 + x**3  # 1+3*x+3*x**2+O(x**3)
+    assert ((x + 1)**2).nseries(x, 0, 3) == 1 + 2*x + x**2 + O(x**3)
+    assert ((x + 1)**3).nseries(x, 0, 3) == 1 + 3*x + 3*x**2 + O(x**3)
 
     assert (1/(1 + x)).nseries(x, 0, 4) == 1 - x + x**2 - x**3 + O(x**4, x)
     assert (x + 3/(1 + 2*x)).nseries(x, 0, 4) == 3 - 5*x + 12*x**2 - 24*x**3 + O(x**4, x)
 
-    assert ((1/x + 1)**3).nseries(x, 0, 3) == 1 + x**(-3) + 3*x**(-2) + 3/x
+    assert ((1/x + 1)**3).nseries(x, 0, 3) == x**(-3) + 3/x**2 + 3/x + 1 + O(x**3)
     assert (1/(1 + 1/x)).nseries(x, 0, 4) == x - x**2 + x**3 - O(x**4, x)
     assert (1/(1 + 1/x**2)).nseries(x, 0, 6) == x**2 - x**4 + O(x**6, x)
 
@@ -164,7 +163,7 @@ def test_exp2():
     e = w**(1 - log(x)/(log(2) + log(x)))
     logw = Symbol("logw")
     assert e.nseries(
-        w, 0, 1, logx=logw) == exp(logw - logw*log(x)/(log(2) + log(x)))
+        w, 0, 1, logx=logw) == exp(logw*log(2)/(log(x) + log(2)))
 
 
 def test_bug3():
@@ -239,7 +238,7 @@ def test_expbug4():
         log(sin(2*x)/x)*(1 + x)).series(x, 0, 2) == 2 + 2*x*log(2) + O(x**2)
 
     assert exp(log(2) + O(x)).nseries(x, 0, 2) == 2 + O(x)
-    assert ((2 + O(x))**(1 + x)).nseries(x, 0, 2) == 2 + O(x)
+    assert ((2 + O(x))**(1 + x)).nseries(x, 0, 2) == 2 + 2*x*log(2) + O(x**2)
 
 
 def test_logbug4():
@@ -260,7 +259,7 @@ def test_issue_3258():
     a = x/(exp(x) - 1)
     assert a.nseries(x, 0, 5) == 1 - x/2 - x**4/720 + x**2/12 + O(x**5)
 
-@XFAIL
+
 def test_issue_3204():
     x = Symbol("x", nonnegative=True)
     f = sin(x**3)**Rational(1, 3)
@@ -366,7 +365,7 @@ def test_series2():
     w = Symbol("w", real=True)
     x = Symbol("x", real=True)
     e = w**(-2)*(w*exp(1/x - w) - w*exp(1/x))
-    assert e.nseries(w, n=4) == -exp(1/x) + w*exp(1/x) / 2 + O(w**2)
+    assert e.nseries(w, n=4) == -exp(1/x) + w*exp(1/x)/2 - w**2*exp(1/x)/6 + w**3*exp(1/x)/24 + O(w**4)
 
 
 def test_series3():
@@ -378,7 +377,7 @@ def test_series3():
 def test_bug4():
     w = Symbol("w")
     e = x/(w**4 + x**2*w**4 + 2*x*w**4)*w**4
-    assert e.nseries(w, n=2) in [x/(1 + 2*x + x**2),
+    assert e.nseries(w, n=2).removeO() in [x/(1 + 2*x + x**2),
         1/(1 + x/2 + 1/x/2)/2, 1/x/(1 + 2/x + x**(-2))]
 
 
@@ -479,7 +478,7 @@ def test_issue_4441():
         a**4*x**4 + O(x**5)
     f = 1/(1 + (a + b)*x)
     assert f.series(x, 0, 3) == 1 + x*(-a - b) + \
-        x**2*(a**2 + 2*a*b + b**2) + O(x**3)
+        x**2*(a + b)**2 + O(x**3)
 
 
 def test_issue_4329():
@@ -493,7 +492,7 @@ def test_issue_4329():
 def test_issue_5183():
     assert abs(x + x**2).series(n=1) == O(x)
     assert abs(x + x**2).series(n=2) == x + O(x**2)
-    assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2
+    assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2 + O(x**6)
     assert (1 + 1/x).series() == 1 + 1/x
     assert Derivative(exp(x).series(), x).doit() == \
         1 + x + x**2/2 + x**3/6 + x**4/24 + O(x**5)


### PR DESCRIPTION
Fixes: #9549
Fixes: #12578
Fixes: #12769
Fixes: #15146
Fixes: #17751 
Fixes: #18008

#### Brief description of what is fixed or changed
The series expansion of `b**e` is computed as follows:
* We express `b` as `f*(1 + g)` where `f` is the leading term of `b`. 
    `g` has order `O(x**d)` where `d` is strictly positive.
* Then `b**e` = `(f**e)*((1 + g)**e)`. `(1 + g)**e` is computed using binomial series.

It was very important to rewrite and clean-up `Pow._eval_nseries()` completely, so that many issues get resolved and it becomes easy to debug any further bugs related to series expansions or limit evaluations.

#### Other Comments
Regression Tests have been added.

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* core
  * Fixes `_eval_nseries()` function of `power.py`
<!-- END RELEASE NOTES -->