### PR TITLE
Improve kwarg-handling of print helper functions

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2,8 +2,6 @@
 A Printer which converts an expression into its LaTeX equivalent.
 """
 
-from __future__ import print_function, division
-
 from typing import Any, Dict
 
 import itertools
@@ -18,7 +16,7 @@ from sympy.logic.boolalg import true
 
 # sympy.printing imports
 from sympy.printing.precedence import precedence_traditional
-from sympy.printing.printer import Printer
+from sympy.printing.printer import Printer, print_function
 from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.precedence import precedence, PRECEDENCE
 
@@ -2709,13 +2707,9 @@ def translate(s):
         return s
 
 
-def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
-          fold_func_brackets=False, fold_short_frac=None, inv_trig_style="abbreviated",
-          itex=False, ln_notation=False, long_frac_ratio=None,
-          mat_delim="[", mat_str=None, mode="plain", mul_symbol=None,
-          order=None, symbol_names=None, root_notation=True,
-          mat_symbol_style="plain", imaginary_unit="i", gothic_re_im=False,
-          decimal_separator="period", perm_cyclic=True, parenthesize_super=True):
+
+@print_function(LatexPrinter)
+def latex(expr, **settings):
     r"""Convert the given expression to LaTeX string representation.
 
     Parameters
@@ -2918,35 +2912,6 @@ def latex(expr, full_prec=False, min=None, max=None, fold_frac_powers=False,
         Unsupported types no longer have their ``str`` representation treated as valid latex.
 
     """
-    if symbol_names is None:
-        symbol_names = {}
-
-    settings = {
-        'full_prec': full_prec,
-        'fold_frac_powers': fold_frac_powers,
-        'fold_func_brackets': fold_func_brackets,
-        'fold_short_frac': fold_short_frac,
-        'inv_trig_style': inv_trig_style,
-        'itex': itex,
-        'ln_notation': ln_notation,
-        'long_frac_ratio': long_frac_ratio,
-        'mat_delim': mat_delim,
-        'mat_str': mat_str,
-        'mode': mode,
-        'mul_symbol': mul_symbol,
-        'order': order,
-        'symbol_names': symbol_names,
-        'root_notation': root_notation,
-        'mat_symbol_style': mat_symbol_style,
-        'imaginary_unit': imaginary_unit,
-        'gothic_re_im': gothic_re_im,
-        'decimal_separator': decimal_separator,
-        'perm_cyclic' : perm_cyclic,
-        'parenthesize_super' : parenthesize_super,
-        'min': min,
-        'max': max,
-    }
-
     return LatexPrinter(settings).doprint(expr)
 
 

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -2,8 +2,6 @@
 A MathML printer.
 """
 
-from __future__ import print_function, division
-
 from typing import Any, Dict
 
 from sympy import sympify, S, Mul
@@ -13,7 +11,7 @@ from sympy.printing.conventions import split_super_sub, requires_partial
 from sympy.printing.precedence import \
     precedence_traditional, PRECEDENCE, PRECEDENCE_TRADITIONAL
 from sympy.printing.pretty.pretty_symbology import greek_unicode
-from sympy.printing.printer import Printer
+from sympy.printing.printer import Printer, print_function
 
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
@@ -2069,6 +2067,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return x
 
 
+@print_function(MathMLPrinterBase)
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation
     then prints Presentation MathML else prints content MathML.

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import itertools
 
 from sympy.core import S
@@ -12,7 +10,7 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import SympifyError
 from sympy.printing.conventions import requires_partial
 from sympy.printing.precedence import PRECEDENCE, precedence, precedence_traditional
-from sympy.printing.printer import Printer
+from sympy.printing.printer import Printer, print_function
 from sympy.printing.str import sstr
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import has_variety
@@ -2716,6 +2714,7 @@ class PrettyPrinter(Printer):
     def _print_Str(self, s):
         return self._print(s.name)
 
+@print_function(PrettyPrinter)
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -211,16 +211,16 @@ an expression when customizing a printer. Mistakes include:
 
 from __future__ import print_function, division
 
-from typing import Any, Dict
-
+from typing import Any, Dict, Type
+import inspect
 from contextlib import contextmanager
+from functools import cmp_to_key, update_wrapper
 
 from sympy import Basic, Add
 
 from sympy.core.core import BasicMeta
 from sympy.core.function import AppliedUndef, UndefinedFunction, Function
 
-from functools import cmp_to_key
 
 
 @contextmanager
@@ -248,15 +248,19 @@ class Printer(object):
 
     printmethod = None  # type: str
 
+    @classmethod
+    def _get_initial_settings(cls):
+        settings = cls._default_settings.copy()
+        for key, val in cls._global_settings.items():
+            if key in cls._default_settings:
+                settings[key] = val
+        return settings
+
     def __init__(self, settings=None):
         self._str = str
 
-        self._settings = self._default_settings.copy()
+        self._settings = self._get_initial_settings()
         self._context = dict()  # mutable during printing
-
-        for key, val in self._global_settings.items():
-            if key in self._default_settings:
-                self._settings[key] = val
 
         if settings is not None:
             self._settings.update(settings)
@@ -343,3 +347,41 @@ class Printer(object):
             return list(expr.args)
         else:
             return expr.as_ordered_terms(order=order)
+
+
+class _PrintFunction:
+    """
+    Function wrapper to replace ``**settings`` in the signature with printer defaults
+    """
+    def __init__(self, f, print_cls: Type[Printer]):
+        # find all the non-setting arguments
+        params = list(inspect.signature(f).parameters.values())
+        assert params.pop(-1).kind == inspect.Parameter.VAR_KEYWORD
+        self.__other_params = params
+
+        self.__print_cls = print_cls
+        update_wrapper(self, f)
+
+    def __repr__(self) -> str:
+        return repr(self.__wrapped__)
+
+    def __call__(self, *args, **kwargs):
+        return self.__wrapped__(*args, **kwargs)
+
+    @property
+    def __signature__(self) -> inspect.Signature:
+        settings = self.__print_cls._get_initial_settings()
+        return inspect.Signature(
+            parameters=self.__other_params + [
+                inspect.Parameter(k, inspect.Parameter.KEYWORD_ONLY, default=v)
+                for k, v in settings.items()
+            ],
+            return_annotation=self.__wrapped__.__annotations__.get('return', inspect.Signature.empty)
+        )
+
+
+def print_function(print_cls):
+    """ A decorator to replace kwargs with the printer settings in __signature__ """
+    def decorator(f):
+        return _PrintFunction(f, print_cls)
+    return decorator

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -5,15 +5,13 @@ The most important function here is srepr that returns a string so that the
 relation eval(srepr(expr))=expr holds in an appropriate environment.
 """
 
-from __future__ import print_function, division
-
 from typing import Any, Dict
 
 from sympy.core.function import AppliedUndef
 from sympy.core.mul import Mul
 from mpmath.libmp import repr_dps, to_str as mlib_to_str
 
-from .printer import Printer
+from .printer import Printer, print_function
 
 
 class ReprPrinter(Printer):
@@ -322,6 +320,7 @@ class ReprPrinter(Printer):
         ext = self._print(f.ext)
         return "ExtElem(%s, %s)" % (rep, ext)
 
+@print_function(ReprPrinter)
 def srepr(expr, **settings):
     """return expr in repr form"""
     return ReprPrinter(settings).doprint(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 from sympy.core import S, Rational, Pow, Basic, Mul, Number
 from sympy.core.mul import _keep_coeff
-from .printer import Printer
+from .printer import Printer, print_function
 from sympy.printing.precedence import precedence, PRECEDENCE
 
 from mpmath.libmp import prec_to_dps, to_str as mlib_to_str
@@ -873,6 +873,7 @@ class StrPrinter(Printer):
     def _print_Str(self, s):
         return self._print(s.name)
 
+@print_function(StrPrinter)
 def sstr(expr, **settings):
     """Returns the expression as a string.
 
@@ -906,6 +907,7 @@ class StrReprPrinter(StrPrinter):
         return "%s(%s)" % (s.__class__.__name__, self._print(s.name))
 
 
+@print_function(StrReprPrinter)
 def sstrrepr(expr, **settings):
     """return expr in mixed str/repr form
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -27,7 +27,7 @@ from sympy.ntheory.factor_ import udivisor_sigma
 from sympy.abc import mu, tau
 from sympy.printing.latex import (latex, translate, greek_letters_set,
                                   tex_greek_dictionary, multiline_latex,
-                                  latex_escape)
+                                  latex_escape, LatexPrinter)
 from sympy.tensor.array import (ImmutableDenseNDimArray,
                                 ImmutableSparseNDimArray,
                                 MutableSparseNDimArray,
@@ -2681,3 +2681,24 @@ def test_emptyPrinter():
 
     # even if they are nested within other objects
     assert latex((MyObject(),)) == r"\left( \mathtt{\text{<MyObject with \{...\}>}},\right)"
+
+def test_global_settings():
+    import inspect
+
+    # settings should be visible in the signature of `latex`
+    assert inspect.signature(latex).parameters['imaginary_unit'].default == 'i'
+    assert latex(I) == 'i'
+    try:
+        # but changing the defaults...
+        LatexPrinter.set_global_settings(imaginary_unit='j')
+        # ... should change the signature
+        assert inspect.signature(latex).parameters['imaginary_unit'].default == 'j'
+        assert latex(I) == 'j'
+    finally:
+        # there's no public API to undo this, but we need to make sure we do
+        # so as not to impact other tests
+        del LatexPrinter._global_settings['imaginary_unit']
+
+    # check we really did undo it
+    assert inspect.signature(latex).parameters['imaginary_unit'].default == 'i'
+    assert latex(I) == 'i'


### PR DESCRIPTION
This reverts two regressions in `latex` introduced in gh-15080, namely that:

* `latex` started accepted positional arguments for settings
* `latex` stopped respecting the global printer defaults

This also makes the signature more useful on `sstr`, `srepr`, `sstrrepr`, `pretty`, and `mathml`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#15080


#### Brief description of what is fixed or changed
See the test


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `latex` now once again requires settings to be passed as keyword and not positional arguments, and respects printer settings changed with `set_global_settings`; restoring the behavior from sympy 1.2 and earlier.
<!-- END RELEASE NOTES -->