### PR TITLE
Implemented an algorithm to find a rational point on a conic

### DIFF
--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -91,7 +91,8 @@ class ImplicitRegion(Basic):
         References
         =========
 
-        - Rational Points on Conics, Erik Hillgarter, 1996. Availaible:
+        - Erik Hillgarter, "Rational Points on Conics", Diploma Thesis, RISC-Linz,
+        J. Kepler Universitat Linz, 1996. Availaible:
         https://www3.risc.jku.at/publications/download/risc_1355/Rational%20Points%20on%20Conics.pdf
 
         """
@@ -372,11 +373,11 @@ class ImplicitRegion(Basic):
         >>> c.rational_parametrization(reg_point=(3/4, 0))
         (0.75 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
 
-        Refrences
+        References
         =========
 
-        - Christoph M. Hoffmann, Conversion Methods between Parametric and
-        Implicit Curves and Surfaces, 1990. Available:
+        - Christoph M. Hoffmann, "Conversion Methods between Parametric and
+        Implicit Curves and Surfaces", Purdue e-Pubs, 1990. Available:
         https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1827&context=cstech
 
         """

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -105,10 +105,9 @@ class ImplicitRegion(Basic):
 
                 if b**2 == 4*a*c:
                     x_reg, y_reg = self._regular_point_parabola(*coeffs)
-                    return x_reg, y_reg
                 else:
                     x_reg, y_reg = self._regular_point_ellipse(*coeffs)
-                    return x_reg, y_reg
+                return x_reg, y_reg
 
         if len(self.variables) == 3:
             x, y, z = self.variables

--- a/sympy/vector/implicitregion.py
+++ b/sympy/vector/implicitregion.py
@@ -75,11 +75,11 @@ class ImplicitRegion(Basic):
         Examples
         ========
 
-        >>> from sympy.abc import x, y
+        >>> from sympy.abc import x, y, z
         >>> from sympy.vector import ImplicitRegion
-        >>> circle = ImplicitRegion((x, y), x**2 + y**2 - 4)
+        >>> circle = ImplicitRegion((x, y), (x + 2)**2 + (y - 3)**2 - 16)
         >>> circle.regular_point()
-        (2, 0)
+        (2, 3)
         >>> parabola = ImplicitRegion((x, y), x**2 - 4*y)
         >>> parabola.regular_point()
         (0, 0)
@@ -87,10 +87,11 @@ class ImplicitRegion(Basic):
         >>> r.regular_point()
         (-10, -10, 20)
 
-        Refrences
+        References
         =========
 
-        - Erik Hillgarter, Rational Points on Conics.
+        - Rational Points on Conics, Erik Hillgarter, 1996. Availaible:
+        https://www3.risc.jku.at/publications/download/risc_1355/Rational%20Points%20on%20Conics.pdf
 
         """
         equation = self.equation
@@ -114,7 +115,7 @@ class ImplicitRegion(Basic):
 
             for x_reg in range(-10, 10):
                 for y_reg in range(-10, 10):
-                    if len(solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals)) > 0:
+                    if not solveset(equation.subs({x: x_reg, y: y_reg}), self.variables[2], domain=S.Reals).is_empty:
                         return (x_reg, y_reg, list(solveset(equation.subs({x: x_reg, y: y_reg})))[0])
 
         if len(self.singular_points()) != 0:
@@ -208,6 +209,7 @@ class ImplicitRegion(Basic):
 
             x, y, z = symbols("x y z")
             eq = a2*x**2 + b2*y**2 + c2*z**2
+
             sol = diophantine(eq)
             sol = list(sol)[0]
             syms = Tuple(*sol).free_symbols
@@ -232,7 +234,7 @@ class ImplicitRegion(Basic):
                 y_reg = (y - b*x_reg - e)/(2*c)
             else:
                 y_reg = (x - 2*e*a + b*d)/K
-                x_reg = (y - b*reg_y - d)/(2*a)
+                x_reg = (y - b*y_reg - d)/(2*a)
 
             return x_reg, y_reg
 
@@ -313,7 +315,7 @@ class ImplicitRegion(Basic):
 
         >>> circle = ImplicitRegion((x, y), Eq(x**2 + y**2, 4))
         >>> circle.rational_parametrization()
-        (-2 + 4/(t**2 + 1), 4*t/(t**2 + 1))
+        (2 - 4/(t**2 + 1), -4*t/(t**2 + 1))
 
         >>> I = ImplicitRegion((x, y), x**3 + x**2 - y**2)
         >>> I.rational_parametrization()
@@ -339,7 +341,8 @@ class ImplicitRegion(Basic):
         =========
 
         - Christoph M. Hoffmann, Conversion Methods between Parametric and
-        Implicit Curves and Surfaces.
+        Implicit Curves and Surfaces, 1990. Available:
+        https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1827&context=cstech
 
         """
         equation = self.equation

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -20,10 +20,14 @@ def test_ImplicitRegion():
 def test_regular_point():
     r1 = ImplicitRegion((x,), x**2 - 16)
     r1.regular_point() == (-4,)
-    c = ImplicitRegion((x, y), x**2 + y**2 - 4)
-    c.regular_point() == (-2, 0)
-    r2 = ImplicitRegion((x, y), (x - S(5)/2)**2 + y**2 - (S(1)/4)**2)
-    raises(NotImplementedError, lambda: r2.regular_point())
+    c1 = ImplicitRegion((x, y), x**2 + y**2 - 4)
+    c1.regular_point() == (2, 0)
+    c2 = ImplicitRegion((x, y), (x - S(5)/2)**2 + y**2 - (S(1)/4)**2)
+    c2.regular_point() == (11/4, 0)
+    c3 = ImplicitRegion((x, y), (y - 5)**2  - 16*(x - 5))
+    c3.regular_point() == (5, 5)
+    r2 = ImplicitRegion((x, y), x**2 - 4*x*y - 3*y**2 + 4*x + 8*y - 5)
+    r2.regular_point == (4/7, 13/21)
 
 
 def test_singular_points_and_multiplicty():

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -28,6 +28,8 @@ def test_regular_point():
     c3.regular_point() == (5, 5)
     r2 = ImplicitRegion((x, y), x**2 - 4*x*y - 3*y**2 + 4*x + 8*y - 5)
     r2.regular_point == (4/7, 13/21)
+    r3 = ImplicitRegion((x, y), x**2 - 2*x*y + 3*y**2 - 2*x - 5*y + 3/2)
+    raises(ValueError, lambda: r3.regular_point())
 
 
 def test_singular_points_and_multiplicty():
@@ -55,34 +57,35 @@ def test_rational_parametrization():
     line = ImplicitRegion((x, y), Eq(y, 3*x + 2))
     assert line.rational_parametrization() == (x, 3*x + 2)
 
-    circle1 = ImplicitRegion((x, y), ((x-2)**2 + (y+3)**2 - 4))
-    assert circle1.rational_parametrization(parameters=t) == (4 - 4/(t**2 + 1), -4*t/(t**2 + 1) - 3)
-    circle2 = ImplicitRegion((x, y), (x - 1/2)**2 + y**2 - (1/4)**2 )
-    assert circle2.rational_parametrization(parameters=t) == (0.75 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
-    circle2.rational_parametrization(t, reg_point=Point(0.75, 0)) == (3/4 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
+    circle1 = ImplicitRegion((x, y), (x-2)**2 + (y+3)**2 - 4)
+    assert circle1.rational_parametrization(parameters=t) == (4*t/(t**2 + 1) + 2, 4*t**2/(t**2 + 1) - 5)
+    circle2 = ImplicitRegion((x, y), (x - S.Half)**2 + y**2 - (S(1)/2)**2)
+    print(circle2.regular_point())
+    print(circle2.rational_parametrization())
+    assert circle2.rational_parametrization(parameters=t) == (t/(t**2 + 1) + S(1)/2, t**2/(t**2 + 1) - S(1)/2)
     circle3 = ImplicitRegion((x, y), Eq(x**2 + y**2, 2*x))
-    assert circle3.rational_parametrization(parameters=(t,)) == (2 - 2/(t**2 + 1), -2*t/(t**2 + 1))
+    assert circle3.rational_parametrization(parameters=(t,)) == (2*t/(t**2 + 1) + 1, 2*t**2/(t**2 + 1) - 1)
 
     parabola = ImplicitRegion((x, y), (y - 3)**2 - 4*(x + 6))
     assert parabola.rational_parametrization(t) == (-6 + 4/t**2, 3 + 4/t)
 
     rect_hyperbola = ImplicitRegion((x, y), x*y - 1)
-    assert rect_hyperbola.rational_parametrization(t) == (-100 + (100*t + S(1)/100)/t, 100*t)
+    assert rect_hyperbola.rational_parametrization(t) == (-1 + (t + 1)/t, t)
 
     cubic_curve = ImplicitRegion((x, y), x**3 + x**2 - y**2)
     assert cubic_curve.rational_parametrization(parameters=(t)) == (t**2 - 1, t*(t**2 - 1))
     cuspidal = ImplicitRegion((x, y), (x**3 - y**2))
     assert cuspidal.rational_parametrization(t) == (t**2, t**3)
 
-    I= ImplicitRegion((x, y), x**3 + x**2 - y**2)
+    I = ImplicitRegion((x, y), x**3 + x**2 - y**2)
     assert I.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
 
     sphere = ImplicitRegion((x, y, z), Eq(x**2 + y**2 + z**2, 2*x))
+    print(sphere.rational_parametrization(parameters=(s, t)))
     assert sphere.rational_parametrization(parameters=(s, t)) == (2/(s**2 + t**2 + 1), 2*t/(s**2 + t**2 + 1), 2*s/(s**2 + t**2 + 1))
 
     conic = ImplicitRegion((x, y), Eq(x**2 + 4*x*y + 3*y**2 + x - y + 10, 0))
-    conic.rational_parametrization(t) == (-100 - 205/(3*(3*t**2 - sqrt(41881)*t + 4*t - 2*sqrt(41881)/3 + 1)),\
-                                -205*t/(3*(3*t**2 - sqrt(41881)*t + 4*t - 2*sqrt(41881)/3 + 1)) - sqrt(41881)/6 + 401/6)
+    conic.rational_parametrization(t) == (17/2 + 4/(3*t**2 + 4*t + 1), 4*t/(3*t**2 + 4*t + 1) - 11/2)
 
     r1 = ImplicitRegion((x, y), y**2 - x**3 + x)
     raises(NotImplementedError, lambda: r1.rational_parametrization())

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -56,12 +56,12 @@ def test_rational_parametrization():
     assert line.rational_parametrization() == (x, 3*x + 2)
 
     circle1 = ImplicitRegion((x, y), ((x-2)**2 + (y+3)**2 - 4))
-    assert circle1.rational_parametrization(parameters=t) == (4/(t**2 + 1), 4*t/(t**2 + 1) - 3)
+    assert circle1.rational_parametrization(parameters=t) == (4 - 4/(t**2 + 1), -4*t/(t**2 + 1) - 3)
     circle2 = ImplicitRegion((x, y), (x - 1/2)**2 + y**2 - (1/4)**2 )
-    raises(NotImplementedError, lambda: circle2.rational_parametrization())
+    assert circle2.rational_parametrization(parameters=t) == (0.75 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
     circle2.rational_parametrization(t, reg_point=Point(0.75, 0)) == (3/4 - 0.5/(t**2 + 1), -0.5*t/(t**2 + 1))
     circle3 = ImplicitRegion((x, y), Eq(x**2 + y**2, 2*x))
-    assert circle3.rational_parametrization(parameters=(t,)) == (2/(t**2 + 1), 2*t/(t**2 + 1))
+    assert circle3.rational_parametrization(parameters=(t,)) == (2 - 2/(t**2 + 1), -2*t/(t**2 + 1))
 
     parabola = ImplicitRegion((x, y), (y - 3)**2 - 4*(x + 6))
     assert parabola.rational_parametrization(t) == (-6 + 4/t**2, 3 + 4/t)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
#19320 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Implemented an algorithm to find a rational point on the conic. To parametrize a monoid of degree d, we need to find a point of multiplicity d - 1. This implies for curves of degree 2, we need to determine a rational point on it. While determining a point of multiplicity >= 2 is easy using sympy's non-linsolve, a separate algorithm needs to be implemented for points of multiplicity 1 or regular points. 

The `regular_point` was based on iterating over a set of points and checking whether they lie on the conic. This PR fixes this for conics. I have not yet implemented the algorithm for [quadrics](https://en.wikipedia.org/wiki/Quadric). 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * Added a function to find a rational point on conic
<!-- END RELEASE NOTES -->