### PR TITLE
Deprecate `sympy.utilities.misc.find_executable`

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from sympy.core.compatibility import unicode, u_decode
 from sympy.utilities.decorator import doctest_depends_on
-from sympy.utilities.misc import find_executable
 from .latex import latex
 
 __doctest_requires__ = {('preview',): ['pyglet']}
@@ -126,7 +125,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
             try:
                 for candidate in candidates[output]:
-                    path = find_executable(candidate)
+                    path = shutil.which(candidate)
                     if path is not None:
                         viewer = path
                         break
@@ -145,7 +144,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a BytesIO "
                                  "compatible object if viewer=\"BytesIO\"")
-        elif viewer not in special and not find_executable(viewer):
+        elif viewer not in special and not shutil.which(viewer):
             raise SystemError("Unrecognized viewer: %s" % viewer)
 
 
@@ -183,7 +182,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)
 
-        if not find_executable('latex'):
+        if not shutil.which('latex'):
             raise RuntimeError("latex program is not installed")
 
         try:
@@ -222,7 +221,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 cmd = ["dvisvgm"]
             else:
                 cmd = ["dvi" + output]
-            if not find_executable(cmd[0]):
+            if not shutil.which(cmd[0]):
                 raise RuntimeError("%s is not installed" % cmd[0])
             try:
                 if dvioptions is not None:

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -29,6 +29,7 @@ import doctest as pdoctest  # avoid clashing with our doctest() function
 from doctest import DocTestFinder, DocTestRunner
 import random
 import subprocess
+import shutil
 import signal
 import stat
 import tempfile
@@ -38,7 +39,6 @@ from contextlib import contextmanager
 from sympy.core.cache import clear_cache
 from sympy.core.compatibility import (exec_, PY3, unwrap,
         unicode)
-from sympy.utilities.misc import find_executable
 from sympy.external import import_module
 
 IS_WINDOWS = (os.name == 'nt')
@@ -1529,7 +1529,7 @@ class SymPyDocTests(object):
         """
 
         for executable in executables:
-            if not find_executable(executable):
+            if not shutil.which(executable):
                 raise DependencyError("Could not find %s" % executable)
 
         for module in modules:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -8,6 +8,7 @@ import re as _re
 import struct
 from textwrap import fill, dedent
 from sympy.core.compatibility import get_function_name, as_int
+from sympy.core.decorators import deprecated
 
 
 class Undecidable(ValueError):
@@ -246,6 +247,10 @@ def debug(*args):
         print(*args, file=sys.stderr)
 
 
+@deprecated(
+    useinstead="the builtin ``shutil.which`` function",
+    issue=19634,
+    deprecated_since_version="1.7")
 def find_executable(executable, path=None):
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to


### PR DESCRIPTION
A more powerful version of this, `shutil.which`, is now built in to the standard library

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `find_executable` is deprecated in favor of the builtin `shutil.which`.
<!-- END RELEASE NOTES -->