### PR TITLE
collect: make sure Dummy are replaced back in rhs (1.6 branch)

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -178,7 +178,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         if not isinstance(rv, dict):
             return rv.xreplace(urep)
         else:
-            return {urep.get(k, k): v for k, v in rv.items()}
+            return {urep.get(k, k): v.xreplace(urep) for k, v in rv.items()}
 
     if evaluate is None:
         evaluate = global_parameters.evaluate

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -223,6 +223,12 @@ def test_collect_5():
                    [x, y]) == 1 + y + x*(1 + 2*y) + x**2 + y**2
 
 
+def test_collect_pr19431():
+    """Unevaluated collect with respect to a product"""
+    a = symbols('a')
+    assert collect(a**2*(a**2 + 1), a**2, evaluate=False)[a**2] == (a**2 + 1)
+
+
 def test_collect_D():
     D = Derivative
     f = Function('f')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Fixes #19557 by applying #19431 to the 1.6 release branch so that #19433 will be fixed in sympy 1.6.1 (#19599).

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * Fixes a bug in collect when collected symbols appear in the factorized expression.
<!-- END RELEASE NOTES -->