### PR TITLE
fixed is_integer of Mul if tree was built with evaluate=False

### DIFF
--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "1.7.rc1"
+__version__ = "1.7rc1"

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1068,7 +1068,15 @@ def fraction(expr, exact=False):
 
     numer, denom = [], []
 
-    for term in Mul.make_args(expr):
+	# we must recurse into args (tree could be constructed with evaluate=False)
+    def mul_args(e):
+        for term in Mul.make_args(e):
+            if term.is_Mul:
+                yield from mul_args(term)
+            else:
+                yield term
+
+    for term in mul_args(expr):
         if term.is_commutative and (term.is_Pow or isinstance(term, exp)):
             b, ex = term.as_base_exp()
             if ex.is_negative:

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1068,7 +1068,7 @@ def fraction(expr, exact=False):
 
     numer, denom = [], []
 
-	# we must recurse into args (tree could be constructed with evaluate=False)
+    # we must recurse into args (tree could be constructed with evaluate=False)
     def mul_args(e):
         for term in Mul.make_args(e):
             if term.is_Mul:

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -421,6 +421,9 @@ def test_fraction():
     assert fraction(m, exact=True) == \
             (Mul(1, 1, evaluate=False), Mul(2, 2, 1, evaluate=False))
 
+    m = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
+    assert fraction(m) == (-1, 2)
+
 
 def test_issue_5615():
     aA, Re, a, b, D = symbols('aA Re a b D')

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -421,7 +421,7 @@ def test_fraction():
     assert fraction(m, exact=True) == \
             (Mul(1, 1, evaluate=False), Mul(2, 2, 1, evaluate=False))
 
-    m = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
+    m = Mul(-1, Mul(1, Pow(2, -1, evaluate=False), evaluate=False), evaluate=False)
     assert fraction(m) == (-1, 2)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Same as #20312 but for the 1.7 branch

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fixed a bug with fraction, when expression was created with evaluate=False.
<!-- END RELEASE NOTES -->