### PR TITLE
Change MatrixSymbol's name from Symbol to Str

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -42,6 +42,7 @@ class Str(Atom):
     def _hashable_content(self):
         return (self.name,)
 
+
 def _filter_assumptions(kwargs):
     """Split the given dict into assumptions and non-assumptions.
     Keys are taken as assumptions if they correspond to an

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -6,6 +6,7 @@ import collections
 from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Mul, Add
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import SYMPY_INTS, default_sort_key
+from sympy.core.symbol import Str
 from sympy.core.sympify import SympifyError, _sympify
 from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -772,7 +773,7 @@ class MatrixSymbol(MatrixExpr):
         cls._check_dim(n)
 
         if isinstance(name, str):
-            name = Symbol(name)
+            name = Str(name)
         obj = Basic.__new__(cls, name, n, m)
         return obj
 

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -35,6 +35,7 @@ def purestr(x, with_args=False):
 
     >>> from sympy import Float, Symbol, MatrixSymbol
     >>> from sympy import Integer # noqa: F401
+    >>> from sympy.core.symbol import Str # noqa: F401
     >>> from sympy.printing.dot import purestr
 
     Applying ``purestr`` for basic symbolic object:
@@ -51,7 +52,7 @@ def purestr(x, with_args=False):
     For matrix symbol:
     >>> code = purestr(MatrixSymbol('x', 2, 2))
     >>> code
-    "MatrixSymbol(Symbol('x'), Integer(2), Integer(2))"
+    "MatrixSymbol(Str('x'), Integer(2), Integer(2))"
     >>> eval(code) == MatrixSymbol('x', 2, 2)
     True
 
@@ -59,8 +60,8 @@ def purestr(x, with_args=False):
     >>> purestr(Float(2), with_args=True)
     ("Float('2.0', precision=53)", ())
     >>> purestr(MatrixSymbol('x', 2, 2), with_args=True)
-    ("MatrixSymbol(Symbol('x'), Integer(2), Integer(2))",
-     ("Symbol('x')", 'Integer(2)', 'Integer(2)'))
+    ("MatrixSymbol(Str('x'), Integer(2), Integer(2))",
+     ("Str('x')", 'Integer(2)', 'Integer(2)'))
     """
     sargs = ()
     if not isinstance(x, Basic):

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -102,7 +102,7 @@ def test_Matrix_and_non_basics():
 #########
 
 "MatrixSymbol(Str('X'), Symbol('n'), Symbol('n'))_()" ["color"="black", "label"="MatrixSymbol", "shape"="ellipse"];
-"Str('X')_(0,)" ["color"="black", "label"="X", "shape"="ellipse"];
+"Str('X')_(0,)" ["color"="blue", "label"="X", "shape"="ellipse"];
 "Symbol('n')_(1,)" ["color"="black", "label"="n", "shape"="ellipse"];
 "Symbol('n')_(2,)" ["color"="black", "label"="n", "shape"="ellipse"];
 

--- a/sympy/printing/tests/test_dot.py
+++ b/sympy/printing/tests/test_dot.py
@@ -101,8 +101,8 @@ def test_Matrix_and_non_basics():
 # Nodes #
 #########
 
-"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" ["color"="black", "label"="MatrixSymbol", "shape"="ellipse"];
-"Symbol('X')_(0,)" ["color"="black", "label"="X", "shape"="ellipse"];
+"MatrixSymbol(Str('X'), Symbol('n'), Symbol('n'))_()" ["color"="black", "label"="MatrixSymbol", "shape"="ellipse"];
+"Str('X')_(0,)" ["color"="black", "label"="X", "shape"="ellipse"];
 "Symbol('n')_(1,)" ["color"="black", "label"="n", "shape"="ellipse"];
 "Symbol('n')_(2,)" ["color"="black", "label"="n", "shape"="ellipse"];
 
@@ -110,9 +110,9 @@ def test_Matrix_and_non_basics():
 # Edges #
 #########
 
-"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('X')_(0,)";
-"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(1,)";
-"MatrixSymbol(Symbol('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(2,)";
+"MatrixSymbol(Str('X'), Symbol('n'), Symbol('n'))_()" -> "Str('X')_(0,)";
+"MatrixSymbol(Str('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(1,)";
+"MatrixSymbol(Str('X'), Symbol('n'), Symbol('n'))_()" -> "Symbol('n')_(2,)";
 }"""
 
 

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -6,6 +6,7 @@ from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol)
 from sympy.combinatorics import Cycle, Permutation
 from sympy.core.compatibility import exec_
+from sympy.core.symbol import Str
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
 from sympy.polys import ring, field, ZZ, QQ, lex, grlex, Poly
@@ -16,7 +17,7 @@ x, y = symbols('x,y')
 
 # eval(srepr(expr)) == expr has to succeed in the right environment. The right
 # environment is the scope of "from sympy import *" for most cases.
-ENV = {}  # type: Dict[str, Any]
+ENV = {"Str": Str}  # type: Dict[str, Any]
 exec_("from sympy import *", ENV)
 
 
@@ -295,9 +296,9 @@ def test_matrix_expressions():
     n = symbols('n', integer=True)
     A = MatrixSymbol("A", n, n)
     B = MatrixSymbol("B", n, n)
-    sT(A, "MatrixSymbol(Symbol('A'), Symbol('n', integer=True), Symbol('n', integer=True))")
-    sT(A*B, "MatMul(MatrixSymbol(Symbol('A'), Symbol('n', integer=True), Symbol('n', integer=True)), MatrixSymbol(Symbol('B'), Symbol('n', integer=True), Symbol('n', integer=True)))")
-    sT(A + B, "MatAdd(MatrixSymbol(Symbol('A'), Symbol('n', integer=True), Symbol('n', integer=True)), MatrixSymbol(Symbol('B'), Symbol('n', integer=True), Symbol('n', integer=True)))")
+    sT(A, "MatrixSymbol(Str('A'), Symbol('n', integer=True), Symbol('n', integer=True))")
+    sT(A*B, "MatMul(MatrixSymbol(Str('A'), Symbol('n', integer=True), Symbol('n', integer=True)), MatrixSymbol(Str('B'), Symbol('n', integer=True), Symbol('n', integer=True)))")
+    sT(A + B, "MatAdd(MatrixSymbol(Str('A'), Symbol('n', integer=True), Symbol('n', integer=True)), MatrixSymbol(Str('B'), Symbol('n', integer=True), Symbol('n', integer=True)))")
 
 
 def test_Cycle():

--- a/sympy/printing/tests/test_tree.py
+++ b/sympy/printing/tests/test_tree.py
@@ -184,11 +184,11 @@ def test_print_tree_MatAdd_noassumptions():
     test_str = \
 """MatAdd: A + B
 +-MatrixSymbol: A
-| +-Symbol: A
+| +-Str: A
 | +-Integer: 3
 | +-Integer: 3
 +-MatrixSymbol: B
-  +-Symbol: B
+  +-Str: B
   +-Integer: 3
   +-Integer: 3
 """

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -2,6 +2,7 @@ from sympy import (
     symbols, powsimp, MatrixSymbol, sqrt, pi, Mul, gamma, Function,
     S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest, root,
     Rational, oo, signsimp)
+from sympy.core.symbol import Str
 
 from sympy.abc import x, y, z, a, b
 
@@ -227,7 +228,7 @@ def test_issue_9324_powsimp_on_matrix_symbol():
     M = MatrixSymbol('M', 10, 10)
     expr = powsimp(M, deep=True)
     assert expr == M
-    assert expr.args[0] == Symbol('M')
+    assert expr.args[0] == Str('M')
 
 
 def test_issue_6367():

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -1,4 +1,5 @@
 from sympy import Add, Basic, symbols, Symbol, And
+from sympy.core.symbol import Str
 from sympy.unify.core import Compound, Variable
 from sympy.unify.usympy import (deconstruct, construct, unify, is_associative,
         is_commutative)
@@ -100,8 +101,8 @@ def test_matrix():
     X = MatrixSymbol('X', n, n)
     Y = MatrixSymbol('Y', 2, 2)
     Z = MatrixSymbol('Z', 2, 3)
-    assert list(unify(X, Y, {}, variables=[n, Symbol('X')])) == [{Symbol('X'): Symbol('Y'), n: 2}]
-    assert list(unify(X, Z, {}, variables=[n, Symbol('X')])) == []
+    assert list(unify(X, Y, {}, variables=[n, Str('X')])) == [{Str('X'): Str('Y'), n: 2}]
+    assert list(unify(X, Z, {}, variables=[n, Str('X')])) == []
 
 def test_non_frankenAdds():
     # the is_commutative property used to fail because of Basic.__new__


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Similar to #19714 
Close #19715

#### Brief description of what is fixed or changed

`MatrixSymbol`'s name argument is now `Str`, not `Symbol`.

#### Other comments

`Symbol` is a class for scalar symbol, which is equipped with assumptions. It should not be used to denote the name of other mathematical objects.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->