### PR TITLE
solveset with piecewise: issue 19718

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -969,6 +969,10 @@ def _solveset(f, symbol, domain, _check=False):
     given symbol."""
     # _check controls whether the answer is checked or not
     from sympy.simplify.simplify import signsimp
+    from sympy.logic.boolalg import BooleanTrue
+
+    if isinstance(f, BooleanTrue):
+        return domain
 
     orig_f = f
     if f.is_Mul:
@@ -1008,7 +1012,6 @@ def _solveset(f, symbol, domain, _check=False):
         a = f.args[0]
         result = solveset_real(a > 0, symbol)
     elif f.is_Piecewise:
-        result = EmptySet
         expr_set_pairs = f.as_expr_set_pairs(domain)
         for (expr, in_set) in expr_set_pairs:
             if in_set.is_Relational:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -694,6 +694,10 @@ def test_piecewise_solveset():
 
     assert solveset(Piecewise((x - 1, Ne(x, I)), (x, True)), x) == FiniteSet(1)
 
+    # issue 19718
+    g = Piecewise((1, x > 10), (0, True))
+    assert solveset(g > 0, x, S.Reals) == Interval.open(10, oo)
+
 
 def test_solveset_complex_polynomial():
     assert solveset_complex(a*x**2 + b*x + c, x) == \

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -698,6 +698,10 @@ def test_piecewise_solveset():
     g = Piecewise((1, x > 10), (0, True))
     assert solveset(g > 0, x, S.Reals) == Interval.open(10, oo)
 
+    from sympy.logic.boolalg import BooleanTrue
+    f = BooleanTrue()
+    assert solveset(f, x, domain=Interval(-3, 10)) == Interval(-3, 10)
+
 
 def test_solveset_complex_polynomial():
     assert solveset_complex(a*x**2 + b*x + c, x) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19718 


#### Brief description of what is fixed or changed

`Solveset` with `inequality` and `Piecewise` does not work properly.
Indeed it is `_solveset` which returns a wrong result when an argument is a `BooleanTrue`.
Now, when the argument is a `BooleanTrue`, it returns the domain.

A test is added.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- solvers
  - Handling of inequalities involving Piecewise is improved in solveset.

<!-- END RELEASE NOTES -->