### PR TITLE
Sign of integral of Parametricregion object

### DIFF
--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -79,7 +79,7 @@ class ParametricIntegral(Basic):
             result = integrate(integrand, (parameter, lower, upper))
 
         elif parametricregion.dimensions == 2:
-            u, v = cls._bounds_case(parametricregion.limits)
+            u, v = cls._bounds_case(parametricregion.parameters, parametricregion.limits)
 
             r_u = diff(r, u)
             r_v = diff(r, v)
@@ -98,7 +98,7 @@ class ParametricIntegral(Basic):
             result = integrate(integrand, (u, lower_u, upper_u), (v, lower_v, upper_v))
 
         else:
-            variables = cls._bounds_case(parametricregion.limits)
+            variables = cls._bounds_case(parametricregion.parameters, parametricregion.limits)
             coeff = Matrix(parametricregion.definition).jacobian(variables).det()
             integrand = simplify(parametricfield*coeff)
 
@@ -111,7 +111,7 @@ class ParametricIntegral(Basic):
             return super().__new__(cls, field, parametricregion)
 
     @classmethod
-    def _bounds_case(cls, limits):
+    def _bounds_case(cls, parameters, limits):
 
         V = list(limits.keys())
         E = list()
@@ -127,7 +127,11 @@ class ParametricIntegral(Basic):
                     continue
                 if lower_p.issuperset(set([q])) or upper_p.issuperset(set([q])):
                     E.append((p, q))
-        return topological_sort((V, E), key=default_sort_key)
+
+        if not E:
+            return parameters
+        else:
+            return topological_sort((V, E), key=default_sort_key)
 
     @property
     def field(self):

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -49,9 +49,12 @@ def test_parametric_volumeintegrals():
     cube = ParametricRegion((x, y, z), (x, 0, 1), (y, 0, 1), (z, 0, 1))
     assert ParametricIntegral(1, cube) == 1
 
-    solidsphere = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
+    solidsphere1 = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
                             (r, 0, 2), (theta, 0, 2*pi), (phi, 0, pi))
-    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere) == -256*pi/15
+    solidsphere2 = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
+                            (r, 0, 2), (phi, 0, pi), (theta, 0, 2*pi))
+    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere1) == -256*pi/15
+    assert ParametricIntegral(C.x**2 + C.y**2, solidsphere2) == 256*pi/15
 
     region_under_plane1 = ParametricRegion((x, y, z), (x, 0, 3), (y, 0, -2*x/3 + 2),\
                                     (z, 0, 6 - 2*x - 3*y))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
See #20021.

#### Brief description of what is fixed or changed
Before this PR, the sign of integral of ParametricRegion objects was independent of the order of bounds at the time of initialization,

Suppose we have two spheres with imits defined in different order.
```python
solidsphere1 = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
                            (r, 0, 2), (theta, 0, 2*pi), (phi, 0, pi))
solidsphere2 = ParametricRegion((r*sin(phi)*cos(theta), r*sin(phi)*sin(theta), r*cos(phi)),\
                            (r, 0, 2), (phi, 0, pi), (theta, 0, 2*pi))
```

Before:
```python
vector_integrate(1, solidsphere1) # -> -18*pi
vector_integrate(1, solidsphere2) # -> -18*pi
```

After this PR:
```
vector_integrate(1, solidsphere1) # -> -18*pi
vector_integrate(1, solidsphere2) # -> 18*pi
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * integral of parametric region depends on the order of limits at the time of initialization.
<!-- END RELEASE NOTES -->