### PR TITLE
Simplifies formula for real_root

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -5,7 +5,6 @@ from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
     ArgumentIndexError)
 from sympy.core.expr import Expr
-from sympy.core.mod import Mod
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -359,6 +359,9 @@ def real_root(arg, n=None, evaluate=None):
         #raise error if arg is not real
         if Eq(im(arg), S.Zero) == False:
             raise ValueError("The argument '%s' is not a real number." %arg)
+        if sympify(arg).is_integer and sympify(n).is_integer:
+            if arg < 0 and n % 2 == 0:
+                raise ValueError("The arguments ('%s', '%s') result in an nonreal result" %(arg, n))
         return Piecewise(
             (arg, Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
             (Mul(sign(arg), root(Abs(arg), n, evaluate=evaluate), evaluate=evaluate), True))

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -356,11 +356,12 @@ def real_root(arg, n=None, evaluate=None):
     from sympy.functions.elementary.complexes import Abs, im, sign
     from sympy.functions.elementary.piecewise import Piecewise
     if n is not None:
+        #raise error if arg is not real
+        if Eq(im(arg), S.Zero) == False:
+            raise ValueError("The argument '%s' is not a real number." %arg)
         return Piecewise(
-            (root(arg, n, evaluate=evaluate), Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
-            (Mul(sign(arg), root(Abs(arg), n, evaluate=evaluate), evaluate=evaluate),
-            And(Eq(im(arg), S.Zero), Eq(Mod(n, 2), S.One))),
-            (root(arg, n, evaluate=evaluate), True))
+            (arg, Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
+            (Mul(sign(arg), root(Abs(arg), n, evaluate=evaluate), evaluate=evaluate), True))
     rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,
                       lambda x:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -362,7 +362,7 @@ def real_root(arg, n=None, evaluate=None):
             if arg < 0 and n % 2 == 0:
                 raise ValueError("The arguments ('%s', '%s') result in an nonreal result" %(arg, n))
         return Piecewise(
-            (arg, Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
+            (root(arg, n, evaluate=evaluate), Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
             (Mul(sign(arg), root(Abs(arg), n, evaluate=evaluate), evaluate=evaluate), True))
     rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -316,7 +316,7 @@ def test_root():
 
 def test_real_root():
     assert real_root(-8, 3) == -2
-    assert real_root(-16, 4) == root(-16, 4)
+    assert real_root(-16, 4) == -root(16, 4)
     r = root(-7, 4)
     assert real_root(r) == r
     r1 = root(-1, 3)
@@ -330,11 +330,6 @@ def test_real_root():
     g = real_root(x, n)
     assert g.subs(dict(x=-8, n=3)) == -2
     assert g.subs(dict(x=8, n=3)) == 2
-    # give principle root if there is no real root -- if this is not desired
-    # then maybe a Root class is needed to raise an error instead
-    assert g.subs(dict(x=I, n=3)) == cbrt(I)
-    assert g.subs(dict(x=-8, n=2)) == sqrt(-8)
-    assert g.subs(dict(x=I, n=2)) == sqrt(I)
 
 
 def test_issue_11463():

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -316,7 +316,6 @@ def test_root():
 
 def test_real_root():
     assert real_root(-8, 3) == -2
-    assert real_root(-16, 4) == -root(16, 4)
     r = root(-7, 4)
     assert real_root(r) == r
     r1 = root(-1, 3)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -31,7 +31,7 @@ from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
                              piecewise_fold, Piecewise)
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
-from sympy.functions.elementary.miscellaneous import real_root
+from sympy.functions.elementary.miscellaneous import root, real_root
 from sympy.logic.boolalg import And
 from sympy.sets import (FiniteSet, EmptySet, imageset, Interval, Intersection,
                         Union, ConditionSet, ImageSet, Complement, Contains)
@@ -235,12 +235,15 @@ def _invert_real(f, g_ys, symbol):
         expo_has_sym = expo.has(symbol)
 
         if not expo_has_sym:
-            res = imageset(Lambda(n, real_root(n, expo)), g_ys)
+            if expo % 2 == 1 and expo > 0:
+                res = imageset(Lambda(n, real_root(n, expo)), g_ys)
+            else:
+                res = imageset(Lambda(n, root(n, expo)), g_ys)
             if expo.is_rational:
                 numer, denom = expo.as_numer_denom()
                 if denom % 2 == 0:
                     base_positive = solveset(base >= 0, symbol, S.Reals)
-                    res = imageset(Lambda(n, real_root(n, expo)
+                    res = imageset(Lambda(n, root(n, expo)
                         ), g_ys.intersect(
                         Interval.Ropen(S.Zero, S.Infinity)))
                     _inv, _set = _invert_real(base, res, symbol)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -302,8 +302,9 @@ def test_solve_univariate_inequality():
     raises(NotImplementedError, lambda: isolve(Abs(x) <= n, x, relational=False))
     c1 = Dummy("c1", positive=True)
     raises(NotImplementedError, lambda: isolve(n/c1 < 0, c1))
-    n = Dummy('n', negative=True)
+    n = Dummy('n', positive=True)
     assert isolve(n/c1 > -2, c1) == (-n/2 < c1)
+    n = Dummy('n', negative=True)
     assert isolve(n/c1 < 0, c1) == True
     assert isolve(n/c1 > 0, c1) == False
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19828 

#### Brief description of what is fixed or changed
- Simplified `real_root` to return:
![image](https://user-images.githubusercontent.com/39923708/89823848-c7245800-db17-11ea-8efe-65263542d11e.png)
instead of:
![image](https://user-images.githubusercontent.com/39923708/89823923-e58a5380-db17-11ea-80f7-9ce1891aff7b.png)


-  Raised a ValueError if `x` is imaginary or if result is imaginary 

#### Other comments
- Since calling something like `real_root(-1, 2)` now raises an error instead of returning `I`,  in `sympy/solvers/solveset.py`, I changed `_invert_real()` so that it calls `real_root()` for odd, positive exponents, and `root()` otherwise.  

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->