### PR TITLE
maint(ci): use 30 minute timeout for conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,7 +218,10 @@ before_install:
         conda config --prepend channels conda-forge --prepend channels symengine/label/dev;
 
         conda info -a;
-        travis_wait conda create -q -n test-environment ${TEST_OPT_DEPENDENCY};
+        # This became very slow: https://github.com/sympy/sympy/issues/20289
+        # We give it a 30 minute wait for now but hopefully this command will
+        # stop being so slow.
+        travis_wait 30 conda create -q -n test-environment ${TEST_OPT_DEPENDENCY};
         source activate test-environment;
         export CPATH=$CONDA_PREFIX/include;
         export LIBRARY_PATH=$CONDA_PREFIX/lib;


### PR DESCRIPTION
The conda install command on Travis became very slow:

  https://github.com/sympy/sympy/issues/20292

This commit adds a 30 minute timeout for that command to stop the
optional dependencies job from timing out.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->