### PR TITLE
zero raised to power -infinity gives zoo

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -291,6 +291,8 @@ class Pow(Expr):
             ).warn()
 
         if evaluate:
+            if b is S.Zero and e is S.NegativeInfinity:
+                return S.ComplexInfinity
             if e is S.ComplexInfinity:
                 return S.NaN
             if e is S.Zero:

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -579,3 +579,7 @@ def test_power_dispatcher():
     assert power(a, b) == NewPow(a, b)
     assert power(b, a) == NewPow(b, a)
     assert power(b, b) == NewPow(b, b)
+
+def test_issue_19572():
+    assert 0 ** -oo is zoo
+    assert power(0, -oo) is zoo

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -266,6 +266,9 @@ def test_zero():
     assert 0**(2*x*y) == 0**(x*y)
     assert 0**(-2*x*y) == S.ComplexInfinity**(x*y)
 
+    #Test issue 19572
+    assert 0 ** -oo is zoo
+    assert power(0, -oo) is zoo
 
 def test_pow_as_base_exp():
     x = Symbol('x')
@@ -579,7 +582,3 @@ def test_power_dispatcher():
     assert power(a, b) == NewPow(a, b)
     assert power(b, a) == NewPow(b, a)
     assert power(b, b) == NewPow(b, b)
-
-def test_issue_19572():
-    assert 0 ** -oo is zoo
-    assert power(0, -oo) is zoo


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19572

#### Brief description of what is fixed or changed
Earlier  0 ** -oo gave 0 instead of zoo

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
     - Zero raised to power Negative Infinity gives ComplexInfinity(zoo) instead of zero
<!-- END RELEASE NOTES -->