### PR TITLE
Increase Precision of FiniteSet.evalf()

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -8,7 +8,7 @@ from sympy.core.compatibility import iterable, ordered, reduce
 from sympy.core.containers import Tuple
 from sympy.core.decorators import (deprecated, sympify_method_args,
     sympify_return)
-from sympy.core.evalf import EvalfMixin
+from sympy.core.evalf import EvalfMixin, prec_to_dps
 from sympy.core.parameters import global_parameters
 from sympy.core.expr import Expr
 from sympy.core.logic import (FuzzyBool, fuzzy_bool, fuzzy_or, fuzzy_and,
@@ -1884,7 +1884,7 @@ class FiniteSet(Set, EvalfMixin):
         return (hash(self) - hash(other))
 
     def _eval_evalf(self, prec):
-        return FiniteSet(*[elem._evalf(prec) for elem in self])
+        return FiniteSet(*[elem.evalf(n=prec_to_dps(prec)) for elem in self])
 
     @property
     def _sorted_args(self):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1596,3 +1596,8 @@ def test_issue_20089():
     C = FiniteSet(FiniteSet(1, 2), FiniteSet(1), 1, 2)
     assert A.issubset(C)
     assert B.issubset(C)
+
+def test_issue_20379():
+    #https://github.com/sympy/sympy/issues/20379
+    x = pi - 3.14159265358979
+    assert FiniteSet(x).evalf(2) == FiniteSet(Float('3.23108914886517e-15', 2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20379

#### Brief description of what is fixed or changed
Earlier `.evalf()` precisions with `x` and `FiniteSet(x)` was different.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    * `.evalf()` precisions with `x` and `FiniteSet(x)`  is same now.
<!-- END RELEASE NOTES -->