### PR TITLE
Move special matrices out of matexpr.py

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2988,8 +2988,8 @@ def test_sympy__matrices__expressions__matexpr__MatrixSymbol():
     assert _test_args(MatrixSymbol('A', 3, 5))
 
 
-def test_sympy__matrices__expressions__matexpr__OneMatrix():
-    from sympy.matrices.expressions.matexpr import OneMatrix
+def test_sympy__matrices__expressions__special__OneMatrix():
+    from sympy.matrices.expressions.special import OneMatrix
     assert _test_args(OneMatrix(3, 5))
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2974,14 +2974,6 @@ def test_sympy__matrices__expressions__matadd__MatAdd():
     assert _test_args(MatAdd(X, Y))
 
 
-def test_sympy__matrices__expressions__matexpr__Identity():
-    from sympy.matrices.expressions.matexpr import Identity
-    assert _test_args(Identity(3))
-
-def test_sympy__matrices__expressions__matexpr__GenericIdentity():
-    from sympy.matrices.expressions.matexpr import GenericIdentity
-    assert _test_args(GenericIdentity())
-
 @SKIP("abstract class")
 def test_sympy__matrices__expressions__matexpr__MatrixExpr():
     pass
@@ -2996,19 +2988,30 @@ def test_sympy__matrices__expressions__matexpr__MatrixSymbol():
     assert _test_args(MatrixSymbol('A', 3, 5))
 
 
-def test_sympy__matrices__expressions__special__ZeroMatrix():
-    from sympy.matrices.expressions.special import ZeroMatrix
-    assert _test_args(ZeroMatrix(3, 5))
-
-
 def test_sympy__matrices__expressions__matexpr__OneMatrix():
     from sympy.matrices.expressions.matexpr import OneMatrix
     assert _test_args(OneMatrix(3, 5))
 
 
+def test_sympy__matrices__expressions__special__ZeroMatrix():
+    from sympy.matrices.expressions.special import ZeroMatrix
+    assert _test_args(ZeroMatrix(3, 5))
+
+
 def test_sympy__matrices__expressions__special__GenericZeroMatrix():
     from sympy.matrices.expressions.special import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())
+
+
+def test_sympy__matrices__expressions__special__Identity():
+    from sympy.matrices.expressions.special import Identity
+    assert _test_args(Identity(3))
+
+
+def test_sympy__matrices__expressions__special__GenericIdentity():
+    from sympy.matrices.expressions.special import GenericIdentity
+    assert _test_args(GenericIdentity())
+
 
 def test_sympy__matrices__expressions__sets__MatrixSet():
     from sympy.matrices.expressions.sets import MatrixSet

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2996,8 +2996,8 @@ def test_sympy__matrices__expressions__matexpr__MatrixSymbol():
     assert _test_args(MatrixSymbol('A', 3, 5))
 
 
-def test_sympy__matrices__expressions__matexpr__ZeroMatrix():
-    from sympy.matrices.expressions.matexpr import ZeroMatrix
+def test_sympy__matrices__expressions__special__ZeroMatrix():
+    from sympy.matrices.expressions.special import ZeroMatrix
     assert _test_args(ZeroMatrix(3, 5))
 
 
@@ -3006,8 +3006,8 @@ def test_sympy__matrices__expressions__matexpr__OneMatrix():
     assert _test_args(OneMatrix(3, 5))
 
 
-def test_sympy__matrices__expressions__matexpr__GenericZeroMatrix():
-    from sympy.matrices.expressions.matexpr import GenericZeroMatrix
+def test_sympy__matrices__expressions__special__GenericZeroMatrix():
+    from sympy.matrices.expressions.special import GenericZeroMatrix
     assert _test_args(GenericZeroMatrix())
 
 def test_sympy__matrices__expressions__sets__MatrixSet():

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,8 +6,7 @@ from .companion import CompanionMatrix
 from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
-from .matexpr import (Identity, MatrixExpr, MatrixSymbol, OneMatrix,
-                      matrix_symbols)
+from .matexpr import MatrixExpr, MatrixSymbol, OneMatrix, matrix_symbols
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
@@ -20,7 +19,7 @@ from .dotproduct import DotProduct
 from .kronecker import kronecker_product, KroneckerProduct, combine_kronecker
 from .permutation import PermutationMatrix, MatrixPermute
 from .sets import MatrixSet
-from .special import ZeroMatrix
+from .special import ZeroMatrix, Identity
 
 __all__ = [
     'MatrixSlice',

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,7 +6,7 @@ from .companion import CompanionMatrix
 from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
-from .matexpr import MatrixExpr, MatrixSymbol, OneMatrix, matrix_symbols
+from .matexpr import MatrixExpr, MatrixSymbol, matrix_symbols
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
@@ -19,7 +19,7 @@ from .dotproduct import DotProduct
 from .kronecker import kronecker_product, KroneckerProduct, combine_kronecker
 from .permutation import PermutationMatrix, MatrixPermute
 from .sets import MatrixSet
-from .special import ZeroMatrix, Identity
+from .special import ZeroMatrix, Identity, OneMatrix
 
 __all__ = [
     'MatrixSlice',

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,7 +6,7 @@ from .companion import CompanionMatrix
 from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
-from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
+from .matexpr import (Identity, MatrixExpr, MatrixSymbol, OneMatrix,
                       matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
@@ -20,6 +20,7 @@ from .dotproduct import DotProduct
 from .kronecker import kronecker_product, KroneckerProduct, combine_kronecker
 from .permutation import PermutationMatrix, MatrixPermute
 from .sets import MatrixSet
+from .special import ZeroMatrix
 
 __all__ = [
     'MatrixSlice',

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -7,7 +7,7 @@ from sympy.strategies.traverse import bottom_up
 from sympy.utilities import sift
 from sympy.utilities.misc import filldedent
 
-from sympy.matrices.expressions.matexpr import MatrixExpr, Identity, MatrixElement
+from sympy.matrices.expressions.matexpr import MatrixExpr, MatrixElement
 from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.matadd import MatAdd
 from sympy.matrices.expressions.matpow import MatPow
@@ -16,7 +16,7 @@ from sympy.matrices.expressions.trace import trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
-from sympy.matrices.expressions.special import ZeroMatrix
+from sympy.matrices.expressions.special import ZeroMatrix, Identity
 from sympy.matrices import Matrix, ShapeError
 from sympy.functions.elementary.complexes import re, im
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -7,7 +7,7 @@ from sympy.strategies.traverse import bottom_up
 from sympy.utilities import sift
 from sympy.utilities.misc import filldedent
 
-from sympy.matrices.expressions.matexpr import MatrixExpr, ZeroMatrix, Identity, MatrixElement
+from sympy.matrices.expressions.matexpr import MatrixExpr, Identity, MatrixElement
 from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.matadd import MatAdd
 from sympy.matrices.expressions.matpow import MatPow
@@ -16,6 +16,7 @@ from sympy.matrices.expressions.trace import trace
 from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.matrices import Matrix, ShapeError
 from sympy.functions.elementary.complexes import re, im
 

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,7 +1,7 @@
 from sympy.core import Mul, sympify
 from sympy.matrices.common import ShapeError
-from sympy.matrices.expressions.matexpr import MatrixExpr, OneMatrix
-from sympy.matrices.expressions.special import ZeroMatrix
+from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.matrices.expressions.special import ZeroMatrix, OneMatrix
 from sympy.strategies import (
     unpack, flatten, condition, exhaust, rm_id, sort
 )

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,8 +1,7 @@
 from sympy.core import Mul, sympify
 from sympy.matrices.common import ShapeError
-from sympy.matrices.expressions.matexpr import (
-    MatrixExpr, OneMatrix, ZeroMatrix
-)
+from sympy.matrices.expressions.matexpr import MatrixExpr, OneMatrix
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.strategies import (
     unpack, flatten, condition, exhaust, rm_id, sort
 )

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -4,8 +4,9 @@
 from sympy.core import Mul, prod, sympify
 from sympy.functions import adjoint
 from sympy.matrices.common import ShapeError
-from sympy.matrices.expressions.matexpr import MatrixExpr, Identity
+from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.matrices.expressions.transpose import transpose
+from sympy.matrices.expressions.special import Identity
 from sympy.matrices.matrices import MatrixBase
 from sympy.strategies import (
     canon, condition, distribute, do_one, exhaust, flatten, typed, unpack)

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -8,8 +8,8 @@ from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, flatten, sort, condition,
     exhaust, do_one, glom)
-from sympy.matrices.expressions.matexpr import (MatrixExpr, ZeroMatrix,
-    GenericZeroMatrix)
+from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.matrices.expressions.special import ZeroMatrix, GenericZeroMatrix
 from sympy.utilities import default_sort_key, sift
 
 # XXX: MatAdd should perhaps not subclass directly from Add

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -945,92 +945,6 @@ class GenericIdentity(Identity):
         return super().__hash__()
 
 
-class ZeroMatrix(MatrixExpr):
-    """The Matrix Zero 0 - additive identity
-
-    Examples
-    ========
-
-    >>> from sympy import MatrixSymbol, ZeroMatrix
-    >>> A = MatrixSymbol('A', 3, 5)
-    >>> Z = ZeroMatrix(3, 5)
-    >>> A + Z
-    A
-    >>> Z*A.T
-    0
-    """
-    is_ZeroMatrix = True
-
-    def __new__(cls, m, n):
-        m, n = _sympify(m), _sympify(n)
-        cls._check_dim(m)
-        cls._check_dim(n)
-
-        return super().__new__(cls, m, n)
-
-    @property
-    def shape(self):
-        return (self.args[0], self.args[1])
-
-    def _eval_power(self, exp):
-        # exp = -1, 0, 1 are already handled at this stage
-        if (exp < 0) == True:
-            raise NonInvertibleMatrixError("Matrix det == 0; not invertible")
-        return self
-
-    def _eval_transpose(self):
-        return ZeroMatrix(self.cols, self.rows)
-
-    def _eval_trace(self):
-        return S.Zero
-
-    def _eval_determinant(self):
-        return S.Zero
-
-    def _eval_inverse(self):
-        raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
-
-    def conjugate(self):
-        return self
-
-    def _entry(self, i, j, **kwargs):
-        return S.Zero
-
-class GenericZeroMatrix(ZeroMatrix):
-    """
-    A zero matrix without a specified shape
-
-    This exists primarily so MatAdd() with no arguments can return something
-    meaningful.
-    """
-    def __new__(cls):
-        # super(ZeroMatrix, cls) instead of super(GenericZeroMatrix, cls)
-        # because ZeroMatrix.__new__ doesn't have the same signature
-        return super(ZeroMatrix, cls).__new__(cls)
-
-    @property
-    def rows(self):
-        raise TypeError("GenericZeroMatrix does not have a specified shape")
-
-    @property
-    def cols(self):
-        raise TypeError("GenericZeroMatrix does not have a specified shape")
-
-    @property
-    def shape(self):
-        raise TypeError("GenericZeroMatrix does not have a specified shape")
-
-    # Avoid Matrix.__eq__ which might call .shape
-    def __eq__(self, other):
-        return isinstance(other, GenericZeroMatrix)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __hash__(self):
-        return super().__hash__()
-
-
 class OneMatrix(MatrixExpr):
     """
     Matrix whose all entries are ones.
@@ -1274,3 +1188,4 @@ from .matadd import MatAdd
 from .matpow import MatPow
 from .transpose import Transpose
 from .inverse import Inverse
+from .special import ZeroMatrix

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -846,105 +846,6 @@ class MatrixSymbol(MatrixExpr):
             )]
 
 
-class Identity(MatrixExpr):
-    """The Matrix Identity I - multiplicative identity
-
-    Examples
-    ========
-
-    >>> from sympy.matrices import Identity, MatrixSymbol
-    >>> A = MatrixSymbol('A', 3, 5)
-    >>> I = Identity(3)
-    >>> I*A
-    A
-    """
-
-    is_Identity = True
-
-    def __new__(cls, n):
-        n = _sympify(n)
-        cls._check_dim(n)
-
-        return super().__new__(cls, n)
-
-    @property
-    def rows(self):
-        return self.args[0]
-
-    @property
-    def cols(self):
-        return self.args[0]
-
-    @property
-    def shape(self):
-        return (self.args[0], self.args[0])
-
-    @property
-    def is_square(self):
-        return True
-
-    def _eval_transpose(self):
-        return self
-
-    def _eval_trace(self):
-        return self.rows
-
-    def _eval_inverse(self):
-        return self
-
-    def conjugate(self):
-        return self
-
-    def _entry(self, i, j, **kwargs):
-        eq = Eq(i, j)
-        if eq is S.true:
-            return S.One
-        elif eq is S.false:
-            return S.Zero
-        return KroneckerDelta(i, j, (0, self.cols-1))
-
-    def _eval_determinant(self):
-        return S.One
-
-    def _eval_power(self, exp):
-        return self
-
-
-class GenericIdentity(Identity):
-    """
-    An identity matrix without a specified shape
-
-    This exists primarily so MatMul() with no arguments can return something
-    meaningful.
-    """
-    def __new__(cls):
-        # super(Identity, cls) instead of super(GenericIdentity, cls) because
-        # Identity.__new__ doesn't have the same signature
-        return super(Identity, cls).__new__(cls)
-
-    @property
-    def rows(self):
-        raise TypeError("GenericIdentity does not have a specified shape")
-
-    @property
-    def cols(self):
-        raise TypeError("GenericIdentity does not have a specified shape")
-
-    @property
-    def shape(self):
-        raise TypeError("GenericIdentity does not have a specified shape")
-
-    # Avoid Matrix.__eq__ which might call .shape
-    def __eq__(self, other):
-        return isinstance(other, GenericIdentity)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __hash__(self):
-        return super().__hash__()
-
-
 class OneMatrix(MatrixExpr):
     """
     Matrix whose all entries are ones.
@@ -1188,4 +1089,4 @@ from .matadd import MatAdd
 from .matpow import MatPow
 from .transpose import Transpose
 from .inverse import Inverse
-from .special import ZeroMatrix
+from .special import ZeroMatrix, Identity

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -7,11 +7,11 @@ from sympy.matrices.common import ShapeError, NonInvertibleMatrixError
 from sympy.matrices.matrices import MatrixBase
 
 from .inverse import Inverse
-from .matexpr import MatrixExpr, OneMatrix
+from .matexpr import MatrixExpr
 from .matpow import MatPow
 from .transpose import transpose
 from .permutation import PermutationMatrix
-from .special import ZeroMatrix, Identity, GenericIdentity
+from .special import ZeroMatrix, Identity, GenericIdentity, OneMatrix
 
 
 # XXX: MatMul should perhaps not subclass directly from Mul

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -7,12 +7,11 @@ from sympy.matrices.common import ShapeError, NonInvertibleMatrixError
 from sympy.matrices.matrices import MatrixBase
 
 from .inverse import Inverse
-from .matexpr import \
-    MatrixExpr, Identity, OneMatrix, GenericIdentity
+from .matexpr import MatrixExpr, OneMatrix
 from .matpow import MatPow
 from .transpose import transpose
 from .permutation import PermutationMatrix
-from .special import ZeroMatrix
+from .special import ZeroMatrix, Identity, GenericIdentity
 
 
 # XXX: MatMul should perhaps not subclass directly from Mul

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -8,10 +8,11 @@ from sympy.matrices.matrices import MatrixBase
 
 from .inverse import Inverse
 from .matexpr import \
-    MatrixExpr, Identity, ZeroMatrix, OneMatrix, GenericIdentity
+    MatrixExpr, Identity, OneMatrix, GenericIdentity
 from .matpow import MatPow
 from .transpose import transpose
 from .permutation import PermutationMatrix
+from .special import ZeroMatrix
 
 
 # XXX: MatMul should perhaps not subclass directly from Mul

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,5 +1,6 @@
 from sympy.matrices.common import NonSquareMatrixError
-from .matexpr import MatrixExpr, Identity
+from .matexpr import MatrixExpr
+from .special import Identity
 from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.matrices import MatrixBase

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -2,7 +2,8 @@ from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.functions import KroneckerDelta
 
-from .matexpr import MatrixExpr, Identity, ZeroMatrix, OneMatrix
+from .matexpr import MatrixExpr, Identity, OneMatrix
+from .special import ZeroMatrix
 
 
 class PermutationMatrix(MatrixExpr):

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -2,8 +2,8 @@ from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.functions import KroneckerDelta
 
-from .matexpr import MatrixExpr, OneMatrix
-from .special import ZeroMatrix, Identity
+from .matexpr import MatrixExpr
+from .special import ZeroMatrix, Identity, OneMatrix
 
 
 class PermutationMatrix(MatrixExpr):

--- a/sympy/matrices/expressions/permutation.py
+++ b/sympy/matrices/expressions/permutation.py
@@ -2,8 +2,8 @@ from sympy.core import S
 from sympy.core.sympify import _sympify
 from sympy.functions import KroneckerDelta
 
-from .matexpr import MatrixExpr, Identity, OneMatrix
-from .special import ZeroMatrix
+from .matexpr import MatrixExpr, OneMatrix
+from .special import ZeroMatrix, Identity
 
 
 class PermutationMatrix(MatrixExpr):

--- a/sympy/matrices/expressions/special.py
+++ b/sympy/matrices/expressions/special.py
@@ -1,3 +1,4 @@
+from sympy.assumptions.ask import ask, Q
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.sympify import _sympify
@@ -191,3 +192,86 @@ class GenericIdentity(Identity):
 
     def __hash__(self):
         return super().__hash__()
+
+
+class OneMatrix(MatrixExpr):
+    """
+    Matrix whose all entries are ones.
+    """
+    def __new__(cls, m, n, evaluate=False):
+        m, n = _sympify(m), _sympify(n)
+        cls._check_dim(m)
+        cls._check_dim(n)
+
+        if evaluate:
+            condition = Eq(m, 1) & Eq(n, 1)
+            if condition == True:
+                return Identity(1)
+
+        obj = super().__new__(cls, m, n)
+        return obj
+
+    @property
+    def shape(self):
+        return self._args
+
+    @property
+    def is_Identity(self):
+        return self._is_1x1() == True
+
+    def as_explicit(self):
+        from sympy import ImmutableDenseMatrix
+        return ImmutableDenseMatrix.ones(*self.shape)
+
+    def doit(self, **hints):
+        args = self.args
+        if hints.get('deep', True):
+            args = [a.doit(**hints) for a in args]
+        return self.func(*args, evaluate=True)
+
+    def _eval_power(self, exp):
+        # exp = -1, 0, 1 are already handled at this stage
+        if self._is_1x1() == True:
+            return Identity(1)
+        if (exp < 0) == True:
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible")
+        if ask(Q.integer(exp)):
+            return self.shape[0] ** (exp - 1) * OneMatrix(*self.shape)
+        return super()._eval_power(exp)
+
+    def _eval_transpose(self):
+        return OneMatrix(self.cols, self.rows)
+
+    def _eval_trace(self):
+        return S.One*self.rows
+
+    def _is_1x1(self):
+        """Returns true if the matrix is known to be 1x1"""
+        shape = self.shape
+        return Eq(shape[0], 1) & Eq(shape[1], 1)
+
+    def _eval_determinant(self):
+        condition = self._is_1x1()
+        if condition == True:
+            return S.One
+        elif condition == False:
+            return S.Zero
+        else:
+            from sympy import Determinant
+            return Determinant(self)
+
+    def _eval_inverse(self):
+        condition = self._is_1x1()
+        if condition == True:
+            return Identity(1)
+        elif condition == False:
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
+        else:
+            from .inverse import Inverse
+            return Inverse(self)
+
+    def conjugate(self):
+        return self
+
+    def _entry(self, i, j, **kwargs):
+        return S.One

--- a/sympy/matrices/expressions/special.py
+++ b/sympy/matrices/expressions/special.py
@@ -1,0 +1,91 @@
+from sympy.core.singleton import S
+from sympy.core.sympify import _sympify
+from sympy.matrices.common import NonInvertibleMatrixError
+from .matexpr import MatrixExpr
+
+
+class ZeroMatrix(MatrixExpr):
+    """The Matrix Zero 0 - additive identity
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol, ZeroMatrix
+    >>> A = MatrixSymbol('A', 3, 5)
+    >>> Z = ZeroMatrix(3, 5)
+    >>> A + Z
+    A
+    >>> Z*A.T
+    0
+    """
+    is_ZeroMatrix = True
+
+    def __new__(cls, m, n):
+        m, n = _sympify(m), _sympify(n)
+        cls._check_dim(m)
+        cls._check_dim(n)
+
+        return super().__new__(cls, m, n)
+
+    @property
+    def shape(self):
+        return (self.args[0], self.args[1])
+
+    def _eval_power(self, exp):
+        # exp = -1, 0, 1 are already handled at this stage
+        if (exp < 0) == True:
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible")
+        return self
+
+    def _eval_transpose(self):
+        return ZeroMatrix(self.cols, self.rows)
+
+    def _eval_trace(self):
+        return S.Zero
+
+    def _eval_determinant(self):
+        return S.Zero
+
+    def _eval_inverse(self):
+        raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
+
+    def conjugate(self):
+        return self
+
+    def _entry(self, i, j, **kwargs):
+        return S.Zero
+
+
+class GenericZeroMatrix(ZeroMatrix):
+    """
+    A zero matrix without a specified shape
+
+    This exists primarily so MatAdd() with no arguments can return something
+    meaningful.
+    """
+    def __new__(cls):
+        # super(ZeroMatrix, cls) instead of super(GenericZeroMatrix, cls)
+        # because ZeroMatrix.__new__ doesn't have the same signature
+        return super(ZeroMatrix, cls).__new__(cls)
+
+    @property
+    def rows(self):
+        raise TypeError("GenericZeroMatrix does not have a specified shape")
+
+    @property
+    def cols(self):
+        raise TypeError("GenericZeroMatrix does not have a specified shape")
+
+    @property
+    def shape(self):
+        raise TypeError("GenericZeroMatrix does not have a specified shape")
+
+    # Avoid Matrix.__eq__ which might call .shape
+    def __eq__(self, other):
+        return isinstance(other, GenericZeroMatrix)
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return super().__hash__()

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -4,7 +4,7 @@ from sympy.matrices.expressions import (
     Identity, MatrixExpr, MatrixSymbol, Determinant,
     det, ZeroMatrix, Transpose
 )
-from sympy.matrices.expressions.matexpr import OneMatrix
+from sympy.matrices.expressions.special import OneMatrix
 from sympy.testing.pytest import raises
 from sympy import refine, Q
 

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,5 +1,5 @@
 from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
-from sympy.matrices.expressions.matexpr import GenericZeroMatrix, ZeroMatrix
+from sympy.matrices.expressions.special import GenericZeroMatrix, ZeroMatrix
 from sympy.matrices import eye, ImmutableMatrix
 from sympy.core import Add, Basic, S
 from sympy.testing.pytest import XFAIL, raises

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -7,8 +7,7 @@ from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint, NonSquareMatrixError, MatrixSet)
-from sympy.matrices.expressions.matexpr import (MatrixElement,
-                                                GenericIdentity, OneMatrix)
+from sympy.matrices.expressions.matexpr import MatrixElement, OneMatrix
 from sympy.testing.pytest import raises, XFAIL
 
 
@@ -57,21 +56,6 @@ def test_one_matrix_creation():
     raises(ValueError, lambda: OneMatrix(n, n))
     n = symbols('n', negative=True)
     raises(ValueError, lambda: OneMatrix(n, n))
-
-
-def test_identity_matrix_creation():
-    assert Identity(2)
-    assert Identity(0)
-    raises(ValueError, lambda: Identity(-1))
-    raises(ValueError, lambda: Identity(2.0))
-    raises(ValueError, lambda: Identity(2j))
-
-    n = symbols('n')
-    assert Identity(n)
-    n = symbols('n', integer=False)
-    raises(ValueError, lambda: Identity(n))
-    n = symbols('n', negative=True)
-    raises(ValueError, lambda: Identity(n))
 
 
 def test_shape():
@@ -490,26 +474,6 @@ def test_issue_7842():
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True
 
-
-def test_generic_identity():
-    I = GenericIdentity()
-    A = MatrixSymbol("A", n, n)
-
-    assert I == I
-    assert I != A
-    assert A != I
-
-    assert I.is_Identity
-    assert I**-1 == I
-
-    raises(TypeError, lambda: I.shape)
-    raises(TypeError, lambda: I.rows)
-    raises(TypeError, lambda: I.cols)
-
-    assert MatMul() == I
-    assert MatMul(I, A) == MatMul(A)
-    # Make sure it is hashable
-    hash(I)
 
 def test_MatMul_postprocessor():
     z = zeros(2)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -1,13 +1,14 @@
-from sympy import (KroneckerDelta, diff, Piecewise, Sum, Dummy, factor,
+from sympy import (KroneckerDelta, diff, Sum, Dummy, factor,
                    expand, zeros, gcd_terms, Eq, Symbol)
 
 from sympy.core import S, symbols, Add, Mul, SympifyError, Rational
-from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
+from sympy.functions import sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
-from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
-        MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
+from sympy.matrices import (ImmutableMatrix, Inverse, MatAdd, MatMul,
+        MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError,
         SparseMatrix, Transpose, Adjoint, NonSquareMatrixError, MatrixSet)
-from sympy.matrices.expressions.matexpr import MatrixElement, OneMatrix
+from sympy.matrices.expressions.matexpr import MatrixElement
+from sympy.matrices.expressions.special import ZeroMatrix, Identity
 from sympy.testing.pytest import raises, XFAIL
 
 
@@ -39,25 +40,6 @@ def test_matrix_symbol_creation():
     raises(ValueError, lambda: MatrixSymbol('A', n, n))
 
 
-def test_one_matrix_creation():
-    assert OneMatrix(2, 2)
-    assert OneMatrix(0, 0)
-    assert Eq(OneMatrix(1, 1), Identity(1))
-    raises(ValueError, lambda: OneMatrix(-1, 2))
-    raises(ValueError, lambda: OneMatrix(2.0, 2))
-    raises(ValueError, lambda: OneMatrix(2j, 2))
-    raises(ValueError, lambda: OneMatrix(2, -1))
-    raises(ValueError, lambda: OneMatrix(2, 2.0))
-    raises(ValueError, lambda: OneMatrix(2, 2j))
-
-    n = symbols('n')
-    assert OneMatrix(n, n)
-    n = symbols('n', integer=False)
-    raises(ValueError, lambda: OneMatrix(n, n))
-    n = symbols('n', negative=True)
-    raises(ValueError, lambda: OneMatrix(n, n))
-
-
 def test_shape():
     assert A.shape == (n, m)
     assert (A*B).shape == (n, l)
@@ -85,123 +67,6 @@ def test_subs():
     C, D = MatrixSymbol('C', 2, 2), MatrixSymbol('D', 2, 2)
 
     assert (C*D).subs({C: A, D: B}) == MatMul(A, B)
-
-
-def test_ZeroMatrix():
-    A = MatrixSymbol('A', n, m)
-    Z = ZeroMatrix(n, m)
-
-    assert A + Z == A
-    assert A*Z.T == ZeroMatrix(n, n)
-    assert Z*A.T == ZeroMatrix(n, n)
-    assert A - A == ZeroMatrix(*A.shape)
-
-    assert Z
-
-    assert transpose(Z) == ZeroMatrix(m, n)
-    assert Z.conjugate() == Z
-
-    assert ZeroMatrix(n, n)**0 == Identity(n)
-    with raises(NonSquareMatrixError):
-        Z**0
-    with raises(NonSquareMatrixError):
-        Z**1
-    with raises(NonSquareMatrixError):
-        Z**2
-
-    assert ZeroMatrix(3, 3).as_explicit() == ImmutableMatrix.zeros(3, 3)
-
-
-def test_ZeroMatrix_doit():
-    Znn = ZeroMatrix(Add(n, n, evaluate=False), n)
-    assert isinstance(Znn.rows, Add)
-    assert Znn.doit() == ZeroMatrix(2*n, n)
-    assert isinstance(Znn.doit().rows, Mul)
-
-
-def test_OneMatrix():
-    A = MatrixSymbol('A', n, m)
-    a = MatrixSymbol('a', n, 1)
-    U = OneMatrix(n, m)
-
-    assert U.shape == (n, m)
-    assert isinstance(A + U, Add)
-    assert transpose(U) == OneMatrix(m, n)
-    assert U.conjugate() == U
-
-    assert OneMatrix(n, n) ** 0 == Identity(n)
-    with raises(NonSquareMatrixError):
-        U ** 0
-    with raises(NonSquareMatrixError):
-        U ** 1
-    with raises(NonSquareMatrixError):
-        U ** 2
-    with raises(ShapeError):
-        a + U
-
-    U = OneMatrix(n, n)
-    assert U[1, 2] == 1
-
-    U = OneMatrix(2, 3)
-    assert U.as_explicit() == ImmutableMatrix.ones(2, 3)
-
-
-def test_OneMatrix_doit():
-    Unn = OneMatrix(Add(n, n, evaluate=False), n)
-    assert isinstance(Unn.rows, Add)
-    assert Unn.doit() == OneMatrix(2 * n, n)
-    assert isinstance(Unn.doit().rows, Mul)
-
-
-def test_OneMatrix_mul():
-    assert OneMatrix(n, m) * OneMatrix(m, k) == OneMatrix(n, k) * m
-    assert w * OneMatrix(1, 1) == w
-    assert OneMatrix(1, 1) * w.T == w.T
-
-
-def test_Identity():
-    A = MatrixSymbol('A', n, m)
-    i, j = symbols('i j')
-
-    In = Identity(n)
-    Im = Identity(m)
-
-    assert A*Im == A
-    assert In*A == A
-
-    assert transpose(In) == In
-    assert In.inverse() == In
-    assert In.conjugate() == In
-
-    assert In[i, j] != 0
-    assert Sum(In[i, j], (i, 0, n-1), (j, 0, n-1)).subs(n,3).doit() == 3
-    assert Sum(Sum(In[i, j], (i, 0, n-1)), (j, 0, n-1)).subs(n,3).doit() == 3
-
-    # If range exceeds the limit `(0, n-1)`, do not remove `Piecewise`:
-    expr = Sum(In[i, j], (i, 0, n-1))
-    assert expr.doit() == 1
-    expr = Sum(In[i, j], (i, 0, n-2))
-    assert expr.doit().dummy_eq(
-        Piecewise(
-            (1, (j >= 0) & (j <= n-2)),
-            (0, True)
-        )
-    )
-    expr = Sum(In[i, j], (i, 1, n-1))
-    assert expr.doit().dummy_eq(
-        Piecewise(
-            (1, (j >= 1) & (j <= n-1)),
-            (0, True)
-        )
-    )
-    assert Identity(3).as_explicit() == ImmutableMatrix.eye(3)
-
-
-def test_Identity_doit():
-    Inn = Identity(Add(n, n, evaluate=False))
-    assert isinstance(Inn.rows, Add)
-    assert Inn.doit() == Identity(2*n)
-    assert isinstance(Inn.doit().rows, Mul)
 
 
 def test_addition():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -2,14 +2,13 @@ from sympy import (KroneckerDelta, diff, Piecewise, Sum, Dummy, factor,
                    expand, zeros, gcd_terms, Eq, Symbol)
 
 from sympy.core import S, symbols, Add, Mul, SympifyError, Rational
-from sympy.core.expr import unchanged
 from sympy.functions import transpose, sin, cos, sqrt, cbrt, exp
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         SparseMatrix, Transpose, Adjoint, NonSquareMatrixError, MatrixSet)
 from sympy.matrices.expressions.matexpr import (MatrixElement,
-                                                GenericZeroMatrix, GenericIdentity, OneMatrix)
+                                                GenericIdentity, OneMatrix)
 from sympy.testing.pytest import raises, XFAIL
 
 
@@ -39,24 +38,6 @@ def test_matrix_symbol_creation():
     raises(ValueError, lambda: MatrixSymbol('A', n, n))
     n = symbols('n', negative=True)
     raises(ValueError, lambda: MatrixSymbol('A', n, n))
-
-
-def test_zero_matrix_creation():
-    assert unchanged(ZeroMatrix, 2, 2)
-    assert unchanged(ZeroMatrix, 0, 0)
-    raises(ValueError, lambda: ZeroMatrix(-1, 2))
-    raises(ValueError, lambda: ZeroMatrix(2.0, 2))
-    raises(ValueError, lambda: ZeroMatrix(2j, 2))
-    raises(ValueError, lambda: ZeroMatrix(2, -1))
-    raises(ValueError, lambda: ZeroMatrix(2, 2.0))
-    raises(ValueError, lambda: ZeroMatrix(2, 2j))
-
-    n = symbols('n')
-    assert unchanged(ZeroMatrix, n, n)
-    n = symbols('n', integer=False)
-    raises(ValueError, lambda: ZeroMatrix(n, n))
-    n = symbols('n', negative=True)
-    raises(ValueError, lambda: ZeroMatrix(n, n))
 
 
 def test_one_matrix_creation():
@@ -508,26 +489,6 @@ def test_issue_7842():
     A = ZeroMatrix(2, 3)
     B = ZeroMatrix(2, 3)
     assert Eq(A, B) == True
-
-
-def test_generic_zero_matrix():
-    z = GenericZeroMatrix()
-    A = MatrixSymbol("A", n, n)
-
-    assert z == z
-    assert z != A
-    assert A != z
-
-    assert z.is_ZeroMatrix
-
-    raises(TypeError, lambda: z.shape)
-    raises(TypeError, lambda: z.rows)
-    raises(TypeError, lambda: z.cols)
-
-    assert MatAdd() == z
-    assert MatAdd(z, A) == MatAdd(A)
-    # Make sure it is hashable
-    hash(z)
 
 
 def test_generic_identity():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -3,7 +3,7 @@ from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
 from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
-from sympy.matrices.expressions.matexpr import GenericIdentity
+from sympy.matrices.expressions.special import GenericIdentity
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, combine_powers, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe

--- a/sympy/matrices/expressions/tests/test_permutation.py
+++ b/sympy/matrices/expressions/tests/test_permutation.py
@@ -4,7 +4,8 @@ from sympy.matrices import Matrix
 from sympy.matrices.expressions import \
     MatMul, BlockDiagMatrix, Determinant, Inverse
 from sympy.matrices.expressions.matexpr import \
-    MatrixSymbol, Identity, ZeroMatrix, OneMatrix
+    MatrixSymbol, Identity, OneMatrix
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.matrices.expressions.permutation import \
     MatrixPermute, PermutationMatrix
 from sympy.testing.pytest import raises

--- a/sympy/matrices/expressions/tests/test_permutation.py
+++ b/sympy/matrices/expressions/tests/test_permutation.py
@@ -3,9 +3,8 @@ from sympy.core.expr import unchanged
 from sympy.matrices import Matrix
 from sympy.matrices.expressions import \
     MatMul, BlockDiagMatrix, Determinant, Inverse
-from sympy.matrices.expressions.matexpr import \
-    MatrixSymbol, Identity, OneMatrix
-from sympy.matrices.expressions.special import ZeroMatrix
+from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy.matrices.expressions.special import ZeroMatrix, OneMatrix, Identity
 from sympy.matrices.expressions.permutation import \
     MatrixPermute, PermutationMatrix
 from sympy.testing.pytest import raises

--- a/sympy/matrices/expressions/tests/test_sets.py
+++ b/sympy/matrices/expressions/tests/test_sets.py
@@ -1,8 +1,9 @@
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.matrices import Matrix
-from sympy.matrices.expressions.matexpr import MatrixSymbol, ZeroMatrix
+from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.sets import MatrixSet
+from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.testing.pytest import raises
 
 

--- a/sympy/matrices/expressions/tests/test_special.py
+++ b/sympy/matrices/expressions/tests/test_special.py
@@ -2,7 +2,9 @@ from sympy.core.expr import unchanged
 from sympy.core.symbol import symbols
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.matadd import MatAdd
-from sympy.matrices.expressions.special import ZeroMatrix, GenericZeroMatrix
+from sympy.matrices.expressions.special import (
+    ZeroMatrix, GenericZeroMatrix, Identity, GenericIdentity)
+from sympy.matrices.expressions.matmul import MatMul
 from sympy.testing.pytest import raises
 
 
@@ -43,3 +45,40 @@ def test_generic_zero_matrix():
     assert MatAdd(z, A) == MatAdd(A)
     # Make sure it is hashable
     hash(z)
+
+
+def test_identity_matrix_creation():
+    assert Identity(2)
+    assert Identity(0)
+    raises(ValueError, lambda: Identity(-1))
+    raises(ValueError, lambda: Identity(2.0))
+    raises(ValueError, lambda: Identity(2j))
+
+    n = symbols('n')
+    assert Identity(n)
+    n = symbols('n', integer=False)
+    raises(ValueError, lambda: Identity(n))
+    n = symbols('n', negative=True)
+    raises(ValueError, lambda: Identity(n))
+
+
+def test_generic_identity():
+    I = GenericIdentity()
+    n = symbols('n', integer=True)
+    A = MatrixSymbol("A", n, n)
+
+    assert I == I
+    assert I != A
+    assert A != I
+
+    assert I.is_Identity
+    assert I**-1 == I
+
+    raises(TypeError, lambda: I.shape)
+    raises(TypeError, lambda: I.rows)
+    raises(TypeError, lambda: I.cols)
+
+    assert MatMul() == I
+    assert MatMul(I, A) == MatMul(A)
+    # Make sure it is hashable
+    hash(I)

--- a/sympy/matrices/expressions/tests/test_special.py
+++ b/sympy/matrices/expressions/tests/test_special.py
@@ -1,0 +1,45 @@
+from sympy.core.expr import unchanged
+from sympy.core.symbol import symbols
+from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy.matrices.expressions.matadd import MatAdd
+from sympy.matrices.expressions.special import ZeroMatrix, GenericZeroMatrix
+from sympy.testing.pytest import raises
+
+
+def test_zero_matrix_creation():
+    assert unchanged(ZeroMatrix, 2, 2)
+    assert unchanged(ZeroMatrix, 0, 0)
+    raises(ValueError, lambda: ZeroMatrix(-1, 2))
+    raises(ValueError, lambda: ZeroMatrix(2.0, 2))
+    raises(ValueError, lambda: ZeroMatrix(2j, 2))
+    raises(ValueError, lambda: ZeroMatrix(2, -1))
+    raises(ValueError, lambda: ZeroMatrix(2, 2.0))
+    raises(ValueError, lambda: ZeroMatrix(2, 2j))
+
+    n = symbols('n')
+    assert unchanged(ZeroMatrix, n, n)
+    n = symbols('n', integer=False)
+    raises(ValueError, lambda: ZeroMatrix(n, n))
+    n = symbols('n', negative=True)
+    raises(ValueError, lambda: ZeroMatrix(n, n))
+
+
+def test_generic_zero_matrix():
+    z = GenericZeroMatrix()
+    n = symbols('n', integer=True)
+    A = MatrixSymbol("A", n, n)
+
+    assert z == z
+    assert z != A
+    assert A != z
+
+    assert z.is_ZeroMatrix
+
+    raises(TypeError, lambda: z.shape)
+    raises(TypeError, lambda: z.rows)
+    raises(TypeError, lambda: z.cols)
+
+    assert MatAdd() == z
+    assert MatAdd(z, A) == MatAdd(A)
+    # Make sure it is hashable
+    hash(z)

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -6,7 +6,7 @@ from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
     ZeroMatrix, trace, MatPow, MatAdd, MatMul
 )
-from sympy.matrices.expressions.matexpr import OneMatrix
+from sympy.matrices.expressions.special import OneMatrix
 from sympy.testing.pytest import raises
 
 n = symbols('n', integer=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

It's an attempt to move special matrices (ZeroMatrix, OneMatrix, ...) out of matexpr.py such that the file doesn't grow bigger and dues not become a place where every miscellaneous stuff are dumped.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->