### PR TITLE
Add support for dvipdfm[x] in printing.preview

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -124,16 +124,18 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             }
 
             try:
-                for candidate in candidates[output]:
-                    path = shutil.which(candidate)
-                    if path is not None:
-                        viewer = path
-                        break
-                else:
-                    raise SystemError(
-                        "No viewers found for '%s' output format." % output)
+                candidate_viewers = candidates[output]
             except KeyError:
                 raise SystemError("Invalid output format: %s" % output)
+
+            for candidate in candidate_viewers:
+                path = shutil.which(candidate)
+                if path is not None:
+                    viewer = path
+                    break
+            else:
+                raise SystemError(
+                    "No viewers found for '%s' output format." % output)
     else:
         if viewer == "StringIO":
             viewer = "BytesIO"
@@ -202,35 +204,52 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 "'latex' exited abnormally with the following output:\n%s" %
                 e.output)
 
+        src = "texput.%s" % (output)
+
         if output != "dvi":
+            # in order of preference
+            commandnames = {
+                "ps": ["dvips"],
+                "pdf": ["dvipdfmx", "dvipdfm", "dvipdf"],
+                "png": ["dvipng"],
+                "svg": ["dvisvgm"],
+            }
+            try:
+                cmd_variants = commandnames[output]
+            except KeyError:
+                raise SystemError("Invalid output format: %s" % output)
+
+            # find an appropriate command
+            for cmd_variant in cmd_variants:
+                cmd_path = shutil.which(cmd_variant)
+                if cmd_path:
+                    cmd = [cmd_path]
+                    break
+            else:
+                if len(cmd_variants) > 1:
+                    raise RuntimeError("None of %s are installed" % ", ".join(cmd_variants))
+                else:
+                    raise RuntimeError("%s is not installed" % cmd_variants[0])
+
             defaultoptions = {
-                "ps": [],
-                "pdf": [],
-                "png": ["-T", "tight", "-z", "9", "--truecolor"],
-                "svg": ["--no-fonts"],
+                "dvipng": ["-T", "tight", "-z", "9", "--truecolor"],
+                "dvisvgm": ["--no-fonts"],
             }
 
             commandend = {
-                "ps": ["-o", "texput.ps", "texput.dvi"],
-                "pdf": ["texput.dvi", "texput.pdf"],
-                "png": ["-o", "texput.png", "texput.dvi"],
-                "svg": ["-o", "texput.svg", "texput.dvi"],
+                "dvips": ["-o", src, "texput.dvi"],
+                "dvipdf": ["texput.dvi", src],
+                "dvipdfm": ["-o", src, "texput.dvi"],
+                "dvipdfmx": ["-o", src, "texput.dvi"],
+                "dvipng": ["-o", src, "texput.dvi"],
+                "dvisvgm": ["-o", src, "texput.dvi"],
             }
 
-            if output == "svg":
-                cmd = ["dvisvgm"]
+            if dvioptions is not None:
+                cmd.extend(dvioptions)
             else:
-                cmd = ["dvi" + output]
-            if not shutil.which(cmd[0]):
-                raise RuntimeError("%s is not installed" % cmd[0])
-            try:
-                if dvioptions is not None:
-                    cmd.extend(dvioptions)
-                else:
-                    cmd.extend(defaultoptions[output])
-                cmd.extend(commandend[output])
-            except KeyError:
-                raise SystemError("Invalid output format: %s" % output)
+                cmd.extend(defaultoptions.get(cmd_variant, []))
+            cmd.extend(commandend[cmd_variant])
 
             try:
                 # Avoid showing a cmd.exe window when running this
@@ -246,7 +265,6 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                     "'%s' exited abnormally with the following output:\n%s" %
                     (' '.join(cmd), e.output))
 
-        src = "texput.%s" % (output)
 
         if viewer == "file":
             if filename is None:


### PR DESCRIPTION
On a windows miktex installation, there is no `dvipdf`, but there is `dvipdfmx`.
A cursory google suggests the latter is a better alternative in almost all regards.

Since the arguments taken by the `m` variants are different to `dvipdf`, the `commandend` dictionary is tweaked to be keyed by the actual executable name, not the format.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `preview(..., output='pdf')` now uses `dvipdfmx` instead of `dvipdf` if available. As a result, it now works with a MiKTeX installation on windows.
<!-- END RELEASE NOTES -->