### PR TITLE
fixed is_integer of Mul by not using fraction but collecting numerators and denominators directly (1.7)

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1262,11 +1262,10 @@ class Mul(Expr, AssocOp):
                     zero = None
         return zero
 
+    # without involving odd/even checks this code would suffice:
     #_eval_is_integer = lambda self: _fuzzy_group(
     #    (a.is_integer for a in self.args), quick_exit=True)
     def _eval_is_integer(self):
-        #return _fuzzy_group(
-        #    (a.is_integer for a in self.args), quick_exit=True)
         from sympy import fraction
         from sympy.core.numbers import Float
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1284,12 +1284,12 @@ class Mul(Expr, AssocOp):
                 if not b.is_integer or not e.is_integer: return
                 if e.is_negative:
                     denominators.append(b)
-                elif e.is_positive:
-                    denominators.append(b)
-                elif e.is_zero:
-                    if b.is_zero: return
                 else:
-                    return
+                    # for integer b and positive integer e: a = b**e would be integer
+                    assert not e.is_positive
+                    # for self being rational and e equal to zero: a = b**e would be 1
+                    assert not e.is_zero
+                    return # sign of e unknown -> self.is_integer cannot be decided
             else:
                 return
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1286,6 +1286,10 @@ class Mul(Expr, AssocOp):
                     denominators.append(b)
                 elif e.is_positive:
                     denominators.append(b)
+                elif e.is_zero:
+                    if b.is_zero: return
+                else:
+                    return
             else:
                 return
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -7,7 +7,7 @@ from .basic import Basic
 from .singleton import S
 from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
-from .logic import fuzzy_not, _fuzzy_group, fuzzy_and
+from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce
 from .expr import Expr
 from .parameters import global_parameters
@@ -1266,9 +1266,6 @@ class Mul(Expr, AssocOp):
     #_eval_is_integer = lambda self: _fuzzy_group(
     #    (a.is_integer for a in self.args), quick_exit=True)
     def _eval_is_integer(self):
-        from sympy import fraction
-        from sympy.core.numbers import Float
-
         is_rational = self._eval_is_rational()
         if is_rational is False:
             return False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1262,7 +1262,11 @@ class Mul(Expr, AssocOp):
                     zero = None
         return zero
 
+    #_eval_is_integer = lambda self: _fuzzy_group(
+    #    (a.is_integer for a in self.args), quick_exit=True)
     def _eval_is_integer(self):
+        #return _fuzzy_group(
+        #    (a.is_integer for a in self.args), quick_exit=True)
         from sympy import fraction
         from sympy.core.numbers import Float
 
@@ -1270,19 +1274,35 @@ class Mul(Expr, AssocOp):
         if is_rational is False:
             return False
 
-        # use exact=True to avoid recomputing num or den
-        n, d = fraction(self, exact=True)
-        if is_rational:
-            if d is S.One:
-                return True
-        if d.is_even:
-            if d.is_prime:  # literal or symbolic 2
-                return n.is_even
-            if n.is_odd:
-                return False  # true even if d = 0
-        if n == d:
-            return fuzzy_and([not bool(self.atoms(Float)),
-            fuzzy_not(d.is_zero)])
+        numerators = []
+        denominators = []
+        for a in self.args:
+            if a.is_integer:
+                numerators.append(a)
+            elif a.is_Rational:
+                n, d = a.as_numer_denom()
+                numerators.append(n)
+                denominators.append(d)
+            elif a.is_Pow:
+                b, e = a.as_base_exp()
+                if not b.is_integer or not e.is_integer: return
+                if e.is_negative:
+                    denominators.append(b)
+                elif e.is_positive:
+                    denominators.append(b)
+            else:
+                return
+
+        if not denominators:
+            return True
+
+        odd = lambda ints: all(i.is_odd for i in ints)
+        even = lambda ints: any(i.is_even for i in ints)
+
+        if odd(numerators) and even(denominators):
+            return False
+        elif even(numerators) and denominators == [2]:
+            return True
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -403,8 +403,8 @@ def test_Mul_is_integer():
     assert m.is_integer
 
     # broken in 1.6 and before, see #20161
-    xq = Symbol('x', rational=True)
-    yq = Symbol('y', rational=True)
+    xq = Symbol('xq', rational=True)
+    yq = Symbol('yq', rational=True)
     assert (xq*yq).is_integer is None
     e_20161 = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
     assert e_20161.is_integer is not True # expand(e_20161) -> -1/2, but no need to see that in the assumption without evaluation

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -378,7 +378,6 @@ def test_Mul_is_integer():
     n = Symbol('n', integer=True)
     nr = Symbol('nr', rational=False)
     nz = Symbol('nz', integer=True, zero=False)
-    nze = Symbol('nze', even=True, zero=False)
     e = Symbol('e', even=True)
     o = Symbol('o', odd=True)
     i2 = Symbol('2', prime=True, even=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -405,7 +405,7 @@ def test_Mul_is_integer():
     # broken in 1.6 and before, see #20161
     xq = Symbol('x', rational=True)
     yq = Symbol('y', rational=True)
-    assert (xq*yq).is_integer is None 
+    assert (xq*yq).is_integer is None
     e_20161 = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
     assert e_20161.is_integer is not True # expand(e_20161) -> -1/2, but no need to see that in the assumption without evaluation
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -374,7 +374,6 @@ def test_Mul_doesnt_expand_exp():
     assert (x**(-log(5)/log(3))*x)/(x*x**( - log(5)/log(3))) == sympify(1)
 
 def test_Mul_is_integer():
-
     k = Symbol('k', integer=True)
     n = Symbol('n', integer=True)
     nr = Symbol('nr', rational=False)
@@ -388,18 +387,27 @@ def test_Mul_is_integer():
     assert (nz/3).is_integer is None
     assert (nr/3).is_integer is False
     assert (x*k*n).is_integer is None
+    assert (e/2).is_integer is True
+    assert (e**2/2).is_integer is True
+    assert ((-1)**k*n).is_integer is True
+    assert (3*k*e/2).is_integer is True
+    assert (2*k*e/3).is_integer is None
     assert (e/o).is_integer is None
     assert (o/e).is_integer is False
     assert (o/i2).is_integer is False
-    assert Mul(o, 1/o, evaluate=False).is_integer is True
     assert Mul(k, 1/k, evaluate=False).is_integer is None
-    assert Mul(nze, 1/nze, evaluate=False).is_integer is True
-    assert Mul(2., S.Half, evaluate=False).is_integer is False
+    assert Mul(2., S.Half, evaluate=False).is_integer is None
 
     s = 2**2**2**Pow(2, 1000, evaluate=False)
     m = Mul(s, s, evaluate=False)
     assert m.is_integer
 
+    # broken in 1.6 and before, see #20161
+    xq = Symbol('x', rational=True)
+    yq = Symbol('y', rational=True)
+    assert (xq*yq).is_integer is None 
+    e_20161 = Mul(-1,Mul(1,Pow(2,-1,evaluate=False),evaluate=False),evaluate=False)
+    assert e_20161.is_integer is not True # expand(e_20161) -> -1/2, but no need to see that in the assumption without evaluation
 
 def test_Add_Mul_is_integer():
     x = Symbol('x')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -396,6 +396,8 @@ def test_Mul_is_integer():
     assert (o/i2).is_integer is False
     assert Mul(k, 1/k, evaluate=False).is_integer is None
     assert Mul(2., S.Half, evaluate=False).is_integer is None
+    assert (2*sqrt(k)).is_integer is None
+    assert (2*k**n).is_integer is None
 
     s = 2**2**2**Pow(2, 1000, evaluate=False)
     m = Mul(s, s, evaluate=False)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -388,6 +388,8 @@ def test_Mul_is_integer():
     assert (x*k*n).is_integer is None
     assert (e/2).is_integer is True
     assert (e**2/2).is_integer is True
+    assert (2/k).is_integer is None
+    assert (2/k**2).is_integer is None
     assert ((-1)**k*n).is_integer is True
     assert (3*k*e/2).is_integer is True
     assert (2*k*e/3).is_integer is None


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #20161

#### Brief description of what is fixed or changed
In Mul._eval_is_integer instead of using the function fraction the args are scanned for contributions to the numerator and denominator.


#### Other comments

This is a cherry-pick of #20322 pointed towards the `1.7` branch.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a few broken cases of expr.is_integer
<!-- END RELEASE NOTES -->