### PR TITLE
Remove python2 from plotting using pyup_dirs

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -10,7 +10,6 @@ ever support anything else than sympy expressions (no Matrices, dictionaries
 and so on).
 """
 
-from __future__ import print_function, division
 
 import re
 from sympy import Symbol, NumberSymbol, I, zoo, oo
@@ -79,7 +78,7 @@ import warnings
 #TODO debugging output
 
 
-class vectorized_lambdify(object):
+class vectorized_lambdify:
     """ Return a sufficiently smart, vectorized and lambdified function.
 
     Returns only reals.
@@ -171,7 +170,7 @@ class vectorized_lambdify(object):
         return results
 
 
-class lambdify(object):
+class lambdify:
     """Returns the lambdified function.
 
     This function uses experimental_lambdify to create a lambdified
@@ -244,7 +243,7 @@ def experimental_lambdify(*args, **kwargs):
     return l
 
 
-class Lambdifier(object):
+class Lambdifier:
     def __init__(self, args, expr, print_lambda=False, use_evalf=False,
                  float_wrap_evalf=False, complex_wrap_evalf=False,
                  use_np=False, use_python_math=False, use_python_cmath=False,

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -31,7 +31,6 @@ The module uses numpy for speed which cannot be achieved with mpmath.
 # A It will not affect most of the plots. The interval arithmetic
 # module based suffers the same problems as that of floating point
 # arithmetic.
-from __future__ import print_function, division
 
 from sympy.core.logic import fuzzy_and
 from sympy.simplify.simplify import nsimplify
@@ -39,7 +38,7 @@ from sympy.simplify.simplify import nsimplify
 from .interval_membership import intervalMembership
 
 
-class interval(object):
+class interval:
     """ Represents an interval containing floating points as start and
     end of the interval
     The is_valid variable tracks whether the interval obtained as the

--- a/sympy/plotting/intervalmath/interval_membership.py
+++ b/sympy/plotting/intervalmath/interval_membership.py
@@ -1,7 +1,7 @@
 from sympy.core.logic import fuzzy_and, fuzzy_or, fuzzy_not, fuzzy_xor
 
 
-class intervalMembership(object):
+class intervalMembership:
     """Represents a boolean expression returned by the comparison of
     the interval object.
 

--- a/sympy/plotting/intervalmath/lib_interval.py
+++ b/sympy/plotting/intervalmath/lib_interval.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy.plotting.intervalmath import interval
 from sympy.external import import_module
 from sympy.core.compatibility import reduce

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -22,7 +22,6 @@ if you care at all about performance. A new backend instance is initialized
 every time you call ``show()`` and the old one is left to the garbage collector.
 """
 
-from __future__ import print_function, division
 
 import warnings
 
@@ -57,7 +56,7 @@ def unset_show():
 ##############################################################################
 
 
-class Plot(object):
+class Plot:
     """The central class of the plotting module.
 
     For interactive work the function ``plot`` is better suited.
@@ -150,7 +149,7 @@ class Plot(object):
         xscale='linear', yscale='linear', legend=False, autoscale=True,
         margin=0, annotations=None, markers=None, rectangles=None,
         fill=None, backend='default', **kwargs):
-        super(Plot, self).__init__()
+        super().__init__()
 
         # Options for the graph as a whole.
         # The possible values for each option are described in the docstring of
@@ -306,7 +305,7 @@ class Plot(object):
             raise TypeError('Expecting Plot or sequence of BaseSeries')
 
 
-class PlotGrid(object):
+class PlotGrid:
     """This class helps to plot subplots from already created sympy plots
     in a single figure.
 
@@ -447,7 +446,7 @@ class PlotGrid(object):
 #TODO more general way to calculate aesthetics (see get_color_array)
 
 ### The base class for all series
-class BaseSeries(object):
+class BaseSeries:
     """Base class for the data objects containing stuff to be plotted.
 
     The backend should check if it supports the data series that it's given.
@@ -504,7 +503,7 @@ class BaseSeries(object):
     # used for calculation aesthetics
 
     def __init__(self):
-        super(BaseSeries, self).__init__()
+        super().__init__()
 
     @property
     def is_3D(self):
@@ -537,7 +536,7 @@ class Line2DBaseSeries(BaseSeries):
     _dim = 2
 
     def __init__(self):
-        super(Line2DBaseSeries, self).__init__()
+        super().__init__()
         self.label = None
         self.steps = False
         self.only_integers = False
@@ -579,7 +578,7 @@ class List2DSeries(Line2DBaseSeries):
 
     def __init__(self, list_x, list_y):
         np = import_module('numpy')
-        super(List2DSeries, self).__init__()
+        super().__init__()
         self.list_x = np.array(list_x)
         self.list_y = np.array(list_y)
         self.label = 'list'
@@ -595,7 +594,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
     """Representation for a line consisting of a SymPy expression over a range."""
 
     def __init__(self, expr, var_start_end, **kwargs):
-        super(LineOver1DRangeSeries, self).__init__()
+        super().__init__()
         self.expr = sympify(expr)
         self.label = kwargs.get('label', None) or str(self.expr)
         self.var = sympify(var_start_end[0])
@@ -628,7 +627,7 @@ class LineOver1DRangeSeries(Line2DBaseSeries):
         """
 
         if self.only_integers or not self.adaptive:
-            return super(LineOver1DRangeSeries, self).get_segments()
+            return super().get_segments()
         else:
             f = lambdify([self.var], self.expr)
             list_segments = []
@@ -715,7 +714,7 @@ class Parametric2DLineSeries(Line2DBaseSeries):
     is_parametric = True
 
     def __init__(self, expr_x, expr_y, var_start_end, **kwargs):
-        super(Parametric2DLineSeries, self).__init__()
+        super().__init__()
         self.expr_x = sympify(expr_x)
         self.expr_y = sympify(expr_y)
         self.label = kwargs.get('label', None) or \
@@ -760,7 +759,7 @@ class Parametric2DLineSeries(Line2DBaseSeries):
 
         """
         if not self.adaptive:
-            return super(Parametric2DLineSeries, self).get_segments()
+            return super().get_segments()
 
         f_x = lambdify([self.var], self.expr_x)
         f_y = lambdify([self.var], self.expr_y)
@@ -839,7 +838,7 @@ class Line3DBaseSeries(Line2DBaseSeries):
     _dim = 3
 
     def __init__(self):
-        super(Line3DBaseSeries, self).__init__()
+        super().__init__()
 
 
 class Parametric3DLineSeries(Line3DBaseSeries):
@@ -847,7 +846,7 @@ class Parametric3DLineSeries(Line3DBaseSeries):
     expressions and a range."""
 
     def __init__(self, expr_x, expr_y, expr_z, var_start_end, **kwargs):
-        super(Parametric3DLineSeries, self).__init__()
+        super().__init__()
         self.expr_x = sympify(expr_x)
         self.expr_y = sympify(expr_y)
         self.expr_z = sympify(expr_z)
@@ -900,7 +899,7 @@ class SurfaceBaseSeries(BaseSeries):
     is_3Dsurface = True
 
     def __init__(self):
-        super(SurfaceBaseSeries, self).__init__()
+        super().__init__()
         self.surface_color = None
 
     def get_color_array(self):
@@ -930,7 +929,7 @@ class SurfaceOver2DRangeSeries(SurfaceBaseSeries):
     """Representation for a 3D surface consisting of a sympy expression and 2D
     range."""
     def __init__(self, expr, var_start_end_x, var_start_end_y, **kwargs):
-        super(SurfaceOver2DRangeSeries, self).__init__()
+        super().__init__()
         self.expr = sympify(expr)
         self.var_x = sympify(var_start_end_x[0])
         self.start_x = float(var_start_end_x[1])
@@ -977,7 +976,7 @@ class ParametricSurfaceSeries(SurfaceBaseSeries):
     def __init__(
         self, expr_x, expr_y, expr_z, var_start_end_u, var_start_end_v,
             **kwargs):
-        super(ParametricSurfaceSeries, self).__init__()
+        super().__init__()
         self.expr_x = sympify(expr_x)
         self.expr_y = sympify(expr_y)
         self.expr_z = sympify(expr_z)
@@ -1045,7 +1044,7 @@ class ContourSeries(BaseSeries):
     is_contour = True
 
     def __init__(self, expr, var_start_end_x, var_start_end_y):
-        super(ContourSeries, self).__init__()
+        super().__init__()
         self.nb_of_points_x = 50
         self.nb_of_points_y = 50
         self.expr = sympify(expr)
@@ -1084,9 +1083,9 @@ class ContourSeries(BaseSeries):
 # Backends
 ##############################################################################
 
-class BaseBackend(object):
+class BaseBackend:
     def __init__(self, parent):
-        super(BaseBackend, self).__init__()
+        super().__init__()
         self.parent = parent
 
 
@@ -1094,7 +1093,7 @@ class BaseBackend(object):
 # we will only be using this backend if we can successfully import matploblib
 class MatplotlibBackend(BaseBackend):
     def __init__(self, parent):
-        super(MatplotlibBackend, self).__init__(parent)
+        super().__init__(parent)
         self.matplotlib = import_module('matplotlib',
             import_kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
             min_module_version='1.1.0', catch=(RuntimeError,))
@@ -1343,7 +1342,7 @@ class MatplotlibBackend(BaseBackend):
 
 class TextBackend(BaseBackend):
     def __init__(self, parent):
-        super(TextBackend, self).__init__(parent)
+        super().__init__(parent)
 
     def show(self):
         if not _show:

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -23,7 +23,6 @@ Arithmetic. Master's thesis. University of Toronto, 1996
 
 """
 
-from __future__ import print_function, division
 
 from .plot import BaseSeries, Plot
 from .experimental_lambdify import experimental_lambdify, vectorized_lambdify
@@ -46,7 +45,7 @@ class ImplicitSeries(BaseSeries):
     def __init__(self, expr, var_start_end_x, var_start_end_y,
             has_equality, use_interval_math, depth, nb_of_points,
             line_color):
-        super(ImplicitSeries, self).__init__()
+        super().__init__()
         self.expr = sympify(expr)
         self.var_x = sympify(var_start_end_x[0])
         self.start_x = float(var_start_end_x[1])

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -1,11 +1,9 @@
-from __future__ import print_function, division
-
 from sympy import Basic, Symbol, symbols, lambdify
 from .util import interpolate, rinterpolate, create_bounds, update_bounds
 from sympy.utilities.iterables import sift
 
 
-class ColorGradient(object):
+class ColorGradient:
     colors = [0.4, 0.4, 0.4], [0.9, 0.9, 0.9]
     intervals = 0.0, 1.0
 
@@ -45,7 +43,7 @@ class ColorGradient(object):
 default_color_schemes = {}  # defined at the bottom of this file
 
 
-class ColorScheme(object):
+class ColorScheme:
 
     def __init__(self, *args, **kwargs):
         self.args = args

--- a/sympy/plotting/pygletplot/managed_window.py
+++ b/sympy/plotting/pygletplot/managed_window.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from pyglet.window import Window
 from pyglet.clock import Clock
 
@@ -43,7 +41,7 @@ class ManagedWindow(Window):
         gl_lock.acquire()
         try:
             try:
-                super(ManagedWindow, self).__init__(**self.win_args)
+                super().__init__(**self.win_args)
                 self.switch_to()
                 self.setup()
             except Exception as e:
@@ -70,7 +68,7 @@ class ManagedWindow(Window):
                     self.has_exit = True
             finally:
                 gl_lock.release()
-        super(ManagedWindow, self).close()
+        super().close()
 
     def close(self):
         """

--- a/sympy/plotting/pygletplot/plot.py
+++ b/sympy/plotting/pygletplot/plot.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from threading import RLock
 
 # it is sufficient to import "pyglet" here once
@@ -25,7 +23,7 @@ from os import getcwd, listdir
 import ctypes
 
 @doctest_depends_on(modules=('pyglet',))
-class PygletPlot(object):
+class PygletPlot:
     """
     Plot Examples
     =============

--- a/sympy/plotting/pygletplot/plot_axes.py
+++ b/sympy/plotting/pygletplot/plot_axes.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import pyglet.gl as pgl
 from pyglet import font
 
@@ -174,7 +172,7 @@ class PlotAxesBase(PlotObject):
 class PlotAxesOrdinate(PlotAxesBase):
 
     def __init__(self, parent_axes):
-        super(PlotAxesOrdinate, self).__init__(parent_axes)
+        super().__init__(parent_axes)
 
     def draw_axis(self, axis, color):
         ticks = self._p._axis_ticks[axis]
@@ -241,7 +239,7 @@ class PlotAxesOrdinate(PlotAxesBase):
 class PlotAxesFrame(PlotAxesBase):
 
     def __init__(self, parent_axes):
-        super(PlotAxesFrame, self).__init__(parent_axes)
+        super().__init__(parent_axes)
 
     def draw_background(self, color):
         pass

--- a/sympy/plotting/pygletplot/plot_camera.py
+++ b/sympy/plotting/pygletplot/plot_camera.py
@@ -1,12 +1,10 @@
-from __future__ import print_function, division
-
 import pyglet.gl as pgl
 from sympy.plotting.pygletplot.plot_rotation import get_spherical_rotatation
 from sympy.plotting.pygletplot.util import get_model_matrix, model_to_screen, \
                                             screen_to_model, vec_subs
 
 
-class PlotCamera(object):
+class PlotCamera:
 
     min_dist = 0.05
     max_dist = 500.0

--- a/sympy/plotting/pygletplot/plot_controller.py
+++ b/sympy/plotting/pygletplot/plot_controller.py
@@ -1,11 +1,9 @@
-from __future__ import print_function, division
-
 from pyglet.window import key
 from pyglet.window.mouse import LEFT, RIGHT, MIDDLE
 from sympy.plotting.pygletplot.util import get_direction_vectors, get_basis_vectors
 
 
-class PlotController(object):
+class PlotController:
 
     normal_mouse_sensitivity = 4.0
     modified_mouse_sensitivity = 1.0

--- a/sympy/plotting/pygletplot/plot_curve.py
+++ b/sympy/plotting/pygletplot/plot_curve.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import pyglet.gl as pgl
 from sympy.core import S
 from sympy.plotting.pygletplot.plot_mode_base import PlotModeBase

--- a/sympy/plotting/pygletplot/plot_interval.py
+++ b/sympy/plotting/pygletplot/plot_interval.py
@@ -1,10 +1,8 @@
-from __future__ import print_function, division
-
 from sympy import Symbol, sympify
 from sympy.core.numbers import Integer
 
 
-class PlotInterval(object):
+class PlotInterval:
     """
     """
     _v, _v_min, _v_max, _v_steps = None, None, None, None

--- a/sympy/plotting/pygletplot/plot_mode.py
+++ b/sympy/plotting/pygletplot/plot_mode.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy import Symbol, sympify
 from sympy.core.compatibility import is_sequence
 from sympy.geometry.entity import GeometryEntity

--- a/sympy/plotting/pygletplot/plot_mode_base.py
+++ b/sympy/plotting/pygletplot/plot_mode_base.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import pyglet.gl as pgl
 from sympy.core import S
 from sympy.core.compatibility import is_sequence
@@ -347,8 +345,8 @@ class PlotModeBase(PlotMode):
             self._on_change_color(v)
             self._color = v
         except Exception as e:
-            raise RuntimeError(("Color change failed. "
-                                "Reason: %s" % (str(e))))
+            raise RuntimeError("Color change failed. "
+                                "Reason: %s" % (str(e)))
 
     style = property(_get_style, _set_style)
     color = property(_get_color, _set_color)
@@ -375,6 +373,6 @@ class PlotModeBase(PlotMode):
              ('color', str(self.color)),
              ('style', str(self.style))]
 
-        o = "'%s'" % (("; ".join("%s=%s" % (k, v)
-                                for k, v in d if v != 'None')))
+        o = "'%s'" % ("; ".join("%s=%s" % (k, v)
+                                for k, v in d if v != 'None'))
         return ", ".join([f, i, o])

--- a/sympy/plotting/pygletplot/plot_modes.py
+++ b/sympy/plotting/pygletplot/plot_modes.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy import lambdify
 from sympy.core.numbers import pi
 from sympy.functions import sin, cos

--- a/sympy/plotting/pygletplot/plot_object.py
+++ b/sympy/plotting/pygletplot/plot_object.py
@@ -1,6 +1,4 @@
-from __future__ import print_function, division
-
-class PlotObject(object):
+class PlotObject:
     """
     Base class for objects which can be displayed in
     a Plot.

--- a/sympy/plotting/pygletplot/plot_rotation.py
+++ b/sympy/plotting/pygletplot/plot_rotation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 try:
     from ctypes import c_float
 except ImportError:

--- a/sympy/plotting/pygletplot/plot_surface.py
+++ b/sympy/plotting/pygletplot/plot_surface.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import pyglet.gl as pgl
 
 from sympy.core import S

--- a/sympy/plotting/pygletplot/plot_window.py
+++ b/sympy/plotting/pygletplot/plot_window.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy.core.compatibility import clock
 
 import pyglet.gl as pgl
@@ -39,7 +37,7 @@ class PlotWindow(ManagedWindow):
         self.caption_update_interval = 0.2
         self.drawing_first_object = True
 
-        super(PlotWindow, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def setup(self):
         self.camera = PlotCamera(self, ortho=self.ortho)
@@ -67,7 +65,7 @@ class PlotWindow(ManagedWindow):
         self.camera.setup_projection()
 
     def on_resize(self, w, h):
-        super(PlotWindow, self).on_resize(w, h)
+        super().on_resize(w, h)
         if self.camera is not None:
             self.camera.setup_projection()
 

--- a/sympy/plotting/pygletplot/util.py
+++ b/sympy/plotting/pygletplot/util.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 try:
     from ctypes import c_float, c_int, c_double
 except ImportError:

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 from sympy.core.numbers import Float
 from sympy.core.symbol import Dummy
 from sympy.utilities.lambdify import lambdify


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Dropping Python 2
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
partial fix for #18816
solves #20019 

#### Brief description of what is fixed or changed
Removed python2 imports and related unnecessary python2 instances from plotting

#### Other comments
Remove future imports using automated tool
pyup for file
pyup_dirs for directory

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->