### PR TITLE
[GSoC] Series: Fixes RecursionError and Timeout in limit evaluations

### DIFF
--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -138,7 +138,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     >>> [simplify(c) for c in  mycoeffs] #doctest: +NORMALIZE_WHITESPACE
     [(h**3/2 + h**2*x - 3*h*x**2 - 4*x**3)/h**4,
     (-sqrt(2)*h**3 - 4*h**2*x + 3*sqrt(2)*h*x**2 + 8*x**3)/h**4,
-    6*x/h**2 - 8*x**3/h**4,
+    (6*h**2*x - 8*x**3)/h**4,
     (sqrt(2)*h**3 - 4*h**2*x - 3*sqrt(2)*h*x**2 + 8*x**3)/h**4,
     (-h**3/2 + h**2*x + 3*h*x**2 - 4*x**3)/h**4]
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -916,7 +916,13 @@ class Add(Expr, AssocOp):
         if not new_expr:
             # simple leading term analysis gave us cancelled terms but we have to send
             # back a term, so compute the leading term (via series)
-            return old.compute_leading_term(x)
+            n0 = min.getn()
+            res = Order(1)
+            incr = S.One
+            while res.is_Order:
+                res = old._eval_nseries(x, n=n0+incr, logx=None, cdir=cdir).cancel().powsimp().trigsimp()
+                incr *= 2
+            return res.as_leading_term(x, cdir=cdir)
 
         elif new_expr is S.NaN:
             return old.func._from_args(infinite)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1766,7 +1766,7 @@ class Mul(Expr, AssocOp):
         return co_residual*self2.func(*margs)*self2.func(*nc)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        from sympy import Mul, Order, ceiling, powsimp
+        from sympy import degree, Mul, Order, ceiling, powsimp
         from itertools import product
 
         def coeff_exp(term, x):
@@ -1821,7 +1821,10 @@ class Mul(Expr, AssocOp):
             if power < n:
                 res += Mul(*coeffs)*(x**power)
 
-        if (res - self).expand() is not S.Zero:
+        if self.is_polynomial(x):
+            if degree(self, x) != degree(res, x):
+                res += Order(x**n, x)
+        elif (res - self).subs(x, 3) is not S.Zero:
             res += Order(x**n, x)
         return res
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1589,10 +1589,11 @@ class Pow(Expr):
             ex = e1 + inex
             res += terms[e1]*inco*x**(ex)
 
-        if (res - self).subs(x, 3) is S.Zero:
-            return res
-
-        return res + O(x**n, x)
+        for i in (1, 2, 3):
+            if (res - self).subs(x, i) is not S.Zero:
+                res += O(x**n, x)
+                break
+        return res
 
     def _eval_as_leading_term(self, x, cdir=0):
         from sympy import exp, I, im, log

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1589,7 +1589,7 @@ class Pow(Expr):
             ex = e1 + inex
             res += terms[e1]*inco*x**(ex)
 
-        if (res - self).cancel() == S.Zero:
+        if (res - self).subs(x, 3) is S.Zero:
             return res
 
         return res + O(x**n, x)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -700,6 +700,7 @@ class log(Function):
                     from sympy.simplify import ratsimp
                     # Check for arguments involving rational multiples of pi
                     t = (i_/r_).cancel()
+                    t1 = (-t).cancel()
                     atan_table = {
                         # first quadrant only
                         sqrt(3): S.Pi/3,
@@ -728,12 +729,12 @@ class log(Function):
                             return cls(modulus) + I * atan_table[t]
                         else:
                             return cls(modulus) + I * (atan_table[t] - S.Pi)
-                    elif -t in atan_table:
+                    elif t1 in atan_table:
                         modulus = ratsimp(coeff * Abs(arg_))
                         if r_.is_positive:
-                            return cls(modulus) + I * (-atan_table[-t])
+                            return cls(modulus) + I * (-atan_table[t1])
                         else:
-                            return cls(modulus) + I * (S.Pi - atan_table[-t])
+                            return cls(modulus) + I * (S.Pi - atan_table[t1])
 
     def as_base_exp(self):
         """

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -673,7 +673,7 @@ def test_diff():
     C_0, C_1, C_2, C_3 = symbols('C_0, C_1, C_2, C_3')
     q = Si(x)
     assert p.diff(x).to_expr() == q.diff()
-    assert p.diff(x, 2).to_expr().subs(C_0, Rational(-1, 3)) == q.diff(x, 2).simplify()
+    assert p.diff(x, 2).to_expr().subs(C_0, Rational(-1, 3)).cancel() == q.diff(x, 2).cancel()
     assert p.diff(x, 3).series().subs({C_3: Rational(-1, 3), C_0: 0}) == q.diff(x, 3).series()
 
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1160,8 +1160,8 @@ def test_atom_bug():
 
 def test_limit_bug():
     z = Symbol('z', zero=False)
-    assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
-        (log(z) + EulerGamma + log(pi))/z - Ci(pi**2*z)/z + log(pi)/z
+    assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)).together() == \
+        (log(z) - Ci(pi**2*z) + EulerGamma + 2*log(pi))/z
 
 
 def test_issue_4703():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -629,7 +629,7 @@ def test_messy():
 
     # where should the logs be simplified?
     assert laplace_transform(Chi(x), x, s) == \
-        ((log(s**(-2)) - log((s**2 - 1)/s**2))/(2*s), 1, True)
+        ((log(s**(-2)) - log(1 - 1/s**2))/(2*s), 1, True)
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -68,7 +68,7 @@ def test_ratint():
     g = x**4 - 2*x**3 + 5*x**2 - 4*x + 4
 
     assert ratint(f/g, x) == \
-        x + S.Half*x**2 + S.Half*log(2 - x + x**2) - (4*x - 9)/(14 - 7*x + 7*x**2) + \
+        x + S.Half*x**2 + S.Half*log(2 - x + x**2) + (9 - 4*x)/(7*x**2 - 7*x + 14) + \
         13*sqrt(7)*atan(Rational(-1, 7)*sqrt(7) + 2*x*sqrt(7)/7)/49
 
     assert ratint(1/(x**2 + x + 1), x) == \

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -415,7 +415,7 @@ def test_integrate_nonlinear_no_specials():
     DE = DifferentialExtension(extension={'D': [Poly(1, x),
         Poly(-t**2 - t/x - (1 - nu**2/x**2), t)], 'Tfuncs': [f]})
     assert integrate_nonlinear_no_specials(a, d, DE) == \
-        (-log(1 + f(x)**2 + x**2/2)/2 - (4 + x**2)/(4 + 2*x**2 + 4*f(x)**2), True)
+        (-log(1 + f(x)**2 + x**2/2)/2 + (- 4 - x**2)/(4 + 2*x**2 + 4*f(x)**2), True)
     assert integrate_nonlinear_no_specials(Poly(t, t), Poly(1, t), DE) == \
         (0, False)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -860,11 +860,11 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     >>> f = 1/(s**2 - 1)
     >>> inverse_mellin_transform(f, s, x, (-oo, -1))
-    (x/2 - 1/(2*x))*Heaviside(x - 1)
+    x*(1 - 1/x**2)*Heaviside(x - 1)/2
     >>> inverse_mellin_transform(f, s, x, (-1, 1))
     -x*Heaviside(1 - x)/2 - Heaviside(x - 1)/(2*x)
     >>> inverse_mellin_transform(f, s, x, (1, oo))
-    (-x/2 + 1/(2*x))*Heaviside(1 - x)
+    (1/2 - x**2/2)*Heaviside(1 - x)/x
 
     See Also
     ========

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -230,7 +230,7 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         return a.denom()
 
     def gcd(self, a, b):
-        return a.gcd(b)
+        return self(1)
 
     def lcm(self, a, b):
         return a.lcm(b)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6652,6 +6652,9 @@ def cancel(f, *gens, **args):
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)
+    opt = {}
+    if 'polys' in args:
+        opt['polys'] = args['polys']
 
     if not isinstance(f, (tuple, Tuple)):
         if f.is_Number or isinstance(f, Relational) or not isinstance(f, Expr):
@@ -6662,8 +6665,9 @@ def cancel(f, *gens, **args):
     elif len(f) == 2:
         p, q = f
         if isinstance(p, Poly) and isinstance(q, Poly):
-            args['polys'] = True
-            args['domain'] = p.domain
+            opt['gens'] = p.gens
+            opt['domain'] = p.domain
+            opt['polys'] = opt.get('polys', True)
         p, q = p.as_expr(), q.as_expr()
     elif isinstance(f, Tuple):
         return factor_terms(f)
@@ -6705,15 +6709,17 @@ def cancel(f, *gens, **args):
             return f.xreplace(dict(reps))
 
     c, (P, Q) = 1, F.cancel(G)
+    if opt.get('polys', False) and not 'gens' in opt:
+        opt['gens'] = R.symbols
 
     if not isinstance(f, (tuple, Tuple)):
         return c*(P.as_expr()/Q.as_expr())
     else:
         P, Q = P.as_expr(), Q.as_expr()
-        if not args.get('polys', False):
+        if not opt.get('polys', False):
             return c, P, Q
         else:
-            return c, Poly(P, *R.symbols, **args), Poly(Q, *R.symbols, **args)
+            return c, Poly(P, *gens, **opt), Poly(Q, *gens, **opt)
 
 
 @public

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2954,7 +2954,8 @@ def test_cancel():
     assert cancel(f) == f
     assert cancel(f, greedy=False) == x + sqrt(2)
 
-    assert cancel((x**2/4 - 1, x/2 - 1)) == (S.Half, x + 2, 1)
+    assert cancel((x**2/4 - 1, x/2 - 1)) == (1, x + 2, 2)
+    # assert cancel((x**2/4 - 1, x/2 - 1)) == (S.Half, x + 2, 1)
 
     assert cancel((x**2 - y)/(x - y)) == 1/(x - y)*(x**2 - y)
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -260,14 +260,21 @@ def mrv(e, x):
         s2, e2 = mrv(b, x)
         return mrv_max1(s1, s2, e.func(i, e1, e2), x)
     elif e.is_Pow:
-        b, e = e.as_base_exp()
-        if b == 1:
-            return SubsSet(), b
-        if e.has(x):
-            return mrv(exp(e * log(b)), x)
+        e1 = S.One
+        while e.is_Pow:
+            b1 = e.base
+            e1 *= e.exp
+            e = b1
+        if b1 == 1:
+            return SubsSet(), b1
+        if e1.has(x):
+            base_lim = limitinf(b1, x)
+            if base_lim is S.One:
+                return mrv(exp(e1 * (b1 - 1)), x)
+            return mrv(exp(e1 * log(b1)), x)
         else:
-            s, expr = mrv(b, x)
-            return s, expr**e
+            s, expr = mrv(b1, x)
+            return s, expr**e1
     elif isinstance(e, log):
         s, expr = mrv(e.args[0], x)
         return s, log(expr)
@@ -496,11 +503,7 @@ def mrv_leadterm(e, x):
         Omega, exps = mrv(e, x)
     if not Omega:
         # e really does not depend on x after simplification
-        series = calculate_series(e, x)
-        c0, e0 = series.leadterm(x)
-        if e0 != 0:
-            raise ValueError("e0 should be 0")
-        return c0, e0
+        return exps, S.Zero
     if x in Omega:
         # move the whole omega up (exponentiate each term):
         Omega_up = moveup2(Omega, x)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -250,7 +250,7 @@ class Limit(Expr):
             else:
                 inve = e.subs(z, 1/u)
             try:
-                f = inve.as_leading_term(u)
+                f = inve.as_leading_term(u).gammasimp()
                 if f.is_meromorphic(u, S.Zero):
                     r = limit(f, u, S.Zero, "+")
                     if isinstance(r, Limit):

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -392,11 +392,12 @@ def test_MrvTestCase_page47_ex3_21():
 
 
 def test_I():
+    from sympy import sign
     y = Symbol("y")
     assert gruntz(I*x, x, oo) == I*oo
     assert gruntz(y*I*x, x, oo) == y*I*oo
     assert gruntz(y*3*I*x, x, oo) == y*I*oo
-    assert gruntz(y*3*sin(I)*x, x, oo).simplify() == y*I*oo
+    assert gruntz(y*3*sin(I)*x, x, oo).simplify() == sign(y)*I*oo
 
 
 def test_issue_4814():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -624,6 +624,10 @@ def test_issue_13462():
     assert limit(n**2*(2*n*(-(1 - 1/(2*n))**x + 1) - x - (-x**2/4 + x/4)/n), n, oo) == x*(x**2 - 3*x + 2)/24
 
 
+def test_issue_14514():
+    assert limit((1/(log(x)**log(x)))**(1/x), x, oo) == 1
+
+
 def test_issue_14574():
     assert limit(sqrt(x)*cos(x - x**2) / (x + 1), x, oo) == 0
 
@@ -645,6 +649,10 @@ def test_issue_15146():
     e = (x/2) * (-2*x**3 - 2*(x**3 - 1) * x**2 * digamma(x**3 + 1) + \
         2*(x**3 - 1) * x**2 * digamma(x**3 + x + 1) + x + 3)
     assert limit(e, x, oo) == S(1)/3
+
+
+def test_issue_15282():
+    assert limit((x**2000 - (x + 1)**2000) / x**1999, x, oo) == -2000
 
 
 def test_issue_15984():
@@ -696,6 +704,10 @@ def test_issue_14556():
 
 def test_issue_14811():
     assert limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) == oo
+
+
+def test_issue_16714():
+    assert limit(((x**(x + 1) + (x + 1)**x) / x**(x + 1))**x, x, oo) == exp(exp(1))
 
 
 def test_issue_16722():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -514,6 +514,10 @@ def test_issue_4503():
         exp(x)/(2*sqrt(exp(x) + 1))
 
 
+def test_issue_8208():
+    assert limit(n**(Rational(1, 1e9) - 1), n, oo) == 0
+
+
 def test_issue_8481():
     k = Symbol('k', integer=True, nonnegative=True)
     lamda = Symbol('lamda', real=True, positive=True)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -625,7 +625,7 @@ def test_issue_13416():
 
 
 def test_issue_13462():
-    assert limit(n**2*(2*n*(-(1 - 1/(2*n))**x + 1) - x - (-x**2/4 + x/4)/n), n, oo) == x*(x**2 - 3*x + 2)/24
+    assert limit(n**2*(2*n*(-(1 - 1/(2*n))**x + 1) - x - (-x**2/4 + x/4)/n), n, oo) == x*(x - 2)*(x - 1)/24
 
 
 def test_issue_14514():
@@ -653,6 +653,14 @@ def test_issue_15146():
     e = (x/2) * (-2*x**3 - 2*(x**3 - 1) * x**2 * digamma(x**3 + 1) + \
         2*(x**3 - 1) * x**2 * digamma(x**3 + x + 1) + x + 3)
     assert limit(e, x, oo) == S(1)/3
+
+
+def test_issue_15202():
+    e = (2**x*(2 + 2**(-x)*(-2*2**x + x + 2))/(x + 1))**(x + 1)
+    assert limit(e, x, oo) == exp(1)
+
+    e = (log(x, 2)**7 + 10*x*factorial(x) + 5**x) / (factorial(x + 1) + 3*factorial(x) + 10**x)
+    assert limit(e, x, oo) == 10
 
 
 def test_issue_15282():

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -392,7 +392,7 @@ def test_meijerg_expand():
     # Testing a bug:
     assert hyperexpand(meijerg([0, 2], [], [], [-1, 1], z)) == \
         Piecewise((0, abs(z) < 1),
-                  (z/2 - 1/(2*z), abs(1/z) < 1),
+                  (z*(1 - 1/z**2)/2, abs(1/z) < 1),
                   (meijerg([0, 2], [], [], [-1, 1], z), True))
 
     # Test that the simplest possible answer is returned:

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -116,5 +116,5 @@ def test_debug_output():
     out, err = proc.communicate()
     out = out.decode('ascii') # utf-8?
     err = err.decode('ascii')
-    expected = 'substituted: -x*(cos(x) - 1), u: 1/x, u_var: _u'
+    expected = 'substituted: -x*(1 - cos(x)), u: 1/x, u_var: _u'
     assert expected in err, err

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2933,7 +2933,7 @@ def test_Y9():
 
 
 def test_Y10():
-    assert (fourier_transform(abs(x)*exp(-3*abs(x)), x, z) ==
+    assert (fourier_transform(abs(x)*exp(-3*abs(x)), x, z).cancel() ==
             (-8*pi**2*z**2 + 18)/(16*pi**4*z**4 + 72*pi**2*z**2 + 81))
 
 


### PR DESCRIPTION
Fixes: #8208
Fixes: #14514
Fixes: #15202
Fixes: #15282
Fixes: #16714

#### Brief description of what is fixed or changed

Changes have been done in `mrv()` function of `gruntz.py` to handle the indeterminant form of `1**oo` more accurately.

Some other changes have been done in `Add._eval_as_leading_term()` to handle cases in a better way, where `leading term` has to be evaluated using `series computation`.

Some major changes have been done in the `cancel()` function of `polytools.py` to speed up the algorithm.

#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Changes in `mrv()` function of `gruntz.py` and `cancel()` function of `polytools.py` resolves `RecursionError` and `Timeout` in limit evaluations
<!-- END RELEASE NOTES -->