### PR TITLE
Fix docs deployment in the release script

### DIFF
--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -862,30 +862,15 @@ def _update_docs(docs_location=None):
 
     git pull
 
-    # See the README of the docs repo. We have to remove the old redirects,
-    # move in the new docs, and create redirects.
-    print("Removing redirects from previous version")
-    rm -r @(previous_version)
-    print("Moving previous latest docs to old version")
-    mv latest @(previous_version)
-
     print("Unzipping docs into repo")
     unzip @(docs_zip) > /dev/null
-    mv @(get_tarball_name('html-nozip')) @(version)
-
-    print("Writing new version to releases.txt")
-    with open(os.path.join(docs_location, "releases.txt"), 'a') as f:
-        f.write("{version}:SymPy {version}\n".format(version=current_version))
+    mv @(get_tarball_name('html-nozip')) latest
 
     print("Generating indexes")
     ./generate_indexes.py
-    mv @(current_version) latest
-
-    print("Generating redirects")
-    ./generate_redirects.py latest @(current_version)
 
     print("Committing")
-    git add -A @(version) latest
+    git add -A latest
     git commit -a -m @('Updating docs to {version}'.format(version=current_version))
 
     print("Pushing")

--- a/release/update_docs.py
+++ b/release/update_docs.py
@@ -46,21 +46,14 @@ def update_docs(sympy_doc_git, doc_html_zip, version, push):
     # We started with a clean tree so restore it on error
     with git_rollback_on_error(sympy_doc_git, branch='gh-pages') as run:
 
-        # Update releases.txt file
-        update_releases_txt(sympy_doc_git, version)
-        run('git', 'diff') # Show change to releases.txt
-        run('git', 'add', 'releases.txt')
-        run('git', 'commit', '-m', 'Add sympy %s to releases.txt' % version)
-
         # Delete docs for the last version
         run('git', 'rm', '-rf', 'latest')
 
         # Extract new docs in replacement
-        extract_docs(sympy_doc_git, doc_html_zip, version)
+        extract_docs(sympy_doc_git, doc_html_zip)
 
         # Commit new docs
         run('git', 'add', 'latest')
-        run('git', 'add', version)
         run('git', 'commit', '-m', 'Add sympy %s docs' % version)
 
         # Update indexes
@@ -105,26 +98,7 @@ def git_rollback_on_error(gitroot_path, branch='master'):
         run('git', 'reset', '--hard', sha_start)
         raise e from None
 
-
-def update_releases_txt(sympy_doc_git, version):
-    """Add line to the releases.txt file"""
-
-    print()
-    print("Updating releases.txt")
-    print()
-
-    releases_txt_path = join(sympy_doc_git, 'releases.txt')
-
-    with open(releases_txt_path) as fin:
-        lines = fin.readlines()
-
-    lines += ["{0}:SymPy {0}\n".format(version)]
-
-    with open(releases_txt_path, "w") as fout:
-        fout.writelines(lines)
-
-
-def extract_docs(sympy_doc_git, doc_html_zip, version):
+def extract_docs(sympy_doc_git, doc_html_zip):
 
     subdirname = splitext(basename(doc_html_zip))[0]
 
@@ -140,14 +114,6 @@ def extract_docs(sympy_doc_git, doc_html_zip, version):
         srcpath = join(tempdir, subdirname)
         dstpath = join(sympy_doc_git, 'latest')
         copytree(srcpath, dstpath)
-
-        print()
-        print('Copying to sympy_doc/%s' % version)
-        print()
-        srcpath = join(tempdir, subdirname)
-        dstpath = join(sympy_doc_git, version)
-        copytree(srcpath, dstpath)
-
 
 if __name__ == "__main__":
     main(*sys.argv[1:])


### PR DESCRIPTION
We no longer serve old versions of the docs in the documentation.

See also https://github.com/sympy/sympy_doc/pull/45.

Fixes #19839.

Note that this is untested. I think we can't really test this fully until we do another release. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->