### PR TITLE
Remove out-of-date printers from physics.vector

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -74,49 +74,7 @@ class VectorLatexPrinter(LatexPrinter):
 
             return r"%s" % (name + supers + subs)
         else:
-            args = [str(self._print(arg)) for arg in expr.args]
-            # How inverse trig functions should be displayed, formats are:
-            # abbreviated: asin, full: arcsin, power: sin^-1
-            inv_trig_style = self._settings['inv_trig_style']
-            # If we are dealing with a power-style inverse trig function
-            inv_trig_power_case = False
-            # If it is applicable to fold the argument brackets
-            can_fold_brackets = self._settings['fold_func_brackets'] and \
-                len(args) == 1 and \
-                not self._needs_function_brackets(expr.args[0])
-
-            inv_trig_table = ["asin", "acos", "atan", "acot"]
-
-            # If the function is an inverse trig function, handle the style
-            if func in inv_trig_table:
-                if inv_trig_style == "abbreviated":
-                    pass
-                elif inv_trig_style == "full":
-                    func = "arc" + func[1:]
-                elif inv_trig_style == "power":
-                    func = func[1:]
-                    inv_trig_power_case = True
-
-                    # Can never fold brackets if we're raised to a power
-                    if exp is not None:
-                        can_fold_brackets = False
-
-            if inv_trig_power_case:
-                name = r"\operatorname{%s}^{-1}" % func
-            elif exp is not None:
-                name = r"\operatorname{%s}^{%s}" % (func, exp)
-            else:
-                name = r"\operatorname{%s}" % func
-
-            if can_fold_brackets:
-                name += r"%s"
-            else:
-                name += r"\left(%s\right)"
-
-            if inv_trig_power_case and exp is not None:
-                name += r"^{%s}" % exp
-
-            return name % ",".join(args)
+            return super()._print_Function(expr, exp)
 
     def _print_Derivative(self, der_expr):
         from sympy.physics.vector.functions import dynamicsymbols

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -2,11 +2,11 @@ from sympy import Derivative
 from sympy.core.function import UndefinedFunction, AppliedUndef
 from sympy.core.symbol import Symbol
 from sympy.interactive.printing import init_printing
-from sympy.printing.conventions import split_super_sub
-from sympy.printing.latex import LatexPrinter, translate
+from sympy.printing.latex import LatexPrinter
 from sympy.printing.pretty.pretty import PrettyPrinter
 from sympy.printing.pretty.pretty_symbology import center_accent
 from sympy.printing.str import StrPrinter
+from sympy.printing.precedence import PRECEDENCE
 
 __all__ = ['vprint', 'vsstrrepr', 'vsprint', 'vpprint', 'vlatex',
            'init_vprinting']
@@ -53,26 +53,16 @@ class VectorLatexPrinter(LatexPrinter):
             not isinstance(type(expr), UndefinedFunction):
             return getattr(self, '_print_' + func)(expr, exp)
         elif isinstance(type(expr), UndefinedFunction) and (expr.args == (t,)):
-
-            name, supers, subs = split_super_sub(func)
-            name = translate(name)
-            supers = [translate(sup) for sup in supers]
-            subs = [translate(sub) for sub in subs]
-
-            if len(supers) != 0:
-                supers = r"^{%s}" % "".join(supers)
+            # treat this function like a symbol
+            expr = Symbol(func)
+            if exp is not None:
+                # copied from LatexPrinter._helper_print_standard_power, which
+                # we can't call because we only have exp as a string.
+                base = self.parenthesize(expr, PRECEDENCE['Pow'])
+                base = self.parenthesize_super(base)
+                return r"%s^{%s}" % (base, exp)
             else:
-                supers = r""
-
-            if len(subs) != 0:
-                subs = r"_{%s}" % "".join(subs)
-            else:
-                subs = r""
-
-            if exp:
-                supers += r"^{%s}" % exp
-
-            return r"%s" % (name + supers + subs)
+                return super()._print(expr)
         else:
             return super()._print_Function(expr, exp)
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -91,7 +91,7 @@ def test_vector_latex():
 
     assert vlatex(v) == (r'(a^{2} + \frac{b}{c})\mathbf{\hat{a}_x} + '
                          r'\sqrt{d}\mathbf{\hat{a}_y} + '
-                         r'\operatorname{cos}\left(\omega\right)'
+                         r'\cos{\left(\omega \right)}'
                          r'\mathbf{\hat{a}_z}')
 
     theta, omega, alpha, q = dynamicsymbols('theta, omega, alpha, q')
@@ -109,12 +109,12 @@ def test_vector_latex():
          cos(phi1) * cos(phi2) * A.y +
          cos(theta1 + phi3) * A.z)
 
-    assert vlatex(v) == (r'\operatorname{sin}\left(\theta_{1}\right)'
-                         r'\mathbf{\hat{a}_x} + \operatorname{cos}'
-                         r'\left(\phi_{1}\right) \operatorname{cos}'
-                         r'\left(\phi_{2}\right)\mathbf{\hat{a}_y} + '
-                         r'\operatorname{cos}\left(\theta_{1} + '
-                         r'\phi_{3}\right)\mathbf{\hat{a}_z}')
+    assert vlatex(v) == (r'\sin{\left(\theta_{1} \right)}'
+                         r'\mathbf{\hat{a}_x} + \cos{'
+                         r'\left(\phi_{1} \right)} \cos{'
+                         r'\left(\phi_{2} \right)}\mathbf{\hat{a}_y} + '
+                         r'\cos{\left(\theta_{1} + '
+                         r'\phi_{3} \right)}\mathbf{\hat{a}_z}')
 
     N = ReferenceFrame('N')
 
@@ -124,7 +124,7 @@ def test_vector_latex():
 
     expected = (r'(a^{2} + \frac{b}{c})\mathbf{\hat{n}_x} + '
                 r'\sqrt{d}\mathbf{\hat{n}_y} + '
-                r'\operatorname{cos}\left(\omega\right)'
+                r'\cos{\left(\omega \right)}'
                 r'\mathbf{\hat{n}_z}')
 
     assert vlatex(v) == expected
@@ -137,11 +137,11 @@ def test_vector_latex():
 
     expected = (r'(a^{2} + \frac{b}{c})\hat{i} + '
                 r'\sqrt{d}\hat{j} + '
-                r'\operatorname{cos}\left(\omega\right)\hat{k}')
+                r'\cos{\left(\omega \right)}\hat{k}')
     assert vlatex(v) == expected
 
-    expected = r'\alpha\mathbf{\hat{n}_x} + \operatorname{asin}\left(\omega' \
-        r'\right)\mathbf{\hat{n}_y} -  \beta \dot{\alpha}\mathbf{\hat{n}_z}'
+    expected = r'\alpha\mathbf{\hat{n}_x} + \operatorname{asin}{\left(\omega ' \
+        r'\right)}\mathbf{\hat{n}_y} -  \beta \dot{\alpha}\mathbf{\hat{n}_z}'
     assert vlatex(ww) == expected
 
     expected = r'- \mathbf{\hat{n}_x}\otimes \mathbf{\hat{n}_y} - ' \
@@ -207,13 +207,13 @@ def test_dyadic_latex():
 
     expected = (r'a^{2}\mathbf{\hat{n}_x}\otimes \mathbf{\hat{n}_y} + '
                 r'b\mathbf{\hat{n}_y}\otimes \mathbf{\hat{n}_y} + '
-                r'c \operatorname{sin}\left(\alpha\right)'
+                r'c \sin{\left(\alpha \right)}'
                 r'\mathbf{\hat{n}_z}\otimes \mathbf{\hat{n}_y}')
 
     assert vlatex(y) == expected
 
     expected = (r'\alpha\mathbf{\hat{n}_x}\otimes \mathbf{\hat{n}_x} + '
-                r'\operatorname{sin}\left(\omega\right)\mathbf{\hat{n}_y}'
+                r'\sin{\left(\omega \right)}\mathbf{\hat{n}_y}'
                 r'\otimes \mathbf{\hat{n}_z} + '
                 r'\alpha \beta\mathbf{\hat{n}_z}\otimes \mathbf{\hat{n}_x}')
 
@@ -241,7 +241,7 @@ def test_vlatex(): # vlatex is broken #12078
     g = Function('g')
     h = Function('h')
 
-    expected = r'J \left(\frac{d}{d x} \operatorname{g}\left(x\right) - \frac{d}{d x} \operatorname{h}\left(x\right)\right)'
+    expected = r'J \left(\frac{d}{d x} g{\left(x \right)} - \frac{d}{d x} h{\left(x \right)}\right)'
 
     expr = J*f(x).diff(x).subs(f(x), g(x)-h(x))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
The contents of `VectorLatexPrinter._print_Function` was copied long ago from `LatexPrinter._print_Function`, and has not been updated since.

This replaces most of the duplicated code with calls to superclass methods.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * `VectorLatexPrinter` now respects the `symbol_names` setting when printing `dynamicsymbols`
  * `VectorLatexPrinter` now know about the same trig functions as the regular printer
<!-- END RELEASE NOTES -->