### PR TITLE
Crypto: Fix contradictory docstring in padded_key

### DIFF
--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -81,10 +81,9 @@ bifid10 = printable
 
 def padded_key(key, symbols):
     """Return a string of the distinct characters of ``symbols`` with
-    those of ``key`` appearing first, omitting characters in ``key``
-    that are not in ``symbols``. A ValueError is raised if a) there are
-    duplicate characters in ``symbols`` or b) there are characters
-    in ``key`` that are  not in ``symbols``.
+    those of ``key`` appearing first. A ValueError is raised if
+    a) there are duplicate characters in ``symbols`` or
+    b) there are characters in ``key`` that are  not in ``symbols``.
 
     Examples
     ========


### PR DESCRIPTION
The earlier docstring of the padded_key() was contradicting
itself and thus was not clear. The commit intends to fix this.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->