### PR TITLE
Fix pickling of print functions

### DIFF
--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -360,6 +360,12 @@ class _PrintFunction:
         self.__print_cls = print_cls
         update_wrapper(self, f)
 
+    def __reduce__(self):
+        # Since this is used as a decorator, it replaces the original function.
+        # The default pickling will try to pickle self.__wrapped__ and fail
+        # because the wrapped function can't be retrieved by name.
+        return self.__wrapped__.__qualname__
+
     def __repr__(self) -> str:
         return repr(self.__wrapped__)  # type:ignore
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2702,3 +2702,8 @@ def test_global_settings():
     # check we really did undo it
     assert inspect.signature(latex).parameters['imaginary_unit'].default == 'i'
     assert latex(I) == 'i'
+
+def test_pickleable():
+    # this tests that the _PrintFunction instance is pickleable
+    import pickle
+    assert pickle.loads(pickle.dumps(latex)) is latex


### PR DESCRIPTION
I doubt anyone really cares about this, but this used to work and I broke it in #20067

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

This no longer fails:
```pycon
>>> import pickle, sympy
>>> pickle.dumps(sympy.latex)
PicklingError: Can't pickle <function latex at 0x0000017F42170AF0>: it's not the same object as sympy.printing.latex.latex
```

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->