### PR TITLE
Add missing `_print_Exp1` function to theanocode printer

### DIFF
--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -611,3 +611,23 @@ def test_complexfunctions():
 def test_constantfunctions():
     tf = theano_function([],[1+1j])
     assert(tf()==1+1j)
+
+
+def test_Exp1():
+    """
+    Test that exp(1) prints without error and evaluates close to sympy's E
+    """
+    # sy.exp(1) should yield same instance of E as sy.E (singleton), but extra
+    # check added for sanity
+    e_a = sy.exp(1)
+    e_b = sy.E
+
+    np.testing.assert_allclose(float(e_a), np.e)
+    np.testing.assert_allclose(float(e_b), np.e)
+
+    e = theano_code_(e_a)
+    np.testing.assert_allclose(float(e_a), e.eval())
+
+    e = theano_code_(e_b)
+    np.testing.assert_allclose(float(e_b), e.eval())
+

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -630,4 +630,3 @@ def test_Exp1():
 
     e = theano_code_(e_b)
     np.testing.assert_allclose(float(e_b), e.eval())
-

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -215,6 +215,9 @@ class TheanoPrinter(Printer):
     def _print_Pi(self, expr, **kwargs):
         return 3.141592653589793
 
+    def _print_Exp1(self, expr, **kwargs):
+        return ts.exp(1)
+
     def _print_Piecewise(self, expr, **kwargs):
         import numpy as np
         e, cond = expr.args[0].args  # First condition and corresponding value


### PR DESCRIPTION
#### References to other Issues or PRs
None, afaik


#### Brief description of what is fixed or changed
Add `_print_Exp1` definition to the `theanocode` printing module. Printed functions containing a `sympy.core.numbers.Exp1` instance currently fail to be printed.

#### Other comments

MWE to reproduce errors:

```python
from sympy.printing.theanocode import TheanoPrinter
import sympy

x1 = sympy.Symbol('x1')
TheanoPrinter()._print(sympy.exp(1))
```

This gives the following traceback:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/usr/lib/python3.8/site-packages/sympy/printing/printer.py", line 289, in _print
    return getattr(self, printmethod)(expr, **kwargs)
  File "/url/lib/python3.8/site-packages/sympy/printing/theanocode.py", line 156, in _print_Basic
    op = mapping[type(expr)]
KeyError: <class 'sympy.core.numbers.Exp1'>
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug where `TheanoPrinter` fails to print Euler's number _e_ (`sympy.core.numbers.Exp1`)
<!-- END RELEASE NOTES -->