### PR TITLE
Enhance str and repr printing of AppliedPredicate

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -156,7 +156,7 @@ class Predicate(Boolean):
         return obj
 
     def _hashable_content(self):
-        return (self.name, tuple(self.handlers))
+        return (self.name,)
 
     def __getnewargs__(self):
         return (self.name, self.handlers)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -156,10 +156,10 @@ class Predicate(Boolean):
         return obj
 
     def _hashable_content(self):
-        return (self.name,)
+        return (self.name, tuple(self.handlers))
 
     def __getnewargs__(self):
-        return (self.name,)
+        return (self.name, self.handlers)
 
     def __call__(self, expr):
         return AppliedPredicate(self, expr)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -241,11 +241,17 @@ class ReprPrinter(Printer):
             )
 
     def _print_Predicate(self, expr):
-        return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        name_repr = self._print(expr.name)
+        if expr.handlers:
+            handlers_repr = self._print(expr.handlers)
+            args_repr = ', '.join([name_repr, handlers_repr])
+        else:
+            args_repr = name_repr
+        return "%s(%s)" % (expr.__class__.__name__, args_repr)
 
     def _print_AppliedPredicate(self, expr):
-        return "%s(%s, %s)" % (
-            expr.__class__.__name__, expr.func, self.reprify(expr.args, ", ")
+        return "%s(%s)" % (
+            expr.__class__.__name__, self.reprify((expr.func,) + expr.args, ", ")
         )
 
     def _print_str(self, expr):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -241,18 +241,12 @@ class ReprPrinter(Printer):
             )
 
     def _print_Predicate(self, expr):
-        name_repr = self._print(expr.name)
-        if expr.handlers:
-            handlers_repr = self._print(expr.handlers)
-            args_repr = ', '.join([name_repr, handlers_repr])
-        else:
-            args_repr = name_repr
-        return "%s(%s)" % (expr.__class__.__name__, args_repr)
+        args = (expr.name, expr.handlers) if expr.handlers else (expr.name,)
+        return "%s(%s)" % (expr.__class__.__name__, self.reprify(args, ","))
 
     def _print_AppliedPredicate(self, expr):
-        return "%s(%s)" % (
-            expr.__class__.__name__, self.reprify((expr.func,) + expr.args, ", ")
-        )
+        args = (expr.func,) + expr.args
+        return "%s(%s)" % (expr.__class__.__name__, self.reprify(args, ", "))
 
     def _print_str(self, expr):
         return repr(expr)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -241,8 +241,7 @@ class ReprPrinter(Printer):
             )
 
     def _print_Predicate(self, expr):
-        args = (expr.name, expr.handlers) if expr.handlers else (expr.name,)
-        return "%s(%s)" % (expr.__class__.__name__, self.reprify(args, ","))
+        return "Q.%s" % expr.name
 
     def _print_AppliedPredicate(self, expr):
         args = (expr.func,) + expr.args

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -244,7 +244,9 @@ class ReprPrinter(Printer):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
 
     def _print_AppliedPredicate(self, expr):
-        return "%s(%s, %s)" % (expr.__class__.__name__, expr.func, expr.arg)
+        return "%s(%s, %s)" % (
+            expr.__class__.__name__, expr.func, self.reprify(expr.args, ", ")
+        )
 
     def _print_str(self, expr):
         return repr(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -87,7 +87,9 @@ class StrPrinter(Printer):
         return self.stringify(expr.args, " ^ ", PRECEDENCE["BitwiseXor"])
 
     def _print_AppliedPredicate(self, expr):
-        return '%s(%s)' % (self._print(expr.func), self._print(expr.arg))
+        return '%s(%s)' % (
+            self._print(expr.func), self.stringify(expr.args, ", ")
+        )
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from sympy.testing.pytest import raises
 from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
-    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol)
+    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol, Q)
 from sympy.combinatorics import Cycle, Permutation
 from sympy.core.compatibility import exec_
 from sympy.core.symbol import Str
@@ -335,3 +335,7 @@ def test_set():
     assert srepr(s) == "set()"
     s = {x, y}
     assert srepr(s) in ("{Symbol('x'), Symbol('y')}", "{Symbol('y'), Symbol('x')}")
+
+
+def test_AppliedPredicate():
+    sT(Q.even(Symbol('z')), "AppliedPredicate(Q.even, Symbol('z'))")

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from sympy.testing.pytest import raises
 from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
-    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol, Q)
+    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol, Q, Predicate)
 from sympy.combinatorics import Cycle, Permutation
 from sympy.core.compatibility import exec_
 from sympy.core.symbol import Str
@@ -337,5 +337,12 @@ def test_set():
     assert srepr(s) in ("{Symbol('x'), Symbol('y')}", "{Symbol('y'), Symbol('x')}")
 
 
+def test_Predicate():
+    sT(Q.even, "Predicate('even', ['sympy.assumptions.handlers.ntheory.AskEvenHandler'])")
+    sT(Predicate('test'), "Predicate('test')")
+
 def test_AppliedPredicate():
-    sT(Q.even(Symbol('z')), "AppliedPredicate(Q.even, Symbol('z'))")
+    sT(
+        Q.even(Symbol('z')),
+        "AppliedPredicate(Predicate('even', ['sympy.assumptions.handlers.ntheory.AskEvenHandler']), Symbol('z'))"
+    )

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -338,11 +338,7 @@ def test_set():
 
 
 def test_Predicate():
-    sT(Q.even, "Predicate('even', ['sympy.assumptions.handlers.ntheory.AskEvenHandler'])")
-    sT(Predicate('test'), "Predicate('test')")
+    sT(Q.even, "Q.even")
 
 def test_AppliedPredicate():
-    sT(
-        Q.even(Symbol('z')),
-        "AppliedPredicate(Predicate('even', ['sympy.assumptions.handlers.ntheory.AskEvenHandler']), Symbol('z'))"
-    )
+    sT(Q.even(Symbol('z')), "AppliedPredicate(Q.even, Symbol('z'))")

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1003,5 +1003,8 @@ def test_NDimArray():
     assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'
 
 
+def test_Predicate():
+    assert sstr(Q.even) == 'Q.even'
+
 def test_AppliedPredicate():
     assert sstr(Q.even(x)) == 'Q.even(x)'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,8 @@ from sympy import (Add, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice)
+    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice,
+    Q,)
 from sympy.core import Expr, Mul
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
 from sympy.physics.units import second, joule
@@ -1000,3 +1001,7 @@ def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=True) == '[1.00000000000000, 2.00000000000000]'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'
+
+
+def test_AppliedPredicate():
+    assert sstr(Q.even(x)) == 'Q.even(x)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Before this PR:
```python
>>> from sympy import *
>>> srepr(Q.even(Symbol('x')))
'AppliedPredicate(Q.even, x)'
>>> eval(srepr(Q.even(Symbol('x'))))
Traceback (most recent call last)
...
NameError: name 'x' is not defined
```

After this PR:
```python
>>> from sympy import *
>>> srepr(Q.even(Symbol('x')))
'AppliedPredicate(Q.even, Symbol('x'))'
>>> eval(srepr(Q.even(Symbol('x'))))
Q.even(x)
```

#### Other comments

Now, printing is based on `args` instead of  `arg` to support potential subclass.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->