### PR TITLE
DOC: complete missed edit in tutorial/gotchas.rst

### DIFF
--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -179,7 +179,7 @@ enough to recognize this basic algebraic fact?
 Recall from above that ``==`` represents *exact* structural equality testing.
 "Exact" here means that two expressions will compare equal with ``==`` only if
 they are exactly equal structurally.  Here, `(x + 1)^2` and `x^2 + 2x + 1` are
-not the same symbolically. One is the power of an addition of two terms, and
+not the same structurally. One is the power of an addition of two terms, and
 the other is the addition of three terms.
 
 It turns out that when using SymPy as a library, having ``==`` test for exact


### PR DESCRIPTION
Prior to #2106, the [Gotchas](https://docs.sympy.org/latest/tutorial/gotchas.html#equals-signs) page of the tutorial contrasted the "symbolic equality" representation of `Eq()` with the "_exact_ symbolic equality" testing of the `==` operator. That contrast was changed to "symbolic equality" versus "structural equality" with 1078e9dc7c84bbdd9d8df69aef03c204ad257011, but it seems one edit was missed. In the third sentence below, "symbolically" should be "structurally":  
> Recall from above that `==` represents _exact_ structural equality testing. “Exact” here means that two expressions will compare equal with `==` only if they are exactly equal structurally. Here, `(x+1)^2 and x2+2x+1` are not the same symbolically. One is the power of an addition of two terms, and the other is the addition of three terms.  
  
**References to other Issues or PRs**  
See #2106, specifically 1078e9dc7c84bbdd9d8df69aef03c204ad257011  
Also #13222  
  
**Brief description of what is fixed or changed**  
"not the same symbolically" changed to "not the same structurally"  
  
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
  