### PR TITLE
Fix placement of free variables in gauss_jordan_solve

### DIFF
--- a/sympy/matrices/solvers.py
+++ b/sympy/matrices/solvers.py
@@ -541,20 +541,17 @@ def _gauss_jordan_solve(M, B, freevar=False):
     pivots    = list(filter(lambda p: p < col, pivots))
     rank      = len(pivots)
 
-    # Bring to block form
-    permutation = Matrix(range(col)).T
+    # Get index of free symbols (free parameters)
+    # non-pivots columns are free variables
+    free_var_index = [c for c in range(A.cols) if c not in pivots]
 
-    for i, c in enumerate(pivots):
-        permutation.col_swap(i, c)
+    # Bring to block form
+    permutation = Matrix(pivots + free_var_index).T
 
     # check for existence of solutions
     # rank of aug Matrix should be equal to rank of coefficient matrix
     if not v[rank:, :].is_zero_matrix:
         raise ValueError("Linear system has no solution")
-
-    # Get index of free symbols (free parameters)
-    # non-pivots columns are free variables
-    free_var_index = permutation[len(pivots):]
 
     # Free parameters
     # what are current unnumbered free symbol names?
@@ -566,7 +563,7 @@ def _gauss_jordan_solve(M, B, freevar=False):
             col - rank, B_cols)
 
     # Full parametric solution
-    V        = A[:rank, [c for c in range(A.cols) if c not in pivots]]
+    V        = A[:rank, free_var_index]
     vt       = v[:rank, :]
     free_sol = tau.vstack(vt - V * tau, tau)
 

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -467,7 +467,7 @@ def test_gauss_jordan_solve():
     b = M[:, -1:]
     sol, params = A.gauss_jordan_solve(b)
     assert params == Matrix(3, 1, [x0, x1, x2])
-    assert sol == Matrix(5, 1, [x1, 0, x0, _x0, x2])
+    assert sol == Matrix(5, 1, [x0, 0, x1, _x0, x2])
 
     # Rectangular, wide, reduced rank, no solution
     A = Matrix([[1, 2, 3, 4], [5, 6, 7, 8], [2, 4, 6, 8]])
@@ -482,6 +482,16 @@ def test_gauss_jordan_solve():
     assert params == ImmutableMatrix(0, 1, [])
     assert sol.__class__ == ImmutableDenseMatrix
     assert params.__class__ == ImmutableDenseMatrix
+
+    # Test placement of free variables
+    A = Matrix([[1, 0, 0, 0], [0, 0, 0, 1]])
+    b = Matrix([1, 1])
+    sol, params = A.gauss_jordan_solve(b)
+    w = {}
+    for s in sol.atoms(Symbol):
+        w[s.name] = s
+    assert sol == Matrix([[1], [w['tau0']], [w['tau1']], [1]])
+    assert params == Matrix([[w['tau0']], [w['tau1']]])
 
 
 def test_solve():

--- a/sympy/matrices/tests/test_solvers.py
+++ b/sympy/matrices/tests/test_solvers.py
@@ -494,6 +494,39 @@ def test_gauss_jordan_solve():
     assert params == Matrix([[w['tau0']], [w['tau1']]])
 
 
+def test_issue_19815():
+    #Test placement of free variables as per issue 19815
+    A = Matrix([[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]])
+    B  = Matrix([1, 2, 1, 1, 1, 1, 1, 2])
+    sol, params = A.gauss_jordan_solve(B)
+    w = {}
+    for s in sol.atoms(Symbol):
+        w[s.name] = s
+    assert params == Matrix([[w['tau0']], [w['tau1']], [w['tau2']],
+                             [w['tau3']], [w['tau4']], [w['tau5']]])
+    assert sol == Matrix([[1 - 1*w['tau2']],
+                          [w['tau2']],
+                          [1 - 1*w['tau0'] + w['tau1']],
+                          [w['tau0']],
+                          [w['tau3'] + w['tau4']],
+                          [-1*w['tau3'] - 1*w['tau4'] - 1*w['tau1']],
+                          [1 - 1*w['tau2']],
+                          [w['tau1']],
+                          [w['tau2']],
+                          [w['tau3']],
+                          [w['tau4']],
+                          [1 - 1*w['tau5']],
+                          [w['tau5']],
+                          [1]])
+
+
 def test_solve():
     A = Matrix([[1,2], [2,4]])
     b = Matrix([[3], [4]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19815

#### Brief description of what is fixed or changed
Sometimes, gauss_jordan_solve swaps the numbering/placement of the free variables while calculating the rest of the results with the assumption that they will be placed ordinally, making the results incorrect. The free variables are still not numbered/placed ordinally because several tests expect that behavior. However, now the rest of the results reflect that and are correct.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * The ordering of parameters in a parametrised solution from `gauss_jordan_solve` was fixed. Previously incorrect results were returned for some underdetermined systems.
<!-- END RELEASE NOTES -->