### PR TITLE
Support frac in pycode printers

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -51,7 +51,7 @@ _known_functions_math = {
     'Sqrt': 'sqrt',
     'tan': 'tan',
     'tanh': 'tanh'
-}  # Not used from ``math``: [copysign isclose isfinite isinf isnan ldexp frexp pow
+}  # Not used from ``math``: [copysign isclose isfinite isinf isnan ldexp frexp pow modf
 # radians trunc fmod fsum gcd degrees fabs]
 _known_constants_math = {
     'Exp1': 'e',

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -453,7 +453,8 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
         return self._print_Rational(expr)
 
     def _print_frac(self, expr):
-        return "%s(%s)[0]" % (self._module_format("math.modf"), self._print(expr.args[0]))
+        from sympy import Mod
+        return self._print_Mod(Mod(expr.args[0], 1))
 
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
@@ -785,9 +786,6 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format('numpy.angle'), self._print(expr.args[0]))
-
-    def _print_frac(self, expr):
-        return "%s(%s)[0]" % (self._module_format('numpy.modf'), self._print(expr.args[0]))
 
     def _print_im(self, expr):
         return "%s(%s)" % (self._module_format('numpy.imag'), self._print(expr.args[0]))

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -51,7 +51,7 @@ _known_functions_math = {
     'Sqrt': 'sqrt',
     'tan': 'tan',
     'tanh': 'tanh'
-}  # Not used from ``math``: [copysign isclose isfinite isinf isnan ldexp frexp pow modf
+}  # Not used from ``math``: [copysign isclose isfinite isinf isnan ldexp frexp pow
 # radians trunc fmod fsum gcd degrees fabs]
 _known_constants_math = {
     'Exp1': 'e',
@@ -452,6 +452,9 @@ class PythonCodePrinter(AbstractPythonCodePrinter):
     def _print_Half(self, expr):
         return self._print_Rational(expr)
 
+    def _print_frac(self, expr):
+        return "%s(%s)[0]" % (self._module_format("math.modf"), self._print(expr.args[0]))
+
     _print_lowergamma = CodePrinter._print_not_supported
     _print_uppergamma = CodePrinter._print_not_supported
     _print_fresnelc = CodePrinter._print_not_supported
@@ -499,6 +502,7 @@ _not_in_mpmath = 'log1p log2'.split()
 _in_mpmath = [(k, v) for k, v in _known_functions_math.items() if k not in _not_in_mpmath]
 _known_functions_mpmath = dict(_in_mpmath, **{
     'beta': 'beta',
+    'frac': 'frac',
     'fresnelc': 'fresnelc',
     'fresnels': 'fresnels',
     'sign': 'sign',
@@ -782,6 +786,9 @@ class NumPyPrinter(PythonCodePrinter):
     def _print_arg(self, expr):
         return "%s(%s)" % (self._module_format('numpy.angle'), self._print(expr.args[0]))
 
+    def _print_frac(self, expr):
+        return "%s(%s)[0]" % (self._module_format('numpy.modf'), self._print(expr.args[0]))
+
     def _print_im(self, expr):
         return "%s(%s)" % (self._module_format('numpy.imag'), self._print(expr.args[0]))
 
@@ -1016,3 +1023,6 @@ class SymPyPrinter(PythonCodePrinter):
 
     def _print_Pow(self, expr, rational=False):
         return self._hprint_Pow(expr, rational=rational, sqrt='sympy.sqrt')
+
+    def _print_frac(self, expr):
+        return "%s(%s)" % (self._module_format('sympy.frac'), self._print(expr.args[0]))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -206,13 +206,13 @@ def test_frac():
     expr = frac(x)
 
     prntr = NumPyPrinter()
-    assert prntr.doprint(expr) == 'numpy.modf(x)[0]'
+    assert prntr.doprint(expr) == 'numpy.mod(x, 1)'
 
     prntr = SciPyPrinter()
-    assert prntr.doprint(expr) == 'numpy.modf(x)[0]'
+    assert prntr.doprint(expr) == 'numpy.mod(x, 1)'
 
     prntr = PythonCodePrinter()
-    assert prntr.doprint(expr) == 'math.modf(x)[0]'
+    assert prntr.doprint(expr) == 'x % 1'
 
     prntr = MpmathPrinter()
     assert prntr.doprint(expr) == 'mpmath.frac(x)'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -200,6 +200,27 @@ def test_sqrt():
     assert prntr._print_Pow(sqrt(x), rational=True) == 'x**(1/2)'
 
 
+def test_frac():
+    from sympy import frac
+
+    expr = frac(x)
+
+    prntr = NumPyPrinter()
+    assert prntr.doprint(expr) == 'numpy.modf(x)[0]'
+
+    prntr = SciPyPrinter()
+    assert prntr.doprint(expr) == 'numpy.modf(x)[0]'
+
+    prntr = PythonCodePrinter()
+    assert prntr.doprint(expr) == 'math.modf(x)[0]'
+
+    prntr = MpmathPrinter()
+    assert prntr.doprint(expr) == 'mpmath.frac(x)'
+
+    prntr = SymPyPrinter()
+    assert prntr.doprint(expr) == 'sympy.frac(x)'
+
+
 class CustomPrintedObject(Expr):
     def _numpycode(self, printer):
         return 'numpy'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -218,7 +218,7 @@ def test_frac():
     assert prntr.doprint(expr) == 'mpmath.frac(x)'
 
     prntr = SymPyPrinter()
-    assert prntr.doprint(expr) == 'sympy.frac(x)'
+    assert prntr.doprint(expr) == 'sympy.functions.elementary.integers.frac(x)'
 
 
 class CustomPrintedObject(Expr):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20112

#### Brief description of what is fixed or changed

Adds frac to pycode printers (for lambdify)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Support `frac` with pycode printers (for lambdify)

<!-- END RELEASE NOTES -->