### PR TITLE
evalf evaluates term in exp

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -730,7 +730,7 @@ def evalf_pow(v, prec, options):
     # Evaluate terms in exponential
     if base is S.Exp1 and (exp.is_Add or exp.is_Mul):
         from sympy.core.power import Pow
-        if not exp.is_complex :
+        if not exp.is_complex:
             exp = exp.evalf()
             return Pow(base, exp), None, None, None
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -730,8 +730,9 @@ def evalf_pow(v, prec, options):
     # Evaluate terms in exponential
     if base is S.Exp1 and (exp.is_Add or exp.is_Mul):
         from sympy.core.power import Pow
-        exp = exp.evalf()
-        return Pow(base, exp), None, None, None
+        if not exp.is_complex :
+            exp = exp.evalf()
+            return Pow(base, exp), None, None, None
 
     # We first evaluate the exponent to find its magnitude
     # This determines the working precision that must be used

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -727,6 +727,12 @@ def evalf_pow(v, prec, options):
         # Positive square root
         return mpf_sqrt(xre, prec), None, prec, None
 
+    # Evaluate terms in exponential
+    if base is S.Exp1 and (exp.is_Add or exp.is_Mul):
+        from sympy.core.power import Pow
+        exp = exp.evalf()
+        return Pow(base, exp), None, None, None
+
     # We first evaluate the exponent to find its magnitude
     # This determines the working precision that must be used
     prec += 10
@@ -1446,7 +1452,7 @@ class EvalfMixin:
         >>> (x + y - z).evalf(subs=values)
         1.00000000000000
         """
-        from sympy import Float, Number
+        from sympy import Float, Number, exp
         n = n if n is not None else 15
 
         if subs and is_sequence(subs):
@@ -1485,6 +1491,8 @@ class EvalfMixin:
                 # Probably contains symbols or unknown functions
                 return v
         re, im, re_acc, im_acc = result
+        if type(re) is exp:
+            return re
         if re:
             p = max(min(prec, re_acc), 1)
             re = Float._new(re, p)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -352,7 +352,8 @@ class exp(ExpBase):
                     out.append(newa)
             if out or argchanged:
                 return Mul(*out)*cls(Add(*add), evaluate=False)
-            return None
+            if not arg.is_complex:
+                return None
 
         elif isinstance(arg, MatrixBase):
             return arg.exp()

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -352,6 +352,7 @@ class exp(ExpBase):
                     out.append(newa)
             if out or argchanged:
                 return Mul(*out)*cls(Add(*add), evaluate=False)
+            return None
 
         elif isinstance(arg, MatrixBase):
             return arg.exp()

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -683,3 +683,8 @@ def test_issue_9116():
 
     assert ln(n).is_nonnegative is True
     assert log(n).is_nonnegative is True
+
+
+def test_issue_19774():
+    assert exp(x/2).evalf() == exp(0.5 * x)
+    assert exp(x/2 + y/2).evalf() == exp(0.5 * x + 0.5 * y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #19774 

#### Brief description of what is fixed or changed
Added a case in eval_power so that evalf can  evaluate terms  in exp.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - Made evalf() evaluate terms in exp.
<!-- END RELEASE NOTES -->