### PR TITLE
Replace hasattr(... '__iter__') by check with `iterable`

### DIFF
--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -10,6 +10,7 @@ from sympy.core import Basic, sympify
 from sympy.polys.polyerrors import GeneratorsError, OptionError, FlagError
 from sympy.utilities import numbered_symbols, topological_sort, public
 from sympy.utilities.iterables import has_dups
+from sympy.core.compatibility import is_sequence
 
 import sympy.polys
 
@@ -283,7 +284,7 @@ class Gens(Option, metaclass=OptionType):
     def preprocess(cls, gens):
         if isinstance(gens, Basic):
             gens = (gens,)
-        elif len(gens) == 1 and hasattr(gens[0], '__iter__'):
+        elif len(gens) == 1 and is_sequence(gens[0]):
             gens = gens[0]
 
         if gens == (None,):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Minor code clean-up.

#### References to other Issues or PRs
I found that Sympy sometimes checks for objects having the `__iter__` attribute while there is some ways to mark your object as not iterable (#19772). However, such checks are not performed when just checking for `__iter__`. 

#### Brief description of what is fixed or changed
Checking for attribute `__iter__` circumvents the Sympy way of checking if something is iterable

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->