### PR TITLE
[GSoC] Dividing system of ODEs into sub-systems

### DIFF
--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -5,7 +5,7 @@ from sympy.core.exprtools import factor_terms
 from sympy.core.numbers import I
 from sympy.core.relational import Eq, Equality
 from sympy.core.symbol import Dummy, Symbol
-from sympy.core.function import expand_mul, expand, Derivative, Function
+from sympy.core.function import expand_mul, expand, Derivative
 from sympy.functions import exp, im, cos, sin, re, Piecewise, piecewise_fold
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.matrices import zeros, Matrix, NonSquareMatrixError, MatrixBase
@@ -1117,7 +1117,8 @@ def _combine_systems(sccs, graph, t):
                 is_type1[i] = False
                 break
 
-        eqs, funcs = list(eqs), list(funcs)
+        eqs = list(eqs)
+        funcs = [e.lhs.args[0] for e in eqs]
         is_type1[i] = _is_type1((eqs, funcs), t) if is_type1[i] else is_type1[i]
         if is_type1[i]:
             min_index = i

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1328,11 +1328,15 @@ def dsolve_system(eqs, funcs=None, t=None, ics=None, doit=False):
             Input to the funcs should be a list of functions.
         '''))
 
-    # Note: This is added to solve a major problem encountered.
-    # Might be best to make a function for this functions
-    # extraction later.
     if funcs is None:
         funcs = _extract_funcs(eqs)
+
+    if any(len(func.args) != 1 for func in funcs):
+        raise ValueError(filldedent('''
+            dsolve_system can solve a system of ODEs with only one independent
+            variable.
+        '''))
+
     if len(eqs) != len(funcs):
         raise ValueError(filldedent('''
             Number of equations and number of functions don't match

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -1384,6 +1384,14 @@ def dsolve_system(eqs, funcs=None, t=None, ics=None, doit=False):
     if t is None:
         t = list(list(eqs[0].atoms(Derivative))[0].atoms(Symbol))[0]
 
+    sys_order = _get_func_order(eqs, funcs)
+
+    # To add higher order to first order reduction later
+    if not all(sys_order[func] == 1 for func in funcs):
+        raise NotImplementedError(filldedent('''
+            Higher order ODEs aren't solvable by dsolve_system
+        '''))
+
     canon_eqs = canonical_odes(eqs, funcs, t)
     sols = []
 

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -39,26 +39,6 @@ def test_get_numbered_constants():
         get_numbered_constants(None)
 
 
-def test_dsolve_system():
-
-    eqs = [f(x).diff(x, 2), g(x).diff(x)]
-    with raises(ValueError):
-        dsolve(eqs) # NotImplementedError would be better
-
-    eqs = [f(x).diff(x) - x, f(x).diff(x) + x]
-    with raises(ValueError):
-        # Could also be NotImplementedError. f(x)=0 is a solution...
-        dsolve(eqs)
-
-    eqs = [f(x, y).diff(x)]
-    with raises(ValueError):
-        dsolve(eqs)
-
-    eqs = [f(x, y).diff(x)+g(x).diff(x), g(x).diff(x)]
-    with raises(ValueError):
-        dsolve(eqs)
-
-
 def test_dsolve_all_hint():
     eq = f(x).diff(x)
     output = dsolve(eq, hint='all')

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -551,12 +551,12 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq19, sol19) == (True, [0, 0])
 
     eq20 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), x(t) + y(t))]
-    sol20 = [Eq(x(t), C1*exp(t)), Eq(y(t), (C1*t + C2)*exp(t))]
+    sol20 = [Eq(x(t), C1*exp(t)), Eq(y(t), (C2 + Integral(C1, t))*exp(t))]
     assert dsolve(eq20) == sol20
     assert checksysodesol(eq20, sol20) == (True, [0, 0])
 
     eq21 = [Eq(Derivative(x(t), t), 3*x(t)), Eq(Derivative(y(t), t), x(t) + y(t))]
-    sol21 = [Eq(x(t), 2*C1*exp(3*t)), Eq(y(t), C1*exp(3*t) + C2*exp(t))]
+    sol21 = [Eq(x(t), C1*exp(3*t)), Eq(y(t), (C2 + Integral(C1*exp(2*t), t))*exp(t))]
     assert dsolve(eq21) == sol21
     assert checksysodesol(eq21, sol21) == (True, [0, 0])
 
@@ -575,13 +575,22 @@ def test_sysode_linear_neq_order1_type1():
     eq1 = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)),
            Eq(Derivative(Z1(t), t), k01*Z0(t) - k10*Z1(t) + k21*Z2(t)),
            Eq(Derivative(Z2(t), t), -(k20 + k21 + k23)*Z2(t)), Eq(Derivative(Z3(t), t), k23*Z2(t) - k30*Z3(t)))
-    sol1 = [Eq(Z0(t), C1*k10/k01 + C2*(-k10 + k30)*exp(-k30*t)/(k01 + k10 - k30) + C3*(k10*k20 + k10*k21 - k10*k30 - k20**2 -
-                k20*k21 - k20*k23 + k20*k30 + k23*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23)) -
-                C4*exp(t*(-k01 - k10))),
-            Eq(Z1(t), C1 - C2*k01*exp(-k30*t)/(k01 + k10 - k30) + C3*(k01*k20 + k01*k21 - k01*k30 - k20*k21 - k21**2 -
-                k21*k23 + k21*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23)) + C4*exp(t*(-k01 - k10))),
-            Eq(Z2(t), C3*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23), Eq(Z3(t), C2*exp(-k30*t) +
-                C3*exp(t*(-k20 - k21 - k23)))]
+    sol1 = [Eq(Z0(t), C1*k10/k01 - C4*exp(-k01*t - k10*t) - exp(-k01*t - k10*t)*Integral(C2*k30*exp(k01*t + k10*t)/(
+                -exp(k30*t) - k10*exp(k30*t)/k01) - C3*k10*k21*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-k01 -
+                k10) + C3*k20*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) + k30*exp(k01*t + k10*t)*
+                Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t) +
+                k10*Integral(-C2*k30/(-exp(k30*t) - k10*exp(k30*t)/k01) - C3*k20*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01)
+                - C3*k21*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) - k30*Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t -
+                k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t)/k01),
+            Eq(Z1(t), C1 + C4*exp(-k01*t - k10*t) + exp(-k01*t - k10*t)*Integral(C2*k30*exp(k01*t + k10*t)/(-exp(k30*t)
+                - k10*exp(k30*t)/k01) - C3*k10*k21*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-k01 - k10) +
+                C3*k20*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) + k30*exp(k01*t + k10*t)*Integral(
+                C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t) + Integral(
+                -C2*k30/(-exp(k30*t) - k10*exp(k30*t)/k01) - C3*k20*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) -
+                C3*k21*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) - k30*Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t -
+                k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t)),
+            Eq(Z2(t), C3*exp(t*(-k20 - k21 - k23))),
+            Eq(Z3(t), (C2 + Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t))*exp(-k30*t))]
 
     assert dsolve(eq1, simplify=False) == sol1
     assert checksysodesol(eq1, sol1) == (True, [0, 0, 0, 0])
@@ -594,10 +603,10 @@ def test_sysode_linear_neq_order1_type1():
         Eq(Derivative(x(t), t), k3*y(t)),
         Eq(Derivative(y(t), t), (-k2 - k3)*y(t))
     )
-    sol2 = {Eq(z(t), C1 - C2*k2*exp(t*(-k2 - k3))/(k2 + k3)),
-            Eq(x(t), -C2*k3*exp(t*(-k2 - k3))/(k2 + k3) + C3),
-            Eq(y(t), C2*exp(t*(-k2 - k3)))}
-    assert set(dsolve(eq2)) == sol2
+    sol2 = [Eq(z(t), C1 + Integral(C2*k2*exp(-k2*t - k3*t), t)),
+            Eq(x(t), C3 + Integral(C2*k3*exp(-k2*t - k3*t), t)),
+            Eq(y(t), C2*exp(t*(-k2 - k3)))]
+    assert dsolve(eq2) == sol2
     assert checksysodesol(eq2, sol2) == (True, [0, 0, 0])
 
     eq3 = [4*u(t) - v(t) - 2*w(t) + Derivative(u(t), t),
@@ -615,10 +624,10 @@ def test_sysode_linear_neq_order1_type1():
            Eq(z(t).diff(t), Rational(37, 9)*z(t) - tw*w(t)),
            Eq(w(t).diff(t), 22*tw*w(t) - 2*tw*z(t))]
 
-    sol4 = [Eq(x(t), (C1 + C2*t)*exp(2*t)),
-            Eq(y(t), C2*exp(2*t) + 2*C3*exp(4*t)),
-            Eq(z(t), 2*C3*exp(4*t) - C4*exp(5*t)/4),
-            Eq(w(t), C3*exp(4*t) + C4*exp(5*t))]
+    sol4 = [Eq(x(t), C3*exp(2*t) + exp(2*t)*Integral(C1 - 2*C2*exp(2*t) + Integral(4*C2*exp(2*t), t), t)),
+            Eq(y(t), (C1 + Integral(4*C2*exp(2*t), t))*exp(2*t)),
+            Eq(z(t), 2*C2*exp(4*t) - C4*exp(5*t)/4),
+            Eq(w(t), C2*exp(4*t) + C4*exp(5*t))]
 
     assert dsolve(eq4) == sol4
     assert checksysodesol(eq4, sol4) == (True, [0, 0, 0, 0])

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -431,7 +431,7 @@ def test_canonical_odes():
     funcs = [f(x), g(x), h(x)]
 
     eqs1 = [Eq(f(x).diff(x, x), f(x) + 2*g(x)), Eq(g(x) + 1, g(x).diff(x) + f(x))]
-    sol1 = [Eq(Derivative(f(x), (x, 2)), f(x) + 2*g(x)), Eq(Derivative(g(x), x), -f(x) + g(x) + 1)]
+    sol1 = [[Eq(Derivative(f(x), (x, 2)), f(x) + 2*g(x)), Eq(Derivative(g(x), x), -f(x) + g(x) + 1)]]
     assert canonical_odes(eqs1, funcs[:2], x) == sol1
 
     eqs2 = [Eq(f(x).diff(x), h(x).diff(x) + f(x)), Eq(g(x).diff(x)**2, f(x) + h(x)), Eq(h(x).diff(x), f(x))]
@@ -551,12 +551,12 @@ def test_sysode_linear_neq_order1_type1():
     assert checksysodesol(eq19, sol19) == (True, [0, 0])
 
     eq20 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), x(t) + y(t))]
-    sol20 = [Eq(x(t), C1*exp(t)), Eq(y(t), (C2 + Integral(C1, t))*exp(t))]
+    sol20 = [Eq(x(t), C1*exp(t)), Eq(y(t), (C1*t + C2)*exp(t))]
     assert dsolve(eq20) == sol20
     assert checksysodesol(eq20, sol20) == (True, [0, 0])
 
     eq21 = [Eq(Derivative(x(t), t), 3*x(t)), Eq(Derivative(y(t), t), x(t) + y(t))]
-    sol21 = [Eq(x(t), C1*exp(3*t)), Eq(y(t), (C2 + Integral(C1*exp(2*t), t))*exp(t))]
+    sol21 = [Eq(x(t), 2*C1*exp(3*t)), Eq(y(t), C1*exp(3*t) + C2*exp(t))]
     assert dsolve(eq21) == sol21
     assert checksysodesol(eq21, sol21) == (True, [0, 0])
 
@@ -575,22 +575,13 @@ def test_sysode_linear_neq_order1_type1():
     eq1 = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)),
            Eq(Derivative(Z1(t), t), k01*Z0(t) - k10*Z1(t) + k21*Z2(t)),
            Eq(Derivative(Z2(t), t), -(k20 + k21 + k23)*Z2(t)), Eq(Derivative(Z3(t), t), k23*Z2(t) - k30*Z3(t)))
-    sol1 = [Eq(Z0(t), C1*k10/k01 - C4*exp(-k01*t - k10*t) - exp(-k01*t - k10*t)*Integral(C2*k30*exp(k01*t + k10*t)/(
-                -exp(k30*t) - k10*exp(k30*t)/k01) - C3*k10*k21*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-k01 -
-                k10) + C3*k20*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) + k30*exp(k01*t + k10*t)*
-                Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t) +
-                k10*Integral(-C2*k30/(-exp(k30*t) - k10*exp(k30*t)/k01) - C3*k20*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01)
-                - C3*k21*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) - k30*Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t -
-                k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t)/k01),
-            Eq(Z1(t), C1 + C4*exp(-k01*t - k10*t) + exp(-k01*t - k10*t)*Integral(C2*k30*exp(k01*t + k10*t)/(-exp(k30*t)
-                - k10*exp(k30*t)/k01) - C3*k10*k21*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-k01 - k10) +
-                C3*k20*exp(k01*t + k10*t)*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) + k30*exp(k01*t + k10*t)*Integral(
-                C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t) + Integral(
-                -C2*k30/(-exp(k30*t) - k10*exp(k30*t)/k01) - C3*k20*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) -
-                C3*k21*exp(-k20*t - k21*t - k23*t)/(-1 - k10/k01) - k30*Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t -
-                k23*t), t)/(-exp(k30*t) - k10*exp(k30*t)/k01), t)),
-            Eq(Z2(t), C3*exp(t*(-k20 - k21 - k23))),
-            Eq(Z3(t), (C2 + Integral(C3*k23*exp(k30*t)*exp(-k20*t - k21*t - k23*t), t))*exp(-k30*t))]
+    sol1 = [Eq(Z0(t), C1*k10/k01 + C2*(-k10 + k30)*exp(-k30*t)/(k01 + k10 - k30) + C3*(k10*k20 + k10*k21 - k10*k30 -
+                k20**2 - k20*k21 - k20*k23 + k20*k30 + k23*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 -
+                k23)) - C4*exp(t*(-k01 - k10))),
+            Eq(Z1(t), C1 - C2*k01*exp(-k30*t)/(k01 + k10 - k30) + C3*(k01*k20 + k01*k21 - k01*k30 - k20*k21 - k21**2 -
+                k21*k23 + k21*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23)) + C4*exp(t*(-k01 - k10))),
+            Eq(Z2(t), C3*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23),
+            Eq(Z3(t), C2*exp(-k30*t) + C3*exp(t*(-k20 - k21 - k23)))]
 
     assert dsolve(eq1, simplify=False) == sol1
     assert checksysodesol(eq1, sol1) == (True, [0, 0, 0, 0])
@@ -603,8 +594,8 @@ def test_sysode_linear_neq_order1_type1():
         Eq(Derivative(x(t), t), k3*y(t)),
         Eq(Derivative(y(t), t), (-k2 - k3)*y(t))
     )
-    sol2 = [Eq(z(t), C1 + Integral(C2*k2*exp(-k2*t - k3*t), t)),
-            Eq(x(t), C3 + Integral(C2*k3*exp(-k2*t - k3*t), t)),
+    sol2 = [Eq(z(t), C1 - C2*k2*exp(t*(-k2 - k3))/(k2 + k3)),
+            Eq(x(t), -C2*k3*exp(t*(-k2 - k3))/(k2 + k3) + C3),
             Eq(y(t), C2*exp(t*(-k2 - k3)))]
     assert dsolve(eq2) == sol2
     assert checksysodesol(eq2, sol2) == (True, [0, 0, 0])
@@ -624,10 +615,10 @@ def test_sysode_linear_neq_order1_type1():
            Eq(z(t).diff(t), Rational(37, 9)*z(t) - tw*w(t)),
            Eq(w(t).diff(t), 22*tw*w(t) - 2*tw*z(t))]
 
-    sol4 = [Eq(x(t), C3*exp(2*t) + exp(2*t)*Integral(C1 - 2*C2*exp(2*t) + Integral(4*C2*exp(2*t), t), t)),
-            Eq(y(t), (C1 + Integral(4*C2*exp(2*t), t))*exp(2*t)),
-            Eq(z(t), 2*C2*exp(4*t) - C4*exp(5*t)/4),
-            Eq(w(t), C2*exp(4*t) + C4*exp(5*t))]
+    sol4 = [Eq(x(t), (C1 + C2*t)*exp(2*t)),
+            Eq(y(t), C2*exp(2*t) + 2*C3*exp(4*t)),
+            Eq(z(t), 2*C3*exp(4*t) - C4*exp(5*t)/4),
+            Eq(w(t), C3*exp(4*t) + C4*exp(5*t))]
 
     assert dsolve(eq4) == sol4
     assert checksysodesol(eq4, sol4) == (True, [0, 0, 0, 0])
@@ -1237,7 +1228,7 @@ def test_linodesolve():
     func = [f(t), g(t)]
     eq = [Eq(f(t).diff(t) + g(t).diff(t), g(t)), Eq(g(t).diff(t), f(t))]
     ceq = canonical_odes(eq, func, t)
-    (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
+    (A1, A0), b = linear_ode_to_matrix(ceq[0], func, t, 1)
     A = A0
     sol = [C1*(-Rational(1, 2) + sqrt(5)/2)*exp(t*(-Rational(1, 2) + sqrt(5)/2)) + C2*(-sqrt(5)/2 - Rational(1, 2))*
            exp(t*(-sqrt(5)/2 - Rational(1, 2))),
@@ -1277,7 +1268,7 @@ def test_linodesolve():
     func = [f(t), g(t)]
     eq = [Eq(f(t).diff(t) + g(t).diff(t), g(t) + t), Eq(g(t).diff(t), f(t))]
     ceq = canonical_odes(eq, func, t)
-    (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
+    (A1, A0), b = linear_ode_to_matrix(ceq[0], func, t, 1)
     A = A0
     sol = [-C1*exp(-t/2 + sqrt(5)*t/2)/2 + sqrt(5)*C1*exp(-t/2 + sqrt(5)*t/2)/2 - sqrt(5)*C2*exp(-sqrt(5)*t/2
                 - t/2)/2 - C2*exp(-sqrt(5)*t/2 - t/2)/2 - exp(-t/2 +
@@ -1321,7 +1312,7 @@ def test_linodesolve():
     func = [f(t), g(t)]
     eq = [Eq(f(t).diff(t), f(t) + t*g(t)), Eq(g(t).diff(t), -t*f(t) + g(t))]
     ceq = canonical_odes(eq, func, t)
-    (A1, A0), b = linear_ode_to_matrix(ceq, func, t, 1)
+    (A1, A0), b = linear_ode_to_matrix(ceq[0], func, t, 1)
     A = A0
     sol = [(C1/2 - I*C2/2)*exp(I*t**2/2 + t) + (C1/2 + I*C2/2)*exp(-I*t**2/2 + t),
            (-I*C1/2 + C2/2)*exp(-I*t**2/2 + t) + (I*C1/2 + C2/2)*exp(I*t**2/2 + t)]
@@ -1363,7 +1354,7 @@ def test_linodesolve():
           Eq(g(x).diff(x), x*(f(x) + g(x) + h(x)) + x),
           Eq(h(x).diff(x), x*(f(x) + g(x) + h(x)) + 1)]
     ceq = canonical_odes(eq, func, x)
-    (A1, A0), b = linear_ode_to_matrix(ceq, func, x, 1)
+    (A1, A0), b = linear_ode_to_matrix(ceq[0], func, x, 1)
     A = A0
     _x1 = exp(-3*x**2/2)
     _x2 = exp(3*x**2/2)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1218,8 +1218,8 @@ def test_component_division():
             Eq(Derivative(g(x), x), f(x)),
             Eq(Derivative(h(x), x), h(x)),
             Eq(Derivative(k(x), x), h(x)**4 + k(x))]
-    sol1 = [Eq(f(x), C1*exp(2*x)),
-            Eq(g(x), C1*exp(2*x)/2 + C2),
+    sol1 = [Eq(f(x), 2*C1*exp(2*x)),
+            Eq(g(x), C1*exp(2*x) + C2),
             Eq(h(x), C3*exp(x)),
             Eq(k(x), (C4 + Integral(C3**4*exp(3*x), x))*exp(x))]
     assert dsolve(eqs1) == sol1
@@ -1229,10 +1229,10 @@ def test_component_division():
             Eq(Derivative(g(x), x), f(x)),
             Eq(Derivative(h(x), x), h(x)),
             Eq(Derivative(k(x), x), f(x)**4 + k(x))]
-    sol2 = [Eq(f(x), C1*exp(2*x)),
-            Eq(g(x), C1*exp(2*x)/2 + C2),
+    sol2 = [Eq(f(x), 2*C1*exp(2*x)),
+            Eq(g(x), C1*exp(2*x) + C2),
             Eq(h(x), C3*exp(x)),
-            Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
+            Eq(k(x), (C4 + Integral(16*C1**4*exp(7*x), x))*exp(x))]
     assert dsolve(eqs2) == sol2
     assert checksysodesol(eqs2, sol2) == (True, [0, 0, 0, 0])
 
@@ -1836,3 +1836,25 @@ def test_dsolve_system():
     raises(NotImplementedError, lambda: dsolve_system(eq, t=x, ics={f(0): 1, g(0): 1}) == ([], []))
     raises(NotImplementedError, lambda: dsolve_system(eq, ics={f(0): 1, g(0): 1}) == ([], []))
     raises(NotImplementedError, lambda: dsolve_system(eq, funcs=[f(x), g(x)], ics={f(0): 1, g(0): 1}) == ([], []))
+
+def test_dsolve():
+
+    f, g = symbols('f g', cls=Function)
+    x, y = symbols('x y')
+
+    eqs = [f(x).diff(x, 2), g(x).diff(x)]
+    with raises(ValueError):
+        dsolve(eqs) # NotImplementedError would be better
+
+    eqs = [f(x).diff(x) - x, f(x).diff(x) + x]
+    with raises(ValueError):
+        # Could also be NotImplementedError. f(x)=0 is a solution...
+        dsolve(eqs)
+
+    eqs = [f(x, y).diff(x)]
+    with raises(ValueError):
+        dsolve(eqs)
+
+    eqs = [f(x, y).diff(x)+g(x).diff(x), g(x).diff(x)]
+    with raises(ValueError):
+        dsolve(eqs)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1210,6 +1210,81 @@ def test_sysode_linear_neq_order1_type4():
     assert checksysodesol(eqs8, sol8) == (True, [0, 0, 0, 0])
 
 
+def test_component_division():
+    f, g, h, k = symbols('f g h k', cls=Function)
+    x = symbols("x")
+
+    eqs1 = [Eq(Derivative(f(x), x), 2*f(x)),
+            Eq(Derivative(g(x), x), f(x)),
+            Eq(Derivative(h(x), x), h(x)),
+            Eq(Derivative(k(x), x), h(x)**4 + k(x))]
+    sol1 = [Eq(f(x), C1*exp(2*x)),
+            Eq(g(x), C1*exp(2*x)/2 + C2),
+            Eq(h(x), C3*exp(x)),
+            Eq(k(x), (C4 + Integral(C3**4*exp(3*x), x))*exp(x))]
+    assert dsolve(eqs1) == sol1
+    assert checksysodesol(eqs1, sol1) == (True, [0, 0, 0, 0])
+
+    eqs2 = [Eq(Derivative(f(x), x), 2*f(x)),
+            Eq(Derivative(g(x), x), f(x)),
+            Eq(Derivative(h(x), x), h(x)),
+            Eq(Derivative(k(x), x), f(x)**4 + k(x))]
+    sol2 = [Eq(f(x), C1*exp(2*x)),
+            Eq(g(x), C1*exp(2*x)/2 + C2),
+            Eq(h(x), C3*exp(x)),
+            Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
+    assert dsolve(eqs2) == sol2
+    assert checksysodesol(eqs2, sol2) == (True, [0, 0, 0, 0])
+
+    eqs3 = [Eq(Derivative(f(x), x), 2*f(x)),
+            Eq(Derivative(g(x), x), f(x) + x),
+            Eq(Derivative(h(x), x), h(x)),
+            Eq(Derivative(k(x), x), f(x)**4 + k(x))]
+    sol3 = [Eq(f(x), C1*exp(2*x)),
+            Eq(g(x), C2 + Integral(C1*exp(2*x) + x, x)),
+            Eq(h(x), C3*exp(x)),
+            Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
+    assert dsolve(eqs3) == sol3
+    assert checksysodesol(eqs3, sol3) == (True, [0, 0, 0, 0])
+
+    eqs4 = [Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
+            Eq(Derivative(g(x), x), f(x) + x*g(x) + x),
+            Eq(Derivative(h(x), x), h(x)),
+            Eq(Derivative(k(x), x), f(x)**4 + k(x))]
+    sol4 = [Eq(f(x), (C1/2 - sqrt(2)*C2/2 - sqrt(2)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
+                sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 +
+                sqrt(2)*x)/2, x)/2)*exp(x**2/2 - sqrt(2)*x) + (C1/2 + sqrt(2)*C2/2 + sqrt(2)*Integral(x*exp(-x**2/2 -
+                sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 -
+                sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2)*exp(x**2/2 + sqrt(2)*x)),
+            Eq(g(x), (-sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 -
+                sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/4)*
+                exp(x**2/2 - sqrt(2)*x) + (sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
+                sqrt(2)*x)/2, x)/2 + sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 +
+                sqrt(2)*x)/2, x)/4)*exp(x**2/2 + sqrt(2)*x)),
+            Eq(h(x), C3*exp(x)),
+            Eq(k(x), C4*exp(x) + exp(x)*Integral((C1*exp(x**2/2 - sqrt(2)*x)/2 + C1*exp(x**2/2 + sqrt(2)*x)/2 -
+                sqrt(2)*C2*exp(x**2/2 - sqrt(2)*x)/2 + sqrt(2)*C2*exp(x**2/2 + sqrt(2)*x)/2 - sqrt(2)*exp(x**2/2 -
+                sqrt(2)*x)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + exp(x**2/2 -
+                sqrt(2)*x)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 +
+                sqrt(2)*exp(x**2/2 + sqrt(2)*x)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
+                sqrt(2)*x)/2, x)/2 + exp(x**2/2 + sqrt(2)*x)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 -
+                sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2)**4*exp(-x), x))]
+    assert dsolve(eqs4) == sol4
+    assert checksysodesol(eqs4, sol4) == (True, [0, 0, 0, 0])
+
+    eqs5 = [Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
+            Eq(Derivative(g(x), x), x*g(x) + f(x)),
+            Eq(Derivative(h(x), x), h(x)),
+            Eq(Derivative(k(x), x), f(x)**4 + k(x))]
+    sol5 = [Eq(f(x), (C1/2 - sqrt(2)*C2/2)*exp(x**2/2 - sqrt(2)*x) + (C1/2 + sqrt(2)*C2/2)*exp(x**2/2 + sqrt(2)*x)),
+            Eq(g(x), (-sqrt(2)*C1/4 + C2/2)*exp(x**2/2 - sqrt(2)*x) + (sqrt(2)*C1/4 + C2/2)*exp(x**2/2 + sqrt(2)*x)),
+            Eq(h(x), C3*exp(x)),
+            Eq(k(x), C4*exp(x) + exp(x)*Integral((C1*exp(x**2/2 - sqrt(2)*x)/2 + C1*exp(x**2/2 + sqrt(2)*x)/2 -
+                sqrt(2)*C2*exp(x**2/2 - sqrt(2)*x)/2 + sqrt(2)*C2*exp(x**2/2 + sqrt(2)*x)/2)**4*exp(-x), x))]
+    assert dsolve(eqs5) == sol5
+    assert checksysodesol(eqs5, sol5) == (True, [0, 0, 0, 0])
+
+
 def test_linodesolve():
     t, x, a = symbols("t x a")
     f, g, h = symbols("f g h", cls=Function)

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1229,10 +1229,10 @@ def test_component_division():
             Eq(Derivative(g(x), x), f(x)),
             Eq(Derivative(h(x), x), h(x)),
             Eq(Derivative(k(x), x), f(x)**4 + k(x))]
-    sol2 = [Eq(f(x), 2*C1*exp(2*x)),
-            Eq(g(x), C1*exp(2*x) + C2),
+    sol2 = [Eq(f(x), C1*exp(2*x)),
+            Eq(g(x), C2 + Integral(C1*exp(2*x), x)),
             Eq(h(x), C3*exp(x)),
-            Eq(k(x), (C4 + Integral(16*C1**4*exp(7*x), x))*exp(x))]
+            Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
     assert dsolve(eqs2) == sol2
     assert checksysodesol(eqs2, sol2) == (True, [0, 0, 0, 0])
 

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1224,17 +1224,17 @@ def test_component_division():
             Eq(g(x), C1*exp(2*x) + C2),
             Eq(h(x), C3*exp(x)),
             Eq(k(x), (C4 + Integral(C3**4*exp(3*x), x))*exp(x))]
-    components1 = [[[Eq(Derivative(f(x), x), 2*f(x))], [Eq(Derivative(g(x), x), f(x))]],
-                    [[Eq(Derivative(h(x), x), h(x))], [Eq(Derivative(k(x), x), h(x)**4 + k(x))]]]
+    components1 = {((Eq(Derivative(f(x), x), 2*f(x)),), (Eq(Derivative(g(x), x), f(x)),)),
+                   ((Eq(Derivative(h(x), x), h(x)),), (Eq(Derivative(k(x), x), h(x)**4 + k(x)),))}
     eqsdict1 = ({f(x): set(), g(x): {f(x)}, h(x): set(), k(x): {h(x)}},
                 {f(x): Eq(Derivative(f(x), x), 2*f(x)),
                 g(x): Eq(Derivative(g(x), x), f(x)),
                 h(x): Eq(Derivative(h(x), x), h(x)),
                 k(x): Eq(Derivative(k(x), x), h(x)**4 + k(x))})
-    graph1 = ([f(x), g(x), h(x), k(x)], [(g(x), f(x)), (k(x), h(x))])
-    assert _component_division(eqs1, funcs, x) == components1
+    graph1 = [{f(x), g(x), h(x), k(x)}, {(g(x), f(x)), (k(x), h(x))}]
+    assert {tuple(tuple(scc) for scc in wcc) for wcc in _component_division(eqs1, funcs, x)} == components1
     assert _eqs2dict(eqs1, funcs) == eqsdict1
-    assert _dict2graph(eqsdict1[0]) == graph1
+    assert [set(element) for element in _dict2graph(eqsdict1[0])] == graph1
     assert dsolve(eqs1) == sol1
     assert checksysodesol(eqs1, sol1) == (True, [0, 0, 0, 0])
 
@@ -1246,19 +1246,19 @@ def test_component_division():
             Eq(g(x), C2 + Integral(C1*exp(2*x), x)),
             Eq(h(x), C3*exp(x)),
             Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
-    components2 = [[[Eq(Derivative(f(x), x), 2*f(x))],
-                    [Eq(Derivative(g(x), x), f(x))],
-                    [Eq(Derivative(k(x), x), f(x)**4 + k(x))]],
-                    [[Eq(Derivative(h(x), x), h(x))]]]
+    components2 = {frozenset([(Eq(Derivative(f(x), x), 2*f(x)),),
+                    (Eq(Derivative(g(x), x), f(x)),),
+                    (Eq(Derivative(k(x), x), f(x)**4 + k(x)),)]),
+                   frozenset([(Eq(Derivative(h(x), x), h(x)),)])}
     eqsdict2 = ({f(x): set(), g(x): {f(x)}, h(x): set(), k(x): {f(x)}},
                  {f(x): Eq(Derivative(f(x), x), 2*f(x)),
                   g(x): Eq(Derivative(g(x), x), f(x)),
                   h(x): Eq(Derivative(h(x), x), h(x)),
                   k(x): Eq(Derivative(k(x), x), f(x)**4 + k(x))})
-    graph2 = ([f(x), g(x), h(x), k(x)], [(g(x), f(x)), (k(x), f(x))])
-    assert _component_division(eqs2, funcs, x) == components2
+    graph2 = [{f(x), g(x), h(x), k(x)}, {(g(x), f(x)), (k(x), f(x))}]
+    assert {frozenset(tuple(scc) for scc in wcc) for wcc in _component_division(eqs2, funcs, x)} == components2
     assert _eqs2dict(eqs2, funcs) == eqsdict2
-    assert _dict2graph(eqsdict2[0]) == graph2
+    assert [set(element) for element in _dict2graph(eqsdict2[0])] == graph2
     assert dsolve(eqs2) == sol2
     assert checksysodesol(eqs2, sol2) == (True, [0, 0, 0, 0])
 
@@ -1270,19 +1270,19 @@ def test_component_division():
             Eq(g(x), C2 + Integral(C1*exp(2*x) + x, x)),
             Eq(h(x), C3*exp(x)),
             Eq(k(x), (C4 + Integral(C1**4*exp(7*x), x))*exp(x))]
-    components3 = [[[Eq(Derivative(f(x), x), 2*f(x))],
-                    [Eq(Derivative(g(x), x), x + f(x))],
-                    [Eq(Derivative(k(x), x), f(x)**4 + k(x))]],
-                    [[Eq(Derivative(h(x), x), h(x))]]]
+    components3 = {frozenset([(Eq(Derivative(f(x), x), 2*f(x)),),
+                    (Eq(Derivative(g(x), x), x + f(x)),),
+                    (Eq(Derivative(k(x), x), f(x)**4 + k(x)),)]),
+                    frozenset([(Eq(Derivative(h(x), x), h(x)),),])}
     eqsdict3 = ({f(x): set(), g(x): {f(x)}, h(x): set(), k(x): {f(x)}},
                 {f(x): Eq(Derivative(f(x), x), 2*f(x)),
                 g(x): Eq(Derivative(g(x), x), x + f(x)),
                 h(x): Eq(Derivative(h(x), x), h(x)),
                 k(x): Eq(Derivative(k(x), x), f(x)**4 + k(x))})
-    graph3 = ([f(x), g(x), h(x), k(x)], [(g(x), f(x)), (k(x), f(x))])
-    assert _component_division(eqs3, funcs, x) == components3
+    graph3 = [{f(x), g(x), h(x), k(x)}, {(g(x), f(x)), (k(x), f(x))}]
+    assert {frozenset(tuple(scc) for scc in wcc) for wcc in _component_division(eqs3, funcs, x)} == components3
     assert _eqs2dict(eqs3, funcs) == eqsdict3
-    assert _dict2graph(eqsdict3[0]) == graph3
+    assert [set(l) for l in _dict2graph(eqsdict3[0])] == graph3
     assert dsolve(eqs3) == sol3
     assert checksysodesol(eqs3, sol3) == (True, [0, 0, 0, 0])
 
@@ -1290,37 +1290,37 @@ def test_component_division():
             Eq(Derivative(g(x), x), f(x) + x*g(x) + x),
             Eq(Derivative(h(x), x), h(x)),
             Eq(Derivative(k(x), x), f(x)**4 + k(x))]
-    sol4 = [Eq(f(x), (C1/2 - sqrt(2)*C2/2 - sqrt(2)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
-                sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 +
-                sqrt(2)*x)/2, x)/2)*exp(x**2/2 - sqrt(2)*x) + (C1/2 + sqrt(2)*C2/2 + sqrt(2)*Integral(x*exp(-x**2/2 -
-                sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 -
-                sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2)*exp(x**2/2 + sqrt(2)*x)),
-            Eq(g(x), (-sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 -
-                sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/4)*
-                exp(x**2/2 - sqrt(2)*x) + (sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
-                sqrt(2)*x)/2, x)/2 + sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 +
-                sqrt(2)*x)/2, x)/4)*exp(x**2/2 + sqrt(2)*x)),
+    sol4 = [Eq(f(x), (C1/2 - sqrt(2)*C2/2 - sqrt(2)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +\
+                sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 +\
+                sqrt(2)*x)/2, x)/2)*exp(x**2/2 - sqrt(2)*x) + (C1/2 + sqrt(2)*C2/2 + sqrt(2)*Integral(x*exp(-x**2/2
+                - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2
+                - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2)*exp(x**2/2 + sqrt(2)*x)),
+            Eq(g(x), (-sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 -\
+                sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2,
+                x)/4)*exp(x**2/2 - sqrt(2)*x) + (sqrt(2)*C1/4 + C2/2 + Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 +
+                x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + sqrt(2)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 -
+                sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/4)*exp(x**2/2 + sqrt(2)*x)),
             Eq(h(x), C3*exp(x)),
             Eq(k(x), C4*exp(x) + exp(x)*Integral((C1*exp(x**2/2 - sqrt(2)*x)/2 + C1*exp(x**2/2 + sqrt(2)*x)/2 -
                 sqrt(2)*C2*exp(x**2/2 - sqrt(2)*x)/2 + sqrt(2)*C2*exp(x**2/2 + sqrt(2)*x)/2 - sqrt(2)*exp(x**2/2 -
                 sqrt(2)*x)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 + exp(x**2/2 -
-                sqrt(2)*x)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2 +
-                sqrt(2)*exp(x**2/2 + sqrt(2)*x)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
+                sqrt(2)*x)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 - sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2,
+                x)/2 + sqrt(2)*exp(x**2/2 + sqrt(2)*x)*Integral(x*exp(-x**2/2 - sqrt(2)*x)/2 + x*exp(-x**2/2 +
                 sqrt(2)*x)/2, x)/2 + exp(x**2/2 + sqrt(2)*x)*Integral(sqrt(2)*x*exp(-x**2/2 - sqrt(2)*x)/2 -
                 sqrt(2)*x*exp(-x**2/2 + sqrt(2)*x)/2, x)/2)**4*exp(-x), x))]
-    components4 = [[[Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
-                    Eq(Derivative(g(x), x), x*g(x) + x + f(x))],
-                    [Eq(Derivative(k(x), x), f(x)**4 + k(x))]],
-                    [[Eq(Derivative(h(x), x), h(x))]]]
+    components4 = {(frozenset([Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
+                    Eq(Derivative(g(x), x), x*g(x) + x + f(x))]),
+                    frozenset([Eq(Derivative(k(x), x), f(x)**4 + k(x)),])),
+                    (frozenset([Eq(Derivative(h(x), x), h(x)),]),)}
     eqsdict4 = ({f(x): {g(x)}, g(x): {f(x)}, h(x): set(), k(x): {f(x)}},
                 {f(x): Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
                 g(x): Eq(Derivative(g(x), x), x*g(x) + x + f(x)),
                 h(x): Eq(Derivative(h(x), x), h(x)),
                 k(x): Eq(Derivative(k(x), x), f(x)**4 + k(x))})
-    graph4 = ([f(x), g(x), h(x), k(x)], [(f(x), g(x)), (g(x), f(x)), (k(x), f(x))])
-    assert _component_division(eqs4, funcs, x) == components4
+    graph4 = [{f(x), g(x), h(x), k(x)}, {(f(x), g(x)), (g(x), f(x)), (k(x), f(x))}]
+    assert {tuple(frozenset(scc) for scc in wcc) for wcc in _component_division(eqs4, funcs, x)} == components4
     assert _eqs2dict(eqs4, funcs) == eqsdict4
-    assert _dict2graph(eqsdict4[0]) == graph4
+    assert [set(element) for element in _dict2graph(eqsdict4[0])] == graph4
     assert dsolve(eqs4) == sol4
     assert checksysodesol(eqs4, sol4) == (True, [0, 0, 0, 0])
 
@@ -1333,19 +1333,19 @@ def test_component_division():
             Eq(h(x), C3*exp(x)),
             Eq(k(x), C4*exp(x) + exp(x)*Integral((C1*exp(x**2/2 - sqrt(2)*x)/2 + C1*exp(x**2/2 + sqrt(2)*x)/2 -
                 sqrt(2)*C2*exp(x**2/2 - sqrt(2)*x)/2 + sqrt(2)*C2*exp(x**2/2 + sqrt(2)*x)/2)**4*exp(-x), x))]
-    components5 = [[[Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
-                    Eq(Derivative(g(x), x), x*g(x) + f(x))],
-                    [Eq(Derivative(k(x), x), f(x)**4 + k(x))]],
-                    [[Eq(Derivative(h(x), x), h(x))]]]
+    components5 = {(frozenset([Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
+                    Eq(Derivative(g(x), x), x*g(x) + f(x))]),
+                    frozenset([Eq(Derivative(k(x), x), f(x)**4 + k(x)),])),
+                    (frozenset([Eq(Derivative(h(x), x), h(x)),]),)}
     eqsdict5 = ({f(x): {g(x)}, g(x): {f(x)}, h(x): set(), k(x): {f(x)}},
                 {f(x): Eq(Derivative(f(x), x), x*f(x) + 2*g(x)),
                 g(x): Eq(Derivative(g(x), x), x*g(x) + f(x)),
                 h(x): Eq(Derivative(h(x), x), h(x)),
                 k(x): Eq(Derivative(k(x), x), f(x)**4 + k(x))})
-    graph5 = ([f(x), g(x), h(x), k(x)], [(f(x), g(x)), (g(x), f(x)), (k(x), f(x))])
-    assert _component_division(eqs5, funcs, x) == components5
+    graph5 = [{f(x), g(x), h(x), k(x)}, {(f(x), g(x)), (g(x), f(x)), (k(x), f(x))}]
+    assert {tuple(frozenset(scc) for scc in wcc) for wcc in _component_division(eqs5, funcs, x)} == components5
     assert _eqs2dict(eqs5, funcs) == eqsdict5
-    assert _dict2graph(eqsdict5[0]) == graph5
+    assert [set(element) for element in _dict2graph(eqsdict5[0])] == graph5
     assert dsolve(eqs5) == sol5
     assert checksysodesol(eqs5, sol5) == (True, [0, 0, 0, 0])
 


### PR DESCRIPTION
#### References to other Issues or PRs


#### Brief description of what is fixed or changed
Completed `_component_division` private function. This function can now divide systems of ODEs into required sub-systems to solve the ODEs by dividing it.

#### Other comments
The library now can handle systems of ODEs such that a part of them is solvable and the other part of them can be solved if the first solvable part is solved. The example below demonstrates this:
```
In [39]: f, g, h, k = symbols('f g h k', cls=Function) 
    ...: eqs = [ 
    ...: Eq(f(x).diff(x), f(x)),  
    ...: Eq(g(x).diff(x), f(x)),  
    ...: Eq(h(x).diff(x), h(x)), 
    ...: Eq(k(x).diff(x), h(x)**4 + k(x))] 
    ...: dsolve(eqs) 
Out[39]: 
[Eq(f(x), C1*exp(x)),
 Eq(g(x), C1*exp(x) + C2),
 Eq(h(x), C3*exp(x)),
 Eq(k(x), (C4 + Integral(C3**4*exp(3*x), x))*exp(x))]

```
The above system as a whole doesn't have a solver but by first solving for `f(x)` and `g(x)` separately, and then just solving for `h(x)` and substituting that solution to solve for `k(x)` leads to the solution using just linear solvers and clever substitutions and division of system.
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Added component division technique to divide the system of ODEs into logical sub-systems and solving each of these separately.
<!-- END RELEASE NOTES -->