### PR TITLE
matrices: Remove __mathml__

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -70,7 +70,6 @@ def make_report(
     cov = coverage.coverage()
     cov.exclude("raise NotImplementedError")
     cov.exclude("def canonize")  # this should be "@decorated"
-    cov.exclude("def __mathml__")
     if use_cache:
         cov.load()
     else:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -776,15 +776,6 @@ class MatrixBase(MatrixDeprecated,
         """
         return self.rows * self.cols
 
-    def __mathml__(self):
-        mml = ""
-        for i in range(self.rows):
-            mml += "<matrixrow>"
-            for j in range(self.cols):
-                mml += self[i, j].__mathml__()
-            mml += "</matrixrow>"
-        return "<matrix>" + mml + "</matrix>"
-
     def _matrix_pow_by_jordan_blocks(self, num):
         from sympy.matrices import diag, MutableMatrix
         from sympy import binomial


### PR DESCRIPTION
This was introduced in 5009295c6f76e95e13780361bc3e88d639463cdb.
There is no need for this to exist, matrices are handled by `print_mathml`.

Furthermore, this method would never have worked, except for matrices containing only other matrices - `self[i, j].__mathml__()` would always raise `AttributeError`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->