### PR TITLE
lambdify loggamma now works for mpmath

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -502,6 +502,7 @@ _known_functions_mpmath = dict(_in_mpmath, **{
     'fresnelc': 'fresnelc',
     'fresnels': 'fresnels',
     'sign': 'sign',
+    'loggamma': 'loggamma',
 })
 _known_constants_mpmath = {
     'Exp1': 'e',

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -17,6 +17,7 @@ from sympy.testing.pytest import raises
 from sympy.tensor import IndexedBase
 from sympy.testing.pytest import skip
 from sympy.external import import_module
+from sympy.functions.special.gamma_functions import loggamma
 
 x, y, z = symbols('x y z')
 p = IndexedBase("p")
@@ -75,6 +76,7 @@ def test_MpmathPrinter():
     assert p.doprint(S.NaN) == 'mpmath.nan'
     assert p.doprint(S.Infinity) == 'mpmath.inf'
     assert p.doprint(S.NegativeInfinity) == 'mpmath.ninf'
+    assert p.doprint(loggamma(x)) == 'mpmath.lgamma(x)'
 
 
 def test_NumPyPrinter():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -76,7 +76,7 @@ def test_MpmathPrinter():
     assert p.doprint(S.NaN) == 'mpmath.nan'
     assert p.doprint(S.Infinity) == 'mpmath.inf'
     assert p.doprint(S.NegativeInfinity) == 'mpmath.ninf'
-    assert p.doprint(loggamma(x)) == 'mpmath.lgamma(x)'
+    assert p.doprint(loggamma(x)) == 'mpmath.loggamma(x)'
 
 
 def test_NumPyPrinter():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -905,6 +905,19 @@ def test_special_printers():
     assert isinstance(func1(), mpi)
     assert isinstance(func2(), mpi)
 
+    # To check Is lambdify loggamma works for mpmath or not
+    exp1 = lambdify(x, loggamma(x), 'mpmath')(5)
+    exp2 = lambdify(x, loggamma(x), 'mpmath')(1.8)
+    exp3 = lambdify(x, loggamma(x), 'mpmath')(15)
+    exp_ls = [exp1, exp2, exp3]
+
+    sol1 = mpmath.loggamma(5)
+    sol2 = mpmath.loggamma(1.8)
+    sol3 = mpmath.loggamma(15)
+    sol_ls = [sol1, sol2, sol3]
+
+    assert exp_ls == sol_ls
+
 
 def test_true_false():
     # We want exact is comparison here, not just ==


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixed #17411

#### Brief description of what is fixed or changed
Lambdifying an expression with loggamma doesn't work for mpmath previously but I made some fixes so that it works. File changed are pycode and test_pycode.

#### Other comments
Nan

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * The mpmath code printer now correctly prints the `loggamma` function.
* utilities
    * Lambdifying an expression with `loggamma` using mpmath no longer raises `ImportError`.
<!-- END RELEASE NOTES -->