### PR TITLE
Fix sympy.testing.pytest.raises to behave like pytest.raises

### DIFF
--- a/sympy/multipledispatch/tests/test_core.py
+++ b/sympy/multipledispatch/tests/test_core.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 
 from sympy.multipledispatch import dispatch
 from sympy.multipledispatch.conflict import AmbiguityWarning
-from sympy.testing.pytest import raises, XFAIL, warns
+from sympy.testing.pytest import raises, warns
 from functools import partial
 
 test_namespace = dict()  # type: Dict[str, Any]
@@ -11,7 +11,6 @@ orig_dispatch = dispatch
 dispatch = partial(dispatch, namespace=test_namespace)
 
 
-@XFAIL
 def test_singledispatch():
     @dispatch(int)
     def f(x): # noqa:F811
@@ -66,7 +65,6 @@ def test_inheritance():
     assert f(C()) == 'a'
 
 
-@XFAIL
 def test_inheritance_and_multiple_dispatch():
     @dispatch(A, A)
     def f(x, y): # noqa:F811

--- a/sympy/multipledispatch/tests/test_dispatcher.py
+++ b/sympy/multipledispatch/tests/test_dispatcher.py
@@ -1,7 +1,7 @@
 from sympy.multipledispatch.dispatcher import (Dispatcher, MDNotImplementedError,
                                          MethodDispatcher, halt_ordering,
                                          restart_ordering)
-from sympy.testing.pytest import raises, XFAIL, warns
+from sympy.testing.pytest import raises, warns
 
 
 def identity(x):
@@ -88,7 +88,6 @@ def test_on_ambiguity():
     assert ambiguities[0]
 
 
-@XFAIL
 def test_raise_error_on_non_class():
     f = Dispatcher('f')
     assert raises(TypeError, lambda: f.add((1,), inc))
@@ -165,7 +164,6 @@ def test_source():
     assert 'x - y' in f._source(1.0, 1.0)
 
 
-@XFAIL
 def test_source_raises_on_missing_function():
     f = Dispatcher('f')
 
@@ -197,13 +195,11 @@ def test_halt_method_resolution():
     assert set(f.ordering) == {(int, object), (object, int)}
 
 
-@XFAIL
 def test_no_implementations():
     f = Dispatcher('f')
     assert raises(NotImplementedError, lambda: f('hello'))
 
 
-@XFAIL
 def test_register_stacking():
     f = Dispatcher('f')
 
@@ -238,7 +234,6 @@ def test_dispatch_method():
     assert f.dispatch(int, int) is add
 
 
-@XFAIL
 def test_not_implemented():
     f = Dispatcher('f')
 
@@ -259,7 +254,6 @@ def test_not_implemented():
     assert raises(NotImplementedError, lambda: f(1, 2))
 
 
-@XFAIL
 def test_not_implemented_error():
     f = Dispatcher('f')
 

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -63,7 +63,7 @@ else:
         >>> from sympy.testing.pytest import raises
 
         >>> raises(ZeroDivisionError, lambda: 1/0)
-        <ExceptionInfo ZeroDivisionError('division by zero')>
+        <ExceptionInfo ZeroDivisionError(...)>
         >>> raises(ZeroDivisionError, lambda: 1/2)
         Traceback (most recent call last):
         ...

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -34,6 +34,15 @@ else:
     # Not using pytest so define the things that would have been imported from
     # there.
 
+    # _pytest._code.code.ExceptionInfo
+    class ExceptionInfo:
+        def __init__(self, value):
+            self.value = value
+
+        def __repr__(self):
+            return "<ExceptionInfo {!r}>".format(self.value)
+
+
     def raises(expectedException, code=None):
         """
         Tests that ``code`` raises the exception ``expectedException``.
@@ -54,6 +63,7 @@ else:
         >>> from sympy.testing.pytest import raises
 
         >>> raises(ZeroDivisionError, lambda: 1/0)
+        <ExceptionInfo ZeroDivisionError('division by zero')>
         >>> raises(ZeroDivisionError, lambda: 1/2)
         Traceback (most recent call last):
         ...
@@ -92,8 +102,8 @@ else:
         elif callable(code):
             try:
                 code()
-            except expectedException:
-                return
+            except expectedException as e:
+                return ExceptionInfo(e)
             raise Failed("DID NOT RAISE")
         elif isinstance(code, str):
             raise TypeError(


### PR DESCRIPTION
~~There seems to be a mistaken impression that `XFAIL` is needed for tests with `raises`. This should not be true.~~

This was true...

Code written as `assert raises(...)` would pass in pytest and fail in sympy, because sympy was not returning an appropriate object from `raises`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
   * `assert sympy.testing.pytest.raises(Exception, func)` no longer always asserts when pytest is not present
<!-- END RELEASE NOTES -->