### PR TITLE
NotIterable should always be respected

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -216,9 +216,9 @@ class NotIterable:
     calling list() on the instance, for example, would result in
     an infinite loop.
     """
-    pass
+    _iterable = False
 
-def iterable(i, exclude=(str, dict, NotIterable)):
+def iterable(i, exclude=(str, dict)):
     """
     Return a boolean indicating whether ``i`` is SymPy iterable.
     True also indicates that the iterator is finite, e.g. you can

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -44,6 +44,7 @@ def test_iterable():
         pass
 
     assert iterable(Test1()) is False
+    assert iterable(Test1(), exclude=str) is False
 
     class Test2(NotIterable):
         _iterable = True
@@ -70,6 +71,14 @@ def test_iterable():
         _iterable = False
 
     assert iterable(Test6()) is False
+
+    class Test8(NotIterable):
+        def __getitem__(self, *idx):
+            return "something"
+
+    assert iter(Test8())
+    assert iterable(Test8()) is False
+    assert iterable(Test8(), exclude=str) is False
 
 
 def test_ordered():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
There is not clear way for a user to express that their types are not iterable. They can throw `TypeError` in `__iter__` but some parts of sympy consider everything with `__iter__` method iterable.

Python seems to consider everything with `__getitem__` iterable.

#### Brief description of what is fixed or changed
`NotIterable` should always be repected by `iterable`. It is defined in the same module as `iterable` an usages of `NotIterable` explicitly want to express that they are not iterable.

It is very easy for user to overwrite that functionality when they have to remember that they also have to exclude the class `NotIterable`.

-> Set  `_iterable = False` for `NotIterable`

#### Other comments

- [x] Will include a test.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `core.compatibility.iterable` Set _iterable = False for `NotIterable` (will respect NotIterable even when you forget to set it in the exclude parameters)
<!-- END RELEASE NOTES -->