### PR TITLE
Cleanup unicode vs str code

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -130,7 +130,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     >>> sympify("x***2")
     Traceback (most recent call last):
     ...
-    SympifyError: SympifyError: "could not parse u'x***2'"
+    SympifyError: SympifyError: "could not parse 'x***2'"
 
     Locals
     ------

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -252,7 +252,7 @@ def test_split_symbols_numeric():
 
 
 def test_unicode_names():
-    assert parse_expr(u'α') == Symbol(u'α')
+    assert parse_expr('α') == Symbol('α')
 
 
 def test_python3_features():

--- a/sympy/physics/optics/polarization.py
+++ b/sympy/physics/optics/polarization.py
@@ -291,7 +291,7 @@ def stokes_vector(psi, chi, p=1, I=1):
 
 
 def jones_2_stokes(e):
-    u"""Return the Stokes vector for a Jones vector `e`.
+    """Return the Stokes vector for a Jones vector `e`.
 
     Parameters
     ----------

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -135,7 +135,7 @@ class AntiCommutator(Expr):
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)
-        pform = prettyForm(*pform.right((prettyForm(u','))))
+        pform = prettyForm(*pform.right((prettyForm(','))))
         pform = prettyForm(*pform.right((printer._print(self.args[1], *args))))
         pform = prettyForm(*pform.parens(left='{', right='}'))
         return pform

--- a/sympy/physics/quantum/boson.py
+++ b/sympy/physics/quantum/boson.py
@@ -120,7 +120,7 @@ class BosonOp(Operator):
         if self.is_annihilation:
             return pform
         else:
-            return pform**prettyForm(u'\N{DAGGER}')
+            return pform**prettyForm('\N{DAGGER}')
 
 
 class BosonFockKet(Ket):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -341,7 +341,7 @@ class Mz(OneQubitGate):
     """
     measurement = True
     gate_name='Mz'
-    gate_name_latex=u'M_z'
+    gate_name_latex='M_z'
 
 class Mx(OneQubitGate):
     """Mock-up of an x measurement gate.
@@ -351,7 +351,7 @@ class Mx(OneQubitGate):
     """
     measurement = True
     gate_name='Mx'
-    gate_name_latex=u'M_x'
+    gate_name_latex='M_x'
 
 class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -224,7 +224,7 @@ class Commutator(Expr):
 
     def _pretty(self, printer, *args):
         pform = printer._print(self.args[0], *args)
-        pform = prettyForm(*pform.right((prettyForm(u','))))
+        pform = prettyForm(*pform.right((prettyForm(','))))
         pform = prettyForm(*pform.right((printer._print(self.args[1], *args))))
         pform = prettyForm(*pform.parens(left='[', right=']'))
         return pform

--- a/sympy/physics/quantum/constants.py
+++ b/sympy/physics/quantum/constants.py
@@ -51,7 +51,7 @@ class HBar(NumberSymbol, metaclass=Singleton):
 
     def _pretty(self, printer, *args):
         if printer._use_unicode:
-            return prettyForm(u'\N{PLANCK CONSTANT OVER TWO PI}')
+            return prettyForm('\N{PLANCK CONSTANT OVER TWO PI}')
         return prettyForm('hbar')
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -106,7 +106,7 @@ class FermionOp(Operator):
         if self.is_annihilation:
             return pform
         else:
-            return pform**prettyForm(u'\N{DAGGER}')
+            return pform**prettyForm('\N{DAGGER}')
 
 
 class FermionFockKet(Ket):

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -20,7 +20,7 @@ import random
 
 from sympy import Add, I, Integer, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence, unicode
+from sympy.core.compatibility import is_sequence
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -137,8 +137,8 @@ class Gate(UnitaryOperator):
 
     _label_separator = ','
 
-    gate_name = u'G'
-    gate_name_latex = u'G'
+    gate_name = 'G'
+    gate_name_latex = 'G'
 
     #-------------------------------------------------------------------------
     # Initialization/creation
@@ -288,7 +288,7 @@ class Gate(UnitaryOperator):
         return '%s(%s)' % (self.gate_name, label)
 
     def _pretty(self, printer, *args):
-        a = stringPict(unicode(self.gate_name))
+        a = stringPict(self.gate_name)
         b = self._print_label_pretty(printer, *args)
         return self._print_subscript_pretty(a, b)
 
@@ -319,8 +319,8 @@ class CGate(Gate):
 
     """
 
-    gate_name = u'C'
-    gate_name_latex = u'C'
+    gate_name = 'C'
+    gate_name_latex = 'C'
 
     # The values this class controls for.
     control_value = Integer(1)
@@ -423,7 +423,7 @@ class CGate(Gate):
         controls = self._print_sequence_pretty(
             self.controls, ',', printer, *args)
         gate = printer._print(self.gate)
-        gate_name = stringPict(unicode(self.gate_name))
+        gate_name = stringPict(self.gate_name)
         first = self._print_subscript_pretty(gate_name, controls)
         gate = self._print_parens_pretty(gate)
         final = prettyForm(*first.right((gate)))
@@ -446,9 +446,9 @@ class CGate(Gate):
         for c in self.controls:
             circ_plot.control_point(gate_idx, int(c))
         if self.simplify_cgate:
-            if self.gate.gate_name == u'X':
+            if self.gate.gate_name == 'X':
                 self.gate.plot_gate_plus(circ_plot, gate_idx)
-            elif self.gate.gate_name == u'Z':
+            elif self.gate.gate_name == 'Z':
                 circ_plot.control_point(gate_idx, self.targets[0])
             else:
                 self.gate.plot_gate(circ_plot, gate_idx)
@@ -499,8 +499,8 @@ class UGate(Gate):
         target qubits and U is a unitary matrix with dimension of
         len(targets).
     """
-    gate_name = u'U'
-    gate_name_latex = u'U'
+    gate_name = 'U'
+    gate_name_latex = 'U'
 
     #-------------------------------------------------------------------------
     # Initialization
@@ -558,7 +558,7 @@ class UGate(Gate):
     def _pretty(self, printer, *args):
         targets = self._print_sequence_pretty(
             self.targets, ',', printer, *args)
-        gate_name = stringPict(unicode(self.gate_name))
+        gate_name = stringPict(self.gate_name)
         return self._print_subscript_pretty(gate_name, targets)
 
     def _latex(self, printer, *args):
@@ -618,8 +618,8 @@ class IdentityGate(OneQubitGate):
     ========
 
     """
-    gate_name = u'1'
-    gate_name_latex = u'1'
+    gate_name = '1'
+    gate_name_latex = '1'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('eye2', format)
@@ -654,8 +654,8 @@ class HadamardGate(HermitianOperator, OneQubitGate):
     sqrt(2)*|00>/2 + sqrt(2)*|11>/2
 
     """
-    gate_name = u'H'
-    gate_name_latex = u'H'
+    gate_name = 'H'
+    gate_name_latex = 'H'
 
     def get_target_matrix(self, format='sympy'):
         if _normalized:
@@ -694,8 +694,8 @@ class XGate(HermitianOperator, OneQubitGate):
     ========
 
     """
-    gate_name = u'X'
-    gate_name_latex = u'X'
+    gate_name = 'X'
+    gate_name_latex = 'X'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('X', format)
@@ -733,8 +733,8 @@ class YGate(HermitianOperator, OneQubitGate):
     ========
 
     """
-    gate_name = u'Y'
-    gate_name_latex = u'Y'
+    gate_name = 'Y'
+    gate_name_latex = 'Y'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('Y', format)
@@ -761,8 +761,8 @@ class ZGate(HermitianOperator, OneQubitGate):
     ========
 
     """
-    gate_name = u'Z'
-    gate_name_latex = u'Z'
+    gate_name = 'Z'
+    gate_name_latex = 'Z'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('Z', format)
@@ -789,8 +789,8 @@ class PhaseGate(OneQubitGate):
     ========
 
     """
-    gate_name = u'S'
-    gate_name_latex = u'S'
+    gate_name = 'S'
+    gate_name_latex = 'S'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('S', format)
@@ -817,8 +817,8 @@ class TGate(OneQubitGate):
     ========
 
     """
-    gate_name = u'T'
-    gate_name_latex = u'T'
+    gate_name = 'T'
+    gate_name_latex = 'T'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('T', format)
@@ -867,7 +867,7 @@ class CNotGate(HermitianOperator, CGate, TwoQubitGate):
 
     """
     gate_name = 'CNOT'
-    gate_name_latex = u'CNOT'
+    gate_name_latex = 'CNOT'
     simplify_cgate = True
 
     #-------------------------------------------------------------------------
@@ -973,7 +973,7 @@ class SwapGate(TwoQubitGate):
 
     """
     gate_name = 'SWAP'
-    gate_name_latex = u'SWAP'
+    gate_name_latex = 'SWAP'
 
     def get_target_matrix(self, format='sympy'):
         return matrix_cache.get_matrix('SWAP', format)

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -89,8 +89,8 @@ class OracleGate(Gate):
         |3>
     """
 
-    gate_name = u'V'
-    gate_name_latex = u'V'
+    gate_name = 'V'
+    gate_name_latex = 'V'
 
     #-------------------------------------------------------------------------
     # Initialization/creation
@@ -194,8 +194,8 @@ class WGate(Gate):
 
     """
 
-    gate_name = u'W'
-    gate_name_latex = u'W'
+    gate_name = 'W'
+    gate_name_latex = 'W'
 
     @classmethod
     def _eval_args(cls, args):

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -98,10 +98,10 @@ class HilbertSpace(Basic):
             return False
 
     def _sympystr(self, printer, *args):
-        return u'H'
+        return 'H'
 
     def _pretty(self, printer, *args):
-        ustr = u'\N{LATIN CAPITAL LETTER H}'
+        ustr = '\N{LATIN CAPITAL LETTER H}'
         return prettyForm(ustr)
 
     def _latex(self, printer, *args):
@@ -175,7 +175,7 @@ class ComplexSpace(HilbertSpace):
         return "C(%s)" % printer._print(self.dimension, *args)
 
     def _pretty(self, printer, *args):
-        ustr = u'\N{LATIN CAPITAL LETTER C}'
+        ustr = '\N{LATIN CAPITAL LETTER C}'
         pform_exp = printer._print(self.dimension, *args)
         pform_base = prettyForm(ustr)
         return pform_base**pform_exp
@@ -227,8 +227,8 @@ class L2(HilbertSpace):
         return "L2(%s)" % printer._print(self.interval, *args)
 
     def _pretty(self, printer, *args):
-        pform_exp = prettyForm(u'2')
-        pform_base = prettyForm(u'L')
+        pform_exp = prettyForm('2')
+        pform_base = prettyForm('L')
         return pform_base**pform_exp
 
     def _latex(self, printer, *args):
@@ -274,7 +274,7 @@ class FockSpace(HilbertSpace):
         return "F"
 
     def _pretty(self, printer, *args):
-        ustr = u'\N{LATIN CAPITAL LETTER F}'
+        ustr = '\N{LATIN CAPITAL LETTER F}'
         return prettyForm(ustr)
 
     def _latex(self, printer, *args):
@@ -419,7 +419,7 @@ class TensorProductHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u' ' + u'\N{N-ARY CIRCLED TIMES OPERATOR}' + u' '))
+                    pform = prettyForm(*pform.right(' ' + '\N{N-ARY CIRCLED TIMES OPERATOR}' + ' '))
                 else:
                     pform = prettyForm(*pform.right(' x '))
         return pform
@@ -529,7 +529,7 @@ class DirectSumHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u' \N{CIRCLED PLUS} '))
+                    pform = prettyForm(*pform.right(' \N{CIRCLED PLUS} '))
                 else:
                     pform = prettyForm(*pform.right(' + '))
         return pform
@@ -640,7 +640,7 @@ class TensorPowerHilbertSpace(HilbertSpace):
     def _pretty(self, printer, *args):
         pform_exp = printer._print(self.exp, *args)
         if printer._use_unicode:
-            pform_exp = prettyForm(*pform_exp.left(prettyForm(u'\N{N-ARY CIRCLED TIMES OPERATOR}')))
+            pform_exp = prettyForm(*pform_exp.left(prettyForm('\N{N-ARY CIRCLED TIMES OPERATOR}')))
         else:
             pform_exp = prettyForm(*pform_exp.left(prettyForm('x')))
         pform_base = printer._print(self.base, *args)

--- a/sympy/physics/quantum/qft.py
+++ b/sympy/physics/quantum/qft.py
@@ -39,8 +39,8 @@ __all__ = [
 
 class RkGate(OneQubitGate):
     """This is the R_k gate of the QTF."""
-    gate_name = u'Rk'
-    gate_name_latex = u'R'
+    gate_name = 'Rk'
+    gate_name_latex = 'R'
 
     def __new__(cls, *args):
         if len(args) != 2:
@@ -157,8 +157,8 @@ class Fourier(Gate):
 class QFT(Fourier):
     """The forward quantum Fourier transform."""
 
-    gate_name = u'QFT'
-    gate_name_latex = u'QFT'
+    gate_name = 'QFT'
+    gate_name_latex = 'QFT'
 
     def decompose(self):
         """Decomposes QFT into elementary gates."""
@@ -187,8 +187,8 @@ class QFT(Fourier):
 class IQFT(Fourier):
     """The inverse quantum Fourier transform."""
 
-    gate_name = u'IQFT'
-    gate_name_latex = u'{QFT^{-1}}'
+    gate_name = 'IQFT'
+    gate_name_latex = '{QFT^{-1}}'
 
     def decompose(self):
         """Decomposes IQFT into elementary gates."""

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -154,7 +154,7 @@ class RaisingOp(SHOOp):
     def _print_contents_pretty(self, printer, *args):
         from sympy.printing.pretty.stringpict import prettyForm
         pform = printer._print(self.args[0], *args)
-        pform = pform**prettyForm(u'\N{DAGGER}')
+        pform = pform**prettyForm('\N{DAGGER}')
         return pform
 
     def _print_contents_latex(self, printer, *args):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -81,7 +81,7 @@ class SpinOpBase(object):
         return '%s%s' % (self.name, self._coord)
 
     def _print_contents_pretty(self, printer, *args):
-        a = stringPict(self.name)
+        a = stringPict(str(self.name))
         b = stringPict(self._coord)
         return self._print_subscript_pretty(a, b)
 
@@ -404,7 +404,7 @@ class J2Op(SpinOpBase, HermitianOperator):
         return self._represent_base(basis, **options)
 
     def _print_contents_pretty(self, printer, *args):
-        a = prettyForm(self.name)
+        a = prettyForm(str(self.name))
         b = prettyForm('2')
         return a**b
 

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division
 from sympy import (Add, binomial, cos, exp, Expr, factorial, I, Integer, Mul,
                    pi, Rational, S, sin, simplify, sqrt, Sum, symbols, sympify,
                    Tuple, Dummy)
-from sympy.core.compatibility import unicode
 from sympy.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import pretty_symbol
@@ -79,15 +78,15 @@ class SpinOpBase(object):
         return self.args[0]
 
     def _print_contents(self, printer, *args):
-        return '%s%s' % (unicode(self.name), self._coord)
+        return '%s%s' % (self.name, self._coord)
 
     def _print_contents_pretty(self, printer, *args):
-        a = stringPict(unicode(self.name))
+        a = stringPict(self.name)
         b = stringPict(self._coord)
         return self._print_subscript_pretty(a, b)
 
     def _print_contents_latex(self, printer, *args):
-        return r'%s_%s' % ((unicode(self.name), self._coord))
+        return r'%s_%s' % ((self.name, self._coord))
 
     def _represent_base(self, basis, **options):
         j = options.get('j', S.Half)
@@ -405,8 +404,8 @@ class J2Op(SpinOpBase, HermitianOperator):
         return self._represent_base(basis, **options)
 
     def _print_contents_pretty(self, printer, *args):
-        a = prettyForm(unicode(self.name))
-        b = prettyForm(u'2')
+        a = prettyForm(self.name)
+        b = prettyForm('2')
         return a**b
 
     def _print_contents_latex(self, printer, *args):
@@ -502,7 +501,7 @@ class Rotation(UnitaryOperator):
 
     def _print_operator_name_pretty(self, printer, *args):
         if printer._use_unicode:
-            return prettyForm(u'\N{SCRIPT CAPITAL R}' + u' ')
+            return prettyForm('\N{SCRIPT CAPITAL R}' + ' ')
         else:
             return prettyForm("R ")
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -36,23 +36,23 @@ _straight_bracket = "|"
 
 # Unicode brackets
 # MATHEMATICAL ANGLE BRACKETS
-_lbracket_ucode = u"\N{MATHEMATICAL LEFT ANGLE BRACKET}"
-_rbracket_ucode = u"\N{MATHEMATICAL RIGHT ANGLE BRACKET}"
+_lbracket_ucode = "\N{MATHEMATICAL LEFT ANGLE BRACKET}"
+_rbracket_ucode = "\N{MATHEMATICAL RIGHT ANGLE BRACKET}"
 # LIGHT VERTICAL BAR
-_straight_bracket_ucode = u"\N{LIGHT VERTICAL BAR}"
+_straight_bracket_ucode = "\N{LIGHT VERTICAL BAR}"
 
 # Other options for unicode printing of <, > and | for Dirac notation.
 
 # LEFT-POINTING ANGLE BRACKET
-# _lbracket = u"\u2329"
-# _rbracket = u"\u232A"
+# _lbracket = "\u2329"
+# _rbracket = "\u232A"
 
 # LEFT ANGLE BRACKET
-# _lbracket = u"\u3008"
-# _rbracket = u"\u3009"
+# _lbracket = "\u3008"
+# _rbracket = "\u3009"
 
 # VERTICAL LINE
-# _straight_bracket = u"\u007C"
+# _straight_bracket = "\u007C"
 
 
 class StateBase(QExpr):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -135,9 +135,9 @@ class StateBase(QExpr):
         # Setup for unicode vs ascii
         if use_unicode:
             lbracket, rbracket = self.lbracket_ucode, self.rbracket_ucode
-            slash, bslash, vert = u'\N{BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT}', \
-                                  u'\N{BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT}', \
-                                  u'\N{BOX DRAWINGS LIGHT VERTICAL}'
+            slash, bslash, vert = '\N{BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT}', \
+                                  '\N{BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT}', \
+                                  '\N{BOX DRAWINGS LIGHT VERTICAL}'
         else:
             lbracket, rbracket = self.lbracket, self.rbracket
             slash, bslash, vert = '/', '\\', '|'

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -200,7 +200,7 @@ class TensorProduct(Expr):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u'\N{N-ARY CIRCLED TIMES OPERATOR}' + u' '))
+                    pform = prettyForm(*pform.right('\N{N-ARY CIRCLED TIMES OPERATOR}' + ' '))
                 else:
                     pform = prettyForm(*pform.right('x' + ' '))
         return pform

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -32,8 +32,6 @@ from sympy.printing import srepr
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.latex import latex
 
-from sympy.core.compatibility import u_decode as u
-
 MutableDenseMatrix = Matrix
 
 
@@ -86,11 +84,11 @@ def test_anticommutator():
 \\    /\
 """
     ucode_str = \
-u("""\
+"""\
 ⎧ 2  ⎫\n\
 ⎨A ,B⎬\n\
 ⎩    ⎭\
-""")
+"""
     assert pretty(ac_tall) == ascii_str
     assert upretty(ac_tall) == ucode_str
     assert latex(ac_tall) == r'\left\{A^{2},B\right\}'
@@ -110,11 +108,11 @@ C       \n\
  1,2,3,4\
 """
     ucode_str = \
-u("""\
+"""\
  5,6    \n\
 C       \n\
  1,2,3,4\
-""")
+"""
     assert pretty(cg) == ascii_str
     assert upretty(cg) == ucode_str
     assert latex(cg) == r'C^{5,6}_{1,2,3,4}'
@@ -127,11 +125,11 @@ C       \n\
 \\2  4  6/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎛1  3  5⎞\n\
 ⎜       ⎟\n\
 ⎝2  4  6⎠\
-""")
+"""
     assert pretty(wigner3j) == ascii_str
     assert upretty(wigner3j) == ucode_str
     assert latex(wigner3j) == \
@@ -145,11 +143,11 @@ u("""\
 \\4  5  6/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎧1  2  3⎫\n\
 ⎨       ⎬\n\
 ⎩4  5  6⎭\
-""")
+"""
     assert pretty(wigner6j) == ascii_str
     assert upretty(wigner6j) == ucode_str
     assert latex(wigner6j) == \
@@ -165,13 +163,13 @@ u("""\
 \\7  8  9/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎧1  2  3⎫\n\
 ⎪       ⎪\n\
 ⎨4  5  6⎬\n\
 ⎪       ⎪\n\
 ⎩7  8  9⎭\
-""")
+"""
     assert pretty(wigner9j) == ascii_str
     assert upretty(wigner9j) == ucode_str
     assert latex(wigner9j) == \
@@ -196,10 +194,10 @@ def test_commutator():
 [A ,B]\
 """
     ucode_str = \
-u("""\
+"""\
 ⎡ 2  ⎤\n\
 ⎣A ,B⎦\
-""")
+"""
     assert pretty(c_tall) == ascii_str
     assert upretty(c_tall) == ucode_str
     assert latex(c_tall) == r'\left[A^{2},B\right]'
@@ -224,10 +222,10 @@ def test_dagger():
 x \
 """
     ucode_str = \
-u("""\
+"""\
  †\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     assert latex(expr) == r'x^{\dagger}'
@@ -262,10 +260,10 @@ def test_gate():
  2        \
 """
     ucode_str = \
-u("""\
+"""\
 1 ⋅❘10101⟩\n\
  2        \
-""")
+"""
     assert pretty(g1*q) == ascii_str
     assert upretty(g1*q) == ucode_str
     assert latex(g1*q) == r'1_{2} {\left|10101\right\rangle }'
@@ -277,10 +275,10 @@ C   /X \\\n\
  3,0\\ 1/\
 """
     ucode_str = \
-u("""\
+"""\
 C   ⎛X ⎞\n\
  3,0⎝ 1⎠\
-""")
+"""
     assert pretty(g2) == ascii_str
     assert upretty(g2) == ucode_str
     assert latex(g2) == r'C_{3,0}{\left(X_{1}\right)}'
@@ -292,10 +290,10 @@ CNOT   \n\
     1,0\
 """
     ucode_str = \
-u("""\
+"""\
 CNOT   \n\
     1,0\
-""")
+"""
     assert pretty(g3) == ascii_str
     assert upretty(g3) == ucode_str
     assert latex(g3) == r'CNOT_{1,0}'
@@ -306,10 +304,10 @@ U \n\
  0\
 """
     ucode_str = \
-u("""\
+"""\
 U \n\
  0\
-""")
+"""
     assert str(g4) == \
 """\
 U((0,),Matrix([\n\
@@ -339,10 +337,10 @@ def test_hilbert():
 C \
 """
     ucode_str = \
-u("""\
+"""\
  2\n\
 C \
-""")
+"""
     assert pretty(h2) == ascii_str
     assert upretty(h2) == ucode_str
     assert latex(h2) == r'\mathcal{C}^{2}'
@@ -359,10 +357,10 @@ C \
 L \
 """
     ucode_str = \
-u("""\
+"""\
  2\n\
 L \
-""")
+"""
     assert pretty(h4) == ascii_str
     assert upretty(h4) == ucode_str
     assert latex(h4) == r'{\mathcal{L}^2}\left( \left[0, \infty\right) \right)'
@@ -374,10 +372,10 @@ L \
 H + C \
 """
     ucode_str = \
-u("""\
+"""\
      2\n\
 H ⊕ C \
-""")
+"""
     assert pretty(h1 + h2) == ascii_str
     assert upretty(h1 + h2) == ucode_str
     assert latex(h1 + h2)
@@ -389,10 +387,10 @@ H ⊕ C \
 H x C \
 """
     ucode_str = \
-u("""\
+"""\
      2\n\
 H ⨂ C \
-""")
+"""
     assert pretty(h1*h2) == ascii_str
     assert upretty(h1*h2) == ucode_str
     assert latex(h1*h2)
@@ -405,10 +403,10 @@ H ⨂ C \
 H  \
 """
     ucode_str = \
-u("""\
+"""\
  ⨂2\n\
 H  \
-""")
+"""
     assert pretty(h1**2) == ascii_str
     assert upretty(h1**2) == ucode_str
     assert latex(h1**2) == r'{\mathcal{H}}^{\otimes 2}'
@@ -456,12 +454,12 @@ def test_innerproduct():
  \\2|2/ \
 """
     ucode_str = \
-u("""\
+"""\
  ╱ │ ╲ \n\
 ╱ x│x ╲\n\
 ╲ ─│─ ╱\n\
  ╲2│2╱ \
-""")
+"""
     assert pretty(ip_tall1) == ascii_str
     assert upretty(ip_tall1) == ucode_str
     assert latex(ip_tall1) == \
@@ -476,12 +474,12 @@ u("""\
  \\ |2/ \
 """
     ucode_str = \
-u("""\
+"""\
  ╱ │ ╲ \n\
 ╱  │x ╲\n\
 ╲ x│─ ╱\n\
  ╲ │2╱ \
-""")
+"""
     assert pretty(ip_tall2) == ascii_str
     assert upretty(ip_tall2) == ucode_str
     assert latex(ip_tall2) == \
@@ -497,12 +495,12 @@ u("""\
  \\2| / \
 """
     ucode_str = \
-u("""\
+"""\
  ╱ │ ╲ \n\
 ╱ x│  ╲\n\
 ╲ ─│x ╱\n\
  ╲2│ ╱ \
-""")
+"""
     assert pretty(ip_tall3) == ascii_str
     assert upretty(ip_tall3) == ucode_str
     assert latex(ip_tall3) == \
@@ -531,10 +529,10 @@ def test_operator():
 A  \
 """
     ucode_str = \
-u("""\
+"""\
  -1\n\
 A  \
-""")
+"""
     assert pretty(inv) == ascii_str
     assert upretty(inv) == ucode_str
     assert latex(inv) == r'A^{-1}'
@@ -547,11 +545,11 @@ DifferentialOperator|--(f(x)),f(x)|\n\
                     \\dx           /\
 """
     ucode_str = \
-u("""\
+"""\
                     ⎛d            ⎞\n\
 DifferentialOperator⎜──(f(x)),f(x)⎟\n\
                     ⎝dx           ⎠\
-""")
+"""
     assert pretty(d) == ascii_str
     assert upretty(d) == ucode_str
     assert latex(d) == \
@@ -611,10 +609,10 @@ L \n\
  z\
 """
     ucode_str = \
-u("""\
+"""\
 L \n\
  z\
-""")
+"""
     assert pretty(lz) == ascii_str
     assert upretty(lz) == ucode_str
     assert latex(lz) == 'L_z'
@@ -626,10 +624,10 @@ L \n\
 J \
 """
     ucode_str = \
-u("""\
+"""\
  2\n\
 J \
-""")
+"""
     assert pretty(J2) == ascii_str
     assert upretty(J2) == ucode_str
     assert latex(J2) == r'J^2'
@@ -641,10 +639,10 @@ J \n\
  z\
 """
     ucode_str = \
-u("""\
+"""\
 J \n\
  z\
-""")
+"""
     assert pretty(Jz) == ascii_str
     assert upretty(Jz) == ucode_str
     assert latex(Jz) == 'J_z'
@@ -696,11 +694,11 @@ D   (4,5,6)\n\
  2,3       \
 """
     ucode_str = \
-u("""\
+"""\
  1         \n\
 D   (4,5,6)\n\
  2,3       \
-""")
+"""
     assert pretty(bigd) == ascii_str
     assert upretty(bigd) == ucode_str
     assert latex(bigd) == r'D^{1}_{2,3}\left(4,5,6\right)'
@@ -713,11 +711,11 @@ d   (4)\n\
  2,3   \
 """
     ucode_str = \
-u("""\
+"""\
  1     \n\
 d   (4)\n\
  2,3   \
-""")
+"""
     assert pretty(smalld) == ascii_str
     assert upretty(smalld) == ucode_str
     assert latex(smalld) == r'd^{1}_{2,3}\left(4\right)'
@@ -751,12 +749,12 @@ def test_state():
  \\2|\
 """
     ucode_str = \
-u("""\
+"""\
  ╱ │\n\
 ╱ x│\n\
 ╲ ─│\n\
  ╲2│\
-""")
+"""
     assert pretty(bra_tall) == ascii_str
     assert upretty(bra_tall) == ucode_str
     assert latex(bra_tall) == r'{\left\langle \frac{x}{2}\right|}'
@@ -770,12 +768,12 @@ u("""\
 |2/ \
 """
     ucode_str = \
-u("""\
+"""\
 │ ╲ \n\
 │x ╲\n\
 │─ ╱\n\
 │2╱ \
-""")
+"""
     assert pretty(ket_tall) == ascii_str
     assert upretty(ket_tall) == ucode_str
     assert latex(ket_tall) == r'{\left|\frac{x}{2}\right\rangle }'
@@ -820,13 +818,13 @@ def test_big_expr():
 \\ z/             \\\\                    \\dx           / /         /                                 \
 """
     ucode_str = \
-u("""\
+"""\
                  ⎧                                      3        ⎫                                 \n\
                  ⎪⎛                                   †⎞         ⎪                                 \n\
     2  ⎛ †    †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
 ⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
 ⎝ z⎠             ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
-""")
+"""
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
@@ -840,11 +838,11 @@ u("""\
 [\\ z/       ] \\         / [    z]\
 """
     ucode_str = \
-u("""\
+"""\
 ⎡    2      ⎤ ⎧ -2  †  †⎫ ⎡ 2   ⎤\n\
 ⎢⎛J ⎞ ,A + B⎥⋅⎨E  ,D ⋅C ⎬⋅⎢J ,J ⎥\n\
 ⎣⎝ z⎠       ⎦ ⎩         ⎭ ⎣    z⎦\
-""")
+"""
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == \
@@ -860,12 +858,12 @@ u("""\
 \\2  4  6/                                                                                             \
 """
     ucode_str = \
-u("""\
+"""\
           ⎡ †          ⎤  ⎛   2     ⎞                                                                 \n\
 ⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,j₁=1,j₂=1⟩ + ❘1,1,j₁=1,j₂=1⟩)⨂ ❘1,-1,j₁=1,j₂=1⟩\n\
 ⎜       ⎟                 ⎝        z⎠                                                                 \n\
 ⎝2  4  6⎠                                                                                             \
-""")
+"""
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
     assert latex(e3) == \
@@ -878,10 +876,10 @@ u("""\
 \\\\C  x C / + F  / x \\L  + H/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎛⎛ 1    2⎞    ⨂2⎞   ⎛ 2    ⎞\n\
 ⎝⎝C  ⨂ C ⎠ ⊕ F  ⎠ ⨂ ⎝L  ⊕ H⎠\
-""")
+"""
     assert pretty(e4) == ascii_str
     assert upretty(e4) == ucode_str
     assert latex(e4) == \

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -73,7 +73,7 @@ def test_anticommutator():
     ac_tall = AntiCommutator(A**2, B)
     assert str(ac) == '{A,B}'
     assert pretty(ac) == '{A,B}'
-    assert upretty(ac) == u'{A,B}'
+    assert upretty(ac) == '{A,B}'
     assert latex(ac) == r'\left\{A,B\right\}'
     sT(ac, "AntiCommutator(Operator(Symbol('A')),Operator(Symbol('B')))")
     assert str(ac_tall) == '{A**2,B}'
@@ -184,7 +184,7 @@ def test_commutator():
     c_tall = Commutator(A**2, B)
     assert str(c) == '[A,B]'
     assert pretty(c) == '[A,B]'
-    assert upretty(c) == u'[A,B]'
+    assert upretty(c) == '[A,B]'
     assert latex(c) == r'\left[A,B\right]'
     sT(c, "Commutator(Operator(Symbol('A')),Operator(Symbol('B')))")
     assert str(c_tall) == '[A**2,B]'
@@ -207,7 +207,7 @@ def test_commutator():
 def test_constants():
     assert str(hbar) == 'hbar'
     assert pretty(hbar) == 'hbar'
-    assert upretty(hbar) == u'ℏ'
+    assert upretty(hbar) == 'ℏ'
     assert latex(hbar) == r'\hbar'
     sT(hbar, "HBar()")
 
@@ -250,7 +250,7 @@ def test_gate():
     g4 = UGate((0,), uMat)
     assert str(g1) == '1(2)'
     assert pretty(g1) == '1 \n 2'
-    assert upretty(g1) == u'1 \n 2'
+    assert upretty(g1) == '1 \n 2'
     assert latex(g1) == r'1_{2}'
     sT(g1, "IdentityGate(Integer(2))")
     assert str(g1*q) == '1(2)*|10101>'
@@ -327,7 +327,7 @@ def test_hilbert():
     h4 = L2(Interval(0, oo))
     assert str(h1) == 'H'
     assert pretty(h1) == 'H'
-    assert upretty(h1) == u'H'
+    assert upretty(h1) == 'H'
     assert latex(h1) == r'\mathcal{H}'
     sT(h1, "HilbertSpace()")
     assert str(h2) == 'C(2)'
@@ -347,7 +347,7 @@ C \
     sT(h2, "ComplexSpace(Integer(2))")
     assert str(h3) == 'F'
     assert pretty(h3) == 'F'
-    assert upretty(h3) == u'F'
+    assert upretty(h3) == 'F'
     assert latex(h3) == r'\mathcal{F}'
     sT(h3, "FockSpace()")
     assert str(h4) == 'L2(Interval(0, oo))'
@@ -424,24 +424,24 @@ def test_innerproduct():
     ip_tall3 = InnerProduct(Bra(x/2), Ket(x))
     assert str(ip1) == '<psi|psi>'
     assert pretty(ip1) == '<psi|psi>'
-    assert upretty(ip1) == u'⟨ψ❘ψ⟩'
+    assert upretty(ip1) == '⟨ψ❘ψ⟩'
     assert latex(
         ip1) == r'\left\langle \psi \right. {\left|\psi\right\rangle }'
     sT(ip1, "InnerProduct(Bra(Symbol('psi')),Ket(Symbol('psi')))")
     assert str(ip2) == '<psi;t|psi;t>'
     assert pretty(ip2) == '<psi;t|psi;t>'
-    assert upretty(ip2) == u'⟨ψ;t❘ψ;t⟩'
+    assert upretty(ip2) == '⟨ψ;t❘ψ;t⟩'
     assert latex(ip2) == \
         r'\left\langle \psi;t \right. {\left|\psi;t\right\rangle }'
     sT(ip2, "InnerProduct(TimeDepBra(Symbol('psi'),Symbol('t')),TimeDepKet(Symbol('psi'),Symbol('t')))")
     assert str(ip3) == "<1,1|1,1>"
     assert pretty(ip3) == '<1,1|1,1>'
-    assert upretty(ip3) == u'⟨1,1❘1,1⟩'
+    assert upretty(ip3) == '⟨1,1❘1,1⟩'
     assert latex(ip3) == r'\left\langle 1,1 \right. {\left|1,1\right\rangle }'
     sT(ip3, "InnerProduct(JzBra(Integer(1),Integer(1)),JzKet(Integer(1),Integer(1)))")
     assert str(ip4) == "<1,1,j1=1,j2=1|1,1,j1=1,j2=1>"
     assert pretty(ip4) == '<1,1,j1=1,j2=1|1,1,j1=1,j2=1>'
-    assert upretty(ip4) == u'⟨1,1,j₁=1,j₂=1❘1,1,j₁=1,j₂=1⟩'
+    assert upretty(ip4) == '⟨1,1,j₁=1,j₂=1❘1,1,j₁=1,j₂=1⟩'
     assert latex(ip4) == \
         r'\left\langle 1,1,j_{1}=1,j_{2}=1 \right. {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }'
     sT(ip4, "InnerProduct(JzBraCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))),JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))))")
@@ -519,7 +519,7 @@ def test_operator():
     op = OuterProduct(Ket(), Bra())
     assert str(a) == 'A'
     assert pretty(a) == 'A'
-    assert upretty(a) == u'A'
+    assert upretty(a) == 'A'
     assert latex(a) == 'A'
     sT(a, "Operator(Symbol('A'))")
     assert str(inv) == 'A**(-1)'
@@ -557,12 +557,12 @@ DifferentialOperator⎜──(f(x)),f(x)⎟\n\
     sT(d, "DifferentialOperator(Derivative(Function('f')(Symbol('x')), Tuple(Symbol('x'), Integer(1))),Function('f')(Symbol('x')))")
     assert str(b) == 'Operator(B,t,1/2)'
     assert pretty(b) == 'Operator(B,t,1/2)'
-    assert upretty(b) == u'Operator(B,t,1/2)'
+    assert upretty(b) == 'Operator(B,t,1/2)'
     assert latex(b) == r'Operator\left(B,t,\frac{1}{2}\right)'
     sT(b, "Operator(Symbol('B'),Symbol('t'),Rational(1, 2))")
     assert str(op) == '|psi><psi|'
     assert pretty(op) == '|psi><psi|'
-    assert upretty(op) == u'❘ψ⟩⟨ψ❘'
+    assert upretty(op) == '❘ψ⟩⟨ψ❘'
     assert latex(op) == r'{\left|\psi\right\rangle }{\left\langle \psi\right|}'
     sT(op, "OuterProduct(Ket(Symbol('psi')),Bra(Symbol('psi')))")
 
@@ -571,7 +571,7 @@ def test_qexpr():
     q = QExpr('q')
     assert str(q) == 'q'
     assert pretty(q) == 'q'
-    assert upretty(q) == u'q'
+    assert upretty(q) == 'q'
     assert latex(q) == r'q'
     sT(q, "QExpr(Symbol('q'))")
 
@@ -581,12 +581,12 @@ def test_qubit():
     q2 = IntQubit(8)
     assert str(q1) == '|0101>'
     assert pretty(q1) == '|0101>'
-    assert upretty(q1) == u'❘0101⟩'
+    assert upretty(q1) == '❘0101⟩'
     assert latex(q1) == r'{\left|0101\right\rangle }'
     sT(q1, "Qubit(Integer(0),Integer(1),Integer(0),Integer(1))")
     assert str(q2) == '|8>'
     assert pretty(q2) == '|8>'
-    assert upretty(q2) == u'❘8⟩'
+    assert upretty(q2) == '❘8⟩'
     assert latex(q2) == r'{\left|8\right\rangle }'
     sT(q2, "IntQubit(8)")
 
@@ -649,41 +649,41 @@ J \n\
     sT(Jz, "JzOp(Symbol('J'))")
     assert str(ket) == '|1,0>'
     assert pretty(ket) == '|1,0>'
-    assert upretty(ket) == u'❘1,0⟩'
+    assert upretty(ket) == '❘1,0⟩'
     assert latex(ket) == r'{\left|1,0\right\rangle }'
     sT(ket, "JzKet(Integer(1),Integer(0))")
     assert str(bra) == '<1,0|'
     assert pretty(bra) == '<1,0|'
-    assert upretty(bra) == u'⟨1,0❘'
+    assert upretty(bra) == '⟨1,0❘'
     assert latex(bra) == r'{\left\langle 1,0\right|}'
     sT(bra, "JzBra(Integer(1),Integer(0))")
     assert str(cket) == '|1,0,j1=1,j2=2>'
     assert pretty(cket) == '|1,0,j1=1,j2=2>'
-    assert upretty(cket) == u'❘1,0,j₁=1,j₂=2⟩'
+    assert upretty(cket) == '❘1,0,j₁=1,j₂=2⟩'
     assert latex(cket) == r'{\left|1,0,j_{1}=1,j_{2}=2\right\rangle }'
     sT(cket, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
     assert str(cbra) == '<1,0,j1=1,j2=2|'
     assert pretty(cbra) == '<1,0,j1=1,j2=2|'
-    assert upretty(cbra) == u'⟨1,0,j₁=1,j₂=2❘'
+    assert upretty(cbra) == '⟨1,0,j₁=1,j₂=2❘'
     assert latex(cbra) == r'{\left\langle 1,0,j_{1}=1,j_{2}=2\right|}'
     sT(cbra, "JzBraCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
     assert str(cket_big) == '|1,0,j1=1,j2=2,j3=3,j(1,2)=3>'
     # TODO: Fix non-unicode pretty printing
     # i.e. j1,2 -> j(1,2)
     assert pretty(cket_big) == '|1,0,j1=1,j2=2,j3=3,j1,2=3>'
-    assert upretty(cket_big) == u'❘1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3⟩'
+    assert upretty(cket_big) == '❘1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3⟩'
     assert latex(cket_big) == \
         r'{\left|1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right\rangle }'
     sT(cket_big, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2), Integer(3)),Tuple(Tuple(Integer(1), Integer(2), Integer(3)), Tuple(Integer(1), Integer(3), Integer(1))))")
     assert str(cbra_big) == '<1,0,j1=1,j2=2,j3=3,j(1,2)=3|'
-    assert pretty(cbra_big) == u'<1,0,j1=1,j2=2,j3=3,j1,2=3|'
-    assert upretty(cbra_big) == u'⟨1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3❘'
+    assert pretty(cbra_big) == '<1,0,j1=1,j2=2,j3=3,j1,2=3|'
+    assert upretty(cbra_big) == '⟨1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3❘'
     assert latex(cbra_big) == \
         r'{\left\langle 1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right|}'
     sT(cbra_big, "JzBraCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2), Integer(3)),Tuple(Tuple(Integer(1), Integer(2), Integer(3)), Tuple(Integer(1), Integer(3), Integer(1))))")
     assert str(rot) == 'R(1,2,3)'
     assert pretty(rot) == 'R (1,2,3)'
-    assert upretty(rot) == u'ℛ (1,2,3)'
+    assert upretty(rot) == 'ℛ (1,2,3)'
     assert latex(rot) == r'\mathcal{R}\left(1,2,3\right)'
     sT(rot, "Rotation(Integer(1),Integer(2),Integer(3))")
     assert str(bigd) == 'WignerD(1, 2, 3, 4, 5, 6)'
@@ -732,12 +732,12 @@ def test_state():
     tket = TimeDepKet()
     assert str(bra) == '<psi|'
     assert pretty(bra) == '<psi|'
-    assert upretty(bra) == u'⟨ψ❘'
+    assert upretty(bra) == '⟨ψ❘'
     assert latex(bra) == r'{\left\langle \psi\right|}'
     sT(bra, "Bra(Symbol('psi'))")
     assert str(ket) == '|psi>'
     assert pretty(ket) == '|psi>'
-    assert upretty(ket) == u'❘ψ⟩'
+    assert upretty(ket) == '❘ψ⟩'
     assert latex(ket) == r'{\left|\psi\right\rangle }'
     sT(ket, "Ket(Symbol('psi'))")
     assert str(bra_tall) == '<x/2|'
@@ -779,13 +779,13 @@ def test_state():
     assert latex(ket_tall) == r'{\left|\frac{x}{2}\right\rangle }'
     sT(ket_tall, "Ket(Mul(Rational(1, 2), Symbol('x')))")
     assert str(tbra) == '<psi;t|'
-    assert pretty(tbra) == u'<psi;t|'
-    assert upretty(tbra) == u'⟨ψ;t❘'
+    assert pretty(tbra) == '<psi;t|'
+    assert upretty(tbra) == '⟨ψ;t❘'
     assert latex(tbra) == r'{\left\langle \psi;t\right|}'
     sT(tbra, "TimeDepBra(Symbol('psi'),Symbol('t'))")
     assert str(tket) == '|psi;t>'
     assert pretty(tket) == '|psi;t>'
-    assert upretty(tket) == u'❘ψ;t⟩'
+    assert upretty(tket) == '❘ψ;t⟩'
     assert latex(tket) == r'{\left|\psi;t\right\rangle }'
     sT(tket, "TimeDepKet(Symbol('psi'),Symbol('t'))")
 
@@ -794,7 +794,7 @@ def test_tensorproduct():
     tp = TensorProduct(JzKet(1, 1), JzKet(1, 0))
     assert str(tp) == '|1,1>x|1,0>'
     assert pretty(tp) == '|1,1>x |1,0>'
-    assert upretty(tp) == u'❘1,1⟩⨂ ❘1,0⟩'
+    assert upretty(tp) == '❘1,1⟩⨂ ❘1,0⟩'
     assert latex(tp) == \
         r'{{\left|1,1\right\rangle }}\otimes {{\left|1,0\right\rangle }}'
     sT(tp, "TensorProduct(JzKet(Integer(1),Integer(1)), JzKet(Integer(1),Integer(0)))")
@@ -889,5 +889,5 @@ def test_big_expr():
 
 def _test_sho1d():
     ad = RaisingOp('a')
-    assert pretty(ad) == u' \N{DAGGER}\na '
+    assert pretty(ad) == ' \N{DAGGER}\na '
     assert latex(ad) == 'a^{\\dagger}'

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,4 @@
 from sympy.core.backend import sympify, Add, ImmutableMatrix as Matrix
-from sympy.core.compatibility import unicode
 from sympy.printing.defaults import Printable
 
 __all__ = ['Dyadic']
@@ -195,20 +194,20 @@ class Dyadic(Printable):
                 ar = e.args  # just to shorten things
                 mpp = printer
                 if len(ar) == 0:
-                    return unicode(0)
-                bar = u"\N{CIRCLED TIMES}" if printer._use_unicode else "|"
+                    return str(0)
+                bar = "\N{CIRCLED TIMES}" if printer._use_unicode else "|"
                 ol = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     # if the coef of the dyadic is 1, we skip the 1
                     if ar[i][0] == 1:
-                        ol.extend([u" + ",
+                        ol.extend([" + ",
                                   mpp.doprint(ar[i][1]),
                                   bar,
                                   mpp.doprint(ar[i][2])])
 
                     # if the coef of the dyadic is -1, we skip the 1
                     elif ar[i][0] == -1:
-                        ol.extend([u" - ",
+                        ol.extend([" - ",
                                   mpp.doprint(ar[i][1]),
                                   bar,
                                   mpp.doprint(ar[i][2])])
@@ -221,18 +220,18 @@ class Dyadic(Printable):
                                 ar[i][0]).parens()[0]
                         else:
                             arg_str = mpp.doprint(ar[i][0])
-                        if arg_str.startswith(u"-"):
+                        if arg_str.startswith("-"):
                             arg_str = arg_str[1:]
-                            str_start = u" - "
+                            str_start = " - "
                         else:
-                            str_start = u" + "
-                        ol.extend([str_start, arg_str, u" ",
+                            str_start = " + "
+                        ol.extend([str_start, arg_str, " ",
                                   mpp.doprint(ar[i][1]),
                                   bar,
                                   mpp.doprint(ar[i][2])])
 
-                outstr = u"".join(ol)
-                if outstr.startswith(u" + "):
+                outstr = "".join(ol)
+                if outstr.startswith(" + "):
                     outstr = outstr[3:]
                 elif outstr.startswith(" "):
                     outstr = outstr[1:]

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -159,9 +159,9 @@ class ReferenceFrame(object):
             self.str_vecs = [(name + '[\'' + indices[0] + '\']'),
                              (name + '[\'' + indices[1] + '\']'),
                              (name + '[\'' + indices[2] + '\']')]
-            self.pretty_vecs = [(name.lower() + u"_" + indices[0]),
-                                (name.lower() + u"_" + indices[1]),
-                                (name.lower() + u"_" + indices[2])]
+            self.pretty_vecs = [(name.lower() + "_" + indices[0]),
+                                (name.lower() + "_" + indices[1]),
+                                (name.lower() + "_" + indices[2])]
             self.latex_vecs = [(r"\mathbf{\hat{%s}_{%s}}" % (name.lower(),
                                indices[0])), (r"\mathbf{\hat{%s}_{%s}}" %
                                (name.lower(), indices[1])),
@@ -171,9 +171,9 @@ class ReferenceFrame(object):
         # Second case, when no custom indices are supplied
         else:
             self.str_vecs = [(name + '.x'), (name + '.y'), (name + '.z')]
-            self.pretty_vecs = [name.lower() + u"_x",
-                                name.lower() + u"_y",
-                                name.lower() + u"_z"]
+            self.pretty_vecs = [name.lower() + "_x",
+                                name.lower() + "_y",
+                                name.lower() + "_z"]
             self.latex_vecs = [(r"\mathbf{\hat{%s}_x}" % name.lower()),
                                (r"\mathbf{\hat{%s}_y}" % name.lower()),
                                (r"\mathbf{\hat{%s}_z}" % name.lower())]

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -136,11 +136,11 @@ class VectorPrettyPrinter(PrettyPrinter):
             return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
 
         # Deal with special symbols
-        dots = {0 : u"",
-                1 : u"\N{COMBINING DOT ABOVE}",
-                2 : u"\N{COMBINING DIAERESIS}",
-                3 : u"\N{COMBINING THREE DOTS ABOVE}",
-                4 : u"\N{COMBINING FOUR DOTS ABOVE}"}
+        dots = {0 : "",
+                1 : "\N{COMBINING DOT ABOVE}",
+                2 : "\N{COMBINING DIAERESIS}",
+                3 : "\N{COMBINING THREE DOTS ABOVE}",
+                4 : "\N{COMBINING FOUR DOTS ABOVE}"}
 
         d = pform.__dict__
         #if unicode is false then calculate number of apostrophes needed and add to output

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -151,7 +151,6 @@ class VectorPrettyPrinter(PrettyPrinter):
             d['picture'][0] += apostrophes + "(t)"
         else:
             d['picture'] = [center_accent(d['picture'][0], dots[dot_i])]
-        d['unicode'] =  center_accent(d['unicode'], dots[dot_i])
         return pform
 
     def _print_Function(self, e):

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -59,8 +59,8 @@ a  n_x + b n_y + c⋅sin(α) n_z\
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
-    expected = ('alpha n_x + sin(omega) n_y + alpha*beta n_z')
-    uexpected = ('α n_x + sin(ω) n_y + α⋅β n_z')
+    expected = 'alpha n_x + sin(omega) n_y + alpha*beta n_z'
+    uexpected = 'α n_x + sin(ω) n_y + α⋅β n_z'
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
@@ -187,8 +187,8 @@ a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
     assert ascii_vpretty(y) == expected
     assert unicode_vpretty(y) == uexpected
 
-    expected = ('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
-    uexpected = ('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
+    expected = 'alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x'
+    uexpected = 'α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x'
     assert ascii_vpretty(x) == expected
     assert unicode_vpretty(x) == uexpected
 
@@ -196,10 +196,10 @@ a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
     assert unicode_vpretty(Dyadic([])) == '0'
 
     assert ascii_vpretty(xx) == '- n_x|n_y - n_x|n_z'
-    assert unicode_vpretty(xx) == ('- n_x⊗n_y - n_x⊗n_z')
+    assert unicode_vpretty(xx) == '- n_x⊗n_y - n_x⊗n_z'
 
     assert ascii_vpretty(xx2) == 'n_x|n_y + n_x|n_z'
-    assert unicode_vpretty(xx2) == ('n_x⊗n_y + n_x⊗n_z')
+    assert unicode_vpretty(xx2) == 'n_x⊗n_y + n_x⊗n_z'
 
 
 def test_dyadic_latex():
@@ -270,35 +270,35 @@ def test_issue_13354():
 def test_vector_derivative_printing():
     # First order
     v = omega.diff() * N.x
-    assert unicode_vpretty(v) == ('ω̇ n_x')
-    assert ascii_vpretty(v) == ("omega'(t) n_x")
+    assert unicode_vpretty(v) == 'ω̇ n_x'
+    assert ascii_vpretty(v) == "omega'(t) n_x"
 
     # Second order
     v = omega.diff().diff() * N.x
 
     assert vlatex(v) == r'\ddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == ('ω̈ n_x')
-    assert ascii_vpretty(v) == ("omega''(t) n_x")
+    assert unicode_vpretty(v) == 'ω̈ n_x'
+    assert ascii_vpretty(v) == "omega''(t) n_x"
 
     # Third order
     v = omega.diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\dddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == ('ω⃛ n_x')
-    assert ascii_vpretty(v) == ("omega'''(t) n_x")
+    assert unicode_vpretty(v) == 'ω⃛ n_x'
+    assert ascii_vpretty(v) == "omega'''(t) n_x"
 
     # Fourth order
     v = omega.diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == ('ω⃜ n_x')
-    assert ascii_vpretty(v) == ("omega''''(t) n_x")
+    assert unicode_vpretty(v) == 'ω⃜ n_x'
+    assert ascii_vpretty(v) == "omega''''(t) n_x"
 
     # Fifth order
     v = omega.diff().diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\frac{d^{5}}{d t^{5}} \omega\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == ('  5\n d\n───(ω) n_x\n  5\ndt')
+    assert unicode_vpretty(v) == '  5\n d\n───(ω) n_x\n  5\ndt'
     assert ascii_vpretty(v) == '  5\n d\n---(omega) n_x\n  5\ndt'
 
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from sympy import symbols, sin, asin, cos, sqrt, Function
-from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols, Dyadic
 from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint,
                                            vsprint, vsstrrepr, vlatex)
@@ -52,16 +51,16 @@ def test_vector_pretty_print():
  2
 a  n_x + b n_y + c*sin(alpha) n_z\
 """
-    uexpected = u("""\
+    uexpected = """\
  2
 a  n_x + b n_y + c⋅sin(α) n_z\
-""")
+"""
 
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
-    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z')
-    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z')
+    expected = ('alpha n_x + sin(omega) n_y + alpha*beta n_z')
+    uexpected = ('α n_x + sin(ω) n_y + α⋅β n_z')
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
@@ -72,12 +71,12 @@ a       b + c       c
 - n_x + ----- n_y + -- n_z
 b         a         b\
 """
-    uexpected = u("""\
+    uexpected = """\
                      2
 a       b + c       c
 ─ n_x + ───── n_y + ── n_z
 b         a         b\
-""")
+"""
 
     assert ascii_vpretty(o) == expected
     assert unicode_vpretty(o) == uexpected
@@ -181,15 +180,15 @@ def test_dyadic_pretty_print():
 a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
 """
 
-    uexpected = u("""\
+    uexpected = """\
  2
 a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
-""")
+"""
     assert ascii_vpretty(y) == expected
     assert unicode_vpretty(y) == uexpected
 
-    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
-    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
+    expected = ('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
+    uexpected = ('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
     assert ascii_vpretty(x) == expected
     assert unicode_vpretty(x) == uexpected
 
@@ -197,10 +196,10 @@ a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
     assert unicode_vpretty(Dyadic([])) == '0'
 
     assert ascii_vpretty(xx) == '- n_x|n_y - n_x|n_z'
-    assert unicode_vpretty(xx) == u('- n_x⊗n_y - n_x⊗n_z')
+    assert unicode_vpretty(xx) == ('- n_x⊗n_y - n_x⊗n_z')
 
     assert ascii_vpretty(xx2) == 'n_x|n_y + n_x|n_z'
-    assert unicode_vpretty(xx2) == u('n_x⊗n_y + n_x⊗n_z')
+    assert unicode_vpretty(xx2) == ('n_x⊗n_y + n_x⊗n_z')
 
 
 def test_dyadic_latex():
@@ -271,35 +270,35 @@ def test_issue_13354():
 def test_vector_derivative_printing():
     # First order
     v = omega.diff() * N.x
-    assert unicode_vpretty(v) == u('ω̇ n_x')
-    assert ascii_vpretty(v) == u("omega'(t) n_x")
+    assert unicode_vpretty(v) == ('ω̇ n_x')
+    assert ascii_vpretty(v) == ("omega'(t) n_x")
 
     # Second order
     v = omega.diff().diff() * N.x
 
     assert vlatex(v) == r'\ddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == u('ω̈ n_x')
-    assert ascii_vpretty(v) == u("omega''(t) n_x")
+    assert unicode_vpretty(v) == ('ω̈ n_x')
+    assert ascii_vpretty(v) == ("omega''(t) n_x")
 
     # Third order
     v = omega.diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\dddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == u('ω⃛ n_x')
-    assert ascii_vpretty(v) == u("omega'''(t) n_x")
+    assert unicode_vpretty(v) == ('ω⃛ n_x')
+    assert ascii_vpretty(v) == ("omega'''(t) n_x")
 
     # Fourth order
     v = omega.diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == u('ω⃜ n_x')
-    assert ascii_vpretty(v) == u("omega''''(t) n_x")
+    assert unicode_vpretty(v) == ('ω⃜ n_x')
+    assert ascii_vpretty(v) == ("omega''''(t) n_x")
 
     # Fifth order
     v = omega.diff().diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\frac{d^{5}}{d t^{5}} \omega\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == u('  5\n d\n───(ω) n_x\n  5\ndt')
+    assert unicode_vpretty(v) == ('  5\n d\n───(ω) n_x\n  5\ndt')
     assert ascii_vpretty(v) == '  5\n d\n---(omega) n_x\n  5\ndt'
 
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -2,7 +2,6 @@ from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros,
     ImmutableMatrix as Matrix)
 from sympy import trigsimp
 from sympy.printing.defaults import Printable
-from sympy.core.compatibility import unicode
 from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']
@@ -256,7 +255,7 @@ class Vector(Printable):
             def render(self, *args, **kwargs):
                 ar = e.args  # just to shorten things
                 if len(ar) == 0:
-                    return unicode(0)
+                    return str(0)
                 pforms = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     for j in 0, 1, 2:

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -54,7 +54,7 @@ class MathMLPrinterBase(Printer):
         class RawText(Text):
             def writexml(self, writer, indent='', addindent='', newl=''):
                 if self.data:
-                    writer.write(u'{}{}{}'.format(indent, self.data, newl))
+                    writer.write('{}{}{}'.format(indent, self.data, newl))
 
         def createRawTextNode(data):
             r = RawText()
@@ -334,7 +334,7 @@ class MathMLContentPrinter(MathMLPrinterBase):
         """We use unicode #x3c6 for Greek letter phi as defined here
         http://www.w3.org/2003/entities/2007doc/isogrk1.html"""
         x = self.dom.createElement('cn')
-        x.appendChild(self.dom.createTextNode(u"\N{GREEK SMALL LETTER PHI}"))
+        x.appendChild(self.dom.createTextNode("\N{GREEK SMALL LETTER PHI}"))
         return x
 
     def _print_Exp1(self, e):
@@ -1098,8 +1098,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 
     def _print_AccumulationBounds(self, i):
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('close', u'\u27e9')
-        brac.setAttribute('open', u'\u27e8')
+        brac.setAttribute('close', '\u27e9')
+        brac.setAttribute('open', '\u27e8')
         brac.appendChild(self._print(i.min))
         brac.appendChild(self._print(i.max))
         return brac
@@ -1657,8 +1657,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         power = expr.args[2]
         sup = self.dom.createElement('msup')
         brac = self.dom.createElement('mfenced')
-        brac.setAttribute('close', u'\u27e9')
-        brac.setAttribute('open', u'\u27e8')
+        brac.setAttribute('close', '\u27e9')
+        brac.setAttribute('open', '\u27e8')
         brac.appendChild(self._print(shift))
         sup.appendChild(brac)
         sup.appendChild(self._print(power))
@@ -1847,8 +1847,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_floor(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
-        x.setAttribute('close', u'\u230B')
-        x.setAttribute('open', u'\u230A')
+        x.setAttribute('close', '\u230B')
+        x.setAttribute('open', '\u230A')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow
@@ -1856,8 +1856,8 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     def _print_ceiling(self, e):
         mrow = self.dom.createElement('mrow')
         x = self.dom.createElement('mfenced')
-        x.setAttribute('close', u'\u2309')
-        x.setAttribute('open', u'\u2308')
+        x.setAttribute('close', '\u2309')
+        x.setAttribute('open', '\u2308')
         x.appendChild(self._print(e.args[0]))
         mrow.appendChild(x)
         return mrow

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1452,7 +1452,7 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return mi
 
     def _print_Range(self, s):
-        dots = u"\u2026"
+        dots = "\u2026"
         brac = self.dom.createElement('mfenced')
         brac.setAttribute('close', '}')
         brac.setAttribute('open', '{')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -261,7 +261,7 @@ class PrettyPrinter(Printer):
             if arg.is_Boolean and not arg.is_Not:
                 pform_arg = prettyForm(*pform_arg.parens())
 
-            pform = prettyForm(*pform.right(u' %s ' % char))
+            pform = prettyForm(*pform.right(' %s ' % char))
             pform = prettyForm(*pform.right(pform_arg))
 
         return pform
@@ -511,7 +511,7 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             # use unicode corners
             horizontal_chr = xobj('-', 1)
-            corner_chr = u'\N{BOX DRAWINGS LIGHT DOWN AND HORIZONTAL}'
+            corner_chr = '\N{BOX DRAWINGS LIGHT DOWN AND HORIZONTAL}'
 
         func_height = pretty_func.height()
 
@@ -673,7 +673,7 @@ class PrettyPrinter(Printer):
 
         LimArg = self._print(z)
         if self._use_unicode:
-            LimArg = prettyForm(*LimArg.right(u'\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{RIGHTWARDS ARROW}'))
+            LimArg = prettyForm(*LimArg.right('\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{RIGHTWARDS ARROW}'))
         else:
             LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
@@ -682,7 +682,7 @@ class PrettyPrinter(Printer):
             dir = ""
         else:
             if self._use_unicode:
-                dir = u'\N{SUPERSCRIPT PLUS SIGN}' if str(dir) == "+" else u'\N{SUPERSCRIPT MINUS}'
+                dir = '\N{SUPERSCRIPT PLUS SIGN}' if str(dir) == "+" else '\N{SUPERSCRIPT MINUS}'
 
         LimArg = prettyForm(*LimArg.right(self._print(dir)))
 
@@ -846,7 +846,7 @@ class PrettyPrinter(Printer):
     def _print_Adjoint(self, expr):
         pform = self._print(expr.arg)
         if self._use_unicode:
-            dag = prettyForm(u'\N{DAGGER}')
+            dag = prettyForm('\N{DAGGER}')
         else:
             dag = prettyForm('+')
         from sympy.matrices import MatrixSymbol
@@ -891,19 +891,19 @@ class PrettyPrinter(Printer):
 
     def _print_Identity(self, expr):
         if self._use_unicode:
-            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL I}')
+            return prettyForm('\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL I}')
         else:
             return prettyForm('I')
 
     def _print_ZeroMatrix(self, expr):
         if self._use_unicode:
-            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO}')
+            return prettyForm('\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ZERO}')
         else:
             return prettyForm('0')
 
     def _print_OneMatrix(self, expr):
         if self._use_unicode:
-            return prettyForm(u'\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ONE}')
+            return prettyForm('\N{MATHEMATICAL DOUBLE-STRUCK DIGIT ONE}')
         else:
             return prettyForm('1')
 
@@ -950,7 +950,7 @@ class PrettyPrinter(Printer):
     def _print_KroneckerProduct(self, expr):
         from sympy import MatAdd, MatMul
         if self._use_unicode:
-            delim = u' \N{N-ARY CIRCLED TIMES OPERATOR} '
+            delim = ' \N{N-ARY CIRCLED TIMES OPERATOR} '
         else:
             delim = ' x '
         return self._print_seq(expr.args, None, None, delim,
@@ -1067,21 +1067,21 @@ class PrettyPrinter(Printer):
             if '\n' in partstr:
                 tempstr = partstr
                 tempstr = tempstr.replace(vectstrs[i], '')
-                if u'\N{right parenthesis extension}' in tempstr:   # If scalar is a fraction
+                if '\N{right parenthesis extension}' in tempstr:   # If scalar is a fraction
                     for paren in range(len(tempstr)):
                         flag[i] = 1
-                        if tempstr[paren] == u'\N{right parenthesis extension}':
-                            tempstr = tempstr[:paren] + u'\N{right parenthesis extension}'\
+                        if tempstr[paren] == '\N{right parenthesis extension}':
+                            tempstr = tempstr[:paren] + '\N{right parenthesis extension}'\
                                          + ' '  + vectstrs[i] + tempstr[paren + 1:]
                             break
-                elif u'\N{RIGHT PARENTHESIS LOWER HOOK}' in tempstr:
+                elif '\N{RIGHT PARENTHESIS LOWER HOOK}' in tempstr:
                     flag[i] = 1
-                    tempstr = tempstr.replace(u'\N{RIGHT PARENTHESIS LOWER HOOK}',
-                                        u'\N{RIGHT PARENTHESIS LOWER HOOK}'
+                    tempstr = tempstr.replace('\N{RIGHT PARENTHESIS LOWER HOOK}',
+                                        '\N{RIGHT PARENTHESIS LOWER HOOK}'
                                         + ' ' + vectstrs[i])
                 else:
-                    tempstr = tempstr.replace(u'\N{RIGHT PARENTHESIS UPPER HOOK}',
-                                        u'\N{RIGHT PARENTHESIS UPPER HOOK}'
+                    tempstr = tempstr.replace('\N{RIGHT PARENTHESIS UPPER HOOK}',
+                                        '\N{RIGHT PARENTHESIS UPPER HOOK}'
                                         + ' ' + vectstrs[i])
                 o1[i] = tempstr
 
@@ -1113,7 +1113,7 @@ class PrettyPrinter(Printer):
                                            3*(len(lengths)-1)))
                     strs[j] += ' '*(lengths[-1]+3)
 
-        return prettyForm(u'\n'.join([s[:-3] for s in strs]))
+        return prettyForm('\n'.join([s[:-3] for s in strs]))
 
     def _print_NDimArray(self, expr):
         from sympy import ImmutableMatrix
@@ -1912,7 +1912,7 @@ class PrettyPrinter(Printer):
             and expt is S.Half and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
-            return prettyForm(*bpretty.left(u'\N{SQUARE ROOT}'))
+            return prettyForm(*bpretty.left('\N{SQUARE ROOT}'))
 
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
@@ -2352,7 +2352,7 @@ class PrettyPrinter(Printer):
 
     def _print_FiniteField(self, expr):
         if self._use_unicode:
-            form = u'\N{DOUBLE-STRUCK CAPITAL Z}_%d'
+            form = '\N{DOUBLE-STRUCK CAPITAL Z}_%d'
         else:
             form = 'GF(%d)'
 
@@ -2360,19 +2360,19 @@ class PrettyPrinter(Printer):
 
     def _print_IntegerRing(self, expr):
         if self._use_unicode:
-            return prettyForm(u'\N{DOUBLE-STRUCK CAPITAL Z}')
+            return prettyForm('\N{DOUBLE-STRUCK CAPITAL Z}')
         else:
             return prettyForm('ZZ')
 
     def _print_RationalField(self, expr):
         if self._use_unicode:
-            return prettyForm(u'\N{DOUBLE-STRUCK CAPITAL Q}')
+            return prettyForm('\N{DOUBLE-STRUCK CAPITAL Q}')
         else:
             return prettyForm('QQ')
 
     def _print_RealField(self, domain):
         if self._use_unicode:
-            prefix = u'\N{DOUBLE-STRUCK CAPITAL R}'
+            prefix = '\N{DOUBLE-STRUCK CAPITAL R}'
         else:
             prefix = 'RR'
 
@@ -2383,7 +2383,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexField(self, domain):
         if self._use_unicode:
-            prefix = u'\N{DOUBLE-STRUCK CAPITAL C}'
+            prefix = '\N{DOUBLE-STRUCK CAPITAL C}'
         else:
             prefix = 'CC'
 
@@ -2503,7 +2503,7 @@ class PrettyPrinter(Printer):
 
     def _print_stieltjes(self, e):
         if self._use_unicode:
-            return self._print_number_function(e, u'\N{GREEK SMALL LETTER GAMMA}')
+            return self._print_number_function(e, '\N{GREEK SMALL LETTER GAMMA}')
         else:
             return self._print_number_function(e, "stieltjes")
 
@@ -2666,7 +2666,7 @@ class PrettyPrinter(Printer):
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys.symbols[field._index].name
-            return self._print(u'\N{DOUBLE-STRUCK ITALIC SMALL D} ' + pretty_symbol(string))
+            return self._print('\N{DOUBLE-STRUCK ITALIC SMALL D} ' + pretty_symbol(string))
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -19,7 +19,7 @@ from sympy.utilities.iterables import has_variety
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
-from sympy.printing.pretty.pretty_symbology import xstr, hobj, vobj, xobj, \
+from sympy.printing.pretty.pretty_symbology import hobj, vobj, xobj, \
     xsym, pretty_symbol, pretty_atom, pretty_use_unicode, greek_unicode, U, \
     pretty_try_use_unicode,  annotated
 
@@ -54,7 +54,7 @@ class PrettyPrinter(Printer):
             raise ValueError("'imaginary_unit' must be either 'i' or 'j', not '{}'".format(self._settings['imaginary_unit']))
 
     def emptyPrinter(self, expr):
-        return prettyForm(xstr(expr))
+        return prettyForm(str(expr))
 
     @property
     def _use_unicode(self):
@@ -234,14 +234,14 @@ class PrettyPrinter(Printer):
             arg = e.args[0]
             pform = self._print(arg)
             if isinstance(arg, Equivalent):
-                return self._print_Equivalent(arg, altchar=u"\N{LEFT RIGHT DOUBLE ARROW WITH STROKE}")
+                return self._print_Equivalent(arg, altchar="\N{LEFT RIGHT DOUBLE ARROW WITH STROKE}")
             if isinstance(arg, Implies):
-                return self._print_Implies(arg, altchar=u"\N{RIGHTWARDS ARROW WITH STROKE}")
+                return self._print_Implies(arg, altchar="\N{RIGHTWARDS ARROW WITH STROKE}")
 
             if arg.is_Boolean and not arg.is_Not:
                 pform = prettyForm(*pform.parens())
 
-            return prettyForm(*pform.left(u"\N{NOT SIGN}"))
+            return prettyForm(*pform.left("\N{NOT SIGN}"))
         else:
             return self._print_Function(e)
 
@@ -268,43 +268,43 @@ class PrettyPrinter(Printer):
 
     def _print_And(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\N{LOGICAL AND}")
+            return self.__print_Boolean(e, "\N{LOGICAL AND}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Or(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\N{LOGICAL OR}")
+            return self.__print_Boolean(e, "\N{LOGICAL OR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Xor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\N{XOR}")
+            return self.__print_Boolean(e, "\N{XOR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nand(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\N{NAND}")
+            return self.__print_Boolean(e, "\N{NAND}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\N{NOR}")
+            return self.__print_Boolean(e, "\N{NOR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Implies(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u"\N{RIGHTWARDS ARROW}", sort=False)
+            return self.__print_Boolean(e, altchar or "\N{RIGHTWARDS ARROW}", sort=False)
         else:
             return self._print_Function(e)
 
     def _print_Equivalent(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u"\N{LEFT RIGHT DOUBLE ARROW}")
+            return self.__print_Boolean(e, altchar or "\N{LEFT RIGHT DOUBLE ARROW}")
         else:
             return self._print_Function(e, sort=True)
 
@@ -774,7 +774,7 @@ class PrettyPrinter(Printer):
 
     def _print_WedgeProduct(self, expr):
         # This should somehow share the code with _print_TensorProduct:
-        wedge_symbol = u"\u2227"
+        wedge_symbol = "\u2227"
         return self._print_seq(expr.args, None, None, wedge_symbol,
             parenthesize=lambda x: precedence_traditional(x) <= PRECEDENCE["Mul"])
 
@@ -1036,11 +1036,11 @@ class PrettyPrinter(Printer):
                 #if the coef of the basis vector is 1
                 #we skip the 1
                 if v == 1:
-                    o1.append(u"" +
+                    o1.append("" +
                               k._pretty_form)
                 #Same for -1
                 elif v == -1:
-                    o1.append(u"(-1) " +
+                    o1.append("(-1) " +
                               k._pretty_form)
                 #For a general expr
                 else:
@@ -1053,7 +1053,7 @@ class PrettyPrinter(Printer):
                 vectstrs.append(k._pretty_form)
 
         #outstr = u("").join(o1)
-        if o1[0].startswith(u" + "):
+        if o1[0].startswith(" + "):
             o1[0] = o1[0][3:]
         elif o1[0].startswith(" "):
             o1[0] = o1[0][1:]
@@ -1595,7 +1595,7 @@ class PrettyPrinter(Printer):
         expr = e.expr
         sig = e.signature
         if self._use_unicode:
-            arrow = u" \N{RIGHTWARDS ARROW FROM BAR} "
+            arrow = " \N{RIGHTWARDS ARROW FROM BAR} "
         else:
             arrow = " -> "
         if len(sig) == 1 and sig[0].is_symbol:
@@ -1614,7 +1614,7 @@ class PrettyPrinter(Printer):
             elif len(expr.variables):
                 pform = prettyForm(*pform.right(self._print(expr.variables[0])))
             if self._use_unicode:
-                pform = prettyForm(*pform.right(u" \N{RIGHTWARDS ARROW} "))
+                pform = prettyForm(*pform.right(" \N{RIGHTWARDS ARROW} "))
             else:
                 pform = prettyForm(*pform.right(" -> "))
             if len(expr.point) > 1:
@@ -2007,7 +2007,7 @@ class PrettyPrinter(Printer):
         if len(p.sets) >= 1 and not has_variety(p.sets):
             return self._print(p.sets[0]) ** self._print(len(p.sets))
         else:
-            prod_char = u"\N{MULTIPLICATION SIGN}" if self._use_unicode else 'x'
+            prod_char = "\N{MULTIPLICATION SIGN}" if self._use_unicode else 'x'
             return self._print_seq(p.sets, None, None, ' %s ' % prod_char,
                                    parenthesize=lambda set: set.is_Union or
                                    set.is_Intersection or set.is_ProductSet)
@@ -2019,7 +2019,7 @@ class PrettyPrinter(Printer):
     def _print_Range(self, s):
 
         if self._use_unicode:
-            dots = u"\N{HORIZONTAL ELLIPSIS}"
+            dots = "\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
 
@@ -2098,7 +2098,7 @@ class PrettyPrinter(Printer):
 
     def _print_ImageSet(self, ts):
         if self._use_unicode:
-            inn = u"\N{SMALL ELEMENT OF}"
+            inn = "\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
         fun = ts.lamda
@@ -2114,10 +2114,10 @@ class PrettyPrinter(Printer):
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:
-            inn = u"\N{SMALL ELEMENT OF}"
+            inn = "\N{SMALL ELEMENT OF}"
             # using _and because and is a keyword and it is bad practice to
             # overwrite them
-            _and = u"\N{LOGICAL AND}"
+            _and = "\N{LOGICAL AND}"
         else:
             inn = 'in'
             _and = 'and'
@@ -2143,7 +2143,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexRegion(self, ts):
         if self._use_unicode:
-            inn = u"\N{SMALL ELEMENT OF}"
+            inn = "\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
         variables = self._print_seq(ts.variables)
@@ -2156,7 +2156,7 @@ class PrettyPrinter(Printer):
     def _print_Contains(self, e):
         var, set = e.args
         if self._use_unicode:
-            el = u" \N{ELEMENT OF} "
+            el = " \N{ELEMENT OF} "
             return prettyForm(*stringPict.next(self._print(var),
                                                el, self._print(set)), binding=8)
         else:
@@ -2164,7 +2164,7 @@ class PrettyPrinter(Printer):
 
     def _print_FourierSeries(self, s):
         if self._use_unicode:
-            dots = u"\N{HORIZONTAL ELLIPSIS}"
+            dots = "\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
         return self._print_Add(s.truncate()) + self._print(dots)
@@ -2179,7 +2179,7 @@ class PrettyPrinter(Printer):
 
     def _print_SeqFormula(self, s):
         if self._use_unicode:
-            dots = u"\N{HORIZONTAL ELLIPSIS}"
+            dots = "\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
 
@@ -2308,7 +2308,7 @@ class PrettyPrinter(Printer):
 
     def _print_UniversalSet(self, s):
         if self._use_unicode:
-            return prettyForm(u"\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL U}")
+            return prettyForm("\N{MATHEMATICAL DOUBLE-STRUCK CAPITAL U}")
         else:
             return prettyForm('UniversalSet')
 
@@ -2670,7 +2670,7 @@ class PrettyPrinter(Printer):
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())
-            return prettyForm(*pform.left(u"\N{DOUBLE-STRUCK ITALIC SMALL D}"))
+            return prettyForm(*pform.left("\N{DOUBLE-STRUCK ITALIC SMALL D}"))
 
     def _print_Tr(self, p):
         #TODO: Handle indices
@@ -2699,7 +2699,7 @@ class PrettyPrinter(Printer):
 
     def _print_Quantity(self, e):
         if e.name.name == 'degree':
-            pform = self._print(u"\N{DEGREE SIGN}")
+            pform = self._print("\N{DEGREE SIGN}")
             return pform
         else:
             return self.emptyPrinter(e)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -8,8 +8,6 @@ from string import ascii_lowercase, ascii_uppercase
 
 unicode_warnings = ''
 
-from sympy.core.compatibility import unicode
-
 # first, setup unicodedate environment
 try:
     import unicodedata
@@ -32,6 +30,7 @@ except ImportError:
 
 from sympy.printing.conventions import split_super_sub
 from sympy.core.alphabets import greeks
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 # prefix conventions when constructing tables
 # L   - LATIN     i
@@ -127,7 +126,7 @@ greek_unicode.update((L[0].upper() + L[1:], G(L)) for L in greek_letters)
 # aliases
 greek_unicode['lambda'] = greek_unicode['lamda']
 greek_unicode['Lambda'] = greek_unicode['Lamda']
-greek_unicode['varsigma'] = u'\N{GREEK SMALL LETTER FINAL SIGMA}'
+greek_unicode['varsigma'] = '\N{GREEK SMALL LETTER FINAL SIGMA}'
 
 # BOLD
 b = lambda l: U('MATHEMATICAL BOLD SMALL %s' % l.upper())
@@ -149,7 +148,7 @@ greek_bold_unicode = dict((L, g(L)) for L in greek_bold_letters)
 greek_bold_unicode.update((L[0].upper() + L[1:], G(L)) for L in greek_bold_letters)
 greek_bold_unicode['lambda'] = greek_unicode['lamda']
 greek_bold_unicode['Lambda'] = greek_unicode['Lamda']
-greek_bold_unicode['varsigma'] = u'\N{MATHEMATICAL BOLD SMALL FINAL SIGMA}'
+greek_bold_unicode['varsigma'] = '\N{MATHEMATICAL BOLD SMALL FINAL SIGMA}'
 
 digit_2txt = {
     '0':    'ZERO',
@@ -216,21 +215,21 @@ for s in '+-=()':
 # TODO: Make brackets adjust to height of contents
 modifier_dict = {
     # Accents
-    'mathring': lambda s: center_accent(s, u'\N{COMBINING RING ABOVE}'),
-    'ddddot': lambda s: center_accent(s, u'\N{COMBINING FOUR DOTS ABOVE}'),
-    'dddot': lambda s: center_accent(s, u'\N{COMBINING THREE DOTS ABOVE}'),
-    'ddot': lambda s: center_accent(s, u'\N{COMBINING DIAERESIS}'),
-    'dot': lambda s: center_accent(s, u'\N{COMBINING DOT ABOVE}'),
-    'check': lambda s: center_accent(s, u'\N{COMBINING CARON}'),
-    'breve': lambda s: center_accent(s, u'\N{COMBINING BREVE}'),
-    'acute': lambda s: center_accent(s, u'\N{COMBINING ACUTE ACCENT}'),
-    'grave': lambda s: center_accent(s, u'\N{COMBINING GRAVE ACCENT}'),
-    'tilde': lambda s: center_accent(s, u'\N{COMBINING TILDE}'),
-    'hat': lambda s: center_accent(s, u'\N{COMBINING CIRCUMFLEX ACCENT}'),
-    'bar': lambda s: center_accent(s, u'\N{COMBINING OVERLINE}'),
-    'vec': lambda s: center_accent(s, u'\N{COMBINING RIGHT ARROW ABOVE}'),
-    'prime': lambda s: s+u'\N{PRIME}',
-    'prm': lambda s: s+u'\N{PRIME}',
+    'mathring': lambda s: center_accent(s, '\N{COMBINING RING ABOVE}'),
+    'ddddot': lambda s: center_accent(s, '\N{COMBINING FOUR DOTS ABOVE}'),
+    'dddot': lambda s: center_accent(s, '\N{COMBINING THREE DOTS ABOVE}'),
+    'ddot': lambda s: center_accent(s, '\N{COMBINING DIAERESIS}'),
+    'dot': lambda s: center_accent(s, '\N{COMBINING DOT ABOVE}'),
+    'check': lambda s: center_accent(s, '\N{COMBINING CARON}'),
+    'breve': lambda s: center_accent(s, '\N{COMBINING BREVE}'),
+    'acute': lambda s: center_accent(s, '\N{COMBINING ACUTE ACCENT}'),
+    'grave': lambda s: center_accent(s, '\N{COMBINING GRAVE ACCENT}'),
+    'tilde': lambda s: center_accent(s, '\N{COMBINING TILDE}'),
+    'hat': lambda s: center_accent(s, '\N{COMBINING CIRCUMFLEX ACCENT}'),
+    'bar': lambda s: center_accent(s, '\N{COMBINING OVERLINE}'),
+    'vec': lambda s: center_accent(s, '\N{COMBINING RIGHT ARROW ABOVE}'),
+    'prime': lambda s: s+'\N{PRIME}',
+    'prm': lambda s: s+'\N{PRIME}',
     # # Faces -- these are here for some compatibility with latex printing
     # 'bold': lambda s: s,
     # 'bm': lambda s: s,
@@ -238,10 +237,10 @@ modifier_dict = {
     # 'scr': lambda s: s,
     # 'frak': lambda s: s,
     # Brackets
-    'norm': lambda s: u'\N{DOUBLE VERTICAL LINE}'+s+u'\N{DOUBLE VERTICAL LINE}',
-    'avg': lambda s: u'\N{MATHEMATICAL LEFT ANGLE BRACKET}'+s+u'\N{MATHEMATICAL RIGHT ANGLE BRACKET}',
-    'abs': lambda s: u'\N{VERTICAL LINE}'+s+u'\N{VERTICAL LINE}',
-    'mag': lambda s: u'\N{VERTICAL LINE}'+s+u'\N{VERTICAL LINE}',
+    'norm': lambda s: '\N{DOUBLE VERTICAL LINE}'+s+'\N{DOUBLE VERTICAL LINE}',
+    'avg': lambda s: '\N{MATHEMATICAL LEFT ANGLE BRACKET}'+s+'\N{MATHEMATICAL RIGHT ANGLE BRACKET}',
+    'abs': lambda s: '\N{VERTICAL LINE}'+s+'\N{VERTICAL LINE}',
+    'mag': lambda s: '\N{VERTICAL LINE}'+s+'\N{VERTICAL LINE}',
 }
 
 # VERTICAL OBJECTS
@@ -596,12 +595,12 @@ def annotated(letter):
     information.
     """
     ucode_pics = {
-        'F': (2, 0, 2, 0, u'\N{BOX DRAWINGS LIGHT DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
-                          u'\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
-                          u'\N{BOX DRAWINGS LIGHT UP}'),
-        'G': (3, 0, 3, 1, u'\N{BOX DRAWINGS LIGHT ARC DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC DOWN AND LEFT}\n'
-                          u'\N{BOX DRAWINGS LIGHT VERTICAL}\N{BOX DRAWINGS LIGHT RIGHT}\N{BOX DRAWINGS LIGHT DOWN AND LEFT}\n'
-                          u'\N{BOX DRAWINGS LIGHT ARC UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC UP AND LEFT}')
+        'F': (2, 0, 2, 0, '\N{BOX DRAWINGS LIGHT DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                          '\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                          '\N{BOX DRAWINGS LIGHT UP}'),
+        'G': (3, 0, 3, 1, '\N{BOX DRAWINGS LIGHT ARC DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC DOWN AND LEFT}\n'
+                          '\N{BOX DRAWINGS LIGHT VERTICAL}\N{BOX DRAWINGS LIGHT RIGHT}\N{BOX DRAWINGS LIGHT DOWN AND LEFT}\n'
+                          '\N{BOX DRAWINGS LIGHT ARC UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC UP AND LEFT}')
     }
     ascii_pics = {
         'F': (3, 0, 3, 0, ' _\n|_\n|\n'),
@@ -618,11 +617,11 @@ def is_combining(sym):
 
     See stringPict.width on usage.
     """
-    return True if (u'\N{COMBINING GRAVE ACCENT}' <= sym <=
-                    u'\N{COMBINING LATIN SMALL LETTER X}' or
+    return True if ('\N{COMBINING GRAVE ACCENT}' <= sym <=
+                    '\N{COMBINING LATIN SMALL LETTER X}' or
 
-                    u'\N{COMBINING LEFT HARPOON ABOVE}' <= sym <=
-                    u'\N{COMBINING ASTERISK ABOVE}') else False
+                    '\N{COMBINING LEFT HARPOON ABOVE}' <= sym <=
+                    '\N{COMBINING ASTERISK ABOVE}') else False
 
 
 def center_accent(string, accent):

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -106,11 +106,11 @@ def pretty_try_use_unicode():
 
 
 def xstr(*args):
-    """call str or unicode depending on current mode"""
-    if _use_unicode:
-        return unicode(*args)
-    else:
-        return str(*args)
+    SymPyDeprecationWarning(
+        feature="``xstr`` function",
+        useinstead="``str``",
+        deprecated_since_version="1.7").warn()
+    return str(*args)
 
 # GREEK
 g = lambda l: U('GREEK SMALL LETTER %s' % l.upper())

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,7 +15,6 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode, is_combining
-from sympy.core.compatibility import unicode
 
 class stringPict(object):
     """An ASCII picture.
@@ -349,10 +348,7 @@ class stringPict(object):
         return super(stringPict, self).__hash__()
 
     def __str__(self):
-        return str.join('\n', self.picture)
-
-    def __unicode__(self):
-        return unicode.join(u'\n', self.picture)
+        return '\n'.join(self.picture)
 
     def __repr__(self):
         return "stringPict(%r,%d)" % ('\n'.join(self.picture), self.baseline)
@@ -388,7 +384,20 @@ class prettyForm(stringPict):
         """Initialize from stringPict and binding power."""
         stringPict.__init__(self, s, baseline)
         self.binding = binding
-        self.unicode = unicode or s
+        if unicode is not None:
+            SymPyDeprecationWarning(
+                feature="``unicode`` argument to ``prettyForm``",
+                useinstead="the ``s`` argument",
+                deprecated_since_version="1.7").warn()
+        self._unicode = unicode or s
+
+    @property
+    def unicode(self):
+        SymPyDeprecationWarning(
+            feature="``prettyForm.unicode`` attribute",
+            useinstead="``stringPrict.s`` attribute",
+            deprecated_since_version="1.7").warn()
+        return self._unicode
 
     # Note: code to handle subtraction is in _print_Add
 

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,6 +15,7 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode, is_combining
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 class stringPict(object):
     """An ASCII picture.
@@ -443,7 +444,7 @@ class prettyForm(stringPict):
         Parentheses are needed around +, - and neg.
         """
         quantity = {
-            'degree': u"\N{DEGREE SIGN}"
+            'degree': "\N{DEGREE SIGN}"
         }
 
         if len(others) == 0:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -13,7 +13,6 @@ from sympy import (
 
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
     SubAugmentedAssignment, MulAugmentedAssignment, DivAugmentedAssignment, ModAugmentedAssignment)
-from sympy.core.compatibility import u_decode as u
 from sympy.core.expr import UnevaluatedExpr
 from sympy.core.trace import Tr
 
@@ -254,108 +253,108 @@ def test_pretty_ascii_str():
 
 
 def test_pretty_unicode_str():
-    assert pretty( u'xxx' ) == u'xxx'
-    assert pretty( u'xxx' ) == u'xxx'
-    assert pretty( u'xxx\'xxx' ) == u'xxx\'xxx'
-    assert pretty( u'xxx"xxx' ) == u'xxx\"xxx'
-    assert pretty( u'xxx\"xxx' ) == u'xxx\"xxx'
-    assert pretty( u"xxx'xxx" ) == u'xxx\'xxx'
-    assert pretty( u"xxx\'xxx" ) == u'xxx\'xxx'
-    assert pretty( u"xxx\"xxx" ) == u'xxx\"xxx'
-    assert pretty( u"xxx\"xxx\'xxx" ) == u'xxx"xxx\'xxx'
-    assert pretty( u"xxx\nxxx" ) == u'xxx\nxxx'
+    assert pretty( u'xxx' ) == 'xxx'
+    assert pretty( u'xxx' ) == 'xxx'
+    assert pretty( u'xxx\'xxx' ) == 'xxx\'xxx'
+    assert pretty( u'xxx"xxx' ) == 'xxx\"xxx'
+    assert pretty( u'xxx\"xxx' ) == 'xxx\"xxx'
+    assert pretty( u"xxx'xxx" ) == 'xxx\'xxx'
+    assert pretty( u"xxx\'xxx" ) == 'xxx\'xxx'
+    assert pretty( u"xxx\"xxx" ) == 'xxx\"xxx'
+    assert pretty( u"xxx\"xxx\'xxx" ) == 'xxx"xxx\'xxx'
+    assert pretty( u"xxx\nxxx" ) == 'xxx\nxxx'
 
 
 def test_upretty_greek():
-    assert upretty( oo ) == u'∞'
-    assert upretty( Symbol('alpha^+_1') ) == u'α⁺₁'
-    assert upretty( Symbol('beta') ) == u'β'
-    assert upretty(Symbol('lambda')) == u'λ'
+    assert upretty( oo ) == '∞'
+    assert upretty( Symbol('alpha^+_1') ) == 'α⁺₁'
+    assert upretty( Symbol('beta') ) == 'β'
+    assert upretty(Symbol('lambda')) == 'λ'
 
 
 def test_upretty_multiindex():
-    assert upretty( Symbol('beta12') ) == u'β₁₂'
-    assert upretty( Symbol('Y00') ) == u'Y₀₀'
-    assert upretty( Symbol('Y_00') ) == u'Y₀₀'
-    assert upretty( Symbol('F^+-') ) == u'F⁺⁻'
+    assert upretty( Symbol('beta12') ) == 'β₁₂'
+    assert upretty( Symbol('Y00') ) == 'Y₀₀'
+    assert upretty( Symbol('Y_00') ) == 'Y₀₀'
+    assert upretty( Symbol('F^+-') ) == 'F⁺⁻'
 
 
 def test_upretty_sub_super():
-    assert upretty( Symbol('beta_1_2') ) == u'β₁ ₂'
-    assert upretty( Symbol('beta^1^2') ) == u'β¹ ²'
-    assert upretty( Symbol('beta_1^2') ) == u'β²₁'
-    assert upretty( Symbol('beta_10_20') ) == u'β₁₀ ₂₀'
-    assert upretty( Symbol('beta_ax_gamma^i') ) == u'βⁱₐₓ ᵧ'
-    assert upretty( Symbol("F^1^2_3_4") ) == u'F¹ ²₃ ₄'
-    assert upretty( Symbol("F_1_2^3^4") ) == u'F³ ⁴₁ ₂'
-    assert upretty( Symbol("F_1_2_3_4") ) == u'F₁ ₂ ₃ ₄'
-    assert upretty( Symbol("F^1^2^3^4") ) == u'F¹ ² ³ ⁴'
+    assert upretty( Symbol('beta_1_2') ) == 'β₁ ₂'
+    assert upretty( Symbol('beta^1^2') ) == 'β¹ ²'
+    assert upretty( Symbol('beta_1^2') ) == 'β²₁'
+    assert upretty( Symbol('beta_10_20') ) == 'β₁₀ ₂₀'
+    assert upretty( Symbol('beta_ax_gamma^i') ) == 'βⁱₐₓ ᵧ'
+    assert upretty( Symbol("F^1^2_3_4") ) == 'F¹ ²₃ ₄'
+    assert upretty( Symbol("F_1_2^3^4") ) == 'F³ ⁴₁ ₂'
+    assert upretty( Symbol("F_1_2_3_4") ) == 'F₁ ₂ ₃ ₄'
+    assert upretty( Symbol("F^1^2^3^4") ) == 'F¹ ² ³ ⁴'
 
 
 def test_upretty_subs_missing_in_24():
-    assert upretty( Symbol('F_beta') ) == u'Fᵦ'
-    assert upretty( Symbol('F_gamma') ) == u'Fᵧ'
-    assert upretty( Symbol('F_rho') ) == u'Fᵨ'
-    assert upretty( Symbol('F_phi') ) == u'Fᵩ'
-    assert upretty( Symbol('F_chi') ) == u'Fᵪ'
+    assert upretty( Symbol('F_beta') ) == 'Fᵦ'
+    assert upretty( Symbol('F_gamma') ) == 'Fᵧ'
+    assert upretty( Symbol('F_rho') ) == 'Fᵨ'
+    assert upretty( Symbol('F_phi') ) == 'Fᵩ'
+    assert upretty( Symbol('F_chi') ) == 'Fᵪ'
 
-    assert upretty( Symbol('F_a') ) == u'Fₐ'
-    assert upretty( Symbol('F_e') ) == u'Fₑ'
-    assert upretty( Symbol('F_i') ) == u'Fᵢ'
-    assert upretty( Symbol('F_o') ) == u'Fₒ'
-    assert upretty( Symbol('F_u') ) == u'Fᵤ'
-    assert upretty( Symbol('F_r') ) == u'Fᵣ'
-    assert upretty( Symbol('F_v') ) == u'Fᵥ'
-    assert upretty( Symbol('F_x') ) == u'Fₓ'
+    assert upretty( Symbol('F_a') ) == 'Fₐ'
+    assert upretty( Symbol('F_e') ) == 'Fₑ'
+    assert upretty( Symbol('F_i') ) == 'Fᵢ'
+    assert upretty( Symbol('F_o') ) == 'Fₒ'
+    assert upretty( Symbol('F_u') ) == 'Fᵤ'
+    assert upretty( Symbol('F_r') ) == 'Fᵣ'
+    assert upretty( Symbol('F_v') ) == 'Fᵥ'
+    assert upretty( Symbol('F_x') ) == 'Fₓ'
 
 
 def test_missing_in_2X_issue_9047():
-    assert upretty( Symbol('F_h') ) == u'Fₕ'
-    assert upretty( Symbol('F_k') ) == u'Fₖ'
-    assert upretty( Symbol('F_l') ) == u'Fₗ'
-    assert upretty( Symbol('F_m') ) == u'Fₘ'
-    assert upretty( Symbol('F_n') ) == u'Fₙ'
-    assert upretty( Symbol('F_p') ) == u'Fₚ'
-    assert upretty( Symbol('F_s') ) == u'Fₛ'
-    assert upretty( Symbol('F_t') ) == u'Fₜ'
+    assert upretty( Symbol('F_h') ) == 'Fₕ'
+    assert upretty( Symbol('F_k') ) == 'Fₖ'
+    assert upretty( Symbol('F_l') ) == 'Fₗ'
+    assert upretty( Symbol('F_m') ) == 'Fₘ'
+    assert upretty( Symbol('F_n') ) == 'Fₙ'
+    assert upretty( Symbol('F_p') ) == 'Fₚ'
+    assert upretty( Symbol('F_s') ) == 'Fₛ'
+    assert upretty( Symbol('F_t') ) == 'Fₜ'
 
 
 def test_upretty_modifiers():
     # Accents
-    assert upretty( Symbol('Fmathring') ) == u'F̊'
-    assert upretty( Symbol('Fddddot') ) == u'F⃜'
-    assert upretty( Symbol('Fdddot') ) == u'F⃛'
-    assert upretty( Symbol('Fddot') ) == u'F̈'
-    assert upretty( Symbol('Fdot') ) == u'Ḟ'
-    assert upretty( Symbol('Fcheck') ) == u'F̌'
-    assert upretty( Symbol('Fbreve') ) == u'F̆'
-    assert upretty( Symbol('Facute') ) == u'F́'
-    assert upretty( Symbol('Fgrave') ) == u'F̀'
-    assert upretty( Symbol('Ftilde') ) == u'F̃'
-    assert upretty( Symbol('Fhat') ) == u'F̂'
-    assert upretty( Symbol('Fbar') ) == u'F̅'
-    assert upretty( Symbol('Fvec') ) == u'F⃗'
-    assert upretty( Symbol('Fprime') ) == u'F′'
-    assert upretty( Symbol('Fprm') ) == u'F′'
+    assert upretty( Symbol('Fmathring') ) == 'F̊'
+    assert upretty( Symbol('Fddddot') ) == 'F⃜'
+    assert upretty( Symbol('Fdddot') ) == 'F⃛'
+    assert upretty( Symbol('Fddot') ) == 'F̈'
+    assert upretty( Symbol('Fdot') ) == 'Ḟ'
+    assert upretty( Symbol('Fcheck') ) == 'F̌'
+    assert upretty( Symbol('Fbreve') ) == 'F̆'
+    assert upretty( Symbol('Facute') ) == 'F́'
+    assert upretty( Symbol('Fgrave') ) == 'F̀'
+    assert upretty( Symbol('Ftilde') ) == 'F̃'
+    assert upretty( Symbol('Fhat') ) == 'F̂'
+    assert upretty( Symbol('Fbar') ) == 'F̅'
+    assert upretty( Symbol('Fvec') ) == 'F⃗'
+    assert upretty( Symbol('Fprime') ) == 'F′'
+    assert upretty( Symbol('Fprm') ) == 'F′'
     # No faces are actually implemented, but test to make sure the modifiers are stripped
-    assert upretty( Symbol('Fbold') ) == u'Fbold'
-    assert upretty( Symbol('Fbm') ) == u'Fbm'
-    assert upretty( Symbol('Fcal') ) == u'Fcal'
-    assert upretty( Symbol('Fscr') ) == u'Fscr'
-    assert upretty( Symbol('Ffrak') ) == u'Ffrak'
+    assert upretty( Symbol('Fbold') ) == 'Fbold'
+    assert upretty( Symbol('Fbm') ) == 'Fbm'
+    assert upretty( Symbol('Fcal') ) == 'Fcal'
+    assert upretty( Symbol('Fscr') ) == 'Fscr'
+    assert upretty( Symbol('Ffrak') ) == 'Ffrak'
     # Brackets
-    assert upretty( Symbol('Fnorm') ) == u'‖F‖'
-    assert upretty( Symbol('Favg') ) == u'⟨F⟩'
-    assert upretty( Symbol('Fabs') ) == u'|F|'
-    assert upretty( Symbol('Fmag') ) == u'|F|'
+    assert upretty( Symbol('Fnorm') ) == '‖F‖'
+    assert upretty( Symbol('Favg') ) == '⟨F⟩'
+    assert upretty( Symbol('Fabs') ) == '|F|'
+    assert upretty( Symbol('Fmag') ) == '|F|'
     # Combinations
-    assert upretty( Symbol('xvecdot') ) == u'x⃗̇'
-    assert upretty( Symbol('xDotVec') ) == u'ẋ⃗'
-    assert upretty( Symbol('xHATNorm') ) == u'‖x̂‖'
-    assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == u'x̊_y̌′__|z̆|'
-    assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == u'α̇̂_n⃗̇__t̃′'
-    assert upretty( Symbol('x_dot') ) == u'x_dot'
-    assert upretty( Symbol('x__dot') ) == u'x__dot'
+    assert upretty( Symbol('xvecdot') ) == 'x⃗̇'
+    assert upretty( Symbol('xDotVec') ) == 'ẋ⃗'
+    assert upretty( Symbol('xHATNorm') ) == '‖x̂‖'
+    assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == 'x̊_y̌′__|z̆|'
+    assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == 'α̇̂_n⃗̇__t̃′'
+    assert upretty( Symbol('x_dot') ) == 'x_dot'
+    assert upretty( Symbol('x__dot') ) == 'x__dot'
 
 
 def test_pretty_Cycle():
@@ -372,8 +371,8 @@ def test_pretty_Permutation():
     assert xpretty(p1, perm_cyclic=True, use_unicode=True) == "(1 2)(3 4)"
     assert xpretty(p1, perm_cyclic=True, use_unicode=False) == "(1 2)(3 4)"
     assert xpretty(p1, perm_cyclic=False, use_unicode=True) == \
-    u'⎛0 1 2 3 4⎞\n'\
-    u'⎝0 2 1 4 3⎠'
+    '⎛0 1 2 3 4⎞\n'\
+    '⎝0 2 1 4 3⎠'
     assert xpretty(p1, perm_cyclic=False, use_unicode=False) == \
     "/0 1 2 3 4\\\n"\
     "\\0 2 1 4 3/"
@@ -392,9 +391,9 @@ def test_pretty_basic():
 oo\
 """
     ucode_str = \
-u("""\
+"""\
 ∞\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -405,10 +404,10 @@ u("""\
 x \
 """
     ucode_str = \
-u("""\
+"""\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -420,11 +419,11 @@ x \
 x\
 """
     ucode_str = \
-u("""\
+"""\
 1\n\
 ─\n\
 x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -436,10 +435,10 @@ x\
 x    \
 """
     ucode_str = \
-("""\
+"""\
  -1.0\n\
 x    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -451,10 +450,10 @@ x    \
 2    \
 """
     ucode_str = \
-("""\
+"""\
  -1.0\n\
 2    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -467,12 +466,12 @@ y \n\
 x \
 """
     ucode_str = \
-u("""\
+"""\
 y \n\
 ──\n\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -484,10 +483,10 @@ x \
 x   \
 """
     ucode_str = \
-u("""\
+"""\
  1/3\n\
 x   \
-""")
+"""
     assert xpretty(expr, use_unicode=False, wrap_line=False,\
     root_notation = False) == ascii_str
     assert xpretty(expr, use_unicode=True, wrap_line=False,\
@@ -502,12 +501,12 @@ x   \
 x   \
 """
     ucode_str = \
-u("""\
+"""\
  1  \n\
 ────\n\
  5/2\n\
 x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -518,10 +517,10 @@ x   \
 (-2) \
 """
     ucode_str = \
-u("""\
+"""\
     x\n\
 (-2) \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -533,10 +532,10 @@ u("""\
 3 \
 """
     ucode_str = \
-u("""\
+"""\
  1\n\
 3 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -557,20 +556,20 @@ x  + x + 1\
 x  + 1 + x\
 """
     ucode_str_1 = \
-u("""\
+"""\
          2\n\
 1 + x + x \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
  2        \n\
 x  + x + 1\
-""")
+"""
     ucode_str_3 = \
-u("""\
+"""\
  2        \n\
 x  + 1 + x\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2, ascii_str_3]
     assert upretty(expr) in [ucode_str_1, ucode_str_2, ucode_str_3]
 
@@ -584,13 +583,13 @@ x  + 1 + x\
 -x + 1\
 """
     ucode_str_1 = \
-u("""\
+"""\
 1 - x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 -x + 1\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -604,13 +603,13 @@ u("""\
 -2*x + 1\
 """
     ucode_str_1 = \
-u("""\
+"""\
 1 - 2⋅x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 -2⋅x + 1\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -622,11 +621,11 @@ x\n\
 y\
 """
     ucode_str = \
-u("""\
+"""\
 x\n\
 ─\n\
 y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -638,11 +637,11 @@ y\
  y \
 """
     ucode_str = \
-u("""\
+"""\
 -x \n\
 ───\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -660,17 +659,17 @@ x + 2\n\
   y  \
 """
     ucode_str_1 = \
-u("""\
+"""\
 2 + x\n\
 ─────\n\
   y  \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 x + 2\n\
 ─────\n\
   y  \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -688,17 +687,17 @@ y*(1 + x)\
 y*(x + 1)\
 """
     ucode_str_1 = \
-u("""\
+"""\
 y⋅(1 + x)\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 (1 + x)⋅y\
-""")
+"""
     ucode_str_3 = \
-u("""\
+"""\
 y⋅(x + 1)\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2, ascii_str_3]
     assert upretty(expr) in [ucode_str_1, ucode_str_2, ucode_str_3]
 
@@ -717,17 +716,17 @@ y⋅(x + 1)\
 x + 10\
 """
     ucode_str_1 = \
-u("""\
+"""\
 -5⋅x  \n\
 ──────\n\
 10 + x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 -5⋅x  \n\
 ──────\n\
 x + 10\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -737,9 +736,9 @@ x + 10\
 -3*x - 1/2\
 """
     ucode_str = \
-u("""\
+"""\
 -3⋅x - 1/2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -749,9 +748,9 @@ u("""\
 1/2 - 3*x\
 """
     ucode_str = \
-u("""\
+"""\
 1/2 - 3⋅x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -763,11 +762,11 @@ u("""\
    2    2\
 """
     ucode_str = \
-u("""\
+"""\
   3⋅x   1\n\
 - ─── - ─\n\
    2    2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -779,11 +778,11 @@ u("""\
 2    2 \
 """
     ucode_str = \
-u("""\
+"""\
 1   3⋅x\n\
 ─ - ───\n\
 2    2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -797,11 +796,11 @@ def test_negative_fractions():
  y \
 """
     ucode_str =\
-u("""\
+"""\
 -x \n\
 ───\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x*z/y
@@ -812,11 +811,11 @@ u("""\
   y  \
 """
     ucode_str =\
-u("""\
+"""\
 -x⋅z \n\
 ─────\n\
   y  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = x**2/y
@@ -828,12 +827,12 @@ x \n\
 y \
 """
     ucode_str =\
-u("""\
+"""\
  2\n\
 x \n\
 ──\n\
 y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x**2/y
@@ -845,12 +844,12 @@ y \
  y  \
 """
     ucode_str =\
-u("""\
+"""\
   2 \n\
 -x  \n\
 ────\n\
  y  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x/(y*z)
@@ -861,11 +860,11 @@ u("""\
 y*z\
 """
     ucode_str =\
-u("""\
+"""\
 -x \n\
 ───\n\
 y⋅z\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -a/y**2
@@ -877,12 +876,12 @@ y⋅z\
  y \
 """
     ucode_str =\
-u("""\
+"""\
 -a \n\
 ───\n\
   2\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = y**(-a/b)
@@ -894,12 +893,12 @@ u("""\
 y   \
 """
     ucode_str =\
-u("""\
+"""\
  -a \n\
  ───\n\
   b \n\
 y   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -1/y**2
@@ -911,12 +910,12 @@ y   \
  y \
 """
     ucode_str =\
-u("""\
+"""\
 -1 \n\
 ───\n\
   2\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -10/b**2
@@ -928,12 +927,12 @@ u("""\
  b  \
 """
     ucode_str =\
-u("""\
+"""\
 -10 \n\
 ────\n\
   2 \n\
  b  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = Rational(-200, 37)
@@ -944,11 +943,11 @@ u("""\
   37 \
 """
     ucode_str =\
-u("""\
+"""\
 -200 \n\
 ─────\n\
   37 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = Mul(0, 1, evaluate=False)
@@ -1005,10 +1004,10 @@ def test_issue_5524():
 """
 
     assert upretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \
-u("""\
+"""\
          2                          \n\
 - (5 - y)  + (x - 5)⋅(-x - 2⋅√2 + 5)\
-""")
+"""
 
 def test_pretty_ordering():
     assert pretty(x**2 + x + 1, order='lex') == \
@@ -1053,12 +1052,12 @@ x - -- + --- + O\\x /\n\
     6    120        \
 """
     ucode_str = \
-u("""\
+"""\
      3     5        \n\
     x     x     ⎛ 6⎞\n\
 x - ── + ─── + O⎝x ⎠\n\
     6    120        \
-""")
+"""
     assert pretty(expr, order=None) == ascii_str
     assert upretty(expr, order=None) == ucode_str
 
@@ -1070,11 +1069,11 @@ x - ── + ─── + O⎝x ⎠\n\
 
 def test_EulerGamma():
     assert pretty(EulerGamma) == str(EulerGamma) == "EulerGamma"
-    assert upretty(EulerGamma) == u"γ"
+    assert upretty(EulerGamma) == "γ"
 
 def test_GoldenRatio():
     assert pretty(GoldenRatio) == str(GoldenRatio) == "GoldenRatio"
-    assert upretty(GoldenRatio) == u"φ"
+    assert upretty(GoldenRatio) == "φ"
 
 def test_pretty_relational():
     expr = Eq(x, y)
@@ -1083,9 +1082,9 @@ def test_pretty_relational():
 x = y\
 """
     ucode_str = \
-u("""\
+"""\
 x = y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1095,9 +1094,9 @@ x = y\
 x < y\
 """
     ucode_str = \
-u("""\
+"""\
 x < y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1107,9 +1106,9 @@ x < y\
 x > y\
 """
     ucode_str = \
-u("""\
+"""\
 x > y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1119,9 +1118,9 @@ x > y\
 x <= y\
 """
     ucode_str = \
-u("""\
+"""\
 x ≤ y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1131,9 +1130,9 @@ x ≤ y\
 x >= y\
 """
     ucode_str = \
-u("""\
+"""\
 x ≥ y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1151,17 +1150,17 @@ x ≥ y\
 y + 1      \
 """
     ucode_str_1 = \
-u("""\
+"""\
   x      2\n\
 ───── ≠ y \n\
 1 + y     \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
   x      2\n\
 ───── ≠ y \n\
 y + 1     \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1172,9 +1171,9 @@ def test_Assignment():
 x := y\
 """
     ucode_str = \
-u("""\
+"""\
 x := y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1185,9 +1184,9 @@ def test_AugmentedAssignment():
 x += y\
 """
     ucode_str = \
-u("""\
+"""\
 x += y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1197,9 +1196,9 @@ x += y\
 x -= y\
 """
     ucode_str = \
-u("""\
+"""\
 x -= y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1209,9 +1208,9 @@ x -= y\
 x *= y\
 """
     ucode_str = \
-u("""\
+"""\
 x *= y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1221,9 +1220,9 @@ x *= y\
 x /= y\
 """
     ucode_str = \
-u("""\
+"""\
 x /= y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1233,9 +1232,9 @@ x /= y\
 x %= y\
 """
     ucode_str = \
-u("""\
+"""\
 x %= y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1249,12 +1248,12 @@ y \n\
 x \
 """
     ucode_str = \
-u("""\
+"""\
 y \n\
 ──\n\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1268,13 +1267,13 @@ y   \n\
 x   \
 """
     ucode_str = \
-u("""\
+"""\
  3/2\n\
 y   \n\
 ────\n\
  5/2\n\
 x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1288,13 +1287,13 @@ sin (x)\n\
 tan (x)\
 """
     ucode_str = \
-u("""\
+"""\
    3   \n\
 sin (x)\n\
 ───────\n\
    2   \n\
 tan (x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1313,15 +1312,15 @@ def test_pretty_functions():
 e  + 2*x\
 """
     ucode_str_1 = \
-u("""\
+"""\
        x\n\
 2⋅x + ℯ \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
  x     \n\
 ℯ + 2⋅x\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1331,9 +1330,9 @@ u("""\
 |x|\
 """
     ucode_str = \
-u("""\
+"""\
 │x│\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1353,19 +1352,19 @@ u("""\
 |x  + 1|\
 """
     ucode_str_1 = \
-u("""\
+"""\
 │  x   │\n\
 │──────│\n\
 │     2│\n\
 │1 + x │\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 │  x   │\n\
 │──────│\n\
 │ 2    │\n\
 │x  + 1│\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1377,11 +1376,11 @@ u("""\
 |y - |x||\
 """
     ucode_str = \
-u("""\
+"""\
     1    \n\
 ─────────\n\
 │y - │x││\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1392,9 +1391,9 @@ u("""\
 n!\
 """
     ucode_str = \
-u("""\
+"""\
 n!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1404,9 +1403,9 @@ n!\
 (2*n)!\
 """
     ucode_str = \
-u("""\
+"""\
 (2⋅n)!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1416,9 +1415,9 @@ u("""\
 ((n!)!)!\
 """
     ucode_str = \
-u("""\
+"""\
 ((n!)!)!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1432,13 +1431,13 @@ u("""\
 (n + 1)!\
 """
     ucode_str_1 = \
-u("""\
+"""\
 (1 + n)!\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 (n + 1)!\
-""")
+"""
 
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
@@ -1449,9 +1448,9 @@ u("""\
 !n\
 """
     ucode_str = \
-u("""\
+"""\
 !n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1461,9 +1460,9 @@ u("""\
 !(2*n)\
 """
     ucode_str = \
-u("""\
+"""\
 !(2⋅n)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1474,9 +1473,9 @@ u("""\
 n!!\
 """
     ucode_str = \
-u("""\
+"""\
 n!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1486,9 +1485,9 @@ n!!\
 (2*n)!!\
 """
     ucode_str = \
-u("""\
+"""\
 (2⋅n)!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1498,9 +1497,9 @@ u("""\
 ((n!!)!!)!!\
 """
     ucode_str = \
-u("""\
+"""\
 ((n!!)!!)!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1514,13 +1513,13 @@ u("""\
 (n + 1)!!\
 """
     ucode_str_1 = \
-u("""\
+"""\
 (1 + n)!!\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 (n + 1)!!\
-""")
+"""
 
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
@@ -1533,11 +1532,11 @@ u("""\
   \\k/\
 """
     ucode_str = \
-u("""\
+"""\
   ⎛n⎞\n\
 2⋅⎜ ⎟\n\
   ⎝k⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1550,11 +1549,11 @@ u("""\
   \\ k /\
 """
     ucode_str = \
-u("""\
+"""\
   ⎛2⋅n⎞\n\
 2⋅⎜   ⎟\n\
   ⎝ k ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1568,12 +1567,12 @@ u("""\
   \\k /\
 """
     ucode_str = \
-u("""\
+"""\
   ⎛ 2⎞\n\
   ⎜n ⎟\n\
 2⋅⎜  ⎟\n\
   ⎝k ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1585,10 +1584,10 @@ C \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 C \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1599,10 +1598,10 @@ C \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 C \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1613,10 +1612,10 @@ B \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 B \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1627,10 +1626,10 @@ B \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 B \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1641,10 +1640,10 @@ B (x)\n\
  n   \
 """
     ucode_str = \
-u("""\
+"""\
 B (x)\n\
  n   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1655,10 +1654,10 @@ F \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 F \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1669,10 +1668,10 @@ L \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 L \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1683,10 +1682,10 @@ T \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 T \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1697,10 +1696,10 @@ stieltjes \n\
          n\
 """
     ucode_str = \
-u("""\
+"""\
 γ \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1711,34 +1710,34 @@ stieltjes (x)\n\
          n   \
 """
     ucode_str = \
-u("""\
+"""\
 γ (x)\n\
  n   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = mathieuc(x, y, z)
     ascii_str = 'C(x, y, z)'
-    ucode_str = u('C(x, y, z)')
+    ucode_str = 'C(x, y, z)'
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = mathieus(x, y, z)
     ascii_str = 'S(x, y, z)'
-    ucode_str = u('S(x, y, z)')
+    ucode_str = 'S(x, y, z)'
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = mathieucprime(x, y, z)
     ascii_str = "C'(x, y, z)"
-    ucode_str = u("C'(x, y, z)")
+    ucode_str = "C'(x, y, z)"
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = mathieusprime(x, y, z)
     ascii_str = "S'(x, y, z)"
-    ucode_str = u("S'(x, y, z)")
+    ucode_str = "S'(x, y, z)"
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1749,10 +1748,10 @@ _\n\
 x\
 """
     ucode_str = \
-u("""\
+"""\
 _\n\
 x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1769,15 +1768,15 @@ ________\n\
 f(x + 1)\
 """
     ucode_str_1 = \
-u("""\
+"""\
 ________\n\
 f(1 + x)\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 ________\n\
 f(x + 1)\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1787,9 +1786,9 @@ f(x + 1)\
 f(x)\
 """
     ucode_str = \
-u("""\
+"""\
 f(x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1799,9 +1798,9 @@ f(x)\
 f(x, y)\
 """
     ucode_str = \
-u("""\
+"""\
 f(x, y)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1819,17 +1818,17 @@ f|-----, y|\n\
  \\y + 1   /\
 """
     ucode_str_1 = \
-u("""\
+"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝1 + y   ⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝y + 1   ⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1844,14 +1843,14 @@ f⎜─────, y⎟\n\
 f\\x             /\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ ⎛ ⎛ ⎛ ⎛ x⎞⎞⎞⎞⎞
  ⎜ ⎜ ⎜ ⎜ ⎝x ⎠⎟⎟⎟⎟
  ⎜ ⎜ ⎜ ⎝x    ⎠⎟⎟⎟
  ⎜ ⎜ ⎝x       ⎠⎟⎟
  ⎜ ⎝x          ⎠⎟
 f⎝x             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1862,10 +1861,10 @@ f⎝x             ⎠\
 sin (x)\
 """
     ucode_str = \
-u("""\
+"""\
    2   \n\
 sin (x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1876,10 +1875,10 @@ _     _\n\
 a - I*b\
 """
     ucode_str = \
-u("""\
+"""\
 _     _\n\
 a - ⅈ⋅b\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1891,11 +1890,11 @@ a - ⅈ⋅b\
 e       \
 """
     ucode_str = \
-u("""\
+"""\
  _     _\n\
  a - ⅈ⋅b\n\
 ℯ       \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1913,17 +1912,17 @@ ___________\n\
 f\\f(x) + 1/\
 """
     ucode_str_1 = \
-u("""\
+"""\
 ___________\n\
  ⎛    ____⎞\n\
 f⎝1 + f(x)⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 ___________\n\
  ⎛____    ⎞\n\
 f⎝f(x) + 1⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1941,17 +1940,17 @@ f|-----, y|\n\
  \\y + 1   /\
 """
     ucode_str_1 = \
-u("""\
+"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝1 + y   ⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝y + 1   ⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1963,11 +1962,11 @@ floor|------------|\n\
      \\y - floor(x)/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎢   1   ⎥\n\
 ⎢───────⎥\n\
 ⎣y - ⌊x⌋⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1979,11 +1978,11 @@ ceiling|--------------|\n\
        \\y - ceiling(x)/\
 """
     ucode_str = \
-u("""\
+"""\
 ⎡   1   ⎤\n\
 ⎢───────⎥\n\
 ⎢y - ⌈x⌉⎥\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1994,10 +1993,10 @@ E \n\
  n\
 """
     ucode_str = \
-u("""\
+"""\
 E \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2015,7 +2014,7 @@ E         \n\
 """
 
     ucode_str = \
-u("""\
+"""\
 E         \n\
      1    \n\
  ─────────\n\
@@ -2024,7 +2023,7 @@ E         \n\
          1\n\
      1 + ─\n\
          n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2035,10 +2034,10 @@ E (x)\n\
  n   \
 """
     ucode_str = \
-u("""\
+"""\
 E (x)\n\
  n   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2050,11 +2049,11 @@ E |-|\n\
  n\\2/\
 """
     ucode_str = \
-u("""\
+"""\
   ⎛x⎞\n\
 E ⎜─⎟\n\
  n⎝2⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2078,10 +2077,10 @@ u"√2"
 \\/ 2 \
 """
     ucode_str = \
-u("""\
+"""\
 3 ___\n\
 ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2092,10 +2091,10 @@ u("""\
   \\/ 2 \
 """
     ucode_str = \
-u("""\
+"""\
 1000___\n\
   ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2107,11 +2106,11 @@ u("""\
 \\/  x  + 1 \
 """
     ucode_str = \
-u("""\
+"""\
    ________\n\
   ╱  2     \n\
 ╲╱  x  + 1 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2123,10 +2122,10 @@ u("""\
 \\/  1 + \\/ 5  \
 """
     ucode_str = \
-u("""\
+"""\
 3 ________\n\
 ╲╱ 1 + √5 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2137,10 +2136,10 @@ x ___\n\
 \\/ 2 \
 """
     ucode_str = \
-u("""\
+"""\
 x ___\n\
 ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2151,10 +2150,10 @@ x ___\n\
 \\/ 2 + pi \
 """
     ucode_str = \
-u("""\
+"""\
   _______\n\
 ╲╱ 2 + π \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2171,7 +2170,7 @@ u("""\
                     \\/  x  + 3 \
 """
     ucode_str = \
-u("""\
+"""\
      ____________              \n\
     ╱      2        1000___    \n\
    ╱      x  + 1      ╲╱ x  + 1\n\
@@ -2179,7 +2178,7 @@ u("""\
 ╲╱        x + 2        ________\n\
                       ╱  2     \n\
                     ╲╱  x  + 3 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2188,10 +2187,10 @@ def test_pretty_sqrt_char_knob():
     # See PR #9234.
     expr = sqrt(2)
     ucode_str1 = \
-u("""\
+"""\
   ___\n\
 ╲╱ 2 \
-""")
+"""
     ucode_str2 = \
 u"√2"
     assert xpretty(expr, use_unicode=True,
@@ -2204,10 +2203,10 @@ def test_pretty_sqrt_longsymbol_no_sqrt_char():
     # Do not use unicode sqrt char for long symbols (see PR #9234).
     expr = sqrt(Symbol('C1'))
     ucode_str = \
-u("""\
+"""\
   ____\n\
 ╲╱ C₁ \
-""")
+"""
     assert upretty(expr) == ucode_str
 
 
@@ -2220,10 +2219,10 @@ d   \n\
  x,y\
 """
     ucode_str = \
-u("""\
+"""\
 δ   \n\
  x,y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2234,7 +2233,7 @@ def test_pretty_product():
     expr = Product(f((n/3)**2), (n, k**2, l))
 
     unicode_str = \
-u("""\
+"""\
     l           \n\
 ─┬──────┬─      \n\
  │      │   ⎛ 2⎞\n\
@@ -2243,7 +2242,7 @@ u("""\
  │      │   ⎝9 ⎠\n\
  │      │       \n\
        2        \n\
-  n = k         """)
+  n = k         """
     ascii_str = \
 """\
     l           \n\
@@ -2259,7 +2258,7 @@ __________      \n\
     expr = Product(f((n/3)**2), (n, k**2, l), (l, 1, m))
 
     unicode_str = \
-u("""\
+"""\
     m          l           \n\
 ─┬──────┬─ ─┬──────┬─      \n\
  │      │   │      │   ⎛ 2⎞\n\
@@ -2268,7 +2267,7 @@ u("""\
  │      │   │      │   ⎝9 ⎠\n\
  │      │   │      │       \n\
   l = 1           2        \n\
-             n = k         """)
+             n = k         """
     ascii_str = \
 """\
     m          l           \n\
@@ -2289,11 +2288,11 @@ def test_pretty_Lambda():
     # S.IdentityFunction is a special case
     expr = Lambda(y, y)
     assert pretty(expr) == "x -> x"
-    assert upretty(expr) == u"x ↦ x"
+    assert upretty(expr) == "x ↦ x"
 
     expr = Lambda(x, x+1)
     assert pretty(expr) == "x -> x + 1"
-    assert upretty(expr) == u"x ↦ x + 1"
+    assert upretty(expr) == "x ↦ x + 1"
 
     expr = Lambda(x, x**2)
     ascii_str = \
@@ -2302,10 +2301,10 @@ def test_pretty_Lambda():
 x -> x \
 """
     ucode_str = \
-u("""\
+"""\
      2\n\
 x ↦ x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2317,11 +2316,11 @@ x ↦ x \
 \\x -> x / \
 """
     ucode_str = \
-u("""\
+"""\
         2
 ⎛     2⎞ \n\
 ⎝x ↦ x ⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2338,10 +2337,10 @@ u("""\
 (x, y) -> x \
 """
     ucode_str = \
-u("""\
+"""\
           2\n\
 (x, y) ↦ x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2352,21 +2351,21 @@ u("""\
 ((x, y),) -> x \
 """
     ucode_str = \
-u("""\
+"""\
              2\n\
 ((x, y),) ↦ x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
 
 def test_pretty_TransferFunction():
     tf1 = TransferFunction(s - 1, s + 1, s)
-    assert upretty(tf1) == u"s - 1\n─────\ns + 1"
+    assert upretty(tf1) == "s - 1\n─────\ns + 1"
     tf2 = TransferFunction(2*s + 1, 3 - p, s)
-    assert upretty(tf2) == u"2⋅s + 1\n───────\n 3 - p "
+    assert upretty(tf2) == "2⋅s + 1\n───────\n 3 - p "
     tf3 = TransferFunction(p, p + 1, p)
-    assert upretty(tf3) == u"  p  \n─────\np + 1"
+    assert upretty(tf3) == "  p  \n─────\np + 1"
 
 
 def test_pretty_Series():
@@ -2374,32 +2373,32 @@ def test_pretty_Series():
     tf2 = TransferFunction(x - y, x + y, y)
     tf3 = TransferFunction(x**2 + y, y - x, y)
     expected1 = \
-u("""\
+"""\
           ⎛ 2    ⎞\n\
 ⎛ x + y ⎞ ⎜x  + y⎟\n\
 ⎜───────⎟⋅⎜──────⎟\n\
 ⎝x - 2⋅y⎠ ⎝-x + y⎠\
-""")
+"""
     expected2 = \
-u("""\
+"""\
 ⎛-x + y⎞ ⎛ -x - y⎞\n\
 ⎜──────⎟⋅⎜───────⎟\n\
 ⎝x + y ⎠ ⎝x - 2⋅y⎠\
-""")
+"""
     expected3 = \
-u("""\
+"""\
 ⎛ 2    ⎞                            \n\
 ⎜x  + y⎟ ⎛ x + y ⎞ ⎛ -x - y   x - y⎞\n\
 ⎜──────⎟⋅⎜───────⎟⋅⎜─────── + ─────⎟\n\
 ⎝-x + y⎠ ⎝x - 2⋅y⎠ ⎝x - 2⋅y   x + y⎠\
-""")
+"""
     expected4 = \
-u("""\
+"""\
                   ⎛         2    ⎞\n\
 ⎛ x + y    x - y⎞ ⎜x - y   x  + y⎟\n\
 ⎜─────── + ─────⎟⋅⎜───── + ──────⎟\n\
 ⎝x - 2⋅y   x + y⎠ ⎝x + y   -x + y⎠\
-""")
+"""
     assert upretty(Series(tf1, tf3)) == expected1
     assert upretty(Series(-tf2, -tf1)) == expected2
     assert upretty(Series(tf3, tf1, Parallel(-tf1, tf2))) == expected3
@@ -2411,31 +2410,31 @@ def test_pretty_Parallel():
     tf2 = TransferFunction(x - y, x + y, y)
     tf3 = TransferFunction(x**2 + y, y - x, y)
     expected1 = \
-u("""\
+"""\
  x + y    x - y\n\
 ─────── + ─────\n\
 x - 2⋅y   x + y\
-""")
+"""
     expected2 = \
-u("""\
+"""\
 -x + y    -x - y\n\
 ────── + ───────\n\
 x + y    x - 2⋅y\
-""")
+"""
     expected3 = \
-u("""\
+"""\
  2                                  \n\
 x  + y    x + y    ⎛ -x - y⎞ ⎛x - y⎞\n\
 ────── + ─────── + ⎜───────⎟⋅⎜─────⎟\n\
 -x + y   x - 2⋅y   ⎝x - 2⋅y⎠ ⎝x + y⎠\
-""")
+"""
     expected4 = \
-u("""\
+"""\
                             ⎛ 2    ⎞\n\
 ⎛ x + y ⎞ ⎛x - y⎞   ⎛x - y⎞ ⎜x  + y⎟\n\
 ⎜───────⎟⋅⎜─────⎟ + ⎜─────⎟⋅⎜──────⎟\n\
 ⎝x - 2⋅y⎠ ⎝x + y⎠   ⎝x + y⎠ ⎝-x + y⎠\
-""")
+"""
     assert upretty(Parallel(tf1, tf2)) == expected1
     assert upretty(Parallel(-tf2, -tf1)) == expected2
     assert upretty(Parallel(tf3, tf1, Series(-tf1, tf2))) == expected3
@@ -2451,7 +2450,7 @@ def test_pretty_Feedback():
     tf5 = TransferFunction(1 - x, x - y, y)
     tf6 = TransferFunction(2, 2, x)
     expected1 = \
-u("""\
+"""\
     ⎛1⎞    \n\
     ⎜─⎟    \n\
     ⎝1⎠    \n\
@@ -2459,9 +2458,9 @@ u("""\
 1    x + y \n\
 ─ + ───────\n\
 1   x - 2⋅y\
-""")
+"""
     expected2 = \
-u("""\
+"""\
                 ⎛1⎞                 \n\
                 ⎜─⎟                 \n\
                 ⎝1⎠                 \n\
@@ -2470,9 +2469,9 @@ u("""\
 1   ⎛x - y⎞ ⎛ x + y ⎞ ⎜y  - 2⋅y + 1⎟\n\
 ─ + ⎜─────⎟⋅⎜───────⎟⋅⎜────────────⎟\n\
 1   ⎝x + y⎠ ⎝x - 2⋅y⎠ ⎝   y + 5    ⎠\
-""")
+"""
     expected3 = \
-u("""\
+"""\
                  ⎛ x + y ⎞                  \n\
                  ⎜───────⎟                  \n\
                  ⎝x - 2⋅y⎠                  \n\
@@ -2481,9 +2480,9 @@ u("""\
 1   ⎛ x + y ⎞ ⎛x - y⎞ ⎜y  - 2⋅y + 1⎟ ⎛1 - x⎞\n\
 ─ + ⎜───────⎟⋅⎜─────⎟⋅⎜────────────⎟⋅⎜─────⎟\n\
 1   ⎝x - 2⋅y⎠ ⎝x + y⎠ ⎝   y + 5    ⎠ ⎝x - y⎠\
-""")
+"""
     expected4 = \
-u("""\
+"""\
   ⎛ x + y ⎞ ⎛x - y⎞  \n\
   ⎜───────⎟⋅⎜─────⎟  \n\
   ⎝x - 2⋅y⎠ ⎝x + y⎠  \n\
@@ -2491,9 +2490,9 @@ u("""\
 1   ⎛ x + y ⎞ ⎛x - y⎞\n\
 ─ + ⎜───────⎟⋅⎜─────⎟\n\
 1   ⎝x - 2⋅y⎠ ⎝x + y⎠\
-""")
+"""
     expected5 = \
-u("""\
+"""\
       ⎛ x + y ⎞ ⎛x - y⎞      \n\
       ⎜───────⎟⋅⎜─────⎟      \n\
       ⎝x - 2⋅y⎠ ⎝x + y⎠      \n\
@@ -2501,9 +2500,9 @@ u("""\
 1   ⎛ x + y ⎞ ⎛x - y⎞ ⎛1 - x⎞\n\
 ─ + ⎜───────⎟⋅⎜─────⎟⋅⎜─────⎟\n\
 1   ⎝x - 2⋅y⎠ ⎝x + y⎠ ⎝x - y⎠\
-""")
+"""
     expected6 = \
-u("""\
+"""\
            ⎛ 2          ⎞                   \n\
            ⎜y  - 2⋅y + 1⎟ ⎛1 - x⎞           \n\
            ⎜────────────⎟⋅⎜─────⎟           \n\
@@ -2513,9 +2512,9 @@ u("""\
 1   ⎜y  - 2⋅y + 1⎟ ⎛1 - x⎞ ⎛x - y⎞ ⎛ x + y ⎞\n\
 ─ + ⎜────────────⎟⋅⎜─────⎟⋅⎜─────⎟⋅⎜───────⎟\n\
 1   ⎝   y + 5    ⎠ ⎝x - y⎠ ⎝x + y⎠ ⎝x - 2⋅y⎠\
-""")
+"""
     expected7 = \
-u("""\
+"""\
     ⎛       3⎞    \n\
     ⎜x - 2⋅y ⎟    \n\
     ⎜────────⎟    \n\
@@ -2525,9 +2524,9 @@ u("""\
 1   ⎜x - 2⋅y ⎟ ⎛2⎞\n\
 ─ + ⎜────────⎟⋅⎜─⎟\n\
 1   ⎝ x + y  ⎠ ⎝2⎠\
-""")
+"""
     expected8 = \
-u("""\
+"""\
  ⎛1 - x⎞ \n\
  ⎜─────⎟ \n\
  ⎝x - y⎠ \n\
@@ -2535,7 +2534,7 @@ u("""\
 1   1 - x\n\
 ─ + ─────\n\
 1   x - y\
-""")
+"""
     assert upretty(Feedback(tf, tf1)) == expected1
     assert upretty(Feedback(tf, tf2*tf1*tf3)) == expected2
     assert upretty(Feedback(tf1, tf2*tf3*tf5)) == expected3
@@ -2553,9 +2552,9 @@ def test_pretty_order():
 O(1)\
 """
     ucode_str = \
-u("""\
+"""\
 O(1)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2567,11 +2566,11 @@ O|-|\n\
  \\x/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛1⎞\n\
 O⎜─⎟\n\
  ⎝x⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2582,10 +2581,10 @@ O⎜─⎟\n\
 O\\x  + y ; (x, y) -> (0, 0)/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ 2    2                 ⎞\n\
 O⎝x  + y ; (x, y) → (0, 0)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2595,9 +2594,9 @@ O⎝x  + y ; (x, y) → (0, 0)⎠\
 O(1; x -> oo)\
 """
     ucode_str = \
-u("""\
+"""\
 O(1; x → ∞)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2609,11 +2608,11 @@ O|-; x -> oo|\n\
  \\x         /\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛1       ⎞\n\
 O⎜─; x → ∞⎟\n\
  ⎝x       ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2624,10 +2623,10 @@ O⎜─; x → ∞⎟\n\
 O\\x  + y ; (x, y) -> (oo, oo)/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ 2    2                 ⎞\n\
 O⎝x  + y ; (x, y) → (∞, ∞)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2642,11 +2641,11 @@ d         \n\
 dx        \
 """
     ucode_str = \
-u("""\
+"""\
 d         \n\
 ──(log(x))\n\
 dx        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2664,17 +2663,17 @@ d             \n\
 dx            \
 """
     ucode_str_1 = \
-u("""\
+"""\
     d         \n\
 x + ──(log(x))\n\
     dx        \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 d             \n\
 ──(log(x)) + x\n\
 dx            \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2693,17 +2692,17 @@ d                 \n\
 dx                \
 """
     ucode_str_1 = \
-u("""\
+"""\
 ∂                 \n\
 ──(log(x + y) + x)\n\
 ∂x                \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 ∂                 \n\
 ──(x + log(x + y))\n\
 ∂x                \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2], upretty(expr)
 
@@ -2724,19 +2723,19 @@ dy dx             \
 dy dx             \
 """
     ucode_str_1 = \
-u("""\
+"""\
    2              \n\
   d  ⎛          2⎞\n\
 ─────⎝log(x) + x ⎠\n\
 dy dx             \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
    2              \n\
   d  ⎛ 2         ⎞\n\
 ─────⎝x  + log(x)⎠\n\
 dy dx             \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2756,19 +2755,19 @@ x  + -----(2*x*y)\n\
      dx dy       \
 """
     ucode_str_1 = \
-u("""\
+"""\
    2             \n\
   ∂             2\n\
 ─────(2⋅x⋅y) + x \n\
 ∂x ∂y            \
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
         2        \n\
  2     ∂         \n\
 x  + ─────(2⋅x⋅y)\n\
      ∂x ∂y       \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2782,13 +2781,13 @@ x  + ─────(2⋅x⋅y)\n\
 dx        \
 """
     ucode_str = \
-u("""\
+"""\
   2       \n\
  ∂        \n\
 ───(2⋅x⋅y)\n\
   2       \n\
 ∂x        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2802,13 +2801,13 @@ d          \n\
 dx         \
 """
     ucode_str = \
-u("""\
+"""\
  17        \n\
 ∂          \n\
 ────(2⋅x⋅y)\n\
   17       \n\
 ∂x         \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2822,13 +2821,13 @@ u("""\
 dy dx        \
 """
     ucode_str = \
-u("""\
+"""\
    3         \n\
   ∂          \n\
 ──────(2⋅x⋅y)\n\
      2       \n\
 ∂y ∂x        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2843,11 +2842,11 @@ u("""\
 dalpha             \
 """
     ucode_str = \
-u("""\
+"""\
 d       \n\
 ──(β(α))\n\
 dα      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2862,13 +2861,13 @@ dα      \
 dx       \
 """
     ucode_str = \
-u("""\
+"""\
   n      \n\
  d       \n\
 ───(f(x))\n\
   n      \n\
 dx       \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2884,11 +2883,11 @@ def test_pretty_integrals():
 /           \
 """
     ucode_str = \
-u("""\
+"""\
 ⌠          \n\
 ⎮ log(x) dx\n\
 ⌡          \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2903,12 +2902,12 @@ u("""\
 /       \
 """
     ucode_str = \
-u("""\
+"""\
 ⌠      \n\
 ⎮  2   \n\
 ⎮ x  dx\n\
 ⌡      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2926,7 +2925,7 @@ u("""\
 /            \
 """
     ucode_str = \
-u("""\
+"""\
 ⌠           \n\
 ⎮    2      \n\
 ⎮ sin (x)   \n\
@@ -2934,7 +2933,7 @@ u("""\
 ⎮    2      \n\
 ⎮ tan (x)   \n\
 ⌡           \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2950,13 +2949,13 @@ u("""\
 /          \
 """
     ucode_str = \
-u("""\
+"""\
 ⌠         \n\
 ⎮  ⎛ x⎞   \n\
 ⎮  ⎝2 ⎠   \n\
 ⎮ x     dx\n\
 ⌡         \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2973,14 +2972,14 @@ u("""\
 1        \
 """
     ucode_str = \
-u("""\
+"""\
 2      \n\
 ⌠      \n\
 ⎮  2   \n\
 ⎮ x  dx\n\
 ⌡      \n\
 1      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2997,14 +2996,14 @@ u("""\
 1/2      \
 """
     ucode_str = \
-u("""\
+"""\
  10      \n\
  ⌠       \n\
  ⎮   2   \n\
  ⎮  x  dx\n\
  ⌡       \n\
 1/2      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3019,12 +3018,12 @@ u("""\
 /  /             \
 """
     ucode_str = \
-u("""\
+"""\
 ⌠ ⌠            \n\
 ⎮ ⎮  2  2      \n\
 ⎮ ⎮ x ⋅y  dx dy\n\
 ⌡ ⌡            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3042,7 +3041,7 @@ u("""\
  0   0                             \
 """
     ucode_str = \
-u("""\
+"""\
 2⋅π π             \n\
  ⌠  ⌠             \n\
  ⎮  ⎮ sin(θ)      \n\
@@ -3050,7 +3049,7 @@ u("""\
  ⎮  ⎮ cos(φ)      \n\
  ⌡  ⌡             \n\
  0  0             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3088,19 +3087,19 @@ def test_pretty_matrix():
 [  y     x + y]\
 """
     ucode_str_1 = \
-u("""\
+"""\
 ⎡     2       ⎤
 ⎢1 + x     1  ⎥
 ⎢             ⎥
 ⎣  y     x + y⎦\
-""")
+"""
     ucode_str_2 = \
-u("""\
+"""\
 ⎡ 2           ⎤
 ⎢x  + 1    1  ⎥
 ⎢             ⎥
 ⎣  y     x + y⎦\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -3115,25 +3114,25 @@ u("""\
 [0  e           1  ]\
 """
     ucode_str = \
-u("""\
+"""\
 ⎡x           ⎤
 ⎢─    y     θ⎥
 ⎢y           ⎥
 ⎢            ⎥
 ⎢    ⅈ⋅k⋅φ   ⎥
 ⎣0  ℯ       1⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     unicode_str = \
-u("""\
+"""\
 ⎡v̇_msc_00     0         0    ⎤
 ⎢                            ⎥
 ⎢   0      v̇_msc_01     0    ⎥
 ⎢                            ⎥
 ⎣   0         0      v̇_msc_02⎦\
-""")
+"""
 
     expr = diag(*MatrixSymbol('vdot_msc',1,3))
     assert upretty(expr) == unicode_str
@@ -3163,13 +3162,13 @@ def test_pretty_ndim_arrays():
 [z  w]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡1   ⎤\n\
 ⎢─  y⎥\n\
 ⎢x   ⎥\n\
 ⎢    ⎥\n\
 ⎣z  w⎦\
-""")
+"""
         assert pretty(M) == ascii_str
         assert upretty(M) == ucode_str
 
@@ -3180,11 +3179,11 @@ u("""\
 [x      ]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡1      ⎤\n\
 ⎢─  y  z⎥\n\
 ⎣x      ⎦\
-""")
+"""
         assert pretty(M1) == ascii_str
         assert upretty(M1) == ucode_str
 
@@ -3200,7 +3199,7 @@ u("""\
 [[x   x]                       ]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡⎡1   y⎤                       ⎤\n\
 ⎢⎢──  ─⎥              ⎡z      ⎤⎥\n\
 ⎢⎢ 2  x⎥  ⎡ y    2 ⎤  ⎢─   y⋅z⎥⎥\n\
@@ -3209,7 +3208,7 @@ u("""\
 ⎢⎢z   w⎥  ⎢        ⎥  ⎢ 2     ⎥⎥\n\
 ⎢⎢─   ─⎥  ⎣y⋅z  w⋅y⎦  ⎣z   w⋅z⎦⎥\n\
 ⎣⎣x   x⎦                       ⎦\
-""")
+"""
         assert pretty(M2) == ascii_str
         assert upretty(M2) == ucode_str
 
@@ -3232,7 +3231,7 @@ u("""\
 [[z   w*z]  [w*z  w  ]]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡ ⎡1   y⎤             ⎤\n\
 ⎢ ⎢──  ─⎥             ⎥\n\
 ⎢ ⎢ 2  x⎥   ⎡ y    2 ⎤⎥\n\
@@ -3248,7 +3247,7 @@ u("""\
 ⎢⎢       ⎥  ⎢        ⎥⎥\n\
 ⎢⎢ 2     ⎥  ⎢      2 ⎥⎥\n\
 ⎣⎣z   w⋅z⎦  ⎣w⋅z  w  ⎦⎦\
-""")
+"""
         assert pretty(M3) == ascii_str
         assert upretty(M3) == ucode_str
 
@@ -3263,11 +3262,11 @@ u("""\
 [[      z]]\
 """
         ucode_str = \
-    u("""\
+    """\
 ⎡⎡      1⎤⎤\n\
 ⎢⎢x  y  ─⎥⎥\n\
 ⎣⎣      z⎦⎦\
-""")
+"""
         assert pretty(Mrow) == ascii_str
         assert upretty(Mrow) == ucode_str
 
@@ -3282,7 +3281,7 @@ u("""\
 [z]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡x⎤\n\
 ⎢ ⎥\n\
 ⎢y⎥\n\
@@ -3290,7 +3289,7 @@ u("""\
 ⎢1⎥\n\
 ⎢─⎥\n\
 ⎣z⎦\
-""")
+"""
         assert pretty(Mcolumn) == ascii_str
         assert upretty(Mcolumn) == ucode_str
 
@@ -3305,7 +3304,7 @@ u("""\
 [[z]]\
 """
         ucode_str = \
-u("""\
+"""\
 ⎡⎡x⎤⎤\n\
 ⎢⎢ ⎥⎥\n\
 ⎢⎢y⎥⎥\n\
@@ -3313,7 +3312,7 @@ u("""\
 ⎢⎢1⎥⎥\n\
 ⎢⎢─⎥⎥\n\
 ⎣⎣z⎦⎦\
-""")
+"""
         assert pretty(Mcol2) == ascii_str
         assert upretty(Mcol2) == ucode_str
 
@@ -3329,7 +3328,7 @@ def test_diffgeom_print_WedgeProduct():
     from sympy.diffgeom.rn import R2
     from sympy.diffgeom import WedgeProduct
     wp = WedgeProduct(R2.dx, R2.dy)
-    assert upretty(wp) == u("ⅆ x∧ⅆ y")
+    assert upretty(wp) == "ⅆ x∧ⅆ y"
 
 
 def test_Adjoint():
@@ -3346,11 +3345,11 @@ def test_Adjoint():
     assert pretty(Inverse(Adjoint(X))) == "    -1\n/ +\\  \n\\X /  "
     assert pretty(Adjoint(Transpose(X))) == "    +\n/ T\\ \n\\X / "
     assert pretty(Transpose(Adjoint(X))) == "    T\n/ +\\ \n\\X / "
-    assert upretty(Adjoint(X)) == u" †\nX "
-    assert upretty(Adjoint(X + Y)) == u"       †\n(X + Y) "
-    assert upretty(Adjoint(X) + Adjoint(Y)) == u" †    †\nX  + Y "
-    assert upretty(Adjoint(X*Y)) == u"     †\n(X⋅Y) "
-    assert upretty(Adjoint(Y)*Adjoint(X)) == u" †  †\nY ⋅X "
+    assert upretty(Adjoint(X)) == " †\nX "
+    assert upretty(Adjoint(X + Y)) == "       †\n(X + Y) "
+    assert upretty(Adjoint(X) + Adjoint(Y)) == " †    †\nX  + Y "
+    assert upretty(Adjoint(X*Y)) == "     †\n(X⋅Y) "
+    assert upretty(Adjoint(Y)*Adjoint(X)) == " †  †\nY ⋅X "
     assert upretty(Adjoint(X**2)) == \
         u"    †\n⎛ 2⎞ \n⎝X ⎠ "
     assert upretty(Adjoint(X)**2) == \
@@ -3374,11 +3373,11 @@ tr|[    ]|
   \\[3  4]/\
 """
     ucode_str_1 = \
-u("""\
+"""\
   ⎛⎡1  2⎤⎞
 tr⎜⎢    ⎥⎟
   ⎝⎣3  4⎦⎠\
-""")
+"""
     ascii_str_2 = \
 """\
   /[1  2]\\     /[2  4]\\
@@ -3386,11 +3385,11 @@ tr|[    ]| + tr|[    ]|
   \\[3  4]/     \\[6  8]/\
 """
     ucode_str_2 = \
-u("""\
+"""\
   ⎛⎡1  2⎤⎞     ⎛⎡2  4⎤⎞
 tr⎜⎢    ⎥⎟ + tr⎜⎢    ⎥⎟
   ⎝⎣3  4⎦⎠     ⎝⎣6  8⎦⎠\
-""")
+"""
     assert pretty(Trace(X)) == ascii_str_1
     assert upretty(Trace(X)) == ucode_str_1
 
@@ -3469,10 +3468,10 @@ def test_MatrixExpressions():
               / T  \\\n\
 (d -> sin(d)).\\X *X/\
 """
-    ucode_str = u("""\
+    ucode_str = """\
              ⎛ T  ⎞\n\
 (d ↦ sin(d))˳⎝X ⋅X⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3483,11 +3482,11 @@ def test_MatrixExpressions():
 |x -> -|.(n*X)\n\
 \\     x/      \
 """
-    ucode_str = u("""\
+    ucode_str = """\
 ⎛    1⎞      \n\
 ⎜x ↦ ─⎟˳(n⋅X)\n\
 ⎝    x⎠      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3501,10 +3500,10 @@ def test_pretty_dotproduct():
     C = Matrix(1, 3, [1, 2, 3])
     D = Matrix(1, 3, [1, 3, 4])
 
-    assert pretty(DotProduct(A, B)) == u"A*B"
-    assert pretty(DotProduct(C, D)) == u"[1  2  3]*[1  3  4]"
-    assert upretty(DotProduct(A, B)) == u"A⋅B"
-    assert upretty(DotProduct(C, D)) == u"[1  2  3]⋅[1  3  4]"
+    assert pretty(DotProduct(A, B)) == "A*B"
+    assert pretty(DotProduct(C, D)) == "[1  2  3]*[1  3  4]"
+    assert upretty(DotProduct(A, B)) == "A⋅B"
+    assert upretty(DotProduct(C, D)) == "[1  2  3]⋅[1  3  4]"
 
 
 def test_pretty_piecewise():
@@ -3518,13 +3517,13 @@ def test_pretty_piecewise():
 \\             \
 """
     ucode_str = \
-u("""\
+"""\
 ⎧x   for x < 1\n\
 ⎪             \n\
 ⎨ 2           \n\
 ⎪x   otherwise\n\
 ⎩             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3538,13 +3537,13 @@ u("""\
  \\\\             /\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛⎧x   for x < 1⎞\n\
  ⎜⎪             ⎟\n\
 -⎜⎨ 2           ⎟\n\
  ⎜⎪x   otherwise⎟\n\
  ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3563,7 +3562,7 @@ x + |<            | + |< 2           | + 1\n\
                       \\\\             /    \
 """
     ucode_str = \
-u("""\
+"""\
                       ⎛⎧x            ⎞    \n\
                       ⎜⎪─   for x < 2⎟    \n\
                       ⎜⎪y            ⎟    \n\
@@ -3573,7 +3572,7 @@ x + ⎜⎨            ⎟ + ⎜⎨ 2           ⎟ + 1\n\
                       ⎜⎪             ⎟    \n\
                       ⎜⎪1   otherwise⎟    \n\
                       ⎝⎩             ⎠    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3592,7 +3591,7 @@ x - |<            | + |< 2           | + 1\n\
                       \\\\             /    \
 """
     ucode_str = \
-u("""\
+"""\
                       ⎛⎧x            ⎞    \n\
                       ⎜⎪─   for x < 2⎟    \n\
                       ⎜⎪y            ⎟    \n\
@@ -3602,7 +3601,7 @@ x - ⎜⎨            ⎟ + ⎜⎨ 2           ⎟ + 1\n\
                       ⎜⎪             ⎟    \n\
                       ⎜⎪1   otherwise⎟    \n\
                       ⎝⎩             ⎠    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3614,11 +3613,11 @@ x*|<            |\n\
   \\\\y  otherwise/\
 """
     ucode_str = \
-u("""\
+"""\
   ⎛⎧x  for x > 0⎞\n\
 x⋅⎜⎨            ⎟\n\
   ⎝⎩y  otherwise⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3637,7 +3636,7 @@ x⋅⎜⎨            ⎟\n\
                 \\\\             /\
 """
     ucode_str = \
-u("""\
+"""\
                 ⎛⎧x            ⎞\n\
                 ⎜⎪─   for x < 2⎟\n\
                 ⎜⎪y            ⎟\n\
@@ -3647,7 +3646,7 @@ u("""\
                 ⎜⎪             ⎟\n\
                 ⎜⎪1   otherwise⎟\n\
                 ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3666,7 +3665,7 @@ u("""\
                  \\\\             /\
 """
     ucode_str = \
-u("""\
+"""\
                  ⎛⎧x            ⎞\n\
                  ⎜⎪─   for x < 2⎟\n\
                  ⎜⎪y            ⎟\n\
@@ -3676,7 +3675,7 @@ u("""\
                  ⎜⎪             ⎟\n\
                  ⎜⎪1   otherwise⎟\n\
                  ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3695,7 +3694,7 @@ u("""\
 \\  \\_|2, 2 \\      1, 0 | y/             \
 """
     ucode_str = \
-u("""\
+"""\
 ⎧                                 1     \n\
 ⎪            0               for ─── < 1\n\
 ⎪                                │y│    \n\
@@ -3705,7 +3704,7 @@ u("""\
 ⎪  ╭─╮0, 2 ⎛2, 1       │ 1⎞             \n\
 ⎪y⋅│╶┐     ⎜           │ ─⎟   otherwise \n\
 ⎩  ╰─╯2, 2 ⎝      1, 0 │ y⎠             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3720,12 +3719,12 @@ u("""\
 \\\\y  otherwise/ \
 """
     ucode_str = \
-u("""\
+"""\
                2\n\
 ⎛⎧x  for x > 0⎞ \n\
 ⎜⎨            ⎟ \n\
 ⎝⎩y  otherwise⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3737,11 +3736,11 @@ def test_pretty_ITE():
         '<            \n'
         '\\z  otherwise'
         )
-    assert upretty(expr) == u("""\
+    assert upretty(expr) == """\
 ⎧y    for x  \n\
 ⎨            \n\
 ⎩z  otherwise\
-""")
+"""
 
 
 def test_pretty_seq():
@@ -3751,9 +3750,9 @@ def test_pretty_seq():
 ()\
 """
     ucode_str = \
-u("""\
+"""\
 ()\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3763,9 +3762,9 @@ u("""\
 []\
 """
     ucode_str = \
-u("""\
+"""\
 []\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3776,9 +3775,9 @@ u("""\
 {}\
 """
     ucode_str = \
-u("""\
+"""\
 {}\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3792,11 +3791,11 @@ u("""\
  x  \
 """
     ucode_str = \
-u("""\
+"""\
 ⎛1 ⎞\n\
 ⎜─,⎟\n\
 ⎝x ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3810,13 +3809,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+"""\
 ⎡                2   ⎤\n\
 ⎢ 2  1        sin (θ)⎥\n\
 ⎢x , ─, x, y, ───────⎥\n\
 ⎢    x           2   ⎥\n\
 ⎣             cos (φ)⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3830,13 +3829,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+"""\
 ⎛                2   ⎞\n\
 ⎜ 2  1        sin (θ)⎟\n\
 ⎜x , ─, x, y, ───────⎟\n\
 ⎜    x           2   ⎟\n\
 ⎝             cos (φ)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3850,13 +3849,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+"""\
 ⎛                2   ⎞\n\
 ⎜ 2  1        sin (θ)⎟\n\
 ⎜x , ─, x, y, ───────⎟\n\
 ⎜    x           2   ⎟\n\
 ⎝             cos (φ)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3867,9 +3866,9 @@ u("""\
 {x: sin(x)}\
 """
     ucode_str = \
-u("""\
+"""\
 {x: sin(x)}\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3884,11 +3883,11 @@ u("""\
  x  y             \
 """
     ucode_str = \
-u("""\
+"""\
 ⎧1  1        2   ⎫\n\
 ⎨─: ─, x: sin (x)⎬\n\
 ⎩x  y            ⎭\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3902,10 +3901,10 @@ u("""\
 [x ]\
 """
     ucode_str = \
-u("""\
+"""\
 ⎡ 2⎤\n\
 ⎣x ⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3916,10 +3915,10 @@ u("""\
 (x ,)\
 """
     ucode_str = \
-u("""\
+"""\
 ⎛ 2 ⎞\n\
 ⎝x ,⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3930,10 +3929,10 @@ u("""\
 (x ,)\
 """
     ucode_str = \
-u("""\
+"""\
 ⎛ 2 ⎞\n\
 ⎝x ,⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3945,11 +3944,11 @@ u("""\
 {x : 1}\
 """
     ucode_str = \
-u("""\
+"""\
 ⎧ 2   ⎫\n\
 ⎨x : 1⎬\n\
 ⎩     ⎭\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3963,11 +3962,11 @@ def test_any_object_in_sequence():
 
     expr = [b2, b1]
     assert pretty(expr) == "[Basic(Basic()), Basic()]"
-    assert upretty(expr) == u"[Basic(Basic()), Basic()]"
+    assert upretty(expr) == "[Basic(Basic()), Basic()]"
 
     expr = {b2, b1}
     assert pretty(expr) == "{Basic(), Basic(Basic())}"
-    assert upretty(expr) == u"{Basic(), Basic(Basic())}"
+    assert upretty(expr) == "{Basic(), Basic(Basic())}"
 
     expr = {b2: b1, b1: b2}
     expr2 = Dict({b2: b1, b1: b2})
@@ -3975,16 +3974,16 @@ def test_any_object_in_sequence():
     assert pretty(
         expr2) == "{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
     assert upretty(
-        expr) == u"{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
+        expr) == "{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
     assert upretty(
-        expr2) == u"{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
+        expr2) == "{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
 
 def test_print_builtin_set():
     assert pretty(set()) == 'set()'
-    assert upretty(set()) == u'set()'
+    assert upretty(set()) == 'set()'
 
     assert pretty(frozenset()) == 'frozenset()'
-    assert upretty(frozenset()) == u'frozenset()'
+    assert upretty(frozenset()) == 'frozenset()'
 
     s1 = {1/x, x}
     s2 = frozenset(s1)
@@ -4046,27 +4045,27 @@ frozenset({x , x*y})\
     assert pretty(Range(0, 3, 1)) == '{0, 1, 2}'
 
     ascii_str = '{0, 1, ..., 29}'
-    ucode_str = u'{0, 1, …, 29}'
+    ucode_str = '{0, 1, …, 29}'
     assert pretty(Range(0, 30, 1)) == ascii_str
     assert upretty(Range(0, 30, 1)) == ucode_str
 
     ascii_str = '{30, 29, ..., 2}'
-    ucode_str = u('{30, 29, …, 2}')
+    ucode_str = '{30, 29, …, 2}'
     assert pretty(Range(30, 1, -1)) == ascii_str
     assert upretty(Range(30, 1, -1)) == ucode_str
 
     ascii_str = '{0, 2, ...}'
-    ucode_str = u'{0, 2, …}'
+    ucode_str = '{0, 2, …}'
     assert pretty(Range(0, oo, 2)) == ascii_str
     assert upretty(Range(0, oo, 2)) == ucode_str
 
     ascii_str = '{..., 2, 0}'
-    ucode_str = u('{…, 2, 0}')
+    ucode_str = '{…, 2, 0}'
     assert pretty(Range(oo, -2, -2)) == ascii_str
     assert upretty(Range(oo, -2, -2)) == ucode_str
 
     ascii_str = '{-2, -3, ...}'
-    ucode_str = u('{-2, -3, …}')
+    ucode_str = '{-2, -3, …}'
     assert pretty(Range(-2, -oo, -1)) == ascii_str
     assert upretty(Range(-2, -oo, -1)) == ucode_str
 
@@ -4075,7 +4074,7 @@ def test_pretty_SetExpr():
     iv = Interval(1, 3)
     se = SetExpr(iv)
     ascii_str = "SetExpr([1, 3])"
-    ucode_str = u("SetExpr([1, 3])")
+    ucode_str = "SetExpr([1, 3])"
     assert pretty(se) == ascii_str
     assert upretty(se) == ucode_str
 
@@ -4083,13 +4082,13 @@ def test_pretty_SetExpr():
 def test_pretty_ImageSet():
     imgset = ImageSet(Lambda((x, y), x + y), {1, 2, 3}, {3, 4})
     ascii_str = '{x + y | x in {1, 2, 3} , y in {3, 4}}'
-    ucode_str = u('{x + y | x ∊ {1, 2, 3} , y ∊ {3, 4}}')
+    ucode_str = '{x + y | x ∊ {1, 2, 3} , y ∊ {3, 4}}'
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
     imgset = ImageSet(Lambda(((x, y),), x + y), ProductSet({1, 2, 3}, {3, 4}))
     ascii_str = '{x + y | (x, y) in {1, 2, 3} x {3, 4}}'
-    ucode_str = u('{x + y | (x, y) ∊ {1, 2, 3} × {3, 4}}')
+    ucode_str = '{x + y | (x, y) ∊ {1, 2, 3} × {3, 4}}'
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
@@ -4113,13 +4112,13 @@ def test_pretty_ConditionSet():
     assert upretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ucode_str
 
     assert pretty(ConditionSet(x, Contains(x, S.Reals, evaluate=False), FiniteSet(1))) == '{1}'
-    assert upretty(ConditionSet(x, Contains(x, S.Reals, evaluate=False), FiniteSet(1))) == u'{1}'
+    assert upretty(ConditionSet(x, Contains(x, S.Reals, evaluate=False), FiniteSet(1))) == '{1}'
 
     assert pretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == "EmptySet"
-    assert upretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == u"∅"
+    assert upretty(ConditionSet(x, And(x > 1, x < -1), FiniteSet(1, 2, 3))) == "∅"
 
     assert pretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == '{2}'
-    assert upretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == u'{2}'
+    assert upretty(ConditionSet(x, Or(x > 1, x < -1), FiniteSet(1, 2))) == '{2}'
 
 
 def test_pretty_ComplexRegion():
@@ -4268,11 +4267,11 @@ def test_pretty_FourierSeries():
 """
 
     ucode_str = \
-u("""\
+"""\
                       2⋅sin(3⋅x)    \n\
 2⋅sin(x) - sin(2⋅x) + ────────── + …\n\
                           3         \
-""")
+"""
 
     assert pretty(f) == ascii_str
     assert upretty(f) == ucode_str
@@ -4296,7 +4295,7 @@ k = 1            \
 """
 
     ucode_str = \
-u("""\
+"""\
   ∞              \n\
  ____            \n\
  ╲               \n\
@@ -4307,7 +4306,7 @@ u("""\
  ╱               \n\
  ‾‾‾‾            \n\
 k = 1            \
-""")
+"""
 
     assert pretty(f) == ascii_str
     assert upretty(f) == ucode_str
@@ -4321,10 +4320,10 @@ def test_pretty_limits():
 x->oo \
 """
     ucode_str = \
-u("""\
+"""\
 lim x\n\
 x─→∞ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4336,11 +4335,11 @@ x─→∞ \
 x->0+  \
 """
     ucode_str = \
-u("""\
+"""\
       2\n\
  lim x \n\
 x─→0⁺  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4352,11 +4351,11 @@ x─→0⁺  \
 x->0+x\
 """
     ucode_str = \
-u("""\
+"""\
      1\n\
  lim ─\n\
 x─→0⁺x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4368,11 +4367,11 @@ x─→0⁺x\
 x->0+\\  x   /\
 """
     ucode_str = \
-u("""\
+"""\
      ⎛sin(x)⎞\n\
  lim ⎜──────⎟\n\
 x─→0⁺⎝  x   ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4384,11 +4383,11 @@ x─→0⁺⎝  x   ⎠\
 x->0-\\  x   /\
 """
     ucode_str = \
-u("""\
+"""\
      ⎛sin(x)⎞\n\
  lim ⎜──────⎟\n\
 x─→0⁻⎝  x   ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4399,10 +4398,10 @@ x─→0⁻⎝  x   ⎠\
 x->0+            \
 """
     ucode_str = \
-u("""\
+"""\
  lim (x + sin(x))\n\
 x─→0⁺            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4414,11 +4413,11 @@ x─→0⁺            \
 \\x->0+ / \
 """
     ucode_str = \
-u("""\
+"""\
         2\n\
 ⎛ lim x⎞ \n\
 ⎝x─→0⁺ ⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4430,11 +4429,11 @@ u("""\
 x->0+\\  y->0+\\2//\
 """
     ucode_str = \
-u("""\
+"""\
      ⎛       ⎛y⎞⎞\n\
  lim ⎜x⋅ lim ⎜─⎟⎟\n\
 x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4446,11 +4445,11 @@ x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
   x->0+\\  y->0+\\2//\
 """
     ucode_str = \
-u("""\
+"""\
        ⎛       ⎛y⎞⎞\n\
 2⋅ lim ⎜x⋅ lim ⎜─⎟⎟\n\
   x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4461,10 +4460,10 @@ lim sin(x)\n\
 x->0      \
 """
     ucode_str = \
-u("""\
+"""\
 lim sin(x)\n\
 x─→0      \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4478,10 +4477,10 @@ def test_pretty_ComplexRootOf():
 CRootOf\\x  + 11*x - 2, 0/\
 """
     ucode_str = \
-u("""\
+"""\
        ⎛ 5              ⎞\n\
 CRootOf⎝x  + 11⋅x - 2, 0⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4495,10 +4494,10 @@ def test_pretty_RootSum():
 RootSum\\x  + 11*x - 2/\
 """
     ucode_str = \
-u("""\
+"""\
        ⎛ 5           ⎞\n\
 RootSum⎝x  + 11⋅x - 2⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4510,10 +4509,10 @@ RootSum⎝x  + 11⋅x - 2⎠\
 RootSum\\x  + 11*x - 2, z -> e /\
 """
     ucode_str = \
-u("""\
+"""\
        ⎛ 5                  z⎞\n\
 RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4527,9 +4526,9 @@ def test_GroebnerBasis():
 GroebnerBasis([], x, y, domain=ZZ, order=lex)\
 """
     ucode_str = \
-u("""\
+"""\
 GroebnerBasis([], x, y, domain=ℤ, order=lex)\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4543,10 +4542,10 @@ GroebnerBasis([], x, y, domain=ℤ, order=lex)\
 GroebnerBasis\\[x  - x - 3*y + 1, y  - 2*x + y - 1], x, y, domain=ZZ, order=grlex/\
 """
     ucode_str = \
-u("""\
+"""\
              ⎛⎡ 2                 2              ⎤                             ⎞\n\
 GroebnerBasis⎝⎣x  - x - 3⋅y + 1, y  - 2⋅x + y - 1⎦, x, y, domain=ℤ, order=grlex⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4559,10 +4558,10 @@ GroebnerBasis⎝⎣x  - x - 3⋅y + 1, y  - 2⋅x + y - 1⎦, x, y, domain=ℤ, 
 GroebnerBasis\\[2*x - y  - y + 1, y  + 2*y  - 3*y  - 16*y + 7], x, y, domain=ZZ, order=lex/\
 """
     ucode_str = \
-u("""\
+"""\
              ⎛⎡       2           4      3      2           ⎤                           ⎞\n\
 GroebnerBasis⎝⎣2⋅x - y  - y + 1, y  + 2⋅y  - 3⋅y  - 16⋅y + 7⎦, x, y, domain=ℤ, order=lex⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4570,123 +4569,123 @@ GroebnerBasis⎝⎣2⋅x - y  - y + 1, y  + 2⋅y  - 3⋅y  - 16⋅y + 7⎦, x, 
 
 def test_pretty_UniversalSet():
     assert pretty(S.UniversalSet) == "UniversalSet"
-    assert upretty(S.UniversalSet) == u'𝕌'
+    assert upretty(S.UniversalSet) == '𝕌'
 
 
 def test_pretty_Boolean():
     expr = Not(x, evaluate=False)
 
     assert pretty(expr) == "Not(x)"
-    assert upretty(expr) == u"¬x"
+    assert upretty(expr) == "¬x"
 
     expr = And(x, y)
 
     assert pretty(expr) == "And(x, y)"
-    assert upretty(expr) == u"x ∧ y"
+    assert upretty(expr) == "x ∧ y"
 
     expr = Or(x, y)
 
     assert pretty(expr) == "Or(x, y)"
-    assert upretty(expr) == u"x ∨ y"
+    assert upretty(expr) == "x ∨ y"
 
     syms = symbols('a:f')
     expr = And(*syms)
 
     assert pretty(expr) == "And(a, b, c, d, e, f)"
-    assert upretty(expr) == u"a ∧ b ∧ c ∧ d ∧ e ∧ f"
+    assert upretty(expr) == "a ∧ b ∧ c ∧ d ∧ e ∧ f"
 
     expr = Or(*syms)
 
     assert pretty(expr) == "Or(a, b, c, d, e, f)"
-    assert upretty(expr) == u"a ∨ b ∨ c ∨ d ∨ e ∨ f"
+    assert upretty(expr) == "a ∨ b ∨ c ∨ d ∨ e ∨ f"
 
     expr = Xor(x, y, evaluate=False)
 
     assert pretty(expr) == "Xor(x, y)"
-    assert upretty(expr) == u"x ⊻ y"
+    assert upretty(expr) == "x ⊻ y"
 
     expr = Nand(x, y, evaluate=False)
 
     assert pretty(expr) == "Nand(x, y)"
-    assert upretty(expr) == u"x ⊼ y"
+    assert upretty(expr) == "x ⊼ y"
 
     expr = Nor(x, y, evaluate=False)
 
     assert pretty(expr) == "Nor(x, y)"
-    assert upretty(expr) == u"x ⊽ y"
+    assert upretty(expr) == "x ⊽ y"
 
     expr = Implies(x, y, evaluate=False)
 
     assert pretty(expr) == "Implies(x, y)"
-    assert upretty(expr) == u"x → y"
+    assert upretty(expr) == "x → y"
 
     # don't sort args
     expr = Implies(y, x, evaluate=False)
 
     assert pretty(expr) == "Implies(y, x)"
-    assert upretty(expr) == u"y → x"
+    assert upretty(expr) == "y → x"
 
     expr = Equivalent(x, y, evaluate=False)
 
     assert pretty(expr) == "Equivalent(x, y)"
-    assert upretty(expr) == u"x ⇔ y"
+    assert upretty(expr) == "x ⇔ y"
 
     expr = Equivalent(y, x, evaluate=False)
 
     assert pretty(expr) == "Equivalent(x, y)"
-    assert upretty(expr) == u"x ⇔ y"
+    assert upretty(expr) == "x ⇔ y"
 
 
 def test_pretty_Domain():
     expr = FF(23)
 
     assert pretty(expr) == "GF(23)"
-    assert upretty(expr) == u"ℤ₂₃"
+    assert upretty(expr) == "ℤ₂₃"
 
     expr = ZZ
 
     assert pretty(expr) == "ZZ"
-    assert upretty(expr) == u"ℤ"
+    assert upretty(expr) == "ℤ"
 
     expr = QQ
 
     assert pretty(expr) == "QQ"
-    assert upretty(expr) == u"ℚ"
+    assert upretty(expr) == "ℚ"
 
     expr = RR
 
     assert pretty(expr) == "RR"
-    assert upretty(expr) == u"ℝ"
+    assert upretty(expr) == "ℝ"
 
     expr = QQ[x]
 
     assert pretty(expr) == "QQ[x]"
-    assert upretty(expr) == u"ℚ[x]"
+    assert upretty(expr) == "ℚ[x]"
 
     expr = QQ[x, y]
 
     assert pretty(expr) == "QQ[x, y]"
-    assert upretty(expr) == u"ℚ[x, y]"
+    assert upretty(expr) == "ℚ[x, y]"
 
     expr = ZZ.frac_field(x)
 
     assert pretty(expr) == "ZZ(x)"
-    assert upretty(expr) == u"ℤ(x)"
+    assert upretty(expr) == "ℤ(x)"
 
     expr = ZZ.frac_field(x, y)
 
     assert pretty(expr) == "ZZ(x, y)"
-    assert upretty(expr) == u"ℤ(x, y)"
+    assert upretty(expr) == "ℤ(x, y)"
 
     expr = QQ.poly_ring(x, y, order=grlex)
 
     assert pretty(expr) == "QQ[x, y, order=grlex]"
-    assert upretty(expr) == u"ℚ[x, y, order=grlex]"
+    assert upretty(expr) == "ℚ[x, y, order=grlex]"
 
     expr = QQ.poly_ring(x, y, order=ilex)
 
     assert pretty(expr) == "QQ[x, y, order=ilex]"
-    assert upretty(expr) == u"ℚ[x, y, order=ilex]"
+    assert upretty(expr) == "ℚ[x, y, order=ilex]"
 
 
 def test_pretty_prec():
@@ -4759,7 +4758,7 @@ def test_pretty_sum():
 k = 0   \
 """
     ucode_str = \
-u("""\
+"""\
   n     \n\
  ___    \n\
  ╲      \n\
@@ -4768,7 +4767,7 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 k = 0   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4784,7 +4783,7 @@ k = 0   \
 k = oo   \
 """
     ucode_str = \
-u("""\
+"""\
   n     \n\
  ___    \n\
  ╲      \n\
@@ -4793,7 +4792,7 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 k = ∞   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4817,7 +4816,7 @@ ______            \n\
  k = 0            \
 """
     ucode_str = \
-u("""\
+"""\
    n            \n\
   n             \n\
 ______          \n\
@@ -4833,7 +4832,7 @@ ______          \n\
 ╱               \n\
 ‾‾‾‾‾‾          \n\
 k = 0           \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4864,7 +4863,7 @@ k = 0           \
   k = 0             \
 """
     ucode_str = \
-u("""\
+"""\
 ∞                 \n\
 ⌠                 \n\
 ⎮   x             \n\
@@ -4884,7 +4883,7 @@ u("""\
  ╱                \n\
  ‾‾‾‾‾‾           \n\
  k = 0            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4917,7 +4916,7 @@ k = n  + n + x  + x + - + -           \n\
                       x   n           \
 """
     ucode_str = \
-u("""\
+"""\
           ∞                          \n\
           ⌠                          \n\
           ⎮   x                      \n\
@@ -4939,7 +4938,7 @@ u("""\
      2        2       1   x          \n\
 k = n  + n + x  + x + ─ + ─          \n\
                       x   n          \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4965,7 +4964,7 @@ n  + n + x  + x + - + -           \n\
          k = 0                    \
 """
     ucode_str = \
-u("""\
+"""\
  2        2       1   x          \n\
 n  + n + x  + x + ─ + ─          \n\
                   x   n          \n\
@@ -4982,7 +4981,7 @@ n  + n + x  + x + ─ + ─          \n\
          ╱                       \n\
          ‾‾‾‾‾‾                  \n\
          k = 0                   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4997,7 +4996,7 @@ n  + n + x  + x + ─ + ─          \n\
 x = 0  \
 """
     ucode_str = \
-u("""\
+"""\
   ∞    \n\
  ___   \n\
  ╲     \n\
@@ -5006,14 +5005,14 @@ u("""\
  ╱     \n\
  ‾‾‾   \n\
 x = 0  \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = Sum(x**2, (x, 0, oo))
     ascii_str = \
-u("""\
+"""\
   oo    \n\
  ___    \n\
  \\  `   \n\
@@ -5021,9 +5020,9 @@ u("""\
   /   x \n\
  /__,   \n\
 x = 0   \
-""")
+"""
     ucode_str = \
-u("""\
+"""\
   ∞     \n\
  ___    \n\
  ╲      \n\
@@ -5032,7 +5031,7 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5050,7 +5049,7 @@ x = 0   \
 x = 0  \
 """
     ucode_str = \
-u("""\
+"""\
   ∞    \n\
  ____  \n\
  ╲     \n\
@@ -5061,7 +5060,7 @@ u("""\
  ╱     \n\
  ‾‾‾‾  \n\
 x = 0  \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5080,7 +5079,7 @@ ____    \n\
 x = 0   \
 """
     ucode_str = \
-u("""\
+"""\
   ∞     \n\
  ____   \n\
  ╲      \n\
@@ -5091,7 +5090,7 @@ u("""\
  ╱      \n\
  ‾‾‾‾   \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5111,7 +5110,7 @@ ____          \n\
 x = 0         \
 """
     ucode_str = \
-u("""\
+"""\
   ∞           \n\
 _____         \n\
 ╲             \n\
@@ -5124,7 +5123,7 @@ _____         \n\
 ╱             \n\
 ‾‾‾‾‾         \n\
 x = 0         \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5143,7 +5142,7 @@ ____    \n\
 x = 0   \
 """
     ucode_str = \
-u("""\
+"""\
   ∞     \n\
  ____   \n\
  ╲      \n\
@@ -5154,7 +5153,7 @@ u("""\
  ╱      \n\
  ‾‾‾‾   \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5173,7 +5172,7 @@ ____      \n\
 x = 0     \
 """
     ucode_str = \
-u("""\
+"""\
   ∞       \n\
  ____     \n\
  ╲        \n\
@@ -5184,7 +5183,7 @@ u("""\
  ╱        \n\
  ‾‾‾‾     \n\
 x = 0     \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5203,7 +5202,7 @@ ____  ____     \n\
 y = 1 x = 0    \
 """
     ucode_str = \
-u("""\
+"""\
   2     ∞      \n\
 ____  ____     \n\
 ╲     ╲        \n\
@@ -5214,7 +5213,7 @@ ____  ____     \n\
 ╱     ╱        \n\
 ‾‾‾‾  ‾‾‾‾     \n\
 y = 1 x = 0    \
-""")
+"""
     expr = Sum(1/(1 + 1/(
         1 + 1/k)) + 1, (k, 111, 1 + 1/n), (k, 1/(1 + m), oo)) + 1/(1 + 1/k)
     ascii_str = \
@@ -5237,7 +5236,7 @@ k = -----                                \n\
     m + 1                                \
 """
     ucode_str = \
-u("""\
+"""\
                1                         \n\
            1 + ─                         \n\
     ∞          n                         \n\
@@ -5256,7 +5255,7 @@ u("""\
       1   k = 111                        \n\
 k = ─────                                \n\
     m + 1                                \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5273,13 +5272,13 @@ kilogram*meter \n\
     second     \
 """
     unicode_str1 = \
-u("""\
+"""\
               2\n\
 kilogram⋅meter \n\
 ───────────────\n\
           2    \n\
     second     \
-""")
+"""
 
     ascii_str2 = \
 """\
@@ -5290,16 +5289,16 @@ kilogram⋅meter \n\
        second        \
 """
     unicode_str2 = \
-u("""\
+"""\
                     2\n\
 3⋅x⋅y⋅kilogram⋅meter \n\
 ─────────────────────\n\
              2       \n\
        second        \
-""")
+"""
 
     from sympy.physics.units import kg, m, s
-    assert upretty(expr) == u("joule")
+    assert upretty(expr) == "joule"
     assert pretty(expr) == "joule"
     assert upretty(expr.convert_to(kg*m**2/s**2)) == unicode_str1
     assert pretty(expr.convert_to(kg*m**2/s**2)) == ascii_str1
@@ -5315,10 +5314,10 @@ def test_pretty_Subs():
       |x=phi \
 """
     unicode_str = \
-u("""\
+"""\
 (f(x))│   2\n\
       │x=φ \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
@@ -5331,11 +5330,11 @@ u("""\
 \\dx      /|x=0\
 """
     unicode_str = \
-u("""\
+"""\
 ⎛d       ⎞│   \n\
 ⎜──(f(x))⎟│   \n\
 ⎝dx      ⎠│x=0\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
@@ -5350,36 +5349,36 @@ u("""\
 \\   y    /|x=0, y=1/2\
 """
     unicode_str = \
-u("""\
+"""\
 ⎛d       ⎞│          \n\
 ⎜──(f(x))⎟│          \n\
 ⎜dx      ⎟│          \n\
 ⎜────────⎟│          \n\
 ⎝   y    ⎠│x=0, y=1/2\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
 
 
 def test_gammas():
-    assert upretty(lowergamma(x, y)) == u"γ(x, y)"
-    assert upretty(uppergamma(x, y)) == u"Γ(x, y)"
-    assert xpretty(gamma(x), use_unicode=True) == u'Γ(x)'
-    assert xpretty(gamma, use_unicode=True) == u'Γ'
-    assert xpretty(symbols('gamma', cls=Function)(x), use_unicode=True) == u'γ(x)'
-    assert xpretty(symbols('gamma', cls=Function), use_unicode=True) == u'γ'
+    assert upretty(lowergamma(x, y)) == "γ(x, y)"
+    assert upretty(uppergamma(x, y)) == "Γ(x, y)"
+    assert xpretty(gamma(x), use_unicode=True) == 'Γ(x)'
+    assert xpretty(gamma, use_unicode=True) == 'Γ'
+    assert xpretty(symbols('gamma', cls=Function)(x), use_unicode=True) == 'γ(x)'
+    assert xpretty(symbols('gamma', cls=Function), use_unicode=True) == 'γ'
 
 
 def test_beta():
-    assert xpretty(beta(x,y), use_unicode=True) == u'Β(x, y)'
-    assert xpretty(beta(x,y), use_unicode=False) == u'B(x, y)'
-    assert xpretty(beta, use_unicode=True) == u'Β'
-    assert xpretty(beta, use_unicode=False) == u'B'
+    assert xpretty(beta(x,y), use_unicode=True) == 'Β(x, y)'
+    assert xpretty(beta(x,y), use_unicode=False) == 'B(x, y)'
+    assert xpretty(beta, use_unicode=True) == 'Β'
+    assert xpretty(beta, use_unicode=False) == 'B'
     mybeta = Function('beta')
-    assert xpretty(mybeta(x), use_unicode=True) == u'β(x)'
-    assert xpretty(mybeta(x, y, z), use_unicode=False) == u'beta(x, y, z)'
-    assert xpretty(mybeta, use_unicode=True) == u'β'
+    assert xpretty(mybeta(x), use_unicode=True) == 'β(x)'
+    assert xpretty(mybeta(x, y, z), use_unicode=False) == 'beta(x, y, z)'
+    assert xpretty(mybeta, use_unicode=True) == 'β'
 
 
 # test that notation passes to subclasses of the same name only
@@ -5444,27 +5443,27 @@ def test_SingularityFunction():
 
 
 def test_deltas():
-    assert xpretty(DiracDelta(x), use_unicode=True) == u'δ(x)'
+    assert xpretty(DiracDelta(x), use_unicode=True) == 'δ(x)'
     assert xpretty(DiracDelta(x, 1), use_unicode=True) == \
-u("""\
+"""\
  (1)    \n\
 δ    (x)\
-""")
+"""
     assert xpretty(x*DiracDelta(x, 1), use_unicode=True) == \
-u("""\
+"""\
    (1)    \n\
 x⋅δ    (x)\
-""")
+"""
 
 
 def test_hyper():
     expr = hyper((), (), z)
     ucode_str = \
-u("""\
+"""\
  ┌─  ⎛  │  ⎞\n\
  ├─  ⎜  │ z⎟\n\
 0╵ 0 ⎝  │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -5477,11 +5476,11 @@ u("""\
 
     expr = hyper((), (1,), x)
     ucode_str = \
-u("""\
+"""\
  ┌─  ⎛  │  ⎞\n\
  ├─  ⎜  │ x⎟\n\
 0╵ 1 ⎝1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -5494,11 +5493,11 @@ u("""\
 
     expr = hyper([2], [1], x)
     ucode_str = \
-u("""\
+"""\
  ┌─  ⎛2 │  ⎞\n\
  ├─  ⎜  │ x⎟\n\
 1╵ 1 ⎝1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -5511,13 +5510,13 @@ u("""\
 
     expr = hyper((pi/3, -2*k), (3, 4, 5, -3), x)
     ucode_str = \
-u("""\
+"""\
      ⎛  π         │  ⎞\n\
  ┌─  ⎜  ─, -2⋅k   │  ⎟\n\
  ├─  ⎜  3         │ x⎟\n\
 2╵ 4 ⎜            │  ⎟\n\
      ⎝3, 4, 5, -3 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
                       \n\
@@ -5532,11 +5531,11 @@ u("""\
 
     expr = hyper((pi, S('2/3'), -2*k), (3, 4, 5, -3), x**2)
     ucode_str = \
-u("""\
+"""\
  ┌─  ⎛π, 2/3, -2⋅k │  2⎞\n\
  ├─  ⎜             │ x ⎟\n\
 3╵ 4 ⎝3, 4, 5, -3  │   ⎠\
-""")
+"""
     ascii_str = \
 """\
   _                      \n\
@@ -5549,7 +5548,7 @@ u("""\
 
     expr = hyper([1, 2], [3, 4], 1/(1/(1/(1/x + 1) + 1) + 1))
     ucode_str = \
-u("""\
+"""\
      ⎛     │       1      ⎞\n\
      ⎜     │ ─────────────⎟\n\
      ⎜     │         1    ⎟\n\
@@ -5559,7 +5558,7 @@ u("""\
      ⎜     │             1⎟\n\
      ⎜     │         1 + ─⎟\n\
      ⎝     │             x⎠\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5581,11 +5580,11 @@ u("""\
 def test_meijerg():
     expr = meijerg([pi, pi, x], [1], [0, 1], [1, 2, 3], z)
     ucode_str = \
-u("""\
+"""\
 ╭─╮2, 3 ⎛π, π, x     1    │  ⎞\n\
 │╶┐     ⎜                 │ z⎟\n\
 ╰─╯4, 5 ⎝ 0, 1    1, 2, 3 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
  __2, 3 /pi, pi, x     1    |  \\\n\
@@ -5597,13 +5596,13 @@ u("""\
 
     expr = meijerg([1, pi/7], [2, pi, 5], [], [], z**2)
     ucode_str = \
-u("""\
+"""\
         ⎛   π          │   ⎞\n\
 ╭─╮0, 2 ⎜1, ─  2, π, 5 │  2⎟\n\
 │╶┐     ⎜   7          │ z ⎟\n\
 ╰─╯5, 0 ⎜              │   ⎟\n\
         ⎝              │   ⎠\
-""")
+"""
     ascii_str = \
 """\
         /   pi           |   \\\n\
@@ -5616,11 +5615,11 @@ u("""\
     assert upretty(expr) == ucode_str
 
     ucode_str = \
-u("""\
+"""\
 ╭─╮ 1, 10 ⎛1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 │  ⎞\n\
 │╶┐       ⎜                                │ z⎟\n\
 ╰─╯11,  2 ⎝             1                1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
  __ 1, 10 /1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 |  \\\n\
@@ -5635,7 +5634,7 @@ u("""\
     expr = meijerg([1, 2, ], [4, 3], [3], [4, 5], 1/(1/(1/(1/x + 1) + 1) + 1))
 
     ucode_str = \
-u("""\
+"""\
         ⎛           │       1      ⎞\n\
         ⎜           │ ─────────────⎟\n\
         ⎜           │         1    ⎟\n\
@@ -5645,7 +5644,7 @@ u("""\
         ⎜           │             1⎟\n\
         ⎜           │         1 + ─⎟\n\
         ⎝           │             x⎠\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5666,7 +5665,7 @@ u("""\
     expr = Integral(expr, x)
 
     ucode_str = \
-u("""\
+"""\
 ⌠                                        \n\
 ⎮         ⎛           │       1      ⎞   \n\
 ⎮         ⎜           │ ─────────────⎟   \n\
@@ -5678,7 +5677,7 @@ u("""\
 ⎮         ⎜           │         1 + ─⎟   \n\
 ⎮         ⎝           │             x⎠   \n\
 ⌡                                        \
-""")
+"""
 
     ascii_str = \
 """\
@@ -5711,10 +5710,10 @@ def test_noncommutative():
 A*B*C  \
 """
     ucode_str = \
-u("""\
+"""\
      -1\n\
 A⋅B⋅C  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -5725,10 +5724,10 @@ A⋅B⋅C  \
 C  *A*B\
 """
     ucode_str = \
-u("""\
+"""\
  -1    \n\
 C  ⋅A⋅B\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -5739,10 +5738,10 @@ C  ⋅A⋅B\
 A*C  *B\
 """
     ucode_str = \
-u("""\
+"""\
    -1  \n\
 A⋅C  ⋅B\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -5755,12 +5754,12 @@ A*C  *B\n\
    x   \
 """
     ucode_str = \
-u("""\
+"""\
    -1  \n\
 A⋅C  ⋅B\n\
 ───────\n\
    x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -5778,11 +5777,11 @@ atan2|-------, \\/ x |\n\
      \\   20         /\
 """
     ucode_str = \
-u("""\
+"""\
      ⎛√2⋅y    ⎞\n\
 atan2⎜────, √x⎟\n\
      ⎝ 20     ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -5824,11 +5823,11 @@ K|-----|\n\
  \\z + 1/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛  1  ⎞\n\
 K⎜─────⎟\n\
  ⎝z + 1⎠\
-""")
+"""
     expr = elliptic_k(1/(z + 1))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5840,11 +5839,11 @@ F|1|-----|\n\
  \\ |z + 1/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ │  1  ⎞\n\
 F⎜1│─────⎟\n\
  ⎝ │z + 1⎠\
-""")
+"""
     expr = elliptic_f(1, 1/(1 + z))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5856,11 +5855,11 @@ E|-----|\n\
  \\z + 1/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛  1  ⎞\n\
 E⎜─────⎟\n\
  ⎝z + 1⎠\
-""")
+"""
     expr = elliptic_e(1/(z + 1))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5872,11 +5871,11 @@ E|1|-----|\n\
  \\ |z + 1/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ │  1  ⎞\n\
 E⎜1│─────⎟\n\
  ⎝ │z + 1⎠\
-""")
+"""
     expr = elliptic_e(1, 1/(1 + z))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5888,11 +5887,11 @@ Pi|3|-|\n\
   \\ |x/\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛ │4⎞\n\
 Π⎜3│─⎟\n\
  ⎝ │x⎠\
-""")
+"""
     expr = elliptic_pi(3, 4/x)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5904,11 +5903,11 @@ Pi|3; -|6|\n\
   \\   x| /\
 """
     ucode_str = \
-u("""\
+"""\
  ⎛   4│ ⎞\n\
 Π⎜3; ─│6⎟\n\
  ⎝   x│ ⎠\
-""")
+"""
     expr = elliptic_pi(3, 4/x, 6)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5917,10 +5916,10 @@ u("""\
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal('x1', 0, 1)
-    assert upretty(where(X > 0)) == u"Domain: 0 < x₁ ∧ x₁ < ∞"
+    assert upretty(where(X > 0)) == "Domain: 0 < x₁ ∧ x₁ < ∞"
 
     D = Die('d1', 6)
-    assert upretty(where(D > 4)) == u'Domain: d₁ = 5 ∨ d₁ = 6'
+    assert upretty(where(D > 4)) == 'Domain: d₁ = 5 ∨ d₁ = 6'
 
     A = Exponential('a', 1)
     B = Exponential('b', 1)
@@ -5934,11 +5933,11 @@ def test_PrettyPoly():
 
     expr = F.convert(x/(x + y))
     assert pretty(expr) == "x/(x + y)"
-    assert upretty(expr) == u"x/(x + y)"
+    assert upretty(expr) == "x/(x + y)"
 
     expr = R.convert(x + y)
     assert pretty(expr) == "x + y"
-    assert upretty(expr) == u"x + y"
+    assert upretty(expr) == "x + y"
 
 
 def test_issue_6285():
@@ -5958,13 +5957,13 @@ def test_issue_6359():
 \\/       / \
 """
     assert upretty(Integral(x**2, x)**2) == \
-u("""\
+"""\
          2
 ⎛⌠      ⎞ \n\
 ⎜⎮  2   ⎟ \n\
 ⎜⎮ x  dx⎟ \n\
 ⎝⌡      ⎠ \
-""")
+"""
 
     assert pretty(Sum(x**2, (x, 0, 1))**2) == \
 """\
@@ -5978,7 +5977,7 @@ u("""\
 \\x = 0   / \
 """
     assert upretty(Sum(x**2, (x, 0, 1))**2) == \
-u("""\
+"""\
           2
 ⎛  1     ⎞ \n\
 ⎜ ___    ⎟ \n\
@@ -5988,7 +5987,7 @@ u("""\
 ⎜ ╱      ⎟ \n\
 ⎜ ‾‾‾    ⎟ \n\
 ⎝x = 0   ⎠ \
-""")
+"""
 
     assert pretty(Product(x**2, (x, 1, 2))**2) == \
 """\
@@ -6001,7 +6000,7 @@ u("""\
 \\x = 1    / \
 """
     assert upretty(Product(x**2, (x, 1, 2))**2) == \
-u("""\
+"""\
            2
 ⎛  2      ⎞ \n\
 ⎜─┬──┬─   ⎟ \n\
@@ -6009,7 +6008,7 @@ u("""\
 ⎜ │  │  x ⎟ \n\
 ⎜ │  │    ⎟ \n\
 ⎝x = 1    ⎠ \
-""")
+"""
 
     f = Function('f')
     assert pretty(Derivative(f(x), x)**2) == \
@@ -6020,12 +6019,12 @@ u("""\
 \\dx      / \
 """
     assert upretty(Derivative(f(x), x)**2) == \
-u("""\
+"""\
           2
 ⎛d       ⎞ \n\
 ⎜──(f(x))⎟ \n\
 ⎝dx      ⎠ \
-""")
+"""
 
 def test_issue_6739():
     ascii_str = \
@@ -6036,11 +6035,11 @@ def test_issue_6739():
 \\/ x \
 """
     ucode_str = \
-u("""\
+"""\
 1 \n\
 ──\n\
 √x\
-""")
+"""
     assert pretty(1/sqrt(x)) == ascii_str
     assert upretty(1/sqrt(x)) == ucode_str
 
@@ -6065,23 +6064,23 @@ def test_categories():
     K1 = Category("K1")
 
     assert pretty(A1) == "A1"
-    assert upretty(A1) == u"A₁"
+    assert upretty(A1) == "A₁"
 
     assert pretty(f1) == "f1:A1-->A2"
-    assert upretty(f1) == u"f₁:A₁——▶A₂"
+    assert upretty(f1) == "f₁:A₁——▶A₂"
     assert pretty(id_A1) == "id:A1-->A1"
-    assert upretty(id_A1) == u"id:A₁——▶A₁"
+    assert upretty(id_A1) == "id:A₁——▶A₁"
 
     assert pretty(f2*f1) == "f2*f1:A1-->A3"
-    assert upretty(f2*f1) == u"f₂∘f₁:A₁——▶A₃"
+    assert upretty(f2*f1) == "f₂∘f₁:A₁——▶A₃"
 
     assert pretty(K1) == "K1"
-    assert upretty(K1) == u"K₁"
+    assert upretty(K1) == "K₁"
 
     # Test how diagrams are printed.
     d = Diagram()
     assert pretty(d) == "EmptySet"
-    assert upretty(d) == u"∅"
+    assert upretty(d) == "∅"
 
     d = Diagram({f1: "unique", f2: S.EmptySet})
     assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
@@ -6102,7 +6101,7 @@ def test_categories():
 
     grid = DiagramGrid(d)
     assert pretty(grid) == "A1  A2\n      \nA3    "
-    assert upretty(grid) == u"A₁  A₂\n      \nA₃    "
+    assert upretty(grid) == "A₁  A₂\n      \nA₃    "
 
 
 def test_PrettyModules():
@@ -6111,10 +6110,10 @@ def test_PrettyModules():
     M = F.submodule([x, y], [1, x**2])
 
     ucode_str = \
-u("""\
+"""\
        2\n\
 ℚ[x, y] \
-""")
+"""
     ascii_str = \
 """\
         2\n\
@@ -6125,10 +6124,10 @@ QQ[x, y] \
     assert pretty(F) == ascii_str
 
     ucode_str = \
-u("""\
+"""\
 ╱        ⎡    2⎤╲\n\
 ╲[x, y], ⎣1, x ⎦╱\
-""")
+"""
     ascii_str = \
 """\
               2  \n\
@@ -6141,10 +6140,10 @@ u("""\
     I = R.ideal(x**2, y)
 
     ucode_str = \
-u("""\
+"""\
 ╱ 2   ╲\n\
 ╲x , y╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6158,13 +6157,13 @@ u("""\
     Q = F / M
 
     ucode_str = \
-u("""\
+"""\
             2    \n\
      ℚ[x, y]     \n\
 ─────────────────\n\
 ╱        ⎡    2⎤╲\n\
 ╲[x, y], ⎣1, x ⎦╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6179,12 +6178,12 @@ u("""\
     assert pretty(Q) == ascii_str
 
     ucode_str = \
-u("""\
+"""\
 ╱⎡    3⎤                                                ╲\n\
 │⎢   x ⎥   ╱        ⎡    2⎤╲           ╱        ⎡    2⎤╲│\n\
 │⎢1, ──⎥ + ╲[x, y], ⎣1, x ⎦╱, [2, y] + ╲[x, y], ⎣1, x ⎦╱│\n\
 ╲⎣   2 ⎦                                                ╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6199,12 +6198,12 @@ def test_QuotientRing():
     R = QQ.old_poly_ring(x)/[x**2 + 1]
 
     ucode_str = \
-u("""\
+"""\
   ℚ[x]  \n\
 ────────\n\
 ╱ 2    ╲\n\
 ╲x  + 1╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6218,10 +6217,10 @@ u("""\
     assert pretty(R) == ascii_str
 
     ucode_str = \
-u("""\
+"""\
     ╱ 2    ╲\n\
 1 + ╲x  + 1╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6241,10 +6240,10 @@ def test_Homomorphism():
     expr = homomorphism(R.free_module(1), R.free_module(1), [0])
 
     ucode_str = \
-u("""\
+"""\
           1         1\n\
 [0] : ℚ[x]  ──> ℚ[x] \
-""")
+"""
 
     ascii_str = \
 """\
@@ -6258,11 +6257,11 @@ u("""\
     expr = homomorphism(R.free_module(2), R.free_module(2), [0, 0])
 
     ucode_str = \
-u("""\
+"""\
 ⎡0  0⎤       2         2\n\
 ⎢    ⎥ : ℚ[x]  ──> ℚ[x] \n\
 ⎣0  0⎦                  \
-""")
+"""
 
     ascii_str = \
 """\
@@ -6277,12 +6276,12 @@ u("""\
     expr = homomorphism(R.free_module(1), R.free_module(1) / [[x]], [0])
 
     ucode_str = \
-u("""\
+"""\
                     1\n\
           1     ℚ[x] \n\
 [0] : ℚ[x]  ──> ─────\n\
                 <[x]>\
-""")
+"""
 
     ascii_str = \
 """\
@@ -6300,7 +6299,7 @@ def test_Tr():
     A, B = symbols('A B', commutative=False)
     t = Tr(A*B)
     assert pretty(t) == r'Tr(A*B)'
-    assert upretty(t) == u'Tr(A⋅B)'
+    assert upretty(t) == 'Tr(A⋅B)'
 
 
 def test_pretty_Add():
@@ -6309,46 +6308,46 @@ def test_pretty_Add():
 
 
 def test_issue_7179():
-    assert upretty(Not(Equivalent(x, y))) == u'x ⇎ y'
-    assert upretty(Not(Implies(x, y))) == u'x ↛ y'
+    assert upretty(Not(Equivalent(x, y))) == 'x ⇎ y'
+    assert upretty(Not(Implies(x, y))) == 'x ↛ y'
 
 
 def test_issue_7180():
-    assert upretty(Equivalent(x, y)) == u'x ⇔ y'
+    assert upretty(Equivalent(x, y)) == 'x ⇔ y'
 
 
 def test_pretty_Complement():
     assert pretty(S.Reals - S.Naturals) == '(-oo, oo) \\ Naturals'
-    assert upretty(S.Reals - S.Naturals) == u'ℝ \\ ℕ'
+    assert upretty(S.Reals - S.Naturals) == 'ℝ \\ ℕ'
     assert pretty(S.Reals - S.Naturals0) == '(-oo, oo) \\ Naturals0'
-    assert upretty(S.Reals - S.Naturals0) == u'ℝ \\ ℕ₀'
+    assert upretty(S.Reals - S.Naturals0) == 'ℝ \\ ℕ₀'
 
 
 def test_pretty_SymmetricDifference():
     from sympy import SymmetricDifference, Interval
     from sympy.testing.pytest import raises
     assert upretty(SymmetricDifference(Interval(2,3), Interval(3,5), \
-           evaluate = False)) == u'[2, 3] ∆ [3, 5]'
+           evaluate = False)) == '[2, 3] ∆ [3, 5]'
     with raises(NotImplementedError):
         pretty(SymmetricDifference(Interval(2,3), Interval(3,5), evaluate = False))
 
 
 def test_pretty_Contains():
     assert pretty(Contains(x, S.Integers)) == 'Contains(x, Integers)'
-    assert upretty(Contains(x, S.Integers)) == u'x ∈ ℤ'
+    assert upretty(Contains(x, S.Integers)) == 'x ∈ ℤ'
 
 
 def test_issue_8292():
     from sympy.core import sympify
     e = sympify('((x+x**4)/(x-1))-(2*(x-1)**4/(x-1)**4)', evaluate=False)
     ucode_str = \
-u("""\
+"""\
            4    4    \n\
   2⋅(x - 1)    x  + x\n\
 - ────────── + ──────\n\
           4    x - 1 \n\
    (x - 1)           \
-""")
+"""
     ascii_str = \
 """\
            4    4    \n\
@@ -6365,11 +6364,11 @@ def test_issue_4335():
     y = Function('y')
     expr = -y(x).diff(x)
     ucode_str = \
-u("""\
+"""\
  d       \n\
 -──(y(x))\n\
  dx      \
-""")
+"""
     ascii_str = \
 """\
   d       \n\
@@ -6384,13 +6383,13 @@ def test_issue_8344():
     from sympy.core import sympify
     e = sympify('2*x*y**2/1**2 + 1', evaluate=False)
     ucode_str = \
-u("""\
+"""\
      2    \n\
 2⋅x⋅y     \n\
 ────── + 1\n\
    2      \n\
   1       \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
@@ -6399,36 +6398,36 @@ def test_issue_6324():
     y = Pow(10, -2, evaluate=False)
     e = Mul(x, y, evaluate=False)
     ucode_str = \
-u("""\
+"""\
   3\n\
  2 \n\
 ───\n\
   2\n\
 10 \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
 def test_issue_7927():
     e = sin(x/2)**cos(x/2)
     ucode_str = \
-u("""\
+"""\
            ⎛x⎞\n\
         cos⎜─⎟\n\
            ⎝2⎠\n\
 ⎛   ⎛x⎞⎞      \n\
 ⎜sin⎜─⎟⎟      \n\
 ⎝   ⎝2⎠⎠      \
-""")
+"""
     assert upretty(e) == ucode_str
     e = sin(x)**(S(11)/13)
     ucode_str = \
-u("""\
+"""\
         11\n\
         ──\n\
         13\n\
 (sin(x))  \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
@@ -6438,13 +6437,13 @@ def test_issue_6134():
 
     e = lamda*x*Integral(phi(t)*pi*sin(pi*t), (t, 0, 1)) + lamda*x**2*Integral(phi(t)*2*pi*sin(2*pi*t), (t, 0, 1))
     ucode_str = \
-u("""\
+"""\
      1                              1                   \n\
    2 ⌠                              ⌠                   \n\
 λ⋅x ⋅⎮ 2⋅π⋅φ(t)⋅sin(2⋅π⋅t) dt + λ⋅x⋅⎮ π⋅φ(t)⋅sin(π⋅t) dt\n\
      ⌡                              ⌡                   \n\
      0                              0                   \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
@@ -6469,7 +6468,7 @@ def test_pretty_primenu():
     from sympy.ntheory.factor_ import primenu
 
     ascii_str1 = "nu(n)"
-    ucode_str1 = u("ν(n)")
+    ucode_str1 = "ν(n)"
 
     n = symbols('n', integer=True)
     assert pretty(primenu(n)) == ascii_str1
@@ -6480,7 +6479,7 @@ def test_pretty_primeomega():
     from sympy.ntheory.factor_ import primeomega
 
     ascii_str1 = "Omega(n)"
-    ucode_str1 = u("Ω(n)")
+    ucode_str1 = "Ω(n)"
 
     n = symbols('n', integer=True)
     assert pretty(primeomega(n)) == ascii_str1
@@ -6491,19 +6490,19 @@ def test_pretty_Mod():
     from sympy.core import Mod
 
     ascii_str1 = "x mod 7"
-    ucode_str1 = u("x mod 7")
+    ucode_str1 = "x mod 7"
 
     ascii_str2 = "(x + 1) mod 7"
-    ucode_str2 = u("(x + 1) mod 7")
+    ucode_str2 = "(x + 1) mod 7"
 
     ascii_str3 = "2*x mod 7"
-    ucode_str3 = u("2⋅x mod 7")
+    ucode_str3 = "2⋅x mod 7"
 
     ascii_str4 = "(x mod 7) + 1"
-    ucode_str4 = u("(x mod 7) + 1")
+    ucode_str4 = "(x mod 7) + 1"
 
     ascii_str5 = "2*(x mod 7)"
-    ucode_str5 = u("2⋅(x mod 7)")
+    ucode_str5 = "2⋅(x mod 7)"
 
     x = symbols('x', integer=True)
     assert pretty(Mod(x, 7)) == ascii_str1
@@ -6528,35 +6527,35 @@ def test_pretty_UnevaluatedExpr():
     he = UnevaluatedExpr(1/x)
 
     ucode_str = \
-u("""\
+"""\
 1\n\
 ─\n\
 x\
-""")
+"""
 
     assert upretty(he) == ucode_str
 
     ucode_str = \
-u("""\
+"""\
    2\n\
 ⎛1⎞ \n\
 ⎜─⎟ \n\
 ⎝x⎠ \
-""")
+"""
 
     assert upretty(he**2) == ucode_str
 
     ucode_str = \
-u("""\
+"""\
     1\n\
 1 + ─\n\
     x\
-""")
+"""
 
     assert upretty(he + 1) == ucode_str
 
     ucode_str = \
-u('''\
+('''\
   1\n\
 x⋅─\n\
   x\
@@ -6568,11 +6567,11 @@ def test_issue_10472():
     M = (Matrix([[0, 0], [0, 0]]), Matrix([0, 0]))
 
     ucode_str = \
-u("""\
+"""\
 ⎛⎡0  0⎤  ⎡0⎤⎞
 ⎜⎢    ⎥, ⎢ ⎥⎟
 ⎝⎣0  0⎦  ⎣0⎦⎠\
-""")
+"""
     assert upretty(M) == ucode_str
 
 
@@ -6583,17 +6582,17 @@ def test_MatrixElement_printing():
     C = MatrixSymbol("C", 1, 3)
 
     ascii_str1 = "A_00"
-    ucode_str1 = u("A₀₀")
+    ucode_str1 = "A₀₀"
     assert pretty(A[0, 0])  == ascii_str1
     assert upretty(A[0, 0]) == ucode_str1
 
     ascii_str1 = "3*A_00"
-    ucode_str1 = u("3⋅A₀₀")
+    ucode_str1 = "3⋅A₀₀"
     assert pretty(3*A[0, 0])  == ascii_str1
     assert upretty(3*A[0, 0]) == ucode_str1
 
     ascii_str1 = "(-B + A)[0, 0]"
-    ucode_str1 = u("(-B + A)[0, 0]")
+    ucode_str1 = "(-B + A)[0, 0]"
     F = C[0, 0].subs(C, A - B)
     assert pretty(F)  == ascii_str1
     assert upretty(F) == ucode_str1
@@ -6605,19 +6604,19 @@ def test_issue_12675():
     e = CoordSys3D('e')
 
     ucode_str = \
-u("""\
+"""\
 ⎛   t⎞    \n\
 ⎜⎛x⎞ ⎟ j_e\n\
 ⎜⎜─⎟ ⎟    \n\
 ⎝⎝y⎠ ⎠    \
-""")
+"""
     assert upretty((x/y)**t*e.j) == ucode_str
     ucode_str = \
-u("""\
+"""\
 ⎛1⎞    \n\
 ⎜─⎟ j_e\n\
 ⎝y⎠    \
-""")
+"""
     assert upretty((1/y)*e.j) == ucode_str
 
 
@@ -6644,27 +6643,27 @@ def test_MatrixSymbol_printing():
 
 def test_degree_printing():
     expr1 = 90*degree
-    assert pretty(expr1) == u'90°'
+    assert pretty(expr1) == '90°'
     expr2 = x*degree
-    assert pretty(expr2) == u'x°'
+    assert pretty(expr2) == 'x°'
     expr3 = cos(x*degree + 90*degree)
-    assert pretty(expr3) == u'cos(x° + 90°)'
+    assert pretty(expr3) == 'cos(x° + 90°)'
 
 
 def test_vector_expr_pretty_printing():
     A = CoordSys3D('A')
 
-    assert upretty(Cross(A.i, A.x*A.i+3*A.y*A.j)) == u("(i_A)×((x_A) i_A + (3⋅y_A) j_A)")
-    assert upretty(x*Cross(A.i, A.j)) == u('x⋅(i_A)×(j_A)')
+    assert upretty(Cross(A.i, A.x*A.i+3*A.y*A.j)) == "(i_A)×((x_A) i_A + (3⋅y_A) j_A)"
+    assert upretty(x*Cross(A.i, A.j)) == 'x⋅(i_A)×(j_A)'
 
-    assert upretty(Curl(A.x*A.i + 3*A.y*A.j)) == u("∇×((x_A) i_A + (3⋅y_A) j_A)")
+    assert upretty(Curl(A.x*A.i + 3*A.y*A.j)) == "∇×((x_A) i_A + (3⋅y_A) j_A)"
 
-    assert upretty(Divergence(A.x*A.i + 3*A.y*A.j)) == u("∇⋅((x_A) i_A + (3⋅y_A) j_A)")
+    assert upretty(Divergence(A.x*A.i + 3*A.y*A.j)) == "∇⋅((x_A) i_A + (3⋅y_A) j_A)"
 
-    assert upretty(Dot(A.i, A.x*A.i+3*A.y*A.j)) == u("(i_A)⋅((x_A) i_A + (3⋅y_A) j_A)")
+    assert upretty(Dot(A.i, A.x*A.i+3*A.y*A.j)) == "(i_A)⋅((x_A) i_A + (3⋅y_A) j_A)"
 
-    assert upretty(Gradient(A.x+3*A.y)) == u("∇(x_A + 3⋅y_A)")
-    assert upretty(Laplacian(A.x+3*A.y)) == u("∆(x_A + 3⋅y_A)")
+    assert upretty(Gradient(A.x+3*A.y)) == "∇(x_A + 3⋅y_A)"
+    assert upretty(Laplacian(A.x+3*A.y)) == "∆(x_A + 3⋅y_A)"
     # TODO: add support for ASCII pretty.
 
 
@@ -6681,9 +6680,9 @@ def test_pretty_print_tensor_expr():
 -i\
 """
     ucode_str = \
-u("""\
+"""\
 -i\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6695,11 +6694,11 @@ A \n\
   \
 """
     ucode_str = \
-u("""\
+"""\
  i\n\
 A \n\
   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6711,11 +6710,11 @@ A   \n\
     \
 """
     ucode_str = \
-u("""\
+"""\
  i₀\n\
 A  \n\
    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6727,11 +6726,11 @@ A \n\
  i\
 """
     ucode_str = \
-u("""\
+"""\
   \n\
 A \n\
  i\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6743,11 +6742,11 @@ A \n\
     i\
 """
     ucode_str = \
-u("""\
+"""\
      \n\
 -3⋅A \n\
     i\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6759,11 +6758,11 @@ H  \n\
   j\
 """
     ucode_str = \
-u("""\
+"""\
  i \n\
 H  \n\
   j\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6775,11 +6774,11 @@ H      \n\
     L_0\
 """
     ucode_str = \
-u("""\
+"""\
  L₀  \n\
 H    \n\
    L₀\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6791,11 +6790,11 @@ H    *A   *B \n\
   L_0        \
 """
     ucode_str = \
-u("""\
+"""\
  i    L₀  k\n\
 H   ⋅A  ⋅B \n\
   L₀       \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6807,11 +6806,11 @@ H   ⋅A  ⋅B \n\
           \
 """
     ucode_str = \
-u("""\
+"""\
          i\n\
 (x + 1)⋅A \n\
           \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6823,11 +6822,11 @@ u("""\
          \
 """
     ucode_str = \
-u("""\
+"""\
    i    i\n\
 3⋅B  + A \n\
          \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6853,13 +6852,13 @@ dA     \n\
        \
 """
     ucode_str = \
-u("""\
+"""\
  ∂ ⎛ i⎞\n\
 ───⎜A ⎟\n\
   j⎝  ⎠\n\
 ∂A     \n\
        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6873,13 +6872,13 @@ A   *---|H    |\n\
                \
 """
     ucode_str = \
-u("""\
+"""\
  L₀  ∂ ⎛ k  ⎞\n\
 A  ⋅───⎜H   ⎟\n\
       j⎝  L₀⎠\n\
     ∂A       \n\
              \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6893,13 +6892,13 @@ A   *---|3*H     + B *C   |\n\
                            \
 """
     ucode_str = \
-u("""\
+"""\
  L₀  ∂ ⎛   k      k    ⎞\n\
 A  ⋅───⎜3⋅H    + B ⋅C  ⎟\n\
       j⎝    L₀       L₀⎠\n\
     ∂A                  \n\
                         \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6913,13 +6912,13 @@ A  ⋅───⎜3⋅H    + B ⋅C  ⎟\n\
                      \
 """
     ucode_str = \
-u("""\
+"""\
 ⎛ i    i⎞  ∂  ⎛ L₀⎞\n\
 ⎜A  + B ⎟⋅────⎜C  ⎟\n\
 ⎝       ⎠   L₀⎝   ⎠\n\
           ∂D       \n\
                    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -6933,36 +6932,36 @@ u("""\
                        \
 """
     ucode_str = \
-u("""\
+"""\
 ⎛ L₀    L₀⎞  ∂ ⎛   ⎞\n\
 ⎜A   + B  ⎟⋅───⎜C  ⎟\n\
 ⎝         ⎠   j⎝ L₀⎠\n\
             ∂D      \n\
                     \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = PartialDerivative(B(-i) + A(-i), A(-j), A(-n))
-    ucode_str = u("""\
+    ucode_str = """\
     2           \n\
    ∂   ⎛       ⎞\n\
 ───────⎜A  + B ⎟\n\
        ⎝ i    i⎠\n\
 ∂A  ∂A          \n\
   n   j         \
-""")
+"""
     assert upretty(expr) == ucode_str
 
     expr = PartialDerivative(3*A(-i), A(-j), A(-n))
-    ucode_str = u("""\
+    ucode_str = """\
     2        \n\
    ∂   ⎛    ⎞\n\
 ───────⎜3⋅A ⎟\n\
        ⎝   i⎠\n\
 ∂A  ∂A       \n\
   n   j      \
-""")
+"""
     assert upretty(expr) == ucode_str
 
     expr = TensorElement(H(i, j), {i:1})
@@ -7039,54 +7038,54 @@ def test_matrixSymbolBold():
 
     from sympy import trace
     A = MatrixSymbol("A", 2, 2)
-    assert boldpretty(trace(A)) == u'tr(𝐀)'
+    assert boldpretty(trace(A)) == 'tr(𝐀)'
 
     A = MatrixSymbol("A", 3, 3)
     B = MatrixSymbol("B", 3, 3)
     C = MatrixSymbol("C", 3, 3)
 
-    assert boldpretty(-A) == u'-𝐀'
-    assert boldpretty(A - A*B - B) == u'-𝐁 -𝐀⋅𝐁 + 𝐀'
-    assert boldpretty(-A*B - A*B*C - B) == u'-𝐁 -𝐀⋅𝐁 -𝐀⋅𝐁⋅𝐂'
+    assert boldpretty(-A) == '-𝐀'
+    assert boldpretty(A - A*B - B) == '-𝐁 -𝐀⋅𝐁 + 𝐀'
+    assert boldpretty(-A*B - A*B*C - B) == '-𝐁 -𝐀⋅𝐁 -𝐀⋅𝐁⋅𝐂'
 
     A = MatrixSymbol("Addot", 3, 3)
-    assert boldpretty(A) == u'𝐀̈'
+    assert boldpretty(A) == '𝐀̈'
     omega = MatrixSymbol("omega", 3, 3)
-    assert boldpretty(omega) == u'ω'
+    assert boldpretty(omega) == 'ω'
     omega = MatrixSymbol("omeganorm", 3, 3)
-    assert boldpretty(omega) == u'‖ω‖'
+    assert boldpretty(omega) == '‖ω‖'
 
     a = Symbol('alpha')
     b = Symbol('b')
     c = MatrixSymbol("c", 3, 1)
     d = MatrixSymbol("d", 3, 1)
 
-    assert boldpretty(a*B*c+b*d) == u'b⋅𝐝 + α⋅𝐁⋅𝐜'
+    assert boldpretty(a*B*c+b*d) == 'b⋅𝐝 + α⋅𝐁⋅𝐜'
 
     d = MatrixSymbol("delta", 3, 1)
     B = MatrixSymbol("Beta", 3, 3)
 
-    assert boldpretty(a*B*c+b*d) == u'b⋅δ + α⋅Β⋅𝐜'
+    assert boldpretty(a*B*c+b*d) == 'b⋅δ + α⋅Β⋅𝐜'
 
     A = MatrixSymbol("A_2", 3, 3)
-    assert boldpretty(A) == u'𝐀₂'
+    assert boldpretty(A) == '𝐀₂'
 
 
 def test_center_accent():
-    assert center_accent('a', u'\N{COMBINING TILDE}') == u'ã'
-    assert center_accent('aa', u'\N{COMBINING TILDE}') == u'aã'
-    assert center_accent('aaa', u'\N{COMBINING TILDE}') == u'aãa'
-    assert center_accent('aaaa', u'\N{COMBINING TILDE}') == u'aaãa'
-    assert center_accent('aaaaa', u'\N{COMBINING TILDE}') == u'aaãaa'
-    assert center_accent('abcdefg', u'\N{COMBINING FOUR DOTS ABOVE}') == u'abcd⃜efg'
+    assert center_accent('a', u'\N{COMBINING TILDE}') == 'ã'
+    assert center_accent('aa', u'\N{COMBINING TILDE}') == 'aã'
+    assert center_accent('aaa', u'\N{COMBINING TILDE}') == 'aãa'
+    assert center_accent('aaaa', u'\N{COMBINING TILDE}') == 'aaãa'
+    assert center_accent('aaaaa', u'\N{COMBINING TILDE}') == 'aaãaa'
+    assert center_accent('abcdefg', u'\N{COMBINING FOUR DOTS ABOVE}') == 'abcd⃜efg'
 
 
 def test_imaginary_unit():
     from sympy import pretty # As it is redefined above
     assert pretty(1 + I, use_unicode=False) == '1 + I'
-    assert pretty(1 + I, use_unicode=True) == u'1 + ⅈ'
+    assert pretty(1 + I, use_unicode=True) == '1 + ⅈ'
     assert pretty(1 + I, use_unicode=False, imaginary_unit='j') == '1 + I'
-    assert pretty(1 + I, use_unicode=True, imaginary_unit='j') == u'1 + ⅉ'
+    assert pretty(1 + I, use_unicode=True, imaginary_unit='j') == '1 + ⅉ'
 
     raises(TypeError, lambda: pretty(I, imaginary_unit=I))
     raises(ValueError, lambda: pretty(I, imaginary_unit="kkk"))
@@ -7095,36 +7094,36 @@ def test_imaginary_unit():
 def test_str_special_matrices():
     from sympy.matrices import Identity, ZeroMatrix, OneMatrix
     assert pretty(Identity(4)) == 'I'
-    assert upretty(Identity(4)) == u'𝕀'
+    assert upretty(Identity(4)) == '𝕀'
     assert pretty(ZeroMatrix(2, 2)) == '0'
-    assert upretty(ZeroMatrix(2, 2)) == u'𝟘'
+    assert upretty(ZeroMatrix(2, 2)) == '𝟘'
     assert pretty(OneMatrix(2, 2)) == '1'
-    assert upretty(OneMatrix(2, 2)) == u'𝟙'
+    assert upretty(OneMatrix(2, 2)) == '𝟙'
 
 
 def test_pretty_misc_functions():
     assert pretty(LambertW(x)) == 'W(x)'
-    assert upretty(LambertW(x)) == u'W(x)'
+    assert upretty(LambertW(x)) == 'W(x)'
     assert pretty(LambertW(x, y)) == 'W(x, y)'
-    assert upretty(LambertW(x, y)) == u'W(x, y)'
+    assert upretty(LambertW(x, y)) == 'W(x, y)'
     assert pretty(airyai(x)) == 'Ai(x)'
-    assert upretty(airyai(x)) == u'Ai(x)'
+    assert upretty(airyai(x)) == 'Ai(x)'
     assert pretty(airybi(x)) == 'Bi(x)'
-    assert upretty(airybi(x)) == u'Bi(x)'
+    assert upretty(airybi(x)) == 'Bi(x)'
     assert pretty(airyaiprime(x)) == "Ai'(x)"
-    assert upretty(airyaiprime(x)) == u"Ai'(x)"
+    assert upretty(airyaiprime(x)) == "Ai'(x)"
     assert pretty(airybiprime(x)) == "Bi'(x)"
-    assert upretty(airybiprime(x)) == u"Bi'(x)"
+    assert upretty(airybiprime(x)) == "Bi'(x)"
     assert pretty(fresnelc(x)) == 'C(x)'
-    assert upretty(fresnelc(x)) == u'C(x)'
+    assert upretty(fresnelc(x)) == 'C(x)'
     assert pretty(fresnels(x)) == 'S(x)'
-    assert upretty(fresnels(x)) == u'S(x)'
+    assert upretty(fresnels(x)) == 'S(x)'
     assert pretty(Heaviside(x)) == 'Heaviside(x)'
-    assert upretty(Heaviside(x)) == u'θ(x)'
+    assert upretty(Heaviside(x)) == 'θ(x)'
     assert pretty(Heaviside(x, y)) == 'Heaviside(x, y)'
-    assert upretty(Heaviside(x, y)) == u'θ(x, y)'
+    assert upretty(Heaviside(x, y)) == 'θ(x, y)'
     assert pretty(dirichlet_eta(x)) == 'dirichlet_eta(x)'
-    assert upretty(dirichlet_eta(x)) == u'η(x)'
+    assert upretty(dirichlet_eta(x)) == 'η(x)'
 
 
 def test_hadamard_power():
@@ -7140,10 +7139,10 @@ def test_hadamard_power():
 A  \
 """
     ucode_str = \
-u("""\
+"""\
  ∘n\n\
 A  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -7154,10 +7153,10 @@ A  \
 A        \
 """
     ucode_str = \
-u("""\
+"""\
  ∘(n + 1)\n\
 A        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -7169,11 +7168,11 @@ A        \
 \\A*B /        \
 """
     ucode_str = \
-u("""\
+"""\
       ∘(n + 1)\n\
 ⎛   T⎞        \n\
 ⎝A⋅B ⎠        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -7189,7 +7188,7 @@ def test_issue_17258():
     'n = -oo  '
 
     assert upretty(Sum(n, (n, -oo, 1))) == \
-u("""\
+"""\
   1     \n\
  ___    \n\
  ╲      \n\
@@ -7198,10 +7197,10 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 n = -∞  \
-""")
+"""
 
 def test_is_combining():
-    line = u("v̇_m")
+    line = "v̇_m"
     assert [is_combining(sym) for sym in line] == \
         [False, True, False, False]
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -253,16 +253,16 @@ def test_pretty_ascii_str():
 
 
 def test_pretty_unicode_str():
-    assert pretty( u'xxx' ) == 'xxx'
-    assert pretty( u'xxx' ) == 'xxx'
-    assert pretty( u'xxx\'xxx' ) == 'xxx\'xxx'
-    assert pretty( u'xxx"xxx' ) == 'xxx\"xxx'
-    assert pretty( u'xxx\"xxx' ) == 'xxx\"xxx'
-    assert pretty( u"xxx'xxx" ) == 'xxx\'xxx'
-    assert pretty( u"xxx\'xxx" ) == 'xxx\'xxx'
-    assert pretty( u"xxx\"xxx" ) == 'xxx\"xxx'
-    assert pretty( u"xxx\"xxx\'xxx" ) == 'xxx"xxx\'xxx'
-    assert pretty( u"xxx\nxxx" ) == 'xxx\nxxx'
+    assert pretty( 'xxx' ) == 'xxx'
+    assert pretty( 'xxx' ) == 'xxx'
+    assert pretty( 'xxx\'xxx' ) == 'xxx\'xxx'
+    assert pretty( 'xxx"xxx' ) == 'xxx\"xxx'
+    assert pretty( 'xxx\"xxx' ) == 'xxx\"xxx'
+    assert pretty( "xxx'xxx" ) == 'xxx\'xxx'
+    assert pretty( "xxx\'xxx" ) == 'xxx\'xxx'
+    assert pretty( "xxx\"xxx" ) == 'xxx\"xxx'
+    assert pretty( "xxx\"xxx\'xxx" ) == 'xxx"xxx\'xxx'
+    assert pretty( "xxx\nxxx" ) == 'xxx\nxxx'
 
 
 def test_upretty_greek():
@@ -2066,7 +2066,7 @@ def test_pretty_sqrt():
 \\/ 2 \
 """
     ucode_str = \
-u"√2"
+"√2"
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2192,7 +2192,7 @@ def test_pretty_sqrt_char_knob():
 ╲╱ 2 \
 """
     ucode_str2 = \
-u"√2"
+"√2"
     assert xpretty(expr, use_unicode=True,
                    use_unicode_sqrt_char=False) == ucode_str1
     assert xpretty(expr, use_unicode=True,
@@ -2326,7 +2326,7 @@ x ↦ x \
 
     expr = Lambda((x, y), x)
     ascii_str = "(x, y) -> x"
-    ucode_str = u"(x, y) ↦ x"
+    ucode_str = "(x, y) ↦ x"
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3262,7 +3262,7 @@ def test_pretty_ndim_arrays():
 [[      z]]\
 """
         ucode_str = \
-    """\
+"""\
 ⎡⎡      1⎤⎤\n\
 ⎢⎢x  y  ─⎥⎥\n\
 ⎣⎣      z⎦⎦\
@@ -3351,17 +3351,17 @@ def test_Adjoint():
     assert upretty(Adjoint(X*Y)) == "     †\n(X⋅Y) "
     assert upretty(Adjoint(Y)*Adjoint(X)) == " †  †\nY ⋅X "
     assert upretty(Adjoint(X**2)) == \
-        u"    †\n⎛ 2⎞ \n⎝X ⎠ "
+        "    †\n⎛ 2⎞ \n⎝X ⎠ "
     assert upretty(Adjoint(X)**2) == \
-        u"    2\n⎛ †⎞ \n⎝X ⎠ "
+        "    2\n⎛ †⎞ \n⎝X ⎠ "
     assert upretty(Adjoint(Inverse(X))) == \
-        u"     †\n⎛ -1⎞ \n⎝X  ⎠ "
+        "     †\n⎛ -1⎞ \n⎝X  ⎠ "
     assert upretty(Inverse(Adjoint(X))) == \
-        u"    -1\n⎛ †⎞  \n⎝X ⎠  "
+        "    -1\n⎛ †⎞  \n⎝X ⎠  "
     assert upretty(Adjoint(Transpose(X))) == \
-        u"    †\n⎛ T⎞ \n⎝X ⎠ "
+        "    †\n⎛ T⎞ \n⎝X ⎠ "
     assert upretty(Transpose(Adjoint(X))) == \
-        u"    T\n⎛ †⎞ \n⎝X ⎠ "
+        "    T\n⎛ †⎞ \n⎝X ⎠ "
 
 def test_pretty_Trace_issue_9044():
     X = Matrix([[1, 2], [3, 4]])
@@ -3995,7 +3995,7 @@ def test_print_builtin_set():
  x    \
 """
     assert upretty(s1) == \
-u"""\
+"""\
 ⎧1   ⎫
 ⎨─, x⎬
 ⎩x   ⎭\
@@ -4008,7 +4008,7 @@ frozenset({-, x})
            x     \
 """
     assert upretty(s2) == \
-u"""\
+"""\
          ⎛⎧1   ⎫⎞
 frozenset⎜⎨─, x⎬⎟
          ⎝⎩x   ⎭⎠\
@@ -4096,10 +4096,10 @@ def test_pretty_ImageSet():
     ascii_str = \
     '  2                 \n'\
     '{x  | x in Naturals}'
-    ucode_str = u('''\
+    ucode_str = '''\
 ⎧ 2        ⎫\n\
 ⎨x  | x ∊ ℕ⎬\n\
-⎩          ⎭''')
+⎩          ⎭'''
     assert pretty(imgset) == ascii_str
     assert upretty(imgset) == ucode_str
 
@@ -4107,7 +4107,7 @@ def test_pretty_ImageSet():
 def test_pretty_ConditionSet():
     from sympy import ConditionSet
     ascii_str = '{x | x in (-oo, oo) and sin(x) = 0}'
-    ucode_str = u'{x | x ∊ ℝ ∧ (sin(x) = 0)}'
+    ucode_str = '{x | x ∊ ℝ ∧ (sin(x) = 0)}'
     assert pretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ascii_str
     assert upretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ucode_str
 
@@ -4123,15 +4123,15 @@ def test_pretty_ConditionSet():
 
 def test_pretty_ComplexRegion():
     from sympy import ComplexRegion
-    ucode_str = u'{x + y⋅ⅈ | x, y ∊ [3, 5] × [4, 6]}'
+    ucode_str = '{x + y⋅ⅈ | x, y ∊ [3, 5] × [4, 6]}'
     assert upretty(ComplexRegion(Interval(3, 5)*Interval(4, 6))) == ucode_str
 
-    ucode_str = u'{r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ [0, 1] × [0, 2⋅π)}'
+    ucode_str = '{r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ [0, 1] × [0, 2⋅π)}'
     assert upretty(ComplexRegion(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == ucode_str
 
 def test_pretty_Union_issue_10414():
     a, b = Interval(2, 3), Interval(4, 7)
-    ucode_str = u'[2, 3] ∪ [4, 7]'
+    ucode_str = '[2, 3] ∪ [4, 7]'
     ascii_str = '[2, 3] U [4, 7]'
     assert upretty(Union(a, b)) == ucode_str
     assert pretty(Union(a, b)) == ascii_str
@@ -4139,7 +4139,7 @@ def test_pretty_Union_issue_10414():
 def test_pretty_Intersection_issue_10414():
     x, y, z, w = symbols('x, y, z, w')
     a, b = Interval(x, y), Interval(z, w)
-    ucode_str = u'[x, y] ∩ [z, w]'
+    ucode_str = '[x, y] ∩ [z, w]'
     ascii_str = '[x, y] n [z, w]'
     assert upretty(Intersection(a, b)) == ucode_str
     assert pretty(Intersection(a, b)) == ascii_str
@@ -4151,14 +4151,14 @@ def test_ProductSet_exponent():
     assert upretty(Interval(0, 1)**2) == ucode_str
 
 def test_ProductSet_parenthesis():
-    ucode_str = u'([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])'
+    ucode_str = '([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])'
 
     a, b = Interval(2, 3), Interval(4, 7)
     assert upretty(Union(a*b, b*FiniteSet(1, 2))) == ucode_str
 
 def test_ProductSet_prod_char_issue_10413():
     ascii_str = '[2, 3] x [4, 7]'
-    ucode_str = u'[2, 3] × [4, 7]'
+    ucode_str = '[2, 3] × [4, 7]'
 
     a, b = Interval(2, 3), Interval(4, 7)
     assert pretty(a*b) == ascii_str
@@ -4169,13 +4169,13 @@ def test_pretty_sequences():
     s2 = SeqPer((1, 2))
 
     ascii_str = '[0, 1, 4, 9, ...]'
-    ucode_str = u'[0, 1, 4, 9, …]'
+    ucode_str = '[0, 1, 4, 9, …]'
 
     assert pretty(s1) == ascii_str
     assert upretty(s1) == ucode_str
 
     ascii_str = '[1, 2, 1, 2, ...]'
-    ucode_str = u'[1, 2, 1, 2, …]'
+    ucode_str = '[1, 2, 1, 2, …]'
     assert pretty(s2) == ascii_str
     assert upretty(s2) == ucode_str
 
@@ -4183,13 +4183,13 @@ def test_pretty_sequences():
     s4 = SeqPer((1, 2), (0, 2))
 
     ascii_str = '[0, 1, 4]'
-    ucode_str = u'[0, 1, 4]'
+    ucode_str = '[0, 1, 4]'
 
     assert pretty(s3) == ascii_str
     assert upretty(s3) == ucode_str
 
     ascii_str = '[1, 2, 1]'
-    ucode_str = u'[1, 2, 1]'
+    ucode_str = '[1, 2, 1]'
     assert pretty(s4) == ascii_str
     assert upretty(s4) == ucode_str
 
@@ -4197,48 +4197,48 @@ def test_pretty_sequences():
     s6 = SeqPer((1, 2), (-oo, 0))
 
     ascii_str = '[..., 9, 4, 1, 0]'
-    ucode_str = u'[…, 9, 4, 1, 0]'
+    ucode_str = '[…, 9, 4, 1, 0]'
 
     assert pretty(s5) == ascii_str
     assert upretty(s5) == ucode_str
 
     ascii_str = '[..., 2, 1, 2, 1]'
-    ucode_str = u'[…, 2, 1, 2, 1]'
+    ucode_str = '[…, 2, 1, 2, 1]'
     assert pretty(s6) == ascii_str
     assert upretty(s6) == ucode_str
 
     ascii_str = '[1, 3, 5, 11, ...]'
-    ucode_str = u'[1, 3, 5, 11, …]'
+    ucode_str = '[1, 3, 5, 11, …]'
 
     assert pretty(SeqAdd(s1, s2)) == ascii_str
     assert upretty(SeqAdd(s1, s2)) == ucode_str
 
     ascii_str = '[1, 3, 5]'
-    ucode_str = u'[1, 3, 5]'
+    ucode_str = '[1, 3, 5]'
 
     assert pretty(SeqAdd(s3, s4)) == ascii_str
     assert upretty(SeqAdd(s3, s4)) == ucode_str
 
     ascii_str = '[..., 11, 5, 3, 1]'
-    ucode_str = u'[…, 11, 5, 3, 1]'
+    ucode_str = '[…, 11, 5, 3, 1]'
 
     assert pretty(SeqAdd(s5, s6)) == ascii_str
     assert upretty(SeqAdd(s5, s6)) == ucode_str
 
     ascii_str = '[0, 2, 4, 18, ...]'
-    ucode_str = u'[0, 2, 4, 18, …]'
+    ucode_str = '[0, 2, 4, 18, …]'
 
     assert pretty(SeqMul(s1, s2)) == ascii_str
     assert upretty(SeqMul(s1, s2)) == ucode_str
 
     ascii_str = '[0, 2, 4]'
-    ucode_str = u'[0, 2, 4]'
+    ucode_str = '[0, 2, 4]'
 
     assert pretty(SeqMul(s3, s4)) == ascii_str
     assert upretty(SeqMul(s3, s4)) == ucode_str
 
     ascii_str = '[..., 18, 4, 2, 0]'
-    ucode_str = u'[…, 18, 4, 2, 0]'
+    ucode_str = '[…, 18, 4, 2, 0]'
 
     assert pretty(SeqMul(s5, s6)) == ascii_str
     assert upretty(SeqMul(s5, s6)) == ucode_str
@@ -4250,8 +4250,8 @@ def test_pretty_sequences():
 
     b = Symbol('b')
     s8 = SeqFormula(b*a**2, (a, 0, 2))
-    ascii_str = u'[0, b, 4*b]'
-    ucode_str = u'[0, b, 4⋅b]'
+    ascii_str = '[0, b, 4*b]'
+    ucode_str = '[0, b, 4⋅b]'
     assert pretty(s8) == ascii_str
     assert upretty(s8) == ucode_str
 
@@ -5800,7 +5800,7 @@ def test_expint():
     assert upretty(expr) == string
 
     expr = expint(1, z)
-    ucode_str = u"E₁(z)"
+    ucode_str = "E₁(z)"
     ascii_str = "expint(1, z)"
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -5924,7 +5924,7 @@ def test_RandomDomain():
     A = Exponential('a', 1)
     B = Exponential('b', 1)
     assert upretty(pspace(Tuple(A, B)).domain) == \
-        u'Domain: 0 ≤ a ∧ 0 ≤ b ∧ a < ∞ ∧ b < ∞'
+        'Domain: 0 ≤ a ∧ 0 ≤ b ∧ a < ∞ ∧ b < ∞'
 
 
 def test_PrettyPoly():
@@ -6087,17 +6087,17 @@ def test_categories():
         "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
         "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}"
 
-    assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
-        "id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}")
+    assert upretty(d) == "{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
+        "id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}"
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
     assert pretty(d) == "{f2*f1:A1-->A3: EmptySet, id:A1-->A1: " \
         "EmptySet, id:A2-->A2: EmptySet, id:A3-->A3: " \
         "EmptySet, f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet}" \
         " ==> {f2*f1:A1-->A3: {unique}}"
-    assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
+    assert upretty(d) == "{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
         "∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
-        " ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}")
+        " ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}"
 
     grid = DiagramGrid(d)
     assert pretty(grid) == "A1  A2\n      \nA3    "
@@ -6448,11 +6448,11 @@ def test_issue_6134():
 
 
 def test_issue_9877():
-    ucode_str1 = u'(2, 3) ∪ ([1, 2] \\ {x})'
+    ucode_str1 = '(2, 3) ∪ ([1, 2] \\ {x})'
     a, b, c = Interval(2, 3, True, True), Interval(1, 2), FiniteSet(x)
     assert upretty(Union(a, Complement(b, c))) == ucode_str1
 
-    ucode_str2 = u'{x} ∩ {y} ∩ ({z} \\ [1, 2])'
+    ucode_str2 = '{x} ∩ {y} ∩ ({z} \\ [1, 2])'
     d, e, f, g = FiniteSet(x), FiniteSet(y), FiniteSet(z), Interval(1, 2)
     assert upretty(Intersection(d, e, Complement(f, g))) == ucode_str2
 
@@ -7018,7 +7018,7 @@ def test_print_lerchphi():
     # Part of issue 6013
     a = Symbol('a')
     pretty(lerchphi(a, 1, 2))
-    uresult = u'Φ(a, 1, 2)'
+    uresult = 'Φ(a, 1, 2)'
     aresult = 'lerchphi(a, 1, 2)'
     assert pretty(lerchphi(a, 1, 2)) == aresult
     assert upretty(lerchphi(a, 1, 2)) == uresult
@@ -7072,12 +7072,12 @@ def test_matrixSymbolBold():
 
 
 def test_center_accent():
-    assert center_accent('a', u'\N{COMBINING TILDE}') == 'ã'
-    assert center_accent('aa', u'\N{COMBINING TILDE}') == 'aã'
-    assert center_accent('aaa', u'\N{COMBINING TILDE}') == 'aãa'
-    assert center_accent('aaaa', u'\N{COMBINING TILDE}') == 'aaãa'
-    assert center_accent('aaaaa', u'\N{COMBINING TILDE}') == 'aaãaa'
-    assert center_accent('abcdefg', u'\N{COMBINING FOUR DOTS ABOVE}') == 'abcd⃜efg'
+    assert center_accent('a', '\N{COMBINING TILDE}') == 'ã'
+    assert center_accent('aa', '\N{COMBINING TILDE}') == 'aã'
+    assert center_accent('aaa', '\N{COMBINING TILDE}') == 'aãa'
+    assert center_accent('aaaa', '\N{COMBINING TILDE}') == 'aaãa'
+    assert center_accent('aaaaa', '\N{COMBINING TILDE}') == 'aaãaa'
+    assert center_accent('abcdefg', '\N{COMBINING FOUR DOTS ABOVE}') == 'abcd⃜efg'
 
 
 def test_imaginary_unit():

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -450,7 +450,7 @@ def test_content_symbol():
 def test_content_mathml_greek():
     mml = mp._print(Symbol('alpha'))
     assert mml.nodeName == 'ci'
-    assert mml.childNodes[0].nodeValue == u'\N{GREEK SMALL LETTER ALPHA}'
+    assert mml.childNodes[0].nodeValue == '\N{GREEK SMALL LETTER ALPHA}'
 
     assert mp.doprint(Symbol('alpha')) == '<ci>&#945;</ci>'
     assert mp.doprint(Symbol('beta')) == '<ci>&#946;</ci>'
@@ -1036,7 +1036,7 @@ def test_presentation_symbol():
 def test_presentation_mathml_greek():
     mml = mpp._print(Symbol('alpha'))
     assert mml.nodeName == 'mi'
-    assert mml.childNodes[0].nodeValue == u'\N{GREEK SMALL LETTER ALPHA}'
+    assert mml.childNodes[0].nodeValue == '\N{GREEK SMALL LETTER ALPHA}'
 
     assert mpp.doprint(Symbol('alpha')) == '<mi>&#945;</mi>'
     assert mpp.doprint(Symbol('beta')) == '<mi>&#946;</mi>'

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -37,8 +37,7 @@ import warnings
 from contextlib import contextmanager
 
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import (exec_, PY3, unwrap,
-        unicode)
+from sympy.core.compatibility import (exec_, PY3, unwrap)
 from sympy.external import import_module
 
 IS_WINDOWS = (os.name == 'nt')
@@ -107,10 +106,6 @@ def _indent(s, indent=4):
     If the string ``s`` is Unicode, it is encoded using the stdout
     encoding and the ``backslashreplace`` error handler.
     """
-    # After a 2to3 run the below code is bogus, so wrap it with a version check
-    if not PY3:
-        if isinstance(s, unicode):
-            s = s.encode(pdoctest._encoding, 'backslashreplace')
     # This regexp matches the start of non-blank lines:
     return re.sub('(?m)^(?!$)', indent*' ', s)
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -3,7 +3,6 @@ from sympy import Integral, latex, Function
 from sympy import pretty as xpretty
 from sympy.vector import CoordSys3D, Vector, express
 from sympy.abc import a, b, c
-from sympy.core.compatibility import u_decode as u
 from sympy.testing.pytest import XFAIL
 
 
@@ -35,64 +34,56 @@ v.append((a**2 + N.x)*N.i + N.k)  # type: ignore
 v.append((a**2 + b)*N.i + 3*(C.y - c)*N.k)  # type: ignore
 f = Function('f')
 v.append(N.j - (Integral(f(b)) - C.x**2)*N.k)  # type: ignore
-upretty_v_8 = u(
-"""\
+upretty_v_8 = """\
       ⎛   2   ⌠        ⎞    \n\
 j_N + ⎜x_C  - ⎮ f(b) db⎟ k_N\n\
       ⎝       ⌡        ⎠    \
-""")
-pretty_v_8 = u(
-    """\
+"""
+pretty_v_8 = """\
 j_N + /         /       \\\n\
       |   2    |        |\n\
       |x_C  -  | f(b) db|\n\
       |        |        |\n\
       \\       /         / \
-""")
+"""
 
 v.append(N.i + C.k)  # type: ignore
 v.append(express(N.i, C))  # type: ignore
 v.append((a**2 + b)*N.i + (Integral(f(b)))*N.k)  # type: ignore
-upretty_v_11 = u(
-"""\
+upretty_v_11 = """\
 ⎛ 2    ⎞        ⎛⌠        ⎞    \n\
 ⎝a  + b⎠ i_N  + ⎜⎮ f(b) db⎟ k_N\n\
                 ⎝⌡        ⎠    \
-""")
-pretty_v_11 = u(
-"""\
+"""
+pretty_v_11 = """\
 / 2    \\ + /  /       \\\n\
 \\a  + b/ i_N| |        |\n\
            | | f(b) db|\n\
            | |        |\n\
            \\/         / \
-""")
+"""
 
 for x in v:
     d.append(x | N.k)  # type: ignore
 s = 3*N.x**2*C.y  # type: ignore
-upretty_s = u(
-"""\
+upretty_s = """\
          2\n\
 3⋅y_C⋅x_N \
-""")
-pretty_s = u(
-"""\
+"""
+pretty_s = """\
          2\n\
 3*y_C*x_N \
-""")
+"""
 
 # This is the pretty form for ((a**2 + b)*N.i + 3*(C.y - c)*N.k) | N.k
-upretty_d_7 = u(
-"""\
+upretty_d_7 = """\
 ⎛ 2    ⎞                                     \n\
 ⎝a  + b⎠ (i_N|k_N)  + (3⋅y_C - 3⋅c) (k_N|k_N)\
-""")
-pretty_d_7 = u(
-"""\
+"""
+pretty_d_7 = """\
 / 2    \\ (i_N|k_N) + (3*y_C - 3*c) (k_N|k_N)\n\
 \\a  + b/                                    \
-""")
+"""
 
 
 def test_str_printing():


### PR DESCRIPTION
In Python 3, there is no distinction between these types. This deprecates:

* The function `sympy.printing.pretty.pretty_symbology.xstr`
* The  `unicode` argument to `sympy.printing.stringpict.prettyForm`
* The `unicode` attribute of `sympy.printing.stringpict.prettyForm`

As well as:

* removing all callers of `compatibility.u_decode`
* removing most `u"..."` strings
* removing a `__unicode__` magic method

Done largely by hand, using regexes here and there.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * `sympy.printing.pretty.pretty_symbology.xstr` has been deprecated
  * The `unicode` argument to `sympy.printing.stringpict.prettyForm` has been deprecated
  * The `unicode` attribute of `sympy.printing.stringpict.prettyForm` has been deprecated
<!-- END RELEASE NOTES -->