### PR TITLE
Fix Gram Schmidt

### DIFF
--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -152,39 +152,25 @@ def _orthogonalize(cls, *vecs, normalize=False, rankcheck=False):
 
     .. [1] https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
     """
+    from .decompositions import _QRdecomposition_optional
 
-    def project(a, b):
-        return b * (a.dot(b, hermitian=True) / b.dot(b, hermitian=True))
+    if not vecs:
+        return []
 
-    def perp_to_subspace(vec, basis):
-        """projects vec onto the subspace given
-        by the orthogonal basis ``basis``"""
+    all_row_vecs = (vecs[0].rows == 1)
 
-        components = [project(vec, b) for b in basis]
+    vecs = [x.vec() for x in vecs]
+    M = cls.hstack(*vecs)
+    Q, R = _QRdecomposition_optional(M, normalize=normalize)
 
-        if len(basis) == 0:
-            return vec
+    if rankcheck and Q.cols < len(vecs):
+        raise ValueError("GramSchmidt: vector set not linearly independent")
 
-        return vec - reduce(lambda a, b: a + b, components)
-
-    ret  = []
-    vecs = list(vecs) # make sure we start with a non-zero vector
-
-    while len(vecs) > 0 and vecs[0].is_zero_matrix:
-        if rankcheck is False:
-            del vecs[0]
+    ret = []
+    for i in range(Q.cols):
+        if all_row_vecs:
+            col = cls(Q[:, i].T)
         else:
-            raise ValueError("GramSchmidt: vector set not linearly independent")
-
-    for vec in vecs:
-        perp = perp_to_subspace(vec, ret)
-
-        if not perp.is_zero_matrix:
-            ret.append(cls(perp))
-        elif rankcheck is True:
-            raise ValueError("GramSchmidt: vector set not linearly independent")
-
-    if normalize:
-        ret = [vec / vec.norm() for vec in ret]
-
+            col = cls(Q[:, i])
+        ret.append(col)
     return ret

--- a/sympy/matrices/subspaces.py
+++ b/sympy/matrices/subspaces.py
@@ -1,5 +1,3 @@
-from sympy.core.compatibility import reduce
-
 from .utilities import _iszero
 
 

--- a/sympy/matrices/tests/test_decompositions.py
+++ b/sympy/matrices/tests/test_decompositions.py
@@ -108,6 +108,12 @@ def test_QR():
     assert R.is_upper
     assert A == Q*R
 
+    A = Matrix([[12, 0, -51], [6, 0, 167], [-4, 0, 24]])
+    Q, R = A.QRdecomposition()
+    assert Q.T * Q == eye(Q.cols)
+    assert R.is_upper
+    assert A == Q*R
+
 def test_QR_non_square():
     # Narrow (cols < rows) matrices
     A = Matrix([[9, 0, 26], [12, 0, -7], [0, 4, 4], [0, -3, -3]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2871,6 +2871,10 @@ def test_gramschmidt_conjugate_dot():
     assert Matrix.orthogonalize(*vecs) == \
         [Matrix([[1], [I]]), Matrix([[1], [-I]])]
 
+    vecs = [Matrix([1, I, 0]), Matrix([I, 0, -I])]
+    assert Matrix.orthogonalize(*vecs) == \
+        [Matrix([[1], [I], [0]]), Matrix([[I/2], [S(1)/2], [-I]])]
+
     mat = Matrix([[1, I], [1, -I]])
     Q, R = mat.QRdecomposition()
     assert Q * Q.H == Matrix.eye(2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20334

#### Brief description of what is fixed or changed

The ordering of dot product is important for gram schmidt process such that we always have to stick to use `a.H * b` instead of `a * b.H`, however, once the orthogonal set of vectors are computed, the orthogonality does not change under  `a.H * b` vs `a * b.H`
I have also done some improvements for QR decomposition.

Gram-Schmidt or QR decomposition without normalization is better for symbolic computation because it makes it possible to operations closed under the ground field without introducing any radical extensions, however, I have not yet introduced this keyword for public use because there can be different conventions to define the diagonals of R to become 1 or squared euclidean norm of the Q matrix,

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Fixed issues with dot product for `Matrix.orthogonalize` with complex vectors.
  - Fixed zero division issues for `Matrix.QRdecomposition` with zero columns coming first than nonzero columns.
<!-- END RELEASE NOTES -->