### PR TITLE
Fix docstring typo in solveset.py and solveset.rst

### DIFF
--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -482,7 +482,7 @@ What will you do with the old solve?
 ------------------------------------
 
  There are still a few things ``solveset`` can't do, which the old ``solve``
- can, such as solving non linear multivariate & LambertW type equations.
+ can, such as solving nonlinear multivariate & LambertW type equations.
  Hence, it's not yet a perfect replacement for old ``solve``. The ultimate
  goal is to:
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3318,7 +3318,7 @@ def _separate_poly_nonpoly(system, symbols):
 
 def nonlinsolve(system, *symbols):
     r"""
-    Solve system of N non linear equations with M variables, which means both
+    Solve system of N nonlinear equations with M variables, which means both
     under and overdetermined systems are supported. Positive dimensional
     system is also supported (A system with infinitely many solutions is said
     to be positive-dimensional). In Positive dimensional system solution will


### PR DESCRIPTION
Fix docstring typo in solveset.py and solveset.rst

#### References to other Issues or PRs
Fix for #20198 


#### Brief description of what is fixed or changed
Fixes the issue of spelling mistake i.e. "non linear" to "nonlinear" in the sections:

- [How are symbolic parameters handled in solveset?](https://docs.sympy.org/latest/modules/solvers/solveset.html#what-will-you-do-with-the-old-solve)

- [nonlinsolve](https://docs.sympy.org/latest/modules/solvers/solveset.html#nonlinsolve)


#### Other comments


#### Release Notes

NO ENTRY

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->