### PR TITLE
printing.pretty: Ensure Matrix is pretty-printed in IPython

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -819,9 +819,6 @@ class MatrixBase(MatrixDeprecated,
         return self._new(P.multiply(diag(*jordan_cells))
                 .multiply(P.inv()))
 
-    def __repr__(self):
-        return sstr(self)
-
     def __str__(self):
         if self.rows == 0 or self.cols == 0:
             return 'Matrix(%s, %s, [])' % (self.rows, self.cols)


### PR DESCRIPTION
This removes the `__repr__` implementation, which was exactly the same as the inherited default.

With `__repr__` present, the IPython pretty printer ignores the printer manually registered for the base class in `init_printing`.

This restores the sympy 1.6 behavior, addressing the comment in https://github.com/sympy/sympy/pull/19425/files#r466367402

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->
(fixes a regression since the last release, so no need for notes)
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->