### PR TITLE
Modify sstrrepr printing of Str

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -51,6 +51,8 @@ class Manifold(Atom):
 
     >>> from sympy.diffgeom import Manifold
     >>> m = Manifold('M', 2)
+    >>> m
+    M
     >>> m.dim
     2
 
@@ -114,6 +116,8 @@ class Patch(Atom):
     >>> from sympy.diffgeom import Manifold, Patch
     >>> m = Manifold('M', 2)
     >>> p = Patch('P', m)
+    >>> p
+    P
     >>> p.dim
     2
 
@@ -200,6 +204,8 @@ class CoordSystem(Atom):
     >>> Car2D = CoordSystem('Car2D', p, [x, y], relation_dict)
     >>> Pol = CoordSystem('Pol', p, [r, theta], relation_dict)
 
+    >>> Car2D
+    Car2D
     >>> Car2D.dim
     2
     >>> Car2D.symbols

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -51,9 +51,6 @@ class Manifold(Atom):
 
     >>> from sympy.diffgeom import Manifold
     >>> m = Manifold('M', 2)
-
-    >>> m.name
-    M
     >>> m.dim
     2
 
@@ -117,9 +114,6 @@ class Patch(Atom):
     >>> from sympy.diffgeom import Manifold, Patch
     >>> m = Manifold('M', 2)
     >>> p = Patch('P', m)
-
-    >>> p.name
-    P
     >>> p.dim
     2
 
@@ -206,8 +200,6 @@ class CoordSystem(Atom):
     >>> Car2D = CoordSystem('Car2D', p, [x, y], relation_dict)
     >>> Pol = CoordSystem('Pol', p, [r, theta], relation_dict)
 
-    >>> Car2D.name
-    Car2D
     >>> Car2D.dim
     2
     >>> Car2D.symbols

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -53,7 +53,7 @@ class Manifold(Atom):
     >>> m = Manifold('M', 2)
 
     >>> m.name
-    'M'
+    M
     >>> m.dim
     2
 
@@ -119,7 +119,7 @@ class Patch(Atom):
     >>> p = Patch('P', m)
 
     >>> p.name
-    'P'
+    P
     >>> p.dim
     2
 
@@ -207,7 +207,7 @@ class CoordSystem(Atom):
     >>> Pol = CoordSystem('Pol', p, [r, theta], relation_dict)
 
     >>> Car2D.name
-    'Car2D'
+    Car2D
     >>> Car2D.dim
     2
     >>> Car2D.symbols

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2650,6 +2650,9 @@ class LatexPrinter(Printer):
                 (self._print(expr.args[0]), exp)
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
+    def _print_Str(self, s):
+        return self._print(s.name)
+
     def emptyPrinter(self, expr):
         # Checks what type of decimal separator to print.
         expr = super().emptyPrinter(expr)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2720,6 +2720,9 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*stringPict.next(l, op, r))
         return pform
 
+    def _print_Str(self, s):
+        return self._print(s.name)
+
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7236,6 +7236,10 @@ def test_issue_18272():
     '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
     '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
 
+def test_Str():
+    from sympy.core.symbol import Str
+    assert pretty(Str('x')) == 'x'
+
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
     x,y = symbols('x y', real=True)

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -341,6 +341,3 @@ class Printer(object):
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)
-
-    def _print_Str(self, s):
-        return self._print(s.name)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -876,13 +876,13 @@ class StrPrinter(Printer):
         return 'Category("%s")' % category.name
 
     def _print_Manifold(self, manifold):
-        return self._print(manifold.name)
+        return manifold.name.name
 
     def _print_Patch(self, patch):
-        return self._print(patch.name)
+        return patch.name.name
 
     def _print_CoordSystem(self, coords):
-        return self._print(coords.name)
+        return coords.name.name
 
     def _print_BaseScalarField(self, field):
         return field._coord_sys.symbols[field._index].name
@@ -900,6 +900,9 @@ class StrPrinter(Printer):
     def _print_Tr(self, expr):
         #TODO : Handle indices
         return "%s(%s)" % ("Tr", self._print(expr.args[0]))
+
+    def _print_Str(self, s):
+        return self._print(s.name)
 
 def sstr(expr, **settings):
     """Returns the expression as a string.
@@ -931,7 +934,7 @@ class StrReprPrinter(StrPrinter):
 
     def _print_Str(self, s):
         # Str does not to be printed same as str here
-        return str(s)
+        return repr(s)
 
 
 def sstrrepr(expr, **settings):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -934,7 +934,7 @@ class StrReprPrinter(StrPrinter):
 
     def _print_Str(self, s):
         # Str does not to be printed same as str here
-        return repr(s)
+        return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
 
 def sstrrepr(expr, **settings):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -929,6 +929,10 @@ class StrReprPrinter(StrPrinter):
     def _print_str(self, s):
         return repr(s)
 
+    def _print_Str(self, s):
+        # Str does not to be printed same as str here
+        return str(s)
+
 
 def sstrrepr(expr, **settings):
     """return expr in mixed str/repr form

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2651,3 +2651,7 @@ def test_latex_decimal_separator():
     raises(ValueError, lambda: latex([1,2.3,4.5], decimal_separator='non_existing_decimal_separator_in_list'))
     raises(ValueError, lambda: latex(FiniteSet(1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_set'))
     raises(ValueError, lambda: latex((1,2.3,4.5), decimal_separator='non_existing_decimal_separator_in_tuple'))
+
+def test_Str():
+    from sympy.core.symbol import Str
+    assert str(Str('x')) == 'x'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -974,9 +974,13 @@ def test_str_special_matrices():
     assert str(ZeroMatrix(2, 2)) == '0'
     assert str(OneMatrix(2, 2)) == '1'
 
-
 def test_issue_14567():
     assert factorial(Sum(-1, (x, 0, 0))) + y  # doesn't raise an error
+
+def test_Str():
+    from sympy.core.symbol import Str
+    assert str(Str('x')) == 'x'
+    assert sstrrepr(Str('x')) == "Str('x')"
 
 def test_diffgeom():
     from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField


### PR DESCRIPTION
Since Str is not strictly str, it is not longer wrapped with ' signs now.
Doctests of diffgeom.py are modified accordingly.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Patch for #19694 and #19714

#### Brief description of what is fixed or changed
sstrrepr of `Str` is no longer wrapped with apostrophe.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->