### PR TITLE
Added Vandermonde matrix

### DIFF
--- a/doc/src/modules/matrices/index.rst
+++ b/doc/src/modules/matrices/index.rst
@@ -18,3 +18,4 @@ Contents:
    sparsetools.rst
    immutablematrices.rst
    expressions.rst
+   namedmatrices.rst

--- a/doc/src/modules/matrices/namedmatrices.rst
+++ b/doc/src/modules/matrices/namedmatrices.rst
@@ -1,0 +1,13 @@
+Named Matrices
+==================
+
+There are some special named matrices defined.
+
+.. module:: sympy.matrices.expressions.fourier
+
+.. autoclass:: DFT
+.. autoclass:: IDFT
+
+.. module:: sympy.matrices.expressions.vandermonde
+
+.. autoclass:: VandermondeMatrix

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3154,6 +3154,13 @@ def test_sympy__matrices__expressions__fourier__IDFT():
     from sympy import S
     assert _test_args(IDFT(S(2)))
 
+def test_sympy__matrices__expressions__vandermonde__VandermondeMatrix():
+    from sympy.matrices.expressions.vandermonde import VandermondeMatrix
+    from sympy import S
+    assert _test_args(VandermondeMatrix([S(1), S(2)]))
+    assert _test_args(VandermondeMatrix([S(1), S(2)], S(2)))
+    assert _test_args(VandermondeMatrix([S(1), S(2)], [S(1), S(2)]))
+
 from sympy.matrices.expressions import MatrixSymbol
 X = MatrixSymbol('X', 10, 10)
 

--- a/sympy/matrices/expressions/tests/test_vandermonde.py
+++ b/sympy/matrices/expressions/tests/test_vandermonde.py
@@ -1,0 +1,63 @@
+from sympy.core import I
+from sympy.core.symbol import symbols
+from sympy.matrices.expressions.fourier import DFT
+from sympy.matrices.expressions.vandermonde import VandermondeMatrix
+from sympy.matrices import det, Matrix
+from sympy.testing.pytest import raises
+
+
+def test_vandermonde_creation():
+    assert VandermondeMatrix([1, 2])
+    assert VandermondeMatrix([1, 2], 4)
+    assert VandermondeMatrix((1, 2), 4)
+    assert VandermondeMatrix(range(4))
+    assert VandermondeMatrix(range(4), 4)
+    assert VandermondeMatrix(range(4), range(4))
+    assert VandermondeMatrix(range(4), range(1, 5))
+    raises(ValueError, lambda: VandermondeMatrix(1, 1))
+    raises(ValueError, lambda: VandermondeMatrix([1, 2, 3], 2.0))
+    raises(ValueError, lambda: VandermondeMatrix([1, 2, 3], -1))
+
+    k, l, m, n = symbols('k l m n')
+    assert VandermondeMatrix([k, l, m])
+    assert VandermondeMatrix([k, l, m], n)
+    assert VandermondeMatrix([k, l, m], 4)
+    assert VandermondeMatrix([k, l, m], range(1, 2, 9))
+
+    assert VandermondeMatrix([1, 2, 3], 4).shape == (3, 4)
+    assert VandermondeMatrix([k, l, m], n).shape == (3, n)
+
+    n = symbols('n', integer=False)
+    raises(ValueError, lambda: VandermondeMatrix([k, l, m], n))
+    n = symbols('n', negative=True)
+    raises(ValueError, lambda: VandermondeMatrix([k, l, m], n))
+
+
+def test_vandermonde():
+    x = symbols('x(1:4)')
+    x1, x2, x3 = x
+    assert VandermondeMatrix(x).as_explicit() == Matrix([[1, x1, x1**2],
+                                                         [1, x2, x2**2],
+                                                         [1, x3, x3**2]])
+    assert VandermondeMatrix(x, range(3)).equals(VandermondeMatrix(x))
+    assert VandermondeMatrix(x, [0, 1, 2]).equals(VandermondeMatrix(x))
+    assert VandermondeMatrix(x, 2).as_explicit() == Matrix([[1, x1],
+                                                            [1, x2],
+                                                            [1, x3]])
+    assert VandermondeMatrix(range(3)).as_explicit() == Matrix([[1, 0, 0],
+                                                                [1, 1, 1],
+                                                                [1, 2, 4]])
+    assert VandermondeMatrix(range(3), range(4)).as_explicit() == Matrix([
+                                                                [1, 0, 0, 0],
+                                                                [1, 1, 1, 1],
+                                                                [1, 2, 4, 8]])
+
+
+def test_vandermonde_dft():
+    assert VandermondeMatrix([1, -I, -1, I], 4).equals(2*DFT(4))
+
+
+def test_vandermonde_determinant():
+    k, l, m = symbols('k l m')
+    assert det(VandermondeMatrix([k, l, m], 3)).equals(VandermondeMatrix([k, l, m], 3).as_explicit().det())
+    assert VandermondeMatrix([k, l, m], 3)._eval_determinant().equals(VandermondeMatrix([k, l, m], 3).as_explicit().det())

--- a/sympy/matrices/expressions/vandermonde.py
+++ b/sympy/matrices/expressions/vandermonde.py
@@ -1,0 +1,131 @@
+from sympy.core.compatibility import iterable
+from sympy.core.sympify import sympify
+from sympy.matrices.expressions import MatrixExpr, Determinant
+from sympy import S, Pow, Range
+
+class VandermondeMatrix(MatrixExpr):
+    r""" Generates a Vandermonde matrix.
+
+        A Vandermonde matrix is a matrix with the terms of a geometric
+        progression in each row. It typically arises in a polynomial
+        least squares fitting, where each row corresponds to a polynomial point
+        and each column corresponds to a power of that point.
+
+        A square Vandermonde matrix for the points `x_1` to `x_n` is
+         .. math ::
+             \begin{bmatrix}
+             1 & x_1 & x_1^2 & \hdots % x_1^{n-1} \\
+             1 & x_2 & x_2^2 & \hdots % x_2^{n-1} \\
+            \vdots & \vdots & \vdots & \ddots & \vdots \\
+             1 & x_n & x_n^2 & \hdots % x_n^{n-1} \\
+             \end{bmatrix}
+
+        Parameters
+        ==========
+
+        points : iterable
+            The points to generate the VandermondeMatrix for.
+
+        n : integer, iterable or None
+            Powers to use. For an integer, the powers range from 0 to n-1.
+            For an iterable, use those powers. If ``None`` (default), the
+            powers range from 0 to ``len(points)``-1.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices.expressions.vandermonde import VandermondeMatrix
+        >>> v = VandermondeMatrix([0, 1, -1])
+        >>> v.as_explicit()
+        Matrix([
+        [1,  0, 0],
+        [1,  1, 1],
+        [1, -1, 1]])
+
+        >>> from sympy import symbols
+        >>> x = symbols('x(1:4)')
+        >>> VandermondeMatrix(x, range(4)).as_explicit()
+        Matrix([
+        [1, x1, x1**2, x1**3],
+        [1, x2, x2**2, x2**3],
+        [1, x3, x3**2, x3**3]])
+
+        Sometimes, a Vandermonde matrix is defined without the power of zero
+        column:
+
+        >>> VandermondeMatrix(x, range(1,4)).as_explicit()
+        Matrix([
+        [x1, x1**2, x1**3],
+        [x2, x2**2, x2**3],
+        [x3, x3**2, x3**3]])
+
+        As it is possible to specify an iterable for the powers, generalized
+        versions can be rapildy created:
+
+        >>> VandermondeMatrix([-1, 2, 3], [1, 3, 6]).as_explicit()
+        Matrix([
+        [-1, -1,   1],
+        [ 2,  8,  64],
+        [ 3, 27, 729]])
+
+        It is also possible to use a symbolic column count:
+        >>> n = symbols('n')
+        >>> VandermondeMatrix([-1, 2, 3], n)
+        VandermondeMatrix((-1, 2, 3), n)
+
+        or symbolic powers
+
+        >>> VandermondeMatrix(x, [0, 1, n]).as_explicit()
+        Matrix([
+        [1, x1, x1**n],
+        [1, x2, x2**n],
+        [1, x3, x3**n]])
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Vandermonde_matrix
+
+    """
+    def __new__(cls, points, n=None):
+        if not iterable(points):
+            raise ValueError("First argument must be an iterable")
+        points = sympify(tuple(points))
+        n = sympify(n)
+        if n:
+            if iterable(n):
+                n = tuple(n)
+                cls.colpows = n
+            else:
+                cls._check_dim(n)
+                cls.colpows = Range(n)
+        else:
+            cls.colpows = Range(len(points))
+
+        if n is None:
+            obj = super().__new__(cls, points)
+        else:
+            obj = super().__new__(cls, points, n)
+        return obj
+
+    @property
+    def shape(self):
+        rows = len(self.args[0])
+        if len(self.args) == 1 or self.args[1] is None:
+            return (rows, rows)
+        elif iterable(self.args[1]):
+            return (rows, len(self.args[1]))
+        else:
+            return (rows, self.args[1])
+
+    def _entry(self, i, j, **kwargs):
+        return Pow(self.args[0][i], self.colpows[j])
+
+    def _eval_determinant(self):
+        if self.is_square and self.colpows == Range(self.shape[1]):
+            tmp = S.One
+            for i in range(self.shape[1]-1):
+                for j in range(i+1, self.shape[1]):
+                    tmp *= (self.args[0][j] - self.args[0][i])
+            return tmp
+        return Determinant(self)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related to #20261

#### Brief description of what is fixed or changed
`VandermondeMatrix` class added for easy creation of Vandermonde-like matrices.

Also added a "Named Matrices" subsection in the matrices module documentation.

#### Other comments
Quite flexible, but that seems to be the easiest way to do it as one would sometimes prefer `range(1, n)` in addition to `range(n)`. In this way there is no additional flag and one can create any type of Vandermonde like matrix.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * `VandermondeMatrix` class added for easy creation of Vandermonde-like matrices.
<!-- END RELEASE NOTES -->