### PR TITLE
Enforce elementwise mul for explicit non-matrix

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2551,8 +2551,10 @@ class MatrixArithmetic(MatrixRequired):
         isimpbool = _get_intermediate_simp_bool(False, dotprodsimp)
         other = _matrixify(other)
         # matrix-like objects can have shapes.  This is
-        # our first sanity check.
-        if hasattr(other, 'shape') and len(other.shape) == 2:
+        # our first sanity check. Double check other is not explicitly not a Matrix.
+        if (hasattr(other, 'shape') and len(other.shape) == 2 and
+            (getattr(other, 'is_Matrix', True) or
+             getattr(other, 'is_MatrixLike', True))):
             if self.shape[1] != other.shape[0]:
                 raise ShapeError("Matrix size mismatch: %s * %s." % (
                     self.shape, other.shape))
@@ -2721,8 +2723,10 @@ class MatrixArithmetic(MatrixRequired):
     def __rmul__(self, other):
         other = _matrixify(other)
         # matrix-like objects can have shapes.  This is
-        # our first sanity check.
-        if hasattr(other, 'shape') and len(other.shape) == 2:
+        # our first sanity check. Double check other is not explicitly not a Matrix.
+        if (hasattr(other, 'shape') and len(other.shape) == 2 and
+            (getattr(other, 'is_Matrix', True) or
+             getattr(other, 'is_MatrixLike', True))):
             if self.shape[0] != other.shape[1]:
                 raise ShapeError("Matrix size mismatch.")
 
@@ -2908,6 +2912,9 @@ def _matrixify(mat):
     `mat` is passed through without modification."""
 
     if getattr(mat, 'is_Matrix', False) or getattr(mat, 'is_MatrixLike', False):
+        return mat
+
+    if not(getattr(mat, 'is_Matrix', True) or getattr(mat, 'is_MatrixLike', True)):
         return mat
 
     shape = None

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1,4 +1,5 @@
 from sympy.assumptions import Q
+from sympy.core.expr import Expr
 from sympy.core.add import Add
 from sympy.core.function import Function
 from sympy.core.numbers import I, Integer, oo, pi, Rational
@@ -729,6 +730,22 @@ def test_matmul():
         pass
     except TypeError:  #TypeError is raised in case of NotImplemented is returned
         pass
+
+
+def test_non_matmul():
+    """
+    Test that if explicitly specified as non-matrix, mul reverts
+    to scalar multiplication.
+    """
+    class foo(Expr):
+        is_Matrix=False
+        is_MatrixLike=False
+        shape = (1, 1)
+
+    A = Matrix([[1, 2], [3, 4]])
+    b = foo()
+    assert b*A == Matrix([[b, 2*b], [3*b, 4*b]])
+    assert A*b == Matrix([[b, 2*b], [3*b, 4*b]])
 
 
 def test_power():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This PR slightly increase the checks in a Matrix mul so that if multiplied by an object that is explicitly not a matrix,  it defaults back to elementwise.

#### Other comments

This is an issue we run into in [Devito](https://github.com/devitocodes/devito), as we have `sympy.Function` and `sympy.Symbols` object but with associated data and shape. These objects are non-matrix (will be made explicit with upcoming tensor algebra update) but error when we try to multiply a Matrix.

for example:

```
A = Matrix([[1, 2], [3, 4]])
b = devito.Function(name="b", grid=Grid((10, 10)))
b* A # should return the Matrix [[ b, 2 *b], [3*b, 4*b]]
```
error as `b.shape = (10, 10)` (so has shape) and `len(b.shape) == 2` so mul thinks b is a matrix and tries to do a MatMat mul with incompatible shapes.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Explicit non-matrix are treated as scalar

<!-- END RELEASE NOTES -->