### PR TITLE
Remove direct calls to __contains__

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -537,9 +537,9 @@ class GeometrySet(GeometryEntity, Set):
         """sympy.sets uses the _contains method, so include it for compatibility."""
 
         if isinstance(other, Set) and other.is_FiniteSet:
-            return all(self.__contains__(i) for i in other)
+            return all(i in self for i in other)
 
-        return self.__contains__(other)
+        return other in self
 
 @dispatch(GeometrySet, Set)  # type:ignore # noqa:F811
 def union_sets(self, o): # noqa:F811

--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -303,7 +303,7 @@ class EllipticCurvePoint:
         self.z = dom(z)
         self._curve = curve
         self._domain = self._curve._domain
-        if not self._curve.__contains__(self):
+        if self not in self._curve:
             raise ValueError("The curve does not contain this point")
 
     def __add__(self, p):

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -258,9 +258,9 @@ class ReferenceFrame(object):
             for i, v in enumerate(outlist):
                 templist = v[-1]._dlist[num].keys()
                 for i2, v2 in enumerate(templist):
-                    if not v.__contains__(v2):
+                    if v2 not in v:
                         littletemplist = v + [v2]
-                        if not outlist.__contains__(littletemplist):
+                        if littletemplist not in outlist:
                             outlist.append(littletemplist)
         for i, v in enumerate(oldlist):
             if v[-1] != other:

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -76,9 +76,9 @@ class Point(object):
             for i, v in enumerate(outlist):
                 templist = v[-1]._pdlist[num].keys()
                 for i2, v2 in enumerate(templist):
-                    if not v.__contains__(v2):
+                    if v2 not in v:
                         littletemplist = v + [v2]
-                        if not outlist.__contains__(littletemplist):
+                        if littletemplist not in outlist:
                             outlist.append(littletemplist)
         for i, v in enumerate(oldlist):
             if v[-1] != other:


### PR DESCRIPTION
Doing this is just weird, the canonical spelling is the `in` operator.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->