### PR TITLE
core: make _sympify reject Basic subclasses

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -899,7 +899,7 @@ class Basic(Printable, metaclass=ManagedProperties):
                 # when old is a string we prefer Symbol
                 s = Symbol(s[0]), s[1]
             try:
-                s = [sympify(_, strict=not isinstance(_, str))
+                s = [sympify(_, strict=not isinstance(_, (str, type)))
                      for _ in s]
             except SympifyError:
                 # if it can't be sympified, skip it
@@ -1216,7 +1216,8 @@ class Basic(Printable, metaclass=ManagedProperties):
             return any(f.func == pattern or f == pattern
             for f in self.atoms(Function, UndefinedFunction))
 
-        pattern = _sympify(pattern)
+        if not (isinstance(pattern, type) and issubclass(pattern, Basic)):
+            pattern = _sympify(pattern)
         if isinstance(pattern, BasicMeta):
             return any(isinstance(arg, pattern)
             for arg in preorder_traversal(self))

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1216,11 +1216,11 @@ class Basic(Printable, metaclass=ManagedProperties):
             return any(f.func == pattern or f == pattern
             for f in self.atoms(Function, UndefinedFunction))
 
-        if not (isinstance(pattern, type) and issubclass(pattern, Basic)):
-            pattern = _sympify(pattern)
         if isinstance(pattern, BasicMeta):
-            return any(isinstance(arg, pattern)
-            for arg in preorder_traversal(self))
+            subtrees = preorder_traversal(self)
+            return any(isinstance(arg, pattern) for arg in subtrees)
+
+        pattern = _sympify(pattern)
 
         _has_matcher = getattr(pattern, '_has_matcher', None)
         if _has_matcher is not None:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -333,8 +333,16 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         and the result will be returned.
 
     """
+    # XXX: If a is a Basic subclass rather than instance (e.g. sin rather than
+    # sin(x)) then a.__sympy__ will be the property. Only on the instance will
+    # a.__sympy__ give the *value* of the property (True). Since sympify(sin)
+    # was used for a long time we allow it to pass. However if strict=True as
+    # is the case in internal calls to _sympify then we only allow
+    # is_sympy=True.
+    #
+    # https://github.com/sympy/sympy/issues/20124
     is_sympy = getattr(a, '__sympy__', None)
-    if is_sympy is not None:
+    if is_sympy is True or (is_sympy is not None and not strict):
         return a
 
     if isinstance(a, CantSympify):

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -288,10 +288,15 @@ def test__sympify():
 
     # positive _sympify
     assert _sympify(x) is x
-    assert _sympify(f) is f
     assert _sympify(1) == Integer(1)
     assert _sympify(0.5) == Float("0.5")
     assert _sympify(1 + 1j) == 1.0 + I*1.0
+
+    # Function f is not Basic and can't sympify to Basic. We allow it to pass
+    # with sympify but not with _sympify.
+    # https://github.com/sympy/sympy/issues/20124
+    assert sympify(f) is f
+    raises(SympifyError, lambda: _sympify(f))
 
     class A:
         def _sympy_(self):


### PR DESCRIPTION
Previously a Basic subclass could pass through _sympify e.g.:
```
  >>> _sympify(sin) is sin
  True
```
This was problemantic because _sympify is used to validate and prepare
args for many Basic subclasses which should only have Basic args. With
this change using _sympify with a Basic subclass will now raise an
error:
```
  >>> _sympify(sin)
  ...
  SympifyError: SympifyError: sin
```
This should mean that the output of _sympify is guaranteed to be of type
Basic.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/20124

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->