### PR TITLE
Round-trippable floats in MathML printing

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -16,7 +16,7 @@ from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer
 
 import mpmath.libmp as mlib
-from mpmath.libmp import prec_to_dps
+from mpmath.libmp import prec_to_dps, repr_dps, to_str as mlib_to_str
 
 
 class MathMLPrinterBase(Printer):
@@ -483,6 +483,12 @@ class MathMLContentPrinter(MathMLPrinterBase):
     def _print_Number(self, e):
         x = self.dom.createElement(self.mathml_tag(e))
         x.appendChild(self.dom.createTextNode(str(e)))
+        return x
+
+    def _print_Float(self, e):
+        x = self.dom.createElement(self.mathml_tag(e))
+        repr_e = mlib_to_str(e._mpf_, repr_dps(e._prec))
+        x.appendChild(self.dom.createTextNode(repr_e))
         return x
 
     def _print_Derivative(self, e):

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -2009,5 +2009,5 @@ def test_issue_17857():
 
 def test_float_roundtrip():
     x = sympify(0.8975979010256552)
-    y = sympify(mp.doprint(x).strip('</cn>'))
+    y = float(mp.doprint(x).strip('</cn>'))
     assert x == y

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -32,6 +32,7 @@ from sympy.sets.sets import FiniteSet, Union, Intersection, Complement, \
 from sympy.stats.rv import RandomSymbol
 from sympy.testing.pytest import raises
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient, Laplacian
+from sympy import sympify
 
 x, y, z, a, b, c, d, e, n = symbols('x:z a:e n')
 mp = MathMLContentPrinter()
@@ -2004,3 +2005,9 @@ def test_issue_17857():
         '<mfenced close="}" open="{"><mi>&#8230;</mi><mn>-1</mn><mn>0</mn><mn>1</mn><mi>&#8230;</mi></mfenced>'
     assert mathml(Range(oo, -oo, -1), printer='presentation') == \
         '<mfenced close="}" open="{"><mi>&#8230;</mi><mn>1</mn><mn>0</mn><mn>-1</mn><mi>&#8230;</mi></mfenced>'
+
+
+def test_float_roundtrip():
+    x = sympify(0.8975979010256552)
+    y = sympify(mp.doprint(x).strip('</cn>'))
+    assert x == y


### PR DESCRIPTION
Printing of `floats` (double-precision) to content MathML is currently not round-trippable. For example,
```python
import sympy as sp
x = sp.sympify(0.8975979010256552)
y = float(sp.mathml(x).strip('</cn>'))
x == y
```
gives `False`.
Fixed by using the same formatting method used in `ReprPrinter`.

Edit: originally hoped to fix roundtrip printing of arbitrary precision `Floats`, but later changed to a lower hanging fruit.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* printing
  * Round-trip printing of `floats` (double-precision) to content MathML.
<!-- END RELEASE NOTES -->