### PR TITLE
(minor) fixes in _solve_trig2

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -661,19 +661,30 @@ def _solve_trig2(f, symbol, domain):
     denominators = []
     numerators = []
 
+    # todo: This solver can be extended to hyperbolics if the
+    # analogous change of variable to tanh (instead of tan)
+    # is used.
+    if not trig_functions:
+        return ConditionSet(symbol, Eq(f_original, 0), domain)
+
+    # todo: The pre-processing below (extraction of numerators, denominators,
+    # gcd, lcm, mu, etc.) should be updated to the enhanced version in
+    # _solve_trig1. (See #19507)
     for ar in trig_arguments:
         try:
             poly_ar = Poly(ar, symbol)
-
-        except ValueError:
+        except PolynomialError:
             raise ValueError("give up, we can't solve if this is not a polynomial in x")
         if poly_ar.degree() > 1:  # degree >1 still bad
             raise ValueError("degree of variable inside polynomial should not exceed one")
         if poly_ar.degree() == 0:  # degree 0, don't care
             continue
         c = poly_ar.all_coeffs()[0]   # got the coefficient of 'symbol'
-        numerators.append(Rational(c).p)
-        denominators.append(Rational(c).q)
+        try:
+            numerators.append(Rational(c).p)
+            denominators.append(Rational(c).q)
+        except TypeError:
+            return ConditionSet(symbol, Eq(f_original, 0), domain)
 
     x = Dummy('x')
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -952,6 +952,12 @@ def test_solve_hyperbolic():
         ImageSet(Lambda(n, n*pi/4 - 13*pi/16 + E), S.Integers),
         ImageSet(Lambda(n, n*pi/4 - 11*pi/16 + E), S.Integers)))
 
+    # issues #18490 / #19489
+    assert solveset(cosh(x) + cosh(3*x) - cosh(5*x), x, S.Reals) == \
+        ConditionSet(x, Eq(cosh(x) + cosh(3*x) - cosh(5*x), 0), S.Reals)
+    assert solveset(sinh(8*x) + coth(12*x)) == ConditionSet(
+        x, Eq(sinh(8*x) + coth(12*x), 0), S.Complexes)
+
 
 def test_solve_trig_hyp_symbolic():
     # actual solver: _solve_trig1


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #18427 (TypeError by `Rational()`)
Fixes #18490 (AssertionError due to absence of trig functions)
Fixes #19489 (Duplicate of #18490)

#### Brief description of what is fixed or changed
This commit applies cleanly to sympy-1.6.
(The three listed issues are regressions from 1.5.1 to 1.6.)

#### Other comments
The first commit also applies cleanly to sympy-1.6.

`_solve_trig2` definitely needs further work. This is a minimal PR for fixing regressions resulting in uncaught exceptions.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed exception handling in `solveset`'s secondary trigonometric solver.
<!-- END RELEASE NOTES -->