### PR TITLE
[GSoC] Functions: Fixes limit evaluations related to LambertW function

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1488,7 +1488,7 @@ class Pow(Expr):
         #    g has order O(x**d) where d is strictly positive.
         # 2) Then b**e = (f**e)*((1 + g)**e).
         #    (1 + g)**e is computed using binomial series.
-        from sympy import im, I, ceiling, polygamma, logcombine, EulerGamma, exp, nan, zoo, log, factorial, ff, PoleError, O, powdenest, Wild
+        from sympy import im, I, ceiling, polygamma, limit, logcombine, EulerGamma, exp, nan, zoo, log, factorial, ff, PoleError, O, powdenest, Wild
         from itertools import product
         self = powdenest(self, force=True).trigsimp()
         b, e = self.as_base_exp()
@@ -1553,7 +1553,14 @@ class Pow(Expr):
                     res[ex] = res.get(ex, S.Zero) + d1[e1]*d2[e2]
             return res
 
-        _, d = g.leadterm(x)
+        try:
+            _, d = g.leadterm(x)
+        except (ValueError, NotImplementedError):
+            if limit(g/x**maxpow, x, 0) == 0:
+                # g has higher order zero
+                return f**e + e*f**e*g  # first term of binomial series
+            else:
+                raise NotImplementedError()
         if not d.is_positive:
             g = (b - f).simplify()/f
             _, d = g.leadterm(x)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -286,6 +286,7 @@ def test_nseries():
     assert cbrt(I*x - 1)._eval_nseries(x, 4, None, -1) == (-1)**(S(1)/3)*exp(-2*I*pi/3) - \
     (-1)**(S(5)/6)*x*exp(-2*I*pi/3)/3 + (-1)**(S(1)/3)*x**2*exp(-2*I*pi/3)/9 + \
     5*(-1)**(S(5)/6)*x**3*exp(-2*I*pi/3)/81 + O(x**4)
+    assert (1 / (exp(-1/x) + 1/x))._eval_nseries(x, 2, None) == -x**2*exp(-1/x) + x
 
 
 def test_issue_6100_12942_4473():

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1004,6 +1004,7 @@ class LambertW(Function):
 
     .. [1] https://en.wikipedia.org/wiki/Lambert_W_function
     """
+    _singularities = (-Pow(S.Exp1, -1, evaluate=False), S.ComplexInfinity)
 
     @classmethod
     def eval(cls, x, k=None):

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -241,7 +241,7 @@ class Limit(Expr):
                 newe = e.subs(z, z + z0)
             try:
                 coeff, ex = newe.leadterm(z, cdir)
-            except ValueError:
+            except (ValueError, NotImplementedError):
                 pass
             else:
                 if ex > 0:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -794,6 +794,12 @@ def test_issue_18508():
     assert limit(sin(x)/sqrt(1-cos(x)), x, 0, dir='-') == -sqrt(2)
 
 
+def test_issue_18969():
+    a, b = symbols('a b', positive=True)
+    assert limit(LambertW(a), a, b) == LambertW(b)
+    assert limit(exp(LambertW(a)), a, b) == exp(LambertW(b))
+
+
 def test_issue_18992():
     assert limit(n/(factorial(n)**(1/n)), n, oo) == exp(1)
 


### PR DESCRIPTION
Fixes: #18969

#### Brief description of what is fixed or changed

Adds `_singularities` to `LambertW` function.

Made minor changes to `Pow._eval_nseries` to have a more general series expansion.


#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* functions
  * Adds `_singularities` to `LambertW` function
<!-- END RELEASE NOTES -->