### PR TITLE
maint: fix version in release.py

### DIFF
--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.rc1"
+__version__ = "1.7rc1"


### PR DESCRIPTION
The version was mistakenly put as 1.7.rc1 but that is not a valid PEP
440 version which should be 1.7rc1 for a release candidate.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->