### PR TITLE
NotImplemented for matrix and tensor addition

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2536,9 +2536,9 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__radd__')
     def __add__(self, other):
-        if isinstance(other, NDimArray):
-            return NotImplemented
         """Return self + other, raising ShapeError if shapes don't match."""
+        if isinstance(other, NDimArray): # Matrix and array addition is currently not implemented
+            return NotImplemented
         other = _matrixify(other)
         # matrix-like objects can have shapes.  This is
         # our first sanity check.

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -26,6 +26,7 @@ from sympy.simplify.simplify import dotprodsimp as _dotprodsimp
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import filldedent
+from sympy.tensor.array import NDimArray
 
 from .utilities import _get_intermediate_simp_bool
 
@@ -2535,6 +2536,8 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__radd__')
     def __add__(self, other):
+        if isinstance(other, NDimArray):
+            return NotImplemented
         """Return self + other, raising ShapeError if shapes don't match."""
         other = _matrixify(other)
         # matrix-like objects can have shapes.  This is

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1065,3 +1065,4 @@ def test_issue_18956():
     A = Array([[1, 2], [3, 4]])
     B = Matrix([[1,2],[3,4]])
     raises(TypeError, lambda: B + A)
+    raises(TypeError, lambda: A + B)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -20,6 +20,7 @@ from sympy.matrices import (Matrix, diag, eye,
 from sympy.polys.polytools import Poly
 from sympy.utilities.iterables import flatten
 from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
+from sympy import Array
 
 from sympy.abc import x, y, z
 
@@ -1059,3 +1060,8 @@ def test_rmul_pr19860():
 
     assert isinstance(c, Foo)
     assert c == Matrix([[7, 10], [15, 22]])
+
+def test_issue_18956():
+    A = Array([[1, 2], [3, 4]])
+    B = Matrix([[1,2],[3,4]])
+    raises(TypeError, lambda: B + A)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -315,12 +315,9 @@ class NDimArray(Printable):
 
     def __add__(self, other):
         from sympy.tensor.array.arrayop import Flatten
-        from sympy.matrices import Matrix
 
         if not isinstance(other, NDimArray):
-            if isinstance(other, Matrix):
-                return NotImplemented
-            raise TypeError(str(other))
+            return NotImplemented
 
         if self.shape != other.shape:
             raise ValueError("array shape mismatch")

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -315,8 +315,11 @@ class NDimArray(Printable):
 
     def __add__(self, other):
         from sympy.tensor.array.arrayop import Flatten
+        from sympy.matrices import Matrix
 
         if not isinstance(other, NDimArray):
+            if isinstance(other, Matrix):
+                return NotImplemented
             raise TypeError(str(other))
 
         if self.shape != other.shape:

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -43,8 +43,3 @@ def test_issue_18361():
     assert simplify(A) == Array([0])
     assert simplify(B) == Array([1, 0])
     assert simplify(C) == Array([x + 1, sin(2*x)])
-
-def test_issue_18956():
-    A = Array([[1, 2], [3, 4]])
-    B = Matrix([[1,2],[3,4]])
-    raises(TypeError, lambda: A+B)

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -6,6 +6,7 @@ from sympy import (
 )
 from sympy.abc import x, y
 
+from sympy.matrices import Matrix
 
 array_types = [
     ImmutableDenseNDimArray,
@@ -42,3 +43,8 @@ def test_issue_18361():
     assert simplify(A) == Array([0])
     assert simplify(B) == Array([1, 0])
     assert simplify(C) == Array([x + 1, sin(2*x)])
+
+def test_issue_18956():
+    A = Array([[1, 2], [3, 4]])
+    B = Matrix([[1,2],[3,4]])
+    raises(TypeError, lambda: A+B)

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -6,8 +6,6 @@ from sympy import (
 )
 from sympy.abc import x, y
 
-from sympy.matrices import Matrix
-
 array_types = [
     ImmutableDenseNDimArray,
     ImmutableSparseNDimArray,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #18956

#### Brief description of what is fixed or changed
Added not implemented  for tensor + matrix, and matrix + tensor.

#### Other comments
Earlier Matrix + Array gave result as a matrix and Array + Matrix gave Type Error . Now both functs would return Not Implemented.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
     * Adding an array and a matrix now consistently gives TypeError.
<!-- END RELEASE NOTES -->