### PR TITLE
Improve trigsimp for hyperbolic functions nested in non-trig functions

### DIFF
--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -437,8 +437,11 @@ They have property ``iszerofunc`` opened up for user to specify zero testing
 method, which can accept any function with single input and boolean output,
 while being defaulted with ``_iszero``.
 
-Here is an example of solving an issue caused by undertested zero.
+Here is an example of solving an issue caused by undertested zero. While the
+output for this particular matrix has since been improved, the technique
+below is still of interest.
 [#zerotestexampleidea-fn]_ [#zerotestexamplediscovery-fn]_
+[#zerotestexampleimproved-fn]_
 
     >>> from sympy import *
     >>> q = Symbol("q", positive = True)
@@ -446,7 +449,7 @@ Here is an example of solving an issue caused by undertested zero.
     ... [-2*cosh(q/3),      exp(-q),            1],
     ... [      exp(q), -2*cosh(q/3),            1],
     ... [           1,            1, -2*cosh(q/3)]])
-    >>> m.nullspace()
+    >>> m.nullspace() # doctest: +SKIP
     []
 
 You can trace down which expression is being underevaluated,
@@ -541,6 +544,8 @@ SymPy issue tracker [#sympyissues-fn]_ to get detailed help from the community.
 .. [#zerotestexampleidea-fn] Inspired by https://gitter.im/sympy/sympy?at=5b7c3e8ee5b40332abdb206c
 
 .. [#zerotestexamplediscovery-fn] Discovered from https://github.com/sympy/sympy/issues/15141
+
+.. [#zerotestexampleimproved-fn] Improved by https://github.com/sympy/sympy/pull/19548
 
 .. [#zerotestsimplifysolution-fn] Suggested from https://github.com/sympy/sympy/issues/10120
 

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -284,6 +284,9 @@ def test_hyperbolic_simp():
     e = 2*cosh(x)**2 - 2*sinh(x)**2
     assert trigsimp(log(e)) == log(2)
 
+    # issue 19535:
+    assert trigsimp(sqrt(cosh(x)**2 - 1)) == sqrt(sinh(x)**2)
+
     assert trigsimp(cosh(x)**2*cosh(y)**2 - cosh(x)**2*sinh(y)**2 - sinh(x)**2,
             recursive=True) == 1
     assert trigsimp(sinh(x)**2*sinh(y)**2 - sinh(x)**2*cosh(y)**2 + cosh(x)**2,

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1102,7 +1102,7 @@ def futrig(e, **kwargs):
 
     if kwargs.pop('hyper', True) and e.has(HyperbolicFunction):
         e, f = hyper_as_trig(e)
-        e = f(_futrig(e))
+        e = f(bottom_up(e, _futrig))
 
     if e != old and e.is_Mul and e.args[0].is_Rational:
         # redistribute leading coeff on 2-arg Add

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1098,7 +1098,7 @@ def futrig(e, **kwargs):
         return e
 
     old = e
-    e = bottom_up(e, lambda x: _futrig(x, **kwargs))
+    e = bottom_up(e, _futrig)
 
     if kwargs.pop('hyper', True) and e.has(HyperbolicFunction):
         e, f = hyper_as_trig(e)
@@ -1110,7 +1110,7 @@ def futrig(e, **kwargs):
     return e
 
 
-def _futrig(e, **kwargs):
+def _futrig(e):
     """Helper for futrig."""
     from sympy.simplify.fu import (
         TR1, TR2, TR3, TR2i, TR10, L, TR10i,


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #19535

#### Brief description of what is fixed or changed
Previously `_futrig` was called via `bottom_up` for "regular" trigonometric functions but not for hyperbolic trigonometric functions. This inhibited some obvious simplifications, e.g. the following stayed unchanged: `trigsimp(sqrt(cosh(x)**2 - 1))`

#### Other comments
This PR also removes unused `**kwargs` in `_futrig`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Improved `trigsimp` for hyperbolic functions nested in non-trig functions.
<!-- END RELEASE NOTES -->