### PR TITLE
Split the pypy tests on Travis three ways

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ matrix:
     - python: "pypy"
       env:
         - TEST_SYMPY="true"
-        - SPLIT="1/2"
+        - SPLIT="1/3"
       addons:
         apt:
           sources:
@@ -188,7 +188,17 @@ matrix:
     - python: "pypy"
       env:
         - TEST_SYMPY="true"
-        - SPLIT="2/2"
+        - SPLIT="2/3"
+      addons:
+        apt:
+          sources:
+            - pypy
+          packages:
+            - pypy3
+    - python: "pypy"
+      env:
+        - TEST_SYMPY="true"
+        - SPLIT="3/3"
       addons:
         apt:
           sources:


### PR DESCRIPTION
The current 2-way split leads to timeouts for the 1/2 split because it takes
about 50 min. to complete, which is the Travis time limit.

We should also investigate if we can make it faster, and if we get faster, we
can move back to a 2-way split.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->