### PR TITLE
Move MatrixSet to separate file

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -56,6 +56,8 @@ Matrix Expressions Core Reference
    :members:
 .. autoclass:: CompanionMatrix
    :members:
+.. autoclass:: MatrixSet
+   :members:
 
 Block Matrices
 --------------

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3011,7 +3011,7 @@ def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
     assert _test_args(GenericZeroMatrix())
 
 def test_sympy__matrices__expressions__matexpr__MatrixSet():
-    from sympy.matrices.expressions.matexpr import MatrixSet
+    from sympy.matrices.expressions.sets import MatrixSet
     from sympy import S
     assert _test_args(MatrixSet(2, 2, S.Reals))
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3010,7 +3010,7 @@ def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
     from sympy.matrices.expressions.matexpr import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())
 
-def test_sympy__matrices__expressions__matexpr__MatrixSet():
+def test_sympy__matrices__expressions__sets__MatrixSet():
     from sympy.matrices.expressions.sets import MatrixSet
     from sympy import S
     assert _test_args(MatrixSet(2, 2, S.Reals))

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -7,7 +7,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
-                      matrix_symbols, MatrixSet)
+                      matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
@@ -19,6 +19,7 @@ from .diagonal import DiagonalMatrix, DiagonalOf, DiagMatrix, diagonalize_vector
 from .dotproduct import DotProduct
 from .kronecker import kronecker_product, KroneckerProduct, combine_kronecker
 from .permutation import PermutationMatrix, MatrixPermute
+from .sets import MatrixSet
 
 __all__ = [
     'MatrixSlice',

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,5 +1,5 @@
 from typing import Any, Callable
-from sympy.core.logic import FuzzyBool, fuzzy_and
+from sympy.core.logic import FuzzyBool
 
 from functools import wraps, reduce
 import collections
@@ -15,7 +15,6 @@ from sympy.simplify import simplify
 from sympy.utilities.misc import filldedent
 from sympy.assumptions.ask import ask, Q
 from sympy.multipledispatch import dispatch
-from sympy.sets.sets import Set
 
 
 def _sympifyit(arg, retval=None):
@@ -1269,63 +1268,6 @@ def _make_matrix(x):
         return x
     return ImmutableDenseMatrix([[x]])
 
-
-class MatrixSet(Set):
-    """
-    MatrixSet represents the set of matrices with ``shape = (n, m)`` over the
-    given set.
-
-    Examples
-    ========
-
-    >>> from sympy.matrices import MatrixSet, Matrix
-    >>> from sympy import S, I
-    >>> M = MatrixSet(2, 2, set=S.Reals)
-    >>> X = Matrix([[1, 2], [3, 4]])
-    >>> X in M
-    True
-    >>> X = Matrix([[1, 2], [I, 4]])
-    >>> X in M
-    False
-
-    """
-    is_empty = False
-
-    def __new__(cls, n, m, set):
-        n, m, set = _sympify(n), _sympify(m), _sympify(set)
-        cls._check_dim(n)
-        cls._check_dim(m)
-        if not isinstance(set, Set):
-            raise TypeError("{} should be an instance of Set.".format(set))
-        return Set.__new__(cls, n, m, set)
-
-    @property
-    def shape(self):
-        return self.args[:2]
-
-    @property
-    def set(self):
-        return self.args[2]
-
-    def _contains(self, other):
-        if not isinstance(other, MatrixExpr):
-            raise TypeError("{} should be an instance of MatrixExpr.".format(other))
-        if other.shape != self.shape:
-            are_symbolic = any(_sympify(x).is_Symbol for x in other.shape + self.shape)
-            if are_symbolic:
-                return None
-            return False
-        return fuzzy_and(self.set.contains(x) for x in other)
-
-    @classmethod
-    def _check_dim(cls, dim):
-        """Helper function to check invalid matrix dimensions"""
-        from sympy.core.assumptions import check_assumptions
-        ok = check_assumptions(dim, integer=True, nonnegative=True)
-        if ok is False:
-            raise ValueError(
-                "The dimension specification {} should be "
-                "a nonnegative integer.".format(dim))
 
 from .matmul import MatMul
 from .matadd import MatAdd

--- a/sympy/matrices/expressions/sets.py
+++ b/sympy/matrices/expressions/sets.py
@@ -1,0 +1,62 @@
+from sympy.core.logic import fuzzy_and
+from sympy.core.sympify import _sympify
+from sympy.sets.sets import Set
+from .matexpr import MatrixExpr
+
+
+class MatrixSet(Set):
+    """
+    MatrixSet represents the set of matrices with ``shape = (n, m)`` over the
+    given set.
+
+    Examples
+    ========
+
+    >>> from sympy.matrices import MatrixSet, Matrix
+    >>> from sympy import S, I
+    >>> M = MatrixSet(2, 2, set=S.Reals)
+    >>> X = Matrix([[1, 2], [3, 4]])
+    >>> X in M
+    True
+    >>> X = Matrix([[1, 2], [I, 4]])
+    >>> X in M
+    False
+
+    """
+    is_empty = False
+
+    def __new__(cls, n, m, set):
+        n, m, set = _sympify(n), _sympify(m), _sympify(set)
+        cls._check_dim(n)
+        cls._check_dim(m)
+        if not isinstance(set, Set):
+            raise TypeError("{} should be an instance of Set.".format(set))
+        return Set.__new__(cls, n, m, set)
+
+    @property
+    def shape(self):
+        return self.args[:2]
+
+    @property
+    def set(self):
+        return self.args[2]
+
+    def _contains(self, other):
+        if not isinstance(other, MatrixExpr):
+            raise TypeError("{} should be an instance of MatrixExpr.".format(other))
+        if other.shape != self.shape:
+            are_symbolic = any(_sympify(x).is_Symbol for x in other.shape + self.shape)
+            if are_symbolic:
+                return None
+            return False
+        return fuzzy_and(self.set.contains(x) for x in other)
+
+    @classmethod
+    def _check_dim(cls, dim):
+        """Helper function to check invalid matrix dimensions"""
+        from sympy.core.assumptions import check_assumptions
+        ok = check_assumptions(dim, integer=True, nonnegative=True)
+        if ok is False:
+            raise ValueError(
+                "The dimension specification {} should be "
+                "a nonnegative integer.".format(dim))

--- a/sympy/matrices/expressions/tests/test_sets.py
+++ b/sympy/matrices/expressions/tests/test_sets.py
@@ -1,0 +1,34 @@
+from sympy.core.singleton import S
+from sympy.core.symbol import symbols
+from sympy.matrices import Matrix
+from sympy.matrices.expressions.matexpr import MatrixSymbol, ZeroMatrix
+from sympy.matrices.expressions.sets import MatrixSet
+from sympy.testing.pytest import raises
+
+
+def test_MatrixSet():
+    n, m = symbols('n m', integer=True)
+    A = MatrixSymbol('A', n, m)
+    C = MatrixSymbol('C', n, n)
+
+    M = MatrixSet(2, 2, set=S.Reals)
+    assert M.shape == (2, 2)
+    assert M.set == S.Reals
+    X = Matrix([[1, 2], [3, 4]])
+    assert X in M
+    X = ZeroMatrix(2, 2)
+    assert X in M
+    raises(TypeError, lambda: A in M)
+    raises(TypeError, lambda: 1 in M)
+    M = MatrixSet(n, m, set=S.Reals)
+    assert A in M
+    raises(TypeError, lambda: C in M)
+    raises(TypeError, lambda: X in M)
+    M = MatrixSet(2, 2, set={1, 2, 3})
+    X = Matrix([[1, 2], [3, 4]])
+    Y = Matrix([[1, 2]])
+    assert (X in M) == S.false
+    assert (Y in M) == S.false
+    raises(ValueError, lambda: MatrixSet(2, -2, S.Reals))
+    raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
+    raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

MatrixSet was added in #19826, but I don't think that it should belong with the same file in MatrixExpr since it is growing too large.
I'm also planning of moving some other stuff like `Identity`, `ZeroMatrix` out of there. But it is a bigger issue because a lot of sympy modules can depend on them. So I'd only deal with MatrixSet here.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->