### PR TITLE
MAINT: Remove sixu and TemporaryDirectory compatibility utils

### DIFF
--- a/doc/ext/docscrape_sphinx.py
+++ b/doc/ext/docscrape_sphinx.py
@@ -10,11 +10,6 @@ import collections
 
 from docscrape import NumpyDocString, FunctionDoc, ClassDoc
 
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
-
 
 class SphinxDocString(NumpyDocString):
     def __init__(self, docstring, config={}):
@@ -137,11 +132,11 @@ class SphinxDocString(NumpyDocString):
 
             if others:
                 maxlen_0 = max(3, max([len(x[0]) for x in others]))
-                hdr = sixu("=")*maxlen_0 + sixu("  ") + sixu("=")*10
-                fmt = sixu('%%%ds  %%s  ') % (maxlen_0,)
+                hdr = "="*maxlen_0 + "  " + "="*10
+                fmt = '%%%ds  %%s  ' % (maxlen_0,)
                 out += ['', '', hdr]
                 for param, param_type, desc in others:
-                    desc = sixu(" ").join(x.strip() for x in desc).strip()
+                    desc = " ".join(x.strip() for x in desc).strip()
                     if param_type:
                         desc = "(%s) %s" % (param_type, desc)
                     out += [fmt % (param.strip(), desc)]

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -30,11 +30,6 @@ if sphinx.__version__ < '1.0.1':
 
 from docscrape_sphinx import get_doc_object, SphinxDocString
 
-if sys.version_info[0] >= 3:
-    sixu = lambda s: s
-else:
-    sixu = lambda s: unicode(s, 'unicode_escape')
-
 
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
@@ -45,12 +40,12 @@ def mangle_docstrings(app, what, name, obj, options, lines,
            app.config.numpydoc_show_inherited_class_members,
            'class_members_toctree': app.config.numpydoc_class_members_toctree}
 
-    u_NL = sixu('\n')
+    u_NL = '\n'
     if what == 'module':
         # Strip top title
         pattern = '^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'
-        title_re = re.compile(sixu(pattern), re.I | re.S)
-        lines[:] = title_re.sub(sixu(''), u_NL.join(lines)).split(u_NL)
+        title_re = re.compile(pattern, re.I | re.S)
+        lines[:] = title_re.sub('', u_NL.join(lines)).split(u_NL)
     else:
         doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
         if sys.version_info[0] >= 3:
@@ -62,18 +57,18 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
             obj.__name__):
         if hasattr(obj, '__module__'):
-            v = dict(full_name=sixu("%s.%s") % (obj.__module__, obj.__name__))
+            v = dict(full_name="%s.%s" % (obj.__module__, obj.__name__))
         else:
             v = dict(full_name=obj.__name__)
-        lines += [sixu(''), sixu('.. htmlonly::'), sixu('')]
-        lines += [sixu('    %s') % x for x in
+        lines += ['', '.. htmlonly::', '']
+        lines += ['    %s' % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
     # replace reference numbers so that there are no duplicates
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
+        m = re.match('^.. \\[([a-z0-9_.-])\\]', line, re.I)
         if m:
             references.append(m.group(1))
 
@@ -82,14 +77,14 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if references:
         for i, line in enumerate(lines):
             for r in references:
-                if re.match(sixu('^\\d+$'), r):
-                    new_r = sixu("R%d") % (reference_offset[0] + int(r))
+                if re.match('^\\d+$', r):
+                    new_r = "R%d" % (reference_offset[0] + int(r))
                 else:
-                    new_r = sixu("%s%d") % (r, reference_offset[0])
-                lines[i] = lines[i].replace(sixu('[%s]_') % r,
-                                            sixu('[%s]_') % new_r)
-                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
-                                            sixu('.. [%s]') % new_r)
+                    new_r = "%s%d" % (r, reference_offset[0])
+                lines[i] = lines[i].replace('[%s]_' % r,
+                                            '[%s]_' % new_r)
+                lines[i] = lines[i].replace('.. [%s]' % r,
+                                            '.. [%s]' % new_r)
 
     reference_offset[0] += len(references)
 
@@ -110,8 +105,8 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
 
     doc = SphinxDocString(pydoc.getdoc(obj))
     if doc['Signature']:
-        sig = re.sub(sixu("^[^(]*"), sixu(""), doc['Signature'])
-        return sig, sixu('')
+        sig = re.sub("^[^(]*", "", doc['Signature'])
+        return sig, ''
 
 
 def setup(app, get_doc_object_=get_doc_object):

--- a/sympy/codegen/tests/test_algorithms.py
+++ b/sympy/codegen/tests/test_algorithms.py
@@ -1,3 +1,4 @@
+import tempfile
 import sympy as sp
 from sympy.core.compatibility import exec_
 from sympy.codegen.ast import Assignment
@@ -8,7 +9,7 @@ from sympy.codegen.pyutils import render_as_module as py_module
 from sympy.external import import_module
 from sympy.printing.ccode import ccode
 from sympy.utilities._compilation import compile_link_import_strings, has_c, has_fortran
-from sympy.utilities._compilation.util import TemporaryDirectory, may_xfail
+from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip, raises
 
 cython = import_module('cython')
@@ -33,7 +34,7 @@ def test_newtons_method_function__ccode():
         skip("No C compiler found.")
 
     compile_kw = dict(std='c99')
-    with TemporaryDirectory() as folder:
+    with tempfile.TemporaryDirectory() as folder:
         mod, info = compile_link_import_strings([
             ('newton.c', ('#include <math.h>\n'
                           '#include <stdio.h>\n') + ccode(func)),
@@ -57,7 +58,7 @@ def test_newtons_method_function__fcode():
         skip("No Fortran compiler found.")
 
     f_mod = f_module([func], 'mod_newton')
-    with TemporaryDirectory() as folder:
+    with tempfile.TemporaryDirectory() as folder:
         mod, info = compile_link_import_strings([
             ('newton.f90', f_mod),
             ('_newton.pyx', ("#cython: language_level={}\n".format("3") +
@@ -94,7 +95,7 @@ def test_newtons_method_function__ccode_parameters():
         skip("cython not installed.")
 
     compile_kw = dict(std='c99')
-    with TemporaryDirectory() as folder:
+    with tempfile.TemporaryDirectory() as folder:
         mod, info = compile_link_import_strings([
             ('newton_par.c', ('#include <math.h>\n'
                           '#include <stdio.h>\n') + ccode(func)),

--- a/sympy/codegen/tests/test_applications.py
+++ b/sympy/codegen/tests/test_applications.py
@@ -1,9 +1,11 @@
 # This file contains tests that exercise multiple AST nodes
 
+import tempfile
+
 from sympy.external import import_module
 from sympy.printing.ccode import ccode
 from sympy.utilities._compilation import compile_link_import_strings, has_c
-from sympy.utilities._compilation.util import TemporaryDirectory, may_xfail
+from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip
 from sympy.codegen.ast import (
     FunctionDefinition, FunctionPrototype, Variable, Pointer, real, Assignment,
@@ -47,7 +49,7 @@ def test_copying_function():
         skip("Cython not found.")
 
     info = None
-    with TemporaryDirectory() as folder:
+    with tempfile.TemporaryDirectory() as folder:
         mod, info = _render_compile_import(_mk_func1(), build_dir=folder)
         inp = np.arange(10.0)
         out = np.empty_like(inp)

--- a/sympy/codegen/tests/test_fnodes.py
+++ b/sympy/codegen/tests/test_fnodes.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from sympy import Symbol, symbols
 from sympy.codegen.ast import (
     Assignment, Print, Declaration, FunctionDefinition, Return, real,
@@ -14,7 +15,7 @@ from sympy.core.expr import unchanged
 from sympy.external import import_module
 from sympy.printing.fcode import fcode
 from sympy.utilities._compilation import has_fortran, compile_run_strings, compile_link_import_strings
-from sympy.utilities._compilation.util import TemporaryDirectory, may_xfail
+from sympy.utilities._compilation.util import may_xfail
 from sympy.testing.pytest import skip
 
 cython = import_module('cython')
@@ -197,7 +198,7 @@ def test_bind_C():
     fd = FunctionDefinition(real, 'rms', [arr, s], body, attrs=[bind_C('rms')])
     f_mod = render_as_module([fd], 'mod_rms')
 
-    with TemporaryDirectory() as folder:
+    with tempfile.TemporaryDirectory() as folder:
         mod, info = compile_link_import_strings([
             ('rms.f90', f_mod),
             ('_rms.pyx', (

--- a/sympy/utilities/_compilation/util.py
+++ b/sympy/utilities/_compilation/util.py
@@ -3,7 +3,6 @@ from hashlib import sha256
 import os
 import shutil
 import sys
-import tempfile
 import fnmatch
 
 from sympy.testing.pytest import XFAIL
@@ -17,22 +16,6 @@ def may_xfail(func):
         return XFAIL(func)
     else:
         return func
-
-
-if sys.version_info[0] == 2:
-    class FileNotFoundError(IOError):
-        pass
-
-    class TemporaryDirectory:
-        def __init__(self):
-            self.path = tempfile.mkdtemp()
-        def __enter__(self):
-            return self.path
-        def __exit__(self, exc, value, tb):
-            shutil.rmtree(self.path)
-else:
-    FileNotFoundError = FileNotFoundError
-    TemporaryDirectory = tempfile.TemporaryDirectory
 
 
 class CompilerNotFoundError(FileNotFoundError):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Work on removing Python 2 code: #17943

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->