### PR TITLE
BUGFIX: preview: viewer="file" with filename raising an error

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -202,7 +202,10 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 raise OSError(
                     "No viewers found for '%s' output format." % output)
     else:
-        if viewer == "StringIO":
+        if viewer == "file":
+            if filename is None:
+                raise ValueError("filename has to be specified if viewer=\"file\"")
+        elif viewer == "StringIO":
             viewer = "BytesIO"
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a BytesIO "


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

Re-enable the `viewer="file"` option in `preview` 

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixing Bug introduced in https://github.com/sympy/sympy/pull/18392
See: https://github.com/sympy/sympy/pull/18392/files#r465720627

#### Brief description of what is fixed or changed
In `preview` the option `viewer="file"` was deprecated when no filename was given (https://github.com/sympy/sympy/issues/7018, #18392).
But now it also raises an Error when a filename is given, which should be possible.

<!-- BEGIN RELEASE NOTES -->
* printing
  * preview: `viewer="file"` option was not available due to a bug
<!-- END RELEASE NOTES -->