### PR TITLE
codegen: Opportunistic rewrite of sin(k*x)/x -> k*sinc(x)

### DIFF
--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -31,7 +31,7 @@ The ``optims_c99`` imported above is tuple containing the following instances
 
 """
 from itertools import chain
-from sympy import cos, exp, log, Max, Min, Wild, expand_log, Dummy
+from sympy import cos, exp, log, Max, Min, Wild, expand_log, Dummy, sin, sinc
 from sympy.assumptions import Q, ask
 from sympy.codegen.cfunctions import log1p, log2, exp2, expm1
 from sympy.codegen.matrix_nodes import MatrixSolve
@@ -133,11 +133,20 @@ exp2_opt = ReplaceOptim(
     lambda p: exp2(p.exp)
 )
 
+
 _d = Wild('d', properties=[lambda x: x.is_Dummy])
 _u = Wild('u', properties=[lambda x: not x.is_number and not x.is_Add])
 _v = Wild('v')
 _w = Wild('w')
+_n = Wild('n', properties=[lambda x: x.is_number])
 
+sinc_opt1 = ReplaceOptim(
+    sin(_w)/_w, sinc(_w)
+)
+sinc_opt2 = ReplaceOptim(
+    sin(_n*_w)/_w, _n*sinc(_n*_w)
+)
+sinc_opts = (sinc_opt1, sinc_opt2)
 
 log2_opt = ReplaceOptim(_v*log(_w)/log(2), _v*log2(_w), cost_function=lambda expr: expr.count(
     lambda e: (  # division & eval of transcendentals are expensive floating point operations...
@@ -263,6 +272,6 @@ logaddexp2_opt = ReplaceOptim(log(Pow(2, _v)+Pow(2, _w)), logaddexp2(_v, _w)*log
 # Collections of optimizations:
 optims_c99 = (expm1_opt, log1p_opt, exp2_opt, log2_opt, log2const_opt)
 
-optims_numpy = (logaddexp_opt, logaddexp2_opt)
+optims_numpy = (logaddexp_opt, logaddexp2_opt,) + sinc_opts
 
 optims_scipy = (cosm1_opt,)

--- a/sympy/codegen/rewriting.py
+++ b/sympy/codegen/rewriting.py
@@ -272,6 +272,6 @@ logaddexp2_opt = ReplaceOptim(log(Pow(2, _v)+Pow(2, _w)), logaddexp2(_v, _w)*log
 # Collections of optimizations:
 optims_c99 = (expm1_opt, log1p_opt, exp2_opt, log2_opt, log2const_opt)
 
-optims_numpy = (logaddexp_opt, logaddexp2_opt,) + sinc_opts
+optims_numpy = optims_c99 + (logaddexp_opt, logaddexp2_opt,) + sinc_opts
 
 optims_scipy = (cosm1_opt,)

--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -1,4 +1,4 @@
-from sympy import log, exp, cos, Symbol, Pow, sin, MatrixSymbol
+from sympy import log, exp, cos, Symbol, Pow, sin, MatrixSymbol, sinc
 from sympy.assumptions import assuming, Q
 from sympy.printing import ccode
 from sympy.codegen.matrix_nodes import MatrixSolve
@@ -7,7 +7,8 @@ from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
 from sympy.codegen.scipy_nodes import cosm1
 from sympy.codegen.rewriting import (
     optimize, cosm1_opt, log2_opt, exp2_opt, expm1_opt, log1p_opt, optims_c99,
-    create_expand_pow_optimization, matinv_opt, logaddexp_opt, logaddexp2_opt
+    create_expand_pow_optimization, matinv_opt, logaddexp_opt, logaddexp2_opt,
+    optims_numpy
 )
 from sympy.testing.pytest import XFAIL
 
@@ -245,3 +246,15 @@ def test_logaddexp2_opt():
     assert logaddexp2(x, y) - opt1 == 0
     assert logaddexp2(y, x) - opt1 == 0
     assert opt1.rewrite(log) == expr1
+
+
+def test_optims_numpy():
+    x = Symbol('x')
+    e1 = sin(x)/x
+    assert optimize(e1, optims_numpy) - sinc(x) == 0
+    e2 = sin(2*x)/(2*x)
+    assert optimize(e2, optims_numpy) - sinc(2*x) == 0
+    e3 = sin(3*x)/x
+    assert optimize(e3, optims_numpy) - 3*sinc(3*x) == 0
+    e4 = x*sin(x)
+    assert optimize(e4, optims_numpy) - x*sin(x) == 0


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Another case along the lines of gh-20011.
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Adds a "rewrite pass" for "*sin(x)/x -> sinc(x)*" to the NumPy optimizations in `.codegen.rewrite`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->