### PR TITLE
Do not use SystemError

### DIFF
--- a/bin/test_executable.py
+++ b/bin/test_executable.py
@@ -16,7 +16,7 @@ def test_executable(path):
             with open(path, 'r') as f:
                 if f.readline()[:2] != "#!":
                     exn_msg = "File at " + path + " either should not be executable or should have a shebang line"
-                    raise SystemError(exn_msg)
+                    raise OSError(exn_msg)
     else:
         for file in os.listdir(path):
             test_executable(os.path.join(path, file))

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -126,7 +126,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             try:
                 candidate_viewers = candidates[output]
             except KeyError:
-                raise SystemError("Invalid output format: %s" % output)
+                raise ValueError("Invalid output format: %s" % output) from None
 
             for candidate in candidate_viewers:
                 path = shutil.which(candidate)
@@ -134,7 +134,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                     viewer = path
                     break
             else:
-                raise SystemError(
+                raise OSError(
                     "No viewers found for '%s' output format." % output)
     else:
         if viewer == "StringIO":
@@ -147,7 +147,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 raise ValueError("outputbuffer has to be a BytesIO "
                                  "compatible object if viewer=\"BytesIO\"")
         elif viewer not in special and not shutil.which(viewer):
-            raise SystemError("Unrecognized viewer: %s" % viewer)
+            raise OSError("Unrecognized viewer: %s" % viewer)
 
 
     if preamble is None:
@@ -217,7 +217,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             try:
                 cmd_variants = commandnames[output]
             except KeyError:
-                raise SystemError("Invalid output format: %s" % output)
+                raise ValueError("Invalid output format: %s" % output) from None
 
             # find an appropriate command
             for cmd_variant in cmd_variants:
@@ -288,7 +288,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 from pyglet.image.codecs.png import PNGImageDecoder
                 img = image.load(join(workdir, src), decoder=PNGImageDecoder())
             else:
-                raise SystemError("pyglet preview works only for 'png' files.")
+                raise ValueError("pyglet preview works only for 'png' files.")
 
             offset = 25
 


### PR DESCRIPTION
The docs for system error are clear:
```
>>> print(SystemError.__doc__)
Internal error in the Python interpreter.

Please report this to the Python maintainer, along with the traceback,
the Python version, and the hardware/OS platform and version.
```
None of these errors justify contacting a Python maintainer.

`OSError` was probably intended, although a few of these make more sense as `ValueError`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * `preview` now throws `OSError` instead of `SystemError` if viewers cannot be found.
<!-- END RELEASE NOTES -->