### PR TITLE
Dagger() * IdentityOperator() now simplifies by default

### DIFF
--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import Expr
+from sympy.core import Expr, Mul
 from sympy.functions.elementary.complexes import adjoint
 
 __all__ = [
@@ -84,6 +84,14 @@ class Dagger(adjoint):
         if obj is not None:
             return obj
         return Expr.__new__(cls, arg)
+
+    def __mul__(self, other):
+        from sympy.physics.quantum import IdentityOperator
+
+        if isinstance(other, IdentityOperator):
+            return self
+
+        return Mul(self,other)
 
 adjoint.__name__ = "Dagger"
 adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -1,7 +1,5 @@
 """Hermitian conjugation."""
 
-from __future__ import print_function, division
-
 from sympy.core import Expr, Mul
 from sympy.functions.elementary.complexes import adjoint
 
@@ -91,7 +89,7 @@ class Dagger(adjoint):
         if isinstance(other, IdentityOperator):
             return self
 
-        return Mul(self,other)
+        return Mul(self, other)
 
 adjoint.__name__ = "Dagger"
 adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -85,7 +85,6 @@ class Dagger(adjoint):
 
     def __mul__(self, other):
         from sympy.physics.quantum import IdentityOperator
-
         if isinstance(other, IdentityOperator):
             return self
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -307,7 +307,7 @@ class IdentityOperator(Operator):
 
     def __mul__(self, other):
 
-        if isinstance(other, Operator) or isinstance(other, Dagger):
+        if isinstance(other, (Operator, Dagger)):
             return other
 
         return Mul(self, other)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -307,7 +307,7 @@ class IdentityOperator(Operator):
 
     def __mul__(self, other):
 
-        if isinstance(other, Operator):
+        if isinstance(other, Operator) or isinstance(other, Dagger):
             return other
 
         return Mul(self, other)

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -1,8 +1,9 @@
-from sympy import I, Matrix, symbols, conjugate, Expr, Integer
+from sympy import I, Matrix, symbols, conjugate, Expr, Integer, Mul
 
 from sympy.physics.quantum.dagger import adjoint, Dagger
 from sympy.external import import_module
 from sympy.testing.pytest import skip
+from sympy.physics.quantum.operator import Operator, IdentityOperator
 
 
 def test_scalars():
@@ -27,6 +28,15 @@ def test_matrix():
     x = symbols('x')
     m = Matrix([[I, x*I], [2, 4]])
     assert Dagger(m) == m.H
+
+
+def test_dagger_mul():
+    O = Operator('O')
+    I = IdentityOperator()
+    assert Dagger(O)*O == Dagger(O)*O
+    assert Dagger(O)*O*I == Mul(Dagger(O), O)*I
+    assert Dagger(O)*Dagger(O) == Dagger(O)**2
+    assert Dagger(O)*Dagger(I) == Dagger(O)
 
 
 class Foo(Expr):

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -94,6 +94,8 @@ def test_identity():
 
     assert I * O == O
     assert O * I == O
+    assert I * Dagger(O) == Dagger(O)
+    assert Dagger(O) * I == Dagger(O)
     assert isinstance(I * I, IdentityOperator)
     assert isinstance(3 * I, Mul)
     assert isinstance(I * x, Mul)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #19747
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
```
from sympy.physics.quantum.dagger import Dagger
from sympy.physics.quantum.operator import Operator
from sympy.physics.quantum import IdentityOperator
A = Operator('A')
Identity = IdentityOperator()
print(B * Identity) 
print(Identity * B)
```
now gives
```
Dagger(A)
Dagger(A)
```



#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
    * Simplification of Dagger() * IdentityOperator() 
<!-- END RELEASE NOTES -->