### PR TITLE
Make signatures of AssocOp, MatAdd, MatMul same

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -42,7 +42,7 @@ def _unevaluated_Add(*args):
     be tested against the output of this function or as one of several
     options:
 
-    >>> opts = (Add(x, y, evaluated=False), Add(y, x, evaluated=False))
+    >>> opts = (Add(x, y, evaluate=False), Add(y, x, evaluate=False))
     >>> a = uAdd(x, y)
     >>> assert a in opts and a == uAdd(x, y)
     >>> uAdd(x + 1, x + 2)

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-from sympy.core.sympify import _sympify, sympify
+from sympy.core.sympify import _sympify as _sympify_, sympify
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import ordered
@@ -34,7 +34,7 @@ class AssocOp(Basic):
         Arguments which are operated
 
     evaluate : bool, optional
-        Default is ``True``. If ``False``, do not evaluate the operation.
+        Evaluate the operation. If not passed, refer to ``global_parameters.evaluate``.
     """
 
     # for performance reason, we don't let is_commutative go to assumptions,
@@ -44,13 +44,13 @@ class AssocOp(Basic):
     _args_type = None
 
     @cacheit
-    def __new__(cls, *args, **options):
+    def __new__(cls, *args, evaluate=None, _sympify=True):
         from sympy import Order
 
         # Allow faster processing by passing ``_sympify=False``, if all arguments
         # are already sympified.
-        if options.get('_sympify', True):
-            args = list(map(_sympify, args))
+        if _sympify:
+            args = list(map(_sympify_, args))
 
         # Disallow non-Expr args in Add/Mul
         typ = cls._args_type
@@ -68,7 +68,6 @@ class AssocOp(Basic):
                     deprecated_since_version="1.7"
                 ).warn()
 
-        evaluate = options.get('evaluate')
         if evaluate is None:
             evaluate = global_parameters.evaluate
         if not evaluate:
@@ -467,7 +466,7 @@ class LatticeOp(AssocOp):
     is_commutative = True
 
     def __new__(cls, *args, **options):
-        args = (_sympify(arg) for arg in args)
+        args = (_sympify_(arg) for arg in args)
 
         try:
             # /!\ args is a generator and _new_args_filter
@@ -599,7 +598,7 @@ class AssocOpDispatcher:
         self._dispatcher.add(tuple(reversed(classes)), typ, on_ambiguity=on_ambiguity)
 
     @cacheit
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, _sympify=True, **kwargs):
         """
         Parameters
         ==========
@@ -607,14 +606,12 @@ class AssocOpDispatcher:
         *args :
             Arguments which are operated
         """
-        if kwargs.get('_sympify', True):
-            args = tuple(map(_sympify, args))
+        if _sympify:
+            args = tuple(map(_sympify_, args))
         handlers = frozenset(map(self._handlergetter, args))
 
-        # If _sympify=True was passed, no need to sympify again so pass _sympify=False.
-        # If _sympify=False was passed, all args are already sympified so pass _sympify=False.
-        kwargs.update(_sympify=False)
-        return self.dispatch(handlers)(*args, **kwargs)
+        # no need to sympify again
+        return self.dispatch(handlers)(*args, _sympify=False, **kwargs)
 
     @cacheit
     def dispatch(self, handlers):

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -33,7 +33,7 @@ class MatAdd(MatrixExpr, Add):
 
     identity = GenericZeroMatrix()
 
-    def __new__(cls, *args, evaluate=False, **kwargs):
+    def __new__(cls, *args, evaluate=False, check=False, _sympify=True):
         if not args:
             return cls.identity
 
@@ -41,7 +41,6 @@ class MatAdd(MatrixExpr, Add):
         # TypeErrors from GenericZeroMatrix().shape
         args = filter(lambda i: cls.identity != i, args)
         args = list(map(sympify, args))
-        check = kwargs.get('check', False)
 
         obj = Basic.__new__(cls, *args)
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -40,7 +40,8 @@ class MatAdd(MatrixExpr, Add):
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
         args = filter(lambda i: cls.identity != i, args)
-        args = list(map(sympify, args))
+        if _sympify:
+            args = list(map(sympify, args))
 
         obj = Basic.__new__(cls, *args)
 

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericZeroMatrix().shape
-        args = filter(lambda i: cls.identity != i, args)
+        args = list(filter(lambda i: cls.identity != i, args))
         if _sympify:
             args = list(map(sympify, args))
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -40,7 +40,7 @@ class MatMul(MatrixExpr, Mul):
 
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
-        args = filter(lambda i: cls.identity != i, args)
+        args = list(filter(lambda i: cls.identity != i, args))
         if _sympify:
             args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -41,7 +41,8 @@ class MatMul(MatrixExpr, Mul):
         # This must be removed aggressively in the constructor to avoid
         # TypeErrors from GenericIdentity().shape
         args = filter(lambda i: cls.identity != i, args)
-        args = list(map(sympify, args))
+        if _sympify:
+            args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #19463 ([comment](https://github.com/sympy/sympy/pull/19463#discussion_r490487762) by @eric-wieser )
Related to #20086 
Related to #20125

#### Brief description of what is fixed or changed

As suggested in eric-wieser's comment, `_sympify` option is explicitly added to call signature of `AssocOpDispatcher`.  
For uniformity, it is added to class signature of `AssocOp` as well.  
`MatAdd` is equipped with `check`, `evaluate` and `_sympify` options in order to have same signature with `MatMul`.

#### Other comments

It needs to be discussed that whether do we need to add private keyword argument to the signature explicitly or not. Also, `_sympify` option in `MatAdd` and `MatMul` does nothing - I wonder if it would be better to bring `**kwargs` back to these classes...

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->