### PR TITLE
Fixed strip_whitespace script for Python3

### DIFF
--- a/bin/strip_whitespace
+++ b/bin/strip_whitespace
@@ -11,8 +11,7 @@ def strip_file(filename, write, report):
     # to re-add \n to a few right-stripped lines. The hit flag will keep us
     # from unecessarily re-writing files with no changes.
 
-    # without "b" all lines appear as \n terminated
-    with open(filename, 'rb') as f:
+    with open(filename, 'r') as f:
         lines = f.readlines()
     hit = False
     cr = False
@@ -51,8 +50,7 @@ def strip_file(filename, write, report):
         print("%s, %d extra newlines at eof" % (filename, extra))
 
     if write and hit:
-        # without "b" the lines may be written in sys-dep format
-        with open(filename, "wb") as f:
+        with open(filename, "w") as f:
             f.writelines(lines)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #19654 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`strip_whitespace` script is used to remove whitespace from modules. It was not working for Python3.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->