### PR TITLE
Restore sympy.printing.{ccode,fcode,cxxcode} for backwards compatibility (1.7 branch)

### DIFF
--- a/sympy/codegen/tests/test_fnodes.py
+++ b/sympy/codegen/tests/test_fnodes.py
@@ -16,7 +16,7 @@ from sympy.external import import_module
 from sympy.printing import fcode
 from sympy.utilities._compilation import has_fortran, compile_run_strings, compile_link_import_strings
 from sympy.utilities._compilation.util import may_xfail
-from sympy.testing.pytest import skip
+from sympy.testing.pytest import skip, XFAIL
 
 cython = import_module('cython')
 np = import_module('numpy')
@@ -53,6 +53,7 @@ def test_size_assumed_shape():
     assert info['exit_status'] == os.EX_OK
 
 
+@XFAIL  # https://github.com/sympy/sympy/issues/20265
 @may_xfail
 def test_ImpliedDoLoop():
     if not has_fortran():
@@ -114,6 +115,7 @@ def test_Module():
     assert stderr == ''
 
 
+@XFAIL  # https://github.com/sympy/sympy/issues/20265
 @may_xfail
 def test_Subroutine():
     # Code to generate the subroutine in the example from

--- a/sympy/parsing/tests/test_c_parser.py
+++ b/sympy/parsing/tests/test_c_parser.py
@@ -1,5 +1,5 @@
 from sympy.parsing.sym_expr import SymPyExpression
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, XFAIL
 from sympy.external import import_module
 
 cin = import_module('clang.cindex', import_kwargs = {'fromlist': ['cindex']})
@@ -151,6 +151,7 @@ if cin:
         )
 
 
+    @XFAIL
     def test_int():
         c_src1 = 'int a = 1;'
         c_src2 = (
@@ -627,6 +628,7 @@ if cin:
             )
 
 
+    @XFAIL
     def test_float():
         c_src1 = 'float a = 1.0;'
         c_src2 = (
@@ -851,6 +853,7 @@ if cin:
             )
 
 
+    @XFAIL
     def  test_bool():
         c_src1 = (
             'bool a = true, b = false;'
@@ -3317,6 +3320,7 @@ if cin:
         raises(NotImplementedError, lambda: SymPyExpression(c_src_raise5, 'c'))
 
 
+    @XFAIL
     def test_var_decl():
         c_src1 = (
             'int b = 100;' + '\n' +

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -3,6 +3,14 @@ This is a shim file to provide backwards compatibility (ccode.py was renamed
 to c.py in SymPy 1.7).
 """
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+SymPyDeprecationWarning(
+    feature="importing from sympy.printing.ccode",
+    useinstead="Import from sympy.printing.c",
+    issue=20256,
+    deprecated_since_version="1.7").warn()
+
 from .c import (ccode, print_ccode, known_functions_C89, known_functions_C99, # noqa:F401
                 reserved_words, reserved_words_c99, get_math_macros,
                 C89CodePrinter, C99CodePrinter, C11CodePrinter,

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -1,0 +1,9 @@
+"""
+This is a shim file to provide backwards compatibility (ccode.py was renamed
+to c.py in SymPy 1.7).
+"""
+
+from .c import (ccode, print_ccode, known_functions_C89, known_functions_C99, # noqa:F401
+                reserved_words, reserved_words_c99, get_math_macros,
+                C89CodePrinter, C99CodePrinter, C11CodePrinter,
+                c_code_printers)

--- a/sympy/printing/cxxcode.py
+++ b/sympy/printing/cxxcode.py
@@ -1,0 +1,7 @@
+"""
+This is a shim file to provide backwards compatibility (cxxcode.py was renamed
+to cxx.py in SymPy 1.7).
+"""
+
+from .cxx import (cxxcode, reserved, CXX98CodePrinter, # noqa:F401
+                  CXX11CodePrinter, CXX17CodePrinter, cxx_code_printers)

--- a/sympy/printing/cxxcode.py
+++ b/sympy/printing/cxxcode.py
@@ -3,5 +3,13 @@ This is a shim file to provide backwards compatibility (cxxcode.py was renamed
 to cxx.py in SymPy 1.7).
 """
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+SymPyDeprecationWarning(
+    feature="importing from sympy.printing.cxxcode",
+    useinstead="Import from sympy.printing.cxx",
+    issue=20256,
+    deprecated_since_version="1.7").warn()
+
 from .cxx import (cxxcode, reserved, CXX98CodePrinter, # noqa:F401
                   CXX11CodePrinter, CXX17CodePrinter, cxx_code_printers)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -3,4 +3,12 @@ This is a shim file to provide backwards compatibility (fcode.py was renamed
 to fortran.py in SymPy 1.7).
 """
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+SymPyDeprecationWarning(
+    feature="importing from sympy.printing.fcode",
+    useinstead="Import from sympy.printing.fortran",
+    issue=20256,
+    deprecated_since_version="1.7").warn()
+
 from .fortran import fcode, print_fcode, known_functions, FCodePrinter # noqa:F401

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -1,0 +1,6 @@
+"""
+This is a shim file to provide backwards compatibility (fcode.py was renamed
+to fortran.py in SymPy 1.7).
+"""
+
+from .fortran import fcode, print_fcode, known_functions, FCodePrinter # noqa:F401

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -10,7 +10,7 @@ from sympy.functions import (
 from sympy.sets import Range
 from sympy.logic import ITE
 from sympy.codegen import For, aug_assign, Assignment
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, warns_deprecated_sympy
 from sympy.printing.c import C89CodePrinter, C99CodePrinter, get_math_macros
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
@@ -838,4 +838,5 @@ def test_ccode_codegen_ast():
 
 def test_ccode_submodule():
     # Test the compatibility sympy.printing.ccode module imports
-    import sympy.printing.ccode # noqa:F401
+    with warns_deprecated_sympy():
+        import sympy.printing.ccode # noqa:F401

--- a/sympy/printing/tests/test_c.py
+++ b/sympy/printing/tests/test_c.py
@@ -835,3 +835,7 @@ def test_ccode_codegen_ast():
         'pwer(x);',
         'return x;',
     ])
+
+def test_ccode_submodule():
+    # Test the compatibility sympy.printing.ccode module imports
+    import sympy.printing.ccode # noqa:F401

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -3,6 +3,8 @@ from sympy.functions import beta, Ei, zeta, Max, Min, sqrt
 from sympy.printing.cxx import CXX98CodePrinter, CXX11CodePrinter, CXX17CodePrinter, cxxcode
 from sympy.codegen.cfunctions import log1p
 
+from sympy.testing.pytest import warns_deprecated_sympy
+
 x, y = symbols('x y')
 
 
@@ -57,4 +59,5 @@ def test_cxxcode():
 
 def test_cxxcode_submodule():
     # Test the compatibility sympy.printing.cxxcode module imports
-    import sympy.printing.cxxcode # noqa:F401
+    with warns_deprecated_sympy():
+        import sympy.printing.cxxcode # noqa:F401

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -54,3 +54,7 @@ def test_CXX17CodePrinter():
 
 def test_cxxcode():
     assert sorted(cxxcode(sqrt(x)*.5).split('*')) == sorted(['0.5', 'std::sqrt(x)'])
+
+def test_cxxcode_submodule():
+    # Test the compatibility sympy.printing.cxxcode module imports
+    import sympy.printing.cxxcode # noqa:F401

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -14,7 +14,7 @@ from sympy.matrices import Matrix, MatrixSymbol
 from sympy.printing.fortran import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, warns_deprecated_sympy
 
 
 def test_printmethod():
@@ -807,4 +807,5 @@ def test_FunctionDefinition_print():
 
 def test_fcode_submodule():
     # Test the compatibility sympy.printing.fcode module imports
-    import sympy.printing.fcode # noqa:F401
+    with warns_deprecated_sympy():
+        import sympy.printing.fcode # noqa:F401

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -804,3 +804,7 @@ def test_FunctionDefinition_print():
     # Should be changed to proper test once multi-line generation is working
     # see https://github.com/sympy/sympy/issues/15824
     raises(NotImplementedError, lambda: fcode(fd1))
+
+def test_fcode_submodule():
+    # Test the compatibility sympy.printing.fcode module imports
+    import sympy.printing.fcode # noqa:F401

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -675,6 +675,9 @@ def _get_doctest_blacklist():
         "sympy/matrices/densearith.py", # raises deprecation warning
         "sympy/matrices/densesolve.py", # raises deprecation warning
         "sympy/matrices/densetools.py", # raises deprecation warning
+        "sympy/printing/ccode.py", # backwards compatibility shim, importing it breaks the codegen doctests
+        "sympy/printing/fcode.py", # backwards compatibility shim, importing it breaks the codegen doctests
+        "sympy/printing/cxxcode.py", # backwards compatibility shim, importing it breaks the codegen doctests
         "sympy/parsing/autolev/_antlr/autolevlexer.py", # generated code
         "sympy/parsing/autolev/_antlr/autolevparser.py", # generated code
         "sympy/parsing/autolev/_antlr/autolevlistener.py", # generated code


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Same as #20250 but for the 1.7 branch.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

(NOTE: No entry for this PR, but we will need to modify the release notes entry added from #19908 when this is merged).
