### PR TITLE
Fix divergence in cylindrical coordinates

### DIFF
--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -3,7 +3,6 @@ from sympy.core.expr import Expr
 from sympy.core import sympify, S, preorder_traversal
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.vector import Vector, VectorMul, VectorAdd, Cross, Dot
-from sympy.vector.scalar import BaseScalar
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.function import Derivative
 from sympy import Add, Mul
@@ -362,6 +361,4 @@ def _diff_conditional(expr, base_scalar, coeff_1, coeff_2):
     """
     from sympy.vector.functions import express
     new_expr = express(expr, base_scalar.system, variables=True)
-    if base_scalar in new_expr.atoms(BaseScalar):
-        return Derivative(coeff_1 * coeff_2 * new_expr, base_scalar)
-    return S.Zero
+    return Derivative(coeff_1 * coeff_2 * new_expr, base_scalar)

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -361,4 +361,5 @@ def _diff_conditional(expr, base_scalar, coeff_1, coeff_2):
     """
     from sympy.vector.functions import express
     new_expr = express(expr, base_scalar.system, variables=True)
-    return Derivative(coeff_1 * coeff_2 * new_expr, base_scalar)
+    arg = coeff_1 * coeff_2 * new_expr
+    return Derivative(arg, base_scalar) if arg else S.Zero


### PR DESCRIPTION
This fix is more general than my particular use case, but I wanted to
compute:

```python
from sympy.vector import divergence, gradient, Vector, CoordSys3D
R = CoordSys3D('R', transformation='cylindrical')
divergence(R.i)
```

The correct solution to this is 1/r, however, sympy returned zero
because it was detecting that no base scalars were in the provided
expression, and then using the special case code, returning zero. A
straight-forward solution to this is removing the special case code, and
simply returning a `Derivative` instantiation every time.

<!-- BEGIN RELEASE NOTES -->
- vector
    - Always return `Derivative` instance from `_diff_conditional` in `operators.py` since the `coeffs` may be functions of the base scalars even if `expr` is not