### PR TITLE
lens maker formula can calculate focal length for thick lens and plano-lens

### DIFF
--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -183,17 +183,17 @@ def test_lens_makers_formula_thick_lens():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert ae(lens_makers_formula(m1, m2, 10, -10, d=1, lens=2), -19.82, 2)
-    assert lens_makers_formula(n1, n2, 1, -1, d=0.1, lens=2) == n2/((2 - (0.1*n1 - 0.1*n2)/n1)*(n1 - n2))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens=2))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens=2))
+    assert ae(lens_makers_formula(m1, m2, 10, -10, d=1, lens='thick'), -19.82, 2)
+    assert lens_makers_formula(n1, n2, 1, -1, d=0.1, lens='thick') == n2/((2 - (0.1*n1 - 0.1*n2)/n1)*(n1 - n2))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens='thick'))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens='thick'))
 
 def test_lens_makers_formula_plano_lens():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert ae(lens_makers_formula(m1, m2, 10, lens=1), -40.30, 2)
-    assert lens_makers_formula(n1, n2, 10,lens=1) == 10*n2/(n1 - n2)
+    assert ae(lens_makers_formula(m1, m2, 10, lens='plano'), -40.30, 2)
+    assert lens_makers_formula(n1, n2, 10,lens='plano') == 10*n2/(n1 - n2)
     raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens=1))
     raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens=1))
 

--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -178,3 +178,26 @@ def test_transverse_magnification():
     si, so = symbols('si, so')
     assert transverse_magnification(si, so) == -si/so
     assert transverse_magnification(30, 15) == -2
+
+def test_lens_makers_formula_thick_lens():
+    n1, n2 = symbols('n1, n2')
+    m1 = Medium('m1', permittivity=e0, n=1)
+    m2 = Medium('m2', permittivity=e0, n=1.33)
+    assert ae(lens_makers_formula(m1, m2, 10, -10, d=1, lens=2), -19.82, 2)
+    assert lens_makers_formula(n1, n2, 1, -1, d=0.1, lens=2) == n2/((2 - (0.1*n1 - 0.1*n2)/n1)*(n1 - n2))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens=2))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens=2))
+
+def test_lens_makers_formula_plano_lens():
+    n1, n2 = symbols('n1, n2')
+    m1 = Medium('m1', permittivity=e0, n=1)
+    m2 = Medium('m2', permittivity=e0, n=1.33)
+    assert ae(lens_makers_formula(m1, m2, 10, lens=1), -40.30, 2)
+    assert lens_makers_formula(n1, n2, 10,lens=1) == 10*n2/(n1 - n2)
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens=1))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens=1))
+
+def test_lens_makers_formula_errors():
+    raises(ValueError, lambda: lens_makers_formula(1,1,1,1,lens=5))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,d=9))
+    raises(ValueError, lambda: lens_makers_formula(1,2,1))

--- a/sympy/physics/optics/tests/test_utils.py
+++ b/sympy/physics/optics/tests/test_utils.py
@@ -16,6 +16,7 @@ from sympy.testing.pytest import raises
 
 ae = lambda a, b, n: comp(a, b, 10**-n)
 
+
 def test_refraction_angle():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1')
@@ -129,7 +130,7 @@ def test_lens_makers_formula():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert lens_makers_formula(n1, n2, 10, -10) == 5*n2/(n1 - n2)
+    assert lens_makers_formula(n1, n2, 10, -10) == 5.0*n2/(n1 - n2)
     assert ae(lens_makers_formula(m1, m2, 10, -10), -20.15, 2)
     assert ae(lens_makers_formula(1.33, 1, 10, -10),  15.15, 2)
 
@@ -169,35 +170,30 @@ def test_lens_formula():
     assert lens_formula(focal_length=f, u=oo) == f
     raises(ValueError, lambda: lens_formula(focal_length=f, u=u, v=v))
 
+
 def test_hyperfocal_distance():
     f, N, c = symbols('f, N, c')
     assert hyperfocal_distance(f=f, N=N, c=c) == f**2/(N*c)
     assert ae(hyperfocal_distance(f=0.5, N=8, c=0.0033), 9.47, 2)
+
 
 def test_transverse_magnification():
     si, so = symbols('si, so')
     assert transverse_magnification(si, so) == -si/so
     assert transverse_magnification(30, 15) == -2
 
+
 def test_lens_makers_formula_thick_lens():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert ae(lens_makers_formula(m1, m2, 10, -10, d=1, lens='thick'), -19.82, 2)
-    assert lens_makers_formula(n1, n2, 1, -1, d=0.1, lens='thick') == n2/((2 - (0.1*n1 - 0.1*n2)/n1)*(n1 - n2))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens='thick'))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens='thick'))
+    assert ae(lens_makers_formula(m1, m2, 10, -10, d=1), -19.82, 2)
+    assert lens_makers_formula(n1, n2, 1, -1, d=0.1) == n2/((2.0 - (0.1*n1 - 0.1*n2)/n1)*(n1 - n2))
+
 
 def test_lens_makers_formula_plano_lens():
     n1, n2 = symbols('n1, n2')
     m1 = Medium('m1', permittivity=e0, n=1)
     m2 = Medium('m2', permittivity=e0, n=1.33)
-    assert ae(lens_makers_formula(m1, m2, 10, lens='plano'), -40.30, 2)
-    assert lens_makers_formula(n1, n2, 10,lens='plano') == 10*n2/(n1 - n2)
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,d=1,lens=1))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,lens=1))
-
-def test_lens_makers_formula_errors():
-    raises(ValueError, lambda: lens_makers_formula(1,1,1,1,lens=5))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1,1,d=9))
-    raises(ValueError, lambda: lens_makers_formula(1,2,1))
+    assert ae(lens_makers_formula(m1, m2, 10, oo), -40.30, 2)
+    assert lens_makers_formula(n1, n2, 10, oo) == 10.0*n2/(n1 - n2)

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -481,7 +481,7 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens='thin'):
     """
     valid_lens = ['thin','thick','plano']
     if lens not in valid_lens :
-        raise ValueError('Parameter lens takes value : 1, 2 or 3 but ' + str(lens) + ' was provided')
+        raise ValueError("Parameter lens takes value : 'thick', 'thin' or 'plano' but " + str(lens) + " was provided.")
     if isinstance(n_lens, Medium):
         n_lens = n_lens.refractive_index
     else:

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -444,7 +444,7 @@ def critical_angle(medium1, medium2):
 
 
 
-def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
+def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens='thin'):
     """
     This function calculates focal length of a lens.
     It follows cartesian sign convention.
@@ -462,10 +462,10 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
         Radius of curvature of second surface.
     d : sympifiable
         Thickness of lens.
-        Applicable when lens = 2
-    lens : integer, default 0
-        0 for Thin Lens, 1 for plano lens,
-        2 for thick lens.
+        Applicable when lens = 'thick'
+    lens : string, default 'thin'
+        Takes value 'thin' for thin lens, 'plano' for
+        plano lens and 'thick' for thick lens
 
     Examples
     ========
@@ -473,13 +473,13 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
     >>> from sympy.physics.optics import lens_makers_formula
     >>> lens_makers_formula(1.33, 1, 10, -10)
     15.1515151515151
-    >>> lens_makers_formula(1.2, 1, 10,lens=1)
+    >>> lens_makers_formula(1.2, 1, 10,lens='plano')
     50.0000000000000
-    >>> lens_makers_formula(1.33, 1, 10, -10, d=1, lens=2)
+    >>> lens_makers_formula(1.33, 1, 10, -10, d=1, lens='thick')
     15.3418463277618
 
     """
-    valid_lens = [0,1,2]
+    valid_lens = ['thin','thick','plano']
     if lens not in valid_lens :
         raise ValueError('Parameter lens takes value : 1, 2 or 3 but ' + str(lens) + ' was provided')
     if isinstance(n_lens, Medium):
@@ -491,7 +491,7 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
     else:
         n_surr = sympify(n_surr)
 
-    if lens == 0: #BiConcave and Biconvex thin lens
+    if lens == 'thin': #BiConcave and Biconvex thin lens
         if d is not None:
             raise ValueError('Parameter d is not required for thin lens, thickness of thin lens is always negligible.')
         if r2 is None:
@@ -500,7 +500,7 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
         r2 = sympify(r2)
         return 1/((n_lens - n_surr)/n_surr*(1/r1 - 1/r2))
 
-    if lens == 1: # Plano-Concave and Plano-Convex thin lens
+    if lens == 'plano': # Plano-Concave and Plano-Convex thin lens
         if d is not None:
             raise ValueError('Parameter d is not required for thin lens, thickness of thin lens is always negligible.')
         if r2 is not None:
@@ -508,7 +508,7 @@ def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
         r1 = sympify(r1)
         return 1/((n_lens - n_surr)/n_surr*(1/r1))
 
-    if lens == 2: #Thick Lens
+    if lens == 'thick': #Thick Lens
         if d is None:
             raise ValueError('Parameter d not defined, thickness of lens is required.')
         if r2 is None:

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -444,9 +444,9 @@ def critical_angle(medium1, medium2):
 
 
 
-def lens_makers_formula(n_lens, n_surr, r1, r2):
+def lens_makers_formula(n_lens, n_surr, r1, r2=None, *, d=None, lens=0):
     """
-    This function calculates focal length of a thin lens.
+    This function calculates focal length of a lens.
     It follows cartesian sign convention.
 
     Parameters
@@ -460,6 +460,12 @@ def lens_makers_formula(n_lens, n_surr, r1, r2):
         Radius of curvature of first surface.
     r2 : sympifiable
         Radius of curvature of second surface.
+    d : sympifiable
+        Thickness of lens.
+        Applicable when lens = 2
+    lens : integer, default 0
+        0 for Thin Lens, 1 for plano lens,
+        2 for thick lens.
 
     Examples
     ========
@@ -467,8 +473,15 @@ def lens_makers_formula(n_lens, n_surr, r1, r2):
     >>> from sympy.physics.optics import lens_makers_formula
     >>> lens_makers_formula(1.33, 1, 10, -10)
     15.1515151515151
+    >>> lens_makers_formula(1.2, 1, 10,lens=1)
+    50.0000000000000
+    >>> lens_makers_formula(1.33, 1, 10, -10, d=1, lens=2)
+    15.3418463277618
 
     """
+    valid_lens = [0,1,2]
+    if lens not in valid_lens :
+        raise ValueError('Parameter lens takes value : 1, 2 or 3 but ' + str(lens) + ' was provided')
     if isinstance(n_lens, Medium):
         n_lens = n_lens.refractive_index
     else:
@@ -478,10 +491,32 @@ def lens_makers_formula(n_lens, n_surr, r1, r2):
     else:
         n_surr = sympify(n_surr)
 
-    r1 = sympify(r1)
-    r2 = sympify(r2)
+    if lens == 0: #BiConcave and Biconvex thin lens
+        if d is not None:
+            raise ValueError('Parameter d is not required for thin lens, thickness of thin lens is always negligible.')
+        if r2 is None:
+            raise ValueError('Radius of curvature of second surface is not defined.')
+        r1 = sympify(r1)
+        r2 = sympify(r2)
+        return 1/((n_lens - n_surr)/n_surr*(1/r1 - 1/r2))
 
-    return 1/((n_lens - n_surr)/n_surr*(1/r1 - 1/r2))
+    if lens == 1: # Plano-Concave and Plano-Convex thin lens
+        if d is not None:
+            raise ValueError('Parameter d is not required for thin lens, thickness of thin lens is always negligible.')
+        if r2 is not None:
+            raise ValueError('Radius of curvature of second surface is taken infinity, no need to define this parameter')
+        r1 = sympify(r1)
+        return 1/((n_lens - n_surr)/n_surr*(1/r1))
+
+    if lens == 2: #Thick Lens
+        if d is None:
+            raise ValueError('Parameter d not defined, thickness of lens is required.')
+        if r2 is None:
+            raise ValueError('Radius of curvature of second surface is not defined.')
+        r1 = sympify(r1)
+        r2 = sympify(r2)
+        d = sympify(d)
+        return 1/( (n_lens - n_surr)/n_surr*(1/r1 - 1/r2 + (((n_lens - n_surr) * d ) / (n_lens * r1 * r2))) )
 
 
 def mirror_formula(focal_length=None, u=None, v=None):

--- a/sympy/physics/optics/utils.py
+++ b/sympy/physics/optics/utils.py
@@ -487,8 +487,7 @@ def lens_makers_formula(n_lens, n_surr, r1, r2, d=0):
         n_surr = sympify(n_surr)
     d = sympify(d)
 
-    focal_length = 1/( (n_lens - n_surr) / n_surr*(1/r1 - 1/r2 + (((n_lens - n_surr) * d) / 
-                        (n_lens * r1 * r2))) )
+    focal_length = 1/((n_lens - n_surr) / n_surr*(1/r1 - 1/r2 + (((n_lens - n_surr) * d) / (n_lens * r1 * r2))))
 
     if focal_length == zoo:
         return S.Infinity


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20168 

#### Brief description of what is fixed or changed
Lens_makers_formula() can now calculate focal length of thick lens and plano-lens.

#### Other comments
Earliers lens_makers_formula() was limited to thin lens only, extended its application to thick lens and plano-lens, without breaking previous API.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- physics.optics 
        - lens_makers_formula() in sympy/physics/optics/utils.py can now calculate focal length of thick and plano lenses.
<!-- END RELEASE NOTES -->