### PR TITLE
assorted GLSL code printing improvements

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -77,10 +77,9 @@ class CodePrinter(StrPrinter):
             The expression to be printed.
 
         assign_to : Symbol, string, MatrixSymbol, list of strings or Symbols (optional)
-            If provided, the printed code will set the expression to a variable or multiple variables.
-            variable with name ``assign_to``.
+            If provided, the printed code will set the expression to a variable or multiple variables
+            with the name or names given in ``assign_to``.
         """
-        from sympy.codegen.ast import Assignment
         from sympy.matrices.expressions.matexpr import MatrixSymbol
         from sympy.codegen.ast import CodeBlock, Assignment
 

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -44,7 +44,7 @@ class GLSLPrinter(CodePrinter):
         'mat_nested': False,
         'mat_separator': ',\n',
         'mat_transpose': False,
-        'base_type': 'float',
+        'array_type': 'float',
         'glsl_types': True,
 
         'order': None,
@@ -110,8 +110,8 @@ class GLSLPrinter(CodePrinter):
         mat_separator = self._settings['mat_separator']
         mat_transpose = self._settings['mat_transpose']
         glsl_types = self._settings['glsl_types']
-        base_type = self._settings['base_type']
-        array_constructor = Template('%s[${size}]' % base_type)
+        array_type = self._settings['array_type']
+        array_constructor = Template('%s[${size}]' % array_type)
         column_vector = (mat.rows == 1) if mat_transpose else (mat.cols == 1)
         A = mat.transpose() if mat_transpose != column_vector else mat
 
@@ -138,7 +138,7 @@ class GLSLPrinter(CodePrinter):
                     A.rows, A.cols
                 )
         elif self._settings['mat_nested']:
-            return '%s[%s][%s](\n%s\n)' % (base_type, A.rows, A.cols,
+            return '%s[%s][%s](\n%s\n)' % (array_type, A.rows, A.cols,
                 A.table(self,rowsep=mat_separator,rowstart='float[](',rowend=')')
             )
 
@@ -176,8 +176,8 @@ class GLSLPrinter(CodePrinter):
     def _print_list(self, expr):
         l = ', '.join(self._print(item) for item in expr)
         glsl_types = self._settings['glsl_types']
-        base_type = self._settings['base_type']
-        array_constructor = Template('%s[${size}]' % base_type)
+        array_type = self._settings['array_type']
+        array_constructor = Template('%s[${size}]' % array_type)
 
         if len(expr) <= 4 and glsl_types:
             return 'vec%s(%s)' % (len(expr),l)
@@ -375,8 +375,8 @@ def glsl_code(expr,assign_to=None,**settings):
         By default, this printer ignores that convention. Setting this option to
         ``True`` transposes all matrix output.
         [default=False]
-    base_type: str, optional
-        The base type for printing a GLSL array constructor.
+    array_type: str, optional
+        The GLSL array constructor type.
         [default='float']
     precision : integer, optional
         The precision for numbers such as pi [default=15].
@@ -426,9 +426,9 @@ def glsl_code(expr,assign_to=None,**settings):
        6, 7, 8, 9, 10
     ) /* a 2x5 matrix */
 
-    Any object printed by default as a GLSL float array can be printed using a
-    different array type using the ``base_type`` parameter:
-    >>> glsl_code(Matrix([1,2,3,4,5]), base_type='int')
+    The type of array constructor used to print GLSL arrays can be controlled
+    via the ``array_type`` parameter:
+    >>> glsl_code(Matrix([1,2,3,4,5]), array_type='int')
     'int[5](1, 2, 3, 4, 5)'
 
     Passing a list of strings or ``symbols`` to the ``assign_to`` parameter will yield

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -334,10 +334,15 @@ def glsl_code(expr,assign_to=None,**settings):
     expr : Expr
         A sympy expression to be converted.
     assign_to : optional
-        When given, the argument is used as the name of the variable to which
-        the expression is assigned. Can be a string, ``Symbol``,
-        ``MatrixSymbol``, or ``Indexed`` type. This is helpful in case of
-        line-wrapping, or for expressions that generate multi-line statements.
+        When given, the argument is used for naming the variable or variables
+        to which the expression is assigned. Can be a string, ``Symbol``, 
+        ``MatrixSymbol`` or ``Indexed`` type object. In cases where ``expr``
+        would be printed as an array, a list of string or ``Symbol`` objects
+        can also be passed.
+
+        This is helpful in case of line-wrapping, or for expressions that
+        generate multi-line statements.  It can also be used to spread an array-like
+        expression into multiple assignments.
     use_operators: bool, optional
         If set to False, then *,/,+,- operators will be replaced with functions
         mul, add, and sub, which must be implemented by the user, e.g. for
@@ -419,7 +424,27 @@ def glsl_code(expr,assign_to=None,**settings):
     alternative constructor by passing a template string via the ``array_constructor``
     parameter:
     >>> int_constructor = 'int[${size}]'
-    >>> glsl_code(Matrix[[1,2,3,4,5]], array_constructor=int_constructor)
+    >>> glsl_code(Matrix([1,2,3,4,5]), array_constructor=int_constructor)
+    int[5](1, 2, 3, 4, 5)
+
+    Passing a list of strings or ``symbols`` to the ``assign_to`` parameter will yield
+    a multi-line assignment for each item in an array-like expression:
+    >>> x_struct_members = symbols('x.a x.b x.c x.d')
+    >>> print(glsl_code(Matrix([1,2,3,4]), assign_to=x_struct_members))
+    x.a = 1;
+    x.b = 2;
+    x.c = 3;
+    x.d = 4;
+
+    This could be useful in cases where it's desirable to modify members of a
+    GLSL ``Struct``.  It could also be used to spread items from an array-like
+    expression into various miscellaneous assignments:
+    >>> misc_assignments = ('x[0]', 'x[1]', 'float y', 'float z')
+    >>> print(glsl_code(Matrix([1,2,3,4]), assign_to=misc_assignments))
+    x[0] = 1;
+    x[1] = 2;
+    float y = 3;
+    float z = 4;
 
     Passing ``mat_nested = True`` instead prints out nested float arrays, which are
     supported in GLSL 4.3 and above.

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -174,10 +174,12 @@ class GLSLPrinter(CodePrinter):
     def _print_list(self, expr):
         l = ', '.join(self._print(item) for item in expr)
         glsl_types = self._settings['glsl_types']
+        array_constructor = Template(self._settings['array_constructor'])
+
         if len(expr) <= 4 and glsl_types:
             return 'vec%s(%s)' % (len(expr),l)
         else:
-            return 'float[%s](%s)' % (len(expr),l)
+            return array_constructor.substitute(size=len(expr))+('(%s)' % l)
 
     _print_tuple = _print_list
     _print_Tuple = _print_list

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -400,15 +400,15 @@ def test_Matrices_1x7():
     assert gl(A) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
     assert gl(A.transpose()) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
 
-def test_Matrices_1x7_base_type_int():
+def test_Matrices_1x7_array_type_int():
     gl = glsl_code
     A = Matrix([1,2,3,4,5,6,7])
-    assert gl(A, base_type = 'int') == 'int[7](1, 2, 3, 4, 5, 6, 7)'
+    assert gl(A, array_type = 'int') == 'int[7](1, 2, 3, 4, 5, 6, 7)'
 
-def test_Tuple_base_type_custom():
+def test_Tuple_array_type_custom():
     gl = glsl_code
     A = symbols('a b c')
-    assert gl(A, base_type = 'AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
+    assert gl(A, array_type = 'AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
 
 def test_Matrices_1x7_assign_to_symbols():
     gl = glsl_code
@@ -422,18 +422,6 @@ x.d = 4;
 x.e = 5;
 x.f = 6;
 x.g = 7;'''
-
-def test_assign_to_nested_symbols():
-    gl = glsl_code
-    expr = ((1,2,3), (1,2,3))
-    assign_to = (symbols('a b c'), symbols('x y z'))
-    assert gl(expr, assign_to = assign_to) == \
-    '''a = 1;
-b = 2;
-c = 3;
-x = 1;
-y = 2;
-z = 3;'''
 
 def test_1xN_vecs():
     gl = glsl_code

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -405,6 +405,19 @@ def test_Matrices_1x7_custom_constructor():
     A = Matrix([1,2,3,4,5,6,7])
     assert gl(A, array_constructor = constructor) == 'SevenNumberStruct(1, 2, 3, 4, 5, 6, 7)'
 
+def test_Matrices_1x7_assign_to_symbols():
+    gl = glsl_code
+    A = Matrix([1,2,3,4,5,6,7])
+    assign_to = symbols('x.a x.b x.c x.d x.e x.f x.g')
+    assert gl(A, assign_to = assign_to) == \
+    '''x.a = 1;
+x.b = 2;
+x.c = 3;
+x.d = 4;
+x.e = 5;
+x.f = 6;
+x.g = 7;'''
+
 def test_1xN_vecs():
     gl = glsl_code
     for i in range(1,10):

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -400,17 +400,15 @@ def test_Matrices_1x7():
     assert gl(A) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
     assert gl(A.transpose()) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
 
-def test_Matrices_1x7_custom_constructor():
+def test_Matrices_1x7_base_type_int():
     gl = glsl_code
-    constructor = 'SevenNumberStruct'
     A = Matrix([1,2,3,4,5,6,7])
-    assert gl(A, array_constructor = constructor) == 'SevenNumberStruct(1, 2, 3, 4, 5, 6, 7)'
+    assert gl(A, base_type = 'int') == 'int[7](1, 2, 3, 4, 5, 6, 7)'
 
-def test_Tuple_custom_constructor():
+def test_Tuple_base_type_custom():
     gl = glsl_code
-    constructor = 'Abc'
     A = symbols('a b c')
-    assert gl(A, array_constructor = constructor, glsl_types=False) == 'Abc(a, b, c)'
+    assert gl(A, base_type = 'AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
 
 def test_Matrices_1x7_assign_to_symbols():
     gl = glsl_code

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -423,6 +423,18 @@ x.e = 5;
 x.f = 6;
 x.g = 7;'''
 
+def test_assign_to_nested_symbols():
+    gl = glsl_code
+    expr = ((1,2,3), (1,2,3))
+    assign_to = (symbols('a b c'), symbols('x y z'))
+    assert gl(expr, assign_to = assign_to) == \
+    '''a = 1;
+b = 2;
+c = 3;
+x = 1;
+y = 2;
+z = 3;'''
+
 def test_1xN_vecs():
     gl = glsl_code
     for i in range(1,10):

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -405,6 +405,12 @@ def test_Matrices_1x7_custom_constructor():
     A = Matrix([1,2,3,4,5,6,7])
     assert gl(A, array_constructor = constructor) == 'SevenNumberStruct(1, 2, 3, 4, 5, 6, 7)'
 
+def test_Tuple_custom_constructor():
+    gl = glsl_code
+    constructor = 'Abc'
+    A = symbols('a b c')
+    assert gl(A, array_constructor = constructor, glsl_types=False) == 'Abc(a, b, c)'
+
 def test_Matrices_1x7_assign_to_symbols():
     gl = glsl_code
     A = Matrix([1,2,3,4,5,6,7])

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -9,6 +9,7 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.matrices import Matrix, MatrixSymbol
 from sympy.core import Tuple
 from sympy import glsl_code
+import textwrap
 
 x, y, z = symbols('x,y,z')
 
@@ -23,6 +24,7 @@ def test_print_without_operators():
     assert glsl_code(x*(y+z),use_operators = False) == 'mul(x, add(y, z))'
     assert glsl_code(x*(y+z**y**0.5),use_operators = False) == 'mul(x, add(y, pow(z, sqrt(y))))'
     assert glsl_code(-x-y, use_operators=False, zero='zero()') == 'sub(zero(), add(x, y))'
+    assert glsl_code(-x-y, use_operators=False) == 'sub(0.0, add(x, y))'
 
 def test_glsl_code_sqrt():
     assert glsl_code(sqrt(x)) == "sqrt(x)"
@@ -403,25 +405,26 @@ def test_Matrices_1x7():
 def test_Matrices_1x7_array_type_int():
     gl = glsl_code
     A = Matrix([1,2,3,4,5,6,7])
-    assert gl(A, array_type = 'int') == 'int[7](1, 2, 3, 4, 5, 6, 7)'
+    assert gl(A, array_type='int') == 'int[7](1, 2, 3, 4, 5, 6, 7)'
 
 def test_Tuple_array_type_custom():
     gl = glsl_code
     A = symbols('a b c')
-    assert gl(A, array_type = 'AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
+    assert gl(A, array_type='AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
 
 def test_Matrices_1x7_assign_to_symbols():
     gl = glsl_code
     A = Matrix([1,2,3,4,5,6,7])
     assign_to = symbols('x.a x.b x.c x.d x.e x.f x.g')
-    assert gl(A, assign_to = assign_to) == \
-    '''x.a = 1;
-x.b = 2;
-x.c = 3;
-x.d = 4;
-x.e = 5;
-x.f = 6;
-x.g = 7;'''
+    assert gl(A, assign_to=assign_to) == textwrap.dedent('''\
+        x.a = 1;
+        x.b = 2;
+        x.c = 3;
+        x.d = 4;
+        x.e = 5;
+        x.f = 6;
+        x.g = 7;'''
+    )
 
 def test_1xN_vecs():
     gl = glsl_code

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -412,7 +412,7 @@ def test_Tuple_array_type_custom():
     A = symbols('a b c')
     assert gl(A, array_type='AbcType', glsl_types=False) == 'AbcType[3](a, b, c)'
 
-def test_Matrices_1x7_assign_to_symbols():
+def test_Matrices_1x7_spread_assign_to_symbols():
     gl = glsl_code
     A = Matrix([1,2,3,4,5,6,7])
     assign_to = symbols('x.a x.b x.c x.d x.e x.f x.g')
@@ -424,6 +424,76 @@ def test_Matrices_1x7_assign_to_symbols():
         x.e = 5;
         x.f = 6;
         x.g = 7;'''
+    )
+
+def test_spread_assign_to_nested_symbols():
+    gl = glsl_code
+    expr = ((1,2,3), (1,2,3))
+    assign_to = (symbols('a b c'), symbols('x y z'))
+    assert gl(expr, assign_to=assign_to) == textwrap.dedent('''\
+        a = 1;
+        b = 2;
+        c = 3;
+        x = 1;
+        y = 2;
+        z = 3;'''
+    )
+
+def test_spread_assign_to_deeply_nested_symbols():
+    gl = glsl_code
+    a, b, c, x, y, z = symbols('a b c x y z')
+    expr = (((1,2),3), ((1,2),3))
+    assign_to = (((a, b), c), ((x, y), z))
+    assert gl(expr, assign_to=assign_to) == textwrap.dedent('''\
+        a = 1;
+        b = 2;
+        c = 3;
+        x = 1;
+        y = 2;
+        z = 3;'''
+    )
+
+def test_matrix_of_tuples_spread_assign_to_symbols():
+    gl = glsl_code
+    expr = Matrix([[(1,2),(3,4)],[(5,6),(7,8)]])
+    assign_to = (symbols('a b'), symbols('c d'), symbols('e f'), symbols('g h'))
+    assert gl(expr, assign_to) == textwrap.dedent('''\
+        a = 1;
+        b = 2;
+        c = 3;
+        d = 4;
+        e = 5;
+        f = 6;
+        g = 7;
+        h = 8;'''
+    )
+
+def test_cannot_assign_to_cause_mismatched_length():
+    expr = (1, 2)
+    assign_to = symbols('x y z')
+    raises(ValueError, lambda: glsl_code(expr, assign_to))
+
+def test_matrix_4x4_assign():
+    gl = glsl_code
+    expr = MatrixSymbol('A',4,4) * MatrixSymbol('B',4,4) + MatrixSymbol('C',4,4)
+    assign_to = MatrixSymbol('X',4,4)
+    assert gl(expr, assign_to=assign_to) == textwrap.dedent('''\
+        X[0][0] = A[0][0]*B[0][0] + A[0][1]*B[1][0] + A[0][2]*B[2][0] + A[0][3]*B[3][0] + C[0][0];
+        X[0][1] = A[0][0]*B[0][1] + A[0][1]*B[1][1] + A[0][2]*B[2][1] + A[0][3]*B[3][1] + C[0][1];
+        X[0][2] = A[0][0]*B[0][2] + A[0][1]*B[1][2] + A[0][2]*B[2][2] + A[0][3]*B[3][2] + C[0][2];
+        X[0][3] = A[0][0]*B[0][3] + A[0][1]*B[1][3] + A[0][2]*B[2][3] + A[0][3]*B[3][3] + C[0][3];
+        X[1][0] = A[1][0]*B[0][0] + A[1][1]*B[1][0] + A[1][2]*B[2][0] + A[1][3]*B[3][0] + C[1][0];
+        X[1][1] = A[1][0]*B[0][1] + A[1][1]*B[1][1] + A[1][2]*B[2][1] + A[1][3]*B[3][1] + C[1][1];
+        X[1][2] = A[1][0]*B[0][2] + A[1][1]*B[1][2] + A[1][2]*B[2][2] + A[1][3]*B[3][2] + C[1][2];
+        X[1][3] = A[1][0]*B[0][3] + A[1][1]*B[1][3] + A[1][2]*B[2][3] + A[1][3]*B[3][3] + C[1][3];
+        X[2][0] = A[2][0]*B[0][0] + A[2][1]*B[1][0] + A[2][2]*B[2][0] + A[2][3]*B[3][0] + C[2][0];
+        X[2][1] = A[2][0]*B[0][1] + A[2][1]*B[1][1] + A[2][2]*B[2][1] + A[2][3]*B[3][1] + C[2][1];
+        X[2][2] = A[2][0]*B[0][2] + A[2][1]*B[1][2] + A[2][2]*B[2][2] + A[2][3]*B[3][2] + C[2][2];
+        X[2][3] = A[2][0]*B[0][3] + A[2][1]*B[1][3] + A[2][2]*B[2][3] + A[2][3]*B[3][3] + C[2][3];
+        X[3][0] = A[3][0]*B[0][0] + A[3][1]*B[1][0] + A[3][2]*B[2][0] + A[3][3]*B[3][0] + C[3][0];
+        X[3][1] = A[3][0]*B[0][1] + A[3][1]*B[1][1] + A[3][2]*B[2][1] + A[3][3]*B[3][1] + C[3][1];
+        X[3][2] = A[3][0]*B[0][2] + A[3][1]*B[1][2] + A[3][2]*B[2][2] + A[3][3]*B[3][2] + C[3][2];
+        X[3][3] = A[3][0]*B[0][3] + A[3][1]*B[1][3] + A[3][2]*B[2][3] + A[3][3]*B[3][3] + C[3][3];'''
     )
 
 def test_1xN_vecs():

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -399,6 +399,12 @@ def test_Matrices_1x7():
     assert gl(A) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
     assert gl(A.transpose()) == 'float[7](1, 2, 3, 4, 5, 6, 7)'
 
+def test_Matrices_1x7_custom_constructor():
+    gl = glsl_code
+    constructor = 'SevenNumberStruct'
+    A = Matrix([1,2,3,4,5,6,7])
+    assert gl(A, array_constructor = constructor) == 'SevenNumberStruct(1, 2, 3, 4, 5, 6, 7)'
+
 def test_1xN_vecs():
     gl = glsl_code
     for i in range(1,10):

--- a/sympy/printing/tests/test_glsl.py
+++ b/sympy/printing/tests/test_glsl.py
@@ -22,6 +22,7 @@ def test_print_without_operators():
     assert glsl_code(x*(y+z),use_operators = False) == 'mul(x, add(y, z))'
     assert glsl_code(x*(y+z),use_operators = False) == 'mul(x, add(y, z))'
     assert glsl_code(x*(y+z**y**0.5),use_operators = False) == 'mul(x, add(y, pow(z, sqrt(y))))'
+    assert glsl_code(-x-y, use_operators=False, zero='zero()') == 'sub(zero(), add(x, y))'
 
 def test_glsl_code_sqrt():
     assert glsl_code(sqrt(x)) == "sqrt(x)"


### PR DESCRIPTION
#### Brief description of what is fixed or changed
I made some improvements to the GLSL printer, along with a small improvement to the generic `codeprinter` submodule.

In `sympy.printing.codeprinter`:
- Allow custom multiline "spread" assignments when printing array-like objects, e.g.:
```
    >>> x_struct_members = symbols('x.a x.b x.c x.d')
    >>> print(glsl_code(Matrix([1,2,3,4]), assign_to=x_struct_members))
    x.a = 1;
    x.b = 2;
    x.c = 3;
    x.d = 4;
```

In `sympy.printing.glsl`:
- allow passing in a `array_type` parameter, to support printing to various GLSL array types (e.g. `float[N](...)`, `int[N](...)`)
- [bugfix] ensure that when operators are printed as functions, i.e. when `3 - x` is printed as `sub(3, x)`, that strictly negative valued expressions print correctly.  For example: `-x` will now print as `sub(0, x)`
  - allow for a custom zero expression (e.g. `zero()`) to support printing expressions of abstract GLSL types.

#### Other comments
I've included tests and inline doctest examples!

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Allow spreading assignments across multiple symbols when printing multi-member objects.
  * Support various array constructor types when printing arrays to GLSL.
  * Fixes a bug when printing negative expressions to GLSL with operators printed as functions.
  * Support a custom `0` substitution for printing expressions representing various GLSL types.
<!-- END RELEASE NOTES -->