### PR TITLE
Don't create the ProductSet for Complexes at import time

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1423,7 +1423,9 @@ class Complexes(CartesianComplexRegion, metaclass=Singleton):
     is_finite_set = False
 
     # Override property from superclass since Complexes has no args
-    sets = ProductSet(S.Reals, S.Reals)
+    @property
+    def sets(self):
+        return ProductSet(S.Reals, S.Reals)
 
     def __new__(cls):
         return Set.__new__(cls)


### PR DESCRIPTION
Aside from unnecessarily slowing down the import time, this also makes it
so sympy can't be imported if creating the ProductSet fails.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is part of my work at https://github.com/sympy/sympy/pull/19907.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- other
  - Make SymPy do less at import time so that `import sympy` is faster. 
<!-- END RELEASE NOTES -->