### PR TITLE
Import PygletPlot from the right module in documentation

### DIFF
--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -103,7 +103,8 @@ the only dependency being ``pyglet``.
 
 Here is the simplest usage:
 
-    >>> from sympy import var, Plot
+    >>> from sympy import var
+    >>> from sympy.plotting.pygletplot import PygletPlot as Plot
     >>> var('x y z')
     >>> Plot(x*y**3-y*x**3)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
[This](https://github.com/sympy/sympy/issues/15327#issuecomment-608181508) comment

#### Brief description of what is fixed or changed
[Here](https://docs.sympy.org/dev/modules/plotting.html#module-sympy.plotting.pygletplot) in the documentation, `PygletPlot()` is incorrectly imported. Running the command gives the following result. 
```
>>> from sympy import var, Plot
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name Plot

```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->