### PR TITLE
Added Communication Classes to Discrete Markov Chains

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -836,7 +836,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         return ImmutableMatrix(t2a)
 
-    def communication_classes(self) -> tTuple[tList[tList], tList[Boolean], tList[Integer]]:
+    def communication_classes(self) -> tList[tTuple[tList[Basic], Boolean, Integer]]:
         """
         Returns the list of communication classes that partition
         the states of the markov chain.
@@ -869,13 +869,16 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         ...             [1, 0, 0],
         ...             [1, 0, 0]])
         >>> X = DiscreteMarkovChain('X', [1, 2, 3], T)
-        >>> classes, recurrence, periods = X.communication_classes()
-        >>> classes
-        [[1, 2], [3]]
-        >>> recurrence
-        [True, False]
-        >>> periods
-        [2, 1]
+        >>> classes = X.communication_classes()
+        >>> for states, is_recurrent, period in classes:
+        ...     states, is_recurrent, period
+        ([1, 2], True, 2)
+        ([3], False, 1)
+
+        From this we can see that states ``1`` and ``2``
+        communicate, are recurrent and have a period
+        of 2. We can also see state ``3`` is transient
+        with a period of 1.
 
         Notes
         =====
@@ -959,7 +962,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         # convert back to the user's state names
         classes = [[self._state_index[i] for i in class_] for class_ in classes]
 
-        return sympify((classes, recurrence, periods))
+        return sympify(list(zip(classes, recurrence, periods)))
 
     def fundamental_matrix(self):
         Q = self._transient2transient()

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -836,7 +836,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         return ImmutableMatrix(t2a)
 
-    def communication_classes(self) -> tTuple[tList[tList], tList[bool], tList[Integer]]:
+    def communication_classes(self) -> tTuple[tList[tList], tList[Boolean], tList[Integer]]:
         """
         Returns the list of communication classes that partition
         the states of the markov chain.
@@ -845,17 +845,20 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         such that every state in that set is reachable from
         every other state in that set. Due to its properties
         this forms a class in the mathematical sense.
+        Communication classes are also known as recurrence
+        classes.
 
         Returns
         =======
-        classes, recurrence, periods : List of List of states, List of bool, List of Integer
+
+        classes, recurrence, periods : List of List of states, List of Boolean, List of Integer
             The ``classes`` are a list each containing a
             single communication class. This partitions
             the state space. The ``recurrence`` is a list
             where the ith item specifies whether the ith
             communication class is recurrent. The ``periods``
             is a list where the ith item is the period
-            of the ith communication class
+            of the ith communication class.
 
         Examples
         ========
@@ -882,9 +885,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         It uses Tarjan's algorithm to find the classes
         themselves and then it uses a breadth-first search
         algorithm to find each class's periodicity.
-        Most of the algorithms components approach ``O(n)``
-        the closer the transition matrix is to the identity
-        matrix.
+        Most of the algorithm's components approach ``O(n)``
+        as the matrix becomes more and more sparse.
 
         References
         ==========
@@ -892,7 +894,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         .. [1] http://www.columbia.edu/~ww2040/4701Sum07/4701-06-Notes-MCII.pdf
         .. [2] http://cecas.clemson.edu/~shierd/Shier/markov.pdf
         .. [3] https://ujcontent.uj.ac.za/vital/access/services/Download/uj:7506/CONTENT1
-        .. [4] https://www.mathworks.com/help/econ/dtmc.classify.html#d122e135589
+        .. [4] https://www.mathworks.com/help/econ/dtmc.classify.html
         """
         n = self.number_of_states
         T = self.transition_probabilities

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1,7 +1,7 @@
 import random
 
 import itertools
-from typing import Sequence as tSequence, Union as tUnion
+from typing import Sequence as tSequence, Union as tUnion, List as tList, Tuple as tTuple
 
 from sympy import (Matrix, MatrixSymbol, S, Indexed, Basic, Tuple, Range,
                    Set, And, Eq, FiniteSet, ImmutableMatrix, Integer, igcd,
@@ -836,7 +836,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
         return ImmutableMatrix(t2a)
 
-    def communication_classes(self):
+    def communication_classes(self) -> tTuple[tList[tList], tList[bool], tList[Integer]]:
         """
         Returns the list of communication classes that partition
         the states of the markov chain.
@@ -957,7 +957,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         # convert back to the user's state names
         classes = [[self._state_index[i] for i in class_] for class_ in classes]
 
-        return classes, recurrence, periods
+        return sympify((classes, recurrence, periods))
 
     def fundamental_matrix(self):
         Q = self._transient2transient()

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -851,14 +851,14 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         Returns
         =======
 
-        classes, recurrence, periods : List of List of states, List of Boolean, List of Integer
-            The ``classes`` are a list each containing a
-            single communication class. This partitions
-            the state space. The ``recurrence`` is a list
-            where the ith item specifies whether the ith
-            communication class is recurrent. The ``periods``
-            is a list where the ith item is the period
-            of the ith communication class.
+        classes : List of Tuple of List, Boolean, Intger
+            The ``classes`` are a list of tuples. Each
+            tuple represents a single communication class
+            with its properties. The first element in the
+            tuple is the list of states in the class, the
+            second element is whether the class is recurrent
+            and the third element is the period of the
+            communication class.
 
         Examples
         ========

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -4,7 +4,7 @@ import itertools
 from typing import Sequence as tSequence, Union as tUnion
 
 from sympy import (Matrix, MatrixSymbol, S, Indexed, Basic, Tuple, Range,
-                   Set, And, Eq, FiniteSet, ImmutableMatrix, Integer,
+                   Set, And, Eq, FiniteSet, ImmutableMatrix, Integer, igcd,
                    Lambda, Mul, Dummy, IndexedBase, Add, Interval, oo,
                    linsolve, eye, Or, Not, Intersection, factorial, Contains,
                    Union, Expr, Function, exp, cacheit, sqrt, pi, gamma,
@@ -13,6 +13,7 @@ from sympy import (Matrix, MatrixSymbol, S, Indexed, Basic, Tuple, Range,
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.iterables import strongly_connected_components
 from sympy.stats.joint_rv import JointDistribution
 from sympy.stats.joint_rv_types import JointDistributionHandmade
 from sympy.stats.rv import (RandomIndexedSymbol, random_symbols, RandomSymbol,
@@ -834,6 +835,129 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
                 for si in trans_states]
 
         return ImmutableMatrix(t2a)
+
+    def communication_classes(self):
+        """
+        Returns the list of communication classes that partition
+        the states of the markov chain.
+
+        A communication class is defined to be a set of states
+        such that every state in that set is reachable from
+        every other state in that set. Due to its properties
+        this forms a class in the mathematical sense.
+
+        Returns
+        =======
+        classes, recurrence, periods : List of List of states, List of bool, List of Integer
+            The ``classes`` are a list each containing a
+            single communication class. This partitions
+            the state space. The ``recurrence`` is a list
+            where the ith item specifies whether the ith
+            communication class is recurrent. The ``periods``
+            is a list where the ith item is the period
+            of the ith communication class
+
+        Examples
+        ========
+
+        >>> from sympy.stats import DiscreteMarkovChain
+        >>> from sympy import Matrix
+        >>> T = Matrix([[0, 1, 0],
+        ...             [1, 0, 0],
+        ...             [1, 0, 0]])
+        >>> X = DiscreteMarkovChain('X', [1, 2, 3], T)
+        >>> classes, recurrence, periods = X.communication_classes()
+        >>> classes
+        [[1, 2], [3]]
+        >>> recurrence
+        [True, False]
+        >>> periods
+        [2, 1]
+
+        Notes
+        =====
+
+        The algorithm used is of order ``O(n**2)`` where
+        ``n`` is the number of states in the markov chain.
+        It uses Tarjan's algorithm to find the classes
+        themselves and then it uses a breadth-first search
+        algorithm to find each class's periodicity.
+        Most of the algorithms components approach ``O(n)``
+        the closer the transition matrix is to the identity
+        matrix.
+
+        References
+        ==========
+
+        .. [1] http://www.columbia.edu/~ww2040/4701Sum07/4701-06-Notes-MCII.pdf
+        .. [2] http://cecas.clemson.edu/~shierd/Shier/markov.pdf
+        .. [3] https://ujcontent.uj.ac.za/vital/access/services/Download/uj:7506/CONTENT1
+        .. [4] https://www.mathworks.com/help/econ/dtmc.classify.html#d122e135589
+        """
+        n = self.number_of_states
+        T = self.transition_probabilities
+
+        # begin Tarjan's algorithm
+        V = Range(n)
+        # don't use state names. Rather use state
+        # indexes since we use them for matrix
+        # indexing here and later onward
+        E = [(i, j) for i in V for j in V if T[i, j] != 0]
+        classes = strongly_connected_components((V, E))
+        # end Tarjan's algorithm
+
+        recurrence = []
+        periods = []
+        for class_ in classes:
+            # begin recurrent check (similar to self._check_trans_probs())
+            submatrix = T[class_, class_]  # get the submatrix with those states
+            is_recurrent = S.true
+            rows = submatrix.tolist()
+            for row in rows:
+                if (sum(row) - 1) != 0:
+                    is_recurrent = S.false
+                    break
+            recurrence.append(is_recurrent)
+            # end recurrent check
+
+            # begin breadth-first search
+            non_tree_edge_values = set()
+            visited = {class_[0]}
+            newly_visited = {class_[0]}
+            level = {class_[0]: 0}
+            current_level = 0
+            done = False  # imitate a do-while loop
+            while not done:  # runs at most len(class_) times
+                done = len(visited) == len(class_)
+                current_level += 1
+
+                # this loop and the while loop above run a combined len(class_) number of times.
+                # so this triple nested loop runs through each of the n states once.
+                for i in newly_visited:
+
+                    # the loop below runs len(class_) number of times
+                    # complexity is around about O(n * avg(len(class_)))
+                    newly_visited = {j for j in class_ if T[i, j] != 0}
+
+                    new_tree_edges = newly_visited.difference(visited)
+                    for j in new_tree_edges:
+                        level[j] = current_level
+
+                    new_non_tree_edges = newly_visited.intersection(visited)
+                    new_non_tree_edge_values = {level[i]-level[j]+1 for j in new_non_tree_edges}
+
+                    non_tree_edge_values = non_tree_edge_values.union(new_non_tree_edge_values)
+                    visited = visited.union(new_tree_edges)
+
+            # igcd needs at least 2 arguments
+            g = igcd(len(class_), len(class_), *{val_e for val_e in non_tree_edge_values if val_e > 0})
+            periods.append(g)
+            # end breadth-first search
+
+        # convert back to the user's state names
+        classes = [[self._state_index[i] for i in class_] for class_ in classes]
+
+        return classes, recurrence, periods
 
     def fundamental_matrix(self):
         Q = self._transient2transient()

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -147,10 +147,11 @@ def test_DiscreteMarkovChain():
                   [0, 10, 0, 0, 0],
                   [0, 3, 0, 3, 4]])/10
     Y7 = DiscreteMarkovChain('Y', trans_probs=TO7)
-    classes, recurrence, periods = Y7.communication_classes()
-    assert classes == [[1, 3], [0, 2], [4]]
-    assert recurrence == [True, False, False]
-    assert periods == [2, 1, 1]
+    tuples = Y7.communication_classes()
+    classes, recurrence, periods = list(zip(*tuples))
+    assert classes == ([1, 3], [0, 2], [4])
+    assert recurrence == (True, False, False)
+    assert periods == (2, 1, 1)
 
     TO8 = Matrix([[0, 0, 0, 10, 0, 0],
                   [5, 0, 5, 0, 0, 0],
@@ -159,10 +160,11 @@ def test_DiscreteMarkovChain():
                   [0, 10, 0, 0, 0, 0],
                   [0, 0, 0, 5, 5, 0]])/10
     Y8 = DiscreteMarkovChain('Y', trans_probs=TO8)
-    classes, recurrence, periods = Y8.communication_classes()
-    assert classes == [[0, 3], [1, 2, 5, 4]]
-    assert recurrence == [True, False]
-    assert periods == [2, 2]
+    tuples = Y8.communication_classes()
+    classes, recurrence, periods = list(zip(*tuples))
+    assert classes == ([0, 3], [1, 2, 5, 4])
+    assert recurrence == (True, False)
+    assert periods == (2, 2)
 
     TO9 = Matrix([[2, 0, 0, 3, 0, 0, 3, 2, 0, 0],
                   [0, 10, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -175,17 +177,19 @@ def test_DiscreteMarkovChain():
                   [3, 0, 1, 0, 0, 0, 0, 0, 4, 2],
                   [0, 0, 4, 0, 0, 0, 0, 0, 3, 3]])/10
     Y9 = DiscreteMarkovChain('Y', trans_probs=TO9)
-    classes, recurrence, periods = Y9.communication_classes()
-    assert classes == [[0, 3, 6, 7], [1], [2, 8, 9], [5], [4]]
-    assert recurrence == [True, True, False, True, False]
-    assert periods == [1, 1, 1, 1, 1]
+    tuples = Y9.communication_classes()
+    classes, recurrence, periods = list(zip(*tuples))
+    assert classes == ([0, 3, 6, 7], [1], [2, 8, 9], [5], [4])
+    assert recurrence == (True, True, False, True, False)
+    assert periods == (1, 1, 1, 1, 1)
 
     # test custom state space
     Y10 = DiscreteMarkovChain('Y', [1, 2, 3], TO2)
-    classes, recurrence, periods = Y10.communication_classes()
-    assert classes == [[1], [2, 3]]
-    assert recurrence == [True, False]
-    assert periods == [1, 1]
+    tuples = Y10.communication_classes()
+    classes, recurrence, periods = list(zip(*tuples))
+    assert classes == ([1], [2, 3])
+    assert recurrence == (True, False)
+    assert periods == (1, 1)
 
     # testing miscellaneous queries
     T = Matrix([[S.Half, Rational(1, 4), Rational(1, 4)],

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -138,6 +138,55 @@ def test_DiscreteMarkovChain():
     assert Y6.fundamental_matrix() == ImmutableMatrix([[Rational(3, 2), S.One, S.Half], [S.One, S(2), S.One], [S.Half, S.One, Rational(3, 2)]])
     assert Y6.absorbing_probabilities() == ImmutableMatrix([[Rational(3, 4), Rational(1, 4)], [S.Half, S.Half], [Rational(1, 4), Rational(3, 4)]])
 
+    # test communication_class
+    # see https://drive.google.com/drive/folders/1HbxLlwwn2b3U8Lj7eb_ASIUb5vYaNIjg?usp=sharing
+    # tutorial 2.pdf
+    TO7 = Matrix([[0, 5, 5, 0, 0],
+                  [0, 0, 0, 10, 0],
+                  [5, 0, 5, 0, 0],
+                  [0, 10, 0, 0, 0],
+                  [0, 3, 0, 3, 4]])/10
+    Y7 = DiscreteMarkovChain('Y', trans_probs=TO7)
+    classes, recurrence, periods = Y7.communication_classes()
+    assert classes == [[1, 3], [0, 2], [4]]
+    assert recurrence == [True, False, False]
+    assert periods == [2, 1, 1]
+
+    TO8 = Matrix([[0, 0, 0, 10, 0, 0],
+                  [5, 0, 5, 0, 0, 0],
+                  [0, 4, 0, 0, 0, 6],
+                  [10, 0, 0, 0, 0, 0],
+                  [0, 10, 0, 0, 0, 0],
+                  [0, 0, 0, 5, 5, 0]])/10
+    Y8 = DiscreteMarkovChain('Y', trans_probs=TO8)
+    classes, recurrence, periods = Y8.communication_classes()
+    assert classes == [[0, 3], [1, 2, 5, 4]]
+    assert recurrence == [True, False]
+    assert periods == [2, 2]
+
+    TO9 = Matrix([[2, 0, 0, 3, 0, 0, 3, 2, 0, 0],
+                  [0, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 2, 2, 0, 0, 0, 0, 0, 3, 3],
+                  [0, 0, 0, 3, 0, 0, 6, 1, 0, 0],
+                  [0, 0, 0, 0, 5, 5, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 10, 0, 0, 0, 0],
+                  [4, 0, 0, 5, 0, 0, 1, 0, 0, 0],
+                  [2, 0, 0, 4, 0, 0, 2, 2, 0, 0],
+                  [3, 0, 1, 0, 0, 0, 0, 0, 4, 2],
+                  [0, 0, 4, 0, 0, 0, 0, 0, 3, 3]])/10
+    Y9 = DiscreteMarkovChain('Y', trans_probs=TO9)
+    classes, recurrence, periods = Y9.communication_classes()
+    assert classes == [[0, 3, 6, 7], [1], [2, 8, 9], [5], [4]]
+    assert recurrence == [True, True, False, True, False]
+    assert periods == [1, 1, 1, 1, 1]
+
+    # test custom state space
+    Y10 = DiscreteMarkovChain('Y', [1, 2, 3], TO2)
+    classes, recurrence, periods = Y10.communication_classes()
+    assert classes == [[1], [2, 3]]
+    assert recurrence == [True, False]
+    assert periods == [1, 1]
+
     # testing miscellaneous queries
     T = Matrix([[S.Half, Rational(1, 4), Rational(1, 4)],
                 [Rational(1, 3), 0, Rational(2, 3)],


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Added the ability to identify the communication classes in a Markov chain, whether they are recurrent or transient and what periodicity they have.

#### Other comments

The algorithms used are as suggested from #20026. The overall algorithm complexity is technically O(n^2) where n is the number states in the chain. This is because of the definition of `E` in the source code. However, the major parts of the algorithm have complexity roughly O(n*m) where m is the average number of states in each recurrence class. This means, as the transition matrix approaches the identity matrix (or becomes more sparse), the algorithm approaches O(n).

There will be more functions added that directly and indirectly follow from this one.

The matrices used in the tests are from [this tutorial](https://drive.google.com/file/d/1mE9IgOdO-Nu9-xAaei74n28v5jVD7yvW/view?usp=sharing).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->