### PR TITLE
Avoid infinite recursion for matrix rmul

### DIFF
--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1036,3 +1036,18 @@ def test_companion():
         Matrix([[0, -c0], [1, -c1]])
     assert Matrix.companion(Poly([1, c2, c1, c0], x)) == \
         Matrix([[0, 0, -c0], [1, 0, -c1], [0, 1, -c2]])
+
+
+def test_rmul_pr19860():
+    class Foo(ImmutableDenseMatrix):
+        _op_priority = MutableDenseMatrix._op_priority + 0.01
+
+    a = Matrix(2, 2, [1, 2, 3, 4])
+    b = Foo(2, 2, [1, 2, 3, 4])
+
+    # This would throw a RecursionError: maximum recursion depth
+    # since b always has higher priority even after a.as_mutable()
+    c = a*b
+
+    assert isinstance(c, Foo)
+    assert c == Matrix([[7, 10], [15, 22]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This small update prevent infinite recursion in some cases for a Matrix `__rmul__`. Currently doing 
```
a  = Matrix(3, 3, rand(3, 3).ravel)
b = MyMatrix(3, 3, rand(3, 3).ravel)
a*b
```
where b is a custom matrix with higher priority than a, the the product produces and infinite recursion since 
`other._new(other.as_mutable() * self) = a._new( a * b) = a*b`. Need to fall back to the actual `evaluate_rmul` the same way
the fallback is `eval_mul` for the `__mul__` case.


#### Other comments

Needs new test

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->


* matrices
  * Prevents infinite recursion with rmul

<!-- END RELEASE NOTES -->