### PR TITLE
Ensure EvaluateFalseTransformer flattens Mul inside Sub

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1057,7 +1057,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             if isinstance(node.op, ast.Sub):
                 right = ast.Call(
                     func=ast.Name(id='Mul', ctx=ast.Load()),
-                    args=[ast.UnaryOp(op=ast.USub(), operand=ast.Num(1)), right],
+                    args=self.flatten([ast.UnaryOp(op=ast.USub(), operand=ast.Num(1)), right], 'Mul'),
                     keywords=[ast.keyword(arg='evaluate', value=ast.NameConstant(value=False, ctx=ast.Load()))],
                     starargs=None,
                     kwargs=None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

When transforming the tree, the code replaces subtraction BinOps with calls to SymPy's Mul class. In doing so it provides the original right argument of the BinOp as the right argument of the new Mul.
If the `right` argument was itself a Mul, you are left with a nested Mul situation that flatten() was designed to fix. It is not flattened by the existing denesting at the end of the function because the overall node is now an Add and so the flattening only affects nested addition.

To see the bug, try for example:
```
> import sympy
> from sympy.parsing.sympy_parser import parse_expr
> sympy.srepr(parse_expr("1-x*y", evaluate=False))
"Add(Integer(1), Mul(Integer(-1), Mul(Symbol('x'), Symbol('y'))))"
```
where clearly the second Mul could easily have been flattened into the first, without changing the meaning or evaluating anything, to form:
```
"Add(Integer(1), Mul(Integer(-1), Symbol('x'), Symbol('y')))"
```
This change leads to the expected behaviour, but may affect cases where the tree is expected to be in a specific format.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * ensure Mul objects inside subtractions get flattened when using `evaluate=False`.
<!-- END RELEASE NOTES -->