### PR TITLE
[GSoC] Extending/Changing checkodesol, constants_renumber and linear_ode_to_matrix

### DIFF
--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -329,13 +329,6 @@ Nonlinear, 3 equations, Order 1, Type 5
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode::_nonlinear_3eq_order1_type5
 
-Other useful functions
-----------------------
-
-checksysodesol
-^^^^^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.subscheck::checksysodesol
-
 Information on the ode module
 -----------------------------
 

--- a/sympy/solvers/ode/subscheck.py
+++ b/sympy/solvers/ode/subscheck.py
@@ -48,7 +48,8 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     r"""
     Substitutes ``sol`` into ``ode`` and checks that the result is ``0``.
 
-    This only works when ``func`` is one function, like `f(x)`.  ``sol`` can
+    This works when ``func`` is one function, like `f(x)` or a list of
+    functions like `[f(x), g(x)]` when `ode` is a system of ODEs.  ``sol`` can
     be a single solution or a list of solutions.  Each solution may be an
     :py:class:`~sympy.core.relational.Equality` that the solution satisfies,
     e.g. ``Eq(f(x), C1), Eq(f(x) + C1, 0)``; or simply an
@@ -92,8 +93,8 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     ========
 
     >>> from sympy import Eq, Function, checkodesol, symbols
-    >>> x, C1 = symbols('x,C1')
-    >>> f = Function('f')
+    >>> x, C1, C2 = symbols('x,C1,C2')
+    >>> f, g = Function('f')
     >>> checkodesol(f(x).diff(x), Eq(f(x), C1))
     (True, 0)
     >>> assert checkodesol(f(x).diff(x), C1)[0]
@@ -101,7 +102,15 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     >>> checkodesol(f(x).diff(x, 2), x**2)
     (False, 2)
 
+    >>> eqs = [Eq(Derivative(f(x), x), f(x)), Eq(Derivative(g(x), x), g(x))]
+    >>> sol = [Eq(f(x), C1*exp(x)), Eq(g(x), C2*exp(x))]
+    >>> checkodesol(eqs, sol)
+    (True, [0, 0])
+
     """
+    if iterable(ode):
+        return checksysodesol(ode, sol, func=func)
+
     if not isinstance(ode, Equality):
         ode = Eq(ode, 0)
     if func is None:

--- a/sympy/solvers/ode/subscheck.py
+++ b/sympy/solvers/ode/subscheck.py
@@ -92,9 +92,10 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     Examples
     ========
 
-    >>> from sympy import Eq, Function, checkodesol, symbols
+    >>> from sympy import (Eq, Function, checkodesol, symbols,
+    ...     Derivative, exp)
     >>> x, C1, C2 = symbols('x,C1,C2')
-    >>> f, g = Function('f')
+    >>> f, g = symbols('f g', cls=Function)
     >>> checkodesol(f(x).diff(x), Eq(f(x), C1))
     (True, 0)
     >>> assert checkodesol(f(x).diff(x), C1)[0]

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -591,7 +591,7 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False):
 
     >>> from sympy import symbols, Function, Eq
     >>> from sympy.solvers.ode.systems import canonical_odes, linear_ode_to_matrix, linodesolve, linodesolve_type
-    >>> from sympy.solvers.ode.subscheck import checksysodesol
+    >>> from sympy.solvers.ode.subscheck import checkodesol
     >>> f, g = symbols("f, g", cls=Function)
     >>> x, a = symbols("x, a")
     >>> funcs = [f(x), g(x)]
@@ -618,10 +618,10 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False):
     >>> system_info = linodesolve_type(A, x, b=b)
     >>> sol_vector = linodesolve(A, x, b=b, B=system_info['antiderivative'], type=system_info['type'])
 
-    Now, we can prove if the solution is correct or not by using :obj:`sympy.solvers.ode.subscheck.checksysodesol()`
+    Now, we can prove if the solution is correct or not by using :obj:`sympy.solvers.ode.checkodesol()`
 
     >>> sol = [Eq(f, s) for f, s in zip(funcs, sol_vector)]
-    >>> checksysodesol(eqs, sol)
+    >>> checkodesol(eqs, sol)
     (True, [0, 0])
 
     We can also use the doit method to evaluate the solutions passed by the function.
@@ -652,7 +652,7 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False):
     Once again, we can verify the solution obtained.
 
     >>> sol = [Eq(f, s) for f, s in zip(funcs, sol_vector)]
-    >>> checksysodesol(eqs, sol)
+    >>> checkodesol(eqs, sol)
     (True, [0, 0])
 
     Returns

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -174,7 +174,7 @@ def linear_ode_to_matrix(eqs, funcs, t, order):
     matrix differential equation [1]. For example the system $x' = x + y + 1$
     and $y' = x - y$ can be represented as
 
-    .. math:: A_1 X' + A_0 X = b
+    .. math:: A_1 X' = A0 X + b
 
     where $A_1$ and $A_0$ are $2 \times 2$ matrices and $b$, $X$ and $X'$ are
     $2 \times 1$ matrices with $X = [x, y]^T$.
@@ -182,7 +182,7 @@ def linear_ode_to_matrix(eqs, funcs, t, order):
     Higher-order systems are represented with additional matrices e.g. a
     second-order system would look like
 
-    .. math:: A_2 X'' + A_1 X' + A_0 X = b
+    .. math:: A_2 X'' =  A_1 X' + A_0 X  + b
 
     Examples
     ========
@@ -212,8 +212,8 @@ def linear_ode_to_matrix(eqs, funcs, t, order):
     [0, 1]])
     >>> A0
     Matrix([
-    [-1, -1],
-    [-1,  1]])
+    [1, 1],
+    [1,  -1]])
     >>> b
     Matrix([
     [1],
@@ -223,7 +223,7 @@ def linear_ode_to_matrix(eqs, funcs, t, order):
 
     >>> eqs_mat = Matrix([eq.lhs - eq.rhs for eq in eqs])
     >>> X = Matrix(funcs)
-    >>> A1 * X.diff(t) + A0 * X - b == eqs_mat
+    >>> A1 * X.diff(t) - A0 * X - b == eqs_mat
     True
 
     If the system of equations has a maximum order greater than the
@@ -308,7 +308,7 @@ def linear_ode_to_matrix(eqs, funcs, t, order):
 
         Ai = Ai.applyfunc(expand_mul)
 
-        As.append(Ai)
+        As.append(Ai if o == order else -Ai)
 
         if o:
             eqs = [-eq for eq in b]
@@ -609,7 +609,7 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False):
     non-homogeneous term if it is there.
 
     >>> (A1, A0), b = linear_ode_to_matrix(eqs, funcs, x, 1)
-    >>> A = -A0
+    >>> A = A0
 
     We have the coefficient matrices and the non-homogeneous term ready. Now, we can use
     :obj:`sympy.solvers.ode.systems.linodesolve_type()` to get the information for the system of ODEs
@@ -635,7 +635,7 @@ def linodesolve(A, t, b=None, B=None, type="auto", doit=False):
     The system defined above is already in the desired form, so we don't have to convert it.
 
     >>> (A1, A0), b = linear_ode_to_matrix(eqs, funcs, x, 1)
-    >>> A = -A0
+    >>> A = A0
 
     A user can also pass the commutative antidervative required for type3 and type4 system of ODEs.
     Passing an incorrect one will lead to incorrect results. If the coefficient matrix is not commutative
@@ -1054,7 +1054,7 @@ def neq_nth_linear_constant_coeff_match(eqs, funcs, t):
             match['rhs'] = b
 
         try:
-            system_info = linodesolve_type(-A, t, b=b)
+            system_info = linodesolve_type(A, t, b=b)
         except NotImplementedError:
             return None
 
@@ -1099,7 +1099,7 @@ def _linear_ode_solver(match):
     funcs = match['func']
 
     rhs = match.get('rhs', None)
-    A = -match['func_coeff']
+    A = match['func_coeff']
     B = match.get('commutative_antiderivative', None)
     type_of_equation = match['type_of_equation']
 

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -2073,6 +2073,17 @@ def test_constant_renumber_order_issue_5308():
         assert constant_renumber(a*(b + x)*(c + y)) == e
 
 
+def test_constant_renumber():
+    e1, e2, x, y = symbols("e1:3 x y")
+    exprs = [e2*x, e1*x + e2*y]
+
+    assert constant_renumber(exprs[0]) == e2*x
+    assert constant_renumber(exprs[0], variables=[x]) == C1*x
+    assert constant_renumber(exprs[0], variables=[x], newconstants=[C2]) == C2*x
+    assert constant_renumber(exprs, variables=[x, y]) == [C1*x, C1*y + C2*x]
+    assert constant_renumber(exprs, variables=[x, y], newconstants=symbols("C3:5")) == [C3*x, C3*y + C4*x]
+
+
 def test_issue_5770():
     k = Symbol("k", real=True)
     t = Symbol('t')

--- a/sympy/solvers/ode/tests/test_subscheck.py
+++ b/sympy/solvers/ode/tests/test_subscheck.py
@@ -63,6 +63,10 @@ def test_checkodesol():
     sol = Eq(f(x), C1*besselj(5*I, sqrt(2)*x) + C2*bessely(5*I, sqrt(2)*x))
     assert checkodesol(eq, sol) == (True, 0)
 
+    eqs = [Eq(f(x).diff(x), f(x) + g(x)), Eq(g(x).diff(x), f(x) + g(x))]
+    sol = [Eq(f(x), -C1 + C2*exp(2*x)), Eq(g(x), C1 + C2*exp(2*x))]
+    assert checkodesol(eqs, sol) == (True, [0, 0])
+
 
 def test_checksysodesol():
     x, y, z = symbols('x, y, z', cls=Function)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -28,22 +28,22 @@ def test_linear_ode_to_matrix():
     h2 = h(t).diff(t, 2)
 
     eqs_1 = [Eq(f1, g(t)), Eq(g1, f(t))]
-    sol_1 = ([Matrix([[1, 0], [0, 1]]), Matrix([[ 0, -1], [-1,  0]])], Matrix([[0],[0]]))
+    sol_1 = ([Matrix([[1, 0], [0, 1]]), Matrix([[ 0, 1], [1,  0]])], Matrix([[0],[0]]))
     assert linear_ode_to_matrix(eqs_1, funcs[:-1], t, 1) == sol_1
 
     eqs_2 = [Eq(f1, f(t) + 2*g(t)), Eq(g1, h(t)), Eq(h1, g(t) + h(t) + f(t))]
-    sol_2 = ([Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), Matrix([[-1, -2,  0], [ 0,  0, -1], [-1, -1, -1]])],
+    sol_2 = ([Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), Matrix([[1, 2,  0], [ 0,  0, 1], [1, 1, 1]])],
              Matrix([[0], [0], [0]]))
     assert linear_ode_to_matrix(eqs_2, funcs, t, 1) == sol_2
 
     eqs_3 = [Eq(2*f1 + 3*h1, f(t) + g(t)), Eq(4*h1 + 5*g1, f(t) + h(t)), Eq(5*f1 + 4*g1, g(t) + h(t))]
-    sol_3 = ([Matrix([[2, 0, 3], [0, 5, 4], [5, 4, 0]]), Matrix([[-1, -1,  0], [-1,  0, -1], [0, -1, -1]])],
+    sol_3 = ([Matrix([[2, 0, 3], [0, 5, 4], [5, 4, 0]]), Matrix([[1, 1,  0], [1,  0, 1], [0, 1, 1]])],
              Matrix([[0], [0], [0]]))
     assert linear_ode_to_matrix(eqs_3, funcs, t, 1) == sol_3
 
     eqs_4 = [Eq(f2 + h(t), f1 + g(t)), Eq(2*h2 + g2 + g1 + g(t), 0), Eq(3*h1, 4)]
-    sol_4 = ([Matrix([[1, 0, 0], [0, 1, 2], [0, 0, 0]]), Matrix([[-1, 0, 0], [0, 1, 0], [0, 0, 3]]),
-              Matrix([[0, -1, 1], [0,  1, 0], [0, 0, 0]])], Matrix([[0], [0], [4]]))
+    sol_4 = ([Matrix([[1, 0, 0], [0, 1, 2], [0, 0, 0]]), Matrix([[1, 0, 0], [0, -1, 0], [0, 0, -3]]),
+              Matrix([[0, 1, -1], [0,  -1, 0], [0, 0, 0]])], Matrix([[0], [0], [4]]))
     assert linear_ode_to_matrix(eqs_4, funcs, t, 2) == sol_4
 
     eqs_5 = [Eq(f2, g(t)), Eq(f1 + g1, f(t))]
@@ -94,7 +94,7 @@ def test_neq_nth_linear_constant_coeff_match():
      'is_linear': True,
      'is_constant': True,
      'is_homogeneous': True,
-     'func_coeff': Matrix([
+     'func_coeff': -Matrix([
      [Rational(12, 5), Rational(-6, 5), 0, 0],
      [Rational(-11, 2),  Rational(3, 2),   0, 0],
      [0, 0, 0, 1],
@@ -114,7 +114,7 @@ def test_neq_nth_linear_constant_coeff_match():
      'is_linear': True,
      'is_constant': True,
      'is_homogeneous': True,
-     'func_coeff': Matrix([
+     'func_coeff': -Matrix([
          [Rational(12, 5), Rational(-6, 5), 0, 0],
          [Rational(-11, 2), Rational(3, 2), 0, 0],
          [0, 0, 0, -1],
@@ -130,7 +130,7 @@ def test_neq_nth_linear_constant_coeff_match():
     answer_6 = {'no_of_equation': 3, 'eq': (Eq(Derivative(x(t), t), 3*y(t) - 11*z(t)), Eq(Derivative(y(t), t), -3*x(t) + 7*z(t)),
             Eq(Derivative(z(t), t), 11*x(t) - 7*y(t))), 'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1},
             'is_linear': True, 'is_constant': True, 'is_homogeneous': True,
-            'func_coeff': Matrix([
+            'func_coeff': -Matrix([
                          [  0, -3, 11],
                          [  3,  0, -7],
                          [-11,  7,  0]]),
@@ -141,7 +141,7 @@ def test_neq_nth_linear_constant_coeff_match():
     eqs_7 = (Eq(x1, y(t)), Eq(y1, x(t)))
     answer_7 = {'no_of_equation': 2, 'eq': (Eq(Derivative(x(t), t), y(t)), Eq(Derivative(y(t), t), x(t))),
                 'func': [x(t), y(t)], 'order': {x(t): 1, y(t): 1}, 'is_linear': True, 'is_constant': True,
-                'is_homogeneous': True, 'func_coeff': Matrix([
+                'is_homogeneous': True, 'func_coeff': -Matrix([
                                                         [ 0, -1],
                                                         [-1,  0]]),
                 'type_of_equation': 'type1', 'is_general': True}
@@ -151,7 +151,7 @@ def test_neq_nth_linear_constant_coeff_match():
     answer_8 = {'no_of_equation': 3, 'eq': (Eq(Derivative(x(t), t), 21*x(t)), Eq(Derivative(y(t), t), 17*x(t) + 3*y(t)),
             Eq(Derivative(z(t), t), 5*x(t) + 7*y(t) + 9*z(t))), 'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1},
             'is_linear': True, 'is_constant': True, 'is_homogeneous': True,
-            'func_coeff': Matrix([
+            'func_coeff': -Matrix([
                             [-21,  0,  0],
                             [-17, -3,  0],
                             [ -5, -7, -9]]),
@@ -164,7 +164,7 @@ def test_neq_nth_linear_constant_coeff_match():
                 Eq(Derivative(y(t), t), x(t) + 13*y(t) + 9*z(t)), Eq(Derivative(z(t), t), 32*x(t) + 41*y(t) + 11*z(t))),
                 'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True,
                 'is_constant': True, 'is_homogeneous': True,
-                'func_coeff': Matrix([
+                'func_coeff': -Matrix([
                             [ -4,  -5,  -2],
                             [ -1, -13,  -9],
                             [-32, -41, -11]]),
@@ -176,7 +176,7 @@ def test_neq_nth_linear_constant_coeff_match():
                 Eq(4*Derivative(y(t), t), -15*x(t) + 15*z(t)), Eq(5*Derivative(z(t), t), 12*x(t) - 12*y(t))),
                 'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True,
                 'is_constant': True, 'is_homogeneous': True,
-                'func_coeff': Matrix([
+                'func_coeff': -Matrix([
                                 [  0, Rational(-20, 3),  Rational(20, 3)],
                                 [Rational(15, 4),     0, Rational(-15, 4)],
                                 [Rational(-12, 5), Rational(12, 5),  0]]),
@@ -186,14 +186,14 @@ def test_neq_nth_linear_constant_coeff_match():
     eq11 = (Eq(x1, 3*y(t) - 11*z(t)), Eq(y1, 7*z(t) - 3*x(t)), Eq(z1, 11*x(t) - 7*y(t)))
     sol11 = {'no_of_equation': 3, 'eq': (Eq(Derivative(x(t), t), 3*y(t) - 11*z(t)), Eq(Derivative(y(t), t), -3*x(t) + 7*z(t)),
             Eq(Derivative(z(t), t), 11*x(t) - 7*y(t))), 'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1},
-            'is_linear': True, 'is_constant': True, 'is_homogeneous': True, 'func_coeff': Matrix([
+            'is_linear': True, 'is_constant': True, 'is_homogeneous': True, 'func_coeff': -Matrix([
             [  0, -3, 11], [  3,  0, -7], [-11,  7,  0]]), 'type_of_equation': 'type1', 'is_general': True}
     assert neq_nth_linear_constant_coeff_match(eq11, funcs_2[:-1], t) == sol11
 
     eq12 = (Eq(Derivative(x(t), t), y(t)), Eq(Derivative(y(t), t), x(t)))
     sol12 = {'no_of_equation': 2, 'eq': (Eq(Derivative(x(t), t), y(t)), Eq(Derivative(y(t), t), x(t))),
              'func': [x(t), y(t)], 'order': {x(t): 1, y(t): 1}, 'is_linear': True, 'is_constant': True,
-             'is_homogeneous': True, 'func_coeff': Matrix([
+             'is_homogeneous': True, 'func_coeff': -Matrix([
             [0, -1],
             [-1, 0]]), 'type_of_equation': 'type1', 'is_general': True}
     assert neq_nth_linear_constant_coeff_match(eq12, [x(t), y(t)], t) == sol12
@@ -204,7 +204,7 @@ def test_neq_nth_linear_constant_coeff_match():
     Eq(Derivative(x(t), t), 21 * x(t)), Eq(Derivative(y(t), t), 17 * x(t) + 3 * y(t)),
     Eq(Derivative(z(t), t), 5 * x(t) + 7 * y(t) + 9 * z(t))), 'func': [x(t), y(t), z(t)],
              'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True, 'is_constant': True, 'is_homogeneous': True,
-             'func_coeff': Matrix([
+             'func_coeff': -Matrix([
                  [-21, 0, 0],
                  [-17, -3, 0],
                  [-5, -7, -9]]), 'type_of_equation': 'type1', 'is_general': True}
@@ -217,7 +217,7 @@ def test_neq_nth_linear_constant_coeff_match():
     Eq(Derivative(x(t), t), 4 * x(t) + 5 * y(t) + 2 * z(t)), Eq(Derivative(y(t), t), x(t) + 13 * y(t) + 9 * z(t)),
     Eq(Derivative(z(t), t), 32 * x(t) + 41 * y(t) + 11 * z(t))), 'func': [x(t), y(t), z(t)],
              'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True, 'is_constant': True, 'is_homogeneous': True,
-             'func_coeff': Matrix([
+             'func_coeff': -Matrix([
                  [-4, -5, -2],
                  [-1, -13, -9],
                  [-32, -41, -11]]), 'type_of_equation': 'type1', 'is_general': True}
@@ -229,7 +229,7 @@ def test_neq_nth_linear_constant_coeff_match():
     Eq(3 * Derivative(x(t), t), 20 * y(t) - 20 * z(t)), Eq(4 * Derivative(y(t), t), -15 * x(t) + 15 * z(t)),
     Eq(5 * Derivative(z(t), t), 12 * x(t) - 12 * y(t))), 'func': [x(t), y(t), z(t)],
              'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True, 'is_constant': True, 'is_homogeneous': True,
-             'func_coeff': Matrix([
+             'func_coeff': -Matrix([
                  [0, Rational(-20, 3), Rational(20, 3)],
                  [Rational(15, 4), 0, Rational(-15, 4)],
                  [Rational(-12, 5), Rational(12, 5), 0]]), 'type_of_equation': 'type1', 'is_general': True}
@@ -240,14 +240,14 @@ def test_neq_nth_linear_constant_coeff_match():
     sol1 = {'no_of_equation': 2, 'eq': (Eq(Derivative(x(t), t), x(t) + y(t) + 9),
         Eq(Derivative(y(t), t), 2*x(t) + 5*y(t) + 23)), 'func': [x(t), y(t)],
         'order': {x(t): 1, y(t): 1}, 'is_linear': True, 'is_constant': True, 'is_homogeneous': False, 'is_general': True,
-        'func_coeff': Matrix([[-1, -1], [-2, -5]]), 'rhs': Matrix([[ 9], [23]]), 'type_of_equation': 'type2'}
+        'func_coeff': -Matrix([[-1, -1], [-2, -5]]), 'rhs': Matrix([[ 9], [23]]), 'type_of_equation': 'type2'}
     assert neq_nth_linear_constant_coeff_match(eq1, funcs, t) == sol1
 
     # Non constant coefficient homogeneous ODEs
     eq1 = (Eq(diff(x(t), t), 5*t*x(t) + 2*y(t)), Eq(diff(y(t), t), 2*x(t) + 5*t*y(t)))
     sol1 = {'no_of_equation': 2, 'eq': (Eq(Derivative(x(t), t), 5*t*x(t) + 2*y(t)), Eq(Derivative(y(t), t), 5*t*y(t) + 2*x(t))),
             'func': [x(t), y(t)], 'order': {x(t): 1, y(t): 1}, 'is_linear': True, 'is_constant': False,
-            'is_homogeneous': True, 'func_coeff': Matrix([ [-5*t,   -2], [  -2, -5*t]]), 'commutative_antiderivative': Matrix([
+            'is_homogeneous': True, 'func_coeff': -Matrix([ [-5*t,   -2], [  -2, -5*t]]), 'commutative_antiderivative': Matrix([
             [5*t**2/2,      2*t], [     2*t, 5*t**2/2]]), 'type_of_equation': 'type3', 'is_general': True}
     assert neq_nth_linear_constant_coeff_match(eq1, funcs, t) == sol1
 
@@ -255,7 +255,7 @@ def test_neq_nth_linear_constant_coeff_match():
     eq1 = [Eq(x1, x(t) + t*y(t) + t), Eq(y1, t*x(t) + y(t))]
     sol1 = {'no_of_equation': 2, 'eq': [Eq(Derivative(x(t), t), t*y(t) + t + x(t)), Eq(Derivative(y(t), t),
             t*x(t) + y(t))], 'func': [x(t), y(t)], 'order': {x(t): 1, y(t): 1}, 'is_linear': True,
-            'is_constant': False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': Matrix([ [-1, -t],
+            'is_constant': False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': -Matrix([ [-1, -t],
             [-t, -1]]), 'commutative_antiderivative': Matrix([ [     t, t**2/2], [t**2/2,      t]]), 'rhs':
             Matrix([ [t], [0]]), 'type_of_equation': 'type4'}
     assert neq_nth_linear_constant_coeff_match(eq1, funcs, t) == sol1
@@ -263,7 +263,7 @@ def test_neq_nth_linear_constant_coeff_match():
     eq2 = [Eq(x1, t*x(t) + t*y(t) + t), Eq(y1, t*x(t) + t*y(t) + cos(t))]
     sol2 = {'no_of_equation': 2, 'eq': [Eq(Derivative(x(t), t), t*x(t) + t*y(t) + t), Eq(Derivative(y(t), t),
             t*x(t) + t*y(t) + cos(t))], 'func': [x(t), y(t)], 'order': {x(t): 1, y(t): 1}, 'is_linear': True,
-            'is_constant': False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': Matrix([ [-t, -t],
+            'is_constant': False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': -Matrix([ [-t, -t],
             [-t, -t]]), 'commutative_antiderivative': Matrix([ [t**2/2, t**2/2], [t**2/2, t**2/2]]), 'rhs':
             Matrix([ [     t], [cos(t)]]), 'type_of_equation': 'type4'}
     assert neq_nth_linear_constant_coeff_match(eq2, funcs, t) == sol2
@@ -272,7 +272,7 @@ def test_neq_nth_linear_constant_coeff_match():
     sol3 = {'no_of_equation': 3, 'eq': [Eq(Derivative(x(t), t), t*(x(t) + y(t) + z(t) + 1)),
             Eq(Derivative(y(t), t), t*(x(t) + y(t) + z(t))), Eq(Derivative(z(t), t), t*(x(t) + y(t) + z(t)))],
             'func': [x(t), y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True, 'is_constant':
-            False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': Matrix([ [-t, -t, -t], [-t, -t,
+            False, 'is_homogeneous': False, 'is_general': True, 'func_coeff': -Matrix([ [-t, -t, -t], [-t, -t,
             -t], [-t, -t, -t]]), 'commutative_antiderivative': Matrix([ [t**2/2, t**2/2, t**2/2], [t**2/2,
             t**2/2, t**2/2], [t**2/2, t**2/2, t**2/2]]), 'rhs': Matrix([ [t], [0], [0]]), 'type_of_equation':
             'type4'}
@@ -282,7 +282,7 @@ def test_neq_nth_linear_constant_coeff_match():
     sol4 = {'no_of_equation': 3, 'eq': [Eq(Derivative(x(t), t), t*z(t) + x(t) + y(t) + 1), Eq(Derivative(y(t),
             t), t*y(t) + x(t) + z(t) + 10), Eq(Derivative(z(t), t), t*x(t) + t + y(t) + z(t))], 'func': [x(t),
             y(t), z(t)], 'order': {x(t): 1, y(t): 1, z(t): 1}, 'is_linear': True, 'is_constant': False,
-            'is_homogeneous': False, 'is_general': True, 'func_coeff': Matrix([ [-1, -1, -t], [-1, -t, -1], [-t,
+            'is_homogeneous': False, 'is_general': True, 'func_coeff': -Matrix([ [-1, -1, -t], [-1, -t, -1], [-t,
             -1, -1]]), 'commutative_antiderivative': Matrix([ [     t,      t, t**2/2], [     t, t**2/2,
             t], [t**2/2,      t,      t]]), 'rhs': Matrix([ [ 1], [10], [ t]]), 'type_of_equation': 'type4'}
     assert neq_nth_linear_constant_coeff_match(eq4, funcs_2[:-1], t) == sol4
@@ -293,7 +293,7 @@ def test_neq_nth_linear_constant_coeff_match():
             Eq(Derivative(y(t), t), t*(w(t) + x(t) + y(t) + z(t))), Eq(Derivative(z(t), t), t*(w(t) + x(t) +
             y(t) + z(t)) + 1), Eq(Derivative(w(t), t), t*(w(t) + x(t) + y(t) + z(t)))], 'func': [x(t), y(t),
             z(t), w(t)], 'order': {x(t): 1, y(t): 1, z(t): 1, w(t): 1}, 'is_linear': True, 'is_constant': False,
-            'is_homogeneous': False, 'is_general': True, 'func_coeff': Matrix([ [-t, -t, -t, -t], [-t, -t, -t,
+            'is_homogeneous': False, 'is_general': True, 'func_coeff': -Matrix([ [-t, -t, -t, -t], [-t, -t, -t,
             -t], [-t, -t, -t, -t], [-t, -t, -t, -t]]), 'commutative_antiderivative': Matrix([ [t**2/2, t**2/2,
             t**2/2, t**2/2], [t**2/2, t**2/2, t**2/2, t**2/2], [t**2/2, t**2/2, t**2/2, t**2/2], [t**2/2,
             t**2/2, t**2/2, t**2/2]]), 'rhs': Matrix([ [0], [0], [1], [0]]), 'type_of_equation': 'type4'}
@@ -1263,7 +1263,7 @@ def test_linodesolve():
     eq = [Eq(f(t).diff(t) + g(t).diff(t), g(t)), Eq(g(t).diff(t), f(t))]
     ceq = canonical_odes(eq, func, t)
     (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
-    A = -A0
+    A = A0
     sol = [C1*(-Rational(1, 2) + sqrt(5)/2)*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*(-sqrt(5)/2 - Rational(1, 2))*
            exp(t*(-sqrt(5)/2 - Rational(1, 2))),
             C1*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*exp(t*(-sqrt(5)/2 - Rational(1, 2)))]
@@ -1302,7 +1302,7 @@ def test_linodesolve():
     eq = [Eq(f(t).diff(t) + g(t).diff(t), g(t) + t), Eq(g(t).diff(t), f(t))]
     ceq = canonical_odes(eq, func, t)
     (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
-    A = -A0
+    A = A0
     sol = [-C1*exp(-t/2 + sqrt(5)*t/2)/2 + sqrt(5)*C1*exp(-t/2 + sqrt(5)*t/2)/2 - sqrt(5)*C2*exp(-sqrt(5)*t/2
             - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 +
             sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5, t)/2 + sqrt(5)*exp(-t/2 +
@@ -1344,7 +1344,7 @@ def test_linodesolve():
     eq = [Eq(f(t).diff(t), f(t) + t*g(t)), Eq(g(t).diff(t), -t*f(t) + g(t))]
     ceq = canonical_odes(eq, func, t)
     (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
-    A = -A0
+    A = A0
     sol = [(C1/2 - I*C2/2)*exp(I*t**2/2 + t) + (C1/2 + I*C2/2)*exp(-I*t**2/2 + t),
             (-I*C1/2 + C2/2)*exp(-I*t**2/2 + t) + (I*C1/2 + C2/2)*exp(I*t**2/2 + t)]
     assert _remove_dummies(linodesolve(A, t), t) == sol
@@ -1385,7 +1385,7 @@ def test_linodesolve():
             Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)) + 1)]
     ceq = canonical_odes(eq, func, x)
     (A1, A0), b = linear_ode_to_matrix(ceq, func, x, 1)
-    A = -A0
+    A = A0
     _x1 = exp(3*x**2/2)
     _x2 = Integral(x/3 + 2*x*exp(-3*x**2/2)/3 - Rational(1, 3) + exp(-3*x**2/2)/3, x)
     _x3 = Integral(-2*x/3 + 2*x*exp(-3*x**2/2)/3 + Rational(2, 3) + exp(-3*x**2/2)/3, x)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -4,6 +4,7 @@ from sympy.core.containers import Tuple
 from sympy.functions import exp, cos, sin, log
 from sympy.matrices import dotprodsimp, NonSquareMatrixError
 from sympy.solvers.ode import dsolve
+from sympy.solvers.ode.ode import constant_renumber
 from sympy.solvers.ode.subscheck import checksysodesol
 from sympy.solvers.ode.systems import (neq_nth_linear_constant_coeff_match, linear_ode_to_matrix,
                                        ODEOrderError, ODENonlinearError, _simpsol, _solsimp,
@@ -526,16 +527,16 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq15, sol15) == (True, [0, 0])
 
     eq16 = [Eq(x(t).diff(t), a*x(t) + b*y(t)), Eq(y(t).diff(t), c*x(t))]
-    sol16 = [Eq(x(t), -2*C1*b*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2))/(a + sqrt(a**2 + 4*b*c)) - 2*C2*b*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2))/(a - sqrt(a**2 + 4*b*c))),
-            Eq(y(t), C1*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2)) + C2*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2)))]
+    sol16 = [Eq(x(t), -2*C1*b*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2))/(a - sqrt(a**2 + 4*b*c)) - 2*C2*b*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2))/(a + sqrt(a**2 + 4*b*c))),
+            Eq(y(t), C1*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2)) + C2*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2)))]
     assert dsolve(eq16) == sol16
     assert checksysodesol(eq16, sol16) == (True, [0, 0])
 
     # Regression test case for issue #18562
     # https://github.com/sympy/sympy/issues/18562
     eq17 = [Eq(x(t).diff(t), x(t) + a*y(t)), Eq(y(t).diff(t), x(t)*a - y(t))]
-    sol17 = [Eq(x(t), -C1*a*exp(-t*sqrt(a**2 + 1))/(sqrt(a**2 + 1) + 1) + C2*a*exp(t*sqrt(a**2 + 1))/(sqrt(a**2 + 1) - 1)),
-            Eq(y(t), C1*exp(-t*sqrt(a**2 + 1)) + C2*exp(t*sqrt(a**2 + 1)))]
+    sol17 = [Eq(x(t), C1*a*exp(t*sqrt(a**2 + 1))/(sqrt(a**2 + 1) - 1) - C2*a*exp(-t*sqrt(a**2 + 1))/(sqrt(a**2 + 1) + 1)),
+            Eq(y(t), C1*exp(t*sqrt(a**2 + 1)) + C2*exp(-t*sqrt(a**2 + 1)))]
     assert dsolve(eq17) == sol17
     assert checksysodesol(eq17, sol17) == (True, [0, 0])
 
@@ -550,17 +551,17 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq19, sol19) == (True, [0, 0])
 
     eq20 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), x(t) + y(t))]
-    sol20 = [Eq(x(t), C2*exp(t)), Eq(y(t), (C1 + C2*t)*exp(t))]
+    sol20 = [Eq(x(t), C1*exp(t)), Eq(y(t), (C1*t + C2)*exp(t))]
     assert dsolve(eq20) == sol20
     assert checksysodesol(eq20, sol20) == (True, [0, 0])
 
-    eq21 = [Eq(x(t).diff(t), 3*x(t)), Eq(y(t).diff(t), x(t) + y(t))]
-    sol21 = [Eq(x(t), 2*C2*exp(3*t)), Eq(y(t), C1*exp(t) + C2*exp(3*t))]
+    eq21 = [Eq(Derivative(x(t), t), 3*x(t)), Eq(Derivative(y(t), t), x(t) + y(t))]
+    sol21 = [Eq(x(t), 2*C1*exp(3*t)), Eq(y(t), C1*exp(3*t) + C2*exp(t))]
     assert dsolve(eq21) == sol21
     assert checksysodesol(eq21, sol21) == (True, [0, 0])
 
-    eq22 = [Eq(x(t).diff(t), 3*x(t)), Eq(y(t).diff(t), y(t))]
-    sol22 = [Eq(x(t), C2*exp(3*t)), Eq(y(t), C1*exp(t))]
+    eq22 = [Eq(Derivative(x(t), t), 3*x(t)), Eq(Derivative(y(t), t), y(t))]
+    sol22 = [Eq(x(t), C1*exp(3*t)), Eq(y(t), C2*exp(t))]
     assert dsolve(eq22) == sol22
     assert checksysodesol(eq22, sol22) == (True, [0, 0])
 
@@ -571,52 +572,48 @@ def test_sysode_linear_neq_order1_type1():
 
     k01, k10, k20, k21, k23, k30 = symbols('k01 k10 k20 k21 k23 k30')
 
-    eq1 = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)), Eq(Derivative(Z1(t), t),
-         k01*Z0(t) - k10*Z1(t) + k21*Z2(t)), Eq(Derivative(Z2(t), t), -(k20 + k21 + k23)*Z2(t)), Eq(Derivative(Z3(t),
-         t), k23*Z2(t) - k30*Z3(t)))
-    sol1 = [
-        Eq(Z0(t), C1*k10/k01 + C2*(-k10 + k30)*exp(-k30*t)/(k01 + k10 - k30)
-            - C3*exp(t*(-k01 - k10)) + C4*(k10*k20 + k10*k21 - k10*k30
-            - k20**2 - k20*k21 - k20*k23 + k20*k30 + k23*k30)*exp(t*(-k20 - k21
-            - k23))/(k23*(k01 + k10 - k20 - k21 - k23))),
-        Eq(Z1(t), C1 - C2*k01*exp(-k30*t)/(k01 + k10 - k30) + C3*exp(t*(-k01
-            - k10)) + C4*(k01*k20 + k01*k21 - k01*k30 - k20*k21 - k21**2
-            - k21*k23 + k21*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10
-            - k20 - k21 - k23))),
-        Eq(Z2(t), C4*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23),
-        Eq(Z3(t), C2*exp(-k30*t) + C4*exp(t*(-k20 - k21 - k23)))
-    ]
+    eq1 = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)),
+           Eq(Derivative(Z1(t), t), k01*Z0(t) - k10*Z1(t) + k21*Z2(t)),
+           Eq(Derivative(Z2(t), t), -(k20 + k21 + k23)*Z2(t)), Eq(Derivative(Z3(t), t), k23*Z2(t) - k30*Z3(t)))
+    sol1 = [Eq(Z0(t), C1*k10/k01 + C2*(-k10 + k30)*exp(-k30*t)/(k01 + k10 - k30) + C3*(k10*k20 + k10*k21 - k10*k30 - k20**2 -
+                k20*k21 - k20*k23 + k20*k30 + k23*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23)) -
+                C4*exp(t*(-k01 - k10))),
+            Eq(Z1(t), C1 - C2*k01*exp(-k30*t)/(k01 + k10 - k30) + C3*(k01*k20 + k01*k21 - k01*k30 - k20*k21 - k21**2 -
+                k21*k23 + k21*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23)) + C4*exp(t*(-k01 - k10))),
+            Eq(Z2(t), C3*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23), Eq(Z3(t), C2*exp(-k30*t) +
+                C3*exp(t*(-k20 - k21 - k23)))]
 
     assert dsolve(eq1, simplify=False) == sol1
     assert checksysodesol(eq1, sol1) == (True, [0, 0, 0, 0])
 
-    x, y, z = symbols('x y z', cls=Function)
+    x, y, z, u, v, w = symbols('x y z u v w', cls=Function)
     k2, k3 = symbols('k2 k3')
+    a_b, a_c = symbols('a_b a_c', real=True)
     eq2 = (
         Eq(Derivative(z(t), t), k2*y(t)),
         Eq(Derivative(x(t), t), k3*y(t)),
         Eq(Derivative(y(t), t), (-k2 - k3)*y(t))
     )
-    sol2 = {Eq(z(t), C1 - C3*k2*exp(t*(-k2 - k3))/(k2 + k3)),
-            Eq(x(t), C2 - C3*k3*exp(t*(-k2 - k3))/(k2 + k3)),
-            Eq(y(t), C3*exp(t*(-k2 - k3)))}
+    sol2 = {Eq(z(t), C1 - C2*k2*exp(t*(-k2 - k3))/(k2 + k3)),
+            Eq(x(t), -C2*k3*exp(t*(-k2 - k3))/(k2 + k3) + C3),
+            Eq(y(t), C2*exp(t*(-k2 - k3)))}
     assert set(dsolve(eq2)) == sol2
     assert checksysodesol(eq2, sol2) == (True, [0, 0, 0])
 
-    u, v, w = symbols('u v w', cls=Function)
     eq3 = [4*u(t) - v(t) - 2*w(t) + Derivative(u(t), t),
            2*u(t) + v(t) - 2*w(t) + Derivative(v(t), t),
            5*u(t) + v(t) - 3*w(t) + Derivative(w(t), t)]
-    sol3 = [Eq(u(t), C1*exp(-2*t) + C2*cos(sqrt(3)*t)/2 - C3*sin(sqrt(3)*t)/2 + sqrt(3)*(C2*sin(sqrt(3)*t)
-            + C3*cos(sqrt(3)*t))/6), Eq(v(t), C2*cos(sqrt(3)*t)/2 - C3*sin(sqrt(3)*t)/2 + sqrt(3)*(C2*sin(sqrt(3)*t)
-            + C3*cos(sqrt(3)*t))/6), Eq(w(t), C1*exp(-2*t) + C2*cos(sqrt(3)*t) - C3*sin(sqrt(3)*t))]
+    sol3 = [Eq(u(t), C1*cos(sqrt(3)*t)/2 - C2*sin(sqrt(3)*t)/2 + C3*exp(-2*t) + sqrt(3)*(C1*sin(sqrt(3)*t) + C2*cos(sqrt(3)*t))/6),
+            Eq(v(t), C1*cos(sqrt(3)*t)/2 - C2*sin(sqrt(3)*t)/2 + sqrt(3)*(C1*sin(sqrt(3)*t) + C2*cos(sqrt(3)*t))/6),
+            Eq(w(t), C1*cos(sqrt(3)*t) - C2*sin(sqrt(3)*t) + C3*exp(-2*t))]
     assert dsolve(eq3) == sol3
     assert checksysodesol(eq3, sol3) == (True, [0, 0, 0])
 
     tw = Rational(2, 9)
     eq4 = [Eq(x(t).diff(t), 2*x(t) + y(t) - tw*4*z(t) - tw*w(t)),
            Eq(y(t).diff(t), 2*y(t) + 8*tw*z(t) + 2*tw*w(t)),
-           Eq(z(t).diff(t), Rational(37, 9)*z(t) - tw*w(t)), Eq(w(t).diff(t), 22*tw*w(t) - 2*tw*z(t))]
+           Eq(z(t).diff(t), Rational(37, 9)*z(t) - tw*w(t)),
+           Eq(w(t).diff(t), 22*tw*w(t) - 2*tw*z(t))]
 
     sol4 = [Eq(x(t), (C1 + C2*t)*exp(2*t)),
             Eq(y(t), C2*exp(2*t) + 2*C3*exp(4*t)),
@@ -633,79 +630,75 @@ def test_sysode_linear_neq_order1_type1():
     assert dsolve(eq5) == sol5
     assert checksysodesol(eq5, sol5) == (True, [0, 0, 0, 0])
 
-    eq6 = [Eq(x(t).diff(t), x(t) + y(t)), Eq(y(t).diff(t), y(t) + z(t)),
-           Eq(z(t).diff(t), z(t) + Rational(-1, 8)*w(t)),
-           Eq(w(t).diff(t), Rational(1, 2)*(w(t) + z(t)))]
-
-    sol6 = [Eq(x(t), (C3 + C4*t)*exp(t) + (4*C1 + 4*C2*t + 48*C2)*exp(3*t/4)),
-            Eq(y(t), C4*exp(t) + (-C1 - C2*t - 8*C2)*exp(3*t/4)),
-            Eq(z(t), (C1/4 + C2*t/4 + C2)*exp(3*t/4)),
-            Eq(w(t), (C1/2 + C2*t/2)*exp(3*t/4))]
-
+    eq6 = [Eq(Derivative(x(t), t), x(t) + y(t)),
+           Eq(Derivative(y(t), t), y(t) + z(t)),
+           Eq(Derivative(z(t), t), -w(t)/8 + z(t)),
+           Eq(Derivative(w(t), t), w(t)/2 + z(t)/2)]
+    sol6 = [Eq(x(t), (C1 + C2*t)*exp(t) + (4*C3 + 4*C4*t + 48*C4)*exp(3*t/4)),
+            Eq(y(t), C2*exp(t) + (-C3 - C4*t - 8*C4)*exp(3*t/4)),
+            Eq(z(t), (C3/4 + C4*t/4 + C4)*exp(3*t/4)),
+            Eq(w(t), (C3/2 + C4*t/2)*exp(3*t/4))]
     assert dsolve(eq6) == sol6
     assert checksysodesol(eq6, sol6) == (True, [0, 0, 0, 0])
 
     # Regression test case for issue #15574
     # https://github.com/sympy/sympy/issues/15574
-    eq7 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), y(t)), Eq(z(t).diff(t), z(t)),
-          Eq(w(t).diff(t), w(t)), Eq(u(t).diff(t), u(t))]
-
+    eq7 = [Eq(Derivative(x(t), t), x(t)), Eq(Derivative(y(t), t), y(t)), Eq(Derivative(z(t), t), z(t)),
+           Eq(Derivative(w(t), t), w(t)), Eq(Derivative(u(t), t), u(t))]
     sol7 = [Eq(x(t), C1*exp(t)), Eq(y(t), C2*exp(t)), Eq(z(t), C3*exp(t)), Eq(w(t), C4*exp(t)),
-           Eq(u(t), C5*exp(t))]
-
+            Eq(u(t), C5*exp(t))]
     assert dsolve(eq7) == sol7
     assert checksysodesol(eq7, sol7) == (True, [0, 0, 0, 0, 0])
 
-    eq8 = [Eq(x(t).diff(t), 2*x(t) + y(t)), Eq(y(t).diff(t), 2*y(t)),
-           Eq(z(t).diff(t), 4*z(t)), Eq(w(t).diff(t), 5*w(t) + u(t)),
-           Eq(u(t).diff(t), 5*u(t))]
-
-    sol8 = [Eq(x(t), (C1 + C2*t)*exp(2*t)), Eq(y(t), C2*exp(2*t)), Eq(z(t), C3*exp(4*t)), Eq(w(t), (C4 + C5*t)*exp(5*t)),
+    eq8 = [Eq(Derivative(x(t), t), 2*x(t) + y(t)), Eq(Derivative(y(t), t), 2*y(t)),
+           Eq(Derivative(z(t), t), 4*z(t)),
+           Eq(Derivative(w(t), t), u(t) + 5*w(t)), Eq(Derivative(u(t), t), 5*u(t))]
+    sol8 = [Eq(x(t), (C1 + C2*t)*exp(2*t)), Eq(y(t), C2*exp(2*t)), Eq(z(t), C3*exp(4*t)),
+            Eq(w(t), (C4 + C5*t)*exp(5*t)),
             Eq(u(t), C5*exp(5*t))]
-
     assert dsolve(eq8) == sol8
     assert checksysodesol(eq8, sol8) == (True, [0, 0, 0, 0, 0])
 
     # Regression test case for issue #15574
     # https://github.com/sympy/sympy/issues/15574
-    eq9 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), y(t)), Eq(z(t).diff(t), z(t))]
+    eq9 = [Eq(Derivative(x(t), t), x(t)), Eq(Derivative(y(t), t), y(t)), Eq(Derivative(z(t), t), z(t))]
     sol9 = [Eq(x(t), C1*exp(t)), Eq(y(t), C2*exp(t)), Eq(z(t), C3*exp(t))]
     assert dsolve(eq9) == sol9
     assert checksysodesol(eq9, sol9) == (True, [0, 0, 0])
 
     # Regression test case for issue #15407
     # https://github.com/sympy/sympy/issues/15407
-    a_b, a_c = symbols('a_b a_c', real=True)
-
-    eq10 = [Eq(x(t).diff(t), (-a_b - a_c)*x(t)), Eq(y(t).diff(t), a_b*y(t)), Eq(z(t).diff(t), a_c*x(t))]
-    sol10 = [Eq(x(t), -C3*(a_b + a_c)*exp(t*(-a_b - a_c))/a_c), Eq(y(t), C2*exp(a_b*t)),
-            Eq(z(t), C1 + C3*exp(t*(-a_b - a_c)))]
+    eq10 = [Eq(Derivative(x(t), t), (-a_b - a_c)*x(t)), Eq(Derivative(y(t), t), a_b*y(t)), Eq(Derivative(z(t), t),
+                                                                                              a_c*x(t))]
+    sol10 = [Eq(x(t), -C1*(a_b + a_c)*exp(t*(-a_b - a_c))/a_c),
+             Eq(y(t), C2*exp(a_b*t)),
+             Eq(z(t), C1*exp(t*(-a_b - a_c)) + C3)]
     assert dsolve(eq10) == sol10
     assert checksysodesol(eq10, sol10) == (True, [0, 0, 0])
 
     # Regression test case for issue #14312
     # https://github.com/sympy/sympy/issues/14312
-    eq11 = (Eq(Derivative(x(t), t), k3*y(t)), Eq(Derivative(y(t), t), -(k3 + k2)*y(t)), Eq(Derivative(z(t), t), k2*y(t)))
-    sol11 = [Eq(x(t), C1 + C3*k3*exp(t*(-k2 - k3))/k2), Eq(y(t), -C3*(k2 + k3)*exp(t*(-k2 - k3))/k2),
-            Eq(z(t), C2 + C3*exp(t*(-k2 - k3)))]
+    eq11 = (Eq(Derivative(x(t), t), k3*y(t)), Eq(Derivative(y(t), t), (-k2 - k3)*y(t)), Eq(Derivative(z(t), t), k2*y(t)))
+    sol11 = [Eq(x(t), C1 + C2*k3*exp(t*(-k2 - k3))/k2),
+             Eq(y(t), -C2*(k2 + k3)*exp(t*(-k2 - k3))/k2),
+             Eq(z(t), C2*exp(t*(-k2 - k3)) + C3)]
     assert dsolve(eq11) == sol11
     assert checksysodesol(eq11, sol11) == (True, [0, 0, 0])
 
     # Regression test case for issue #14312
     # https://github.com/sympy/sympy/issues/14312
-    eq12 = (Eq(Derivative(z(t), t), k2*y(t)), Eq(Derivative(x(t), t), k3*y(t)), Eq(Derivative(y(t), t), -(k3 + k2)*y(t)))
-    sol12 = [Eq(z(t), C1 - C3*k2*exp(t*(-k2 - k3))/(k2 + k3)), Eq(x(t), C2 - C3*k3*exp(t*(-k2 - k3))/(k2 + k3)),
-            Eq(y(t), C3*exp(t*(-k2 - k3)))]
+    eq12 = (Eq(Derivative(z(t), t), k2*y(t)), Eq(Derivative(x(t), t), k3*y(t)), Eq(Derivative(y(t), t), (-k2 - k3)*y(t)))
+    sol12 = [Eq(z(t), C1 - C2*k2*exp(t*(-k2 - k3))/(k2 + k3)),
+             Eq(x(t), -C2*k3*exp(t*(-k2 - k3))/(k2 + k3) + C3),
+             Eq(y(t), C2*exp(t*(-k2 - k3)))]
     assert dsolve(eq12) == sol12
     assert checksysodesol(eq12, sol12) == (True, [0, 0, 0])
 
     # Regression test case for issue #15474
     # https://github.com/sympy/sympy/issues/15474
-    eq13 = [Eq(diff(f(t), t), 2*f(t) + g(t)),
-            Eq(diff(g(t), t), a*f(t))]
-    sol13 = [Eq(f(t), -C1*exp(t*(1 - sqrt(a + 1)))/(sqrt(a + 1) + 1) + C2*exp(t*(sqrt(a + 1) + 1))/(sqrt(a + 1) - 1)),
-            Eq(g(t), C1*exp(t*(1 - sqrt(a + 1))) + C2*exp(t*(sqrt(a + 1) + 1)))]
-
+    eq13 = [Eq(Derivative(f(t), t), 2*f(t) + g(t)), Eq(Derivative(g(t), t), a*f(t))]
+    sol13 = [Eq(f(t), C1*exp(t*(sqrt(a + 1) + 1))/(sqrt(a + 1) - 1) - C2*exp(t*(1 - sqrt(a + 1)))/(sqrt(a + 1) + 1)),
+             Eq(g(t), C1*exp(t*(sqrt(a + 1) + 1)) + C2*exp(t*(1 - sqrt(a + 1))))]
     assert dsolve(eq13) == sol13
     assert checksysodesol(eq13, sol13) == (True, [0, 0])
 
@@ -713,9 +706,11 @@ def test_sysode_linear_neq_order1_type1():
             Eq(g(t).diff(t), 4*h(t) - 2*f(t)),
             Eq(h(t).diff(t), 3*f(t) - 4*g(t))]
     sol14 = [Eq(f(t), 2*C1 - 8*C2*cos(sqrt(29)*t)/25 + 8*C3*sin(sqrt(29)*t)/25 - 3*sqrt(29)*(C2*sin(sqrt(29)*t)
-            + C3*cos(sqrt(29)*t))/25), Eq(g(t), 3*C1/2 - 6*C2*cos(sqrt(29)*t)/25 + 6*C3*sin(sqrt(29)*t)/25
-            + 4*sqrt(29)*(C2*sin(sqrt(29)*t) + C3*cos(sqrt(29)*t))/25), Eq(h(t), C1 + C2*cos(sqrt(29)*t)
-            - C3*sin(sqrt(29)*t))]
+                + C3*cos(sqrt(29)*t))/25),
+             Eq(g(t), 3*C1/2 - 6*C2*cos(sqrt(29)*t)/25 + 6*C3*sin(sqrt(29)*t)/25
+                + 4*sqrt(29)*(C2*sin(sqrt(29)*t) + C3*cos(sqrt(29)*t))/25),
+             Eq(h(t), C1 + C2*cos(sqrt(29)*t)
+                - C3*sin(sqrt(29)*t))]
 
     assert dsolve(eq14) == sol14
     assert checksysodesol(eq14, sol14) == (True, [0, 0, 0])
@@ -723,26 +718,29 @@ def test_sysode_linear_neq_order1_type1():
     eq15 = [Eq(2*f(t).diff(t), 3*4*(g(t) - h(t))),
             Eq(3*g(t).diff(t), 2*4*(h(t) - f(t))),
             Eq(4*h(t).diff(t), 2*3*(f(t) - g(t)))]
-    sol15 = [Eq(f(t), C1 - 16*C2*cos(sqrt(29)*t)/13 + 16*C3*sin(sqrt(29)*t)/13 - 6*sqrt(29)*(C2*sin(sqrt(29)*t)
-            + C3*cos(sqrt(29)*t))/13), Eq(g(t), C1 - 16*C2*cos(sqrt(29)*t)/13 + 16*C3*sin(sqrt(29)*t)/13
-            + 8*sqrt(29)*(C2*sin(sqrt(29)*t) + C3*cos(sqrt(29)*t))/39), Eq(h(t), C1 + C2*cos(sqrt(29)*t) - C3*sin(sqrt(29)*t))]
+    sol15 = [Eq(f(t), C1 - 16*C2*cos(sqrt(29)*t)/13 + 16*C3*sin(sqrt(29)*t)/13 - 6*sqrt(29)*(
+                C2*sin(sqrt(29)*t) + C3*cos(sqrt(29)*t))/13),
+            Eq(g(t), C1 - 16*C2*cos(sqrt(29)*t)/13 + 16*C3*sin(sqrt(29)*t)/13 + 8*sqrt(29)*(C2*sin(sqrt(29)*t) +
+                C3*cos(sqrt(29)*t))/39),
+            Eq(h(t), C1 + C2*cos(sqrt(29)*t) - C3*sin(sqrt(29)*t))]
 
     assert dsolve(eq15) == sol15
     assert checksysodesol(eq15, sol15) == (True, [0, 0, 0])
 
     eq16 = (Eq(diff(x(t), t), 21*x(t)), Eq(diff(y(t), t), 17*x(t) + 3*y(t)),
             Eq(diff(z(t), t), 5*x(t) + 7*y(t) + 9*z(t)))
-    sol16 = [Eq(x(t), 216*C3*exp(21*t)/209), Eq(y(t), -6*C1*exp(3*t)/7 + 204*C3*exp(21*t)/209),
-            Eq(z(t), C1*exp(3*t) + C2*exp(9*t) + C3*exp(21*t))]
-
+    sol16 = [Eq(x(t), 216*C1*exp(21*t)/209),
+             Eq(y(t), 204*C1*exp(21*t)/209 - 6*C2*exp(3*t)/7),
+             Eq(z(t), C1*exp(21*t) + C2*exp(3*t) + C3*exp(9*t))]
     assert dsolve(eq16) == sol16
     assert checksysodesol(eq16, sol16) == (True, [0, 0, 0])
 
     eq17 = (Eq(diff(x(t), t), 3*y(t) - 11*z(t)), Eq(diff(y(t), t), 7*z(t) - 3*x(t)), Eq(diff(z(t), t), 11*x(t) - 7*y(t)))
-    sol17 = [Eq(x(t), 7*C1/3 - 21*C2*cos(sqrt(179)*t)/170 + 21*C3*sin(sqrt(179)*t)/170 - 11*sqrt(179)*(C2*sin(sqrt(179)*t)
-            + C3*cos(sqrt(179)*t))/170), Eq(y(t), 11*C1/3 - 33*C2*cos(sqrt(179)*t)/170 + 33*C3*sin(sqrt(179)*t)/170
-            + 7*sqrt(179)*(C2*sin(sqrt(179)*t) + C3*cos(sqrt(179)*t))/170), Eq(z(t), C1 + C2*cos(sqrt(179)*t)
-            - C3*sin(sqrt(179)*t))]
+    sol17 = [Eq(x(t), 7*C1/3 - 21*C2*cos(sqrt(179)*t)/170 + 21*C3*sin(sqrt(179)*t)/170 - 11*sqrt(179)*(
+                C2*sin(sqrt(179)*t) + C3*cos(sqrt(179)*t))/170),
+             Eq(y(t), 11*C1/3 - 33*C2*cos(sqrt(179)*t)/170 + 33*C3*sin(sqrt(179)*t)/170 + 7*sqrt(179)*(
+                 C2*sin(sqrt(179)*t) + C3*cos(sqrt(179)*t))/170),
+             Eq(z(t), C1 + C2*cos(sqrt(179)*t) - C3*sin(sqrt(179)*t))]
 
     assert dsolve(eq17) == sol17
     assert checksysodesol(eq17, sol17) == (True, [0, 0, 0])
@@ -750,49 +748,47 @@ def test_sysode_linear_neq_order1_type1():
     eq18 = (Eq(3*diff(x(t), t), 4*5*(y(t) - z(t))), Eq(4*diff(y(t), t), 3*5*(z(t) - x(t))),
             Eq(5*diff(z(t), t), 3*4*(x(t) - y(t))))
     sol18 = [Eq(x(t), C1 - C2*cos(5*sqrt(2)*t) + C3*sin(5*sqrt(2)*t) - 4*sqrt(2)*(C2*sin(5*sqrt(2)*t) + C3*cos(5*sqrt(2)*t))/3),
-            Eq(y(t), C1 - C2*cos(5*sqrt(2)*t) + C3*sin(5*sqrt(2)*t) + 3*sqrt(2)*(C2*sin(5*sqrt(2)*t) + C3*cos(5*sqrt(2)*t))/4),
-            Eq(z(t), C1 + C2*cos(5*sqrt(2)*t) - C3*sin(5*sqrt(2)*t))]
+             Eq(y(t), C1 - C2*cos(5*sqrt(2)*t) + C3*sin(5*sqrt(2)*t) + 3*sqrt(2)*(C2*sin(5*sqrt(2)*t) + C3*cos(5*sqrt(2)*t))/4),
+             Eq(z(t), C1 + C2*cos(5*sqrt(2)*t) - C3*sin(5*sqrt(2)*t))]
 
     assert dsolve(eq18) == sol18
     assert checksysodesol(eq18, sol18) == (True, [0, 0, 0])
 
     eq19 = (Eq(diff(x(t), t), 4*x(t) - z(t)), Eq(diff(y(t), t), 2*x(t) + 2*y(t) - z(t)), Eq(diff(z(t), t), 3*x(t) + y(t)))
-    sol19 = [Eq(x(t), (C1 + C2*t + 2*C2 + C3*t**2/2 + 2*C3*t + C3)*exp(2*t)),
-            Eq(y(t), (C1 + C2*t + 2*C2 + C3*t**2/2 + 2*C3*t)*exp(2*t)),
-            Eq(z(t), (2*C1 + 2*C2*t + 3*C2 + C3*t**2 + 3*C3*t)*exp(2*t))]
-
+    sol19 = [Eq(x(t), (C1 + C2*t**2/2 + 2*C2*t + C2 + C3*t + 2*C3)*exp(2*t)),
+             Eq(y(t), (C1 + C2*t**2/2 + 2*C2*t + C3*t + 2*C3)*exp(2*t)),
+             Eq(z(t), (2*C1 + C2*t**2 + 3*C2*t + 2*C3*t + 3*C3)*exp(2*t))]
     assert dsolve(eq19) == sol19
     assert checksysodesol(eq19, sol19) == (True, [0, 0, 0])
 
     eq20 = (Eq(diff(x(t), t), 4*x(t) - y(t) - 2*z(t)), Eq(diff(y(t), t), 2*x(t) + y(t) - 2*z(t)),
             Eq(diff(z(t), t), 5*x(t) - 3*z(t)))
-    sol20 = [Eq(x(t), C1*exp(2*t) - C2*sin(t)/5 + 3*C2*cos(t)/5 - 3*C3*sin(t)/5 - C3*cos(t)/5),
-             Eq(y(t), -C2*sin(t)/5 + 3*C2*cos(t)/5 - 3*C3*sin(t)/5 - C3*cos(t)/5),
-             Eq(z(t), C1*exp(2*t) + C2*cos(t) - C3*sin(t))]
-
+    sol20 = [Eq(x(t), C1*exp(2*t) - 3*C2*sin(t)/5 - C2*cos(t)/5 - C3*sin(t)/5 + 3*C3*cos(t)/5),
+             Eq(y(t), -3*C2*sin(t)/5 - C2*cos(t)/5 - C3*sin(t)/5 + 3*C3*cos(t)/5),
+             Eq(z(t), C1*exp(2*t) - C2*sin(t) + C3*cos(t))]
     assert dsolve(eq20) == sol20
     assert checksysodesol(eq20, sol20) == (True, [0, 0, 0])
 
     eq21 = (Eq(diff(x(t), t), 9*y(t)), Eq(diff(y(t), t), 12*x(t)))
     sol21 = [Eq(x(t), -sqrt(3)*C1*exp(-6*sqrt(3)*t)/2 + sqrt(3)*C2*exp(6*sqrt(3)*t)/2),
-            Eq(y(t), C1*exp(-6*sqrt(3)*t) + C2*exp(6*sqrt(3)*t))]
+             Eq(y(t), C1*exp(-6*sqrt(3)*t) + C2*exp(6*sqrt(3)*t))]
 
     assert dsolve(eq21) == sol21
     assert checksysodesol(eq21, sol21) == (True, [0, 0])
 
-    eq22 = (Eq(diff(x(t), t), 2*x(t) + 4*y(t)), Eq(diff(y(t), t), 12*x(t) + 41*y(t)))
-    sol22 = [Eq(x(t), C1*(-sqrt(1713)/24 + Rational(-13, 8))*exp(t*(Rational(43, 2) - sqrt(1713)/2)) \
-            + C2*(Rational(-13, 8) + sqrt(1713)/24)*exp(t*(sqrt(1713)/2 + Rational(43, 2)))),
-            Eq(y(t), C1*exp(t*(Rational(43, 2) - sqrt(1713)/2)) + C2*exp(t*(sqrt(1713)/2 + Rational(43, 2))))]
-
+    eq22 = (Eq(Derivative(x(t), t), 2*x(t) + 4*y(t)), Eq(Derivative(y(t), t), 12*x(t) + 41*y(t)))
+    sol22 = [Eq(x(t), C1*(-Rational(13, 8) + sqrt(1713)/24)*exp(t*(sqrt(1713)/2 + Rational(43, 2))) + C2*(
+                - sqrt(1713)/24 - Rational(13, 8))*exp(t*(Rational(43, 2) - sqrt(1713)/2))),
+             Eq(y(t), C1*exp(t*(sqrt(1713)/2 + Rational(43, 2))) + C2*exp(t*(Rational(43, 2) - sqrt(1713)/2)))]
     assert dsolve(eq22) == sol22
     assert checksysodesol(eq22, sol22) == (True, [0, 0])
 
-    eq23 = (Eq(diff(x(t), t), x(t) + y(t)), Eq(diff(y(t), t), -2*x(t) + 2*y(t)))
-    sol23 = [Eq(x(t), (C1*cos(sqrt(7)*t/2)/4 - C2*sin(sqrt(7)*t/2)/4 + sqrt(7)*(C1*sin(sqrt(7)*t/2)
-                        + C2*cos(sqrt(7)*t/2))/4)*exp(3*t/2)),
-            Eq(y(t), (C1*cos(sqrt(7)*t/2) - C2*sin(sqrt(7)*t/2))*exp(3*t/2))]
-
+    eq23 = (Eq(Derivative(x(t), t), x(t) + y(t)), Eq(Derivative(y(t), t), -2*x(t) + 2*y(t)))
+    sol23 = [
+        Eq(x(t), (C1*cos(sqrt(7)*t/2)/4 - C2*sin(sqrt(7)*t/2)/4 + sqrt(7)*(C1*sin(sqrt(7)*t/2) + C2*cos(
+            sqrt(7)*t/2))/4)*exp(3*t/2)),
+        Eq(y(t), (C1*cos(sqrt(7)*t/2) - C2*sin(sqrt(7)*t/2))*exp(3*t/2))
+    ]
     assert dsolve(eq23) == sol23
     assert checksysodesol(eq23, sol23) == (True, [0, 0])
 
@@ -801,7 +797,6 @@ def test_sysode_linear_neq_order1_type1():
     a = Symbol("a", real=True)
     eq24 = [x(t).diff(t) - a*y(t), y(t).diff(t) + a*x(t)]
     sol24 = [Eq(x(t), C1*sin(a*t) + C2*cos(a*t)), Eq(y(t), C1*cos(a*t) - C2*sin(a*t))]
-
     assert dsolve(eq24) == sol24
     assert checksysodesol(eq24, sol24) == (True, [0, 0])
 
@@ -813,26 +808,28 @@ def test_sysode_linear_neq_order1_type1():
             Eq(Derivative(y(t), t), 1/(c*b)*(-2*y(t) + x(t) + h(t))),
             Eq(Derivative(h(t), t), 0)]
 
-    sol25 = [Eq(f(t), 4*C1 - 3*C2),
-             Eq(g(t), 3*C1 - 2*C2 - C3*exp(-2*t/(b*c)) + C4*exp(t*(-2 - sqrt(2))/(b*c)) + C5*exp(t*(-2 + sqrt(2))/(b*c))),
-             Eq(x(t), 2*C1 - C2 - sqrt(2)*C4*exp(t*(-2 - sqrt(2))/(b*c)) + sqrt(2)*C5*exp(t*(-2 + sqrt(2))/(b*c))),
-             Eq(y(t), C1 + C3*exp(-2*t/(b*c)) + C4*exp(t*(-2 - sqrt(2))/(b*c)) + C5*exp(t*(-2 + sqrt(2))/(b*c))),
-             Eq(h(t), C2)]
+    sol25 = [Eq(f(t), -3*C1 + 4*C2),
+             Eq(g(t), -2*C1 + 3*C2 - C3*exp(-2*t/(b*c)) + C4*exp(t*(-2 - sqrt(2))/(b*c)) +
+                C5*exp(t*(-2 + sqrt(2))/(b*c))),
+             Eq(x(t), -C1 + 2*C2 - sqrt(2)*C4*exp(t*(-2 - sqrt(2))/(b*c)) + sqrt(2)*C5*exp(t*(-2 + sqrt(2))/(b*c))),
+             Eq(y(t), C2 + C3*exp(-2*t/(b*c)) + C4*exp(t*(-2 - sqrt(2))/(b*c)) + C5*exp(
+                 t*(-2 + sqrt(2))/(b*c))),
+             Eq(h(t), C1)]
 
     assert dsolve(eq25) == sol25
     assert checksysodesol(eq25, sol25) == (True, [0, 0, 0, 0, 0])
 
-    eq26 = [Eq(diff(f(t), t), 2*f(t)), Eq(diff(g(t), t), 3*f(t) + 7*g(t))]
+    eq26 = [Eq(Derivative(f(t), t), 2*f(t)), Eq(Derivative(g(t), t), 3*f(t) + 7*g(t))]
     sol26 = [Eq(f(t), -5*C1*exp(2*t)/3), Eq(g(t), C1*exp(2*t) + C2*exp(7*t))]
     assert dsolve(eq26) == sol26
     assert checksysodesol(eq26, sol26) == (True, [0, 0])
 
-    eq27 = [Eq(diff(f(t), t), -9*I*f(t) - 4*g(t)), Eq(diff(g(t), t), -4*I*g(t))]
-    sol27 = [Eq(f(t), C1*exp(-9*I*t) + 4*I*C2*exp(-4*I*t)/5), Eq(g(t), C2*exp(-4*I*t))]
+    eq27 = [Eq(Derivative(f(t), t), -9*I*f(t) - 4*g(t)), Eq(Derivative(g(t), t), -4*I*g(t))]
+    sol27 = [Eq(f(t), 4*I*C1*exp(-4*I*t)/5 + C2*exp(-9*I*t)), Eq(g(t), C1*exp(-4*I*t))]
     assert dsolve(eq27) == sol27
     assert checksysodesol(eq27, sol27) == (True, [0, 0])
 
-    eq28 = [Eq(diff(f(t), t), -9*I*f(t)), Eq(diff(g(t), t), -4*I*g(t))]
+    eq28 = [Eq(Derivative(f(t), t), -9*I*f(t)), Eq(Derivative(g(t), t), -4*I*g(t))]
     sol28 = [Eq(f(t), C1*exp(-9*I*t)), Eq(g(t), C2*exp(-4*I*t))]
     assert dsolve(eq28) == sol28
     assert checksysodesol(eq28, sol28) == (True, [0, 0])
@@ -843,7 +840,7 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq29, sol29) == (True, [0, 0])
 
     eq30 = [Eq(Derivative(f(t), t), f(t)), Eq(Derivative(g(t), t), 0)]
-    sol30 = [Eq(f(t), C2 * exp(t)), Eq(g(t), C1)]
+    sol30 = [Eq(f(t), C1*exp(t)), Eq(g(t), C2)]
     assert dsolve(eq30) == sol30
     assert checksysodesol(eq30, sol30) == (True, [0, 0])
 
@@ -853,7 +850,7 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq31, sol31) == (True, [0, 0])
 
     eq32 = [Eq(Derivative(f(t), t), 0), Eq(Derivative(g(t), t), f(t))]
-    sol32 = [Eq(f(t), C2), Eq(g(t), C1 + C2*t)]
+    sol32 = [Eq(f(t), C1), Eq(g(t), C1*t + C2)]
     assert dsolve(eq32) == sol32
     assert checksysodesol(eq32, sol32) == (True, [0, 0])
 
@@ -868,7 +865,7 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq34, sol34) == (True, [0, 0])
 
     eq35 = [Eq(Derivative(f(t), t), I*f(t)), Eq(Derivative(g(t), t), -I*g(t))]
-    sol35 = [Eq(f(t), C2*exp(I*t)), Eq(g(t), C1*exp(-I*t))]
+    sol35 = [Eq(f(t), C1*exp(I*t)), Eq(g(t), C2*exp(-I*t))]
     assert dsolve(eq35) == sol35
     assert checksysodesol(eq35, sol35) == (True, [0, 0])
 
@@ -884,8 +881,10 @@ def test_sysode_linear_neq_order1_type1():
 
     # Multiple systems
     eq1 = [Eq(Derivative(f(t), t)**2, g(t)**2), Eq(-f(t) + Derivative(g(t), t), 0)]
-    sol1 = [[Eq(f(t), -C1*sin(t) - C2*cos(t)), Eq(g(t), C1*cos(t) - C2*sin(t))], [Eq(f(t), -C1*exp(-t) +
-            C2*exp(t)), Eq(g(t), C1*exp(-t) + C2*exp(t))]]
+    sol1 = [[Eq(f(t), -C1*sin(t) - C2*cos(t)),
+             Eq(g(t), C1*cos(t) - C2*sin(t))],
+            [Eq(f(t), -C1*exp(-t) + C2*exp(t)),
+             Eq(g(t), C1*exp(-t) + C2*exp(t))]]
     assert dsolve(eq1) == sol1
     for sol in sol1:
         assert checksysodesol(eq1, sol) == (True, [0, 0])
@@ -898,77 +897,62 @@ def test_sysode_linear_neq_order1_type2():
 
     eq1 = [Eq(diff(f(x), x),  f(x) + g(x) + 5),
            Eq(diff(g(x), x), -f(x) - g(x) + 7)]
-    sol1 = [Eq(f(x), C1 + C2*x + C2 + x*Integral(12, x) + Integral(12, x) + Integral(-12*x - 7, x)), Eq(g(x), -C1 -
-                C2*x - x*Integral(12, x) - Integral(-12*x - 7, x))]
+    sol1 = [Eq(f(x), C1 + C2*x + C2 + x*Integral(12, x) + Integral(12, x) + Integral(-12*x - 7, x)),
+            Eq(g(x), -C1 - C2*x - x*Integral(12, x) - Integral(-12*x - 7, x))]
     assert dsolve(eq1) == sol1
     assert checksysodesol(eq1, sol1) == (True, [0, 0])
 
     eq2 = [Eq(diff(f(x), x), f(x) + g(x) + 5),
            Eq(diff(g(x), x), f(x) + g(x) + 7)]
-    sol2 = [Eq(f(x), -C1 + C2*exp(2*x) + exp(2*x)*Integral(6*exp(-2*x), x) - Integral(1, x)), Eq(g(x), C1 + C2*exp(2*x)
-                + exp(2*x)*Integral(6*exp(-2*x), x) + Integral(1, x))]
+    sol2 = [Eq(f(x), -C1 + C2*exp(2*x) + exp(2*x)*Integral(6*exp(-2*x), x) - Integral(1, x)),
+            Eq(g(x), C1 + C2*exp(2*x) + exp(2*x)*Integral(6*exp(-2*x), x) + Integral(1, x))]
     assert dsolve(eq2) == sol2
     assert checksysodesol(eq2, sol2) == (True, [0, 0])
 
     eq3 = [Eq(diff(f(x), x), f(x) + 5), Eq(diff(g(x), x), f(x) + 7)]
-    sol3 = [Eq(f(x), C2*exp(x) + exp(x)*Integral(5*exp(-x), x)), Eq(g(x), C1 + C2*exp(x) + exp(x)*Integral(5*exp(-x), x)
-                + Integral(2, x))]
+    sol3 = [Eq(f(x), C1*exp(x) + exp(x)*Integral(5*exp(-x), x)),
+            Eq(g(x), C1*exp(x) + C2 + exp(x)*Integral(5*exp(-x), x) + Integral(2, x))]
     assert dsolve(eq3) == sol3
     assert checksysodesol(eq3, sol3) == (True, [0, 0])
 
     eq4 = [Eq(diff(f(x), x), f(x) + exp(x)), Eq(diff(g(x), x), f(x) + g(x) + x*exp(x))]
-    sol4 = [Eq(f(x), (C2 + Integral(1, x))*exp(x)), Eq(g(x), (C1 + C2*x + x*Integral(1, x) + Integral(0, x))*exp(x))]
+    sol4 = [Eq(f(x), (C1 + Integral(1, x))*exp(x)), Eq(g(x), (C1*x + C2 + x*Integral(1, x) + Integral(0, x))*exp(x))]
     assert dsolve(eq4) == sol4
     assert checksysodesol(eq4, sol4) == (True, [0, 0])
 
     eq5 = [Eq(diff(f(x), x), f(x) + g(x) + 5*x), Eq(diff(g(x), x), f(x) - g(x))]
-    sol5 = [Eq(f(x), C2*exp(sqrt(2)*x) + sqrt(2)*C2*exp(sqrt(2)*x) + (-sqrt(2)*C1
-            + C1 - sqrt(2)*Integral(5*sqrt(2)*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)) -
-            5*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)), x) +
-            Integral(5*sqrt(2)*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)) -
-            5*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)), x))*exp(-sqrt(2)*x) +
-            exp(sqrt(2)*x)*Integral(5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x) +
-            sqrt(2)*exp(sqrt(2)*x)*Integral(5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x)),
-            Eq(g(x), C2*exp(sqrt(2)*x) + (C1 +
-            Integral(5*sqrt(2)*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)) -
-            5*x*exp(sqrt(2)*x)/(-4 + 2*sqrt(2)), x))*exp(-sqrt(2)*x) +
-            exp(sqrt(2)*x)*Integral(5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x))]
-    with dotprodsimp(True):
-        assert dsolve(eq5) == sol5
+    sol5 = [Eq(f(x), C1*exp(sqrt(2)*x) + sqrt(2)*C1*exp(sqrt(2)*x) + (-sqrt(2)*C2 + C2 - sqrt(2)*Integral(
+                -5*sqrt(2)*x*exp(sqrt(2)*x)/4, x) + Integral(-5*sqrt(2)*x*exp(sqrt(2)*x)/4, x))*exp(-sqrt(2)*x) +
+                exp(sqrt(2)*x)*Integral(5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x) + sqrt(2)*exp(sqrt(2)*x)*Integral(
+                5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x)),
+            Eq(g(x), C1*exp(sqrt(2)*x) + (C2 + Integral(-5*sqrt(2)*x*exp(sqrt(2)*x)/4, x))*exp(-sqrt(2)*x) + exp(
+                sqrt(2)*x)*Integral(5*sqrt(2)*x*exp(-sqrt(2)*x)/4, x))]
+    assert dsolve(eq5) == sol5
     assert checksysodesol(eq5, sol5) == (True, [0, 0])
 
     eq6 = [Eq(diff(f(x), x), -9*f(x) - 4*g(x)),
-         Eq(diff(g(x), x), -4*g(x)),
-         Eq(diff(h(x), x), h(x) + exp(x))]
-    sol6 = [Eq(f(x), (C1 + Integral(0, x))*exp(-9*x) + (-4*C2/5 - 4*Integral(0,
-            x)/5)*exp(-4*x)), Eq(g(x), (C2 + Integral(0, x))*exp(-4*x)), Eq(h(x),
-            (C3 + Integral(1, x))*exp(x))]
+           Eq(diff(g(x), x), -4*g(x)),
+           Eq(diff(h(x), x), h(x) + exp(x))]
+    sol6 = [Eq(f(x), (-4*C1/5 - 4*Integral(0, x)/5)*exp(-4*x) + (C2 + Integral(0, x))*exp(-9*x)),
+            Eq(g(x), (C1 + Integral(0, x))*exp(-4*x)), Eq(h(x), (C3 + Integral(1, x))*exp(x))]
     assert dsolve(eq6) == sol6
     assert checksysodesol(eq6, sol6) == (True, [0, 0, 0])
 
     # Regression test case for issue #8859
     # https://github.com/sympy/sympy/issues/8859
     eq7 = [Eq(diff(f(t), t), f(t) + 3*t), Eq(diff(g(t), t), g(t))]
-    sol7 = [Eq(f(t), C1*exp(t) + exp(t)*Integral(3*t*exp(-t), t)), Eq(g(t),
-            C2*exp(t) + exp(t)*Integral(0, t))]
+    sol7 = [Eq(f(t), C1*exp(t) + exp(t)*Integral(3*t*exp(-t), t)), Eq(g(t), C2*exp(t) + exp(t)*Integral(0, t))]
     assert dsolve(eq7) == sol7
     assert checksysodesol(eq7, sol7) == (True, [0, 0])
 
     # Regression test case for issue #8567
     # https://github.com/sympy/sympy/issues/8567
     eq8 = [Eq(f(t).diff(t), f(t) + 2*g(t)), Eq(g(t).diff(t), -2*f(t) + g(t) + 2*exp(t))]
-    sol8 = [
-        Eq(f(t),
-            (C1*sin(2*t) + C2*cos(2*t)
-            + sin(2*t)*Integral(-2*sin(2*t)**2/cos(2*t) + 2/cos(2*t), t)
-            + cos(2*t)*Integral(-2*sin(2*t), t))*exp(t)),
-        Eq(g(t),
-            (C1*cos(2*t) - C2*sin(2*t)
-            - sin(2*t)*Integral(-2*sin(2*t), t)
-            + cos(2*t)*Integral(-2*sin(2*t)**2/cos(2*t) + 2/cos(2*t), t))*exp(t))
-    ]
-    with dotprodsimp(True):
-        assert dsolve(eq8) == sol8
+    sol8 = [Eq(f(t), (C1*sin(2*t) + C2*cos(2*t) + sin(2*t)*Integral(-2*sin(2*t)**2/cos(2*t) + 2/cos(2*t), t) +
+                cos(2*t)*Integral(-2*sin(2*t), t))*exp(t)),
+            Eq(g(t), (C1*cos(2*t) - C2*sin(2*t) - sin(2*t)*Integral(-2*sin(2*t), t) +
+                cos(2*t)*Integral(-2*sin(2*t)**2/cos(2*t) + 2/cos(2*t), t))*exp(t))]
+    assert dsolve(eq8) == sol8
     assert checksysodesol(eq8, sol8) == (True, [0, 0])
 
     # Regression test case for issue #19150
@@ -976,119 +960,105 @@ def test_sysode_linear_neq_order1_type2():
     eq9 = [Eq(Derivative(f(t), t), 1/(a*b)*(-2*f(t) + g(t) + c)),
            Eq(Derivative(g(t), t), 1/(a*b)*(-2*g(t) + f(t) + h(t))),
            Eq(Derivative(h(t), t), 1/(a*b)*(-2*h(t) + g(t) + d))]
-    sol9 = [Eq(f(t), (-C1 + C2*exp(-sqrt(2)*t/(a*b)) + C3*exp(sqrt(2)*t/(a*b)) +
-            exp(sqrt(2)*t/(a*b))*Integral(c*exp(-sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t) -
-            Integral(-c*exp(2*t/(a*b))/(2*a*b) + d*exp(2*t/(a*b))/(2*a*b), t) +
-            exp(-sqrt(2)*t/(a*b))*Integral(c*exp(sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b),
-            t))*exp(-2*t/(a*b))), Eq(g(t), (-sqrt(2)*C2*exp(-sqrt(2)*t/(a*b)) +
-            sqrt(2)*C3*exp(sqrt(2)*t/(a*b)) +
-            sqrt(2)*exp(sqrt(2)*t/(a*b))*Integral(c*exp(-sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t) -
-            sqrt(2)*exp(-sqrt(2)*t/(a*b))*Integral(c*exp(sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b),
-            t))*exp(-2*t/(a*b))), Eq(h(t), (C1 + C2*exp(-sqrt(2)*t/(a*b)) +
-            C3*exp(sqrt(2)*t/(a*b)) +
-            exp(sqrt(2)*t/(a*b))*Integral(c*exp(-sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t) +
-            Integral(-c*exp(2*t/(a*b))/(2*a*b) + d*exp(2*t/(a*b))/(2*a*b), t) +
-            exp(-sqrt(2)*t/(a*b))*Integral(c*exp(sqrt(2)*t/(a*b) +
-            2*t/(a*b))/(4*a*b) + d*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b),
-            t))*exp(-2*t/(a*b)))]
-
+    sol9 = [Eq(f(t), (-C1 + C2*exp(-sqrt(2)*t/(a*b)) + C3*exp(sqrt(2)*t/(a*b)) + exp(sqrt(2)*t/(a*b))*Integral(
+                c*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) + d*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t) - Integral(
+                -c*exp(2*t/(a*b))/(2*a*b) + d*exp(2*t/(a*b))/(2*a*b), t) + exp(-sqrt(2)*t/(a*b))*Integral(
+                c*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) + d*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t))*exp(
+                -2*t/(a*b))),
+            Eq(g(t), (-sqrt(2)*C2*exp(-sqrt(2)*t/(a*b)) + sqrt(2)*C3*exp(sqrt(2)*t/(a*b)) +
+                sqrt(2)*exp(sqrt(2)*t/(a*b))*Integral(c*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) + d*exp(-sqrt(2)*t/(a*b) +
+                2*t/(a*b))/(4*a*b), t) - sqrt(2)*exp(-sqrt(2)*t/(a*b))*Integral(c*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) +
+                d*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t))*exp(-2*t/(a*b))),
+            Eq(h(t), (C1 + C2*exp(-sqrt(2)*t/(a*b)) +
+                C3*exp(sqrt(2)*t/(a*b)) + exp(sqrt(2)*t/(a*b))*Integral(c*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) +
+                d*exp(-sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t) + Integral(-c*exp(2*t/(a*b))/(2*a*b) + d*exp(2*t/(a*b))/(
+                2*a*b), t) + exp(-sqrt(2)*t/(a*b))*Integral(c*exp(sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b) + d*exp(
+                sqrt(2)*t/(a*b) + 2*t/(a*b))/(4*a*b), t))*exp(-2*t/(a*b)))]
     assert dsolve(eq9) == sol9
     assert checksysodesol(eq9, sol9) == (True, [0, 0, 0])
 
     # Simpsol and Solsimp testing
-    _x1 = exp(-2*t/(a*b))
-    _x2 = sqrt(2)
-    _x3 = exp(-_x2*t/(a*b))
+    _x1 = sqrt(2)
+    _x2 = exp(2*_x1*t/(a*b))
+    _x3 = 4*C3*_x2*a*b
     _x4 = exp(2*t/(a*b))
-    _x5 = exp(2*_x2*t/(a*b))
-    _x6 = Integral(_x3*_x4, t)
-    _x7 = exp(_x2*t/(a*b))
+    _x5 = exp(_x1*t/(a*b))
+    _x6 = Integral(_x4*_x5, t)
+    _x7 = exp(-2*t/(a*b))
+    _x8 = exp(-_x1*t/(a*b))
+    _x9 = Integral(_x4*_x8, t)
+    _x10 = _x2*_x9*d
+    _x11 = 4*C2*a*b
     sol9_simpsol = [
-        Eq(f(t), _x1*_x3*(
-            -4*C1*_x7*a*b + 4*C2*a*b + 4*C3*_x5*a*b + _x5*_x6*c + _x5*_x6*d + 2*_x7*c*Integral(
-            _x4, t) - 2*_x7*d*Integral(_x4, t) + c*Integral(_x4*_x7, t) + d*Integral(_x4*_x7, t))/(
+        Eq(f(t), _x7*_x8*(-4*C1*_x5*a*b + _x10 + _x11 + _x2*_x9*c + _x3 + 2*_x5*c*Integral(_x4,
+                                                                                           t) - 2*_x5*d*Integral(
+            _x4, t) + _x6*c + _x6*d)/(4*a*b)),
+        Eq(g(t), _x7*_x8*(
+            -4*C2*_x1*a*b + 4*C3*_x1*_x2*a*b + _x1*_x2*_x9*c + _x1*_x2*_x9*d - _x1*_x6*c - _x1*_x6*d)/(
                4*a*b)),
-        Eq(g(t), _x1*_x3*(
-            -4*C2*_x2*a*b + 4*C3*_x2*_x5*a*b + _x2*_x5*_x6*c + _x2*_x5*_x6*d - _x2*c*Integral(
-            _x4*_x7, t) - _x2*d*Integral(_x4*_x7, t))/(4*a*b)),
-        Eq(h(t), _x1*_x3*(
-            4*C1*_x7*a*b + 4*C2*a*b + 4*C3*_x5*a*b + _x5*_x6*c + _x5*_x6*d - 2*_x7*c*Integral(
-            _x4, t) + 2*_x7*d*Integral(_x4, t) + c*Integral(_x4*_x7, t) + d*Integral(_x4*_x7, t))/(
-               4*a*b)),
+        Eq(h(t), _x7*_x8*(4*C1*_x5*a*b + _x10 + _x11 + _x2*_x9*c + _x3 - 2*_x5*c*Integral(_x4,
+                                                                                          t) + 2*_x5*d*Integral(
+            _x4, t) + _x6*c + _x6*d)/(4*a*b)),
     ]
     assert [_simpsol(s) for s in sol9] == sol9_simpsol
 
-    _x1 = exp(-2*t/(a*b))
-    _x2 = Integral(-c*exp(2*t/(a*b))/(2*a*b) + d*exp(2*t/(a*b))/(2*a*b), t)
-    _x3 = exp(t*(-2 + sqrt(2))/(a*b))
-    _x4 = exp(-t*(sqrt(2) + 2)/(a*b))
-    _x5 = Integral(
-        c*exp(t*(2 - sqrt(2))/(a*b))/(4*a*b) + d*exp(t*(2 - sqrt(2))/(a*b))/(4*a*b), t)
-    _x6 = Integral(
-        c*exp(t*(sqrt(2) + 2)/(a*b))/(4*a*b) + d*exp(t*(sqrt(2) + 2)/(a*b))/(4*a*b), t)
+    _x1 = sqrt(2)
+    _x2 = 1/b
+    _x3 = exp(_x2*t*(2 - _x1)/a)
+    _x4 = exp(_x2*t*(_x1 + 2)/a)
+    _x5 = exp(-2*_x2*t/a)
+    _x6 = exp(2*_x2*t/a)
+    _x7 = Integral(-_x2*_x6*c/(2*a) + _x2*_x6*d/(2*a), t)
+    _x8 = exp(_x2*t*(_x1 - 2)/a)
+    _x9 = exp(-_x2*t*(_x1 + 2)/a)
+    _x10 = Integral(_x2*_x3*c/(4*a) + _x2*_x3*d/(4*a), t)
+    _x11 = Integral(_x2*_x4*c/(4*a) + _x2*_x4*d/(4*a), t)
     sol9_solsimp = [
-        Eq(f(t), -C1*_x1 + C2*_x4 + C3*_x3 - _x1*_x2 + _x3*_x5 + _x4*_x6),
-        Eq(g(t), -sqrt(2)*C2*_x4 + sqrt(2)*C3*_x3 + sqrt(2)*_x3*_x5 - sqrt(2)*_x4*_x6),
-        Eq(h(t), C1*_x1 + C2*_x4 + C3*_x3 + _x1*_x2 + _x3*_x5 + _x4*_x6),
+        Eq(f(t), -C1*_x5 + C2*_x9 + C3*_x8 + _x10*_x8 + _x11*_x9 - _x5*_x7),
+        Eq(g(t), -C2*_x1*_x9 + C3*_x1*_x8 + _x1*_x10*_x8 - _x1*_x11*_x9),
+        Eq(h(t), C1*_x5 + C2*_x9 + C3*_x8 + _x10*_x8 + _x11*_x9 + _x5*_x7),
     ]
     assert [Eq(s.lhs, _solsimp(s.rhs, t)) for s in sol9] == sol9_solsimp
 
     # Regression test case for issue #16635
     # https://github.com/sympy/sympy/issues/16635
     eq10 = [Eq(f(t).diff(t), f(t) - g(t) + 15*t - 10), Eq(g(t).diff(t), f(t) - g(t) - 15*t - 5)]
-    sol10 = [Eq(f(t), C1 + C2*t + C2 + t*Integral(30*t - 5, t) + Integral(30*t - 5, t) + Integral(-30*t**2 -
-            10*t - 5, t)), Eq(g(t), C1 + C2*t + t*Integral(30*t - 5, t) + Integral(-30*t**2 - 10*t - 5, t))]
+    sol10 = [Eq(f(t), C1 + C2*t + C2 + t*Integral(30*t - 5, t) + Integral(30*t - 5, t) + Integral(-30*t**2 - 10*t - 5, t)),
+             Eq(g(t), C1 + C2*t + t*Integral(30*t - 5, t) + Integral(-30*t**2 - 10*t - 5, t))]
     assert dsolve(eq10) == sol10
     assert checksysodesol(eq10, sol10) == (True, [0, 0])
 
     # Multiple equations
     eq1 = [Eq(Derivative(f(t), t)**2 - 2*Derivative(f(t), t) + 1, 4),
             Eq(-y*f(t) + Derivative(g(t), t), 0)]
-    sol1 = [[Eq(f(t), C2 + Integral(-1, t)), Eq(g(t), C1*y + C2*t*y + t*y*Integral(-1, t) + y*Integral(t, t))],
-             [Eq(f(t), C2 + Integral(3, t)), Eq(g(t), C1*y + C2*t*y + t*y*Integral(3, t) + y*Integral(-3*t, t))]]
+    sol1 = [[Eq(f(t), C1 + Integral(-1, t)),
+             Eq(g(t), C1*t*y + C2*y + t*y*Integral(-1, t) + y*Integral(t, t))],
+            [Eq(f(t), C1 + Integral(3, t)),
+             Eq(g(t), C1*t*y + C2*y + t*y*Integral(3, t) + y*Integral(-3*t, t))]]
     assert dsolve(eq1) == sol1
     for sol in sol1:
         assert checksysodesol(eq1, sol) == (True, [0, 0])
 
 
 def test_sysode_linear_neq_order1_type3():
-    from sympy.core import Mul
 
     f, g, h, k = symbols('f g h k', cls=Function)
     x, t, a = symbols('x t a')
     r = symbols('r', real=True)
     eqs1 = [Eq(diff(f(r), r),  f(r) + r*g(r)),
            Eq(diff(g(r), r),-r*f(r) + g(r))]
-    sol1 = [Eq(f(r), (C1*cos(r**2/2) + C2*sin(r**2/2))*exp(r)),
-           Eq(g(r), (-C1*sin(r**2/2) + C2*cos(r**2/2))*exp(r))]
+    sol1 = [Eq(f(r), (C1*sin(r**2/2) + C2*cos(r**2/2))*exp(r)), Eq(g(r), (C1*cos(r**2/2) - C2*sin(r**2/2))*exp(r))]
     assert dsolve(eqs1) == sol1
     assert checksysodesol(eqs1, sol1) == (True, [0, 0])
 
     eqs2 = [Eq(diff(f(x), x),  x*f(x) + x**2*g(x)),
            Eq(diff(g(x), x),  2*x**2*f(x) + (x + 3*x**2)*g(x))]
-    sol2 = [
-        Eq(f(x),
-          - 2*sqrt(17)*C1*x**3*exp(x**3/2 + sqrt(17)*x**3/6 + x**2/2)/Mul(51, (-sqrt(17)*x**3/6 - x**3/2), evaluate=False)
-          + 2*sqrt(17)*C1*x**3*exp(-sqrt(17)*x**3/6 + x**3/2 + x**2/2)/Mul(51, (-x**3/2 + sqrt(17)*x**3/6), evaluate=False)
-          + 2*sqrt(17)*C2*x**6*exp(-sqrt(17)*x**3/6 + x**3/2 + x**2/2)/(153*(-x**3/2 + sqrt(17)*x**3/6)**2)
-          - C2*x**3*exp(-sqrt(17)*x**3/6 + x**3/2 + x**2/2)/Mul(3, (-x**3/2 + sqrt(17)*x**3/6), evaluate=False)
-          + sqrt(17)*C2*exp(x**3/2 + sqrt(17)*x**3/6 + x**2/2)/17),
-        Eq(g(x),
-          + 2*sqrt(17)*C1*exp(x**3/2 + sqrt(17)*x**3/6 + x**2/2)/17
-          - 2*sqrt(17)*C1*exp(-sqrt(17)*x**3/6 + x**3/2 + x**2/2)/17
-          + 2*sqrt(17)*C2*x**3*exp(x**3/2 + sqrt(17)*x**3/6
-          + x**2/2)/Mul(51, -x**3/2 + sqrt(17)*x**3/6, evaluate=False)
-          - 2*sqrt(17)*C2*x**3*exp(-sqrt(17)*x**3/6 + x**3/2
-          + x**2/2)/Mul(51, -x**3/2 + sqrt(17)*x**3/6, evaluate=False)
-          + C2*exp(-sqrt(17)*x**3/6 + x**3/2 + x**2/2))
-    ]
+    sol2 = [Eq(f(x), (3*C1/17 + 4*C2/17 + (8*C1 - 12*C2)/(51 + 17*sqrt(17)))*exp(x**2*(3*x + sqrt(17)*x + 3)/6) + (13*C1/51 +
+                2*C2/17 + (16*C1 - 24*C2)/(-663 + 153*sqrt(17)))*exp(x**2*(-sqrt(17)*x + 3*x + 3)/6)),
+            Eq(g(x), (4*C1/17 - 6*C2/17 + (12*C1 + 16*C2)/(-51 + 17*sqrt(17)))*exp(x**2*(3*x + sqrt(17)*x + 3)/6) + (
+                13*C1/17 + 6*C2/17 + (-12*C1 - 16*C2)/(-51 + 17*sqrt(17)))*exp(x**2*(-sqrt(17)*x + 3*x + 3)/6))]
 
-    assert dsolve(eqs2) == sol2
+    assert [_simpsol(s) for s in dsolve(eqs2)] == sol2
     assert checksysodesol(eqs2, sol2) == (True, [0, 0])
 
     eqs3 = [Eq(f(x).diff(x), x*f(x) + g(x)), Eq(g(x).diff(x), -f(x) + x*g(x))]
@@ -1097,18 +1067,19 @@ def test_sysode_linear_neq_order1_type3():
     assert dsolve(eqs3) == sol3
     assert checksysodesol(eqs3, sol3) == (True, [0, 0])
 
-    eqs4 = [Eq(f(x).diff(x), x*(f(x) + g(x) + h(x))), Eq(g(x).diff(x), x*(f(x) + g(x) + h(x))), Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)))]
-    sol4 = [Eq(f(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)),
-            Eq(g(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)),
-            Eq(h(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2))]
+    eqs4 = [Eq(f(x).diff(x), x*(f(x) + g(x) + h(x))), Eq(g(x).diff(x), x*(f(x) + g(x) + h(x))),
+            Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)))]
+    sol4 = [Eq(f(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)),
+            Eq(g(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)),
+            Eq(h(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2))]
     assert dsolve(eqs4) == sol4
     assert checksysodesol(eqs4, sol4) == (True, [0, 0, 0])
 
     eqs5 = [Eq(f(x).diff(x), x**2*(f(x) + g(x) + h(x))), Eq(g(x).diff(x), x**2*(f(x) + g(x) + h(x))),
             Eq(h(x).diff(x), x**2*(f(x) + g(x) + h(x)))]
-    sol5 = [Eq(f(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3)),
-            Eq(g(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3)),
-            Eq(h(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3))]
+    sol5 = [Eq(f(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3)),
+            Eq(g(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3)),
+            Eq(h(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(x**3))]
     assert dsolve(eqs5) == sol5
     assert checksysodesol(eqs5, sol5) == (True, [0, 0, 0])
 
@@ -1116,17 +1087,17 @@ def test_sysode_linear_neq_order1_type3():
             Eq(Derivative(g(x), x), x*(f(x) + g(x) + h(x) + k(x))),
             Eq(Derivative(h(x), x), x*(f(x) + g(x) + h(x) + k(x))),
             Eq(Derivative(k(x), x), x*(f(x) + g(x) + h(x) + k(x)))]
-    sol6 = [Eq(f(x), 3*C1/4 - C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
-            Eq(g(x), -C1/4 + 3*C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
-            Eq(h(x), -C1/4 - C2/4 + 3*C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
-            Eq(k(x), -C1/4 - C2/4 - C3/4 + 3*C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2))]
+    sol6 = [Eq(f(x), -C1/4 - C2/4 - C3/4 + 3*C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
+            Eq(g(x), 3*C1/4 - C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
+            Eq(h(x), -C1/4 + 3*C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2)),
+            Eq(k(x), -C1/4 - C2/4 + 3*C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4)*exp(2*x**2))]
     assert dsolve(eqs6) == sol6
     assert checksysodesol(eqs6, sol6) == (True, [0, 0, 0, 0])
 
     y = symbols("y", real=True)
 
     eqs7 = [Eq(Derivative(f(y), y), y*f(y) + g(y)), Eq(Derivative(g(y), y), y*g(y) - f(y))]
-    sol7 = [Eq(f(y), (C1*cos(y) + C2*sin(y))*exp(y**2/2)), Eq(g(y), (-C1*sin(y) + C2*cos(y))*exp(y**2/2))]
+    sol7 = [Eq(f(y), (C1*sin(y) + C2*cos(y))*exp(y**2/2)), Eq(g(y), (C1*cos(y) - C2*sin(y))*exp(y**2/2))]
     assert dsolve(eqs7) == sol7
     assert checksysodesol(eqs7, sol7) == (True, [0, 0])
 
@@ -1138,22 +1109,20 @@ def test_sysode_linear_neq_order1_type4():
     r = symbols('r', real=True)
 
     eqs1 = [Eq(diff(f(r), r), f(r) + r*g(r) + r**2), Eq(diff(g(r), r), -r*f(r) + g(r) + r)]
-    sol1 = [Eq(f(r), C1*exp(r)*cos(r**2/2) + C2*exp(r)*sin(r**2/2) +
-            exp(r)*sin(r**2/2)*Integral(r**2*exp(-r)*sin(r**2/2) + r*exp(-r)*cos(r**2/2), r) +
-            exp(r)*cos(r**2/2)*Integral(r**2*exp(-r)*cos(r**2/2) - r*exp(-r)*sin(r**2/2), r)), Eq(g(r),
-            -C1*exp(r)*sin(r**2/2) + C2*exp(r)*cos(r**2/2) -
-            exp(r)*sin(r**2/2)*Integral(r**2*exp(-r)*cos(r**2/2) - r*exp(-r)*sin(r**2/2), r) +
-            exp(r)*cos(r**2/2)*Integral(r**2*exp(-r)*sin(r**2/2) + r*exp(-r)*cos(r**2/2), r))]
+    sol1 = [Eq(f(r), C1*exp(r)*sin(r**2/2) + C2*exp(r)*cos(r**2/2) + exp(r)*sin(r**2/2)*Integral(r**2*exp(-r)*sin(r**2/2) +
+                r*exp(-r)*cos(r**2/2), r) + exp(r)*cos(r**2/2)*Integral(r**2*exp(-r)*cos(r**2/2) - r*exp(-r)*sin(r**2/2), r)),
+            Eq(g(r), C1*exp(r)*cos(r**2/2) - C2*exp(r)*sin(r**2/2) - exp(r)*sin(r**2/2)*Integral(r**2*exp(-r)*cos(r**2/2) -
+                r*exp(-r)*sin(r**2/2), r) + exp(r)*cos(r**2/2)*Integral(r**2*exp(-r)*sin(r**2/2) + r*exp(-r)*cos(r**2/2), r))]
     assert dsolve(eqs1) == sol1
     assert checksysodesol(eqs1, sol1) == (True, [0, 0])
 
     eqs2 = [Eq(diff(f(r), r), f(r) + r*g(r) + r), Eq(diff(g(r), r), -r*f(r) + g(r) + log(r))]
-    sol2 = [Eq(f(r), C1*exp(r)*cos(r**2/2) + C2*exp(r)*sin(r**2/2) +
-            exp(r)*sin(r**2/2)*Integral(r*exp(-r)*sin(r**2/2) + exp(-r)*log(r)*cos(r**2/2), r) +
-            exp(r)*cos(r**2/2)*Integral(r*exp(-r)*cos(r**2/2) - exp(-r)*log(r)*sin(r**2/2), r)), Eq(g(r),
-            -C1*exp(r)*sin(r**2/2) + C2*exp(r)*cos(r**2/2) - exp(r)*sin(r**2/2)*Integral(r*exp(-r)*cos(r**2/2) -
-            exp(-r)*log(r)*sin(r**2/2), r) + exp(r)*cos(r**2/2)*Integral(r*exp(-r)*sin(r**2/2) +
-            exp(-r)*log(r)*cos(r**2/2), r))]
+    sol2 = [Eq(f(r), C1*exp(r)*sin(r**2/2) + C2*exp(r)*cos(r**2/2) + exp(r)*sin(r**2/2)*Integral(r*exp(-r)*sin(r**2/2) +
+                exp(-r)*log(r)*cos(r**2/2), r) + exp(r)*cos(r**2/2)*Integral(r*exp(-r)*cos(r**2/2) - exp(-r)*log(r)*sin(
+                r**2/2), r)),
+            Eq(g(r), C1*exp(r)*cos(r**2/2) - C2*exp(r)*sin(r**2/2) - exp(r)*sin(r**2/2)*Integral(r*exp(-r)*cos(r**2/2) -
+                exp(-r)*log(r)*sin(r**2/2), r) + exp(r)*cos(r**2/2)*Integral(r*exp(-r)*sin(r**2/2) + exp(-r)*log(r)*cos(
+                r**2/2), r))]
     assert dsolve(eqs2) == sol2
     assert checksysodesol(eqs2, sol2) == (True, [0, 0])
 
@@ -1162,63 +1131,65 @@ def test_sysode_linear_neq_order1_type4():
     _x1 = exp(-3*x**2/2)
     _x2 = exp(3*x**2/2)
     _x3 = Integral(2*_x1*x/3 + _x1/3 + x/3 - Rational(1, 3), x)
-    _x4 = 2*_x2*_x3/3
-    _x5 = Integral(2*_x1*x/3 + _x1/3 - 2*x/3 + Rational(2, 3), x)
+    _x4 = Integral(2*_x1*x/3 + _x1/3 - 2*x/3 + Rational(2, 3), x)
     sol3 = [
         Eq(f(x),
-           C1*_x2/3 + 2*C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 - C3/3 + _x2*_x5/3 + _x3/3 + _x4 - _x5/3),
+           C1*_x2/3 - C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 + 2*C3/3 + 2*_x2*_x3/3 + _x2*_x4/3 + _x3/3 - _x4/3),
         Eq(g(x),
-           C1*_x2/3 - C1/3 + C2*_x2/3 + 2*C2/3 + C3*_x2/3 - C3/3 + _x2*_x5/3 + _x3/3 + _x4 - _x5/3),
+           C1*_x2/3 + 2*C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 - C3/3 + 2*_x2*_x3/3 + _x2*_x4/3 + _x3/3 - _x4/3),
         Eq(h(x),
-           C1*_x2/3 - C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 + 2*C3/3 + _x2*_x5/3 - 2*_x3/3 + _x4 + 2*_x5/3),
+           C1*_x2/3 - C1/3 + C2*_x2/3 + 2*C2/3 + C3*_x2/3 - C3/3 + 2*_x2*_x3/3 + _x2*_x4/3 - 2*_x3/3 + 2*_x4/3),
     ]
     assert dsolve(eqs3) == sol3
     assert checksysodesol(eqs3, sol3) == (True, [0, 0, 0])
 
     eqs4 = [Eq(f(x).diff(x), x*(f(x) + g(x) + h(x)) + sin(x)), Eq(g(x).diff(x), x*(f(x) + g(x) + h(x)) + sin(x)),
             Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)) + sin(x))]
-    sol4 = [Eq(f(x), C1*exp(3*x**2/2)/3 + 2*C1/3 + C2*exp(3*x**2/2)/3 - C2/3 + C3*exp(3*x**2/2)/3 - C3/3 +
-            exp(3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x)), Eq(g(x), C1*exp(3*x**2/2)/3 - C1/3 +
-            C2*exp(3*x**2/2)/3 + 2*C2/3 + C3*exp(3*x**2/2)/3 - C3/3 +
-            exp(3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x)), Eq(h(x), C1*exp(3*x**2/2)/3 - C1/3 +
-            C2*exp(3*x**2/2)/3 - C2/3 + C3*exp(3*x**2/2)/3 + 2*C3/3 +
-            exp(3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x))]
+    sol4 = [Eq(f(x), C1*exp(3*x**2/2)/3 - C1/3 + C2*exp(3*x**2/2)/3 - C2/3 + C3*exp(3*x**2/2)/3 + 2*C3/3 +
+                exp(3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x)),
+            Eq(g(x), C1*exp(3*x**2/2)/3 + 2*C1/3 + C2*exp(3*x**2/2)/3 - C2/3 +
+                C3*exp(3*x**2/2)/3 - C3/3 + exp(3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x)),
+            Eq(h(x), C1*exp(3*x**2/2)/3 - C1/3 + C2*exp(3*x**2/2)/3 + 2*C2/3 + C3*exp(3*x**2/2)/3 - C3/3 + exp(
+                3*x**2/2)*Integral(exp(-3*x**2/2)*sin(x), x))]
     assert dsolve(eqs4) == sol4
     assert checksysodesol(eqs4, sol4) == (True, [0, 0, 0])
 
     eqs5 = [Eq(Derivative(f(x), x), x*(f(x) + g(x) + h(x) + k(x) + 1)), Eq(Derivative(g(x), x), x*(f(x) + g(x)
             + h(x) + k(x) + 1)), Eq(Derivative(h(x), x), x*(f(x) + g(x) + h(x) + k(x) + 1)), Eq(Derivative(k(x),
             x), x*(f(x) + g(x) + h(x) + k(x) + 1))]
-    sol5 = [Eq(f(x), C1*exp(2*x**2)/4 + 3*C1/4 + C2*exp(2*x**2)/4 - C2/4 + C3*exp(2*x**2)/4 - C3/4 +
-            C4*exp(2*x**2)/4 - C4/4 + exp(2*x**2)*Integral(x*exp(-2*x**2), x)), Eq(g(x), C1*exp(2*x**2)/4 - C1/4
-            + C2*exp(2*x**2)/4 + 3*C2/4 + C3*exp(2*x**2)/4 - C3/4 + C4*exp(2*x**2)/4 - C4/4 +
-            exp(2*x**2)*Integral(x*exp(-2*x**2), x)), Eq(h(x), C1*exp(2*x**2)/4 - C1/4 + C2*exp(2*x**2)/4 - C2/4
-            + C3*exp(2*x**2)/4 + 3*C3/4 + C4*exp(2*x**2)/4 - C4/4 + exp(2*x**2)*Integral(x*exp(-2*x**2), x)),
-            Eq(k(x), C1*exp(2*x**2)/4 - C1/4 + C2*exp(2*x**2)/4 - C2/4 + C3*exp(2*x**2)/4 - C3/4 +
-            C4*exp(2*x**2)/4 + 3*C4/4 + exp(2*x**2)*Integral(x*exp(-2*x**2), x))]
+    sol5 = [Eq(f(x), C1*exp(2*x**2)/4 - C1/4 + C2*exp(2*x**2)/4 - C2/4 + C3*exp(2*x**2)/4 - C3/4 + C4*exp(2*x**2)/4 + 3*C4/4 +
+                exp(2*x**2)*Integral(x*exp(-2*x**2), x)),
+            Eq(g(x), C1*exp(2*x**2)/4 + 3*C1/4 + C2*exp(2*x**2)/4 - C2/4 +
+                C3*exp(2*x**2)/4 - C3/4 + C4*exp(2*x**2)/4 - C4/4 + exp(2*x**2)*Integral(x*exp(-2*x**2), x)),
+            Eq(h(x), C1*exp(2*x**2)/4 - C1/4 + C2*exp(2*x**2)/4 + 3*C2/4 + C3*exp(2*x**2)/4 - C3/4 + C4*exp(2*x**2)/4 - C4/4 +
+                exp(2*x**2)*Integral(x*exp(-2*x**2), x)),
+            Eq(k(x), C1*exp(2*x**2)/4 - C1/4 + C2*exp(2*x**2)/4 - C2/4 + C3*exp(2*x**2)/4
+                + 3*C3/4 + C4*exp(2*x**2)/4 - C4/4 + exp(2*x**2)*Integral(x*exp(-2*x**2), x))]
     assert dsolve(eqs5) == sol5
     assert checksysodesol(eqs5, sol5) == (True, [0, 0, 0, 0])
 
     eqs6 = [Eq(Derivative(f(x), x), x**2*(f(x) + g(x) + h(x) + k(x) + 1)), Eq(Derivative(g(x), x), x**2*(f(x) +
             g(x) + h(x) + k(x) + 1)), Eq(Derivative(h(x), x), x**2*(f(x) + g(x) + h(x) + k(x) + 1)),
             Eq(Derivative(k(x), x), x**2*(f(x) + g(x) + h(x) + k(x) + 1))]
-    sol6 = [Eq(f(x), C1*exp(4*x**3/3)/4 + 3*C1/4 + C2*exp(4*x**3/3)/4 - C2/4 + C3*exp(4*x**3/3)/4 - C3/4 +
-            C4*exp(4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)), Eq(g(x),
-            C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 + 3*C2/4 + C3*exp(4*x**3/3)/4 - C3/4 +
-            C4*exp(4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)), Eq(h(x),
-            C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 - C2/4 + C3*exp(4*x**3/3)/4 + 3*C3/4 +
-            C4*exp(4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)), Eq(k(x),
-            C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 - C2/4 + C3*exp(4*x**3/3)/4 - C3/4 +
-            C4*exp(4*x**3/3)/4 + 3*C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x))]
+    sol6 = [Eq(f(x), C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 - C2/4 + C3*exp(4*x**3/3)/4 - C3/4 + C4*exp(4*x**3/3)/4 +
+                3*C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)),
+            Eq(g(x), C1*exp(4*x**3/3)/4 + 3*C1/4 + C2*exp(4*x**3/3)/4 - C2/4 + C3*exp(4*x**3/3)/4 - C3/4 + C4*exp(
+                4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)),
+            Eq(h(x), C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 + 3*C2/4 + C3*exp(4*x**3/3)/4 - C3/4 + C4*exp(
+                4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x)),
+            Eq(k(x), C1*exp(4*x**3/3)/4 - C1/4 + C2*exp(4*x**3/3)/4 - C2/4 +
+                C3*exp(4*x**3/3)/4 + 3*C3/4 + C4*exp(4*x**3/3)/4 - C4/4 + exp(4*x**3/3)*Integral(x**2*exp(-4*x**3/3), x))]
     assert dsolve(eqs6) == sol6
     assert checksysodesol(eqs6, sol6) == (True, [0, 0, 0, 0])
 
     eqs7 = [Eq(Derivative(f(x), x), (f(x) + g(x) + h(x))*log(x) + sin(x)), Eq(Derivative(g(x), x), (f(x) + g(x)
             + h(x))*log(x) + sin(x)), Eq(Derivative(h(x), x), (f(x) + g(x) + h(x))*log(x) + sin(x))]
-    sol7 = [Eq(f(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3 + Integral(exp(-3*x*log(x) + 3*x)*sin(x),
-            x))*exp(3*x*log(x) - 3*x)), Eq(g(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3 +
-            Integral(exp(-3*x*log(x) + 3*x)*sin(x), x))*exp(3*x*log(x) - 3*x)), Eq(h(x), -C1/3 - C2/3 + 2*C3/3 +
-            (C1/3 + C2/3 + C3/3 + Integral(exp(-3*x*log(x) + 3*x)*sin(x), x))*exp(3*x*log(x) - 3*x))]
+    sol7 = [Eq(f(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3 + Integral(exp(-3*x*log(x) + 3*x)*sin(x), x))*exp(3*x*log(x) -
+                3*x)),
+            Eq(g(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3 + Integral(exp(-3*x*log(x) + 3*x)*sin(x), x))*exp(3*x*log(x)
+                - 3*x)),
+            Eq(h(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3 + Integral(exp(-3*x*log(x) + 3*x)*sin(x),
+                x))*exp(3*x*log(x) - 3*x))]
     with dotprodsimp(True):
         assert dsolve(eqs7) == sol7
     assert checksysodesol(eqs7, sol7) == (True, [0, 0, 0])
@@ -1226,22 +1197,17 @@ def test_sysode_linear_neq_order1_type4():
     eqs8 = [Eq(Derivative(f(x), x), (f(x) + g(x) + h(x) + k(x))*log(x) + sin(x)), Eq(Derivative(g(x), x), (f(x)
             + g(x) + h(x) + k(x))*log(x) + sin(x)), Eq(Derivative(h(x), x), (f(x) + g(x) + h(x) + k(x))*log(x) +
             sin(x)), Eq(Derivative(k(x), x), (f(x) + g(x) + h(x) + k(x))*log(x) + sin(x))]
-    sol8 = [Eq(f(x), 3*C1/4 - C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 + Integral(exp(-4*x*log(x) +
-            4*x)*sin(x), x))*exp(4*x*log(x) - 4*x)), Eq(g(x), -C1/4 + 3*C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4
-            + C4/4 + Integral(exp(-4*x*log(x) + 4*x)*sin(x), x))*exp(4*x*log(x) - 4*x)), Eq(h(x), -C1/4 - C2/4 +
-            3*C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 + Integral(exp(-4*x*log(x) + 4*x)*sin(x),
-            x))*exp(4*x*log(x) - 4*x)), Eq(k(x), -C1/4 - C2/4 - C3/4 + 3*C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 +
-            Integral(exp(-4*x*log(x) + 4*x)*sin(x), x))*exp(4*x*log(x) - 4*x))]
+    sol8 = [Eq(f(x), -C1/4 - C2/4 - C3/4 + 3*C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 + Integral(exp(-4*x*log(x) + 4*x)*sin(x),
+                x))*exp(4*x*log(x) - 4*x)),
+            Eq(g(x), 3*C1/4 - C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 + Integral(exp(-4*x*log(x)
+            + 4*x)*sin(x), x))*exp(4*x*log(x) - 4*x)),
+            Eq(h(x), -C1/4 + 3*C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 + C4/4 +
+                Integral(exp(-4*x*log(x) + 4*x)*sin(x), x))*exp(4*x*log(x) - 4*x)),
+            Eq(k(x), -C1/4 - C2/4 + 3*C3/4 - C4/4 + (C1/4 + C2/4
+                + C3/4 + C4/4 + Integral(exp(-4*x*log(x) + 4*x)*sin(x), x))*exp(4*x*log(x) - 4*x))]
     with dotprodsimp(True):
         assert dsolve(eqs8) == sol8
     assert checksysodesol(eqs8, sol8) == (True, [0, 0, 0, 0])
-
-
-def _remove_dummies(vec, t):
-    dummies = sorted(Tuple(*vec).free_symbols - {t}, key=lambda x: x.dummy_index)
-    dummies_to_constants = {d: Symbol('C{}'.format(i+1)) for i, d in enumerate(dummies)}
-
-    return [v.subs(dummies_to_constants) for v in vec]
 
 
 def test_linodesolve():
@@ -1266,8 +1232,8 @@ def test_linodesolve():
     A = A0
     sol = [C1*(-Rational(1, 2) + sqrt(5)/2)*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*(-sqrt(5)/2 - Rational(1, 2))*
            exp(t*(-sqrt(5)/2 - Rational(1, 2))),
-            C1*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*exp(t*(-sqrt(5)/2 - Rational(1, 2)))]
-    assert _remove_dummies(linodesolve(A, t), t) == sol
+           C1*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*exp(t*(-sqrt(5)/2 - Rational(1, 2)))]
+    assert constant_renumber(linodesolve(A, t), variables=Tuple(*eq).free_symbols) == sol
 
     # Testing the Errors
     raises(ValueError, lambda: linodesolve(1, t, b=Matrix([t+1])))
@@ -1295,7 +1261,8 @@ def test_linodesolve():
     b1 = Matrix([15*t - 10, -15*t - 5])
     sol1 = [C1 + C2*t + C2 - 10*t**3 + 10*t**2 + t*(15*t**2 - 5*t) - 10*t,
             C1 + C2*t - 10*t**3 - 5*t**2 + t*(15*t**2 - 5*t) - 5*t]
-    assert _remove_dummies(linodesolve(A1, t, b=b1, type="type2", doit=True), t) == sol1
+    assert constant_renumber(linodesolve(A1, t, b=b1, type="type2", doit=True),
+                             variables=[t]) == sol1
 
     # Testing auto functionality
     func = [f(t), g(t)]
@@ -1304,22 +1271,24 @@ def test_linodesolve():
     (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
     A = A0
     sol = [-C1*exp(-t/2 + sqrt(5)*t/2)/2 + sqrt(5)*C1*exp(-t/2 + sqrt(5)*t/2)/2 - sqrt(5)*C2*exp(-sqrt(5)*t/2
-            - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 +
-            sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5, t)/2 + sqrt(5)*exp(-t/2 +
-            sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5, t)/2 - sqrt(5)*exp(-sqrt(5)*t/2 -
-            t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)/2 - exp(-sqrt(5)*t/2 -
-            t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)/2, C1*exp(-t/2 + sqrt(5)*t/2) +
-            C2*exp(-sqrt(5)*t/2 - t/2) + exp(-t/2 + sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5,
-            t) + exp(-sqrt(5)*t/2 - t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)]
-    assert _remove_dummies(linodesolve(A, t, b=b), t) == sol
+                - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 +
+                sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5, t)/2 + sqrt(5)*exp(-t/2 +
+                sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5, t)/2 - sqrt(5)*exp(-sqrt(5)*t/2 -
+                t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)/2 - exp(-sqrt(5)*t/2 -
+                t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)/2,
+            C1*exp(-t/2 + sqrt(5)*t/2) +
+                C2*exp(-sqrt(5)*t/2 - t/2) + exp(-t/2 + sqrt(5)*t/2)*Integral(sqrt(5)*t*exp(-sqrt(5)*t/2 + t/2)/5,
+                t) + exp(-sqrt(5)*t/2 - t/2)*Integral(-sqrt(5)*t*exp(t/2 + sqrt(5)*t/2)/5, t)]
+    assert constant_renumber(linodesolve(A, t, b=b), variables=[t]) == sol
 
     # non-homogeneous term assumed to be 0
     sol1 = [-C1*exp(-t/2 + sqrt(5)*t/2)/2 + sqrt(5)*C1*exp(-t/2 + sqrt(5)*t/2)/2 - sqrt(5)*C2*exp(-sqrt(5)*t/2
-            - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 + sqrt(5)*t/2)*Integral(0, t)/2 +
-            sqrt(5)*exp(-t/2 + sqrt(5)*t/2)*Integral(0, t)/2 - sqrt(5)*exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)/2
-            - exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)/2, C1*exp(-t/2 + sqrt(5)*t/2) + C2*exp(-sqrt(5)*t/2 - t/2)
-            + exp(-t/2 + sqrt(5)*t/2)*Integral(0, t) + exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)]
-    assert _remove_dummies(linodesolve(A, t, type="type2"), t) == sol1
+                - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 + sqrt(5)*t/2)*Integral(0, t)/2 +
+                sqrt(5)*exp(-t/2 + sqrt(5)*t/2)*Integral(0, t)/2 - sqrt(5)*exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)/2
+                - exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)/2,
+            C1*exp(-t/2 + sqrt(5)*t/2) + C2*exp(-sqrt(5)*t/2 - t/2)
+                + exp(-t/2 + sqrt(5)*t/2)*Integral(0, t) + exp(-sqrt(5)*t/2 - t/2)*Integral(0, t)]
+    assert constant_renumber(linodesolve(A, t, type="type2"), variables=[t]) == sol1
 
     # Testing the Errors
     raises(ValueError, lambda: linodesolve(t+10, t))
@@ -1346,9 +1315,9 @@ def test_linodesolve():
     (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
     A = A0
     sol = [(C1/2 - I*C2/2)*exp(I*t**2/2 + t) + (C1/2 + I*C2/2)*exp(-I*t**2/2 + t),
-            (-I*C1/2 + C2/2)*exp(-I*t**2/2 + t) + (I*C1/2 + C2/2)*exp(I*t**2/2 + t)]
-    assert _remove_dummies(linodesolve(A, t), t) == sol
-    assert _remove_dummies(linodesolve(A, t, type="type3"), t) == sol
+           (-I*C1/2 + C2/2)*exp(-I*t**2/2 + t) + (I*C1/2 + C2/2)*exp(I*t**2/2 + t)]
+    assert constant_renumber(linodesolve(A, t), variables=Tuple(*eq).free_symbols) == sol
+    assert constant_renumber(linodesolve(A, t, type="type3"), variables=Tuple(*eq).free_symbols) == sol
 
     A1 = Matrix([[t, 1], [t, -1]])
     raises(NotImplementedError, lambda: linodesolve(A1, t))
@@ -1381,30 +1350,33 @@ def test_linodesolve():
 
     # Testing auto functionality
     func = [f(x), g(x), h(x)]
-    eq = [Eq(f(x).diff(x), x*(f(x) + g(x) + h(x)) + x), Eq(g(x).diff(x), x*(f(x) + g(x) + h(x)) + x),
-            Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)) + 1)]
+    eq = [Eq(f(x).diff(x), x*(f(x) + g(x) + h(x)) + x),
+          Eq(g(x).diff(x), x*(f(x) + g(x) + h(x)) + x),
+          Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)) + 1)]
     ceq = canonical_odes(eq, func, x)
     (A1, A0), b = linear_ode_to_matrix(ceq, func, x, 1)
     A = A0
-    _x1 = exp(3*x**2/2)
-    _x2 = Integral(x/3 + 2*x*exp(-3*x**2/2)/3 - Rational(1, 3) + exp(-3*x**2/2)/3, x)
-    _x3 = Integral(-2*x/3 + 2*x*exp(-3*x**2/2)/3 + Rational(2, 3) + exp(-3*x**2/2)/3, x)
+    _x1 = exp(-3*x**2/2)
+    _x2 = exp(3*x**2/2)
+    _x3 = Integral(2*_x1*x/3 + _x1/3 + x/3 - Rational(1, 3), x)
+    _x4 = 2*_x2*_x3/3
+    _x5 = Integral(2*_x1*x/3 + _x1/3 - 2*x/3 + Rational(2, 3), x)
     sol = [
-        C1*_x1/3 + 2*C1/3 + C2*_x1/3 - C2/3 + C3*_x1/3 - C3/3 + 2*_x1*_x2/3 + _x1*_x3/3 + _x2/3 - _x3/3,
-        C1*_x1/3 - C1/3 + C2*_x1/3 + 2*C2/3 + C3*_x1/3 - C3/3 + 2*_x1*_x2/3 + _x1*_x3/3 + _x2/3 - _x3/3,
-        C1*_x1/3 - C1/3 + C2*_x1/3 - C2/3 + C3*_x1/3 + 2*C3/3 + 2*_x1*_x2/3 + _x1*_x3/3 - 2*_x2/3 + 2*_x3/3,
+        C1*_x2/3 - C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 + 2*C3/3 + _x2*_x5/3 + _x3/3 + _x4 - _x5/3,
+        C1*_x2/3 + 2*C1/3 + C2*_x2/3 - C2/3 + C3*_x2/3 - C3/3 + _x2*_x5/3 + _x3/3 + _x4 - _x5/3,
+        C1*_x2/3 - C1/3 + C2*_x2/3 + 2*C2/3 + C3*_x2/3 - C3/3 + _x2*_x5/3 - 2*_x3/3 + _x4 + 2*_x5/3,
     ]
-    assert _remove_dummies(linodesolve(A, x, b=b), x) == sol
-    assert _remove_dummies(linodesolve(A, x, b=b, type="type4"), x) == sol
+    assert constant_renumber(linodesolve(A, x, b=b), variables=Tuple(*eq).free_symbols) == sol
+    assert constant_renumber(linodesolve(A, x, b=b, type="type4"),
+                             variables=Tuple(*eq).free_symbols) == sol
 
     A1 = Matrix([[t, 1], [t, -1]])
     raises(NotImplementedError, lambda: linodesolve(A1, t, b=b1))
 
     # non-homogeneous term not passed
-    sol1 = [2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2),
-             -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2),
-             -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)]
-    assert _remove_dummies(linodesolve(A, x, type="type4", doit=True), x) == sol1
+    sol1 = [-C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2),
+            -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 + C3/3)*exp(3*x**2/2)]
+    assert constant_renumber(linodesolve(A, x, type="type4", doit=True), variables=Tuple(*eq).free_symbols) == sol1
 
 
 @slow
@@ -1422,7 +1394,7 @@ def test_linear_3eq_order1_type4_slow():
 
 
 @slow
-def test_linear_neq_order1_type2_big_test_cases():
+def test_linear_neq_order1_type2_slow1():
     i, r1, c1, r2, c2, t = symbols('i, r1, c1, r2, c2, t')
     x1 = Function('x1')
     x2 = Function('x2')
@@ -1431,22 +1403,25 @@ def test_linear_neq_order1_type2_big_test_cases():
     eq2 = r2*c1*Derivative(x1(t), t) + r2*c2*Derivative(x2(t), t) + x2(t) - r2*i
     eq = [eq1, eq2]
 
-    z1 = c1**2*r1**2 + 2*c1**2*r1*r2 + c1**2*r2**2 - 2*c1*c2*r1*r2 + 2*c1*c2*r2**2 + c2**2*r2**2
-    z2 = exp(-t/(2*c2*r2) - t/(2*c2*r1) - t/(2*c1*r1) + t*sqrt(z1)/(2*c1*c2*r1*r2))
-    z3 = exp(-t/(2*c2*r2) - t/(2*c2*r1) - t/(2*c1*r1) - t*sqrt(z1)/(2*c1*c2*r1*r2))
-    z4 = Integral(i*r2*exp(t/(2*c2*r2) + t/(2*c2*r1) + t/(2*c1*r1) - t*sqrt(z1)/(2*c1*c2*r1*r2))/sqrt(z1), t)
-    z5 = Integral(-i*r2*exp(t/(2*c2*r2) + t/(2*c2*r1) + t/(2*c1*r1) + t*sqrt(z1)/(2*c1*c2*r1*r2))/sqrt(z1), t)
+    _x1 = sqrt(
+        c1**2*r1**2 + 2*c1**2*r1*r2 + c1**2*r2**2 - 2*c1*c2*r1*r2 + 2*c1*c2*r2**2 + c2**2*r2**2)
+    _x2 = -_x1*t/(2*c1*c2*r1*r2)
+    _x3 = 1/(_x1 - c1*r1 - c1*r2 + c2*r2)
+    _x4 = 1/(_x1 + c1*r1 + c1*r2 - c2*r2)
+    _x5 = 1/(2*_x3*c1*c2*r2 + 2*_x4*c1*c2*r2)
+    _x6 = Integral(_x5*i*exp(_x2 + t/(2*c2*r2) + t/(2*c2*r1) + t/(2*c1*r1)), t)
+    _x7 = Integral(
+        -_x5*i*exp(_x1*t/(2*c1*c2*r1*r2) + t/(2*c2*r2) + t/(2*c2*r1) + t/(2*c1*r1)),
+        t)
+    _x8 = exp(_x1*t/(2*c1*c2*r1*r2) - t/(2*c2*r2) - t/(2*c2*r1) - t/(2*c1*r1))
+    _x9 = exp(_x2 - t/(2*c2*r2) - t/(2*c2*r1) - t/(2*c1*r1))
     sol = [
         Eq(x1(t),
-            z2*(C2*r1/(2*r2) + C2/2 - C2*c2/(2*c1) + C2*sqrt(z1)/(2*c1*r2)
-          + r1*z4/(2*r2) + z4/2 - c2*z4/(2*c1) + sqrt(z1)*z4/(2*c1*r2))
-          + z3*(C1*r1/(2*r2) + C1/2 - C1*c2/(2*c1) - C1*sqrt(z1)/(2*c1*r2)
-          + r1*z5/(2*r2) + z5/2 - c2*z5/(2*c1) - sqrt(z1)*z5/(2*c1*r2))),
-        Eq(x2(t), z2*(C2 + z4) + z3*(C1 + z5)),
+           2*C1*_x3*_x8*c2*r2 - 2*C2*_x4*_x9*c2*r2 + 2*_x3*_x6*_x8*c2*r2 - 2*_x4*_x7*_x9*c2*r2),
+        Eq(x2(t), C1*_x8 + C2*_x9 + _x6*_x8 + _x7*_x9),
     ]
 
-    with dotprodsimp(True):
-        assert dsolve(eq) == sol
+    assert dsolve(eq) == sol
     assert checksysodesol(eq, sol) == (True, [0, 0])
 
 
@@ -1467,37 +1442,35 @@ def _de_lorentz_solution():
 
     # The code for the solution here is made using
     # printsol from https://github.com/sympy/sympy/issues/19574
-    z1 = exp(2*q*t*sqrt(-b1**2 - b2**2 - b3**2)/m)
-    z2 = exp(q*t*sqrt(-b1**2 - b2**2 - b3**2)/m)
-    z3 = 1/(-b1**2*b3*z2 - b2**2*b3*z2)
-    z4 = sqrt(b1**2 + b2**2 + b3**2)
-    z5 = Integral(b1*b3*e1*q/(b1**2*m + b2**2*m + b3**2*m)
-                + b2*b3*e2*q/(b1**2*m + b2**2*m + b3**2*m)
-                + b3**2*e3*q/(b1**2*m + b2**2*m + b3**2*m), t)
-    z6 = 1/(-2*I*b1**2*m*z2*z4 - 2*I*b2**2*m*z2*z4 - 2*I*b3**2*m*z2*z4)
-    z7 = Integral(b1**3*e2*q*z6 - b1**2*b2*e1*q*z6 - I*b1**2*e3*q*z4*z6
-                + b1*b2**2*e2*q*z6 + b1*b3**2*e2*q*z6 + I*b1*b3*e1*q*z4*z6
-                - b2**3*e1*q*z6 - I*b2**2*e3*q*z4*z6 - b2*b3**2*e1*q*z6 + I*b2*b3*e2*q*z4*z6, t)
-    z8 = 1/(-2*b1**3*b3*m - 2*I*b1**2*b2*m*z4 - 2*b1*b2**2*b3*m - 2*b1*b3**3*m - 2*I*b2**3*m*z4 - 2*I*b2*b3**2*m*z4)
-    z9 = Integral(-b1**3*b2*e2*q*z2*z8 - b1**3*b3*e3*q*z2*z8 + b1**2*b2**2*e1*q*z2*z8
-                - I*b1**2*b2*e3*q*z2*z4*z8 + b1**2*b3**2*e1*q*z2*z8 + I*b1**2*b3*e2*q*z2*z4*z8
-                - b1*b2**3*e2*q*z2*z8 - b1*b2**2*b3*e3*q*z2*z8 + b2**4*e1*q*z2*z8
-                - I*b2**3*e3*q*z2*z4*z8 + b2**2*b3**2*e1*q*z2*z8 + I*b2**2*b3*e2*q*z2*z4*z8, t)
-    z10 = 1/(b1**2*b3*z2 + b2**2*b3*z2)
+    _x1 = 1/m
+    _x2 = b1**2
+    _x3 = b2**2
+    _x4 = b3**2
+    _x5 = sqrt(-_x2 - _x3 - _x4)
+    _x6 = exp(2*_x1*_x5*q*t)
+    _x7 = exp(_x1*_x5*q*t)
+    _x8 = 1/(-_x2*_x7*b3 - _x3*_x7*b3)
+    _x9 = sqrt(_x2 + _x3 + _x4)
+    _x10 = 1/(_x2*m + _x3*m + _x4*m)
+    _x11 = Integral(_x10*_x4*e3*q + _x10*b1*b3*e1*q + _x10*b2*b3*e2*q, t)
+    _x12 = b1**3
+    _x13 = b2**3
+    _x14 = 1/(-2*I*_x2*_x7*_x9*m - 2*I*_x3*_x7*_x9*m - 2*I*_x4*_x7*_x9*m)
+    _x15 = Integral(
+        _x12*_x14*e2*q - _x13*_x14*e1*q - I*_x14*_x2*_x9*e3*q - _x14*_x2*b2*e1*q - I*_x14*_x3*_x9*e3*q + _x14*_x3*b1*e2*q + _x14*_x4*b1*e2*q - _x14*_x4*b2*e1*q + I*_x14*_x9*b1*b3*e1*q + I*_x14*_x9*b2*b3*e2*q,
+        t)
+    _x16 = 1/(
+        -2*_x12*b3*m - 2*I*_x13*_x9*m - 2*I*_x2*_x9*b2*m - 2*_x3*b1*b3*m - 2*I*_x4*_x9*b2*m - 2*b1*b3**3*m)
+    _x17 = Integral(
+        -_x12*_x16*_x7*b2*e2*q - _x12*_x16*_x7*b3*e3*q - I*_x13*_x16*_x7*_x9*e3*q - _x13*_x16*_x7*b1*e2*q + _x16*_x2*_x3*_x7*e1*q + _x16*_x2*_x4*_x7*e1*q - I*_x16*_x2*_x7*_x9*b2*e3*q + I*_x16*_x2*_x7*_x9*b3*e2*q + _x16*_x3*_x4*_x7*e1*q + I*_x16*_x3*_x7*_x9*b3*e2*q - _x16*_x3*_x7*b1*b3*e3*q + _x16*_x7*b2**4*e1*q,
+        t)
+    _x18 = 1/(_x2*_x7*b3 + _x3*_x7*b3)
     sol = [
         Eq(v1(t),
-            C1*b1**3*z10*z2 + C1*b1*b2**2*z10*z2
-          - C2*b1*b3**2*z10 - I*C2*b2*b3*z10*z4
-          - C3*b1*b3**2*z1*z10 + I*C3*b2*b3*z1*z10*z4
-          + b1**3*z10*z2*z5 + b1*b2**2*z10*z2*z5 - b1*b3**2*z1*z10*z7
-          - b1*b3**2*z10*z9 + I*b2*b3*z1*z10*z4*z7 - I*b2*b3*z10*z4*z9),
+           -C1*_x18*_x4*b1 - I*C1*_x18*_x9*b2*b3 + C2*_x12*_x18*_x7 + C2*_x18*_x3*_x7*b1 - C3*_x18*_x4*_x6*b1 + I*C3*_x18*_x6*_x9*b2*b3 + _x11*_x12*_x18*_x7 + _x11*_x18*_x3*_x7*b1 - _x15*_x18*_x4*_x6*b1 + I*_x15*_x18*_x6*_x9*b2*b3 - _x17*_x18*_x4*b1 - I*_x17*_x18*_x9*b2*b3),
         Eq(v2(t),
-          - C1*b1**2*b2*z2*z3 - C1*b2**3*z2*z3
-          - I*C2*b1*b3*z3*z4 + C2*b2*b3**2*z3
-          + I*C3*b1*b3*z1*z3*z4 + C3*b2*b3**2*z1*z3
-          - b1**2*b2*z2*z3*z5 + I*b1*b3*z1*z3*z4*z7 - I*b1*b3*z3*z4*z9
-          - b2**3*z2*z3*z5 + b2*b3**2*z1*z3*z7 + b2*b3**2*z3*z9),
-        Eq(v3(t), C1 + C3*z2 + z2*z7 + z5 + (C2 + z9)*exp(-q*t*sqrt(-b1**2 - b2**2 - b3**2)/m)),
+           C1*_x4*_x8*b2 - I*C1*_x8*_x9*b1*b3 - C2*_x13*_x7*_x8 - C2*_x2*_x7*_x8*b2 + C3*_x4*_x6*_x8*b2 + I*C3*_x6*_x8*_x9*b1*b3 - _x11*_x13*_x7*_x8 - _x11*_x2*_x7*_x8*b2 + _x15*_x4*_x6*_x8*b2 + I*_x15*_x6*_x8*_x9*b1*b3 + _x17*_x4*_x8*b2 - I*_x17*_x8*_x9*b1*b3),
+        Eq(v3(t), C2 + C3*_x7 + _x11 + _x15*_x7 + (C1 + _x17)*exp(-_x1*_x5*q*t)),
     ]
 
     return eqs, sol
@@ -1616,24 +1589,26 @@ def _neq_order1_type4_slow1():
     _x3 = 1/(161*_x1 + 663)
     _x4 = 1/(51*_x1 - 221)
     _x5 = 1/(161*_x1 - 663)
-    _x6 = exp(_x1*x**3/6 - x**3/2 - x**2/2)
-    _x7 = -_x1*x**3/6
-    _x8 = exp(_x7 - x**3/2 - x**2/2)
-    _x9 = Integral(
-        139*_x1*_x3*_x6*x - 39*_x1*_x3*_x6 + 22*_x1*_x3*_x8*x + 39*_x1*_x3*_x8 + 573*_x3*_x6*x - 161*_x3*_x6 + 90*_x3*_x8*x + 161*_x3*_x8,
+    _x6 = -x**3/2
+    _x7 = _x1*x**3/6
+    _x8 = exp(_x6 + _x7 - x**2/2)
+    _x9 = -_x1*x**3/6
+    _x10 = exp(_x6 + _x9 - x**2/2)
+    _x11 = Integral(
+        22*_x1*_x10*_x3*x + 39*_x1*_x10*_x3 + 139*_x1*_x3*_x8*x - 39*_x1*_x3*_x8 + 90*_x10*_x3*x + 161*_x10*_x3 + 573*_x3*_x8*x - 161*_x3*_x8,
         x)
-    _x10 = exp(_x7 + x**3/2 + x**2/2)
-    _x11 = exp(_x1*x**3/6 + x**3/2 + x**2/2)
-    _x12 = Integral(
-        -22*_x1*_x2*_x6*x + 6*_x1*_x2*_x6 + 22*_x1*_x2*_x8*x + 39*_x1*_x2*_x8 - 90*_x2*_x6*x + 26*_x2*_x6 + 90*_x2*_x8*x + 161*_x2*_x8,
+    _x12 = exp(_x9 + x**3/2 + x**2/2)
+    _x13 = exp(_x7 + x**3/2 + x**2/2)
+    _x14 = Integral(
+        22*_x1*_x10*_x2*x + 39*_x1*_x10*_x2 - 22*_x1*_x2*_x8*x + 6*_x1*_x2*_x8 + 90*_x10*_x2*x + 161*_x10*_x2 - 90*_x2*_x8*x + 26*_x2*_x8,
         x)
     sol = [
-        Eq(f(x), _x10*(
-            22*C1*_x1*_x5 - 90*C1*_x5 + 39*C2*_x1*_x5 - 161*C2*_x5 + 39*_x1*_x12*_x5 + 22*_x1*_x5*_x9 - 161*_x12*_x5 - 90*_x5*_x9) + _x11*(
-               139*C1*_x1*_x5 - 573*C1*_x5 - 39*C2*_x1*_x5 + 161*C2*_x5 - 39*_x1*_x12*_x5 + 139*_x1*_x5*_x9 + 161*_x12*_x5 - 573*_x5*_x9)),
-        Eq(g(x), _x10*(
-            26*C1*_x1*_x4 - 102*C1*_x4 + 45*C2*_x1*_x4 - 187*C2*_x4 + 45*_x1*_x12*_x4 + 26*_x1*_x4*_x9 - 187*_x12*_x4 - 102*_x4*_x9) + _x11*(
-               -26*C1*_x1*_x4 + 102*C1*_x4 + 6*C2*_x1*_x4 - 34*C2*_x4 + 6*_x1*_x12*_x4 - 26*_x1*_x4*_x9 - 34*_x12*_x4 + 102*_x4*_x9)),
+        Eq(f(x), _x12*(
+            39*C1*_x1*_x5 - 161*C1*_x5 + 22*C2*_x1*_x5 - 90*C2*_x5 + 22*_x1*_x11*_x5 + 39*_x1*_x14*_x5 - 90*_x11*_x5 - 161*_x14*_x5) + _x13*(
+               -39*C1*_x1*_x5 + 161*C1*_x5 + 139*C2*_x1*_x5 - 573*C2*_x5 + 139*_x1*_x11*_x5 - 39*_x1*_x14*_x5 - 573*_x11*_x5 + 161*_x14*_x5)),
+        Eq(g(x), _x12*(
+            45*C1*_x1*_x4 - 187*C1*_x4 + 26*C2*_x1*_x4 - 102*C2*_x4 + 26*_x1*_x11*_x4 + 45*_x1*_x14*_x4 - 102*_x11*_x4 - 187*_x14*_x4) + _x13*(
+               6*C1*_x1*_x4 - 34*C1*_x4 - 26*C2*_x1*_x4 + 102*C2*_x4 - 26*_x1*_x11*_x4 + 6*_x1*_x14*_x4 + 102*_x11*_x4 - 34*_x14*_x4)),
     ]
 
     return eqs, sol
@@ -1653,6 +1628,7 @@ def test_neq_order1_type4_slow_check1():
     eqs, sol = _neq_order1_type4_slow1()
     assert checksysodesol(eqs, sol) == (True, [0, 0])
 
+
 def _neq_order1_type4_slow2():
     f, g, h = symbols("f, g, h", cls=Function)
     x = Symbol("x")
@@ -1660,22 +1636,19 @@ def _neq_order1_type4_slow2():
     eqs = [Eq(Derivative(f(x), x), x*h(x) + f(x) + g(x) + 1), Eq(Derivative(g(x), x), x*g(x) + f(x) + h(x) +
             10), Eq(Derivative(h(x), x), x*f(x) + x + g(x) + h(x))]
     _x1 = -x**2/2
-    _x2 = exp(_x1 + x)
-    _x3 = exp(_x1 - 2*x)
-    _x4 = exp(x**2/2 - x)
-    _x5 = 11*_x3/3
-    _x6 = _x3*x/3
-    _x7 = Integral(-_x2*x/3 + 19*_x2/3 + _x5 + _x6, x)
-    _x8 = _x2*x/6
-    _x9 = -19*_x2/6
-    _x10 = Integral(-_x4*x/2 + _x4/2 + _x5 + _x6 + _x8 + _x9, x)
-    _x11 = Integral(_x4*x/2 - _x4/2 + _x5 + _x6 + _x8 + _x9, x)
-    _x12 = _x4*(C1/6 - C2/3 + C3/6 + _x10/6 + _x11/6 - _x7/3)
-    _x13 = (C1/3 + C2/3 + C3/3 + _x10/3 + _x11/3 + _x7/3)*exp(x**2/2 + 2*x)
+    _x2 = Integral(x*exp(_x1 - 2*x)/3 - x*exp(_x1 + x)/3 + 11*exp(_x1 - 2*x)/3 + 19*exp(_x1 + x)/3,
+                   x)
+    _x3 = Integral(x*exp(_x1 - 2*x)/3 + x*exp(_x1 + x)/6 - x*exp(x**2/2 - x)/2 + 11*exp(
+        _x1 - 2*x)/3 - 19*exp(_x1 + x)/6 + exp(x**2/2 - x)/2, x)
+    _x4 = Integral(x*exp(_x1 - 2*x)/3 + x*exp(_x1 + x)/6 + x*exp(x**2/2 - x)/2 + 11*exp(
+        _x1 - 2*x)/3 - 19*exp(_x1 + x)/6 - exp(x**2/2 - x)/2, x)
+    _x5 = (C1/3 + C2/3 + C3/3 + _x2/3 + _x3/3 + _x4/3)*exp(x**2/2 + 2*x)
     sol = [
-        Eq(f(x), _x12 + _x13 + _x2*(C1/2 - C3/2 + _x10/2 - _x11/2)),
-        Eq(g(x), _x13 + _x4*(-C1/3 + 2*C2/3 - C3/3 - _x10/3 - _x11/3 + 2*_x7/3)),
-        Eq(h(x), _x12 + _x13 + _x2*(-C1/2 + C3/2 - _x10/2 + _x11/2)),
+        Eq(f(x), _x5 + (-C1/2 + C2/2 + _x3/2 - _x4/2)*exp(_x1 + x) + (
+            C1/6 + C2/6 - C3/3 - _x2/3 + _x3/6 + _x4/6)*exp(x**2/2 - x)),
+        Eq(g(x), _x5 + (-C1/3 - C2/3 + 2*C3/3 + 2*_x2/3 - _x3/3 - _x4/3)*exp(x**2/2 - x)),
+        Eq(h(x), _x5 + (C1/2 - C2/2 - _x3/2 + _x4/2)*exp(_x1 + x) + (
+            C1/6 + C2/6 - C3/3 - _x2/3 + _x3/6 + _x4/6)*exp(x**2/2 - x)),
     ]
 
     return eqs, sol
@@ -1744,8 +1717,6 @@ def test_linear_3eq_order1_type4_long_dsolve_slow_xfail():
 def test_linear_3eq_order1_type4_long_dsolve_dotprodsimp():
     if ON_TRAVIS:
         skip("Too slow for travis.")
-
-    from sympy.matrices import dotprodsimp
 
     eq, sol = _linear_3eq_order1_type4_long()
 


### PR DESCRIPTION
#### References to other Issues or PRs


#### Brief description of what is fixed or changed
Three tasks are carried out in this PR:
1. Adding `checksysodesol` call in `checkodesol`
2. Fixing `constants_renumber` to handle a system of ODEs
3. Synchronizing the outputs of `linear_ode_to_matrix` and `canonical_odes`

#### Other comments
These tasks will help simplify work for an end-user and helps for the internal workings of the solvers.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Extending `checkodesol` and `constants_renumber` to handle system of ODEs
<!-- END RELEASE NOTES -->