### PR TITLE
doc: Convert equations to latex

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -90,12 +90,14 @@ class Point(object):
                          ' and ' + self.name)
 
     def a1pt_theory(self, otherpoint, outframe, interframe):
-        """Sets the acceleration of this point with the 1-point theory.
+        r"""Sets the acceleration of this point with the 1-point theory.
 
         The 1-point theory for point acceleration looks like this:
 
-        ^N a^P = ^B a^P + ^N a^O + ^N alpha^B x r^OP + ^N omega^B x (^N omega^B
-        x r^OP) + 2 ^N omega^B x ^B v^P
+        .. math::
+            {}^Na^P = {}^Ba^P + {}^N a^O + {}^N\alpha^B \times r^{OP}
+                    + {}^N\omega^B \times ({}^N\omega^B \times r^{OP})
+                    + 2 {}^N\omega^B \times {}^Bv^P
 
         where O is a point fixed in B, P is a point moving in B, and B is
         rotating in frame N.
@@ -147,11 +149,13 @@ class Point(object):
         return self.acc(outframe)
 
     def a2pt_theory(self, otherpoint, outframe, fixedframe):
-        """Sets the acceleration of this point with the 2-point theory.
+        r"""Sets the acceleration of this point with the 2-point theory.
 
         The 2-point theory for point acceleration looks like this:
 
-        ^N a^P = ^N a^O + ^N alpha^B x r^OP + ^N omega^B x (^N omega^B x r^OP)
+        ..math::
+            {}^N a^P = {}^N a^O + {}^N \alpha^B \times r^{OP}
+                     + {}^N \omega^B x (^N \omega^B \times r^{OP})
 
         where O and P are both points fixed in frame B, which is rotating in
         frame N.
@@ -372,11 +376,11 @@ class Point(object):
         self._vel_dict.update({frame: value})
 
     def v1pt_theory(self, otherpoint, outframe, interframe):
-        """Sets the velocity of this point with the 1-point theory.
+        r"""Sets the velocity of this point with the 1-point theory.
 
         The 1-point theory for point velocity looks like this:
 
-        ^N v^P = ^B v^P + ^N v^O + ^N omega^B x r^OP
+        .. math:: {}^Nv^P = {}^Bv^P + {}^Nv^O + {}^N\omega^B \times r^{OP}
 
         where O is a point fixed in B, P is a point moving in B, and B is
         rotating in frame N.
@@ -425,11 +429,11 @@ class Point(object):
         return self.vel(outframe)
 
     def v2pt_theory(self, otherpoint, outframe, fixedframe):
-        """Sets the velocity of this point with the 2-point theory.
+        r"""Sets the velocity of this point with the 2-point theory.
 
         The 2-point theory for point velocity looks like this:
 
-        ^N v^P = ^N v^O + ^N omega^B x r^OP
+        .. math:: {}^Nv^P = {}^Nv^O + {}^N\omega^B \times r^{OP}
 
         where O and P are both points fixed in frame B, which is rotating in
         frame N.

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -155,7 +155,7 @@ class Point(object):
 
         ..math::
             {}^N a^P = {}^N a^O + {}^N \alpha^B \times r^{OP}
-                     + {}^N \omega^B x (^N \omega^B \times r^{OP})
+                     + {}^N \omega^B \times (^N \omega^B \times r^{OP})
 
         where O and P are both points fixed in frame B, which is rotating in
         frame N.


### PR DESCRIPTION
This translates the `^` in the original notation into superscripts, which is mostly likely the original intent.
Note that `{}^Na` is needed to put superscript N on the left of a

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->