### PR TITLE
[don't merge] handle a potential zero denominator in a substitution in _meijerint_indefinite_1

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1641,7 +1641,7 @@ def meijerint_indefinite(f, x):
 
 def _meijerint_indefinite_1(f, x):
     """ Helper that does not attempt any substitution. """
-    from sympy import Integral, piecewise_fold, nan, zoo, solve, integrate
+    from sympy import Integral, piecewise_fold, nan, zoo, solve
     _debug('Trying to compute the indefinite integral of', f, 'wrt', x)
 
     gs = _rewrite1(f, x)
@@ -1667,10 +1667,11 @@ def _meijerint_indefinite_1(f, x):
             if not den.is_Number and den.is_zero is not False:
                 zero_sol = solve(den, dict=True)
                 for sol in zero_sol:
-                    zero_res = integrate(f.subs(sol), x)
+                    zero_res = Integral(f.subs(sol), x)
                     zero_cond = cond
                     for vz, sz in sol.items():
                         zero_cond = And(zero_cond, Eq(vz, sz))
+                    zero_cond = _my_unpolarify(zero_cond)
                     special_results.append(Piecewise((zero_res, zero_cond)))
 
         # we now use t**rho*G(params, t) = G(params + rho, t)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1641,7 +1641,7 @@ def meijerint_indefinite(f, x):
 
 def _meijerint_indefinite_1(f, x):
     """ Helper that does not attempt any substitution. """
-    from sympy import Integral, piecewise_fold, nan, zoo, solve
+    from sympy import Integral, piecewise_fold, nan, zoo, solve, integrate
     _debug('Trying to compute the indefinite integral of', f, 'wrt', x)
 
     gs = _rewrite1(f, x)
@@ -1664,10 +1664,10 @@ def _meijerint_indefinite_1(f, x):
         # handle zero denominators in the above substitution
         special_results = []
         for den in (a, b):
-            if not den.is_Number and not den.is_nonzero:
+            if not den.is_Number and den.is_zero is not False:
                 zero_sol = solve(den, dict=True)
                 for sol in zero_sol:
-                    zero_res = _meijerint_indefinite_1(f.subs(sol), x)
+                    zero_res = integrate(f.subs(sol), x)
                     zero_cond = cond
                     for vz, sz in sol.items():
                         zero_cond = And(zero_cond, Eq(vz, sz))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1527,8 +1527,11 @@ def test_issue_15432():
 def test_issue_15124():
     omega = IndexedBase('omega')
     m, p = symbols('m p', cls=Idx)
+
     assert integrate(exp(x*I*(omega[m] + omega[p])), x, conds='none') == \
+        Piecewise((x, Eq(omega[m], -omega[p])), (
         -I*exp(I*x*omega[m])*exp(I*x*omega[p])/(omega[m] + omega[p])
+        , True))
 
 
 def test_issue_15218():
@@ -1661,9 +1664,11 @@ def test_issue_17473():
     x = Symbol('x')
     n = Symbol('n')
     assert integrate(sin(x**n), x) == \
+        Piecewise((x*sin(1), Eq(n, 0)), (
         x*x**n*gamma(S(1)/2 + 1/(2*n))*hyper((S(1)/2 + 1/(2*n),),
                      (S(3)/2, S(3)/2 + 1/(2*n)),
                      -x**(2*n)/4)/(2*n*gamma(S(3)/2 + 1/(2*n)))
+        , True))
 
 
 def test_issue_17671():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -731,7 +731,7 @@ def test_issue_6462():
 def test_issue_5949_ensure_unpolarified_special_case_integrand():
     # Based on test_issue_15124:
     # In the handling of the special case Eq(a, -b) below we must ensure
-    # Integral(1, x) is evaluated rather than the unpolarified
+    # Integral(1, x) is evaluated rather than the polarified
     # Integral(exp(I*x*(-n*exp_polar(0) + n)), x) which currently raises:
     assert meijerint_indefinite(exp(x*I*(a + b)), x) == \
         Piecewise((x, Eq(a, -b)), (-I*exp(I*a*x)*exp(I*b*x)/(a + b), True))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -1,6 +1,7 @@
 from sympy import (meijerg, I, S, integrate, Integral, oo, gamma, cosh, sinc,
                    hyperexpand, exp, simplify, sqrt, pi, erf, erfc, sin, cos,
-                   exp_polar, polygamma, hyper, log, expand_func, Rational)
+                   exp_polar, polygamma, hyper, log, expand_func, Rational,
+                   Eq, Piecewise)
 from sympy.integrals.meijerint import (_rewrite_single, _rewrite1,
         meijerint_indefinite, _inflate_g, _create_lookup_table,
         meijerint_definite, meijerint_inversion)
@@ -725,3 +726,12 @@ def test_issue_6462():
     # exception
     assert integrate(cos(x**n)/x**n, x, meijerg=True).subs(n, 2).equals(
             integrate(cos(x**2)/x**2, x, meijerg=True))
+
+
+def test_issue_5949_ensure_unpolarified_special_case_integrand():
+    # Based on test_issue_15124:
+    # In the handling of the special case Eq(a, -b) below we must ensure
+    # Integral(1, x) is evaluated rather than the unpolarified
+    # Integral(exp(I*x*(-n*exp_polar(0) + n)), x) which currently raises:
+    assert meijerint_indefinite(exp(x*I*(a + b)), x) == \
+        Piecewise((x, Eq(a, -b)), (-I*exp(I*a*x)*exp(I*b*x)/(a + b), True))


### PR DESCRIPTION
towards a solution of integrate((x**(n-1))*sqrt(1+x**n), x) not returning a Piecewise with the n = 0 case.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

doesn't quite address #5949

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->