### PR TITLE
[GSoC] Allow more than one RV in compound distribution

### DIFF
--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -16,10 +16,6 @@ class CompoundPSpace(PSpace):
     parent distribution.
     """
 
-    is_Finite = None
-    is_Continuous = None
-    is_Discrete = None
-
     def __new__(cls, s, distribution):
         s = _symbol_converter(s)
         if isinstance(distribution, ContinuousDistribution):
@@ -31,9 +27,6 @@ class CompoundPSpace(PSpace):
         if not isinstance(distribution, CompoundDistribution):
             raise ValueError("%s should be an isinstance of "
                         "CompoundDistribution"%(distribution))
-        cls.is_Finite = distribution.is_Finite
-        cls.is_Continuous = distribution.is_Continuous
-        cls.is_Discrete = distribution.is_Discrete
         return Basic.__new__(cls, s, distribution)
 
     @property
@@ -43,6 +36,18 @@ class CompoundPSpace(PSpace):
     @property
     def symbol(self):
         return self.args[0]
+
+    @property
+    def is_Continuous(self):
+        return self.distribution.is_Continuous
+
+    @property
+    def is_Finite(self):
+        return self.distribution.is_Finite
+
+    @property
+    def is_Discrete(self):
+        return self.distribution.is_Discrete
 
     @property
     def distribution(self):
@@ -147,18 +152,9 @@ class CompoundDistribution(Basic, NamedArgsMixin):
 
     """
 
-    is_Finite = None
-    is_Continuous = None
-    is_Discrete = None
-
     def __new__(cls, dist):
-        if isinstance(dist, ContinuousDistribution):
-            cls.is_Continuous = True
-        elif isinstance(dist, DiscreteDistribution):
-            cls.is_Discrete = True
-        elif isinstance(dist, SingleFiniteDistribution):
-            cls.is_Finite = True
-        else:
+        if not isinstance(dist, (ContinuousDistribution,
+                SingleFiniteDistribution, DiscreteDistribution)):
             message = "Compound Distribution for %s is not implemeted yet" % str(dist)
             raise NotImplementedError(message)
         if not cls._compound_check(dist):
@@ -168,6 +164,18 @@ class CompoundDistribution(Basic, NamedArgsMixin):
     @property
     def set(self):
         return self.args[0].set
+
+    @property
+    def is_Continuous(self):
+        return isinstance(self.args[0], ContinuousDistribution)
+
+    @property
+    def is_Finite(self):
+        return isinstance(self.args[0], SingleFiniteDistribution)
+
+    @property
+    def is_Discrete(self):
+        return isinstance(self.args[0], DiscreteDistribution)
 
     def pdf(self, x):
         dist = self.args[0]

--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -1,4 +1,4 @@
-from sympy import Basic, integrate, Sum, Dummy, Lambda, Integral
+from sympy import Basic, Sum, Dummy, Lambda, Integral
 from sympy.stats.rv import (NamedArgsMixin, random_symbols, _symbol_converter,
                         PSpace, RandomSymbol, is_random)
 from sympy.stats.crv import ContinuousDistribution, SingleContinuousPSpace

--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -142,7 +142,7 @@ class CompoundDistribution(Basic, NamedArgsMixin):
     >>> C = CompoundDistribution(N)
     >>> C.set
     Interval(-oo, oo)
-    >>> C.pdf(x).simplify()
+    >>> C.pdf(x, evaluate=True).simplify()
     exp(-x**2/64 + x/16 - 1/16)/(8*sqrt(pi))
 
     References

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -813,6 +813,7 @@ class Density(Basic):
         from sympy.stats.random_matrix import RandomMatrixPSpace
         from sympy.stats.joint_rv import JointPSpace
         from sympy.stats.matrix_distributions import MatrixPSpace
+        from sympy.stats.compound_rv import CompoundPSpace
         from sympy.stats.frv import SingleFiniteDistribution
         expr, condition = self.expr, self.condition
 
@@ -829,6 +830,8 @@ class Density(Basic):
                 return expr.pspace.distribution
             elif isinstance(expr.pspace, RandomMatrixPSpace):
                 return expr.pspace.model
+        if isinstance(pspace(expr), CompoundPSpace):
+            kwargs['compound_evaluate'] = evaluate
         result = pspace(expr).compute_density(expr, **kwargs)
 
         if evaluate and hasattr(result, 'doit'):

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -89,7 +89,7 @@ def test_Compound_Distribution():
     C = CompoundDistribution(N)
     assert C.is_Continuous
     assert C.set == Interval(-oo, oo)
-    assert C.pdf(x, True).simplify() == exp(-x**2/64 + x/16 - S(1)/16)/(8*sqrt(pi))
+    assert C.pdf(x, evaluate=True).simplify() == exp(-x**2/64 + x/16 - S(1)/16)/(8*sqrt(pi))
 
     assert not isinstance(CompoundDistribution(NormalDistribution(2, 3)),
                             CompoundDistribution)
@@ -102,7 +102,7 @@ def test_Compound_Distribution():
     assert C.is_Finite
     assert C.set == {0, 1}
     y = symbols('y', negative=False, integer=True)
-    assert C.pdf(y, True) == Piecewise((S(1)/(30*beta(2, 4)), Eq(y, 0)),
+    assert C.pdf(y, evaluate=True) == Piecewise((S(1)/(30*beta(2, 4)), Eq(y, 0)),
                 (S(1)/(60*beta(2, 4)), Eq(y, 1)), (0, True))
 
     k, t, z = symbols('k t z', positive=True, real=True)
@@ -111,7 +111,8 @@ def test_Compound_Distribution():
     C = CompoundDistribution(X)
     assert C.is_Discrete
     assert C.set == S.Naturals0
-    assert C.pdf(z, True).simplify() == t**z*(t + 1)**(-k - z)*gamma(k + z)/(gamma(k)*gamma(z + 1))
+    assert C.pdf(z, evaluate=True).simplify() == t**z*(t + 1)**(-k - z)*gamma(k \
+                    + z)/(gamma(k)*gamma(z + 1))
 
 
 def test_compound_pspace():

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, S, erf, sqrt, pi, exp, gamma, Interval, oo, beta,
-                    Eq, Piecewise, Integral, Abs, arg, Dummy)
+                    Eq, Piecewise, Integral, Abs, arg, Dummy, Sum, factorial)
 from sympy.stats import (Normal, P, E, density, Gamma, Poisson, Rayleigh,
                         variance, Bernoulli, Beta, Uniform, cdf)
 from sympy.stats.compound_rv import CompoundDistribution, CompoundPSpace
@@ -67,6 +67,13 @@ def test_unevaluated_CompoundDist():
     (sqrt(2)*_k*Integral(exp(-(_k**4 + 16*(_k - 3)**2)/(32*_k**2)),
     (_k, 0, oo))/(32*sqrt(pi)), True)), (_k, -oo, oo))
     assert (E(X, evaluate=False).simplify()).dummy_eq(expre.simplify())
+
+    X = Poisson('X', 1)
+    Y = Poisson('Y', X)
+    Z = Poisson('Z', Y)
+    exprd = exp(-1)*Sum(exp(-Y)*Y**x*Sum(exp(-X)*X**Y/(factorial(X)*factorial(Y)
+                ), (X, 0, oo)), (Y, 0, oo))/factorial(x)
+    assert density(Z)(x).simplify() == exprd
 
 
 def test_Compound_Distribution():

--- a/sympy/stats/tests/test_compound_rv.py
+++ b/sympy/stats/tests/test_compound_rv.py
@@ -63,10 +63,9 @@ def test_unevaluated_CompoundDist():
     (_k, 0, oo))/(32*sqrt(pi)), True))
     assert (density(X)(x).simplify()).dummy_eq(exprd.simplify())
 
-    expre = Integral(Piecewise((_k*exp(S(3)/4 - _k/4)/8, 2*Abs(arg(_k - 3)) <= pi/2),
-    (sqrt(2)*_k*Integral(exp(-(_k**4 + 16*(_k - 3)**2)/(32*_k**2)),
-    (_k, 0, oo))/(32*sqrt(pi)), True)), (_k, -oo, oo))
-    assert (E(X, evaluate=False).simplify()).dummy_eq(expre.simplify())
+    expre = Integral(_k*Integral(sqrt(2)*exp(-_k**2/32)*exp(-(_k - 3)**2/(2*_k**2)
+    )/(32*sqrt(pi)), (_k, 0, oo)), (_k, -oo, oo))
+    assert E(X, evaluate=False).dummy_eq(expre)
 
     X = Poisson('X', 1)
     Y = Poisson('Y', X)
@@ -75,6 +74,13 @@ def test_unevaluated_CompoundDist():
                 ), (X, 0, oo)), (Y, 0, oo))/factorial(x)
     assert density(Z)(x).simplify() == exprd
 
+    N = Normal('N', 1, 2)
+    M = Normal('M', 3, 4)
+    D = Normal('D', M, N)
+    exprd = Integral(sqrt(2)*exp(-(_k - 1)**2/8)*Integral(exp(-(-_k + x
+    )**2/(2*_k**2))*exp(-(_k - 3)**2/32)/(8*pi*_k)
+    , (_k, -oo, oo))/(4*sqrt(pi)), (_k, -oo, oo))
+    assert density(D, evaluate=False)(x).dummy_eq(exprd)
 
 def test_Compound_Distribution():
     X = Normal('X', 2, 4)
@@ -82,7 +88,7 @@ def test_Compound_Distribution():
     C = CompoundDistribution(N)
     assert C.is_Continuous
     assert C.set == Interval(-oo, oo)
-    assert C.pdf(x).simplify() == exp(-x**2/64 + x/16 - S(1)/16)/(8*sqrt(pi))
+    assert C.pdf(x, True).simplify() == exp(-x**2/64 + x/16 - S(1)/16)/(8*sqrt(pi))
 
     assert not isinstance(CompoundDistribution(NormalDistribution(2, 3)),
                             CompoundDistribution)
@@ -95,7 +101,7 @@ def test_Compound_Distribution():
     assert C.is_Finite
     assert C.set == {0, 1}
     y = symbols('y', negative=False, integer=True)
-    assert C.pdf(y) == Piecewise((S(1)/(30*beta(2, 4)), Eq(y, 0)),
+    assert C.pdf(y, True) == Piecewise((S(1)/(30*beta(2, 4)), Eq(y, 0)),
                 (S(1)/(60*beta(2, 4)), Eq(y, 1)), (0, True))
 
     k, t, z = symbols('k t z', positive=True, real=True)
@@ -104,7 +110,7 @@ def test_Compound_Distribution():
     C = CompoundDistribution(X)
     assert C.is_Discrete
     assert C.set == S.Naturals0
-    assert C.pdf(z).simplify() == t**z*(t + 1)**(-k - z)*gamma(k + z)/(gamma(k)*gamma(z + 1))
+    assert C.pdf(z, True).simplify() == t**z*(t + 1)**(-k - z)*gamma(k + z)/(gamma(k)*gamma(z + 1))
 
 
 def test_compound_pspace():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to discussions in #19728 

#### Brief description of what is fixed or changed
Previously:
```py
>>> from sympy.stats import *
>>> N = Normal('N', 0, 1)
>>> M = Normal('M', N, 1)
>>> D = Normal('D', 0, M)
>>> density(D)(x)
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/home/czgdp1807ssd/sympy_project/sympy/sympy/stats/rv.py", line 882, in density
    return Density(expr, condition).doit(evaluate=evaluate, **kwargs)
  File "/home/czgdp1807ssd/sympy_project/sympy/sympy/stats/rv.py", line 832, in doit
    result = pspace(expr).compute_density(expr, **kwargs)
  File "/home/czgdp1807ssd/sympy_project/sympy/sympy/stats/compound_rv.py", line 82, in compute_density
    new_pspace = self._get_newpspace()
  File "/home/czgdp1807ssd/sympy_project/sympy/sympy/stats/compound_rv.py", line 60, in _get_newpspace
    Lambda(x, self.distribution.pdf(x)))
  File "/home/czgdp1807ssd/sympy_project/sympy/sympy/stats/compound_rv.py", line 171, in pdf
    raise NotImplementedError("Compound Distributions for more than"
NotImplementedError: Compound Distributions for more than one random argument is not implemented yet.
```
After changing the marginalization algorithm:
```py
In [1]: from sympy.stats import *

In [2]: N = Normal('N', 0, 1)

In [3]: M = Normal('M', N, 1)

In [4]: D = Normal('D', 0, M)

In [5]: density(D)(x)
Out[5]:
⎧                                                                       π
⎪                         0                            for 2⋅│arg(x)│ ≤ ─
⎪                                                                       2
⎪
⎪∞

⎪⌠
⎪⎮     ⎛                 2       2         ⎞
⎪⎮     ⎜               -M      -M          ⎟    2
⎪⎮     ⎜               ────    ────        ⎟  -x
⎨⎮     ⎜⎛        ⎛M⎞⎞   4       4       ⎛M⎞⎟  ────
⎪⎮     ⎜⎜2 - erfc⎜─⎟⎟⋅ℯ       ℯ    ⋅erfc⎜─⎟⎟     2
⎪⎮     ⎜⎝        ⎝2⎠⎠                   ⎝2⎠⎟  2⋅M
⎪⎮  √2⋅⎜─────────────────── + ─────────────⎟⋅ℯ
⎪⎮     ⎝        4⋅√π               4⋅√π    ⎠
⎪⎮  ────────────────────────────────────────────── dM      otherwise
⎪⎮                      2⋅√π⋅M
⎪⌡
⎪-∞
⎩
```


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Allowing `CompoundDistribution` to handle more than one random variables
<!-- END RELEASE NOTES -->
ping @czgdp1807 @Upabjojr @jmig5776 