### PR TITLE
Rename RandomMatrixEnsemble to RandomMatrixEnsembleModel

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1732,44 +1732,45 @@ def test_sympy__stats__stochastic_process_types__GammaProcess():
 
 def test_sympy__stats__random_matrix__RandomMatrixPSpace():
     from sympy.stats.random_matrix import RandomMatrixPSpace
-    from sympy.stats.random_matrix_models import RandomMatrixEnsemble
-    assert _test_args(RandomMatrixPSpace('P', RandomMatrixEnsemble('R', 3)))
+    from sympy.stats.random_matrix_models import RandomMatrixEnsembleModel
+    model = RandomMatrixEnsembleModel('R', 3)
+    assert _test_args(RandomMatrixPSpace('P', model=model))
 
-def test_sympy__stats__random_matrix_models__RandomMatrixEnsemble():
-    from sympy.stats.random_matrix_models import RandomMatrixEnsemble
-    assert _test_args(RandomMatrixEnsemble('R', 3))
+def test_sympy__stats__random_matrix_models__RandomMatrixEnsembleModel():
+    from sympy.stats.random_matrix_models import RandomMatrixEnsembleModel
+    assert _test_args(RandomMatrixEnsembleModel('R', 3))
 
-def test_sympy__stats__random_matrix_models__GaussianEnsemble():
-    from sympy.stats.random_matrix_models import GaussianEnsemble
-    assert _test_args(GaussianEnsemble('G', 3))
+def test_sympy__stats__random_matrix_models__GaussianEnsembleModel():
+    from sympy.stats.random_matrix_models import GaussianEnsembleModel
+    assert _test_args(GaussianEnsembleModel('G', 3))
 
-def test_sympy__stats__random_matrix_models__GaussianUnitaryEnsemble():
-    from sympy.stats import GaussianUnitaryEnsemble
-    assert _test_args(GaussianUnitaryEnsemble('U', 3))
+def test_sympy__stats__random_matrix_models__GaussianUnitaryEnsembleModel():
+    from sympy.stats.random_matrix_models import GaussianUnitaryEnsembleModel
+    assert _test_args(GaussianUnitaryEnsembleModel('U', 3))
 
-def test_sympy__stats__random_matrix_models__GaussianOrthogonalEnsemble():
-    from sympy.stats import GaussianOrthogonalEnsemble
-    assert _test_args(GaussianOrthogonalEnsemble('U', 3))
+def test_sympy__stats__random_matrix_models__GaussianOrthogonalEnsembleModel():
+    from sympy.stats.random_matrix_models import GaussianOrthogonalEnsembleModel
+    assert _test_args(GaussianOrthogonalEnsembleModel('U', 3))
 
-def test_sympy__stats__random_matrix_models__GaussianSymplecticEnsemble():
-    from sympy.stats import GaussianSymplecticEnsemble
-    assert _test_args(GaussianSymplecticEnsemble('U', 3))
+def test_sympy__stats__random_matrix_models__GaussianSymplecticEnsembleModel():
+    from sympy.stats.random_matrix_models import GaussianSymplecticEnsembleModel
+    assert _test_args(GaussianSymplecticEnsembleModel('U', 3))
 
-def test_sympy__stats__random_matrix_models__CircularEnsemble():
-    from sympy.stats import CircularEnsemble
-    assert _test_args(CircularEnsemble('C', 3))
+def test_sympy__stats__random_matrix_models__CircularEnsembleModel():
+    from sympy.stats.random_matrix_models import CircularEnsembleModel
+    assert _test_args(CircularEnsembleModel('C', 3))
 
-def test_sympy__stats__random_matrix_models__CircularUnitaryEnsemble():
-    from sympy.stats import CircularUnitaryEnsemble
-    assert _test_args(CircularUnitaryEnsemble('U', 3))
+def test_sympy__stats__random_matrix_models__CircularUnitaryEnsembleModel():
+    from sympy.stats.random_matrix_models import CircularUnitaryEnsembleModel
+    assert _test_args(CircularUnitaryEnsembleModel('U', 3))
 
-def test_sympy__stats__random_matrix_models__CircularOrthogonalEnsemble():
-    from sympy.stats import CircularOrthogonalEnsemble
-    assert _test_args(CircularOrthogonalEnsemble('O', 3))
+def test_sympy__stats__random_matrix_models__CircularOrthogonalEnsembleModel():
+    from sympy.stats.random_matrix_models import CircularOrthogonalEnsembleModel
+    assert _test_args(CircularOrthogonalEnsembleModel('O', 3))
 
-def test_sympy__stats__random_matrix_models__CircularSymplecticEnsemble():
-    from sympy.stats import CircularSymplecticEnsemble
-    assert _test_args(CircularSymplecticEnsemble('S', 3))
+def test_sympy__stats__random_matrix_models__CircularSymplecticEnsembleModel():
+    from sympy.stats.random_matrix_models import CircularSymplecticEnsembleModel
+    assert _test_args(CircularSymplecticEnsembleModel('S', 3))
 
 def test_sympy__stats__symbolic_multivariate_probability__ExpectationMatrix():
     from sympy.stats import ExpectationMatrix

--- a/sympy/stats/random_matrix_models.py
+++ b/sympy/stats/random_matrix_models.py
@@ -100,19 +100,6 @@ class GaussianEnsembleModel(RandomMatrixEnsembleModel):
         return Lambda(tuple(syms), (term1 * term2)/Zbn)
 
 class GaussianUnitaryEnsembleModel(GaussianEnsembleModel):
-    """
-    Represents Gaussian Unitary Ensembles.
-
-    Examples
-    ========
-
-    >>> from sympy.stats import GaussianUnitaryEnsemble as GUE, density
-    >>> from sympy import MatrixSymbol
-    >>> G = GUE('U', 2)
-    >>> X = MatrixSymbol('X', 2, 2)
-    >>> density(G)(X)
-    exp(-Trace(X**2))/(2*pi**2)
-    """
     @property
     def normalization_constant(self):
         n = self.dimension
@@ -133,19 +120,6 @@ class GaussianUnitaryEnsembleModel(GaussianEnsembleModel):
         return Lambda(s, f)
 
 class GaussianOrthogonalEnsembleModel(GaussianEnsembleModel):
-    """
-    Represents Gaussian Orthogonal Ensembles.
-
-    Examples
-    ========
-
-    >>> from sympy.stats import GaussianOrthogonalEnsemble as GOE, density
-    >>> from sympy import MatrixSymbol
-    >>> G = GOE('U', 2)
-    >>> X = MatrixSymbol('X', 2, 2)
-    >>> density(G)(X)
-    exp(-Trace(X**2)/2)/Integral(exp(-Trace(_H**2)/2), _H)
-    """
     @property
     def normalization_constant(self):
         n = self.dimension
@@ -167,19 +141,6 @@ class GaussianOrthogonalEnsembleModel(GaussianEnsembleModel):
         return Lambda(s, f)
 
 class GaussianSymplecticEnsembleModel(GaussianEnsembleModel):
-    """
-    Represents Gaussian Symplectic Ensembles.
-
-    Examples
-    ========
-
-    >>> from sympy.stats import GaussianSymplecticEnsemble as GSE, density
-    >>> from sympy import MatrixSymbol
-    >>> G = GSE('U', 2)
-    >>> X = MatrixSymbol('X', 2, 2)
-    >>> density(G)(X)
-    exp(-2*Trace(X**2))/Integral(exp(-2*Trace(_H**2)), _H)
-    """
     @property
     def normalization_constant(self):
         n = self.dimension
@@ -207,18 +168,57 @@ def GaussianEnsemble(sym, dim):
     return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
 def GaussianUnitaryEnsemble(sym, dim):
+    """
+    Represents Gaussian Unitary Ensembles.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import GaussianUnitaryEnsemble as GUE, density
+    >>> from sympy import MatrixSymbol
+    >>> G = GUE('U', 2)
+    >>> X = MatrixSymbol('X', 2, 2)
+    >>> density(G)(X)
+    exp(-Trace(X**2))/(2*pi**2)
+    """
     sym, dim = _symbol_converter(sym), _sympify(dim)
     model = GaussianUnitaryEnsembleModel(sym, dim)
     rmp = RandomMatrixPSpace(sym, model=model)
     return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
 def GaussianOrthogonalEnsemble(sym, dim):
+    """
+    Represents Gaussian Orthogonal Ensembles.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import GaussianOrthogonalEnsemble as GOE, density
+    >>> from sympy import MatrixSymbol
+    >>> G = GOE('U', 2)
+    >>> X = MatrixSymbol('X', 2, 2)
+    >>> density(G)(X)
+    exp(-Trace(X**2)/2)/Integral(exp(-Trace(_H**2)/2), _H)
+    """
     sym, dim = _symbol_converter(sym), _sympify(dim)
     model = GaussianOrthogonalEnsembleModel(sym, dim)
     rmp = RandomMatrixPSpace(sym, model=model)
     return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
 def GaussianSymplecticEnsemble(sym, dim):
+    """
+    Represents Gaussian Symplectic Ensembles.
+
+    Examples
+    ========
+
+    >>> from sympy.stats import GaussianSymplecticEnsemble as GSE, density
+    >>> from sympy import MatrixSymbol
+    >>> G = GSE('U', 2)
+    >>> X = MatrixSymbol('X', 2, 2)
+    >>> density(G)(X)
+    exp(-2*Trace(X**2))/Integral(exp(-2*Trace(_H**2)), _H)
+    """
     sym, dim = _symbol_converter(sym), _sympify(dim)
     model = GaussianSymplecticEnsembleModel(sym, dim)
     rmp = RandomMatrixPSpace(sym, model=model)
@@ -259,6 +259,24 @@ class CircularEnsembleModel(RandomMatrixEnsembleModel):
         return Lambda(tuple(syms), f/Zbn)
 
 class CircularUnitaryEnsembleModel(CircularEnsembleModel):
+    def joint_eigen_distribution(self):
+        return self._compute_joint_eigen_distribution(S(2))
+
+class CircularOrthogonalEnsembleModel(CircularEnsembleModel):
+    def joint_eigen_distribution(self):
+        return self._compute_joint_eigen_distribution(S.One)
+
+class CircularSymplecticEnsembleModel(CircularEnsembleModel):
+    def joint_eigen_distribution(self):
+        return self._compute_joint_eigen_distribution(S(4))
+
+def CircularEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def CircularUnitaryEnsemble(sym, dim):
     """
     Represents Cicular Unitary Ensembles.
 
@@ -278,10 +296,12 @@ class CircularUnitaryEnsembleModel(CircularEnsembleModel):
     is not evaluated becuase the exact definition is based on haar measure of
     unitary group which is not unique.
     """
-    def joint_eigen_distribution(self):
-        return self._compute_joint_eigen_distribution(S(2))
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularUnitaryEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
-class CircularOrthogonalEnsembleModel(CircularEnsembleModel):
+def CircularOrthogonalEnsemble(sym, dim):
     """
     Represents Cicular Orthogonal Ensembles.
 
@@ -301,10 +321,12 @@ class CircularOrthogonalEnsembleModel(CircularEnsembleModel):
     is not evaluated becuase the exact definition is based on haar measure of
     unitary group which is not unique.
     """
-    def joint_eigen_distribution(self):
-        return self._compute_joint_eigen_distribution(S.One)
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularOrthogonalEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
-class CircularSymplecticEnsembleModel(CircularEnsembleModel):
+def CircularSymplecticEnsemble(sym, dim):
     """
     Represents Cicular Symplectic Ensembles.
 
@@ -324,29 +346,6 @@ class CircularSymplecticEnsembleModel(CircularEnsembleModel):
     is not evaluated becuase the exact definition is based on haar measure of
     unitary group which is not unique.
     """
-
-    def joint_eigen_distribution(self):
-        return self._compute_joint_eigen_distribution(S(4))
-
-def CircularEnsemble(sym, dim):
-    sym, dim = _symbol_converter(sym), _sympify(dim)
-    model = CircularEnsembleModel(sym, dim)
-    rmp = RandomMatrixPSpace(sym, model=model)
-    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
-
-def CircularUnitaryEnsemble(sym, dim):
-    sym, dim = _symbol_converter(sym), _sympify(dim)
-    model = CircularUnitaryEnsembleModel(sym, dim)
-    rmp = RandomMatrixPSpace(sym, model=model)
-    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
-
-def CircularOrthogonalEnsemble(sym, dim):
-    sym, dim = _symbol_converter(sym), _sympify(dim)
-    model = CircularOrthogonalEnsembleModel(sym, dim)
-    rmp = RandomMatrixPSpace(sym, model=model)
-    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
-
-def CircularSymplecticEnsemble(sym, dim):
     sym, dim = _symbol_converter(sym), _sympify(dim)
     model = CircularSymplecticEnsembleModel(sym, dim)
     rmp = RandomMatrixPSpace(sym, model=model)

--- a/sympy/stats/random_matrix_models.py
+++ b/sympy/stats/random_matrix_models.py
@@ -27,7 +27,7 @@ def _(x):
     return True
 
 
-class RandomMatrixEnsemble(Basic):
+class RandomMatrixEnsembleModel(Basic):
     """
     Base class for random matrix ensembles.
     It acts as an umbrella and contains
@@ -39,9 +39,7 @@ class RandomMatrixEnsemble(Basic):
         if dim.is_integer == False:
             raise ValueError("Dimension of the random matrices must be "
                                 "integers, received %s instead."%(dim))
-        self = Basic.__new__(cls, sym, dim)
-        rmp = RandomMatrixPSpace(sym, model=self)
-        return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+        return Basic.__new__(cls, sym, dim)
 
     symbol = property(lambda self: self.args[0])
     dimension = property(lambda self: self.args[1])
@@ -52,7 +50,7 @@ class RandomMatrixEnsemble(Basic):
     def __call__(self, expr):
         return self.density(expr)
 
-class GaussianEnsemble(RandomMatrixEnsemble):
+class GaussianEnsembleModel(RandomMatrixEnsembleModel):
     """
     Abstract class for Gaussian ensembles.
     Contains the properties common to all the
@@ -101,7 +99,7 @@ class GaussianEnsemble(RandomMatrixEnsemble):
         syms = ArrayComprehension(l[k], (k, 1, n)).doit()
         return Lambda(tuple(syms), (term1 * term2)/Zbn)
 
-class GaussianUnitaryEnsemble(GaussianEnsemble):
+class GaussianUnitaryEnsembleModel(GaussianEnsembleModel):
     """
     Represents Gaussian Unitary Ensembles.
 
@@ -134,7 +132,7 @@ class GaussianUnitaryEnsemble(GaussianEnsemble):
         f = (32/pi**2)*(s**2)*exp((-4/pi)*s**2)
         return Lambda(s, f)
 
-class GaussianOrthogonalEnsemble(GaussianEnsemble):
+class GaussianOrthogonalEnsembleModel(GaussianEnsembleModel):
     """
     Represents Gaussian Orthogonal Ensembles.
 
@@ -168,7 +166,7 @@ class GaussianOrthogonalEnsemble(GaussianEnsemble):
         f = (pi/2)*s*exp((-pi/4)*s**2)
         return Lambda(s, f)
 
-class GaussianSymplecticEnsemble(GaussianEnsemble):
+class GaussianSymplecticEnsembleModel(GaussianEnsembleModel):
     """
     Represents Gaussian Symplectic Ensembles.
 
@@ -202,7 +200,31 @@ class GaussianSymplecticEnsemble(GaussianEnsemble):
         f = ((S(2)**18)/((S(3)**6)*(pi**3)))*(s**4)*exp((-64/(9*pi))*s**2)
         return Lambda(s, f)
 
-class CircularEnsemble(RandomMatrixEnsemble):
+def GaussianEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = GaussianEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def GaussianUnitaryEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = GaussianUnitaryEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def GaussianOrthogonalEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = GaussianOrthogonalEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def GaussianSymplecticEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = GaussianSymplecticEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+class CircularEnsembleModel(RandomMatrixEnsembleModel):
     """
     Abstract class for Circular ensembles.
     Contains the properties and methods
@@ -236,7 +258,7 @@ class CircularEnsemble(RandomMatrixEnsemble):
                     (k, 1, n - 1)).doit()
         return Lambda(tuple(syms), f/Zbn)
 
-class CircularUnitaryEnsemble(CircularEnsemble):
+class CircularUnitaryEnsembleModel(CircularEnsembleModel):
     """
     Represents Cicular Unitary Ensembles.
 
@@ -259,7 +281,7 @@ class CircularUnitaryEnsemble(CircularEnsemble):
     def joint_eigen_distribution(self):
         return self._compute_joint_eigen_distribution(S(2))
 
-class CircularOrthogonalEnsemble(CircularEnsemble):
+class CircularOrthogonalEnsembleModel(CircularEnsembleModel):
     """
     Represents Cicular Orthogonal Ensembles.
 
@@ -282,7 +304,7 @@ class CircularOrthogonalEnsemble(CircularEnsemble):
     def joint_eigen_distribution(self):
         return self._compute_joint_eigen_distribution(S.One)
 
-class CircularSymplecticEnsemble(CircularEnsemble):
+class CircularSymplecticEnsembleModel(CircularEnsembleModel):
     """
     Represents Cicular Symplectic Ensembles.
 
@@ -305,6 +327,30 @@ class CircularSymplecticEnsemble(CircularEnsemble):
 
     def joint_eigen_distribution(self):
         return self._compute_joint_eigen_distribution(S(4))
+
+def CircularEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def CircularUnitaryEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularUnitaryEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def CircularOrthogonalEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularOrthogonalEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
+
+def CircularSymplecticEnsemble(sym, dim):
+    sym, dim = _symbol_converter(sym), _sympify(dim)
+    model = CircularSymplecticEnsembleModel(sym, dim)
+    rmp = RandomMatrixPSpace(sym, model=model)
+    return RandomMatrixSymbol(sym, dim, dim, pspace=rmp)
 
 def joint_eigen_distribution(mat):
     """

--- a/sympy/stats/tests/test_random_matrix.py
+++ b/sympy/stats/tests/test_random_matrix.py
@@ -105,3 +105,8 @@ def test_JointEigenDistribution():
     JointDistributionHandmade(-sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] + A[1, 1]**2)/2 +
     A[0, 0]/2 + A[1, 1]/2, sqrt(A[0, 0]**2 - 2*A[0, 0]*A[1, 1] + 4*A[0, 1]*A[1, 0] + A[1, 1]**2)/2 + A[0, 0]/2 + A[1, 1]/2)
     raises(ValueError, lambda: JointEigenDistribution(Matrix([[1, 0], [2, 1]])))
+
+def test_issue_19841():
+    G1 = GUE('U', 2)
+    G2 = G1.xreplace({2: 2})
+    assert G1 == G2

--- a/sympy/stats/tests/test_random_matrix.py
+++ b/sympy/stats/tests/test_random_matrix.py
@@ -109,4 +109,4 @@ def test_JointEigenDistribution():
 def test_issue_19841():
     G1 = GUE('U', 2)
     G2 = G1.xreplace({2: 2})
-    assert G1 == G2
+    assert G1.args == G2.args


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#19841 

#### Brief description of what is fixed or changed

This fixes the specific behavior of https://github.com/sympy/sympy/issues/19841#issuecomment-663878581 which had caused random matrix ensemble classes to infinitely expand inside itself when some sympy methods like `xreplace` is applied.

I would first test out this approach to see if it integrates well.
However, some documentations should be moved to the stub function creators.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- stats
  - Fixed `xreplace` infinitely expanding random matrix ensemble classes.
  - All the ensemble classes (`RandomMatrixEnsemble`, `GaussianEnsemble`, `GaussianOrthogonalEnsemble`, ...) now becomes stub function constructors.
  If you want to use them as classes, you should import them as `RandomMatrixEnsembleModel`, `GaussianEnsembleModel`, ...
<!-- END RELEASE NOTES -->