### PR TITLE
Added symbol support

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -698,11 +698,15 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
     This gives the same answer as the ``[0, 1, 2]`` state space.
     Currently, there is no support for state names within probability
-    and expectation statements. Here is a work-around using ``index_of``:
+    and expectation statements. Here is a work-around using ``Str``:
 
-    >>> P(Eq(Y[3], Y.index_of['Rainy']), Eq(Y[1], Y.index_of['Cloudy'])).round(2)
+    >>> from sympy.core.symbol import Str
+    >>> P(Eq(Y[3], Str('Rainy')), Eq(Y[1], Str('Cloudy'))).round(2)
     0.36
 
+    >>> E(Y[3], Eq(Y[1], Str("Cloudy")))
+    0.38*Cloudy + 0.36*Rainy + 0.26*Sunny
+    
     Symbol state names can also be used:
 
     >>> sunny, cloudy, rainy = symbols('Sunny, Cloudy, Rainy')

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -433,8 +433,8 @@ class MarkovProcess(StochasticProcess):
 
         # `not None` is `True`. So the old test fails for symbolic sizes.
         # Need to build the statement differently.
-        cond1 = (not isinstance(state_index, Range) and
-                 FiniteSet(*[i for i in range(trans_probs.shape[0])]).is_subset(FiniteSet(*[j for j in state_index])) is False)
+        sym_cond = isinstance((state_index.args[1] - state_index.args[0]) // state_index.args[2], Symbol)
+        cond1 = not sym_cond and len(state_index) != trans_probs.shape[0]
         if cond1:
             raise ValueError("state space is not compatible with the transition probabilities.")
         state_index = FiniteSet(*[i for i in range(trans_probs.shape[0])])
@@ -732,7 +732,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     than state names. For example, with the Sunny-Cloudy-Rainy
     model with string state names:
 
-    >>> Y = DiscreteMarkovChain("Y", ['Sunny', 'Cloudy', 'Rainy'], T)
+    >>> from sympy.core.symbol import Str
+    >>> Y = DiscreteMarkovChain("Y", [Str('Sunny'), Str('Cloudy'), Str('Rainy')], T)
     >>> P(Eq(Y[3], 2), Eq(Y[1], 1)).round(2)
     0.36
 
@@ -740,7 +741,6 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     Currently, there is no support for state names within probability
     and expectation statements. Here is a work-around using ``Str``:
 
-    >>> from sympy.core.symbol import Str
     >>> P(Eq(Y[3], Str('Rainy')), Eq(Y[1], Str('Cloudy'))).round(2)
     0.36
 

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -432,7 +432,7 @@ class MarkovProcess(StochasticProcess):
 
         # `not None` is `True`. So the old test fails for symbolic sizes.
         # Need to build the statement differently.
-        sym_cond = isinstance(self.number_of_states, Symbol)
+        sym_cond = not isinstance(self.number_of_states, (int, Integer))
         cond1 = not sym_cond and len(state_index) != trans_probs.shape[0]
         if cond1:
             raise ValueError("state space is not compatible with the transition probabilities.")

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -312,7 +312,7 @@ class StochasticStateSpaceOf(Boolean):
                                 "support StochasticStateSpaceOf.")
         state_space = _state_converter(state_space)
         if isinstance(state_space, Range):
-            ss_size = (state_space.stop - state_space.start) // state_space.step
+            ss_size = ceiling((state_space.stop - state_space.start) / state_space.step)
         else:
             ss_size = len(state_space)
         state_index = Range(ss_size)
@@ -430,7 +430,6 @@ class MarkovProcess(StochasticProcess):
                         given_condition.atoms(RandomIndexedSymbol))
             if len(rand_var) == 1:
                 state_index = rand_var[0].pspace.set
-                print(state_index)
 
         # `not None` is `True`. So the old test fails for symbolic sizes.
         # Need to build the statement differently.
@@ -474,8 +473,11 @@ class MarkovProcess(StochasticProcess):
 
     def replace_with_index(self, condition):
         if isinstance(condition, Relational):
-            condition = type(condition)(self.index_of.get(condition.lhs, condition.lhs),
-                                        self.index_of.get(condition.rhs, condition.rhs))
+            lhs, rhs = condition.lhs, condition.rhs
+            if not isinstance(lhs, RandomIndexedSymbol):
+                lhs, rhs = rhs, lhs
+            condition = type(condition)(self.index_of.get(lhs, lhs),
+                                        self.index_of.get(rhs, rhs))
         return condition
 
     def probability(self, condition, given_condition=None, evaluate=True, **kwargs):
@@ -743,7 +745,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     Currently, there is no support for state names within probability
     and expectation statements. Here is a work-around using ``Str``:
 
-    >>> P(Eq(Y[3], Str('Rainy')), Eq(Y[1], Str('Cloudy'))).round(2)
+    >>> P(Eq(Str('Rainy'), Y[3]), Eq(Y[1], Str('Cloudy'))).round(2)
     0.36
 
     Symbol state names can also be used:

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -426,12 +426,9 @@ class MarkovProcess(StochasticProcess):
             if condition.rhs.is_symbol:
                 try:
                     return Eq(condition.lhs, self.state_space.index(condition.rhs))
-                except (NameError, ValueError) as e:
+                except:
                     raise NameError('%s not found in the state space'%condition.rhs)
-            else:
-                return condition
-        else:
-            return condition
+        return condition
 
     def probability(self, condition, given_condition=None, evaluate=True, **kwargs):
         """

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -430,14 +430,16 @@ class MarkovProcess(StochasticProcess):
                         given_condition.atoms(RandomIndexedSymbol))
             if len(rand_var) == 1:
                 state_index = rand_var[0].pspace.set
+                print(state_index)
 
         # `not None` is `True`. So the old test fails for symbolic sizes.
         # Need to build the statement differently.
-        sym_cond = isinstance((state_index.args[1] - state_index.args[0]) // state_index.args[2], Symbol)
+        sym_cond = isinstance(self.number_of_states, Symbol)
         cond1 = not sym_cond and len(state_index) != trans_probs.shape[0]
         if cond1:
             raise ValueError("state space is not compatible with the transition probabilities.")
-        state_index = FiniteSet(*[i for i in range(trans_probs.shape[0])])
+        if not isinstance(trans_probs.shape[0], Symbol):
+            state_index = FiniteSet(*[i for i in range(trans_probs.shape[0])])
         return state_index
 
     @cacheit
@@ -547,7 +549,7 @@ class MarkovProcess(StochasticProcess):
 
             if any((k not in self.index_set) for k in (rv.key, min_key_rv.key)):
                 raise IndexError("The timestamps of the process are not in it's index set.")
-            states = Intersection(states, state_index)
+            states = Intersection(states, state_index) if not isinstance(self.number_of_states, Symbol) else states
             for state in Union(states, FiniteSet(gstate)):
                 if not isinstance(state, (int, Integer)) or Ge(state, mat.shape[0]) is True:
                     raise IndexError("No information is available for (%s, %s) in "

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -426,7 +426,7 @@ class MarkovProcess(StochasticProcess):
             if condition.rhs.is_symbol:
                 try:
                     return Eq(condition.lhs, self.state_space.index(condition.rhs))
-                except:
+                except NameError:
                     raise NameError('%s not found in the state space'%condition.rhs)
         return condition
 

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -25,7 +25,6 @@ from sympy.stats.frv_types import Bernoulli, BernoulliDistribution, FiniteRV
 from sympy.stats.drv_types import Poisson, PoissonDistribution
 from sympy.stats.crv_types import Normal, NormalDistribution, Gamma, GammaDistribution
 from sympy.core.sympify import _sympify, sympify
-from sympy.core.symbol import Str
 
 __all__ = [
     'StochasticProcess',

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -704,12 +704,12 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
     >>> sunny, cloudy, rainy = symbols('Sunny, Cloudy, Rainy')
     >>> Y = DiscreteMarkovChain("Y", [sunny, cloudy, rainy], T)
-    >>> P(Eq(Y[3], Y.index_of[rainy]), Eq(Y[1], Y.index_of[cloudy])).round(2)
+    >>> P(Eq(Y[3], rainy), Eq(Y[1], cloudy)).round(2)
     0.36
 
     Expectations will be calculated as follows:
 
-    >>> E(Y[3], Eq(Y[1], Y.index_of[cloudy]))
+    >>> E(Y[3], Eq(Y[1], cloudy))
     0.38*Cloudy + 0.36*Rainy + 0.26*Sunny
 
     There is limited support for arbitrarily sized states:

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -334,14 +334,14 @@ class MarkovProcess(StochasticProcess):
         The number of states in the Markov Chain.
         """
         return _sympify(self.args[2].shape[0])
-    
+
     @property
     def _state_index(self) -> Range:
         """
         Returns state index as Range.
         """
         return Range(self.number_of_states)
-    
+
     @classmethod
     def _sanity_checks(cls, state_space, trans_probs):
         # Try to never have None as state_space or trans_probs.
@@ -375,7 +375,7 @@ class MarkovProcess(StochasticProcess):
             if ss_size != trans_probs.shape[0]:
                 raise ValueError('The size of the state space and the number of '
                                  'rows of the transition matrix must be the same.')
-        
+
         return state_space, trans_probs
 
     def _extract_information(self, given_condition):
@@ -471,7 +471,7 @@ class MarkovProcess(StochasticProcess):
 
     def replace_with_index(self, condition):
         if isinstance(condition, Relational):
-            condition = type(condition)(self.index_of.get(condition.lhs, condition.lhs), 
+            condition = type(condition)(self.index_of.get(condition.lhs, condition.lhs),
                                         self.index_of.get(condition.rhs, condition.rhs))
         return condition
 

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -433,7 +433,9 @@ class MarkovProcess(StochasticProcess):
 
         # `not None` is `True`. So the old test fails for symbolic sizes.
         # Need to build the statement differently.
-        if FiniteSet(*[i for i in range(trans_probs.shape[0])]).is_subset(FiniteSet(*[j for j in state_index])) is False:
+        cond1 = (not isinstance(state_index, Range) and
+                 FiniteSet(*[i for i in range(trans_probs.shape[0])]).is_subset(FiniteSet(*[j for j in state_index])) is False)
+        if cond1:
             raise ValueError("state space is not compatible with the transition probabilities.")
         state_index = FiniteSet(*[i for i in range(trans_probs.shape[0])])
         return state_index
@@ -741,9 +743,6 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
     >>> from sympy.core.symbol import Str
     >>> P(Eq(Y[3], Str('Rainy')), Eq(Y[1], Str('Cloudy'))).round(2)
     0.36
-
-    >>> E(Y[3], Eq(Y[1], Str("Cloudy")))
-    0.38*Cloudy + 0.36*Rainy + 0.26*Sunny
 
     Symbol state names can also be used:
 

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -706,7 +706,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
     >>> E(Y[3], Eq(Y[1], Str("Cloudy")))
     0.38*Cloudy + 0.36*Rainy + 0.26*Sunny
-    
+
     Symbol state names can also be used:
 
     >>> sunny, cloudy, rainy = symbols('Sunny, Cloudy, Rainy')

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -549,7 +549,7 @@ class MarkovProcess(StochasticProcess):
                 raise IndexError("The timestamps of the process are not in it's index set.")
             states = Intersection(states, state_index)
             for state in Union(states, FiniteSet(gstate)):
-                if Ge(state, mat.shape[0]) == True:
+                if not isinstance(state, (int, Integer)) or Ge(state, mat.shape[0]) is True:
                     raise IndexError("No information is available for (%s, %s) in "
                         "transition probabilities of shape, (%s, %s). "
                         "State space is zero indexed."

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -1,5 +1,5 @@
 from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And,
-                   ImmutableMatrix, Ne, Lt, Gt, exp, Not, Rational, Lambda, erf,
+                   ImmutableMatrix, Ne, Lt, Le, Gt, Ge, exp, Not, Rational, Lambda, erf,
                    Piecewise, factorial, Interval, oo, Contains, sqrt, pi, ceiling,
                    gamma, lowergamma, Sum, Range, Tuple, ImmutableDenseMatrix)
 from sympy.stats import (DiscreteMarkovChain, P, TransitionMatrixOf, E,
@@ -38,12 +38,12 @@ def test_DiscreteMarkovChain():
     # pass name and state_space
     # any hashable object should be a valid state
     # states should be valid as a tuple/set/list/Tuple/Range
-    sym = symbols('a', real=True)
+    sym, rainy, cloudy, sunny = symbols('a Rainy Cloudy Sunny', real=True)
     state_spaces = [(1, 2, 3), [Str('Hello'), sym, DiscreteMarkovChain],
-                    Tuple(1, exp(sym), Str('World'), sympify=False), Range(-1, 7, 2)]
-    chains = [DiscreteMarkovChain("Y", state_spaces[0]),
-              DiscreteMarkovChain("Y", state_spaces[1]),
-              DiscreteMarkovChain("Y", state_spaces[2])]
+                    Tuple(1, exp(sym), Str('World'), sympify=False), Range(-1, 5, 2),
+                    [rainy, cloudy, sunny]]
+    chains = [DiscreteMarkovChain("Y", state_space) for state_space in state_spaces]
+
     for i, Y in enumerate(chains):
         assert isinstance(Y.transition_probabilities, MatrixSymbol)
         assert Y.state_space == Tuple(*state_spaces[i])
@@ -58,6 +58,8 @@ def test_DiscreteMarkovChain():
         assert E(Y[0]) == Expectation(Y[0])
 
         raises(ValueError, lambda: next(sample_stochastic_process(Y)))
+
+    assert P(Ge(rainy, Y[3]), Eq(Y[1], cloudy)) == P(Le(Y[3], 0), Eq(Y[1], Str("Cloudy")))
 
     raises(TypeError, lambda: DiscreteMarkovChain("Y", dict((1, 1))))
     Y = DiscreteMarkovChain("Y", Range(1, t, 2))

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -31,6 +31,12 @@ def test_DiscreteMarkovChain():
     raises(TypeError, lambda: DiscreteMarkovChain(1))
     raises(NotImplementedError, lambda: X(t))
 
+    nz = Symbol('n', integer=True)
+    TZ = MatrixSymbol('M', nz, nz)
+    SZ = Range(nz)
+    YZ = DiscreteMarkovChain('Y', SZ, TZ)
+    assert P(Eq(YZ[2], 1), Eq(YZ[1], 0)) == TZ[0, 1]
+
     raises(ValueError, lambda: sample_stochastic_process(t))
     raises(ValueError, lambda: next(sample_stochastic_process(X)))
     # pass name and state_space
@@ -96,7 +102,7 @@ def test_DiscreteMarkovChain():
     raises(ValueError, lambda: E(Y[2], Eq(Y[3], 1)))
 
 
-    # extended tests for probability queries
+    # extended tests for probability queriess
     TO1 = Matrix([[Rational(1, 4), Rational(3, 4), 0],[Rational(1, 3), Rational(1, 3), Rational(1, 3)],[0, Rational(1, 4), Rational(3, 4)]])
     assert P(And(Eq(Y[2], 1), Eq(Y[1], 1), Eq(Y[0], 0)),
             Eq(Probability(Eq(Y[0], 0)), Rational(1, 4)) & TransitionMatrixOf(Y, TO1)) == Rational(1, 16)

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -1,7 +1,7 @@
 from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And,
                    ImmutableMatrix, Ne, Lt, Le, Gt, Ge, exp, Not, Rational, Lambda, erf,
                    Piecewise, factorial, Interval, oo, Contains, sqrt, pi, ceiling,
-                   gamma, lowergamma, Sum, Range, Tuple, ImmutableDenseMatrix)
+                   gamma, lowergamma, Sum, Range, Tuple, ImmutableDenseMatrix, Symbol)
 from sympy.stats import (DiscreteMarkovChain, P, TransitionMatrixOf, E,
                          StochasticStateSpaceOf, variance, ContinuousMarkovChain,
                          BernoulliProcess, PoissonProcess, WienerProcess,
@@ -23,8 +23,6 @@ def test_DiscreteMarkovChain():
     # pass only the name
     X = DiscreteMarkovChain("X")
     assert isinstance(X.state_space, Range)
-    assert isinstance(X.index_of, Range)
-    assert not X._is_numeric
     assert X.index_set == S.Naturals0
     assert isinstance(X.transition_probabilities, MatrixSymbol)
     t = symbols('t', positive=True, integer=True)
@@ -48,7 +46,6 @@ def test_DiscreteMarkovChain():
         assert isinstance(Y.transition_probabilities, MatrixSymbol)
         assert Y.state_space == Tuple(*state_spaces[i])
         assert Y.number_of_states == 3
-        assert not Y._is_numeric  # because no transition matrix is provided
         assert Y.index_of[state_spaces[i][0]] == 0
         assert Y.index_of[state_spaces[i][1]] == 1
         assert Y.index_of[state_spaces[i][2]] == 2
@@ -59,12 +56,9 @@ def test_DiscreteMarkovChain():
 
         raises(ValueError, lambda: next(sample_stochastic_process(Y)))
 
-    assert P(Ge(rainy, Y[3]), Eq(Y[1], cloudy)) == P(Le(Y[3], 0), Eq(Y[1], Str("Cloudy")))
-
     raises(TypeError, lambda: DiscreteMarkovChain("Y", dict((1, 1))))
     Y = DiscreteMarkovChain("Y", Range(1, t, 2))
     assert Y.number_of_states == ceiling((t-1)/2)
-    raises(NotImplementedError, lambda: Y.index_of)
 
     # pass name and transition_probabilities
     chains = [DiscreteMarkovChain("Y", trans_probs=Matrix([[]])),
@@ -74,7 +68,6 @@ def test_DiscreteMarkovChain():
         assert Z.number_of_states == Z.transition_probabilities.shape[0]
         assert isinstance(Z.transition_probabilities, ImmutableDenseMatrix)
         assert isinstance(Z.state_space, Tuple)
-        assert Z._is_numeric
 
     # pass name, state_space and transition_probabilities
     T = Matrix([[0.5, 0.2, 0.3],[0.2, 0.5, 0.3],[0.2, 0.3, 0.5]])
@@ -89,7 +82,7 @@ def test_DiscreteMarkovChain():
     assert (P(Eq(YS[3], 2), Eq(YS[1], 1)) -
             (TS[0, 2]*TS[1, 0] + TS[1, 1]*TS[1, 2] + TS[1, 2]*TS[2, 2])).simplify() == 0
     assert P(Eq(YS[1], 1), Eq(YS[2], 2)) == Probability(Eq(YS[1], 1))
-    assert P(Eq(YS[3], 3), Eq(YS[1], 1)) is S.Zero
+    assert P(Eq(YS[3], 3), Eq(YS[1], 1)) == TS[0, 2]*TS[1, 0] + TS[1, 1]*TS[1, 2] + TS[1, 2]*TS[2, 2]
     TO = Matrix([[0.25, 0.75, 0],[0, 0.25, 0.75],[0.75, 0, 0.25]])
     assert P(Eq(Y[3], 2), Eq(Y[1], 1) & TransitionMatrixOf(Y, TO)).round(3) == Float(0.375, 3)
     with ignore_warnings(UserWarning): ### TODO: Restore tests once warnings are removed
@@ -229,6 +222,10 @@ def test_ContinuousMarkovChain():
     CS1 = ContinuousMarkovChain('C', [0, 1, 2], TS1)
     A = CS1.generator_matrix
     assert CS1.transition_probabilities(A)(t) == exp(t*A)
+
+    C3 = ContinuousMarkovChain('C', [Symbol('0'), Symbol('1'), Symbol('2')], T2)
+    assert P(Eq(C3(1), 1), Eq(C3(0), 1)) == exp(-2)/2 + S.Half
+    assert P(Eq(C3(1), Symbol('1')), Eq(C3(0), Symbol('1'))) == exp(-2)/2 + S.Half
 
 def test_BernoulliProcess():
 

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -50,11 +50,8 @@ def test_DiscreteMarkovChain():
 
     for i, Y in enumerate(chains):
         assert isinstance(Y.transition_probabilities, MatrixSymbol)
-        assert Y.state_space == Tuple(*state_spaces[i])
+        assert Y.state_space == state_spaces[i] or Y.state_space == FiniteSet(*state_spaces[i])
         assert Y.number_of_states == 3
-        assert Y.index_of[state_spaces[i][0]] == 0
-        assert Y.index_of[state_spaces[i][1]] == 1
-        assert Y.index_of[state_spaces[i][2]] == 2
 
         with ignore_warnings(UserWarning):  # TODO: Restore tests once warnings are removed
             assert P(Eq(Y[2], 1), Eq(Y[0], 2), evaluate=False) == Probability(Eq(Y[2], 1), Eq(Y[0], 2))
@@ -73,7 +70,6 @@ def test_DiscreteMarkovChain():
     for Z in chains:
         assert Z.number_of_states == Z.transition_probabilities.shape[0]
         assert isinstance(Z.transition_probabilities, ImmutableDenseMatrix)
-        assert isinstance(Z.state_space, Tuple)
 
     # pass name, state_space and transition_probabilities
     T = Matrix([[0.5, 0.2, 0.3],[0.2, 0.5, 0.3],[0.2, 0.3, 0.5]])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -102,7 +102,7 @@ def test_DiscreteMarkovChain():
     raises(ValueError, lambda: E(Y[2], Eq(Y[3], 1)))
 
 
-    # extended tests for probability queriess
+    # extended tests for probability queries
     TO1 = Matrix([[Rational(1, 4), Rational(3, 4), 0],[Rational(1, 3), Rational(1, 3), Rational(1, 3)],[0, Rational(1, 4), Rational(3, 4)]])
     assert P(And(Eq(Y[2], 1), Eq(Y[1], 1), Eq(Y[0], 0)),
             Eq(Probability(Eq(Y[0], 0)), Rational(1, 4)) & TransitionMatrixOf(Y, TO1)) == Rational(1, 16)

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -1,5 +1,5 @@
 from sympy import (S, symbols, FiniteSet, Eq, Matrix, MatrixSymbol, Float, And,
-                   ImmutableMatrix, Ne, Lt, Le, Gt, Ge, exp, Not, Rational, Lambda, erf,
+                   ImmutableMatrix, Ne, Lt, Gt, exp, Not, Rational, Lambda, erf,
                    Piecewise, factorial, Interval, oo, Contains, sqrt, pi, ceiling,
                    gamma, lowergamma, Sum, Range, Tuple, ImmutableDenseMatrix, Symbol)
 from sympy.stats import (DiscreteMarkovChain, P, TransitionMatrixOf, E,


### PR DESCRIPTION
Fix #20138 

#### Brief description of what is fixed or changed
I've added a function which removes index_of for symbols

#### Other comments
To be done for strings as well

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* stats
    * The state space of `ContinuousMarkovChain` is now by default a `Range` object instead of `S.Reals`.
    * The generator matrix of `ContinuousMarkovChain` is now by default a `MatrixSymbol` object instead of `None`.
<!-- END RELEASE NOTES -->