### PR TITLE
Remove support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,6 +263,7 @@ install:
         if [[ "${TEST_SETUP}" == "true" ]]; then
           # The install cycle below is to test installation on systems without
           # setuptools.
+          pip install virtualenv
           virtualenv ~/.venv-no-setuptools;
           ~/.venv-no-setuptools/bin/pip install mpmath;
           ~/.venv-no-setuptools/bin/pip uninstall -y setuptools;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 dist: trusty
 
 python:
-  - 3.5
+  - 3.6
 
 jobs:
   fast_finish: true
@@ -64,23 +64,66 @@ jobs:
             - gfortran
             - python-scipy
 
+    # Full tests. Hopefully basic problems were picked up in the previous
+    # stage.
     - stage: test
-      python: 2.7
+
+      # Code coverage tests. These are slow so put them first.
+      python: 3.7
       dist: xenial
       env:
-        - TEST_PY2_IMPORT="true"
+        - TEST_SYMPY="true"
+        - SPLIT="1/4"
+        - TEST_COVERAGE="true"
     - python: 3.7
       dist: xenial
       env:
-        - TEST_DOCTESTS="true" TEST_SETUP="true" TEST_EXAMPLES="true"
+        - TEST_SYMPY="true"
+        - SPLIT="2/4"
+        - TEST_COVERAGE="true"
     - python: 3.7
       dist: xenial
       env:
-        - TEST_SYMPY="true" SPLIT="1/2"
+        - TEST_SYMPY="true"
+        - SPLIT="3/4"
+        - TEST_COVERAGE="true"
     - python: 3.7
       dist: xenial
       env:
-        - TEST_SYMPY="true" SPLIT="2/2"
+        - TEST_SYMPY="true"
+        - SPLIT="4/4"
+        - TEST_COVERAGE="true"
+
+    # PyPy tests are slow so put them first
+    - python: "pypy"
+      env:
+        - TEST_DOCTESTS="true" TEST_EXAMPLES="true"
+      addons:
+        apt:
+          sources:
+            - pypy
+          packages:
+            - pypy3
+    - python: "pypy"
+      env:
+        - TEST_SYMPY="true"
+        - SPLIT="1/2"
+      addons:
+        apt:
+          sources:
+            - pypy
+          packages:
+            - pypy3
+    - python: "pypy"
+      env:
+        - TEST_SYMPY="true"
+        - SPLIT="2/2"
+      addons:
+        apt:
+          sources:
+            - pypy
+          packages:
+            - pypy3
 
     - python: 3.9-dev
       dist: xenial
@@ -132,66 +175,14 @@ jobs:
         - TEST_SLOW="true"
         - SPLIT="2/2"
 
-    # Code coverage tests
-    - python: 3.6
+    - python: 2.7
       dist: xenial
       env:
-        - TEST_SYMPY="true"
-        - SPLIT="1/4"
-        - TEST_COVERAGE="true"
-    - python: 3.6
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="2/4"
-        - TEST_COVERAGE="true"
-    - python: 3.6
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="3/4"
-        - TEST_COVERAGE="true"
-    - python: 3.6
-      dist: xenial
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="4/4"
-        - TEST_COVERAGE="true"
+        - TEST_PY2_IMPORT="true"
 
-    # PyPy randomly fails because of some PyPy bugs
-    # (Fatal RPython error: AssertionError)
-    - python: "pypy"
-      env:
-        - TEST_DOCTESTS="true" TEST_EXAMPLES="true"
-      addons:
-        apt:
-          sources:
-            - pypy
-          packages:
-            - pypy3
-    - python: "pypy"
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="1/2"
-      addons:
-        apt:
-          sources:
-            - pypy
-          packages:
-            - pypy3
-    - python: "pypy"
-      env:
-        - TEST_SYMPY="true"
-        - SPLIT="2/2"
-      addons:
-        apt:
-          sources:
-            - pypy
-          packages:
-            - pypy3
-
-    - stage: allowed_failures
-      python: 3.6
+    # Note: This never actually fails. The benchmark script doesn't report any
+    # failure exit code.
+    - python: 3.6
       dist: xenial
       env:
         - BENCHMARK="true"

--- a/bin/test_py2_import.py
+++ b/bin/test_py2_import.py
@@ -18,7 +18,7 @@ try:
     import sympy
 except ImportError as exc:
     message = str(exc)
-    # "Python version 3.5 or above is required for SymPy."
+    # e.g. "Python version 3.5 or above is required for SymPy."
     assert message.startswith("Python version")
     assert message.endswith(" or above is required for SymPy.")
 else:

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ except ImportError:
               % min_mpmath_version)
         sys.exit(-1)
 
-if sys.version_info < (3, 5):
-    print("SymPy requires Python 3.5 or newer. Python %d.%d detected"
+if sys.version_info < (3, 6):
+    print("SymPy requires Python 3.6 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 
@@ -448,7 +448,7 @@ if __name__ == '__main__':
                     'antlr': antlr,
                     'sdist': sdist_sympy,
                     },
-          python_requires='>=3.5',
+          python_requires='>=3.6',
           classifiers=[
             'License :: OSI Approved :: BSD License',
             'Operating System :: OS Independent',
@@ -457,7 +457,6 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Physics',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -13,8 +13,8 @@ See the webpage for more information and documentation:
 
 
 import sys
-if sys.version_info < (3, 5):
-    raise ImportError("Python version 3.5 or above is required for SymPy.")
+if sys.version_info < (3, 6):
+    raise ImportError("Python version 3.6 or above is required for SymPy.")
 del sys
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Remove tests for Python 3.5 on Travis.

Update minimum supported Python version in setup.py

#### Other comments

Python 3.5 has reached EOL.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- other
  - Support for Python 3.5 has been dropped. SymPy now requires Python 3.6 or newer.
<!-- END RELEASE NOTES -->