### PR TITLE
Remove BasicMeta/ordering of classes (redux)

### DIFF
--- a/doc/man/isympy.1
+++ b/doc/man/isympy.1
@@ -112,7 +112,7 @@ in the printed expression will have no canonical order
 Example: isympy -o rev-lax
 
 \fIORDER\fR must be one of 'lex', 'rev-lex', 'grlex',
-\&'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.
+\&'rev-grlex', 'grevlex', 'rev-grevlex', or 'none'.
 .TP
 \*(T<\fB\-q\fR\*(T>, \*(T<\fB\-\-quiet\fR\*(T>
 Print only Python's and SymPy's versions to stdout at startup, and nothing else.

--- a/doc/man/isympy.xml
+++ b/doc/man/isympy.xml
@@ -249,7 +249,7 @@ this will generate isympy.1 in the current directory. -->
 					<para>Example: isympy -o rev-lax</para>
 
                     <para><replaceable class="parameter">ORDER</replaceable> must be one of 'lex', 'rev-lex', 'grlex',
-                    'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.</para>
+                    'rev-grlex', 'grevlex', 'rev-grevlex', or 'none'.</para>
 				</listitem>
             </varlistentry>
             <varlistentry>

--- a/isympy.py
+++ b/isympy.py
@@ -75,7 +75,7 @@ COMMAND LINE OPTIONS
         $isympy -o rev-lex
 
     ORDER must be one of 'lex', 'rev-lex', 'grlex', 'rev-grlex',
-    'grevlex', 'rev-grevlex', 'old', or 'none'.
+    'grevlex', 'rev-grevlex', or 'none'.
 
     Note that for very large expressions, ORDER='none' may speed up
     printing considerably but the terms will have no canonical order.
@@ -231,7 +231,7 @@ def main():
         default=None,
         metavar='ORDER',
         choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
-        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none; defaults to lex')
+        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | none; defaults to lex')
 
     parser.add_argument(
         '-q', '--quiet',
@@ -329,6 +329,8 @@ def main():
         args['pretty_print'] = False
 
     if options.order is not None:
+        if options.order == 'old':
+            parser.error('-o old is no longer supported')
         args['order'] = options.order
 
     args['quiet'] = options.quiet

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,6 +1,4 @@
 from collections import defaultdict
-from functools import cmp_to_key
-from .basic import Basic
 from .compatibility import reduce, is_sequence, default_sort_key
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
@@ -9,10 +7,6 @@ from .operations import AssocOp
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
-
-
-# Key for sorting commutative args in canonical order
-_args_sortkey = cmp_to_key(Basic.compare)
 
 
 def _addsort(args):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from functools import cmp_to_key
 from .basic import Basic
-from .compatibility import reduce, is_sequence
+from .compatibility import reduce, is_sequence, default_sort_key
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
@@ -10,13 +10,14 @@ from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
 
+
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)
 
 
 def _addsort(args):
     # in-place sorting of args
-    args.sort(key=_args_sortkey)
+    args.sort(key=default_sort_key)
 
 
 def _unevaluated_Add(*args):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2,9 +2,8 @@
 from collections import defaultdict
 from itertools import chain, zip_longest
 
-from .assumptions import ManagedProperties
+from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
-from .core import BasicMeta
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import iterable, ordered, Mapping
 from .singleton import S

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -2,8 +2,9 @@
 from collections import defaultdict
 from itertools import chain, zip_longest
 
-from .assumptions import BasicMeta, ManagedProperties
+from .assumptions import ManagedProperties
 from .cache import cacheit
+from .core import BasicMeta
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import iterable, ordered, Mapping
 from .singleton import S

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -182,78 +182,6 @@ class Basic(Printable, metaclass=ManagedProperties):
         """
         return {}
 
-    def compare(self, other):
-        """
-        Return -1, 0, 1 if the object is smaller, equal, or greater than other.
-
-        Not in the mathematical sense. If the object is of a different type
-        from the "other" then their classes are ordered according to
-        the sorted_classes list.
-
-        Examples
-        ========
-
-        >>> from sympy.abc import x, y
-        >>> x.compare(y)
-        -1
-        >>> x.compare(x)
-        0
-        >>> y.compare(x)
-        1
-
-        """
-        # all redefinitions of __cmp__ method should start with the
-        # following lines:
-        if self is other:
-            return 0
-        n1 = self.__class__
-        n2 = other.__class__
-        c = (n1 > n2) - (n1 < n2)
-        if c:
-            return c
-        #
-        st = self._hashable_content()
-        ot = other._hashable_content()
-        c = (len(st) > len(ot)) - (len(st) < len(ot))
-        if c:
-            return c
-        for l, r in zip(st, ot):
-            l = Basic(*l) if isinstance(l, frozenset) else l
-            r = Basic(*r) if isinstance(r, frozenset) else r
-            if isinstance(l, Basic):
-                c = l.compare(r)
-            else:
-                c = (l > r) - (l < r)
-            if c:
-                return c
-        return 0
-
-    @staticmethod
-    def _compare_pretty(a, b):
-        from sympy.series.order import Order
-        if isinstance(a, Order) and not isinstance(b, Order):
-            return 1
-        if not isinstance(a, Order) and isinstance(b, Order):
-            return -1
-
-        if a.is_Rational and b.is_Rational:
-            l = a.p * b.q
-            r = b.p * a.q
-            return (l > r) - (l < r)
-        else:
-            from sympy.core.symbol import Wild
-            p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
-            r_a = a.match(p1 * p2**p3)
-            if r_a and p3 in r_a:
-                a3 = r_a[p3]
-                r_b = b.match(p1 * p2**p3)
-                if r_b and p3 in r_b:
-                    b3 = r_b[p3]
-                    c = Basic.compare(a3, b3)
-                    if c != 0:
-                        return c
-
-        return Basic.compare(a, b)
 
     @classmethod
     def fromiter(cls, args, **assumptions):
@@ -313,8 +241,6 @@ class Basic(Printable, metaclass=ManagedProperties):
         """Return a boolean indicating whether a == b on the basis of
         their symbolic trees.
 
-        This is the same as a.compare(b) == 0 but faster.
-
         Notes
         =====
 
@@ -356,13 +282,8 @@ class Basic(Printable, metaclass=ManagedProperties):
         return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
-        """``a != b``  -> Compare two symbolic trees and see whether they are different
-
-        this is the same as:
-
-        ``a.compare(b) != 0``
-
-        but faster
+        """
+        ``a != b``  -> Compare two symbolic trees and see whether they are different
         """
         return not self == other
 

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -102,3 +102,6 @@ class BasicMeta(type):
         if cls.__cmp__(other) == 1:
             return True
         return False
+
+class BasicMeta(type):
+    pass

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -102,6 +102,3 @@ class BasicMeta(type):
         if cls.__cmp__(other) == 1:
             return True
         return False
-
-class BasicMeta(type):
-    pass

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1062,6 +1062,8 @@ class Expr(Basic, EvalfMixin):
 
     def as_ordered_factors(self, order=None):
         """Return list of ordered factors (if Mul) else [self]."""
+        if order == 'old':
+            raise ValueError("'old' ordering has been removed")
         return [self]
 
     def as_poly(self, *gens, **args):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from functools import cmp_to_key
 import operator
 
 from .sympify import sympify
@@ -25,7 +24,6 @@ class NC_Marker:
     is_commutative = False
 
 # Key for sorting commutative args in canonical order
-_args_sortkey = cmp_to_key(Basic.compare)
 def _mulsort(args):
     # in-place sorting of args
     args.sort(key=default_sort_key)
@@ -1892,6 +1890,8 @@ class Mul(Expr, AssocOp):
         [2, x, y, sin(x), cos(x)]
 
         """
+        if order == 'old':
+            raise ValueError("'old' ordering has been removed")
         cpart, ncpart = self.args_cnc()
         cpart.sort(key=lambda expr: expr.sort_key(order=order))
         return cpart + ncpart

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -8,7 +8,7 @@ from .singleton import S
 from .operations import AssocOp
 from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group, fuzzy_and
-from .compatibility import reduce
+from .compatibility import reduce, default_sort_key
 from .expr import Expr
 from .parameters import global_parameters
 
@@ -24,12 +24,11 @@ class NC_Marker:
 
     is_commutative = False
 
-
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)
 def _mulsort(args):
     # in-place sorting of args
-    args.sort(key=_args_sortkey)
+    args.sort(key=default_sort_key)
 
 
 def _unevaluated_Mul(*args):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,5 +1,5 @@
 from sympy import (Basic, Symbol, sin, cos, atan, exp, sqrt, Rational,
-        Float, re, pi, sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols,
+        Float, re, pi, sympify, Add, Mul, Pow, Mod, I, log, S, Max, Min, symbols,
         oo, zoo, Integer, sign, im, nan, Dummy, factorial, comp, floor, Poly,
         FiniteSet
 )
@@ -2015,13 +2015,11 @@ def test_issue_6040():
 
 
 def test_issue_6082():
-    # Comparison is symmetric
-    assert Basic.compare(Max(x, 1), Max(x, 2)) == \
-      - Basic.compare(Max(x, 2), Max(x, 1))
-    # Equal expressions compare equal
-    assert Basic.compare(Max(x, 1), Max(x, 1)) == 0
-    # Basic subtypes (such as Max) compare different than standard types
-    assert Basic.compare(Max(1, x), frozenset((1, x))) != 0
+    # Original issue was with Basic.compare, which is gone. Test the original
+    # expression from the issue doesn't fail.
+    a = Symbol('a')
+    assert Max(a, 1)*Max(a, 2) == Max(a, 2)*Max(a, 1)
+    assert Min(a, 1)*Min(a, 2) == Min(a, 2)*Min(a, 1)
 
 
 def test_issue_6077():

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -348,7 +348,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
-        old, which is used for compatibility reasons and for long expressions;
         None, which sets it to lex.
     use_unicode : boolean or None, default=None
         If True, use unicode characters;
@@ -441,9 +440,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> init_printing(order='grevlex') # doctest: +SKIP
     >>> str(y * x**2 + x * y**2) # doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_printing(order='old') # doctest: +SKIP
-    >>> str(x**2 + y**2 + x + y) # doctest: +SKIP
-    x**2 + x + y**2 + y
     >>> init_printing(num_columns=10) # doctest: +SKIP
     >>> x**2 + x + y**2 + y # doctest: +SKIP
     x + y +
@@ -484,6 +480,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     import sys
     from sympy.printing.printer import Printer
 
+    if order == 'old':
+        raise ValueError("'old' ordering has been removed")
     if pretty_print:
         if pretty_printer is not None:
             stringify_func = pretty_printer

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -316,7 +316,6 @@ def init_session(ipython=None, pretty_print=True, order=None,
         lex (default), which is lexographic order;
         grlex, which is graded lexographic order;
         grevlex, which is reversed graded lexographic order;
-        old, which is used for compatibility reasons and for long expressions;
         None, which sets it to lex.
     use_unicode: boolean or None
         If True, use unicode characters;
@@ -381,9 +380,6 @@ def init_session(ipython=None, pretty_print=True, order=None,
     >>> init_session(order='grevlex') #doctest: +SKIP
     >>> y * x**2 + x * y**2 #doctest: +SKIP
     x**2*y + x*y**2
-    >>> init_session(order='old') #doctest: +SKIP
-    >>> x**2 + y**2 + x + y #doctest: +SKIP
-    x + y + x**2 + y**2
     >>> theta = Symbol('theta') #doctest: +SKIP
     >>> theta #doctest: +SKIP
     theta

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy import S, Expr, Mul, Integer
+from sympy import S, Expr, Mul, Integer, default_sort_key
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.operator import Operator
@@ -101,7 +101,7 @@ class AntiCommutator(Expr):
 
         # Canonical ordering of arguments
         #The Commutator [A,B] is on canonical form if A < B.
-        if a.compare(b) == 1:
+        if sorted([a, b], key=default_sort_key) == [a, b]:
             return cls(b, a)
 
     def doit(self, **hints):

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy import S, Expr, Mul, Add, Pow
+from sympy import S, Expr, Mul, Add, Pow, default_sort_key
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.dagger import Dagger
@@ -114,7 +114,7 @@ class Commutator(Expr):
 
         # Canonical ordering of arguments
         # The Commutator [A, B] is in canonical form if A < B.
-        if a.compare(b) == 1:
+        if sorted([a, b], key=default_sort_key) == [a, b]:
             return S.NegativeOne*cls(b, a)
 
     def _expand_pow(self, A, B, sign):

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -20,7 +20,7 @@ import random
 
 from sympy import Add, I, Integer, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence, unicode
+from sympy.core.compatibility import is_sequence, unicode, default_sort_key
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -34,7 +34,6 @@ from sympy.physics.quantum.matrixcache import matrix_cache
 
 from sympy.matrices.matrices import MatrixBase
 
-from sympy.utilities import default_sort_key
 
 __all__ = [
     'Gate',
@@ -1222,10 +1221,10 @@ def gate_sort(circuit):
                 first_base, first_exp = circ_array[i].as_base_exp()
                 second_base, second_exp = circ_array[i + 1].as_base_exp()
 
-                # Use sympy's hash based sorting. This is not mathematical
-                # sorting, but is rather based on comparing hashes of objects.
-                # See Basic.compare for details.
-                if first_base.compare(second_base) > 0:
+                # Use sympy's canonical sorting. This is not mathematical
+                # sorting, but an arbitrary canonical sorting of the
+                # expression trees.
+                if sorted([first_base, second_base], key=default_sort_key) == [first_base, second_base]:
                     if Commutator(first_base, second_base).doit() == 0:
                         new_args = (circuit.args[:i] + (circuit.args[i + 1],) +
                                    (circuit.args[i],) + circuit.args[i + 2:])

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -466,8 +466,8 @@ class CodePrinter(StrPrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -139,8 +139,8 @@ class JuliaCodePrinter(CodePrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -508,8 +508,8 @@ class LatexPrinter(Printer):
             if not expr.is_Mul:
                 return str(self._print(expr))
             else:
-                if self.order not in ('old', 'none'):
-                    args = expr.as_ordered_factors()
+                if self.order != 'none':
+                    args = expr.as_ordered_factors(self.order)
                 else:
                     args = list(expr.args)
 
@@ -1680,7 +1680,7 @@ class LatexPrinter(Printer):
 
         args = expr.args
         if isinstance(args[0], Mul):
-            args = args[0].as_ordered_factors() + list(args[1:])
+            args = args[0].as_ordered_factors(self.order) + list(args[1:])
         else:
             args = list(args)
 
@@ -2772,10 +2772,9 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
         ``dot``, or ``times``.
     order: string, optional
         Any of the supported monomial orderings (currently ``lex``, ``grlex``,
-        or ``grevlex``), ``old``, and ``none``. This parameter does nothing for
-        Mul objects. Setting order to ``old`` uses the compatibility ordering
-        for Add defined in Printer. For very large expressions, set the
-        ``order`` keyword to ``none`` if speed is a concern.
+        or ``grevlex``), and ``none``. This parameter does nothing for
+        Mul objects. For very large expressions, set the ``order`` keyword to
+        ``none`` if speed is a concern.
     symbol_names : dictionary of strings mapped to symbols, optional
         Dictionary of symbols and the custom strings they should be emitted as.
     root_notation : boolean, optional

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -223,7 +223,7 @@ class MathMLContentPrinter(MathMLPrinterBase):
             # think a coeff of 1 can remain
             return self._print(terms[0])
 
-        if self.order != 'old':
+        if self.order != 'none':
             terms = Mul._from_args(terms).as_ordered_factors()
 
         x = self.dom.createElement('apply')
@@ -684,8 +684,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             if coeff is S.One and len(terms) == 1:
                 mrow.appendChild(self._print(terms[0]))
                 return mrow
-            if self.order != 'old':
-                terms = Mul._from_args(terms).as_ordered_factors()
+            if self.order != 'none':
+                terms = Mul._from_args(terms).as_ordered_factors(self.order)
 
             if coeff != 1:
                 x = self._print(coeff)
@@ -1780,7 +1780,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         x = self.dom.createElement('mrow')
         args = expr.args
         if isinstance(args[0], Mul):
-            args = args[0].as_ordered_factors() + list(args[1:])
+            args = args[0].as_ordered_factors(self.order) + list(args[1:])
         else:
             args = list(args)
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -158,7 +158,7 @@ class OctaveCodePrinter(CodePrinter):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
+        if self.order != 'none':
             args = expr.as_ordered_factors()
         else:
             # use make_args in case expr was something like -x -> x

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1858,8 +1858,8 @@ class PrettyPrinter(Printer):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        if self.order not in ('old', 'none'):
-            args = product.as_ordered_factors()
+        if self.order != 'none':
+            args = product.as_ordered_factors(self.order)
         else:
             args = list(product.args)
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -338,7 +338,7 @@ class Printer(object):
         order = order or self.order
 
         if order == 'old':
-            return sorted(Add.make_args(expr), key=cmp_to_key(Basic._compare_pretty))
+            raise ValueError("'old' ordering has been removed")
         elif order == 'none':
             return list(expr.args)
         else:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -202,8 +202,8 @@ class ReprPrinter(Printer):
         return "nan"
 
     def _print_Mul(self, expr, order=None):
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -296,8 +296,8 @@ class StrPrinter(Printer):
 
         pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
-        if self.order not in ('old', 'none'):
-            args = expr.as_ordered_factors()
+        if self.order != 'none':
+            args = expr.as_ordered_factors(self.order)
         else:
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -47,7 +47,7 @@ def test_printmethod():
 def test_Add():
     sT(x + y, "Add(Symbol('x'), Symbol('y'))")
     assert srepr(x**2 + 1, order='lex') == "Add(Pow(Symbol('x'), Integer(2)), Integer(1))"
-    assert srepr(x**2 + 1, order='old') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
+    raises(ValueError, lambda: srepr(x**2 + 1, order='old'))
     assert srepr(sympify('x + 3 - 2', evaluate=False), order='none') == "Add(Symbol('x'), Integer(3), Mul(Integer(-1), Integer(2)))"
 
 
@@ -204,7 +204,7 @@ def test_settins():
 
 def test_Mul():
     sT(3*x**3*y, "Mul(Integer(3), Pow(Symbol('x'), Integer(3)), Symbol('y'))")
-    assert srepr(3*x**3*y, order='old') == "Mul(Integer(3), Symbol('y'), Pow(Symbol('x'), Integer(3)))"
+    raises(ValueError, lambda: srepr(3*x**3*y, order='old'))
     assert srepr(sympify('(x+4)*2*x*7', evaluate=False), order='none') == "Mul(Add(Symbol('x'), Integer(4)), Integer(2), Symbol('x'), Integer(7))"
 
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -83,13 +83,12 @@ from sympy.utilities.iterables import sift
 
 # function to define "buckets"
 def _mod1(x):
-    # TODO see if this can work as Mod(x, 1); this will require
-    # different handling of the "buckets" since these need to
-    # be sorted and that fails when there is a mixture of
-    # integers and expressions with parameters. With the current
-    # Mod behavior, Mod(k, 1) == Mod(1, 1) == 0 if k is an integer.
-    # Although the sorting can be done with Basic.compare, this may
-    # still require different handling of the sorted buckets.
+    # TODO see if this can work as Mod(x, 1); this will require different
+    # handling of the "buckets" since these need to be sorted and that fails
+    # when there is a mixture of integers and expressions with parameters.
+    # With the current Mod behavior, Mod(k, 1) == Mod(1, 1) == 0 if k is an
+    # integer. Although the sorting can be done with default_sort_key, this
+    # may still require different handling of the sorted buckets.
     if x.is_Number:
         return Mod(x, 1)
     c, x = x.as_coeff_Add()


### PR DESCRIPTION
I have a lull in my work and will have little more time to work on SymPy, so I thought I would try a redux of #13059.

This removes the deprecated ordering of classes in the core. See #4269. 

The ordering of classes is non-pythonic, and unnecessarily restricted to only a subset of SymPy classes. In Python 3, it is not expected for arbitrary types to be comparable, and for places where this is used in actual comparisons like Add and Mul args ordering, we can use other orderings like `default_sort_key`. It also unnecessarily adds a metaclass to the core. This PR won't remove all metaclasses from the core because we will still have the ManagedProperties, which handles the old assumptions.

I ended up giving up on previous pull request because it was too much work. However, now that we have dropped Python 2 support, I expect this to be much easier to fix, since far fewer places in the code will actually be making use of this behavior. 

We need to be very careful about performance here, as this affects the deep core.

This is still a work in progress, so please don't merge until it is complete. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Closes #13059
Fixes #4269

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
  - Remove the deprecated sorting of classes.
<!-- END RELEASE NOTES -->