### PR TITLE
Fixed a bug in PermutationGroup.minimal_blocks

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2194,18 +2194,19 @@ class PermutationGroup(Basic):
                 # check if the system is minimal with
                 # respect to the already discovere ones
                 minimal = True
-                to_remove = []
+                blocks_remove_mask = [False] * len(blocks)
                 for i, r in enumerate(rep_blocks):
                     if len(r) > len(rep) and rep.issubset(r):
                         # i-th block system is not minimal
-                        del num_blocks[i], blocks[i]
-                        to_remove.append(rep_blocks[i])
+                        blocks_remove_mask[i] = True
                     elif len(r) < len(rep) and r.issubset(rep):
                         # the system being checked is not minimal
                         minimal = False
                         break
                 # remove non-minimal representative blocks
-                rep_blocks = [r for r in rep_blocks if r not in to_remove]
+                blocks = [b for i, b in enumerate(blocks) if not blocks_remove_mask[i]]
+                num_blocks = [n for i, n in enumerate(num_blocks) if not blocks_remove_mask[i]]
+                rep_blocks = [r for i, r in enumerate(rep_blocks) if not blocks_remove_mask[i]]
 
                 if minimal and num_block not in num_blocks:
                     blocks.append(block)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -905,6 +905,14 @@ def test_sylow_subgroup():
     assert G.order() % S.order() == 0
     assert G.order()/S.order() % 2 > 0
 
+    G = DihedralGroup(18)
+    S = G.sylow_subgroup(p=2)
+    assert S.order() == 4
+
+    G = DihedralGroup(50)
+    S = G.sylow_subgroup(p=2)
+    assert S.order() == 4
+
 
 @slow
 def test_presentation():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19927.


#### Brief description of what is fixed or changed
The PermutationGroup.minimal_blocks method contained a bug. It consisted in modifying a list while iterating over it. The bug caused errors in sylow_subgroup which uses that method. I fixed it.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- combinatorics
  - Fixed a bug in PermutationGroup.minimal_blocks caused by modifying a list while iterating over its indices.
<!-- END RELEASE NOTES -->