### PR TITLE
Fix vector_integrate docstring

### DIFF
--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -150,14 +150,14 @@ def vector_integrate(field, *region):
     Examples
     ========
     >>> from sympy.vector import CoordSys3D, ParametricRegion, vector_integrate
-    >>> from sympy.abc import t
+    >>> from sympy.abc import x, y, t
     >>> C = CoordSys3D('C')
 
     >>> region = ParametricRegion((t, t**2), (t, 1, 5))
     >>> vector_integrate(C.x*C.i, region)
     12
 
-    Integrals over special regions can also be calculated using geometry module.
+    Integrals over some objects of geometry module can also be calculated.
 
     >>> from sympy.geometry import Point, Circle, Triangle
     >>> c = Circle(Point(0, 2), 5)
@@ -168,17 +168,24 @@ def vector_integrate(field, *region):
     -8
 
     Integrals over some simple implicit regions can be computed. But in most cases,
-    it takes too long to compute over them.
-    >>> from sympy.abc import x, y
+    it takes too long to compute over them. This is due to the expressions of parametric
+    representation becoming large.
+
     >>> from sympy.vector import ImplicitRegion
     >>> c2 = ImplicitRegion((x, y), (x - 2)**2 + (y - 1)**2 - 9)
     >>> vector_integrate(1, c2)
     12*pi
 
+    Integral of fields with respect to base scalars:
+
     >>> vector_integrate(12*C.y**3, (C.y, 1, 3))
     240
     >>> vector_integrate(C.x**2*C.z, C.x)
     C.x**3*C.z/3
+    >>> vector_integrate(C.x*C.i - C.y*C.k, C.x)
+    (Integral(C.x, C.x))*C.i + (Integral(-C.y, C.x))*C.k
+    >>> _.doit()
+    C.x**2/2*C.i + (-C.x*C.y)*C.k
 
     """
     if len(region) == 1:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Minor fix in the docstring of `vector_integrate`. It was not displaying correctly earlier due to missing newline.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
See the end of https://docs.sympy.org/dev/modules/vector/api/vectorfunctions.html#vector-integrate

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->