### PR TITLE
printing: Show unsupported types in monospace font

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2906,11 +2906,22 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
     >>> print(latex(log(10), ln_notation=True))
     \ln{\left(10 \right)}
 
-    ``latex()`` also supports the builtin container types list, tuple, and
-    dictionary.
+    ``latex()`` also supports the builtin container types :class:`list`,
+    :class:`tuple`, and :class:`dict`:
 
     >>> print(latex([2/x, y], mode='inline'))
     $\left[ 2 / x, \  y\right]$
+
+    .. versionchanged:: 1.7.0
+        Unsupported types are now embedded as monospaced plaintext:
+
+        >>> print(latex(int))
+        \mathtt{\text{<class 'int'>}}
+        >>> print(latex("plain % text"))
+        \mathtt{\text{plain \% text}}
+
+        See :ref:`printer_method_example` for an example of how to override
+        this behavior for your own types by implementing ``_latex``.
 
     """
     if symbol_names is None:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2921,7 +2921,6 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
 
     See :ref:`printer_method_example` for an example of how to override
     this behavior for your own types by implementing ``_latex``.
-    
     .. versionchanged:: 1.7.0
         Unsupported types no longer have their ``str`` representation treated as valid latex.
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2912,16 +2912,18 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
     >>> print(latex([2/x, y], mode='inline'))
     $\left[ 2 / x, \  y\right]$
 
+    Unsupported types are rendered as monospaced plaintext:
+
+    >>> print(latex(int))
+    \mathtt{\text{<class 'int'>}}
+    >>> print(latex("plain % text"))
+    \mathtt{\text{plain \% text}}
+
+    See :ref:`printer_method_example` for an example of how to override
+    this behavior for your own types by implementing ``_latex``.
+    
     .. versionchanged:: 1.7.0
-        Unsupported types are now embedded as monospaced plaintext:
-
-        >>> print(latex(int))
-        \mathtt{\text{<class 'int'>}}
-        >>> print(latex("plain % text"))
-        \mathtt{\text{plain \% text}}
-
-        See :ref:`printer_method_example` for an example of how to override
-        this behavior for your own types by implementing ``_latex``.
+        Unsupported types no longer have their ``str`` representation treated as valid latex.
 
     """
     if symbol_names is None:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2921,6 +2921,7 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
 
     See :ref:`printer_method_example` for an example of how to override
     this behavior for your own types by implementing ``_latex``.
+
     .. versionchanged:: 1.7.0
         Unsupported types no longer have their ``str`` representation treated as valid latex.
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -71,10 +71,10 @@ While looking for the method, it follows these steps:
     As fall-back ``self.emptyPrinter`` will be called with the expression. If
     not defined in the Printer subclass this will be the same as ``str(expr)``.
 
+.. _printer_example:
+
 Example of Custom Printer
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _printer_example:
 
 In the example below, we have a printer which prints the derivative of a function
 in a shorter form.
@@ -126,6 +126,8 @@ The output of the code above is::
 
     \\frac{\\partial^{2}}{\\partial x\\partial y}  f{\\left(x,y \\right)}
     f_{xy}
+
+.. _printer_method_example:
 
 Example of Custom Printing Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -26,7 +26,8 @@ from sympy.ntheory.factor_ import udivisor_sigma
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
-                                  tex_greek_dictionary, multiline_latex)
+                                  tex_greek_dictionary, multiline_latex,
+                                  latex_escape)
 from sympy.tensor.array import (ImmutableDenseNDimArray,
                                 ImmutableSparseNDimArray,
                                 MutableSparseNDimArray,
@@ -2639,7 +2640,7 @@ def test_latex_decimal_separator():
     assert(latex(S(.3), decimal_separator='comma')== r'0{,}3')
 
 
-    assert(latex(5.8*10**(-7), decimal_separator='comma') ==r'5{,}8e-07')
+    assert(latex(5.8*10**(-7), decimal_separator='comma') ==r'5{,}8 \cdot 10^{-7}')
     assert(latex(S(5.7)*10**(-7), decimal_separator='comma')==r'5{,}7 \cdot 10^{-7}')
     assert(latex(S(5.7*10**(-7)), decimal_separator='comma')==r'5{,}7 \cdot 10^{-7}')
 
@@ -2655,3 +2656,28 @@ def test_latex_decimal_separator():
 def test_Str():
     from sympy.core.symbol import Str
     assert str(Str('x')) == 'x'
+
+def test_latex_escape():
+    assert latex_escape(r"~^\&%$#_{}") == "".join([
+        r'\textasciitilde',
+        r'\textasciicircum',
+        r'\textbackslash',
+        r'\&',
+        r'\%',
+        r'\$',
+        r'\#',
+        r'\_',
+        r'\{',
+        r'\}',
+    ])
+
+def test_emptyPrinter():
+    class MyObject:
+        def __repr__(self):
+            return "<MyObject with {...}>"
+
+    # unknown objects are monospaced
+    assert latex(MyObject()) == r"\mathtt{\text{<MyObject with \{...\}>}}"
+
+    # even if they are nested within other objects
+    assert latex((MyObject(),)) == r"\left( \mathtt{\text{<MyObject with \{...\}>}},\right)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses some comments in #19425 
* https://github.com/sympy/sympy/pull/19425#issuecomment-643337256
* https://github.com/sympy/sympy/pull/19425#issuecomment-643333862

~~This builds upon #19614. Let's review that diff separately.~~


#### Brief description of what is fixed or changed

The output of `sympy.latex(unsupported_object)` no longer messily interprets the content as latex.

##### Before:

![image](https://user-images.githubusercontent.com/425260/85285935-a92c6680-b489-11ea-829a-f9ffff8fb5fc.png)


##### After:

![image](https://user-images.githubusercontent.com/425260/85285778-666a8e80-b489-11ea-85fd-2fce65d1fc2e.png)


#### Other comments

It's possible that we want to make some exceptions for builtin types. For instance, `float` and `Decimal` could be printed as if they were `Float`. Right now there is a single test which fails due to this behavior, but it looks to me like little thought was put into whether the test makes sense.

Decisions to make:
* Is `\mathtt{\text{ ... }}` a better choice than `\text{ ... }`
* Should `float` be treated like `Float`? (today it mostly isn't)
* Should `str` be treated as containing latex? (today it mostly is, except `.` is sometimes converted to `,`!)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Types which are not recognized by the LaTeX printer no longer have their `__str__` interpreted as LaTeX, and have their `str(...)` printed as pre-formatted text as if they were printed normally. This includes the builtin ``str`` type: `latex("hello")` now results in the latex `\mathtt{\text{hello}}`.

    If a custom type intends to be interpreted as latex, it should define the `_latex` hook [as described in the docs](https://docs.sympy.org/dev/modules/printing.html#example-of-custom-printing-method):
    ```python
    def _latex(self, printer):
        return str(self)  # indicate that the result of __str__ is LaTeX-compatible
    ```

    To print a string containing LaTeX math using MathJax, use
    
    ```python
    import IPython
    IPython.display.Math(string)
    ```
  * The latex printer now shows builtin `float`s using `...x10^...` notation instead of `...e...` notation.
<!-- END RELEASE NOTES -->