### PR TITLE
Fix issues with substitution for random matrix

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -776,24 +776,13 @@ class MatrixSymbol(MatrixExpr):
         obj = Basic.__new__(cls, name, n, m)
         return obj
 
-    def _hashable_content(self):
-        return (self.name, self.shape)
-
     @property
     def shape(self):
-        return self.args[1:3]
+        return self.args[1], self.args[2]
 
     @property
     def name(self):
         return self.args[0].name
-
-    def _eval_subs(self, old, new):
-        # only do substitutions in shape
-        shape = Tuple(*self.shape)._subs(old, new)
-        return MatrixSymbol(self.args[0], *shape)
-
-    def __call__(self, *args):
-        raise TypeError("%s object is not callable" % self.__class__)
 
     def _entry(self, i, j, **kwargs):
         return MatrixElement(self, i, j)
@@ -801,13 +790,6 @@ class MatrixSymbol(MatrixExpr):
     @property
     def free_symbols(self):
         return {self}
-
-    def doit(self, **hints):
-        if hints.get('deep', True):
-            return type(self)(self.args[0], self.args[1].doit(**hints),
-                    self.args[2].doit(**hints))
-        else:
-            return self
 
     def _eval_simplify(self, **kwargs):
         return self

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -3,7 +3,7 @@ from sympy.core.logic import FuzzyBool
 from functools import wraps, reduce
 import collections
 
-from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Mul, Add
+from sympy.core import S, Symbol, Integer, Basic, Expr, Mul, Add
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import SYMPY_INTS, default_sort_key
 from sympy.core.sympify import SympifyError, _sympify

--- a/sympy/stats/tests/test_random_matrix.py
+++ b/sympy/stats/tests/test_random_matrix.py
@@ -1,5 +1,5 @@
 from sympy import (sqrt, exp, Trace, pi, S, Integral, MatrixSymbol, Lambda,
-                    Dummy, Product, Abs, IndexedBase, Matrix, I, Rational)
+                   Dummy, Product, Abs, IndexedBase, Matrix, I, Rational)
 from sympy.stats import (GaussianUnitaryEnsemble as GUE, density,
                          GaussianOrthogonalEnsemble as GOE,
                          GaussianSymplecticEnsemble as GSE,
@@ -12,7 +12,7 @@ from sympy.stats import (GaussianUnitaryEnsemble as GUE, density,
                          Normal, Beta)
 from sympy.stats.joint_rv_types import JointDistributionHandmade
 from sympy.stats.rv import RandomMatrixSymbol
-from sympy.stats.random_matrix_models import GaussianEnsemble
+from sympy.stats.random_matrix_models import GaussianEnsemble, RandomMatrixPSpace
 from sympy.testing.pytest import raises
 
 def test_GaussianEnsemble():
@@ -110,3 +110,15 @@ def test_issue_19841():
     G1 = GUE('U', 2)
     G2 = G1.xreplace({2: 2})
     assert G1.args == G2.args
+
+    X = MatrixSymbol('X', 2, 2)
+    G = GSE('U', 2)
+    h_pspace = RandomMatrixPSpace('P', model=density(G))
+    H = RandomMatrixSymbol('H', 2, 2, pspace=h_pspace)
+    H2 = RandomMatrixSymbol('H', 2, 2, pspace=None)
+    assert H.doit() == H
+
+    assert (2*H).xreplace({H: X}) == 2*X
+    assert (2*H).xreplace({H2: X}) == 2*H
+    assert (2*H2).xreplace({H: X}) == 2*H2
+    assert (2*H2).xreplace({H2: X}) == 2*X


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19841

#### Brief description of what is fixed or changed

The issue was tricky to solve because there were multiple issues in the design of MatrixSymbol itself which overrides equality and substitution in adhoc manner.

So I've removed the adhoc methods for MatrixSymbol to allow the substitution of its own name because I see it can likely break the consistency if any child class of MatrixSymbol is going to be implemented in sympy.
So these types of substitution should work for MatrixSymbols now
```
X = MatrixSymbol('X', 2, 2)
x = Symbol('X')
y = Symbol('Y')
X.subs(x, y)
```

I've also removed the custom error messages for `__call__` because they are redundant

Although i have opened up an another attempt in #19715, I think that the actual issue should be independent of using Str vs Symbol, so this can be fixed first

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- stats
  - `RandomMatrixSymbol.doit` will be invariant upon call.
 
<!-- END RELEASE NOTES -->