### PR TITLE
Fix wrong result for sqrtdenest 

### DIFF
--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -442,7 +442,6 @@ def _sqrt_numeric_denest(a, b, r, d2):
 
     If it cannot be denested, it returns ``None``.
     """
-    from sympy.simplify.radsimp import radsimp
     d = sqrt(d2)
     s = a + d
     # sqrt_depth(res) <= sqrt_depth(s) + 1
@@ -452,8 +451,8 @@ def _sqrt_numeric_denest(a, b, r, d2):
     if sqrt_depth(s) < sqrt_depth(r) + 1 or (s**2).is_Rational:
         s1, s2 = sign(s), sign(b)
         if s1 == s2 == -1:
-            s1 = 1
-        res = s1 * (s + b * sqrt(r)) * radsimp(1 / sqrt(2 * s))
+            s1 = s2 = 1
+        res = (s1 * sqrt(a + d) + s2 * sqrt(a - d)) * sqrt(2) / 2
         return res.expand()
 
 

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -1,9 +1,7 @@
-from __future__ import print_function, division
-
-from sympy.core import S, sympify, Mul, Add, Expr
-from sympy.core.function import expand_mul, count_ops, _mexpand
+from sympy.core import Add, Expr, Mul, S, sympify
+from sympy.core.function import _mexpand, count_ops, expand_mul
 from sympy.core.symbol import Dummy
-from sympy.functions import sqrt, sign, root
+from sympy.functions import root, sign, sqrt
 from sympy.polys import Poly, PolynomialError
 from sympy.utilities import default_sort_key
 
@@ -439,20 +437,24 @@ def _sqrt_symbolic_denest(a, b, r):
 
 
 def _sqrt_numeric_denest(a, b, r, d2):
-    """Helper that denest expr = a + b*sqrt(r), with d2 = a**2 - b**2*r > 0
-    or returns None if not denested.
+    r"""Helper that denest
+    $\sqrt{a + b \sqrt{r}}, d^2 = a^2 - b^2 r > 0$
+
+    If it cannot be denested, it returns ``None``.
     """
-    from sympy.simplify.simplify import radsimp
-    depthr = sqrt_depth(r)
+    from sympy.simplify.radsimp import radsimp
     d = sqrt(d2)
-    vad = a + d
-    # sqrt_depth(res) <= sqrt_depth(vad) + 1
-    # sqrt_depth(expr) = depthr + 2
-    # there is denesting if sqrt_depth(vad)+1 < depthr + 2
-    # if vad**2 is Number there is a fourth root
-    if sqrt_depth(vad) < depthr + 1 or (vad**2).is_Rational:
-        vad1 = radsimp(1/vad)
-        return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
+    s = a + d
+    # sqrt_depth(res) <= sqrt_depth(s) + 1
+    # sqrt_depth(expr) = sqrt_depth(r) + 2
+    # there is denesting if sqrt_depth(s) + 1 < sqrt_depth(r) + 2
+    # if s**2 is Number there is a fourth root
+    if sqrt_depth(s) < sqrt_depth(r) + 1 or (s**2).is_Rational:
+        s1, s2 = sign(s), sign(b)
+        if s1 == s2 == -1:
+            s1 = 1
+        res = s1 * (s + b * sqrt(r)) * radsimp(1 / sqrt(2 * s))
+        return res.expand()
 
 
 def sqrt_biquadratic_denest(expr, a, b, r, d2):

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,5 +1,7 @@
-from sympy import sqrt, root, Symbol, sqrtdenest, Integral, cos, Rational, I
-from sympy.simplify.sqrtdenest import _subsets as subsets
+from sympy import (
+    sqrt, root, Symbol, sqrtdenest, Integral, cos, Rational, I, Integer)
+from sympy.simplify.sqrtdenest import (
+    _subsets as subsets, _sqrt_numeric_denest)
 from sympy.testing.pytest import slow
 
 r2, r3, r5, r6, r7, r10, r15, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 10,
@@ -17,7 +19,7 @@ def test_sqrtdenest():
          r2*sqrt(6 + 3*r7)/(2*(5 + 2*r7)**Rational(1, 4)),
         sqrt(3 + 2*r3): 3**Rational(3, 4)*(r6/2 + 3*r2/2)/3}
     for i in d:
-        assert sqrtdenest(i) == d[i]
+        assert sqrtdenest(i) == d[i], i
 
 
 def test_sqrtdenest2():
@@ -191,3 +193,13 @@ def test_sqrt_ratcomb():
 def test_issue_18041():
     e = -sqrt(-2 + 2*sqrt(3)*I)
     assert sqrtdenest(e) == -1 - sqrt(3)*I
+
+def test_issue_19914():
+    a = Integer(-8)
+    b = Integer(-1)
+    r = Integer(63)
+    d2 = a*a - b*b*r
+
+    assert _sqrt_numeric_denest(a, b, r, d2) == \
+        sqrt(14)*I/2 + 3*sqrt(2)*I/2
+    assert sqrtdenest(sqrt(-8-sqrt(63))) == sqrt(14)*I/2 + 3*sqrt(2)*I/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19914

#### Brief description of what is fixed or changed

I've used the formula `(s1 * sqrt(a + d) + s2 * sqrt(a - d)) * sqrt(2) / 2` which is a modified formula of 
![image](https://user-images.githubusercontent.com/34944973/89736119-1cbe1d80-daa2-11ea-9ba1-1124ff29cb02.png) 
that is more simpler formula than before which doesn't need much intermediate simplification calls.
Although I can't give any proof how the choice of sign works if we allow complex roots, but experimentally I think that it's working fine in any region.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- simplify
  - Fixed `sqrtdenest` giving wrong results for some forms of `sqrt(a + b*sqrt(r))`
<!-- END RELEASE NOTES -->