### PR TITLE
Added a special case for fixing recursion error 

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -644,6 +644,10 @@ class LatexPrinter(Printer):
             # special case for 1^(-x), issue 9216
             if expr.base == 1:
                 return r"%s^{%s}" % (expr.base, expr.exp)
+            # special case for (1/x)^(-y) and (-1/-x)^(-y), issue 20252
+            if expr.base.is_Rational and \
+                    expr.base.p*expr.base.q == abs(expr.base.q):
+                return r"{%s/%s}^{%s}" % (expr.base.p, expr.base.q, expr.exp)
             # things like 1/x
             return self._print_Mul(expr)
         else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20252 

#### Brief description of what is fixed or changed
Fixed the issue by adding a special check for the above mentioned issue. Before the changes the latex() function gave recursion error whenever there was a base of the form 1/x where x is any positive integer and power was negative integer. Now after the special check is added it gives a suitable output. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->