### PR TITLE
Added various functions for Markov Chains

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1700,6 +1700,10 @@ def test_sympy__stats__stochastic_process_types__StochasticStateSpaceOf():
     DMC = DiscreteMarkovChain("Y")
     assert _test_args(StochasticStateSpaceOf(DMC, [0, 1, 2]))
 
+def test_sympy__stats__stochastic_process_types__CommunicationClass():
+    from sympy.stats.stochastic_process_types import CommunicationClass
+    assert _test_args(CommunicationClass([0, 1, 2], True, 1))
+
 def test_sympy__stats__stochastic_process_types__DiscreteMarkovChain():
     from sympy.stats.stochastic_process_types import DiscreteMarkovChain
     from sympy import MatrixSymbol

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -343,7 +343,7 @@ class MarkovProcess(StochasticProcess):
             if len(rand_var) == 1:
                 state_space = rand_var[0].pspace.set
         if not FiniteSet(*[i for i in range(trans_probs.shape[0])]).is_subset(state_space):
-            raise ValueError("state space is not compatible with the transition probabilites.")
+            raise ValueError("state space is not compatible with the transition probabilities.")
         state_space = FiniteSet(*[i for i in range(trans_probs.shape[0])])
         return state_space
 
@@ -588,6 +588,7 @@ class CommunicationClass:
 
         Parameters
         ==========
+
         states : list
             The list of integer states that are part of the equivalence class.
         recurrent : bool, optional
@@ -785,6 +786,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -808,11 +810,13 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         References
         ==========
+
         .. [1] https://www.probabilitycourse.com/chapter11/11_2_6_stationary_and_limiting_distributions.php
         .. [2] https://galton.uchicago.edu/~yibi/teaching/stat317/2014/Lectures/Lecture4_6up.pdf
 
         See Also
         ========
+
         sympy.stats.stochastic_processes_types.DiscreteMarkovChain.limiting_distribution
         """
         trans_probs = self.transition_probabilities
@@ -863,14 +867,16 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Parameters
         ==========
+
         p0
             The inital state vector as a row Matrix. This
-            is only needed for reducible or perioidic
+            is only needed for reducible or periodic
             Markov Chains. If None is given, it defaults
             to ``1/n`` for each of the ``n`` states.
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -883,7 +889,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         >>> X.limiting_distribution()
         Matrix([[2/5, 2/5, 1/5]])
 
-        A reducible aperioidic Markov Chain
+        A reducible aperiodic Markov Chain
         >>> T = Matrix([[S(1)/2, S(1)/2, 0],
         ...             [S(4)/5, S(1)/5, 0],
         ...             [1, 0, 0]])
@@ -901,11 +907,13 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         References
         ==========
+
         .. [1] https://www.probabilitycourse.com/chapter11/11_2_6_stationary_and_limiting_distributions.php
         .. [2] https://galton.uchicago.edu/~yibi/teaching/stat317/2014/Lectures/Lecture4_6up.pdf
 
         See Also
         ========
+
         sympy.stats.stochastic_processes_types.DiscreteMarkovChain.stationary_distribution
         """
         trans_probs = self.transition_probabilities
@@ -961,12 +969,14 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Returns
         =======
+
         classes : List of CommunicationClass, optional
             The list of communication classes that make up the
             Markov Chain.
 
         Notes
         =====
+
         This method uses the following algorithm:
 
         To find the periods of each state, take the one-step transition
@@ -1047,6 +1057,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Returns
         =======
+
         (states, P_new)
             ``states`` is the list that describes the order of the
             new states in the matrix
@@ -1056,6 +1067,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -1091,7 +1103,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         See Also
         ========
-        sympy.stats.DiscreteMarkovChain.decompose
+
+        sympy.stats.stochastic_processes_types.DiscreteMarkovChain.decompose
         """
         trans_probs = self.transition_probabilities
         n = self.num_states
@@ -1131,6 +1144,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Returns
         =======
+
         (states, A, B, C)
 
             ``states`` - a list of state names with the first being
@@ -1143,6 +1157,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -1154,16 +1169,23 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         ...             [0, 0, S(1)/2, S(1)/2, 0],
         ...             [S(1)/2, 0, 0, 0, S(1)/2]])
         >>> X = DiscreteMarkovChain('X', trans_probs=T)
-        >>> X.decompose()
-        ([2, 0, 1, 3, 4], Matrix([[1]]), Matrix([
+        >>> states, A, B, C = X.decompose()
+        >>> states
+        [2, 0, 1, 3, 4]
+        >>> A   # recurrent to recurrent
+        Matrix([[1]])
+        >>> B  # transient to recurrent
+        Matrix([
         [  0],
         [2/5],
         [1/2],
-        [  0]]), Matrix([
+        [  0]])
+        >>> C  # transient to transient
+        Matrix([
         [1/2, 1/2,   0,   0],
         [2/5, 1/5,   0,   0],
         [  0,   0, 1/2,   0],
-        [1/2,   0,   0, 1/2]]))
+        [1/2,   0,   0, 1/2]])
 
         This means that state 2 is the only absorbing state
         (since A is a 1x1 matrix). B is a 4x1 matrix since
@@ -1173,10 +1195,12 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         See Also
         ========
-        sympy.stats.DiscreteMarkovChain.canonical_form
+
+        sympy.stats.stochastic_processes_types.DiscreteMarkovChain.canonical_form
 
         References
         ==========
+
         .. [1] https://en.wikipedia.org/wiki/Absorbing_Markov_chain
         .. [2] http://people.brandeis.edu/~igusa/Math56aS08/Math56a_S08_notes015.pdf
 
@@ -1225,6 +1249,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Parameters
         ==========
+
         C
             The submatrix of the transition matrix that
             has probabilities of transitions from transient
@@ -1259,6 +1284,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -1305,6 +1331,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -1345,6 +1372,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S
 
@@ -1370,6 +1398,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         References
         ==========
+
+        .. [1] https://www.stat.auckland.ac.nz/~fewster/325/notes/ch8.pdf
         """
         states, A, B, C = self.decompose()
         new_from_old = states
@@ -1391,6 +1421,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Parameters
         ==========
+
         t : int, Symbol
             The number of time steps for which to calculate the
             first passage probability matrix. This can be an int or Symbol.
@@ -1407,12 +1438,14 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         Returns
         =======
+
         Ft : Matrix, Expr
             The first passage probability matrix for time step t. If i and j are
             specified, an expression is given intstead.
 
         Examples
         ========
+
         >>> from sympy.stats import DiscreteMarkovChain
         >>> from sympy import Matrix, S, symbols
 
@@ -1454,7 +1487,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         [0**(t - 1)*(1 - a) + b*(0**(t - 1)*a/(b - 1) - a*(1 - b)**(t - 1)/(b - 1)),                                                         a*(1 - a)**(t - 1)],
         [                                                        b*(1 - b)**(t - 1), 0**(t - 1)*(1 - b) + a*(0**(t - 1)*b/(a - 1) - b*(1 - a)**(t - 1)/(a - 1))]])
 
-        Specify i, j for quicker evauluation
+        Specify i, j for quicker evaluation
 
         >>> T = Matrix([[S(1)/2, S(1)/2, 0, 0],
         ...             [S(4)/5, S(1)/5, 0, 0],
@@ -1466,6 +1499,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         References
         ==========
+
         .. [1] https://scholar.uwindsor.ca/cgi/viewcontent.cgi?article=1125&context=major-papers
         .. [2] http://maths.dur.ac.uk/stats/courses/ProbMC2H/_files/handouts/1516MarkovChains2H.pdf
         """

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -581,28 +581,6 @@ class MarkovProcess(StochasticProcess):
         raise NotImplementedError("Mechanism for handling (%s, %s) queries hasn't been "
                                 "implemented yet."%(expr, condition))
 
-# TODO: add tests
-"""
-Errors with existing code:
-misidentifies some recurrent communication classes as transient if they dont have prob
-of 1 returning to itself eg Matrix([[0, 1], [1, 0]])
-
-The limiting distribution is not the same as the stationary distribution
-
-State space argument is not useful: it can only take the form of range(n)
-since if you insert [2, 1, 3], the states will be sorted (and hence incorrect)
-Also string values cannot be used which would probably be the most common use of it
-
-
-Questions
-Is it fine to remove the state space parameter?
-Matrices can't be indexed with custom indexes as far as I know
-
-Type hints
-
-Since stochastic processes will get very large,
-maybe put them into classes like dsp.py and csp.py
-"""
 
 class CommunicationClass:
     def __init__(self, states: list, recurrent: bool = None, period: int = None):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -710,8 +710,10 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         The number of states in the Markov Chain. Can be symbolic.
         """
-        return self.transition_probabilities.shape[0] \
-            if self.transition_probabilities is not None else None
+        if self.transition_probabilities is None:
+            return None
+        else:
+            return self.transition_probabilities.shape[0]
 
     @property
     def is_irreducible(self):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -582,8 +582,8 @@ class MarkovProcess(StochasticProcess):
                                 "implemented yet."%(expr, condition))
 
 
-class CommunicationClass:
-    def __init__(self, states: list, recurrent: bool = None, period: int = None):
+class CommunicationClass(Basic):
+    def __new__(cls, states: list, recurrent: bool = None, period: int = None):
         """Represents a single communication class for a Markov Chain.
 
         Parameters
@@ -596,9 +596,12 @@ class CommunicationClass:
         period: int, optional
             The period of the states. None if it is transient.
         """
+        # shamefully stolen from MutableDenseMatrix
+        self = Basic.__new__(cls)
         self.states = states
         self.recurrent = recurrent
         self.period = period
+        return self
 
     def __add__(self, other):
         """Finds the union of two communication classes"""

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -32,7 +32,7 @@ def test_DiscreteMarkovChain():
     raises(NotImplementedError, lambda: X(t))
     assert X.communication_classes() is None
     assert X.stationary_distribution() is None
-    assert X.limiting_distribution() is None
+    assert X.limiting_distribution is None
 
     raises(ValueError, lambda: sample_stochastic_process(t))
     raises(ValueError, lambda: next(sample_stochastic_process(X)))
@@ -46,7 +46,7 @@ def test_DiscreteMarkovChain():
 
     assert Y.communication_classes() is None
     assert Y.stationary_distribution() is None
-    assert Y.limiting_distribution() is None
+    assert Y.limiting_distribution is None
 
     raises(TypeError, lambda: DiscreteMarkovChain("Y", dict((1, 1))))
     raises(ValueError, lambda: next(sample_stochastic_process(Y)))
@@ -102,10 +102,10 @@ def test_DiscreteMarkovChain():
     assert Y3.is_irreducible
 
     p = Y2.stationary_distribution()
-    l = Y2.limiting_distribution()
+    l = Y2.limiting_distribution
     assert p * TO2 == p == l
     p = Y3.stationary_distribution()
-    l = Y3.limiting_distribution()
+    l = Y3.limiting_distribution
     assert p * TO3 == p == l
     assert Y2.communication_classes() == [CommunicationClass([0], True, 1),
                                           CommunicationClass([1, 2], False, 1)]
@@ -137,11 +137,11 @@ def test_DiscreteMarkovChain():
     TO4 = Matrix([[Rational(1, 5), Rational(2, 5), Rational(2, 5)], [Rational(1, 10), S.Half, Rational(2, 5)], [Rational(3, 5), Rational(3, 10), Rational(1, 10)]])
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
     w = ImmutableMatrix([[Rational(11, 39), Rational(16, 39), Rational(4, 13)]])
-    assert Y4.limiting_distribution() == w
+    assert Y4.limiting_distribution == w
     assert Y4.is_regular() == True
     TS1 = MatrixSymbol('T', 3, 3)
     Y5 = DiscreteMarkovChain('Y', trans_probs=TS1)
-    assert Y5.limiting_distribution()(w, TO4).doit() == True
+    assert Y5.limiting_distribution(w, TO4).doit() == True
     TO6 = Matrix([[S.One, 0, 0, 0, 0],[S.Half, 0, S.Half, 0, 0],[0, S.Half, 0, S.Half, 0], [0, 0, S.Half, 0, S.Half], [0, 0, 0, 0, 1]])
     Y6 = DiscreteMarkovChain('Y', trans_probs=TO6)
     assert Y6._transient2absorbing() == ImmutableMatrix([[S.Half, 0], [0, 0], [0, S.Half]])
@@ -163,10 +163,20 @@ def test_DiscreteMarkovChain():
     TO8 = Matrix([[0, 1, 0, 0], [1, 0, 0, 0], [S.Half, 0, S.Half, 0], [0, 0, S.Half, S.Half]])
     Y8 = DiscreteMarkovChain('Y', trans_probs=TO8)
     p = Y8.stationary_distribution()
-    l1 = Y8.limiting_distribution()
-    l2 = Y8.limiting_distribution(Matrix([[0, 0, 0, 1]]))
+    l1 = Y8.limiting_distribution
+    l2 = Y8.limiting_dist(Matrix([[0, 0, 0, 1]]))
     assert p * TO8 == p != l1 != l2
     assert Y8.decompose() == ([0, 1, 2, 3], TO8[0:2, 0:2], TO8[2:4, 0:2], TO8[2:4, 2:4])
+
+    # 0 by 0 matrix
+    TO9 = Matrix([[]])
+    Y9 = DiscreteMarkovChain('Y', trans_probs=TO9)
+    assert Y9.num_states == 0
+    assert Y9.transition_probabilities == Matrix([[]])
+    assert Y9.canonical_form() == ([], Matrix([[]]))
+    assert Y9.decompose() == ([], Matrix([[]]), Matrix([[]]), Matrix([[]]))
+    assert Y9.stationary_distribution() == Y9.limiting_distribution == Matrix([[]])
+    assert Y9.first_passage_matrix(2) == Matrix([[]])
 
     # testing miscellaneous queries
     T = Matrix([[S.Half, Rational(1, 4), Rational(1, 4)],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added various functions for Discrete Markov Chains within the stats module. Any input welcome.

#### Other comments
I may well have added backwards incomparable changes but I am unaware of them. The only thing I know I changed was that `limiting_distribution` is no longer a `@property` but rather a function. Please let me know if you manage to find any others.

Problems that I found with existing code:
1. It misidentifies some recurrent communication classes as transient if they don't have probability of 1 returning to itself eg `Matrix([[0, 1], [1, 0]])` should have recurrent states but current code says that it is transient. This PR fixes that.
2. The limiting distribution is not the same as the stationary distribution. This code fixes that. 
3. The `state_space` argument is not useful: it can only take the form of `range(n)`. If you insert [2, 1, 3], the states will be sorted (and hence incorrect). Also string values cannot be used which would probably be the most common use of it if it works. I suggest removing this feature but it has not been done yet in this PR. As it stands, this causes problems with functions such as `canonical_form`.
4. `P(Eq(YS[1], 1), Eq(YS[2], 2))` should not be equal to `Probability(Eq(YS[1], 1))`. This would mean that `YS[1]` and `YS[2]` are independent. But they are in fact dependent. Knowledge of the future does give knowledge of the present. Easy fix but has not been done yet.

Questions:
- Can we remove the `state_space` argument? Or at least change it to some kind of list that keeps its order.
- I think `stochastic_processes_types.py` will get large within the coming years. Should we separate them into continuous and discrete modules for time and space domains? For example, we will have `dsctsp_types.py` standing for for discrete time continuous space stochastic processes types.
- Should I look to see what functions can be bumped up to `MarkovProcess` so that `ContinuousMarkovProcess` can access them too?

If you are worried about the mathematical correctness of code that I did not reference, I can add my professor's lecture notes in the comments here (the PR). I don't think it will be good to put a Google Doc in the references in the code itself.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->