### PR TITLE
Reuse pole detection/reintegration logic from heurisch_wrapper in meijerint

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -178,16 +178,9 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     # If there is one condition, put the generic case first. Otherwise,
     # doing so may lead to longer Piecewise formulas
     if len(pairs) == 1:
-        pairs = [(heurisch(f, x, rewrite, hints, mappings, retries,
-                              degree_offset, unnecessary_permutations,
-                              _try_heurisch),
-                              generic),
-                 (pairs[0][0], True)]
+        pairs = [(res, generic), (pairs[0][0], True)]
     else:
-        pairs.append((heurisch(f, x, rewrite, hints, mappings, retries,
-                              degree_offset, unnecessary_permutations,
-                              _try_heurisch),
-                              True))
+        pairs.append((res, True))
     return Piecewise(*pairs)
 
 class BesselTable:

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -173,7 +173,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         cond = And(*[Eq(key, value) for key, value in sub_dict.items()])
         generic = Or(*[Ne(key, value) for key, value in sub_dict.items()])
         if expr is None:
-            expr = integrate(f.subs(sub_dict),x)
+            expr = integrate(f.subs(sub_dict), x, conds='none')
         pairs.append((expr, cond))
     # If there is one condition, put the generic case first. Otherwise,
     # doing so may lead to longer Piecewise formulas

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -8,7 +8,7 @@ from sympy.core.function import diff
 from sympy.core.logic import fuzzy_bool
 from sympy.core.mul import Mul
 from sympy.core.numbers import oo, pi
-from sympy.core.relational import Ne
+from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
 from sympy.core.sympify import sympify
@@ -25,7 +25,6 @@ from sympy.integrals.meijerint import (meijerint_definite,
 from sympy.logic.boolalg import And, Or
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
-from sympy.core.relational import Eq, Ne
 from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -20,12 +20,15 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
+from sympy.logic.boolalg import And, Or
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
+from sympy.core.relational import Eq, Ne
 from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
 from sympy.simplify.fu import sincos_to_sum
+from sympy.utilities.iterables import uniq
 from sympy.utilities.misc import filldedent
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -1596,3 +1599,61 @@ def line_integrate(field, curve, vars):
 
     integral = Integral(Ft, curve.limits).doit(deep=False)
     return integral
+
+
+def pole_reintegrate(f, x, antideriv,
+                     reintegrator=lambda f, x: integrate(f, x, conds="none")):
+    """
+    Takes an integrand f with integration variable x with an initially
+    computed antiderivative and checks for poles in the denominator. For each
+    of these poles, the integral is reevaluated, and the final integration
+    result is given in terms of a Piecewise.
+
+    See Also
+    ========
+
+    heurisch_wrapper
+    """
+    from sympy.solvers.solvers import solve, denoms
+
+    # We consider each denominator in the expression, and try to find
+    # cases where one or more symbolic denominator might be zero. The
+    # conditions for these cases are stored in the list slns.
+    slns = []
+    for d in denoms(antideriv):
+        try:
+            slns += solve(d, dict=True, exclude=(x,))
+        except NotImplementedError:
+            pass
+    if not slns:
+        return antideriv
+    slns = list(uniq(slns))
+    # Remove the solutions corresponding to poles in the original expression.
+    slns0 = []
+    for d in denoms(f):
+        try:
+            slns0 += solve(d, dict=True, exclude=(x,))
+        except NotImplementedError:
+            pass
+    slns = [s for s in slns if s not in slns0]
+    if not slns:
+        return antideriv
+    if len(slns) > 1:
+        eqs = []
+        for sub_dict in slns:
+            eqs.extend([Eq(key, value) for key, value in sub_dict.items()])
+        slns = solve(eqs, dict=True, exclude=(x,)) + slns
+    # For each case listed in the list slns, we reevaluate the integral.
+    pairs = []
+    for sub_dict in slns:
+        expr = reintegrator(f.subs(sub_dict), x)
+        cond = And(*[Eq(key, value) for key, value in sub_dict.items()])
+        generic = Or(*[Ne(key, value) for key, value in sub_dict.items()])
+        pairs.append((expr, cond))
+    # If there is one condition, put the generic case first. Otherwise,
+    # doing so may lead to longer Piecewise formulas
+    if len(pairs) == 1:
+        pairs = [(antideriv, generic), (pairs[0][0], True)]
+    else:
+        pairs.append((antideriv, True))
+    return Piecewise(*pairs)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -19,7 +19,9 @@ from sympy.functions.elementary.complexes import Abs, sign
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
-from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
+from sympy.integrals.meijerint import (meijerint_definite,
+                                       meijerint_indefinite,
+                                       meijerint_indefinite_wrapper)
 from sympy.logic.boolalg import And, Or
 from sympy.matrices import MatrixBase
 from sympy.polys import Poly, PolynomialError
@@ -1069,7 +1071,10 @@ class Integral(AddWithLimits):
             if meijerg is not False and h is None:
                 # rewrite using G functions
                 try:
-                    h = meijerint_indefinite(g, x)
+                    if conds == 'piecewise':
+                        h = meijerint_indefinite_wrapper(g, x)
+                    else:
+                        h = meijerint_indefinite(g, x)
                 except NotImplementedError:
                     from sympy.integrals.meijerint import _debug
                     _debug('NotImplementedError from meijerint_definite')

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1601,6 +1601,38 @@ def _rewrite2(f, x):
                     return fac, po, g1[0], g2[0], cond
 
 
+def meijerint_indefinite_wrapper(f, x):
+    """
+    A wrapper that takes the result from meijerint_definite and checks for
+    poles in the denominator. For each of these poles, the integral is
+    reevaluated, and the final integration result is given in terms of a
+    Piecewise. The reevaluation uses the top-level `integrate` routine which
+    may call a different integration routine than meijerint_indefinite.
+
+    Examples
+    ========
+
+    >>> from sympy.integrals.meijerint import meijerint_indefinite_wrapper
+    >>> from sympy import sin
+    >>> from sympy.abc import x, n, k
+    >>> meijerint_indefinite_wrapper(sin(x**(n*k + 1)), x)
+    Piecewise((x*x**(k*n)*x**(k*n/(k*n + 1))*x**(1/(k*n + 1))*gamma(1/2 + 1/(2*(k*n + 1)))*hyper((1/2 + 1/(2*(k*n + 1)),), (3/2, 3/2 + 1/(2*(k*n + 1))), -x**2*x**(2*k*n)/4)/(2*k*n*gamma(3/2 + 1/(2*(k*n + 1))) + 2*gamma(3/2 + 1/(2*(k*n + 1)))), Ne(k, -1/n)), (x*sin(1), True))
+
+    See Also
+    ========
+
+    heurisch_wrapper
+    pole_reintegrate
+    """
+    from sympy.integrals.integrals import pole_reintegrate
+
+    res = meijerint_indefinite(f, x)
+    if not res:
+        return res
+
+    return pole_reintegrate(f, x, res)
+
+
 def meijerint_indefinite(f, x):
     """
     Compute an indefinite integral of ``f`` by rewriting it as a G function.

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1661,9 +1661,10 @@ def test_issue_17473():
     x = Symbol('x')
     n = Symbol('n')
     assert integrate(sin(x**n), x) == \
-        x*x**n*gamma(S(1)/2 + 1/(2*n))*hyper((S(1)/2 + 1/(2*n),),
-                     (S(3)/2, S(3)/2 + 1/(2*n)),
-                     -x**(2*n)/4)/(2*n*gamma(S(3)/2 + 1/(2*n)))
+        Piecewise((x*x**n*gamma(S(1)/2 + 1/(2*n))*hyper((S(1)/2 + 1/(2*n),),
+                   (S(3)/2, S(3)/2 + 1/(2*n)),
+                   -x**(2*n)/4)/(2*n*gamma(S(3)/2 + 1/(2*n))), Ne(n, 0)),
+                  (x*sin(1), True))
 
 
 def test_issue_17671():
@@ -1676,7 +1677,9 @@ def test_issue_2975():
     w = Symbol('w')
     C = Symbol('C')
     y = Symbol('y')
-    assert integrate(1/(y**2+C)**(S(3)/2), (y, -w/2, w/2)) == w/(C**(S(3)/2)*sqrt(1 + w**2/(4*C)))
+    assert integrate(1/(y**2+C)**(S(3)/2), (y, -w/2, w/2)) == \
+        Piecewise((w/(C**(S(3)/2)*sqrt(1 + w**2/(4*C))), (C > -oo) & (C < oo) & Ne(C, 0)),
+                  (0, True))
 
 
 def test_issue_7827():
@@ -1704,3 +1707,9 @@ def test_issue_4231():
 def test_issue_17841():
     f = diff(1/(x**2+x+I), x)
     assert integrate(f, x) == 1/(x**2 + x + I)
+
+
+def test_issue_5949():
+    assert integrate((x**(n - 1))*sqrt(1 + x**n), x) == \
+        Piecewise((2*x**n*sqrt(x**n + 1)/(3*n) + 2*sqrt(x**n + 1)/(3*n), Ne(n, 0)),
+                  (sqrt(2)*log(x), True))

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -6691,7 +6691,7 @@ def _nonlinear_2eq_order1_type3(x, y, t, eq):
     if isinstance(sol2r, Expr):
         sol2r = [sol2r]
     for sol2s in sol2r:
-        sol1 = solve(Integral(1/F.subs(v(u), sol2s.rhs), u).doit() - t - C2, u)
+        sol1 = solve(Integral(1/F.subs(v(u), sol2s.rhs), u).doit(conds='none') - t - C2, u)
     sol = []
     for sols in sol1:
         sol.append(Eq(x(t), sols))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #5949

#### Brief description of what is fixed or changed

Moves the code in `heurisch_wrapper` to a shared function, `pole_reintegrate` that can also be used by `meijerint` (via a new `meijerint_indefinite_wrapper`.

#### Other comments

reused heurisch_wrapper logic originally from #1622

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * `meijerg=True` option of `integrate` now returns a `Piecewise` handling cases where the indefinite integral returned by `meijerint_indefinite` could have a zero denominator. This affects any uses of the `integrals` module that rely on `meijerint`. This behavior can be disabled using the `integrate` option `conds='none'`.

<!-- END RELEASE NOTES -->