### PR TITLE
Allow subclasses of sympy objects to override `_repr_latex_`

### DIFF
--- a/sympy/core/_print_helpers.py
+++ b/sympy/core/_print_helpers.py
@@ -4,8 +4,6 @@ Base class to provide str and repr hooks that `init_printing` can overwrite.
 This is exposed publicly in the `printing.defaults` module,
 but cannot be defined there without causing circular imports.
 """
-from typing import Any
-
 
 class Printable:
     """
@@ -27,10 +25,27 @@ class Printable:
 
     __repr__ = __str__
 
-    # We don't define _repr_png_ here because it would add a large amount of
+    def _repr_disabled(self):
+        """
+        No-op repr function used to disable jupyter display hooks.
+
+        When :func:`sympy.init_printing` is used to disable certain display
+        formats, this function is copied into the appropriate ``_repr_*_``
+        attributes.
+
+        While we could just set the attributes to `None``, doing it this way
+        allows derived classes to call `super()`.
+        """
+        return None
+
+    # We don't implement _repr_png_ here because it would add a large amount of
     # data to any notebook containing SymPy expressions, without adding
     # anything useful to the notebook. It can still enabled manually, e.g.,
     # for the qtconsole, with init_printing().
+    _repr_png_ = _repr_disabled
+
+    _repr_svg_ = _repr_disabled
+
     def _repr_latex_(self):
         """
         IPython/Jupyter LaTeX printing
@@ -43,5 +58,3 @@ class Printable:
         from sympy.printing.latex import latex
         s = latex(self, mode='plain')
         return "$\\displaystyle %s$" % s
-
-    _repr_latex_orig = _repr_latex_  # type: Any

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -190,3 +190,28 @@ def test_matplotlib_bad_latex():
     # issue 9799
     app.run_cell("from sympy import Piecewise, Symbol, Eq")
     app.run_cell("x = Symbol('x'); pw = format(Piecewise((1, Eq(x, 0)), (0, True)))")
+
+
+def test_override_repr_latex():
+    # Initialize and setup IPython session
+    app = init_ipython_session()
+    app.run_cell("import IPython")
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("inst = ip.instance()")
+    app.run_cell("format = inst.display_formatter.format")
+    app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
+    app.run_cell("from sympy import init_printing")
+    app.run_cell("from sympy import Symbol")
+    app.run_cell("init_printing(use_latex=True)")
+    app.run_cell("""\
+    class SymbolWithOverload(Symbol):
+        def _repr_latex_(self):
+            return r"Hello " + super()._repr_latex_() + " world"
+    """)
+    app.run_cell("a = format(SymbolWithOverload('s'))")
+
+    if int(ipython.__version__.split(".")[0]) < 1:
+        latex = app.user_ns['a']['text/latex']
+    else:
+        latex = app.user_ns['a'][0]['text/latex']
+    assert latex == r'Hello $\displaystyle s$ world'


### PR DESCRIPTION
The previous behavior was to completely ignore this hook once `init_printing` had been called, which was surprising to the user.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
This fixes an issue related to #10062, but only for subclasses of sympy types.

#### Brief description of what is fixed or changed
`init_printing()` no longer causes `_repr_latex_` methods defined on `Printable` subclasses to be completely ignored. The rules in IPython for looking up magic methods are currently (https://github.com/ipython/ipython/issues/8938):
* Walk the mro for explicitly-registered printers
* Walk the mro for method-registered printers

But would make more sense as:
* Walk the mro for:
   * explicitly-registered printers
   * method-registered printers

Since this probably won't change any time soon, the workaround is to register printers for `Printable` via methods not explicit hooks - this allows users to override them if they so wish.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* interactive
   * The `_repr_latex_`, `_repr_svg_`, and `_repr_png_` methods of subclasses of sympy objects are no longer discarded when `init_printing()` is called.
<!-- END RELEASE NOTES -->