### PR TITLE
make GF(n) raise for composite n

### DIFF
--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -9,6 +9,8 @@ from sympy.polys.domains.simpledomain import SimpleDomain
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
+from sympy.ntheory import isprime
+
 @public
 class FiniteField(Field, SimpleDomain):
     """General class for finite fields. """
@@ -27,6 +29,8 @@ class FiniteField(Field, SimpleDomain):
     def __init__(self, mod, dom=None, symmetric=True):
         if mod <= 0:
             raise ValueError('modulus must be a positive integer, got %s' % mod)
+        if not(isprime(mod)):
+            raise ValueError("Only fields of prime order are supported")
         if dom is None:
             from sympy.polys.domains import ZZ
             dom = ZZ

--- a/sympy/polys/domains/tests/test_finitefield.py
+++ b/sympy/polys/domains/tests/test_finitefield.py
@@ -1,0 +1,8 @@
+"""Tests for Finite Fields."""
+
+from sympy.polys.domains.finitefield import FiniteField
+
+from sympy.utilities.pytest import raises
+
+def test_finitefield():
+    raises(ValueError, lambda: FiniteField(42))

--- a/sympy/polys/domains/tests/test_finitefield.py
+++ b/sympy/polys/domains/tests/test_finitefield.py
@@ -1,8 +1,7 @@
 """Tests for Finite Fields."""
 
 from sympy.polys.domains.finitefield import FiniteField
+from sympy.testing.pytest import raises
 
-from sympy.utilities.pytest import raises
-
-def test_finitefield():
+def test_FiniteField():
     raises(ValueError, lambda: FiniteField(42))

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -450,9 +450,8 @@ def test_dup_mul():
 
     assert dup_mul(f, f, ZZ) == h
 
-    K = FF(6)
-
-    assert dup_mul([K(2), K(1)], [K(3), K(4)], K) == [K(5), K(4)]
+    K = FF(5)
+    assert dup_mul([K(2), K(1)], [K(3), K(4)], K) == [K(1), K(1), K(4)]
 
     p1 = dup_normal([79, -1, 78, -94, -10, 11, 32, -19, 78, 2, -89, 30, 73, 42,
         85, 77, 83, -30, -34, -2, 95, -81, 37, -49, -46, -58, -16, 37, 35, -11,
@@ -670,10 +669,9 @@ def test_dmp_mul():
     assert dmp_mul([[[QQ(2, 7)]]], [[[QQ(1, 3)]]], 2, QQ) == [[[QQ(2, 21)]]]
     assert dmp_mul([[[QQ(1, 7)]]], [[[QQ(2, 3)]]], 2, QQ) == [[[QQ(2, 21)]]]
 
-    K = FF(6)
-
+    K = FF(5)
     assert dmp_mul(
-        [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(5)], [K(4)]]
+        [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(1)], [K(1)], [K(4)]]
 
 
 def test_dup_sqr():
@@ -689,9 +687,8 @@ def test_dup_sqr():
 
     assert dup_sqr(f, ZZ) == dup_normal([4, 0, 0, 4, 28, 0, 1, 14, 49], ZZ)
 
-    K = FF(9)
-
-    assert dup_sqr([K(3), K(4)], K) == [K(6), K(7)]
+    K = FF(7)
+    assert dup_sqr([K(3), K(4)], K) == [K(2), K(3), K(2)]
 
 
 def test_dmp_sqr():
@@ -704,9 +701,8 @@ def test_dmp_sqr():
     assert dmp_sqr([[[]]], 2, QQ) == [[[]]]
     assert dmp_sqr([[[QQ(2, 3)]]], 2, QQ) == [[[QQ(4, 9)]]]
 
-    K = FF(9)
-
-    assert dmp_sqr([[K(3)], [K(4)]], 1, K) == [[K(6)], [K(7)]]
+    K = FF(7)
+    assert dmp_sqr([[K(3)], [K(4)]], 1, K) == [[K(2)], [K(3)], [K(2)]]
 
 
 def test_dup_pow():


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #13893
related to #13893
related to #13894 (in fact it finishes it)
#### Brief description of what is fixed or changed
This is a stopgap fix to avoid further confusion concerning `FiniteField`s that are not actually fields...

Nothing much is lost, but technically it takes out the ring obtained by `GF(n)` for a composite `n`. It was unused though and undocumented.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixes `GF(n)` to raise an exception for non-prime `n`.
<!-- END RELEASE NOTES -->