### PR TITLE
Fix dummy name selection of Function._eval_nseries

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -671,7 +671,7 @@ class Function(Application, Expr):
 
         """
         from sympy import Order
-        from sympy.core.symbol import _uniquely_named_symbol
+        from sympy.core.symbol import uniquely_named_symbol
         from sympy.sets.sets import FiniteSet
         args = self.args
         args0 = [t.limit(x, 0) for t in args]
@@ -727,19 +727,7 @@ class Function(Application, Expr):
                 series = term
                 fact = S.One
 
-                # choose dummy name which isn't in self.args
-                def _modify(s):
-                    # each time applied, return xi0, xi1, xi2, ...
-                    root_char = ''
-                    for c in s:
-                        if not c.isnumeric():
-                            root_char += c
-                        else:
-                            break
-                    num_char = s.lstrip(root_char)
-                    num = 0 if not num_char else int(num_char)+1
-                    return root_char + str(num)
-                _x = _uniquely_named_symbol('xi', self, modify=_modify)
+                _x = uniquely_named_symbol('xi', self)
                 e = e.subs(x, _x)
                 for i in range(n - 1):
                     i += 1

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -671,6 +671,7 @@ class Function(Application, Expr):
 
         """
         from sympy import Order
+        from sympy.core.symbol import _uniquely_named_symbol
         from sympy.sets.sets import FiniteSet
         args = self.args
         args0 = [t.limit(x, 0) for t in args]
@@ -725,7 +726,20 @@ class Function(Application, Expr):
                     raise PoleError("Cannot expand %s around 0" % (self))
                 series = term
                 fact = S.One
-                _x = Dummy('x')
+
+                # choose dummy name which isn't in self.args
+                def _modify(s):
+                    # each time applied, return xi0, xi1, xi2, ...
+                    root_char = ''
+                    for c in s:
+                        if not c.isnumeric():
+                            root_char += c
+                        else:
+                            break
+                    num_char = s.lstrip(root_char)
+                    num = 0 if not num_char else int(num_char)+1
+                    return root_char + str(num)
+                _x = _uniquely_named_symbol('xi', self, modify=_modify)
                 e = e.subs(x, _x)
                 for i in range(n - 1):
                     i += 1

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -556,7 +556,7 @@ def test_function__eval_nseries():
     # issue 19065:
     xi = Symbol('xi')
     s = f(xi, y).series(y, n=2)
-    assert {i.name for i in s.atoms(Symbol)} == ('xi', 'xi0', 'y')
+    assert {i.name for i in s.atoms(Symbol)} == {'xi', 'xi0', 'y'}
 
 def test_doit():
     n = Symbol('n', integer=True)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -553,6 +553,12 @@ def test_function__eval_nseries():
     assert sin(sqrt(x))._eval_nseries(x, 3, None) == \
         sqrt(x) - x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + O(x**3)
 
+    # issue 19065:
+    xi = Symbol('xi')
+    xi0, xi1, xi2 = symbols('xi0:3')
+    s = f(xi, xi0, xi1, xi2).series(xi1)
+    assert s.getO().expr.args[0].name == 'xi1'
+
 
 def test_doit():
     n = Symbol('n', integer=True)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -555,10 +555,8 @@ def test_function__eval_nseries():
 
     # issue 19065:
     xi = Symbol('xi')
-    xi0, xi1, xi2 = symbols('xi0:3')
-    s = f(xi, xi0, xi1, xi2).series(xi1)
-    assert s.getO().expr.args[0].name == 'xi1'
-
+    s = f(xi, y).series(y, n=2)
+    assert {i.name for i in s.atoms(Symbol)} == ('xi', 'xi0', 'y')
 
 def test_doit():
     n = Symbol('n', integer=True)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -554,9 +554,11 @@ def test_function__eval_nseries():
         sqrt(x) - x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + O(x**3)
 
     # issue 19065:
+    s1 = f(x,y).series(y, n=2)
+    assert {i.name for i in s1.atoms(Symbol)} == {'x', 'xi', 'y'}
     xi = Symbol('xi')
-    s = f(xi, y).series(y, n=2)
-    assert {i.name for i in s.atoms(Symbol)} == {'xi', 'xi0', 'y'}
+    s2 = f(xi, y).series(y, n=2)
+    assert {i.name for i in s2.atoms(Symbol)} == {'xi', 'xi0', 'y'}
 
 def test_doit():
     n = Symbol('n', integer=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19065

#### Brief description of what is fixed or changed
Now, `Function._eval_nseries` uses `uniquely_named_symbol`.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->