### PR TITLE
update ConditionSet

### DIFF
--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -3,19 +3,20 @@ from __future__ import print_function, division
 from sympy import S
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
-from sympy.core.expr import Expr
 from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
 from sympy.core.relational import Eq
-from sympy.core.symbol import Symbol, Dummy
+from sympy.core.symbol import Dummy
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import And, as_Boolean
 from sympy.utilities.iterables import sift
-from sympy.utilities.misc import filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .contains import Contains
 from .sets import Set, EmptySet, Union, FiniteSet
+
+
+adummy = Dummy('conditionset')
 
 
 class ConditionSet(Set):
@@ -57,67 +58,47 @@ class ConditionSet(Set):
     >>> ConditionSet(n, cond, S.Integers)
     EmptySet
 
-    In addition, substitution of a dummy symbol can only be
-    done with a generic symbol with matching commutativity
-    or else a symbol that has identical assumptions. If the
-    base set contains the dummy symbol it is logically distinct
-    and will be the target of substitution.
+    Only free symbols can be changed by using `subs`:
 
     >>> c = ConditionSet(x, x < 1, {x, z})
     >>> c.subs(x, y)
     ConditionSet(x, x < 1, FiniteSet(y, z))
 
-    A second substitution is needed to change the dummy symbol, too:
+    To check if ``pi`` is in ``c`` use:
 
-    >>> _.subs(x, y)
-    ConditionSet(y, y < 1, FiniteSet(y, z))
-
-    And trying to replace the dummy symbol with anything but a symbol
-    is ignored: the only change possible will be in the base set:
-
-    >>> ConditionSet(y, y < 1, {y, z}).subs(y, 1)
-    ConditionSet(y, y < 1, FiniteSet(z))
-    >>> _.subs(y, 1)
-    ConditionSet(y, y < 1, FiniteSet(z))
+    >>> pi in c
+    False
 
     If no base set is specified, the universal set is implied:
 
     >>> ConditionSet(x, x < 1).base_set
     UniversalSet
 
-    Although expressions other than symbols may be used, this
-    is discouraged and will raise an error if the expression
-    is not found in the condition:
+    Only symbols or symbol-like expressions can be used:
 
     >>> ConditionSet(x + 1, x + 1 < 1, S.Integers)
-    ConditionSet(x + 1, x + 1 < 1, Integers)
-
-    >>> ConditionSet(x + 1, x < 1, S.Integers)
     Traceback (most recent call last):
     ...
     ValueError: non-symbol dummy not recognized in condition
 
-    Although the name is usually respected, it must be replaced if
-    the base set is another ConditionSet and the dummy symbol
-    appears as a free symbol in the base set and the dummy symbol
-    of the base set appears as a free symbol in the condition:
+    When the base set is a ConditionSet, the symbols will be
+    unified if possible with preference for the outermost symbols:
 
-    >>> ConditionSet(x, x < y, ConditionSet(y, x + y < 2, S.Integers))
-    ConditionSet(lambda, (lambda < y) & (lambda + x < 2), Integers)
-
-    The best way to do anything with the dummy symbol is to access
-    it with the sym property.
-
-    >>> _.subs(_.sym, Symbol('_x'))
-    ConditionSet(_x, (_x < y) & (_x + x < 2), Integers)
+    >>> ConditionSet(x, x < y, ConditionSet(z, z + y < 2, S.Integers))
+    ConditionSet(x, (x < y) & (x + y < 2), Integers)
 
     """
     def __new__(cls, sym, condition, base_set=S.UniversalSet):
-        # nonlinsolve uses ConditionSet to return an unsolved system
-        # of equations (see _return_conditionset in solveset) so until
-        # that is changed we do minimal checking of the args
+        from sympy.core.function import BadSignatureError
+        from sympy.utilities.iterables import flatten, has_dups
         sym = _sympify(sym)
+        flat = flatten([sym])
+        if has_dups(flat):
+            raise BadSignatureError("Duplicate symbols detected")
         base_set = _sympify(base_set)
+        if not isinstance(base_set, Set):
+            raise TypeError(
+                'base set should be a Set object, not %s' % base_set)
         condition = _sympify(condition)
 
         if isinstance(condition, FiniteSet):
@@ -133,18 +114,22 @@ class ConditionSet(Set):
 
         condition = as_Boolean(condition)
 
-        if isinstance(sym, Tuple):  # unsolved eqns syntax
-            return Basic.__new__(cls, sym, condition, base_set)
-
-        if not isinstance(base_set, Set):
-            raise TypeError('expecting set for base_set')
+        if condition is S.true:
+            return base_set
 
         if condition is S.false:
             return S.EmptySet
-        elif condition is S.true:
-            return base_set
+
         if isinstance(base_set, EmptySet):
             return base_set
+
+        # no simple answers, so now check syms
+        for i in flat:
+            if not getattr(i, '_diff_wrt', False):
+                raise ValueError('`%s` is not symbol-like' % i)
+
+        if base_set.contains(sym) is S.false:
+            raise TypeError('sym `%s` is not in base_set `%s`' % (sym, base_set))
 
         know = None
         if isinstance(base_set, FiniteSet):
@@ -157,30 +142,24 @@ class ConditionSet(Set):
                 return FiniteSet(*sifted[True])
 
         if isinstance(base_set, cls):
-            s, c, base_set = base_set.args
-            if sym == s:
+            s, c, b = base_set.args
+            def sig(s):
+                return cls(s, Eq(adummy, 0)).as_dummy().sym
+            sa, sb = map(sig, (sym, s))
+            if sa != sb:
+                raise BadSignatureError('sym does not match sym of base set')
+            reps = dict(zip(flatten([sym]), flatten([s])))
+            if s == sym:
                 condition = And(condition, c)
-            elif sym not in c.free_symbols:
-                condition = And(condition, c.xreplace({s: sym}))
-            elif s not in condition.free_symbols:
-                condition = And(condition.xreplace({sym: s}), c)
-                sym = s
-            else:
-                # user will have to use cls.sym to get symbol
-                dum = Symbol('lambda')
-                if dum in condition.free_symbols or \
-                        dum in c.free_symbols:
-                    dum = Dummy(str(dum))
-                condition = And(
-                    condition.xreplace({sym: dum}),
-                    c.xreplace({s: dum}))
-                sym = dum
-
-        if not isinstance(sym, Symbol):
-            s = Dummy('lambda')
-            if s not in condition.xreplace({sym: s}).free_symbols:
-                raise ValueError(
-                    'non-symbol dummy not recognized in condition')
+                base_set = b
+            elif not c.free_symbols & sym.free_symbols:
+                reps = {v: k for k, v in reps.items()}
+                condition = And(condition, c.xreplace(reps))
+                base_set = b
+            elif not condition.free_symbols & s.free_symbols:
+                sym = sym.xreplace(reps)
+                condition = And(condition.xreplace(reps), c)
+                base_set = b
 
         rv = Basic.__new__(cls, sym, condition, base_set)
         return rv if know is None else Union(know, rv)
@@ -196,57 +175,50 @@ class ConditionSet(Set):
 
     @property
     def bound_symbols(self):
-        return self.sym.free_symbols
+        from sympy.utilities.iterables import flatten
+        return flatten([self.sym])
 
     def _contains(self, other):
-        return And(
-            Contains(other, self.base_set),
-            Lambda(self.sym, self.condition)(other))
+        def ok_sig(a, b):
+            tuples = [isinstance(i, Tuple) for i in (a, b)]
+            c = tuples.count(True)
+            if c == 1:
+                return False
+            if c == 0:
+                return True
+            return len(a) == len(b) and all(
+                ok_sig(i, j) for i, j in zip(a, b))
+        if not ok_sig(self.sym, other):
+            return S.false
+        try:
+            return And(
+                Contains(other, self.base_set),
+                Lambda((self.sym,), self.condition)(other))
+        except TypeError:
+            return Contains(other, self, evaluate=False)
 
     def as_relational(self, other):
-        return And(Lambda(self.sym, self.condition)(
-            other), self.base_set.contains(other))
+        f = Lambda(self.sym, self.condition)
+        if isinstance(self.sym, Tuple):
+            f = f(*other)
+        else:
+            f = f(other)
+        return And(f, self.base_set.contains(other))
 
     def _eval_subs(self, old, new):
-        if not isinstance(self.sym, Expr):
-            # Don't do anything with the equation set syntax;
-            # that should go away, eventually.
-            return self
         sym, cond, base = self.args
-        if old == sym:
-            # we try to be as lenient as possible to allow
-            # the dummy symbol to be changed
-            base = base.subs(old, new)
-            if isinstance(new, Symbol):
-                # if the assumptions don't match, the cond
-                # might evaluate or change
-                if (new.assumptions0 == old.assumptions0 or
-                        len(new.assumptions0) == 1 and
-                        old.is_commutative == new.is_commutative):
-                    if base != self.base_set:
-                        # it will be aggravating to have the dummy
-                        # symbol change if you are trying to target
-                        # the base set so if the base set is changed
-                        # leave the dummy symbol alone -- a second
-                        # subs will be needed to change the dummy
-                        return self.func(sym, cond, base)
-                    else:
-                        return self.func(new, cond.subs(old, new), base)
-                raise ValueError(filldedent('''
-                    A dummy symbol can only be
-                    replaced with a symbol having the same
-                    assumptions or one having a single assumption
-                    having the same commutativity.
-                '''))
-            # don't target cond: it is there to tell how
-            # the base set should be filtered and if new is not in
-            # the base set then this substitution is ignored
-            return self.func(sym, cond, base)
+        dsym = sym.subs(old, adummy)
+        insym = dsym.has(adummy)
+        # prioritize changing a symbol in the base
+        newbase = base.subs(old, new)
+        if newbase != base:
+            if not insym:
+                cond = cond.subs(old, new)
+            return self.func(sym, cond, newbase)
+        if insym:
+            pass  # no change of bound symbols via subs
+        elif getattr(new, '_diff_wrt', False):
+            cond = cond.subs(old, new)
         else:
-            cond = self.condition.subs(old, new)
-            base = self.base_set.subs(old, new)
-            # The condition may have become true due to assumptions
-            # on 'sym'. In order for .subs() to be consistent with
-            # __new__ we *don't* check if 'sym' actually belongs to
-            # 'base'. In other words: assumptions are ignored.
-            return self.func(self.sym, cond, base)
+            pass  # let error about the symbol raise from __new__
+        return self.func(sym, cond, base)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -324,6 +324,8 @@ class Set(Basic):
         """
         other = sympify(other, strict=True)
         c = self._contains(other)
+        if isinstance(c, Contains):
+            return c
         if c is None:
             return Contains(other, self, evaluate=False)
         b = tfn[c]
@@ -669,6 +671,8 @@ class Set(Basic):
         c = self._contains(other)
         b = tfn[c]
         if b is None:
+            # x in y must evaluate to T or F; to entertain a None
+            # result with Set use y.contains(x)
             raise TypeError('did not evaluate to a bool: %r' % c)
         return b
 

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,15 +1,15 @@
+from sympy.core.expr import unchanged
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
     EmptySet, Union, Contains, ImageSet)
 from sympy import (Symbol, Eq, Ne, S, Abs, sin, asin, pi, Interval,
-    And, Mod, oo, Function, Lambda)
-from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+    And, Mod, oo, Function, Lambda, symbols)
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 w = Symbol('w')
 x = Symbol('x')
 y = Symbol('y')
 z = Symbol('z')
-L = Symbol('lambda')
 f = Function('f')
 
 
@@ -30,52 +30,70 @@ def test_CondSet():
     # not depend on the dummy symbol): the result is `y > 5`.
     # In this case, ConditionSet is just acting like
     # Piecewise((Interval(1, 7), y > 5), (S.EmptySet, True)).
-    raises(TypeError, lambda: 6 in ConditionSet(x, y > 5, Interval(1, 7)))
+    raises(TypeError, lambda: 6 in ConditionSet(x, y > 5,
+        Interval(1, 7)))
 
-    assert isinstance(ConditionSet(x, x < 1, {x, y}).base_set, FiniteSet)
+    assert isinstance(ConditionSet(x, x < 1, {x, y}).base_set,
+        FiniteSet)
     raises(TypeError, lambda: ConditionSet(x, x + 1, {x, y}))
     raises(TypeError, lambda: ConditionSet(x, x, 1))
 
     I = S.Integers
+    U = S.UniversalSet
     C = ConditionSet
+    assert C(x, False, I) is S.EmptySet
+    assert C(x, True, I) is I
     assert C(x, x < 1, C(x, x < 2, I)
         ) == C(x, (x < 1) & (x < 2), I)
     assert C(y, y < 1, C(x, y < 2, I)
-        ) == C(x, (x < 1) & (y < 2), I)
+        ) == C(x, (x < 1) & (y < 2), I), C(y, y < 1, C(x, y < 2, I))
     assert C(y, y < 1, C(x, x < 2, I)
         ) == C(y, (y < 1) & (y < 2), I)
     assert C(y, y < 1, C(x, y < x, I)
         ) == C(x, (x < 1) & (y < x), I)
-    assert C(y, x < 1, C(x, y < x, I)
-        ) == C(L, (x < 1) & (y < L), I)
-    c = C(y, x < 1, C(x, L < y, I))
-    assert c == C(c.sym, (L < y) & (x < 1), I)
-    assert c.sym not in (x, y, L)
-    c = C(y, x < 1, C(x, y < x, FiniteSet(L)))
-    assert c == C(L, And(x < 1, y < L), FiniteSet(L))
+    assert unchanged(C, y, x < 1, C(x, y < x, I))
+    assert ConditionSet(x, x < 1).base_set is U
+    # arg checking is not done at instantiation but this
+    # will raise an error when containment is tested
+    assert ConditionSet((x,), x < 1).base_set is U
+
+    c = ConditionSet((x, y), x < y, I**2)
+    assert (1, 2) in c
+    assert (1, pi) not in c
+
+    raises(TypeError, lambda: C(x, x > 1, C((x, y), x > 1, I**2)))
+    # signature mismatch since only 3 args are accepted
+    raises(TypeError, lambda: C((x, y), x + y < 2, U, U))
 
 
 def test_CondSet_intersect():
-    input_conditionset = ConditionSet(x, x**2 > 4, Interval(1, 4, False, False))
+    input_conditionset = ConditionSet(x, x**2 > 4, Interval(1, 4, False,
+        False))
     other_domain = Interval(0, 3, False, False)
-    output_conditionset = ConditionSet(x, x**2 > 4, Interval(1, 3, False, False))
-    assert Intersection(input_conditionset, other_domain) == output_conditionset
+    output_conditionset = ConditionSet(x, x**2 > 4, Interval(
+        1, 3, False, False))
+    assert Intersection(input_conditionset, other_domain
+        ) == output_conditionset
 
 
 def test_issue_9849():
-    assert ConditionSet(x, Eq(x, x), S.Naturals) == S.Naturals
-    assert ConditionSet(x, Eq(Abs(sin(x)), -1), S.Naturals) == S.EmptySet
+    assert ConditionSet(x, Eq(x, x), S.Naturals
+        ) is S.Naturals
+    assert ConditionSet(x, Eq(Abs(sin(x)), -1), S.Naturals
+        ) == S.EmptySet
 
 
 def test_simplified_FiniteSet_in_CondSet():
-    assert ConditionSet(x, And(x < 1, x > -3), FiniteSet(0, 1, 2)) == FiniteSet(0)
+    assert ConditionSet(x, And(x < 1, x > -3), FiniteSet(0, 1, 2)
+        ) == FiniteSet(0)
     assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet
     assert ConditionSet(x, And(x < -3), EmptySet) == EmptySet
     y = Symbol('y')
     assert (ConditionSet(x, And(x > 0), FiniteSet(-1, 0, 1, y)) ==
         Union(FiniteSet(1), ConditionSet(x, And(x > 0), FiniteSet(y))))
     assert (ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(1, 4, 2, y)) ==
-        Union(FiniteSet(1, 4), ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(y))))
+        Union(FiniteSet(1, 4), ConditionSet(x, Eq(Mod(x, 3), 1),
+        FiniteSet(y))))
 
 
 def test_free_symbols():
@@ -85,23 +103,23 @@ def test_free_symbols():
         ).free_symbols == {z}
     assert ConditionSet(x, Eq(x, 0), FiniteSet(x, z)
         ).free_symbols == {x, z}
-    assert ConditionSet(x, Eq(x, 0), ImageSet(Lambda(y, y**2), S.Integers)
-        ).free_symbols == set()
+    assert ConditionSet(x, Eq(x, 0), ImageSet(Lambda(y, y**2),
+        S.Integers)).free_symbols == set()
 
 
 def test_bound_symbols():
     assert ConditionSet(x, Eq(y, 0), FiniteSet(z)
-        ).bound_symbols == {x}
+        ).bound_symbols == [x]
     assert ConditionSet(x, Eq(x, 0), FiniteSet(x, y)
-        ).bound_symbols == {x}
+        ).bound_symbols == [x]
     assert ConditionSet(x, x < 10, ImageSet(Lambda(y, y**2), S.Integers)
-        ).bound_symbols == {x}
+        ).bound_symbols == [x]
     assert ConditionSet(x, x < 10, ConditionSet(y, y > 1, S.Integers)
-        ).bound_symbols == {x}
+        ).bound_symbols == [x]
 
 
 def test_as_dummy():
-    _0 = Symbol('_0')
+    _0, _1 = symbols('_0 _1')
     assert ConditionSet(x, x < 1, Interval(y, oo)
         ).as_dummy() == ConditionSet(_0, _0 < 1, Interval(y, oo))
     assert ConditionSet(x, x < 1, Interval(x, oo)
@@ -109,25 +127,20 @@ def test_as_dummy():
     assert ConditionSet(x, x < 1, ImageSet(Lambda(y, y**2), S.Integers)
         ).as_dummy() == ConditionSet(
             _0, _0 < 1, ImageSet(Lambda(_0, _0**2), S.Integers))
+    e = ConditionSet((x, y), x <= y, S.Reals**2)
+    assert e.bound_symbols == [x, y]
+    assert e.as_dummy() == ConditionSet((_0, _1), _0 <= _1, S.Reals**2)
+    assert e.as_dummy() == ConditionSet((y, x), y <= x, S.Reals**2
+        ).as_dummy()
 
 
 def test_subs_CondSet():
     s = FiniteSet(z, y)
     c = ConditionSet(x, x < 2, s)
-    # you can only replace sym with a symbol that is not in
-    # the free symbols
-    assert c.subs(x, 1) == c
-    assert c.subs(x, y) == ConditionSet(y, y < 2, s)
+    assert c.subs(x, y) == c
+    assert c.subs(z, y) == ConditionSet(x, x < 2, FiniteSet(y))
+    assert c.xreplace({x: y}) == ConditionSet(y, y < 2, s)
 
-    # double subs needed to change dummy if the base set
-    # also contains the dummy
-    orig = ConditionSet(y, y < 2, s)
-    base = orig.subs(y, w)
-    and_dummy = base.subs(y, w)
-    assert base == ConditionSet(y, y < 2, {w, z})
-    assert and_dummy == ConditionSet(w, w < 2, {w, z})
-
-    assert c.subs(x, w) == ConditionSet(w, w < 2, s)
     assert ConditionSet(x, x < y, s
         ).subs(y, w) == ConditionSet(x, x < w, s.subs(y, w))
     # if the user uses assumptions that cause the condition
@@ -136,23 +149,18 @@ def test_subs_CondSet():
     assert ConditionSet(n, 0 < n, S.Integers) is S.EmptySet
     p = Symbol('p', positive=True)
     assert ConditionSet(n, n < y, S.Integers
-        ).subs(n, x) == ConditionSet(x, x < y, S.Integers)
-    nc = Symbol('nc', commutative=False)
-    raises(ValueError, lambda: ConditionSet(
-        x, x < p, S.Integers).subs(x, nc))
-    raises(ValueError, lambda: ConditionSet(
-        x, x < p, S.Integers).subs(x, n))
+        ).subs(n, x) == ConditionSet(n, n < y, S.Integers)
     raises(ValueError, lambda: ConditionSet(
         x + 1, x < 1, S.Integers))
-    raises(ValueError, lambda: ConditionSet(
-        x + 1, x < 1, s))
     assert ConditionSet(
-        n, n < x, Interval(0, oo)).subs(x, p) == Interval(0, oo)
+        p, n < x, Interval(-5, 5)).subs(x, p) == Interval(-5, 5), ConditionSet(
+        p, n < x, Interval(-5, 5)).subs(x, p)
     assert ConditionSet(
-        n, n < x, Interval(-oo, 0)).subs(x, p) == Interval(-oo, 0)
+        n, n < x, Interval(-oo, 0)).subs(x, p
+        ) == Interval(-oo, 0)
 
     assert ConditionSet(f(x), f(x) < 1, {w, z}
-        ).subs(f(x), y) == ConditionSet(y, y < 1, {w, z})
+        ).subs(f(x), y) == ConditionSet(f(x), f(x) < 1, {w, z})
 
     # issue 17341
     k = Symbol('k')
@@ -161,14 +169,15 @@ def test_subs_CondSet():
     assert ConditionSet(x, Contains(
         y, Interval(-1,1)), img1).subs(y, S.One/3).dummy_eq(img2)
 
+    assert (0, 1) in ConditionSet((x, y), x + y < 3, S.Integers**2)
+
+    raises(TypeError, lambda: ConditionSet(n, n < -10, Interval(0, 10)))
+
 
 def test_subs_CondSet_tebr():
     with warns_deprecated_sympy():
-        assert ConditionSet((x, y), {x + 1, x + y}, S.Reals) == \
-            ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals)
-
-    c = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals)
-    assert c.subs(x, z) == c
+        assert ConditionSet((x, y), {x + 1, x + y}, S.Reals**2) == \
+            ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals**2)
 
 
 def test_dummy_eq():
@@ -179,9 +188,9 @@ def test_dummy_eq():
     assert c.dummy_eq(1) == False
     assert c.dummy_eq(C(x, x < 1, S.Reals)) == False
 
-    c1 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals)
-    c2 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals)
-    c3 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Complexes)
+    c1 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals**2)
+    c2 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Reals**2)
+    c3 = ConditionSet((x, y), Eq(x + 1, 0) & Eq(x + y, 0), S.Complexes**2)
     assert c1.dummy_eq(c2)
     assert c1.dummy_eq(c3) is False
     assert c.dummy_eq(c1) is False
@@ -205,18 +214,34 @@ def test_contains():
     # enough information for that result
     raises(TypeError,
         lambda: 6 in ConditionSet(x, y > 5, Interval(1, 7)))
+    # here, there is enough information but the comparison is
+    # not defined
+    raises(TypeError, lambda: 0 in ConditionSet(x, 1/x >= 0, S.Reals))
     assert ConditionSet(x, y > 5, Interval(1, 7)
         ).contains(6) == (y > 5)
     assert ConditionSet(x, y > 5, Interval(1, 7)
         ).contains(8) is S.false
     assert ConditionSet(x, y > 5, Interval(1, 7)
         ).contains(w) == And(Contains(w, Interval(1, 7)), y > 5)
-
-@XFAIL
-def test_failing_contains():
-    # XXX This may have to return unevaluated Contains object
+    # This returns an unevaluated Contains object
     # because 1/0 should not be defined for 1 and 0 in the context of
-    # reals, but there is a nonsensical evaluation to ComplexInfinity
-    # and the comparison is giving an error.
+    # reals.
     assert ConditionSet(x, 1/x >= 0, S.Reals).contains(0) == \
         Contains(0, ConditionSet(x, 1/x >= 0, S.Reals), evaluate=False)
+    c = ConditionSet((x, y), x + y > 1, S.Integers**2)
+    assert not c.contains(1)
+    assert c.contains((2, 1))
+    assert not c.contains((0, 1))
+    c = ConditionSet((w, (x, y)), w + x + y > 1, S.Integers*S.Integers**2)
+    assert not c.contains(1)
+    assert not c.contains((1, 2))
+    assert not c.contains(((1, 2), 3))
+    assert not c.contains(((1, 2), (3, 4)))
+    assert c.contains((1, (3, 4)))
+
+
+def test_as_relational():
+    assert ConditionSet((x, y), x > 1, S.Integers**2).as_relational((x, y)
+        ) == (x > 1) & Contains((x, y), S.Integers**2)
+    assert ConditionSet(x, x > 1, S.Integers).as_relational(x
+        ) == Contains(x, S.Integers) & (x > 1)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -620,7 +620,7 @@ def test_ProductSet():
 
 def test_ProductSet_of_single_arg_is_not_arg():
     assert unchanged(ProductSet, Interval(0, 1))
-    assert ProductSet(Interval(0, 1)) != Interval(0, 1)
+    assert unchanged(ProductSet, ProductSet(Interval(0, 1)))
 
 
 def test_ProductSet_is_empty():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -342,9 +342,7 @@ def test_solve_polynomial():
     assert solveset_real(x**Rational(1, 3) - 3, x) == FiniteSet(27)
     assert len(solveset_real(x**5 + x**3 + 1, x)) == 1
     assert len(solveset_real(-2*x**3 + 4*x**2 - 2*x + 6, x)) > 0
-
-    assert solveset_real(x**6 + x**4  + I, x) == ConditionSet(x,
-                                        Eq(x**6 + x**4 + I, 0), S.Reals)
+    assert solveset_real(x**6 + x**4 + I, x) is S.EmptySet
 
 
 def test_return_root_of():
@@ -607,7 +605,8 @@ def test_poly_gens():
 def test_solve_abs():
     n = Dummy('n')
     raises(ValueError, lambda: solveset(Abs(x) - 1, x))
-    assert solveset(Abs(x) - n, x, S.Reals) == ConditionSet(x, Contains(n, Interval(0, oo)), {-n, n})
+    assert solveset(Abs(x) - n, x, S.Reals).dummy_eq(
+        ConditionSet(x, Contains(n, Interval(0, oo)), {-n, n}))
     assert solveset_real(Abs(x) - 2, x) == FiniteSet(-2, 2)
     assert solveset_real(Abs(x) + 2, x) is S.EmptySet
     assert solveset_real(Abs(x + 3) - 2*Abs(x - 3), x) == \
@@ -953,10 +952,11 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, n*pi/4 - 11*pi/16 + E), S.Integers)))
 
     # issues #18490 / #19489
-    assert solveset(cosh(x) + cosh(3*x) - cosh(5*x), x, S.Reals) == \
-        ConditionSet(x, Eq(cosh(x) + cosh(3*x) - cosh(5*x), 0), S.Reals)
-    assert solveset(sinh(8*x) + coth(12*x)) == ConditionSet(
-        x, Eq(sinh(8*x) + coth(12*x), 0), S.Complexes)
+    assert solveset(cosh(x) + cosh(3*x) - cosh(5*x), x, S.Reals
+        ).dummy_eq(ConditionSet(x,
+        Eq(cosh(x) + cosh(3*x) - cosh(5*x), 0), S.Reals))
+    assert solveset(sinh(8*x) + coth(12*x)).dummy_eq(
+        ConditionSet(x, Eq(sinh(8*x) + coth(12*x), 0), S.Complexes))
 
 
 def test_solve_trig_hyp_symbolic():
@@ -1211,23 +1211,23 @@ def test__solveset_multi():
 
 
 def test_conditionset():
-    assert solveset(Eq(sin(x)**2 + cos(x)**2, 1), x, domain=S.Reals) == \
-        ConditionSet(x, True, S.Reals)
+    assert solveset(Eq(sin(x)**2 + cos(x)**2, 1), x, domain=S.Reals
+        ) is S.Reals
 
     assert solveset(Eq(x**2 + x*sin(x), 1), x, domain=S.Reals
-        ) == ConditionSet(x, Eq(x**2 + x*sin(x) - 1, 0), S.Reals)
+        ).dummy_eq(ConditionSet(x, Eq(x**2 + x*sin(x) - 1, 0), S.Reals))
 
     assert dumeq(solveset(Eq(-I*(exp(I*x) - exp(-I*x))/2, 1), x
         ), imageset(Lambda(n, 2*n*pi + pi/2), S.Integers))
 
     assert solveset(x + sin(x) > 1, x, domain=S.Reals
-        ) == ConditionSet(x, x + sin(x) > 1, S.Reals)
+        ).dummy_eq(ConditionSet(x, x + sin(x) > 1, S.Reals))
 
     assert solveset(Eq(sin(Abs(x)), x), x, domain=S.Reals
-        ) == ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals)
+        ).dummy_eq(ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals))
 
-    assert solveset(y**x-z, x, S.Reals) == \
-        ConditionSet(x, Eq(y**x - z, 0), S.Reals)
+    assert solveset(y**x-z, x, S.Reals
+        ).dummy_eq(ConditionSet(x, Eq(y**x - z, 0), S.Reals))
 
 
 @XFAIL
@@ -1246,7 +1246,7 @@ def test_improve_coverage():
     from sympy.solvers.solveset import _has_rational_power
     solution = solveset(exp(x) + sin(x), x, S.Reals)
     unsolved_object = ConditionSet(x, Eq(exp(x) + sin(x), 0), S.Reals)
-    assert solution == unsolved_object
+    assert solution.dummy_eq(unsolved_object)
 
     assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)
     assert _has_rational_power((sin(x)**2)*(exp(x) + 1)**3, x) == (False, S.One)
@@ -1899,10 +1899,10 @@ def test_simplification():
 def test_issue_10555():
     f = Function('f')
     g = Function('g')
-    assert solveset(f(x) - pi/2, x, S.Reals) == \
-        ConditionSet(x, Eq(f(x) - pi/2, 0), S.Reals)
-    assert solveset(f(g(x)) - pi/2, g(x), S.Reals) == \
-        ConditionSet(g(x), Eq(f(g(x)) - pi/2, 0), S.Reals)
+    assert solveset(f(x) - pi/2, x, S.Reals).dummy_eq(
+        ConditionSet(x, Eq(f(x) - pi/2, 0), S.Reals))
+    assert solveset(f(g(x)) - pi/2, g(x), S.Reals).dummy_eq(
+        ConditionSet(g(x), Eq(f(g(x)) - pi/2, 0), S.Reals))
 
 
 def test_issue_8715():
@@ -2092,7 +2092,8 @@ def test_exponential_real():
     assert solveset_real(x**2 - y**2/exp(x), y) == Intersection(
         S.Reals, FiniteSet(-sqrt(x**2*exp(x)), sqrt(x**2*exp(x))))
     p = Symbol('p', positive=True)
-    assert solveset_real((1/p + 1)**(p + 1), p) == EmptySet()
+    assert solveset_real((1/p + 1)**(p + 1), p).dummy_eq(
+        ConditionSet(x, Eq((1 + 1/x)**(x + 1), 0), S.Reals))
 
 
 @XFAIL
@@ -2134,16 +2135,16 @@ def test_expo_conditionset():
     f4 = log(x) - exp(x)
     f5 = 2**x + 3**x - 5**x
 
-    assert solveset(f1, x, S.Reals) == ConditionSet(
-        x, Eq((exp(x) + 1)**x - 2, 0), S.Reals)
-    assert solveset(f2, x, S.Reals) == ConditionSet(
-        x, Eq(x*(x + 2)**y - 3, 0), S.Reals)
-    assert solveset(f3, x, S.Reals) == ConditionSet(
-        x, Eq(2**x - exp(x) - 3, 0), S.Reals)
-    assert solveset(f4, x, S.Reals) == ConditionSet(
-        x, Eq(-exp(x) + log(x), 0), S.Reals)
-    assert solveset(f5, x, S.Reals) == ConditionSet(
-        x, Eq(2**x + 3**x - 5**x, 0), S.Reals)
+    assert solveset(f1, x, S.Reals).dummy_eq(ConditionSet(
+        x, Eq((exp(x) + 1)**x - 2, 0), S.Reals))
+    assert solveset(f2, x, S.Reals).dummy_eq(ConditionSet(
+        x, Eq(x*(x + 2)**y - 3, 0), S.Reals))
+    assert solveset(f3, x, S.Reals).dummy_eq(ConditionSet(
+        x, Eq(2**x - exp(x) - 3, 0), S.Reals))
+    assert solveset(f4, x, S.Reals).dummy_eq(ConditionSet(
+        x, Eq(-exp(x) + log(x), 0), S.Reals))
+    assert solveset(f5, x, S.Reals).dummy_eq(ConditionSet(
+        x, Eq(2**x + 3**x - 5**x, 0), S.Reals))
 
 
 def test_exponential_symbols():
@@ -2156,18 +2157,25 @@ def test_exponential_symbols():
     f2 = (x/y)**w - 2
     sol1 = Intersection({log(2)/(log(x) - log(y))}, S.Reals)
     sol2 = Intersection({log(2)/log(x/y)}, S.Reals)
-    assert solveset(f1, w, S.Reals) == sol1
-    assert solveset(f2, w, S.Reals) == sol2
+    assert solveset(f1, w, S.Reals) == sol1, solveset(f1, w, S.Reals)
+    assert solveset(f2, w, S.Reals) == sol2, solveset(f2, w, S.Reals)
 
-    assert solveset(x**x, x, S.Reals) == S.EmptySet
+    assert solveset(x**x, x, Interval.Lopen(0,oo)).dummy_eq(
+        ConditionSet(w, Eq(w**w, 0), Interval.open(0, oo)))
     assert solveset(x**y - 1, y, S.Reals) == FiniteSet(0)
     assert solveset(exp(x/y)*exp(-z/y) - 2, y, S.Reals) == FiniteSet(
         (x - z)/log(2)) - FiniteSet(0)
 
-    assert solveset_real(a**x - b**x, x) == ConditionSet(
-        x, (a > 0) & (b > 0), FiniteSet(0))
-    assert solveset(a**x - b**x, x) == ConditionSet(
-        x, Ne(a, 0) & Ne(b, 0), FiniteSet(0))
+    assert solveset(a**x - b**x, x).dummy_eq(ConditionSet(
+        w, Ne(a, 0) & Ne(b, 0), FiniteSet(0)))
+
+
+def test_ignore_assumptions():
+    # make sure assumptions are ignored
+    xpos = symbols('x', positive=True)
+    x = symbols('x')
+    assert solveset_complex(xpos**2 - 4, xpos
+        ) == solveset_complex(x**2 - 4, x)
 
 
 @XFAIL
@@ -2322,16 +2330,20 @@ def test_invert_modular():
 def test_solve_modular():
     n = Dummy('n', integer=True)
     # if rhs has symbol (need to be implemented in future).
-    assert solveset(Mod(x, 4) - x, x, S.Integers) == \
-            ConditionSet(x, Eq(-x + Mod(x, 4), 0), \
-            S.Integers)
+    assert solveset(Mod(x, 4) - x, x, S.Integers
+        ).dummy_eq(
+            ConditionSet(x, Eq(-x + Mod(x, 4), 0),
+            S.Integers))
     # when _invert_modular fails to invert
-    assert solveset(3 - Mod(sin(x), 7), x, S.Integers) == \
-            ConditionSet(x, Eq(Mod(sin(x), 7) - 3, 0), S.Integers)
-    assert solveset(3 - Mod(log(x), 7), x, S.Integers) == \
-            ConditionSet(x, Eq(Mod(log(x), 7) - 3, 0), S.Integers)
-    assert solveset(3 - Mod(exp(x), 7), x, S.Integers) == \
-            ConditionSet(x, Eq(Mod(exp(x), 7) - 3, 0), S.Integers)
+    assert solveset(3 - Mod(sin(x), 7), x, S.Integers
+        ).dummy_eq(
+            ConditionSet(x, Eq(Mod(sin(x), 7) - 3, 0), S.Integers))
+    assert solveset(3 - Mod(log(x), 7), x, S.Integers
+        ).dummy_eq(
+            ConditionSet(x, Eq(Mod(log(x), 7) - 3, 0), S.Integers))
+    assert solveset(3 - Mod(exp(x), 7), x, S.Integers
+        ).dummy_eq(ConditionSet(x, Eq(Mod(exp(x), 7) - 3, 0),
+        S.Integers))
     # EmptySet solution definitely
     assert solveset(7 - Mod(x, 5), x, S.Integers) == EmptySet()
     assert solveset(5 - Mod(x, 5), x, S.Integers) == EmptySet()
@@ -2387,10 +2399,12 @@ def test_solve_modular():
     # Complex args
     assert solveset(Mod(x, 3) - I, x, S.Integers) == \
             EmptySet()
-    assert solveset(Mod(I*x, 3) - 2, x, S.Integers) == \
-            ConditionSet(x, Eq(Mod(I*x, 3) - 2, 0), S.Integers)
-    assert solveset(Mod(I + x, 3) - 2, x, S.Integers) == \
-            ConditionSet(x, Eq(Mod(x + I, 3) - 2, 0), S.Integers)
+    assert solveset(Mod(I*x, 3) - 2, x, S.Integers
+        ).dummy_eq(
+            ConditionSet(x, Eq(Mod(I*x, 3) - 2, 0), S.Integers))
+    assert solveset(Mod(I + x, 3) - 2, x, S.Integers
+        ).dummy_eq(
+            ConditionSet(x, Eq(Mod(x + I, 3) - 2, 0), S.Integers))
 
     # issue 17373 (https://github.com/sympy/sympy/issues/17373)
     assert dumeq(solveset(Mod(x**4, 14) - 11, x, S.Integers),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

closes #19520
closes #19517 
have not checked if #11174 has been fixed with these changes

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
  * nested multi-symbol first arg for ConditionSet now handled with subs/as_dummy
  * the bound symbols cannot be replaced with `subs`
  * the error checking for mismatched signatures for sym and the base set has been improved
  * ConditionSet still tries to unify symbols and denest a base set that is given as a ConditionSet but will no longer introduce new symbols (and will leave the base set a a ConditionSet) when this cannot be done
* solvers
  * solveset will always use a symbol that has only either the real or complex attribute and no other attribute; when a ConditionSet is returned, the original symbol for which the solution is being sought will be used if it does not cause evaluation of the result.
<!-- END RELEASE NOTES -->