### PR TITLE
Mark the antlr files as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.py    diff=python
 *.sh    eol=lf
+
+# auto-collapse generated files in github diffs
+sympy/parsing/*/_antlr/*.py    linguist-generated=true


### PR DESCRIPTION
This makes them marked as such and collapsed in github diffs (but still expandable)

Proof this works (from https://github.com/sympy/sympy/pull/19981/files):

![image](https://user-images.githubusercontent.com/425260/90506325-f6584c00-e14b-11ea-9631-03fe068c62da.png)


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->