### PR TITLE
Adding ArrayDerivative class as subclass of Derivative, will handle d…

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1690,21 +1690,6 @@ class Basic(Printable, metaclass=ManagedProperties):
 
         return self.func(*args) if hints.get('evaluate', True) else self
 
-    def _accept_eval_derivative(self, s):
-        # This method needs to be overridden by array-like objects
-        return s._visit_eval_derivative_scalar(self)
-
-    def _visit_eval_derivative_scalar(self, base):
-        # Base is a scalar
-        # Types are (base: scalar, self: scalar)
-        return base._eval_derivative(self)
-
-    def _visit_eval_derivative_array(self, base):
-        # Types are (base: array/matrix, self: scalar)
-        # Base is some kind of array/matrix,
-        # it should have `.applyfunc(lambda x: x.diff(self)` implemented:
-        return base._eval_derivative_array(self)
-
     def _eval_derivative_n_times(self, s, n):
         # This is the default evaluator for derivatives (as called by `diff`
         # and `Derivative`), it will attempt a loop to derive the expression
@@ -1716,7 +1701,7 @@ class Basic(Printable, metaclass=ManagedProperties):
         if isinstance(n, (int, Integer)):
             obj = self
             for i in range(n):
-                obj2 = obj._accept_eval_derivative(s)
+                obj2 = obj._eval_derivative(s)
                 if obj == obj2 or obj2 is None:
                     break
                 obj = obj2

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3443,7 +3443,7 @@ class Expr(Basic, EvalfMixin):
 
     def diff(self, *symbols, **assumptions):
         assumptions.setdefault("evaluate", True)
-        return Derivative(self, *symbols, **assumptions)
+        return _derivative_dispatch(self, *symbols, **assumptions)
 
     ###########################################################################
     ###################### EXPRESSION EXPANSION METHODS #######################
@@ -4016,7 +4016,7 @@ class ExprBuilder:
 from .mul import Mul
 from .add import Add
 from .power import Pow
-from .function import Derivative, Function
+from .function import Derivative, Function, _derivative_dispatch
 from .mod import Mod
 from .exprtools import factor_terms
 from .numbers import Integer, Rational

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4016,7 +4016,7 @@ class ExprBuilder:
 from .mul import Mul
 from .add import Add
 from .power import Pow
-from .function import Derivative, Function, _derivative_dispatch
+from .function import Function, _derivative_dispatch
 from .mod import Mod
 from .exprtools import factor_terms
 from .numbers import Integer, Rational

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -768,14 +768,14 @@ class Function(Application, Expr):
         A = self.args[ix]
         if A._diff_wrt:
             if len(self.args) == 1 or not A.is_Symbol:
-                return Derivative(self, A)
+                return _derivative_dispatch(self, A)
             for i, v in enumerate(self.args):
                 if i != ix and A in v.free_symbols:
                     # it can't be in any other argument's free symbols
                     # issue 8510
                     break
             else:
-                    return Derivative(self, A)
+                    return _derivative_dispatch(self, A)
 
         # See issue 4624 and issue 4719, 5600 and 8510
         D = Dummy('xi_%i' % argindex, dummy_index=hash(A))
@@ -1400,13 +1400,7 @@ class Derivative(Expr):
                             zero = True
                             break
             if zero:
-                if isinstance(expr, (MatrixCommon, NDimArray)):
-                    return expr.zeros(*expr.shape)
-                elif isinstance(expr, MatrixExpr):
-                    from sympy import ZeroMatrix
-                    return ZeroMatrix(*expr.shape)
-                elif expr.is_scalar:
-                    return S.Zero
+                return cls._get_zero_with_shape_like(expr)
 
             # make the order of symbols canonical
             #TODO: check if assumption of discontinuous derivatives exist
@@ -1416,7 +1410,7 @@ class Derivative(Expr):
         if isinstance(expr, Derivative):
             variable_count = list(expr.variable_count) + variable_count
             expr = expr.expr
-            return Derivative(expr, *variable_count, **kwargs)
+            return _derivative_dispatch(expr, *variable_count, **kwargs)
 
         # we return here if evaluate is False or if there is no
         # _eval_derivative method
@@ -1459,11 +1453,7 @@ class Derivative(Expr):
                     # _eval_derivative defined
                     expr *= old_v.diff(old_v)
 
-            # Evaluate the derivative `n` times.  If
-            # `_eval_derivative_n_times` is not overridden by the current
-            # object, the default in `Basic` will call a loop over
-            # `_eval_derivative`:
-            obj = expr._eval_derivative_n_times(v, count)
+            obj = cls._dispatch_eval_derivative_n_times(expr, v, count)
             if obj is not None and obj.is_zero:
                 return obj
 
@@ -1734,7 +1724,7 @@ class Derivative(Expr):
             old_vars = Counter(dict(reversed(old.variable_count)))
             self_vars = Counter(dict(reversed(self.variable_count)))
             if _subset(old_vars, self_vars):
-                return Derivative(new, *(self_vars - old_vars).items()).canonical
+                return _derivative_dispatch(new, *(self_vars - old_vars).items()).canonical
 
         args = list(self.args)
         newargs = list(x._subs(old, new) for x in args)
@@ -1742,7 +1732,7 @@ class Derivative(Expr):
             # complete replacement of self.expr
             # we already checked that the new is valid so we know
             # it won't be a problem should it appear in variables
-            return Derivative(*newargs)
+            return _derivative_dispatch(*newargs)
 
         if newargs[0] != args[0]:
             # case (1) can't change expr by introducing something that is in
@@ -1797,7 +1787,7 @@ class Derivative(Expr):
                 return Subs(Derivative(newe, *vc), *zip(*subs))
 
         # everything was ok
-        return Derivative(*newargs)
+        return _derivative_dispatch(*newargs)
 
     def _eval_lseries(self, x, logx, cdir=0):
         dx = self.variables
@@ -1911,6 +1901,29 @@ class Derivative(Expr):
         """
         from ..calculus.finite_diff import _as_finite_diff
         return _as_finite_diff(self, points, x0, wrt)
+
+    @classmethod
+    def _get_zero_with_shape_like(cls, expr):
+        return S.Zero
+
+    @classmethod
+    def _dispatch_eval_derivative_n_times(cls, expr, v, count):
+        # Evaluate the derivative `n` times.  If
+        # `_eval_derivative_n_times` is not overridden by the current
+        # object, the default in `Basic` will call a loop over
+        # `_eval_derivative`:
+        return expr._eval_derivative_n_times(v, count)
+
+
+def _derivative_dispatch(expr, *variables, **kwargs):
+    from sympy.matrices.common import MatrixCommon
+    from sympy import MatrixExpr
+    from sympy import NDimArray
+    array_types = (MatrixCommon, MatrixExpr, NDimArray, list, tuple, Tuple)
+    if isinstance(expr, array_types) or any(isinstance(i[0], array_types) if isinstance(i, (tuple, list, Tuple)) else isinstance(i, array_types) for i in variables):
+        from sympy.tensor.array.array_derivatives import ArrayDerivative
+        return ArrayDerivative(expr, *variables, **kwargs)
+    return Derivative(expr, *variables, **kwargs)
 
 
 class Lambda(Expr):
@@ -2444,7 +2457,7 @@ def diff(f, *symbols, **kwargs):
     if hasattr(f, 'diff'):
         return f.diff(*symbols, **kwargs)
     kwargs.setdefault('evaluate', True)
-    return Derivative(f, *symbols, **kwargs)
+    return _derivative_dispatch(f, *symbols, **kwargs)
 
 
 def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4285,6 +4285,13 @@ def test_sympy__tensor__array__arrayop__Flatten():
     assert _test_args(fla)
 
 
+def test_sympy__tensor__array__array_derivatives__ArrayDerivative():
+    from sympy.tensor.array.array_derivatives import ArrayDerivative
+    A = MatrixSymbol("A", 2, 2)
+    arrder = ArrayDerivative(A, A, evaluate=False)
+    assert _test_args(arrder)
+
+
 def test_sympy__tensor__functions__TensorProduct():
     from sympy.tensor.functions import TensorProduct
     A = MatrixSymbol('A', 3, 3)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -195,35 +195,16 @@ class MatrixExpr(Expr):
         from sympy.matrices.expressions.adjoint import Adjoint
         return Adjoint(self)
 
-    def _eval_derivative_array(self, x):
-        if isinstance(x, MatrixExpr):
-            return _matrix_derivative(self, x)
-        else:
-            return self._eval_derivative(x)
-
     def _eval_derivative_n_times(self, x, n):
         return Basic._eval_derivative_n_times(self, x, n)
 
-    def _visit_eval_derivative_scalar(self, x):
+    def _eval_derivative(self, x):
         # `x` is a scalar:
-        if x.has(self):
-            return _matrix_derivative(x, self)
+        if self.has(x):
+            # See if there are other methods using it:
+            return super(MatrixExpr, self)._eval_derivative(x)
         else:
             return ZeroMatrix(*self.shape)
-
-    def _visit_eval_derivative_array(self, x):
-        if x.has(self):
-            return _matrix_derivative(x, self)
-        else:
-            from sympy import Derivative
-            return Derivative(x, self)
-
-    def _accept_eval_derivative(self, s):
-        from sympy import MatrixBase, NDimArray
-        if isinstance(s, (MatrixBase, NDimArray, MatrixExpr)):
-            return s._visit_eval_derivative_array(self)
-        else:
-            return s._visit_eval_derivative_scalar(self)
 
     @classmethod
     def _check_dim(cls, dim):
@@ -650,7 +631,7 @@ Basic._constructor_postprocessor_mapping[MatrixExpr] = {
 
 
 def _matrix_derivative(expr, x):
-    from sympy import Derivative
+    from sympy.tensor.array.array_derivatives import ArrayDerivative
     lines = expr._eval_derivative_matrix_lines(x)
 
     parts = [i.build() for i in lines]
@@ -693,7 +674,7 @@ def _matrix_derivative(expr, x):
     if rank <= 2:
         return Add.fromiter([contract_one_dims(i) for i in parts])
 
-    return Derivative(expr, x)
+    return ArrayDerivative(expr, x)
 
 
 class MatrixElement(Expr):

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -4,7 +4,7 @@ Some examples have been taken from:
 http://www.math.uwaterloo.ca/~hwolkowi//matrixcookbook.pdf
 """
 from sympy import (MatrixSymbol, Inverse, symbols, Determinant, Trace,
-                   Derivative, sin, exp, cos, tan, log, S, sqrt,
+                   sin, exp, cos, tan, log, S, sqrt,
                    hadamard_product, DiagMatrix, OneMatrix,
                    HadamardProduct, HadamardPower, KroneckerDelta, Sum,
                    Rational)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -9,6 +9,7 @@ from sympy import (MatrixSymbol, Inverse, symbols, Determinant, Trace,
                    HadamardProduct, HadamardPower, KroneckerDelta, Sum,
                    Rational)
 from sympy import MatAdd, Identity, MatMul, ZeroMatrix
+from sympy.tensor.array.array_derivatives import ArrayDerivative
 from sympy.matrices.expressions import hadamard_power
 
 k = symbols("k")
@@ -72,17 +73,17 @@ def test_matrix_derivative_by_scalar():
 
 def test_matrix_derivative_non_matrix_result():
     # This is a 4-dimensional array:
-    assert A.diff(A) == Derivative(A, A)
-    assert A.T.diff(A) == Derivative(A.T, A)
-    assert (2*A).diff(A) == Derivative(2*A, A)
-    assert MatAdd(A, A).diff(A) == Derivative(MatAdd(A, A), A)
-    assert (A + B).diff(A) == Derivative(A + B, A)  # TODO: `B` can be removed.
+    assert A.diff(A) == ArrayDerivative(A, A)
+    assert A.T.diff(A) == ArrayDerivative(A.T, A)
+    assert (2*A).diff(A) == ArrayDerivative(2*A, A)
+    assert MatAdd(A, A).diff(A) == ArrayDerivative(MatAdd(A, A), A)
+    assert (A + B).diff(A) == ArrayDerivative(A + B, A)  # TODO: `B` can be removed.
 
 
 def test_matrix_derivative_trivial_cases():
     # Cookbook example 33:
     # TODO: find a way to represent a four-dimensional zero-array:
-    assert X.diff(A) == Derivative(X, A)
+    assert X.diff(A) == ArrayDerivative(X, A)
 
 
 def test_matrix_derivative_with_inverse():
@@ -159,7 +160,7 @@ def test_matrix_derivative_vectors_and_scalars():
 def test_matrix_derivatives_of_traces():
 
     expr = Trace(A)*A
-    assert expr.diff(A) == Derivative(Trace(A)*A, A)
+    assert expr.diff(A) == ArrayDerivative(Trace(A)*A, A)
     assert expr[i, j].diff(A[m, n]).doit() == (
         KDelta(i, m)*KDelta(j, n)*Trace(A) +
         KDelta(m, n)*A[i, j]
@@ -323,7 +324,7 @@ def test_mixed_deriv_mixed_expressions():
 
     expr = Trace(A)*A
     # TODO: this is not yet supported:
-    assert expr.diff(A) == Derivative(expr, A)
+    assert expr.diff(A) == ArrayDerivative(expr, A)
 
     expr = Trace(Trace(A)*A)
     assert expr.diff(A) == (2*Trace(A))*Identity(k)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -454,9 +454,9 @@ class MatrixCalculus(MatrixCommon):
         limit
         """
         # XXX this should be handled here rather than in Derivative
-        from sympy import Derivative
+        from sympy.tensor.array.array_derivatives import ArrayDerivative
         kwargs.setdefault('evaluate', True)
-        deriv = Derivative(self, *args, evaluate=True)
+        deriv = ArrayDerivative(self, *args, evaluate=True)
         if not isinstance(self, Basic):
             return deriv.as_mutable()
         else:
@@ -464,18 +464,6 @@ class MatrixCalculus(MatrixCommon):
 
     def _eval_derivative(self, arg):
         return self.applyfunc(lambda x: x.diff(arg))
-
-    def _accept_eval_derivative(self, s):
-        return s._visit_eval_derivative_array(self)
-
-    def _visit_eval_derivative_scalar(self, base):
-        # Types are (base: scalar, self: matrix)
-        return self.applyfunc(lambda x: base.diff(x))
-
-    def _visit_eval_derivative_array(self, base):
-        # Types are (base: array/matrix, self: matrix)
-        from sympy import derive_by_array
-        return derive_by_array(base, self)
 
     def integrate(self, *args, **kwargs):
         """Integrate each element of the matrix.  ``args`` will

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -1,4 +1,10 @@
-from sympy import Derivative, Integer
+from sympy import Derivative, Integer, Expr
+from sympy.matrices.common import MatrixCommon
+from .ndim_array import NDimArray
+from .arrayop import derive_by_array
+from sympy import MatrixExpr
+from sympy import ZeroMatrix
+from sympy.matrices.expressions.matexpr import _matrix_derivative
 
 
 class ArrayDerivative(Derivative):
@@ -27,13 +33,9 @@ class ArrayDerivative(Derivative):
 
     @classmethod
     def _get_zero_with_shape_like(cls, expr):
-        from sympy.matrices.common import MatrixCommon
-        from sympy import NDimArray
-        from sympy import MatrixExpr
         if isinstance(expr, (MatrixCommon, NDimArray)):
             return expr.zeros(*expr.shape)
         elif isinstance(expr, MatrixExpr):
-            from sympy import ZeroMatrix
             return ZeroMatrix(*expr.shape)
 
     @staticmethod
@@ -42,8 +44,6 @@ class ArrayDerivative(Derivative):
 
     @staticmethod
     def _call_derive_scalar_by_matexpr(expr, v):  # type: (Expr, MatrixExpr) -> Expr
-        from sympy import ZeroMatrix
-        from sympy.matrices.expressions.matexpr import _matrix_derivative
         if expr.has(v):
             return _matrix_derivative(expr, v)
         else:
@@ -55,7 +55,6 @@ class ArrayDerivative(Derivative):
 
     @staticmethod
     def _call_derive_matrix_by_scalar(expr, v):  # type: (MatrixCommon, Expr) -> Expr
-        from sympy.matrices.expressions.matexpr import _matrix_derivative
         return _matrix_derivative(expr, v)
 
     @staticmethod
@@ -68,7 +67,6 @@ class ArrayDerivative(Derivative):
 
     @staticmethod
     def _call_derive_default(expr, v):  # type: (Expr, Expr) -> Expr
-        from sympy.matrices.expressions.matexpr import _matrix_derivative
         if expr.has(v):
             return _matrix_derivative(expr, v)
         else:
@@ -84,9 +82,6 @@ class ArrayDerivative(Derivative):
         if not isinstance(count, (int, Integer)) or ((count <= 0) == True):
             return None
 
-        from sympy.matrices.common import MatrixCommon
-        from sympy import NDimArray
-        from sympy import MatrixExpr
         # TODO: this could be done with multiple-dispatching:
         if expr.is_scalar:
             if isinstance(v, MatrixCommon):
@@ -111,7 +106,6 @@ class ArrayDerivative(Derivative):
                 return None
         else:
             # Both `expr` and `v` are some array/matrix type:
-            from sympy import derive_by_array
             if isinstance(expr, MatrixCommon) or isinstance(expr, MatrixCommon):
                 result = derive_by_array(expr, v)
             elif isinstance(expr, MatrixExpr) and isinstance(v, MatrixExpr):

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -115,6 +115,8 @@ class ArrayDerivative(Derivative):
                 return None
             else:
                 result = derive_by_array(expr, v)
+        if result is None:
+            return None
         if count == 1:
             return result
         else:

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -1,0 +1,127 @@
+from sympy import Derivative, Integer
+
+
+class ArrayDerivative(Derivative):
+
+    is_scalar = False
+
+    def __new__(cls, expr, *variables, **kwargs):
+        obj = super(ArrayDerivative, cls).__new__(cls, expr, *variables, **kwargs)
+        if isinstance(obj, ArrayDerivative):
+            obj._shape = obj._get_shape()
+        return obj
+
+    def _get_shape(self):
+        shape = ()
+        for v, count in self.variable_count:
+            if hasattr(v, "shape"):
+                for i in range(count):
+                    shape += v.shape
+        if hasattr(self.expr, "shape"):
+            shape += self.expr.shape
+        return shape
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @classmethod
+    def _get_zero_with_shape_like(cls, expr):
+        from sympy.matrices.common import MatrixCommon
+        from sympy import NDimArray
+        from sympy import MatrixExpr
+        if isinstance(expr, (MatrixCommon, NDimArray)):
+            return expr.zeros(*expr.shape)
+        elif isinstance(expr, MatrixExpr):
+            from sympy import ZeroMatrix
+            return ZeroMatrix(*expr.shape)
+
+    @staticmethod
+    def _call_derive_scalar_by_matrix(expr, v):  # type: (Expr, MatrixCommon) -> Expr
+        return v.applyfunc(lambda x: expr.diff(x))
+
+    @staticmethod
+    def _call_derive_scalar_by_matexpr(expr, v):  # type: (Expr, MatrixExpr) -> Expr
+        from sympy import ZeroMatrix
+        from sympy.matrices.expressions.matexpr import _matrix_derivative
+        if expr.has(v):
+            return _matrix_derivative(expr, v)
+        else:
+            return ZeroMatrix(*v.shape)
+
+    @staticmethod
+    def _call_derive_scalar_by_array(expr, v):  # type: (Expr, NDimArray) -> Expr
+        return v.applyfunc(lambda x: expr.diff(x))
+
+    @staticmethod
+    def _call_derive_matrix_by_scalar(expr, v):  # type: (MatrixCommon, Expr) -> Expr
+        from sympy.matrices.expressions.matexpr import _matrix_derivative
+        return _matrix_derivative(expr, v)
+
+    @staticmethod
+    def _call_derive_matexpr_by_scalar(expr, v):  # type: (MatrixExpr, Expr) -> Expr
+        return expr._eval_derivative(v)
+
+    @staticmethod
+    def _call_derive_array_by_scalar(expr, v):  # type: (NDimArray, Expr) -> Expr
+        return expr.applyfunc(lambda x: x.diff(v))
+
+    @staticmethod
+    def _call_derive_default(expr, v):  # type: (Expr, Expr) -> Expr
+        from sympy.matrices.expressions.matexpr import _matrix_derivative
+        if expr.has(v):
+            return _matrix_derivative(expr, v)
+        else:
+            return None
+
+    @classmethod
+    def _dispatch_eval_derivative_n_times(cls, expr, v, count):
+        # Evaluate the derivative `n` times.  If
+        # `_eval_derivative_n_times` is not overridden by the current
+        # object, the default in `Basic` will call a loop over
+        # `_eval_derivative`:
+
+        if not isinstance(count, (int, Integer)) or ((count <= 0) == True):
+            return None
+
+        from sympy.matrices.common import MatrixCommon
+        from sympy import NDimArray
+        from sympy import MatrixExpr
+        # TODO: this could be done with multiple-dispatching:
+        if expr.is_scalar:
+            if isinstance(v, MatrixCommon):
+                result = cls._call_derive_scalar_by_matrix(expr, v)
+            elif isinstance(v, MatrixExpr):
+                result = cls._call_derive_scalar_by_matexpr(expr, v)
+            elif isinstance(v, NDimArray):
+                result = cls._call_derive_scalar_by_array(expr, v)
+            elif v.is_scalar:
+                # scalar by scalar has a special
+                return super(ArrayDerivative, cls)._dispatch_eval_derivative_n_times(expr, v, count)
+            else:
+                return None
+        elif v.is_scalar:
+            if isinstance(expr, MatrixCommon):
+                result = cls._call_derive_matrix_by_scalar(expr, v)
+            elif isinstance(expr, MatrixExpr):
+                result = cls._call_derive_matexpr_by_scalar(expr, v)
+            elif isinstance(expr, NDimArray):
+                result = cls._call_derive_array_by_scalar(expr, v)
+            else:
+                return None
+        else:
+            # Both `expr` and `v` are some array/matrix type:
+            from sympy import derive_by_array
+            if isinstance(expr, MatrixCommon) or isinstance(expr, MatrixCommon):
+                result = derive_by_array(expr, v)
+            elif isinstance(expr, MatrixExpr) and isinstance(v, MatrixExpr):
+                result = cls._call_derive_default(expr, v)
+            elif isinstance(expr, MatrixExpr) or isinstance(v, MatrixExpr):
+                # if one expression is a symbolic matrix expression while the other isn't, don't evaluate:
+                return None
+            else:
+                result = derive_by_array(expr, v)
+        if count == 1:
+            return result
+        else:
+            return cls._dispatch_eval_derivative_n_times(result, v, count - 1)

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -38,7 +38,7 @@ class ArrayDerivative(Derivative):
         elif isinstance(expr, MatrixExpr):
             return ZeroMatrix(*expr.shape)
         else:
-            raise RuntimeError("...")
+            raise RuntimeError("Unable to determine shape of array-derivative.")
 
     @staticmethod
     def _call_derive_scalar_by_matrix(expr, v):  # type: (Expr, MatrixCommon) -> Expr

--- a/sympy/tensor/array/array_derivatives.py
+++ b/sympy/tensor/array/array_derivatives.py
@@ -37,6 +37,8 @@ class ArrayDerivative(Derivative):
             return expr.zeros(*expr.shape)
         elif isinstance(expr, MatrixExpr):
             return ZeroMatrix(*expr.shape)
+        else:
+            raise RuntimeError("...")
 
     @staticmethod
     def _call_derive_scalar_by_matrix(expr, v):  # type: (Expr, MatrixCommon) -> Expr

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -3,9 +3,8 @@ import itertools
 from sympy import S, Tuple, diff, Basic
 
 from sympy.core.compatibility import Iterable
-from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.tensor.array.ndim_array import NDimArray
-from sympy.tensor.array.dense_ndim_array import DenseNDimArray
+from sympy.tensor.array.dense_ndim_array import DenseNDimArray, ImmutableDenseNDimArray
 from sympy.tensor.array.sparse_ndim_array import SparseNDimArray
 
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -7,7 +7,6 @@ from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify
 from sympy.core.compatibility import SYMPY_INTS, Iterable
 from sympy.printing.defaults import Printable
-from sympy.tensor.array.array_derivatives import ArrayDerivative
 
 import itertools
 
@@ -242,7 +241,7 @@ class NDimArray(Printable):
         [[1, 0], [0, y]]
 
         """
-        from sympy import Derivative
+        from sympy.tensor.array.array_derivatives import ArrayDerivative
         kwargs.setdefault('evaluate', True)
         return ArrayDerivative(self.as_immutable(), *args, **kwargs)
 

--- a/sympy/tensor/array/tests/test_array_derivatives.py
+++ b/sympy/tensor/array/tests/test_array_derivatives.py
@@ -1,0 +1,49 @@
+from sympy import Matrix, symbols, MatrixSymbol, NDimArray
+from sympy.matrices.common import MatrixCommon
+from sympy.tensor.array.array_derivatives import ArrayDerivative
+
+x, y, z, t = symbols("x y z t")
+
+m = Matrix([[x, y], [z, t]])
+
+M = MatrixSymbol("M", 3, 2)
+N = MatrixSymbol("N", 4, 3)
+
+
+def test_array_derivative_construction():
+
+    d = ArrayDerivative(x, m, evaluate=False)
+    assert d.shape == (2, 2)
+    expr = d.doit()
+    assert isinstance(expr, MatrixCommon)
+    assert expr.shape == (2, 2)
+
+    d = ArrayDerivative(m, m, evaluate=False)
+    assert d.shape == (2, 2, 2, 2)
+    expr = d.doit()
+    assert isinstance(expr, NDimArray)
+    assert expr.shape == (2, 2, 2, 2)
+
+    d = ArrayDerivative(m, x, evaluate=False)
+    assert d.shape == (2, 2)
+    expr = d.doit()
+    assert isinstance(expr, MatrixCommon)
+    assert expr.shape == (2, 2)
+
+    d = ArrayDerivative(M, N, evaluate=False)
+    assert d.shape == (4, 3, 3, 2)
+    expr = d.doit()
+    assert isinstance(expr, ArrayDerivative)
+    assert expr.shape == (4, 3, 3, 2)
+
+    d = ArrayDerivative(M, (N, 2), evaluate=False)
+    assert d.shape == (4, 3, 4, 3, 3, 2)
+    expr = d.doit()
+    assert isinstance(expr, ArrayDerivative)
+    assert expr.shape == (4, 3, 4, 3, 3, 2)
+
+    d = ArrayDerivative(M.as_explicit(), (N.as_explicit(), 2), evaluate=False)
+    assert d.doit().shape == (4, 3, 4, 3, 3, 2)
+    expr = d.doit()
+    assert isinstance(expr, ArrayDerivative)
+    assert expr.shape == (4, 3, 4, 3, 3, 2)


### PR DESCRIPTION
Adding ArrayDerivative class as subclass of Derivative, will handle derivatives involving non scalar expressions.

Getting rid of the visitor pattern in order to perform double-dispatch and decide how to handle derivatives.

This PR does not change the logic of SymPy, it's just code clean-up.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Adding ArrayDerivative class as subclass of Derivative. This new handles derivatives involving non-scalar expressions.
<!-- END RELEASE NOTES -->