### PR TITLE
[GSoC] Functions: Fixes limit evaluations involving error functions

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1509,7 +1509,7 @@ class Pow(Expr):
             if b.has(polygamma, EulerGamma) and logx is not None:
                 raise ValueError()
             _, m = b.leadterm(x)
-        except ValueError:
+        except (ValueError, NotImplementedError):
             b = b._eval_nseries(x, n=max(2, n), logx=logx, cdir=cdir).removeO()
             if b.has(nan, zoo):
                 raise NotImplementedError()

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -216,9 +216,11 @@ class erf(Function):
         return sqrt(z**2)/z - z*expint(S.Half, z**2)/sqrt(S.Pi)
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
-        from sympy import sign
-        if z.is_real:
-            return (S.One - _erfs(abs(z))*exp(-z**2))*sign(z)
+        from sympy.series.limits import limit
+        if 'var' in kwargs:
+            lim = limit(z, kwargs['var'], S.Infinity)
+            if lim is S.NegativeInfinity:
+                return S.NegativeOne + _erfs(-z)*exp(-z**2)
         return S.One - _erfs(z)*exp(-z**2)
 
     def _eval_rewrite_as_erfc(self, z, **kwargs):
@@ -381,6 +383,8 @@ class erfc(Function):
         return self.args[0].is_extended_real
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
+        if 'var' in kwargs:
+            return self.rewrite(erf).rewrite("tractable", deep=True, var=kwargs['var'])
         return self.rewrite(erf).rewrite("tractable", deep=True)
 
     def _eval_rewrite_as_erf(self, z, **kwargs):
@@ -561,6 +565,8 @@ class erfi(Function):
             return True
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
+        if 'var' in kwargs:
+            return self.rewrite(erf).rewrite("tractable", deep=True, var=kwargs['var'])
         return self.rewrite(erf).rewrite("tractable", deep=True)
 
     def _eval_rewrite_as_erf(self, z, **kwargs):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -216,6 +216,9 @@ class erf(Function):
         return sqrt(z**2)/z - z*expint(S.Half, z**2)/sqrt(S.Pi)
 
     def _eval_rewrite_as_tractable(self, z, **kwargs):
+        from sympy import sign
+        if z.is_real:
+            return (S.One - _erfs(abs(z))*exp(-z**2))*sign(z)
         return S.One - _erfs(z)*exp(-z**2)
 
     def _eval_rewrite_as_erfc(self, z, **kwargs):
@@ -229,7 +232,7 @@ class erf(Function):
         arg = self.args[0].as_leading_term(x)
 
         if x in arg.free_symbols and Order(1, x).contains(arg):
-            return 2*x/sqrt(pi)
+            return 2*arg/sqrt(pi)
         else:
             return self.func(arg)
 
@@ -2468,6 +2471,10 @@ class _erfs(Function):
     tractable for the Gruntz algorithm.
 
     """
+    @classmethod
+    def eval(cls, arg):
+        if arg.is_zero:
+            return S.One
 
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import Order

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -46,6 +46,8 @@ def test_erf():
     assert conjugate(erf(z)) == erf(conjugate(z))
 
     assert erf(x).as_leading_term(x) == 2*x/sqrt(pi)
+    assert erf(x*y).as_leading_term(y) == 2*x*y/sqrt(pi)
+    assert (erf(x*y)/erf(y)).as_leading_term(y) == x
     assert erf(1/x).as_leading_term(x) == erf(1/x)
 
     assert erf(z).rewrite('uppergamma') == sqrt(z**2)*(1 - erfc(sqrt(z**2)))/z
@@ -64,6 +66,8 @@ def test_erf():
     assert limit((1 - erf(z))*exp(z**2)*z, z, oo) == 1/sqrt(pi)
     assert limit((1 - erf(x))*exp(x**2)*sqrt(pi)*x, x, oo) == 1
     assert limit(((1 - erf(x))*exp(x**2)*sqrt(pi)*x - 1)*2*x**2, x, oo) == -1
+    assert limit(erf(x)/x, x, 0) == 2/sqrt(pi)
+    assert limit(x**(-4) - sqrt(pi)*erf(x**2) / (2*x**6), x, 0) == S(1)/3
 
     assert erf(x).as_real_imag() == \
         (erf(re(x) - I*im(x))/2 + erf(re(x) + I*im(x))/2,

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -386,6 +386,14 @@ def test_issue_9569():
     assert integrate(1/(2 - cos(x))) == 2*sqrt(3)*(atan(sqrt(3)*tan(x/2)) + pi*floor((x/2 - pi/2)/pi))/3
 
 
+def test_issue_13733():
+    s = Symbol('s', positive=True)
+    pz = exp(-(z - y)**2/(2*s*s))/sqrt(2*pi*s*s)
+    pzgx = integrate(pz, (z, x, oo))
+    assert integrate(pzgx, (x, 0, oo)) == sqrt(2)*s*exp(-y**2/(2*s**2))/(2*sqrt(pi)) + \
+        y*erf(sqrt(2)*y/(2*s))/2 + y/2
+
+
 def test_issue_13749():
     assert integrate(1 / (2 + cos(x)), (x, 0, pi)) == pi/sqrt(3)
     assert integrate(1/(2 + cos(x))) == 2*sqrt(3)*(atan(sqrt(3)*tan(x/2)/3) + pi*floor((x/2 - pi/2)/pi))/3

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -435,7 +435,7 @@ def limitinf(e, x, leadsimp=False):
         p = Dummy('p', positive=True)
         e = e.subs(x, p)
         x = p
-    e = e.rewrite('tractable', deep=True)
+    e = e.rewrite('tractable', deep=True, var=x)
     e = powdenest(e)
     c0, e0 = mrv_leadterm(e, x)
     sig = sign(e0, x)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -5,7 +5,7 @@ from sympy import (
     atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
-    acos, erf, erfi, LambertW, factorial, digamma, Ei, EulerGamma,
+    acos, erf, erfc, erfi, LambertW, factorial, digamma, Ei, EulerGamma,
     asin, atanh, acot, acoth, asec, acsc, cbrt)
 
 from sympy.calculus.util import AccumBounds
@@ -518,6 +518,11 @@ def test_issue_8208():
     assert limit(n**(Rational(1, 1e9) - 1), n, oo) == 0
 
 
+def test_issue_8433():
+    d, t = symbols('d t', positive=True)
+    assert limit(erf(1 - t/d), t, oo) == -1
+
+
 def test_issue_8481():
     k = Symbol('k', integer=True, nonnegative=True)
     lamda = Symbol('lamda', real=True, positive=True)
@@ -537,6 +542,11 @@ def test_issue_10801():
     assert limit(16**k / (k * binomial(2*k, k)**2), k, oo) == pi
 
 
+def test_issue_10976():
+    s, x = symbols('s x', real=True)
+    assert limit(erf(s*x)/erf(s), s, 0) == Abs(x)*sign(x)
+
+
 def test_issue_9041():
     assert limit(factorial(n) / ((n/exp(1))**n * sqrt(2*pi*n)), n, oo) == 1
 
@@ -552,6 +562,10 @@ def test_issue_9205():
 def test_issue_9471():
     assert limit((((27**(log(n,3))))/n**3),n,oo) == 1
     assert limit((((27**(log(n,3)+1)))/n**3),n,oo) == 27
+
+
+def test_issue_11496():
+    assert limit(erfc(log(1/x)), x, oo) == 2
 
 
 def test_issue_11879():
@@ -626,6 +640,12 @@ def test_issue_13416():
 
 def test_issue_13462():
     assert limit(n**2*(2*n*(-(1 - 1/(2*n))**x + 1) - x - (-x**2/4 + x/4)/n), n, oo) == x*(x - 2)*(x - 1)/24
+
+
+def test_issue_13750():
+    a = Symbol('a')
+    assert limit(erf(a - x), x, oo) == -1
+    assert limit(erf(sqrt(x) - x), x, oo) == -1
 
 
 def test_issue_14514():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -544,7 +544,7 @@ def test_issue_10801():
 
 def test_issue_10976():
     s, x = symbols('s x', real=True)
-    assert limit(erf(s*x)/erf(s), s, 0) == Abs(x)*sign(x)
+    assert limit(erf(s*x)/erf(s), s, 0) == x
 
 
 def test_issue_9041():


### PR DESCRIPTION
Fixes: #8433
Fixes: #10976
Fixes: #11496
Fixes: #13733
Fixes: #13750

#### Brief description of what is fixed or changed

Rectifies `_eval_rewrite_as_tractable` method of `class erf`.

Adds `eval` method to `class _erfs` so that `_erfs(0)` evaluates to `1`.

Corrects the `_eval_as_leading_term` method of `class erf`.


#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* functions
  * Rectifies `_eval_rewrite_as_tractable` method of `class erf`
<!-- END RELEASE NOTES -->