### PR TITLE
physics.vector: respect local printer settings in Dyadic and Vector 

### DIFF
--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -227,6 +227,8 @@ the reference frame is created and the kinematics are done. ::
   >>> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame
   >>> from sympy.physics.mechanics import RigidBody, Particle, Point, outer
   >>> from sympy.physics.mechanics import linear_momentum, angular_momentum
+  >>> from sympy.physics.vector import init_vprinting
+  >>> init_vprinting(pretty_print=False)
   >>> m, M, l1 = symbols('m M l1')
   >>> q1d = dynamicsymbols('q1d')
   >>> N = ReferenceFrame('N')
@@ -331,6 +333,8 @@ by going through an identical procedure. ::
   >>> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, outer
   >>> from sympy.physics.mechanics import RigidBody, Particle
   >>> from sympy.physics.mechanics import kinetic_energy, potential_energy, Point
+  >>> from sympy.physics.vector import init_vprinting
+  >>> init_vprinting(pretty_print=False)
   >>> m, M, l1, g, h, H = symbols('m M l1 g h H')
   >>> omega = dynamicsymbols('omega')
   >>> N = ReferenceFrame('N')
@@ -352,9 +356,9 @@ The user can then determine the kinetic energy of any number of entities of the
 system: ::
 
   >>> kinetic_energy(N, Pa)
-  2*l1**2*m*omega(t)**2
+  2*l1**2*m*omega**2
   >>> kinetic_energy(N, Pa, A)
-  M*l1**2*omega(t)**2/2 + 2*l1**2*m*omega(t)**2 + omega(t)**2/2
+  M*l1**2*omega**2/2 + 2*l1**2*m*omega**2 + omega**2/2
 
 It should be noted that the user can determine either kinetic energy relative
 to any frame in :mod:`sympy.physics.mechanics` as the user is allowed to specify the
@@ -375,7 +379,9 @@ be determined: ::
 One can also determine the Lagrangian for this system: ::
 
   >>> from sympy.physics.mechanics import Lagrangian
+  >>> from sympy.physics.vector import init_vprinting
+  >>> init_vprinting(pretty_print=False)
   >>> Lagrangian(N, Pa, A)
-  -H*M*g + M*l1**2*omega(t)**2/2 - g*h*m + 2*l1**2*m*omega(t)**2 + omega(t)**2/2
+  -H*M*g + M*l1**2*omega**2/2 - g*h*m + 2*l1**2*m*omega**2 + omega**2/2
 
 Please refer to the docstrings to learn more about each function.

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -30,6 +30,8 @@ frame is rotated 90 degrees.
     >>> from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame,
     ...                                      Particle, Point)
     >>> import sympy.physics.mechanics.system as system
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
 
 The first step will be to initialize all of the dynamic and constant symbols. ::
 
@@ -146,54 +148,54 @@ equations of motion formats. ::
 
     >>> symsystem1.states
     Matrix([
-    [     x(t)],
-    [     y(t)],
-    [     u(t)],
-    [     v(t)],
-    [lambda(t)]])
+    [     x],
+    [     y],
+    [     u],
+    [     v],
+    [lambda]])
     >>> symsystem2.coordinates
     Matrix([
-    [x(t)],
-    [y(t)]])
+    [x],
+    [y]])
     >>> symsystem3.speeds
     Matrix([
-    [u(t)],
-    [v(t)]])
+    [u],
+    [v]])
     >>> symsystem1.comb_explicit_rhs
     Matrix([
-    [                                   u(t)],
-    [                                   v(t)],
-    [(-g*y(t) + u(t)**2 + v(t)**2)*x(t)/l**2],
-    [(-g*y(t) + u(t)**2 + v(t)**2)*y(t)/l**2],
-    [   m*(-g*y(t) + u(t)**2 + v(t)**2)/l**2]])
+    [                          u],
+    [                          v],
+    [(-g*y + u**2 + v**2)*x/l**2],
+    [(-g*y + u**2 + v**2)*y/l**2],
+    [m*(-g*y + u**2 + v**2)/l**2]])
     >>> symsystem2.comb_implicit_rhs
     Matrix([
-    [                       u(t)],
-    [                       v(t)],
-    [                          0],
-    [                          0],
-    [-g*y(t) + u(t)**2 + v(t)**2]])
+    [                 u],
+    [                 v],
+    [                 0],
+    [                 0],
+    [-g*y + u**2 + v**2]])
     >>> symsystem2.comb_implicit_mat
     Matrix([
-    [1, 0, 0, 0,       0],
-    [0, 1, 0, 0,       0],
-    [0, 0, 1, 0, -x(t)/m],
-    [0, 0, 0, 1, -y(t)/m],
-    [0, 0, 0, 0,  l**2/m]])
+    [1, 0, 0, 0,      0],
+    [0, 1, 0, 0,      0],
+    [0, 0, 1, 0,   -x/m],
+    [0, 0, 0, 1,   -y/m],
+    [0, 0, 0, 0, l**2/m]])
     >>> symsystem3.dyn_implicit_rhs
     Matrix([
-    [                          0],
-    [                          0],
-    [-g*y(t) + u(t)**2 + v(t)**2]])
+    [                 0],
+    [                 0],
+    [-g*y + u**2 + v**2]])
     >>> symsystem3.dyn_implicit_mat
     Matrix([
-    [1, 0, -x(t)/m],
-    [0, 1, -y(t)/m],
-    [0, 0,  l**2/m]])
+    [1, 0,   -x/m],
+    [0, 1,   -y/m],
+    [0, 0, l**2/m]])
     >>> symsystem3.kin_explicit_rhs
     Matrix([
-    [u(t)],
-    [v(t)]])
+    [u],
+    [v]])
     >>> symsystem1.alg_con
     [4]
     >>> symsystem1.bodies

--- a/doc/src/modules/physics/vector/kinematics.rst
+++ b/doc/src/modules/physics/vector/kinematics.rst
@@ -430,6 +430,7 @@ velocity definition. ::
 
   >>> from sympy import Symbol, sin, cos
   >>> from sympy.physics.vector import *
+  >>> init_vprinting(pretty_print=False)
   >>> N = ReferenceFrame('N')
   >>> q1 = dynamicsymbols('q1')
   >>> A = N.orientnew('A', 'Axis', [q1, N.x])

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -96,13 +96,15 @@ class Particle(object):
 
         >>> from sympy.physics.mechanics import Particle, Point, ReferenceFrame
         >>> from sympy.physics.mechanics import dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> m, v = dynamicsymbols('m v')
         >>> N = ReferenceFrame('N')
         >>> P = Point('P')
         >>> A = Particle('A', P, m)
         >>> P.set_vel(N, v * N.x)
         >>> A.linear_momentum(N)
-        m(t)*v(t)*N.x
+        m*v*N.x
 
         """
 
@@ -134,6 +136,8 @@ class Particle(object):
 
         >>> from sympy.physics.mechanics import Particle, Point, ReferenceFrame
         >>> from sympy.physics.mechanics import dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> m, v, r = dynamicsymbols('m v r')
         >>> N = ReferenceFrame('N')
         >>> O = Point('O')
@@ -141,7 +145,7 @@ class Particle(object):
         >>> P = Particle('P', A, m)
         >>> P.point.set_vel(N, v * N.y)
         >>> P.angular_momentum(O, N)
-        m(t)*r(t)*v(t)*N.z
+        m*r*v*N.z
 
         """
 

--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -102,7 +102,7 @@ class Particle(object):
         >>> A = Particle('A', P, m)
         >>> P.set_vel(N, v * N.x)
         >>> A.linear_momentum(N)
-        m*v*N.x
+        m(t)*v(t)*N.x
 
         """
 
@@ -141,7 +141,7 @@ class Particle(object):
         >>> P = Particle('P', A, m)
         >>> P.point.set_vel(N, v * N.y)
         >>> P.angular_momentum(O, N)
-        m*r*v*N.z
+        m(t)*r(t)*v(t)*N.z
 
         """
 

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -142,6 +142,8 @@ class RigidBody(object):
 
         >>> from sympy.physics.mechanics import Point, ReferenceFrame, outer
         >>> from sympy.physics.mechanics import RigidBody, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> M, v = dynamicsymbols('M v')
         >>> N = ReferenceFrame('N')
         >>> P = Point('P')
@@ -150,7 +152,7 @@ class RigidBody(object):
         >>> Inertia_tuple = (I, P)
         >>> B = RigidBody('B', P, N, M, Inertia_tuple)
         >>> B.linear_momentum(N)
-        M(t)*v(t)*N.x
+        M*v*N.x
 
         """
 
@@ -182,6 +184,8 @@ class RigidBody(object):
 
         >>> from sympy.physics.mechanics import Point, ReferenceFrame, outer
         >>> from sympy.physics.mechanics import RigidBody, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> M, v, r, omega = dynamicsymbols('M v r omega')
         >>> N = ReferenceFrame('N')
         >>> b = ReferenceFrame('b')
@@ -191,7 +195,7 @@ class RigidBody(object):
         >>> I = outer(b.x, b.x)
         >>> B = RigidBody('B', P, b, M, (I, P))
         >>> B.angular_momentum(P, N)
-        omega(t)*b.x
+        omega*b.x
 
         """
         I = self.central_inertia

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -150,7 +150,7 @@ class RigidBody(object):
         >>> Inertia_tuple = (I, P)
         >>> B = RigidBody('B', P, N, M, Inertia_tuple)
         >>> B.linear_momentum(N)
-        M*v*N.x
+        M(t)*v(t)*N.x
 
         """
 
@@ -191,7 +191,7 @@ class RigidBody(object):
         >>> I = outer(b.x, b.x)
         >>> B = RigidBody('B', P, b, M, (I, P))
         >>> B.angular_momentum(P, N)
-        omega*b.x
+        omega(t)*b.x
 
         """
         I = self.central_inertia

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -389,12 +389,14 @@ class Dyadic(Printable):
         ========
 
         >>> from sympy.physics.vector import ReferenceFrame, outer, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> N = ReferenceFrame('N')
         >>> q = dynamicsymbols('q')
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
         >>> d = outer(N.x, N.x)
         >>> d.express(B, N)
-        cos(q(t))*(B.x|N.x) - sin(q(t))*(B.y|N.x)
+        cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
 
         """
         from sympy.physics.vector.functions import express
@@ -470,12 +472,14 @@ class Dyadic(Printable):
         ========
 
         >>> from sympy.physics.vector import ReferenceFrame, outer, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> N = ReferenceFrame('N')
         >>> q = dynamicsymbols('q')
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
         >>> d = outer(N.x, N.x)
         >>> d.dt(B)
-        - Derivative(q(t), t)*(N.y|N.x) - Derivative(q(t), t)*(N.x|N.y)
+        - q'*(N.y|N.x) - q'*(N.x|N.y)
 
         """
         from sympy.physics.vector.functions import time_derivative

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,7 +1,6 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
 from sympy.core.compatibility import unicode
 from sympy.printing.defaults import Printable
-from .printing import VectorLatexPrinter, VectorStrPrinter
 
 __all__ = ['Dyadic']
 
@@ -157,22 +156,21 @@ class Dyadic(Printable):
         if len(ar) == 0:
             return str(0)
         ol = []  # output list, to be concatenated to a string
-        mlp = VectorLatexPrinter()
         for i, v in enumerate(ar):
             # if the coef of the dyadic is 1, we skip the 1
             if ar[i][0] == 1:
-                ol.append(' + ' + mlp.doprint(ar[i][1]) + r"\otimes " +
-                          mlp.doprint(ar[i][2]))
+                ol.append(' + ' + printer._print(ar[i][1]) + r"\otimes " +
+                          printer._print(ar[i][2]))
             # if the coef of the dyadic is -1, we skip the 1
             elif ar[i][0] == -1:
                 ol.append(' - ' +
-                          mlp.doprint(ar[i][1]) +
+                          printer._print(ar[i][1]) +
                           r"\otimes " +
-                          mlp.doprint(ar[i][2]))
+                          printer._print(ar[i][2]))
             # If the coefficient of the dyadic is not 1 or -1,
             # we might wrap it in parentheses, for readability.
             elif ar[i][0] != 0:
-                arg_str = mlp.doprint(ar[i][0])
+                arg_str = printer._print(ar[i][0])
                 if isinstance(ar[i][0], Add):
                     arg_str = '(%s)' % arg_str
                 if arg_str.startswith('-'):
@@ -180,8 +178,8 @@ class Dyadic(Printable):
                     str_start = ' - '
                 else:
                     str_start = ' + '
-                ol.append(str_start + arg_str + mlp.doprint(ar[i][1]) +
-                          r"\otimes " + mlp.doprint(ar[i][2]))
+                ol.append(str_start + arg_str + printer._print(ar[i][1]) +
+                          r"\otimes " + printer._print(ar[i][2]))
         outstr = ''.join(ol)
         if outstr.startswith(' + '):
             outstr = outstr[3:]
@@ -307,11 +305,6 @@ class Dyadic(Printable):
         ar = self.args  # just to shorten things
         if len(ar) == 0:
             return printer._print(0)
-
-        # Ignore parent printer class and settings and use our own.
-        # TODO: Remove this, it's only here to preserve old behavior
-        printer = VectorStrPrinter()
-
         ol = []  # output list, to be concatenated to a string
         for i, v in enumerate(ar):
             # if the coef of the dyadic is 1, we skip the 1
@@ -323,7 +316,7 @@ class Dyadic(Printable):
             # If the coefficient of the dyadic is not 1 or -1,
             # we might wrap it in parentheses, for readability.
             elif ar[i][0] != 0:
-                arg_str = printer.doprint(ar[i][0])
+                arg_str = printer._print(ar[i][0])
                 if isinstance(ar[i][0], Add):
                     arg_str = "(%s)" % arg_str
                 if arg_str[0] == '-':
@@ -401,7 +394,7 @@ class Dyadic(Printable):
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
         >>> d = outer(N.x, N.x)
         >>> d.express(B, N)
-        cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
+        cos(q(t))*(B.x|N.x) - sin(q(t))*(B.y|N.x)
 
         """
         from sympy.physics.vector.functions import express
@@ -482,7 +475,7 @@ class Dyadic(Printable):
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
         >>> d = outer(N.x, N.x)
         >>> d.dt(B)
-        - q'*(N.y|N.x) - q'*(N.x|N.y)
+        - Derivative(q(t), t)*(N.y|N.x) - Derivative(q(t), t)*(N.x|N.y)
 
         """
         from sympy.physics.vector.functions import time_derivative

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -71,9 +71,9 @@ def express(expr, frame, frame2=None, variables=False):
     >>> d = outer(N.x, N.x)
     >>> from sympy.physics.vector import express
     >>> express(d, B, N)
-    cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
+    cos(q(t))*(B.x|N.x) - sin(q(t))*(B.y|N.x)
     >>> express(B.x, N)
-    cos(q)*N.x + sin(q)*N.y
+    cos(q(t))*N.x + sin(q(t))*N.y
     >>> express(N[0], B, variables=True)
     B_x*cos(q(t)) - B_y*sin(q(t))
 
@@ -169,14 +169,14 @@ def time_derivative(expr, frame, order=1):
     >>> A.set_ang_vel(N, 10*A.x)
     >>> from sympy.physics.vector import time_derivative
     >>> time_derivative(v, N)
-    u1'*N.x
+    Derivative(u1(t), t)*N.x
     >>> time_derivative(u1*A[0], N)
     N_x*Derivative(u1(t), t)
     >>> B = N.orientnew('B', 'Axis', [u1, N.z])
     >>> from sympy.physics.vector import outer
     >>> d = outer(N.x, N.x)
     >>> time_derivative(d, B)
-    - u1'*(N.y|N.x) - u1'*(N.x|N.y)
+    - Derivative(u1(t), t)*(N.y|N.x) - Derivative(u1(t), t)*(N.x|N.y)
 
     """
 
@@ -425,7 +425,7 @@ def get_motion_params(frame, **kwargs):
     >>> v1, v2, v3 = dynamicsymbols('v1 v2 v3')
     >>> v = v1*R.x + v2*R.y + v3*R.z
     >>> get_motion_params(R, position = v)
-    (v1''*R.x + v2''*R.y + v3''*R.z, v1'*R.x + v2'*R.y + v3'*R.z, v1*R.x + v2*R.y + v3*R.z)
+    (Derivative(v1(t), (t, 2))*R.x + Derivative(v2(t), (t, 2))*R.y + Derivative(v3(t), (t, 2))*R.z, Derivative(v1(t), t)*R.x + Derivative(v2(t), t)*R.y + Derivative(v3(t), t)*R.z, v1(t)*R.x + v2(t)*R.y + v3(t)*R.z)
     >>> a, b, c = symbols('a b c')
     >>> v = a*R.x + b*R.y + c*R.z
     >>> get_motion_params(R, velocity = v)

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -65,17 +65,19 @@ def express(expr, frame, frame2=None, variables=False):
     ========
 
     >>> from sympy.physics.vector import ReferenceFrame, outer, dynamicsymbols
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
     >>> N = ReferenceFrame('N')
     >>> q = dynamicsymbols('q')
     >>> B = N.orientnew('B', 'Axis', [q, N.z])
     >>> d = outer(N.x, N.x)
     >>> from sympy.physics.vector import express
     >>> express(d, B, N)
-    cos(q(t))*(B.x|N.x) - sin(q(t))*(B.y|N.x)
+    cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
     >>> express(B.x, N)
-    cos(q(t))*N.x + sin(q(t))*N.y
+    cos(q)*N.x + sin(q)*N.y
     >>> express(N[0], B, variables=True)
-    B_x*cos(q(t)) - B_y*sin(q(t))
+    B_x*cos(q) - B_y*sin(q)
 
     """
 
@@ -160,6 +162,8 @@ def time_derivative(expr, frame, order=1):
     ========
 
     >>> from sympy.physics.vector import ReferenceFrame, dynamicsymbols
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
     >>> from sympy import Symbol
     >>> q1 = Symbol('q1')
     >>> u1 = dynamicsymbols('u1')
@@ -169,14 +173,14 @@ def time_derivative(expr, frame, order=1):
     >>> A.set_ang_vel(N, 10*A.x)
     >>> from sympy.physics.vector import time_derivative
     >>> time_derivative(v, N)
-    Derivative(u1(t), t)*N.x
+    u1'*N.x
     >>> time_derivative(u1*A[0], N)
-    N_x*Derivative(u1(t), t)
+    N_x*u1'
     >>> B = N.orientnew('B', 'Axis', [u1, N.z])
     >>> from sympy.physics.vector import outer
     >>> d = outer(N.x, N.x)
     >>> time_derivative(d, B)
-    - Derivative(u1(t), t)*(N.y|N.x) - Derivative(u1(t), t)*(N.x|N.y)
+    - u1'*(N.y|N.x) - u1'*(N.x|N.y)
 
     """
 
@@ -420,12 +424,14 @@ def get_motion_params(frame, **kwargs):
     ========
 
     >>> from sympy.physics.vector import ReferenceFrame, get_motion_params, dynamicsymbols
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
     >>> from sympy import symbols
     >>> R = ReferenceFrame('R')
     >>> v1, v2, v3 = dynamicsymbols('v1 v2 v3')
     >>> v = v1*R.x + v2*R.y + v3*R.z
     >>> get_motion_params(R, position = v)
-    (Derivative(v1(t), (t, 2))*R.x + Derivative(v2(t), (t, 2))*R.y + Derivative(v3(t), (t, 2))*R.z, Derivative(v1(t), t)*R.x + Derivative(v2(t), t)*R.y + Derivative(v3(t), t)*R.z, v1(t)*R.x + v2(t)*R.y + v3(t)*R.z)
+    (v1''*R.x + v2''*R.y + v3''*R.z, v1'*R.x + v2'*R.y + v3'*R.z, v1*R.x + v2*R.y + v3*R.z)
     >>> a, b, c = symbols('a b c')
     >>> v = a*R.x + b*R.y + c*R.z
     >>> get_motion_params(R, velocity = v)

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -28,7 +28,7 @@ class Point(object):
     >>> u1, u2, u3 = dynamicsymbols('u1 u2 u3')
     >>> O.set_vel(N, u1 * N.x + u2 * N.y + u3 * N.z)
     >>> O.acc(N)
-    u1'*N.x + u2'*N.y + u3'*N.z
+    Derivative(u1(t), t)*N.x + Derivative(u2(t), t)*N.y + Derivative(u3(t), t)*N.z
 
     symbols() can be used to create multiple Points in a single step, for example:
 
@@ -42,7 +42,7 @@ class Point(object):
     >>> A.set_vel(N, u1 * N.x + u2 * N.y)
     >>> B.set_vel(N, u2 * N.x + u1 * N.y)
     >>> A.acc(N) - B.acc(N)
-    (u1' - u2')*N.x + (-u1' + u2')*N.y
+    (Derivative(u1(t), t) - Derivative(u2(t), t))*N.x + (-Derivative(u1(t), t) + Derivative(u2(t), t))*N.y
 
     """
 
@@ -123,7 +123,7 @@ class Point(object):
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.a1pt_theory(O, N, B)
-        (-25*q + q'')*B.x + q2''*B.y - 10*q'*B.z
+        (-25*q(t) + Derivative(q(t), (t, 2)))*B.x + Derivative(q2(t), (t, 2))*B.y - 10*Derivative(q(t), t)*B.z
 
         """
 
@@ -172,7 +172,7 @@ class Point(object):
         >>> P = O.locatenew('P', 10 * B.x)
         >>> O.set_vel(N, 5 * N.x)
         >>> P.a2pt_theory(O, N, B)
-        - 10*q'**2*B.x + 10*q''*B.y
+        - 10*Derivative(q(t), t)**2*B.x + 10*Derivative(q(t), (t, 2))*B.y
 
         """
 
@@ -400,7 +400,7 @@ class Point(object):
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.v1pt_theory(O, N, B)
-        q'*B.x + q2'*B.y - 5*q*B.z
+        Derivative(q(t), t)*B.x + Derivative(q2(t), t)*B.y - 5*q(t)*B.z
 
         """
 
@@ -446,7 +446,7 @@ class Point(object):
         >>> P = O.locatenew('P', 10 * B.x)
         >>> O.set_vel(N, 5 * N.x)
         >>> P.v2pt_theory(O, N, B)
-        5*N.x + 10*q'*B.y
+        5*N.x + 10*Derivative(q(t), t)*B.y
 
         """
 

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -22,17 +22,21 @@ class Point(object):
     ========
 
     >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
     >>> N = ReferenceFrame('N')
     >>> O = Point('O')
     >>> P = Point('P')
     >>> u1, u2, u3 = dynamicsymbols('u1 u2 u3')
     >>> O.set_vel(N, u1 * N.x + u2 * N.y + u3 * N.z)
     >>> O.acc(N)
-    Derivative(u1(t), t)*N.x + Derivative(u2(t), t)*N.y + Derivative(u3(t), t)*N.z
+    u1'*N.x + u2'*N.y + u3'*N.z
 
     symbols() can be used to create multiple Points in a single step, for example:
 
     >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
+    >>> from sympy.physics.vector import init_vprinting
+    >>> init_vprinting(pretty_print=False)
     >>> from sympy import symbols
     >>> N = ReferenceFrame('N')
     >>> u1, u2 = dynamicsymbols('u1 u2')
@@ -42,7 +46,7 @@ class Point(object):
     >>> A.set_vel(N, u1 * N.x + u2 * N.y)
     >>> B.set_vel(N, u2 * N.x + u1 * N.y)
     >>> A.acc(N) - B.acc(N)
-    (Derivative(u1(t), t) - Derivative(u2(t), t))*N.x + (-Derivative(u1(t), t) + Derivative(u2(t), t))*N.y
+    (u1' - u2')*N.x + (-u1' + u2')*N.y
 
     """
 
@@ -111,6 +115,8 @@ class Point(object):
 
         >>> from sympy.physics.vector import Point, ReferenceFrame
         >>> from sympy.physics.vector import dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> q = dynamicsymbols('q')
         >>> q2 = dynamicsymbols('q2')
         >>> qd = dynamicsymbols('q', 1)
@@ -123,7 +129,7 @@ class Point(object):
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.a1pt_theory(O, N, B)
-        (-25*q(t) + Derivative(q(t), (t, 2)))*B.x + Derivative(q2(t), (t, 2))*B.y - 10*Derivative(q(t), t)*B.z
+        (-25*q + q'')*B.x + q2''*B.y - 10*q'*B.z
 
         """
 
@@ -164,6 +170,8 @@ class Point(object):
         ========
 
         >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> q = dynamicsymbols('q')
         >>> qd = dynamicsymbols('q', 1)
         >>> N = ReferenceFrame('N')
@@ -172,7 +180,7 @@ class Point(object):
         >>> P = O.locatenew('P', 10 * B.x)
         >>> O.set_vel(N, 5 * N.x)
         >>> P.a2pt_theory(O, N, B)
-        - 10*Derivative(q(t), t)**2*B.x + 10*Derivative(q(t), (t, 2))*B.y
+        - 10*q'**2*B.x + 10*q''*B.y
 
         """
 
@@ -388,6 +396,8 @@ class Point(object):
 
         >>> from sympy.physics.vector import Point, ReferenceFrame
         >>> from sympy.physics.vector import dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> q = dynamicsymbols('q')
         >>> q2 = dynamicsymbols('q2')
         >>> qd = dynamicsymbols('q', 1)
@@ -400,7 +410,7 @@ class Point(object):
         >>> P.set_vel(B, qd * B.x + q2d * B.y)
         >>> O.set_vel(N, 0)
         >>> P.v1pt_theory(O, N, B)
-        Derivative(q(t), t)*B.x + Derivative(q2(t), t)*B.y - 5*q(t)*B.z
+        q'*B.x + q2'*B.y - 5*q*B.z
 
         """
 
@@ -438,6 +448,8 @@ class Point(object):
         ========
 
         >>> from sympy.physics.vector import Point, ReferenceFrame, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> q = dynamicsymbols('q')
         >>> qd = dynamicsymbols('q', 1)
         >>> N = ReferenceFrame('N')
@@ -446,7 +458,7 @@ class Point(object):
         >>> P = O.locatenew('P', 10 * B.x)
         >>> O.set_vel(N, 5 * N.x)
         >>> P.v2pt_theory(O, N, B)
-        5*N.x + 10*Derivative(q(t), t)*B.y
+        5*N.x + 10*q'*B.y
 
         """
 

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -395,7 +395,6 @@ def init_vprinting(**kwargs):
     ========
 
     >>> from sympy import Function, symbols
-    >>> from sympy.physics.vector import init_vprinting
     >>> t, x = symbols('t, x')
     >>> omega = Function('omega')
     >>> omega(x).diff()
@@ -405,6 +404,7 @@ def init_vprinting(**kwargs):
 
     Now use the string printer:
 
+    >>> from sympy.physics.vector import init_vprinting
     >>> init_vprinting(pretty_print=False)
     >>> omega(x).diff()
     Derivative(omega(x), x)

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -153,6 +153,11 @@ def test_vector_latex():
     assert vlatex(xx2) == expected
 
 
+def test_vector_latex_arguments():
+    assert vlatex(N.x * 3.0, full_prec=False) == r'3.0\mathbf{\hat{n}_x}'
+    assert vlatex(N.x * 3.0, full_prec=True) == r'3.00000000000000\mathbf{\hat{n}_x}'
+
+
 def test_vector_latex_with_functions():
 
     N = ReferenceFrame('N')
@@ -218,12 +223,12 @@ def test_dyadic_latex():
 
 
 def test_dyadic_str():
-    assert str(Dyadic([])) == '0'
-    assert str(y) == 'a**2*(N.x|N.y) + b*(N.y|N.y) + c*sin(alpha)*(N.z|N.y)'
-    assert str(x) == 'alpha*(N.x|N.x) + sin(omega)*(N.y|N.z) + alpha*beta*(N.z|N.x)'
-    assert str(ww) == "alpha*N.x + asin(omega)*N.y - beta*alpha'*N.z"
-    assert str(xx) == '- (N.x|N.y) - (N.x|N.z)'
-    assert str(xx2) == '(N.x|N.y) + (N.x|N.z)'
+    assert vsprint(Dyadic([])) == '0'
+    assert vsprint(y) == 'a**2*(N.x|N.y) + b*(N.y|N.y) + c*sin(alpha)*(N.z|N.y)'
+    assert vsprint(x) == 'alpha*(N.x|N.x) + sin(omega)*(N.y|N.z) + alpha*beta*(N.z|N.x)'
+    assert vsprint(ww) == "alpha*N.x + asin(omega)*N.y - beta*alpha'*N.z"
+    assert vsprint(xx) == '- (N.x|N.y) - (N.x|N.z)'
+    assert vsprint(xx2) == '(N.x|N.y) + (N.x|N.z)'
 
 
 def test_vlatex(): # vlatex is broken #12078
@@ -302,3 +307,23 @@ def test_vector_str_printing():
     assert vsprint(w) == 'alpha*N.x + sin(omega)*N.y + alpha*beta*N.z'
     assert vsprint(omega.diff() * N.x) == "omega'*N.x"
     assert vsstrrepr(w) == 'alpha*N.x + sin(omega)*N.y + alpha*beta*N.z'
+
+
+def test_vector_str_arguments():
+    assert vsprint(N.x * 3.0, full_prec=False) == '3.0*N.x'
+    assert vsprint(N.x * 3.0, full_prec=True) == '3.00000000000000*N.x'
+
+
+def test_issue_14041():
+    import sympy.physics.mechanics as me
+
+    A_frame = me.ReferenceFrame('A')
+    thetad, phid = me.dynamicsymbols('theta, phi', 1)
+    L = symbols('L')
+
+    assert vlatex(L*(phid + thetad)**2*A_frame.x) == \
+        r"L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
+    assert vlatex((phid + thetad)**2*A_frame.x) == \
+        r"\left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
+    assert vlatex((phid*thetad)**a*A_frame.x) == \
+        r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -507,13 +507,15 @@ class Vector(Printable):
         >>> from sympy import Symbol
         >>> from sympy.physics.vector import dynamicsymbols, ReferenceFrame
         >>> from sympy.physics.vector import Vector
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> Vector.simp = True
         >>> t = Symbol('t')
         >>> q1 = dynamicsymbols('q1')
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.diff(t, N)
-        - Derivative(q1(t), t)*A.z
+        - q1'*A.z
         >>> B = ReferenceFrame('B')
         >>> u1, u2 = dynamicsymbols('u1, u2')
         >>> v = u1 * A.x + u2 * B.y
@@ -567,11 +569,13 @@ class Vector(Printable):
         ========
 
         >>> from sympy.physics.vector import ReferenceFrame, dynamicsymbols
+        >>> from sympy.physics.vector import init_vprinting
+        >>> init_vprinting(pretty_print=False)
         >>> q1 = dynamicsymbols('q1')
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.express(N)
-        cos(q1(t))*N.x - sin(q1(t))*N.z
+        cos(q1)*N.x - sin(q1)*N.z
 
         """
         from sympy.physics.vector import express

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -217,8 +217,6 @@ class Vector(Printable):
     def _latex(self, printer):
         """Latex Printing method. """
 
-        from sympy.physics.vector.printing import VectorLatexPrinter
-
         ar = self.args  # just to shorten things
         if len(ar) == 0:
             return str(0)
@@ -234,7 +232,7 @@ class Vector(Printable):
                 elif ar[i][0][j] != 0:
                     # If the coefficient of the basis vector is not 1 or -1;
                     # also, we might wrap it in parentheses, for readability.
-                    arg_str = VectorLatexPrinter().doprint(ar[i][0][j])
+                    arg_str = printer._print(ar[i][0][j])
                     if isinstance(ar[i][0][j], Add):
                         arg_str = "(%s)" % arg_str
                     if arg_str[0] == '-':
@@ -261,23 +259,22 @@ class Vector(Printable):
                 ar = e.args  # just to shorten things
                 if len(ar) == 0:
                     return unicode(0)
-                vp = printer
                 pforms = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     for j in 0, 1, 2:
                         # if the coef of the basis vector is 1, we skip the 1
                         if ar[i][0][j] == 1:
-                            pform = vp._print(ar[i][1].pretty_vecs[j])
+                            pform = printer._print(ar[i][1].pretty_vecs[j])
                         # if the coef of the basis vector is -1, we skip the 1
                         elif ar[i][0][j] == -1:
-                            pform = vp._print(ar[i][1].pretty_vecs[j])
+                            pform = printer._print(ar[i][1].pretty_vecs[j])
                             pform = prettyForm(*pform.left(" - "))
                             bin = prettyForm.NEG
                             pform = prettyForm(binding=bin, *pform)
                         elif ar[i][0][j] != 0:
                             # If the basis vector coeff is not 1 or -1,
                             # we might wrap it in parentheses, for readability.
-                            pform = vp._print(ar[i][0][j])
+                            pform = printer._print(ar[i][0][j])
 
                             if isinstance(ar[i][0][j], Add):
                                 tmp = pform.parens()
@@ -343,8 +340,6 @@ class Vector(Printable):
 
     def _sympystr(self, printer, order=True):
         """Printing method. """
-        from sympy.physics.vector.printing import VectorStrPrinter
-
         if not order or len(self.args) == 1:
             ar = list(self.args)
         elif len(self.args) == 0:
@@ -367,7 +362,7 @@ class Vector(Printable):
                 elif ar[i][0][j] != 0:
                     # If the coefficient of the basis vector is not 1 or -1;
                     # also, we might wrap it in parentheses, for readability.
-                    arg_str = VectorStrPrinter().doprint(ar[i][0][j])
+                    arg_str = printer._print(ar[i][0][j])
                     if isinstance(ar[i][0][j], Add):
                         arg_str = "(%s)" % arg_str
                     if arg_str[0] == '-':
@@ -518,7 +513,7 @@ class Vector(Printable):
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.diff(t, N)
-        - q1'*A.z
+        - Derivative(q1(t), t)*A.z
         >>> B = ReferenceFrame('B')
         >>> u1, u2 = dynamicsymbols('u1, u2')
         >>> v = u1 * A.x + u2 * B.y
@@ -576,7 +571,7 @@ class Vector(Printable):
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.express(N)
-        cos(q1)*N.x - sin(q1)*N.z
+        cos(q1(t))*N.x - sin(q1(t))*N.z
 
         """
         from sympy.physics.vector import express

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2272,21 +2272,6 @@ def test_WedgeProduct_printing():
     assert latex(wp) == r"\operatorname{d}x \wedge \operatorname{d}y"
 
 
-def test_issue_14041():
-    import sympy.physics.mechanics as me
-
-    A_frame = me.ReferenceFrame('A')
-    thetad, phid = me.dynamicsymbols('theta, phi', 1)
-    L = Symbol('L')
-
-    assert latex(L*(phid + thetad)**2*A_frame.x) == \
-        r"L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
-    assert latex((phid + thetad)**2*A_frame.x) == \
-        r"\left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
-    assert latex((phid*thetad)**a*A_frame.x) == \
-        r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
-
-
 def test_issue_9216():
     expr_1 = Pow(1, -1, evaluate=False)
     assert latex(expr_1) == r"1^{-1}"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Builds upon #19621, ~~marking as draft until that is merged.~~

Same idea as #19424.

#### Brief description of what is fixed or changed
Previously, Both `_sympystr` and `_latex` would ignore the settings (and subclass) of the printer passed in, instead constructing their own printer. The test added in this PR previously failed.

This follow the same idea as 7c804f0.

As a result of this changing, no vector printing customizations will be enabled until `init_vprinting` is called.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * When printing, `Vector` and `Dyadic` now respect keyword-arguments to `sstr` and `latex`. As a result, these no longer use vector printing customizations unless `init_vprinting` has been called.
<!-- END RELEASE NOTES -->