### PR TITLE
Fixing dead link 

### DIFF
--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -184,7 +184,7 @@ common superclass of :class:`~.Integral` and :class:`~.Sum`.
 
 TODO and Bugs
 -------------
-There are still lots of functions that SymPy does not know how to integrate. For bugs related to this module, see https://github.com/sympy/sympy/issues?q=label%3AIntegration
+There are still lots of functions that SymPy does not know how to integrate. For bugs related to this module, see https://github.com/sympy/sympy/issues?q=is%3Aissue+is%3Aopen+label%3Aintegrals
 
 Numeric Integrals
 =================


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None


#### Brief description of what is fixed or changed
The [link](https://github.com/sympy/sympy/issues?q=label%3AIntegration) pointing to issues in the [TODO and Bugs](https://docs.sympy.org/latest/modules/integrals/integrals.html#todo-and-bugs) section in the documentation for the `integration` module was incorrect and is changed to point at open issues labelled 'integrals' now.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->