### PR TITLE
Stats SciPy sampling now uses a dictionary

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -153,7 +153,7 @@ class SampleContinuousScipy:
     @classmethod
     def _sample_scipy(cls, dist, size):
         """Sample from SciPy."""
-        import scipy.stats as st
+        import scipy.stats
         # scipy does not require map as it can handle using custom distributions.
         # However, we will still use a map where we can.
 
@@ -162,34 +162,34 @@ class SampleContinuousScipy:
         # See links below referring to sections beginning with "A common parametrization..."
         # I will remove all these comments if everything is ok.
         scipy_rv_map = {
-            'BetaDistribution': lambda dist, size: st.beta.rvs(
+            'BetaDistribution': lambda dist, size: scipy.stats.beta.rvs(
                 a=float(dist.alpha), b=float(dist.beta), size=size),
             # same parametrisation
-            'CauchyDistribution': lambda dist, size: st.cauchy.rvs(
+            'CauchyDistribution': lambda dist, size: scipy.stats.cauchy.rvs(
                 loc=float(dist.x0), scale=float(dist.gamma), size=size),
             # same parametrisation
-            'ChiSquaredDistribution': lambda dist, size: st.chi2.rvs(
+            'ChiSquaredDistribution': lambda dist, size: scipy.stats.chi2.rvs(
                 df=float(dist.k), size=size),
             # same parametrisation
-            'ExponentialDistribution': lambda dist, size: st.expon.rvs(
+            'ExponentialDistribution': lambda dist, size: scipy.stats.expon.rvs(
                 scale=1 / float(dist.rate), size=size),
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html#scipy.stats.expon
-            'GammaDistribution': lambda dist, size: st.gamma.rvs(
+            'GammaDistribution': lambda dist, size: scipy.stats.gamma.rvs(
                 a=float(dist.k), scale=float(dist.theta), size=size),
             # https://stackoverflow.com/questions/42150965/how-to-plot-gamma-distribution-with-alpha-and-beta-parameters-in-python
-            'LogNormalDistribution': lambda dist, size: st.lognorm.rvs(
+            'LogNormalDistribution': lambda dist, size: scipy.stats.lognorm.rvs(
                 scale=float(exp(dist.mean)), s=float(dist.std), size=size),
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
-            'NormalDistribution': lambda dist, size: st.norm.rvs(
+            'NormalDistribution': lambda dist, size: scipy.stats.norm.rvs(
                 loc=float(dist.mean), scale=float(dist.std), size=size),
             # same parametrisation
-            'ParetoDistribution': lambda dist, size: st.pareto.rvs(
+            'ParetoDistribution': lambda dist, size: scipy.stats.pareto.rvs(
                 b=float(dist.alpha), scale=float(dist.xm), size=size),
             # https://stackoverflow.com/questions/42260519/defining-pareto-distribution-in-python-scipy
-            'StudentTDistribution': lambda dist, size: st.t.rvs(
+            'StudentTDistribution': lambda dist, size: scipy.stats.t.rvs(
                 df=float(dist.nu), size=size),
             # same parametrisation
-            'UniformDistribution': lambda dist, size: st.uniform.rvs(
+            'UniformDistribution': lambda dist, size: scipy.stats.uniform.rvs(
                 loc=float(dist.left), scale=float(dist.right - dist.left), size=size)
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.uniform.html
         }
@@ -200,7 +200,7 @@ class SampleContinuousScipy:
 
         z = Dummy('z')
         handmade_pdf = lambdify(z, dist.pdf(z), ['numpy', 'scipy'])
-        class scipy_pdf(st.rv_continuous):
+        class scipy_pdf(scipy.stats.rv_continuous):
             def _pdf(self, x):
                 return handmade_pdf(x)
         scipy_rv = scipy_pdf(a=float(dist.set._inf),

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -163,23 +163,32 @@ class SampleContinuousScipy:
         # I will remove all these comments if everything is ok.
         scipy_rv_map = {
             'BetaDistribution': lambda dist, size: st.beta.rvs(
-                a=float(dist.alpha), b=float(dist.beta), size=size),  # same parametrisation
+                a=float(dist.alpha), b=float(dist.beta), size=size),
+            # same parametrisation
+            'CauchyDistribution': lambda dist, size: st.cauchy.rvs(
+                loc=float(dist.x0), scale=float(dist.gamma), size=size),
+            # same parametrisation
             'ChiSquaredDistribution': lambda dist, size: st.chi2.rvs(
-                df=float(dist.k), size=size),  # same parametrisation
+                df=float(dist.k), size=size),
+            # same parametrisation
             'ExponentialDistribution': lambda dist, size: st.expon.rvs(
                 scale=1 / float(dist.rate), size=size),
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html#scipy.stats.expon
             'GammaDistribution': lambda dist, size: st.gamma.rvs(
                 a=float(dist.k), scale=float(dist.theta), size=size),
-            # assuming scale!=1/theta https://stackoverflow.com/questions/42150965/how-to-plot-gamma-distribution-with-alpha-and-beta-parameters-in-python
+            # https://stackoverflow.com/questions/42150965/how-to-plot-gamma-distribution-with-alpha-and-beta-parameters-in-python
             'LogNormalDistribution': lambda dist, size: st.lognorm.rvs(
                 scale=float(exp(dist.mean)), s=float(dist.std), size=size),
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
             'NormalDistribution': lambda dist, size: st.norm.rvs(
-                loc=float(dist.mean), scale=float(dist.std), size=size),  # same parametrisation
+                loc=float(dist.mean), scale=float(dist.std), size=size),
+            # same parametrisation
             'ParetoDistribution': lambda dist, size: st.pareto.rvs(
                 b=float(dist.alpha), scale=float(dist.xm), size=size),
             # https://stackoverflow.com/questions/42260519/defining-pareto-distribution-in-python-scipy
+            'StudentTDistribution': lambda dist, size: st.t.rvs(
+                df=float(dist.nu), size=size),
+            # same parametrisation
             'UniformDistribution': lambda dist, size: st.uniform.rvs(
                 loc=float(dist.left), scale=float(dist.right - dist.left), size=size)
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.uniform.html

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -153,11 +153,45 @@ class SampleContinuousScipy:
     @classmethod
     def _sample_scipy(cls, dist, size):
         """Sample from SciPy."""
-        # scipy does not require map as it can handle using custom distributions
-        from scipy.stats import rv_continuous
+        import scipy.stats as st
+        # scipy does not require map as it can handle using custom distributions.
+        # However, we will still use a map where we can.
+
+        # TODO: do this for drv.py and frv.py if necessary.
+        # TODO: add more distributions here if there are more
+        # See links below referring to sections beginning with "A common parametrization..."
+        # I will remove all these comments if everything is ok.
+        scipy_rv_map = {
+            'BetaDistribution': lambda dist, size: st.beta.rvs(
+                a=float(dist.alpha), b=float(dist.beta), size=size),  # same parametrisation
+            'ChiSquaredDistribution': lambda dist, size: st.chi2.rvs(
+                df=float(dist.k), size=size),  # same parametrisation
+            'ExponentialDistribution': lambda dist, size: st.expon.rvs(
+                scale=1 / float(dist.rate), size=size),
+            # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html#scipy.stats.expon
+            'GammaDistribution': lambda dist, size: st.gamma.rvs(
+                a=float(dist.k), scale=float(dist.theta), size=size),
+            # assuming scale!=1/theta https://stackoverflow.com/questions/42150965/how-to-plot-gamma-distribution-with-alpha-and-beta-parameters-in-python
+            'LogNormalDistribution': lambda dist, size: st.lognorm.rvs(
+                scale=float(exp(dist.mean)), s=float(dist.std), size=size),
+            # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
+            'NormalDistribution': lambda dist, size: st.norm.rvs(
+                loc=float(dist.mean), scale=float(dist.std), size=size),  # same parametrisation
+            'ParetoDistribution': lambda dist, size: st.pareto.rvs(
+                b=float(dist.alpha), scale=float(dist.xm), size=size),
+            # https://stackoverflow.com/questions/42260519/defining-pareto-distribution-in-python-scipy
+            'UniformDistribution': lambda dist, size: st.uniform.rvs(
+                loc=float(dist.left), scale=float(dist.right - dist.left), size=size)
+            # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.uniform.html
+        }
+
+        # if we don't need to make a handmade pdf, we won't
+        if dist.__class__.__name__ in scipy_rv_map:
+            return scipy_rv_map[dist.__class__.__name__](dist, size)
+
         z = Dummy('z')
         handmade_pdf = lambdify(z, dist.pdf(z), ['numpy', 'scipy'])
-        class scipy_pdf(rv_continuous):
+        class scipy_pdf(st.rv_continuous):
             def _pdf(self, x):
                 return handmade_pdf(x)
         scipy_rv = scipy_pdf(a=float(dist.set._inf),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20376 
Fixes #20344 

#### Brief description of what is fixed or changed

The numpy and pymc3 sampling functions both use a dictionary to map sympy's distributions to their distributions. scipy did not have to do this since it could take a lambdified pdf. However, this caused problems with some distributions (see the issues that this fixes).

I can add more distributions and possibly for the discrete rv's. However, the main issue occurs when scipy cannot numerically integrate the given pdf.

Note that I have found another issue when doing this:
The StudentT, Cauchy and LogNormal distributions all have defined means but sympy cannot calculate `E(X)` because the mgf is undefined. sympy should use a different strategy to find the mean in this case. Maybe use the cf or the pmf itself.

#### Other comments

Please verify the dictionary for each distribution. I have added links in the code that I will remove once verified.
You can also try running the following to check that the mean and variance roughly match E(X) and Var(X):
```python
from sympy import *
from sympy.stats import *

n = 1000
arr = [
    Beta('X', 2, 2),
    ChiSquared('X', 5),
    Exponential('X', 3),
    Gamma("X", 2, 2),
    exp(Normal("X", -4, 2)),
    Normal('X', 0, 1),
    Pareto("X", 4, 4),
    Uniform('X', -1, 4)
]
for X in arr:
    lst = (next(sample(X, size=n)))
    print(E(X).evalf(), sum(lst)/n)
    print(variance(X).evalf(), (sum([i**2 for i in lst]) - sum(lst)**2/n)/(n-1))
```
The above prints the mean and the sample mean on the same line. This is then followed by the variance and sample variance. This is repeated for each distribution in `arr`.

The above sample values should be within ~10% of the correct value. (except for the heavy tailed distributions such as LogNormal, Pareto and Cauchy).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->