### PR TITLE
Define a meta-hint to expand multinomials up to a certain degree

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2455,9 +2455,9 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
     hints are supported but not applied unless set to True:  ``complex``,
     ``func``, and ``trig``.  In addition, the following meta-hints are
     supported by some or all of the other hints:  ``frac``, ``numer``,
-    ``denom``, ``modulus``, and ``force``.  ``deep`` is supported by all
-    hints.  Additionally, subclasses of Expr may define their own hints or
-    meta-hints.
+    ``denom``, ``max_degree``, ``modulus``, and ``force``.  ``deep`` is
+    supported by all hints.  Additionally, subclasses of Expr may define
+    their own hints or meta-hints.
 
     The ``basic`` hint is used for any special rewriting of an object that
     should be done automatically (along with the other hints like ``mul``)
@@ -2494,8 +2494,13 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
 
     Expand (x + y + ...)**n where n is a positive integer.
 
+    The ``max_degree`` meta-hint can be applied to only expand
+    multinomials when n is less than or equal to max_degree.
+
     >>> ((x + y + z)**2).expand(multinomial=True)
     x**2 + 2*x*y + 2*x*z + y**2 + 2*y*z + z**2
+    >>> ((x + y + z)**2).expand(multinomial=True, max_degree=1)
+    (x + y + z)**2
 
     power_exp
     ---------
@@ -2811,7 +2816,7 @@ def expand_mul(expr, deep=True):
     power_base=False, basic=False, multinomial=False, log=False)
 
 
-def expand_multinomial(expr, deep=True):
+def expand_multinomial(expr, deep=True, max_degree=S.Infinity):
     """
     Wrapper around expand that only uses the multinomial hint.  See the expand
     docstring for more information.
@@ -2825,8 +2830,9 @@ def expand_multinomial(expr, deep=True):
     x**2 + 2*x*exp(x + 1) + exp(2*x + 2)
 
     """
-    return sympify(expr).expand(deep=deep, mul=False, power_exp=False,
-    power_base=False, basic=False, multinomial=True, log=False)
+    return sympify(expr).expand(deep=deep, max_degree=max_degree,
+        mul=False, power_exp=False, power_base=False, basic=False,
+        multinomial=True, log=False)
 
 
 def expand_log(expr, deep=True, force=False, factor=False):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1089,6 +1089,14 @@ class Pow(Expr):
 
             n = int(exp)
 
+            max_degree = _sympify(hints.get('max_degree', S.Infinity))
+            if max_degree is not S.Infinity:
+                if not max_degree.is_Integer or max_degree < 0:
+                    raise ValueError(
+                        "max_degree must be a positive integer, got %s" % max_degree)
+            if n > max_degree:
+                return result
+
             if base.is_commutative:
                 order_terms, other_terms = [], []
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -406,6 +406,7 @@ def test_expand_function():
     assert expand(x + y) == x + y
     assert expand(x + y, complex=True) == I*im(x) + I*im(y) + re(x) + re(y)
     assert expand((x + y)**11, modulus=11) == x**11 + y**11
+    assert expand((x + y)**11, max_degree=10) == (x + y)**11
 
 
 def test_function_comparable():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Expansion of high degree polynomials can be slow and produce unwieldy output.  The ``max_degree=n`` meta-hint for the ``expand`` function only expands multinomials of degree less than or equal to n where n is a positive integer.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added a max_degree meta-hint for the expand function.
<!-- END RELEASE NOTES -->