### PR TITLE
Revert "Fixed strip_whitespace script for Python3"

### DIFF
--- a/bin/strip_whitespace
+++ b/bin/strip_whitespace
@@ -11,7 +11,7 @@ def strip_file(filename, write, report):
     # to re-add \n to a few right-stripped lines. The hit flag will keep us
     # from unecessarily re-writing files with no changes.
 
-    # without newline="", all lines appear as \n terminated
+    # newline="" keeps current line endings
     with open(filename, newline="") as f:
         lines = f.readlines()
     hit = False
@@ -51,7 +51,7 @@ def strip_file(filename, write, report):
         print("%s, %d extra newlines at eof" % (filename, extra))
 
     if write and hit:
-        # without newline="", the lines may be written in sys-dep format
+        # newline="" leaves line endings unchanged
         with open(filename, "w", newline="") as f:
             f.writelines(lines)
 

--- a/bin/strip_whitespace
+++ b/bin/strip_whitespace
@@ -11,8 +11,8 @@ def strip_file(filename, write, report):
     # to re-add \n to a few right-stripped lines. The hit flag will keep us
     # from unecessarily re-writing files with no changes.
 
-    # without "b" all lines appear as \n terminated
-    with open(filename, 'rb') as f:
+    # without newline="", all lines appear as \n terminated
+    with open(filename, newline="") as f:
         lines = f.readlines()
     hit = False
     cr = False
@@ -51,8 +51,8 @@ def strip_file(filename, write, report):
         print("%s, %d extra newlines at eof" % (filename, extra))
 
     if write and hit:
-        # without "b" the lines may be written in sys-dep format
-        with open(filename, "wb") as f:
+        # without newline="", the lines may be written in sys-dep format
+        with open(filename, "w", newline="") as f:
             f.writelines(lines)
 
 

--- a/bin/strip_whitespace
+++ b/bin/strip_whitespace
@@ -11,7 +11,8 @@ def strip_file(filename, write, report):
     # to re-add \n to a few right-stripped lines. The hit flag will keep us
     # from unecessarily re-writing files with no changes.
 
-    with open(filename, 'r') as f:
+    # without "b" all lines appear as \n terminated
+    with open(filename, 'rb') as f:
         lines = f.readlines()
     hit = False
     cr = False
@@ -50,7 +51,8 @@ def strip_file(filename, write, report):
         print("%s, %d extra newlines at eof" % (filename, extra))
 
     if write and hit:
-        with open(filename, "w") as f:
+        # without "b" the lines may be written in sys-dep format
+        with open(filename, "wb") as f:
             f.writelines(lines)
 
 


### PR DESCRIPTION
Reverts sympy/sympy#19665, which did not preserve the intended behavior of the script.

The second commit in this patch is the correct fix.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->