### PR TITLE
Fix sign of 2 equations in Beam module

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -28,8 +28,12 @@ class Beam:
 
     .. note::
        While solving a beam bending problem, a user should choose its
-       own sign convention and should stick to it. The results will
-       automatically follow the chosen sign convention.
+       own right-handed sign convention and should stick to it. The results will
+       automatically follow the chosen sign convention. However the sign
+       convention must respect the rule that, on the positive side of the
+       beam axis, a force giving positive shear yields a negative moment
+       (discordant shear and moment). Such rule is in agreement with the
+       conventions most commonly used for internal forces.
 
     Examples
     ========
@@ -834,7 +838,7 @@ class Beam:
         -8*SingularityFunction(x, 0, 0) + 6*SingularityFunction(x, 10, 0) + 120*SingularityFunction(x, 30, -1) + 2*SingularityFunction(x, 30, 0)
         """
         x = self.variable
-        return integrate(self.load, x)
+        return integrate(-self.load, x)
 
     def max_shear_force(self):
         """Returns maximum Shear force and its coordinate
@@ -1074,7 +1078,7 @@ class Beam:
             return slope
 
         C3 = Symbol('C3')
-        slope_curve = integrate(S.One/(E*I)*self.bending_moment(), x) + C3
+        slope_curve = integrate(-S.One/(E*I)*self.bending_moment(), x) + C3
 
         bc_eqs = []
         for position, value in self._boundary_conditions['slope']:
@@ -1172,7 +1176,7 @@ class Beam:
                 return deflection
             base_char = self._base_char
             C3, C4 = symbols(base_char + '3:5')    # Integration constants
-            slope_curve = integrate(self.bending_moment(), x) + C3
+            slope_curve = integrate(-self.bending_moment(), x) + C3
             deflection_curve = integrate(slope_curve, x) + C4
             bc_eqs = []
             for position, value in self._boundary_conditions['deflection']:


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #20204
See also #18045

#### Brief description of what is fixed or changed

Fix the sign of 2 equations used in the code:

1)  q =dV/dx   becomes   -q =dV/dx   (where q is distributed vertical load, V is shear, x is beam axis)
2)  EJ v'' = M   becomes   -EJ v'' = M   (where v is vertical displacement, M is moment, E is elastic modulus, J is moment of inertia)

The first equation is responsible (before fix) for wrong shear sign.
The second is responsible (before fix) for wrong results when used together with another equation present in code, **V = dM/dx**. In fact    **V = dM/dx**   and    **EJ v'' = M**   are incompatible, one of the two must have its sign changed, and changing sign to the latter equation allows to use the sign conventions most commonly used for internal forces ("discordant" shear and moment).

#### Other comments

- TO DO: update docstrings and documentation examples which have incorrect results, mostly on shear sign.
- Optional TO DO: add an option to allow user to choose between "discordant" and "concordant" shear and moment convention.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* physics.continuum_mechanics
  * make beam module compute correctly shear and rotation/deflection
<!-- END RELEASE NOTES -->