### PR TITLE
polys: Replace algorithm of primitive_element for ex=True

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2447,6 +2447,11 @@ class AlgebraicNumber(Expr):
     is_algebraic = True
     is_number = True
 
+    # Optional alias symbol is not free.
+    # Actually, alias should be a Str, but some methods
+    # expect that it be an instance of Expr.
+    free_symbols = set()
+
     def __new__(cls, expr, coeffs=None, alias=None, **args):
         """Construct a new algebraic number. """
         from sympy import Poly

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -2,6 +2,7 @@
 
 
 from sympy.core import sympify
+from sympy.core.compatibility import ordered
 from sympy.core.evalf import pure_complex
 from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, EX
 from sympy.polys.domains.complexfield import ComplexField
@@ -102,7 +103,7 @@ def _construct_algebraic(coeffs, opt):
 
         result.append(coeff)
 
-    exts = list(exts)
+    exts = list(ordered(exts))
 
     g, span, H = primitive_element(exts, ex=True, polys=True)
     root = sum([ s*ext for s, ext in zip(span, exts) ])

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -82,27 +82,24 @@ def _construct_algebraic(coeffs, opt):
     """We know that coefficients are algebraic so construct the extension. """
     from sympy.polys.numberfields import primitive_element
 
-    result, exts = [], set()
+    exts = set()
 
-    for coeff in coeffs:
-        if coeff.is_Rational:
-            coeff = (None, 0, QQ.from_sympy(coeff))
-        else:
-            a = coeff.as_coeff_add()[0]
-            coeff -= a
+    def build_trees(args):
+        trees = []
+        for a in args:
+            if a.is_Rational:
+                tree = ('Q', QQ.from_sympy(a))
+            elif a.is_Add:
+                tree = ('+', build_trees(a.args))
+            elif a.is_Mul:
+                tree = ('*', build_trees(a.args))
+            else:
+                tree = ('e', a)
+                exts.add(a)
+            trees.append(tree)
+        return trees
 
-            b = coeff.as_coeff_mul()[0]
-            coeff /= b
-
-            exts.add(coeff)
-
-            a = QQ.from_sympy(a)
-            b = QQ.from_sympy(b)
-
-            coeff = (coeff, b, a)
-
-        result.append(coeff)
-
+    trees = build_trees(coeffs)
     exts = list(ordered(exts))
 
     g, span, H = primitive_element(exts, ex=True, polys=True)
@@ -110,13 +107,27 @@ def _construct_algebraic(coeffs, opt):
 
     domain, g = QQ.algebraic_field((g, root)), g.rep.rep
 
-    for i, (coeff, a, b) in enumerate(result):
-        if coeff is not None:
-            coeff = a*domain.dtype.from_list(H[exts.index(coeff)], g, QQ) + b
-        else:
-            coeff = domain.dtype.from_list([b], g, QQ)
+    exts_dom = [domain.dtype.from_list(h, g, QQ) for h in H]
+    exts_map = dict(zip(exts, exts_dom))
 
-        result[i] = coeff
+    def convert_tree(tree):
+        op, args = tree
+        if op == 'Q':
+            return domain.dtype.from_list([args], g, QQ)
+        elif op == '+':
+            return sum((convert_tree(a) for a in args), domain.zero)
+        elif op == '*':
+            # return prod(convert(a) for a in args)
+            t = convert_tree(args[0])
+            for a in args[1:]:
+                t *= convert_tree(a)
+            return t
+        elif op == 'e':
+            return exts_map[args]
+        else:
+            raise RuntimeError
+
+    result = [convert_tree(tree) for tree in trees]
 
     return domain, result
 

--- a/sympy/polys/domainmatrix.py
+++ b/sympy/polys/domainmatrix.py
@@ -253,8 +253,9 @@ def ddm_irref(a):
 
         # normalise row
         ai = a[i]
+        aijinv = aij**-1
         for l in range(j, n):
-            ai[l] /= aij # ai[j] = one
+            ai[l] *= aijinv # ai[j] = one
 
         # eliminate above and below to the right
         for k, ak in enumerate(a):

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -60,8 +60,11 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
 
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
-        from sympy.polys.numberfields import AlgebraicNumber
-        return AlgebraicNumber(self.ext, a).as_expr()
+        # Precompute a converter to be reused:
+        if not hasattr(self, '_converter'):
+            self._converter = _make_converter(self)
+
+        return self._converter(a)
 
     def from_sympy(self, a):
         """Convert SymPy's expression to ``dtype``. """
@@ -137,3 +140,44 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
     def from_GaussianRationalField(K1, a, K0):
         """Convert a GaussianRational element 'a' to ``dtype``. """
         return K1.from_sympy(K0.to_sympy(a))
+
+
+def _make_converter(K):
+    """Construct the converter to convert back to Expr"""
+    # Precompute the effect of converting to sympy and expanding expressions
+    # like (sqrt(2) + sqrt(3))**2. Asking Expr to do the expansion on every
+    # conversion from K to Expr is slow. Here we compute the expansions for
+    # each power of the generator and collect together the resulting algebraic
+    # terms and the rational coefficients into a matrix.
+    from sympy import Add, S
+
+    gen = K.ext.as_expr()
+    todom = K.dom.from_sympy
+
+    # We'll let Expr compute the expansions. We won't make any presumptions
+    # about what this results in except that it is QQ-linear in some terms
+    # that we will call algebraics. The final result will be expressed in
+    # terms of those.
+    powers = [S.One, gen]
+    for n in range(2, K.mod.degree()):
+        powers.append((gen * powers[-1]).expand())
+
+    # Collect the rational coefficients and algebraic Expr that can
+    # map the ANP coefficients into an expanded sympy expression
+    terms = [dict(t.as_coeff_Mul()[::-1] for t in Add.make_args(p)) for p in powers]
+    algebraics = set().union(*terms)
+    matrix = [[todom(t.get(a, S.Zero)) for t in terms] for a in algebraics]
+
+    # Create a function to do the conversion efficiently:
+
+    def converter(a):
+        """Convert a to Expr using converter"""
+        from sympy import Add, Mul
+        ai = a.rep[::-1]
+        tosympy = K.dom.to_sympy
+        coeffs_dom = [sum(mij*aj for mij, aj in zip(mi, ai)) for mi in matrix]
+        coeffs_sympy = [tosympy(c) for c in coeffs_dom]
+        res = Add(*(Mul(c, a) for c, a in zip(coeffs_sympy, algebraics)))
+        return res
+
+    return converter

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -18,7 +18,6 @@ from sympy.polys.domains import ZZ, QQ
 from sympy.polys.orthopolys import dup_chebyshevt
 from sympy.polys.polyerrors import (
     IsomorphismFailed,
-    CoercionFailed,
     NotAlgebraic,
     GeneratorsError,
 )
@@ -36,7 +35,7 @@ from sympy.printing.pycode import PythonCodePrinter, MpmathPrinter
 from sympy.simplify.radsimp import _split_gcd
 from sympy.simplify.simplify import _is_sum_surds
 from sympy.utilities import (
-    numbered_symbols, variations, lambdify, public, sift
+    numbered_symbols, lambdify, public, sift
 )
 
 from mpmath import pslq, mp

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -842,12 +842,7 @@ def primitive_element(extension, x=None, *, ex=False, coeffs=_coeffs_generator, 
 
     if not ex:
         gen, coeffs = extension[0], [1]
-        # XXX when minimal_polynomial is extended to work
-        # with AlgebraicNumbers this test can be removed
-        if isinstance(gen, AlgebraicNumber):
-            g = gen.minpoly.replace(x)
-        else:
-            g = minimal_polynomial(gen, x, polys=True)
+        g = minimal_polynomial(gen, x, polys=True)
         for ext in extension[1:]:
             _, factors = factor_list(g, extension=ext)
             g = _choose_factor(factors, x, gen)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -13,6 +13,7 @@ from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
+from sympy.polys.densetools import dup_eval
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.orthopolys import dup_chebyshevt
 from sympy.polys.polyerrors import (
@@ -818,17 +819,25 @@ def _minpoly_groebner(ex, x, cls):
 
 minpoly = minimal_polynomial
 
-def _coeffs_generator(n):
-    """Generate coefficients for `primitive_element()`. """
-    for coeffs in variations([1, -1, 2, -2, 3, -3], n, repetition=True):
-        # Two linear combinations with coeffs of opposite signs are
-        # opposites of each other. Hence it suffices to test only one.
-        if coeffs[0] > 0:
-            yield list(coeffs)
+
+def _switch_domain(g, K):
+    # An algebraic relation f(a, b) = 0 over Q can also be written
+    # g(b) = 0 where g is in Q(a)[x] and h(a) = 0 where h is in Q(b)[x].
+    # This function transforms g into h where Q(b) = K.
+    frep = g.rep.inject()
+    hrep = frep.eject(K, front=True)
+
+    return g.new(hrep, g.gens[0])
+
+
+def _linsolve(p):
+    # Compute root of linear polynomial.
+    c, d = p.rep.rep
+    return -d/c
 
 
 @public
-def primitive_element(extension, x=None, *, ex=False, coeffs=_coeffs_generator, polys=False):
+def primitive_element(extension, x=None, *, ex=False, polys=False):
     """Construct a common number field for all extensions. """
     if not extension:
         raise ValueError("can't compute primitive element for empty extension")
@@ -837,8 +846,6 @@ def primitive_element(extension, x=None, *, ex=False, coeffs=_coeffs_generator, 
         x, cls = sympify(x), Poly
     else:
         x, cls = Dummy('x'), PurePoly
-
-    coeffs_generator = coeffs
 
     if not ex:
         gen, coeffs = extension[0], [1]
@@ -855,47 +862,29 @@ def primitive_element(extension, x=None, *, ex=False, coeffs=_coeffs_generator, 
         else:
             return cls(g), coeffs
 
-    generator = numbered_symbols('y', cls=Dummy)
+    gen, coeffs = extension[0], [1]
+    f = minimal_polynomial(gen, x, polys=True)
+    K = QQ.algebraic_field((f, gen))  # incrementally constructed field
+    reps = [K.unit]  # representations of extension elements in K
+    for ext in extension[1:]:
+        p = minimal_polynomial(ext, x, polys=True)
+        L = QQ.algebraic_field((p, ext))
+        _, factors = factor_list(f, domain=L)
+        f = _choose_factor(factors, x, gen)
+        s, g, f = f.sqf_norm()
+        gen += s*ext
+        coeffs.append(s)
+        K = QQ.algebraic_field((f, gen))
+        h = _switch_domain(g, K)
+        erep = _linsolve(h.gcd(p))  # ext as element of K
+        ogen = K.unit - s*erep  # old gen as element of K
+        reps = [dup_eval(_.rep, ogen, K) for _ in reps] + [erep]
 
-    F, Y = [], []
-
-    for ext in extension:
-        y = next(generator)
-
-        if ext.is_Poly:
-            if ext.is_univariate:
-                f = ext.as_expr(y)
-            else:
-                raise ValueError("expected minimal polynomial, got %s" % ext)
-        else:
-            f = minpoly(ext, y)
-
-        F.append(f)
-        Y.append(y)
-
-    for coeffs in coeffs_generator(len(Y)):
-        f = x - sum([ c*y for c, y in zip(coeffs, Y)])
-        G = groebner(F + [f], Y + [x], order='lex', field=True)
-
-        H, g = G[:-1], cls(G[-1], x, domain='QQ')
-
-        for i, (h, y) in enumerate(zip(H, Y)):
-            try:
-                H[i] = Poly(y - h, x,
-                            domain='QQ').all_coeffs()  # XXX: composite=False
-            except CoercionFailed:  # pragma: no cover
-                break  # G is not a triangular set
-        else:
-            break
-    else:  # pragma: no cover
-        raise RuntimeError("run out of coefficient configurations")
-
-    _, g = g.clear_denoms()
-
+    H = [_.rep for _ in reps]
     if not polys:
-        return g.as_expr(), coeffs, H
+        return f.as_expr(), coeffs, H
     else:
-        return g, coeffs, H
+        return f, coeffs, H
 
 
 def is_isomorphism_possible(a, b):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -163,10 +163,12 @@ def sring(exprs, *symbols, **options):
     reps, opt = _parallel_dict_from_expr(exprs, opt)
 
     if opt.domain is None:
-        # NOTE: this is inefficient because construct_domain() automatically
-        # performs conversion to the target domain. It shouldn't do this.
         coeffs = sum([ list(rep.values()) for rep in reps ], [])
-        opt.domain, _ = construct_domain(coeffs, opt=opt)
+
+        opt.domain, coeffs_dom = construct_domain(coeffs, opt=opt)
+
+        coeff_map = dict(zip(coeffs, coeffs_dom))
+        reps = [{m: coeff_map[c] for m, c in rep.items()} for rep in reps]
 
     _ring = PolyRing(opt.gens, opt.domain, opt.order)
     polys = list(map(_ring.from_dict, reps))

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -367,9 +367,14 @@ def _solve_lin_sys_component(eqs_coeffs, eqs_rhs, ring):
     else:
         sols = {}
         g = ring.gens
-        echelon = echelon.rep
+        # Extract ground domain coefficients and convert to the ring:
+        if hasattr(ring, 'ring'):
+            convert = ring.ring.ground_new
+        else:
+            convert = ring.ground_new
+        echelon = [[convert(eij) for eij in ei] for ei in echelon.rep]
         for i, p in enumerate(pivots):
-            v = echelon[i][-1] - sum(echelon[i][j]*g[j] for j in range(p+1, len(g)))
+            v = echelon[i][-1] - sum(echelon[i][j]*g[j] for j in range(p+1, len(g)) if echelon[i][j])
             sols[keys[p]] = v
 
     return sols

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -160,6 +160,12 @@ def test_minimal_polynomial():
     48*x - 19*(19 - 3*sqrt(33))**Rational(2, 3) - 3*sqrt(33)*(19 - 3*sqrt(33))**Rational(2, 3) \
     - 16*(19 - 3*sqrt(33))**Rational(1, 3) - 16
 
+    # AlgebraicNumber with an alias.
+    # Wester H24
+    phi = AlgebraicNumber(S.GoldenRatio.expand(func=True), alias='phi')
+    minimal_polynomial(phi, x) == x**2 - x - 1
+
+
 def test_minimal_polynomial_hi_prec():
     p = 1/sqrt(1 - 9*sqrt(2) + 7*sqrt(3) + Rational(1, 10)**30)
     mp = minimal_polynomial(p, x)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -18,6 +18,7 @@ from sympy.polys.numberfields import (
     isolate, IntervalPrinter,
 )
 
+from sympy.polys.partfrac import apart
 from sympy.polys.polyerrors import (
     IsomorphismFailed,
     NotAlgebraic,
@@ -796,3 +797,12 @@ def test_issue_19760():
     for comp in (True, False):
         mp = Poly(minimal_polynomial(e, compose=comp))
         assert mp(x) == mp_expected, "minimal_polynomial(e, compose=%s) = %s; %s expected" % (comp, mp(x), mp_expected)
+
+
+def test_issue_20163():
+    assert apart(1/(x**6+1), extension=[sqrt(3), I]) == \
+        (sqrt(3) + I)/(2*x + sqrt(3) + I)/6 + \
+        (sqrt(3) - I)/(2*x + sqrt(3) - I)/6 - \
+        (sqrt(3) - I)/(2*x - sqrt(3) + I)/6 - \
+        (sqrt(3) + I)/(2*x - sqrt(3) - I)/6 + \
+        I/(x + I)/6 - I/(x - I)/6

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -171,7 +171,7 @@ def test_sring():
 
     r = sqrt(2) - sqrt(3)
     R, a = sring(r, extension=True)
-    assert R.domain == QQ.algebraic_field(r)
+    assert R.domain == QQ.algebraic_field(sqrt(2) + sqrt(3))
     assert R.gens == ()
     assert a == R.domain.from_sympy(r)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20163

#### Brief description of what is fixed or changed


The algorithm currently used by primitive_element for ex=True is
based on the `groebner` function. That does not work reliably if
the input extension elements are not linearly disjoint (see e.g.
#14117). This commit implements the same iterative method
that is used for the ex=False case extended
by including representations of field elements.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- polys
  - numberfields: implemented new algorithm for `primitive_element` in case `ex=True`.
<!-- END RELEASE NOTES -->