### PR TITLE
Report slow test functions with filename

### DIFF
--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1317,10 +1317,12 @@ class SymPyTests(object):
                 reporter.test_pass()
             taken = time.time() - start
             if taken > self._slow_threshold:
+                filename = os.path.relpath(filename, reporter._root_dir)
                 reporter.slow_test_functions.append(
                     (filename + "::" + f.__name__, taken))
             if getattr(f, '_slow', False) and slow:
                 if taken < self._fast_threshold:
+                    filename = os.path.relpath(filename, reporter._root_dir)
                     reporter.fast_test_functions.append(
                         (filename + "::" + f.__name__, taken))
         reporter.leaving_filename()

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1317,10 +1317,12 @@ class SymPyTests(object):
                 reporter.test_pass()
             taken = time.time() - start
             if taken > self._slow_threshold:
-                reporter.slow_test_functions.append((f.__name__, taken))
+                reporter.slow_test_functions.append(
+                    (filename + "::" + f.__name__, taken))
             if getattr(f, '_slow', False) and slow:
                 if taken < self._fast_threshold:
-                    reporter.fast_test_functions.append((f.__name__, taken))
+                    reporter.fast_test_functions.append(
+                        (filename + "::" + f.__name__, taken))
         reporter.leaving_filename()
 
     def _timeout(self, function, timeout, fail_on_timeout):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

I find it annoying that test functions with same names across different test files are reported only as name of the function. This modifies the test runner to append the filename, but let's see if this looks too verbose or not.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->