### PR TITLE
Added fix for wrong dimension calculations in case of some mathematical functions

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -472,6 +472,21 @@ def test_issue_14547():
     e = foot + 1
     assert e.is_Add and set(e.args) == {foot, 1}
 
+def test_issue_20288():
+    # the issue was that sympy was not considering the results of 
+    # mathematical functions as dimensionless
+    from sympy.physics.units import energy
+    from sympy.core.numbers import E
+    from sympy import sympify
+    u = Quantity('u')
+    v = Quantity('v')
+    SI.set_quantity_dimension(u, energy)
+    SI.set_quantity_dimension(v, energy)
+    u.set_global_relative_scale_factor(1, energy)
+    v.set_global_relative_scale_factor(1, energy)
+    expr = 1 + exp(u/v)
+    assert (sympify(1 + E), Dimension(1)) == SI._collect_factor_and_dimension(expr)
+
 
 def test_deprecated_quantity_methods():
     step = Quantity("step")

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -473,7 +473,7 @@ def test_issue_14547():
     assert e.is_Add and set(e.args) == {foot, 1}
 
 def test_issue_20288():
-    # the issue was that sympy was not considering the results of 
+    # the issue was that sympy was not considering the results of
     # mathematical functions as dimensionless
     from sympy.physics.units import energy
     from sympy.core.numbers import E

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -208,7 +208,7 @@ class UnitSystem(_QuantityMapper):
             fds = [self._collect_factor_and_dimension(
                 arg) for arg in expr.args]
             return (expr.func(*(f[0] for f in fds)),
-                    expr.func(*(d[1] for d in fds)))
+                    *(d[1] for d in fds))
         elif isinstance(expr, Dimension):
             return 1, expr
         else:


### PR DESCRIPTION
…al functions

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20288 

#### Brief description of what is fixed or changed
Fixed the return value for the function _collect_factor_and_dimension(). Previous return value led to wrong dimensional evaluation for expressions containing predefined mathematical functions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
    * Fixed dimensional evaluation for expressions containing predefined mathematical functions. 
<!-- END RELEASE NOTES -->