### PR TITLE
Fix issues in NDimArray

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1807,11 +1807,6 @@ class LatexPrinter(Printer):
 
         return out_str
 
-    _print_ImmutableDenseNDimArray = _print_NDimArray
-    _print_ImmutableSparseNDimArray = _print_NDimArray
-    _print_MutableDenseNDimArray = _print_NDimArray
-    _print_MutableSparseNDimArray = _print_NDimArray
-
     def _printer_tensor_indices(self, name, indices, index_map={}):
         out_str = self._print(name)
         last_valence = None

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1150,11 +1150,6 @@ class PrettyPrinter(Printer):
 
         return self._print(out_expr)
 
-    _print_ImmutableDenseNDimArray = _print_NDimArray
-    _print_ImmutableSparseNDimArray = _print_NDimArray
-    _print_MutableDenseNDimArray = _print_NDimArray
-    _print_MutableSparseNDimArray = _print_NDimArray
-
     def _printer_tensor_indices(self, name, indices, index_map={}):
         center = stringPict(name)
         top = stringPict(" "*center.width())

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -624,12 +624,6 @@ class StrPrinter(Printer):
         return '%s**%s' % (self.parenthesize(expr.base, PREC, strict=False),
                          self.parenthesize(expr.exp, PREC, strict=False))
 
-    def _print_ImmutableDenseNDimArray(self, expr):
-        return str(expr)
-
-    def _print_ImmutableSparseNDimArray(self, expr):
-        return str(expr)
-
     def _print_Integer(self, expr):
         if self._settings.get("sympy_integers", False):
             return "S(%s)" % (expr)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -11,6 +11,7 @@ from sympy.physics.units import second, joule
 from sympy.polys import (Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ,
     ZZ_I, QQ_I, lex, grlex)
 from sympy.geometry import Point, Circle, Polygon, Ellipse, Triangle
+from sympy.tensor import NDimArray
 
 from sympy.testing.pytest import raises
 
@@ -993,3 +994,9 @@ def test_diffgeom():
     assert str(rect) == "rect"
     b = BaseScalarField(rect, 0)
     assert str(b) == "x"
+
+def test_NDimArray():
+    assert sstr(NDimArray(1.0), full_prec=True) == '1.00000000000000'
+    assert sstr(NDimArray(1.0), full_prec=False) == '1.0'
+    assert sstr(NDimArray([1.0, 2.0]), full_prec=True) == '[1.00000000000000, 2.00000000000000]'
+    assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -292,27 +292,16 @@ class NDimArray(Printable):
 
         return type(self)(map(f, Flatten(self)), self.shape)
 
-    def __str__(self):
-        """Returns string, allows to use standard functions print() and str().
-
-        Examples
-        ========
-
-        >>> from sympy import MutableDenseNDimArray
-        >>> a = MutableDenseNDimArray.zeros(2, 2)
-        >>> a
-        [[0, 0], [0, 0]]
-
-        """
+    def _sympystr(self, printer):
         def f(sh, shape_left, i, j):
             if len(shape_left) == 1:
-                return "["+", ".join([str(self[self._get_tuple_index(e)]) for e in range(i, j)])+"]"
+                return "["+", ".join([printer._print(self[self._get_tuple_index(e)]) for e in range(i, j)])+"]"
 
             sh //= shape_left[0]
             return "[" + ", ".join([f(sh, shape_left[1:], i+e*sh, i+(e+1)*sh) for e in range(shape_left[0])]) + "]" # + "\n"*len(shape_left)
 
         if self.rank() == 0:
-            return self[()].__str__()
+            return printer._print(self[()])
 
         return f(self._loop_size, self.shape, 0, self._loop_size)
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -305,9 +305,6 @@ class NDimArray(Printable):
 
         return f(self._loop_size, self.shape, 0, self._loop_size)
 
-    def __repr__(self):
-        return self.__str__()
-
     def tolist(self):
         """
         Converting MutableDenseNDimArray to one-dim list


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Cleanup, bugfix, and regression fix in a single PR:

* Remove unnecessary print overrides for NDimArray subclasses (like #19899 but far simpler)
* Respect printer settings for elements of NDimArray
* Fix the regression described in https://github.com/sympy/sympy/pull/19425/files#r466367402

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * When printing, `NDimArray` now respects keyword-arguments to `sstr`
<!-- END RELEASE NOTES -->