### PR TITLE
Break RefrenceFrame.orient() into seperate methods.

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -630,6 +630,7 @@ class ReferenceFrame:
         ``B.dcm(N)``:
 
         >>> A.orient_explicit(N, N.dcm(B))
+        >>> A.dcm(N)
         Matrix([
         [1,       0,      0],
         [0,  cos(q1), sin(q1)],

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -475,72 +475,40 @@ class ReferenceFrame:
         self._dcm_cache[otherframe] = outdcm
         otherframe._dcm_cache[self] = outdcm.T
         return outdcm
-
-    def orient(self, parent, rot_type, amounts, rot_order=''):
-        """Sets the orientation of this reference frame relative to another
-        (parent) reference frame.
-
-        Parameters
-        ==========
-
-        parent : ReferenceFrame
+    
+    def orient_axis(self, parent, amounts):
+    	"""Sets the orientation of this frame with respect to a another(parent)
+    	reference frame by rotating about a fixed axis.
+       	It creates a direction cosine matrix defined by a simple rotation about a
+    	single axis fixed in both reference frames. This is a rotation about an
+    	arbitrary, non-time-varying axis by some angle. The axis is supplied as a Vector.
+    	
+    	Parameters
+    	==========
+    	
+    	parent : ReferenceFrame
             Reference frame that this reference frame will be rotated relative
             to.
-        rot_type : str
-            The method used to generate the direction cosine matrix. Supported
-            methods are:
-
-            - ``'Axis'``: simple rotations about a single common axis
-            - ``'DCM'``: for setting the direction cosine matrix directly
-            - ``'Body'``: three successive rotations about new intermediate
-              axes, also called "Euler and Tait-Bryan angles"
-            - ``'Space'``: three successive rotations about the parent
-              frames' unit vectors
-            - ``'Quaternion'``: rotations defined by four parameters which
-              result in a singularity free direction cosine matrix
-
-        amounts :
-            Expressions defining the rotation angles or direction cosine
-            matrix. These must match the ``rot_type``. See examples below for
-            details. The input types are:
-
-            - ``'Axis'``: 2-tuple (expr/sym/func, Vector)
-            - ``'DCM'``: Matrix, shape(3,3)
-            - ``'Body'``: 3-tuple of expressions, symbols, or functions
-            - ``'Space'``: 3-tuple of expressions, symbols, or functions
-            - ``'Quaternion'``: 4-tuple of expressions, symbols, or
-              functions
-
-        rot_order : str or int, optional
-            If applicable, the order of the successive of rotations. The string
-            ``'123'`` and integer ``123`` are equivalent, for example. Required
-            for ``'Body'`` and ``'Space'``.
-
-        Examples
-        ========
-
-        Setup variables for the examples:
+            
+        amounts : 2-tuple (expr/sym/func, Vector)
+        	The first element is the amount by which it the frame is to be rotated.
+        	The second element is the axis(a vector in the parent frame) about which
+        	the frame is to be rotated. It need not be a unit vector.
+        	
+    	Examples
+    	==========
+    	
+    	Setup variables for the examples:
 
         >>> from sympy import symbols
         >>> from sympy.physics.vector import ReferenceFrame
-        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
+        >>> q1 = symbols('q1')
         >>> N = ReferenceFrame('N')
         >>> B = ReferenceFrame('B')
-        >>> B1 = ReferenceFrame('B')
-        >>> B2 = ReferenceFrame('B2')
+        
+    	>>> B.orient_axis(N, (q1, N.x))
 
-        Axis
-        ----
-
-        ``rot_type='Axis'`` creates a direction cosine matrix defined by a
-        simple rotation about a single axis fixed in both reference frames.
-        This is a rotation about an arbitrary, non-time-varying
-        axis by some angle. The axis is supplied as a Vector. This is how
-        simple rotations are defined.
-
-        >>> B.orient(N, 'Axis', (q1, N.x))
-
-        The ``orient()`` method generates a direction cosine matrix and its
+        The ``orient_axis()`` method generates a direction cosine matrix and its
         transpose which defines the orientation of B relative to N and vice
         versa. Once orient is called, ``dcm()`` outputs the appropriate
         direction cosine matrix.
@@ -554,230 +522,33 @@ class ReferenceFrame:
         The following two lines show how the sense of the rotation can be
         defined. Both lines produce the same result.
 
-        >>> B.orient(N, 'Axis', (q1, -N.x))
-        >>> B.orient(N, 'Axis', (-q1, N.x))
-
-        The axis does not have to be defined by a unit vector, it can be any
-        vector in the parent frame.
-
-        >>> B.orient(N, 'Axis', (q1, N.x + 2 * N.y))
-
-        DCM
-        ---
-
-        The direction cosine matrix can be set directly. The orientation of a
-        frame A can be set to be the same as the frame B above like so:
-
-        >>> B.orient(N, 'Axis', (q1, N.x))
-        >>> A = ReferenceFrame('A')
-        >>> A.orient(N, 'DCM', N.dcm(B))
-        >>> A.dcm(N)
-        Matrix([
-        [1,       0,      0],
-        [0,  cos(q1), sin(q1)],
-        [0, -sin(q1), cos(q1)]])
-
-        **Note carefully that** ``N.dcm(B)`` **was passed into** ``orient()``
-        **for** ``A.dcm(N)`` **to match** ``B.dcm(N)``.
-
-        Body
-        ----
-
-        ``rot_type='Body'`` rotates this reference frame relative to the
-        provided reference frame by rotating through three successive simple
-        rotations.  Each subsequent axis of rotation is about the "body fixed"
-        unit vectors of the new intermediate reference frame. This type of
-        rotation is also referred to rotating through the `Euler and Tait-Bryan
-        Angles <https://en.wikipedia.org/wiki/Euler_angles>`_.
-
-        For example, the classic Euler Angle rotation can be done by:
-
-        >>> B.orient(N, 'Body', (q1, q2, q3), 'XYX')
-        >>> B.dcm(N)
-        Matrix([
-        [        cos(q2),                            sin(q1)*sin(q2),                           -sin(q2)*cos(q1)],
-        [sin(q2)*sin(q3), -sin(q1)*sin(q3)*cos(q2) + cos(q1)*cos(q3),  sin(q1)*cos(q3) + sin(q3)*cos(q1)*cos(q2)],
-        [sin(q2)*cos(q3), -sin(q1)*cos(q2)*cos(q3) - sin(q3)*cos(q1), -sin(q1)*sin(q3) + cos(q1)*cos(q2)*cos(q3)]])
-
-        This rotates B relative to N through ``q1`` about ``N.x``, then rotates
-        B again through q2 about B.y, and finally through q3 about B.x. It is
-        equivalent to:
-
-        >>> B1.orient(N, 'Axis', (q1, N.x))
-        >>> B2.orient(B1, 'Axis', (q2, B1.y))
-        >>> B.orient(B2, 'Axis', (q3, B2.x))
-        >>> B.dcm(N)
-        Matrix([
-        [        cos(q2),                            sin(q1)*sin(q2),                           -sin(q2)*cos(q1)],
-        [sin(q2)*sin(q3), -sin(q1)*sin(q3)*cos(q2) + cos(q1)*cos(q3),  sin(q1)*cos(q3) + sin(q3)*cos(q1)*cos(q2)],
-        [sin(q2)*cos(q3), -sin(q1)*cos(q2)*cos(q3) - sin(q3)*cos(q1), -sin(q1)*sin(q3) + cos(q1)*cos(q2)*cos(q3)]])
-
-        Acceptable rotation orders are of length 3, expressed in as a string
-        ``'XYZ'`` or ``'123'`` or integer ``123``. Rotations about an axis
-        twice in a row are prohibited.
-
-        >>> B.orient(N, 'Body', (q1, q2, 0), 'ZXZ')
-        >>> B.orient(N, 'Body', (q1, q2, 0), '121')
-        >>> B.orient(N, 'Body', (q1, q2, q3), 123)
-
-        Space
-        -----
-
-        ``rot_type='Space'`` also rotates the reference frame in three
-        successive simple rotations but the axes of rotation are the
-        "Space-fixed" axes. For example:
-
-        >>> B.orient(N, 'Space', (q1, q2, q3), '312')
-        >>> B.dcm(N)
-        Matrix([
-        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
-        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],
-        [                           sin(q3)*cos(q2),        -sin(q2),                           cos(q2)*cos(q3)]])
-
-        is equivalent to:
-
-        >>> B1.orient(N, 'Axis', (q1, N.z))
-        >>> B2.orient(B1, 'Axis', (q2, N.x))
-        >>> B.orient(B2, 'Axis', (q3, N.y))
-        >>> B.dcm(N).simplify()  # doctest: +SKIP
-        Matrix([
-        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
-        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],
-        [                           sin(q3)*cos(q2),        -sin(q2),                           cos(q2)*cos(q3)]])
-
-        It is worth noting that space-fixed and body-fixed rotations are
-        related by the order of the rotations, i.e. the reverse order of body
-        fixed will give space fixed and vice versa.
-
-        >>> B.orient(N, 'Space', (q1, q2, q3), '231')
-        >>> B.dcm(N)
-        Matrix([
-        [cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3), -sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)],
-        [       -sin(q2),                           cos(q2)*cos(q3),                            sin(q3)*cos(q2)],
-        [sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1),  sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3)]])
-
-        >>> B.orient(N, 'Body', (q3, q2, q1), '132')
-        >>> B.dcm(N)
-        Matrix([
-        [cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3), -sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)],
-        [       -sin(q2),                           cos(q2)*cos(q3),                            sin(q3)*cos(q2)],
-        [sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1),  sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3)]])
-
-        Quaternion
-        ----------
-
-        ``rot_type='Quaternion'`` orients the reference frame using
-        quaternions. Quaternion rotation is defined as a finite rotation about
-        lambda, a unit vector, by an amount theta. This orientation is
-        described by four parameters:
-
-        - ``q0 = cos(theta/2)``
-        - ``q1 = lambda_x sin(theta/2)``
-        - ``q2 = lambda_y sin(theta/2)``
-        - ``q3 = lambda_z sin(theta/2)``
-
-        This type does not need a ``rot_order``.
-
-        >>> B.orient(N, 'Quaternion', (q0, q1, q2, q3))
-        >>> B.dcm(N)
-        Matrix([
-        [q0**2 + q1**2 - q2**2 - q3**2,             2*q0*q3 + 2*q1*q2,            -2*q0*q2 + 2*q1*q3],
-        [           -2*q0*q3 + 2*q1*q2, q0**2 - q1**2 + q2**2 - q3**2,             2*q0*q1 + 2*q2*q3],
-        [            2*q0*q2 + 2*q1*q3,            -2*q0*q1 + 2*q2*q3, q0**2 - q1**2 - q2**2 + q3**2]])
-
-        """
-
+        >>> B.orient_axis(N, (q1, -N.x))
+        >>> B.orient_axis(N, (-q1, N.x))"""
+        
         from sympy.physics.vector.functions import dynamicsymbols
         _check_frame(parent)
-
-        # Allow passing a rotation matrix manually.
-        if rot_type == 'DCM':
-            # When rot_type == 'DCM', then amounts must be a Matrix type object
-            # (e.g. sympy.matrices.dense.MutableDenseMatrix).
-            if not isinstance(amounts, MatrixBase):
-                raise TypeError("Amounts must be a sympy Matrix type object.")
-        else:
-            amounts = list(amounts)
-            for i, v in enumerate(amounts):
-                if not isinstance(v, Vector):
-                    amounts[i] = sympify(v)
-
-        def _rot(axis, angle):
-            """DCM for simple axis 1,2,or 3 rotations. """
-            if axis == 1:
-                return Matrix([[1, 0, 0],
-                               [0, cos(angle), -sin(angle)],
-                               [0, sin(angle), cos(angle)]])
-            elif axis == 2:
-                return Matrix([[cos(angle), 0, sin(angle)],
-                               [0, 1, 0],
-                               [-sin(angle), 0, cos(angle)]])
-            elif axis == 3:
-                return Matrix([[cos(angle), -sin(angle), 0],
-                               [sin(angle), cos(angle), 0],
-                               [0, 0, 1]])
-
-        approved_orders = ('123', '231', '312', '132', '213', '321', '121',
-                           '131', '212', '232', '313', '323', '')
-        # make sure XYZ => 123 and rot_type is in upper case
-        rot_order = translate(str(rot_order), 'XYZxyz', '123123')
-        rot_type = rot_type.upper()
-        if rot_order not in approved_orders:
-            raise TypeError('The supplied order is not an approved type')
-        parent_orient = []
-        if rot_type == 'AXIS':
-            if not rot_order == '':
-                raise TypeError('Axis orientation takes no rotation order')
-            if not (isinstance(amounts, (list, tuple)) & (len(amounts) == 2)):
-                raise TypeError('Amounts are a list or tuple of length 2')
-            theta = amounts[0]
-            axis = amounts[1]
-            axis = _check_vector(axis)
-            if not axis.dt(parent) == 0:
-                raise ValueError('Axis cannot be time-varying')
-            axis = axis.express(parent).normalize()
-            axis = axis.args[0][0]
-            parent_orient = ((eye(3) - axis * axis.T) * cos(theta) +
-                             Matrix([[0, -axis[2], axis[1]],
-                                     [axis[2], 0, -axis[0]],
-                                     [-axis[1], axis[0], 0]]) *
-                             sin(theta) + axis * axis.T)
-        elif rot_type == 'QUATERNION':
-            if not rot_order == '':
-                raise TypeError(
-                    'Quaternion orientation takes no rotation order')
-            if not (isinstance(amounts, (list, tuple)) & (len(amounts) == 4)):
-                raise TypeError('Amounts are a list or tuple of length 4')
-            q0, q1, q2, q3 = amounts
-            parent_orient = (Matrix([[q0**2 + q1**2 - q2**2 - q3**2,
-                                      2 * (q1 * q2 - q0 * q3),
-                                      2 * (q0 * q2 + q1 * q3)],
-                                     [2 * (q1 * q2 + q0 * q3),
-                                      q0**2 - q1**2 + q2**2 - q3**2,
-                                      2 * (q2 * q3 - q0 * q1)],
-                                     [2 * (q1 * q3 - q0 * q2),
-                                      2 * (q0 * q1 + q2 * q3),
-                                      q0**2 - q1**2 - q2**2 + q3**2]]))
-        elif rot_type == 'BODY':
-            if not (len(amounts) == 3 & len(rot_order) == 3):
-                raise TypeError('Body orientation takes 3 values & 3 orders')
-            a1 = int(rot_order[0])
-            a2 = int(rot_order[1])
-            a3 = int(rot_order[2])
-            parent_orient = (_rot(a1, amounts[0]) * _rot(a2, amounts[1]) *
-                             _rot(a3, amounts[2]))
-        elif rot_type == 'SPACE':
-            if not (len(amounts) == 3 & len(rot_order) == 3):
-                raise TypeError('Space orientation takes 3 values & 3 orders')
-            a1 = int(rot_order[0])
-            a2 = int(rot_order[1])
-            a3 = int(rot_order[2])
-            parent_orient = (_rot(a3, amounts[2]) * _rot(a2, amounts[1]) *
-                             _rot(a1, amounts[0]))
-        elif rot_type == 'DCM':
-            parent_orient = amounts
-        else:
-            raise NotImplementedError('That is not an implemented rotation')
+        
+        amounts = list(amounts)
+        for i, v in enumerate(amounts):
+            if not isinstance(v, Vector):
+                amounts[i] = sympify(v)
+        if not (isinstance(amounts, (list, tuple)) & (len(amounts) == 2)):
+            raise TypeError('Amounts are a list or tuple of length 2')    
+        theta = amounts[0]
+        axis = amounts[1]
+        axis = _check_vector(axis)
+        parent_orient_axis = []
+        
+        if not axis.dt(parent) == 0:
+            raise ValueError('Axis cannot be time-varying')
+        axis = axis.express(parent).normalize()
+        axis = axis.args[0][0]
+        parent_orient_axis = ((eye(3) - axis * axis.T) * cos(theta) +
+                         Matrix([[0, -axis[2], axis[1]],
+                                 [axis[2], 0, -axis[0]],
+                                 [-axis[1], axis[0], 0]]) *
+                         sin(theta) + axis * axis.T)
+ 
         # Reset the _dcm_cache of this frame, and remove it from the
         # _dcm_caches of the frames it is linked to. Also remove it from the
         # _dcm_dict of its parent
@@ -794,44 +565,463 @@ class ReferenceFrame:
             del frame._dcm_cache[self]
         # Add the dcm relationship to _dcm_dict
         self._dcm_dict = self._dlist[0] = {}
-        self._dcm_dict.update({parent: parent_orient.T})
-        parent._dcm_dict.update({self: parent_orient})
+        self._dcm_dict.update({parent: parent_orient_axis.T})
+        parent._dcm_dict.update({self: parent_orient_axis})
         # Also update the dcm cache after resetting it
         self._dcm_cache = {}
-        self._dcm_cache.update({parent: parent_orient.T})
-        parent._dcm_cache.update({self: parent_orient})
-        if rot_type == 'QUATERNION':
-            t = dynamicsymbols._t
-            q0, q1, q2, q3 = amounts
-            q0d = diff(q0, t)
-            q1d = diff(q1, t)
-            q2d = diff(q2, t)
-            q3d = diff(q3, t)
-            w1 = 2 * (q1d * q0 + q2d * q3 - q3d * q2 - q0d * q1)
-            w2 = 2 * (q2d * q0 + q3d * q1 - q1d * q3 - q0d * q2)
-            w3 = 2 * (q3d * q0 + q1d * q2 - q2d * q1 - q0d * q3)
-            wvec = Vector([(Matrix([w1, w2, w3]), self)])
-        elif rot_type == 'AXIS':
-            thetad = (amounts[0]).diff(dynamicsymbols._t)
-            wvec = thetad * amounts[1].express(parent).normalize()
-        elif rot_type == 'DCM':
+        self._dcm_cache.update({parent: parent_orient_axis.T})
+        parent._dcm_cache.update({self: parent_orient_axis})
+        thetad = (amounts[0]).diff(dynamicsymbols._t)
+        wvec = thetad * amounts[1].express(parent).normalize()
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
+        
+	def orient_dcm(self, parent, amounts):
+		"""Sets the orientation of this reference frame relative to another
+        (parent) reference frame by setting the direction cosine matrix directly.
+        
+        Parameters
+        ==========
+        
+        parent : ReferenceFrame
+        	Reference frame that this referece frame will be rotated relative to.
+        	
+    	amounts : Matrix, shape(3, 3)
+    	
+    	Examples
+    	==========
+    	
+    	Setup variables for the examples:
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q1 = symbols('q1')
+        >>> B = ReferenceFrame('B')
+        >>> N = ReferenceFrame('N')
+        
+    	The orientation of frame A can be set to be the same as frame B in the following way:
+    	
+    	>>> B.orient_axis(N, (q1, N.x))
+        >>> A = ReferenceFrame('A')
+        >>> A.orient_dcm(N, N.dcm(B))
+        >>> A.dcm(N)
+        Matrix([
+        [1,       0,      0],
+        [0,  cos(q1), sin(q1)],
+        [0, -sin(q1), cos(q1)]])
+
+        **Note carefully that** ``N.dcm(B)`` **was passed into** ``orient_dcm()``
+        **for** ``A.dcm(N)`` **to match** ``B.dcm(N)``.
+    	"""
+        from sympy.physics.vector.functions import dynamicsymbols
+        _check_frame(parent)
+        # amounts must be a Matrix type object
+        # (e.g. sympy.matrices.dense.MutableDenseMatrix).
+        if not isinstance(amounts, MatrixBase):
+            raise TypeError("Amounts must be a sympy Matrix type object.")
+            
+	    parent_orient_dcm = []
+    	parent_orient_dcm = amounts
+
+        # Reset the _dcm_cache of this frame, and remove it from the
+        # _dcm_caches of the frames it is linked to. Also remove it from the
+        # _dcm_dict of its parent
+        frames = self._dcm_cache.keys()
+        dcm_dict_del = []
+        dcm_cache_del = []
+        for frame in frames:
+            if frame in self._dcm_dict:
+                dcm_dict_del += [frame]
+            dcm_cache_del += [frame]
+        for frame in dcm_dict_del:
+            del frame._dcm_dict[self]
+        for frame in dcm_cache_del:
+            del frame._dcm_cache[self]
+        # Add the dcm relationship to _dcm_dict
+        self._dcm_dict = self._dlist[0] = {}
+        self._dcm_dict.update({parent: parent_orient_dcm.T})
+        parent._dcm_dict.update({self: parent_orient_dcm})
+        # Also update the dcm cache after resetting it
+        self._dcm_cache = {}
+        self._dcm_cache.update({parent: parent_orient_dcm.T})
+        parent._dcm_cache.update({self: parent_orient_dcm})
+        wvec = self._w_diff_dcm(parent)
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
+
+    def _rot(axis, angle):
+        """DCM for simple axis 1,2,or 3 rotations. """
+        if axis == 1:
+            return Matrix([[1, 0, 0],
+                           [0, cos(angle), -sin(angle)],
+                           [0, sin(angle), cos(angle)]])
+        elif axis == 2:
+            return Matrix([[cos(angle), 0, sin(angle)],
+                           [0, 1, 0],
+                           [-sin(angle), 0, cos(angle)]])
+        elif axis == 3:
+            return Matrix([[cos(angle), -sin(angle), 0],
+                           [sin(angle), cos(angle), 0],
+                           [0, 0, 1]])
+        
+    def orient_body(self, parent, amounts, rot_order=''):
+    	"""Rotates this reference frame relative to the provided reference frame(parent)
+        by rotating through three successive simple rotations. Each subsequent axis
+        of rotation is about the "body fixed" unit vectors of the new intermediate
+        reference frame. This type of rotation is also referred to rotating through
+        the `Euler and Tait-Bryan Angles <https://en.wikipedia.org/wiki/Euler_angles>`_.
+        
+        Parameters
+        ==========
+
+		parent : ReferenceFrame
+            Reference frame that this reference frame will be rotated relative
+            to.
+            
+        amounts : 3-tuple of expressions, symbols, or functions
+        The string ``'123'`` and integer ``123`` are equivalent.
+        
+        Examples
+        =========
+        Setup variables for the examples:
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
+        >>> N = ReferenceFrame('N')
+        >>> B = ReferenceFrame('B')
+        >>> B1 = ReferenceFrame('B')
+        >>> B2 = ReferenceFrame('B2')
+        
+        For example, the classic Euler Angle rotation can be done by:
+
+        >>> B.orient_body(N, (q1, q2, q3), 'XYX')
+        >>> B.dcm(N)
+        Matrix([
+        [        cos(q2),                            sin(q1)*sin(q2),                           -sin(q2)*cos(q1)],
+        [sin(q2)*sin(q3), -sin(q1)*sin(q3)*cos(q2) + cos(q1)*cos(q3),  sin(q1)*cos(q3) + sin(q3)*cos(q1)*cos(q2)],
+        [sin(q2)*cos(q3), -sin(q1)*cos(q2)*cos(q3) - sin(q3)*cos(q1), -sin(q1)*sin(q3) + cos(q1)*cos(q2)*cos(q3)]])
+
+        This rotates B relative to N through ``q1`` about ``N.x``, then rotates
+        B again through q2 about B.y, and finally through q3 about B.x. It is
+        equivalent to:
+
+        >>> B1.orient_axis(N, (q1, N.x))
+        >>> B2.orient_axis(B1, (q2, B1.y))
+        >>> B.orient_axis(B2, (q3, B2.x))
+        >>> B.dcm(N)
+        Matrix([
+        [        cos(q2),                            sin(q1)*sin(q2),                           -sin(q2)*cos(q1)],
+        [sin(q2)*sin(q3), -sin(q1)*sin(q3)*cos(q2) + cos(q1)*cos(q3),  sin(q1)*cos(q3) + sin(q3)*cos(q1)*cos(q2)],
+        [sin(q2)*cos(q3), -sin(q1)*cos(q2)*cos(q3) - sin(q3)*cos(q1), -sin(q1)*sin(q3) + cos(q1)*cos(q2)*cos(q3)]])
+
+        Acceptable rotation orders are of length 3, expressed in as a string
+        ``'XYZ'`` or ``'123'`` or integer ``123``. Rotations about an axis
+        twice in a row are prohibited.
+
+        >>> B.orient_body(N, (q1, q2, 0), 'ZXZ')
+        >>> B.orient_body(N, (q1, q2, 0), '121')
+        >>> B.orient_body(N, (q1, q2, q3), 123)"""
+        from sympy.physics.vector.functions import dynamicsymbols
+        _check_frame(parent)
+
+        amounts = list(amounts)
+        for i, v in enumerate(amounts):
+            if not isinstance(v, Vector):
+                amounts[i] = sympify(v)
+
+        approved_orders = ('123', '231', '312', '132', '213', '321', '121',
+                           '131', '212', '232', '313', '323', '')
+        # make sure XYZ => 123
+        rot_order = translate(str(rot_order), 'XYZxyz', '123123')
+        if rot_order not in approved_orders:
+            raise TypeError('The supplied order is not an approved type')
+
+        parent_orient_body = []
+        if not (len(amounts) == 3 & len(rot_order) == 3):
+            raise TypeError('Body orientation takes 3 values & 3 orders')
+        a1 = int(rot_order[0])
+        a2 = int(rot_order[1])
+        a3 = int(rot_order[2])
+        parent_orient_body = (_rot(a1, amounts[0]) * _rot(a2, amounts[1]) *
+                         _rot(a3, amounts[2]))
+        # Reset the _dcm_cache of this frame, and remove it from the
+        # _dcm_caches of the frames it is linked to. Also remove it from the
+        # _dcm_dict of its parent
+        frames = self._dcm_cache.keys()
+        dcm_dict_del = []
+        dcm_cache_del = []
+        for frame in frames:
+            if frame in self._dcm_dict:
+                dcm_dict_del += [frame]
+            dcm_cache_del += [frame]
+        for frame in dcm_dict_del:
+            del frame._dcm_dict[self]
+        for frame in dcm_cache_del:
+            del frame._dcm_cache[self]
+        # Add the dcm relationship to _dcm_dict
+        self._dcm_dict = self._dlist[0] = {}
+        self._dcm_dict.update({parent: parent_orient_body.T})
+        parent._dcm_dict.update({self: parent_orient_body})
+        # Also update the dcm cache after resetting it
+        self._dcm_cache = {}
+        self._dcm_cache.update({parent: parent_orient_body.T})
+        parent._dcm_cache.update({self: parent_orient_body})
+        try:
+            from sympy.polys.polyerrors import CoercionFailed
+            from sympy.physics.vector.functions import kinematic_equations
+            q1, q2, q3 = amounts
+            u1, u2, u3 = symbols('u1, u2, u3', cls=Dummy)
+            templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
+                                           'body', rot_order)
+            templist = [expand(i) for i in templist]
+            td = solve(templist, [u1, u2, u3])
+            u1 = expand(td[u1])
+            u2 = expand(td[u2])
+            u3 = expand(td[u3])
+            wvec = u1 * self.x + u2 * self.y + u3 * self.z
+        except (CoercionFailed, AssertionError):
             wvec = self._w_diff_dcm(parent)
-        else:
-            try:
-                from sympy.polys.polyerrors import CoercionFailed
-                from sympy.physics.vector.functions import kinematic_equations
-                q1, q2, q3 = amounts
-                u1, u2, u3 = symbols('u1, u2, u3', cls=Dummy)
-                templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
-                                               rot_type, rot_order)
-                templist = [expand(i) for i in templist]
-                td = solve(templist, [u1, u2, u3])
-                u1 = expand(td[u1])
-                u2 = expand(td[u2])
-                u3 = expand(td[u3])
-                wvec = u1 * self.x + u2 * self.y + u3 * self.z
-            except (CoercionFailed, AssertionError):
-                wvec = self._w_diff_dcm(parent)
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
+        
+	def orient_space(self, parent, amounts, rot_order=''):
+		"""Sets the orientation of this reference frame relative to another
+		(parent) reference frame.
+		
+		Parameters
+		==========
+		
+		parent : ReferenceFrame
+			Referernce frame that this reference frame will be rotated relative to.
+			
+		amounts : 3-tuple of expressions, symbols, or functions
+			Expressions defining the rotation angles or direction cosine
+            matrix.
+            
+        rot_order : str or int
+			The string ``'123'`` and integer ``123`` are equivalent.
+		
+		Examples
+		==========
+		Rotates the reference frame in three
+        successive simple rotations but the axes of rotation are the
+        "Space-fixed" axes. For example:
+        
+        Setup variables for the examples:
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
+        >>> N = ReferenceFrame('N')
+        >>> B = ReferenceFrame('B')
+        >>> B1 = ReferenceFrame('B')
+        >>> B2 = ReferenceFrame('B2')
+
+        >>> B.orient_space(N, (q1, q2, q3), '312')
+        >>> B.dcm(N)
+        Matrix([
+        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
+        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],
+        [                           sin(q3)*cos(q2),        -sin(q2),                           cos(q2)*cos(q3)]])
+
+        is equivalent to:
+
+        >>> B1.orient_axis(N, (q1, N.z))
+        >>> B2.orient_axis(B1, (q2, N.x))
+        >>> B.orient_axis(B2, (q3, N.y))
+        >>> B.dcm(N).simplify()  # doctest: +SKIP
+        Matrix([
+        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
+        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],
+        [                           sin(q3)*cos(q2),        -sin(q2),                           cos(q2)*cos(q3)]])
+
+        It is worth noting that space-fixed and body-fixed rotations are
+        related by the order of the rotations, i.e. the reverse order of body
+        fixed will give space fixed and vice versa.
+
+        >>> B.orient_space(N, (q1, q2, q3), '231')
+        >>> B.dcm(N)
+        Matrix([
+        [cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3), -sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)],
+        [       -sin(q2),                           cos(q2)*cos(q3),                            sin(q3)*cos(q2)],
+        [sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1),  sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3)]])
+
+        >>> B.orient_body(N, (q3, q2, q1), '132')
+        >>> B.dcm(N)
+        Matrix([
+        [cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3), -sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1)],
+        [       -sin(q2),                           cos(q2)*cos(q3),                            sin(q3)*cos(q2)],
+        [sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1),  sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3)]])"""
+
+        from sympy.physics.vector.functions import dynamicsymbols
+        _check_frame(parent)
+
+        amounts = list(amounts)
+        for i, v in enumerate(amounts):
+            if not isinstance(v, Vector):
+                amounts[i] = sympify(v)
+                
+        approved_orders = ('123', '231', '312', '132', '213', '321', '121',
+                           '131', '212', '232', '313', '323', '')
+        # make sure XYZ => 123
+        rot_order = translate(str(rot_order), 'XYZxyz', '123123')
+        if rot_order not in approved_orders:
+            raise TypeError('The supplied order is not an approved type')
+        parent_orient_space = []
+
+        if not (len(amounts) == 3 & len(rot_order) == 3):
+            raise TypeError('Space orientation takes 3 values & 3 orders')
+        a1 = int(rot_order[0])
+        a2 = int(rot_order[1])
+        a3 = int(rot_order[2])
+        parent_orient_space = (_rot(a3, amounts[2]) * _rot(a2, amounts[1]) *
+                         _rot(a1, amounts[0]))
+
+        # Reset the _dcm_cache of this frame, and remove it from the
+        # _dcm_caches of the frames it is linked to. Also remove it from the
+        # _dcm_dict of its parent
+        frames = self._dcm_cache.keys()
+        dcm_dict_del = []
+        dcm_cache_del = []
+        for frame in frames:
+            if frame in self._dcm_dict:
+                dcm_dict_del += [frame]
+            dcm_cache_del += [frame]
+        for frame in dcm_dict_del:
+            del frame._dcm_dict[self]
+        for frame in dcm_cache_del:
+            del frame._dcm_cache[self]
+        # Add the dcm relationship to _dcm_dict
+        self._dcm_dict = self._dlist[0] = {}
+        self._dcm_dict.update({parent: parent_orient_space.T})
+        parent._dcm_dict.update({self: parent_orient_space})
+        # Also update the dcm cache after resetting it
+        self._dcm_cache = {}
+        self._dcm_cache.update({parent: parent_orient_space.T})
+        parent._dcm_cache.update({self: parent_orient_space})
+
+        try:
+            from sympy.polys.polyerrors import CoercionFailed
+            from sympy.physics.vector.functions import kinematic_equations
+            q1, q2, q3 = amounts
+            u1, u2, u3 = symbols('u1, u2, u3', cls=Dummy)
+            templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
+                                           'space', rot_order)
+            templist = [expand(i) for i in templist]
+            td = solve(templist, [u1, u2, u3])
+            u1 = expand(td[u1])
+            u2 = expand(td[u2])
+            u3 = expand(td[u3])
+            wvec = u1 * self.x + u2 * self.y + u3 * self.z
+        except (CoercionFailed, AssertionError):
+            wvec = self._w_diff_dcm(parent)
+        self._ang_vel_dict.update({parent: wvec})
+        parent._ang_vel_dict.update({self: -wvec})
+        self._var_dict = {}
+        
+    def orient_quaternion(self, parent, amounts):
+    	"""Sets the orientation of this reference frame relative to another
+        (parent) reference frame.
+
+        Parameters
+        ==========
+
+        parent : ReferenceFrame
+            Reference frame that this reference frame will be rotated relative to.
+
+        amounts : 4-tuple of expressions, symbols, or functions.
+            Expressions defining the rotation angles or direction cosine
+            matrix.
+            
+        Examples
+        =========
+        
+        Setup variables for the examples:
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector import ReferenceFrame
+        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
+        >>> N = ReferenceFrame('N')
+        >>> B = ReferenceFrame('B')
+
+        This method orients the reference frame using
+        quaternions. Quaternion rotation is defined as a finite rotation about
+        lambda, a unit vector, by an amount theta. This orientation is
+        described by four parameters:
+
+        - ``q0 = cos(theta/2)``
+        - ``q1 = lambda_x sin(theta/2)``
+        - ``q2 = lambda_y sin(theta/2)``
+        - ``q3 = lambda_z sin(theta/2)``
+
+        >>> B.orient_quaternion(N, (q0, q1, q2, q3))
+        >>> B.dcm(N)
+        Matrix([
+        [q0**2 + q1**2 - q2**2 - q3**2,             2*q0*q3 + 2*q1*q2,            -2*q0*q2 + 2*q1*q3],
+        [           -2*q0*q3 + 2*q1*q2, q0**2 - q1**2 + q2**2 - q3**2,             2*q0*q1 + 2*q2*q3],
+        [            2*q0*q2 + 2*q1*q3,            -2*q0*q1 + 2*q2*q3, q0**2 - q1**2 - q2**2 + q3**2]])
+		"""
+
+        from sympy.physics.vector.functions import dynamicsymbols
+        _check_frame(parent)
+
+        amounts = list(amounts)
+        for i, v in enumerate(amounts):
+            if not isinstance(v, Vector):
+                amounts[i] = sympify(v)
+        
+        parent_orient_quaternion = []
+        if not (isinstance(amounts, (list, tuple)) & (len(amounts) == 4)):
+            raise TypeError('Amounts are a list or tuple of length 4')
+        q0, q1, q2, q3 = amounts
+        parent_orient_quaternion = (Matrix([[q0**2 + q1**2 - q2**2 - q3**2,
+                                  2 * (q1 * q2 - q0 * q3),
+                                  2 * (q0 * q2 + q1 * q3)],
+                                 [2 * (q1 * q2 + q0 * q3),
+                                  q0**2 - q1**2 + q2**2 - q3**2,
+                                  2 * (q2 * q3 - q0 * q1)],
+                                 [2 * (q1 * q3 - q0 * q2),
+                                  2 * (q0 * q1 + q2 * q3),
+                                  q0**2 - q1**2 - q2**2 + q3**2]]))
+       
+        # Reset the _dcm_cache of this frame, and remove it from the
+        # _dcm_caches of the frames it is linked to. Also remove it from the
+        # _dcm_dict of its parent
+        frames = self._dcm_cache.keys()
+        dcm_dict_del = []
+        dcm_cache_del = []
+        for frame in frames:
+            if frame in self._dcm_dict:
+                dcm_dict_del += [frame]
+            dcm_cache_del += [frame]
+        for frame in dcm_dict_del:
+            del frame._dcm_dict[self]
+        for frame in dcm_cache_del:
+            del frame._dcm_cache[self]
+        # Add the dcm relationship to _dcm_dict
+        self._dcm_dict = self._dlist[0] = {}
+        self._dcm_dict.update({parent: parent_orient_quaternion.T})
+        parent._dcm_dict.update({self: parent_orient_quaternion})
+        # Also update the dcm cache after resetting it
+        self._dcm_cache = {}
+        self._dcm_cache.update({parent: parent_orient_quaternion.T})
+        parent._dcm_cache.update({self: parent_orient_quaternion})
+
+        t = dynamicsymbols._t
+        q0, q1, q2, q3 = amounts
+        q0d = diff(q0, t)
+        q1d = diff(q1, t)
+        q2d = diff(q2, t)
+        q3d = diff(q3, t)
+        w1 = 2 * (q1d * q0 + q2d * q3 - q3d * q2 - q0d * q1)
+        w2 = 2 * (q2d * q0 + q3d * q1 - q1d * q3 - q0d * q2)
+        w3 = 2 * (q3d * q0 + q1d * q2 - q2d * q1 - q0d * q3)
+        wvec = Vector([(Matrix([w1, w2, w3]), self)])
+        
         self._ang_vel_dict.update({parent: wvec})
         parent._ang_vel_dict.update({self: -wvec})
         self._var_dict = {}
@@ -841,8 +1031,10 @@ class ReferenceFrame:
         r"""Returns a new reference frame oriented with respect to this
         reference frame.
 
-        See ``ReferenceFrame.orient()`` for detailed examples of how to orient
-        reference frames.
+        See ``ReferenceFrame.orient_axis(), ReferenceFrame.orient_dcm(),
+        ReferenceFrame.orient_body(), ReferenceFrame.orient_space(), 
+        ReferenceFrame.orient_quaternion()`` for detailed examples of 
+        how to orient reference frames.
 
         Parameters
         ==========
@@ -920,7 +1112,24 @@ class ReferenceFrame:
 
         newframe = self.__class__(newname, variables=variables,
                                   indices=indices, latexs=latexs)
-        newframe.orient(self, rot_type, amounts, rot_order)
+      	rot_type = rot_type.lower()
+      	if rot_type == 'axis':
+      		newframe.orient_axis(self, amounts)
+      		
+  		elif rot_type == 'dcm':
+  			newframe.orient_dcm(self, amounts)
+  			
+		elif rot_type == 'body':
+			newframe.orient_body(self, amounts, rot_order)
+			
+		elif rot_type == 'space':
+			newframe.orient_space(self, amounts, rot_order)
+			
+		elif rot_type == 'quaternion':
+			newframe.orient_quaternion(self, amounts)
+			
+		else:
+			raise NotImplementedError('That is not an implemented rotation')
         return newframe
 
     def set_ang_acc(self, otherframe, value):

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -457,7 +457,7 @@ class ReferenceFrame:
              \hat{\mathbf{a}}_3
            \end{bmatrix}.
 
-        :math:`^{}A\mathbf{R}^B` is the matrix that expresses the B unit
+        :math:`{}^A\mathbf{R}^B` is the matrix that expresses the B unit
         vectors in terms of the A unit vectors.
 
         """
@@ -918,6 +918,10 @@ class ReferenceFrame:
         - ``q2 = lambda_y*sin(theta/2)``
         - ``q3 = lambda_z*sin(theta/2)``
 
+        See `Quaternions and Spatial Rotation
+        <https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation>`_ on
+        Wikipedia for more information.
+
         Parameters
         ==========
         parent : ReferenceFrame
@@ -992,6 +996,10 @@ class ReferenceFrame:
     def orient(self, parent, rot_type, amounts, rot_order=''):
         """Sets the orientation of this reference frame relative to another
         (parent) reference frame.
+
+        .. note:: It is now recommended to use the ``.orient_axis,
+           .orient_body_fixed, .orient_space_fixed, .orient_quaternion``
+           methods for the different rotation types.
 
         Parameters
         ==========

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -556,6 +556,7 @@ class ReferenceFrame:
         amount = sympify(angle)
         theta = amount
         axis = _check_vector(axis)
+        vector_axis = axis
         parent_orient_axis = []
 
         if not axis.dt(parent) == 0:
@@ -571,7 +572,7 @@ class ReferenceFrame:
         self._dcm(parent, parent_orient_axis)
 
         thetad = (amount).diff(dynamicsymbols._t)
-        wvec = thetad*axis.express(parent).normalize()
+        wvec = thetad* vector_axis.express(parent).normalize()
         self._ang_vel_dict.update({parent: wvec})
         parent._ang_vel_dict.update({self: -wvec})
         self._var_dict = {}

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -596,7 +596,7 @@ class ReferenceFrame:
 
         Setup variables for the examples:
 
-        >>> from sympy import symbols
+        >>> from sympy import symbols, Matrix
         >>> from sympy.physics.vector import ReferenceFrame
         >>> q1 = symbols('q1')
         >>> A = ReferenceFrame('A')
@@ -831,9 +831,9 @@ class ReferenceFrame:
         >>> B.orient_axis(B2, N.y, q3)
         >>> B.dcm(N).simplify()
         Matrix([
-        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2), sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
-        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(q1)*sin(q3) + sin(q2)*cos(q1)*cos(q3)],
-        [                           sin(q3)*cos(q2),        -sin(q2),                           cos(q2)*cos(q3)]])
+        [ sin(q1)*sin(q2)*sin(q3) + cos(q1)*cos(q3), sin(q1)*cos(q2),                                                                                sin(q1)*sin(q2)*cos(q3) - sin(q3)*cos(q1)],
+        [-sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1), cos(q1)*cos(q2), sin(-q1 + q2 + q3)/4 - sin(q1 - q2 + q3)/4 + sin(q1 + q2 - q3)/4 + sin(q1 + q2 + q3)/4 + cos(q1 - q3)/2 - cos(q1 + q3)/2],
+        [                           sin(q3)*cos(q2),        -sin(q2),                                                                                                          cos(q2)*cos(q3)]])
 
         It is worth noting that space-fixed and body-fixed rotations are
         related by the order of the rotations, i.e. the reverse order of body

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -596,7 +596,7 @@ class ReferenceFrame:
 
         Setup variables for the examples:
 
-        >>> from sympy import symbols, Matrix
+        >>> from sympy import symbols, Matrix, sin, cos
         >>> from sympy.physics.vector import ReferenceFrame
         >>> q1 = symbols('q1')
         >>> A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -367,7 +367,7 @@ def test_reference_frame():
     raises(TypeError, lambda: B.orient(N, 'Space', [q1, q2, q3], '222'))
     raises(TypeError, lambda: B.orient(N, 'Axis', [q1, N.x + 2 * N.y], '222'))
     raises(TypeError, lambda: B.orient(N, 'Axis', q1))
-    raises(TypeError, lambda: B.orient(N, 'Axis', [q1]))
+    raises(IndexError, lambda: B.orient(N, 'Axis', [q1]))
     raises(TypeError, lambda: B.orient(N, 'Quaternion', [q0, q1, q2, q3], '222'))
     raises(TypeError, lambda: B.orient(N, 'Quaternion', q0))
     raises(TypeError, lambda: B.orient(N, 'Quaternion', [q0, q1, q2]))
@@ -416,3 +416,32 @@ def test_dcm_diff_16824():
 
     assert simplify(AwB.dot(A.y) - alpha2) == 0
     assert simplify(AwB.dot(B.y) - beta2) == 0
+
+def test_orient_explicit():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    A.orient_explicit(B, eye(3))
+    assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+def test_orient_axis():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    assert A.orient_axis(B,-B.x, 1) == A.orient_axis(B, B.x, -1)
+
+def test_orient_body():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    B.orient_body_fixed(A, (1,1,0), 'XYX')
+    assert B.dcm(A) == Matrix([[cos(1), sin(1)**2, -sin(1)*cos(1)], [0, cos(1), sin(1)], [sin(1), -sin(1)*cos(1), cos(1)**2]])
+
+def test_orient_space():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    B.orient_space_fixed(A, (0,0,0), '123')
+    assert B.dcm(A) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+def test_orient_quaternion():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    B.orient_quaternion(A, (0,0,0,0))
+    assert B.dcm(A) == Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17758 
Fixes #18798
#### Brief description of what is fixed or changed
Break RefrenceFrame.orient() into seperate methods.

`.orient()` is trying to do too many things, so this change both organizes the library code better as well as provide users with easier to understand and use methods. We do not plan to deprecate `.orient()` as it would disrupt too much code in the wild.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- physics.vector
      - Introduced new methods on ReferenceFrame: `.orient_axis()`, `.orient_explicit()`, `.orient_body_fixed()`, `.orient_space_fixed()`, and `.orient_quaternion()`. `.orient()` calls out to each new method and it is recommended to use the new methods. 
<!-- END RELEASE NOTES -->