### PR TITLE
divmod on sympy.Float with 0 numerator now results in (0, 0).

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -643,7 +643,7 @@ class Number(AtomicExpr):
         else:
             rat = self/other
         if other.is_finite:
-            w = int(rat) if rat > 0 else int(rat) - 1
+            w = int(rat) if rat >= 0 else int(rat) - 1
             r = self - other*w
         else:
             w = 0 if not self or (sign(self) == sign(other)) else -1

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -187,6 +187,8 @@ def test_divmod():
     assert [divmod(i, -OO) for i in range(-2, 3)] == ANS
     assert divmod(S(3.5), S(-2)) == divmod(3.5, -2)
     assert divmod(-S(3.5), S(-2)) == divmod(-3.5, -2)
+    assert divmod(S(0.0), S(9)) == divmod(0.0, 9)
+    assert divmod(S(0), S(9.0)) == divmod(0, 9.0)
 
 
 def test_igcd():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
We expect `divmod(S(0.0), S(9))` to give `(0, 0)`.  Instead, it was giving `(-1, 9.0)`, which is unexpected and different from Python (but still satisfies the expected invariant of course).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * divmod on sympy.Float with 0 numerator now results in (0, 0).
<!-- END RELEASE NOTES -->