### PR TITLE
codegen(cnode): Improved and extended cnodes

### DIFF
--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -51,7 +51,7 @@ class Label(Node):
 
     >>> from sympy import Symbol
     >>> from sympy.codegen.cnodes import Label, PreIncrement
-    >>> from sympy.printing.ccode import ccode
+    >>> from sympy.printing import ccode
     >>> print(ccode(Label('foo')))
     foo:
     >>> print(ccode(Label('bar', [PreIncrement(Symbol('a'))])))

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -2,7 +2,10 @@
 AST nodes specific to the C family of languages
 """
 
-from sympy.codegen.ast import Attribute, Declaration, Node, String, Token, Type, none, FunctionCall
+from sympy.codegen.ast import (
+    Attribute, Declaration, Node, String, Token, Type, none,
+    FunctionCall, CodeBlock
+    )
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
 from sympy.core.sympify import sympify
@@ -40,18 +43,33 @@ class CommaOperator(Basic):
         return Basic.__new__(cls, *[sympify(arg) for arg in args])
 
 
-class Label(String):
+class Label(Node):
     """ Label for use with e.g. goto statement.
 
     Examples
     ========
 
-    >>> from sympy.codegen.cnodes import Label
-    >>> from sympy.printing import ccode
+    >>> from sympy import Symbol
+    >>> from sympy.codegen.cnodes import Label, PreIncrement
+    >>> from sympy.printing.ccode import ccode
     >>> print(ccode(Label('foo')))
     foo:
+    >>> print(ccode(Label('bar', [PreIncrement(Symbol('a'))])))
+    bar:
+    ++(a);
 
     """
+    __slots__ = ('name', 'body')
+    defaults = {'body': none}
+    _construct_name = String
+
+    @classmethod
+    def _construct_body(cls, itr):
+        if isinstance(itr, CodeBlock):
+            return itr
+        else:
+            return CodeBlock(*itr)
+
 
 class goto(Token):
     """ Represents goto in C """

--- a/sympy/printing/c.py
+++ b/sympy/printing/c.py
@@ -23,7 +23,8 @@ from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
     complex64, complex128, intc, value_const, pointer_const,
-    int8, int16, int32, int64, uint8, uint16, uint32, uint64, untyped
+    int8, int16, int32, int64, uint8, uint16, uint32, uint64, untyped,
+    none
 )
 from sympy.printing.codeprinter import CodePrinter, requires
 from sympy.printing.precedence import precedence, PRECEDENCE
@@ -589,10 +590,14 @@ class C89CodePrinter(CodePrinter):
         return '(%s)' % ', '.join(map(lambda arg: self._print(arg), expr.args))
 
     def _print_Label(self, expr):
-        return '%s:' % str(expr)
+        if expr.body == none:
+            return '%s:' % str(expr.name)
+        if len(expr.body.args) == 1:
+            return '%s:\n%s' % (str(expr.name), self._print_CodeBlock(expr.body))
+        return '%s:\n{\n%s\n}' % (str(expr.name), self._print_CodeBlock(expr.body))
 
     def _print_goto(self, expr):
-        return 'goto %s' % expr.label
+        return 'goto %s' % expr.label.name
 
     def _print_PreIncrement(self, expr):
         arg, = expr.args


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
Refer #19309 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Added `name`and `body` to `Label` class in cnodes
(Label was not able to store its child or body. While trying to implement loops in C parser, I came across this issue of label)
- Modified printing of `Label`
- Added corresponding tests
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->