### PR TITLE
Make experimental lambdify to utilize lambdify

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -177,7 +177,7 @@ class lambdify(object):
     def __call__(self, args):
         try:
             #The result can be sympy.Float. Hence wrap it with complex type.
-            result = self.candidates[0](args)
+            result = self.candidates[0](complex(args))
             result = complex(result)
             if abs(result.imag) > 1e-7 * abs(result):
                 return None

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -13,7 +13,7 @@ from sympy.plotting.plot import (
 from sympy.plotting.plot import (
     unset_show, plot_contour, PlotGrid, DefaultBackend, MatplotlibBackend,
     TextBackend)
-from sympy.testing.pytest import skip, raises, warns
+from sympy.testing.pytest import skip, raises
 from sympy.utilities import lambdify as lambdify_
 
 

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -323,14 +323,11 @@ def test_plot_and_save_4():
     # is the only way to evaluate the integral. We should perhaps just remove
     # that warning.
     with TemporaryDirectory(prefix='sympy_') as tmpdir:
-        with warns(
-            UserWarning,
-            match="The evaluation of the expression is problematic"):
-            i = Integral(log((sin(x)**2 + 1)*sqrt(x**2 + 1)), (x, 0, y))
-            p = plot(i, (y, 1, 5))
-            filename = 'test_advanced_integral.png'
-            p.save(os.path.join(tmpdir, filename))
-            p._backend.close()
+        i = Integral(log((sin(x)**2 + 1)*sqrt(x**2 + 1)), (x, 0, y))
+        p = plot(i, (y, 1, 5))
+        filename = 'test_advanced_integral.png'
+        p.save(os.path.join(tmpdir, filename))
+        p._backend.close()
 
 
 def test_plot_and_save_5():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This is also able to make a lot of plotting examples faster for the tests
`> python bin/test sympy/plotting/tests/test_plot`
- From: `tests finished: 22 passed, in 96.10 seconds`
- To: `tests finished: 22 passed, in 73.02 seconds`

And since most of the time consuming examples are impractically slow examples that relies on sympy `evalf`, this will be especially faster for functions where numpy or mpmath can be used.

The only functions from that still needs the evalf fallback are:

- `Sum(x**(-y), (x, 1, oo))`
- `Sum(1/x, (x, 1, y))`
- `(meijerg(((0.5,), ()), ((5, 0, 0.5), ()), 5*x**2*exp_polar(-I*pi)/2) + meijerg(((0.5,), ()), ((5, 0, 0.5), ()), 5*x**2*exp_polar(I*pi)/2))/(48*pi)`

And I think that they should be improved in lambdify or any other framework in sympy for code generation, in order to remove the experimental_lambdify completely.

I've also improved the warning message such that it can sort out the expressions triggering the fallback,
so it can hopefully collect some examples from the users where the lambdify is not able to generate the code.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->