### PR TITLE
Extend factorial2 to real numbers

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -498,16 +498,12 @@ class factorial2(CombinatorialFunction):
         from sympy import gamma, cos
         return 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * gamma(n/2 + 1)
 
-    def _eval_rewrite_as_gamma(self, n, piecewise=False, **kwargs):
-        from sympy import gamma, cos, Piecewise, sqrt
+    def _eval_rewrite_as_factorial(self, n, **kwargs):
+        from sympy import gamma, cos
+        return 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * factorial(n/2)
 
-        if piecewise:  # this seems wonky
-            return 2 ** (n / 2) * gamma(n/2 + 1) * Piecewise(
-                (1, Eq(Mod(n, 2), 0)),
-                (sqrt(2/pi), Eq(Mod(n, 2), 1)),
-                ((2 / pi) ** ((1 - cos(pi*n))/4), True)
-            )
-
+    def _eval_rewrite_as_gamma(self, n, **kwargs):
+        from sympy import gamma, cos
         return 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * gamma(n/2 + 1)
 
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -389,20 +389,37 @@ class subfactorial(CombinatorialFunction):
 
 
 class factorial2(CombinatorialFunction):
-    r"""The double factorial `n!!`, not to be confused with `(n!)!`
+    r"""The double factorial `n!!`, is not to be confused with `(n!)!`.
 
-    The double factorial is defined for nonnegative integers and for odd
-    negative integers as:
+    The double factorial of a positive integer n is defined as:
 
-    .. math:: n!! = \begin{cases} 1 & n = 0 \\
-                    n(n-2)(n-4) \cdots 1 & n\ \text{positive odd} \\
-                    n(n-2)(n-4) \cdots 2 & n\ \text{positive even} \\
-                    (n+2)!!/(n+2) & n\ \text{negative odd} \end{cases}
+    .. math:: n!! = \begin{cases}
+                    n (n-2) (n-4) \cdots 1 & n > 0\ \text{odd} \\
+                    n (n-2) (n-4) \cdots 2 & n > 0\ \text{even} \\
+                    1 & n = 0, -1
+                    \end{cases}
+
+    The double factorial is not well defined at negative even integers,
+    but its value at odd negative integers can be calculated using:
+
+    .. math:: (-n)!! = \frac{-1^{(n-1)/2} \times n}{n!!}
+
+    The double factorial of a odd negative integer is also given by:
+
+    .. math:: n!! = \frac{(n + 2)!!}{n + 2}
+
+    More generally, the double factorial for real valued arguments is computed by [3]_:
+
+    .. math:: n!! = 2^{n/2}
+                    \left(\frac{2}{\pi}\right)^{\frac{1}{4}(1-\cos(\pi n))}
+                    \Gamma\left(\frac{n}{2}+1\right)
 
     References
     ==========
 
     .. [1] https://en.wikipedia.org/wiki/Double_factorial
+    .. [2] https://mathworld.wolfram.com/DoubleFactorial.html
+    .. [3] http://functions.wolfram.com/06.02.02.0001.01
 
     Examples
     ========
@@ -419,6 +436,10 @@ class factorial2(CombinatorialFunction):
     1
     >>> factorial2(-5)
     1/3
+    >>> factorial2(-8)
+    zoo
+    >>> factorial2(S(1)/2)
+    factorial2(1/2)
 
     See Also
     ========
@@ -433,7 +454,7 @@ class factorial2(CombinatorialFunction):
         if arg.is_complex and not arg.is_extended_real:
             raise ValueError("argument must be a real value")
 
-        if arg.is_zero:
+        if arg.is_zero or arg is S.NegativeOne:
             return S.One
         if arg is S.Infinity:
             return S.Infinity
@@ -498,7 +519,7 @@ class factorial2(CombinatorialFunction):
         return 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * gamma(n/2 + 1)
 
     def _eval_rewrite_as_factorial(self, n, **kwargs):
-        from sympy import gamma, cos
+        from sympy import cos
         return 2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi*n))/4) * factorial(n/2)
 
     def _eval_rewrite_as_gamma(self, n, **kwargs):

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,12 +1,11 @@
 from typing import List
 
-from sympy.core import S, sympify, Dummy, Mod
+from sympy.core import S, sympify, Dummy
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import reduce, HAS_GMPY
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import Integer, pi
-from sympy.core.relational import Eq
 from sympy.ntheory import sieve
 from sympy.polys.polytools import Poly
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -424,7 +424,7 @@ class factorial2(CombinatorialFunction):
     Examples
     ========
 
-    >>> from sympy import factorial2, var
+    >>> from sympy import factorial2, var, S
     >>> n = var('n')
     >>> n
     n

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,9 +1,10 @@
 from sympy import (S, Symbol, symbols, factorial, factorial2, Float, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise,
-                   Mod, Eq, sqrt, Poly, Dummy, I, Rational)
+                   Mod, Eq, sqrt, Poly, Dummy, I, Rational, cos)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
+from sympy.core.numbers import comp
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.functions.special.gamma_functions import uppergamma
 from sympy.testing.pytest import XFAIL, raises, slow
@@ -300,6 +301,7 @@ def test_factorial_rewrite():
     _i = Dummy('i')
     assert factorial(k).rewrite(Product).dummy_eq(Product(_i, (_i, 1, k)))
     assert factorial(n).rewrite(Product) == factorial(n)
+    assert factorial(n).rewrite(factorial2) == factorial2(n) * factorial2(n - 1)
 
 
 def test_factorial2():
@@ -309,6 +311,15 @@ def test_factorial2():
     assert factorial2(0) == 1
     assert factorial2(7) == 105
     assert factorial2(8) == 384
+    assert factorial2(15) == 2027025
+    assert factorial2(-13) == Rational(1, 10395)
+    assert factorial2(41) == 13113070457687988603440625
+
+    assert factorial2(n).func == factorial2
+    assert factorial2(2 * n + 1).func == factorial2
+    assert factorial2(Rational(3, 4)).func == factorial2
+    assert comp(factorial2(S.Half).evalf(), S("0.96282778244641754792"), 1e-15)
+    assert comp(factorial2(Rational(27, 5)).evalf(), S("23.377811716549217531"), 1e-15)
 
     # The following is exhaustive
     tt = Symbol('tt', integer=True, nonnegative=True)
@@ -325,10 +336,13 @@ def test_factorial2():
     nf = Symbol('nf', nonnegative=False)
     nn = Symbol('nn')
     z = Symbol('z', zero=True)
-    #Solves and Fixes Issue #10388 - This is the updated test for the same solved issue
-    raises(ValueError, lambda: factorial2(oo))
-    raises(ValueError, lambda: factorial2(Rational(5, 2)))
-    raises(ValueError, lambda: factorial2(-4))
+
+    # factorial2 now accepts all real valued arguments
+    assert factorial2(oo) is oo
+    assert factorial2(-26) is zoo
+
+    raises(ValueError, lambda: factorial2(1 + I))
+
     assert factorial2(n).is_integer is None
     assert factorial2(tt - 1).is_integer
     assert factorial2(tte - 1).is_integer
@@ -382,11 +396,19 @@ def test_factorial2():
 
 def test_factorial2_rewrite():
     n = Symbol('n', integer=True)
-    assert factorial2(n).rewrite(gamma) == \
-        2**(n/2)*Piecewise((1, Eq(Mod(n, 2), 0)), (sqrt(2)/sqrt(pi), Eq(Mod(n, 2), 1)))*gamma(n/2 + 1)
     assert factorial2(2*n).rewrite(gamma) == 2**n*gamma(n + 1)
     assert factorial2(2*n + 1).rewrite(gamma) == \
-        sqrt(2)*2**(n + S.Half)*gamma(n + Rational(3, 2))/sqrt(pi)
+           sqrt(2)*2**(n + S.Half)*gamma(n + Rational(3, 2))/sqrt(pi)
+    assert factorial2(n).rewrite(gamma) == factorial2(n).rewrite(cos) == \
+           2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi * n)) / 4) * gamma(n / 2 + 1)
+
+    assert factorial2(n).rewrite(gamma, piecewise=True) == 2 ** (n / 2) * \
+           gamma(n / 2 + 1) * \
+           Piecewise(
+               (1, Eq(Mod(n, 2), 0)),
+               (sqrt(2 / pi), Eq(Mod(n, 2), 1)),
+               ((2 / pi) ** ((1 - cos(pi * n)) / 4), True),
+           )
 
 
 def test_binomial():

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,7 +1,7 @@
 from sympy import (S, Symbol, symbols, factorial, factorial2, Float, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise,
-                   Mod, Eq, sqrt, Poly, Dummy, I, Rational, cos)
+                   Mod, sqrt, Poly, Dummy, I, Rational, cos)
 from sympy.core.expr import unchanged
 from sympy.core.function import ArgumentIndexError
 from sympy.core.numbers import comp

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -401,14 +401,8 @@ def test_factorial2_rewrite():
            sqrt(2)*2**(n + S.Half)*gamma(n + Rational(3, 2))/sqrt(pi)
     assert factorial2(n).rewrite(gamma) == factorial2(n).rewrite(cos) == \
            2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi * n)) / 4) * gamma(n / 2 + 1)
-
-    assert factorial2(n).rewrite(gamma, piecewise=True) == 2 ** (n / 2) * \
-           gamma(n / 2 + 1) * \
-           Piecewise(
-               (1, Eq(Mod(n, 2), 0)),
-               (sqrt(2 / pi), Eq(Mod(n, 2), 1)),
-               ((2 / pi) ** ((1 - cos(pi * n)) / 4), True),
-           )
+    assert factorial2(n).rewrite(factorial) == \
+           2 ** (n / 2) * (2 / pi) ** ((1 - cos(pi * n)) / 4) * factorial(n / 2)
 
 
 def test_binomial():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -77,6 +77,7 @@ MPMATH_TRANSLATIONS = {
     "Ci": "ci",
     "RisingFactorial": "rf",
     "FallingFactorial": "ff",
+    "factorial2": "fac2",
 }
 
 NUMPY_TRANSLATIONS = {}  # type: Dict[str, str]


### PR DESCRIPTION
#### References to other Issues or PRs
Closes #20253 

#### Brief description of what is fixed or changed
- `factorial2` returns for real valued inputs. (using this [extension](https://functions.wolfram.com/GammaBetaErf/Factorial2/02/0001/))
- updated rewrite methods for `factorial2`
- `factorial` has a rewrite as `factorial2` method.
- additional tests for `factorial2`

#### Other comments

This is a neater version of #20380

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
     * factorial2 accepts real valued arguments.
<!-- END RELEASE NOTES -->