### PR TITLE
Added gradient_vectorfield function to calculate gradient of vector fields

### DIFF
--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -13,7 +13,8 @@ from sympy.vector.functions import (express, matrix_to_vector,
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence
+from sympy.vector.operators import (Gradient, Divergence, Curl, Laplacian, gradient,
+                                    curl, divergence, gradient_vectorfield)
 from sympy.vector.parametricregion import (ParametricRegion, parametric_region_list)
 from sympy.vector.integrals import (ParametricIntegral, vector_integrate)
 
@@ -38,7 +39,7 @@ __all__ = [
     'AxisOrienter', 'BodyOrienter', 'SpaceOrienter', 'QuaternionOrienter',
 
     'Gradient', 'Divergence', 'Curl', 'Laplacian', 'gradient', 'curl',
-    'divergence',
+    'divergence', 'gradient_vectorfield',
 
     'ParametricRegion', 'parametric_region_list', 'ParametricIntegral', 'vector_integrate',
 ]

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -7,6 +7,7 @@ from sympy.vector.scalar import BaseScalar
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.function import Derivative
 from sympy import Add, Mul
+from sympy.matrices import Matrix
 
 
 def _get_coord_systems(expr):
@@ -325,6 +326,38 @@ def gradient(scalar_field, coord_sys=None, doit=True):
             s = _split_mul_args_wrt_coordsys(scalar_field)
             return VectorAdd.fromiter(scalar_field / i * gradient(i) for i in s)
         return Gradient(scalar_field)
+
+
+def gradient_vectorfield(vector_field, coord_sys=None):
+    """
+    Returns the gradient of a vector field wrt base scalars
+    of the given coordinate system.
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSys3D, gradient_vectorfield
+    >>> R = CoordSys3D('R')
+    >>> v = R.x*R.y*(R.i + R.j)
+    >>> gradient_vectorfield(v)
+    Matrix([
+    [R.y, R.x, 0],
+    [R.y, R.x, 0],
+    [  0,   0, 0]])
+
+    """
+
+    coord_sys = _get_coord_sys_from_expr(vector_field, coord_sys)
+
+    if len(coord_sys) == 1:
+        coord_sys = next(iter(coord_sys))
+        x, y, z = coord_sys.base_scalars()
+        mat = (vector_field.to_matrix(coord_sys))
+        d = Matrix([x, y, z])
+
+        return mat.jacobian(d)
+    else:
+        raise ValueError("Vector fields with multiple coordinate system components not supported")
 
 
 class Laplacian(Expr):

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -1,4 +1,5 @@
 from sympy.core.function import Derivative
+from sympy.matrices import Matrix
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.simplify import simplify
@@ -6,7 +7,8 @@ from sympy.core.symbol import symbols
 from sympy.core import S
 from sympy import sin, cos
 from sympy.vector.vector import Dot
-from sympy.vector.operators import curl, divergence, gradient, Gradient, Divergence, Cross
+from sympy.vector.operators import (curl, divergence, gradient, Gradient,
+                                    Divergence, Cross, gradient_vectorfield)
 from sympy.vector.deloperator import Del
 from sympy.vector.functions import (is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
@@ -320,3 +322,20 @@ def test_mixed_coordinates():
                 a.x**2*b.x*Dot(a.i, c.i) +\
                 b.x**2*c.x*Dot(b.i, a.i) +\
                 a.x*b.x**2*Dot(b.i, c.i)
+
+def test_gradient_vectorfield():
+    assert gradient_vectorfield(C.x*C.i - C.z**2*C.j + C.y**3*C.k) == \
+            Matrix([
+            [1,        0,      0],
+            [0,        0, -2*C.z],
+            [0, 3*C.y**2,      0]])
+    assert gradient_vectorfield(C.x*C.y*C.z*C.i + C.x/3*C.j) == \
+            Matrix([
+            [C.y*C.z, C.x*C.z, C.x*C.y],
+            [    S(1)/3,       0,       0],
+            [      0,       0,       0]])
+    assert gradient_vectorfield((C.x*3*C.y**4*C.i - C.x**2*C.k).cross(C.i + C.y**2*C.j)) == \
+            Matrix([
+            [2*C.x*C.y**2,  2*C.x**2*C.y, 0],
+            [      -2*C.x,             0, 0],
+            [    3*C.y**6, 18*C.x*C.y**5, 0]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19212

#### Brief description of what is fixed or changed
Added new function to calculate the gradient of a vector field.
#### Other comments
The function works only for the cartesian coordinate system.
We can also modify the gradient function instead of adding a new function.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * Added support to calculate gradient of vector fields.
<!-- END RELEASE NOTES -->