### PR TITLE
Tests identifying bugs in support for finitely presented groups, partial fix

### DIFF
--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -365,6 +365,7 @@ class CosetTable(DefaultPrinting):
                     self.modified_coincidence(f, b, f_p**-1*b_p)
                 else:
                     self.coincidence(f, b)
+                return
             elif j == i:
                 # deduction process
                 table[f][A_dict[word[i]]] = b
@@ -642,6 +643,7 @@ class CosetTable(DefaultPrinting):
                 j -= 1
             if j < i:
                 self.coincidence_c(f, b)
+                return
             elif j == i:
                 table[f][A_dict[word[i]]] = b
                 table[b][A_dict_inv[word[i]]] = f

--- a/sympy/combinatorics/tests/test_coset_table.py
+++ b/sympy/combinatorics/tests/test_coset_table.py
@@ -139,6 +139,28 @@ def test_coset_enumeration():
     assert C_r.table == table1
     assert C_c.table == table1
 
+    # Example 5.4 from [1]
+    # Fibonacci group F(2,5)
+    F, a, b, c, d, e = free_group("a, b, c, d, e")
+    f = FpGroup(F, [a*b*(c**-1), b*c*(d**-1), c*d*(e**-1), d*e*(a**-1), e*a*(b**-1)])
+    C_r = coset_enumeration_r(f, [])
+    C_r.compress(); C_r.standardize()
+    C_c = coset_enumeration_c(f, [])
+    C_c.compress(); C_c.standardize()
+    table1 = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [8, 0, 5, 10, 6, 4, 2, 9, 3, 7], [0, 7, 9, 6, 3, 5, 10, 1, 8, 4], [5, 9, 10, 0, 7, 2, 8, 6, 4, 1], [10, 6, 0, 9, 1, 8, 5, 7, 2, 3], [6, 3, 7, 1, 2, 0, 9, 4, 10, 8], [4, 5, 2, 8, 0, 1, 3, 10, 7, 9], [2, 10, 8, 5, 9, 3, 4, 0, 1, 6], [9, 1, 6, 7, 4, 10, 0, 3, 5, 2], [3, 8, 4, 2, 10, 7, 1, 5, 6, 0], [7, 4, 1, 3, 8, 9, 6, 2, 0, 5]]
+    assert C_r.table == table1
+    assert C_c.table == table1
+
+    F, a, b, c, d, e = free_group("a, b, c, d, e")
+    f = FpGroup(F, [a*b*(c**-1), b*c*(d**-1), c*d*(e**-1), d*e*(a**-1), e*a*(b**-1)])
+    C_r = coset_enumeration_r(f, [a])
+    C_r.compress(); C_r.standardize()
+    C_c = coset_enumeration_c(f, [a])
+    C_c.compress(); C_c.standardize()
+    table1 = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+    assert C_r.table == table1
+    assert C_c.table == table1
+
     # E1 from [2] Pg. 474
     F, r, s, t = free_group("r, s, t")
     E1 = FpGroup(F, [t**-1*r*t*r**-2, r**-1*s*r*s**-2, s**-1*t*s*t**-2])

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -168,6 +168,12 @@ def test_order():
     f = FpGroup(free_group('')[0], [])
     assert f.order() == 1
 
+    # Example 5.4 page 160 of D. Holt et al., Handbook of Computational Group Theory
+    # Fibonacci group F(2,5)
+    F, a, b, c, d, e = free_group("a, b, c, d, e")
+    f = FpGroup(F, [a*b*(c**-1), b*c*(d**-1), c*d*(e**-1), d*e*(a**-1), e*a*(b**-1)])
+    assert f.order() == 11
+
 def test_fp_subgroup():
     def _test_subgroup(K, T, S):
         _gens = T(K.generators)

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -168,6 +168,9 @@ def test_order():
     f = FpGroup(free_group('')[0], [])
     assert f.order() == 1
 
+from sympy.testing.pytest import XFAIL # Will move it properly at a later stage...
+@XFAIL
+def test_order_failing():
     # Example 5.4 page 160 of D. Holt et al., Handbook of Computational Group Theory
     # Fibonacci group F(2,5)
     F, a, b, c, d, e = free_group("a, b, c, d, e")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix of #19898

#### Brief description of what is fixed or changed

Added tests for both FP order computation, and coset enumeration.

See #19898 for the fix in the relator-based coset enumeration algorithm. However, the order computation triggers a different bug in the computation of a rewriting system.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * added the Fibonacci group to tests of CosetTable and FpGroup
  * fixed the scan and fill procedure

<!-- END RELEASE NOTES -->