### PR TITLE
Core: Allow Big numbers to be compared

### DIFF
--- a/sympy/codegen/tests/test_cfunctions.py
+++ b/sympy/codegen/tests/test_cfunctions.py
@@ -32,7 +32,7 @@ def test_expm1():
 def test_log1p():
     # Eval
     assert log1p(0) == 0
-    d = S(10)
+    d = S(5)
     assert expand_log(log1p(d**-1000) - log(d**1000 + 1) + log(d**1000)) == 0
 
     x = Symbol('x', real=True, finite=True)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -178,11 +178,16 @@ class Add(Expr, AssocOp):
                 c, s = o.as_coeff_Mul()
 
             # check for unevaluated Pow, e.g. 2**3 or 2**(-1/2)
+            # and add it to the sequence if and only if, the unevaluated Pow actually can be evaluated
             elif o.is_Pow:
                 b, e = o.as_base_exp()
                 if b.is_Number and (e.is_Integer or
                                    (e.is_Rational and e.is_negative)):
-                    seq.append(b**e)
+                    p = b**e
+                    if not p.is_Pow:
+                        seq.append(p)
+                    else:
+                       extra.append(p)
                     continue
                 c, s = S.One, o
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -841,7 +841,7 @@ class Expr(Basic, EvalfMixin):
             if self.is_extended_real is False:
                 return False
 
-            # check to see that we can get a value
+            # # check to see that we can get a value
             try:
                 n2 = self._eval_evalf(2)
             # XXX: This shouldn't be caught here

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -317,8 +317,13 @@ class Mul(Expr, AssocOp):
                         # combined below, but don't combine negatives unless
                         # the exponent is an integer
                         if e.is_Rational:
+
                             if e.is_Integer:
-                                coeff *= Pow(b, e)  # it is an unevaluated power
+                                c = Pow(b, e)
+                                if c.is_Number:
+                                    coeff *= c
+                                else:
+                                    c_part.append(c)
                                 continue
                             elif e.is_negative:    # also a sign of an unevaluated power
                                 seq.append(Pow(b, e))
@@ -487,12 +492,15 @@ class Mul(Expr, AssocOp):
         num_rat = []
         for e, b in comb_e.items():
             b = cls(*b)
-            if e.q == 1:
-                coeff *= Pow(b, e)
+            c = Pow(b, e)
+            if e.q == 1 and c.is_Number:
+                coeff *= c
                 continue
             if e.p > e.q:
                 e_i, ep = divmod(e.p, e.q)
-                coeff *= Pow(b, e_i)
+                c = Pow(b, e_i)
+                if c.is_Number:
+                    coeff *= Pow(b, e_i)
                 e = Rational(ep, e.q)
             num_rat.append((b, e))
         del comb_e

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -500,7 +500,7 @@ class Mul(Expr, AssocOp):
                 e_i, ep = divmod(e.p, e.q)
                 c = Pow(b, e_i)
                 if c.is_Number:
-                    coeff *= Pow(b, e_i)
+                    coeff *= c
                 e = Rational(ep, e.q)
             num_rat.append((b, e))
         del comb_e

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3893,6 +3893,18 @@ I = S.ImaginaryUnit
 def _eval_is_eq(self, other): # noqa: F811
     return False
 
+@dispatch(Number, Number)
+def _eval_is_ge(lhs, rhs):
+    if lhs.is_comparable and rhs.is_comparable:
+        dif = (lhs - rhs).evalf(2)
+
+        if not dif.is_comparable:
+            return None
+
+        if dif in (S.Infinity, S.NegativeInfinity):
+            dif = float(dif)
+        return dif >= 0
+
 def sympify_fractions(f):
     return Rational(f.numerator, f.denominator, 1)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1628,7 +1628,11 @@ class Rational(Number):
                     else:
                         return Rational(p.numerator, p.denominator, 1)
 
-                if not isinstance(p, Rational):
+
+                # if p is a Real sympy type, then go in and put it over one but not rational, we
+                # still can put it over one.
+                # allows us to handle unevaluated objects
+                if not isinstance(p, Rational) and not p is Pow:
                     raise TypeError('invalid input: %s' % p)
 
             q = 1

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1629,10 +1629,8 @@ class Rational(Number):
                         return Rational(p.numerator, p.denominator, 1)
 
 
-                # if p is a Real sympy type, then go in and put it over one but not rational, we
-                # still can put it over one.
-                # allows us to handle unevaluated objects
-                if not isinstance(p, Rational) and not p is Pow:
+                # if p is a Real sympy type but not rational, then go in and put it over one
+                if not isinstance(p, Rational):
                     raise TypeError('invalid input: %s' % p)
 
             q = 1

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1743,8 +1743,7 @@ def _eval_is_ge(a, b):
     if is_ge(a.base, S.One) and is_ge(b.base, S.One):
         base_greater = is_ge(a.base, b.base)
         exp_greater = is_ge(a.exp, b.exp)
-        if (not base_greater is None) and (not exp_greater is None):
-            return base_greater and exp_greater
+        return fuzzy_and([base_greater, exp_greater])
 
 from .add import Add
 from .numbers import Integer

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1741,8 +1741,10 @@ class Pow(Expr):
 def _eval_is_ge(a, b):
     from sympy.core.relational import is_ge
     if is_ge(a.base, S.One) and is_ge(b.base, S.One):
-        if is_ge(a.base, b.base) and is_ge(a.exp, b.exp):
-            return True
+        base_greater = is_ge(a.base, b.base)
+        exp_greater = is_ge(a.exp, b.exp)
+        if (not base_greater is None) and (not exp_greater is None):
+            return base_greater and exp_greater
 
 from .add import Add
 from .numbers import Integer

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -17,6 +17,7 @@ from mpmath.libmp import sqrtrem as mpmath_sqrtrem
 
 from math import sqrt as _sqrt
 
+from ..multipledispatch import dispatch
 
 
 def isqrt(n):
@@ -288,6 +289,10 @@ class Pow(Expr):
                 issue=19445,
                 deprecated_since_version="1.7"
             ).warn()
+
+        if e.is_Number and (not e is S.NaN) and e >= S(100):
+            if b.is_Number and (not b is S.NaN) and b >= S(100):
+                evaluate = False
 
         if evaluate:
             if e is S.ComplexInfinity:
@@ -1732,6 +1737,12 @@ class Pow(Expr):
             new_e = e.subs(n, n + step)
             return (b**(new_e - e) - 1) * self
 
+@dispatch(Pow, Pow)
+def _eval_is_ge(a, b):
+    from sympy.core.relational import is_ge
+    if is_ge(a.base, S.One) and is_ge(b.base, S.One):
+        if is_ge(a.base, b.base) and is_ge(a.exp, b.exp):
+            return True
 
 from .add import Add
 from .numbers import Integer

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1198,13 +1198,7 @@ def is_ge(lhs, rhs):
     if retval is not None:
         return retval
     else:
-        # n2 = _n2(lhs, rhs)
-        # if n2 is not None:
-        #     # use float comparison for infinity.
-        #     # otherwise get stuck in infinite recursion
-        #     if n2 in (S.Infinity, S.NegativeInfinity):
-        #         n2 = float(n2)
-        #     return _sympify(n2 >= 0)
+        
         if lhs.is_extended_real and rhs.is_extended_real:
             if (lhs.is_infinite and lhs.is_extended_positive) or (rhs.is_infinite and rhs.is_extended_negative):
                 return True

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1198,13 +1198,13 @@ def is_ge(lhs, rhs):
     if retval is not None:
         return retval
     else:
-        n2 = _n2(lhs, rhs)
-        if n2 is not None:
-            # use float comparison for infinity.
-            # otherwise get stuck in infinite recursion
-            if n2 in (S.Infinity, S.NegativeInfinity):
-                n2 = float(n2)
-            return _sympify(n2 >= 0)
+        # n2 = _n2(lhs, rhs)
+        # if n2 is not None:
+        #     # use float comparison for infinity.
+        #     # otherwise get stuck in infinite recursion
+        #     if n2 in (S.Infinity, S.NegativeInfinity):
+        #         n2 = float(n2)
+        #     return _sympify(n2 >= 0)
         if lhs.is_extended_real and rhs.is_extended_real:
             if (lhs.is_infinite and lhs.is_extended_positive) or (rhs.is_infinite and rhs.is_extended_negative):
                 return True

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1198,7 +1198,6 @@ def is_ge(lhs, rhs):
     if retval is not None:
         return retval
     else:
-        
         if lhs.is_extended_real and rhs.is_extended_real:
             if (lhs.is_infinite and lhs.is_extended_positive) or (rhs.is_infinite and rhs.is_extended_negative):
                 return True

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2078,7 +2078,7 @@ def test_issue_5160_6087_6089_6090():
 
 
 def test_float_int_round():
-    assert int(float(sqrt(10))) == int(sqrt(10))
+    assert int(float(sqrt(5))) == int(sqrt(5))
     assert int(pi**1000) % 10 == 2
     assert int(Float('1.123456789012345678901234567890e20', '')) == \
         int(112345678901234567890)

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -1,3 +1,4 @@
+from sympy import Add
 from sympy.core import (
     Basic, Rational, Symbol, S, Float, Integer, Mul, Number, Pow,
     Expr, I, nan, pi, symbols, oo, zoo, N)
@@ -234,7 +235,7 @@ def test_power_rewrite_exp():
     assert expr.rewrite(exp) == exp((6 + 7*I)*log(5))
     assert expr.rewrite(exp).expand() == 15625*exp(7*I*log(5))
 
-    assert Pow(123, 789, evaluate=False).rewrite(exp) == 123**789
+    assert Pow(12, 78, evaluate=False).rewrite(exp) == 12**78
     assert (1**I).rewrite(exp) == 1**I
     assert (0**I).rewrite(exp) == 0**I
 
@@ -555,3 +556,13 @@ def test_issue_18762():
     e, p = symbols('e p')
     g0 = sqrt(1 + e**2 - 2*e*cos(p))
     assert len(g0.series(e, 1, 3).args) == 4
+
+def test_mul_add_unevaluated():
+    m = Mul(Pow(200, 200, evaluate=False), 2)
+    assert m.args[1] == Pow(200, 200, evaluate=False)
+    a = Add(Pow(200, 200, evaluate=False), 2)
+    assert a.args[1] == Pow(200, 200, evaluate=False)
+
+def test_pow_large_comparison():
+    assert Pow(200, 300) > Pow(200, 100)
+    assert Pow(200, 300) < Pow(200, 500)


### PR DESCRIPTION
#### References to other Issues or PRs
#6835 

#### Brief description of what is fixed or changed
Fixing very large numbers not being compared,  by not forcing Pow to be evaluated in Multiplication or additions, via multiplication or addition.
If a power cannot be evaluated during Mul._flatten or Add._flatten, it will simply add it to the arguments.
Also, by blocking evalf when a Power would resulting in a floating point overflow error.

Examples:
    >>> from sympy import Pow, S
    >>> Pow(10, Pow(10, 100)) < Pow(10, Pow(10, 101))
    False

Example if we assume this blocks powers of 200 or above are to remain unevaluated.
    >>>print(Mul(Pow(200, Pow(200)), 2))
    200**200 + 2

Before the changes this would have been something like:
1.6069380442589902755419620923412e+460

#### Release Notes
<!-- BEGIN RELEASE NOTES -->

* core
    * enabled large Pow comparisons to occur.

<!-- END RELEASE NOTES -->