### PR TITLE
Array expressions: parse_matrix_expression is now able to parse traces of matrices

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1047,6 +1047,9 @@ def parse_matrix_expression(expr: MatrixExpr) -> Basic:
         return CodegenArrayPermuteDims(
                 parse_matrix_expression(expr.args[0]), [1, 0]
         )
+    elif isinstance(expr, Trace):
+        inner_expr = parse_matrix_expression(expr.arg)
+        return CodegenArrayContraction(inner_expr, (0, len(inner_expr.shape) - 1))
     else:
         return expr
 

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -358,6 +358,10 @@ def test_parsing_of_matrix_expressions():
     rexpr = recognize_matrix_expression(res)
     assert expr.expand() == rexpr.doit()
 
+    expr = Trace(M)
+    result = CodegenArrayContraction(M, (0, 1))
+    assert parse_matrix_expression(expr) == result
+
 
 def test_special_matrices():
     a = MatrixSymbol("a", k, 1)


### PR DESCRIPTION
Array expressions: parse_matrix_expression is now able to parse traces of matrices

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* codegen
  * parse_matrix_expression( ) is now able to parse traces of matrices.

<!-- END RELEASE NOTES -->