### PR TITLE
Added parenthesis to fix SparseMatrix printer

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -929,7 +929,7 @@ class SciPyPrinter(NumPyPrinter):
             j.append(c)
             data.append(v)
 
-        return "{name}({data}, ({i}, {j}), shape={shape})".format(
+        return "{name}(({data}, ({i}, {j})), shape={shape})".format(
             name=self._module_format('scipy.sparse.coo_matrix'),
             data=data, i=i, j=j, shape=expr.shape
         )

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -149,7 +149,8 @@ def test_SciPyPrinter():
     assert 'numpy' in p.module_imports
     assert not any(m.startswith('scipy') for m in p.module_imports)
     smat = SparseMatrix(2, 5, {(0, 1): 3})
-    assert p.doprint(smat) == 'scipy.sparse.coo_matrix([3], ([0], [1]), shape=(2, 5))'
+    assert p.doprint(smat) == \
+        'scipy.sparse.coo_matrix(([3], ([0], [1])), shape=(2, 5))'
     assert 'scipy.sparse' in p.module_imports
 
     assert p.doprint(S.GoldenRatio) == 'scipy.constants.golden_ratio'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -6,15 +6,16 @@ import mpmath
 from sympy.testing.pytest import raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
-    Float, Matrix, Lambda, Piecewise, exp, E, Integral, oo, I, Abs, Function,
+    Float, Lambda, Piecewise, exp, E, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk, S, beta,
-    MatrixSymbol, fresnelc, fresnels)
+    fresnelc, fresnels)
 from sympy.functions.elementary.complexes import re, im, arg
 from sympy.functions.special.polynomials import \
     chebyshevt, chebyshevu, legendre, hermite, laguerre, gegenbauer, \
     assoc_legendre, assoc_laguerre, jacobi
+from sympy.matrices import Matrix, MatrixSymbol, SparseMatrix
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.printing.pycode import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function, lambdastr
@@ -29,7 +30,7 @@ import sympy
 MutableDenseMatrix = Matrix
 
 numpy = import_module('numpy')
-scipy = import_module('scipy')
+scipy = import_module('scipy', import_kwargs={'fromlist': ['sparse']})
 numexpr = import_module('numexpr')
 tensorflow = import_module('tensorflow')
 
@@ -431,6 +432,15 @@ def test_numpy_old_matrix():
     f = lambdify((x, y, z), A, [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy'])
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     assert isinstance(f(1, 2, 3), numpy.matrix)
+
+
+def test_scipy_sparse_matrix():
+    if not scipy:
+        skip("scipy not installed.")
+    A = SparseMatrix([[x, 0], [0, y]])
+    f = lambdify((x, y), A, modules="scipy")
+    B = f(1, 2)
+    assert isinstance(B, scipy.sparse.coo_matrix)
 
 
 def test_python_div_zero_issue_11306():


### PR DESCRIPTION
<!-- Added Parenthesis to fix SparseMatrix printer -->

#### References to other Issues or PRs
Fixes Issue #19632 

#### Brief description of what is fixed or changed
Using lambdify with a SparseMatrix resulted in a TypeError as some parenthesis where missing in the SciPy printer of coo_matrix

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed the SciPy printer for sparse matrices
<!-- END RELEASE NOTES -->