### PR TITLE
Fixed wrong naming of constants

### DIFF
--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -66,7 +66,7 @@ from sympy.core.compatibility import default_sort_key
 from sympy.utilities.iterables import numbered_symbols
 
 
-def rsolve_poly(coeffs, f, n, **hints):
+def rsolve_poly(coeffs, f, n, shift=0, **hints):
     r"""
     Given linear recurrence operator `\operatorname{L}` of order
     `k` with polynomial coefficients and inhomogeneous equation
@@ -188,7 +188,7 @@ def rsolve_poly(coeffs, f, n, **hints):
         y = E = S.Zero
 
         for i in range(N + 1):
-            C.append(Symbol('C' + str(i)))
+            C.append(Symbol('C' + str(i + shift)))
             y += C[i] * n**i
 
         for i in range(r + 1):
@@ -301,7 +301,7 @@ def rsolve_poly(coeffs, f, n, **hints):
         if not homogeneous:
             h = Add(*[(g*p).expand() for g, p in zip(G, P)])
 
-        C = [Symbol('C' + str(i)) for i in range(A)]
+        C = [Symbol('C' + str(i + shift)) for i in range(A)]
 
         g = lambda i: Add(*[c*_delta(q, i) for c, q in zip(C, Q)])
 
@@ -614,11 +614,14 @@ def rsolve_hyper(coeffs, f, n, **hints):
             if coeff is not S.Zero:
                 poly += coeff * Z**i
 
+        constants = []
+
         for z in roots(poly, Z).keys():
             if z.is_zero:
                 continue
 
-            (C, s) = rsolve_poly([polys[i].as_expr()*z**i for i in range(r + 1)], 0, n, symbols=True)
+            (C, s) = rsolve_poly([polys[i].as_expr()*z**i for i in range(r + 1)], 0, n, len(constants), symbols=True)
+            constants.extend(s)
 
             if C is not None and C is not S.Zero:
                 symbols |= set(s)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -214,6 +214,14 @@ def test_issue_18751():
     assert rsolve(f, y(n)) == \
         C0*(r*(cos(theta) - I*Abs(sin(theta))))**n + C1*(r*(cos(theta) + I*Abs(sin(theta))))**n
 
+def test_constant_naming():
+    #issue 8697
+    assert rsolve(y(n+3) - y(n+2) - y(n+1) + y(n), y(n)) == (-1)**n*C0+C1+C2*n
+    assert rsolve(y(n+3)+3*y(n+2)+3*y(n+1)+y(n), y(n)).expand() == C0*(-1)**n + (-1)**n*C1*n + (-1)**n*C2*n**2
+    assert rsolve(y(n) - 2*y(n - 3) + 5*y(n - 2) - 4*y(n - 1),y(n),[1,3,8]) == 3*2**n - n - 2
+
+    #issue 19630
+    assert rsolve(y(n+3) - 3*y(n+1) + 2*y(n), y(n), {y(1):0, y(2):8, y(3):-2}) == (-2)**n + 2*n
 
 @slow
 def test_issue_15751():


### PR DESCRIPTION
Naming of constants was wrong which led to `rsolve` giving the wrong answer

#### References to other Issues or PRs
Fixes #8697, #19630

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed incorrect solutions from rsolve for higher order recurrences
<!-- END RELEASE NOTES -->