### PR TITLE
Added implementation for a zero-variance Normal distribution.

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2854,17 +2854,17 @@ class NormalDistribution(SingleContinuousDistribution):
 
     def pdf(self, x):
         # https://en.wikipedia.org/wiki/Normal_distribution#Zero-variance%20limit
-        if self.std == 0:
-            return DiracDelta(x - self.mean)
+        zero_var_pdf = DiracDelta(x - self.mean, H0=1)
+        positive_var_pdf = exp(-(x - self.mean)**2 / (2*self.std**2)) / (sqrt(2*pi) * self.std)
 
-        return exp(-(x - self.mean)**2 / (2*self.std**2)) / (sqrt(2*pi)*self.std)
+        return Piecewise((zero_var_pdf, self.std == 0), (positive_var_pdf, True))
 
     def _cdf(self, x):
         mean, std = self.mean, self.std
-        if std == 0:
-            return Heaviside(x - mean)
+        zero_var_cdf = Heaviside(x - mean, H0=1)
+        positive_var_cdf = erf(sqrt(2) * (-mean + x) / (2 * std)) / 2 + S.Half
 
-        return erf(sqrt(2)*(-mean + x)/(2*std))/2 + S.Half
+        return Piecewise((zero_var_cdf, self.std == 0), (positive_var_cdf, True))
 
     def _characteristic_function(self, t):
         mean, std = self.mean, self.std

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2878,18 +2878,6 @@ class NormalDistribution(SingleContinuousDistribution):
         mean, std = self.mean, self.std
         return mean + std*sqrt(2)*erfinv(2*p - 1)
 
-    def sample(self, size=(), library='scipy'):
-        if self.std == 0:
-            # Dirac Delta is not implemented in scipy so we must do sampling another way
-            # use another `sample` method instead of returning `[self.mean]*size`
-            # so that return types are consistent and doesn't break with new updates.
-            # import inside function to avoid extra overhead of the overall class.
-            from sympy.stats.frv_types import DiscreteUniform
-            # I'm not sure how else to do this. The Sampling classes are too complex for me.
-            return list(DiscreteUniform('_', [self.mean]).pspace
-                .sample(size=size, library=library).values())[0]
-
-        return super().sample(size=size, library=library)
 
 def Normal(name, mean, std):
     r"""

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2889,7 +2889,7 @@ class NormalDistribution(SingleContinuousDistribution):
             return list(DiscreteUniform('_', [self.mean]).pspace
                 .sample(size=size, library=library).values())[0]
 
-        return super(NormalDistribution, self).sample(size=size, library=library)
+        return super().sample(size=size, library=library)
 
 def Normal(name, mean, std):
     r"""

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2854,7 +2854,7 @@ class NormalDistribution(SingleContinuousDistribution):
 
     def pdf(self, x):
         # https://en.wikipedia.org/wiki/Normal_distribution#Zero-variance%20limit
-        zero_var_pdf = DiracDelta(x - self.mean, H0=1)
+        zero_var_pdf = DiracDelta(x - self.mean)
         positive_var_pdf = exp(-(x - self.mean)**2 / (2*self.std**2)) / (sqrt(2*pi) * self.std)
 
         return Piecewise((zero_var_pdf, self.std == 0), (positive_var_pdf, True))

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,8 +4,7 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re, Lambda, asin,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, erfi, besselj, besselk,
-                   DiracDelta, Heaviside)
+                   factorial, binomial, erfi, besselj, besselk)
 from sympy.external import import_module
 from sympy.functions.special.error_functions import erfinv
 from sympy.functions.special.hyper import meijerg

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -152,9 +152,12 @@ def test_cdf():
     X = Normal('x', 1, 0)
     d = cdf(X)
     assert d(0.9) == 0
-    assert d(1) == Heaviside(0)
-    assert P(X < 1) == Heaviside(0)  # probably more natural to make this 0
-    assert P(X <= 1) == Heaviside(0)  # and to make this 1
+    assert d(1) == 1
+    # The following 2 lines should produce the same result,
+    # However, P(X <= 1) integrates the pdf instead of using the cdf
+    # which it should not for computational and efficiency purposes.
+    assert P(X < 1) == Heaviside(0)
+    assert P(X <= 1) == Heaviside(0)
 
 
 def test_characteristic_function():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,7 +4,8 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re, Lambda, asin,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, erfi, besselj, besselk)
+                   factorial, binomial, erfi, besselj, besselk,
+                   DiracDelta, Heaviside)
 from sympy.external import import_module
 from sympy.functions.special.error_functions import erfinv
 from sympy.functions.special.hyper import meijerg
@@ -148,6 +149,13 @@ def test_cdf():
     Z = Exponential('z', 1)
     f = cdf(Z)
     assert f(z) == Piecewise((1 - exp(-z), z >= 0), (0, True))
+
+    X = Normal('x', 1, 0)
+    d = cdf(X)
+    assert d(0.9) == 0
+    assert d(1) == 1
+    assert P(X < 1) == 0
+    assert P(X <= 1) == 1
 
 
 def test_characteristic_function():
@@ -1328,10 +1336,11 @@ def test_prefab_sampling():
 def test_input_value_assertions():
     a, b = symbols('a b')
     p, q = symbols('p q', positive=True)
-    m, n = symbols('m n', positive=False, real=True)
+    m, n = symbols('m n', nonpositive=True)
+    i, j = symbols('i j', negative=True)
 
-    raises(ValueError, lambda: Normal('x', 3, 0))
-    raises(ValueError, lambda: Normal('x', m, n))
+    raises(ValueError, lambda: Normal('x', i, j))
+    Normal('x', m, n)  # No error raised
     Normal('X', a, p)  # No error raised
     raises(ValueError, lambda: Exponential('x', m))
     Exponential('Ex', p)  # No error raised
@@ -1572,6 +1581,7 @@ def test_sample_numpy():
     distribs_numpy = [
         Beta("B", 1, 1),
         Normal("N", 0, 1),
+        Normal("N", 1, 0),
         Gamma("G", 2, 7),
         Exponential("E", 2),
         LogNormal("LN", 0, 1),
@@ -1601,6 +1611,7 @@ def test_sample_scipy():
         Cauchy("C", 1, 1),
         Chi("C", 1),
         Normal("N", 0, 1),
+        Normal("N", 1, 0),
         Gamma("G", 2, 7),
         GammaInverse("GI", 1, 1),
         GaussianInverse("GUI", 1, 1),
@@ -1634,6 +1645,7 @@ def test_sample_pymc3():
         Beta("B", 1, 1),
         Cauchy("C", 1, 1),
         Normal("N", 0, 1),
+        Normal("N", 1, 0),
         Gamma("G", 2, 7),
         GaussianInverse("GI", 1, 1),
         Exponential("E", 2),

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -153,9 +153,6 @@ def test_cdf():
     d = cdf(X)
     assert d(0.9) == 0
     assert d(1) == 1
-    # The following 2 lines should produce the same result,
-    # However, P(X <= 1) integrates the pdf instead of using the cdf
-    # which it should not for computational and efficiency purposes.
     assert P(X < 1) == Heaviside(0)
     assert P(X <= 1) == Heaviside(0)
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -4,7 +4,7 @@ from sympy import (Symbol, Abs, exp, expint, S, pi, simplify, Interval, erf, erf
                    gamma, beta, Piecewise, Integral, sin, cos, tan, sinh, cosh,
                    besseli, floor, expand_func, Rational, I, re, Lambda, asin,
                    im, lambdify, hyper, diff, Or, Mul, sign, Dummy, Sum,
-                   factorial, binomial, erfi, besselj, besselk)
+                   factorial, binomial, erfi, besselj, besselk, Heaviside)
 from sympy.external import import_module
 from sympy.functions.special.error_functions import erfinv
 from sympy.functions.special.hyper import meijerg
@@ -152,9 +152,9 @@ def test_cdf():
     X = Normal('x', 1, 0)
     d = cdf(X)
     assert d(0.9) == 0
-    assert d(1) == 1
-    assert P(X < 1) == 0
-    assert P(X <= 1) == 1
+    assert d(1) == Heaviside(0)
+    assert P(X < 1) == Heaviside(0)  # probably more natural to make this 0
+    assert P(X <= 1) == Heaviside(0)  # and to make this 1
 
 
 def test_characteristic_function():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
One can now set the variance to `0` in the initialization of the Normal distribution like so: `Normal('X', 0, 0)`.
This should be useful for cases that use limiting normal distributions without needing a limit (particularly for the `WienerProcess`). 

A reason why a constant or a discrete distribution should not be used to do the job:
- They provide incorrect pdfs and cdfs.

Minor problem:
- `P(X == 0)` is `0` for `X = Normal('X', 0, 0)`. I'm not sure if it should be 1 since my math knowledge is not advanced enough to know whether $\int_{0}^{0} \delta(x) \text{d}x$ is 0 or 1.

#### Other comments
If I should rather make separate distribution and try to do things from there, please let me know.
Any help with the sampling function (or in general) is much appreciated. Right now, sampling feels fairly unprofessional.
Other than the 0, functionality is unchanged as long as `self.std` implements `__hash__` or `__eq__`.
If you think you can improve this, any improvement is highly welcome.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->