### PR TITLE
Added .xreplace() to Vector and Dyadic

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -597,7 +597,7 @@ class Dyadic(Printable, EvalfMixin):
                     new_args.append(tuple(new_inlist))
                     changed |= a_xr[1]
                 else:
-                    new_args.append(tuple(new_inlist))
+                    new_args.append(inlist)
             if changed:
                 return Dyadic(new_args), True
         return self, False

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -541,37 +541,38 @@ class Dyadic(Printable, EvalfMixin):
 
     def xreplace(self, rule):
         """
-        Replace occurrences of objects within the expression.
+        Replace occurrences of objects within the measure numbers of the Dyadic.
 
         Parameters
         ==========
 
         rule : dict-like
-            Expresses a replacement rule
+            Expresses a replacement rule.
 
         Returns
         =======
 
-        xreplace : the result of the replacement
+        Dyadic : Result of the replacement.
 
         Examples
         ========
 
         >>> from sympy import symbols, pi
-        >>> from sympy.physics.vector import ReferenceFrame
+        >>> from sympy.physics.vector import ReferenceFrame, outer
         >>> N = ReferenceFrame('N')
+        >>> D = outer(N.x, N.x)
         >>> x, y, z = symbols('x y z')
-        >>> ((1 + x*y) * (N.x | N.x)).xreplace({x: pi})
+        >>> ((1 + x*y) * D).xreplace({x: pi})
         (pi*y + 1)*(N.x|N.x)
-        >>> ((1 + x*y) * (N.x | N.x)).xreplace({x: pi, y: 2})
+        >>> ((1 + x*y) * D).xreplace({x: pi, y: 2})
         (1 + 2*pi)*(N.x|N.x)
 
         Replacements occur only if an entire node in the expression tree is
         matched:
 
-        >>> ((x*y + z) * (N.x | N.x)).xreplace({x*y: pi})
+        >>> ((x*y + z) * D).xreplace({x*y: pi})
         (z + pi)*(N.x|N.x)
-        >>> ((x*y*z) * (N.x | N.x)).xreplace({x*y: pi})
+        >>> ((x*y*z) * D).xreplace({x*y: pi})
         x*y*z*(N.x|N.x)
 
         """

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -552,7 +552,8 @@ class Dyadic(Printable, EvalfMixin):
         Returns
         =======
 
-        Dyadic : Result of the replacement.
+        Dyadic
+            Result of the replacement.
 
         Examples
         ========

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -576,31 +576,12 @@ class Dyadic(Printable, EvalfMixin):
 
         """
 
-        value, _ = self._xreplace(rule)
-        return value
-
-    def _xreplace(self, rule):
-        """
-        Helper for xreplace. Tracks whether a replacement actually occurred.
-        """
-
-        if rule:
-            changed = False
-            new_args = []
-            for inlist in self.args:
-                new_inlist = list(inlist)
-                a = new_inlist[0]
-                _xreplace = getattr(a, '_xreplace', None)
-                if _xreplace is not None:
-                    a_xr = _xreplace(rule)
-                    new_inlist[0] = a_xr[0]
-                    new_args.append(tuple(new_inlist))
-                    changed |= a_xr[1]
-                else:
-                    new_args.append(inlist)
-            if changed:
-                return Dyadic(new_args), True
-        return self, False
+        new_args = []
+        for inlist in self.args:
+            new_inlist = list(inlist)
+            new_inlist[0] = new_inlist[0].xreplace(rule)
+            new_args.append(tuple(new_inlist))
+        return Dyadic(new_args)
 
 def _check_dyadic(other):
     if not isinstance(other, Dyadic):

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -104,3 +104,15 @@ def test_dyadic_evalf():
     s = symbols('s')
     a = 5 * s * pi* (N.x | N.x)
     assert a.evalf(2) == Float('5', 2) * Float('3.1416', 2) * s * (N.x | N.x)
+
+def test_dyadic_xreplace():
+    x, y, z = symbols('x y z')
+    N = ReferenceFrame('N')
+    v = x*y * (N.x | N.x)
+    assert v.xreplace({x : cos(x)}) == cos(x)*y * (N.x | N.x)
+    assert v.xreplace({x*y : pi}) == pi * (N.x | N.x)
+    v = (x*y)**z * (N.x | N.x)
+    assert v.xreplace({(x*y)**z : 1}) == (N.x | N.x)
+    assert v.xreplace({x:1, z:0}) == (N.x | N.x)
+    raises(TypeError, lambda: v.xreplace())
+    raises(TypeError, lambda: v.xreplace([x, y]))

--- a/sympy/physics/vector/tests/test_dyadic.py
+++ b/sympy/physics/vector/tests/test_dyadic.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, symbols, pi, Float, ImmutableMatrix as Matrix
-from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols
+from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols, outer
 from sympy.physics.vector.dyadic import _check_dyadic
 from sympy.testing.pytest import raises
 
@@ -108,11 +108,12 @@ def test_dyadic_evalf():
 def test_dyadic_xreplace():
     x, y, z = symbols('x y z')
     N = ReferenceFrame('N')
-    v = x*y * (N.x | N.x)
-    assert v.xreplace({x : cos(x)}) == cos(x)*y * (N.x | N.x)
-    assert v.xreplace({x*y : pi}) == pi * (N.x | N.x)
-    v = (x*y)**z * (N.x | N.x)
-    assert v.xreplace({(x*y)**z : 1}) == (N.x | N.x)
-    assert v.xreplace({x:1, z:0}) == (N.x | N.x)
+    D = outer(N.x, N.x)
+    v = x*y * D
+    assert v.xreplace({x : cos(x)}) == cos(x)*y * D
+    assert v.xreplace({x*y : pi}) == pi * D
+    v = (x*y)**z * D
+    assert v.xreplace({(x*y)**z : 1}) == D
+    assert v.xreplace({x:1, z:0}) == D
     raises(TypeError, lambda: v.xreplace())
     raises(TypeError, lambda: v.xreplace([x, y]))

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -177,3 +177,13 @@ def test_vector_evalf():
     assert v.evalf(2) == Float('3.1416', 2) * A.x
     v = pi * A.x + 5 * a * A.y - b * A.z
     assert v.evalf(3) == Float('3.1416', 3) * A.x + Float('5', 3) * a * A.y - b * A.z
+
+def test_vector_xreplace():
+    x, y, z = symbols('x y z')
+    v = x**2 * A.x + x*y * A.y + x*y*z * A.z
+    assert v.xreplace({x : cos(x)}) == cos(x)**2 * A.x + y*cos(x) * A.y + y*z*cos(x) * A.z
+    assert v.xreplace({x*y : pi}) == x**2 * A.x + pi * A.y + x*y*z * A.z
+    assert v.xreplace({x*y*z : 1}) == x**2*A.x + x*y*A.y + A.z
+    assert v.xreplace({x:1, z:0}) == A.x + y * A.y
+    raises(TypeError, lambda: v.xreplace())
+    raises(TypeError, lambda: v.xreplace([x, y]))

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -756,30 +756,11 @@ class Vector(Printable, EvalfMixin):
 
         """
 
-        value, _ = self._xreplace(rule)
-        return value
-
-    def _xreplace(self, rule):
-        """
-        Helper for xreplace. Tracks whether a replacement actually occurred.
-        """
-        if self in rule:
-            return rule[self], True
-        elif rule:
-            changed = False
-            new_args = []
-            for mat, frame in self.args:
-                _xreplace = getattr(mat, '_xreplace', None)
-                if _xreplace is not None:
-                    mat_xr = _xreplace(rule)
-                    new_args.append([mat_xr[0], frame])
-                    changed |= mat_xr[1]
-                else:
-                    new_args.append([mat, frame])
-            if changed:
-                return Vector(new_args), True
-        return self, False
-
+        new_args = []
+        for mat, frame in self.args:
+            mat = mat.xreplace(rule)
+            new_args.append([mat, frame])
+        return Vector(new_args)
 
 class VectorTypeError(TypeError):
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -732,7 +732,8 @@ class Vector(Printable, EvalfMixin):
         Returns
         =======
 
-        Vector : Result of the replacement.
+        Vector
+            Result of the replacement.
 
         Examples
         ========

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -721,18 +721,18 @@ class Vector(Printable, EvalfMixin):
 
     def xreplace(self, rule):
         """
-        Replace occurrences of objects within the expression.
+        Replace occurrences of objects within the measure numbers of the vector.
 
         Parameters
         ==========
 
         rule : dict-like
-            Expresses a replacement rule
+            Expresses a replacement rule.
 
         Returns
         =======
 
-        xreplace : the result of the replacement
+        Vector : Result of the replacement.
 
         Examples
         ========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20445 

#### Brief description of what is fixed or changed
Physics Vector and Dyadic is missing core sympy methods. This PR adds .xreplace() to these classes.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
    * Added .xreplace() to Vector Class.
    * Added .xreplace() to Dyadic Class.
<!-- END RELEASE NOTES -->