### PR TITLE
Fixed set is equal to set only

### DIFF
--- a/sympy/sets/handlers/comparison.py
+++ b/sympy/sets/handlers/comparison.py
@@ -1,8 +1,9 @@
 from sympy.core.relational import Eq, is_eq
+from sympy.core.basic import Basic
 from sympy.core.logic import fuzzy_and, fuzzy_bool
 from sympy.logic.boolalg import And
 from sympy.multipledispatch import dispatch
-from sympy.sets.sets import tfn, ProductSet, Interval, FiniteSet
+from sympy.sets.sets import tfn, ProductSet, Interval, FiniteSet, Set
 
 
 @dispatch(Interval, FiniteSet) # type:ignore
@@ -46,3 +47,13 @@ def _eval_is_eq(lhs, rhs): # noqa: F811
 
     eqs = (is_eq(x, y) for x, y in zip(lhs.sets, rhs.sets))
     return tfn[fuzzy_and(map(fuzzy_bool, eqs))]
+
+
+@dispatch(Set, Basic) # type:ignore
+def _eval_is_eq(lhs, rhs): # noqa: F811
+    return False
+
+
+@dispatch(Set, Set) # type:ignore
+def _eval_is_eq(lhs, rhs): # noqa: F811
+    return None

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1585,7 +1585,14 @@ def test_DisjointUnion_len():
 def test_issue_20089():
     B = FiniteSet(FiniteSet(1, 2), FiniteSet(1))
     assert not 1 in B
-    assert Eq(1, FiniteSet(1, 2)) == False
+    assert not 1.0 in B
+    assert not Eq(1, FiniteSet(1, 2))
     assert FiniteSet(1) in B
     A = FiniteSet(1, 2)
+    assert A in B
+    assert B.issubset(B)
     assert not A.issubset(B)
+    assert 1 in A
+    C = FiniteSet(FiniteSet(1, 2), FiniteSet(1), 1, 2)
+    assert A.issubset(C)
+    assert B.issubset(C)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1581,3 +1581,11 @@ def test_DisjointUnion_len():
     assert len(DisjointUnion(FiniteSet(3, 5, 7, 9), FiniteSet(x, y, z))) == 7
     assert len(DisjointUnion(S.EmptySet, S.EmptySet, FiniteSet(x, y, z), S.EmptySet)) == 3
     raises(ValueError, lambda: len(DisjointUnion(Interval(0, 1), S.EmptySet)))
+
+def test_issue_20089():
+    B = FiniteSet(FiniteSet(1, 2), FiniteSet(1))
+    assert not 1 in B
+    assert Eq(1, FiniteSet(1, 2)) == False
+    assert FiniteSet(1) in B
+    A = FiniteSet(1, 2)
+    assert not A.issubset(B)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20089 

#### Brief description of what is fixed or changed
Earlier #in #subset gave wrong output due to inconsistency of #Eq with sets and expr

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- sets
     - Earlier expr and sets were treated equal which gave incorrect output for some set functions(mainly : - in, is_subset), made sets and expr not to be equal
<!-- END RELEASE NOTES -->