### PR TITLE
fixed is_integer of Mul if tree was built with evaluate=False

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1074,7 +1074,15 @@ def fraction(expr, exact=False):
 
     numer, denom = [], []
 
-    for term in Mul.make_args(expr):
+	# we must recurse into args (tree could be constructed with evaluate=False)
+    def mul_args(e):
+        for term in Mul.make_args(e):
+            if term.is_Mul:
+                yield from mul_args(term)
+            else:
+                yield term
+
+    for term in mul_args(expr):
         if term.is_commutative and (term.is_Pow or isinstance(term, exp)):
             b, ex = term.as_base_exp()
             if ex.is_negative:

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1074,7 +1074,7 @@ def fraction(expr, exact=False):
 
     numer, denom = [], []
 
-	# we must recurse into args (tree could be constructed with evaluate=False)
+    # we must recurse into args (tree could be constructed with evaluate=False)
     def mul_args(e):
         for term in Mul.make_args(e):
             if term.is_Mul:

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -421,6 +421,9 @@ def test_fraction():
     assert fraction(m, exact=True) == \
             (Mul(1, 1, evaluate=False), Mul(2, 2, 1, evaluate=False))
 
+    m = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
+    assert fraction(m) == (-1, 2)
+
 
 def test_issue_5615():
     aA, Re, a, b, D = symbols('aA Re a b D')

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -421,7 +421,7 @@ def test_fraction():
     assert fraction(m, exact=True) == \
             (Mul(1, 1, evaluate=False), Mul(2, 2, 1, evaluate=False))
 
-    m = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
+    m = Mul(-1, Mul(1, Pow(2, -1, evaluate=False), evaluate=False), evaluate=False)
     assert fraction(m) == (-1, 2)
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes 20161

#### Brief description of what is fixed or changed
In function `fraction` recurse into args of `Mul`. This can be necessary if expression tree was built with `evaluate=False`.

#### Other comments


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->