### PR TITLE
maint(docs): use xelatex for latex docs build

### DIFF
--- a/doc/src/documentation-style-guide.rst
+++ b/doc/src/documentation-style-guide.rst
@@ -289,6 +289,17 @@ web browser.
 
 Open ``_build/html/index.html``.
 
+To build the LaTeX documentation, run::
+
+   cd doc
+
+   make latex
+   cd _build/latex
+   export LATEXMKOPTS='-xelatex -silent'
+   make all
+
+This will create a pdf file ``sympy-version.pdf``.
+
 3. Make a Contribution
 ----------------------
 

--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -114,7 +114,10 @@ def build_docs():
         make latex
 
         cd _build/latex
-        make
+        # Build with xelatex because pdflatex can not be used with fontspec.
+        # https://github.com/sympy/sympy/issues/20307
+        export LATEXMKOPTS='-xelatex -silent'
+        make all
         cp @(tarball_format['pdf-orig']) @("../../../dist/{pdf}".format(**tarball_format))
         cd ../../../
 


### PR DESCRIPTION
The PDF docs build was failing with
```
  ! Fatal fontspec error: "cannot-use-pdftex"
  !
  ! The fontspec package requires either XeTeX or LuaTeX.
```
https://github.com/sympy/sympy/issues/20307

This commit changes the release script to use xelatex instead of
pdflatex.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Same as #20309 but for master instead of the 1.7 branch.


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->