### PR TITLE
printing.preview: Fix regressions introduced in gh-18392

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 import io
-from io import BytesIO
 import os
 from os.path import join
 import shutil
@@ -136,11 +135,9 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             except KeyError:
                 raise SystemError("Invalid output format: %s" % output)
     else:
-        if viewer == "StringIO":
-            viewer = "BytesIO"
-            if outputbuffer is None:
-                raise ValueError("outputbuffer has to be a BytesIO "
-                                 "compatible object if viewer=\"StringIO\"")
+        if viewer == "file":
+            if filename is None:
+                raise ValueError("filename has to be specified if viewer=\"file\"")
         elif viewer == "BytesIO":
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a BytesIO "
@@ -250,13 +247,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         src = "texput.%s" % (output)
 
         if viewer == "file":
-            if filename is None:
-                buffer = BytesIO()
-                with open(join(workdir, src), 'rb') as fh:
-                    buffer.write(fh.read())
-                return buffer
-            else:
-                shutil.move(join(workdir,src), filename)
+            shutil.move(join(workdir, src), filename)
         elif viewer == "BytesIO":
             with open(join(workdir, src), 'rb') as fh:
                 outputbuffer.write(fh.read())


### PR DESCRIPTION
These were:

* `viewer="StringIO"` being undeprecated again
* `viewer="file"` becoming broken

With thanks to @MuellerSeb

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Regression is from gh-18392

This is a backport of #19905

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
   - Calling `preview` with `viewer="file"` no longer looks for a `file` executable (a regression in 1.6.0)
   - The deprecation of calling `preview` with `viewer="StringIO"` is now expired instead of forgotten  (a regression in 1.6.0)
<!-- END RELEASE NOTES -->