### PR TITLE
Add support for Integral with lambdify (using scipy or mpmath)

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -516,6 +516,25 @@ _known_constants_mpmath = {
 }
 
 
+def _unpack_integral_limits(integral_expr):
+    """ helper function for _print_Integral that
+        - accepts an Integral expression
+        - returns a tuple of
+           - a list variables of integration
+           - a list of tuples of the upper and lower limits of integration
+    """
+    integration_vars = []
+    limits = []
+    for integration_range in integral_expr.args[1:]:
+        try:
+            integration_var, lower_limit, upper_limit = integration_range
+        except (TypeError, ValueError):
+            raise NotImplementedError("Only definite integrals are supported")
+        integration_vars.append(integration_var)
+        limits.append((lower_limit, upper_limit))
+    return integration_vars, limits
+
+
 class MpmathPrinter(PythonCodePrinter):
     """
     Lambda printer for mpmath which maintains precision for floats
@@ -573,6 +592,15 @@ class MpmathPrinter(PythonCodePrinter):
 
     def _print_Pow(self, expr, rational=False):
         return self._hprint_Pow(expr, rational=rational, sqrt='mpmath.sqrt')
+
+    def _print_Integral(self, e):
+        integration_vars, limits = _unpack_integral_limits(e)
+
+        return "{0}(lambda {1}: {2}, {3})".format(
+                self._module_format("mpmath.quad"),
+                ", ".join(map(self._print, integration_vars)),
+                self._print(e.args[0]),
+                ", ".join("(%s, %s)" % tuple(map(self._print, l)) for l in limits))
 
 
 for k in MpmathPrinter._kf:
@@ -991,6 +1019,24 @@ class SciPyPrinter(NumPyPrinter):
         return "{0}({1})[3]".format(
                 self._module_format("scipy.special.airy"),
                 self._print(expr.args[0]))
+
+    def _print_Integral(self, e):
+        integration_vars, limits = _unpack_integral_limits(e)
+
+        if len(limits) == 1:
+            # nicer (but not necessary) to prefer quad over nquad for 1D case
+            module_str = self._module_format("scipy.integrate.quad")
+            limit_str = "%s, %s" % tuple(map(self._print, limits[0]))
+        else:
+            module_str = self._module_format("scipy.integrate.nquad")
+            limit_str = "({})".format(", ".join(
+                "(%s, %s)" % tuple(map(self._print, l)) for l in limits))
+
+        return "{0}(lambda {1}: {2}, {3})[0]".format(
+                module_str,
+                ", ".join(map(self._print, integration_vars)),
+                self._print(e.args[0]),
+                limit_str)
 
 
 for k in SciPyPrinter._kf:

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -525,10 +525,10 @@ def _unpack_integral_limits(integral_expr):
     """
     integration_vars = []
     limits = []
-    for integration_range in integral_expr.args[1:]:
-        try:
+    for integration_range in integral_expr.limits:
+        if len(integration_range) == 3:
             integration_var, lower_limit, upper_limit = integration_range
-        except (TypeError, ValueError):
+        else:
             raise NotImplementedError("Only definite integrals are supported")
         integration_vars.append(integration_var)
         limits.append((lower_limit, upper_limit))

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -250,6 +250,27 @@ def test_issue_16535_16536():
     assert prntr.doprint(expr2) == '  # Not supported in Python:\n  # uppergamma\nuppergamma(a, x)'
 
 
+def test_Integral():
+    from sympy import Integral, exp
+
+    single = Integral(exp(-x), (x, 0, oo))
+    double = Integral(x**2*exp(x*y), (x, -z, z), (y, 0, z))
+    indefinite = Integral(x**2, x)
+    evaluateat = Integral(x**2, (x, 1))
+
+    prntr = SciPyPrinter()
+    assert prntr.doprint(single) == 'scipy.integrate.quad(lambda x: numpy.exp(-x), 0, numpy.PINF)[0]'
+    assert prntr.doprint(double) == 'scipy.integrate.nquad(lambda x, y: x**2*numpy.exp(x*y), ((-z, z), (0, z)))[0]'
+    raises(NotImplementedError, lambda: prntr.doprint(indefinite))
+    raises(NotImplementedError, lambda: prntr.doprint(evaluateat))
+
+    prntr = MpmathPrinter()
+    assert prntr.doprint(single) == 'mpmath.quad(lambda x: mpmath.exp(-x), (0, mpmath.inf))'
+    assert prntr.doprint(double) == 'mpmath.quad(lambda x, y: x**2*mpmath.exp(x*y), (-z, z), (0, z))'
+    raises(NotImplementedError, lambda: prntr.doprint(indefinite))
+    raises(NotImplementedError, lambda: prntr.doprint(evaluateat))
+
+
 def test_fresnel_integrals():
     from sympy import fresnelc, fresnels
 

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -70,8 +70,7 @@ def test_issue_6408():
     assert nsolve(Piecewise((x, x < 1), (x**2, True)), x, 2) == 0.0
 
 
-@XFAIL
-def test_issue_6408_fail():
+def test_issue_6408_integral():
     x, y = symbols('x y')
     assert nsolve(Integral(x*y, (x, 0, 5)), y, 2) == 0.0
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -296,6 +296,22 @@ def test_trig():
     assert -prec < d[0] + 1 < prec
     assert -prec < d[1] < prec
 
+
+def test_integral():
+    f = Lambda(x, exp(-x**2))
+    l = lambdify(y, Integral(f(x), (x, y, oo)))
+    d = l(-oo)
+    assert 1.77245385 < d < 1.772453851
+
+
+def test_double_integral():
+    # example from http://mpmath.org/doc/current/calculus/integration.html
+    i = Integral(1/(1 - x**2*y**2), (x, 0, 1), (y, 0, z))
+    l = lambdify([z], i)
+    d = l(1)
+    assert 1.23370055 < d < 1.233700551
+
+
 #================== Test vectors ===================================
 
 
@@ -697,12 +713,6 @@ def test_tensorflow_array_arg():
 #================== Test symbolic ==================================
 
 
-def test_integral():
-    f = Lambda(x, exp(-x**2))
-    l = lambdify(x, Integral(f(x), (x, -oo, oo)), modules="sympy")
-    assert l(x) == Integral(exp(-x**2), (x, -oo, oo))
-
-
 def test_sym_single_arg():
     f = lambdify(x, x * y)
     assert f(z) == z * y
@@ -716,6 +726,7 @@ def test_sym_list_args():
 def test_sym_integral():
     f = Lambda(x, exp(-x**2))
     l = lambdify(x, Integral(f(x), (x, -oo, oo)), modules="sympy")
+    assert l(y) == Integral(exp(-y**2), (y, -oo, oo))
     assert l(y).doit() == sqrt(pi)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #19641, Fixes #6408, Fixes #4470, Fixes #4471, Fixes #5932

#### Brief description of what is fixed or changed

Add support for Integral with lambdify (using scipy or mpmath printers)

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* utilities
   * Add support for Integral with lambdify (using scipy or mpmath)

<!-- END RELEASE NOTES -->