### PR TITLE
Improve apply_support method of Beam module

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -378,12 +378,12 @@ class Beam:
         loc = sympify(loc)
         self._applied_supports.append((loc, type))
         if type == "pin" or type == "roller":
-            reaction_load = Symbol('R_'+str(loc))
+            reaction_load = Symbol('R_'+str(loc).rstrip('0'))
             self.apply_load(reaction_load, loc, -1)
             self.bc_deflection.append((loc, 0))
         else:
-            reaction_load = Symbol('R_'+str(loc))
-            reaction_moment = Symbol('M_'+str(loc))
+            reaction_load = Symbol('R_'+str(loc).rstrip('0'))
+            reaction_moment = Symbol('M_'+str(loc).rstrip('0'))
             self.apply_load(reaction_load, loc, -1)
             self.apply_load(reaction_moment, loc, -2)
             self.bc_deflection.append((loc, 0))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Currently if you add a support to a beam at a location defined by decimal value, such as

    b.apply_support(0.2,'fixed') # fixed, pin, roller

and you try to catch the symbols created by the method with

    M,R = symbols('M_0.2, R_0.2')

the code fails because method `apply_support`, when converting numerical value of location to a string in order to create symbols, maintains the trailing zeros. In order to make the code work the user should write something like

    M,R = symbols('M_0.200000000, R_0.200000000')

which is clearly counter-intuitive (how many zeros?) if not incorrect.

With this simple fix trailing zeros are stripped from created symbols so that the code that the user is expecting to work runs correctly.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * make symbols definition needed after `apply_support` coherent with `location` argument of `apply_support` when `location` is not an integer value
<!-- END RELEASE NOTES -->