### PR TITLE
use literal suffix for number in C89CodePrinter._print_Pow

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -277,7 +277,8 @@ class C89CodePrinter(CodePrinter):
         PREC = precedence(expr)
         suffix = self._get_func_suffix(real)
         if expr.exp == -1:
-            return '1.0%s/%s' % (suffix.upper(), self.parenthesize(expr.base, PREC))
+            literal_suffix = self._get_literal_suffix(real)
+            return '1.0%s/%s' % (literal_suffix, self.parenthesize(expr.base, PREC))
         elif expr.exp == 0.5:
             return '%ssqrt%s(%s)' % (self._ns, suffix, self._print(expr.base))
         elif expr.exp == S.One/3 and self.standard != 'C89':


### PR DESCRIPTION
Fixes #19709

#### Brief description of what is fixed or changed

Use the correct suffix for the 1.0 numerator in C89CodePrinter's _print_Pow when the exponent is -1. This does not change the default behaviour but will change the printed code if either the function suffix or the literal suffix have been changed.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Use literal suffix for 1.0 in C89CodePrinter's printing of pow when the exponent is -1
<!-- END RELEASE NOTES -->