### PR TITLE
Allow vector_integrate to handle ImplicitRegion objects

### DIFF
--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -14,8 +14,8 @@ from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
 from sympy.vector.operators import Gradient, Divergence, Curl, Laplacian, gradient, curl, divergence
-from sympy.vector.parametricregion import (ParametricRegion, parametric_region_list)
 from sympy.vector.implicitregion import ImplicitRegion
+from sympy.vector.parametricregion import (ParametricRegion, parametric_region_list)
 from sympy.vector.integrals import (ParametricIntegral, vector_integrate)
 
 __all__ = [

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -162,6 +162,14 @@ def vector_integrate(field, *region):
     >>> vector_integrate(3*C.x**2*C.y*C.i + C.j, triangle)
     -8
 
+    Integrals over some simple implicit regions can be computed. But in most cases,
+    it takes too long to compute over them.
+    >>> from sympy.abc import x, y
+    >>> from sympy.vector import ImplicitRegion
+    >>> c2 = ImplicitRegion((x, y), (x - 2)**2 + (y - 1)**2 - 9)
+    >>> vector_integrate(1, c2)
+    12*pi
+
     >>> vector_integrate(12*C.y**3, (C.y, 1, 3))
     240
     >>> vector_integrate(C.x**2*C.z, C.x)

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -1,7 +1,8 @@
 from sympy import S, simplify
 from sympy.core import Basic, diff
 from sympy.matrices import Matrix
-from sympy.vector import CoordSys3D, Vector, ParametricRegion, parametric_region_list
+from sympy.vector import (CoordSys3D, Vector, ParametricRegion,
+                        parametric_region_list, ImplicitRegion)
 from sympy.vector.operators import _get_coord_sys_from_expr
 from sympy.integrals import Integral, integrate
 from sympy.utilities.iterables import topological_sort, default_sort_key
@@ -170,6 +171,10 @@ def vector_integrate(field, *region):
     if len(region) == 1:
         if isinstance(region[0], ParametricRegion):
             return ParametricIntegral(field, region[0])
+
+        if isinstance(region[0], ImplicitRegion):
+            region = parametric_region_list(region[0])[0]
+            return vector_integrate(field, region)
 
         if isinstance(region[0], GeometryEntity):
             regions_list = parametric_region_list(region[0])

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,5 +1,5 @@
 from functools import singledispatch
-from sympy import pi, tan
+from sympy import pi, tan, oo
 from sympy.simplify import trigsimp
 from sympy.core import Basic, Tuple
 from sympy.core.symbol import _symbol
@@ -178,6 +178,7 @@ def _(obj, parameters=('t', 's')):
     bounds = []
 
     for i in range(len(obj.variables) - 1):
+        # Each parameter is replaced by its tangent to simplify intergation
         parameter = _symbol(parameters[i], real=True)
         definition = [trigsimp(elem.subs(parameter, tan(parameter))) for elem in definition]
         bounds.append((parameter, 0, 2*pi),)

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,5 +1,5 @@
 from functools import singledispatch
-from sympy import pi, tan, oo
+from sympy import pi, tan
 from sympy.simplify import trigsimp
 from sympy.core import Basic, Tuple
 from sympy.core.symbol import _symbol

--- a/sympy/vector/parametricregion.py
+++ b/sympy/vector/parametricregion.py
@@ -1,9 +1,11 @@
 from functools import singledispatch
-from sympy import pi
+from sympy import pi, tan
+from sympy.simplify import trigsimp
 from sympy.core import Basic, Tuple
 from sympy.core.symbol import _symbol
 from sympy.solvers import solve
 from sympy.geometry import Point, Segment, Curve, Ellipse, Polygon
+from sympy.vector import ImplicitRegion
 
 
 class ParametricRegion(Basic):
@@ -168,3 +170,17 @@ def _(obj, parameter='t'):
 def _(obj, parameter='t'):
     l = [parametric_region_list(side, parameter)[0] for side in obj.sides]
     return l
+
+
+@parametric_region_list.register(ImplicitRegion)
+def _(obj, parameters=('t', 's')):
+    definition = obj.rational_parametrization(parameters)
+    bounds = []
+
+    for i in range(len(obj.variables) - 1):
+        parameter = _symbol(parameters[i], real=True)
+        definition = [trigsimp(elem.subs(parameter, tan(parameter))) for elem in definition]
+        bounds.append((parameter, 0, 2*pi),)
+
+    definition = Tuple(*definition)
+    return [ParametricRegion(definition, *bounds)]

--- a/sympy/vector/tests/test_implicitregion.py
+++ b/sympy/vector/tests/test_implicitregion.py
@@ -60,8 +60,7 @@ def test_rational_parametrization():
     circle1 = ImplicitRegion((x, y), (x-2)**2 + (y+3)**2 - 4)
     assert circle1.rational_parametrization(parameters=t) == (4*t/(t**2 + 1) + 2, 4*t**2/(t**2 + 1) - 5)
     circle2 = ImplicitRegion((x, y), (x - S.Half)**2 + y**2 - (S(1)/2)**2)
-    print(circle2.regular_point())
-    print(circle2.rational_parametrization())
+
     assert circle2.rational_parametrization(parameters=t) == (t/(t**2 + 1) + S(1)/2, t**2/(t**2 + 1) - S(1)/2)
     circle3 = ImplicitRegion((x, y), Eq(x**2 + y**2, 2*x))
     assert circle3.rational_parametrization(parameters=(t,)) == (2*t/(t**2 + 1) + 1, 2*t**2/(t**2 + 1) - 1)
@@ -81,7 +80,6 @@ def test_rational_parametrization():
     assert I.rational_parametrization(t) == (t**2 - 1, t*(t**2 - 1))
 
     sphere = ImplicitRegion((x, y, z), Eq(x**2 + y**2 + z**2, 2*x))
-    print(sphere.rational_parametrization(parameters=(s, t)))
     assert sphere.rational_parametrization(parameters=(s, t)) == (2/(s**2 + t**2 + 1), 2*t/(s**2 + t**2 + 1), 2*s/(s**2 + t**2 + 1))
 
     conic = ImplicitRegion((x, y), Eq(x**2 + 4*x*y + 3*y**2 + x - y + 10, 0))

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -3,6 +3,7 @@ from sympy.testing.pytest import raises
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.integrals import ParametricIntegral, vector_integrate
 from sympy.vector.parametricregion import ParametricRegion
+from sympy.vector.implicitregion import ImplicitRegion
 from sympy.abc import x, y, z, u, v, r, t, theta, phi
 from sympy.geometry import Point, Segment, Curve, Circle, Polygon, Plane
 
@@ -89,6 +90,11 @@ def test_vector_integrate():
 
     point = Point(2, 3)
     assert vector_integrate(C.i*C.y - C.z, point) == ParametricIntegral(C.y*C.i, ParametricRegion((2, 3)))
+
+    c3 = ImplicitRegion((x, y), x**2 + y**2 - 4)
+    assert vector_integrate(45, c3) == 360*pi
+    c4 = ImplicitRegion((x, y), (x - 3)**2 + (y - 4)**2 - 9)
+    assert vector_integrate(1, c4) == 12*pi
 
     pl = Plane(Point(1, 1, 1), Point(2, 3, 4), Point(2, 2, 2))
     raises(ValueError, lambda: vector_integrate(C.x*C.z*C.i + C.k, pl))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19320

#### Brief description of what is fixed or changed
The purpose of this PR is to modify the `vector_integrate` method to directly integrate over `ImplicitRegion` objects.

Example:
```python
>>> circle = ImplicitRegion((x, y), x**2 + y**2 - 4)
>>> parametric_region_list(circle)
[ParametricRegion((2*sin(2*t), -2*cos(2*t)), (t, 0, 2*pi))]
>>> vector_integrate(1, circle)
8*pi
```
#### Other comments

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * `vector_integrate` can integrate over `ImplicitRegion` objects.
<!-- END RELEASE NOTES -->