### PR TITLE
#19766 Fixes incorrect limit

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -861,3 +861,7 @@ def test_issue_15055():
 
 def test_issue_19739():
     assert limit((-S(1)/4)**x, x, oo) == 0
+
+
+def test_issue_19766():
+    assert limit(2**(-x)*sqrt(4**(x + 1) + 1), x, oo) == 2


### PR DESCRIPTION
Fixes partially #19766 
Added a test case for the limit.
`limit(2**(-x)*sqrt(4**(x+1)+1), x, oo)`

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->