### PR TITLE
TRmorrie now takes powers of cos into account

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1206,8 +1206,8 @@ def TRmorrie(rv):
                             c.remove(cc)
                     new.append(newarg**take)
                 else:
-                    no.append(c.pop(0))
-            c[:] = no
+                    b = cos(c.pop(0)*a)
+                    other.append(b**coss[b])
 
         if new:
             rv = Mul(*(new + other + [

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1180,7 +1180,6 @@ def TRmorrie(rv):
         for a in args:
             c = args[a]
             c.sort()
-            no = []
             while c:
                 k = 0
                 cc = ci = c[0]

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -352,6 +352,9 @@ def test_TRmorrie():
     # issue 17063
     eq = cos(x)/cos(x/2)
     assert TRmorrie(eq) == eq
+    # issue #20430
+    eq = cos(x/2)*sin(x/2)*cos(x)**3
+    assert TRmorrie(eq) == sin(2*x)*cos(x)**2/4
 
 
 def test_TRpower():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #20430 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed

TRmorrie was ignoring the powers of cos(x) terms while doing the simplification cos(x)*cos(2*x)*...*cos(2**(k-1)*x) -> sin(2**k*x)/(2**k*sin(x))

Fixed this ( as suggested by @smichr in issue ) by passing the remainder cos term with it's powers to `other` list which appended it to final `rv` return value along with the sin() terms with appropriately.

#### Other comments

The only change made to the suggested code was that index 0 had to be passed explicitly to `c.pop()` . Otherwise it was failing certain cases.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

- simplify
  - TRmorrie now takes powers of cos terms into account

<!-- END RELEASE NOTES -->