### PR TITLE
Extend factorial2 to real numbers

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,12 +1,11 @@
 from typing import List
 
-from sympy.core import S, sympify, Dummy, Mod
+from sympy.core import S, sympify, Dummy
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import reduce, HAS_GMPY
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import Integer, pi
-from sympy.core.relational import Eq
 from sympy.ntheory import sieve
 from sympy.polys.polytools import Poly
 
@@ -182,7 +181,7 @@ class factorial(CombinatorialFunction):
         # simultaneous exponentiation at a later stage
         pw = [1]*N
 
-        m = 2 # to initialize the if condition below
+        m = 2  # to initialize the if condition below
         for prime in sieve.primerange(2, n + 1):
             if m > 1:
                 m, y = 0, n // prime
@@ -226,14 +225,14 @@ class factorial(CombinatorialFunction):
                     if isprime and (d - 1 < n):
                         fc = self._facmod(d - 1, aq)
                         fc = pow(fc, aq - 2, aq)
-                        if d%2:
+                        if d % 2:
                             fc = -fc
                     else:
                         fc = self._facmod(n, aq)
 
                     return S(fc % q)
 
-    def _eval_rewrite_as_gamma(self, n, piecewise=True, **kwargs):
+    def _eval_rewrite_as_gamma(self, n, **kwargs):
         from sympy import gamma
         return gamma(n + 1)
 
@@ -288,6 +287,7 @@ class factorial(CombinatorialFunction):
         ####################################################
         return self.func(arg)
 
+
 class MultiFactorial(CombinatorialFunction):
     pass
 
@@ -337,7 +337,7 @@ class subfactorial(CombinatorialFunction):
 
     @classmethod
     @cacheit
-    def _eval(self, n):
+    def _eval(cls, n):
         if not n:
             return S.One
         elif n == 1:
@@ -372,7 +372,7 @@ class subfactorial(CombinatorialFunction):
         f = S.NegativeOne**i / factorial(i)
         return factorial(arg) * summation(f, (i, 0, arg))
 
-    def _eval_rewrite_as_gamma(self, arg, piecewise=True, **kwargs):
+    def _eval_rewrite_as_gamma(self, arg, **kwargs):
         from sympy import exp, gamma, I, lowergamma
         return ((-1)**(arg + 1)*exp(-I*pi*arg)*lowergamma(arg + 1, -1) + gamma(arg + 1))*exp(-1)
 
@@ -460,7 +460,6 @@ class factorial2(CombinatorialFunction):
         arg = self.args[0]
         fact = (2 ** (arg / 2) * (2 / pi) ** ((1-cos(pi*arg))/4) * gamma(arg/2 + 1))
         return fact._evalf(prec)
-
 
     def _eval_is_even(self):
         # Double factorial is even for every positive even input
@@ -606,16 +605,17 @@ class RisingFactorial(CombinatorialFunction):
                     else:
                         if isinstance(x, Poly):
                             gens = x.gens
-                            if len(gens)!= 1:
-                                raise ValueError("rf only defined for "
-                                            "polynomials on one generator")
+                            if len(gens) != 1:
+                                raise ValueError(
+                                    "rf only defined for polynomials on one generator"
+                                )
                             else:
                                 return reduce(lambda r, i:
                                               r*(x.shift(i)),
                                               range(0, int(k)), 1)
                         else:
                             return reduce(lambda r, i: r*(x + i),
-                                        range(0, int(k)), 1)
+                                          range(0, int(k)), 1)
 
                 else:
                     if x is S.Infinity:
@@ -625,9 +625,10 @@ class RisingFactorial(CombinatorialFunction):
                     else:
                         if isinstance(x, Poly):
                             gens = x.gens
-                            if len(gens)!= 1:
-                                raise ValueError("rf only defined for "
-                                            "polynomials on one generator")
+                            if len(gens) != 1:
+                                raise ValueError(
+                                    "rf only defined for polynomials on one generator"
+                                )
                             else:
                                 return 1/reduce(lambda r, i:
                                                 r*(x.shift(-i)),
@@ -670,9 +671,9 @@ class RisingFactorial(CombinatorialFunction):
         if limitvar:
             k_lim = k.subs(limitvar, S.Infinity)
             if k_lim is S.Infinity:
-                return (gamma(x + k).rewrite('tractable', deep=True) / gamma(x))
+                return gamma(x + k).rewrite('tractable', deep=True) / gamma(x)
             elif k_lim is S.NegativeInfinity:
-                return ((-1)**k*gamma(1 - x) / gamma(-k - x + 1).rewrite('tractable', deep=True))
+                return (-1)**k*gamma(1 - x) / gamma(-k - x + 1).rewrite('tractable', deep=True)
         return self.rewrite(gamma).rewrite('tractable', deep=True)
 
     def _eval_is_integer(self):
@@ -771,9 +772,10 @@ class FallingFactorial(CombinatorialFunction):
                     else:
                         if isinstance(x, Poly):
                             gens = x.gens
-                            if len(gens)!= 1:
-                                raise ValueError("ff only defined for "
-                                            "polynomials on one generator")
+                            if len(gens) != 1:
+                                raise ValueError(
+                                    "ff only defined for polynomials on one generator"
+                                )
                             else:
                                 return reduce(lambda r, i:
                                               r*(x.shift(-i)),
@@ -789,9 +791,10 @@ class FallingFactorial(CombinatorialFunction):
                     else:
                         if isinstance(x, Poly):
                             gens = x.gens
-                            if len(gens)!= 1:
-                                raise ValueError("rf only defined for "
-                                            "polynomials on one generator")
+                            if len(gens) != 1:
+                                raise ValueError(
+                                    "rf only defined for polynomials on one generator"
+                                )
                             else:
                                 return 1/reduce(lambda r, i:
                                                 r*(x.shift(i)),
@@ -829,9 +832,9 @@ class FallingFactorial(CombinatorialFunction):
         if limitvar:
             k_lim = k.subs(limitvar, S.Infinity)
             if k_lim is S.Infinity:
-                return ((-1)**k*gamma(k - x).rewrite('tractable', deep=True) / gamma(-x))
+                return (-1)**k * gamma(k - x).rewrite('tractable', deep=True) / gamma(-x)
             elif k_lim is S.NegativeInfinity:
-                return (gamma(x + 1) / gamma(x - k + 1).rewrite('tractable', deep=True))
+                return gamma(x + 1) / gamma(x - k + 1).rewrite('tractable', deep=True)
         return self.rewrite(gamma).rewrite('tractable', deep=True)
 
     def _eval_is_integer(self):
@@ -840,8 +843,7 @@ class FallingFactorial(CombinatorialFunction):
 
     def _sage_(self):
         import sage.all as sage
-        return sage.falling_factorial(self.args[0]._sage_(),
-                                      self.args[1]._sage_())
+        return sage.falling_factorial(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 rf = RisingFactorial
@@ -935,18 +937,16 @@ class binomial(CombinatorialFunction):
         if argindex == 1:
             # http://functions.wolfram.com/GammaBetaErf/Binomial/20/01/01/
             n, k = self.args
-            return binomial(n, k)*(polygamma(0, n + 1) - \
-                polygamma(0, n - k + 1))
+            return binomial(n, k)*(polygamma(0, n + 1) - polygamma(0, n - k + 1))
         elif argindex == 2:
             # http://functions.wolfram.com/GammaBetaErf/Binomial/20/01/02/
             n, k = self.args
-            return binomial(n, k)*(polygamma(0, n - k + 1) - \
-                polygamma(0, k + 1))
+            return binomial(n, k)*(polygamma(0, n - k + 1) - polygamma(0, k + 1))
         else:
             raise ArgumentIndexError(self, argindex)
 
     @classmethod
-    def _eval(self, n, k):
+    def _eval(cls, n, k):
         # n.is_Number and k.is_Integer and k != 1 and n != k
 
         if k.is_Integer:
@@ -981,10 +981,10 @@ class binomial(CombinatorialFunction):
         d = n - k
         n_nonneg, n_isint = n.is_nonnegative, n.is_integer
         if k.is_zero or ((n_nonneg or n_isint is False)
-                and d.is_zero):
+                         and d.is_zero):
             return S.One
         if (k - 1).is_zero or ((n_nonneg or n_isint is False)
-                and (d - 1).is_zero):
+                               and (d - 1).is_zero):
             return n
         if k.is_integer:
             if k.is_negative or (n_nonneg and n_isint and d.is_negative):
@@ -1014,7 +1014,7 @@ class binomial(CombinatorialFunction):
                 return S.Zero
             if n < 0:
                 n = -n + k - 1
-                res = -1 if k%2 else 1
+                res = -1 if k % 2 else 1
 
             # non negative integers k and n
             if k > n:
@@ -1134,4 +1134,4 @@ class binomial(CombinatorialFunction):
             if n.is_nonnegative or k.is_negative or k.is_even:
                 return True
             elif k.is_even is False:
-                return  False
+                return False

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,10 +1,10 @@
-from sympy import (S, Symbol, symbols, factorial, factorial2, Float, binomial,
-                   rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
-                   oo, zoo, cos, simplify, expand_func, Product, Mul, Piecewise,
-                   Mod, Eq, sqrt, Poly, Dummy, I, Rational)
+from sympy import (
+    Dummy, EulerGamma, Float, I, Mul, O, Piecewise, Poly, Product, Rational, S,
+    Symbol, binomial, cos, expand_func, factorial, factorial2, ff, gamma, nan,
+    oo, pi, polygamma, rf, simplify, sqrt, symbols, zoo)
 from sympy.core.expr import unchanged
-from sympy.core.numbers import comp
 from sympy.core.function import ArgumentIndexError
+from sympy.core.numbers import comp
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.functions.special.gamma_functions import uppergamma
 from sympy.testing.pytest import XFAIL, raises, slow
@@ -94,6 +94,7 @@ def test_rf_eval_apply():
     assert rf(x, y).rewrite(binomial) == rf(x, y)
 
     import random
+
     from mpmath import rf as mpmath_rf
     for i in range(100):
         x = -500 + 500 * random.random()
@@ -181,6 +182,7 @@ def test_ff_eval_apply():
     assert ff(x, y).rewrite(binomial) == ff(x, y)
 
     import random
+
     from mpmath import ff as mpmath_ff
     for i in range(100):
         x = -500 + 500 * random.random()

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,7 +1,7 @@
 from sympy import (
-    Dummy, EulerGamma, Float, I, Mul, O, Piecewise, Poly, Product, Rational, S,
-    Symbol, binomial, cos, expand_func, factorial, factorial2, ff, gamma, nan,
-    oo, pi, polygamma, rf, simplify, sqrt, symbols, zoo)
+    Dummy, EulerGamma, Float, I, Mod, Mul, O, Piecewise, Poly, Product,
+    Rational, S, Symbol, binomial, cos, expand_func, factorial, factorial2, ff,
+    gamma, nan, oo, pi, polygamma, rf, simplify, sqrt, symbols, zoo)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.core.numbers import comp
@@ -9,12 +9,13 @@ from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.functions.special.gamma_functions import uppergamma
 from sympy.testing.pytest import XFAIL, raises, slow
 
-#Solves and Fixes Issue #10388 - This is the updated test for the same solved issue
+# Solves and Fixes Issue #10388 - This is the updated test for the same solved issue
+
 
 def test_rf_eval_apply():
-    x, y = symbols('x,y')
-    n, k = symbols('n k', integer=True)
-    m = Symbol('m', integer=True, nonnegative=True)
+    x, y = symbols("x,y")
+    n, k = symbols("n k", integer=True)
+    m = Symbol("m", integer=True, nonnegative=True)
 
     assert rf(nan, y) is nan
     assert rf(x, nan) is nan
@@ -35,31 +36,35 @@ def test_rf_eval_apply():
     assert rf(-5, 1 + I) == 0
 
     assert unchanged(rf, -3, k)
-    assert unchanged(rf, x, Symbol('k', integer=False))
-    assert rf(-3, Symbol('k', integer=False)) == 0
-    assert rf(Symbol('x', negative=True, integer=True), Symbol('k', integer=False)) == 0
+    assert unchanged(rf, x, Symbol("k", integer=False))
+    assert rf(-3, Symbol("k", integer=False)) == 0
+    assert rf(Symbol("x", negative=True, integer=True), Symbol("k", integer=False)) == 0
 
     assert rf(x, 0) == 1
     assert rf(x, 1) == x
-    assert rf(x, 2) == x*(x + 1)
-    assert rf(x, 3) == x*(x + 1)*(x + 2)
-    assert rf(x, 5) == x*(x + 1)*(x + 2)*(x + 3)*(x + 4)
+    assert rf(x, 2) == x * (x + 1)
+    assert rf(x, 3) == x * (x + 1) * (x + 2)
+    assert rf(x, 5) == x * (x + 1) * (x + 2) * (x + 3) * (x + 4)
 
-    assert rf(x, -1) == 1/(x - 1)
-    assert rf(x, -2) == 1/((x - 1)*(x - 2))
-    assert rf(x, -3) == 1/((x - 1)*(x - 2)*(x - 3))
+    assert rf(x, -1) == 1 / (x - 1)
+    assert rf(x, -2) == 1 / ((x - 1) * (x - 2))
+    assert rf(x, -3) == 1 / ((x - 1) * (x - 2) * (x - 3))
 
     assert rf(1, 100) == factorial(100)
 
-    assert rf(x**2 + 3*x, 2) == (x**2 + 3*x)*(x**2 + 3*x + 1)
-    assert isinstance(rf(x**2 + 3*x, 2), Mul)
-    assert rf(x**3 + x, -2) == 1/((x**3 + x - 1)*(x**3 + x - 2))
+    assert rf(x ** 2 + 3 * x, 2) == (x ** 2 + 3 * x) * (x ** 2 + 3 * x + 1)
+    assert isinstance(rf(x ** 2 + 3 * x, 2), Mul)
+    assert rf(x ** 3 + x, -2) == 1 / ((x ** 3 + x - 1) * (x ** 3 + x - 2))
 
-    assert rf(Poly(x**2 + 3*x, x), 2) == Poly(x**4 + 8*x**3 + 19*x**2 + 12*x, x)
-    assert isinstance(rf(Poly(x**2 + 3*x, x), 2), Poly)
-    raises(ValueError, lambda: rf(Poly(x**2 + 3*x, x, y), 2))
-    assert rf(Poly(x**3 + x, x), -2) == 1/(x**6 - 9*x**5 + 35*x**4 - 75*x**3 + 94*x**2 - 66*x + 20)
-    raises(ValueError, lambda: rf(Poly(x**3 + x, x, y), -2))
+    assert rf(Poly(x ** 2 + 3 * x, x), 2) == Poly(
+        x ** 4 + 8 * x ** 3 + 19 * x ** 2 + 12 * x, x
+    )
+    assert isinstance(rf(Poly(x ** 2 + 3 * x, x), 2), Poly)
+    raises(ValueError, lambda: rf(Poly(x ** 2 + 3 * x, x, y), 2))
+    assert rf(Poly(x ** 3 + x, x), -2) == 1 / (
+        x ** 6 - 9 * x ** 5 + 35 * x ** 4 - 75 * x ** 3 + 94 * x ** 2 - 66 * x + 20
+    )
+    raises(ValueError, lambda: rf(Poly(x ** 3 + x, x, y), -2))
 
     assert rf(x, m).is_integer is None
     assert rf(n, k).is_integer is None
@@ -70,10 +75,11 @@ def test_rf_eval_apply():
 
     def check(x, k, o, n):
         a, b = Dummy(), Dummy()
-        r = lambda x, k: o(a, b).rewrite(n).subs({a:x,b:k})
-        for i in range(-5,5):
-          for j in range(-5,5):
-              assert o(i, j) == r(i, j), (o, n, i, j)
+        r = lambda x, k: o(a, b).rewrite(n).subs({a: x, b: k})
+        for i in range(-5, 5):
+            for j in range(-5, 5):
+                assert o(i, j) == r(i, j), (o, n, i, j)
+
     check(x, k, rf, ff)
     check(x, k, rf, binomial)
     check(n, k, rf, factorial)
@@ -82,30 +88,33 @@ def test_rf_eval_apply():
 
     assert rf(x, k).rewrite(ff) == ff(x + k - 1, k)
     assert rf(x, k).rewrite(gamma) == Piecewise(
-        (gamma(k + x)/gamma(x), x > 0),
-        ((-1)**k*gamma(1 - x)/gamma(-k - x + 1), True))
-    assert rf(5, k).rewrite(gamma) == gamma(k + 5)/24
-    assert rf(x, k).rewrite(binomial) == factorial(k)*binomial(x + k - 1, k)
+        (gamma(k + x) / gamma(x), x > 0),
+        ((-1) ** k * gamma(1 - x) / gamma(-k - x + 1), True),
+    )
+    assert rf(5, k).rewrite(gamma) == gamma(k + 5) / 24
+    assert rf(x, k).rewrite(binomial) == factorial(k) * binomial(x + k - 1, k)
     assert rf(n, k).rewrite(factorial) == Piecewise(
-        (factorial(k + n - 1)/factorial(n - 1), n > 0),
-        ((-1)**k*factorial(-n)/factorial(-k - n), True))
-    assert rf(5, k).rewrite(factorial) == factorial(k + 4)/24
+        (factorial(k + n - 1) / factorial(n - 1), n > 0),
+        ((-1) ** k * factorial(-n) / factorial(-k - n), True),
+    )
+    assert rf(5, k).rewrite(factorial) == factorial(k + 4) / 24
     assert rf(x, y).rewrite(factorial) == rf(x, y)
     assert rf(x, y).rewrite(binomial) == rf(x, y)
 
     import random
 
     from mpmath import rf as mpmath_rf
+
     for i in range(100):
         x = -500 + 500 * random.random()
         k = -500 + 500 * random.random()
-        assert (abs(mpmath_rf(x, k) - rf(x, k)) < 10**(-15))
+        assert abs(mpmath_rf(x, k) - rf(x, k)) < 10 ** (-15)
 
 
 def test_ff_eval_apply():
-    x, y = symbols('x,y')
-    n, k = symbols('n k', integer=True)
-    m = Symbol('m', integer=True, nonnegative=True)
+    x, y = symbols("x,y")
+    n, k = symbols("n k", integer=True)
+    m = Symbol("m", integer=True, nonnegative=True)
 
     assert ff(nan, y) is nan
     assert ff(x, nan) is nan
@@ -124,26 +133,29 @@ def test_ff_eval_apply():
 
     assert ff(x, 0) == 1
     assert ff(x, 1) == x
-    assert ff(x, 2) == x*(x - 1)
-    assert ff(x, 3) == x*(x - 1)*(x - 2)
-    assert ff(x, 5) == x*(x - 1)*(x - 2)*(x - 3)*(x - 4)
+    assert ff(x, 2) == x * (x - 1)
+    assert ff(x, 3) == x * (x - 1) * (x - 2)
+    assert ff(x, 5) == x * (x - 1) * (x - 2) * (x - 3) * (x - 4)
 
-    assert ff(x, -1) == 1/(x + 1)
-    assert ff(x, -2) == 1/((x + 1)*(x + 2))
-    assert ff(x, -3) == 1/((x + 1)*(x + 2)*(x + 3))
+    assert ff(x, -1) == 1 / (x + 1)
+    assert ff(x, -2) == 1 / ((x + 1) * (x + 2))
+    assert ff(x, -3) == 1 / ((x + 1) * (x + 2) * (x + 3))
 
     assert ff(100, 100) == factorial(100)
 
-    assert ff(2*x**2 - 5*x, 2) == (2*x**2  - 5*x)*(2*x**2 - 5*x - 1)
-    assert isinstance(ff(2*x**2 - 5*x, 2), Mul)
-    assert ff(x**2 + 3*x, -2) == 1/((x**2 + 3*x + 1)*(x**2 + 3*x + 2))
+    assert ff(2 * x ** 2 - 5 * x, 2) == (2 * x ** 2 - 5 * x) * (2 * x ** 2 - 5 * x - 1)
+    assert isinstance(ff(2 * x ** 2 - 5 * x, 2), Mul)
+    assert ff(x ** 2 + 3 * x, -2) == 1 / ((x ** 2 + 3 * x + 1) * (x ** 2 + 3 * x + 2))
 
-    assert ff(Poly(2*x**2 - 5*x, x), 2) == Poly(4*x**4 - 28*x**3 + 59*x**2 - 35*x, x)
-    assert isinstance(ff(Poly(2*x**2 - 5*x, x), 2), Poly)
-    raises(ValueError, lambda: ff(Poly(2*x**2 - 5*x, x, y), 2))
-    assert ff(Poly(x**2 + 3*x, x), -2) == 1/(x**4 + 12*x**3 + 49*x**2 + 78*x + 40)
-    raises(ValueError, lambda: ff(Poly(x**2 + 3*x, x, y), -2))
-
+    assert ff(Poly(2 * x ** 2 - 5 * x, x), 2) == Poly(
+        4 * x ** 4 - 28 * x ** 3 + 59 * x ** 2 - 35 * x, x
+    )
+    assert isinstance(ff(Poly(2 * x ** 2 - 5 * x, x), 2), Poly)
+    raises(ValueError, lambda: ff(Poly(2 * x ** 2 - 5 * x, x, y), 2))
+    assert ff(Poly(x ** 2 + 3 * x, x), -2) == 1 / (
+        x ** 4 + 12 * x ** 3 + 49 * x ** 2 + 78 * x + 40
+    )
+    raises(ValueError, lambda: ff(Poly(x ** 2 + 3 * x, x, y), -2))
 
     assert ff(x, m).is_integer is None
     assert ff(n, k).is_integer is None
@@ -157,10 +169,11 @@ def test_ff_eval_apply():
 
     def check(x, k, o, n):
         a, b = Dummy(), Dummy()
-        r = lambda x, k: o(a, b).rewrite(n).subs({a:x,b:k})
-        for i in range(-5,5):
-          for j in range(-5,5):
-              assert o(i, j) == r(i, j), (o, n)
+        r = lambda x, k: o(a, b).rewrite(n).subs({a: x, b: k})
+        for i in range(-5, 5):
+            for j in range(-5, 5):
+                assert o(i, j) == r(i, j), (o, n)
+
     check(x, k, ff, rf)
     check(x, k, ff, gamma)
     check(n, k, ff, factorial)
@@ -170,13 +183,15 @@ def test_ff_eval_apply():
 
     assert ff(x, k).rewrite(rf) == rf(x - k + 1, k)
     assert ff(x, k).rewrite(gamma) == Piecewise(
-        (gamma(x + 1)/gamma(-k + x + 1), x >= 0),
-        ((-1)**k*gamma(k - x)/gamma(-x), True))
-    assert ff(5, k).rewrite(gamma) == 120/gamma(6 - k)
+        (gamma(x + 1) / gamma(-k + x + 1), x >= 0),
+        ((-1) ** k * gamma(k - x) / gamma(-x), True),
+    )
+    assert ff(5, k).rewrite(gamma) == 120 / gamma(6 - k)
     assert ff(n, k).rewrite(factorial) == Piecewise(
-        (factorial(n)/factorial(-k + n), n >= 0),
-        ((-1)**k*factorial(k - n - 1)/factorial(-n - 1), True))
-    assert ff(5, k).rewrite(factorial) == 120/factorial(5 - k)
+        (factorial(n) / factorial(-k + n), n >= 0),
+        ((-1) ** k * factorial(k - n - 1) / factorial(-n - 1), True),
+    )
+    assert ff(5, k).rewrite(factorial) == 120 / factorial(5 - k)
     assert ff(x, k).rewrite(binomial) == factorial(k) * binomial(x, k)
     assert ff(x, y).rewrite(factorial) == ff(x, y)
     assert ff(x, y).rewrite(binomial) == ff(x, y)
@@ -184,45 +199,47 @@ def test_ff_eval_apply():
     import random
 
     from mpmath import ff as mpmath_ff
+
     for i in range(100):
         x = -500 + 500 * random.random()
         k = -500 + 500 * random.random()
         a = mpmath_ff(x, k)
         b = ff(x, k)
-        assert (abs(a - b) < abs(a) * 10**(-15))
+        assert abs(a - b) < abs(a) * 10 ** (-15)
 
 
 def test_rf_ff_eval_hiprec():
-    maple = Float('6.9109401292234329956525265438452')
+    maple = Float("6.9109401292234329956525265438452")
     us = ff(18, Rational(2, 3)).evalf(32)
-    assert abs(us - maple)/us < 1e-31
+    assert abs(us - maple) / us < 1e-31
 
-    maple = Float('6.8261540131125511557924466355367')
+    maple = Float("6.8261540131125511557924466355367")
     us = rf(18, Rational(2, 3)).evalf(32)
-    assert abs(us - maple)/us < 1e-31
+    assert abs(us - maple) / us < 1e-31
 
-    maple = Float('34.007346127440197150854651814225')
-    us = rf(Float('4.4', 32), Float('2.2', 32));
-    assert abs(us - maple)/us < 1e-31
+    maple = Float("34.007346127440197150854651814225")
+    us = rf(Float("4.4", 32), Float("2.2", 32))
+    assert abs(us - maple) / us < 1e-31
 
 
 def test_rf_lambdify_mpmath():
     from sympy import lambdify
-    x, y = symbols('x,y')
-    f = lambdify((x,y), rf(x, y), 'mpmath')
-    maple = Float('34.007346127440197')
+
+    x, y = symbols("x,y")
+    f = lambdify((x, y), rf(x, y), "mpmath")
+    maple = Float("34.007346127440197")
     us = f(4.4, 2.2)
-    assert abs(us - maple)/us < 1e-15
+    assert abs(us - maple) / us < 1e-15
 
 
 def test_factorial():
-    x = Symbol('x')
-    n = Symbol('n', integer=True)
-    k = Symbol('k', integer=True, nonnegative=True)
-    r = Symbol('r', integer=False)
-    s = Symbol('s', integer=False, negative=True)
-    t = Symbol('t', nonnegative=True)
-    u = Symbol('u', noninteger=True)
+    x = Symbol("x")
+    n = Symbol("n", integer=True)
+    k = Symbol("k", integer=True, nonnegative=True)
+    r = Symbol("r", integer=False)
+    s = Symbol("s", integer=False, negative=True)
+    t = Symbol("t", nonnegative=True)
+    u = Symbol("u", noninteger=True)
 
     assert factorial(-2) is zoo
     assert factorial(0) == 1
@@ -230,7 +247,7 @@ def test_factorial():
     assert factorial(19) == 121645100408832000
     assert factorial(31) == 8222838654177922817725562880000000
     assert factorial(n).func == factorial
-    assert factorial(2*n).func == factorial
+    assert factorial(2 * n).func == factorial
 
     assert factorial(x).is_integer is None
     assert factorial(n).is_integer is None
@@ -261,9 +278,9 @@ def test_factorial():
 
 
 def test_factorial_Mod():
-    pr = Symbol('pr', prime=True)
-    p, q = 10**9 + 9, 10**9 + 33 # prime modulo
-    r, s = 10**7 + 5, 33333333 # composite modulo
+    pr = Symbol("pr", prime=True)
+    p, q = 10 ** 9 + 9, 10 ** 9 + 33  # prime modulo
+    r, s = 10 ** 7 + 5, 33333333  # composite modulo
     assert Mod(factorial(pr - 1), pr) == pr - 1
     assert Mod(factorial(pr - 1), -pr) == -1
     assert Mod(factorial(r - 1, evaluate=False), r) == 0
@@ -279,35 +296,36 @@ def test_factorial_Mod():
 
 
 def test_factorial_diff():
-    n = Symbol('n', integer=True)
+    n = Symbol("n", integer=True)
 
-    assert factorial(n).diff(n) == \
-        gamma(1 + n)*polygamma(0, 1 + n)
-    assert factorial(n**2).diff(n) == \
-        2*n*gamma(1 + n**2)*polygamma(0, 1 + n**2)
-    raises(ArgumentIndexError, lambda: factorial(n**2).fdiff(2))
+    assert factorial(n).diff(n) == gamma(1 + n) * polygamma(0, 1 + n)
+    assert factorial(n ** 2).diff(n) == 2 * n * gamma(1 + n ** 2) * polygamma(
+        0, 1 + n ** 2
+    )
+    raises(ArgumentIndexError, lambda: factorial(n ** 2).fdiff(2))
 
 
 def test_factorial_series():
-    n = Symbol('n', integer=True)
+    n = Symbol("n", integer=True)
 
-    assert factorial(n).series(n, 0, 3) == \
-        1 - n*EulerGamma + n**2*(EulerGamma**2/2 + pi**2/12) + O(n**3)
+    assert factorial(n).series(n, 0, 3) == 1 - n * EulerGamma + n ** 2 * (
+        EulerGamma ** 2 / 2 + pi ** 2 / 12
+    ) + O(n ** 3)
 
 
 def test_factorial_rewrite():
-    n = Symbol('n', integer=True)
-    k = Symbol('k', integer=True, nonnegative=True)
+    n = Symbol("n", integer=True)
+    k = Symbol("k", integer=True, nonnegative=True)
 
     assert factorial(n).rewrite(gamma) == gamma(n + 1)
-    _i = Dummy('i')
+    _i = Dummy("i")
     assert factorial(k).rewrite(Product).dummy_eq(Product(_i, (_i, 1, k)))
     assert factorial(n).rewrite(Product) == factorial(n)
     assert factorial(n).rewrite(factorial2) == factorial2(n) * factorial2(n - 1)
 
 
 def test_factorial2():
-    n = Symbol('n', integer=True)
+    n = Symbol("n", integer=True)
 
     assert factorial2(-1) == 1
     assert factorial2(0) == 1
@@ -318,26 +336,26 @@ def test_factorial2():
     assert factorial2(41) == 13113070457687988603440625
 
     assert factorial2(n).func == factorial2
-    assert factorial2(2*n + 1).func == factorial2
+    assert factorial2(2 * n + 1).func == factorial2
     assert factorial2(Rational(3, 4)).func == factorial2
     assert comp(factorial2(S.Half).evalf(), S("0.96282778244641754792"), 1e-15)
     assert comp(factorial2(Rational(27, 5)).evalf(), S("23.377811716549217531"), 1e-15)
 
     # The following is exhaustive
-    tt = Symbol('tt', integer=True, nonnegative=True)
-    tte = Symbol('tte', even=True, nonnegative=True)
-    tpe = Symbol('tpe', even=True, positive=True)
-    tto = Symbol('tto', odd=True, nonnegative=True)
-    tf = Symbol('tf', integer=True, nonnegative=False)
-    tfe = Symbol('tfe', even=True, nonnegative=False)
-    tfo = Symbol('tfo', odd=True, nonnegative=False)
-    ft = Symbol('ft', integer=False, nonnegative=True)
-    ff = Symbol('ff', integer=False, nonnegative=False)
-    fn = Symbol('fn', integer=False)
-    nt = Symbol('nt', nonnegative=True)
-    nf = Symbol('nf', nonnegative=False)
-    nn = Symbol('nn')
-    z = Symbol('z', zero=True)
+    tt = Symbol("tt", integer=True, nonnegative=True)
+    tte = Symbol("tte", even=True, nonnegative=True)
+    tpe = Symbol("tpe", even=True, positive=True)
+    tto = Symbol("tto", odd=True, nonnegative=True)
+    tf = Symbol("tf", integer=True, nonnegative=False)
+    tfe = Symbol("tfe", even=True, nonnegative=False)
+    tfo = Symbol("tfo", odd=True, nonnegative=False)
+    ft = Symbol("ft", integer=False, nonnegative=True)
+    ff = Symbol("ff", integer=False, nonnegative=False)
+    fn = Symbol("fn", integer=False)
+    nt = Symbol("nt", nonnegative=True)
+    nf = Symbol("nf", nonnegative=False)
+    nn = Symbol("nn")
+    z = Symbol("z", zero=True)
 
     # factorial2 now accepts all real valued arguments
     assert factorial2(oo) is oo
@@ -401,26 +419,29 @@ def test_factorial2():
 
 
 def test_factorial2_rewrite():
-    n = Symbol('n', integer=True)
-    assert factorial2(n).rewrite(gamma) == factorial2(n).rewrite(cos) == \
-           2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * gamma(n/2 + 1)
+    n = Symbol("n", integer=True)
+    assert (
+        factorial2(n).rewrite(gamma)
+        == factorial2(n).rewrite(cos)
+        == 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi * n)) / 4) * gamma(n / 2 + 1)
+    )
 
 
 def test_binomial():
-    x = Symbol('x')
-    n = Symbol('n', integer=True)
-    nz = Symbol('nz', integer=True, nonzero=True)
-    k = Symbol('k', integer=True)
-    kp = Symbol('kp', integer=True, positive=True)
-    kn = Symbol('kn', integer=True, negative=True)
-    u = Symbol('u', negative=True)
-    v = Symbol('v', nonnegative=True)
-    p = Symbol('p', positive=True)
-    z = Symbol('z', zero=True)
-    nt = Symbol('nt', integer=False)
-    kt = Symbol('kt', integer=False)
-    a = Symbol('a', integer=True, nonnegative=True)
-    b = Symbol('b', integer=True, nonnegative=True)
+    x = Symbol("x")
+    n = Symbol("n", integer=True)
+    nz = Symbol("nz", integer=True, nonzero=True)
+    k = Symbol("k", integer=True)
+    kp = Symbol("kp", integer=True, positive=True)
+    kn = Symbol("kn", integer=True, negative=True)
+    u = Symbol("u", negative=True)
+    v = Symbol("v", nonnegative=True)
+    p = Symbol("p", positive=True)
+    z = Symbol("z", zero=True)
+    nt = Symbol("nt", integer=False)
+    kt = Symbol("kt", integer=False)
+    a = Symbol("a", integer=True, nonnegative=True)
+    b = Symbol("b", integer=True, nonnegative=True)
 
     assert binomial(0, 0) == 1
     assert binomial(1, 1) == 1
@@ -434,20 +455,20 @@ def test_binomial():
     assert binomial(S.Half, S.Half) == 1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
-    assert binomial(n, -1) == 0 # holds for all integers (negative, zero, positive)
+    assert binomial(n, -1) == 0  # holds for all integers (negative, zero, positive)
     assert binomial(kp, -1) == 0
     assert binomial(nz, 0) == 1
     assert expand_func(binomial(n, 1)) == n
-    assert expand_func(binomial(n, 2)) == n*(n - 1)/2
-    assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
+    assert expand_func(binomial(n, 2)) == n * (n - 1) / 2
+    assert expand_func(binomial(n, n - 2)) == n * (n - 1) / 2
     assert expand_func(binomial(n, n - 1)) == n
     assert binomial(n, 3).func == binomial
-    assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
-    assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
-    assert binomial(n, n).func == binomial # e.g. (-1, -1) == 0, (2, 2) == 1
+    assert binomial(n, 3).expand(func=True) == n ** 3 / 6 - n ** 2 / 2 + n / 3
+    assert expand_func(binomial(n, 3)) == n * (n - 2) * (n - 1) / 6
+    assert binomial(n, n).func == binomial  # e.g. (-1, -1) == 0, (2, 2) == 1
     assert binomial(n, n + 1).func == binomial  # e.g. (-1, 0) == 1
     assert binomial(kp, kp + 1) == 0
-    assert binomial(kn, kn) == 0 # issue #14529
+    assert binomial(kn, kn) == 0  # issue #14529
     assert binomial(n, u).func == binomial
     assert binomial(kp, u).func == binomial
     assert binomial(n, p).func == binomial
@@ -455,18 +476,36 @@ def test_binomial():
     assert binomial(n, n + p).func == binomial
     assert binomial(kp, kp + p).func == binomial
 
-    assert expand_func(binomial(n, n - 3)) == n*(n - 2)*(n - 1)/6
+    assert expand_func(binomial(n, n - 3)) == n * (n - 2) * (n - 1) / 6
 
     assert binomial(n, k).is_integer
     assert binomial(nt, k).is_integer is None
     assert binomial(x, nt).is_integer is False
 
-    assert binomial(gamma(25), 6) == 79232165267303928292058750056084441948572511312165380965440075720159859792344339983120618959044048198214221915637090855535036339620413440000
-    assert binomial(1324, 47) == 906266255662694632984994480774946083064699457235920708992926525848438478406790323869952
-    assert binomial(1735, 43) == 190910140420204130794758005450919715396159959034348676124678207874195064798202216379800
-    assert binomial(2512, 53) == 213894469313832631145798303740098720367984955243020898718979538096223399813295457822575338958939834177325304000
-    assert binomial(3383, 52) == 27922807788818096863529701501764372757272890613101645521813434902890007725667814813832027795881839396839287659777235
-    assert binomial(4321, 51) == 124595639629264868916081001263541480185227731958274383287107643816863897851139048158022599533438936036467601690983780576
+    assert (
+        binomial(gamma(25), 6)
+        == 79232165267303928292058750056084441948572511312165380965440075720159859792344339983120618959044048198214221915637090855535036339620413440000
+    )
+    assert (
+        binomial(1324, 47)
+        == 906266255662694632984994480774946083064699457235920708992926525848438478406790323869952
+    )
+    assert (
+        binomial(1735, 43)
+        == 190910140420204130794758005450919715396159959034348676124678207874195064798202216379800
+    )
+    assert (
+        binomial(2512, 53)
+        == 213894469313832631145798303740098720367984955243020898718979538096223399813295457822575338958939834177325304000
+    )
+    assert (
+        binomial(3383, 52)
+        == 27922807788818096863529701501764372757272890613101645521813434902890007725667814813832027795881839396839287659777235
+    )
+    assert (
+        binomial(4321, 51)
+        == 124595639629264868916081001263541480185227731958274383287107643816863897851139048158022599533438936036467601690983780576
+    )
 
     assert binomial(a, b).is_nonnegative is True
     assert binomial(-1, 2, evaluate=False).is_nonnegative is True
@@ -486,11 +525,11 @@ def test_binomial():
     assert isinstance(binomial(x, x), binomial)
     assert isinstance(binomial(x, x - 1), binomial)
 
-    #issue #18802
+    # issue #18802
     assert expand_func(binomial(x + 1, x)) == x + 1
     assert expand_func(binomial(x, x - 1)) == x
-    assert expand_func(binomial(x + 1, x - 1)) == x*(x + 1)/2
-    assert expand_func(binomial(x**2 + 1, x**2)) == x**2 + 1
+    assert expand_func(binomial(x + 1, x - 1)) == x * (x + 1) / 2
+    assert expand_func(binomial(x ** 2 + 1, x ** 2)) == x ** 2 + 1
 
     # issue #13980 and #13981
     assert binomial(-7, -5) == 0
@@ -498,27 +537,42 @@ def test_binomial():
     assert binomial(Rational(13, 2), -10) == 0
     assert binomial(-49, -51) == 0
 
-    assert binomial(19, Rational(-7, 2)) == S(-68719476736)/(911337863661225*pi)
-    assert binomial(0, Rational(3, 2)) == S(-2)/(3*pi)
+    assert binomial(19, Rational(-7, 2)) == S(-68719476736) / (911337863661225 * pi)
+    assert binomial(0, Rational(3, 2)) == S(-2) / (3 * pi)
     assert binomial(-3, Rational(-7, 2)) is zoo
     assert binomial(kn, kt) is zoo
 
     assert binomial(nt, kt).func == binomial
-    assert binomial(nt, Rational(15, 6)) == 8*gamma(nt + 1)/(15*sqrt(pi)*gamma(nt - Rational(3, 2)))
-    assert binomial(Rational(20, 3), Rational(-10, 8)) == gamma(Rational(23, 3))/(gamma(Rational(-1, 4))*gamma(Rational(107, 12)))
+    assert binomial(nt, Rational(15, 6)) == 8 * gamma(nt + 1) / (
+        15 * sqrt(pi) * gamma(nt - Rational(3, 2))
+    )
+    assert binomial(Rational(20, 3), Rational(-10, 8)) == gamma(Rational(23, 3)) / (
+        gamma(Rational(-1, 4)) * gamma(Rational(107, 12))
+    )
     assert binomial(Rational(19, 2), Rational(-7, 2)) == Rational(-1615, 8388608)
-    assert binomial(Rational(-13, 5), Rational(-7, 8)) == gamma(Rational(-8, 5))/(gamma(Rational(-29, 40))*gamma(Rational(1, 8)))
-    assert binomial(Rational(-19, 8), Rational(-13, 5)) == gamma(Rational(-11, 8))/(gamma(Rational(-8, 5))*gamma(Rational(49, 40)))
+    assert binomial(Rational(-13, 5), Rational(-7, 8)) == gamma(Rational(-8, 5)) / (
+        gamma(Rational(-29, 40)) * gamma(Rational(1, 8))
+    )
+    assert binomial(Rational(-19, 8), Rational(-13, 5)) == gamma(Rational(-11, 8)) / (
+        gamma(Rational(-8, 5)) * gamma(Rational(49, 40))
+    )
 
     # binomial for complexes
     from sympy import I
-    assert binomial(I, Rational(-89, 8)) == gamma(1 + I)/(gamma(Rational(-81, 8))*gamma(Rational(97, 8) + I))
-    assert binomial(I, 2*I) == gamma(1 + I)/(gamma(1 - I)*gamma(1 + 2*I))
+
+    assert binomial(I, Rational(-89, 8)) == gamma(1 + I) / (
+        gamma(Rational(-81, 8)) * gamma(Rational(97, 8) + I)
+    )
+    assert binomial(I, 2 * I) == gamma(1 + I) / (gamma(1 - I) * gamma(1 + 2 * I))
     assert binomial(-7, I) is zoo
-    assert binomial(Rational(-7, 6), I) == gamma(Rational(-1, 6))/(gamma(Rational(-1, 6) - I)*gamma(1 + I))
-    assert binomial((1+2*I), (1+3*I)) == gamma(2 + 2*I)/(gamma(1 - I)*gamma(2 + 3*I))
-    assert binomial(I, 5) == Rational(1, 3) - I/S(12)
-    assert binomial((2*I + 3), 7) == -13*I/S(63)
+    assert binomial(Rational(-7, 6), I) == gamma(Rational(-1, 6)) / (
+        gamma(Rational(-1, 6) - I) * gamma(1 + I)
+    )
+    assert binomial((1 + 2 * I), (1 + 3 * I)) == gamma(2 + 2 * I) / (
+        gamma(1 - I) * gamma(2 + 3 * I)
+    )
+    assert binomial(I, 5) == Rational(1, 3) - I / S(12)
+    assert binomial((2 * I + 3), 7) == -13 * I / S(63)
     assert isinstance(binomial(I, n), binomial)
     assert expand_func(binomial(3, 2, evaluate=False)) == 3
     assert expand_func(binomial(n, 0, evaluate=False)) == 1
@@ -527,12 +581,14 @@ def test_binomial():
 
 
 def test_binomial_Mod():
-    p, q = 10**5 + 3, 10**9 + 33 # prime modulo
-    r = 10**7 + 5 # composite modulo
+    p, q = 10 ** 5 + 3, 10 ** 9 + 33  # prime modulo
+    r = 10 ** 7 + 5  # composite modulo
 
     # A few tests to get coverage
     # Lucas Theorem
-    assert Mod(binomial(156675, 4433, evaluate=False), p) == Mod(binomial(156675, 4433), p)
+    assert Mod(binomial(156675, 4433, evaluate=False), p) == Mod(
+        binomial(156675, 4433), p
+    )
 
     # factorial Mod
     assert Mod(binomial(1234, 432, evaluate=False), q) == Mod(binomial(1234, 432), q)
@@ -541,64 +597,81 @@ def test_binomial_Mod():
     assert Mod(binomial(253, 113, evaluate=False), r) == Mod(binomial(253, 113), r)
 
 
-
 @slow
 def test_binomial_Mod_slow():
-    p, q = 10**5 + 3, 10**9 + 33 # prime modulo
-    r, s = 10**7 + 5, 33333333 # composite modulo
+    p, q = 10 ** 5 + 3, 10 ** 9 + 33  # prime modulo
+    r, s = 10 ** 7 + 5, 33333333  # composite modulo
 
-    n, k, m = symbols('n k m')
+    n, k, m = symbols("n k m")
     assert (binomial(n, k) % q).subs({n: s, k: p}) == Mod(binomial(s, p), q)
     assert (binomial(n, k) % m).subs({n: 8, k: 5, m: 13}) == 4
     assert (binomial(9, k) % 7).subs(k, 2) == 1
 
     # Lucas Theorem
-    assert Mod(binomial(123456, 43253, evaluate=False), p) == Mod(binomial(123456, 43253), p)
-    assert Mod(binomial(-178911, 237, evaluate=False), p) == Mod(-binomial(178911 + 237 - 1, 237), p)
-    assert Mod(binomial(-178911, 238, evaluate=False), p) == Mod(binomial(178911 + 238 - 1, 238), p)
+    assert Mod(binomial(123456, 43253, evaluate=False), p) == Mod(
+        binomial(123456, 43253), p
+    )
+    assert Mod(binomial(-178911, 237, evaluate=False), p) == Mod(
+        -binomial(178911 + 237 - 1, 237), p
+    )
+    assert Mod(binomial(-178911, 238, evaluate=False), p) == Mod(
+        binomial(178911 + 238 - 1, 238), p
+    )
 
     # factorial Mod
     assert Mod(binomial(9734, 451, evaluate=False), q) == Mod(binomial(9734, 451), q)
-    assert Mod(binomial(-10733, 4459, evaluate=False), q) == Mod(binomial(-10733, 4459), q)
-    assert Mod(binomial(-15733, 4458, evaluate=False), q) == Mod(binomial(-15733, 4458), q)
+    assert Mod(binomial(-10733, 4459, evaluate=False), q) == Mod(
+        binomial(-10733, 4459), q
+    )
+    assert Mod(binomial(-15733, 4458, evaluate=False), q) == Mod(
+        binomial(-15733, 4458), q
+    )
     assert Mod(binomial(23, -38, evaluate=False), q) is S.Zero
     assert Mod(binomial(23, 38, evaluate=False), q) is S.Zero
 
     # binomial factorize
     assert Mod(binomial(753, 119, evaluate=False), r) == Mod(binomial(753, 119), r)
     assert Mod(binomial(3781, 948, evaluate=False), s) == Mod(binomial(3781, 948), s)
-    assert Mod(binomial(25773, 1793, evaluate=False), s) == Mod(binomial(25773, 1793), s)
+    assert Mod(binomial(25773, 1793, evaluate=False), s) == Mod(
+        binomial(25773, 1793), s
+    )
     assert Mod(binomial(-753, 118, evaluate=False), r) == Mod(binomial(-753, 118), r)
-    assert Mod(binomial(-25773, 1793, evaluate=False), s) == Mod(binomial(-25773, 1793), s)
+    assert Mod(binomial(-25773, 1793, evaluate=False), s) == Mod(
+        binomial(-25773, 1793), s
+    )
 
 
 def test_binomial_diff():
-    n = Symbol('n', integer=True)
-    k = Symbol('k', integer=True)
+    n = Symbol("n", integer=True)
+    k = Symbol("k", integer=True)
 
-    assert binomial(n, k).diff(n) == \
-        (-polygamma(0, 1 + n - k) + polygamma(0, 1 + n))*binomial(n, k)
-    assert binomial(n**2, k**3).diff(n) == \
-        2*n*(-polygamma(
-            0, 1 + n**2 - k**3) + polygamma(0, 1 + n**2))*binomial(n**2, k**3)
+    assert binomial(n, k).diff(n) == (
+        -polygamma(0, 1 + n - k) + polygamma(0, 1 + n)
+    ) * binomial(n, k)
+    assert binomial(n ** 2, k ** 3).diff(n) == 2 * n * (
+        -polygamma(0, 1 + n ** 2 - k ** 3) + polygamma(0, 1 + n ** 2)
+    ) * binomial(n ** 2, k ** 3)
 
-    assert binomial(n, k).diff(k) == \
-        (-polygamma(0, 1 + k) + polygamma(0, 1 + n - k))*binomial(n, k)
-    assert binomial(n**2, k**3).diff(k) == \
-        3*k**2*(-polygamma(
-            0, 1 + k**3) + polygamma(0, 1 + n**2 - k**3))*binomial(n**2, k**3)
+    assert binomial(n, k).diff(k) == (
+        -polygamma(0, 1 + k) + polygamma(0, 1 + n - k)
+    ) * binomial(n, k)
+    assert binomial(n ** 2, k ** 3).diff(k) == 3 * k ** 2 * (
+        -polygamma(0, 1 + k ** 3) + polygamma(0, 1 + n ** 2 - k ** 3)
+    ) * binomial(n ** 2, k ** 3)
     raises(ArgumentIndexError, lambda: binomial(n, k).fdiff(3))
 
 
 def test_binomial_rewrite():
-    n = Symbol('n', integer=True)
-    k = Symbol('k', integer=True)
-    x = Symbol('x')
+    n = Symbol("n", integer=True)
+    k = Symbol("k", integer=True)
+    x = Symbol("x")
 
-    assert binomial(n, k).rewrite(
-        factorial) == factorial(n)/(factorial(k)*factorial(n - k))
-    assert binomial(
-        n, k).rewrite(gamma) == gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
+    assert binomial(n, k).rewrite(factorial) == factorial(n) / (
+        factorial(k) * factorial(n - k)
+    )
+    assert binomial(n, k).rewrite(gamma) == gamma(n + 1) / (
+        gamma(k + 1) * gamma(n - k + 1)
+    )
     assert binomial(n, k).rewrite(ff) == ff(n, k) / factorial(k)
     assert binomial(n, x).rewrite(ff) == binomial(n, x)
 
@@ -607,32 +680,43 @@ def test_binomial_rewrite():
 def test_factorial_simplify_fail():
     # simplify(factorial(x + 1).diff(x) - ((x + 1)*factorial(x)).diff(x))) == 0
     from sympy.abc import x
-    assert simplify(x*polygamma(0, x + 1) - x*polygamma(0, x + 2) +
-                    polygamma(0, x + 1) - polygamma(0, x + 2) + 1) == 0
+
+    assert (
+        simplify(
+            x * polygamma(0, x + 1)
+            - x * polygamma(0, x + 2)
+            + polygamma(0, x + 1)
+            - polygamma(0, x + 2)
+            + 1
+        )
+        == 0
+    )
 
 
 def test_subfactorial():
-    assert all(subfactorial(i) == ans for i, ans in enumerate(
-        [1, 0, 1, 2, 9, 44, 265, 1854, 14833, 133496]))
+    assert all(
+        subfactorial(i) == ans
+        for i, ans in enumerate([1, 0, 1, 2, 9, 44, 265, 1854, 14833, 133496])
+    )
     assert subfactorial(oo) is oo
     assert subfactorial(nan) is nan
     assert subfactorial(23) == 9510425471055777937262
     assert unchanged(subfactorial, 2.2)
 
-    x = Symbol('x')
-    assert subfactorial(x).rewrite(uppergamma) == uppergamma(x + 1, -1)/S.Exp1
+    x = Symbol("x")
+    assert subfactorial(x).rewrite(uppergamma) == uppergamma(x + 1, -1) / S.Exp1
 
-    tt = Symbol('tt', integer=True, nonnegative=True)
-    tf = Symbol('tf', integer=True, nonnegative=False)
-    tn = Symbol('tf', integer=True)
-    ft = Symbol('ft', integer=False, nonnegative=True)
-    ff = Symbol('ff', integer=False, nonnegative=False)
-    fn = Symbol('ff', integer=False)
-    nt = Symbol('nt', nonnegative=True)
-    nf = Symbol('nf', nonnegative=False)
-    nn = Symbol('nf')
-    te = Symbol('te', even=True, nonnegative=True)
-    to = Symbol('to', odd=True, nonnegative=True)
+    tt = Symbol("tt", integer=True, nonnegative=True)
+    tf = Symbol("tf", integer=True, nonnegative=False)
+    tn = Symbol("tf", integer=True)
+    ft = Symbol("ft", integer=False, nonnegative=True)
+    ff = Symbol("ff", integer=False, nonnegative=False)
+    fn = Symbol("ff", integer=False)
+    nt = Symbol("nt", nonnegative=True)
+    nf = Symbol("nf", nonnegative=False)
+    nn = Symbol("nf")
+    te = Symbol("te", even=True, nonnegative=True)
+    to = Symbol("to", odd=True, nonnegative=True)
     assert subfactorial(tt).is_integer
     assert subfactorial(tf).is_integer is None
     assert subfactorial(tn).is_integer is None


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #20253 

#### Brief description of what is fixed or changed
- `factorial2` returns for real valued inputs. (using this [extension](https://functions.wolfram.com/GammaBetaErf/Factorial2/02/0001/))
- rewriting `factorial2` as `gamma` (or `cos`) gives the new identity.
- `factorial` has a rewrite as `factorial2` method.
- additional tests for `factorial2`

#### Other comments

This is a neater version of #20345

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
     * factorial2 accepts real valued arguments.
<!-- END RELEASE NOTES -->