### PR TITLE
Fix sympify -> _sympify in sympy/core/containers.py

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, MutableSet
-from sympy.core.sympify import sympify, converter
+from sympy.core.sympify import _sympify, sympify, converter, SympifyError
 from sympy.utilities.iterables import iterable
 
 class Tuple(Basic):
@@ -105,10 +105,10 @@ class Tuple(Basic):
         return tuple(a._to_mpmath(prec) for a in self.args)
 
     def __lt__(self, other):
-        return sympify(self.args < other.args)
+        return _sympify(self.args < other.args)
 
     def __le__(self, other):
-        return sympify(self.args <= other.args)
+        return _sympify(self.args <= other.args)
 
     # XXX: Basic defines count() as something different, so we can't
     # redefine it here. Originally this lead to cse() test failure.
@@ -223,7 +223,12 @@ class Dict(Basic):
 
     def __getitem__(self, key):
         """x.__getitem__(y) <==> x[y]"""
-        return self._dict[sympify(key)]
+        try:
+            key = _sympify(key)
+        except SympifyError:
+            raise KeyError(key)
+
+        return self._dict[key]
 
     def __setitem__(self, key, value):
         raise NotImplementedError("SymPy Dicts are Immutable")
@@ -262,14 +267,22 @@ class Dict(Basic):
 
     def get(self, key, default=None):
         '''Returns the value for key if the key is in the dictionary.'''
-        return self._dict.get(sympify(key), default)
+        try:
+            key = _sympify(key)
+        except SympifyError:
+            return default
+        return self._dict.get(key, default)
 
     def __contains__(self, key):
         '''D.__contains__(k) -> True if D has a key k, else False'''
-        return sympify(key) in self._dict
+        try:
+            key = _sympify(key)
+        except SympifyError:
+            return False
+        return key in self._dict
 
     def __lt__(self, other):
-        return sympify(self.args < other.args)
+        return _sympify(self.args < other.args)
 
     @property
     def _sorted_args(self):

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -149,11 +149,13 @@ def test_Dict():
     assert d[x] == 1
     assert d[y] == 2
     raises(KeyError, lambda: d[2])
+    raises(KeyError, lambda: d['2'])
     assert len(d) == 3
     assert set(d.keys()) == {x, y, z}
     assert set(d.values()) == {S.One, S(2), S(3)}
     assert d.get(5, 'default') == 'default'
-    assert x in d and z in d and not 5 in d
+    assert d.get('5', 'default') == 'default'
+    assert x in d and z in d and not 5 in d and not '5' in d
     assert d.has(x) and d.has(1)  # SymPy Basic .has method
 
     # Test input types


### PR DESCRIPTION
This also makes sure that various operations on Dict don't raise SympifyError.

This commit was originally part of #13059.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

This is part of my work at https://github.com/sympy/sympy/pull/19907.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core 
  - `Dict` operations no longer automatically converts strings into SymPy types.
  - `Dict` operations no longer raise SympifyError.
<!-- END RELEASE NOTES -->