### PR TITLE
Create custom data type for dotprodsim_state (1.6 branch)

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2981,7 +2981,7 @@ def test_func():
 
 def test_issue_19809():
     def f():
-        assert _dotprodsimp_state.state == False
+        assert _dotprodsimp_state.state is None
         m = Matrix([[1]])
         m = m * m
         return True

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,4 +1,5 @@
 import random
+import concurrent.futures
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, Poly, Pow, PurePoly, Rational,
@@ -2975,3 +2976,14 @@ def test_func():
 
     A = Matrix([[0, 2, 1, 6], [0, 0, 1, 2], [0, 0, 0, 3], [0, 0, 0, 0]])
     assert A.analytic_func(exp(x*t), x) == expand(simplify((A*t).exp()))
+
+
+def test_issue_19809():
+    def f():
+        m = Matrix([[1]])
+        m = m * m
+        return True
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(f)
+        assert future.result()

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -14,6 +14,7 @@ from sympy.matrices import (
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
     MatrixSymbol, dotprodsimp)
+from sympy.matrices.utilities import _dotprodsimp_state
 from sympy.core.compatibility import iterable, Hashable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -2980,10 +2981,12 @@ def test_func():
 
 def test_issue_19809():
     def f():
+        assert _dotprodsimp_state.state == False
         m = Matrix([[1]])
         m = m * m
         return True
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(f)
-        assert future.result()
+    with dotprodsimp(True):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(f)
+            assert future.result()

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -7,7 +7,7 @@ from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 
 class DotProdSimpState(local):
     def __init__(self):
-        self.state = False
+        self.state = None
 
 _dotprodsimp_state = DotProdSimpState()
 

--- a/sympy/matrices/utilities.py
+++ b/sympy/matrices/utilities.py
@@ -5,8 +5,11 @@ from sympy.core.function import expand_mul
 from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 
 
-_dotprodsimp_state       = local()
-_dotprodsimp_state.state = None
+class DotProdSimpState(local):
+    def __init__(self):
+        self.state = False
+
+_dotprodsimp_state = DotProdSimpState()
 
 @contextmanager
 def dotprodsimp(x):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
https://github.com/sympy/sympy/issues/19809

#### Brief description of what is fixed or changed
Create a custom class inherited from threading.local that sets the default state on init. This makes sure that new threads also start with the correct value.

See https://github.com/python/cpython/blob/master/Lib/_threading_local.py#L55 for more information about subclassing threading.local.

#### Other comments
When putting a print statement in the `__init__` function this is printed twice, once on import, once when starting the thread.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
      * Fixed a bug that made matrix operations fail in a multithreaded application.
<!-- END RELEASE NOTES -->