### PR TITLE
Added GeometricError for eccentricity>=1 and for eccentricity <0

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -158,7 +158,7 @@ class Ellipse(GeometrySet):
 
         if hradius is zoo or vradius is zoo:
             raise GeometryError("Invalid value encountered when computing hradius / vradius.")
-        
+
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)
 
     def _svg(self, scale_factor=1., fill_color="#66cc99"):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if S(eccentricity).is_negative is True:
+            if eccentricity.is_negative is True:
                 raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -6,7 +6,7 @@ Contains
 
 """
 
-from sympy import Expr, Eq
+from sympy import Expr, Eq, zoo
 from sympy.core import S, pi, sympify
 from sympy.core.parameters import global_parameters
 from sympy.core.logic import fuzzy_bool
@@ -159,9 +159,8 @@ class Ellipse(GeometrySet):
         if simplify(hradius).is_real and hradius !=0 and vradius == 0:
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if (simplify(hradius).is_real is True and hradius<0) or (simplify(vradius).is_real is True and vradius<0):
-            raise GeometryError("hradius or vradius cannot be negative.")
-
+        if hradius is zoo or vradius is zoo:
+            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)
 
     def _svg(self, scale_factor=1., fill_color="#66cc99"):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if eccentricity.is_negative is True:
+            if eccentricity.is_negative:
                 raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -156,7 +156,7 @@ class Ellipse(GeometrySet):
         if (hradius.is_complex is True and hradius.is_real is False) or (vradius.is_complex is True and vradius.is_real is False):
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if hradius !=0 and vradius == 0:
+        if hradius.is_real and hradius !=0 and vradius == 0:
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
         if (hradius.isreal is True and hradius<0) or (vradius.isreal is True and vradius<0):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -139,6 +139,9 @@ class Ellipse(GeometrySet):
                 Exactly two arguments of "hradius", "vradius", and
                 "eccentricity" must not be None.'''))
 
+        if eccentricity > 1:
+            raise GeometryError("eccentricity of ellipse/circle can only be less than or equal to 1")
+
         if eccentricity is not None:
             if hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -139,14 +139,14 @@ class Ellipse(GeometrySet):
                 Exactly two arguments of "hradius", "vradius", and
                 "eccentricity" must not be None.'''))
 
-        if eccentricity > 1:
-            raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
-
         if eccentricity is not None:
-            if hradius is None:
+            if eccentricity > 1:
+                raise GeometryError("eccentricity of ellipse/circle can only be less than 1")            
+            elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)
             elif vradius is None:
                 vradius = hradius * sqrt(1 - eccentricity**2)
+
 
         if hradius == vradius:
             return Circle(center, hradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity > 1:
-            raise GeometryError("eccentricity of ellipse/circle can only be less than or equal to 1")
+            raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
 
         if eccentricity is not None:
             if hradius is None:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if S(eccentricity).is_negative == True:
+            if S(eccentricity).is_negative is True:
                 raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -153,13 +153,13 @@ class Ellipse(GeometrySet):
         if hradius == 0 or vradius == 0:
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
 
-        if hradius.is_real is False or vradius.is_real is False:
+        if (hradius.is_complex is True and hradius.is_real is False) or (vradius.is_complex is True and vradius.is_real is False):
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
         if hradius !=0 and vradius == 0:
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if hradius<0 or vradius<0:
+        if (hradius.isreal is True and hradius<0) or (vradius.isreal is True and vradius<0):
             raise GeometryError("hradius or vradius cannot be negative.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,13 +140,12 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if eccentricity.is_real == True and eccentricity > 1:
+            if eccentricity.is_real is True and eccentricity >= 1:
                 raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)
             elif vradius is None:
                 vradius = hradius * sqrt(1 - eccentricity**2)
-
 
         if hradius == vradius:
             return Circle(center, hradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,8 +140,8 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if eccentricity.is_real is True and eccentricity >= 1:
-                raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
+            if eccentricity.is_real is True and eccentricity < 0:
+                raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)
             elif vradius is None:
@@ -152,6 +152,15 @@ class Ellipse(GeometrySet):
 
         if hradius == 0 or vradius == 0:
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
+
+        if hradius.is_real is False or vradius.is_real is False:
+            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
+
+        if hradius !=0 and vradius == 0:
+            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
+
+        if hradius<0 or vradius<0:
+            raise GeometryError("hradius or vradius cannot be negative.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -153,14 +153,12 @@ class Ellipse(GeometrySet):
         if hradius == 0 or vradius == 0:
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
 
-        if (simplify(hradius).is_complex is True and simplify(hradius).is_real is False) or (simplify(vradius).is_complex is True and simplify(vradius).is_real is False):
-            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
-
-        if simplify(hradius).is_real and hradius !=0 and vradius == 0:
-            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
+        if (hradius.is_complex is True and hradius.is_real is False) or (vradius.is_complex is True and vradius.is_real is False):
+            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
 
         if hradius is zoo or vradius is zoo:
-            raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
+            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
+        
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)
 
     def _svg(self, scale_factor=1., fill_color="#66cc99"):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -6,7 +6,7 @@ Contains
 
 """
 
-from sympy import Expr, Eq, zoo
+from sympy import Expr, Eq
 from sympy.core import S, pi, sympify
 from sympy.core.parameters import global_parameters
 from sympy.core.logic import fuzzy_bool

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -153,10 +153,7 @@ class Ellipse(GeometrySet):
         if hradius == 0 or vradius == 0:
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
 
-        if (hradius.is_complex is True and hradius.is_real is False) or (vradius.is_complex is True and vradius.is_real is False):
-            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
-
-        if hradius is zoo or vradius is zoo:
+        if hradius.is_real is False or vradius.is_real is False:
             raise GeometryError("Invalid value encountered when computing hradius / vradius.")
 
         if hradius is oo or vradius is oo:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if eccentricity > 1:
+            if eccentricity.is_real == True and eccentricity > 1:
                 raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -141,7 +141,7 @@ class Ellipse(GeometrySet):
 
         if eccentricity is not None:
             if eccentricity > 1:
-                raise GeometryError("eccentricity of ellipse/circle can only be less than 1")            
+                raise GeometryError("eccentricity of ellipse/circle can only be less than 1")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)
             elif vradius is None:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -159,7 +159,7 @@ class Ellipse(GeometrySet):
         if simplify(hradius).is_real and hradius !=0 and vradius == 0:
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if (simplify(hradius).isreal is True and hradius<0) or (simplify(vradius).isreal is True and vradius<0):
+        if (simplify(hradius).is_real is True and hradius<0) or (simplify(vradius).is_real is True and vradius<0):
             raise GeometryError("hradius or vradius cannot be negative.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if eccentricity.is_real is True and eccentricity < 0:
+            if simplify(eccentricity).is_negative == True:
                 raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -6,7 +6,7 @@ Contains
 
 """
 
-from sympy import Expr, Eq, zoo
+from sympy import Expr, Eq, zoo, oo
 from sympy.core import S, pi, sympify
 from sympy.core.parameters import global_parameters
 from sympy.core.logic import fuzzy_bool
@@ -157,6 +157,12 @@ class Ellipse(GeometrySet):
             raise GeometryError("Invalid value encountered when computing hradius / vradius.")
 
         if hradius is zoo or vradius is zoo:
+            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
+
+        if hradius is oo or vradius is oo:
+            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
+
+        if hradius is -oo or vradius is -oo:
             raise GeometryError("Invalid value encountered when computing hradius / vradius.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -6,7 +6,7 @@ Contains
 
 """
 
-from sympy import Expr, Eq, zoo, oo
+from sympy import Expr, Eq, zoo
 from sympy.core import S, pi, sympify
 from sympy.core.parameters import global_parameters
 from sympy.core.logic import fuzzy_bool

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -153,13 +153,13 @@ class Ellipse(GeometrySet):
         if hradius == 0 or vradius == 0:
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
 
-        if (hradius.is_complex is True and hradius.is_real is False) or (vradius.is_complex is True and vradius.is_real is False):
+        if (simplify(hradius).is_complex is True and simplify(hradius).is_real is False) or (simplify(vradius).is_complex is True and simplify(vradius).is_real is False):
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if hradius.is_real and hradius !=0 and vradius == 0:
+        if simplify(hradius).is_real and hradius !=0 and vradius == 0:
             raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
 
-        if (hradius.isreal is True and hradius<0) or (vradius.isreal is True and vradius<0):
+        if (simplify(hradius).isreal is True and hradius<0) or (simplify(vradius).isreal is True and vradius<0):
             raise GeometryError("hradius or vradius cannot be negative.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -140,7 +140,7 @@ class Ellipse(GeometrySet):
                 "eccentricity" must not be None.'''))
 
         if eccentricity is not None:
-            if simplify(eccentricity).is_negative == True:
+            if S(eccentricity).is_negative == True:
                 raise GeometryError("Eccentricity of ellipse/circle should lie between [0, 1)")
             elif hradius is None:
                 hradius = vradius / sqrt(1 - eccentricity**2)
@@ -154,12 +154,6 @@ class Ellipse(GeometrySet):
             return Segment(Point(center[0] - hradius, center[1] - vradius), Point(center[0] + hradius, center[1] + vradius))
 
         if hradius.is_real is False or vradius.is_real is False:
-            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
-
-        if hradius is oo or vradius is oo:
-            raise GeometryError("Invalid value encountered when computing hradius / vradius.")
-
-        if hradius is -oo or vradius is -oo:
             raise GeometryError("Invalid value encountered when computing hradius / vradius.")
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -347,10 +347,6 @@ def test_construction():
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = -3))
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = -0.5))
 
-    # tests for hradius/ vradius negative
-    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=1, vradius = -3))
-    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=-4, vradius = 1))
-
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)
     e3 = Ellipse(Point(0, 0), y1, y1)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -341,7 +341,7 @@ def test_construction():
     #if vradius is not defined
     assert Ellipse(None, 1, None, 1).length == 2
     #if hradius is not defined
-    raises(GeometryError, lambda: Ellipse(None, 1, eccentricity = 1))
+    raises(GeometryError, lambda: Ellipse(None, None, 1, eccentricity = 1))
 
     #tests for eccentricity < 0
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = -3))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -337,6 +337,19 @@ def test_construction():
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=sec(5)))
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=S.Pi-S(2)))
 
+    #tests for eccentricity = 1
+    #if vradius is not defined
+    assert Ellipse(None, 1, None, 1).length == 2
+    #if hradius is not defined
+    raises(GeometryError, lambda: Ellipse(None, 1, eccentricity = 1))
+
+    #tests for eccentricity < 0
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = -3))
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = -0.5))
+
+    # tests for hradius/ vradius negative
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=1, vradius = -3))
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=-4, vradius = 1))
 
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)
@@ -494,9 +507,6 @@ def test_circumference():
     assert Ellipse(Point(0, 0), M, m).circumference == 4 * M * elliptic_e((M ** 2 - m ** 2) / M**2)
 
     assert Ellipse(Point(0, 0), 5, 4).circumference == 20 * elliptic_e(S(9) / 25)
-
-    # degenerate ellipse
-    assert Ellipse(None, 1, None, 1).length == 2
 
     # circle
     assert Ellipse(None, 1, None, 0).circumference == 2*pi

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -1,4 +1,4 @@
-from sympy import Eq, Rational, S, Symbol, symbols, pi, sqrt, oo, Point2D, Segment2D, Abs
+from sympy import Eq, Rational, S, Symbol, symbols, pi, sqrt, oo, Point2D, Segment2D, Abs, sec
 from sympy.geometry import (Circle, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment,
                             Triangle, intersection)
@@ -331,6 +331,11 @@ def test_construction():
     # eccentricity would be filtered out in this case and the constructor would throw an error
     e4 = Ellipse(Point(0, 0), hradius=1, eccentricity=0)
     assert e4.vradius == 1
+
+    #tests for eccentricity > 1
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=sqrt(3)-sqrt(2) +0.6899))
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=sec(5)))
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=S.Pi-S(2)))
 
 
 def test_ellipse_random_point():

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -333,7 +333,7 @@ def test_construction():
     assert e4.vradius == 1
 
     #tests for eccentricity > 1
-    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=sqrt(3)-sqrt(2) +0.6899))
+    raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity = S(3)/2))
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=sec(5)))
     raises(GeometryError, lambda: Ellipse(Point(3, 1), hradius=3, eccentricity=S.Pi-S(2)))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
--

#### Brief description of what is fixed or changed
`>>> from sympy import Ellipse, Point, Rational`
`>>> e2 = Ellipse(Point(3, 1), hradius=3, eccentricity=Rational(6, 5))`
The above code should raise an geometric error as eccentricity of ellipse is always less than 1.
Instead it was being solved by complex number.

To fix this,
`raise GeometryError("eccentricity of ellipse/circle can only be less than 1")`
for eccentricity>1 was added in ellipse.py.


#### Other comments
References:- https://en.wikipedia.org/wiki/Eccentricity_(mathematics)#:~:text=The%20eccentricity%20of%20a%20circle,hyperbola%20is%20greater%20than%201.
Addition of Hyperbola would be a great addition and is incomplete.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* geometry
    * Ellipses with `eccentricity >=1` and for `eccentricity < 0` will be handled as trivial cases

<!-- END RELEASE NOTES -->