### PR TITLE
Added `MatrixSet` to represent set of Matrices

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3010,6 +3010,11 @@ def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
     from sympy.matrices.expressions.matexpr import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())
 
+def test_sympy__matrices__expressions__matexpr__MatrixSet():
+    from sympy.matrices.expressions.matexpr import MatrixSet
+    from sympy import S
+    assert _test_args(MatrixSet(2, 2, S.Reals))
+
 def test_sympy__matrices__expressions__matmul__MatMul():
     from sympy.matrices.expressions.matmul import MatMul
     from sympy.matrices.expressions import MatrixSymbol

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -28,7 +28,7 @@ from .expressions import (
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagMatrix, DiagonalMatrix, DiagonalOf, trace,
     DotProduct, kronecker_product, KroneckerProduct,
-    PermutationMatrix, MatrixPermute)
+    PermutationMatrix, MatrixPermute, MatrixSet)
 
 from .utilities import dotprodsimp
 
@@ -61,7 +61,7 @@ __all__ = [
     'hadamard_product', 'HadamardProduct', 'HadamardPower', 'Determinant',
     'det', 'diagonalize_vector', 'DiagMatrix', 'DiagonalMatrix',
     'DiagonalOf', 'trace', 'DotProduct', 'kronecker_product',
-    'KroneckerProduct', 'PermutationMatrix', 'MatrixPermute',
+    'KroneckerProduct', 'PermutationMatrix', 'MatrixPermute', 'MatrixSet',
 
     'dotprodsimp',
 ]

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -7,7 +7,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
-                      matrix_symbols)
+                      matrix_symbols, MatrixSet)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
@@ -33,7 +33,7 @@ __all__ = [
     'MatAdd',
 
     'Identity', 'MatrixExpr', 'MatrixSymbol', 'ZeroMatrix', 'OneMatrix',
-    'matrix_symbols',
+    'matrix_symbols', 'MatrixSet',
 
     'MatMul',
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1311,7 +1311,7 @@ class MatrixSet(Set):
         if not isinstance(other, MatrixExpr):
             raise TypeError("{} should be an instance of MatrixExpr.".format(other))
         if other.shape != self.shape:
-            are_symbolic = any(x.is_Symbol for x in other.shape + self.shape)
+            are_symbolic = any(_sympify(x).is_Symbol for x in other.shape + self.shape)
             if are_symbolic:
                 return None
             return False

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -7,7 +7,7 @@ from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
-        SparseMatrix, Transpose, Adjoint, NonSquareMatrixError)
+        SparseMatrix, Transpose, Adjoint, NonSquareMatrixError, MatrixSet)
 from sympy.matrices.expressions.matexpr import (MatrixElement,
                                                 GenericZeroMatrix, GenericIdentity, OneMatrix)
 from sympy.testing.pytest import raises, XFAIL
@@ -669,3 +669,26 @@ def test_as_explicit():
         [Z[1, 0], Z[1, 1], Z[1, 2]],
     ])
     raises(ValueError, lambda: A.as_explicit())
+
+def test_MatrixSet():
+    M = MatrixSet(2, 2, set=S.Reals)
+    assert M.shape == (2, 2)
+    assert M.set == S.Reals
+    X = Matrix([[1, 2], [3, 4]])
+    assert X in M
+    X = ZeroMatrix(2, 2)
+    assert X in M
+    raises(TypeError, lambda: A in M)
+    raises(TypeError, lambda: 1 in M)
+    M = MatrixSet(n, m, set=S.Reals)
+    assert A in M
+    raises(TypeError, lambda: C in M)
+    raises(TypeError, lambda: X in M)
+    M = MatrixSet(2, 2, set={1, 2, 3})
+    X = Matrix([[1, 2], [3, 4]])
+    Y = Matrix([[1, 2], [3, 1]])
+    assert (X in M) == S.false
+    assert Y in M
+    raises(ValueError, lambda: MatrixSet(2, -2, S.Reals))
+    raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
+    raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -686,9 +686,9 @@ def test_MatrixSet():
     raises(TypeError, lambda: X in M)
     M = MatrixSet(2, 2, set={1, 2, 3})
     X = Matrix([[1, 2], [3, 4]])
-    Y = Matrix([[1, 2], [3, 1]])
+    Y = Matrix([[1, 2]])
     assert (X in M) == S.false
-    assert Y in M
+    assert (Y in M) == S.false
     raises(ValueError, lambda: MatrixSet(2, -2, S.Reals))
     raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
     raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related comment https://github.com/sympy/sympy/pull/19795#discussion_r457919332

#### Brief description of what is fixed or changed
MatrixSet represents the set of matrices of given shape over the given set.
Examples:
```py
>>> from sympy.matrices import MatrixSet, Matrix
>>> from sympy import S, I
>>> M = MatrixSet(2, 2, set=S.Reals)
>>> X = Matrix([[1, 2], [3, 4]])
>>> X in M
True
>>> X = Matrix([[1, 2], [I, 4]])
>>> X in M
False
```

#### Other comments
- [x] Add docs and class `MatrixSet`
- [x] Add tests

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added class `MatrixSet` to represent the set of matrices
<!-- END RELEASE NOTES -->
ping @oscarbenjamin 