### PR TITLE
Update check_dimensions to not raise error for derived dimensions

### DIFF
--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -122,6 +122,7 @@ def test_check_dimensions():
     assert check_dimensions(length + x) == length + x
     # after subs we get 2*length; check will clear the constant
     assert check_dimensions((length + x).subs(x, length)) == length
+    assert check_dimensions(newton*meter + joule) == joule + meter*inch
     raises(ValueError, lambda: check_dimensions(inch + 1))
     raises(ValueError, lambda: check_dimensions(length + 1))
     raises(ValueError, lambda: check_dimensions(length + time))

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -122,7 +122,7 @@ def test_check_dimensions():
     assert check_dimensions(length + x) == length + x
     # after subs we get 2*length; check will clear the constant
     assert check_dimensions((length + x).subs(x, length)) == length
-    assert check_dimensions(newton*meter + joule) == joule + meter*inch
+    assert check_dimensions(newton*meter + joule) == joule + meter*newton
     raises(ValueError, lambda: check_dimensions(inch + 1))
     raises(ValueError, lambda: check_dimensions(length + 1))
     raises(ValueError, lambda: check_dimensions(length + time))

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -158,8 +158,6 @@ def check_dimensions(expr, unit_system="SI"):
     # Also, when doing substitutions, multiplicative constants
     # might be introduced, so remove those now
 
-    import functools
-    import operator
     from sympy.physics.units import UnitSystem
     unit_system = UnitSystem.get_unit_system(unit_system)
 

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -149,8 +149,8 @@ def quantity_simplify(expr):
 
 
 def check_dimensions(expr, unit_system="SI"):
-    """Return expr if there are not unitless values added to
-    dimensional quantities, else raise a ValueError."""
+    """Return expr if units in addends have the same
+    base dimensions, else raise a ValueError."""
     # the case of adding a number to a dimensional quantity
     # is ignored for the sake of SymPy core routines, so this
     # function will raise an error now if such an addend is

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -162,7 +162,7 @@ def check_dimensions(expr, unit_system="SI"):
     import operator
     from sympy.physics.units import UnitSystem
     unit_system = UnitSystem.get_unit_system(unit_system)
-    
+
     def addDict(dict1, dict2):
         """Merge dictionaries by adding values of common keys and
         removing keys with value of 0."""


### PR DESCRIPTION
#### References to other Issues or PRs
This addresses the second part of  #16754. 


#### Brief description of what is fixed or changed
check_dimensions was modified to recognise compatible base and derived dimensions, e.g. newton*meter is compatible with joule.

#### Other comments
The purpose of check_dimensions is still not well documented, but it could be very useful.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fixed a bug with derived units and dimensions in check_dimensions.
<!-- END RELEASE NOTES -->