### PR TITLE
Adding classes to represent implicitly defined regions

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4892,6 +4892,12 @@ def test_sympy__vector__deloperator__Del():
     assert _test_args(Del())
 
 
+def test_sympy__vector__implicitregion__ImplicitRegion():
+    from sympy.vector.implicitregion import ImplicitRegion
+    from sympy.abc import x, y
+    assert _test_args(ImplicitRegion((x, y), y**3 - 4*x))
+
+
 def test_sympy__vector__integrals__ParametricIntegral():
     from sympy.vector.integrals import ParametricIntegral
     from sympy.vector.parametricregion import ParametricRegion

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -15,6 +15,7 @@ from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
 from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence
 from sympy.vector.parametricregion import (ParametricRegion, parametric_region_list)
+from sympy.vector.implicitregion import ImplicitRegion
 from sympy.vector.integrals import (ParametricIntegral, vector_integrate)
 
 __all__ = [
@@ -40,5 +41,7 @@ __all__ = [
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
     'divergence',
 
-    'ParametricRegion', 'parametric_region_list', 'ParametricIntegral', 'vector_integrate',
+    'ParametricRegion', 'parametric_region_list', 'ImplicitRegion',
+
+    'ParametricIntegral', 'vector_integrate',
 ]

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -1,229 +1,308 @@
 from sympy import S
-from sympy.core import Basic, Tuple, Eq, diff, expand
+from sympy.core import Basic, Tuple, diff, expand, Eq
 from sympy.core.symbol import _symbol
 from sympy.solvers import solveset, nonlinsolve
-from sympy.polys.polytools import total_degree
+from sympy.polys import total_degree
+from sympy.geometry import Point
 
 
 class ImplicitRegion(Basic):
     """
-    Represents an implicit region in space. 
+    Represents an implicit region in space.
 
     Example
     =======
 
-    >>> from sympy.abc import x, y
-    >>> from sympy.vector import ImplicitRegion, parametric_region_list, vector_integrate
+    >>> from sympy import Eq
+    >>> from sympy.abc import x, y, z, t
+    >>> from sympy.vector import ImplicitRegion
 
-    >>> circle1 = ImplicitRegion((x, y), Eq(x**2 + y**2 -1))
-    >>> parametric_region_list(circle)
-    [ParametricRegion((sin(2*theta), -cos(2*theta)), (theta, 0, pi))]
+    >>> ImplicitRegion((x, y), x**2 + y**2 - 4)
+    ImplicitRegion((x, y), x**2 + y**2 - 4)
+    >>> ImplicitRegion((x, y), Eq(y*x, 1))
+    ImplicitRegion((x, y), x*y - 1)
 
-    >>> circle2 = ImplicitRegion((x, y), (x - 3)**2 + (y + 2)**2 - 16)
-    >>> parametric_region_list(circle2)
-    [ParametricRegion((2*(-sqrt(7)*tan(theta) + 3)*cos(theta)**2, 3*sin(2*theta) + sqrt(7)*cos(2*theta) - 2), (theta, 0, pi))]
-    >>> vector_integrate(1, circle2)
-    8*pi
+    >>> parabola = ImplicitRegion((x, y), y**2 - 4*x)
+    >>> parabola.degree
+    2
+    >>> parabola.equation
+    -4*x + y**2
+    >>> parabola.rational_parametrization(t)
+    (4/t**2, 4/t)
 
-    >>> ellipse = ImplicitRegion(x**2/4 + y**2/16 - 1)
-    >>> parametric_region_list(ellipse)
-    [ParametricRegion((8*tan(theta)/(tan(theta)**2 + 4), -4 + 8*tan(theta)**2/(tan(theta)**2 + 4)), (theta, 0, pi))]
-    >>> vector_integrate(2, ellipse)
-    ### It gets stuck
+    >>> r = ImplicitRegion((x, y, z), Eq(z, x**2 + y**2))
+    >>> r.variables
+    (x, y, z)
+    >>> r.singular_points()
+    FiniteSet((0, 0, 0))
+    >>> r.regular_point()
+    (-10, -10, 200)
+
+    Parameters
+    ==========
+
+    variables: tuple to map variables in implicit equation to base scalars.
+
+    equation: An expression or Eq denoting the implicit equation of the region.
 
     """
     def __new__(cls, variables, equation):
         if not isinstance(variables, Tuple):
             variables = Tuple(*variables)
-            
+
         if isinstance(equation, Eq):
             equation = equation.lhs - equation.rhs
-            
+
         return super().__new__(cls, variables, equation)
 
     @property
     def variables(self):
         return self.args[0]
-    
+
     @property
     def equation(self):
         return self.args[1]
-        
-    @property   
+
+    @property
     def degree(self):
         return total_degree(self.equation)
-        
+
     def regular_point(self):
         """
-        Returns a smooth point on the implicit region.
-        
+        Returns a point on the implicit region.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import x, y
+        >>> from sympy.vector import ImplicitRegion
         >>> circle = ImplicitRegion((x, y), (x + 2)**2 + (y - 3)**2 - 16)
-        >>> circle.regular_point
+        >>> circle.regular_point()
         (-6, 3)
-         
+
         """
+
+        # TODO: implement the algorithm to find regular point on a Conic.
+        # Now it iterates over a range and tries to find a point on the region.
         equation = self.equation
 
         if len(self.variables) == 1:
-            return list(solveset(equation, self.variables[0], domain=S.Reals))[0]
+            return (list(solveset(equation, self.variables[0], domain=S.Reals))[0],)
         elif len(self.variables) == 2:
             x, y = self.variables
-    
-            for x_reg in range(-100, 100): 
+
+            for x_reg in range(-100, 100):
                 if len(solveset(equation.subs(x, x_reg), self.variables[1], domain=S.Reals)) > 0:
-                    return (x_reg, list(solveset(equation.subs(x, x_reg), domain=S.Reals))[0])            
+                    return (x_reg, list(solveset(equation.subs(x, x_reg), domain=S.Reals))[0])
         elif len(self.variables) == 3:
             x, y, z = self.variables
-            
-            for x_reg in range(-10, 10): 
+
+            for x_reg in range(-10, 10):
                 for y_reg in range(-10, 10):
                     if len(solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals)) > 0:
                         return (x_reg, y_reg, list(solveset(equation.subs({x: x_reg, y: y_reg})))[0])
-        
+
+        if len(self.singular_points()) != 0:
+            return list[self.singular_points()][0]
+
         raise NotImplementedError()
-        
+
     def singular_points(self):
         """
         Returns a set of singular points of the region.
-        
+
         The singular points are those points on the region
         where all partial derivatives vanish.
-        
+
         Examples
         ========
-        
+
+        >>> from sympy.abc import x, y
+        >>> from sympy.vector import ImplicitRegion
         >>> I = ImplicitRegion((x, y), (y-1)**2 -x**3 + 2*x**2 -x)
         >>> I.singular_points()
         FiniteSet((1, 1))
-        
+
         """
         eq_list = [self.equation]
         for var in self.variables:
             eq_list += [diff(self.equation, var)]
-        
-        print(eq_list)    
+
         return nonlinsolve(eq_list, list(self.variables))
 
     def multiplicity(self, point):
         """
         Returns the multiplicity of a singular point on the region.
-        
-        A singular point (x,y) of region is said to be of multiplicity m 
+
+        A singular point (x,y) of region is said to be of multiplicity m
         if all the partial derivatives off to order m - 1 vanish there.
-        
+
         Examples
         ========
-        
-        >>> I = ImplicitRegion((x, y), x**2 + y**3 - z**4)
+
+        >>> from sympy.abc import x, y, z
+        >>> from sympy.vector import ImplicitRegion
+        >>> I = ImplicitRegion((x, y, z), x**2 + y**3 - z**4)
         >>> I.singular_points()
-        FiniteSet((0, 0))
-        >>> I.multiplicity((0, 0))
+        FiniteSet((0, 0, 0))
+        >>> I.multiplicity((0, 0, 0))
         2
-        
+
         """
-        if point not in self.singular_points():
-            raise ValueError()
+        if isinstance(point, Point):
+            point = point.args
 
         modified_eq = self.equation
 
         for i, var in enumerate(self.variables):
             modified_eq = modified_eq.subs(var, var + point[i])
         modified_eq = expand(modified_eq)
-        
-        terms = modified_eq.args
-        m = min([total_degree(term) for term in terms])
+
+        if len(modified_eq.args) != 0:
+            terms = modified_eq.args
+            m = min([total_degree(term) for term in terms])
+        else:
+            terms = modified_eq
+            m = total_degree(terms)
+
         return m
-        
-    def rational_parametrization(self, singular_point=None, parameter='theta'):
+
+    def rational_parametrization(self, parameter1='t', parameter2='s', reg_point=None):
         """
-        Returns a rational parametrization of implict region.
-        
+        Returns the rational parametrization of implict region.
+
         Examples
         ========
-        
+
+        >>> from sympy import Eq
+        >>> from sympy.abc import x, y, z, s, t
+        >>> from sympy.vector import ImplicitRegion
+
         >>> parabola = ImplicitRegion((x, y), y**2 - 4*x)
         >>> parabola.rational_parametrization()
         (4/t**2, 4/t)
-        
+
         >>> circle = ImplicitRegion((x, y), Eq(x**2 + y**2, 4))
         >>> circle.rational_parametrization()
-        (2 + 4/(t**2 + 1), 4*t/(t**2 + 1))
-        
+        (-2 + 4/(t**2 + 1), 4*t/(t**2 + 1))
+
         >>> I = ImplicitRegion((x, y), x**3 + x**2 - y**2)
         >>> I.rational_parametrization()
         (t**2 - 1, t*(t**2 - 1))
-        
+
         >>> cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
-        >>> cubic_curve.rational_parametrization()
+        >>> cubic_curve.rational_parametrization(t)
         (t**2 - 1, t*(t**2 - 1))
-        
-        >>> sphere = ImplicitRegion((x, y, z), x**2 + y**2 + z**2 - 4) 
-        >>> sphere.rational_parametrization()
+
+        >>> sphere = ImplicitRegion((x, y, z), x**2 + y**2 + z**2 - 4)
+        >>> sphere.rational_parametrization(parameter1=t, parameter2=s)
         (-2 + 4/(s**2 + t**2 + 1), 4*s/(s**2 + t**2 + 1), 4*t/(s**2 + t**2 + 1))
-         
+
+        For some conics, regular_points() is unable to find a point on curve.
+        To calulcate the parametric representation in such cases, user need
+        to determine a point on the region and pass it using reg_point.
+
+        >>> c = ImplicitRegion((x, y), (x  - 1/2)**2 + (y)**2 - (1/4)**2)
+        >>> c.rational_parametrization(reg_point=(3/4, 0))
+        (0.75 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
+
+        Refrences
+        =========
+
+        - Christoph M. Hoffmann, Conversion Methods between Parametric and
+        Implicit Curves and Surfaces.
+
         """
         equation = self.equation
         degree = self.degree
-        
+
         if degree == 1:
             if len(self.variables) == 1:
-                return equation
+                return (equation,)
             elif len(self.variables) == 2:
                 x, y = self.variables
-                y_par = list(solveset(equation, x))[0]
-                return x, y_par 
+                y_par = list(solveset(equation, y))[0]
+                return x, y_par
             else:
                 raise NotImplementedError()
-        
+
         point = ()
+
+        # Finding the (n - 1) fold point of the monoid of degree
+        if degree == 2:
+            # For degree 2 curves, either a regular point or a singular point can be used.
+            if reg_point is not None:
+                # Using point provided by the user as regular point
+                if isinstance(point, Point):
+                    point = point.args
+                point = reg_point
+            else:
+                if len(self.singular_points()) != 0:
+                    point = list(self.singular_points())[0]
+                else:
+                    point = self.regular_point()
+
         if len(self.singular_points()) != 0:
             singular_points = self.singular_points()
             for spoint in singular_points:
                 if self.multiplicity(spoint) == degree - 1:
-                    point = spoint                                
-        elif degree == 2 and len(point) == 0:
-                point = self.regular_point()
-                    
+                    point = spoint
+                    break
+
+        if len(point) == 0:
+            # The region in not a monoid
+            raise NotImplementedError()
+
         modified_eq = equation
-        
+
+        # Shifting the region such that fold point moves to origin
         for i, var in enumerate(self.variables):
             modified_eq = modified_eq.subs(var, var + point[i])
         modified_eq = expand(modified_eq)
-        
+
         hn = hn_1 = 0
         for term in modified_eq.args:
             if total_degree(term) == degree:
                 hn += term
             else:
                 hn_1 += term
-        
+
         hn_1 = -1*hn_1
 
         if len(self.variables) == 2:
 
-            s = _symbol('s', real=True)
-            t = _symbol('t', real=True)
-            
+            if parameter1 == 's':
+                # To avoid name conflict between parameters
+                s = _symbol('s_', real=True)
+            else:
+                s = _symbol('s', real=True)
+            t = _symbol(parameter1, real=True)
+
             hn = hn.subs({self.variables[0]: s, self.variables[1]: t})
             hn_1 = hn_1.subs({self.variables[0]: s, self.variables[1]: t})
-            
+
             x_par = (s*(hn_1/hn)).subs(s, 1) + point[0]
             y_par = (t*(hn_1/hn)).subs(s, 1) + point[1]
-            
+
             return x_par, y_par
-        
+
         elif len(self.variables) == 3:
-            r = _symbol('r', real=True)
-            s = _symbol('s', real=True)
-            t = _symbol('t', real=True)
-            
+
+            if parameter1 == 'r' or parameter2 == 'r':
+                # To avoid name conflict between parameters
+                r = _symbol('r_', real=True)
+            else:
+                r = _symbol('r', real=True)
+            s = _symbol(parameter2, real=True)
+            t = _symbol(parameter1, real=True)
+
             hn = hn.subs({self.variables[0]: r, self.variables[1]: s, self.variables[2]: t})
             hn_1 = hn_1.subs({self.variables[0]: r, self.variables[1]: s, self.variables[2]: t})
-            
+
             x_par = (r*(hn_1/hn)).subs(r, 1) + point[0]
             y_par = (s*(hn_1/hn)).subs(r, 1) + point[1]
             z_par = (t*(hn_1/hn)).subs(r, 1) + point[2]
-            print(hn, hn_1, "eah")
+
             return x_par, y_par, z_par
-            
+
         raise NotImplementedError()

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -1,7 +1,7 @@
 from sympy import tan, pi
 from sympy.abc import theta
 from sympy.core import expand_trig, Eq
-from sympy.solvers import solve
+from sympy.solvers import solveset
 from sympy.simplify.trigsimp import trigsimp
 from sympy.vector import ParametricRegion
 
@@ -40,14 +40,14 @@ def ImplicitConicSection(equation, x, y):
     # Needs to find a better way than random looping.
     for i in range(100):
         eq = equation.subs(x, i)
-        if len(solve(eq, y)) > 0:
+        if len(solveset(eq, y)) > 0:
             p_x = i
-            p_y = solve(eq, y)[0]
+            p_y = next(iter(solveset(eq, y)))
             break
 
     y_dash = tan(theta)*(x- p_x) + p_y
     eq2 = equation.subs(y, y_dash)
-    x_par_list = solve(eq2, x)
+    x_par_list = solveset(eq2, x)
 
     for x_ in x_par_list:
         if x_ != p_x:

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -92,14 +92,14 @@ class ImplicitRegion(Basic):
             x, y = self.variables
 
             for x_reg in range(-100, 100):
-                if len(solveset(equation.subs(x, x_reg), self.variables[1], domain=S.Reals)) > 0:
+                if not solveset(equation.subs(x, x_reg), self.variables[1], domain=S.Reals).is_empty:
                     return (x_reg, list(solveset(equation.subs(x, x_reg), domain=S.Reals))[0])
         elif len(self.variables) == 3:
             x, y, z = self.variables
 
             for x_reg in range(-10, 10):
                 for y_reg in range(-10, 10):
-                    if len(solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals)) > 0:
+                    if not solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals).is_empty:
                         return (x_reg, y_reg, list(solveset(equation.subs({x: x_reg, y: y_reg})))[0])
 
         if len(self.singular_points()) != 0:
@@ -167,7 +167,7 @@ class ImplicitRegion(Basic):
 
         return m
 
-    def rational_parametrization(self, parameter1='t', parameter2='s', reg_point=None):
+    def rational_parametrization(self, parameters=('t', 's'), reg_point=None):
         """
         Returns the rational parametrization of implict region.
 
@@ -191,11 +191,11 @@ class ImplicitRegion(Basic):
         (t**2 - 1, t*(t**2 - 1))
 
         >>> cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
-        >>> cubic_curve.rational_parametrization(t)
+        >>> cubic_curve.rational_parametrization(parameters=(t))
         (t**2 - 1, t*(t**2 - 1))
 
         >>> sphere = ImplicitRegion((x, y, z), x**2 + y**2 + z**2 - 4)
-        >>> sphere.rational_parametrization(parameter1=t, parameter2=s)
+        >>> sphere.rational_parametrization(parameters=(t, s))
         (-2 + 4/(s**2 + t**2 + 1), 4*s/(s**2 + t**2 + 1), 4*t/(s**2 + t**2 + 1))
 
         For some conics, regular_points() is unable to find a point on curve.
@@ -269,8 +269,12 @@ class ImplicitRegion(Basic):
 
         hn_1 = -1*hn_1
 
+        if not isinstance(parameters, tuple):
+            parameters = (parameters,)
+
         if len(self.variables) == 2:
 
+            parameter1 = parameters[0]
             if parameter1 == 's':
                 # To avoid name conflict between parameters
                 s = _symbol('s_', real=True)
@@ -288,6 +292,7 @@ class ImplicitRegion(Basic):
 
         elif len(self.variables) == 3:
 
+            parameter1, parameter2 = parameters
             if parameter1 == 'r' or parameter2 == 'r':
                 # To avoid name conflict between parameters
                 r = _symbol('r_', real=True)

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -1,11 +1,11 @@
-from sympy import tan, pi
-from sympy.abc import theta
-from sympy.core import expand_trig, Eq
+from sympy import S
+from sympy.core import Basic, Tuple, Eq, diff, expand
+from sympy.core.symbol import _symbol
 from sympy.solvers import solveset, nonlinsolve
-from sympy.simplify.trigsimp import trigsimp
-from sympy.vector import ParametricRegion
+from sympy.polys.polytools import total_degree
 
-def ImplicitRegion(Basic):
+
+class ImplicitRegion(Basic):
     """
     Represents an implicit region in space. 
 
@@ -15,28 +15,215 @@ def ImplicitRegion(Basic):
     >>> from sympy.abc import x, y
     >>> from sympy.vector import ImplicitRegion, parametric_region_list, vector_integrate
 
-    >>> circle1 = ImplicitRegion(Eq(x**2 + y**2 -1), x, y)
+    >>> circle1 = ImplicitRegion((x, y), Eq(x**2 + y**2 -1))
     >>> parametric_region_list(circle)
     [ParametricRegion((sin(2*theta), -cos(2*theta)), (theta, 0, pi))]
 
-    >>> circle2 = ImplicitRegion((x - 3)**2 + (y + 2)**2 - 16, x, y)
+    >>> circle2 = ImplicitRegion((x, y), (x - 3)**2 + (y + 2)**2 - 16)
     >>> parametric_region_list(circle2)
     [ParametricRegion((2*(-sqrt(7)*tan(theta) + 3)*cos(theta)**2, 3*sin(2*theta) + sqrt(7)*cos(2*theta) - 2), (theta, 0, pi))]
     >>> vector_integrate(1, circle2)
     8*pi
 
-    >>> ellipse = ImplicitRegion(x**2/4 + y**2/16 - 1, x, y)
+    >>> ellipse = ImplicitRegion(x**2/4 + y**2/16 - 1)
     >>> parametric_region_list(ellipse)
     [ParametricRegion((8*tan(theta)/(tan(theta)**2 + 4), -4 + 8*tan(theta)**2/(tan(theta)**2 + 4)), (theta, 0, pi))]
     >>> vector_integrate(2, ellipse)
     ### It gets stuck
 
     """
-    def __init__(cls, equation, x, y, z):
+    def __new__(cls, variables, equation):
+        if not isinstance(variables, Tuple):
+            variables = Tuple(*variables)
+            
         if isinstance(equation, Eq):
             equation = equation.lhs - equation.rhs
-        return super.__new__(cls, equation, x, y, z)
+            
+        return super().__new__(cls, variables, equation)
+
+    @property
+    def variables(self):
+        return self.args[0]
     
     @property
     def equation(self):
-        return self.args[0]
+        return self.args[1]
+        
+    @property   
+    def degree(self):
+        return total_degree(self.equation)
+        
+    def regular_point(self):
+        """
+        Returns a smooth point on the implicit region.
+        
+        >>> circle = ImplicitRegion((x, y), (x + 2)**2 + (y - 3)**2 - 16)
+        >>> circle.regular_point
+        (-6, 3)
+         
+        """
+        equation = self.equation
+
+        if len(self.variables) == 1:
+            return list(solveset(equation, self.variables[0], domain=S.Reals))[0]
+        elif len(self.variables) == 2:
+            x, y = self.variables
+    
+            for x_reg in range(-100, 100): 
+                if len(solveset(equation.subs(x, x_reg), self.variables[1], domain=S.Reals)) > 0:
+                    return (x_reg, list(solveset(equation.subs(x, x_reg), domain=S.Reals))[0])            
+        elif len(self.variables) == 3:
+            x, y, z = self.variables
+            
+            for x_reg in range(-10, 10): 
+                for y_reg in range(-10, 10):
+                    if len(solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals)) > 0:
+                        return (x_reg, y_reg, list(solveset(equation.subs({x: x_reg, y: y_reg})))[0])
+        
+        raise NotImplementedError()
+        
+    def singular_points(self):
+        """
+        Returns a set of singular points of the region.
+        
+        The singular points are those points on the region
+        where all partial derivatives vanish.
+        
+        Examples
+        ========
+        
+        >>> I = ImplicitRegion((x, y), (y-1)**2 -x**3 + 2*x**2 -x)
+        >>> I.singular_points()
+        FiniteSet((1, 1))
+        
+        """
+        eq_list = [self.equation]
+        for var in self.variables:
+            eq_list += [diff(self.equation, var)]
+        
+        print(eq_list)    
+        return nonlinsolve(eq_list, list(self.variables))
+
+    def multiplicity(self, point):
+        """
+        Returns the multiplicity of a singular point on the region.
+        
+        A singular point (x,y) of region is said to be of multiplicity m 
+        if all the partial derivatives off to order m - 1 vanish there.
+        
+        Examples
+        ========
+        
+        >>> I = ImplicitRegion((x, y), x**2 + y**3 - z**4)
+        >>> I.singular_points()
+        FiniteSet((0, 0))
+        >>> I.multiplicity((0, 0))
+        2
+        
+        """
+        if point not in self.singular_points():
+            raise ValueError()
+
+        modified_eq = self.equation
+
+        for i, var in enumerate(self.variables):
+            modified_eq = modified_eq.subs(var, var + point[i])
+        modified_eq = expand(modified_eq)
+        
+        terms = modified_eq.args
+        m = min([total_degree(term) for term in terms])
+        return m
+        
+    def rational_parametrization(self, singular_point=None, parameter='theta'):
+        """
+        Returns a rational parametrization of implict region.
+        
+        Examples
+        ========
+        
+        >>> parabola = ImplicitRegion((x, y), y**2 - 4*x)
+        >>> parabola.rational_parametrization()
+        (4/t**2, 4/t)
+        
+        >>> circle = ImplicitRegion((x, y), Eq(x**2 + y**2, 4))
+        >>> circle.rational_parametrization()
+        (2 + 4/(t**2 + 1), 4*t/(t**2 + 1))
+        
+        >>> I = ImplicitRegion((x, y), x**3 + x**2 - y**2)
+        >>> I.rational_parametrization()
+        (t**2 - 1, t*(t**2 - 1))
+        
+        >>> cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
+        >>> cubic_curve.rational_parametrization()
+        (t**2 - 1, t*(t**2 - 1))
+        
+        >>> sphere = ImplicitRegion((x, y, z), x**2 + y**2 + z**2 - 4) 
+        >>> sphere.rational_parametrization()
+        (-2 + 4/(s**2 + t**2 + 1), 4*s/(s**2 + t**2 + 1), 4*t/(s**2 + t**2 + 1))
+         
+        """
+        equation = self.equation
+        degree = self.degree
+        
+        if degree == 1:
+            if len(self.variables) == 1:
+                return equation
+            elif len(self.variables) == 2:
+                x, y = self.variables
+                y_par = list(solveset(equation, x))[0]
+                return x, y_par 
+            else:
+                raise NotImplementedError()
+        
+        point = ()
+        if len(self.singular_points()) != 0:
+            singular_points = self.singular_points()
+            for spoint in singular_points:
+                if self.multiplicity(spoint) == degree - 1:
+                    point = spoint                                
+        elif degree == 2 and len(point) == 0:
+                point = self.regular_point()
+                    
+        modified_eq = equation
+        
+        for i, var in enumerate(self.variables):
+            modified_eq = modified_eq.subs(var, var + point[i])
+        modified_eq = expand(modified_eq)
+        
+        hn = hn_1 = 0
+        for term in modified_eq.args:
+            if total_degree(term) == degree:
+                hn += term
+            else:
+                hn_1 += term
+        
+        hn_1 = -1*hn_1
+
+        if len(self.variables) == 2:
+
+            s = _symbol('s', real=True)
+            t = _symbol('t', real=True)
+            
+            hn = hn.subs({self.variables[0]: s, self.variables[1]: t})
+            hn_1 = hn_1.subs({self.variables[0]: s, self.variables[1]: t})
+            
+            x_par = (s*(hn_1/hn)).subs(s, 1) + point[0]
+            y_par = (t*(hn_1/hn)).subs(s, 1) + point[1]
+            
+            return x_par, y_par
+        
+        elif len(self.variables) == 3:
+            r = _symbol('r', real=True)
+            s = _symbol('s', real=True)
+            t = _symbol('t', real=True)
+            
+            hn = hn.subs({self.variables[0]: r, self.variables[1]: s, self.variables[2]: t})
+            hn_1 = hn_1.subs({self.variables[0]: r, self.variables[1]: s, self.variables[2]: t})
+            
+            x_par = (r*(hn_1/hn)).subs(r, 1) + point[0]
+            y_par = (s*(hn_1/hn)).subs(r, 1) + point[1]
+            z_par = (t*(hn_1/hn)).subs(r, 1) + point[2]
+            print(hn, hn_1, "eah")
+            return x_par, y_par, z_par
+            
+        raise NotImplementedError()

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -1,7 +1,7 @@
 from sympy import tan, pi
 from sympy.abc import theta
 from sympy.core import expand_trig, Eq
-from sympy.solvers import solveset
+from sympy.solvers import solveset, nonlinsolve
 from sympy.simplify.trigsimp import trigsimp
 from sympy.vector import ParametricRegion
 
@@ -36,14 +36,16 @@ def ImplicitConicSection(equation, x, y):
     if isinstance(equation, Eq):
         equation = equation.lhs - equation.rhs
 
-    # Finding  a point on the Curve.
-    # Needs to find a better way than random looping.
-    for i in range(100):
-        eq = equation.subs(x, i)
-        if len(solveset(eq, y)) > 0:
-            p_x = i
-            p_y = next(iter(solveset(eq, y)))
-            break
+    diff_x = diff(equation, x)
+    diff_y = diff(equation, y)
+    
+    singular_points = nonlinsolve([equation, diff_x, diff_y], x, y)
+    
+    if len(singular_points) == 0:
+        # No singular points
+        raise ValueError()
+
+    p_x, p_y = next(iter(singular_points))
 
     y_dash = tan(theta)*(x- p_x) + p_y
     eq2 = equation.subs(y, y_dash)

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -5,62 +5,38 @@ from sympy.solvers import solveset, nonlinsolve
 from sympy.simplify.trigsimp import trigsimp
 from sympy.vector import ParametricRegion
 
-
-def ImplicitConicSection(equation, x, y):
+def ImplicitRegion(Basic):
     """
-    Returns the parametric form of the conic section defined using implict equation.
+    Represents an implicit region in space. 
 
     Example
     =======
 
     >>> from sympy.abc import x, y
-    >>> from sympy.vector import ImplicitConicSection, vector_integrate
+    >>> from sympy.vector import ImplicitRegion, parametric_region_list, vector_integrate
 
-    >>> ImplicitConicSection(Eq(x**2 + y**2 -1), x, y)
-    ParametricRegion((sin(2*theta), -cos(2*theta)), (theta, 0, pi))
+    >>> circle1 = ImplicitRegion(Eq(x**2 + y**2 -1), x, y)
+    >>> parametric_region_list(circle)
+    [ParametricRegion((sin(2*theta), -cos(2*theta)), (theta, 0, pi))]
 
-    >>> c = ImplicitConicSection((x - 3)**2 + (y + 2)**2 - 16, x, y)
-    >>> c
-    ParametricRegion((2*(-sqrt(7)*tan(theta) + 3)*cos(theta)**2, 3*sin(2*theta) + sqrt(7)*cos(2*theta) - 2), (theta, 0, pi))
-    >>> vector_integrate(1, c)
+    >>> circle2 = ImplicitRegion((x - 3)**2 + (y + 2)**2 - 16, x, y)
+    >>> parametric_region_list(circle2)
+    [ParametricRegion((2*(-sqrt(7)*tan(theta) + 3)*cos(theta)**2, 3*sin(2*theta) + sqrt(7)*cos(2*theta) - 2), (theta, 0, pi))]
+    >>> vector_integrate(1, circle2)
     8*pi
 
-    >>> ellipse = ImplicitConicSection(x**2/4 + y**2/16 - 1, x, y)
-    >>> ellipse
-    ParametricRegion((8*tan(theta)/(tan(theta)**2 + 4), -4 + 8*tan(theta)**2/(tan(theta)**2 + 4)), (theta, 0, pi))
-    >>> vector_integrate
+    >>> ellipse = ImplicitRegion(x**2/4 + y**2/16 - 1, x, y)
+    >>> parametric_region_list(ellipse)
+    [ParametricRegion((8*tan(theta)/(tan(theta)**2 + 4), -4 + 8*tan(theta)**2/(tan(theta)**2 + 4)), (theta, 0, pi))]
+    >>> vector_integrate(2, ellipse)
     ### It gets stuck
 
     """
-
-    if isinstance(equation, Eq):
-        equation = equation.lhs - equation.rhs
-
-    diff_x = diff(equation, x)
-    diff_y = diff(equation, y)
+    def __init__(cls, equation, x, y, z):
+        if isinstance(equation, Eq):
+            equation = equation.lhs - equation.rhs
+        return super.__new__(cls, equation, x, y, z)
     
-    singular_points = nonlinsolve([equation, diff_x, diff_y], x, y)
-    
-    if len(singular_points) == 0:
-        # No singular points
-        raise ValueError()
-
-    p_x, p_y = next(iter(singular_points))
-
-    y_dash = tan(theta)*(x- p_x) + p_y
-    eq2 = equation.subs(y, y_dash)
-    x_par_list = solveset(eq2, x)
-
-    for x_ in x_par_list:
-        if x_ != p_x:
-            x_par = x_
-            break
-
-    y_par = tan(theta)*(x_par - p_x) + p_y
-
-    ans = {}
-    ans[x] = trigsimp(expand_trig(x_par))
-    ans[y] = trigsimp(expand_trig(y_par))
-
-    p = ParametricRegion((ans[x], ans[y]), (theta, 0, pi))
-    return p
+    @property
+    def equation(self):
+        return self.args[0]

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -1,0 +1,64 @@
+from sympy import tan, pi
+from sympy.abc import theta
+from sympy.core import expand_trig, Eq
+from sympy.solvers import solve
+from sympy.simplify.trigsimp import trigsimp
+from sympy.vector import ParametricRegion
+
+
+def ImplicitConicSection(equation, x, y):
+    """
+    Returns the parametric form of the conic section defined using implict equation.
+
+    Example
+    =======
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.vector import ImplicitConicSection, vector_integrate
+
+    >>> ImplicitConicSection(Eq(x**2 + y**2 -1), x, y)
+    ParametricRegion((sin(2*theta), -cos(2*theta)), (theta, 0, pi))
+
+    >>> c = ImplicitConicSection((x - 3)**2 + (y + 2)**2 - 16, x, y)
+    >>> c
+    ParametricRegion((2*(-sqrt(7)*tan(theta) + 3)*cos(theta)**2, 3*sin(2*theta) + sqrt(7)*cos(2*theta) - 2), (theta, 0, pi))
+    >>> vector_integrate(1, c)
+    8*pi
+
+    >>> ellipse = ImplicitConicSection(x**2/4 + y**2/16 - 1, x, y)
+    >>> ellipse
+    ParametricRegion((8*tan(theta)/(tan(theta)**2 + 4), -4 + 8*tan(theta)**2/(tan(theta)**2 + 4)), (theta, 0, pi))
+    >>> vector_integrate
+    ### It gets stuck
+
+    """
+
+    if isinstance(equation, Eq):
+        equation = equation.lhs - equation.rhs
+
+    # Finding  a point on the Curve.
+    # Needs to find a better way than random looping.
+    for i in range(100):
+        eq = equation.subs(x, i)
+        if len(solve(eq, y)) > 0:
+            p_x = i
+            p_y = solve(eq, y)[0]
+            break
+
+    y_dash = tan(theta)*(x- p_x) + p_y
+    eq2 = equation.subs(y, y_dash)
+    x_par_list = solve(eq2, x)
+
+    for x_ in x_par_list:
+        if x_ != p_x:
+            x_par = x_
+            break
+
+    y_par = tan(theta)*(x_par - p_x) + p_y
+
+    ans = {}
+    ans[x] = trigsimp(expand_trig(x_par))
+    ans[y] = trigsimp(expand_trig(y_par))
+
+    p = ParametricRegion((ans[x], ans[y]), (theta, 0, pi))
+    return p

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,11 +1,9 @@
 from functools import singledispatch
-from sympy import tan, pi
-from sympy.core import Basic, Tuple, expand
+from sympy import pi
+from sympy.core import Basic, Tuple
 from sympy.core.symbol import _symbol
-from sympy.solvers import solveset, nonlinsolve
-from sympy.simplify.trigsimp import trigsimp
+from sympy.solvers import solve
 from sympy.geometry import Point, Segment, Curve, Ellipse, Polygon
-from sympy.vector import ImplicitRegion
 
 
 class ParametricRegion(Basic):
@@ -155,11 +153,11 @@ def _(obj, parameter='t'):
     definition = obj.arbitrary_point(t).args
 
     for i in range(0, 3):
-        lower_bound = solveset(definition[i] - obj.points[0].args[i], t)
-        upper_bound = solveset(definition[i] - obj.points[1].args[i], t)
+        lower_bound = solve(definition[i] - obj.points[0].args[i], t)
+        upper_bound = solve(definition[i] - obj.points[1].args[i], t)
 
         if len(lower_bound) == 1 and len(upper_bound) == 1:
-            bounds = t, next(iter(lower_bound)), next(iter(upper_bound))
+            bounds = t, lower_bound[0], upper_bound[0]
             break
 
     definition_tuple = obj.arbitrary_point(parameter).args
@@ -170,8 +168,3 @@ def _(obj, parameter='t'):
 def _(obj, parameter='t'):
     l = [parametric_region_list(side, parameter)[0] for side in obj.sides]
     return l
-    
-
-@parametric_region_list.register(ImplicitRegion)
-def _(obj, parameter='theta'):
-    pass

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -174,32 +174,4 @@ def _(obj, parameter='t'):
 
 @parametric_region_list.register(ImplicitRegion)
 def _(obj, parameter='theta'):
-    equation = obj.equation
-    diff_x = diff(equation, x)
-    diff_y = diff(equation, y)
-    
-    singular_points = nonlinsolve([equation, diff_x, diff_y], x, y)
-    
-    if len(singular_points) == 0:
-        return obj
-
-    p_x, p_y = next(iter(singular_points))
-    theta = _symbol(parameter, real=True)
-
-    y_dash = tan(theta)*(x- p_x) + p_y
-    eq2 = equation.subs(y, y_dash)
-    x_par_list = solveset(eq2, x)
-
-    for x_ in x_par_list:
-        if x_ != p_x:
-            x_par = x_
-            break
-
-    y_par = tan(theta)*(x_par - p_x) + p_y
-
-    definition = {}
-    definition[x] = trigsimp(expand_trig(x_par))
-    definition[y] = trigsimp(expand_trig(y_par))
-
-    p = [ParametricRegion((definition[x], definition[y]), (theta, 0, pi))]
-    return p    
+    pass

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -1,0 +1,82 @@
+from sympy import Eq, S, sqrt
+from sympy.abc import x, y, z, s, t
+from sympy.sets import FiniteSet, EmptySet
+from sympy.geometry import Point
+from sympy.vector import ImplicitRegion
+from sympy.testing.pytest import raises
+
+
+def test_ImplicitRegion():
+    ellipse = ImplicitRegion((x, y), (x**2/4 + y**2/16 - 1))
+    assert ellipse.equation == x**2/4 + y**2/16 - 1
+    assert ellipse.variables == (x, y)
+    assert ellipse.degree == 2
+    r = ImplicitRegion((x, y, z), Eq(x**4 + y**2 - x*y, 6))
+    assert r.equation == x**4 + y**2 - x*y - 6
+    assert r.variables == (x, y, z)
+    assert r.degree == 4
+
+
+def test_regular_point():
+    r1 = ImplicitRegion((x,), x**2 - 16)
+    r1.regular_point() == (-4,)
+    c = ImplicitRegion((x, y), x**2 + y**2 - 4)
+    c.regular_point() == (-2, 0)
+    r2 = ImplicitRegion((x, y), (x - S(5)/2)**2 + y**2 - (S(1)/4)**2)
+    raises(NotImplementedError, lambda: r2.regular_point())
+
+
+def test_singular_points_and_multiplicty():
+    r1 = ImplicitRegion((x, y, z), Eq(x + y + z, 0))
+    assert r1.singular_points() == FiniteSet((-y - z, y, z))
+    assert r1.multiplicity((0, 0, 0)) == 1
+    assert r1.multiplicity((-y - z, y, z)) == 1
+    r2 = ImplicitRegion((x, y, z), x*y*z + y**4 -x**2*z**2)
+    assert r2.singular_points() == FiniteSet((0, 0, z), ((-y*sqrt(4*y**2 + 1)/2 + y/2)/z, y, z),\
+                            ((y*sqrt(4*y**2 + 1)/2 + y/2)/z, y, z))
+    assert r2.multiplicity((0, 0, 0)) == 3
+    assert r2.multiplicity((0, 0, 6)) == 2
+    r3 = ImplicitRegion((x, y, z), z**2 - x**2 - y**2)
+    assert r3.singular_points() == FiniteSet((0, 0, 0))
+    assert r3.multiplicity((0, 0, 0)) == 2
+    r4 = ImplicitRegion((x, y), x**2 + y**2 - 2*x)
+    assert r4.singular_points() == EmptySet
+    assert r4.multiplicity(Point(1, 3)) == 0
+
+
+def test_rational_parametrization():
+    p = ImplicitRegion((x,), x - 2)
+    assert p.rational_parametrization() == (x - 2,)
+
+    line = ImplicitRegion((x, y), Eq(y, 3*x + 2))
+    assert line.rational_parametrization() == (x, 3*x + 2)
+
+    circle1 = ImplicitRegion((x, y), ((x-2)**2 + (y+3)**2 - 4))
+    assert circle1.rational_parametrization(parameter1=t) == (4/(t**2 + 1), 4*t/(t**2 + 1) - 3)
+    circle2 = ImplicitRegion((x, y), (x - 1/2)**2 + y**2 - (1/4)**2 )
+    raises(NotImplementedError, lambda: circle2.rational_parametrization())
+    circle2.rational_parametrization(t, reg_point=Point(0.75, 0)) == (3/4 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
+    circle3 = ImplicitRegion((x, y), Eq(x**2 + y**2, 2*x))
+    assert circle3.rational_parametrization(parameter1=t) == (2/(t**2 + 1), 2*t/(t**2 + 1))
+
+    parabola = ImplicitRegion((x, y), (y - 3)**2 - 4*(x + 6))
+    assert parabola.rational_parametrization(t) == (-6 + 4/t**2, 3 + 4/t)
+
+    rect_hyperbola = ImplicitRegion((x, y), x*y - 1)
+    assert rect_hyperbola.rational_parametrization(t) == (-100 + (100*t + S(1)/100)/t, 100*t)
+
+    cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
+    assert cubic_curve.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
+    cuspidal = ImplicitRegion((x, y), (x**3 - y**2))
+    assert cuspidal.rational_parametrization(t) == (t**2, t**3)
+
+    I= ImplicitRegion((x, y), x**3 + x**2 - y**2)
+    assert I.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
+
+    sphere = ImplicitRegion((x, y, z), Eq(x**2 + y**2 + z**2, 2*x))
+    assert sphere.rational_parametrization(s, t) == (2/(s**2 + t**2 + 1), 2*t/(s**2 + t**2 + 1), 2*s/(s**2 + t**2 + 1))
+
+    r1 = ImplicitRegion((x, y), y**2 - x**3 + x)
+    raises(NotImplementedError, lambda: r1.rational_parametrization())
+    r2 = ImplicitRegion((x, y), y**2 - x**3 - x**2 + 1)
+    raises(NotImplementedError, lambda: r2.rational_parametrization())

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -52,12 +52,12 @@ def test_rational_parametrization():
     assert line.rational_parametrization() == (x, 3*x + 2)
 
     circle1 = ImplicitRegion((x, y), ((x-2)**2 + (y+3)**2 - 4))
-    assert circle1.rational_parametrization(parameter1=t) == (4/(t**2 + 1), 4*t/(t**2 + 1) - 3)
+    assert circle1.rational_parametrization(parameters=t) == (4/(t**2 + 1), 4*t/(t**2 + 1) - 3)
     circle2 = ImplicitRegion((x, y), (x - 1/2)**2 + y**2 - (1/4)**2 )
     raises(NotImplementedError, lambda: circle2.rational_parametrization())
     circle2.rational_parametrization(t, reg_point=Point(0.75, 0)) == (3/4 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
     circle3 = ImplicitRegion((x, y), Eq(x**2 + y**2, 2*x))
-    assert circle3.rational_parametrization(parameter1=t) == (2/(t**2 + 1), 2*t/(t**2 + 1))
+    assert circle3.rational_parametrization(parameters=(t,)) == (2/(t**2 + 1), 2*t/(t**2 + 1))
 
     parabola = ImplicitRegion((x, y), (y - 3)**2 - 4*(x + 6))
     assert parabola.rational_parametrization(t) == (-6 + 4/t**2, 3 + 4/t)
@@ -66,7 +66,7 @@ def test_rational_parametrization():
     assert rect_hyperbola.rational_parametrization(t) == (-100 + (100*t + S(1)/100)/t, 100*t)
 
     cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
-    assert cubic_curve.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
+    assert cubic_curve.rational_parametrization(parameters=(t)) == (t**2 - 1, t*(t**2 - 1))
     cuspidal = ImplicitRegion((x, y), (x**3 - y**2))
     assert cuspidal.rational_parametrization(t) == (t**2, t**3)
 
@@ -74,7 +74,11 @@ def test_rational_parametrization():
     assert I.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
 
     sphere = ImplicitRegion((x, y, z), Eq(x**2 + y**2 + z**2, 2*x))
-    assert sphere.rational_parametrization(s, t) == (2/(s**2 + t**2 + 1), 2*t/(s**2 + t**2 + 1), 2*s/(s**2 + t**2 + 1))
+    assert sphere.rational_parametrization(parameters=(s, t)) == (2/(s**2 + t**2 + 1), 2*t/(s**2 + t**2 + 1), 2*s/(s**2 + t**2 + 1))
+
+    conic = ImplicitRegion((x, y), Eq(x**2 + 4*x*y + 3*y**2 + x - y + 10, 0))
+    conic.rational_parametrization(t) == (-100 - 205/(3*(3*t**2 - sqrt(41881)*t + 4*t - 2*sqrt(41881)/3 + 1)),\
+                                -205*t/(3*(3*t**2 - sqrt(41881)*t + 4*t - 2*sqrt(41881)/3 + 1)) - sqrt(41881)/6 + 401/6)
 
     r1 = ImplicitRegion((x, y), y**2 - x**3 + x)
     raises(NotImplementedError, lambda: r1.rational_parametrization())


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19320 

#### Brief description of what is fixed or changed
The vector module has support to define regions using parametric representation and integrate over them.
In some cases, It is easier to work to define regions using their implicit equation. This Pull Request aims to add classes to represent implicitly defined regions.

#### Other comments
This PR is a draft and the structure of the PR is not fixed. 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * Added support to create implictly defined regions.
<!-- END RELEASE NOTES -->