### PR TITLE
feat(polys): add detection of CC domain

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -4,6 +4,7 @@
 from sympy.core import sympify
 from sympy.core.evalf import pure_complex
 from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, EX
+from sympy.polys.domains.complexfield import ComplexField
 from sympy.polys.domains.realfield import RealField
 from sympy.polys.polyoptions import build_options
 from sympy.polys.polyutils import parallel_dict_from_basic
@@ -12,7 +13,8 @@ from sympy.utilities import public
 
 def _construct_simple(coeffs, opt):
     """Handle simple domains, e.g.: ZZ, QQ, RR and algebraic domains. """
-    rationals = reals = gaussians = algebraics = False
+    rationals = floats = complexes = algebraics = False
+    float_numbers = []
 
     if opt.extension is True:
         is_algebraic = lambda coeff: coeff.is_number and coeff.is_algebraic
@@ -24,51 +26,53 @@ def _construct_simple(coeffs, opt):
             if not coeff.is_Integer:
                 rationals = True
         elif coeff.is_Float:
-            if algebraics or gaussians:
+            if algebraics:
                 # there are both reals and algebraics -> EX
                 return False
             else:
-                reals = True
+                floats = True
+                float_numbers.append(coeff)
         else:
             is_complex = pure_complex(coeff)
             if is_complex:
-                # there are both reals and algebraics -> EX
-                if reals:
-                    return False
+                complexes = True
                 x, y = is_complex
                 if x.is_Rational and y.is_Rational:
-                    gaussians = True
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True
                     continue
-            if is_algebraic(coeff):
-                if not reals:
-                    algebraics = True
                 else:
+                    floats = True
+                    if x.is_Float:
+                        float_numbers.append(x)
+                    if y.is_Float:
+                        float_numbers.append(y)
+            if is_algebraic(coeff):
+                if floats:
                     # there are both algebraics and reals -> EX
                     return False
+                algebraics = True
             else:
                 # this is a composite domain, e.g. ZZ[X], EX
                 return None
 
+    # Use the maximum precision of all coefficients for the RR or CC
+    # precision
+    max_prec = max(c._prec for c in float_numbers) if float_numbers else 53
+
     if algebraics:
         domain, result = _construct_algebraic(coeffs, opt)
     else:
-        if reals:
-            # Use the maximum precision of all coefficients for the RR's
-            # precision
-            max_prec = max([c._prec for c in coeffs])
+        if floats and complexes:
+            domain = ComplexField(prec=max_prec)
+        elif floats:
             domain = RealField(prec=max_prec)
+        elif rationals or opt.field:
+            domain = QQ_I if complexes else QQ
         else:
-            if opt.field or rationals:
-                domain = QQ_I if gaussians else QQ
-            else:
-                domain = ZZ_I if gaussians else ZZ
+            domain = ZZ_I if complexes else ZZ
 
-        result = []
-
-        for coeff in coeffs:
-            result.append(domain.from_sympy(coeff))
+        result = [domain.from_sympy(coeff) for coeff in coeffs]
 
     return domain, result
 
@@ -175,30 +179,38 @@ def _construct_composite(coeffs, opt):
             coeffs.update(list(numer.values()))
             coeffs.update(list(denom.values()))
 
-    rationals = reals = gaussians = False
+    rationals = floats = complexes = False
+    float_numbers = []
 
     for coeff in coeffs:
         if coeff.is_Rational:
             if not coeff.is_Integer:
                 rationals = True
         elif coeff.is_Float:
-            reals = True
-            break
+            floats = True
+            float_numbers.append(coeff)
         else:
             is_complex = pure_complex(coeff)
             if is_complex is not None:
+                complexes = True
                 x, y = is_complex
                 if x.is_Rational and y.is_Rational:
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True
-                    gaussians = True
                 else:
-                    pass # XXX: CC?
+                    floats = True
+                    if x.is_Float:
+                        float_numbers.append(x)
+                    if y.is_Float:
+                        float_numbers.append(y)
 
-    if reals:
-        max_prec = max([c._prec for c in coeffs])
+    max_prec = max(c._prec for c in float_numbers) if float_numbers else 53
+
+    if floats and complexes:
+        ground = ComplexField(prec=max_prec)
+    elif floats:
         ground = RealField(prec=max_prec)
-    elif gaussians:
+    elif complexes:
         if rationals:
             ground = QQ_I
         else:

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -1,8 +1,9 @@
 """Tests for tools for constructing domains for expressions. """
 
 from sympy.polys.constructor import construct_domain
-from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, EX
+from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, CC, EX
 from sympy.polys.domains.realfield import RealField
+from sympy.polys.domains.complexfield import ComplexField
 
 from sympy import S, sqrt, sin, Float, E, I, GoldenRatio, pi, Catalan, Rational
 from sympy.abc import x, y
@@ -20,6 +21,10 @@ def test_construct_domain():
     result = construct_domain([3.14, 1, S.Half])
     assert isinstance(result[0], RealField)
     assert result[1] == [RR(3.14), RR(1.0), RR(0.5)]
+
+    result = construct_domain([3.14, I, S.Half])
+    assert isinstance(result[0], ComplexField)
+    assert result[1] == [CC(3.14), CC(1.0j), CC(0.5)]
 
     assert construct_domain([1, I]) == (ZZ_I, [ZZ_I(1, 0), ZZ_I(0, 1)])
     assert construct_domain([1, I/2]) == (QQ_I, [QQ_I(1, 0), QQ_I(0, S.Half)])
@@ -91,6 +96,26 @@ def test_construct_domain():
 
     assert construct_domain([x/2, 3.5*y]) == \
         (dom, [dom.convert(x/2), dom.convert(3.5*y)])
+
+    dom = CC[x]
+
+    assert construct_domain([I*x/2, 3.5]) == \
+        (dom, [dom.convert(I*x/2), dom.convert(3.5)])
+
+    dom = CC[x, y]
+
+    assert construct_domain([I*x/2, 3.5*y]) == \
+        (dom, [dom.convert(I*x/2), dom.convert(3.5*y)])
+
+    dom = CC[x]
+
+    assert construct_domain([x/2, I*3.5]) == \
+        (dom, [dom.convert(x/2), dom.convert(I*3.5)])
+
+    dom = CC[x, y]
+
+    assert construct_domain([x/2, I*3.5*y]) == \
+        (dom, [dom.convert(x/2), dom.convert(I*3.5*y)])
 
     dom = ZZ.frac_field(x)
 


### PR DESCRIPTION
Rewrite the logic in construct_domain to detect CC as the domain when
both I and floats appear in the coefficients.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Partial fix for #20034.

#### Brief description of what is fixed or changed

Adds detection of the `CC` and e.g. `CC[x]` domains in `construct_domain`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
    * Polys with complex floating point coefficients will now use the CC domain rather than EX.
<!-- END RELEASE NOTES -->