### PR TITLE
fix(other): Remove references to typing.Type

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -4,7 +4,7 @@ we support. Also some functions that are needed SymPy-wide and are located
 here for easy import.
 """
 
-from typing import Tuple, Type
+# from typing import Tuple, Type
 
 import operator
 from collections import defaultdict
@@ -728,7 +728,7 @@ if GROUND_TYPES == 'gmpy' and not HAS_GMPY:
     GROUND_TYPES = 'python'
 
 # SYMPY_INTS is a tuple containing the base types for valid integer types.
-SYMPY_INTS = (int, )  # type: Tuple[Type, ...]
+SYMPY_INTS = (int, )  ## type: Tuple[Type, ...]
 
 if GROUND_TYPES == 'gmpy':
     SYMPY_INTS += (type(gmpy.mpz(0)),)

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -7,7 +7,8 @@ at present this is mainly needed for facts.py , feel free however to improve
 this stuff for general purpose.
 """
 
-from typing import Dict, Type, Union
+# from typing import Dict, Type
+from typing import Union
 
 
 # Type of a fuzzy bool
@@ -223,7 +224,7 @@ def fuzzy_nand(args):
 class Logic:
     """Logical expression"""
     # {} 'op' -> LogicClass
-    op_2class = {}  # type: Dict[str, Type[Logic]]
+    op_2class = {}  ## type: Dict[str, Type[Logic]]
 
     def __new__(cls, *args):
         obj = object.__new__(cls)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,4 +1,4 @@
-from typing import Dict, Type, Union
+# from typing import Dict, Union, Type
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from .add import _unevaluated_Add, Add
@@ -59,7 +59,7 @@ class Relational(Boolean, EvalfMixin):
     """
     __slots__ = ()
 
-    ValidRelationOperator = {}  # type: Dict[Union[str, None], Type[Relational]]
+    ValidRelationOperator = {}  ## type: Dict[Union[str, None], Type[Relational]]
 
     is_Relational = True
 

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -1,7 +1,7 @@
 """Singleton mechanism"""
 
 
-from typing import Any, Dict, Type
+# from typing import Any, Dict, Type
 
 from .core import Registry
 from .assumptions import ManagedProperties
@@ -160,7 +160,7 @@ class Singleton(ManagedProperties):
     subclass may use a subclassed metaclass).
     """
 
-    _instances = {}  # type: Dict[Type[Any], Any]
+    _instances = {}  ## type: Dict[Type[Any], Any]
     "Maps singleton classes to their instances."
 
     def __new__(cls, *args, **kwargs):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -1,6 +1,6 @@
 """sympify -- convert objects SymPy internal format"""
 
-from typing import Dict, Type, Callable, Any
+# from typing import Any, Callable, Dict, Type
 
 from inspect import getmro
 
@@ -23,7 +23,7 @@ class SympifyError(ValueError):
 
 
 # See sympify docstring.
-converter = {}  # type: Dict[Type[Any], Callable[[Any], Basic]]
+converter = {}  ## type: Dict[Type[Any], Callable[[Any], Basic]]
 
 
 class CantSympify:
@@ -542,4 +542,4 @@ def kernS(s):
 
 
 # Avoid circular import
-from .basic import Basic
+# from .basic import Basic

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from typing import Any, Optional, Type
+from typing import Any, Optional
 
 from sympy.core import Basic, sympify
 from sympy.core.compatibility import HAS_GMPY, is_sequence
@@ -17,7 +17,7 @@ from sympy.utilities import default_sort_key, public
 class Domain(object):
     """Represents an abstract domain. """
 
-    dtype = None  # type: Optional[Type]
+    dtype = None  ## type: Optional[Type]
     zero = None  # type: Optional[Any]
     one = None  # type: Optional[Any]
 

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from typing import Any, Dict, Tuple, Type
+# from typing import Any, Dict, Tuple, Type
 
 import operator
 
@@ -178,7 +178,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
     def invert(self):
         return self.__class__(self._invert(self.val))
 
-_modular_integer_cache = {}  # type: Dict[Tuple[Any, Any, Any], Type[ModularInteger]]
+_modular_integer_cache = {}  ## type: Dict[Tuple[Any, Any, Any], Type[ModularInteger]]
 
 def ModularIntegerFactory(_mod, _dom, _sym, parent):
     """Create custom class for specific integer modulus."""

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -4,7 +4,8 @@ from __future__ import print_function, division
 
 __all__ = ["Options"]
 
-from typing import Dict, List, Optional, Type
+# from typing import Dict, Type
+from typing import List, Optional
 
 from sympy.core import Basic, sympify
 from sympy.polys.polyerrors import GeneratorsError, OptionError, FlagError
@@ -123,7 +124,7 @@ class Options(dict):
     """
 
     __order__ = None
-    __options__ = {}  # type: Dict[str, Type[Option]]
+    __options__ = {}  ## type: Dict[str, Type[Option]]
 
     def __init__(self, gens, args, flags=None, strict=False):
         dict.__init__(self)

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1,11 +1,14 @@
 #
 # This is the module for ODE solver classes for single ODEs.
 #
-import typing
 
-if typing.TYPE_CHECKING:
-    from typing import ClassVar
-from typing import Dict, Iterable, List, Optional, Type
+#import typing
+#
+#if typing.TYPE_CHECKING:
+#    from typing import ClassVar
+#from typing import Dict, Type
+
+from typing import Iterable, List, Optional
 
 from sympy.core import S
 from sympy.core.exprtools import factor_terms
@@ -178,11 +181,11 @@ class SingleODESolver:
 
     # Subclasses should store the hint name (the argument to dsolve) in this
     # attribute
-    hint = None  # type: ClassVar[str]
+    hint = None  ## type: ClassVar[str]
 
     # Subclasses should define this to indicate if they support an _Integral
     # hint.
-    has_integral = None  # type: ClassVar[bool]
+    has_integral = None  ## type: ClassVar[bool]
 
     # The ODE to be solved
     ode_problem = None  # type: SingleODEProblem
@@ -351,7 +354,7 @@ class NthAlgebraic(SingleODESolver):
     # be stored in cached results we need to ensure that we always get the
     # same class back for each particular integration variable so we store these
     # classes in a global dict:
-    _diffx_stored = {}  # type: Dict[Symbol, Type[Function]]
+    _diffx_stored = {}  ## type: Dict[Symbol, Type[Function]]
 
     @staticmethod
     def _get_diffx(var):


### PR DESCRIPTION
This ensures that sympy is importable on early Python 3.5.y versions
since typing.Type was added in Python 3.5.2.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->