### PR TITLE
Fix some issues of initializing Poly from domain element

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -21,6 +21,7 @@ from sympy.logic.boolalg import BooleanAtom
 from sympy.polys import polyoptions as options
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import FF, QQ, ZZ
+from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.fglmtools import matrix_fglm
 from sympy.polys.groebnertools import groebner as _groebner
 from sympy.polys.monomials import Monomial
@@ -151,6 +152,8 @@ class Poly(Basic):
                 return cls._from_dict(rep, opt)
             else:
                 return cls._from_list(list(rep), opt)
+        elif isinstance(rep, DomainElement):
+            return cls._from_domain_element(rep, opt)
         else:
             rep = sympify(rep)
 
@@ -288,6 +291,16 @@ class Poly(Basic):
         """Construct a polynomial from an expression. """
         rep, opt = _dict_from_expr(rep, opt)
         return cls._from_dict(rep, opt)
+
+    @classmethod
+    def _from_domain_element(cls, rep, opt):
+        gens = opt.gens
+        domain = opt.domain
+
+        level = len(gens) - 1
+        rep = [domain.convert(rep)]
+
+        return cls.new(DMP.from_list(rep, level, domain), *gens)
 
     def __hash__(self):
         return super(Poly, self).__hash__()

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -147,13 +147,13 @@ class Poly(Basic):
         if 'order' in opt:
             raise NotImplementedError("'order' keyword is not implemented yet")
 
-        if iterable(rep, exclude=str):
+        if isinstance(rep, DomainElement):
+            return cls._from_domain_element(rep, opt)
+        elif iterable(rep, exclude=str):
             if isinstance(rep, dict):
                 return cls._from_dict(rep, opt)
             else:
                 return cls._from_list(list(rep), opt)
-        elif isinstance(rep, DomainElement):
-            return cls._from_domain_element(rep, opt)
         else:
             rep = sympify(rep)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -26,7 +26,7 @@ from sympy.polys.fglmtools import matrix_fglm
 from sympy.polys.groebnertools import groebner as _groebner
 from sympy.polys.monomials import Monomial
 from sympy.polys.orderings import monomial_key
-from sympy.polys.polyclasses import DMP
+from sympy.polys.polyclasses import DMP, DMF, ANP
 from sympy.polys.polyerrors import (
     OperationNotSupported, DomainError,
     CoercionFailed, UnificationFailed,
@@ -147,7 +147,7 @@ class Poly(Basic):
         if 'order' in opt:
             raise NotImplementedError("'order' keyword is not implemented yet")
 
-        if isinstance(rep, DomainElement):
+        if isinstance(rep, (DMP, DMF, ANP, DomainElement)):
             return cls._from_domain_element(rep, opt)
         elif iterable(rep, exclude=str):
             if isinstance(rep, dict):

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -282,6 +282,18 @@ def test_Poly_from_expr():
     assert Poly.from_expr(y + 5, x, y, domain=ZZ).rep == DMP([[1, 5]], ZZ)
 
 
+def test_poly_from_domain_element():
+    dom = ZZ[x]
+    assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
+    dom = dom.get_field()
+    assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
+
+    dom = QQ[x]
+    assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
+    dom = dom.get_field()
+    assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
+
+
 def test_Poly__new__():
     raises(GeneratorsError, lambda: Poly(x + 1, x, x))
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -293,6 +293,19 @@ def test_poly_from_domain_element():
     dom = dom.get_field()
     assert Poly(dom(x+1), y, domain=dom).rep == DMP([dom(x+1)], dom)
 
+    dom = ZZ.old_poly_ring(x)
+    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    dom = dom.get_field()
+    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+
+    dom = QQ.old_poly_ring(x)
+    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+    dom = dom.get_field()
+    assert Poly(dom([1, 1]), y, domain=dom).rep == DMP([dom([1, 1])], dom)
+
+    dom = QQ.algebraic_field(I)
+    assert Poly(dom([1, 1]), x, domain=dom).rep == DMP([dom([1, 1])], dom)
+
 
 def test_Poly__new__():
     raises(GeneratorsError, lambda: Poly(x + 1, x, x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This resolves two issues with Poly initialized with arguments of DomainElement.

One problem is that the constructor assumes `PolyElement` as an iterable and initializes with unpacked form even if the `PolyElement` has different generators.
```
>>> from sympy import *
>>> x, y = symbols('x y')
>>> dom = ZZ.poly_ring(x)
>>> Poly(dom(x+2), y, domain=dom)
# Should be Poly(x + 2, y, domain='ZZ[x]') 
# but it gives Poly(y + 2, y, domain='ZZ[x]')
```

The other problem is that FracFieldElement is not working because of sympify error.
```
>>> from sympy import *
>>> x, y = symbols('x y')
>>> dom = ZZ.frac_field(x)
>>> Poly(dom(x+2), y, domain=dom)
# Should be Poly(x + 2, y, domain='ZZ(x)')
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - Fixed `Poly` initialized with `PolyElement` mutating the generator of the coefficient in the form of polynomial. 
  (e.g. `Poly(ZZ[x](x+1), y, domain=ZZ[x])` becomes `Poly(y+1, y, domain=ZZ[x])`)
  - Fixed `Poly` initialized with `FracElement` raising `SympifyError`.
  (e.g. `dom = ZZ.frac_field(x); Poly(dom(x+2), y, domain=dom)`)
<!-- END RELEASE NOTES -->