### PR TITLE
Refactor row_del and col_del

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -201,7 +201,7 @@ class MatrixShaping(MatrixRequired):
         if col < 0:
             col += self.cols
         if not 0 <= col < self.cols:
-            raise ValueError("Column {} out of range.".format(col))
+            raise IndexError("Column {} is out of range.".format(col))
         return self._eval_col_del(col)
 
     def col_insert(self, pos, other):
@@ -437,7 +437,7 @@ class MatrixShaping(MatrixRequired):
         if row < 0:
             row += self.rows
         if not 0 <= row < self.rows:
-            raise ValueError("Row {} out of range.".format(row))
+            raise IndexError("Row {} is out of range.".format(row))
 
         return self._eval_row_del(row)
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -360,33 +360,14 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
     def as_mutable(self):
         return self.copy()
 
-    def col_del(self, i):
-        """Delete the given column.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import eye
-        >>> M = eye(3)
-        >>> M.col_del(1)
-        >>> M
-        Matrix([
-        [1, 0],
-        [0, 0],
-        [0, 1]])
-
-        See Also
-        ========
-
-        col
-        row_del
-        """
-        if i < -self.cols or i >= self.cols:
-            raise IndexError("Index out of range: 'i=%s', valid -%s <= i < %s"
-                             % (i, self.cols, self.cols))
-        for j in range(self.rows - 1, -1, -1):
-            del self._mat[i + j*self.cols]
+    def _eval_col_del(self, col):
+        for j in range(self.rows-1, -1, -1):
+            del self._mat[col + j*self.cols]
         self.cols -= 1
+
+    def _eval_row_del(self, row):
+        del self._mat[row*self.cols: (row+1)*self.cols]
+        self.rows -= 1
 
     def col_op(self, j, f):
         """In-place operation on col j using two-arg functor whose args are
@@ -532,34 +513,6 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         ones
         """
         self._mat = [value]*len(self)
-
-    def row_del(self, i):
-        """Delete the given row.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import eye
-        >>> M = eye(3)
-        >>> M.row_del(1)
-        >>> M
-        Matrix([
-        [1, 0, 0],
-        [0, 0, 1]])
-
-        See Also
-        ========
-
-        row
-        col_del
-        """
-        if i < -self.rows or i >= self.rows:
-            raise IndexError("Index out of range: 'i = %s', valid -%s <= i"
-                             " < %s" % (i, self.rows, self.rows))
-        if i < 0:
-            i += self.rows
-        del self._mat[i*self.cols:(i+1)*self.cols]
-        self.rows -= 1
 
     def row_op(self, i, f):
         """In-place operation on row ``i`` using two-arg functor whose args are

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -744,32 +744,9 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
 
     __hash__ = None  # type: ignore
 
-    def col_del(self, k):
-        """Delete the given column of the matrix.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import SparseMatrix
-        >>> M = SparseMatrix([[0, 0], [0, 1]])
-        >>> M
-        Matrix([
-        [0, 0],
-        [0, 1]])
-        >>> M.col_del(0)
-        >>> M
-        Matrix([
-        [0],
-        [1]])
-
-        See Also
-        ========
-
-        row_del
-        """
+    def _eval_col_del(self, k):
         newD = {}
-        k = a2idx(k, self.cols)
-        for (i, j) in self._smat:
+        for i, j in self._smat:
             if j == k:
                 pass
             elif j > k:
@@ -778,6 +755,18 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
                 newD[i, j] = self._smat[i, j]
         self._smat = newD
         self.cols -= 1
+
+    def _eval_row_del(self, k):
+        newD = {}
+        for i, j in self._smat:
+            if i == k:
+                pass
+            elif i > k:
+                newD[i - 1, j] = self._smat[i, j]
+            else:
+                newD[i, j] = self._smat[i, j]
+        self._smat = newD
+        self.rows -= 1
 
     def col_join(self, other):
         """Returns B augmented beneath A (row-wise joining)::
@@ -957,39 +946,6 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
             v = self._sympify(value)
             self._smat = {(i, j): v
                 for i in range(self.rows) for j in range(self.cols)}
-
-    def row_del(self, k):
-        """Delete the given row of the matrix.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import SparseMatrix
-        >>> M = SparseMatrix([[0, 0], [0, 1]])
-        >>> M
-        Matrix([
-        [0, 0],
-        [0, 1]])
-        >>> M.row_del(0)
-        >>> M
-        Matrix([[0, 1]])
-
-        See Also
-        ========
-
-        col_del
-        """
-        newD = {}
-        k = a2idx(k, self.rows)
-        for (i, j) in self._smat:
-            if i == k:
-                pass
-            elif i > k:
-                newD[i - 1, j] = self._smat[i, j]
-            else:
-                newD[i, j] = self._smat[i, j]
-        self._smat = newD
-        self.rows -= 1
 
     def row_join(self, other):
         """Returns B appended after A (column-wise augmenting)::

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -127,10 +127,10 @@ def test_tolist():
 
 def test_row_col_del():
     e = ShapingOnlyMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-    raises(ValueError, lambda: e.row_del(5))
-    raises(ValueError, lambda: e.row_del(-5))
-    raises(ValueError, lambda: e.col_del(5))
-    raises(ValueError, lambda: e.col_del(-5))
+    raises(IndexError, lambda: e.row_del(5))
+    raises(IndexError, lambda: e.row_del(-5))
+    raises(IndexError, lambda: e.col_del(5))
+    raises(IndexError, lambda: e.col_del(-5))
 
     assert e.row_del(2) == e.row_del(-1) == Matrix([[1, 2, 3], [4, 5, 6]])
     assert e.col_del(2) == e.col_del(-1) == Matrix([[1, 2], [4, 5], [7, 8]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - `row_del` and `col_del` will raise `IndexError` rather than `ValueError` when the index is out of bounds.
<!-- END RELEASE NOTES -->