### PR TITLE
Add fix in MatMul

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,6 +1,6 @@
 import random
 
-from sympy.core import SympifyError, Add
+from sympy.core import SympifyError
 from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence, reduce
 from sympy.core.expr import Expr
@@ -156,7 +156,7 @@ class DenseMatrix(MatrixBase):
                 col_indices = range(col, other_len, other.cols)
                 vec = [mat[a]*other_mat[b] for a, b in zip(row_indices, col_indices)]
                 try:
-                    new_mat[i] = Add(*vec)
+                    new_mat[i] = sum(*vec)
                 except (TypeError, SympifyError):
                     # Some matrices don't work with `sum` or `Add`
                     # They don't work with `sum` because `sum` tries to add `0`


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Currently, MatMul hardcodes `sympy.Add` which prevents its usage with custom types with their own Add. `sum` does check if objects have their own add first and is safer. It also avoids local import.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Switch Add to sum in matmul.

<!-- END RELEASE NOTES -->