### PR TITLE
Fix 19547 is positive semidefinite incorrect

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ long_description_content_type = text/markdown
 [flake8]
 doctests = True
 ignore = F403
-select = F,E722
+select = F,E722,W
 exclude = sympy/parsing/latex/_antlr/*,
           sympy/parsing/autolev/_antlr/*,
           sympy/parsing/autolev/test-examples/*,

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ long_description_content_type = text/markdown
 [flake8]
 doctests = True
 ignore = F403
-select = F,E722,W
+select = F,E722
 exclude = sympy/parsing/latex/_antlr/*,
           sympy/parsing/autolev/_antlr/*,
           sympy/parsing/autolev/test-examples/*,

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -780,11 +780,9 @@ def _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M):
             if M[k, k].is_negative:
                 return False
             M[k, k] = sqrt(M[k, k])
+            M[k, (k+1):] /= M[k, k]
             for j in range(k+1, M.rows):
-                M[k, j] /= M[k, k]
-            for j in range(k+1, M.rows):
-                for i in range(k+1, j+1):
-                    M[i, j] -= M[k, i] * M[k, j]
+                M[(k+1):(j+1), j] = M[k, (k+1):(j+1)].T * M[k, j]
     return M[-1, -1].is_nonnegative
 
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -1,11 +1,9 @@
 from types import FunctionType
 from collections import Counter
-import itertools
 
 from mpmath import mp, workprec
 from mpmath.libmp.libmpf import prec_to_dps
 
-from sympy import Symbol
 from sympy.core.compatibility import default_sort_key
 from sympy.core.evalf import DEFAULT_MAXPREC, PrecisionExhausted
 from sympy.core.logic import fuzzy_and, fuzzy_or
@@ -701,18 +699,21 @@ def _is_positive_semidefinite(M):
     if nonnegative_diagonals and M.is_weakly_diagonally_dominant:
         return True
 
-    try:
-        return _is_positive_semidefinite_cholesky(M)
-    except Exception:
-        pass
-
-    if M.rows < 5 or all(a.func != Symbol for a in M.atoms()):
-        try:
-            return _is_positive_semidefinite_evals(M)
-        except Exception:
-            pass
-
-    return _is_positive_semidefinite_minors(M)
+    # uses Cholesky factorization with complete pivoting
+    # see http://eprints.ma.man.ac.uk/1199/1/covered/MIMS_ep2008_116.pdf
+    M = M.copy()
+    for k in range(M.rows):
+        pivot = max(range(k, M.rows), key=lambda i: M[i, i])
+        if pivot > k:
+            M.col_swap(k, pivot)
+            M.row_swap(k, pivot)
+        if M[k, k].is_negative:
+            return False
+        M[k, k] = sqrt(M[k, k])
+        M[k, (k+1):] /= M[k, k]
+        for j in range(k+1, M.rows):
+            M[(k+1):(j+1), j] -= M[k, (k+1):(j+1)].T * M[k, j]
+    return M[-1, -1].is_nonnegative
 
 
 def _is_negative_definite(M):
@@ -752,56 +753,6 @@ def _is_positive_definite_GE(M):
         for j in range(i+1, size):
             M[j, i+1:] = M[i, i] * M[j, i+1:] - M[j, i] * M[i, i+1:]
     return True
-
-
-def _is_positive_semidefinite_minors(M):
-    """A method to evaluate all principal minors for testing
-    positive-semidefiniteness by using Sylvestre's crieterion."""
-    return all(
-        M[idx, idx].det(method='berkowitz').is_nonnegative
-        for minor_size in range(1, M.rows+1)
-        for idx in itertools.combinations(range(M.rows), minor_size)
-    )
-
-
-def _is_positive_semidefinite_evals(M):
-    """Determines if a matrix is positive semidefinite by checking
-    if all the eigenvalues are nonnegative"""
-    return all(eigenvalue.is_nonnegative for eigenvalue in M.eigenvals())
-
-
-def _is_positive_semidefinite_cholesky(M):
-    """Determines if a matrix is positive semidefinite by computing its
-    Cholesky decomposition with complete pivoting
-
-    Any symmetric positive semidefinite matrix has a factorization
-    P.T * A * P = R.T * R, where
-
-    R = [R_11  R_22]
-        [0     0   ],
-
-    and R_11 is rxr upper triangular with positive diagonal elements,
-    rank(A) = r, and P is a permutation matrix.
-
-    An algorithm for computing R is described in [1]. If at any point in
-    the algorithm a negative diagonal term is obtained, then A is not
-    positive semidefinite, so the algorithm exits early and returns False.
-
-    [1] http://eprints.ma.man.ac.uk/1199/1/covered/MIMS_ep2008_116.pdf
-    """
-    M = M.copy()
-    for k in range(M.rows):
-        pivot = max(range(k, M.rows), key=lambda i: M[i, i])
-        if pivot > k:
-            M.col_swap(k, pivot)
-            M.row_swap(k, pivot)
-        if M[k, k].is_negative:
-            return False
-        M[k, k] = sqrt(M[k, k])
-        M[k, (k+1):] /= M[k, k]
-        for j in range(k+1, M.rows):
-            M[(k+1):(j+1), j] -= M[k, (k+1):(j+1)].T * M[k, j]
-    return M[-1, -1].is_nonnegative
 
 
 _doc_positive_definite = \

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -771,6 +771,24 @@ def _is_positive_semidefinite_by_eigenvalues(M):
 
 
 def _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M):
+    """Determines if a matrix is positive semidefinite by computing its
+    Cholesky decomposition with complete pivoting
+
+    Any symmetric positive semidefinite matrix has a factorization
+    P.T * A * P = R.T * R, where
+
+    R = [R_11  R_22]
+        [0     0   ],
+
+    and R_11 is rxr upper triangular with positive diagonal elements,
+    rank(A) = r, and P is a permutation matrix.
+
+    An algorithm for computing R is described in [1]. If at any point in
+    the algorithm a negative diagonal term is obtained, then A is not
+    positive semidefinite, so the algorithm exits early and returns False.
+
+    [1] http://eprints.ma.man.ac.uk/1199/1/covered/MIMS_ep2008_116.pdf
+    """
     M = M.copy()
     for k in range(M.rows):
         pivot = max(range(k, M.rows), key=lambda i: M[i, i])
@@ -784,7 +802,6 @@ def _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M):
             for j in range(k+1, M.rows):
                 M[(k+1):(j+1), j] = M[k, (k+1):(j+1)].T * M[k, j]
     return M[-1, -1].is_nonnegative
-
 
 
 _doc_positive_definite = \

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -793,14 +793,14 @@ def _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M):
     for k in range(M.rows):
         pivot = max(range(k, M.rows), key=lambda i: M[i, i])
         if pivot > k:
-            M[[k, pivot], :] = M[[pivot, k], :]
-            M[:, [k, pivot]] = M[:, [pivot, k]]
-            if M[k, k].is_negative:
-                return False
-            M[k, k] = sqrt(M[k, k])
-            M[k, (k+1):] /= M[k, k]
-            for j in range(k+1, M.rows):
-                M[(k+1):(j+1), j] = M[k, (k+1):(j+1)].T * M[k, j]
+            M.col_swap(k, pivot)
+            M.row_swap(k, pivot)
+        if M[k, k].is_negative:
+            return False
+        M[k, k] = sqrt(M[k, k])
+        M[k, (k+1):] /= M[k, k]
+        for j in range(k+1, M.rows):
+            M[(k+1):(j+1), j] -= M[k, (k+1):(j+1)].T * M[k, j]
     return M[-1, -1].is_nonnegative
 
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -702,17 +702,17 @@ def _is_positive_semidefinite(M):
         return True
 
     try:
-        return _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M)
+        return _is_positive_semidefinite_cholesky(M)
     except Exception:
         pass
 
     if M.rows < 5 or all(a.func != Symbol for a in M.atoms()):
         try:
-            return _is_positive_semidefinite_by_eigenvalues(M)
+            return _is_positive_semidefinite_evals(M)
         except Exception:
             pass
 
-    return _is_positive_semidefinite_by_minors(M)
+    return _is_positive_semidefinite_minors(M)
 
 
 def _is_negative_definite(M):
@@ -754,7 +754,7 @@ def _is_positive_definite_GE(M):
     return True
 
 
-def _is_positive_semidefinite_by_minors(M):
+def _is_positive_semidefinite_minors(M):
     """A method to evaluate all principal minors for testing
     positive-semidefiniteness by using Sylvestre's crieterion."""
     return all(
@@ -764,13 +764,13 @@ def _is_positive_semidefinite_by_minors(M):
     )
 
 
-def _is_positive_semidefinite_by_eigenvalues(M):
+def _is_positive_semidefinite_evals(M):
     """Determines if a matrix is positive semidefinite by checking
     if all the eigenvalues are nonnegative"""
     return all(eigenvalue.is_nonnegative for eigenvalue in M.eigenvals())
 
 
-def _is_positive_semidefinite_by_cholesky_factorization_with_pivots(M):
+def _is_positive_semidefinite_cholesky(M):
     """Determines if a matrix is positive semidefinite by computing its
     Cholesky decomposition with complete pivoting
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -5,6 +5,7 @@ import itertools
 from mpmath import mp, workprec
 from mpmath.libmp.libmpf import prec_to_dps
 
+from sympy import Symbol
 from sympy.core.compatibility import default_sort_key
 from sympy.core.evalf import DEFAULT_MAXPREC, PrecisionExhausted
 from sympy.core.logic import fuzzy_and, fuzzy_or
@@ -700,6 +701,12 @@ def _is_positive_semidefinite(M):
     if nonnegative_diagonals and M.is_weakly_diagonally_dominant:
         return True
 
+    if M.rows < 5 or all(a.func != Symbol for a in M.atoms()):
+        try:
+            return _is_positive_semidefinite_by_eigenvalues(M)
+        except Exception:
+            pass
+
     return _is_positive_semidefinite_by_minors(M)
 
 
@@ -750,6 +757,12 @@ def _is_positive_semidefinite_by_minors(M):
         for minor_size in range(1, M.rows+1)
         for idx in itertools.combinations(range(M.rows), minor_size)
     )
+
+
+def _is_positive_semidefinite_by_eigenvalues(M):
+    """Determines if a matrix is positive semidefinite by checking
+    if all the eigenvalues are nonnegative"""
+    return all(eigenvalue.is_nonnegative for eigenvalue in M.eigenvals())
 
 
 _doc_positive_definite = \

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -4,11 +4,6 @@ from sympy import (
 from sympy.matrices import eye, Matrix
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises, XFAIL
-from sympy.matrices.eigen import (
-    _is_positive_semidefinite_cholesky,
-    _is_positive_semidefinite_evals,
-    _is_positive_semidefinite_minors
-)
 from sympy.matrices.matrices import NonSquareMatrixError, MatrixError
 from sympy.simplify.simplify import simplify
 from sympy.matrices.immutable import ImmutableMatrix
@@ -498,9 +493,6 @@ def test_definite():
     m = Matrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m)
-    assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -508,9 +500,6 @@ def test_definite():
     m = Matrix([[5, 4], [4, 5]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m)
-    assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -519,9 +508,6 @@ def test_definite():
     m = Matrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m)
-    assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -529,9 +515,6 @@ def test_definite():
     m = Matrix([[1, 2], [2, 4]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m.T + m)
-    assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -541,9 +524,6 @@ def test_definite():
     m = Matrix([[2, 3], [4, 8]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m.T + m)
-    assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -552,9 +532,6 @@ def test_definite():
     m = Matrix([[1, 2*I], [-I, 4]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m.H + m)
-    assert _is_positive_semidefinite_evals(m.H + m)
-    assert _is_positive_semidefinite_minors(m.H + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -565,9 +542,6 @@ def test_definite():
     m = Matrix([[a, 0, 0], [0, a, 0], [0, 0, a]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m)
-    assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -575,9 +549,6 @@ def test_definite():
     m = Matrix([[b, 0, 0], [0, b, 0], [0, 0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
-    assert not _is_positive_semidefinite_cholesky(m)
-    assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == True
     assert m.is_negative_semidefinite == True
     assert m.is_indefinite == False
@@ -585,9 +556,6 @@ def test_definite():
     m = Matrix([[a, 0], [0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
-    assert not _is_positive_semidefinite_cholesky(m)
-    assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == True
@@ -604,9 +572,6 @@ def test_definite():
     ])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_cholesky(m.T + m)
-    assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_indefinite == False
 
     # test for issue 19547: https://github.com/sympy/sympy/issues/19547
@@ -617,6 +582,3 @@ def test_definite():
     ])
     assert not m.is_positive_definite
     assert not m.is_positive_semidefinite
-    assert not _is_positive_semidefinite_cholesky(m)
-    assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -500,7 +500,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m)
     assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m) 
+    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -510,7 +510,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m)
     assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m) 
+    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -521,7 +521,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m)
     assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m) 
+    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -531,7 +531,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m.T + m)
     assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m) 
+    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -543,7 +543,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m.T + m)
     assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m) 
+    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -554,7 +554,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m.H + m)
     assert _is_positive_semidefinite_evals(m.H + m)
-    assert _is_positive_semidefinite_minors(m.H + m) 
+    assert _is_positive_semidefinite_minors(m.H + m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -567,7 +567,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m)
     assert _is_positive_semidefinite_evals(m)
-    assert _is_positive_semidefinite_minors(m) 
+    assert _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -577,7 +577,7 @@ def test_definite():
     assert m.is_positive_semidefinite == False
     assert not _is_positive_semidefinite_cholesky(m)
     assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m) 
+    assert not _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == True
     assert m.is_negative_semidefinite == True
     assert m.is_indefinite == False
@@ -587,7 +587,7 @@ def test_definite():
     assert m.is_positive_semidefinite == False
     assert not _is_positive_semidefinite_cholesky(m)
     assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m) 
+    assert not _is_positive_semidefinite_minors(m)
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == True
@@ -606,7 +606,7 @@ def test_definite():
     assert m.is_positive_semidefinite == True
     assert _is_positive_semidefinite_cholesky(m.T + m)
     assert _is_positive_semidefinite_evals(m.T + m)
-    assert _is_positive_semidefinite_minors(m.T + m) 
+    assert _is_positive_semidefinite_minors(m.T + m)
     assert m.is_indefinite == False
 
     # test for issue 19547: https://github.com/sympy/sympy/issues/19547
@@ -619,5 +619,4 @@ def test_definite():
     assert not m.is_positive_semidefinite
     assert not _is_positive_semidefinite_cholesky(m)
     assert not _is_positive_semidefinite_evals(m)
-    assert not _is_positive_semidefinite_minors(m) 
- 
+    assert not _is_positive_semidefinite_minors(m)

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -5,9 +5,9 @@ from sympy.matrices import eye, Matrix
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises, XFAIL
 from sympy.matrices.eigen import (
-    _is_positive_semidefinite_by_eigenvalues,
-    _is_positive_semidefinite_by_cholesky_factorization_with_pivots,
-    _is_positive_semidefinite_by_minors
+    _is_positive_semidefinite_cholesky,
+    _is_positive_semidefinite_evals,
+    _is_positive_semidefinite_minors
 )
 from sympy.matrices.matrices import NonSquareMatrixError, MatrixError
 from sympy.simplify.simplify import simplify
@@ -498,9 +498,9 @@ def test_definite():
     m = Matrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert _is_positive_semidefinite_by_eigenvalues(m)
-    assert _is_positive_semidefinite_by_minors(m) 
+    assert _is_positive_semidefinite_cholesky(m)
+    assert _is_positive_semidefinite_evals(m)
+    assert _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -508,9 +508,9 @@ def test_definite():
     m = Matrix([[5, 4], [4, 5]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert _is_positive_semidefinite_by_eigenvalues(m)
-    assert _is_positive_semidefinite_by_minors(m) 
+    assert _is_positive_semidefinite_cholesky(m)
+    assert _is_positive_semidefinite_evals(m)
+    assert _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -519,9 +519,9 @@ def test_definite():
     m = Matrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert _is_positive_semidefinite_by_eigenvalues(m)
-    assert _is_positive_semidefinite_by_minors(m) 
+    assert _is_positive_semidefinite_cholesky(m)
+    assert _is_positive_semidefinite_evals(m)
+    assert _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -529,9 +529,9 @@ def test_definite():
     m = Matrix([[1, 2], [2, 4]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
-    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
-    assert _is_positive_semidefinite_by_minors(m.T + m) 
+    assert _is_positive_semidefinite_cholesky(m.T + m)
+    assert _is_positive_semidefinite_evals(m.T + m)
+    assert _is_positive_semidefinite_minors(m.T + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -541,9 +541,9 @@ def test_definite():
     m = Matrix([[2, 3], [4, 8]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
-    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
-    assert _is_positive_semidefinite_by_minors(m.T + m) 
+    assert _is_positive_semidefinite_cholesky(m.T + m)
+    assert _is_positive_semidefinite_evals(m.T + m)
+    assert _is_positive_semidefinite_minors(m.T + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -552,9 +552,9 @@ def test_definite():
     m = Matrix([[1, 2*I], [-I, 4]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.H + m)
-    assert _is_positive_semidefinite_by_eigenvalues(m.H + m)
-    assert _is_positive_semidefinite_by_minors(m.H + m) 
+    assert _is_positive_semidefinite_cholesky(m.H + m)
+    assert _is_positive_semidefinite_evals(m.H + m)
+    assert _is_positive_semidefinite_minors(m.H + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -565,9 +565,9 @@ def test_definite():
     m = Matrix([[a, 0, 0], [0, a, 0], [0, 0, a]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert _is_positive_semidefinite_by_eigenvalues(m)
-    assert _is_positive_semidefinite_by_minors(m) 
+    assert _is_positive_semidefinite_cholesky(m)
+    assert _is_positive_semidefinite_evals(m)
+    assert _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -575,9 +575,9 @@ def test_definite():
     m = Matrix([[b, 0, 0], [0, b, 0], [0, 0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
-    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert not _is_positive_semidefinite_by_eigenvalues(m)
-    assert not _is_positive_semidefinite_by_minors(m) 
+    assert not _is_positive_semidefinite_cholesky(m)
+    assert not _is_positive_semidefinite_evals(m)
+    assert not _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == True
     assert m.is_negative_semidefinite == True
     assert m.is_indefinite == False
@@ -585,9 +585,9 @@ def test_definite():
     m = Matrix([[a, 0], [0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
-    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert not _is_positive_semidefinite_by_eigenvalues(m)
-    assert not _is_positive_semidefinite_by_minors(m) 
+    assert not _is_positive_semidefinite_cholesky(m)
+    assert not _is_positive_semidefinite_evals(m)
+    assert not _is_positive_semidefinite_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == True
@@ -604,9 +604,9 @@ def test_definite():
     ])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
-    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
-    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
-    assert _is_positive_semidefinite_by_minors(m.T + m) 
+    assert _is_positive_semidefinite_cholesky(m.T + m)
+    assert _is_positive_semidefinite_evals(m.T + m)
+    assert _is_positive_semidefinite_minors(m.T + m) 
     assert m.is_indefinite == False
 
     # test for issue 19547: https://github.com/sympy/sympy/issues/19547
@@ -617,7 +617,7 @@ def test_definite():
     ])
     assert not m.is_positive_definite
     assert not m.is_positive_semidefinite
-    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
-    assert not _is_positive_semidefinite_by_eigenvalues(m)
-    assert not _is_positive_semidefinite_by_minors(m) 
+    assert not _is_positive_semidefinite_cholesky(m)
+    assert not _is_positive_semidefinite_evals(m)
+    assert not _is_positive_semidefinite_minors(m) 
  

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -4,6 +4,11 @@ from sympy import (
 from sympy.matrices import eye, Matrix
 from sympy.core.singleton import S
 from sympy.testing.pytest import raises, XFAIL
+from sympy.matrices.eigen import (
+    _is_positive_semidefinite_by_eigenvalues,
+    _is_positive_semidefinite_by_cholesky_factorization_with_pivots,
+    _is_positive_semidefinite_by_minors
+)
 from sympy.matrices.matrices import NonSquareMatrixError, MatrixError
 from sympy.simplify.simplify import simplify
 from sympy.matrices.immutable import ImmutableMatrix
@@ -493,6 +498,9 @@ def test_definite():
     m = Matrix([[2, -1, 0], [-1, 2, -1], [0, -1, 2]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert _is_positive_semidefinite_by_eigenvalues(m)
+    assert _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -500,6 +508,9 @@ def test_definite():
     m = Matrix([[5, 4], [4, 5]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert _is_positive_semidefinite_by_eigenvalues(m)
+    assert _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -508,6 +519,9 @@ def test_definite():
     m = Matrix([[2, -1, -1], [-1, 2, -1], [-1, -1, 2]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert _is_positive_semidefinite_by_eigenvalues(m)
+    assert _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -515,6 +529,9 @@ def test_definite():
     m = Matrix([[1, 2], [2, 4]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
+    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
+    assert _is_positive_semidefinite_by_minors(m.T + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -524,13 +541,20 @@ def test_definite():
     m = Matrix([[2, 3], [4, 8]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
+    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
+    assert _is_positive_semidefinite_by_minors(m.T + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
 
+    # Hermetian matrices
     m = Matrix([[1, 2*I], [-I, 4]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.H + m)
+    assert _is_positive_semidefinite_by_eigenvalues(m.H + m)
+    assert _is_positive_semidefinite_by_minors(m.H + m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -541,6 +565,9 @@ def test_definite():
     m = Matrix([[a, 0, 0], [0, a, 0], [0, 0, a]])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert _is_positive_semidefinite_by_eigenvalues(m)
+    assert _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == False
@@ -548,6 +575,9 @@ def test_definite():
     m = Matrix([[b, 0, 0], [0, b, 0], [0, 0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
+    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert not _is_positive_semidefinite_by_eigenvalues(m)
+    assert not _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == True
     assert m.is_negative_semidefinite == True
     assert m.is_indefinite == False
@@ -555,6 +585,9 @@ def test_definite():
     m = Matrix([[a, 0], [0, b]])
     assert m.is_positive_definite == False
     assert m.is_positive_semidefinite == False
+    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert not _is_positive_semidefinite_by_eigenvalues(m)
+    assert not _is_positive_semidefinite_by_minors(m) 
     assert m.is_negative_definite == False
     assert m.is_negative_semidefinite == False
     assert m.is_indefinite == True
@@ -571,6 +604,9 @@ def test_definite():
     ])
     assert m.is_positive_definite == True
     assert m.is_positive_semidefinite == True
+    assert _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m.T + m)
+    assert _is_positive_semidefinite_by_eigenvalues(m.T + m)
+    assert _is_positive_semidefinite_by_minors(m.T + m) 
     assert m.is_indefinite == False
 
     # test for issue 19547: https://github.com/sympy/sympy/issues/19547
@@ -581,3 +617,7 @@ def test_definite():
     ])
     assert not m.is_positive_definite
     assert not m.is_positive_semidefinite
+    assert not _is_positive_semidefinite_by_cholesky_factorization_with_pivots(m)
+    assert not _is_positive_semidefinite_by_eigenvalues(m)
+    assert not _is_positive_semidefinite_by_minors(m) 
+ 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
This PR adds more efficient algorithms for determining if a matrix is symmetric positive semidefinite than Sylvester's criterion. The first method tried is Cholesky factorization with complete pivoting as described [here](http://eprints.ma.man.ac.uk/1199/1/covered/MIMS_ep2008_116.pdf). If that fails, an eigenvalue criterion is used. If that also fails, Sylvester's criterion is used as a last resort. 
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
[Related issue](https://github.com/sympy/sympy/issues/19547)
[Follow up to this PR](https://github.com/sympy/sympy/pull/19556)

#### Brief description of what is fixed or changed
Adds two new private functions to `eigen.py`

 1. `_is_positive_semidefinite_cholesky`
 2. `_is_positive_semidefinite_evals`

Also changes the logic of `_is_positive_semidefinite` to attempt Cholesky factorization first, then eigenvalue method, then the original approach.

Adds tests for the individual positive semidefinite test cases to help ensure all the methods are correct.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Use more efficient Cholesky factorization method to check if matrices are positive semidefinite.
<!-- END RELEASE NOTES -->