### PR TITLE
[WIP] Adding ParametricIntegral class

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4856,6 +4856,14 @@ def test_sympy__vector__deloperator__Del():
     assert _test_args(Del())
 
 
+def test_sympy__vector__integrals__ParametricIntegral():
+    from sympy.vector.integrals import ParametricIntegral
+    from sympy.vector.parametricregion import ParametricRegion
+    from sympy.vector.coordsysrect import CoordSys3D
+    C = CoordSys3D('C')
+    assert _test_args(ParametricIntegral(C.y*C.i - 10*C.j,\
+                    ParametricRegion((x, y), (x, 1, 3), (y, -2, 2))))
+
 def test_sympy__vector__operators__Curl():
     from sympy.vector.operators import Curl
     from sympy.vector.coordsysrect import CoordSys3D

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -15,6 +15,7 @@ from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
 from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence
 from sympy.vector.parametricregion import ParametricRegion
+from sympy.vector.integrals import (ParametricIntegral, vector_integrate)
 
 __all__ = [
     'Vector', 'VectorAdd', 'VectorMul', 'BaseVector', 'VectorZero', 'Cross',
@@ -39,5 +40,5 @@ __all__ = [
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
     'divergence',
 
-    'ParametricRegion', 'ParametricIntegral',
+    'ParametricRegion', 'ParametricIntegral', 'vector_integrate',
 ]

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -39,5 +39,5 @@ __all__ = [
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
     'divergence',
 
-    'ParametricRegion',
+    'ParametricRegion', 'ParametricIntegral',
 ]

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -1,7 +1,7 @@
 from sympy.core.basic import Basic
-from sympy.simplify import simplify
+from sympy import simplify
 from sympy.matrices import Matrix
-from sympy.vector import CoordSys3D, Vector
+from sympy.vector import CoordSys3D, Vector, ParametricRegion
 from sympy.vector.operators import _get_coord_sys_from_expr
 from sympy.integrals import Integral, integrate
 from sympy.core.function import diff
@@ -15,36 +15,41 @@ class ParametricIntegral(Basic):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSys3D, ParametricRegion
-    >>> from sympy.abc import t
+    >>> from sympy import cos, sin, pi
+    >>> from sympy.vector import CoordSys3D, ParametricRegion, ParametricIntegral
+    >>> from sympy.abc import r, t, theta, phi
 
-    >>> C = CoordSys3D('C)
+    >>> C = CoordSys3D('C')
     >>> curve = ParametricRegion((3*t - 2, t + 1), (t, 1, 2))
     >>> ParametricIntegral(C.x, curve)
     5*sqrt(10)/2
     >>> length = ParametricIntegral(1, curve)
+    >>> length
     sqrt(10)
     >>> semisphere = ParametricRegion((2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi)),\
                             (theta, 0, 2*pi), (phi, 0, pi/2))
     >>> ParametricIntegral(C.z, semisphere)
     8*pi
 
-    >>> ParametricIntegral(C.j - C.k, ParametricRegion((r*cos(theta), r*sin(theta)), r, theta))
-    ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
+    >>> ParametricIntegral(C.j + C.k, ParametricRegion((r*cos(theta), r*sin(theta)), r, theta))
+    ParametricIntegral(C.j + C.k, ParametricRegion((r*cos(theta), r*sin(theta)), r, theta))
 
     """
-    
+
     def __new__(cls, field, parametricregion):
-            
+
         coord_set = _get_coord_sys_from_expr(field)
-        
+
         if len(coord_set) == 0:
             coord_sys = CoordSys3D('C')
         elif len(coord_set) > 1:
             raise ValueError
         else:
             coord_sys = next(iter(coord_set))
-        
+
+        if parametricregion.dimensions == 0:
+            return super().__new__(cls, field, parametricregion)
+
         base_vectors = coord_sys.base_vectors()
         base_scalars = coord_sys.base_scalars()
 
@@ -53,7 +58,7 @@ class ParametricIntegral(Basic):
         r = Vector.zero
         for i in range(len(parametricregion.definition)):
             r += base_vectors[i]*parametricregion.definition[i]
-        
+
         if len(coord_set) != 0:
             for i in range(len(parametricregion.definition)):
                 parametricfield = parametricfield.subs(base_scalars[i], parametricregion.definition[i])
@@ -61,73 +66,94 @@ class ParametricIntegral(Basic):
         if parametricregion.dimensions == 1:
             parameter = parametricregion.parameters[0]
 
-            r_diff = diff(r, parameter)        
-
+            r_diff = diff(r, parameter)
             lower, upper = parametricregion.limits[parameter][0], parametricregion.limits[parameter][1]
-            
+
             if isinstance(parametricfield, Vector):
-                result = integrate(r_diff.dot(parametricfield), (parameter, lower, upper))
-                print(result)
+                integrand = simplify(r_diff.dot(parametricfield))
             else:
-                result = integrate(r_diff.magnitude()*parametricfield, (parameter, lower, upper))            
+                integrand = simplify(r_diff.magnitude()*parametricfield)
+
+            result = integrate(integrand, (parameter, lower, upper))
+
         elif parametricregion.dimensions == 2:
-            u, v = parametricregion.parameters[0], parametricregion.parameters[1]
-            
+            u, v = cls._bounds_case(parametricregion.limits)
+
             r_u = diff(r, u)
             r_v = diff(r, v)
             normal_vector = simplify(r_u.cross(r_v))
-            
+
             if isinstance(parametricfield, Vector):
                 integrand = parametricfield.dot(normal_vector)
-            else:   
+            else:
                 integrand = parametricfield*normal_vector.magnitude()
-            
+
             integrand = simplify(integrand)
-            
-            u, v = cls._bounds_case(parametricregion.parameters, parametricregion.limits)
-            
+
             lower_u, upper_u = parametricregion.limits[u][0], parametricregion.limits[u][1]
             lower_v, upper_v = parametricregion.limits[v][0], parametricregion.limits[v][1]
 
-            result = integrate(integrand, (u, lower_u, upper_u), (v, lower_v, upper_v))    
-                
+            result = integrate(integrand, (u, lower_u, upper_u), (v, lower_v, upper_v))
+
         else:
-            coeff = Matrix(parametricregion.definition).jacobian(parametricregion.parameters).det()
+            variables = cls._bounds_case(parametricregion.limits)
+            coeff = Matrix(parametricregion.definition).jacobian(variables).det()
             integrand = simplify(parametricfield*coeff)
-            variables = cls._bounds_case(parametricregion.parameters, parametricregion.limits)
 
             l = [(var, parametricregion.limits[var][0], parametricregion.limits[var][1]) for var in variables]
-            
             result = integrate(integrand, *l)
-                            
+
         if not isinstance(result, Integral):
-            return result     
-        else: 
+            return result
+        else:
             return super().__new__(cls, field, parametricregion)
-    
-    @classmethod             
-    def _bounds_case(cls, parameters, limits):
-    
-        V = list(parameters)
+
+    @classmethod
+    def _bounds_case(cls, limits):
+
+        V = list(limits.keys())
         E = list()
-        
-        for p in parameters:
+
+        for p in V:
             lower_p = limits[p][0]
             upper_p = limits[p][1]
-            
+
             lower_p = lower_p.atoms()
             upper_p = upper_p.atoms()
-            for q in parameters:
+            for q in V:
                 if p == q:
                     continue
                 if lower_p.issuperset(set([q])) or upper_p.issuperset(set([q])):
-                    E.append((p, q))   
-        return topological_sort((V, E), key=default_sort_key)                   
-             
+                    E.append((p, q))
+        return topological_sort((V, E), key=default_sort_key)
+
     @property
     def field(self):
         return self.args[0]
-    
+
     @property
     def parametricregion(self):
         return self.args[1]
+
+def vector_integrate(field, *region):
+    """
+    Compute the integral of a vector/scalar field
+    over a a region or a set of parameters.
+
+    Examples:
+    =========
+    >>> from sympy.vector import CoordSys3D, ParametricRegion, vector_integrate
+    >>> from sympy.abc import t
+    >>> C = CoordSys3D('C')
+
+    >>> region = ParametricRegion((t, t**2), (t, 1, 5))
+    >>> vector_integrate(C.x*C.i, region)
+    12
+
+    >>> vector_integrate(C.x**2*C.z, C.x)
+    C.x**3*C.z/3
+    """
+    if len(region) == 1:
+        if isinstance(region[0], ParametricRegion):
+            return ParametricIntegral(field, region[0])
+    return integrate(field, *region)

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -1,7 +1,10 @@
-from sympy.vector.coordsysrect import CoordSys3D
-from sympy.integrals import Integral
+from sympy.core.basic import Basic
+from sympy.vector import CoordSys3D, Vector
+from sympy.vector.operators import _get_coord_sys_from_expr
+from sympy.integrals import Integral, integrate
+from sympy.core.function import diff
 
-class ParametricIntegral(Integral):
+class ParametricIntegral(Basic):
     """
     Represents integral of a scalar or vector field
     over a Parametric Region
@@ -13,7 +16,8 @@ class ParametricIntegral(Integral):
     >>> from sympy.abc import t
 
     >>> C = CoordSys3D('C)
-    >>> curve = ParametricRegion(t, (t, t**2), {t: (-1, 1)})
+    >>> curve = ParametricRegion(t, (3*t - 2, t + 1), {t: (1, 2)})
+
     >>> ParametricIntegral(C.x, curve)
     0
     >>> semisphere = ParametricRegion((phi, theta), (2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi))
@@ -25,6 +29,51 @@ class ParametricIntegral(Integral):
     ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
 
     """
+    
+    def __new__(cls, field, parametricregion):
+        obj = super().__new__(cls, field, parametricregion)
+        return obj
 
-    def __int__(self, field, parametricregion):
-        pass
+    def eval(self):
+        parametricregion = self.parametricregion
+        field = self.field
+        
+        coord_sys = _get_coord_sys_from_expr(field)
+        
+        if len(coord_sys) > 1:
+            raise ValueError
+        
+        coord_sys = next(iter(coord_sys))
+
+        if parametricregion.dimension == 1:
+            parameter = parametricregion.parameters[0]
+            
+            r_diff_tuple = [diff(comp, parameter) for comp in parametricregion.definition]
+            
+            base_vectors = coord_sys.base_vectors()
+            base_scalars = coord_sys.base_scalars()
+            r_diff = Vector.zero
+            parametricfield = field
+            
+            for i in range(len(parametricregion.definition)):
+                r_diff += base_vectors[i]*r_diff_tuple[i]        
+            
+            for i in range(len(parametricregion.definition)):
+                parametricfield = parametricfield.subs(base_scalars[i], parametricregion.definition[i])
+            
+            lower, upper = parametricregion.limits[parameter][0], parametricregion.limits[parameter][1]
+            
+            if isinstance(parametricfield, Vector):
+                result = integrate(r_diff.dot(parametricfield), (parameter, lower, upper))
+            else:
+                result = integrate(r_diff.magnitude()*parametricfield, (parameter, lower, upper))
+                
+            return result            
+            
+    @property
+    def field(self):
+        return self.args[0]
+    
+    @property
+    def parametricregion(self):
+        return self.args[1]  

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -1,4 +1,5 @@
 from sympy.core.basic import Basic
+from sympy.simplify import simplify
 from sympy.vector import CoordSys3D, Vector
 from sympy.vector.operators import _get_coord_sys_from_expr
 from sympy.integrals import Integral, integrate
@@ -26,7 +27,7 @@ class ParametricIntegral(Basic):
     8*pi
 
     >>> ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
-    ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
+    ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))-
 
     """
     
@@ -67,24 +68,69 @@ class ParametricIntegral(Basic):
                 result = integrate(r_diff.dot(parametricfield), (parameter, lower, upper))
             else:
                 result = integrate(r_diff.magnitude()*parametricfield, (parameter, lower, upper))
+            
+            if not isinstance(result, Integral):
+                return result
                 
         elif parametricregion.dimension == 2:
             u, v = parametricregion.parameters[0], parametricregion.parameters[1]
             
             r_u = diff(r, u)
             r_v = diff(r, v)
-            normal_vector = r_u.cross(r_v)
+            normal_vector = simplify(r_u.cross(r_v))
             
             lower_u, upper_u = parametricregion.limits[u][0], parametricregion.limits[u][1]
             lower_v, upper_v = parametricregion.limits[v][0], parametricregion.limits[v][1]
             
             if isinstance(parametricfield, Vector):
-                result = integrate(parametricfield.dot(normal_vector), (u, lower_u, upper_u),\
-                            (v, lower_v, upper_v))
-            else:
-                result = integrate(parametricfield*normal_vector.magnitude(), (u, lower_u, upper_u), (v, lower_v, upper_v))
+                integrand = parametricfield.dot(normal_vector)
+            else:   
+                integrand = parametricfield*normal_vector.magnitude()
+            
+            integrand = simplify(integrand)
+            
+            case = self._bounds_case(u, v, parametricregion.limits)
+            
+            # Check the bounds to ascertain the order
+            # Case 1 : Both bounds are constants : can  perform integration in any order
+            # Case 2 : Bounds for u are in terms of v : integrate wrt to u first
+            # Case 3 : Bounds for v are in terms of u : integrate wrt to v first
+            
+            if case == 1 or case == 3:
+                result = integrate(integrand, (u, lower_u, upper_u), (v, lower_v, upper_v))    
+                
+                if not isinstance(result, Integral):
+                    return result
+            
+            if case == 2 or case == 3:
+                result = integrate(integrand, (v, lower_v, upper_v), (u, lower_u, upper_u))
+                
+                if not isinstance(result, Integral):
+                    return result
+                
+        return self
+                 
+    def _bounds_case(self, u, v, limits):
+        lower_u = limits[u][0]
+        upper_u = limits[u][1]
         
-        return result   
+        lower_u = lower_u.atoms()
+        upper_u = upper_u.atoms()
+        
+        if lower_u.issuperset(set([v])) or upper_u.issuperset(set([v])):
+            return 1
+        
+        lower_v = limits[v][0]
+        upper_v = limits[v][1]
+        
+        lower_v = lower_v.atoms()
+        upper_v = upper_v.atoms()
+        
+        if lower_v.issuperset(set([u])) or upper_v.issuperset(set([u])):
+            return 2
+            
+        return 3
+        
             
     @property
     def field(self):

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -1,0 +1,30 @@
+from sympy.vector.coordsysrect import CoordSys3D
+from sympy.integrals import Integral
+
+class ParametricIntegral(Integral):
+    """
+    Represents integral of a scalar or vector field
+    over a Parametric Region
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSys3D, ParametricRegion
+    >>> from sympy.abc import t
+
+    >>> C = CoordSys3D('C)
+    >>> curve = ParametricRegion(t, (t, t**2), {t: (-1, 1)})
+    >>> ParametricIntegral(C.x, curve)
+    0
+    >>> semisphere = ParametricRegion((phi, theta), (2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi))
+                            {theta: (0, 2*pi), phi: (0, pi/2)})
+    >>> ParametricIntegral(C.z, semisphere)
+    8*pi
+
+    >>> ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
+    ParametricIntegral(C.j - C.k, ParametricRegion((r, theta), (r*cos(theta), r*sin(theta))))
+
+    """
+
+    def __int__(self, field, parametricregion):
+        pass

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -1,51 +1,60 @@
+from sympy import sin, cos, pi
 from sympy.vector.coordsysrect import CoordSys3D
+from sympy.vector.integrals import ParametricIntegral
 from sympy.vector.parametricregion import ParametricRegion
-from sympy.abc import x, y, u, v, t, theta, phi, pi
+from sympy.abc import x, y, z, u, v, r, t, theta, phi, pi
 
 C = CoordSys3D('C')
 
 def test_lineintegrals():
-    halfcircle = ParametricRegion(theta, (4*cos(theta), 4*sin(theta)), {theta: (-pi/2, pi/2)})
+    halfcircle = ParametricRegion((4*cos(theta), 4*sin(theta)), (theta, -pi/2, pi/2))
     assert ParametricIntegral(C.x*C.y**4, halfcircle) == 1638.4
 
-    curve = ParametricRegion(t, (t, t**2, t**3), {t: (0, 1)})
+    curve = ParametricRegion((t, t**2, t**3), (t, 0, 1))
     field1 = 8*C.x**2*C.y*C.z*C.i + 5*C.z*C.j - 4*C.x*C.y*C.k
     assert ParametricIntegral(field, curve) == 1
-    line = ParametricRegion(t, (4*t − 1, 2 − 2*t, t), {t: (0, 1)})
+    line = ParametricRegion((4*t - 1, 2 - 2*t, t), (t, 0, 1))
     assert ParametricIntegral(C.x*C.z*C.i - C.y*C.z*C.k, line) == 3
 
-    assert ParametricIntegral(4*R.x**3, ParametricRegion(t, (1, t), {t: (0, 2)})) = 8
+    assert ParametricIntegral(4*R.x**3, ParametricRegion((1, t), (t, 0, 2))) == 8
 
-    helix = ParametricRegion(t, (cos(t), sin(t), 3*t), {t: (0, 4)})
-    assert ParametricIntegral(C.x*C.y*C.z, helix) == −3*sqrt(10)*pi
+    helix = ParametricRegion((cos(t), sin(t), 3*t), (t, 0, 4))
+    assert ParametricIntegral(C.x*C.y*C.z, helix) == -3*sqrt(10)*pi
 
     field2 = C.y*C.i + C.z*C.j + C.z*C.k
-    assert ParametricIntegral(field2, ParametricRegion(t, (cos(t), sin(t), t**2), {t: (0, pi)})) == 8*pi**4
+    assert ParametricIntegral(field2, ParametricRegion((cos(t), sin(t), t**2), (t, 0, pi))) == 8*pi**4
 
-def test_surfaceintegrals()
+def test_surfaceintegrals():
 
-    semisphere = ParametricRegion((phi, theta), (2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi))
-                            {theta: (0, 2*pi), phi: (0, pi/2)})
+    semisphere = ParametricRegion((2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi)),\
+                            (theta, 0, 2*pi), (phi, 0, pi/2))
     assert ParametricIntegral(C.z, semisphere) == 8*pi
 
-    cylinder = ParametricRegion((theta, z), (sqrt(3)*cos(theta), sqrt(3)*sin(theta), z), {z: (0, 6), theta: (0, 2*pi))
+    cylinder = ParametricRegion((sqrt(3)*cos(theta), sqrt(3)*sin(theta), z), (z, 0, 6), (theta, 0, 2*pi))
     assert ParametricIntegral(C.y, cylinder) == 0
+    cone = ParametricRegion((v*cosu, v*sinu, v), (u, 0, 2*pi), (v, 0, 1))
 
-    cone = ParametricRegion((u, v), (v*cosu, v*sinu, v), {u: (0, 2*pi), v: (0, 1)})
     assert ParametricIntegral(C.x*C.i + C.y*C.z + C.z**4*C.k, cone) == pi/3
     
-    triangle = ParametricRegion((x, y), (x, y), {x: (0, 2), y: (0, 10 - 5*x)})
+    triangle1 = ParametricRegion((x, y), (x, 0, 2), (y, 0, 10 - 5*x))
+    triangle2 = ParametricRegion((x, y), (y, 0, 10 - 5*x), (x, 0, 2))
+    assert ParametricIntegral(-15.6*C.y*C.k, traingle1) == ParametricIntegral(-15.6*C.y*C.k, traingle2)
     assert ParametricIntegral(C.z, triangle) == 10*C.z
 
-def test_volumeintegrals()
+def test_volumeintegrals():
 
-    cube = ParametricRegion(C, (), {C.x : (0, 1), C.y : (0, 1), C.z : (0, 1)})
+    cube = ParametricRegion((x, y, z), (x, 0, 1), (y, 0, 1), (z, 0, 1))
     assert ParametricIntegral(1, cube) == 1
     
-    solidsphere = ParametricRegion((r, phi, theta), (r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
-                            {r: (0, 2), theta: (0, 2*pi), phi: (0, pi)})
-    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere) == 256*pi/15
+    solidsphere = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
+                            (r, 0, 2), (theta, 0, 2*pi), (phi, 0, pi))
+    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere) == -256*pi/15
 
-    region_under_plane = ParametricRegion((x, y, z), (x, y, z), {x: (0, 3/2), y: (0, -2*3/x + 2),
-                                    z: (0, 6 - 2*C.x - 3*C,y)})
+    region_under_plane1 = ParametricRegion((x, y, z), (x, 0, 3/2), (y, 0, -2*3/x + 2),\
+                                    (z, 0, 6 - 2*C.x - 3*C,y))
+    region_under_plane2 = ParametricRegion((x, y, z), (x, 0, 3/2), (z, 0, 6 - 2*C.x - 3*C,y),\
+                                    (y, 0, -2*3/x + 2))
+    
+    assert ParametricIntegral(C.i*C.k + C.j - 100*C.k, region-under_plane1) == \
+        ParametricIntegral(C.i*C.k + C.j - 100*C.k, region-under_plane2)    
     assert ParametricIntegral(2*C.x, region_under_plane) == 9

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -1,28 +1,28 @@
-from sympy import sin, cos, pi
+from sympy import sin, cos, pi, S, sqrt
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.integrals import ParametricIntegral
 from sympy.vector.parametricregion import ParametricRegion
-from sympy.abc import x, y, z, u, v, r, t, theta, phi, pi
+from sympy.abc import x, y, z, u, v, r, t, theta, phi
 
 C = CoordSys3D('C')
 
 def test_lineintegrals():
     halfcircle = ParametricRegion((4*cos(theta), 4*sin(theta)), (theta, -pi/2, pi/2))
-    assert ParametricIntegral(C.x*C.y**4, halfcircle) == 1638.4
+    assert ParametricIntegral(C.x*C.y**4, halfcircle) == S(8192)/5
 
     curve = ParametricRegion((t, t**2, t**3), (t, 0, 1))
     field1 = 8*C.x**2*C.y*C.z*C.i + 5*C.z*C.j - 4*C.x*C.y*C.k
-    assert ParametricIntegral(field, curve) == 1
+    assert ParametricIntegral(field1, curve) == 1
     line = ParametricRegion((4*t - 1, 2 - 2*t, t), (t, 0, 1))
     assert ParametricIntegral(C.x*C.z*C.i - C.y*C.z*C.k, line) == 3
 
-    assert ParametricIntegral(4*R.x**3, ParametricRegion((1, t), (t, 0, 2))) == 8
+    assert ParametricIntegral(4*C.x**3, ParametricRegion((1, t), (t, 0, 2))) == 8
 
-    helix = ParametricRegion((cos(t), sin(t), 3*t), (t, 0, 4))
+    helix = ParametricRegion((cos(t), sin(t), 3*t), (t, 0, 4*pi))
     assert ParametricIntegral(C.x*C.y*C.z, helix) == -3*sqrt(10)*pi
 
     field2 = C.y*C.i + C.z*C.j + C.z*C.k
-    assert ParametricIntegral(field2, ParametricRegion((cos(t), sin(t), t**2), (t, 0, pi))) == 8*pi**4
+    assert ParametricIntegral(field2, ParametricRegion((cos(t), sin(t), t**2), (t, 0, pi))) == -5*pi/2 + pi**4/2
 
 def test_surfaceintegrals():
 
@@ -32,29 +32,29 @@ def test_surfaceintegrals():
 
     cylinder = ParametricRegion((sqrt(3)*cos(theta), sqrt(3)*sin(theta), z), (z, 0, 6), (theta, 0, 2*pi))
     assert ParametricIntegral(C.y, cylinder) == 0
-    cone = ParametricRegion((v*cosu, v*sinu, v), (u, 0, 2*pi), (v, 0, 1))
 
-    assert ParametricIntegral(C.x*C.i + C.y*C.z + C.z**4*C.k, cone) == pi/3
-    
+    cone = ParametricRegion((v*cos(u), v*sin(u), v), (u, 0, 2*pi), (v, 0, 1))
+    assert ParametricIntegral(C.x*C.i + C.y*C.j + C.z**4*C.k, cone) == pi/3
+
     triangle1 = ParametricRegion((x, y), (x, 0, 2), (y, 0, 10 - 5*x))
     triangle2 = ParametricRegion((x, y), (y, 0, 10 - 5*x), (x, 0, 2))
-    assert ParametricIntegral(-15.6*C.y*C.k, traingle1) == ParametricIntegral(-15.6*C.y*C.k, traingle2)
-    assert ParametricIntegral(C.z, triangle) == 10*C.z
+    assert ParametricIntegral(-15.6*C.y*C.k, triangle1) == ParametricIntegral(-15.6*C.y*C.k, triangle2)
+    assert ParametricIntegral(C.z, triangle1) == 10*C.z
 
 def test_volumeintegrals():
 
     cube = ParametricRegion((x, y, z), (x, 0, 1), (y, 0, 1), (z, 0, 1))
     assert ParametricIntegral(1, cube) == 1
-    
+
     solidsphere = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
                             (r, 0, 2), (theta, 0, 2*pi), (phi, 0, pi))
     assert ParametricIntegral(C.x**2 + C.y**2, solidsphere) == -256*pi/15
 
-    region_under_plane1 = ParametricRegion((x, y, z), (x, 0, 3/2), (y, 0, -2*3/x + 2),\
-                                    (z, 0, 6 - 2*C.x - 3*C,y))
-    region_under_plane2 = ParametricRegion((x, y, z), (x, 0, 3/2), (z, 0, 6 - 2*C.x - 3*C,y),\
-                                    (y, 0, -2*3/x + 2))
-    
-    assert ParametricIntegral(C.i*C.k + C.j - 100*C.k, region-under_plane1) == \
-        ParametricIntegral(C.i*C.k + C.j - 100*C.k, region-under_plane2)    
-    assert ParametricIntegral(2*C.x, region_under_plane) == 9
+    region_under_plane1 = ParametricRegion((x, y, z), (x, 0, 3), (y, 0, -2*x/3 + 2),\
+                                    (z, 0, 6 - 2*x - 3*y))
+    region_under_plane2 = ParametricRegion((x, y, z), (x, 0, 3), (z, 0, 6 - 2*x - 3*y),\
+                                    (y, 0, -2*x/3 + 2))
+
+    assert ParametricIntegral(C.x*C.i + C.j - 100*C.k, region_under_plane1) == \
+        ParametricIntegral(C.x*C.i + C.j - 100*C.k, region_under_plane2)
+    assert ParametricIntegral(2*C.x, region_under_plane2) == -9

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -33,6 +33,9 @@ def test_surfaceintegrals()
 
     cone = ParametricRegion((u, v), (v*cosu, v*sinu, v), {u: (0, 2*pi), v: (0, 1)})
     assert ParametricIntegral(C.x*C.i + C.y*C.z + C.z**4*C.k, cone) == pi/3
+    
+    triangle = ParametricRegion((x, y), (x, y), {x: (0, 2), y: (0, 10 - 5*x)})
+    assert ParametricIntegral(C.z, triangle) == 10*C.z
 
 def test_volumeintegrals()
 

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -1,0 +1,44 @@
+from sympy.vector.coordsysrect import CoordSys3D
+from sympy.vector.parametricregion import ParametricRegion
+from sympy.abc import x, y, u, v, t, theta, phi, pi
+
+C = CoordSys3D('C')
+
+def test_lineintegrals():
+    halfcircle = ParametricRegion(theta, (4*cos(theta), 4*sin(theta)), {theta: (-pi/2, pi/2)})
+    assert ParametricIntegral(C.x*C.y**4, halfcircle) == 1638.4
+
+    curve = ParametricRegion(t, (t, t**2, t**3), {t: (0, 1)})
+    field1 = 8*C.x**2*C.y*C.z*C.i + 5*C.z*C.j - 4*C.x*C.y*C.k
+    assert ParametricIntegral(field, curve) == 1
+    line = ParametricRegion(t, (4*t − 1, 2 − 2*t, t), {t: (0, 1)})
+    assert ParametricIntegral(C.x*C.z*C.i - C.y*C.z*C.k, line) == 3
+
+    assert ParametricIntegral(4*R.x**3, ParametricRegion(t, (1, t), {t: (0, 2)})) = 8
+
+    helix = ParametricRegion(t, (cos(t), sin(t), 3*t), {t: (0, 4)})
+    assert ParametricIntegral(C.x*C.y*C.z, helix) == −3*sqrt(10)*pi
+
+    field2 = C.y*C.i + C.z*C.j + C.z*C.k
+    assert ParametricIntegral(field2, ParametricRegion(t, (cos(t), sin(t), t**2), {t: (0, pi)})) == 8*pi**4
+
+def test_surfaceintegrals()
+
+    semisphere = ParametricRegion((phi, theta), (2*sin(phi)*cos(theta), 2*sin(phi)*sin(theta), 2*cos(phi))
+                            {theta: (0, 2*pi), phi: (0, pi/2)})
+    assert ParametricIntegral(C.z, semisphere) == 8*pi
+
+    cylinder = ParametricRegion((theta, z), (sqrt(3)*cos(theta), sqrt(3)*sin(theta), z), {z: (0, 6), theta: (0, 2*pi))
+    assert ParametricIntegral(C.y, cylinder) == 0
+
+    cone = ParametricRegion((u, v), (v*cosu, v*sinu, v), {u: (0, 2*pi), v: (0, 1)})
+    assert ParametricIntegral(C.x*C.i + C.y*C.z + C.z**4*C.k, cone) == pi/3
+
+def test_volumeintegrals()
+
+    cube = ParametricRegion(C, (), {C.x : (0, 1), C.y : (0, 1), C.z : (0, 1)})
+    assert ParametricIntegral(1, cube) == 1
+
+    region_under_plane = ParametricRegion((x, y, z), (x, y, z), {x: (0, 3/2), y: (0, -2*3/x + 2),
+                                    z: (0, 6 - 2*C.x - 3*C,y)})
+    assert ParametricIntegral(2*C.x, region_under_plane) == 9

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -41,6 +41,10 @@ def test_volumeintegrals()
 
     cube = ParametricRegion(C, (), {C.x : (0, 1), C.y : (0, 1), C.z : (0, 1)})
     assert ParametricIntegral(1, cube) == 1
+    
+    solidsphere = ParametricRegion((r, phi, theta), (r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
+                            {r: (0, 2), theta: (0, 2*pi), phi: (0, pi)})
+    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere) == 256*pi/15
 
     region_under_plane = ParametricRegion((x, y, z), (x, y, z), {x: (0, 3/2), y: (0, -2*3/x + 2),
                                     z: (0, 6 - 2*C.x - 3*C,y)})


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19320 

#### Brief description of what is fixed or changed
An object of ParametricIntegral represents integral of a scalar or vector field over a Parametric Region.

#### Other comments
`_bounds_case` function is taken from @prasoon2211  [PR](https://github.com/sympy/sympy/pull/2208/files) with some modification. I have added him as a coauthor for the corresponding commit. 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * added class to represent integral of scalar/vector field over a parametric surface.
<!-- END RELEASE NOTES -->