### PR TITLE
Add test for limit_seq in series

### DIFF
--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, Symbol, oo, Sum, harmonic, exp, Add, S, binomial,
-    factorial, log, fibonacci, subfactorial, sin, cos, pi, I, sqrt, Rational)
+    factorial, log, fibonacci, subfactorial, sin, cos, pi, I, sqrt, Rational, gamma)
 from sympy.series.limitseq import limit_seq
 from sympy.series.limitseq import difference_delta as dd
 from sympy.testing.pytest import raises, XFAIL
@@ -131,6 +131,10 @@ def test_issue_11672():
 
 def test_issue_16735():
     assert limit_seq(5**n/factorial(n), n) == 0
+
+
+def test_issue_19868():
+    assert limit_seq(1/gamma(n + S.One/2), n) == 0
 
 
 @XFAIL


### PR DESCRIPTION
####References to other Issues or PRs
Fixes #19868 

#### Brief description of what is fixed or changed
Added simple test case for limit_seq, to ensure correct output of 0 instead of oo.
Current master gives 0.

#### Other comments
NA

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->