### PR TITLE
Backport #19376 to 1.6.x

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1147,7 +1147,7 @@ def dmp_ext_factor(f, u, K):
         return lc, []
 
     f, F = dmp_sqf_part(f, u, K), f
-    s, g, r = dmp_sqf_norm(F, u, K)
+    s, g, r = dmp_sqf_norm(f, u, K)
 
     factors = dmp_factor_list_include(r, u, K.dom)
 

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -17,7 +17,7 @@ from sympy.polys.densebasic import (
     dmp_raise, dmp_inject,
     dup_convert)
 from sympy.polys.densetools import (
-    dup_diff, dmp_diff,
+    dup_diff, dmp_diff, dmp_diff_in,
     dup_shift, dmp_compose,
     dup_monic, dmp_ground_monic,
     dup_primitive, dmp_ground_primitive)
@@ -252,7 +252,9 @@ def dmp_sqf_part(f, u, K):
     if K.is_negative(dmp_ground_LC(f, u, K)):
         f = dmp_neg(f, u, K)
 
-    gcd = dmp_gcd(f, dmp_diff(f, 1, u, K), u, K)
+    gcd = f
+    for i in range(u+1):
+        gcd = dmp_gcd(gcd, dmp_diff_in(f, 1, i, u, K), u, K)
     sqf = dmp_quo(f, gcd, u, K)
 
     if K.is_Field:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3350,3 +3350,11 @@ def test_issue_19113():
     raises(PolynomialError, lambda: nroots(eq))
     raises(PolynomialError, lambda: ground_roots(eq))
     raises(PolynomialError, lambda: nth_power_roots_poly(eq, 2))
+
+
+def test_issue_19360():
+    f = 2*x**2 - 2*sqrt(2)*x*y + y**2
+    assert factor(f, extension=sqrt(2)) == 2*(x - (sqrt(2)*y/2))**2
+
+    f = -I*t*x - t*y + x*z - I*y*z
+    assert factor(f, extension=I) == (x - I*y)*(-I*t + z)


### PR DESCRIPTION
Fixed typo in factortools.py and fixed issues in sqfreetools.py.

Fix for #19688

```
git cherry-pick -m 1 d6382c1577bd7fd906764bd27cedc27d38537068
```

<!-- BEGIN RELEASE NOTES -->
* polys
    * Using factor with the extension argument no longer hangs in some cases.
<!-- END RELEASE NOTES -->