### PR TITLE
Support for generating code using numpy.logaddexp

### DIFF
--- a/sympy/codegen/numpy_nodes.py
+++ b/sympy/codegen/numpy_nodes.py
@@ -30,13 +30,19 @@ class logaddexp(Function):
             raise ArgumentIndexError(self, argindex)
         return 1/(1 + exp(other-wrt))
 
-    def _eval_expand_func(self, **hints):
-        return _logaddexpr(*self.args)
-
     def _eval_rewrite_as_log(self, x1, x2, **kwargs):
         return _logaddexp(x1, x2)
 
-    _eval_rewrite_as_tractable = _eval_rewrite_as_log
-
     def _eval_simplify(self, *args, **kwargs):
-        return self.rewrite(log).simplify(*args, **kwargs)
+        a, b = map(lambda x: x.simplify(**kwargs), self.args)
+        candidate = _logaddexp(a, b)
+        if candidate.is_Function and candidate.func == log and len(candidate.args[0].args) == 2:
+            for arg in candidate.args[0].args:
+                if arg.is_Function and arg.func == exp:
+                    continue
+                else:
+                    break
+            else:
+                return logaddexp(a, b)  # no simplification made
+
+        return candidate  # simplified

--- a/sympy/codegen/numpy_nodes.py
+++ b/sympy/codegen/numpy_nodes.py
@@ -1,0 +1,42 @@
+from sympy.core.function import ArgumentIndexError, Function
+from sympy.functions.elementary.exponential import exp, log
+from sympy.utilities import default_sort_key
+
+
+def _logaddexp(x1, x2):
+    return log(exp(x1) + exp(x2))
+
+
+class logaddexp(Function):
+    """ Logarithm of the sum of exponentiations of the inputs.
+
+    Helper class for use with e.g. numpy.logaddexp
+    See: https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.logaddexp.html
+    """
+    nargs = 2
+
+    def __new__(cls, *args):
+        return Function.__new__(cls, *sorted(args, key=default_sort_key))
+
+    def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of this function.
+        """
+        if argindex == 1:
+            wrt, other = self.args
+        elif argindex == 2:
+            other, wrt = self.args
+        else:
+            raise ArgumentIndexError(self, argindex)
+        return 1/(1 + exp(other-wrt))
+
+    def _eval_expand_func(self, **hints):
+        return _logaddexpr(*self.args)
+
+    def _eval_rewrite_as_log(self, x1, x2, **kwargs):
+        return _logaddexp(x1, x2)
+
+    _eval_rewrite_as_tractable = _eval_rewrite_as_log
+
+    def _eval_simplify(self, *args, **kwargs):
+        return self.rewrite(log).simplify(*args, **kwargs)

--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -36,6 +36,7 @@ from sympy.assumptions import Q, ask
 from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core.expr import UnevaluatedExpr
+from sympy.codegen.numpy_nodes import logaddexp
 from sympy.core.mul import Mul
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.utilities.iterables import sift
@@ -250,5 +251,9 @@ def _matinv_transform(expr):
 matinv_opt = ReplaceOptim(_matinv_predicate, _matinv_transform)
 
 
+logaddexp_opt = ReplaceOptim(log(exp(_v)+exp(_w)), logaddexp(_v, _w))
+
 # Collections of optimizations:
 optims_c99 = (expm1_opt, log1p_opt, exp2_opt, log2_opt, log2const_opt)
+
+optims_numpy = (logaddexp_opt,)

--- a/sympy/codegen/tests/test_numpy_nodes.py
+++ b/sympy/codegen/tests/test_numpy_nodes.py
@@ -12,3 +12,12 @@ def test_logaddexp():
             lae_xy.diff(wrt, deriv_order) -
             ref_xy.diff(wrt, deriv_order)
         ).rewrite(log).simplify() == 0
+
+    one_third_e = 1*exp(1)/3
+    two_thirds_e = 2*exp(1)/3
+    logThirdE = log(one_third_e)
+    logTwoThirdsE = log(two_thirds_e)
+    lae_sum_to_e = logaddexp(logThirdE, logTwoThirdsE)
+    assert lae_sum_to_e.rewrite(log) == 1
+    assert lae_sum_to_e.simplify() == 1
+    assert logaddexp(2, 3).simplify() == logaddexp(2, 3)  # cannot simplify with 2, 3

--- a/sympy/codegen/tests/test_numpy_nodes.py
+++ b/sympy/codegen/tests/test_numpy_nodes.py
@@ -11,4 +11,4 @@ def test_logaddexp():
         assert (
             lae_xy.diff(wrt, deriv_order) -
             ref_xy.diff(wrt, deriv_order)
-        ).simplify() == 0
+        ).rewrite(log).simplify() == 0

--- a/sympy/codegen/tests/test_numpy_nodes.py
+++ b/sympy/codegen/tests/test_numpy_nodes.py
@@ -1,0 +1,14 @@
+from itertools import product
+from sympy import symbols, exp, log
+from sympy.codegen.numpy_nodes import logaddexp
+
+x, y, z = symbols('x y z')
+
+def test_logaddexp():
+    lae_xy = logaddexp(x, y)
+    ref_xy = log(exp(x) + exp(y))
+    for wrt, deriv_order in product([x, y, z], range(0, 3)):
+        assert (
+            lae_xy.diff(wrt, deriv_order) -
+            ref_xy.diff(wrt, deriv_order)
+        ).simplify() == 0

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -3,9 +3,10 @@ from sympy.assumptions import assuming, Q
 from sympy.printing.ccode import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
+from sympy.codegen.numpy_nodes import logaddexp
 from sympy.codegen.rewriting import (
     optimize, log2_opt, exp2_opt, expm1_opt, log1p_opt, optims_c99,
-    create_expand_pow_optimization, matinv_opt
+    create_expand_pow_optimization, matinv_opt, logaddexp_opt
 )
 from sympy.testing.pytest import XFAIL
 
@@ -182,3 +183,12 @@ def test_matsolve():
     with assuming(Q.fullrank(A)):
         assert optimize(A**(-1) * x, [matinv_opt]) == MatrixSolve(A, x)
         assert optimize(A**(-1) * x + x, [matinv_opt]) == MatrixSolve(A, x) + x
+
+
+def test_logaddexp_opt():
+    x, y = map(Symbol, 'x y'.split())
+    expr1 = log(exp(x) + exp(y))
+    opt1 = optimize(expr1, [logaddexp_opt])
+    assert logaddexp(x, y) - opt1 == 0
+    assert logaddexp(y, x) - opt1 == 0
+    assert opt1.rewrite(log) == expr1

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -452,7 +452,7 @@ def test_sympy__codegen__fnodes__product_():
     assert _test_args(product_('arr'))
 
 
-def test_sympy_codegen__numpy_nodes__logaddexp():
+def test_sympy__codegen__numpy_nodes__logaddexp():
     from sympy.codegen.numpy_nodes import logaddexp
     assert _test_args(logaddexp(x, y))
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -452,6 +452,11 @@ def test_sympy__codegen__fnodes__product_():
     assert _test_args(product_('arr'))
 
 
+def test_sympy_codegen__numpy_nodes__logaddexp():
+    from sympy.codegen.numpy_nodes import logaddexp
+    assert _test_args(logaddexp(x, y))
+
+
 @XFAIL
 def test_sympy__combinatorics__graycode__GrayCode():
     from sympy.combinatorics.graycode import GrayCode

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -593,6 +593,7 @@ _known_functions_numpy = dict(_in_numpy, **{
     'atanh': 'arctanh',
     'exp2': 'exp2',
     'sign': 'sign',
+    'logaddexp': 'logaddexp',
 })
 _known_constants_numpy = {
     'Exp1': 'e',

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -6,6 +6,7 @@ from sympy import eye
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.core import Pow
 from sympy.codegen.matrix_nodes import MatrixSolve
+from sympy.codegen.numpy_nodes import logaddexp
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Sqrt
 from sympy.codegen.array_utils import (CodegenArrayTensorProduct, CodegenArrayDiagonal,
                                        CodegenArrayPermuteDims, CodegenArrayElementwiseAdd, parse_matrix_expression)
@@ -29,6 +30,10 @@ def test_numpy_piecewise_regression():
     assert printer.doprint(p) == \
         'numpy.select([numpy.less(x, 0),True], [1,0], default=numpy.nan)'
     assert printer.module_imports == {'numpy': {'select', 'less', 'nan'}}
+
+def test_numpy_logaddexp():
+    lae = logaddexp(a, b)
+    assert NumPyPrinter().doprint(lae) == 'numpy.logaddexp(a, b)'
 
 
 def test_sum():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This is a new PR based on gh-15937. I recently rebased on master and fixed failing tests, so this PR should hopefully be ready to go.
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This will add support for generating code leveraging [numpy.logaddexp](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.logaddexp.html)

This is a typical optimization against possible precision loss which will be hard to spot manually in large expressions.

#### Other comments
Future PRs could perhaps also add support for:
- [numpy.logaddexp2](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.logaddexp2.html#numpy.logaddexp2)
- [scipy.misc.logsumexp](https://docs.scipy.org/doc/scipy-0.18.1/reference/generated/scipy.misc.logsumexp.html)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->