### PR TITLE
Fixed Mod function lambdify bug

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -731,7 +731,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     from sympy.core.symbol import Symbol
 
     # If the user hasn't specified any modules, use what is available.
-    if modules is None:
+    if modules is None or modules == []:
         try:
             _import("scipy")
         except ImportError:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17737


#### Brief description of what is fixed or changed
```
x, y = symbols('x y')
expr = -Mod(x, y)
```
While using lambdify function without modules parameter , the answer was correct
```
f = lambdify([x, y], expr)
f(3, 7)
-3
```
But when we pass modules parameters as an empty list as shown below , the answer was incorrect
```
g = lambdify([x, y], expr, modules=[])
g(3, 7)
4
```
So I maded a change in sympy/utilities/lambdify.py 



#### Other comments
Corrected Output
```
g = lambdify([x, y], expr, modules=[])
g(3, 7)
-3
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug in the lambdify function


<!-- END RELEASE NOTES -->