### PR TITLE
An obvious typo in fem.py

### DIFF
--- a/examples/advanced/fem.py
+++ b/examples/advanced/fem.py
@@ -115,7 +115,7 @@ def create_point_set(order, nsd):
             for j in range(0, order + 1):
                 y = j*h
                 for k in range(0, order + 1):
-                    z = j*h
+                    z = k*h
                     if x + y + z <= 1:
                         set.append((x, y, z))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
During 3D point set creation, `z` is supposed to be `k*h`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->