### PR TITLE
Introduce polyadic predicate and Q.coprime

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1245,8 +1245,10 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     if isinstance(proposition, AppliedPredicate):
         key, expr = proposition.func, sympify(proposition.arg)
+        args = proposition.args
     else:
         key, expr = Q.is_true, sympify(proposition)
+        args = (expr,)
 
     assump = CNF.from_prop(assumptions)
     assump.extend(context)
@@ -1281,7 +1283,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
                     return False
 
     # direct resolution method, no logic
-    res = key(expr)._eval_ask(assumptions)
+    res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
     # using satask (still costly)
@@ -1301,7 +1303,7 @@ def ask_full_inference(proposition, assumptions, known_facts_cnf):
     return None
 
 
-def register_handler(key, handler):
+def register_handler(key, handler, arity=1):
     """
     Register a handler in the ask system. key must be a string and handler a
     class inheriting from AskHandler::
@@ -1325,7 +1327,7 @@ def register_handler(key, handler):
     if Qkey is not None:
         Qkey.add_handler(handler)
     else:
-        setattr(Q, key, Predicate(key, handlers=[handler]))
+        setattr(Q, key, Predicate(key, handlers=[handler], arity=arity))
 
 
 def remove_handler(key, handler):
@@ -1416,7 +1418,7 @@ def compute_known_facts(known_facts, known_facts_keys):
 _val_template = 'sympy.assumptions.handlers.%s'
 _handlers = [
     ("antihermitian",     "sets.AskAntiHermitianHandler"),
-    ("finite",           "calculus.AskFiniteHandler"),
+    ("finite",            "calculus.AskFiniteHandler"),
     ("commutative",       "AskCommutativeHandler"),
     ("complex",           "sets.AskComplexHandler"),
     ("composite",         "ntheory.AskCompositeHandler"),
@@ -1453,8 +1455,13 @@ _handlers = [
     ("complex_elements",  "matrices.AskComplexElementsHandler"),
 ]
 
-for name, value in _handlers:
-    register_handler(name, _val_template % value)
+for tup in _handlers:
+    if len(tup) == 2:
+        name, value = tup
+        arity = 1
+    else:
+        name, value, arity = tup
+    register_handler(name, _val_template % value, arity)
 
 @cacheit
 def get_known_facts_keys():

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1453,6 +1453,7 @@ _handlers = [
     ("integer_elements",  "matrices.AskIntegerElementsHandler"),
     ("real_elements",     "matrices.AskRealElementsHandler"),
     ("complex_elements",  "matrices.AskComplexElementsHandler"),
+    ("coprime",           "ntheory.AskCoprimeHandler",              2),
 ]
 
 for tup in _handlers:

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -121,6 +121,13 @@ class AppliedPredicate(Boolean):
                 return i.binary_symbols
         return set()
 
+class PolyadicAppliedPredicate(AppliedPredicate):
+    def __new__(cls, predicate, *args):
+        if predicate.arity != len(args):
+            raise TypeError("%s takes %d argument but %d were given" % (predicate, predicate.arity, len(args)))
+        args = Tuple(*[_sympify(a) for a in args])
+        return Boolean.__new__(cls, predicate, args)
+
 
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.
@@ -167,7 +174,10 @@ class Predicate(Boolean):
         return (self.name,)
 
     def __call__(self, *args):
-        return AppliedPredicate(self, *args)
+        if len(args) == 1:
+            arg, = args
+            return AppliedPredicate(self, arg)
+        return PolyadicAppliedPredicate(self, args)
 
     def add_handler(self, handler):
         self.handlers.append(handler)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -165,12 +165,16 @@ class Predicate(Boolean):
 
     is_Atom = True
 
-    def __new__(cls, name, handlers=None, arity=1):
-        obj = Boolean.__new__(cls)
+    def __new__(cls, name, handlers=None, arity=S.One):
+        arity = _sympify(arity)
+        obj = Boolean.__new__(cls, arity)
         obj.name = name
         obj.handlers = handlers or []
-        obj.arity = arity
         return obj
+
+    @property
+    def arity(self):
+        return self.args[0]
 
     def _hashable_content(self):
         return (self.name,)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -233,14 +233,13 @@ class Predicate(Boolean):
 
         This uses only direct resolution methods, not logical inference.
         """
-        args_types = [type(a) for a in args]
         handlers = [h for h in self.handlers]
         while handlers:
             handler = handlers.pop(0)
             dispatcher = get_class(handler)
             try:
                 res = dispatcher(*args, assumptions=assumptions)
-            except NotImplementedError as error:
+            except NotImplementedError:
                 if handlers:
                     continue
                 return None

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -62,11 +62,9 @@ class AppliedPredicate(Boolean):
     """
     __slots__ = ()
 
-    def __new__(cls, predicate, *args):
-        if predicate.arity != len(args):
-            raise TypeError("%s takes %d argument but %d were given" % (predicate, predicate.arity, len(args)))
-        args = Tuple(*[_sympify(a) for a in args])
-        return Boolean.__new__(cls, predicate, args)
+    def __new__(cls, predicate, arg):
+        arg = _sympify(arg)
+        return Boolean.__new__(cls, predicate, arg)
 
     is_Atom = True  # do not attempt to decompose this
 
@@ -122,7 +120,7 @@ class AppliedPredicate(Boolean):
         return set()
 
 class PolyadicAppliedPredicate(AppliedPredicate):
-    def __new__(cls, predicate, *args):
+    def __new__(cls, predicate, args):
         if predicate.arity != len(args):
             raise TypeError("%s takes %d argument but %d were given" % (predicate, predicate.arity, len(args)))
         args = Tuple(*[_sympify(a) for a in args])

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -100,7 +100,7 @@ class AppliedPredicate(Boolean):
                 S.One.sort_key(), S.One)
 
     def __eq__(self, other):
-        if type(other) is AppliedPredicate:
+        if type(self) is type(other):
             return self._args == other._args
         return False
 
@@ -243,7 +243,7 @@ class Predicate(Boolean):
             except NotImplementedError as error:
                 if handlers:
                     continue
-                raise error
+                return None
         return res
 
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -126,6 +126,13 @@ class PolyadicAppliedPredicate(AppliedPredicate):
         args = Tuple(*[_sympify(a) for a in args])
         return Boolean.__new__(cls, predicate, args)
 
+    @property
+    def args(self):
+        return self.arg
+
+    def _eval_ask(self, assumptions):
+        return self.func.polyadic_eval(self.arg, assumptions)
+
 
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.
@@ -216,6 +223,27 @@ class Predicate(Boolean):
                     if _res != res:
                         raise ValueError('incompatible resolutors')
                 break
+        return res
+
+    def polyadic_eval(self, args, assumptions=True):
+        """
+        Evaluate ``self(*args)`` under the given assumptions using multipledispatch.
+        This method is for polyadic predicates. For monadic predicates,
+        use ``eval`` method.
+
+        This uses only direct resolution methods, not logical inference.
+        """
+        args_types = [type(a) for a in args]
+        handlers = [h for h in self.handlers]
+        while handlers:
+            handler = handlers.pop(0)
+            dispatcher = get_class(handler)
+            try:
+                res = dispatcher(*args, assumptions=assumptions)
+            except NotImplementedError as error:
+                if handlers:
+                    continue
+                raise error
         return res
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2272,3 +2272,22 @@ def test_custom_AskHandler():
 
     n = Symbol('n', integer=True)
     assert ask(Q.mersenne(n), Q.mersenne(n))
+
+
+def test_coprime_query():
+    a, b = symbols('a b', integer=True, even=True)
+    c, d = symbols('c d', integer=True, odd=True)
+    e, f = symbols('e f', integer=True)
+
+    assert ask(Q.coprime(2, 3)) is True
+    assert ask(Q.coprime(6, 8)) is False
+
+    assert ask(Q.coprime(a, b)) is False
+    assert ask(Q.coprime(a, c)) is True
+    assert ask(Q.coprime(c, d)) is None
+    assert ask(Q.coprime(a, e)) is None
+    assert ask(Q.coprime(c, e)) is None
+    assert ask(Q.coprime(e, f)) is None
+
+    assert ask(Q.coprime(e, f), Q.coprime(e, f)) is True
+    assert ask(Q.coprime(e, f), ~Q.coprime(e, f)) is False

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -90,7 +90,7 @@ def test_sympy__assumptions__assume__AppliedPredicate():
 
 def test_sympy__assumptions__assume__PolyadicAppliedPredicate():
     from sympy.assumptions.assume import PolyadicAppliedPredicate, Predicate
-    assert _test_args(PolyadicAppliedPredicate(Predicate("test", arity=2), 2,3))
+    assert _test_args(PolyadicAppliedPredicate(Predicate("test", arity=2), (2,3)))
 
 def test_sympy__assumptions__assume__Predicate():
     from sympy.assumptions.assume import Predicate

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -88,12 +88,10 @@ def test_sympy__assumptions__assume__AppliedPredicate():
     assert _test_args(AppliedPredicate(Predicate("test"), 2))
     assert _test_args(Q.is_true(True))
 
-def test_sympy__assumptions__assume__PolyadicAppliedPredicate():
-    from sympy.assumptions.assume import PolyadicAppliedPredicate, Predicate
-    assert _test_args(PolyadicAppliedPredicate(Predicate("test", arity=2), (2,3)))
-
+@XFAIL
 def test_sympy__assumptions__assume__Predicate():
     from sympy.assumptions.assume import Predicate
+    # Will be fixed after the mutability of Predicate is resolved
     assert _test_args(Predicate("test"))
 
 def test_sympy__assumptions__sathandlers__UnevaluatedOnFree():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -88,6 +88,10 @@ def test_sympy__assumptions__assume__AppliedPredicate():
     assert _test_args(AppliedPredicate(Predicate("test"), 2))
     assert _test_args(Q.is_true(True))
 
+def test_sympy__assumptions__assume__PolyadicAppliedPredicate():
+    from sympy.assumptions.assume import PolyadicAppliedPredicate, Predicate
+    assert _test_args(PolyadicAppliedPredicate(Predicate("test", arity=2), 2,3))
+
 def test_sympy__assumptions__assume__Predicate():
     from sympy.assumptions.assume import Predicate
     assert _test_args(Predicate("test"))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #20003

#### Brief description of what is fixed or changed

Polyadic predicate is introduced. `Q.coprime` is implemented as an example.

#### Other comments

Before this PR, only monadic predicate was available. This PR makes n-ary predicate possible.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- assumptions
    - Dyadic predicate `Q.coprime` is introduced.
<!-- END RELEASE NOTES -->