### PR TITLE
parsing(c_parser): added support for label and goto construct in C parser

### DIFF
--- a/sympy/parsing/c/c_parser.py
+++ b/sympy/parsing/c/c_parser.py
@@ -49,7 +49,7 @@ if cin:
         uint8, uint16, uint32, uint64, float32, float64, float80,
         aug_assign, bool_, While, CodeBlock)
     from sympy.codegen.cnodes import (PreDecrement, PostDecrement,
-        PreIncrement, PostIncrement)
+        PreIncrement, PostIncrement, Label, goto)
     from sympy.core import Add, Mod, Mul, Pow, Rel
     from sympy.logic.boolalg import And, as_Boolean, Not, Or
     from sympy import Symbol, sympify, true, false
@@ -1059,6 +1059,37 @@ if cin:
                 statement_block = CodeBlock(statements)
 
             return While(condition, statement_block)
+
+        def transform_label_stmt(self, node):
+            """Transformation function for handling label statement
+
+            Returns
+            =======
+
+            label statement : Codegen AST Node
+                contains the label statement node which has children
+                until goto statement is encountered
+
+            """
+
+            children = []
+            for child in node.get_children():
+                children.append(self.transform(child))
+
+            return Label(node.spelling, children)
+
+        def transform_goto_stmt(self, node):
+            """Transformation function for handling goto statement
+
+            Returns
+            =======
+
+            goto statement : Codegen AST Node
+                contains the goto statement node having label reference
+
+            """
+            label_ref = Label(next(node.get_children()).spelling)
+            return goto(label_ref)
 
 
 

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -13,7 +13,7 @@ if cin:
         MulAugmentedAssignment, DivAugmentedAssignment,
         ModAugmentedAssignment, While)
     from sympy.codegen.cnodes import (PreDecrement, PostDecrement,
-        PreIncrement, PostIncrement)
+        PreIncrement, PostIncrement, Label, goto)
     from sympy.core import (Add, Mul, Mod, Pow, Rational,
         StrictLessThan, LessThan, StrictGreaterThan, GreaterThan,
         Equality, Unequality)
@@ -5223,6 +5223,113 @@ if cin:
                     Integer(1),
                     body=CodeBlock(
                         NoneToken()
+                        )
+                    )
+                )
+            )
+
+
+    def test_label_goto():
+
+        c_src1 = (
+            'void func()'+
+            '{' + '\n' +
+                'int a = 0;' + '\n' +
+                'int b;' + '\n' +
+                'label:' + '\n' +
+                ' b = a + 10;' + '\n' +
+                'goto label;' + '\n' +
+            '}'
+        )
+
+        c_src2 = (
+            'void func()'+
+            '{' + '\n' +
+                'int i = 0;' + '\n' +
+                'int j = 100;' + '\n' +
+                'label:' + '\n' +
+                ' i++;' + '\n' +
+                ' j--;' + '\n' +
+                'goto label;' + '\n' +
+            '}'
+        )
+
+        res1 = SymPyExpression(c_src1, 'c').return_expr()
+        res2 = SymPyExpression(c_src2, 'c').return_expr()
+
+        assert res1[0] == FunctionDefinition(
+            NoneToken(),
+            name=String('func'),
+            parameters=(),
+            body=CodeBlock(
+                Declaration(
+                    Variable(
+                        Symbol('a'),
+                        type=IntBaseType(String('intc')),
+                        value=Integer(0)
+                        )
+                    ),
+                Declaration(
+                    Variable(
+                        Symbol('b'),
+                        type=IntBaseType(String('intc'))
+                        )
+                    ),
+                Label(
+                    String('label'),
+                    body=CodeBlock(
+                        Assignment(
+                            Variable(
+                                Symbol('b')
+                                ),
+                            Add(
+                                Symbol('a'),
+                                Integer(10)
+                                )
+                            )
+                        )
+                    ),
+                goto(
+                    Label(
+                        String('label')
+                        )
+                    )
+                )
+            )
+
+        assert res2[0] == FunctionDefinition(
+            NoneToken(),
+            name=String('func'),
+            parameters=(),
+            body=CodeBlock(
+                Declaration(
+                    Variable(
+                        Symbol('i'),
+                        type=IntBaseType(String('intc')),
+                        value=Integer(0)
+                        )
+                    ),
+                Declaration(
+                    Variable(
+                        Symbol('j'),
+                        type=IntBaseType(String('intc')),
+                        value=Integer(100)
+                        )
+                    ),
+                Label(
+                    String('label'),
+                    body=CodeBlock(
+                        PostIncrement(
+                            Symbol('i')
+                            )
+                        )
+                    ),
+                PostDecrement(
+                    Symbol('j')
+                    ),
+                goto(
+                    Label(
+                        String('label')
                         )
                     )
                 )


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
- Added support for `label` statement
- Added support for `goto` statement
- Added corresponding tests

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- parsing
    - Added support for `label` and `goto` in C parser 
<!-- END RELEASE NOTES -->