### PR TITLE
Fix _minpoly_groebner (expressions with negative powers could lead to wrong results)

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -729,20 +729,15 @@ def _minpoly_groebner(ex, x, cls):
             return Mul(*[ bottom_up_scan(g) for g in ex.args ])
         elif ex.is_Pow:
             if ex.exp.is_Rational:
-                if ex.exp < 0 and ex.base.is_Add:
-                    coeff, terms = ex.base.as_coeff_add()
-                    elt, _ = primitive_element(terms, polys=True)
-
-                    alg = ex.base - coeff
-
-                    # XXX: turn this into eval()
-                    inverse = invert(elt.gen + coeff, elt).as_expr()
-                    base = inverse.subs(elt.gen, alg).expand()
+                if ex.exp < 0:
+                    minpoly_base = _minpoly_groebner(ex.base, x, cls)
+                    inverse = invert(x, minpoly_base).as_expr()
+                    base_inv = inverse.subs(x, ex.base).expand()
 
                     if ex.exp == -1:
-                        return bottom_up_scan(base)
+                        return bottom_up_scan(base_inv)
                     else:
-                        ex = base**(-ex.exp)
+                        ex = base_inv**(-ex.exp)
                 if not ex.exp.is_Integer:
                     base, exp = (
                         ex.base**ex.exp.p).expand(), Rational(1, ex.exp.q)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -783,9 +783,10 @@ def test_issue_13230():
     + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)
     + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
 
-def test_sympyissue_19760():
+def test_issue_19760():
     e = 1/(sqrt(1 + sqrt(2)) - sqrt(2)*sqrt(1 + sqrt(2))) + 1
+    mp_expected = x**4 - 4*x**3 + 4*x**2 - 2
 
     for comp in (True, False):
         mp = Poly(minimal_polynomial(e, compose=comp))
-        assert mp(x) == x**4 - 4*x**3 + 4*x**2 - 2
+        assert mp(x) == mp_expected, "minimal_polynomial(e, compose=%s) = %s; %s expected" % (comp, mp(x), mp_expected)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -782,3 +782,10 @@ def test_issue_13230():
     + 9*sqrt(5)/29 + sqrt(196*sqrt(35) + 1941)/29), -2*sqrt(7)/29 + 9*sqrt(5)/29
     + sqrt(196*sqrt(35) + 1941)/29), Point2D(-1 + (-sqrt(7) + sqrt(5))*(-sqrt(196*sqrt(35)
     + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29), -sqrt(196*sqrt(35) + 1941)/29 - 2*sqrt(7)/29 + 9*sqrt(5)/29)]
+
+def test_sympyissue_19760():
+    e = 1/(sqrt(1 + sqrt(2)) - sqrt(2)*sqrt(1 + sqrt(2))) + 1
+
+    for comp in (True, False):
+        mp = Poly(minimal_polynomial(e, compose=comp))
+        assert mp(x) == x**4 - 4*x**3 + 4*x**2 - 2


### PR DESCRIPTION
Fixes #19760

For computing the inverse of an expression (base with negative exponent) the use of primitive element as module does not always work; use the minimal polynomial instead. This seems also to speed up computation considerably (in case of the previously failed expression by a factor of ~10). Computation of the minimal polynomial of expression under test using Groebner bases is now faster than the default method (roughly by a factor of 4).

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug in minimal_polynomial when using Groebner bases (compose=False)
<!-- END RELEASE NOTES -->
