### PR TITLE
test(external): XFAIL some autowrap tests

### DIFF
--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -5,7 +5,7 @@ from sympy import symbols, Eq, Mod
 from sympy.external import import_module
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.autowrap import autowrap, ufuncify, CodeWrapError
-from sympy.testing.pytest import skip
+from sympy.testing.pytest import skip, XFAIL
 
 numpy = import_module('numpy', min_module_version='1.6.1')
 Cython = import_module('Cython', min_module_version='0.15.1')
@@ -216,41 +216,65 @@ def test_issue_15337_f95_f2py():
 # Cython
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_wrap_twice_c_cython():
     has_module('Cython')
     runtest_autowrap_twice('C', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_autowrap_trace_C_Cython():
     has_module('Cython')
     runtest_autowrap_trace('C99', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_autowrap_matrix_vector_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_vector('C99', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_autowrap_matrix_matrix_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_matrix('C99', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_ufuncify_C_Cython():
     has_module('Cython')
     runtest_ufuncify('C99', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_issue_10274_C_cython():
     has_module('Cython')
     runtest_issue_10274('C89', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_issue_15337_C_cython():
     has_module('Cython')
     runtest_issue_15337('C89', 'cython')
 
 
+# Fails on Travis possibly due to updated dependencies:
+# https://github.com/sympy/sympy/issues/19700
+@XFAIL
 def test_autowrap_custom_printer():
     has_module('Cython')
 


### PR DESCRIPTION
Add XFAIL to some autowrap tests that are failing in CI most likely due
to updated dependencies:

See:  https://github.com/sympy/sympy/issues/19700

There might be a better way to fix this by pinning the dependencies. Most likely the root cause is a bug upstream but that isn't confirmed yet. This PR is a quick way to get CI back up and running so that other unrelated work can continue.

Adding XFAIL means that these can be unXFAILed if the tests start to pass again in future. It isn't clear that the issue is reported upstream anywhere though and I'm not sure even which dependencies the problem relates to.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->