### PR TITLE
Use frozenset in meijerint _mytype

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -82,7 +82,7 @@ def _create_lookup_table(table):
     def constant(a):
         return [(a, meijerg([1], [], [], [0], z)),
                 (a, meijerg([], [1], [0], [], z))]
-    table[()] = [(a, constant(a), True, True)]
+    table[frozenset()] = [(a, constant(a), True, True)]
 
     # [P], Section 8.
 
@@ -288,16 +288,15 @@ timeit = timethis('meijerg')
 def _mytype(f, x):
     """ Create a hashable entity describing the type of f. """
     if x not in f.free_symbols:
-        return ()
+        return frozenset()
     elif f.is_Function:
-        return (type(f),)
+        return frozenset((type(f),))
     else:
         types = [_mytype(a, x) for a in f.args]
         res = []
         for t in types:
-            res += list(t)
-        res.sort()
-        return tuple(res)
+            res += frozenset(t)
+        return frozenset(res)
 
 
 class _CoeffExpValueError(ValueError):

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -12,7 +12,7 @@ _create_lookup_table(t)
 
 doc = ""
 
-for about, category in sorted(t.items()):
+for about, category in sorted(t.items(), key=lambda x: sorted(x[0], key=str)):
     if about == ():
         doc += 'Elementary functions:\n\n'
     else:


### PR DESCRIPTION
The previous behavior of sorting needed to change (sorting of types is going
away). However, not sorting is also wrong, as we need the keys to be
canonicalized. Since the order does not appear to matter (the "type" is just
used as a quick lookup before doing a full match), just use a frozenset.

This commit was originally from #13059.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is part of my work at https://github.com/sympy/sympy/pull/19907.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->