### PR TITLE
Return NotImplemented instead of TypeError

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -329,7 +329,7 @@ class NDimArray(Printable):
         from sympy.tensor.array.arrayop import Flatten
 
         if not isinstance(other, NDimArray):
-            raise NotImplemented
+            raise NotImplementedError('Unsupported operand type(s) for - : ' + str(type(other)) + ' and ' + str(type(self)))
 
         if self.shape != other.shape:
             raise ValueError("array shape mismatch")

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -329,7 +329,7 @@ class NDimArray(Printable):
         from sympy.tensor.array.arrayop import Flatten
 
         if not isinstance(other, NDimArray):
-            raise TypeError(str(other))
+            raise NotImplemented
 
         if self.shape != other.shape:
             raise ValueError("array shape mismatch")

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -329,7 +329,7 @@ class NDimArray(Printable):
         from sympy.tensor.array.arrayop import Flatten
 
         if not isinstance(other, NDimArray):
-            raise NotImplementedError('Unsupported operand type(s) for - : ' + str(type(other)) + ' and ' + str(type(self)))
+            return NotImplemented
 
         if self.shape != other.shape:
             raise ValueError("array shape mismatch")

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -2,7 +2,7 @@ from sympy.testing.pytest import raises
 from sympy import (
     Array, ImmutableDenseNDimArray, ImmutableSparseNDimArray,
     MutableDenseNDimArray, MutableSparseNDimArray, sin, cos,
-    simplify
+    simplify, Matrix
 )
 from sympy.abc import x, y
 
@@ -41,3 +41,8 @@ def test_issue_18361():
     assert simplify(A) == Array([0])
     assert simplify(B) == Array([1, 0])
     assert simplify(C) == Array([x + 1, sin(2*x)])
+
+def test_issue_20222():
+    A = Array([[1, 2], [3, 4]])
+    B = Matrix([[1,2],[3,4]])
+    raises(TypeError, lambda: A - B)

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -45,4 +45,4 @@ def test_issue_18361():
 def test_issue_20222():
     A = Array([[1, 2], [3, 4]])
     B = Matrix([[1,2],[3,4]])
-    raises(TypeError, lambda: A - B)
+    raises(NotImplementedError, lambda: A - B)

--- a/sympy/tensor/array/tests/test_ndim_array.py
+++ b/sympy/tensor/array/tests/test_ndim_array.py
@@ -45,4 +45,4 @@ def test_issue_18361():
 def test_issue_20222():
     A = Array([[1, 2], [3, 4]])
     B = Matrix([[1,2],[3,4]])
-    raises(NotImplementedError, lambda: A - B)
+    raises(TypeError, lambda: A - B)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20222

#### Brief description of what is fixed or changed
Array subtraction returns NotImplemented instead of TypeError

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
-  tensor
     -  Adding an array with any other type now consistently gives NotImplemented.
<!-- END RELEASE NOTES -->