### PR TITLE
Removed deprecation warning for swapped arguments in kanes_equations.

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -8,7 +8,6 @@ from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.physics.mechanics.functions import (msubs, find_dynamicsymbols,
                                                _f_list_parser)
 from sympy.physics.mechanics.linearize import Linearizer
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iterable
 
 __all__ = ['KanesMethod']

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -522,17 +522,6 @@ class KanesMethod:
             Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
         """
-        if (bodies is None and loads is not None) or isinstance(bodies[0], tuple):
-            # This switches the order if they use the old way.
-            bodies, loads = loads, bodies
-            SymPyDeprecationWarning(value='The API for kanes_equations() has changed such '
-                    'that the loads (forces and torques) are now the second argument '
-                    'and is optional with None being the default.',
-                    feature='The kanes_equation() argument order',
-                    useinstead='switched argument order to update your code, For example: '
-                    'kanes_equations(loads, bodies) > kanes_equations(bodies, loads).',
-                    issue=10945, deprecated_since_version="1.1").warn()
-
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,5 +1,3 @@
-from sympy.testing.pytest import warns_deprecated_sympy
-
 from sympy.core.backend import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
                                 zeros)
 from sympy import simplify
@@ -24,10 +22,7 @@ def test_one_dof():
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
-    # The old input format raises a deprecation warning, so catch it here so
-    # it doesn't cause py.test to fail.
-    with warns_deprecated_sympy():
-        KM.kanes_equations(FL, BL)
+    KM.kanes_equations(BL, FL)
 
     MM = KM.mass_matrix
     forcing = KM.forcing
@@ -67,10 +62,7 @@ def test_two_dof():
     # pass relevant information, and form Fr & Fr*. Then we calculate the mass
     # matrix and forcing terms, and finally solve for the udots.
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
-    # The old input format raises a deprecation warning, so catch it here so
-    # it doesn't cause py.test to fail.
-    with warns_deprecated_sympy():
-        KM.kanes_equations(FL, BL)
+    KM.kanes_equations(BL, FL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -96,8 +88,7 @@ def test_pend():
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
-    with warns_deprecated_sympy():
-        KM.kanes_equations(FL, BL)
+    KM.kanes_equations(BL, FL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -160,8 +151,7 @@ def test_rolling_disc():
     # terms, then solve for the u dots (time derivatives of the generalized
     # speeds).
     KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd)
-    with warns_deprecated_sympy():
-        KM.kanes_equations(ForceList, BodyList)
+    KM.kanes_equations(BodyList, ForceList)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -217,15 +207,13 @@ def test_aux():
 
     KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3, u4, u5],
                      kd_eqs=kd)
-    with warns_deprecated_sympy():
-        (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
+    (fr, frstar) = KM.kanes_equations(BodyList, ForceList)
     fr = fr.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
     frstar = frstar.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
 
     KM2 = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd,
                       u_auxiliary=[u4, u5])
-    with warns_deprecated_sympy():
-        (fr2, frstar2) = KM2.kanes_equations(ForceList, BodyList)
+    (fr2, frstar2) = KM2.kanes_equations(BodyList, ForceList)
     fr2 = fr2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
     frstar2 = frstar2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
 
@@ -288,8 +276,7 @@ def test_parallel_axis():
                  (C, N.x * F)]
 
     km = KanesMethod(N, [q1, q2], [u1, u2], kindiffs)
-    with warns_deprecated_sympy():
-        (fr, frstar) = km.kanes_equations(forceList, bodyList)
+    (fr, frstar) = km.kanes_equations(bodyList, forceList)
     mm = km.mass_matrix_full
     assert mm[3, 3] == Iz
 

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -4,7 +4,6 @@ from sympy.physics.mechanics import (cross, dot, dynamicsymbols,
                                      find_dynamicsymbols, KanesMethod, inertia,
                                      inertia_of_point_mass, Point,
                                      ReferenceFrame, RigidBody)
-from sympy.testing.pytest import warns_deprecated_sympy
 
 
 def test_aux_dep():
@@ -178,8 +177,7 @@ def test_aux_dep():
         )
 
     # fr, frstar, frstar_steady and kdd(kinematic differential equations).
-    with warns_deprecated_sympy():
-        (fr, frstar)= kane.kanes_equations(forceList, bodyList)
+    (fr, frstar)= kane.kanes_equations(bodyList, forceList)
     frstar_steady = frstar.subs(ud_zero).subs(u_dep_dict).subs(steady_conditions)\
                     .subs({q[3]: -r*cos(q[1])}).expand()
     kdd = kane.kindiffdict()
@@ -267,8 +265,7 @@ def test_non_central_inertia():
 
     forces = [(pS_star, -M*g*F.x), (pQ, Q1*A.x + Q2*A.y + Q3*A.z)]
     bodies = [rbA, rbB, rbC]
-    with warns_deprecated_sympy():
-        fr, fr_star = km.kanes_equations(forces, bodies)
+    fr, fr_star = km.kanes_equations(bodies, forces)
     vc_map = solve(vc, [u4, u5])
 
     # KanesMethod returns the negative of Fr, Fr* as defined in Kane1985.
@@ -289,8 +286,7 @@ def test_non_central_inertia():
                                            rb.frame)
         bodies2.append(RigidBody('', rb.masscenter, rb.frame, rb.mass,
                                  (I, pD)))
-    with warns_deprecated_sympy():
-        fr2, fr_star2 = km.kanes_equations(forces, bodies2)
+    fr2, fr_star2 = km.kanes_equations(bodies2, forces)
 
     t = trigsimp(fr_star2.subs(vc_map).subs({u3: 0})).doit()
     assert (fr_star_expected - t).expand() == zeros(3, 1)
@@ -379,8 +375,7 @@ def test_sub_qdot():
             -(mA + 2*mB +2*J/R**2) * u2.diff(t) + mA*a*u1**2,
             0])
 
-    with warns_deprecated_sympy():
-        fr, fr_star = km.kanes_equations(forces, bodies)
+    fr, fr_star = km.kanes_equations(bodies, forces)
     assert (fr.expand() == fr_expected.expand())
     assert ((fr_star_expected - trigsimp(fr_star)).expand() == zeros(3, 1))
 
@@ -440,8 +435,7 @@ def test_sub_qdot2():
     u_expr += qd[3:]
     kde = [ui - e for ui, e in zip(u, u_expr)]
     km1 = KanesMethod(A, q, u, kde)
-    with warns_deprecated_sympy():
-        fr1, _ = km1.kanes_equations(forces, [])
+    fr1, _ = km1.kanes_equations([], forces)
 
     ## Calculate generalized active forces if we impose the condition that the
     # disk C is rolling without slipping
@@ -450,8 +444,7 @@ def test_sub_qdot2():
     vc = [pC_hat.vel(A) & uv for uv in [A.x, A.y]]
     km2 = KanesMethod(A, q, u_indep, kde,
                       u_dependent=u_dep, velocity_constraints=vc)
-    with warns_deprecated_sympy():
-        fr2, _ = km2.kanes_equations(forces, [])
+    fr2, _ = km2.kanes_equations([], forces)
 
     fr1_expected = Matrix([
         -R*g*m*sin(q[1]),

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,7 +1,7 @@
 from sympy import evalf, symbols, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
                                      KanesMethod, RigidBody, Point, dot, msubs)
-from sympy.testing.pytest import slow, ON_TRAVIS, skip, warns_deprecated_sympy
+from sympy.testing.pytest import slow, ON_TRAVIS, skip
 
 
 @slow
@@ -171,8 +171,7 @@ def test_bicycle():
             u_ind=[u2, u3, u5],
             u_dependent=[u1, u4, u6], velocity_constraints=conlist_speed,
             kd_eqs=kd)
-    with warns_deprecated_sympy():
-        (fr, frstar) = KM.kanes_equations(FL, BL)
+    (fr, frstar) = KM.kanes_equations(BL, FL)
 
     # This is the start of entering in the numerical values from the benchmark
     # paper to validate the eigen values of the linearized equations from this

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -3,7 +3,7 @@ from sympy import solve, simplify, sympify
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\
     LagrangesMethod
-from sympy.testing.pytest import slow, warns_deprecated_sympy
+from sympy.testing.pytest import slow
 
 
 @slow
@@ -74,8 +74,7 @@ def test_linearize_rolling_disc_kane():
     KM = KanesMethod(N, [q1, q2, q3, q4, q5], [u1, u2, u3], kd_eqs=kindiffs,
             q_dependent=[q6], configuration_constraints=f_c,
             u_dependent=[u4, u5, u6], velocity_constraints=f_v)
-    with warns_deprecated_sympy():
-        (fr, fr_star) = KM.kanes_equations(FL, BL)
+    (fr, fr_star) = KM.kanes_equations(BL, FL)
 
     # Test generalized form equations
     linearizer = KM.to_linearizer()
@@ -158,8 +157,7 @@ def test_linearize_pendulum_kane_minimal():
 
     # Solve for eom with kanes method
     KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], kd_eqs=kde)
-    with warns_deprecated_sympy():
-        (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    (fr, frstar) = KM.kanes_equations([pP], [(P, R)])
 
     # Linearize
     A, B, inp_vec = KM.linearize(A_and_B=True, simplify=True)
@@ -218,8 +216,7 @@ def test_linearize_pendulum_kane_nonminimal():
     KM = KanesMethod(N, q_ind=[q2], u_ind=[u2], q_dependent=[q1],
             u_dependent=[u1], configuration_constraints=f_c,
             velocity_constraints=f_v, acceleration_constraints=f_a, kd_eqs=kde)
-    with warns_deprecated_sympy():
-        (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    (fr, frstar) = KM.kanes_equations([pP], [(P, R)])
 
     # Set the operating point to be straight down, and non-moving
     q_op = {q1: L, q2: 0}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->



#### Brief description of what is fixed or changed

Fixes #10945

This has been deprecated since version 1.1, so time to go.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->