### PR TITLE
Fix GeneratorsError for creating FractionField element with domain of PolynomialRing or FractionField

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -190,17 +190,27 @@ class FracField(DefaultPrinting):
         if isinstance(element, FracElement):
             if self == element.field:
                 return element
-            elif self.domain.field == element.field:
+
+            if isinstance(self.domain, FractionField) and \
+                self.domain.field == element.field:
+                return self.ground_new(element)
+            elif isinstance(self.domain, PolynomialRing) and \
+                self.domain.ring.to_field() == element.field:
                 return self.ground_new(element)
             else:
                 raise NotImplementedError("conversion")
         elif isinstance(element, PolyElement):
             denom, numer = element.clear_denoms()
+
             if isinstance(self.domain, PolynomialRing) and \
                 numer.ring == self.domain.ring:
                 numer = self.ring.ground_new(numer)
+            elif isinstance(self.domain, FractionField) and \
+                numer.ring == self.domain.field.to_ring():
+                numer = self.ring.ground_new(numer)
             else:
                 numer = numer.set_ring(self.ring)
+
             denom = self.ring.ground_new(denom)
             return self.raw_new(numer, denom)
         elif isinstance(element, tuple) and len(element) == 2:

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -190,11 +190,17 @@ class FracField(DefaultPrinting):
         if isinstance(element, FracElement):
             if self == element.field:
                 return element
+            elif self.domain.field == element.field:
+                return self.ground_new(element)
             else:
                 raise NotImplementedError("conversion")
         elif isinstance(element, PolyElement):
             denom, numer = element.clear_denoms()
-            numer = numer.set_ring(self.ring)
+            if isinstance(self.domain, PolynomialRing) and \
+                numer.ring == self.domain.ring:
+                numer = self.ring.ground_new(numer)
+            else:
+                numer = numer.set_ring(self.ring)
             denom = self.ring.ground_new(denom)
             return self.raw_new(numer, denom)
         elif isinstance(element, tuple) and len(element) == 2:

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -141,16 +141,17 @@ def test_FracField_nested():
     a, b, x = symbols('a b x')
     F1 = ZZ.frac_field(a, b)
     F2 = F1.frac_field(x)
-    numer = F2(a + b).numer
-    numer == F1.poly_ring(x)(a + b)
-    numer.coeffs() == [F1(a + b)]
-    F2(a + b).denom == F1.poly_ring(x)(1)
+    frac = F2(a + b)
+    assert frac.numer == F1.poly_ring(x)(a + b)
+    assert frac.numer.coeffs() == [F1(a + b)]
+    assert frac.denom == F1.poly_ring(x)(1)
 
     F1 = ZZ.poly_ring(a, b)
     F2 = F1.frac_field(x)
-    numer == F1.poly_ring(x)(a + b)
-    numer.coeffs() == [F1(a + b)]
-    F2(a + b).denom == F1.poly_ring(x)(1)
+    frac = F2(a + b)
+    assert frac.numer == F1.poly_ring(x)(a + b)
+    assert frac.numer.coeffs() == [F1(a + b)]
+    assert frac.denom == F1.poly_ring(x)(1)
 
 
 def test_FracElement__lt_le_gt_ge__():

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -146,12 +146,22 @@ def test_FracField_nested():
     assert frac.numer.coeffs() == [F1(a + b)]
     assert frac.denom == F1.poly_ring(x)(1)
 
-    F1 = ZZ.poly_ring(a, b)
-    F2 = F1.frac_field(x)
-    frac = F2(a + b)
+    F3 = ZZ.poly_ring(a, b)
+    F4 = F3.frac_field(x)
+    frac = F4(a + b)
+    assert frac.numer == F3.poly_ring(x)(a + b)
+    assert frac.numer.coeffs() == [F3(a + b)]
+    assert frac.denom == F3.poly_ring(x)(1)
+
+    frac = F2(F3(a + b))
     assert frac.numer == F1.poly_ring(x)(a + b)
     assert frac.numer.coeffs() == [F1(a + b)]
     assert frac.denom == F1.poly_ring(x)(1)
+
+    frac = F4(F1(a + b))
+    assert frac.numer == F3.poly_ring(x)(a + b)
+    assert frac.numer.coeffs() == [F3(a + b)]
+    assert frac.denom == F3.poly_ring(x)(1)
 
 
 def test_FracElement__lt_le_gt_ge__():

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -137,6 +137,22 @@ def test_FracElement_from_expr():
         FracElement)
 
 
+def test_FracField_nested():
+    a, b, x = symbols('a b x')
+    F1 = ZZ.frac_field(a, b)
+    F2 = F1.frac_field(x)
+    numer = F2(a + b).numer
+    numer == F1.poly_ring(x)(a + b)
+    numer.coeffs() == [F1(a + b)]
+    F2(a + b).denom == F1.poly_ring(x)(1)
+
+    F1 = ZZ.poly_ring(a, b)
+    F2 = F1.frac_field(x)
+    numer == F1.poly_ring(x)(a + b)
+    numer.coeffs() == [F1(a + b)]
+    F2(a + b).denom == F1.poly_ring(x)(1)
+
+
 def test_FracElement__lt_le_gt_ge__():
     F, x, y = field("x,y", ZZ)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19581

#### Brief description of what is fixed or changed

Fraction field can have domain of fraction field or polynomial ring 
and sometimes the coefficient itself can be the element from its domain.

This fixes two issues for constructing
`ZZ.frac_field(a, b).frac_field(x)(a+b)`
`ZZ.poly_ring(a, b).frac_field(x)(a+b)`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - Fixed `GeneratorsError` for creating some elements of `FractionField` when its ground domain is `FractionField` or `PolynomialRing`.

<!-- END RELEASE NOTES -->