### PR TITLE
[GSoC] Series: Fixes Incorrect limit evaluations

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1372,6 +1372,8 @@ class AccumulationBounds(AtomicExpr):
         else:
             return self
 
+    _eval_Abs = __abs__
+
     def __lt__(self, other):
         """
         Returns True if range of values attained by `self` AccumulationBounds

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -941,7 +941,7 @@ class log(Function):
             while s.is_Order:
                 n += 1
                 s = arg.nseries(x, n=n, logx=logx)
-            a, b = s.leadterm(x)
+        a, b = s.removeO().leadterm(x)
         p = cancel(s/(a*x**b) - 1)
         if p.has(exp):
             p = logcombine(p)
@@ -963,7 +963,7 @@ class log(Function):
         from sympy import I, im
         arg = self.args[0].together()
         x0 = arg.subs(x, 0)
-        if x0 is S.One:
+        if x0 == 1:
             return (arg - S.One).as_leading_term(x)
         if cdir != 0:
             cdir = self.args[0].dir(x, cdir)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -235,7 +235,7 @@ class exp(ExpBase):
         from sympy.calculus import AccumBounds
         from sympy.sets.setexpr import SetExpr
         from sympy.matrices.matrices import MatrixBase
-        from sympy import logcombine
+        from sympy import im, logcombine, re
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -283,6 +283,15 @@ class exp(ExpBase):
 
             # but it can't be multiplied by oo
             if coeff in [S.NegativeInfinity, S.Infinity]:
+                if terms.is_number:
+                    if coeff is S.NegativeInfinity:
+                        terms = -terms
+                    if re(terms).is_zero and terms is not S.Zero:
+                        return S.NaN
+                    if re(terms).is_positive and im(terms) is not S.Zero:
+                        return S.ComplexInfinity
+                    if re(terms).is_negative:
+                        return S.Zero
                 return None
 
             coeffs, log_term = [coeff], None

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -520,7 +520,7 @@ def mrv_leadterm(e, x):
     # For limits of complex functions, the algorithm would have to be
     # improved, or just find limits of Re and Im components separately.
     #
-    w = Dummy("w", real=True, positive=True, finite=True)
+    w = Dummy("w", real=True, positive=True)
     f, logw = rewrite(exps, Omega, x, w)
     f = f.subs(log(w), logw)
     series = calculate_series(f, w, logx=logw)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -522,6 +522,7 @@ def mrv_leadterm(e, x):
     #
     w = Dummy("w", real=True, positive=True, finite=True)
     f, logw = rewrite(exps, Omega, x, w)
+    f = f.subs(log(w), logw)
     series = calculate_series(f, w, logx=logw)
     return series.leadterm(w)
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -522,7 +522,6 @@ def mrv_leadterm(e, x):
     #
     w = Dummy("w", real=True, positive=True)
     f, logw = rewrite(exps, Omega, x, w)
-    f = f.subs(log(w), logw)
     series = calculate_series(f, w, logx=logw)
     return series.leadterm(w)
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -188,7 +188,7 @@ class Limit(Expr):
         hints : optional keyword arguments
             To be passed to ``doit`` methods; only used if deep is True.
         """
-        from sympy import exp, log, sign
+        from sympy import Abs, exp, log, sign
         from sympy.calculus.util import AccumBounds
         from sympy.functions import RisingFactorial
 
@@ -214,6 +214,32 @@ class Limit(Expr):
             cdir = 1
         elif str(dir) == "-":
             cdir = -1
+
+        while e.has(Abs):
+            term = e
+            while term:
+                cnt = 0
+                for t in term.args:
+                    if t.has(Abs):
+                        cnt += 1
+                        break
+                if cnt == 1:
+                    term = t
+                else:
+                    fin = term
+                    term = 0
+            sig = limit(fin.args[0], z, z0, dir)
+            if sig.is_zero:
+                sig = limit(1/fin.args[0], z, z0, dir)
+            if sig.is_extended_real:
+                if (sig < 0) == True:
+                    e = e.subs(fin, -fin.args[0])
+                elif (sig > 0) == True:
+                    e = e.subs(fin, fin.args[0])
+                else:
+                    break
+            else:
+                break
 
         if e.is_meromorphic(z, z0):
             if abs(z0) is S.Infinity:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -215,31 +215,23 @@ class Limit(Expr):
         elif str(dir) == "-":
             cdir = -1
 
-        while e.has(Abs):
-            term = e
-            while term:
-                cnt = 0
-                for t in term.args:
-                    if t.has(Abs):
-                        cnt += 1
-                        break
-                if cnt == 1:
-                    term = t
-                else:
-                    fin = term
-                    term = 0
-            sig = limit(fin.args[0], z, z0, dir)
-            if sig.is_zero:
-                sig = limit(1/fin.args[0], z, z0, dir)
-            if sig.is_extended_real:
-                if (sig < 0) == True:
-                    e = e.subs(fin, -fin.args[0])
-                elif (sig > 0) == True:
-                    e = e.subs(fin, fin.args[0])
-                else:
-                    break
-            else:
-                break
+        def remove_abs(expr):
+            newargs = tuple(remove_abs(arg) for arg in expr.args)
+            if newargs != expr.args:
+                expr = expr.func(*newargs)
+            if isinstance(expr, Abs):
+                sig = limit(expr.args[0], z, z0, dir)
+                if sig.is_zero:
+                    sig = limit(1/expr.args[0], z, z0, dir)
+                if sig.is_extended_real:
+                    if (sig < 0) == True:
+                        return -expr.args[0]
+                    elif (sig > 0) == True:
+                        return expr.args[0]
+            return expr
+
+        if e.has(Abs):
+            e = remove_abs(e)
 
         if e.is_meromorphic(z, z0):
             if abs(z0) is S.Infinity:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -265,8 +265,7 @@ class Limit(Expr):
             return Order(limit(e.expr, z, z0), *e.args[1:])
 
         if e.is_Pow:
-            if (e.has(S.Infinity) or e.has(S.NegativeInfinity)
-                or e.has(S.ComplexInfinity) or e.has(S.NaN)):
+            if e.has(S.Infinity, S.NegativeInfinity, S.ComplexInfinity, S.NaN):
                 return self
 
             b1, e1 = e.base, e.exp

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -216,6 +216,8 @@ class Limit(Expr):
             cdir = -1
 
         def remove_abs(expr):
+            if not expr.args:
+                return expr
             newargs = tuple(remove_abs(arg) for arg in expr.args)
             if newargs != expr.args:
                 expr = expr.func(*newargs)
@@ -230,8 +232,7 @@ class Limit(Expr):
                         return expr.args[0]
             return expr
 
-        if e.has(Abs):
-            e = remove_abs(e)
+        e = remove_abs(e)
 
         if e.is_meromorphic(z, z0):
             if abs(z0) is S.Infinity:
@@ -295,9 +296,12 @@ class Limit(Expr):
             ex_lim = limit(e1, z, z0)
             base_lim = limit(b1, z, z0)
 
-            if base_lim is S.One and ex_lim in (S.Infinity, S.NegativeInfinity):
-                res = limit(e1*(b1 - 1), z, z0)
-                return exp(res)
+            if base_lim is S.One:
+                if ex_lim in (S.Infinity, S.NegativeInfinity):
+                    res = limit(e1*(b1 - 1), z, z0)
+                    return exp(res)
+                elif ex_lim.is_real:
+                    return S.One
 
             if base_lim in (S.Zero, S.Infinity, S.NegativeInfinity) and ex_lim is S.Zero:
                 res = limit(f1, z, z0)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -36,7 +36,7 @@ def test_basic1():
     assert limit((1 + x)**(1 + sqrt(2)), x, 0) == 1
     assert limit((1 + x)**oo, x, 0) == Limit((x + 1)**oo, x, 0)
     assert limit((1 + x)**oo, x, 0, dir='-') == Limit((x + 1)**oo, x, 0, dir='-')
-    assert limit((1 + x + y)**oo, x, 0, dir='-') == (1 + y)**(oo)
+    assert limit((1 + x + y)**oo, x, 0, dir='-') == Limit((x + y + 1)**oo, x, 0, dir='-')
     assert limit(y/x/log(x), x, 0) == -oo*sign(y)
     assert limit(cos(x + y)/x, x, 0) == sign(cos(y))*oo
     assert limit(gamma(1/x + 3), x, oo) == 2
@@ -75,7 +75,7 @@ def test_basic1():
     assert limit(x**2, x, 0, dir='-') == 0
     assert limit(sqrt(x), x, 0, dir='-') == 0
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
-    assert limit((1 + cos(x))**oo, x, 0) is oo
+    assert limit((1 + cos(x))**oo, x, 0) == Limit((cos(x) + 1)**oo, x, 0)
 
 
 def test_basic2():
@@ -210,7 +210,6 @@ def test_exponential():
     assert limit((2 + 6*x)**x/(6*x)**x, x, oo) == exp(S('1/3'))
 
 
-@XFAIL
 def test_exponential2():
     n = Symbol('n')
     assert limit((1 + x/(n + sin(n)))**n, n, oo) == exp(x)
@@ -756,6 +755,11 @@ def test_issue_18306():
 
 def test_issue_18378():
     assert limit(log(exp(3*x) + x)/log(exp(x) + x**100), x, oo) == 3
+
+
+def test_issue_18399():
+    assert limit((1 - S(1)/2*x)**(3*x), x, oo) is zoo
+    assert limit((-x)**x, x, oo) is zoo
 
 
 def test_issue_18442():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -571,6 +571,11 @@ def test_issue_6599():
     assert limit((n + cos(n))/n, n, oo) == 1
 
 
+def test_issue_12398():
+    assert limit(Abs(log(x)/x**3), x, oo) == 0
+    assert limit(x*(Abs(log(x)/x**3)/Abs(log(x + 1)/(x + 1)**3) - 1), x, oo) == 3
+
+
 def test_issue_12555():
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, -oo) == 2
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) is oo


### PR DESCRIPTION
Fixes: #4114
Fixes: #12398 
Fixes: #18399 

#### Brief description of what is fixed or changed

Adds `e.is_Pow` heuristic to `limits.py` to handle limit evaluations of `Pow` objects using the help of `meromorphic` check, or by separately evaluating the `limit` of `base` and `exponent` and then determining the final `limit` which needs to be evaluated.

Adds some code to `limits.py` which improves the evaluation of limits having `Abs` expressions.


#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* series
  * Adds `e.is_Pow` heuristic to `limits.py` to improve the limit evaluations of `Pow` objects
<!-- END RELEASE NOTES -->