### PR TITLE
perf(core): make sympify faster for Basic subclasses.

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -344,8 +344,13 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     #
     # https://github.com/sympy/sympy/issues/20124
     is_sympy = getattr(a, '__sympy__', None)
-    if is_sympy is True or (is_sympy is not None and not strict):
+    if is_sympy is True:
         return a
+    elif is_sympy is not None:
+        if not strict:
+            return a
+        else:
+            raise SympifyError(a)
 
     if isinstance(a, CantSympify):
         raise SympifyError(a)


### PR DESCRIPTION
The behaviour of sympify was changed in

  https://github.com/sympy/sympy/pull/20128

so that sympifying a Basic subclass would be an error when strict=True.
That change made the codepath for calling e.g. _sympify(Basic) slower as
more checks would be done before returning. This commit adds an early
raise for the case of calling _sympify(a) where a is a Basic subclass.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

https://github.com/sympy/sympy/issues/20234#issuecomment-711086552

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->