### PR TITLE
[GSoC] Functions: Fixes limit evaluations related to uppergamma and besselk function

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -460,12 +460,10 @@ class besselk(BesselBase):
                 return S.ComplexInfinity
             elif re(nu).is_zero:
                 return S.NaN
-        if im(z) is S.Infinity or im(z) is S.NegativeInfinity:
+        if z in (S.Infinity, I*S.Infinity, I*S.NegativeInfinity):
             return S.Zero
 
         if nu.is_integer:
-            if z is S.Infinity:
-                return S.Zero
             if nu.could_extract_minus_sign():
                 return besselk(-nu, z)
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -464,6 +464,8 @@ class besselk(BesselBase):
             return S.Zero
 
         if nu.is_integer:
+            if z is S.Infinity:
+                return S.Zero
             if nu.could_extract_minus_sign():
                 return besselk(-nu, z)
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -364,6 +364,16 @@ class lowergamma(Function):
         if x not in (S.Zero, S.NegativeInfinity):
             return self.func(self.args[0].conjugate(), x.conjugate())
 
+    def _eval_aseries(self, n, args0, x, logx):
+        from sympy import O
+        s, z = self.args
+        if args0[0] is S.Infinity and not z.has(x):
+            coeff = z**s*exp(-z)
+            sum_expr = sum(z**k/rf(s, k + 1) for k in range(n - 1))
+            o = O(s**(-n - 1))
+            return coeff*sum_expr + o
+        return super()._eval_aseries(n, args0, x, logx)
+
     def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
 
@@ -525,6 +535,9 @@ class uppergamma(Function):
 
     def _eval_rewrite_as_lowergamma(self, s, x, **kwargs):
         return gamma(s) - lowergamma(s, x)
+
+    def _eval_rewrite_as_tractable(self, s, x, **kwargs):
+        return exp(loggamma(s)) - lowergamma(s, x)
 
     def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy import expint

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -364,13 +364,30 @@ class lowergamma(Function):
         if x not in (S.Zero, S.NegativeInfinity):
             return self.func(self.args[0].conjugate(), x.conjugate())
 
+    def _eval_is_meromorphic(self, x, a):
+        # By https://en.wikipedia.org/wiki/Incomplete_gamma_function#Holomorphic_extension,
+        #    lowergamma(s, z) = z**s*gamma(s)*gammastar(s, z),
+        # where gammastar(s, z) is holomorphic for all s and z.
+        # Hence the singularities of lowergamma are z = 0  (branch
+        # point) and nonpositive integer values of s (poles of gamma(s)).
+        s, z = self.args
+        args_merom = fuzzy_and([z._eval_is_meromorphic(x, a),
+            s._eval_is_meromorphic(x, a)])
+        if not args_merom:
+            return args_merom
+        z0 = z.subs(x, a)
+        if s.is_integer:
+            return fuzzy_and([s.is_positive, z0.is_finite])
+        s0 = s.subs(x, a)
+        return fuzzy_and([s0.is_finite, z0.is_finite, fuzzy_not(z0.is_zero)])
+
     def _eval_aseries(self, n, args0, x, logx):
         from sympy import O
         s, z = self.args
         if args0[0] is S.Infinity and not z.has(x):
             coeff = z**s*exp(-z)
             sum_expr = sum(z**k/rf(s, k + 1) for k in range(n - 1))
-            o = O(s**(-n - 1))
+            o = O(z**s*s**(-n))
             return coeff*sum_expr + o
         return super()._eval_aseries(n, args0, x, logx)
 
@@ -532,6 +549,9 @@ class uppergamma(Function):
         z = self.args[1]
         if not z in (S.Zero, S.NegativeInfinity):
             return self.func(self.args[0].conjugate(), z.conjugate())
+
+    def _eval_is_meromorphic(self, x, a):
+        return lowergamma._eval_is_meromorphic(self, x, a)
 
     def _eval_rewrite_as_lowergamma(self, s, x, **kwargs):
         return gamma(s) - lowergamma(s, x)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -140,8 +140,27 @@ def test_lowergamma():
     assert conjugate(lowergamma(x, 0)) == 0
     assert unchanged(conjugate, lowergamma(x, -oo))
 
-    assert lowergamma(x, 1).series(x, oo, 3) == \
-        (1 + 1/(x + 1))*exp(-1)/x + O(x**(-3), (x, oo))
+    assert lowergamma(0, x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(S(1)/3, x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(1, x, evaluate=False)._eval_is_meromorphic(x, 0) == True
+    assert lowergamma(x, x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(x + 1, x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(1/x, x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(0, x + 1)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(S(1)/3, x + 1)._eval_is_meromorphic(x, 0) == True
+    assert lowergamma(1, x + 1, evaluate=False)._eval_is_meromorphic(x, 0) == True
+    assert lowergamma(x, x + 1)._eval_is_meromorphic(x, 0) == True
+    assert lowergamma(x + 1, x + 1)._eval_is_meromorphic(x, 0) == True
+    assert lowergamma(1/x, x + 1)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(0, 1/x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(S(1)/3, 1/x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(1, 1/x, evaluate=False)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(x, 1/x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(x + 1, 1/x)._eval_is_meromorphic(x, 0) == False
+    assert lowergamma(1/x, 1/x)._eval_is_meromorphic(x, 0) == False
+
+    assert lowergamma(x, 2).series(x, oo, 3) == \
+        2**x*(1 + 2/(x + 1))*exp(-2)/x + O(exp(x*log(2))/x**3, (x, oo))
 
     assert lowergamma(
         x, y).rewrite(expint) == -y**x*expint(-x + 1, y) + gamma(x)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -140,6 +140,9 @@ def test_lowergamma():
     assert conjugate(lowergamma(x, 0)) == 0
     assert unchanged(conjugate, lowergamma(x, -oo))
 
+    assert lowergamma(x, 1).series(x, oo, 3) == \
+        (1 + 1/(x + 1))*exp(-1)/x + O(x**(-3), (x, oo))
+
     assert lowergamma(
         x, y).rewrite(expint) == -y**x*expint(-x + 1, y) + gamma(x)
     k = Symbol('k', integer=True)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -5,8 +5,8 @@ from sympy import (
     atan, Abs, gamma, Symbol, S, pi, Integral, Rational, I,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
     binomial, simplify, frac, Float, sec, zoo, fresnelc, fresnels,
-    acos, erf, erfc, erfi, LambertW, factorial, digamma, Ei, EulerGamma,
-    asin, atanh, acot, acoth, asec, acsc, cbrt)
+    acos, erf, erfc, erfi, LambertW, factorial, digamma, uppergamma,
+    Ei, EulerGamma, asin, atanh, acot, acoth, asec, acsc, cbrt, besselk)
 
 from sympy.calculus.util import AccumBounds
 from sympy.core.add import Add
@@ -705,6 +705,10 @@ def test_issue_15984():
     assert limit((-x + log(exp(x) + 1))/x, x, oo, dir='-').doit() == 0
 
 
+def test_issue_13571():
+    assert limit(uppergamma(x, 1) / gamma(x), x, oo) == 1
+
+
 def test_issue_13575():
     assert limit(acos(erfi(x)), x, 1).cancel() == acos(-I*erf(I))
 
@@ -750,6 +754,10 @@ def test_issue_14556():
 
 def test_issue_14811():
     assert limit(((1 + ((S(2)/3)**(x + 1)))**(2**x))/(2**((S(4)/3)**(x - 1))), x, oo) == oo
+
+
+def test_issue_14874():
+    assert limit(besselk(0, x), x, oo) == 0
 
 
 def test_issue_16222():


### PR DESCRIPTION
Fixes: #13571 
Fixes: #14874 

#### Brief description of what is fixed or changed

  1) Adds `_eval_is_meromorphic` method and  `_eval_aseries` to `class lowergamma` 
  2) Adds  `_eval_is_meromorphic` method and `_eval_rewrite_as_tractable` method to `class uppergamma`
  3) Rectifies `eval` method of `class besselk`


#### Other Comments
Regression Tests have been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
* functions
  * Adds `_eval_is_meromorphic` method and  `_eval_aseries` to `class lowergamma` 
  * Adds  `_eval_is_meromorphic` method and `_eval_rewrite_as_tractable` method to `class uppergamma`
  * Rectifies `eval` method of `class besselk`
<!-- END RELEASE NOTES -->