### PR TITLE
[WIP] DOC: docstyle enforcement for stats module

### DIFF
--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -209,10 +209,10 @@ working on extending SymPy Stats to other random variable types.
 
 Users will not use this class structure. Instead these mechanics are exposed
 through variable creation functions Die, Coin, FiniteRV, Normal, Exponential,
-etc.... These build the appropriate SinglePSpaces and return the corresponding
+etc. These build the appropriate SinglePSpaces and return the corresponding
 RandomVariable. Conditional and Product spaces are formed in the natural
 construction of SymPy expressions and the use of interface functions E, Given,
-Density, etc....
+Density, etc.
 
 
 .. function:: sympy.stats.Die

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -4,7 +4,7 @@ SymPy statistics module
 Introduces a random variable type into the SymPy language.
 
 Random variables may be declared using prebuilt functions such as
-Normal, Exponential, Coin, Die, etc...  or built with functions like FiniteRV.
+Normal, Exponential, Coin, Die, etc. or built with functions like FiniteRV.
 
 Queries on random expressions can be made using the functions
 
@@ -40,7 +40,7 @@ Examples
 One could also create custom distribution and define custom random variables
 as follows:
 
-1. If the you want to create a Continuous Random Variable:
+1. If you want to create a Continuous Random Variable:
 
 >>> from sympy.stats import ContinuousRV, P, E
 >>> from sympy import exp, Symbol, Interval, oo
@@ -81,7 +81,7 @@ exp(-x)
 >>> dist.pdf(x)
 2**(1 - x)/2
 
-3. If the you want to create a Finite Random Variable:
+3. If you want to create a Finite Random Variable:
 
 >>> from sympy.stats import FiniteRV, P, E
 >>> from sympy import Rational

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -159,6 +159,9 @@ def ContinuousRV(symbol, density, set=Interval(-oo, oo)):
     """
     Create a Continuous Random Variable given the following:
 
+    Many common continuous random variable types are already implemented.
+    This function should be necessary only very rarely.
+
     Parameters
     ==========
 
@@ -173,10 +176,6 @@ def ContinuousRV(symbol, density, set=Interval(-oo, oo)):
     =======
 
     RandomSymbol
-
-    Many common continuous random variable types are already implemented.
-    This function should be necessary only very rarely.
-
 
     Examples
     ========
@@ -236,17 +235,6 @@ def Arcsin(name, a=0, b=1):
 
     with :math:`x \in (a,b)`. It must hold that :math:`-\infty < a < b < \infty`.
 
-    Parameters
-    ==========
-
-    a : Real number, the left interval boundary
-    b : Real number, the right interval boundary
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -267,6 +255,16 @@ def Arcsin(name, a=0, b=1):
             (2*asin(sqrt((-a + z)/(-a + b)))/pi, b >= z),
             (1, True))
 
+    Parameters
+    ==========
+
+    a : Real number, the left interval boundary
+    b : Real number, the right interval boundary
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -317,18 +315,6 @@ def Benini(name, alpha, beta, sigma):
     This is a heavy-tailed distribution and is also known as the log-Rayleigh
     distribution.
 
-    Parameters
-    ==========
-
-    alpha : Real number, `\alpha > 0`, a shape
-    beta : Real number, `\beta > 0`, a shape
-    sigma : Real number, `\sigma > 0`, a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -354,6 +340,17 @@ def Benini(name, alpha, beta, sigma):
     Piecewise((1 - exp(-alpha*log(z/sigma) - beta*log(z/sigma)**2), sigma <= z),
             (0, True))
 
+    Parameters
+    ==========
+
+    alpha : Real number, `\alpha > 0`, a shape
+    beta : Real number, `\beta > 0`, a shape
+    sigma : Real number, `\sigma > 0`, a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -400,17 +397,6 @@ def Beta(name, alpha, beta):
 
     with :math:`x \in [0,1]`.
 
-    Parameters
-    ==========
-
-    alpha : Real number, `\alpha > 0`, a shape
-    beta : Real number, `\beta > 0`, a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -435,6 +421,17 @@ def Beta(name, alpha, beta):
 
     >>> factor(simplify(variance(X)))
     alpha*beta/((alpha + beta)**2*(alpha + beta + 1))
+
+    Parameters
+    ==========
+
+    alpha : Real number, `\alpha > 0`, a shape
+    beta : Real number, `\beta > 0`, a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -479,18 +476,6 @@ def BetaNoncentral(name, alpha, beta, lamda):
 
     with :math:`x \in [0,1]`.
 
-    Parameters
-    ==========
-
-    alpha : Real number, `\alpha > 0`, a shape
-    beta : Real number, `\beta > 0`, a shape
-    lamda: Real number, `\lambda >= 0`, noncentrality parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -519,12 +504,25 @@ def BetaNoncentral(name, alpha, beta, lamda):
     /____,
     k = 0
 
-    Compute cdf with specific 'x', 'alpha', 'beta' and 'lamda' values as follows :
+    Compute cdf with specific ``x``, ``alpha``, ``beta`` and ``lamda`` values as follows:
+    
     >>> cdf(BetaNoncentral("x", 1, 1, 1), evaluate=False)(2).doit()
     2*exp(1/2)
 
     The argument evaluate=False prevents an attempt at evaluation
     of the sum for general x, before the argument 2 is passed.
+
+    Parameters
+    ==========
+
+    alpha : Real number, `\alpha > 0`, a shape
+    beta : Real number, `\beta > 0`, a shape
+    lamda : Real number, `\lambda >= 0`, noncentrality parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -566,17 +564,6 @@ def BetaPrime(name, alpha, beta):
 
     with :math:`x > 0`.
 
-    Parameters
-    ==========
-
-    alpha : Real number, `\alpha > 0`, a shape
-    beta : Real number, `\beta > 0`, a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -595,6 +582,17 @@ def BetaPrime(name, alpha, beta):
     z         *(z + 1)
     -------------------------------
              B(alpha, beta)
+
+    Parameters
+    ==========
+
+    alpha : Real number, `\alpha > 0`, a shape
+    beta : Real number, `\beta > 0`, a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -712,17 +710,6 @@ def Cauchy(name, x0, gamma):
     .. math::
         f(x) := \frac{1}{\pi \gamma [1 + {(\frac{x-x_0}{\gamma})}^2]}
 
-    Parameters
-    ==========
-
-    x0 : Real number, the location
-    gamma : Real number, `\gamma > 0`, a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -737,6 +724,17 @@ def Cauchy(name, x0, gamma):
 
     >>> density(X)(z)
     1/(pi*gamma*(1 + (-x0 + z)**2/gamma**2))
+
+    Parameters
+    ==========
+
+    x0 : Real number, the location
+    gamma : Real number, `\gamma > 0`, a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -792,16 +790,6 @@ def Chi(name, k):
 
     with :math:`x \geq 0`.
 
-    Parameters
-    ==========
-
-    k : Positive integer, The number of degrees of freedom
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -818,6 +806,16 @@ def Chi(name, k):
 
     >>> simplify(E(X))
     sqrt(2)*gamma(k/2 + 1/2)/gamma(k/2)
+
+    Parameters
+    ==========
+
+    k : Positive integer, the number of degrees of freedom
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -861,17 +859,6 @@ def ChiNoncentral(name, k, l):
     with `x \geq 0`. Here, `I_\nu (x)` is the
     :ref:`modified Bessel function of the first kind <besseli>`.
 
-    Parameters
-    ==========
-
-    k : A positive Integer, `k > 0`, the number of degrees of freedom
-    lambda : Real number, `\lambda > 0`, Shift parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -886,6 +873,17 @@ def ChiNoncentral(name, k, l):
 
     >>> density(X)(z)
     l*z**k*(l*z)**(-k/2)*exp(-l**2/2 - z**2/2)*besseli(k/2 - 1, l*z)
+
+    Parameters
+    ==========
+
+    k : A positive Integer, `k > 0`, the number of degrees of freedom
+    lambda : Real number, `\lambda > 0`, shift parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -938,16 +936,6 @@ def ChiSquared(name, k):
 
     with :math:`x \geq 0`.
 
-    Parameters
-    ==========
-
-    k : Positive integer, The number of degrees of freedom
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -970,6 +958,16 @@ def ChiSquared(name, k):
 
     >>> moment(X, 3)
     k**3 + 6*k**2 + 8*k
+
+    Parameters
+    ==========
+
+    k : Positive integer, the number of degrees of freedom
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1016,18 +1014,6 @@ def Dagum(name, p, a, b):
 
     with :math:`x > 0`.
 
-    Parameters
-    ==========
-
-    p : Real number, `p > 0`, a shape
-    a : Real number, `a > 0`, a shape
-    b : Real number, `b > 0`, a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1047,6 +1033,17 @@ def Dagum(name, p, a, b):
     >>> cdf(X)(z)
     Piecewise(((1 + (z/b)**(-a))**(-p), z >= 0), (0, True))
 
+    Parameters
+    ==========
+
+    p : Real number, `p > 0`, a shape
+    a : Real number, `a > 0`, a shape
+    b : Real number, `b > 0`, a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1071,17 +1068,6 @@ def Erlang(name, k, l):
         f(x) := \frac{\lambda^k x^{k-1} e^{-\lambda x}}{(k-1)!}
 
     with :math:`x \in [0,\infty]`.
-
-    Parameters
-    ==========
-
-    k : Positive integer
-    l : Real number, `\lambda > 0`, the rate
-
-    Returns
-    =======
-
-    RandomSymbol
 
     Examples
     ========
@@ -1116,6 +1102,17 @@ def Erlang(name, k, l):
 
     >>> simplify(variance(X))
     k/l**2
+
+    Parameters
+    ==========
+
+    k : Positive integer
+    l : Real number, `\lambda > 0`, the rate
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1185,20 +1182,6 @@ def ExGaussian(name, mean, std, rate):
 
     with `x > 0`. Note that the expected value is `1/\lambda`.
 
-    Parameters
-    ==========
-
-    mu : A Real number, the mean of Gaussian component
-    std: A positive Real number,
-        :math: `\sigma^2 > 0` the variance of Gaussian component
-    lambda: A positive Real number,
-        :math: `\lambda > 0` the rate of Exponential component
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1233,6 +1216,21 @@ def ExGaussian(name, mean, std, rate):
 
     >>> simplify(skewness(X))
     2/(lamda**2*sigma**2 + 1)**(3/2)
+
+    Parameters
+    ==========
+
+    mu : Real number
+        mean of Gaussian component
+    std : positive Real number
+        `\sigma^2 > 0`, the variance of Gaussian component
+    lambda : positive Real number
+        `\lambda > 0`, the rate of Exponential component
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1285,16 +1283,6 @@ def Exponential(name, rate):
 
     with `x > 0`. Note that the expected value is `1/\lambda`.
 
-    Parameters
-    ==========
-
-    rate : A positive Real number, `\lambda > 0`, the rate (or inverse scale/inverse mean)
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1335,6 +1323,17 @@ def Exponential(name, rate):
 
     >>> std(X)
     1/10
+
+    Parameters
+    ==========
+
+    rate : positive Real number
+        `\lambda > 0`, the rate (or inverse scale/inverse mean)
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1470,17 +1469,6 @@ def FDistribution(name, d1, d2):
 
     with :math:`x > 0`.
 
-    Parameters
-    ==========
-
-    d1 : `d_1 > 0`, where d_1 is the degrees of freedom (n_1 - 1)
-    d2 : `d_2 > 0`, where d_2 is the degrees of freedom (n_2 - 1)
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1503,6 +1491,17 @@ def FDistribution(name, d1, d2):
                     /d1  d2\
                  z*B|--, --|
                     \2   2 /
+
+    Parameters
+    ==========
+
+    d1 : `d_1 > 0`, where d_1 is the degrees of freedom (n_1 - 1)
+    d2 : `d_2 > 0`, where d_2 is the degrees of freedom (n_2 - 1)
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1545,17 +1544,6 @@ def FisherZ(name, d1, d2):
 
     .. TODO - What is the difference between these degrees of freedom?
 
-    Parameters
-    ==========
-
-    d1 : `d_1 > 0`, degree of freedom
-    d2 : `d_2 > 0`, degree of freedom
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1579,6 +1567,17 @@ def FisherZ(name, d1, d2):
                      /d1  d2\
                     B|--, --|
                      \2   2 /
+
+    Parameters
+    ==========
+
+    d1 : `d_1 > 0`, degree of freedom
+    d2 : `d_2 > 0`, degree of freedom
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1628,18 +1627,6 @@ def Frechet(name, a, s=1, m=0):
 
     with :math:`x \geq m`.
 
-    Parameters
-    ==========
-
-    a : Real number, :math:`a \in \left(0, \infty\right)` the shape
-    s : Real number, :math:`s \in \left(0, \infty\right)` the scale
-    m : Real number, :math:`m \in \left(-\infty, \infty\right)` the minimum
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1658,6 +1645,18 @@ def Frechet(name, a, s=1, m=0):
 
     >>> cdf(X)(z)
      Piecewise((exp(-((-m + z)/s)**(-a)), m <= z), (0, True))
+
+    Parameters
+    ==========
+
+    a : Real number, :math:`a \in \left(0, \infty\right)` the shape
+    s : Real number, :math:`s \in \left(0, \infty\right)` the scale
+    m : Real number, :math:`m \in \left(-\infty, \infty\right)` the minimum
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1709,17 +1708,6 @@ def Gamma(name, k, theta):
 
     with :math:`x \in [0,1]`.
 
-    Parameters
-    ==========
-
-    k : Real number, `k > 0`, a shape
-    theta : Real number, `\theta > 0`, a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1759,6 +1747,16 @@ def Gamma(name, k, theta):
            2
     k*theta
 
+    Parameters
+    ==========
+
+    k : Real number, `k > 0`, a shape
+    theta : Real number, `\theta > 0`, a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1813,17 +1811,6 @@ def GammaInverse(name, a, b):
 
     with :math:`x > 0`.
 
-    Parameters
-    ==========
-
-    a : Real number, `a > 0` a shape
-    b : Real number, `b > 0` a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1848,6 +1835,16 @@ def GammaInverse(name, a, b):
     >>> cdf(X)(z)
     Piecewise((uppergamma(a, b/z)/gamma(a), z > 0), (0, True))
 
+    Parameters
+    ==========
+
+    a : Real number, `a > 0` a shape
+    b : Real number, `b > 0` a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1917,18 +1914,6 @@ def Gumbel(name, beta, mu, minimum=False):
 
     with :math:`x \in [ - \infty, \infty ]`.
 
-    Parameters
-    ==========
-
-    mu : Real number, 'mu' is a location
-    beta : Real number, 'beta > 0' is a scale
-    minimum : Boolean, by default, False, set to True for enabling minimum distribution
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -1942,6 +1927,18 @@ def Gumbel(name, beta, mu, minimum=False):
     exp(-exp(-(-mu + x)/beta) - (-mu + x)/beta)/beta
     >>> cdf(X)(x)
     exp(-exp(-(-mu + x)/beta))
+
+    Parameters
+    ==========
+
+    mu : Real number, 'mu' is a location
+    beta : Real number, 'beta > 0' is a scale
+    minimum : Boolean, by default, False, set to True for enabling minimum distribution
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -1990,17 +1987,6 @@ def Gompertz(name, b, eta):
 
     with :math: 'x \in [0, \inf)'.
 
-    Parameters
-    ==========
-
-    b: Real number, 'b > 0' a scale
-    eta: Real number, 'eta > 0' a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2015,6 +2001,17 @@ def Gompertz(name, b, eta):
 
     >>> density(X)(z)
     b*eta*exp(eta)*exp(b*z)*exp(-eta*exp(b*z))
+
+    Parameters
+    ==========
+
+    b : Real number, 'b > 0' a scale
+    eta : Real number, 'eta > 0' a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2060,17 +2057,6 @@ def Kumaraswamy(name, a, b):
 
     with :math:`x \in [0,1]`.
 
-    Parameters
-    ==========
-
-    a : Real number, `a > 0` a shape
-    b : Real number, `b > 0` a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2091,6 +2077,17 @@ def Kumaraswamy(name, a, b):
 
     >>> cdf(X)(z)
     Piecewise((0, z < 0), (1 - (1 - z**a)**b, z <= 1), (1, True))
+
+    Parameters
+    ==========
+
+    a : Real number, `a > 0` a shape
+    b : Real number, `b > 0` a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2141,19 +2138,6 @@ def Laplace(name, mu, b):
     .. math::
         f(x) := \frac{1}{2 b} \exp \left(-\frac{|x-\mu|}b \right)
 
-    Parameters
-    ==========
-
-    mu : Real number or a list/matrix, the location (mean) or the
-        location vector
-    b : Real number or a positive definite matrix, representing a scale
-        or the covariance matrix.
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2178,6 +2162,19 @@ def Laplace(name, mu, b):
     e *besselk\0, \/ 35 /
     ---------------------
               pi
+
+    Parameters
+    ==========
+
+    mu : Real number or a list/matrix
+        the location (mean) or the location vector
+    b : Real number or a positive definite matrix,
+        representing a scale or the covariance matrix.
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2234,17 +2231,6 @@ def Levy(name, mu, c):
     .. math::
         f(x) := \sqrt(\frac{c}{2 \pi}) \frac{\exp -\frac{c}{2 (x - \mu)}}{(x - \mu)^{3/2}}
 
-    Parameters
-    ==========
-
-    mu : Real number, the location parameter
-    c : Real number, `c > 0`, a scale parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2262,6 +2248,17 @@ def Levy(name, mu, c):
 
     >>> cdf(X)(z)
     erfc(sqrt(c)*sqrt(1/(-2*mu + 2*z)))
+
+    Parameters
+    ==========
+
+    mu : Real number, the location parameter
+    c : Real number, `c > 0`, a scale parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2310,17 +2307,6 @@ def Logistic(name, mu, s):
     .. math::
         f(x) := \frac{e^{-(x-\mu)/s}} {s\left(1+e^{-(x-\mu)/s}\right)^2}
 
-    Parameters
-    ==========
-
-    mu : Real number, the location (mean)
-    s : Real number, `s > 0` a scale
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2338,6 +2324,17 @@ def Logistic(name, mu, s):
 
     >>> cdf(X)(z)
     1/(exp((mu - z)/s) + 1)
+
+    Parameters
+    ==========
+
+    mu : Real number, the location (mean)
+    s : Real number, `s > 0` a scale
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2390,17 +2387,6 @@ def LogLogistic(name, alpha, beta):
         f(x) := \frac{(\frac{\beta}{\alpha})(\frac{x}{\alpha})^{\beta - 1}}
                 {(1 + (\frac{x}{\alpha})^{\beta})^2}
 
-    Parameters
-    ==========
-
-    alpha : Real number, `\alpha > 0`, scale parameter and median of distribution
-    beta : Real number, `\beta > 0` a shape parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2432,6 +2418,17 @@ def LogLogistic(name, alpha, beta):
 
     >>> quantile(X)(p)
     alpha*(p/(1 - p))**(1/beta)
+
+    Parameters
+    ==========
+
+    alpha : Real number, `\alpha > 0`, scale parameter and median of distribution
+    beta : Real number, `\beta > 0` a shape parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2481,17 +2478,6 @@ def LogNormal(name, mean, std):
 
     with :math:`x \geq 0`.
 
-    Parameters
-    ==========
-
-    mu : Real number, the log-scale
-    sigma : Real number, :math:`\sigma^2 > 0` a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2521,6 +2507,17 @@ def LogNormal(name, mean, std):
 
     >>> density(X)(z)
     sqrt(2)*exp(-log(z)**2/2)/(2*sqrt(pi)*z)
+
+    Parameters
+    ==========
+
+    mu : Real number, the log-scale
+    sigma : Real number, `\sigma^2 > 0` a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2627,19 +2624,7 @@ def Maxwell(name, a):
     .. math::
         f(x) := \sqrt{\frac{2}{\pi}} \frac{x^2 e^{-x^2/(2a^2)}}{a^3}
 
-    with :math:`x \geq 0`.
-
-    .. TODO - what does the parameter mean?
-
-    Parameters
-    ==========
-
-    a : Real number, `a > 0`
-
-    Returns
-    =======
-
-    RandomSymbol
+    with `x \geq 0`.
 
     Examples
     ========
@@ -2660,6 +2645,18 @@ def Maxwell(name, a):
 
     >>> simplify(variance(X))
     a**2*(-8 + 3*pi)/pi
+
+    .. TODO - what does the parameter mean?
+
+    Parameters
+    ==========
+
+    a : Real number, `a > 0`
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2710,19 +2707,6 @@ def Moyal(name, mu, sigma):
 
     with :math:`x \in \mathbb{R}`.
 
-    Parameters
-    ==========
-
-    mu : Real number
-        Location parameter
-    sigma : Real positive number
-        Scale parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2736,6 +2720,19 @@ def Moyal(name, mu, sigma):
     sqrt(2)*exp(-exp((mu - z)/sigma)/2 - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)
     >>> simplify(cdf(X)(z))
     1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
+
+    Parameters
+    ==========
+
+    mu : Real number
+        Location parameter
+    sigma : Real positive number
+        Scale parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2783,17 +2780,6 @@ def Nakagami(name, mu, omega):
 
     with :math:`x > 0`.
 
-    Parameters
-    ==========
-
-    mu : Real number, `\mu \geq \frac{1}{2}` a shape
-    omega : Real number, `\omega > 0`, the spread
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -2830,6 +2816,16 @@ def Nakagami(name, mu, omega):
     Piecewise((lowergamma(mu, mu*z**2/omega)/gamma(mu), z > 0),
             (0, True))
 
+    Parameters
+    ==========
+
+    mu : Real number, `\mu \geq \frac{1}{2}` a shape
+    omega : Real number, `\omega > 0`, the spread
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -2878,18 +2874,6 @@ def Normal(name, mean, std):
 
     .. math::
         f(x) := \frac{1}{\sigma\sqrt{2\pi}} e^{ -\frac{(x-\mu)^2}{2\sigma^2} }
-
-    Parameters
-    ==========
-
-    mu : Real number or a list representing the mean or the mean vector
-    sigma : Real number or a positive definite square matrix,
-         :math:`\sigma^2 > 0` the variance
-
-    Returns
-    =======
-
-    RandomSymbol
 
     Examples
     ========
@@ -2944,6 +2928,17 @@ def Normal(name, mean, std):
     >>> marginal_distribution(m, m[0])(1)
      1/(2*sqrt(pi))
 
+    Parameters
+    ==========
+
+    mu : Real number or a list representing the mean or the mean vector
+    sigma : Real number or a positive definite square matrix,
+        `\sigma^2 > 0` the variance
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -3009,17 +3004,6 @@ def GaussianInverse(name, mean, shape):
     .. math::
         f(x) := \sqrt{\frac{\lambda}{2\pi x^3}} e^{-\frac{\lambda(x-\mu)^2}{2x\mu^2}}
 
-    Parameters
-    ==========
-
-    mu : Positive number representing the mean
-    lambda : Positive number representing the shape parameter
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -3051,6 +3035,17 @@ def GaussianInverse(name, mean, shape):
 
     >>> skewness(X).expand()
     3*sqrt(mu)/sqrt(lambda)
+
+    Parameters
+    ==========
+
+    mu : Positive number representing the mean
+    lambda : Positive number representing the shape parameter
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -4199,17 +4194,6 @@ def Weibull(name, alpha, beta):
                   0 & x<0
                 \end{cases}
 
-    Parameters
-    ==========
-
-    lambda : Real number, :math:`\lambda > 0` a scale
-    k : Real number, `k > 0` a shape
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -4230,6 +4214,17 @@ def Weibull(name, alpha, beta):
 
     >>> simplify(variance(X))
     lambda**2*(-gamma(1 + 1/k)**2 + gamma(1 + 2/k))
+
+    Parameters
+    ==========
+
+    lambda : Real number, :math:`\lambda > 0` a scale
+    k : Real number, `k > 0` a shape
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -4279,16 +4274,6 @@ def WignerSemicircle(name, R):
 
     with :math:`x \in [-R,R]`.
 
-    Parameters
-    ==========
-
-    R : Real number, `R > 0`, the radius
-
-    Returns
-    =======
-
-    A `RandomSymbol`.
-
     Examples
     ========
 
@@ -4305,6 +4290,16 @@ def WignerSemicircle(name, R):
 
     >>> E(X)
     0
+
+    Parameters
+    ==========
+
+    R : Real number, `R > 0`, the radius
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -505,7 +505,7 @@ def BetaNoncentral(name, alpha, beta, lamda):
     k = 0
 
     Compute cdf with specific ``x``, ``alpha``, ``beta`` and ``lamda`` values as follows:
-    
+
     >>> cdf(BetaNoncentral("x", 1, 1, 1), evaluate=False)(2).doit()
     2*exp(1/2)
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -166,11 +166,11 @@ def ContinuousRV(symbol, density, set=Interval(-oo, oo)):
     ==========
 
     symbol : Symbol
-        Represents name of the random variable.
+        The name of the random variable.
     density : Expression containing symbol
-        Represents probability density function.
+        The probability density function.
     set : set/Interval
-        Represents the region where the pdf is valid, by default is real line.
+        The region where the pdf is valid, by default is real line.
 
     Returns
     =======
@@ -2167,9 +2167,9 @@ def Laplace(name, mu, b):
     ==========
 
     mu : Real number or a list/matrix
-        the location (mean) or the location vector
+        The location (mean) or the location vector
     b : Real number or a positive definite matrix,
-        representing a scale or the covariance matrix.
+        A scale or the covariance matrix.
 
     Returns
     =======
@@ -2931,7 +2931,8 @@ def Normal(name, mean, std):
     Parameters
     ==========
 
-    mu : Real number or a list representing the mean or the mean vector
+    mu : Real number, list
+        The mean or the mean vector
     sigma : Real number or a positive definite square matrix,
         `\sigma^2 > 0` the variance
 
@@ -3039,8 +3040,10 @@ def GaussianInverse(name, mean, shape):
     Parameters
     ==========
 
-    mu : Positive number representing the mean
-    lambda : Positive number representing the shape parameter
+    mu : Positive number
+        The mean
+    lambda : Positive number
+        The shape parameter
 
     Returns
     =======

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1389,9 +1389,9 @@ def ExponentialPower(name, mu, alpha, beta):
     Parameters
     ==========
 
-    mu : Real number, 'mu' is a location
-    alpha : Real number, 'alpha > 0' is a scale
-    beta : Real number, 'beta > 0' is a shape
+    mu : Real number, `mu` is a location
+    alpha : Real number, `alpha > 0` is a scale
+    beta : Real number, `beta > 0` is a shape
 
     Returns
     =======
@@ -1931,8 +1931,8 @@ def Gumbel(name, beta, mu, minimum=False):
     Parameters
     ==========
 
-    mu : Real number, 'mu' is a location
-    beta : Real number, 'beta > 0' is a scale
+    mu : Real number, `mu` is a location
+    beta : Real number, `beta > 0` is a scale
     minimum : Boolean, by default, False, set to True for enabling minimum distribution
 
     Returns
@@ -2005,8 +2005,8 @@ def Gompertz(name, b, eta):
     Parameters
     ==========
 
-    b : Real number, 'b > 0' a scale
-    eta : Real number, 'eta > 0' a shape
+    b : Real number, `b > 0` a scale
+    eta : Real number, `eta > 0` a shape
 
     Returns
     =======
@@ -3574,8 +3574,8 @@ def ShiftedGompertz(name, b, eta):
     Parameters
     ==========
 
-    b: Real number, 'b > 0' a scale
-    eta: Real number, 'eta > 0' a shape
+    b: Real number, `b > 0` a scale
+    eta: Real number, `eta > 0` a shape
 
     Returns
     =======

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -157,7 +157,7 @@ class ContinuousDistributionHandmade(SingleContinuousDistribution):
 
 def ContinuousRV(symbol, density, set=Interval(-oo, oo)):
     """
-    Create a Continuous Random Variable given the following:
+    Create a Continuous Random Variable.
 
     Many common continuous random variable types are already implemented.
     This function should be necessary only very rarely.

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -555,8 +555,8 @@ def Skellam(name, mu1, mu2):
     Parameters
     ==========
 
-    mu1 : A non-negative value
-    mu2 : A non-negative value
+    mu1 : nonnegative number
+    mu2 : nonnegative number
 
     Returns
     =======

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -520,8 +520,8 @@ def Skellam(name, mu1, mu2):
     r"""
     Create a discrete random variable with a Skellam distribution.
 
-    The Skellam is the distribution of the difference N1 - N2 of two 
-    statistically independent random variables N1 and N2, each 
+    The Skellam is the distribution of the difference N1 - N2 of two
+    statistically independent random variables N1 and N2, each
     Poisson-distributed, with respective expected values ``mu1`` and ``mu2``.
 
     The density of the Skellam distribution is given by

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -68,11 +68,11 @@ def DiscreteRV(symbol, density, set=S.Integers):
     ==========
 
     symbol : Symbol
-        Represents name of the random variable.
+        Name of the random variable.
     density : Expression containing symbol
-        Represents probability density function.
+        Probability density function.
     set : set
-        Represents the region where the pdf is valid, by default is real line.
+        The region where the pdf is valid, by default is real line.
 
     Examples
     ========

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -132,16 +132,6 @@ def Geometric(name, p):
     .. math::
         f(k) := p (1 - p)^{k - 1}
 
-    Parameters
-    ==========
-
-    p: A probability between 0 and 1
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -161,6 +151,16 @@ def Geometric(name, p):
 
     >>> variance(X)
     20
+
+    Parameters
+    ==========
+
+    p : A probability between 0 and 1
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -215,17 +215,6 @@ def Hermite(name, a1, a2):
         f(x):= e^{-a_1 -a_2}\sum_{j=0}^{\left \lfloor x/2 \right \rfloor}
                     \frac{a_{1}^{x-2j}a_{2}^{j}}{(x-2j)!j!}
 
-    Parameters
-    ==========
-
-    a1: A Positive number greater than equal to 0.
-    a2: A Positive number greater than equal to 0.
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -246,6 +235,17 @@ def Hermite(name, a1, a2):
 
     >>> variance(H)
     21
+
+    Parameters
+    ==========
+
+    a1 : A Positive number greater than equal to 0.
+    a2 : A Positive number greater than equal to 0.
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -291,16 +291,6 @@ def Logarithmic(name, p):
     .. math::
         f(k) := \frac{-p^k}{k \ln{(1 - p)}}
 
-    Parameters
-    ==========
-
-    p: A value between 0 and 1
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -320,6 +310,16 @@ def Logarithmic(name, p):
 
     >>> variance(X)
     -1/((-4*log(5) + 8*log(2))*(-2*log(5) + 4*log(2))) + 1/(-64*log(2)*log(5) + 64*log(2)**2 + 16*log(5)**2) - 10/(-32*log(5) + 64*log(2))
+
+    Parameters
+    ==========
+
+    p : A value between 0 and 1
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -371,17 +371,6 @@ def NegativeBinomial(name, r, p):
     .. math::
         f(k) := \binom{k + r - 1}{k} (1 - p)^r p^k
 
-    Parameters
-    ==========
-
-    r: A positive value
-    p: A value between 0 and 1
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -402,6 +391,17 @@ def NegativeBinomial(name, r, p):
 
     >>> variance(X)
     25/16
+
+    Parameters
+    ==========
+
+    r : A positive value
+    p : A value between 0 and 1
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -444,16 +444,6 @@ def Poisson(name, lamda):
     .. math::
         f(k) := \frac{\lambda^{k} e^{- \lambda}}{k!}
 
-    Parameters
-    ==========
-
-    lamda: Positive number, a rate
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -473,6 +463,16 @@ def Poisson(name, lamda):
 
     >>> simplify(variance(X))
     lambda
+
+    Parameters
+    ==========
+
+    lamda : Positive number, a rate
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -520,25 +520,14 @@ def Skellam(name, mu1, mu2):
     r"""
     Create a discrete random variable with a Skellam distribution.
 
-    The Skellam is the distribution of the difference N1 - N2
-    of two statistically independent random variables N1 and N2
-    each Poisson-distributed with respective expected values mu1 and mu2.
+    The Skellam is the distribution of the difference N1 - N2 of two 
+    statistically independent random variables N1 and N2, each 
+    Poisson-distributed, with respective expected values ``mu1`` and ``mu2``.
 
     The density of the Skellam distribution is given by
 
     .. math::
         f(k) := e^{-(\mu_1+\mu_2)}(\frac{\mu_1}{\mu_2})^{k/2}I_k(2\sqrt{\mu_1\mu_2})
-
-    Parameters
-    ==========
-
-    mu1: A non-negative value
-    mu2: A non-negative value
-
-    Returns
-    =======
-
-    RandomSymbol
 
     Examples
     ========
@@ -562,6 +551,17 @@ def Skellam(name, mu1, mu2):
     mu1 - mu2
     >>> variance(X).expand()
     mu1 + mu2
+
+    Parameters
+    ==========
+
+    mu1 : A non-negative value
+    mu2 : A non-negative value
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -608,16 +608,6 @@ def YuleSimon(name, rho):
     .. math::
         f(k) := \rho B(k, \rho + 1)
 
-    Parameters
-    ==========
-
-    rho: A positive value
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -637,6 +627,16 @@ def YuleSimon(name, rho):
 
     >>> simplify(variance(X))
     25/48
+
+    Parameters
+    ==========
+
+    rho : A positive value
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -678,16 +678,6 @@ def Zeta(name, s):
     .. math::
         f(k) := \frac{1}{k^s \zeta{(s)}}
 
-    Parameters
-    ==========
-
-    s: A value greater than 1
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -707,6 +697,16 @@ def Zeta(name, s):
 
     >>> variance(X)
     -pi**8/(8100*zeta(5)**2) + zeta(3)/zeta(5)
+
+    Parameters
+    ==========
+
+    s : A value greater than 1
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -72,12 +72,6 @@ def FiniteRV(name, density):
     r"""
     Create a Finite Random Variable given a dict representing the density.
 
-    Parameters
-    ==========
-
-    density: A dict
-        Dictionary conatining the pdf of finite distribution
-
     Examples
     ========
 
@@ -90,6 +84,12 @@ def FiniteRV(name, density):
     2.00000000000000
     >>> P(X >= 2)
     0.700000000000000
+
+    Parameters
+    ==========
+
+    density : A dict
+        Dictionary conatining the pdf of finite distribution
 
     Returns
     =======
@@ -140,14 +140,7 @@ class DiscreteUniformDistribution(SingleFiniteDistribution):
 
 def DiscreteUniform(name, items):
     r"""
-    Create a Finite Random Variable representing a uniform distribution over
-    the input set.
-
-    Parameters
-    ==========
-
-    items: list/tuple
-        Items over which Uniform distribution is to be made
+    Create a Finite Random Variable representing a uniform distribution.
 
     Examples
     ========
@@ -162,6 +155,12 @@ def DiscreteUniform(name, items):
     >>> Y = DiscreteUniform('Y', list(range(5))) # distribution over a range
     >>> density(Y).dict
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
+
+    Parameters
+    ==========
+
+    items : list/tuple
+        Items over which Uniform distribution is to be made
 
     Returns
     =======
@@ -216,23 +215,17 @@ def Die(name, sides=6):
     r"""
     Create a Finite Random Variable representing a fair die.
 
-    Parameters
-    ==========
-
-    sides: Integer
-        Represents the number of sides of the Die, by default is 6
-
     Examples
     ========
 
     >>> from sympy.stats import Die, density
     >>> from sympy import Symbol
 
-    >>> D6 = Die('D6', 6) # Six sided Die
+    >>> D6 = Die('D6') # Six-sided Die
     >>> density(D6).dict
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
 
-    >>> D4 = Die('D4', 4) # Four sided Die
+    >>> D4 = Die('D4', 4) # Four-sided Die
     >>> density(D4).dict
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
 
@@ -242,6 +235,12 @@ def Die(name, sides=6):
     Density(DieDistribution(n))
     >>> density(Dn).dict.subs(n, 4).doit()
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
+
+    Parameters
+    ==========
+
+    sides : Integer
+        Represents the number of sides of the Die, default is 6
 
     Returns
     =======
@@ -278,16 +277,6 @@ def Bernoulli(name, p, succ=1, fail=0):
     r"""
     Create a Finite Random Variable representing a Bernoulli process.
 
-    Parameters
-    ==========
-
-    p : Rational number between 0 and 1
-       Represents probability of success
-    succ : Integer/symbol/string
-       Represents event of success
-    fail : Integer/symbol/string
-       Represents event of failure
-
     Examples
     ========
 
@@ -301,6 +290,16 @@ def Bernoulli(name, p, succ=1, fail=0):
     >>> X = Bernoulli('X', S.Half, 'Heads', 'Tails') # A fair coin toss
     >>> density(X).dict
     {Heads: 1/2, Tails: 1/2}
+
+    Parameters
+    ==========
+
+    p : Rational number between 0 and 1
+       Represents probability of success
+    succ : Integer/symbol/string
+       Represents event of success
+    fail : Integer/symbol/string
+       Represents event of failure
 
     Returns
     =======
@@ -322,12 +321,6 @@ def Coin(name, p=S.Half):
     r"""
     Create a Finite Random Variable representing a Coin toss.
 
-    Parameters
-    ==========
-
-    p : Rational Numeber between 0 and 1
-      Represents probability of getting "Heads", by default is Half
-
     Examples
     ========
 
@@ -341,6 +334,12 @@ def Coin(name, p=S.Half):
     >>> C2 = Coin('C2', Rational(3, 5)) # An unfair coin
     >>> density(C2).dict
     {H: 3/5, T: 2/5}
+
+    Parameters
+    ==========
+
+    p : Rational Numeber between 0 and 1
+      Represents probability of getting "Heads", by default is Half
 
     Returns
     =======
@@ -410,18 +409,6 @@ def Binomial(name, n, p, succ=1, fail=0):
     r"""
     Create a Finite Random Variable representing a binomial distribution.
 
-    Parameters
-    ==========
-
-    n : Positive Integer
-      Represents number of trials
-    p : Rational Number between 0 and 1
-      Represents probability of success
-    succ : Integer/symbol/string
-      Represents event of success, by default is 1
-    fail : Integer/symbol/string
-      Represents event of failure, by default is 0
-
     Examples
     ========
 
@@ -439,6 +426,18 @@ def Binomial(name, n, p, succ=1, fail=0):
     Density(BinomialDistribution(n, 1/2, 1, 0))
     >>> density(X).dict.subs(n, 4).doit()
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
+
+    Parameters
+    ==========
+
+    n : Positive Integer
+      Represents number of trials
+    p : Rational Number between 0 and 1
+      Represents probability of success
+    succ : Integer/symbol/string
+      Represents event of success, by default is 1
+    fail : Integer/symbol/string
+      Represents event of failure, by default is 0
 
     Returns
     =======
@@ -497,14 +496,6 @@ def BetaBinomial(name, n, alpha, beta):
     r"""
     Create a Finite Random Variable representing a Beta-binomial distribution.
 
-    Parameters
-    ==========
-
-    n : Positive Integer
-      Represents number of trials
-    alpha : Real positive number
-    beta : Real positive number
-
     Examples
     ========
 
@@ -513,6 +504,14 @@ def BetaBinomial(name, n, alpha, beta):
     >>> X = BetaBinomial('X', 2, 1, 1)
     >>> density(X).dict
     {0: 1/3, 1: 2*beta(2, 2), 2: 1/3}
+
+    Parameters
+    ==========
+
+    n : Positive Integer
+      Represents number of trials
+    alpha : Real positive number
+    beta : Real positive number
 
     Returns
     =======
@@ -570,6 +569,15 @@ def Hypergeometric(name, N, m, n):
     r"""
     Create a Finite Random Variable representing a hypergeometric distribution.
 
+    Examples
+    ========
+
+    >>> from sympy.stats import Hypergeometric, density
+
+    >>> X = Hypergeometric('X', 10, 5, 3) # 10 marbles, 5 white (success), 3 draws
+    >>> density(X).dict
+    {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
+
     Parameters
     ==========
 
@@ -579,16 +587,6 @@ def Hypergeometric(name, N, m, n):
       Represents number of trials with required feature.
     n : Positive Integer
       Represents numbers of draws.
-
-
-    Examples
-    ========
-
-    >>> from sympy.stats import Hypergeometric, density
-
-    >>> X = Hypergeometric('X', 10, 5, 3) # 10 marbles, 5 white (success), 3 draws
-    >>> density(X).dict
-    {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
 
     Returns
     =======

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -295,11 +295,11 @@ def Bernoulli(name, p, succ=1, fail=0):
     ==========
 
     p : Rational number between 0 and 1
-       Represents probability of success
+        Represents probability of success
     succ : Integer/symbol/string
-       Represents event of success
+        Represents event of success
     fail : Integer/symbol/string
-       Represents event of failure
+        Represents event of failure
 
     Returns
     =======
@@ -339,7 +339,7 @@ def Coin(name, p=S.Half):
     ==========
 
     p : Rational Numeber between 0 and 1
-      Represents probability of getting "Heads", by default is Half
+        Represents probability of getting "Heads", by default is Half
 
     Returns
     =======
@@ -431,13 +431,13 @@ def Binomial(name, n, p, succ=1, fail=0):
     ==========
 
     n : Positive Integer
-      Represents number of trials
+        Represents number of trials
     p : Rational Number between 0 and 1
-      Represents probability of success
+        Represents probability of success
     succ : Integer/symbol/string
-      Represents event of success, by default is 1
+        Represents event of success, by default is 1
     fail : Integer/symbol/string
-      Represents event of failure, by default is 0
+        Represents event of failure, by default is 0
 
     Returns
     =======
@@ -509,7 +509,7 @@ def BetaBinomial(name, n, alpha, beta):
     ==========
 
     n : Positive Integer
-      Represents number of trials
+        Represents number of trials
     alpha : Real positive number
     beta : Real positive number
 
@@ -582,11 +582,11 @@ def Hypergeometric(name, N, m, n):
     ==========
 
     N : Positive Integer
-      Represents finite population of size N.
+        Represents finite population of size N.
     m : Positive Integer
-      Represents number of trials with required feature.
+        Represents number of trials with required feature.
     n : Positive Integer
-      Represents numbers of draws.
+        Represents numbers of draws.
 
     Returns
     =======

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -240,7 +240,7 @@ def Die(name, sides=6):
     ==========
 
     sides : Integer
-        Represents the number of sides of the Die, default is 6
+        The number of sides of the Die, default is 6
 
     Returns
     =======
@@ -295,11 +295,11 @@ def Bernoulli(name, p, succ=1, fail=0):
     ==========
 
     p : Rational number between 0 and 1
-        Represents probability of success
+        Probability of success
     succ : Integer/symbol/string
-        Represents event of success
+        Event of success
     fail : Integer/symbol/string
-        Represents event of failure
+        Event of failure
 
     Returns
     =======
@@ -339,7 +339,7 @@ def Coin(name, p=S.Half):
     ==========
 
     p : Rational Numeber between 0 and 1
-        Represents probability of getting "Heads", by default is Half
+        Probability of getting "Heads", by default is Half
 
     Returns
     =======
@@ -431,13 +431,13 @@ def Binomial(name, n, p, succ=1, fail=0):
     ==========
 
     n : Positive Integer
-        Represents number of trials
+        Number of trials
     p : Rational Number between 0 and 1
-        Represents probability of success
+        Probability of success
     succ : Integer/symbol/string
-        Represents event of success, by default is 1
+        Event of success, by default is 1
     fail : Integer/symbol/string
-        Represents event of failure, by default is 0
+        Event of failure, by default is 0
 
     Returns
     =======
@@ -509,7 +509,7 @@ def BetaBinomial(name, n, alpha, beta):
     ==========
 
     n : Positive Integer
-        Represents number of trials
+        Number of trials
     alpha : Real positive number
     beta : Real positive number
 
@@ -582,11 +582,11 @@ def Hypergeometric(name, N, m, n):
     ==========
 
     N : Positive Integer
-        Represents finite population of size N.
+        Finite population of size N.
     m : Positive Integer
-        Represents number of trials with required feature.
+        Number of trials with required feature.
     n : Positive Integer
-        Represents numbers of draws.
+        Numbers of draws.
 
     Returns
     =======

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -89,7 +89,7 @@ def FiniteRV(name, density):
     ==========
 
     density : A dict
-        Dictionary conatining the pdf of finite distribution
+        Dictionary conatining the PMF of finite distribution
 
     Returns
     =======

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -412,15 +412,15 @@ def NormalGamma(sym, mu, lamda, alpha, beta):
     Parameters
     ==========
 
-    sym : A symbol/str
-        For identifying the random variable.
-    m u: A real number
+    sym : symbol/str
+        For identifying the random variable
+    mu: real number
         The mean of the normal distribution
-    lamda : A positive integer
+    lamda : positive integer
         Parameter of joint distribution
-    alpha : A positive integer
+    alpha : positive integer
         Parameter of joint distribution
-    beta : A positive integer
+    beta : positive integer
         Parameter of joint distribution
 
     Returns
@@ -677,7 +677,7 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
     Note
     ====
 
-    If ``GeneralizedMultivariateLogGamma`` is too long to type, use 
+    If ``GeneralizedMultivariateLogGamma`` is too long to type, use
     ``from sympy.stats.joint_rv_types import GeneralizedMultivariateLogGamma as GMVLG``
 
     If you want to pass the matrix omega instead of the constant delta, then use

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -178,9 +178,10 @@ def MultivariateNormal(name, mu, sigma):
     Parameters
     ==========
 
-    mu : List representing the mean or the mean vector
+    mu : List
+        The mean or the mean vector
     sigma : Positive definite square matrix
-        Represents covariance Matrix
+        Covariance Matrix
 
     Returns
     =======
@@ -256,9 +257,10 @@ def MultivariateLaplace(name, mu, sigma):
     Parameters
     ==========
 
-    mu : List representing the mean or the mean vector
+    mu : List
+        The mean or the mean vector
     sigma : Positive definite square matrix
-        Represents covariance Matrix
+        Covariance Matrix
 
     Returns
     =======
@@ -336,9 +338,9 @@ def MultivariateT(syms, mu, sigma, v):
     ==========
 
     syms: A symbol/str
-        For identifying the random variable.
+        Identifies the random variable.
     mu: A list/matrix
-        Representing the location vector
+        The location vector
     sigma : The shape matrix for the distribution
 
     Returns
@@ -413,7 +415,7 @@ def NormalGamma(sym, mu, lamda, alpha, beta):
     ==========
 
     sym : symbol/str
-        For identifying the random variable
+        Identifies the random variable
     mu: real number
         The mean of the normal distribution
     lamda : positive integer
@@ -657,7 +659,8 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
     Parameters
     ==========
 
-    syms : list/tuple/set of symbols for identifying each component
+    syms : list/tuple/set of symbols
+        Identifies each component
     delta : A constant in range [0, 1]
     v : Positive real number
     lamda : List of positive real numbers
@@ -710,7 +713,7 @@ def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     ==========
 
     syms: list/tuple/set of symbols
-        For identifying each component
+        Identifies each component
     omega: A square matrix
         Every element of square matrix must be absolute value of
         square root of correlation coefficient
@@ -805,7 +808,7 @@ def Multinomial(syms, n, *p):
     ==========
 
     n : Positive integer
-        Represents number of trials
+        Number of trials
     p : List of event probabilites
         Must be in the range of [0, 1]
 
@@ -879,7 +882,7 @@ def NegativeMultinomial(syms, k0, *p):
     ==========
 
     k0 : positive integer
-        Represents number of failures before the experiment is stopped
+        Number of failures before the experiment is stopped
     p : List of event probabilites
         Must be in the range of [0, 1]
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -712,8 +712,8 @@ def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     syms: list/tuple/set of symbols
         For identifying each component
     omega: A square matrix
-           Every element of square matrix must be absolute value of
-           square root of correlation coefficient
+        Every element of square matrix must be absolute value of
+        square root of correlation coefficient
     v : Positive real number
     lamda : List of positive real numbers
     mu : List of positive real numbers

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -79,12 +79,7 @@ class JointDistributionHandmade(JointDistribution):
 
 def JointRV(symbol, pdf, _set=None):
     """
-    Create a Joint Random Variable where each of its component is conitinuous,
-    given the following:
-
-    -- a symbol
-    -- a PDF in terms of indexed symbols of the symbol given
-    as the first argument
+    Create a Joint Random Variable where each of its components is continuous.
 
     NOTE: As of now, the set for each component for a `JointRV` is
     equal to the set of all integers, which can not be changed.
@@ -99,6 +94,14 @@ def JointRV(symbol, pdf, _set=None):
     >>> N1 = JointRV('x', pdf) #Multivariate Normal distribution
     >>> density(N1)(1, 2)
     exp(-2)/(2*pi)
+
+    Parameters
+    ==========
+
+    symbol : a symbol
+
+    pdf : a PDF in terms of indexed symbols of the symbol given
+    as the first argument
 
     Returns
     =======
@@ -317,15 +320,6 @@ def MultivariateT(syms, mu, sigma, v):
     """
     Creates a joint random variable with multivariate T-distribution.
 
-    Parameters
-    ==========
-
-    syms: A symbol/str
-        For identifying the random variable.
-    mu: A list/matrix
-        Representing the location vector
-    sigma: The shape matrix for the distribution
-
     Examples
     ========
 
@@ -337,6 +331,15 @@ def MultivariateT(syms, mu, sigma, v):
 
     >>> density(X)(1, 2)
     2/(9*pi)
+
+    Parameters
+    ==========
+
+    syms: A symbol/str
+        For identifying the random variable.
+    mu: A list/matrix
+        Representing the location vector
+    sigma : The shape matrix for the distribution
 
     Returns
     =======
@@ -394,25 +397,6 @@ def NormalGamma(sym, mu, lamda, alpha, beta):
     Creates a bivariate joint random variable with multivariate Normal gamma
     distribution.
 
-    Parameters
-    ==========
-
-    sym: A symbol/str
-        For identifying the random variable.
-    mu: A real number
-        The mean of the normal distribution
-    lamda: A positive integer
-        Parameter of joint distribution
-    alpha: A positive integer
-        Parameter of joint distribution
-    beta: A positive integer
-        Parameter of joint distribution
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -424,6 +408,25 @@ def NormalGamma(sym, mu, lamda, alpha, beta):
 
     >>> density(X)(y, z)
     9*sqrt(2)*z**(3/2)*exp(-3*z)*exp(-y**2*z/2)/(2*sqrt(pi))
+
+    Parameters
+    ==========
+
+    sym : A symbol/str
+        For identifying the random variable.
+    m u: A real number
+        The mean of the normal distribution
+    lamda : A positive integer
+        Parameter of joint distribution
+    alpha : A positive integer
+        Parameter of joint distribution
+    beta : A positive integer
+        Parameter of joint distribution
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -465,17 +468,6 @@ def MultivariateBeta(syms, *alpha):
 
     The density of the dirichlet distribution can be found at [1].
 
-    Parameters
-    ==========
-
-    alpha: Positive real numbers
-        Signifies concentration numbers.
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -491,6 +483,17 @@ def MultivariateBeta(syms, *alpha):
     x**(a1 - 1)*y**(a2 - 1)*gamma(a1 + a2)/(gamma(a1)*gamma(a2))
     >>> marginal_distribution(C, C[0])(x)
     x**(a1 - 1)*gamma(a1 + a2)/(a2*gamma(a1)*gamma(a2))
+
+    Parameters
+    ==========
+
+    alpha : Positive real numbers
+        Signifies concentration numbers.
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -558,19 +561,6 @@ def MultivariateEwens(syms, n, theta):
 
     The density of the said distribution can be found at [1].
 
-    Parameters
-    ==========
-
-    n: Positive integer
-        Size of the sample or the integer whose partitions are considered
-    theta: Positive real number
-        Denotes Mutation rate
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -583,6 +573,19 @@ def MultivariateEwens(syms, n, theta):
     Piecewise((2**(-a2)/(factorial(a1)*factorial(a2)), Eq(a1 + 2*a2, 2)), (0, True))
     >>> marginal_distribution(ed, ed[0])(a1)
     Piecewise((1/factorial(a1), Eq(a1, 2)), (0, True))
+
+    Parameters
+    ==========
+
+    n : Positive integer
+        Size of the sample or the integer whose partitions are considered
+    theta : Positive real number
+        Denotes Mutation rate
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -636,20 +639,6 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
 
     The joint pdf can be found at [1].
 
-    Parameters
-    ==========
-
-    syms: list/tuple/set of symbols for identifying each component
-    delta: A constant in range [0, 1]
-    v: Positive real number
-    lamda: List of positive real numbers
-    mu: List of positive real numbers
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -665,6 +654,20 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
     Sum(2**(-n)*exp((n + 1)*(y_1 + y_2 + y_3) - exp(y_1) - exp(y_2) -
     exp(y_3))/gamma(n + 1)**3, (n, 0, oo))/2
 
+    Parameters
+    ==========
+
+    syms : list/tuple/set of symbols for identifying each component
+    delta : A constant in range [0, 1]
+    v : Positive real number
+    lamda : List of positive real numbers
+    mu : List of positive real numbers
+
+    Returns
+    =======
+
+    RandomSymbol
+
     References
     ==========
 
@@ -674,10 +677,11 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
     Note
     ====
 
-    If the GeneralizedMultivariateLogGamma is too long to type use,
-    `from sympy.stats.joint_rv_types import GeneralizedMultivariateLogGamma as GMVLG`
-    If you want to pass the matrix omega instead of the constant delta, then use,
-    GeneralizedMultivariateLogGammaOmega.
+    If ``GeneralizedMultivariateLogGamma`` is too long to type, use 
+    ``from sympy.stats.joint_rv_types import GeneralizedMultivariateLogGamma as GMVLG``
+
+    If you want to pass the matrix omega instead of the constant delta, then use
+    ``GeneralizedMultivariateLogGammaOmega``.
 
     """
     return multivariate_rv(GeneralizedMultivariateLogGammaDistribution,
@@ -686,23 +690,6 @@ def GeneralizedMultivariateLogGamma(syms, delta, v, lamda, mu):
 def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     """
     Extends GeneralizedMultivariateLogGamma.
-
-    Parameters
-    ==========
-
-    syms: list/tuple/set of symbols
-        For identifying each component
-    omega: A square matrix
-           Every element of square matrix must be absolute value of
-           square root of correlation coefficient
-    v: Positive real number
-    lamda: List of positive real numbers
-    mu: List of positive real numbers
-
-    Returns
-    =======
-
-    RandomSymbol
 
     Examples
     ========
@@ -718,6 +705,23 @@ def GeneralizedMultivariateLogGammaOmega(syms, omega, v, lamda, mu):
     >>> density(G)(y[0], y[1], y[2])
     sqrt(2)*Sum((1 - sqrt(2)/2)**n*exp((n + 1)*(y_1 + y_2 + y_3) - exp(y_1) -
     exp(y_2) - exp(y_3))/gamma(n + 1)**3, (n, 0, oo))/2
+
+    Parameters
+    ==========
+
+    syms: list/tuple/set of symbols
+        For identifying each component
+    omega: A square matrix
+           Every element of square matrix must be absolute value of
+           square root of correlation coefficient
+    v : Positive real number
+    lamda : List of positive real numbers
+    mu : List of positive real numbers
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -783,19 +787,6 @@ def Multinomial(syms, n, *p):
 
     The density of the said distribution can be found at [1].
 
-    Parameters
-    ==========
-
-    n: Positive integer
-        Represents number of trials
-    p: List of event probabilites
-        Must be in the range of [0, 1]
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -809,6 +800,19 @@ def Multinomial(syms, n, *p):
     Eq(x1 + x2 + x3, 3)), (0, True))
     >>> marginal_distribution(M, M[0])(x1).subs(x1, 1)
     3*p1*p2**2 + 6*p1*p2*p3 + 3*p1*p3**2
+
+    Parameters
+    ==========
+
+    n : Positive integer
+        Represents number of trials
+    p : List of event probabilites
+        Must be in the range of [0, 1]
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========
@@ -856,19 +860,6 @@ def NegativeMultinomial(syms, k0, *p):
 
     The density of the said distribution can be found at [1].
 
-    Parameters
-    ==========
-
-    k0: positive integer
-        Represents number of failures before the experiment is stopped
-    p: List of event probabilites
-        Must be in the range of [0, 1]
-
-    Returns
-    =======
-
-    RandomSymbol
-
     Examples
     ========
 
@@ -884,6 +875,18 @@ def NegativeMultinomial(syms, k0, *p):
     >>> marginal_distribution(N_c, N_c[0])(1).evalf().round(2)
     0.25
 
+    Parameters
+    ==========
+
+    k0 : positive integer
+        Represents number of failures before the experiment is stopped
+    p : List of event probabilites
+        Must be in the range of [0, 1]
+
+    Returns
+    =======
+
+    RandomSymbol
 
     References
     ==========

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1043,7 +1043,7 @@ def sample(expr, condition=None, size=(), library='scipy', numsamples=1,
     condition : Expr containing RandomSymbols
         A conditional expression
     size : int, tuple
-        Represents size of each sample in numsamples
+        The size of each sample in numsamples
     library : str
         - 'scipy' : Sample using scipy
         - 'numpy' : Sample using numpy
@@ -1130,7 +1130,7 @@ def sample_iter(expr, condition=None, size=(), library='scipy',
     condition: Expr, optional
         A conditional expression
     size : int, tuple
-        Represents size of each sample in numsamples
+        The size of each sample in numsamples
     numsamples: integer, optional
         Length of the iterator (defaults to infinity)
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1044,21 +1044,20 @@ def sample(expr, condition=None, size=(), library='scipy', numsamples=1,
         A conditional expression
     size : int, tuple
         The size of each sample in numsamples
-    library : str
+    library : {'scipy', 'numpy', 'pymc3'}
+        Choose any of the available options to sample from as string,
+        default is 'scipy':
         - 'scipy' : Sample using scipy
         - 'numpy' : Sample using numpy
         - 'pymc3' : Sample using PyMC3
-
-        Choose any of the available options to sample from as string,
-        by default is 'scipy'
     numsamples : int
         Number of samples, each with size as ``size``
 
     Returns
     =======
 
-    sample: iterator object
-        iterator object containing the sample/samples of given expr
+    sample : iterator object
+        Iterator object containing the sample/samples of given expr
 
     """
     ### TODO: Remove the user warnings in the future releases

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -723,6 +723,19 @@ def expectation(expr, condition=None, numsamples=None, evaluate=True, **kwargs):
     """
     Returns the expected value of a random expression
 
+    Examples
+    ========
+
+    >>> from sympy.stats import E, Die
+    >>> X = Die('X', 6)
+    >>> E(X)
+    7/2
+    >>> E(2*X + 1)
+    8
+
+    >>> E(X, X > 3) # Expectation of X given that it is above 3
+    5
+
     Parameters
     ==========
 
@@ -736,19 +749,6 @@ def expectation(expr, condition=None, numsamples=None, evaluate=True, **kwargs):
         If sampling return a number rather than a complex expression
     evaluate : Bool (defaults to True)
         In case of continuous systems return unevaluated integral
-
-    Examples
-    ========
-
-    >>> from sympy.stats import E, Die
-    >>> X = Die('X', 6)
-    >>> E(X)
-    7/2
-    >>> E(2*X + 1)
-    8
-
-    >>> E(X, X > 3) # Expectation of X given that it is above 3
-    5
     """
 
     if not is_random(expr):  # expr isn't random?
@@ -770,19 +770,6 @@ def probability(condition, given_condition=None, numsamples=None,
     """
     Probability that a condition is true, optionally given a second condition
 
-    Parameters
-    ==========
-
-    condition : Combination of Relationals containing RandomSymbols
-        The condition of which you want to compute the probability
-    given_condition : Combination of Relationals containing RandomSymbols
-        A conditional expression. P(X > 1, X > 0) is expectation of X > 1
-        given X > 0
-    numsamples : int
-        Enables sampling and approximates the probability with this many samples
-    evaluate : Bool (defaults to True)
-        In case of continuous systems return unevaluated integral
-
     Examples
     ========
 
@@ -795,6 +782,19 @@ def probability(condition, given_condition=None, numsamples=None,
     1/4
     >>> P(X > Y)
     5/12
+
+    Parameters
+    ==========
+
+    condition : Combination of Relationals containing RandomSymbols
+        The condition of which you want to compute the probability
+    given_condition : Combination of Relationals containing RandomSymbols
+        A conditional expression. P(X > 1, X > 0) is expectation of X > 1
+        given X > 0
+    numsamples : int
+        Enables sampling and approximates the probability with this many samples
+    evaluate : Bool (defaults to True)
+        In case of continuous systems return unevaluated integral
     """
 
     kwargs['numsamples'] = numsamples
@@ -859,17 +859,6 @@ def density(expr, condition=None, evaluate=True, numsamples=None, **kwargs):
     probability spaces. Discrete variables produce Dicts. Continuous
     variables produce Lambdas.
 
-    Parameters
-    ==========
-
-    expr : Expr containing RandomSymbols
-        The expression of which you want to compute the density value
-    condition : Relational containing RandomSymbols
-        A conditional expression. density(X > 1, X > 0) is density of X > 1
-        given X > 0
-    numsamples : int
-        Enables sampling and approximates the density with this many samples
-
     Examples
     ========
 
@@ -886,6 +875,17 @@ def density(expr, condition=None, evaluate=True, numsamples=None, **kwargs):
     {2: 1/6, 4: 1/6, 6: 1/6, 8: 1/6, 10: 1/6, 12: 1/6}
     >>> density(X)(x)
     sqrt(2)*exp(-x**2/2)/(2*sqrt(pi))
+
+    Parameters
+    ==========
+
+    expr : Expr containing RandomSymbols
+        The expression of which you want to compute the density value
+    condition : Relational containing RandomSymbols
+        A conditional expression. density(X > 1, X > 0) is density of X > 1
+        given X > 0
+    numsamples : int
+        Enables sampling and approximates the density with this many samples
     """
 
     if numsamples:
@@ -1017,6 +1017,24 @@ def sample(expr, condition=None, size=(), library='scipy', numsamples=1,
     """
     A realization of the random expression
 
+    Examples
+    ========
+
+    >>> from sympy.stats import Die, sample, Normal
+    >>> X, Y, Z = Die('X', 6), Die('Y', 6), Die('Z', 6)
+
+    >>> die_roll = sample(X + Y + Z) # doctest: +SKIP
+    >>> N = Normal('N', 3, 4)
+    >>> samp = next(sample(N)) # doctest: +SKIP
+    >>> samp in N.pspace.domain.set # doctest: +SKIP
+    True
+    >>> samp = next(sample(N, N>0)) # doctest: +SKIP
+    >>> samp > 0 # doctest: +SKIP
+    True
+    >>> samp_list = next(sample(N, size=4)) # doctest: +SKIP
+    >>> [sam in N.pspace.domain.set for sam in samp_list] # doctest: +SKIP
+    [True, True, True, True]
+
     Parameters
     ==========
 
@@ -1035,24 +1053,6 @@ def sample(expr, condition=None, size=(), library='scipy', numsamples=1,
         by default is 'scipy'
     numsamples : int
         Number of samples, each with size as ``size``
-
-    Examples
-    ========
-
-    >>> from sympy.stats import Die, sample, Normal
-    >>> X, Y, Z = Die('X', 6), Die('Y', 6), Die('Z', 6)
-
-    >>> die_roll = sample(X + Y + Z) # doctest: +SKIP
-    >>> N = Normal('N', 3, 4)
-    >>> samp = next(sample(N)) # doctest: +SKIP
-    >>> samp in N.pspace.domain.set # doctest: +SKIP
-    True
-    >>> samp = next(sample(N, N>0)) # doctest: +SKIP
-    >>> samp > 0 # doctest: +SKIP
-    True
-    >>> samp_list = next(sample(N, size=4)) # doctest: +SKIP
-    >>> [sam in N.pspace.domain.set for sam in samp_list] # doctest: +SKIP
-    [True, True, True, True]
 
     Returns
     =======

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -112,7 +112,7 @@ def entropy(expr, condition=None, **kwargs):
     expression : the random expression whose entropy is to be calculated
     condition : optional, to specify conditions on random expression
     b: base of the logarithm, optional
-       By default, it is taken as Euler's number
+        By default, it is taken as Euler's number
 
     Returns
     =======
@@ -256,7 +256,7 @@ def skewness(X, condition=None, **kwargs):
     ==========
 
     condition : Expr containing RandomSymbols
-            A conditional expression. skewness(X, X>0) is skewness of X given X > 0
+        A conditional expression. skewness(X, X>0) is skewness of X given X > 0
 
     Examples
     ========
@@ -290,7 +290,7 @@ def kurtosis(X, condition=None, **kwargs):
     ==========
 
     condition : Expr containing RandomSymbols
-            A conditional expression. kurtosis(X, X>0) is kurtosis of X given X > 0
+        A conditional expression. kurtosis(X, X>0) is kurtosis of X given X > 0
 
     Examples
     ========
@@ -328,9 +328,8 @@ def factorial_moment(X, n, condition=None, **kwargs):
     ==========
 
     n: A natural number, n-th factorial moment.
-
     condition : Expr containing RandomSymbols
-            A conditional expression.
+        A conditional expression.
 
     Examples
     ========
@@ -424,13 +423,13 @@ def coskewness(X, Y, Z, condition=None, **kwargs):
     ==========
 
     X : RandomSymbol
-            Random Variable used to calculate coskewness
+        Random Variable used to calculate coskewness
     Y : RandomSymbol
-            Random Variable used to calculate coskewness
+        Random Variable used to calculate coskewness
     Z : RandomSymbol
-            Random Variable used to calculate coskewness
+        Random Variable used to calculate coskewness
     condition : Expr containing RandomSymbols
-            A conditional expression
+        A conditional expression
 
     Examples
     ========

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -94,6 +94,18 @@ def entropy(expr, condition=None, **kwargs):
     """
     Calculuates entropy of a probability distribution
 
+    Examples
+    ========
+
+    >>> from sympy.stats import Normal, Die, entropy
+    >>> X = Normal('X', 0, 1)
+    >>> entropy(X)
+    log(2)/2 + 1/2 + log(pi)/2
+
+    >>> D = Die('D', 4)
+    >>> entropy(D)
+    log(4)
+
     Parameters
     ==========
 
@@ -106,18 +118,6 @@ def entropy(expr, condition=None, **kwargs):
     =======
 
     result : Entropy of the expression, a constant
-
-    Examples
-    ========
-
-    >>> from sympy.stats import Normal, Die, entropy
-    >>> X = Normal('X', 0, 1)
-    >>> entropy(X)
-    log(2)/2 + 1/2 + log(pi)/2
-
-    >>> D = Die('D', 4)
-    >>> entropy(D)
-    log(4)
 
     References
     ==========

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -888,7 +888,7 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     failure : Integer/str
         The event which is considered to be failure, by default is 0.
     p : Real Number between 0 and 1
-        Represents the probability of getting success.
+        The probability of success.
 
     References
     ==========

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -884,11 +884,11 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
 
     sym : Symbol/str
     success : Integer/str
-            The event which is considered to be success, by default is 1.
+        The event which is considered to be success, by default is 1.
     failure : Integer/str
-            The event which is considered to be failure, by default is 0.
+        The event which is considered to be failure, by default is 0.
     p : Real Number between 0 and 1
-            Represents the probability of getting success.
+        Represents the probability of getting success.
 
     References
     ==========
@@ -966,10 +966,10 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
         ==========
 
         condition: Relational
-                Condition for which probability has to be computed. Must
-                contain a RandomIndexedSymbol of the process.
+            Condition for which probability has to be computed. Must
+            contain a RandomIndexedSymbol of the process.
         given_condition: Relational/And
-                The given conditions under which computations should be done.
+            The given conditions under which computations should be done.
 
         Returns
         =======
@@ -1069,10 +1069,10 @@ class _SubstituteRV:
         ==========
 
         condition: Relational
-                Condition for which probability has to be computed. Must
-                contain a RandomIndexedSymbol of the process.
+            Condition for which probability has to be computed. Must
+            contain a RandomIndexedSymbol of the process.
         given_condition: Relational/And
-                The given conditions under which computations should be done.
+            The given conditions under which computations should be done.
 
         Returns
         =======

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -584,15 +584,6 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     """
     Represents discrete time Markov chain.
 
-    Parameters
-    ==========
-
-    sym: Symbol/str
-    state_space: Set
-        Optional, by default, S.Reals
-    trans_probs: Matrix/ImmutableMatrix/MatrixSymbol
-        Optional, by default, None
-
     Examples
     ========
 
@@ -614,6 +605,15 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     T[0, 2]*T[1, 0] + T[1, 1]*T[1, 2] + T[1, 2]*T[2, 2]
     >>> P(Eq(Y[3], 2), Eq(Y[1], 1)).round(2)
     0.36
+
+    Parameters
+    ==========
+
+    sym : Symbol/str
+    state_space : Set
+        Optional, by default, S.Reals
+    trans_probs : Matrix/ImmutableMatrix/MatrixSymbol
+        Optional, by default, None
 
     References
     ==========
@@ -845,17 +845,6 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     are independent of all the rest. Therefore Bernoulli Processs
     is Discrete State and Discrete Time Stochastic Process.
 
-    Parameters
-    ==========
-
-    sym: Symbol/str
-    success: Integer/str
-            The event which is considered to be success, by default is 1.
-    failure: Integer/str
-            The event which is considered to be failure, by default is 0.
-    p: Real Number between 0 and 1
-            Represents the probability of getting success.
-
     Examples
     ========
 
@@ -889,6 +878,17 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     2.10
     >>> P(B[1] < 1).round(2)
     0.30
+
+    Parameters
+    ==========
+
+    sym : Symbol/str
+    success : Integer/str
+            The event which is considered to be success, by default is 1.
+    failure : Integer/str
+            The event which is considered to be failure, by default is 0.
+    p : Real Number between 0 and 1
+            Represents the probability of getting success.
 
     References
     ==========


### PR DESCRIPTION
Enforcement of [Documentation Style Guide](https://docs.sympy.org/latest/documentation-style-guide.html#docstring-sections) for the [stats module](https://docs.sympy.org/latest/modules/stats.html)

#### References to other Issues or PRs
https://github.com/sympy/sympy/issues/19591 Update documentation to follow the documentation style guide

#### Brief description of what is fixed or changed
- Corrected order of sections
- Corrected parameter formatting
- Minor grammar corrections

#### Other comments
- [ ] There are two documentation TODOs in crv_types.py
- [ ] Many summary lines are too long
- [ ] Most Parameter sections need an overhaul
- [ ] Inconsistency in Examples for aliased functions

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->