### PR TITLE
Deprecated mdft in physics.matrices

### DIFF
--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -3,7 +3,36 @@ from sympy.matrices.expressions import MatrixExpr
 from sympy import S, I, sqrt, exp
 
 class DFT(MatrixExpr):
-    """ Discrete Fourier Transform """
+    r"""
+    Returns a discrete Fourier transform matrix.
+
+    Parameters
+    ==========
+
+    n : integer or Symbol
+        Size of the transform
+
+    Examples
+    ========
+
+    >>> from sympy.abc import n
+    >>> from sympy.matrices.expressions.fourier import DFT
+    >>> DFT(3)
+    DFT(3)
+    >>> DFT(3).as_explicit()
+    Matrix([
+    [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],
+    [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3,  sqrt(3)*exp(2*I*pi/3)/3],
+    [sqrt(3)/3,  sqrt(3)*exp(2*I*pi/3)/3, sqrt(3)*exp(-2*I*pi/3)/3]])
+    >>> DFT(n).shape
+    (n, n)
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/DFT_matrix
+
+    """
     def __new__(cls, n):
         n = _sympify(n)
         cls._check_dim(n)
@@ -22,7 +51,30 @@ class DFT(MatrixExpr):
         return IDFT(self.n)
 
 class IDFT(DFT):
-    """ Inverse Discrete Fourier Transform """
+    r"""
+    Returns an inverse discrete Fourier transform matrix.
+
+    Parameters
+    ==========
+
+    n : integer or Symbol
+        Size of the transform
+
+    Examples
+    ========
+
+    >>> from sympy.matrices.expressions.fourier import DFT, IDFT
+    >>> IDFT(3)
+    IDFT(3)
+    >>> IDFT(4)*DFT(4)
+    I
+
+    See Also
+    ========
+
+    sympy.matrices.expressions.fourier.DFT
+
+    """
     def _entry(self, i, j, **kwargs):
         w = exp(-2*S.Pi*I/self.n)
         return w**(-i*j) / sqrt(self.n)

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,4 +1,4 @@
-from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
+from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt, Rational
 from sympy.core.symbol import symbols
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity
@@ -27,3 +27,11 @@ def test_dft():
     assert Abs(simplify(det(Matrix(DFT(4))))) == 1
     assert DFT(n)*IDFT(n) == Identity(n)
     assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)
+
+def test_dft2():
+    assert DFT(1).as_explicit() == Matrix([[1]])
+    assert DFT(2).as_explicit() == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
+    assert DFT(4).as_explicit() == Matrix([[S.Half,  S.Half,  S.Half, S.Half],
+                                           [S.Half, -I/2, Rational(-1,2),  I/2],
+                                           [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],
+                                           [S.Half,  I/2, Rational(-1,2), -I/2]])

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,5 +1,5 @@
 from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt, Rational
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import symbols
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity
 from sympy.testing.pytest import raises
@@ -12,11 +12,11 @@ def test_dft_creation():
     raises(ValueError, lambda: DFT(2.0))
     raises(ValueError, lambda: DFT(2 + 1j))
 
-    n = Symbol('n')
+    n = symbols('n')
     assert DFT(n)
-    n = Symbol('n', integer=False)
+    n = symbols('n', integer=False)
     raises(ValueError, lambda: DFT(n))
-    n = Symbol('n', negative=True)
+    n = symbols('n', negative=True)
     raises(ValueError, lambda: DFT(n))
 
 
@@ -36,16 +36,3 @@ def test_dft2():
                                            [S.Half, -I/2, Rational(-1,2),  I/2],
                                            [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],
                                            [S.Half,  I/2, Rational(-1,2), -I/2]])
-
-
-def test_unitary():
-    assert DFT(2, unitary=False).as_explicit() == Matrix([[1,1],[1,-1]])
-    assert DFT(2, unitary=False)*IDFT(2, unitary=False) == Identity(2)
-    assert DFT(2)*IDFT(2, unitary=False) == sqrt(2)/2*Identity(2)
-
-
-def test_twiddle():
-    w = Symbol('w')
-    assert DFT(3, twiddle=w).as_explicit() == Matrix([[sqrt(3)/3, sqrt(3)/3, sqrt(3)/3],
-                                                      [sqrt(3)/3, sqrt(3)*w/3, sqrt(3)*w**2/3],
-                                                      [sqrt(3)/3, sqrt(3)*w**2/3, sqrt(3)*w**4/3]])

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,5 +1,5 @@
 from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt, Rational
-from sympy.core.symbol import symbols
+from sympy.core.symbol import Symbol
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity
 from sympy.testing.pytest import raises
@@ -12,11 +12,11 @@ def test_dft_creation():
     raises(ValueError, lambda: DFT(2.0))
     raises(ValueError, lambda: DFT(2 + 1j))
 
-    n = symbols('n')
+    n = Symbol('n')
     assert DFT(n)
-    n = symbols('n', integer=False)
+    n = Symbol('n', integer=False)
     raises(ValueError, lambda: DFT(n))
-    n = symbols('n', negative=True)
+    n = Symbol('n', negative=True)
     raises(ValueError, lambda: DFT(n))
 
 
@@ -28,6 +28,7 @@ def test_dft():
     assert DFT(n)*IDFT(n) == Identity(n)
     assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)
 
+
 def test_dft2():
     assert DFT(1).as_explicit() == Matrix([[1]])
     assert DFT(2).as_explicit() == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
@@ -35,3 +36,16 @@ def test_dft2():
                                            [S.Half, -I/2, Rational(-1,2),  I/2],
                                            [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],
                                            [S.Half,  I/2, Rational(-1,2), -I/2]])
+
+
+def test_unitary():
+    assert DFT(2, unitary=False).as_explicit() == Matrix([[1,1],[1,-1]])
+    assert DFT(2, unitary=False)*IDFT(2, unitary=False) == Identity(2)
+    assert DFT(2)*IDFT(2, unitary=False) == sqrt(2)/2*Identity(2)
+
+
+def test_twiddle():
+    w = Symbol('w')
+    assert DFT(3, twiddle=w).as_explicit() == Matrix([[sqrt(3)/3, sqrt(3)/3, sqrt(3)/3],
+                                                      [sqrt(3)/3, sqrt(3)*w/3, sqrt(3)*w**2/3],
+                                                      [sqrt(3)/3, sqrt(3)*w**2/3, sqrt(3)*w**4/3]])

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -162,11 +162,7 @@ def mdft(n):
     r"""
     Deprecated. Use DFT from sympy.matrices.expressions.fourier instead.
 
-    See Also
-    ========
-
-    sympy.matrices.expressions.fourier
-
+    To get identical behavior to ``mdft(n)``, use ``DFT(n).as_mutable()``.
     """
     mat = [[None for x in range(n)] for y in range(n)]
     base = exp(-2*pi*I/n)

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -160,26 +160,13 @@ minkowski_tensor = Matrix( (
             deprecated_since_version="1.7")
 def mdft(n):
     r"""
-    Returns an expression of a discrete Fourier transform as a matrix multiplication.
-    It is an n X n matrix.
+    Deprecated. Use DFT from sympy.matrices.expressions.fourier instead.
 
-    References
-    ==========
-
-    .. [1] https://en.wikipedia.org/wiki/DFT_matrix
-
-    Examples
+    See Also
     ========
 
-    >>> from sympy.physics.matrices import mdft
-    >>> from sympy.utilities.exceptions import SymPyDeprecationWarning
-    >>> import warnings
-    >>> warnings.simplefilter("ignore", SymPyDeprecationWarning)
-    >>> mdft(3)
-    Matrix([
-    [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],
-    [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3,  sqrt(3)*exp(2*I*pi/3)/3],
-    [sqrt(3)/3,  sqrt(3)*exp(2*I*pi/3)/3, sqrt(3)*exp(-2*I*pi/3)/3]])
+    sympy.matrices.expressions.fourier.DFT
+
     """
     mat = [[None for x in range(n)] for y in range(n)]
     base = exp(-2*pi*I/n)

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -157,7 +157,7 @@ minkowski_tensor = Matrix( (
 
 
 @deprecated(issue=20246, useinstead="DFT(n).as_mutable(), DFT(n), DFT(n).as_explicit()",
-            deprecated_since_version="1.7")
+            deprecated_since_version="1.9")
 def mdft(n):
     r"""
     Deprecated. Use DFT from sympy.matrices.expressions.fourier instead.

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -172,6 +172,9 @@ def mdft(n):
     ========
 
     >>> from sympy.physics.matrices import mdft
+    >>> from sympy.utilities.exceptions import SymPyDeprecationWarning
+    >>> import warnings
+    >>> warnings.simplefilter("ignore", SymPyDeprecationWarning)
     >>> mdft(3)
     Matrix([
     [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -2,6 +2,7 @@
 
 from sympy import Matrix, I, pi, sqrt
 from sympy.functions import exp
+from sympy.core.decorators import deprecated
 
 
 def msigma(i):
@@ -154,6 +155,9 @@ minkowski_tensor = Matrix( (
     (0, 0, 0, -1)
 ))
 
+
+@deprecated(issue=20246, useinstead="DFT(n) or DFT(n).as_explicit()",
+            deprecated_since_version="1.7")
 def mdft(n):
     r"""
     Returns an expression of a discrete Fourier transform as a matrix multiplication.

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -156,7 +156,7 @@ minkowski_tensor = Matrix( (
 ))
 
 
-@deprecated(issue=20246, useinstead="DFT(n) or DFT(n).as_explicit()",
+@deprecated(issue=20246, useinstead="DFT(n).as_mutable(), DFT(n), DFT(n).as_explicit()",
             deprecated_since_version="1.7")
 def mdft(n):
     r"""
@@ -165,7 +165,7 @@ def mdft(n):
     See Also
     ========
 
-    sympy.matrices.expressions.fourier.DFT
+    sympy.matrices.expressions.fourier
 
     """
     mat = [[None for x in range(n)] for y in range(n)]

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -1,7 +1,6 @@
 from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, mdft
 from sympy import zeros, eye, I, Matrix, sqrt, Rational, S
-from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import warns_deprecated_sympy
 
 
 def test_parallel_axis_theorem():
@@ -71,11 +70,11 @@ def test_Dirac():
         mgamma(0, True)*mgamma(1, True)*mgamma(2, True)*mgamma(3, True)*I
 
 def test_mdft():
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         assert mdft(1) == Matrix([[1]])
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         assert mdft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
-    with raises(SymPyDeprecationWarning):
+    with warns_deprecated_sympy():
         assert mdft(4) == Matrix([[S.Half,  S.Half,  S.Half, S.Half],
                                   [S.Half, -I/2, Rational(-1,2),  I/2],
                                   [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -1,5 +1,7 @@
 from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, mdft
 from sympy import zeros, eye, I, Matrix, sqrt, Rational, S
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.testing.pytest import raises
 
 
 def test_parallel_axis_theorem():
@@ -69,9 +71,12 @@ def test_Dirac():
         mgamma(0, True)*mgamma(1, True)*mgamma(2, True)*mgamma(3, True)*I
 
 def test_mdft():
-    assert mdft(1) == Matrix([[1]])
-    assert mdft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
-    assert mdft(4) == Matrix([[S.Half,  S.Half,  S.Half, S.Half],
-                              [S.Half, -I/2, Rational(-1,2),  I/2],
-                              [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],
-                              [S.Half,  I/2, Rational(-1,2), -I/2]])
+    with raises(SymPyDeprecationWarning):
+        assert mdft(1) == Matrix([[1]])
+    with raises(SymPyDeprecationWarning):
+        assert mdft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
+    with raises(SymPyDeprecationWarning):
+        assert mdft(4) == Matrix([[S.Half,  S.Half,  S.Half, S.Half],
+                                  [S.Half, -I/2, Rational(-1,2),  I/2],
+                                  [S.Half, Rational(-1,2),  S.Half, Rational(-1,2)],
+                                  [S.Half,  I/2, Rational(-1,2), -I/2]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See #20246

#### Brief description of what is fixed or changed
Deprecates the redundant `mdft` in `physics.matrices`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.matrices
    * Deprecated `mdft`, use `DFT` from `matrices.fourier` instead.
<!-- END RELEASE NOTES -->