### PR TITLE
maint(parsing): XFAIL tests in parsing

### DIFF
--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -1,5 +1,5 @@
 from sympy.parsing.sym_expr import SymPyExpression
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, XFAIL
 from sympy.external import import_module
 
 cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
@@ -151,6 +151,7 @@ if cin:
         )
 
 
+    @XFAIL
     def test_int():
         c_src1 = 'int a = 1;'
         c_src2 = (
@@ -627,6 +628,7 @@ if cin:
             )
 
 
+    @XFAIL
     def test_float():
         c_src1 = 'float a = 1.0;'
         c_src2 = (
@@ -851,6 +853,7 @@ if cin:
             )
 
 
+    @XFAIL
     def  test_bool():
         c_src1 = (
             'bool a = true, b = false;'
@@ -3317,6 +3320,7 @@ if cin:
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise5, 'c'))
 
 
+    @XFAIL
     def test_var_decl():
         c_src1 = (
             'int b = 100;' + '\n' +


### PR DESCRIPTION
These tests started failing in CI most likely due to a change in the
dependencies:

  https://github.com/sympy/sympy/issues/20265

This commit marks the failing tests as XFAIL to unblock CI until a fix
can be found.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->