### PR TITLE
CuPy support in `lambdify`

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -22,6 +22,7 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 # by simple variable maps, like I => 1j
 MATH_DEFAULT = {}  # type: Dict[str, Any]
 MPMATH_DEFAULT = {}  # type: Dict[str, Any]
+CUPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 NUMPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 SCIPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 TENSORFLOW_DEFAULT = {}  # type: Dict[str, Any]
@@ -34,6 +35,7 @@ NUMEXPR_DEFAULT = {}  # type: Dict[str, Any]
 
 MATH = MATH_DEFAULT.copy()
 MPMATH = MPMATH_DEFAULT.copy()
+CUPY = CUPY_DEFAULT.copy()
 NUMPY = NUMPY_DEFAULT.copy()
 SCIPY = SCIPY_DEFAULT.copy()
 TENSORFLOW = TENSORFLOW_DEFAULT.copy()
@@ -79,6 +81,7 @@ MPMATH_TRANSLATIONS = {
     "FallingFactorial": "ff",
 }
 
+CUPY_TRANSLATIONS = {}  # type: Dict[str, str]
 NUMPY_TRANSLATIONS = {}  # type: Dict[str, str]
 SCIPY_TRANSLATIONS = {}  # type: Dict[str, str]
 
@@ -92,6 +95,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
+    "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy; import scipy; from scipy import *; from scipy.special import *",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
@@ -786,6 +790,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
             from sympy.printing.pycode import SciPyPrinter as Printer # type: ignore
         elif _module_present('numpy', namespaces):
             from sympy.printing.pycode import NumPyPrinter as Printer # type: ignore
+        elif _module_present('cupy', namespaces):
+            from sympy.printing.pycode import CuPyPrinter as Printer # type: ignore
         elif _module_present('numexpr', namespaces):
             from sympy.printing.lambdarepr import NumExprPrinter as Printer # type: ignore
         elif _module_present('tensorflow', namespaces):


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* utilities
   * lambdify: Added support for CuPy
<!-- END RELEASE NOTES -->

Hello,

This PR adds support for CuPy to be used as a module in `lambdify`.
[CuPy](https://github.com/cupy/cupy) is a NumPy compatible GPU accelerated ndarray library that can be useful for SymPy when dealing with large array calculations. CuPy can be used as a drop-in replacement of NumPy in the majority of use cases.

This PR is in the initial stage so only basic support is added,  things we need to discuss are:
Add CuPy examples in the documentation and tests? this will require a GPU to run those so maybe from the point of view of your CI this is difficult to deal with.

The following code is an example
```
from sympy import sin, cos, symbols, lambdify
import cupy as cp

x = symbols('x')
expr = sin(x) + cos(x)
f = lambdify(x, expr, 'cupy')
a = cp.arange(10000000)
for i in range(1000):
    f(a)
```