### PR TITLE
Do not make Immutable matrices the target of :mod:`sympy` links (1.6 branch)

### DIFF
--- a/doc/src/modules/index.rst
+++ b/doc/src/modules/index.rst
@@ -3,6 +3,8 @@
 SymPy Modules Reference
 =======================
 
+.. module:: sympy
+
 Because every feature of SymPy must have a test case, when you are not sure how
 to use something, just look into the ``tests/`` directories, find that feature
 and read the tests for it, that will tell you everything you need to know.

--- a/doc/src/modules/matrices/immutablematrices.rst
+++ b/doc/src/modules/matrices/immutablematrices.rst
@@ -1,7 +1,7 @@
 Immutable Matrices
 ==================
 
-.. module:: sympy
+.. currentmodule:: sympy
 
 The standard :obj:`~.Matrix` class in SymPy is mutable. This is important for
 performance reasons but means that standard matrices cannot interact well with


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Applies #19430 to the 1.6 branch

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * intersphinx links to `` :mod:`sympy` `` no longer point to the documentation for Immutable Matrices
<!-- END RELEASE NOTES -->