### PR TITLE
printing: Do not create new printers within the printers

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -133,7 +133,7 @@ class VectorLatexPrinter(LatexPrinter):
         test1 = not all([True for i in red if i.free_symbols == {t}])
         test2 = not all([(t == i) for i in syms])
         if test1 or test2:
-            return LatexPrinter().doprint(der_expr)
+            return super()._print_Derivative(der_expr)
 
         # done checking
         dots = len(syms)
@@ -149,7 +149,7 @@ class VectorLatexPrinter(LatexPrinter):
         elif dots == 4:
             base = r"\ddddot{%s}" % base
         else: # Fallback to standard printing
-            return LatexPrinter().doprint(der_expr)
+            return super()._print_Derivative(der_expr)
         if len(base_split) != 1:
             base += '_' + base_split[1]
         return base

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -236,7 +236,7 @@ def test_vlatex(): # vlatex is broken #12078
     g = Function('g')
     h = Function('h')
 
-    expected = r'J \left(\frac{d}{d x} g{\left(x \right)} - \frac{d}{d x} h{\left(x \right)}\right)'
+    expected = r'J \left(\frac{d}{d x} \operatorname{g}\left(x\right) - \frac{d}{d x} \operatorname{h}\left(x\right)\right)'
 
     expr = J*f(x).diff(x).subs(f(x), g(x)-h(x))
 
@@ -293,7 +293,7 @@ def test_vector_derivative_printing():
     # Fifth order
     v = omega.diff().diff().diff().diff().diff() * N.x
 
-    assert vlatex(v) == r'\frac{d^{5}}{d t^{5}} \omega{\left(t \right)}\mathbf{\hat{n}_x}'
+    assert vlatex(v) == r'\frac{d^{5}}{d t^{5}} \omega\mathbf{\hat{n}_x}'
     assert unicode_vpretty(v) == u('  5\n d\n───(ω) n_x\n  5\ndt')
     assert ascii_vpretty(v) == '  5\n d\n---(omega) n_x\n  5\ndt'
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -716,7 +716,7 @@ class LatexPrinter(Printer):
                 elif v == -1:
                     o1.append(' - ' + k._latex_form)
                 else:
-                    arg_str = '(' + LatexPrinter().doprint(v) + ')'
+                    arg_str = '(' + self._print(v) + ')'
                     o1.append(' + ' + arg_str + k._latex_form)
 
         outstr = (''.join(o1))


### PR DESCRIPTION
Instantiating a new printer from within the printer results in all the local printer settings being discarded.
No new tests because actually constructing print settings that matter is more trouble that it's worth.
The idea is just to remove all occurrences of this anti-pattern.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->