### PR TITLE
Added determinant (and eigenvalue) computation to DFT and IDFT

### DIFF
--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -1,4 +1,4 @@
-from sympy import Basic, Expr, S, sympify
+from sympy import Basic, Expr, S, sympify, Mul
 from sympy.matrices.common import NonSquareMatrixError
 
 
@@ -37,7 +37,12 @@ class Determinant(Expr):
         try:
             return self.arg._eval_determinant()
         except (AttributeError, NotImplementedError):
-            return self
+            try:
+                eigs = self.arg._eval_eigenvals()
+                return Mul(*[e**c for e, c in eigs.items()])
+            except (AttributeError, NotImplementedError):
+                return self
+
 
 def det(matexpr):
     """ Matrix Determinant

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -1,6 +1,8 @@
 from sympy.core.sympify import _sympify
 from sympy.matrices.expressions import MatrixExpr
+from sympy.matrices.expressions.determinant import Determinant
 from sympy import S, I, sqrt, exp
+
 
 class DFT(MatrixExpr):
     """ Discrete Fourier Transform """
@@ -21,6 +23,32 @@ class DFT(MatrixExpr):
     def _eval_inverse(self):
         return IDFT(self.n)
 
+    def _eval_determinant(self):
+        eigs = self._eval_eigenvals()
+        if eigs:
+            tmp = 1
+            for e, cnt in eigs.items():
+                tmp *= e**cnt
+            return tmp
+        return Determinant(self)
+
+    def _eval_eigenvals(self):
+        # Based on Dickinson and Steiglitz, "Eigenvectors and Functions of the
+        # Discrete Fourier Transform", 1982
+        if self.n.is_Integer:
+            m = self.n // 4
+            r = self.n % 4
+            if r == 0:
+                ret = {1: m+1, -1: m, I: m-1, -I: m}
+            elif r == 1:
+                ret = {1: m+1, -1: m, I: m, -I: m}
+            elif r == 2:
+                ret = {1: m+1, -1: m+1, I: m, -I: m}
+            elif r == 3:
+                ret = {1: m+1, -1: m+1, I: m, -I: m+1}
+            return {eig: ret[eig] for eig in ret if ret[eig] > 0}
+
+
 class IDFT(DFT):
     """ Inverse Discrete Fourier Transform """
     def _entry(self, i, j, **kwargs):
@@ -29,3 +57,19 @@ class IDFT(DFT):
 
     def _eval_inverse(self):
         return DFT(self.n)
+
+    def _eval_eigenvals(self):
+        # Based on Dickinson and Steiglitz, "Eigenvectors and Functions of the
+        # Discrete Fourier Transform", 1982
+        if self.n.is_Integer:
+            m = self.n // 4
+            r = self.n % 4
+            if r == 0:
+                ret = {S.One: m+1, -1: m, I: m, -I: m-1}
+            elif r == 1:
+                ret = {S.One: m+1, -1: m, I: m, -I: m}
+            elif r == 2:
+                ret = {S.One: m+1, -1: m+1, I: m, -I: m}
+            elif r == 3:
+                ret = {S.One: m+1, -1: m+1, I: m+1, -I: m}
+            return {eig: ret[eig] for eig in ret if ret[eig] > 0}

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -1,6 +1,5 @@
 from sympy.core.sympify import _sympify
 from sympy.matrices.expressions import MatrixExpr
-from sympy.matrices.expressions.determinant import Determinant
 from sympy import S, I, sqrt, exp
 
 
@@ -23,15 +22,6 @@ class DFT(MatrixExpr):
     def _eval_inverse(self):
         return IDFT(self.n)
 
-    def _eval_determinant(self):
-        eigs = self._eval_eigenvals()
-        if eigs:
-            tmp = 1
-            for e, cnt in eigs.items():
-                tmp *= e**cnt
-            return tmp
-        return Determinant(self)
-
     def _eval_eigenvals(self):
         # Based on Dickinson and Steiglitz, "Eigenvectors and Functions of the
         # Discrete Fourier Transform", 1982
@@ -39,13 +29,17 @@ class DFT(MatrixExpr):
             m = self.n // 4
             r = self.n % 4
             if r == 0:
-                ret = {1: m+1, -1: m, I: m-1, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m,
+                       S.ImaginaryUnit: m-1, S.NegativeOne*S.ImaginaryUnit: m}
             elif r == 1:
-                ret = {1: m+1, -1: m, I: m, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m}
             elif r == 2:
-                ret = {1: m+1, -1: m+1, I: m, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m+1,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m}
             elif r == 3:
-                ret = {1: m+1, -1: m+1, I: m, -I: m+1}
+                ret = {S.One: m+1, S.NegativeOne: m+1,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m+1}
             return {eig: ret[eig] for eig in ret if ret[eig] > 0}
 
 
@@ -65,11 +59,15 @@ class IDFT(DFT):
             m = self.n // 4
             r = self.n % 4
             if r == 0:
-                ret = {S.One: m+1, -1: m, I: m, -I: m-1}
+                ret = {S.One: m+1, S.NegativeOne: m,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m-1}
             elif r == 1:
-                ret = {S.One: m+1, -1: m, I: m, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m}
             elif r == 2:
-                ret = {S.One: m+1, -1: m+1, I: m, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m+1,
+                       S.ImaginaryUnit: m, S.NegativeOne*S.ImaginaryUnit: m}
             elif r == 3:
-                ret = {S.One: m+1, -1: m+1, I: m+1, -I: m}
+                ret = {S.One: m+1, S.NegativeOne: m+1,
+                       S.ImaginaryUnit: m+1, S.NegativeOne*S.ImaginaryUnit: m}
             return {eig: ret[eig] for eig in ret if ret[eig] > 0}

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,7 +1,7 @@
 from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
 from sympy.core.symbol import symbols
 from sympy.matrices.expressions.fourier import DFT, IDFT
-from sympy.matrices import det, Matrix, Identity
+from sympy.matrices import det, Matrix, Identity, Determinant
 from sympy.testing.pytest import raises
 
 
@@ -27,3 +27,37 @@ def test_dft():
     assert Abs(simplify(det(Matrix(DFT(4))))) == 1
     assert DFT(n)*IDFT(n) == Identity(n)
     assert DFT(n)[i, j] == exp(-2*S.Pi*I/n)**(i*j) / sqrt(n)
+
+
+def test_dft_determinant():
+    assert det(DFT(4)) == I
+    assert det(DFT(5)) == -1
+    assert det(DFT(6)) == 1
+    assert det(DFT(7)) == -I
+    assert det(DFT(4)) == DFT(4).as_explicit().det()
+    assert det(DFT(27)) == I
+
+    assert det(IDFT(4)) == -I
+    assert det(IDFT(4)) == IDFT(4).as_explicit().det()
+
+    n = symbols('n')
+    assert det(DFT(n)) == Determinant(DFT(n))
+
+
+def test_dft_eval_eigenvals():
+    assert DFT(3)._eval_eigenvals() == {-1: 1, 1: 1, -I: 1}
+    assert DFT(44)._eval_eigenvals() == {-1: 11, 1: 12, -I: 11, I: 10}
+    assert DFT(37)._eval_eigenvals() == {-1: 9, 1: 10, -I: 9, I: 9}
+    assert DFT(26)._eval_eigenvals() == {-1: 7, 1: 7, -I: 6, I: 6}
+
+    DFT(4)._eval_eigenvals() == DFT(4).as_explicit().eigenvals()
+
+    assert IDFT(3)._eval_eigenvals() == {-1: 1, 1: 1, I: 1}
+    assert IDFT(44)._eval_eigenvals() == {-1: 11, 1: 12, -I: 10, I: 11}
+    assert IDFT(37)._eval_eigenvals() == {-1: 9, 1: 10, -I: 9, I: 9}
+    assert IDFT(26)._eval_eigenvals() == {-1: 7, 1: 7, -I: 6, I: 6}
+
+    IDFT(4)._eval_eigenvals() == IDFT(4).as_explicit().eigenvals()
+
+    n = symbols('n')
+    assert DFT(n)._eval_eigenvals() is None

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,4 +1,4 @@
-from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
+from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt, Integer
 from sympy.core.symbol import symbols
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity, Determinant
@@ -39,6 +39,7 @@ def test_dft_determinant():
 
     assert det(IDFT(4)) == -I
     assert det(IDFT(4)) == IDFT(4).as_explicit().det()
+    assert isinstance(Determinant(DFT(0)).doit(), Integer)
 
     n = symbols('n')
     assert det(DFT(n)) == Determinant(DFT(n))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added `_eval_determinant` to `DFT` for faster (and better) computation of determinant of DFT and IDFT matrices.

As part of it, added `_eval_eigenvals` which in the future can be used for matrix specific eigenvalue computations.

#### Other comments
Earlier
```
In [111]: DFT(3).as_explicit().det()
Out[111]: sqrt(3)*exp(2*I*pi/3)/3 - sqrt(3)*exp(-2*I*pi/3)/3

In [112]: DFT(3).as_explicit().det().simplify()
Out[112]: (-1)**(1/3)*sqrt(3)*(1 + (-1)**(1/3))/3
```

Now
```
In [109]: det(DFT(3))
Out[109]: I
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * Improved computation of determinant and eigenvalues for `DFT` and `IDFT`.
<!-- END RELEASE NOTES -->