### PR TITLE
Modified order.py

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1050,6 +1050,8 @@ def test_is_convergent():
     assert Sum(1/(x**3), (x, 1, oo)).is_convergent() is S.true
     assert Sum(1/(x**S.Half), (x, 1, oo)).is_convergent() is S.false
 
+    # issue 19545
+    assert Sum(1/n - 3/(3*n +2), (n, 1, oo)).is_convergent() is S.true
 
 def test_is_absolutely_convergent():
     assert Sum((-1)**n, (n, 1, oo)).is_absolutely_convergent() is S.false

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -212,6 +212,8 @@ class Order(Expr):
                 # x*y (wrong order term!).  That's why we want to deal with
                 # expand()'ed expr (handled in "if expr.is_Add" branch below).
                 expr = expr.expand()
+            else:
+                expr = expr.factor()
 
             old_expr = None
             while old_expr != expr:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -197,8 +197,7 @@ class Order(Expr):
             expr = expr.subs(s)
 
             if expr.is_Add:
-                from sympy import expand_multinomial
-                expr = expand_multinomial(expr)
+                expr = expr.factor()
 
             if s:
                 args = tuple([r[0] for r in rs.items()])
@@ -212,8 +211,6 @@ class Order(Expr):
                 # x*y (wrong order term!).  That's why we want to deal with
                 # expand()'ed expr (handled in "if expr.is_Add" branch below).
                 expr = expr.expand()
-            else:
-                expr = expr.factor()
 
             old_expr = None
             while old_expr != expr:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -376,6 +376,8 @@ def test_order_at_infinity():
     assert Order(exp(x), (x, oo)).expr == Order(2*exp(x), (x, oo)).expr == exp(x)
     assert Order(y**x, (x, oo)).expr == Order(2*y**x, (x, oo)).expr == exp(log(y)*x)
 
+    # issue 19545
+    assert Order(1/x - 3/(3*x + 2), (x, oo)).expr == x**(-2)
 
 def test_mixing_order_at_zero_and_infinity():
     assert (Order(x, (x, 0)) + Order(x, (x, oo))).is_Add


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19545

#### Brief description of what is fixed or changed

The code `Order(1/n - 3/(3*n +2), (n, oo))` returns `1/n`, which
is not a sharp result.
As a consequence `Sum(1/n - 3/(3*n +2), (n, 1, oo)).is_convergent()`
gives the wrong result `False`.
In the lines 208-214 of `order.py`, if the number of variables are >= 2,
then the expression is expanded and is handled in `expr.is_Add` case.
However in the case of a single variable,
the alghorithm for the other case seems better.
Factorizing the expression forces to use the better alghoritm in the case
of a single variable.

modified:   sympy/concrete/tests/test_sums_products.py
modified:   sympy/series/order.py
modified:   sympy/series/tests/test_order.py

#### Other comments

See also   #18340


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- series
    - modified order.py to better work with Add objects.
<!-- END RELEASE NOTES -->