### PR TITLE
RST needs double backticks

### DIFF
--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -837,9 +837,7 @@ _is_indefinite.__doc__            = _doc_positive_definite
 
 def _jordan_form(M, calc_transform=True, **kwargs):
     """Return $(P, J)$ where $J$ is a Jordan block
-    matrix and $P$ is a matrix such that
-
-        $M == P*J*P**-1$
+    matrix and $P$ is a matrix such that $M = P J P^{-1}$
 
     Parameters
     ==========

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -146,8 +146,8 @@ def _eigenvals(
     Notes
     =====
 
-    Eigenvalues of a matrix `A` can be computed by solving a matrix
-    equation `\det(A - \lambda I) = 0`
+    Eigenvalues of a matrix ``A`` can be computed by solving a matrix
+    equation ``\det(A - \lambda I) = 0``
     """
     if not M:
         if multiple:
@@ -525,7 +525,7 @@ def _bidiagonal_decomposition(M, upper=True):
     """
     Returns (U,B,V.H)
 
-    `A = UBV^{H}`
+    ``A = UBV^{H}``
 
     where A is the input matrix, and B is its Bidiagonalized form
 
@@ -557,7 +557,7 @@ def _bidiagonal_decomposition(M, upper=True):
 
 def _bidiagonalize(M, upper=True):
     """
-    Returns `B`
+    Returns ``B``
 
     where B is the Bidiagonalized form of the input matrix.
 
@@ -838,8 +838,8 @@ _is_indefinite.__doc__            = _doc_positive_definite
 
 
 def _jordan_form(M, calc_transform=True, **kwargs):
-    """Return ``(P, J)`` where `J` is a Jordan block
-    matrix and `P` is a matrix such that
+    """Return ``(P, J)`` where ``J`` is a Jordan block
+    matrix and ``P`` is a matrix such that
 
         ``M == P*J*P**-1``
 
@@ -847,7 +847,7 @@ def _jordan_form(M, calc_transform=True, **kwargs):
     ==========
 
     calc_transform : bool
-        If ``False``, then only `J` is returned.
+        If ``False``, then only ``J`` is returned.
 
     chop : bool
         All matrices are converted to exact types when computing

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -146,8 +146,8 @@ def _eigenvals(
     Notes
     =====
 
-    Eigenvalues of a matrix ``A`` can be computed by solving a matrix
-    equation ``\det(A - \lambda I) = 0``
+    Eigenvalues of a matrix $A$ can be computed by solving a matrix
+    equation $\det(A - \lambda I) = 0$
     """
     if not M:
         if multiple:
@@ -525,7 +525,7 @@ def _bidiagonal_decomposition(M, upper=True):
     """
     Returns (U,B,V.H)
 
-    ``A = UBV^{H}``
+    $A = UBV^{H}$
 
     where A is the input matrix, and B is its Bidiagonalized form
 
@@ -557,9 +557,7 @@ def _bidiagonal_decomposition(M, upper=True):
 
 def _bidiagonalize(M, upper=True):
     """
-    Returns ``B``
-
-    where B is the Bidiagonalized form of the input matrix.
+    Returns $B$, the Bidiagonalized form of the input matrix.
 
     Note: Bidiagonal Computation can hang for symbolic matrices.
 
@@ -838,16 +836,16 @@ _is_indefinite.__doc__            = _doc_positive_definite
 
 
 def _jordan_form(M, calc_transform=True, **kwargs):
-    """Return ``(P, J)`` where ``J`` is a Jordan block
-    matrix and ``P`` is a matrix such that
+    """Return $(P, J)$ where $J$ is a Jordan block
+    matrix and $P$ is a matrix such that
 
-        ``M == P*J*P**-1``
+        $M == P*J*P**-1$
 
     Parameters
     ==========
 
     calc_transform : bool
-        If ``False``, then only ``J`` is returned.
+        If ``False``, then only $J$ is returned.
 
     chop : bool
         All matrices are converted to exact types when computing


### PR DESCRIPTION
#### Brief description of what is fixed or changed

RST in line literals require double backticks (unlike markdown usage).

Issue noticed while reading the Sphinx rendering of the API docs:

https://docs.sympy.org/latest/modules/matrices/matrices.html

#### Other comments

Note: I have not attempted to update other docstrings in this file where there are no backticks on the mathematical variables.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->