### PR TITLE
Units module: fixing bug in convert_to

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -1,7 +1,7 @@
 from sympy import (Abs, Add, Function, Number, Rational, S, Symbol,
                    diff, exp, integrate, log, sin, sqrt, symbols)
 from sympy.physics.units import (amount_of_substance, convert_to, find_unit,
-                                 volume, kilometer)
+                                 volume, kilometer, joule)
 from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
     day, foot, grams, hour, inch, kg, km, m, meter, millimeter,
     minute, quart, s, second, speed_of_light, bit,
@@ -44,6 +44,10 @@ def test_convert_to():
     # Wrong dimension to convert:
     assert q.convert_to(s) == q
     assert speed_of_light.convert_to(m) == speed_of_light
+
+    expr = joule*second
+    conv = convert_to(expr, joule)
+    assert conv == joule*second
 
 
 def test_Quantity_definition():

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -4,6 +4,7 @@ Several methods to simplify expressions involving unit objects.
 
 from sympy import Add, Mul, Pow, Tuple, sympify
 from sympy.core.compatibility import reduce, Iterable, ordered
+from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension
 from sympy.physics.units.prefixes import Prefix
 from sympy.physics.units.quantities import Quantity
@@ -30,7 +31,11 @@ def _get_conversion_matrix_for_expr(expr, target_units, unit_system):
     camat = Matrix([[dimension_system.get_dimensional_dependencies(i, mark_dimensionless=True).get(j, 0) for i in target_dims] for j in canon_dim_units])
     exprmat = Matrix([dim_dependencies.get(k, 0) for k in canon_dim_units])
 
-    res_exponents = camat.solve_least_squares(exprmat, method=None)
+    try:
+        res_exponents = camat.solve(exprmat)
+    except NonInvertibleMatrixError:
+        return None
+
     return res_exponents
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #18368

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fix bug in convert_to returning wrong units in some cases where the linear equation system between canonical units is unsolvable.
<!-- END RELEASE NOTES -->