### PR TITLE
Remove __nonzero__, __long__, __div__, and __rdiv__

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -185,12 +185,8 @@ class Quaternion(Expr):
     def __truediv__(self, other):
         return self * sympify(other)**-1
 
-    __div__ = __truediv__
-
     def __rtruediv__(self, other):
         return sympify(other) * self**-1
-
-    __rdiv__ = __rtruediv__
 
     def _eval_Integral(self, *args):
         return self.integrate(*args)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1203,7 +1203,7 @@ class AccumulationBounds(AtomicExpr):
     __rmul__ = __mul__
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Expr):
             if isinstance(other, AccumBounds):
                 if other.min.is_positive or other.max.is_negative:
@@ -1262,10 +1262,8 @@ class AccumulationBounds(AtomicExpr):
 
         return NotImplemented
 
-    __truediv__ = __div__
-
     @_sympifyit('other', NotImplemented)
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if isinstance(other, Expr):
             if other.is_extended_real:
                 if other.is_zero:
@@ -1288,8 +1286,6 @@ class AccumulationBounds(AtomicExpr):
             return Mul(other, 1 / self, evaluate=False)
         else:
             return NotImplemented
-
-    __rtruediv__ = __rdiv__
 
     @_sympifyit('other', NotImplemented)
     def __pow__(self, other):

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -533,23 +533,19 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         zero_mul_simp(r, len(self.array_form) - 1)
         return group.dtype(tuple(r))
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         group = self.group
         if not isinstance(other, group.dtype):
             raise TypeError("only FreeGroup elements of same FreeGroup can "
                     "be multiplied")
         return self*(other.inverse())
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         group = self.group
         if not isinstance(other, group.dtype):
             raise TypeError("only FreeGroup elements of same FreeGroup can "
                     "be multiplied")
         return other*(self.inverse())
-
-    __truediv__ = __div__
-
-    __rtruediv__ = __rdiv__
 
     def __add__(self, other):
         return NotImplemented

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -326,7 +326,6 @@ class Expr(Basic, EvalfMixin):
             if diff_sign != isign:
                 i -= isign
         return i
-    __long__ = __int__
 
     def __float__(self):
         # Don't bother testing if it's a number; if it's not this is going

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -235,8 +235,8 @@ class Expr(Basic, EvalfMixin):
         return Pow(other, self)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         denom = Pow(other, S.NegativeOne)
         if self is S.One:
             return denom
@@ -244,16 +244,13 @@ class Expr(Basic, EvalfMixin):
             return Mul(self, denom)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    @call_highest_priority('__div__')
-    def __rdiv__(self, other):
+    @call_highest_priority('__truediv__')
+    def __rtruediv__(self, other):
         denom = Pow(self, S.NegativeOne)
         if other is S.One:
             return denom
         else:
             return Mul(other, denom)
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmod__')

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -790,10 +790,8 @@ class Factors:
     def __divmod__(self, other):  # Factors
         return self.div(other)
 
-    def __div__(self, other):  # Factors
+    def __truediv__(self, other):  # Factors
         return self.quo(other)
-
-    __truediv__ = __div__
 
     def __mod__(self, other):  # Factors
         return self.rem(other)
@@ -899,13 +897,11 @@ class Term:
         else:
             return NotImplemented
 
-    def __div__(self, other):  # Term
+    def __truediv__(self, other):  # Term
         if isinstance(other, Term):
             return self.quo(other)
         else:
             return NotImplemented
-
-    __truediv__ = __div__
 
     def __pow__(self, other):  # Term
         if isinstance(other, SYMPY_INTS):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -756,15 +756,13 @@ class Number(AtomicExpr):
         return AtomicExpr.__mul__(self, other)
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Number) and global_parameters.evaluate:
             if other is S.NaN:
                 return S.NaN
             elif other is S.Infinity or other is S.NegativeInfinity:
                 return S.Zero
-        return AtomicExpr.__div__(self, other)
-
-    __truediv__ = __div__
+        return AtomicExpr.__truediv__(self, other)
 
     def __eq__(self, other):
         raise NotImplementedError('%s needs .__eq__() method' %
@@ -1310,13 +1308,11 @@ class Float(Number):
         return Number.__mul__(self, other)
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Number) and other != 0 and global_parameters.evaluate:
             rhs, prec = other._as_mpf_op(self._prec)
             return Float._new(mlib.mpf_div(self._mpf_, rhs, prec, rnd), prec)
-        return Number.__div__(self, other)
-
-    __truediv__ = __div__
+        return Number.__truediv__(self, other)
 
     @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
@@ -1747,7 +1743,7 @@ class Rational(Number):
     __rmul__ = __mul__
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
                 if self.p and other.p == S.Zero:
@@ -1759,10 +1755,10 @@ class Rational(Number):
             elif isinstance(other, Float):
                 return self*(1/other)
             else:
-                return Number.__div__(self, other)
-        return Number.__div__(self, other)
+                return Number.__truediv__(self, other)
+        return Number.__truediv__(self, other)
     @_sympifyit('other', NotImplemented)
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
                 return Rational(other.p*self.q, self.p, igcd(self.p, other.p))
@@ -1771,9 +1767,8 @@ class Rational(Number):
             elif isinstance(other, Float):
                 return other*(1/self)
             else:
-                return Number.__rdiv__(self, other)
-        return Number.__rdiv__(self, other)
-    __truediv__ = __div__
+                return Number.__rtruediv__(self, other)
+        return Number.__rtruediv__(self, other)
 
     @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
@@ -2880,7 +2875,7 @@ class Infinity(Number, metaclass=Singleton):
     __rmul__ = __mul__
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Number) and global_parameters.evaluate:
             if other is S.Infinity or \
                 other is S.NegativeInfinity or \
@@ -2889,9 +2884,7 @@ class Infinity(Number, metaclass=Singleton):
             if other.is_extended_nonnegative:
                 return self
             return S.NegativeInfinity
-        return Number.__div__(self, other)
-
-    __truediv__ = __div__
+        return Number.__truediv__(self, other)
 
     def __abs__(self):
         return S.Infinity
@@ -3048,7 +3041,7 @@ class NegativeInfinity(Number, metaclass=Singleton):
     __rmul__ = __mul__
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Number) and global_parameters.evaluate:
             if other is S.Infinity or \
                 other is S.NegativeInfinity or \
@@ -3057,9 +3050,7 @@ class NegativeInfinity(Number, metaclass=Singleton):
             if other.is_extended_nonnegative:
                 return self
             return S.Infinity
-        return Number.__div__(self, other)
-
-    __truediv__ = __div__
+        return Number.__truediv__(self, other)
 
     def __abs__(self):
         return S.Infinity
@@ -3226,10 +3217,8 @@ class NaN(Number, metaclass=Singleton):
         return self
 
     @_sympifyit('other', NotImplemented)
-    def __div__(self, other):
+    def __truediv__(self, other):
         return self
-
-    __truediv__ = __div__
 
     def floor(self):
         return self

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1282,10 +1282,8 @@ class Float(Number):
     def _eval_is_zero(self):
         return self._mpf_ == fzero
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self._mpf_ != fzero
-
-    __bool__ = __nonzero__
 
     def __neg__(self):
         return Float._new(mlib.mpf_neg(self._mpf_), self._prec)
@@ -1383,8 +1381,6 @@ class Float(Number):
         if self._mpf_ == fzero:
             return 0
         return int(mlib.to_int(self._mpf_))  # uses round_fast = round_down
-
-    __long__ = __int__
 
     def __eq__(self, other):
         from sympy.logic.boolalg import Boolean
@@ -1851,8 +1847,6 @@ class Rational(Number):
             return -int(-p//q)
         return int(p//q)
 
-    __long__ = __int__
-
     def floor(self):
         return Integer(self.p // self.q)
 
@@ -2116,8 +2110,6 @@ class Integer(Rational):
     # Arithmetic operations are here for efficiency
     def __int__(self):
         return self.p
-
-    __long__ = __int__
 
     def floor(self):
         return Integer(self.p)
@@ -2636,10 +2628,8 @@ class Zero(IntegerConstant, metaclass=Singleton):
         # Order(0,x) -> 0
         return self
 
-    def __nonzero__(self):
+    def __bool__(self):
         return False
-
-    __bool__ = __nonzero__
 
     def as_coeff_Mul(self, rational=False):  # XXX this routine should be deleted
         """Efficiently extract the coefficient of a summation. """
@@ -3405,9 +3395,6 @@ class NumberSymbol(AtomicExpr):
     def __int__(self):
         # subclass with appropriate return value
         raise NotImplementedError
-
-    def __long__(self):
-        return self.__int__()
 
     def __hash__(self):
         return super().__hash__()

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -387,10 +387,8 @@ class Relational(Boolean, EvalfMixin):
         args = (arg.expand(**kwargs) for arg in self.args)
         return self.func(*args)
 
-    def __nonzero__(self):
+    def __bool__(self):
         raise TypeError("cannot determine truth value of Relational")
-
-    __bool__ = __nonzero__
 
     def _eval_as_set(self):
         # self is univariate and periodicity(self, x) in (0, None)
@@ -962,11 +960,11 @@ class GreaterThan(_Greater):
         (1) x > y > z
         (2) (x > y) and (y > z)
         (3) (GreaterThanObject) and (y > z)
-        (4) (GreaterThanObject.__nonzero__()) and (y > z)
+        (4) (GreaterThanObject.__bool__()) and (y > z)
         (5) TypeError
 
        Because of the "and" added at step 2, the statement gets turned into a
-       weak ternary statement, and the first object's __nonzero__ method will
+       weak ternary statement, and the first object's __bool__ method will
        raise TypeError.  Thus, creating a chained inequality is not possible.
 
            In Python, there is no way to override the ``and`` operator, or to

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -76,7 +76,7 @@ class SingletonRegistry(Registry):
     as ``x + Rational(1, 2)``, but this is a lot more typing. A shorter
     version is ``x + S(1)/2``. Since ``S(1)`` returns ``Integer(1)``, the
     division will return a ``Rational`` type, since it will call
-    ``Integer.__div__``, which knows how to return a ``Rational``.
+    ``Integer.__truediv__``, which knows how to return a ``Rational``.
 
     """
     __slots__ = ()

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1548,11 +1548,9 @@ def test_issue_3531():
     # https://github.com/sympy/sympy/issues/3531
     # https://github.com/sympy/sympy/pull/18116
     class MightyNumeric(tuple):
-        def __rdiv__(self, other):
-            return "something"
-
         def __rtruediv__(self, other):
             return "something"
+
     assert sympify(1)/MightyNumeric((1, 2)) == "something"
 
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -34,12 +34,6 @@ class DummyNumber:
             return a + self.number
         return NotImplemented
 
-    def __truediv__(a, b):
-        return a.__div__(b)
-
-    def __rtruediv__(a, b):
-        return a.__rdiv__(b)
-
     def __add__(self, a):
         if isinstance(a, (int, float, DummyNumber)):
             return self.number + a
@@ -65,12 +59,12 @@ class DummyNumber:
             return self.number * a
         return NotImplemented
 
-    def __rdiv__(self, a):
+    def __rtruediv__(self, a):
         if isinstance(a, (int, float)):
             return a / self.number
         return NotImplemented
 
-    def __div__(self, a):
+    def __truediv__(self, a):
         if isinstance(a, (int, float, DummyNumber)):
             return self.number / a
         return NotImplemented
@@ -189,14 +183,11 @@ class NonBasic:
     def __rmul__(self, other):
         return SpecialOp('*', other, self)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return SpecialOp('/', self, other)
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         return SpecialOp('/', other, self)
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def __floordiv__(self, other):
         return SpecialOp('//', self, other)

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -53,12 +53,12 @@ class Higher(Integer):
     def __rpow__(self, other):
         return 2*self.result
 
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         return self.result
 
-    @call_highest_priority('__div__')
-    def __rdiv__(self, other):
+    @call_highest_priority('__truediv__')
+    def __rtruediv__(self, other):
         return 2*self.result
 
     @call_highest_priority('__rmod__')
@@ -76,9 +76,6 @@ class Higher(Integer):
     @call_highest_priority('__floordiv__')
     def __rfloordiv__(self, other):
         return 2*self.result
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
 
 class Lower(Higher):

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -126,9 +126,9 @@ class GeometryEntity(Basic):
         """Implementation of reverse add method."""
         return a.__add__(self)
 
-    def __rdiv__(self, a):
+    def __rtruediv__(self, a):
         """Implementation of reverse division method."""
-        return a.__div__(self)
+        return a.__truediv__(self)
 
     def __repr__(self):
         """String representation of a GeometryEntity that can be evaluated

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -222,7 +222,7 @@ class Point(GeometryEntity):
     def __contains__(self, item):
         return item in self.args
 
-    def __div__(self, divisor):
+    def __truediv__(self, divisor):
         """Divide point's coordinates by a factor."""
         divisor = sympify(divisor)
         coords = [simplify(x/divisor) for x in self.args]
@@ -853,8 +853,6 @@ class Point(GeometryEntity):
         return self / abs(self)
 
     n = evalf
-
-    __truediv__ = __div__
 
 class Point2D(Point):
     """A point in a 2-dimensional Euclidean space.

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -293,11 +293,8 @@ class DifferentialOperator:
     def __neg__(self):
         return -1 * self
 
-    def __div__(self, other):
-        return self * (S.One / other)
-
     def __truediv__(self, other):
-        return self.__div__(other)
+        return self * (S.One / other)
 
     def __pow__(self, n):
         if n == 1:
@@ -1120,11 +1117,8 @@ class HolonomicFunction:
     def __neg__(self):
         return -1 * self
 
-    def __div__(self, other):
-        return self * (S.One / other)
-
     def __truediv__(self, other):
-        return self.__div__(other)
+        return self * (S.One / other)
 
     def __pow__(self, n):
         if self.annihilator.order <= 1:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -318,10 +318,8 @@ class BooleanTrue(BooleanAtom, metaclass=Singleton):
     sympy.logic.boolalg.BooleanFalse
 
     """
-    def __nonzero__(self):
+    def __bool__(self):
         return True
-
-    __bool__ = __nonzero__
 
     def __hash__(self):
         return hash(True)
@@ -388,10 +386,8 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
     sympy.logic.boolalg.BooleanTrue
 
     """
-    def __nonzero__(self):
+    def __bool__(self):
         return False
-
-    __bool__ = __nonzero__
 
     def __hash__(self):
         return hash(False)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -203,9 +203,7 @@ class BooleanAtom(Boolean):
     __rmul__ = _noop
     __pow__ = _noop
     __rpow__ = _noop
-    __rdiv__ = _noop
     __truediv__ = _noop
-    __div__ = _noop
     __rtruediv__ = _noop
     __mod__ = _noop
     __rmod__ = _noop

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2562,8 +2562,8 @@ class MatrixArithmetic(MatrixRequired):
 
         raise TypeError('cannot add %s and %s' % (type(self), type(other)))
 
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         return self * (self.one / other)
 
     @call_highest_priority('__rmatmul__')
@@ -2842,10 +2842,6 @@ class MatrixArithmetic(MatrixRequired):
     @call_highest_priority('__rsub__')
     def __sub__(self, a):
         return self + (-a)
-
-    @call_highest_priority('__rtruediv__')
-    def __truediv__(self, other):
-        return self.__div__(other)
 
 
 class MatrixCommon(MatrixArithmetic, MatrixOperations, MatrixProperties,

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,4 +1,3 @@
-from typing import Any, Callable
 from sympy.core.logic import FuzzyBool
 
 from functools import wraps, reduce
@@ -135,18 +134,15 @@ class MatrixExpr(Expr):
         raise NotImplementedError("Matrix Power not defined")
 
     @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         return self * other**S.NegativeOne
 
     @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__div__')
-    def __rdiv__(self, other):
+    @call_highest_priority('__truediv__')
+    def __rtruediv__(self, other):
         raise NotImplementedError()
         #return MatMul(other, Pow(self, S.NegativeOne))
-
-    __truediv__ = __div__  # type: Callable[[MatrixExpr, Any], Any]
-    __rtruediv__ = __rdiv__  # type: Callable[[MatrixExpr, Any], Any]
 
     @property
     def rows(self):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -45,8 +45,6 @@ def test_args():
 
 def test_division():
     v = Matrix(1, 2, [x, y])
-    assert v.__div__(z) == Matrix(1, 2, [x/z, y/z])
-    assert v.__truediv__(z) == Matrix(1, 2, [x/z, y/z])
     assert v/z == Matrix(1, 2, [x/z, y/z])
 
 

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -245,14 +245,11 @@ class Dimension(Expr):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return self*Pow(other, -1)
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         return other * pow(self, -1)
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     @classmethod
     def _from_dimensional_dependencies(cls, dependencies):

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -89,9 +89,9 @@ class Prefix(Expr):
 
         return self.scale_factor * other
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         if not hasattr(other, "scale_factor"):
-            return super(Prefix, self).__div__(other)
+            return super(Prefix, self).__truediv__(other)
 
         fact = self.scale_factor / other.scale_factor
 
@@ -105,16 +105,12 @@ class Prefix(Expr):
 
         return self.scale_factor / other
 
-    __truediv__ = __div__
-
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if other == 1:
             for p in PREFIXES:
                 if PREFIXES[p].scale_factor == 1 / self.scale_factor:
                     return PREFIXES[p]
         return other / self.scale_factor
-
-    __rtruediv__ = __rdiv__
 
 
 def prefix_unit(unit, prefixes):

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -97,11 +97,9 @@ class Dyadic(Printable):
                 ol += v[0] * v[1] * (v[2] & other)
         return ol
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """Divides the Dyadic by a sympifyable expression. """
         return self.__mul__(1 / other)
-
-    __truediv__ = __div__
 
     def __eq__(self, other):
         """Tests for equality.

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -106,11 +106,9 @@ class Vector(Printable):
         else:
             return sympify(out)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """This uses mul and inputs self and 1 divided by other. """
         return self.__mul__(sympify(1) / other)
-
-    __truediv__ = __div__
 
     def __eq__(self, other):
         """Tests for equality.

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -269,16 +269,16 @@ class interval(object):
         else:
             return self.start <= other.start and other.end <= self.end
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         if isinstance(other, (int, float)):
             other = interval(other)
-            return other.__div__(self)
+            return other.__truediv__(self)
         elif isinstance(other, interval):
-            return other.__div__(self)
+            return other.__truediv__(self)
         else:
             return NotImplemented
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         # Both None and False are handled
         if not self.is_valid:
             # Don't divide as the value is not valid
@@ -318,9 +318,6 @@ class interval(object):
                 return interval(start, end)
         else:
             return NotImplemented
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def __pow__(self, other):
         # Implements only power to an integer.

--- a/sympy/plotting/pygletplot/plot.py
+++ b/sympy/plotting/pygletplot/plot.py
@@ -410,10 +410,8 @@ class ScreenShot:
         self.invisibleMode = False
         self.flag = 0
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.screenshot_requested
-
-    __bool__ = __nonzero__
 
     def _execute_saving(self):
         if self.flag < 3:

--- a/sympy/polys/agca/homomorphisms.py
+++ b/sympy/polys/agca/homomorphisms.py
@@ -321,13 +321,11 @@ class ModuleHomomorphism(object):
     # NOTE: _compose will never be called from rmul
     __rmul__ = __mul__
 
-    def __div__(self, oth):
+    def __truediv__(self, oth):
         try:
             return self._mul_scalar(1/self.ring.convert(oth))
         except CoercionFailed:
             return NotImplemented
-
-    __truediv__ = __div__
 
     def __add__(self, oth):
         if self._check_hom(oth):

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -88,12 +88,10 @@ class Module(object):
         """Generate a quotient module."""
         raise NotImplementedError
 
-    def __div__(self, e):
+    def __truediv__(self, e):
         if not isinstance(e, Module):
             e = self.submodule(*e)
         return self.quotient_module(e)
-
-    __truediv__ = __div__
 
     def contains(self, elem):
         """Return True if ``elem`` is an element of this module."""
@@ -234,15 +232,13 @@ class ModuleElement(object):
 
     __rmul__ = __mul__
 
-    def __div__(self, o):
+    def __truediv__(self, o):
         if not isinstance(o, self.module.ring.dtype):
             try:
                 o = self.module.ring.convert(o)
             except CoercionFailed:
                 return NotImplemented
         return self.__class__(self.module, self.div(self.data, o))
-
-    __truediv__ = __div__
 
     def __eq__(self, om):
         if not isinstance(om, self.__class__) or om.module != self.module:

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -114,9 +114,6 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __rtruediv__(f, g):
             return f.simplify(f.__class__(g).ex/f.ex)
 
-        __div__ = __truediv__
-        __rdiv__ = __rtruediv__
-
         def __eq__(f, g):
             return f.ex == f.__class__(g).ex
 

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -123,10 +123,8 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         def __ne__(f, g):
             return not f == g
 
-        def __nonzero__(f):
+        def __bool__(f):
             return f.ex != 0
-
-        __bool__ = __nonzero__
 
         def gcd(f, g):
             from sympy.polys import gcd

--- a/sympy/polys/domains/field.py
+++ b/sympy/polys/domains/field.py
@@ -22,11 +22,11 @@ class Field(Ring):
         return self
 
     def exquo(self, a, b):
-        """Exact quotient of ``a`` and ``b``, implies ``__div__``.  """
+        """Exact quotient of ``a`` and ``b``, implies ``__truediv__``.  """
         return a / b
 
     def quo(self, a, b):
-        """Quotient of ``a`` and ``b``, implies ``__div__``. """
+        """Quotient of ``a`` and ``b``, implies ``__truediv__``. """
         return a / b
 
     def rem(self, a, b):
@@ -34,7 +34,7 @@ class Field(Ring):
         return self.zero
 
     def div(self, a, b):
-        """Division of ``a`` and ``b``, implies ``__div__``. """
+        """Division of ``a`` and ``b``, implies ``__truediv__``. """
         return a / b, self.zero
 
     def gcd(self, a, b):

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -69,11 +69,11 @@ class GMPYRationalField(RationalField):
         return GMPYRational(*map(int, K0.to_rational(a)))
 
     def exquo(self, a, b):
-        """Exact quotient of `a` and `b`, implies `__div__`.  """
+        """Exact quotient of `a` and `b`, implies `__truediv__`.  """
         return GMPYRational(a) / GMPYRational(b)
 
     def quo(self, a, b):
-        """Quotient of `a` and `b`, implies `__div__`. """
+        """Quotient of `a` and `b`, implies `__truediv__`. """
         return GMPYRational(a) / GMPYRational(b)
 
     def rem(self, a, b):
@@ -81,7 +81,7 @@ class GMPYRationalField(RationalField):
         return self.zero
 
     def div(self, a, b):
-        """Division of `a` and `b`, implies `__div__`. """
+        """Division of `a` and `b`, implies `__truediv__`. """
         return GMPYRational(a) / GMPYRational(b), self.zero
 
     def numer(self, a):

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -99,7 +99,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
     def __rmul__(self, other):
         return self.__mul__(other)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         val = self._get_val(other)
 
         if val is not None:
@@ -107,11 +107,8 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         else:
             return NotImplemented
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         return self.invert().__mul__(other)
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def __mod__(self, other):
         val = self._get_val(other)

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -166,10 +166,8 @@ class ModularInteger(PicklableWithSlots, DomainElement):
     def __ge__(self, other):
         return self._compare(other, operator.ge)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.val)
-
-    __bool__ = __nonzero__
 
     @classmethod
     def _invert(cls, value):

--- a/sympy/polys/domains/pythonrational.py
+++ b/sympy/polys/domains/pythonrational.py
@@ -232,10 +232,8 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
 
         return self.__class__(p**exp, q**exp, _gcd=False)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.p != 0
-
-    __bool__ = __nonzero__
 
     def __eq__(self, other):
         if isinstance(other, PythonRational):

--- a/sympy/polys/domains/pythonrational.py
+++ b/sympy/polys/domains/pythonrational.py
@@ -187,7 +187,7 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
 
         return self.__class__(p, q, _gcd=False)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         from sympy.polys.domains.groundtypes import python_gcd as gcd
         if isinstance(other, PythonRational):
             ap, aq, bp, bq = self.p, self.q, other.p, other.q
@@ -203,9 +203,7 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
 
         return self.__class__(p, q, _gcd=False)
 
-    __truediv__ = __div__
-
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         from sympy.polys.domains.groundtypes import python_gcd as gcd
         if not isinstance(other, int):
             return NotImplemented
@@ -215,8 +213,6 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
         q = self.p//x
 
         return self.__class__(p, q)
-
-    __rtruediv__ = __rdiv__
 
     def __mod__(self, other):
         return self.__class__(0)

--- a/sympy/polys/domains/quotientring.py
+++ b/sympy/polys/domains/quotientring.py
@@ -60,20 +60,16 @@ class QuotientRingElement(object):
 
     __rmul__ = __mul__
 
-    def __rdiv__(self, o):
+    def __rtruediv__(self, o):
         return self.ring.revert(self)*o
 
-    __rtruediv__ = __rdiv__
-
-    def __div__(self, o):
+    def __truediv__(self, o):
         if not isinstance(o, self.__class__):
             try:
                 o = self.ring.convert(o)
             except (NotImplementedError, CoercionFailed):
                 return NotImplemented
         return self.ring.revert(o)*self
-
-    __truediv__ = __div__
 
     def __pow__(self, oth):
         return self.ring(self.data**oth)

--- a/sympy/polys/domains/ring.py
+++ b/sympy/polys/domains/ring.py
@@ -115,7 +115,5 @@ class Ring(Domain):
             e = self.ideal(*e)
         return QuotientRing(self, e)
 
-    def __div__(self, e):
+    def __truediv__(self, e):
         return self.quotient_ring(e)
-
-    __truediv__ = __div__

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -551,8 +551,6 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify):
         else:
             return f.new(f.numer*g_denom, f.denom*g_numer)
 
-    __div__ = __truediv__
-
     def __rtruediv__(f, c):
         if not f:
             raise ZeroDivisionError
@@ -567,8 +565,6 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify):
             return NotImplemented
         else:
             return f.new(f.denom*g_numer, f.numer*g_denom)
-
-    __rdiv__ = __rtruediv__
 
     def __pow__(f, n):
         """Raise ``f`` to a non-negative power ``n``. """

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -335,10 +335,8 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify):
     def __ne__(f, g):
         return not f == g
 
-    def __nonzero__(f):
+    def __bool__(f):
         return bool(f.numer)
-
-    __bool__ = __nonzero__
 
     def sort_key(self):
         return (self.denom.sort_key(), self.numer.sort_key())

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -583,7 +583,7 @@ class Monomial(PicklableWithSlots):
 
         return self.rebuild(monomial_mul(self.exponents, exponents))
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         if isinstance(other, Monomial):
             exponents = other.exponents
         elif isinstance(other, (tuple, Tuple)):
@@ -598,7 +598,7 @@ class Monomial(PicklableWithSlots):
         else:
             raise ExactQuotientFailed(self, Monomial(other))
 
-    __floordiv__ = __truediv__ = __div__
+    __floordiv__ = __truediv__
 
     def __pow__(self, other):
         n = int(other)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -1054,10 +1054,8 @@ class DMP(PicklableWithSlots, CantSympify):
         _, _, _, F, G = f.unify(g)
         return F >= G
 
-    def __nonzero__(f):
+    def __bool__(f):
         return not dmp_zero_p(f.rep, f.lev)
-
-    __bool__ = __nonzero__
 
 
 def init_normal_DMF(num, den, lev, dom):
@@ -1501,10 +1499,8 @@ class DMF(PicklableWithSlots, CantSympify):
         _, _, _, F, G = f.frac_unify(g)
         return F >= G
 
-    def __nonzero__(f):
+    def __bool__(f):
         return not dmp_zero_p(f.num, f.lev)
-
-    __bool__ = __nonzero__
 
 
 def init_normal_ANP(rep, mod, dom):
@@ -1772,7 +1768,5 @@ class ANP(PicklableWithSlots, CantSympify):
         _, _, F, G, _ = f.unify(g)
         return F >= G
 
-    def __nonzero__(f):
+    def __bool__(f):
         return bool(f.rep)
-
-    __bool__ = __nonzero__

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -960,7 +960,7 @@ class DMP(PicklableWithSlots, CantSympify):
                         pass
                 return NotImplemented
 
-    def __div__(f, g):
+    def __truediv__(f, g):
         if isinstance(g, DMP):
             return f.exquo(g)
         else:
@@ -976,7 +976,7 @@ class DMP(PicklableWithSlots, CantSympify):
                         pass
                 return NotImplemented
 
-    def __rdiv__(f, g):
+    def __rtruediv__(f, g):
         if isinstance(g, DMP):
             return g.exquo(f)
         elif f.ring is not None:
@@ -985,9 +985,6 @@ class DMP(PicklableWithSlots, CantSympify):
             except (CoercionFailed, NotImplementedError):
                 pass
         return NotImplemented
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def __rmul__(f, g):
         return f.__mul__(g)
@@ -1423,7 +1420,7 @@ class DMF(PicklableWithSlots, CantSympify):
     def __pow__(f, n):
         return f.pow(n)
 
-    def __div__(f, g):
+    def __truediv__(f, g):
         if isinstance(g, (DMP, DMF)):
             return f.quo(g)
 
@@ -1439,15 +1436,12 @@ class DMF(PicklableWithSlots, CantSympify):
                     pass
             return NotImplemented
 
-    def __rdiv__(self, g):
+    def __rtruediv__(self, g):
         r = self.invert(check=False)*g
         if self.ring and r not in self.ring:
             from sympy.polys.polyerrors import ExactQuotientFailed
             raise ExactQuotientFailed(g, self, self.ring)
         return r
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def __eq__(f, g):
         try:
@@ -1725,7 +1719,7 @@ class ANP(PicklableWithSlots, CantSympify):
     def __mod__(f, g):
         return f.rem(g)
 
-    def __div__(f, g):
+    def __truediv__(f, g):
         if isinstance(g, ANP):
             return f.quo(g)
         else:
@@ -1733,8 +1727,6 @@ class ANP(PicklableWithSlots, CantSympify):
                 return f.quo(f.per(g))
             except (CoercionFailed, TypeError):
                 return NotImplemented
-
-    __truediv__ = __div__
 
     def __eq__(f, g):
         try:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4128,15 +4128,12 @@ class Poly(Basic):
         return g.quo(f)
 
     @_sympifyit('g', NotImplemented)
-    def __div__(f, g):
+    def __truediv__(f, g):
         return f.as_expr()/g.as_expr()
 
     @_sympifyit('g', NotImplemented)
-    def __rdiv__(f, g):
+    def __rtruediv__(f, g):
         return g.as_expr()/f.as_expr()
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     @_sympifyit('other', NotImplemented)
     def __eq__(self, other):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4160,10 +4160,8 @@ class Poly(Basic):
     def __ne__(f, g):
         return not f == g
 
-    def __nonzero__(f):
+    def __bool__(f):
         return not f.is_zero
-
-    __bool__ = __nonzero__
 
     def eq(f, g, strict=False):
         if not strict:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1349,8 +1349,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def __rtruediv__(p1, p2):
         return NotImplemented
 
-    __floordiv__ = __div__ = __truediv__
-    __rfloordiv__ = __rdiv__ = __rtruediv__
+    __floordiv__ = __truediv__
+    __rfloordiv__ = __rtruediv__
 
     # TODO: use // (__floordiv__) for exquo()?
 

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -266,7 +266,7 @@ def test_FracElement___mul__():
     assert dict(f.numer) == {(1, 1, 0, 0): u + 1, (0, 0, 0, 0): 1}
     assert dict(f.denom) == {(0, 0, 1, 0): v - 1, (0, 0, 0, 1): -u*v, (0, 0, 0, 0): -1}
 
-def test_FracElement___div__():
+def test_FracElement___truediv__():
     F, x,y = field("x,y", QQ)
 
     f, g = 1/x, 1/y

--- a/sympy/polys/tests/test_pythonrational.py
+++ b/sympy/polys/tests/test_pythonrational.py
@@ -98,7 +98,7 @@ def test_PythonRational__mul__():
     assert 2 * QQ(1, 2) == QQ(1)
     assert QQ(1, 2) * 2 == QQ(1)
 
-def test_PythonRational__div__():
+def test_PythonRational__truediv__():
     assert QQ(-1, 2) / QQ( 1, 2) == QQ(-1)
     assert QQ( 1, 2) / QQ(-1, 2) == QQ(-1)
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -573,7 +573,7 @@ def test_PolyElement___mul__():
 
     assert dict(EX(pi)*x*y*z) == dict(x*y*z*EX(pi)) == {(1, 1, 1): EX(pi)}
 
-def test_PolyElement___div__():
+def test_PolyElement___truediv__():
     R, x,y,z = ring("x,y,z", ZZ)
 
     assert (2*x**2 - 4)/2 == x**2 - 2

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -410,7 +410,7 @@ class prettyForm(stringPict):
             result.append(arg)
         return prettyForm(binding=prettyForm.ADD, *stringPict.next(*result))
 
-    def __div__(self, den, slashed=False):
+    def __truediv__(self, den, slashed=False):
         """Make a pretty division; stacked or slashed.
         """
         if slashed:
@@ -428,9 +428,6 @@ class prettyForm(stringPict):
             num,
             stringPict.LINE,
             den))
-
-    def __truediv__(self, o):
-        return self.__div__(o)
 
     def __mul__(self, *others):
         """Make a pretty multiplication.

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -735,10 +735,8 @@ class Range(Set):
             return True
         return self.size.is_finite
 
-    def __nonzero__(self):
+    def __bool__(self):
         return self.start != self.stop
-
-    __bool__ = __nonzero__
 
     def __getitem__(self, i):
         from sympy.functions.elementary.integers import ceiling

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -67,17 +67,14 @@ class SetExpr(Expr):
         return _setexpr_apply_operation(set_pow, other, self)
 
     @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         return _setexpr_apply_operation(set_div, self, other)
 
     @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__div__')
-    def __rdiv__(self, other):
+    @call_highest_priority('__truediv__')
+    def __rtruediv__(self, other):
         return _setexpr_apply_operation(set_div, other, self)
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def _eval_func(self, func):
         # TODO: this could be implemented straight into `imageset`:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -850,8 +850,6 @@ class ProductSet(Set):
     def __bool__(self):
         return all([bool(s) for s in self.sets])
 
-    __nonzero__ = __bool__
-
 
 class Interval(Set, EvalfMixin):
     """

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -390,7 +390,7 @@ class NDimArray(Printable):
         result_list = [other*i for i in Flatten(self)]
         return type(self)(result_list, self.shape)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         from sympy.matrices.matrices import MatrixBase
         from sympy.tensor.array import SparseNDimArray
         from sympy.tensor.array.arrayop import Flatten
@@ -405,7 +405,7 @@ class NDimArray(Printable):
         result_list = [i/other for i in Flatten(self)]
         return type(self)(result_list, self.shape)
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         raise NotImplementedError('unsupported operation on NDimArray')
 
     def __neg__(self):
@@ -463,9 +463,6 @@ class NDimArray(Printable):
 
     def __ne__(self, other):
         return not self == other
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def _eval_transpose(self):
         if self.rank() != 2:

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -164,7 +164,7 @@ def test_sparse():
     assert a * 0 == ImmutableSparseNDimArray({}, (100000, 200000))
     assert 0 * a == ImmutableSparseNDimArray({}, (100000, 200000))
 
-    # __div__
+    # __truediv__
     assert a/3 == ImmutableSparseNDimArray({200001: Rational(1, 3)}, (100000, 200000))
 
     # __neg__

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -170,7 +170,7 @@ def test_sparse():
     assert a * 0 == MutableSparseNDimArray({}, (100000, 200000))
     assert 0 * a == MutableSparseNDimArray({}, (100000, 200000))
 
-    # __div__
+    # __truediv__
     assert a/3 == MutableSparseNDimArray({200001: Rational(1, 3)}, (100000, 200000))
 
     # __neg__

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1922,13 +1922,13 @@ class TensExpr(Expr, metaclass=_TensorMetaclass):
     def __rmul__(self, other):
         return TensMul(other, self).doit()
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         other = _sympify(other)
         if isinstance(other, TensExpr):
             raise ValueError('cannot divide by a tensor')
         return TensMul(self, S.One/other).doit()
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         raise ValueError('cannot divide by a tensor')
 
     def __pow__(self, other):
@@ -1953,9 +1953,6 @@ class TensExpr(Expr, metaclass=_TensorMetaclass):
 
     def __rpow__(self, other):
         raise NotImplementedError
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     @property
     @abstractmethod

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -497,8 +497,8 @@ def test_TensExpr():
     #raises(NotImplementedError, lambda: TensExpr.__radd__(t, 'a'))
     #raises(NotImplementedError, lambda: TensExpr.__sub__(t, 'a'))
     #raises(NotImplementedError, lambda: TensExpr.__rsub__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__div__(t, 'a'))
-    #raises(NotImplementedError, lambda: TensExpr.__rdiv__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensExpr.__truediv__(t, 'a'))
+    #raises(NotImplementedError, lambda: TensExpr.__rtruediv__(t, 'a'))
     with ignore_warnings(SymPyDeprecationWarning):
         # DO NOT REMOVE THIS AFTER DEPRECATION REMOVED:
         raises(ValueError, lambda: A(a, b)**2)

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -46,16 +46,13 @@ class BasisDependent(Expr):
         return self._mul_func(S.NegativeOne, self)
 
     @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__rdiv__')
-    def __div__(self, other):
+    @call_highest_priority('__rtruediv__')
+    def __truediv__(self, other):
         return self._div_helper(other)
 
-    @call_highest_priority('__div__')
-    def __rdiv__(self, other):
+    @call_highest_priority('__truediv__')
+    def __rtruediv__(self, other):
         return TypeError("Invalid divisor for division")
-
-    __truediv__ = __div__
-    __rtruediv__ = __rdiv__
 
     def evalf(self, n=15, subs=None, maxn=100, chop=False, strict=False, quad=None, verbose=False):
         """


### PR DESCRIPTION
None of these are real magic methods in Python 3

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Relates to #5916


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->