### PR TITLE
Improvement in solveset for inequalities

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -511,7 +511,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
 
             inf, sup = domain.inf, domain.sup
             if sup - inf is S.Infinity:
-                domain = Interval(0, period, False, True)
+                domain = Interval(0, period, False, True).intersect(_domain)
+                _domain = domain
 
         if rv is None:
             n, d = e.as_numer_denom()
@@ -640,7 +641,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             sol_sets = [S.EmptySet]
 
             start = domain.inf
-            if valid(start) and start.is_finite:
+            if start in domain and valid(start) and start.is_finite:
                 sol_sets.append(FiniteSet(start))
 
             for x in reals:
@@ -663,7 +664,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 start = end
 
             end = domain.sup
-            if valid(end) and end.is_finite:
+            if end in domain and valid(end) and end.is_finite:
                 sol_sets.append(FiniteSet(end))
 
             if valid(_pt(start, end)):

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -327,19 +327,19 @@ def test_solve_univariate_inequality():
 def test_trig_inequalities():
     # all the inequalities are solved in a periodic interval.
     assert isolve(sin(x) < S.Half, x, relational=False) == \
-        Union(Interval(0, pi/6, False, True), Interval(pi*Rational(5, 6), 2*pi, True, False))
+        Union(Interval(0, pi/6, False, True), Interval.open(pi*Rational(5, 6), 2*pi))
     assert isolve(sin(x) > S.Half, x, relational=False) == \
         Interval(pi/6, pi*Rational(5, 6), True, True)
     assert isolve(cos(x) < S.Zero, x, relational=False) == \
         Interval(pi/2, pi*Rational(3, 2), True, True)
     assert isolve(cos(x) >= S.Zero, x, relational=False) == \
-        Union(Interval(0, pi/2), Interval(pi*Rational(3, 2), 2*pi))
+        Union(Interval(0, pi/2), Interval.Ropen(pi*Rational(3, 2), 2*pi))
 
     assert isolve(tan(x) < S.One, x, relational=False) == \
-        Union(Interval.Ropen(0, pi/4), Interval.Lopen(pi/2, pi))
+        Union(Interval.Ropen(0, pi/4), Interval.open(pi/2, pi))
 
     assert isolve(sin(x) <= S.Zero, x, relational=False) == \
-        Union(FiniteSet(S.Zero), Interval(pi, 2*pi))
+        Union(FiniteSet(S.Zero), Interval.Ropen(pi, 2*pi))
 
     assert isolve(sin(x) <= S.One, x, relational=False) == S.Reals
     assert isolve(cos(x) < S(-2), x, relational=False) == S.EmptySet

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1159,6 +1159,9 @@ def test_solveset():
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
 
+    # issue 19977
+    assert solveset(atan(log(x)) > 0, x, domain=Interval.open(0, oo)) == Interval.open(1, oo)
+
 
 def test__solveset_multi():
     from sympy.solvers.solveset import _solveset_multi


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #19977 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

The inequality `atan(log(x)) > 0` in the domain `Interval.open(0, oo)` is not properly solved by `solveset`, which
returns `ConditionSet` instead of `Interval.Open(1, oo)`. This is due mainly to line 643 (and line 666) of `inequalities.py`.
Indeed `valid(start)` in such situation returns `NotImplementedError` and so the execution of `solve_univariate_inequality` stops.
In such case `start` is equal to `0`, which is outside the domain; so it is useless to add `start` to `sol_sets`.

Incidentally this change produces some failures in `test_inequalities.py`, due to periodicity issue.
Indeed in such cases, `solve_univariate_inequality` checks the periodicity (which is `pi` or `2pi`) and at lines 513-514 defines a new domain accordingly. The new domain is left closed and right open.
So if one respects this choice, then we need to eliminate the rightmost point in the solution.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- solvers
  - improved functionality for solveset in case of inequalities


<!-- END RELEASE NOTES -->