### PR TITLE
Permanent of matrix

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -424,7 +424,7 @@ __all__ = [
     'HadamardPower', 'Determinant', 'det', 'diagonalize_vector', 'DiagMatrix',
     'DiagonalMatrix', 'DiagonalOf', 'trace', 'DotProduct',
     'kronecker_product', 'KroneckerProduct', 'PermutationMatrix',
-    'MatrixPermute',
+    'MatrixPermute', 'Permanent', 'per',
 
     # sympy.geometry
     'Point', 'Point2D', 'Point3D', 'Line', 'Ray', 'Segment', 'Line2D',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -190,7 +190,7 @@ from .matrices import (ShapeError, NonSquareMatrixError, GramSchmidt,
         Adjoint, hadamard_product, HadamardProduct, HadamardPower,
         Determinant, det, diagonalize_vector, DiagMatrix, DiagonalMatrix,
         DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct,
-        PermutationMatrix, MatrixPermute)
+        PermutationMatrix, MatrixPermute, Permanent, per)
 
 from .geometry import (Point, Point2D, Point3D, Line, Ray, Segment, Line2D,
         Segment2D, Ray2D, Line3D, Segment3D, Ray3D, Plane, Ellipse, Circle,

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3137,6 +3137,10 @@ def test_sympy__matrices__expressions__determinant__Determinant():
     from sympy.matrices.expressions import MatrixSymbol
     assert _test_args(Determinant(MatrixSymbol('A', 3, 3)))
 
+def test_sympy__matrices__expressions__determinant__Permanent():
+    from sympy.matrices.expressions.determinant import Permanent
+    from sympy.matrices.expressions import MatrixSymbol
+    assert _test_args(Permanent(MatrixSymbol('A', 3, 4)))
 
 def test_sympy__matrices__expressions__funcmatrix__FunctionMatrix():
     from sympy.matrices.expressions.funcmatrix import FunctionMatrix

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -28,7 +28,7 @@ from .expressions import (
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagMatrix, DiagonalMatrix, DiagonalOf, trace,
     DotProduct, kronecker_product, KroneckerProduct,
-    PermutationMatrix, MatrixPermute, MatrixSet)
+    PermutationMatrix, MatrixPermute, MatrixSet, Permanent, per)
 
 from .utilities import dotprodsimp
 
@@ -62,6 +62,7 @@ __all__ = [
     'det', 'diagonalize_vector', 'DiagMatrix', 'DiagonalMatrix',
     'DiagonalOf', 'trace', 'DotProduct', 'kronecker_product',
     'KroneckerProduct', 'PermutationMatrix', 'MatrixPermute', 'MatrixSet',
+    'Permanent', 'per',
 
     'dotprodsimp',
 ]

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -6,6 +6,8 @@ from sympy.core.symbol import uniquely_named_symbol
 from sympy.polys import PurePoly, cancel
 from sympy.simplify.simplify import (simplify as _simplify,
     dotprodsimp as _dotprodsimp)
+from sympy import sympify
+from sympy.functions.combinatorial.numbers import nC
 
 from .common import MatrixError, NonSquareMatrixError
 from .utilities import (
@@ -479,6 +481,59 @@ def _cofactor_matrix(M, method="berkowitz"):
     return M._new(M.rows, M.cols,
             lambda i, j: M.cofactor(i, j, method))
 
+def _per(M):
+    """Returns the permanent of a matrix. Unlike determinant,
+    permanent is defined for both square and non-square matrices.
+
+    For an m x n matrix, with m less than or equal to n,
+    it is given as the sum over the permutations s of size
+    less than or equal to m on [1, 2, . . . n] of the product
+    from i = 1 to m of M[i, s[i]]. Taking the transpose will
+    not affect the value of the permanent.
+
+    In the case of a square matrix, this is the same as the permutation
+    definition of the determinant, but it does not take the sign of the
+    permutation into account. Computing the permanent with this definition
+    is quite inefficient, so here the Ryser formula is used.
+
+    Examples
+    ========
+    >>> from sympy import Matrix
+    >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> M.per()
+    450
+    >>> M = Matrix([1, 5, 7])
+    >>> M.per()
+    13
+    References
+    ==========
+        .. [1] Prof. Frank Ben's notes: https://math.berkeley.edu/~bernd/ban275.pdf
+        .. [2] Wikipedia article on Permanent: https://en.wikipedia.org/wiki/Permanent_(mathematics)
+        .. [3] https://reference.wolfram.com/language/ref/Permanent.html
+        .. [4] Permanent of a rectangular matrix : https://arxiv.org/pdf/0904.3251.pdf
+    """
+    import itertools
+
+    m, n = M.shape
+    if m > n:
+        M = M.T
+        m, n = n, m
+    s = list(range(n))
+
+    subsets = []
+    for i in range(1, m + 1):
+        subsets += list(map(list, itertools.combinations(s, i)))
+
+    perm = 0
+    for subset in subsets:
+        prod = 1
+        sub_len = len(subset)
+        for i in range(m):
+             prod *= sum([M[i, j] for j in subset])
+        perm += prod * (-1)**sub_len * nC(n - sub_len, m - sub_len)
+    perm *= (-1)**m
+    perm = sympify(perm)
+    return perm.simplify()
 
 # This functions is a candidate for caching if it gets implemented for matrices.
 def _det(M, method="bareiss", iszerofunc=None):

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -510,10 +510,10 @@ def _per(M):
     References
     ==========
 
-        .. [1] Prof. Frank Ben's notes: https://math.berkeley.edu/~bernd/ban275.pdf
-        .. [2] Wikipedia article on Permanent: https://en.wikipedia.org/wiki/Permanent_(mathematics)
-        .. [3] https://reference.wolfram.com/language/ref/Permanent.html
-        .. [4] Permanent of a rectangular matrix : https://arxiv.org/pdf/0904.3251.pdf
+    .. [1] Prof. Frank Ben's notes: https://math.berkeley.edu/~bernd/ban275.pdf
+    .. [2] Wikipedia article on Permanent: https://en.wikipedia.org/wiki/Permanent_(mathematics)
+    .. [3] https://reference.wolfram.com/language/ref/Permanent.html
+    .. [4] Permanent of a rectangular matrix : https://arxiv.org/pdf/0904.3251.pdf
     """
     import itertools
 

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -498,6 +498,7 @@ def _per(M):
 
     Examples
     ========
+
     >>> from sympy import Matrix
     >>> M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> M.per()
@@ -505,8 +506,10 @@ def _per(M):
     >>> M = Matrix([1, 5, 7])
     >>> M.per()
     13
+
     References
     ==========
+
         .. [1] Prof. Frank Ben's notes: https://math.berkeley.edu/~bernd/ban275.pdf
         .. [2] Wikipedia article on Permanent: https://en.wikipedia.org/wiki/Permanent_(mathematics)
         .. [3] https://reference.wolfram.com/language/ref/Permanent.html

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -10,7 +10,7 @@ from .matexpr import MatrixExpr, MatrixSymbol, matrix_symbols
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
-from .determinant import Determinant, det
+from .determinant import Determinant, det, Permanent, per
 from .transpose import Transpose
 from .adjoint import Adjoint
 from .hadamard import hadamard_product, HadamardProduct, hadamard_power, HadamardPower
@@ -57,4 +57,6 @@ __all__ = [
     'kronecker_product', 'KroneckerProduct', 'combine_kronecker',
 
     'PermutationMatrix', 'MatrixPermute',
+
+    'Permanent', 'per'
 ]

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -55,6 +55,57 @@ def det(matexpr):
 
     return Determinant(matexpr).doit()
 
+class Permanent(Expr):
+    """Matrix Permanent
+
+    Represents the permanent of a matrix expression.
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol, Permanent, ones
+    >>> A = MatrixSymbol('A', 3, 3)
+    >>> Permanent(A)
+    Permanent(A)
+    >>> Permanent(ones(3, 3)).doit()
+    6
+    """
+
+    def __new__(cls, mat):
+        mat = sympify(mat)
+        if not mat.is_Matrix:
+            raise TypeError("Input to Permanent, %s, not a matrix" % str(mat))
+
+        return Basic.__new__(cls, mat)
+
+    @property
+    def arg(self):
+        return self.args[0]
+
+    def doit(self, expand=False):
+        try:
+            return self.arg.per()
+        except (AttributeError, NotImplementedError):
+            return self
+
+def per(matexpr):
+    """ Matrix Permanent
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol, Matrix, per, ones
+    >>> A = MatrixSymbol('A', 3, 3)
+    >>> per(A)
+    Permanent(A)
+    >>> per(ones(5, 5))
+    120
+    >>> M = Matrix([1, 2, 5])
+    >>> per(M)
+    8
+    """
+
+    return Permanent(matexpr).doit()
 
 from sympy.assumptions.ask import ask, Q
 from sympy.assumptions.refine import handlers_dict

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -30,7 +30,7 @@ from .utilities import _iszero, _is_zero_after_expand_mul
 
 from .determinant import (
     _find_reasonable_pivot, _find_reasonable_pivot_naive,
-    _adjugate, _charpoly, _cofactor, _cofactor_matrix,
+    _adjugate, _charpoly, _cofactor, _cofactor_matrix, _per,
     _det, _det_bareiss, _det_berkowitz, _det_LU, _minor, _minor_submatrix)
 
 from .reductions import _is_echelon, _echelon_form, _rank, _rref
@@ -123,6 +123,9 @@ class MatrixDeterminant(MatrixCommon):
     def det(self, method="bareiss", iszerofunc=None):
         return _det(self, method=method, iszerofunc=iszerofunc)
 
+    def per(self):
+        return _per(self)
+
     def minor(self, i, j, method="berkowitz"):
         return _minor(self, i, j, method=method)
 
@@ -140,6 +143,7 @@ class MatrixDeterminant(MatrixCommon):
     cofactor.__doc__                     = _cofactor.__doc__
     cofactor_matrix.__doc__              = _cofactor_matrix.__doc__
     det.__doc__                          = _det.__doc__
+    per.__doc__                          = _per.__doc__
     minor.__doc__                        = _minor.__doc__
     minor_submatrix.__doc__              = _minor_submatrix.__doc__
 

--- a/sympy/matrices/tests/test_determinant.py
+++ b/sympy/matrices/tests/test_determinant.py
@@ -6,6 +6,7 @@ from sympy.abc import x, y, z
 from sympy.testing.pytest import raises
 from sympy.matrices.matrices import MatrixDeterminant
 from sympy.matrices.common import NonSquareMatrixError, _MinimalMatrix,  _CastableMatrix
+from sympy.functions.combinatorial.factorials import factorial, subfactorial
 
 class DeterminantOnlyMatrix(_MinimalMatrix, _CastableMatrix, MatrixDeterminant):
     pass
@@ -276,6 +277,17 @@ def test_det():
     assert g.det() == i*j*k
     assert h.det() == 1
     raises(ValueError, lambda: e.det(iszerofunc="test"))
+
+def test_permanent():
+    M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    assert M.per() == 450
+    for i in range(1, 12):
+        assert ones(i, i).per() == ones(i, i).T.per() == factorial(i)
+        assert (ones(i, i)-eye(i)).per() == (ones(i, i)-eye(i)).T.per() == subfactorial(i)
+
+    a1, a2, a3, a4, a5 = symbols('a_1 a_2 a_3 a_4 a_5')
+    M = Matrix([a1, a2, a3, a4, a5])
+    assert M.per() == M.T.per() == a1 + a2 + a3 + a4 + a5
 
 def test_adjugate():
     x = Symbol('x')


### PR DESCRIPTION
Added a method to compute permanent of a matrix

#### References to other Issues or PRs
#19041 

#### Brief description of what is fixed or changed
The previous PR is obselete and was only for square matrices. With this PR, permanent of square and rectangular matrices can be calculated. I have implemented Ryser's algorithm which is the fastest known algorithm presently.

#### Other comments
I have added tests in the determinant file itself. If required, we can create a new file for permanent.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added a function to compute the permanent of a matrix
<!-- END RELEASE NOTES -->