### PR TITLE
series: Test added for order.py

### DIFF
--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -418,6 +418,11 @@ def test_issue_9192():
     assert O(1)*O(1) == O(1)
     assert O(1)**O(1) == O(1)
 
+
+def test_issue_9910():
+    assert O(x*log(x) + sin(x), (x, oo)) == O(x*log(x), (x, oo))
+
+
 def test_performance_of_adding_order():
     l = list(x**i for i in range(1000))
     l.append(O(x**1001))
@@ -441,6 +446,3 @@ def test_issue_15539():
 
 def test_issue_18606():
     assert unchanged(Order, 0)
-
-def test_issue_9910():
-    assert O(x*log(x)+sin(x), (x, oo)) == O(x*log(x), (x, oo))

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -441,3 +441,6 @@ def test_issue_15539():
 
 def test_issue_18606():
     assert unchanged(Order, 0)
+
+def test_issue_9910():
+    assert O(x*log(x)+sin(x), (x, oo)) == O(x*log(x), (x, oo))


### PR DESCRIPTION
For the case of O(n*log(n)+sin(n), (n, oo)),
the function did not omit sin(n), which was fixed later. This
is a test for the same.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #9910 

#### Brief description of what is fixed or changed
Test added for O(n*log(n)+sin(n), (n, oo))

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->