### PR TITLE
Change minlex to use the linear time least_rotation.

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1083,7 +1083,7 @@ class Permutation(Atom):
                     unchecked[j] = False
                 if len(cycle) > 1:
                     cyclic_form.append(cycle)
-                    assert cycle == list(minlex(cycle, is_set=True))
+                    assert cycle == list(minlex(cycle))
         cyclic_form.sort()
         self._cyclic_form = cyclic_form[:]
         return cyclic_form

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -3,7 +3,7 @@ from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.core import Basic, Tuple
 from sympy.core.compatibility import as_int
 from sympy.sets import FiniteSet
-from sympy.utilities.iterables import (minlex, unflatten, flatten)
+from sympy.utilities.iterables import (minlex, unflatten, flatten, default_sort_key)
 
 rmul = Perm.rmul
 
@@ -386,7 +386,7 @@ class Polyhedron(Basic):
         .. [1] www.ocf.berkeley.edu/~wwu/articles/platonicsolids.pdf
 
         """
-        faces = [minlex(f, directed=False) for f in faces]
+        faces = [minlex(f, directed=False, key=default_sort_key) for f in faces]
         corners, faces, pgroup = args = \
             [Tuple(*a) for a in (corners, faces, pgroup)]
         obj = Basic.__new__(cls, *args)

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -386,7 +386,7 @@ class Polyhedron(Basic):
         .. [1] www.ocf.berkeley.edu/~wwu/articles/platonicsolids.pdf
 
         """
-        faces = [tuple(minlex(f, directed=False)) for f in faces]
+        faces = [minlex(f, directed=False) for f in faces]
         corners, faces, pgroup = args = \
             [Tuple(*a) for a in (corners, faces, pgroup)]
         obj = Basic.__new__(cls, *args)

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -386,7 +386,7 @@ class Polyhedron(Basic):
         .. [1] www.ocf.berkeley.edu/~wwu/articles/platonicsolids.pdf
 
         """
-        faces = [minlex(f, directed=False, is_set=True) for f in faces]
+        faces = [tuple(minlex(f, directed=False)) for f in faces]
         corners, faces, pgroup = args = \
             [Tuple(*a) for a in (corners, faces, pgroup)]
         obj = Basic.__new__(cls, *args)
@@ -697,7 +697,7 @@ def _pgroup_calcs():
             reorder = unflatten([c[j] for j in flat_faces], n)
             # make them canonical
             reorder = [tuple(map(as_int,
-                       minlex(f, directed=False, is_set=True)))
+                       minlex(f, directed=False)))
                        for f in reorder]
             # map face to vertex: the resulting list of vertices are the
             # permutation that we seek for the double

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -9,9 +9,8 @@ from operator import gt
 from sympy.core import Basic
 
 # this is the logical location of these functions
-from sympy.core.compatibility import (
-    as_int, default_sort_key, is_sequence, iterable, ordered
-)
+from sympy.core.compatibility import (as_int, is_sequence, iterable, ordered)
+from sympy.core.compatibility import default_sort_key  # noqa: F401
 
 import sympy
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1302,11 +1302,11 @@ def least_rotation(x):
         sj = S[j]
         i = f[j-k-1]
         while i != -1 and sj != S[k+i+1]:
-            if sj < S[k+i+1]:
+            if default_sort_key(sj) < default_sort_key(S[k+i+1]):
                 k = j-i-1
             i = f[i]
         if sj != S[k+i+1]:
-            if sj < S[k]:
+            if default_sort_key(sj) < default_sort_key(S[k]):
                 k = j
             f[j-k] = -1
         else:
@@ -2398,20 +2398,13 @@ def generate_oriented_forest(n):
                 break
 
 
-def minlex(seq, directed=True, is_set=False, small=None):
+def minlex(seq, directed=True):
     """
-    Return a tuple representing the rotation of the sequence in which
-    the lexically smallest elements appear first, e.g. `cba ->acb`.
+    Return the rotation of the sequence in which the lexically smallest
+    elements appear first, e.g. `cba ->acb`.
 
     If ``directed`` is False then the smaller of the sequence and the
     reversed sequence is returned, e.g. `cba -> abc`.
-
-    For more efficient processing, ``is_set`` can be set to True if there
-    are no duplicates in the sequence.
-
-    If the smallest element is known at the time of calling, it can be
-    passed as ``small`` and the calculation of the smallest element will
-    be omitted.
 
     Examples
     ========
@@ -2430,50 +2423,13 @@ def minlex(seq, directed=True, is_set=False, small=None):
     '00011001011'
 
     """
-    is_str = isinstance(seq, str)
-    seq = list(seq)
-    if small is None:
-        small = min(seq, key=default_sort_key)
-    if is_set:
-        i = seq.index(small)
-        if not directed:
-            n = len(seq)
-            p = (i + 1) % n
-            m = (i - 1) % n
-            if default_sort_key(seq[p]) > default_sort_key(seq[m]):
-                seq = list(reversed(seq))
-                i = n - i - 1
-        if i:
-            seq = rotate_left(seq, i)
-        best = seq
-    else:
-        count = seq.count(small)
-        if count == 1 and directed:
-            best = rotate_left(seq, seq.index(small))
-        else:
-            # if not directed, and not a set, we can't just
-            # pass this off to minlex with is_set True since
-            # peeking at the neighbor may not be sufficient to
-            # make the decision so we continue...
-            best = seq
-            for i in range(count):
-                seq = rotate_left(seq, seq.index(small, count != 1))
-                if seq < best:
-                    best = seq
-                # it's cheaper to rotate now rather than search
-                # again for these in reversed order so we test
-                # the reverse now
-                if not directed:
-                    seq = rotate_left(seq, 1)
-                    seq = list(reversed(seq))
-                    if seq < best:
-                        best = seq
-                    seq = list(reversed(seq))
-                    seq = rotate_right(seq, 1)
-    # common return
-    if is_str:
-        return ''.join(best)
-    return tuple(best)
+
+    best = rotate_left(seq, least_rotation(seq))
+    if not directed:
+        rseq = seq[::-1]
+        rbest = rotate_left(rseq, least_rotation(rseq))
+        return min(best, rbest, key=default_sort_key)
+    return best
 
 
 def runs(seq, op=gt):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2403,6 +2403,9 @@ def minlex(seq, directed=True):
     Return the rotation of the sequence in which the lexically smallest
     elements appear first, e.g. `cba ->acb`.
 
+    The sequence returned is a tuple, unless the input sequence is a string
+    in which case a string is returned.
+
     If ``directed`` is False then the smaller of the sequence and the
     reversed sequence is returned, e.g. `cba -> abc`.
 
@@ -2428,8 +2431,10 @@ def minlex(seq, directed=True):
     if not directed:
         rseq = seq[::-1]
         rbest = rotate_left(rseq, least_rotation(rseq))
-        return min(best, rbest, key=default_sort_key)
-    return best
+        best = min(best, rbest, key=default_sort_key)
+
+    # Convert to tuple, unless we started with a string.
+    return tuple(best) if not isinstance(seq, str) else best
 
 
 def runs(seq, op=gt):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -640,7 +640,7 @@ def test_common_prefix_suffix():
 
 
 def test_minlex():
-    assert minlex([1, 2, 0]) == (0, 1, 2)
+    assert minlex([1, 2, 0]) == [0, 1, 2]
     assert minlex((1, 2, 0)) == (0, 1, 2)
     assert minlex((1, 0, 2)) == (0, 2, 1)
     assert minlex((1, 0, 2), directed=False) == (0, 1, 2)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -645,6 +645,7 @@ def test_minlex():
     assert minlex((1, 0, 2)) == (0, 2, 1)
     assert minlex((1, 0, 2), directed=False) == (0, 1, 2)
     assert minlex('aba') == 'aab'
+    assert minlex(('bb', 'aaa', 'c', 'a'), key=len) == ('c', 'a', 'bb', 'aaa')
 
 
 def test_ordered():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -640,7 +640,7 @@ def test_common_prefix_suffix():
 
 
 def test_minlex():
-    assert minlex([1, 2, 0]) == [0, 1, 2]
+    assert minlex([1, 2, 0]) == (0, 1, 2)
     assert minlex((1, 2, 0)) == (0, 1, 2)
     assert minlex((1, 0, 2)) == (0, 2, 1)
     assert minlex((1, 0, 2), directed=False) == (0, 1, 2)


### PR DESCRIPTION
Currently the `minlex` utility function computes the earliest rotation of an iterable by producing all rotations of the iterable and looking for the smallest one. This is a quadratic time operation since there are linearly many rotations and it takes linear time to determine whether a rotation is smaller than the best rotation found so far. The utility function `least_rotation` uses Booth's algorithm to compute the index of the smallest rotation in linear time hence `minlex` can be fundamentally done using:
``` return left_rotate(seq, least_rotation(seq))```
however a few extra cases are needed since `minlex` can also check for the smallest rotation of the iterable and its reverse.

Since this is now a linear time algorithm there is no benefit in passing in some of the hints that speed up the old function such as `is_set` and `small`.

<!-- BEGIN RELEASE NOTES -->
* utilities
    * minlex no longer accepts is_set or small arguments
    * minlex and least_rotation now accept `key=` arguments similar to `sorted`.
<!-- END RELEASE NOTES -->