### PR TITLE
Remove weird __str__ overloads with extra arguments

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,7 +1,7 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.compatibility import unicode
 from sympy.printing.defaults import Printable
-from .printing import (VectorLatexPrinter, VectorStrPrinter)
+from .printing import VectorLatexPrinter, VectorStrPrinter
 
 __all__ = ['Dyadic']
 
@@ -302,23 +302,28 @@ class Dyadic(Printable):
             ol += v[0] * ((other ^ v[1]) | v[2])
         return ol
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         """Printing method. """
         ar = self.args  # just to shorten things
         if len(ar) == 0:
-            return str(0)
+            return printer._print(0)
+
+        # Ignore parent printer class and settings and use our own.
+        # TODO: Remove this, it's only here to preserve old behavior
+        printer = VectorStrPrinter()
+
         ol = []  # output list, to be concatenated to a string
         for i, v in enumerate(ar):
             # if the coef of the dyadic is 1, we skip the 1
             if ar[i][0] == 1:
-                ol.append(' + (' + str(ar[i][1]) + '|' + str(ar[i][2]) + ')')
+                ol.append(' + (' + printer._print(ar[i][1]) + '|' + printer._print(ar[i][2]) + ')')
             # if the coef of the dyadic is -1, we skip the 1
             elif ar[i][0] == -1:
-                ol.append(' - (' + str(ar[i][1]) + '|' + str(ar[i][2]) + ')')
+                ol.append(' - (' + printer._print(ar[i][1]) + '|' + printer._print(ar[i][2]) + ')')
             # If the coefficient of the dyadic is not 1 or -1,
             # we might wrap it in parentheses, for readability.
             elif ar[i][0] != 0:
-                arg_str = VectorStrPrinter().doprint(ar[i][0])
+                arg_str = printer.doprint(ar[i][0])
                 if isinstance(ar[i][0], Add):
                     arg_str = "(%s)" % arg_str
                 if arg_str[0] == '-':
@@ -326,8 +331,8 @@ class Dyadic(Printable):
                     str_start = ' - '
                 else:
                     str_start = ' + '
-                ol.append(str_start + arg_str + '*(' + str(ar[i][1]) +
-                          '|' + str(ar[i][2]) + ')')
+                ol.append(str_start + arg_str + '*(' + printer._print(ar[i][1]) +
+                          '|' + printer._print(ar[i][2]) + ')')
         outstr = ''.join(ol)
         if outstr.startswith(' + '):
             outstr = outstr[3:]
@@ -366,9 +371,6 @@ class Dyadic(Printable):
             ol += v[0] * (v[1] | (v[2] ^ other))
         return ol
 
-    _sympystr = __str__
-    _sympyrepr = _sympystr
-    __repr__ = __str__
     __radd__ = __add__
     __rmul__ = __mul__
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -341,14 +341,14 @@ class Vector(Printable):
     def __rsub__(self, other):
         return (-1 * self) + other
 
-    def __str__(self, printer=None, order=True):
+    def _sympystr(self, printer, order=True):
         """Printing method. """
         from sympy.physics.vector.printing import VectorStrPrinter
 
         if not order or len(self.args) == 1:
             ar = list(self.args)
         elif len(self.args) == 0:
-            return str(0)
+            return printer._print(0)
         else:
             d = {v[1]: v[0] for v in self.args}
             keys = sorted(d.keys(), key=lambda x: x.index)
@@ -447,9 +447,6 @@ class Vector(Printable):
             outlist += _det(tempm).args
         return Vector(outlist)
 
-    _sympystr = __str__
-    _sympyrepr = _sympystr
-    __repr__ = __str__
     __radd__ = __add__
     __rand__ = __and__
     __rmul__ = __mul__

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -288,15 +288,12 @@ class BasisDependentMul(BasisDependent, Mul):
 
         return obj
 
-    def __str__(self, printer=None):
-        measure_str = self._measure_number.__str__()
+    def _sympystr(self, printer):
+        measure_str = printer._print(self._measure_number)
         if ('(' in measure_str or '-' in measure_str or
                 '+' in measure_str):
             measure_str = '(' + measure_str + ')'
-        return measure_str + '*' + self._base_instance.__str__(printer)
-
-    __repr__ = __str__
-    _sympystr = __str__
+        return measure_str + '*' + printer._print(self._base_instance)
 
 
 class BasisDependentZero(BasisDependent):
@@ -360,8 +357,5 @@ class BasisDependentZero(BasisDependent):
         """
         return self
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return '0'
-
-    __repr__ = __str__
-    _sympystr = __str__

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -252,11 +252,8 @@ class CoordSys3D(Basic):
         # Return the instance
         return obj
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return self._name
-
-    __repr__ = __str__
-    _sympystr = __str__
 
     def __iter__(self):
         return iter(self.base_vectors())

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -125,8 +125,5 @@ class Del(Basic):
     __xor__ = cross
     __xor__.__doc__ = cross.__doc__
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return self._name
-
-    __repr__ = __str__
-    _sympystr = __str__

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -221,11 +221,9 @@ class BaseDyadic(Dyadic, AtomicExpr):
 
         return obj
 
-    def __str__(self, printer=None):
-        return "(" + str(self.args[0]) + "|" + str(self.args[1]) + ")"
-
-    _sympystr = __str__
-    _sympyrepr = _sympystr
+    def _sympystr(self, printer):
+        return "({}|{})".format(
+            printer._print(self.args[0]), printer._print(self.args[1]))
 
 
 class DyadicMul(BasisDependentMul, Dyadic):
@@ -255,17 +253,10 @@ class DyadicAdd(BasisDependentAdd, Dyadic):
         obj = BasisDependentAdd.__new__(cls, *args, **options)
         return obj
 
-    def __str__(self, printer=None):
-        ret_str = ''
+    def _sympystr(self, printer):
         items = list(self.components.items())
         items.sort(key=lambda x: x[0].__str__())
-        for k, v in items:
-            temp_dyad = k * v
-            ret_str += temp_dyad.__str__(printer) + " + "
-        return ret_str[:-3]
-
-    __repr__ = __str__
-    _sympystr = __str__
+        return " + ".join(printer._print(k * v) for k, v in items)
 
 
 class DyadicZero(BasisDependentZero, Dyadic):

--- a/sympy/vector/point.py
+++ b/sympy/vector/point.py
@@ -147,8 +147,5 @@ class Point(Basic):
         # Express it in the given coordinate system
         return tuple(pos_vect.to_matrix(coordinate_system))
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return self._name
-
-    __repr__ = __str__
-    _sympystr = __str__

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -67,8 +67,5 @@ class BaseScalar(AtomicExpr):
     def system(self):
         return self._system
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return self._name
-
-    __repr__ = __str__
-    _sympystr = __str__

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -388,15 +388,12 @@ class BaseVector(Vector, AtomicExpr):
     def system(self):
         return self._system
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         return self._name
 
     @property
     def free_symbols(self):
         return {self}
-
-    __repr__ = __str__
-    _sympystr = __str__
 
 
 class VectorAdd(BasisDependentAdd, Vector):
@@ -408,7 +405,7 @@ class VectorAdd(BasisDependentAdd, Vector):
         obj = BasisDependentAdd.__new__(cls, *args, **options)
         return obj
 
-    def __str__(self, printer=None):
+    def _sympystr(self, printer):
         ret_str = ''
         items = list(self.separate().items())
         items.sort(key=lambda x: x[0].__str__())
@@ -417,11 +414,8 @@ class VectorAdd(BasisDependentAdd, Vector):
             for x in base_vects:
                 if x in vect.components:
                     temp_vect = self.components[x] * x
-                    ret_str += temp_vect.__str__(printer) + " + "
+                    ret_str += printer._print(temp_vect) + " + "
         return ret_str[:-3]
-
-    __repr__ = __str__
-    _sympystr = __str__
 
 
 class VectorMul(BasisDependentMul, Vector):


### PR DESCRIPTION
`__str__` shouldn't be receiving a sympy printer, that's what _ sympystr is for.
These classes will inherit appropriate `__str__` and `__repr__` implemented in terms of it from their base classes.

This also removes the custom `_sympyrepr` - the default supplied by sympy is usually sufficient.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Addresses some comments in #19425.

~~Pausing work on this until #19625 is merged.~~

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->