### PR TITLE
Add support for cosm1 to codegen

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -165,8 +165,8 @@ class _FuncMinusOne:
         self.func = func
         self.func_m_1 = func_m_1
 
-    def _try_func_m_1(self, ex_pr):
-        protected, old_new =  ex_pr.replace(self.func, lambda arg: Dummy(), map=True)
+    def _try_func_m_1(self, expr):
+        protected, old_new =  expr.replace(self.func, lambda arg: Dummy(), map=True)
         factored = protected.factor()
         new_old = {v: k for k, v in old_new.items()}
         return factored.replace(_d - 1, lambda d: self.func_m_1(new_old[d].args[0])).xreplace(new_old)

--- a/sympy/codegen/scipy_nodes.py
+++ b/sympy/codegen/scipy_nodes.py
@@ -1,0 +1,38 @@
+from sympy.core.function import Add, ArgumentIndexError, Function
+from sympy.core.singleton import S
+from sympy.functions.elementary.trigonometric import cos, sin
+
+
+def _cosm1(x, *, evaluate=True):
+    return Add(cos(x, evaluate=evaluate), -S.One, evaluate=evaluate)
+
+
+class cosm1(Function):
+    """ Minus one plus cosine of x, i.e. cos(x) - 1. For use when x is close to zero.
+
+    Helper class for use with e.g. scipy.special.cosm1
+    See: https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.cosm1.html
+    """
+    nargs = 1
+
+    def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of this function.
+        """
+        if argindex == 1:
+            return -sin(*self.args)
+        else:
+            raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_cos(self, x, **kwargs):
+        return _cosm1(x)
+
+    def _eval_evalf(self, *args, **kwargs):
+        return self.rewrite(cos).evalf(*args, **kwargs)
+
+    def _eval_simplify(self, x, **kwargs):
+        candidate = _cosm1(x.simplify(**kwargs))
+        if candidate != _cosm1(x, evaluate=False):
+            return candidate
+        else:
+            return cosm1(x)

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -1,11 +1,12 @@
-from sympy import log, exp, Symbol, Pow, sin, MatrixSymbol
+from sympy import log, exp, cos, Symbol, Pow, sin, MatrixSymbol
 from sympy.assumptions import assuming, Q
 from sympy.printing import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
+from sympy.codegen.scipy_nodes import cosm1
 from sympy.codegen.rewriting import (
-    optimize, log2_opt, exp2_opt, expm1_opt, log1p_opt, optims_c99,
+    optimize, cosm1_opt, log2_opt, exp2_opt, expm1_opt, log1p_opt, optims_c99,
     create_expand_pow_optimization, matinv_opt, logaddexp_opt, logaddexp2_opt
 )
 from sympy.testing.pytest import XFAIL
@@ -87,6 +88,49 @@ def test_expm1_two_exp_terms():
     expr1 = exp(x) + exp(y) - 2
     opt1 = optimize(expr1, [expm1_opt])
     assert opt1 == expm1(x) + expm1(y)
+
+
+def test_cosm1_opt():
+    x = Symbol('x')
+
+    expr1 = cos(x) - 1
+    opt1 = optimize(expr1, [cosm1_opt])
+    assert cosm1(x) - opt1 == 0
+    assert opt1.rewrite(cos) == expr1
+
+    expr2 = 3*cos(x) - 3
+    opt2 = optimize(expr2, [cosm1_opt])
+    assert 3*cosm1(x) == opt2
+    assert opt2.rewrite(cos) == expr2
+
+    expr3 = 3*cos(x) - 5
+    assert expr3 == optimize(expr3, [cosm1_opt])
+
+    expr4 = 3*cos(x) + log(x) - 3
+    opt4 = optimize(expr4, [cosm1_opt])
+    assert 3*cosm1(x) + log(x) == opt4
+    assert opt4.rewrite(cos) == expr4
+
+    expr5 = 3*cos(2*x) - 3
+    opt5 = optimize(expr5, [cosm1_opt])
+    assert 3*cosm1(2*x) == opt5
+    assert opt5.rewrite(cos) == expr5
+
+
+@XFAIL
+def test_cosm1_two_cos_terms():
+    x, y = map(Symbol, 'x y'.split())
+    expr1 = cos(x) + cos(y) - 2
+    opt1 = optimize(expr1, [cosm1_opt])
+    assert opt1 == cosm1(x) + cosm1(y)
+
+
+@XFAIL
+def test_expm1_cosm1_mixed():
+    x = Symbol('x')
+    expr1 = exp(x) + cos(x) - 2
+    opt1 = optimize(expr1, [expm1_opt, cosm1_opt])  # need a combined opt pass?
+    assert opt1 == cosm1(x) + expm1(x)
 
 
 def test_log1p_opt():

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -82,7 +82,7 @@ def test_expm1_opt():
     assert opt5.rewrite(exp) == expr5
 
 
-@XFAIL
+@XFAIL  # ideally this test should pass: need to improve `expm1_opt`
 def test_expm1_two_exp_terms():
     x, y = map(Symbol, 'x y'.split())
     expr1 = exp(x) + exp(y) - 2
@@ -117,7 +117,7 @@ def test_cosm1_opt():
     assert opt5.rewrite(cos) == expr5
 
 
-@XFAIL
+@XFAIL  # ideally this test should pass: need to improve `cosm1_opt`
 def test_cosm1_two_cos_terms():
     x, y = map(Symbol, 'x y'.split())
     expr1 = cos(x) + cos(y) - 2
@@ -125,7 +125,7 @@ def test_cosm1_two_cos_terms():
     assert opt1 == cosm1(x) + cosm1(y)
 
 
-@XFAIL
+@XFAIL  # ideally this test should pass: need to add a new combined expm1_cosm1_opt?
 def test_expm1_cosm1_mixed():
     x = Symbol('x')
     expr1 = exp(x) + cos(x) - 2

--- a/sympy/codegen/tests/test_scipy_nodes.py
+++ b/sympy/codegen/tests/test_scipy_nodes.py
@@ -1,0 +1,20 @@
+from itertools import product
+from sympy import symbols, cos
+from sympy.core.numbers import pi
+from sympy.codegen.scipy_nodes import cosm1
+
+x, y, z = symbols('x y z')
+
+
+def test_cosm1():
+    cm1_xy = cosm1(x*y)
+    ref_xy = cos(x*y) - 1
+    for wrt, deriv_order in product([x, y, z], range(0, 3)):
+        assert (
+            cm1_xy.diff(wrt, deriv_order) -
+            ref_xy.diff(wrt, deriv_order)
+        ).rewrite(cos).simplify() == 0
+
+    expr_minus2 = cosm1(pi)
+    assert expr_minus2.rewrite(cos) == -2
+    assert cosm1(3.14).simplify() == cosm1(3.14)  # cannot simplify with 3.14

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -462,6 +462,11 @@ def test_sympy__codegen__numpy_nodes__logaddexp2():
     assert _test_args(logaddexp2(x, y))
 
 
+def test_sympy__codegen__scipy_nodes__cosm1():
+    from sympy.codegen.scipy_nodes import cosm1
+    assert _test_args(cosm1(x))
+
+
 @XFAIL
 def test_sympy__combinatorics__graycode__GrayCode():
     from sympy.combinatorics.graycode import GrayCode

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -889,6 +889,7 @@ _known_functions_scipy_special = {
     'bessely': 'yv',
     'besseli': 'iv',
     'besselk': 'kv',
+    'cosm1': 'cosm1',
     'factorial': 'factorial',
     'gamma': 'gamma',
     'loggamma': 'gammaln',

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from sympy.codegen import Assignment
 from sympy.codegen.ast import none
+from sympy.codegen.cfunctions import expm1, log1p
+from sympy.codegen.scipy_nodes import cosm1
 from sympy.codegen.matrix_nodes import MatrixSolve
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt, zoo, oo, Rational, Pow
 from sympy.core.numbers import pi
@@ -324,3 +326,10 @@ def test_airy_prime():
     prntr = PythonCodePrinter()
     assert prntr.doprint(expr1) == '  # Not supported in Python:\n  # airyaiprime\nairyaiprime(x)'
     assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # airybiprime\nairybiprime(x)'
+
+
+def test_numerical_accuracy_functions():
+    prntr = SciPyPrinter()
+    assert prntr.doprint(expm1(x)) == 'numpy.expm1(x)'
+    assert prntr.doprint(log1p(x)) == 'numpy.log1p(x)'
+    assert prntr.doprint(cosm1(x)) == 'scipy.special.cosm1(x)'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -13,6 +13,7 @@ from sympy import (
     fresnelc, fresnels)
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, log10, hypot
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
+from sympy.codegen.scipy_nodes import cosm1
 from sympy.functions.elementary.complexes import re, im, arg
 from sympy.functions.special.polynomials import \
     chebyshevt, chebyshevu, legendre, hermite, laguerre, gegenbauer, \
@@ -1302,3 +1303,11 @@ def test_numpy_special_math():
 
     lae2 = lambdify((x, y), logaddexp2(log2(x), log2(y)))
     assert abs(2.0**lae2(1e-50, 2.5e-50) - 3.5e-50) < 1e-62  # from NumPy's docstring
+
+
+def test_scipy_special_math():
+    if not scipy:
+        skip("scipy not installed")
+
+    cm1 = lambdify((x,), cosm1(x), modules='scipy')
+    assert abs(cm1(1e-20) + 5e-41) < 1e-200


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
scipy has cosm1 which avoids catasrophic cancellation when the argument is small. This adds support to the SciPy printer to emit code using this function.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Added support for generating calls to `scipy.special.cosm1`.
<!-- END RELEASE NOTES -->