### PR TITLE
Adding a warning when a set is used as argument for `lambdify`

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -332,8 +332,8 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
         arguments do not redefine any built-in names.
 
     sort_args: bool, optional
-            Lambdify can take care of sorting your iterable ``args`` in consistent
-            way using fixed sorting criterion by alphabetical order
+            Lambdify can take care of sorting your iterable ``args`` in a consistent
+            way using fixed sorting criterion by alphabetical order (using .name of the symbols)
 
     Examples
     ========

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,6 +9,7 @@ import inspect
 import keyword
 import textwrap
 import linecache
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 from sympy.core.compatibility import (exec_, is_sequence, iterable,

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -806,7 +806,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
     if isinstance(args, set):
         SymPyDeprecationWarning(
                     feature="The list of arguments is a `set`. This leads to unpredictable results",
-                    useinstead="convert set into list or tuple",
+                    useinstead=": Convert set into list or tuple",
                     issue=19735,
                     deprecated_since_version="1.6.3"
                 ).warn()

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -811,7 +811,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
     if  type(args) is set:
         SymPyDeprecationWarning(
                     feature="The list of arguments is a `set`. This leads to unpredictable results",
-                    useinstead="concvet set into list or tuple",
+                    useinstead="convert set into list or tuple",
                     issue=19735,
                     deprecated_since_version="1.6.3"
                 ).warn()

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,8 +9,7 @@ import inspect
 import keyword
 import textwrap
 import linecache
-from sympy.utilities.exceptions import SymPyDeprecationWarning
-
+from  .exceptions import SymPyDeprecationWarning
 
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, builtins)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -180,7 +180,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
        This function uses ``enumerate`` on ``args``, thus you should
        provide `args` that is a fixed-ordering iterable, e.g. a sequence,
         or take responsibility for making sure the args are in the order
-        you want them to be.
+        you want them to be. If a set is passed lambdify will return a False
 
     Explanation
     ===========

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -807,7 +807,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
         SymPyDeprecationWarning(
                     feature="The list of arguments is a `set`. This leads to unpredictable results",
                     useinstead=": Convert set into list or tuple",
-                    issue=19735,
+                    issue=20013,
                     deprecated_since_version="1.6.3"
                 ).warn()
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -815,8 +815,6 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
                     issue=19735,
                     deprecated_since_version="1.6.3"
                 ).warn()
-        #warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify`, but its outcome is not predictable. Lambdify will stop here and return `False`', category=DeprecationWarning)
-        #return False  # Anything else that block the code would be fine
 
     # Get the names of the args, for creating a docstring
     if not iterable(args):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -177,12 +177,12 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
        unsanitized input.
 
     .. versionchanged:: 1.7.0
-        Python set is no longer supported type for args
+       Python set is no longer supported type for args
     .. warning::
        This function uses ``enumerate`` on ``args``, thus you should
        provide `args` that is a fixed-ordering iterable, e.g. a sequence,
-        or take responsibility for making sure the args are in the order
-        you want them to be. If a set is passed lambdify will return a False
+       or take responsibility for making sure the args are in the order
+       you want them to be. If a set is passed lambdify will return a False
 
     Explanation
     ===========

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,8 +9,8 @@ import inspect
 import keyword
 import textwrap
 import linecache
-from  .exceptions import SymPyDeprecationWarning
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, builtins)
 from sympy.utilities.misc import filldedent

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,7 +9,6 @@ import inspect
 import keyword
 import textwrap
 import linecache
-import warnings
 
 
 from sympy.core.compatibility import (exec_, is_sequence, iterable,

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -168,7 +168,7 @@ _lambdify_generated_counter = 1
 
 @doctest_depends_on(modules=('numpy', 'tensorflow', ), python_version=(3,))
 def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
-             dummify=False, sort_args=False):
+             dummify=False):
     """Convert a SymPy expression into a function that allows for fast
     numeric evaluation.
 
@@ -331,9 +331,6 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
         (if ``args`` is not a string) - for example, to ensure that the
         arguments do not redefine any built-in names.
 
-    sort_args: bool, optional
-            Lambdify can take care of sorting your iterable ``args`` in consistent
-            way using fixed sorting criterion by alphabetical order
 
     Examples
     ========
@@ -811,20 +808,9 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
 
 
     if  type(args) is set:
-        warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify` but its outcome is not predictable', category=DeprecationWarning)
-        #print('WARNING: Convert your argument list to an iterable that can be enumerated in a predictable way, e.g. a sequence, list or OrderedDicts')
-        if not sort_args:
-            warnings.warn('WARNING: If you wish you can let `lambdify` sort your args in a predictable way. Set the optional argument `sort_args=True` ', category=DeprecationWarning)
-        if sort_args:
-            def sort_symbols(_args):
-                return sorted(list( _args ) ,key=lambda s: s.name)
+        warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify`, but its outcome is not predictable. Lambdify will stop here and return `False`', category=DeprecationWarning)
+        return False  # Anything else that block the code would be fine
 
-            sorted_args=sort_symbols(args)
-            change_warning='WARNING: You gave a set as args ' + str(args) + ' and they have been sorted to ' + str(sorted_args)
-            warnings.warn( change_warning, category=DeprecationWarning )
-            args=sorted_args
-
-    #print('WARNING: Your args are', args)
 
 
     # Get the names of the args, for creating a docstring

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,6 +9,8 @@ import inspect
 import keyword
 import textwrap
 import linecache
+import warnings
+
 
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
     NotIterable, builtins)
@@ -809,17 +811,17 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
 
 
     if  type(args) is set:
-        print('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify` but its outcome is not predictable')
-        print('WARNING: Convert your argument list to an iterable that can be enumerated in a predictable way, e.g. a sequence, list or OrderedDicts')
+        warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify` but its outcome is not predictable', category=DeprecationWarning)
+        #print('WARNING: Convert your argument list to an iterable that can be enumerated in a predictable way, e.g. a sequence, list or OrderedDicts')
         if not sort_args:
-            print('WARNING: If you wish you can let `lambdify` sort your args in a predictable way. Set the optional argument `sort_args=True` ')
+            warnings.warn('WARNING: If you wish you can let `lambdify` sort your args in a predictable way. Set the optional argument `sort_args=True` ', category=DeprecationWarning)
         if sort_args:
             def sort_symbols(_args):
                 return sorted(list( _args ) ,key=lambda s: s.name)
 
             sorted_args=sort_symbols(args)
             change_warning='WARNING: You gave a set as args ' + str(args) + ' and they have been sorted to ' + str(sorted_args)
-            print( change_warning )
+            warnings.warn( change_warning, category=DeprecationWarning )
             args=sorted_args
 
     #print('WARNING: Your args are', args)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -803,7 +803,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
                            'allow_unknown_functions': True,
                            'user_functions': user_functions})
 
-    if  type(args) is set:
+    if isinstance(args, set):
         SymPyDeprecationWarning(
                     feature="The list of arguments is a `set`. This leads to unpredictable results",
                     useinstead="convert set into list or tuple",

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -176,6 +176,8 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
        This function uses ``exec``, and thus shouldn't be used on
        unsanitized input.
 
+    .. versionchanged:: 1.7.0
+        Python set is no longer supported type for args
     .. warning::
        This function uses ``enumerate`` on ``args``, thus you should
        provide `args` that is a fixed-ordering iterable, e.g. a sequence,
@@ -807,8 +809,14 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
                            'user_functions': user_functions})
 
     if  type(args) is set:
-        warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify`, but its outcome is not predictable. Lambdify will stop here and return `False`', category=DeprecationWarning)
-        return False  # Anything else that block the code would be fine
+        SymPyDeprecationWarning(
+                    feature="The list of arguments is a `set`. This leads to unpredictable results",
+                    useinstead="concvet set into list or tuple",
+                    issue=19735,
+                    deprecated_since_version="1.6.3"
+                ).warn()
+        #warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify`, but its outcome is not predictable. Lambdify will stop here and return `False`', category=DeprecationWarning)
+        #return False  # Anything else that block the code would be fine
 
     # Get the names of the args, for creating a docstring
     if not iterable(args):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -176,7 +176,8 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
        unsanitized input.
 
     .. versionchanged:: 1.7.0
-       Passing a set for the *args* parameter is deprecated as sets are unordered. Use an ordered iterable such as a list or tuple.
+       Passing a set for the *args* parameter is deprecated as sets are
+       unordered. Use an ordered iterable such as a list or tuple.
 
     Explanation
     ===========

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -177,12 +177,7 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
        unsanitized input.
 
     .. versionchanged:: 1.7.0
-       Python set is no longer supported type for args
-    .. warning::
-       This function uses ``enumerate`` on ``args``, thus you should
-       provide `args` that is a fixed-ordering iterable, e.g. a sequence,
-       or take responsibility for making sure the args are in the order
-       you want them to be. If a set is passed lambdify will return a False
+       Passing a set for the *args* parameter is deprecated as sets are unordered. Use an ordered iterable such as a list or tuple.
 
     Explanation
     ===========

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -806,18 +806,14 @@ def lambdify(args: iterable, expr, modules=None, printer=None, use_imps=True,
                            'allow_unknown_functions': True,
                            'user_functions': user_functions})
 
-
     if  type(args) is set:
         warnings.warn('WARNING: The list of arguments is a `set`. The outcome of enumerate(args) is used to `lambdify`, but its outcome is not predictable. Lambdify will stop here and return `False`', category=DeprecationWarning)
         return False  # Anything else that block the code would be fine
-
-
 
     # Get the names of the args, for creating a docstring
     if not iterable(args):
         args = (args,)
     names = []
-
 
     # Grab the callers frame, for getting the names by inspection (if needed)
     callers_local_vars = inspect.currentframe().f_back.f_locals.items()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Arguments are `enumerate`d in lambdify, which is fine for sequnces or lists, but may lead to unpredictable results for a set. I have put a warning to the user that the ordering is not guaranteed in the signature of the produced lambdified function.
I have also implemented a sorting function and added an optional parameter to lamdbify to allow users to sort argument internally in lambdify so to be guaranteed a consistent ordering.

#### Other comments
See https://groups.google.com/forum/#!topic/sympy/zmQfdK8X9Jk

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  functions
    *  `lambdify` added a warning when args is a `set`.
<!-- END RELEASE NOTES -->