### PR TITLE
Added canonical form functions for Discrete Markov Chains

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -9,7 +9,8 @@ from sympy import (Matrix, MatrixSymbol, S, Indexed, Basic, Tuple, Range,
                    linsolve, eye, Or, Not, Intersection, factorial, Contains,
                    Union, Expr, Function, exp, cacheit, sqrt, pi, gamma,
                    Ge, Piecewise, Symbol, NonSquareMatrixError, EmptySet,
-                   ceiling, MatrixBase, ConditionSet, ones, zeros, Identity)
+                   ceiling, MatrixBase, ConditionSet, ones, zeros, Identity,
+                   BlockMatrix)
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -851,7 +852,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         Returns
         =======
 
-        classes : List of Tuple of List, Boolean, Intger
+        classes
             The ``classes`` are a list of tuples. Each
             tuple represents a single communication class
             with its properties. The first element in the
@@ -901,6 +902,9 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         n = self.number_of_states
         T = self.transition_probabilities
+
+        if isinstance(T, MatrixSymbol):
+            raise NotImplementedError("Cannot perform the operation with a symbolic matrix.")
 
         # begin Tarjan's algorithm
         V = Range(n)
@@ -1111,6 +1115,182 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         distribution of a discrete Markov chain.
         """
         return self.fixed_row_vector()
+
+    def decompose(self) -> tTuple[tList[Basic], ImmutableMatrix, ImmutableMatrix, ImmutableMatrix]:
+        """
+        The transition matrix can be decomposed into 4 submatrices:
+        - A - the submatrix from recurrent states to recurrent states.
+        - B - the submatrix from transient to recurrent states.
+        - C - the submatrix from transient to transient states.
+        - O - the submatrix of zeros for recurrent to transient states.
+
+        Returns
+        =======
+
+        states, A, B, C
+            ``states`` - a list of state names with the first being
+            the recurrent states and the last being
+            the transient states in the order
+            of the row names of A and then the row names of C.
+            ``A`` - the submatrix from recurrent states to recurrent states.
+            ``B`` - the submatrix from transient to recurrent states.
+            ``C`` - the submatrix from transient to transient states.
+
+        Examples
+        ========
+
+        >>> from sympy.stats import DiscreteMarkovChain
+        >>> from sympy import Matrix, S
+
+        One can decompose this chain for example:
+
+        >>> T = Matrix([[S(1)/2, S(1)/2, 0,      0,      0],
+        ...             [S(2)/5, S(1)/5, S(2)/5, 0,      0],
+        ...             [0,      0,      1,      0,      0],
+        ...             [0,      0,      S(1)/2, S(1)/2, 0],
+        ...             [S(1)/2, 0,      0,      0, S(1)/2]])
+        >>> X = DiscreteMarkovChain('X', trans_probs=T)
+        >>> states, A, B, C = X.decompose()
+        >>> states
+        [2, 0, 1, 3, 4]
+
+        >>> A   # recurrent to recurrent
+        Matrix([[1]])
+
+        >>> B  # transient to recurrent
+        Matrix([
+        [  0],
+        [2/5],
+        [1/2],
+        [  0]])
+
+        >>> C  # transient to transient
+        Matrix([
+        [1/2, 1/2,   0,   0],
+        [2/5, 1/5,   0,   0],
+        [  0,   0, 1/2,   0],
+        [1/2,   0,   0, 1/2]])
+
+        This means that state 2 is the only absorbing state
+        (since A is a 1x1 matrix). B is a 4x1 matrix since
+        the 4 remaining transient states all merge into reccurent
+        state 2. And C is the 4x4 matrix that shows how the
+        transient states 0, 1, 3, 4 all interact.
+
+        See Also
+        ========
+
+        sympy.stats.stochastic_process_types.DiscreteMarkovChain.communication_classes
+        sympy.stats.stochastic_process_types.DiscreteMarkovChain.canonical_form
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Absorbing_Markov_chain
+        .. [2] http://people.brandeis.edu/~igusa/Math56aS08/Math56a_S08_notes015.pdf
+        """
+        trans_probs = self.transition_probabilities
+
+        classes = self.communication_classes()
+        r_states = []
+        t_states = []
+
+        for states, recurrent, period in classes:
+            if recurrent:
+                r_states += states
+            else:
+                t_states += states
+
+        states = r_states + t_states
+        indexes = [self.index_of[state] for state in states]
+
+        A = Matrix(len(r_states), len(r_states),
+                   lambda i, j: trans_probs[indexes[i], indexes[j]])
+
+        B = Matrix(len(t_states), len(r_states),
+                   lambda i, j: trans_probs[indexes[len(r_states) + i], indexes[j]])
+
+        C = Matrix(len(t_states), len(t_states),
+                   lambda i, j: trans_probs[indexes[len(r_states) + i], indexes[len(r_states) + j]])
+
+        return states, A.as_immutable(), B.as_immutable(), C.as_immutable()
+
+    def canonical_form(self) -> tTuple[tList[Basic], ImmutableMatrix]:
+        """
+        Reorders the one-step transition matrix
+        so that recurrent states appear first and transient
+        states appear last. Other notations include inserting
+        transient states first and recurrent states last but
+        that method creates n-step transition matrix with
+        poor visual appeal.
+
+        Returns
+        =======
+
+        states, P_new
+            ``states`` is the list that describes the order of the
+            new states in the matrix
+            so that the ith element in ``states`` is the state of the
+            ith row of A.
+            ``P_new`` is the new transition matrix in canonical form.
+
+        Examples
+        ========
+
+        >>> from sympy.stats import DiscreteMarkovChain
+        >>> from sympy import Matrix, S
+
+        You can convert your chain into canonical form:
+
+        >>> T = Matrix([[S(1)/2, S(1)/2, 0,      0,      0],
+        ...             [S(2)/5, S(1)/5, S(2)/5, 0,      0],
+        ...             [0,      0,      1,      0,      0],
+        ...             [0,      0,      S(1)/2, S(1)/2, 0],
+        ...             [S(1)/2, 0,      0,      0, S(1)/2]])
+        >>> X = DiscreteMarkovChain('X', list(range(1, 6)), trans_probs=T)
+        >>> states, new_matrix = X.canonical_form()
+        >>> states
+        [3, 1, 2, 4, 5]
+
+        >>> new_matrix
+        Matrix([
+        [  1,   0,   0,   0,   0],
+        [  0, 1/2, 1/2,   0,   0],
+        [2/5, 2/5, 1/5,   0,   0],
+        [1/2,   0,   0, 1/2,   0],
+        [  0, 1/2,   0,   0, 1/2]])
+
+        The new states are [3, 1, 2, 4, 5] and you can
+        create a new chain with this and its canonical
+        form will remain the same (since it is already
+        in canonical form).
+
+        >>> X = DiscreteMarkovChain('X', states, new_matrix)
+        >>> states, new_matrix = X.canonical_form()
+        >>> states
+        [3, 1, 2, 4, 5]
+
+        >>> new_matrix
+        Matrix([
+        [  1,   0,   0,   0,   0],
+        [  0, 1/2, 1/2,   0,   0],
+        [2/5, 2/5, 1/5,   0,   0],
+        [1/2,   0,   0, 1/2,   0],
+        [  0, 1/2,   0,   0, 1/2]])
+
+        The output should be the same as the first
+        call but setting a state space results in that
+        state space being sorted instead of kept in place.
+
+        See Also
+        ========
+
+        sympy.stats.stochastic_process_types.DiscreteMarkovChain.communication_classes
+        sympy.stats.stochastic_process_types.DiscreteMarkovChain.decompose
+        """
+        states, A, B, C = self.decompose()
+        O = zeros(A.shape[0], C.shape[1])
+        return states, BlockMatrix([[A, O], [B, C]]).as_explicit()
 
     def sample(self):
         """

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1118,6 +1118,9 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
 
     def decompose(self) -> tTuple[tList[Basic], ImmutableMatrix, ImmutableMatrix, ImmutableMatrix]:
         """
+        Decomposes the transition matrix into submatrices with
+        special properties.
+
         The transition matrix can be decomposed into 4 submatrices:
         - A - the submatrix from recurrent states to recurrent states.
         - B - the submatrix from transient to recurrent states.
@@ -1219,10 +1222,8 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         Reorders the one-step transition matrix
         so that recurrent states appear first and transient
-        states appear last. Other notations include inserting
-        transient states first and recurrent states last but
-        that method creates n-step transition matrix with
-        poor visual appeal.
+        states appear last. Other representations include inserting
+        transient states first and recurrent states last.
 
         Returns
         =======
@@ -1278,15 +1279,37 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         [1/2,   0,   0, 1/2,   0],
         [  0, 1/2,   0,   0, 1/2]])
 
-        The output should be the same as the first
-        call but setting a state space results in that
-        state space being sorted instead of kept in place.
+        This is not limited to absorbing chains:
+
+        >>> T = Matrix([[0, 5,  5, 0,  0],
+        ...             [0, 0,  0, 10, 0],
+        ...             [5, 0,  5, 0,  0],
+        ...             [0, 10, 0, 0,  0],
+        ...             [0, 3,  0, 3,  4]])/10
+        >>> X = DiscreteMarkovChain('X', trans_probs=T)
+        >>> states, new_matrix = X.canonical_form()
+        >>> states
+        [1, 3, 0, 2, 4]
+
+        >>> new_matrix
+        Matrix([
+        [   0,    1,   0,   0,   0],
+        [   1,    0,   0,   0,   0],
+        [ 1/2,    0,   0, 1/2,   0],
+        [   0,    0, 1/2, 1/2,   0],
+        [3/10, 3/10,   0,   0, 2/5]])
 
         See Also
         ========
 
         sympy.stats.stochastic_process_types.DiscreteMarkovChain.communication_classes
         sympy.stats.stochastic_process_types.DiscreteMarkovChain.decompose
+
+        References
+        ==========
+
+        .. [1] https://onlinelibrary.wiley.com/doi/pdf/10.1002/9780470316887.app1
+        .. [2] http://www.columbia.edu/~ww2040/6711F12/lect1023big.pdf
         """
         states, A, B, C = self.decompose()
         O = zeros(A.shape[0], C.shape[1])

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -30,6 +30,9 @@ def test_DiscreteMarkovChain():
     assert E(X[0]) == Expectation(X[0])
     raises(TypeError, lambda: DiscreteMarkovChain(1))
     raises(NotImplementedError, lambda: X(t))
+    raises(NotImplementedError, lambda: X.communication_classes())
+    raises(NotImplementedError, lambda: X.canonical_form())
+    raises(NotImplementedError, lambda: X.decompose())
 
     nz = Symbol('n', integer=True)
     TZ = MatrixSymbol('M', nz, nz)
@@ -123,6 +126,10 @@ def test_DiscreteMarkovChain():
     raises (ValueError, lambda: Y3.fundamental_matrix())
     assert Y2.is_absorbing_chain() == True
     assert Y3.is_absorbing_chain() == False
+    assert Y2.canonical_form() == ([0, 1, 2], TO2)
+    assert Y3.canonical_form() == ([0, 1, 2], TO3)
+    assert Y2.decompose() == ([0, 1, 2], TO2[0:1, 0:1], TO2[1:3, 0:1], TO2[1:3, 1:3])
+    assert Y3.decompose() == ([0, 1, 2], TO3, Matrix(0, 3, []), Matrix(0, 0, []))
     TO4 = Matrix([[Rational(1, 5), Rational(2, 5), Rational(2, 5)], [Rational(1, 10), S.Half, Rational(2, 5)], [Rational(3, 5), Rational(3, 10), Rational(1, 10)]])
     Y4 = DiscreteMarkovChain('Y', trans_probs=TO4)
     w = ImmutableMatrix([[Rational(11, 39), Rational(16, 39), Rational(4, 13)]])
@@ -143,6 +150,10 @@ def test_DiscreteMarkovChain():
     X = DiscreteMarkovChain('X', trans_probs=Matrix([[]]))
     assert X.number_of_states == 0
     assert X.stationary_distribution() == Matrix([[]])
+    assert X.communication_classes() == []
+    assert X.canonical_form() == ([], Matrix([[]]))
+    assert X.decompose() == ([], Matrix([[]]), Matrix([[]]), Matrix([[]]))
+
     # test communication_class
     # see https://drive.google.com/drive/folders/1HbxLlwwn2b3U8Lj7eb_ASIUb5vYaNIjg?usp=sharing
     # tutorial 2.pdf
@@ -195,6 +206,8 @@ def test_DiscreteMarkovChain():
     assert classes == ([1], [2, 3])
     assert recurrence == (True, False)
     assert periods == (1, 1)
+    assert Y10.canonical_form() == ([1, 2, 3], TO2)
+    assert Y10.decompose() == ([1, 2, 3], TO2[0:1, 0:1], TO2[1:3, 0:1], TO2[1:3, 1:3])
 
     # testing miscellaneous queries
     T = Matrix([[S.Half, Rational(1, 4), Rational(1, 4)],

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -199,6 +199,28 @@ def test_DiscreteMarkovChain():
     assert recurrence == (True, True, False, True, False)
     assert periods == (1, 1, 1, 1, 1)
 
+    # test canonical form
+    # see https://www.dartmouth.edu/~chance/teaching_aids/books_articles/probability_book/Chapter11.pdf
+    # example 11.13
+    T = Matrix([[1, 0, 0, 0, 0],
+                [S(1) / 2, 0, S(1) / 2, 0, 0],
+                [0, S(1) / 2, 0, S(1) / 2, 0],
+                [0, 0, S(1) / 2, 0, S(1) / 2],
+                [0, 0, 0, 0, S(1)]])
+    DW = DiscreteMarkovChain('DW', [0, 1, 2, 3, 4], T)
+    states, A, B, C = DW.decompose()
+    assert states == [0, 4, 1, 2, 3]
+    assert A == Matrix([[1, 0], [0, 1]])
+    assert B == Matrix([[S(1)/2, 0], [0, 0], [0, S(1)/2]])
+    assert C == Matrix([[0, S(1)/2, 0], [S(1)/2, 0, S(1)/2], [0, S(1)/2, 0]])
+    states, new_matrix = DW.canonical_form()
+    assert states == [0, 4, 1, 2, 3]
+    assert new_matrix == Matrix([[1, 0, 0, 0, 0],
+                                 [0, 1, 0, 0, 0],
+                                 [S(1)/2, 0, 0, S(1)/2, 0],
+                                 [0, 0, S(1)/2, 0, S(1)/2],
+                                 [0, S(1)/2, 0, S(1)/2, 0]])
+
     # test custom state space
     Y10 = DiscreteMarkovChain('Y', [1, 2, 3], TO2)
     tuples = Y10.communication_classes()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

Added two functions to `DiscreteMarkovChain`. These functions are both used to attain a canonical form for the Markov chain. See the docstring for more details.

#### Other comments

These functions will also be useful for `ContinuousMarkovChain`. But they use a function called `communication_classes` which is only valid for `DiscreteMarkovChain` since a continuous Markov chain does not have a periodicity. In a future PR, I will move all of the functions that I can up to `MarkovChain`.

I removed the type hint in the docstrings since there is already a type annotation. This docstring hint has caused my IDE to bug out (and so with other users of my IDE I assume).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->