### PR TITLE
Made Dagger() subclass Operator()

### DIFF
--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -2,13 +2,14 @@
 
 from sympy.core import Expr, Mul
 from sympy.functions.elementary.complexes import adjoint
+from sympy.physics.quantum.operator import Operator
 
 __all__ = [
     'Dagger'
 ]
 
 
-class Dagger(adjoint):
+class Dagger(adjoint, Operator):
     """General Hermitian conjugate operation.
 
     Take the Hermetian conjugate of an argument [1]_. For matrices this
@@ -83,12 +84,8 @@ class Dagger(adjoint):
             return obj
         return Expr.__new__(cls, arg)
 
-    def __mul__(self, other):
-        from sympy.physics.quantum import IdentityOperator
-        if isinstance(other, IdentityOperator):
-            return self
-
-        return Mul(self, other)
+    def _print_contents(self, printer, *args):
+        return 'Dagger(%s)' % self.args[0]._print_contents(printer, *args)
 
 adjoint.__name__ = "Dagger"
 adjoint._sympyrepr = lambda a, b: "Dagger(%s)" % b._print(a.args[0])

--- a/sympy/physics/quantum/dagger.py
+++ b/sympy/physics/quantum/dagger.py
@@ -1,6 +1,6 @@
 """Hermitian conjugation."""
 
-from sympy.core import Expr, Mul
+from sympy.core import Expr
 from sympy.functions.elementary.complexes import adjoint
 from sympy.physics.quantum.operator import Operator
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -13,7 +13,6 @@ from __future__ import print_function, division
 
 from sympy import Derivative, Expr, Integer, oo, Mul, expand, Add
 from sympy.printing.pretty.stringpict import prettyForm
-from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr, dispatch_method
 from sympy.matrices import eye
 
@@ -307,7 +306,7 @@ class IdentityOperator(Operator):
 
     def __mul__(self, other):
 
-        if isinstance(other, (Operator, Dagger)):
+        if isinstance(other, Operator):
             return other
 
         return Mul(self, other)
@@ -455,6 +454,7 @@ class OuterProduct(Operator):
         return self.args[1]
 
     def _eval_adjoint(self):
+        from sympy.physics.quantum import Dagger
         return OuterProduct(Dagger(self.bra), Dagger(self.ket))
 
     def _sympystr(self, printer, *args):

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -5,7 +5,6 @@ from sympy.printing.pretty.stringpict import prettyForm
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import is_sequence
 
-from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.matrixutils import (
     numpy_ndarray, scipy_sparse_matrix,
     to_sympy, to_numpy, to_scipy_sparse
@@ -189,6 +188,7 @@ class QExpr(Expr):
     #-------------------------------------------------------------------------
 
     def _eval_adjoint(self):
+        from sympy.physics.quantum.dagger import Dagger
         obj = Expr._eval_adjoint(self)
         if obj is None:
             obj = Expr.__new__(Dagger, self)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -136,7 +136,7 @@ def represent(expr, **options):
     """
 
     format = options.get('format', 'sympy')
-    if isinstance(expr, QExpr) and not isinstance(expr, OuterProduct):
+    if isinstance(expr, QExpr) and (not isinstance(expr, OuterProduct) and not isinstance(expr, Dagger)):
         options['replace_none'] = False
         temp_basis = get_basis(expr, **options)
         if temp_basis is not None:


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

 This is an improvement on #19783 from which some of the changes were reverted. Provides a better fix for #19747.

#### Brief description of what is fixed or changed

`Dagger` now inherits from `Operator`. Fixed circular imports and override _print_contents() for Dagger.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
    * Make `Dagger` inherit from `Operator`
<!-- END RELEASE NOTES -->