### PR TITLE
Fixed wrong relational simplifications and added tests

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -705,6 +705,11 @@ def test_simplify_relational():
     assert simplify(x*(y + 1) - x*y - x + 1 < x) == (x > 1)
     assert simplify(x*(y + 1) - x*y - x - 1 < x) == (x > -1)
     assert simplify(x < x*(y + 1) - x*y - x + 1) == (x < 1)
+    q, r = symbols("q r")
+    assert (((-q + r) - (q - r)) <= 0).simplify() == (q >= r)
+    root2 = sqrt(2)
+    equation = ((root2 * (-q + r) - root2 * (q - r)) <= 0).simplify()
+    assert equation == (q >= r)
     r = S.One < x
     # canonical operations are not the same as simplification,
     # so if there is no simplification, canonicalization will

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5219,7 +5219,8 @@ def gcd_list(seq, *gens, **args):
                 lc = 1
                 for frc in lst:
                     lc = lcm(lc, frc.as_numer_denom()[0])
-                return a/lc
+                # abs ensures that the gcd is always non-negative
+                return abs(a/lc)
 
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
@@ -5282,7 +5283,8 @@ def gcd(f, g=None, *gens, **args):
         if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
             frc = (a/b).ratsimp()
             if frc.is_rational:
-                return a/frc.as_numer_denom()[0]
+                # abs ensures that the returned gcd is always non-negative
+                return abs(a/frc.as_numer_denom()[0])
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1900,7 +1900,8 @@ def test_gcd_list():
     gcd = gcd_list([], x, polys=True)
     assert gcd.is_Poly and gcd.is_zero
 
-    assert gcd_list([sqrt(2), -sqrt(2)]) == sqrt(2)
+    a = sqrt(2)
+    assert gcd_list([a, -a]) == gcd_list([-a, a]) == a
 
     raises(ComputationFailed, lambda: gcd_list([], polys=True))
 
@@ -1996,7 +1997,7 @@ def test_gcd():
     assert lcm(f, g, modulus=11, symmetric=False) == l
 
     a, b = sqrt(2), -sqrt(2)
-    assert gcd(a, b) == a
+    assert gcd(a, b) == gcd(b, a) == a
 
     a, b = sqrt(-2), -sqrt(-2)
     assert gcd(a, b) == a

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1900,6 +1900,8 @@ def test_gcd_list():
     gcd = gcd_list([], x, polys=True)
     assert gcd.is_Poly and gcd.is_zero
 
+    assert gcd_list([sqrt(2), -sqrt(2)]) == sqrt(2)
+
     raises(ComputationFailed, lambda: gcd_list([], polys=True))
 
 
@@ -1992,6 +1994,12 @@ def test_gcd():
     assert cofactors(f, g, modulus=11, symmetric=False) == (h, s, t)
     assert gcd(f, g, modulus=11, symmetric=False) == h
     assert lcm(f, g, modulus=11, symmetric=False) == l
+
+    a, b = sqrt(2), -sqrt(2)
+    assert gcd(a, b) == a
+
+    a, b = sqrt(-2), -sqrt(-2)
+    assert gcd(a, b) == a
 
     raises(TypeError, lambda: gcd(x))
     raises(TypeError, lambda: lcm(x))


### PR DESCRIPTION
In earlier version, the following simplification gave wrong result:
```python
>> import sympy
>> q, r = sympy.symbols("q r")
>> root2 = sympy.sqrt(2)
>> ((root2 * (-q + r) - root2 * (q - r)) <= 0).simplify()
q <= r
```

The correct output should have been ```q >=r```.
This issue was raised at #19407. I fixed this issue by ensuring
```sympy.polys.gcd``` always returned a non-negative number, which was
called inside ```eval_simplify()``` in ```sympy/core/relational.py```. I have
also added relevant tests.


#### References to other Issues or PRs
Fixes #19407

#### Brief description of what is fixed or changed
Modified ```gcd_list()``` and ```gcd()``` in ```sympy/polys/polytools.py``` to return non-negative constant.
Added tests in ```sympy/core/tests/test_relational.py``` and ```sympy/polys/tests/test_polytools.py```.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed GCD to always return a non-negative constant.
<!-- END RELEASE NOTES -->