### PR TITLE
Adding limits.py functionality: alternating sign expressions now computable

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -127,7 +127,18 @@ from sympy.utilities.misc import debug_decorator as debug
 from sympy.utilities.timeutils import timethis
 timeit = timethis('gruntz')
 
+class SignException(Exception):
+    """
+    Custom exception thrown in the rewrite() function if there exists a term
+    in the limit with a sign not equal to 1 or -1.
 
+    "sig" should be the sign of the problematic term.
+
+    See the Limit().doit function in limits.py for how this exception is dealt
+    with.
+    """
+    def __init__(self, sig):
+        self.sign = sig
 
 def compare(a, b, x):
     """Returns "<" if a<b, "=" for a == b, ">" for a>b"""
@@ -591,7 +602,7 @@ def rewrite(e, Omega, x, wsym):
     for g, _ in Omega:
         sig = sign(g.args[0], x)
         if sig != 1 and sig != -1:
-            raise NotImplementedError('Result depends on the sign of %s' % sig)
+            raise SignException(sig)
     if sig == 1:
         wsym = 1/wsym  # if g goes to oo, substitute 1/w
     # O2 is a list, which results by rewriting each item in Omega using "w"

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -8,7 +8,6 @@ from sympy.series.order import Order
 from sympy.simplify.ratsimp import ratsimp
 from sympy.simplify.simplify import together
 from .gruntz import gruntz, SignException
-#from sympy.series.limitseq import limitseq
 
 def limit(e, z, z0, dir="+"):
     """Computes the limit of ``e(z)`` at the point ``z0``.
@@ -316,7 +315,6 @@ class Limit(Expr):
                     return res
 
         l = None
-
         try:
             if str(dir) == '+-':
                 r = gruntz(e, z, z0, '+')
@@ -351,7 +349,7 @@ class Limit(Expr):
             from .limitseq import limit_seq
             try:
                 return limit_seq(e, z)
-            except:
+            except (NotImplementedError):
                 raise NotImplementedError('Result depends on the sign of %s' % sig)
             return r
         except (PoleError, ValueError):

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -12,7 +12,6 @@ from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.series.limits import Limit
 
 
 def difference_delta(expr, n=None, step=1):
@@ -105,8 +104,9 @@ def dominant(expr, n):
 
 
 def _limit_inf(expr, n):
+    from sympy.series.limits import Limit
     try:
-        return Limit(expr, n, S.Infinity).doit(deep=False)
+        return Limit(expr, n, S.Infinity).doit(deep=False, seq=True)
     except (NotImplementedError, PoleError):
         return None
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -377,7 +377,7 @@ class Order(Expr):
             ratio = powsimp(ratio, deep=True, combine='exp')
             for s in common_symbols:
                 from sympy.series.limits import Limit
-                l = Limit(ratio, s, point).doit(heuristics=False)
+                l = Limit(ratio, s, point).doit(heuristics=False,seq=False)
                 if not isinstance(l, Limit):
                     l = l != 0
                 else:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -18,7 +18,6 @@ from sympy.testing.pytest import XFAIL, raises
 from sympy.abc import x, y, z, k
 n = Symbol('n', integer=True, positive=True)
 
-
 def test_basic1():
     assert limit(x, x, oo) is oo
     assert limit(x, x, -oo) is -oo
@@ -77,7 +76,7 @@ def test_basic1():
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
     assert limit((1 + cos(x))**oo, x, 0) == Limit((cos(x) + 1)**oo, x, 0)
 
-
+    
 def test_basic2():
     assert limit(x**x, x, 0, dir="+") == 1
     assert limit((exp(x) - 1)/x, x, 0) == 1
@@ -381,11 +380,9 @@ def test_order_oo():
     assert Order(x)*oo != Order(1, x)
     assert limit(oo/(x**2 - 4), x, oo) is oo
 
-
 def test_issue_5436():
     raises(NotImplementedError, lambda: limit(exp(x*y), x, oo))
     raises(NotImplementedError, lambda: limit(exp(-x*y), x, oo))
-
 
 def test_Limit_dir():
     raises(TypeError, lambda: Limit(x, x, 0, dir=0))
@@ -895,3 +892,16 @@ def test_issue_19770():
     m = Symbol('m', nonzero=True)
     assert limit(cos(m*x), x, oo) == AccumBounds(-1, 1)
     assert limit(cos(m*x)/x, x, oo) == 0
+
+def test_issue_19823():
+    # Original issue
+    limit((-1)**n/n,n,oo)
+    # Other alternating sign tests modified from test_limitseq.py
+    assert limit((-1)**n/n**2, n, oo) == 0
+    assert limit((-2)**(n+1)/(n + 3**n), n, oo) == 0
+    assert limit((2*n + (-1)**n)/(n + 1), n, oo) == 2
+    assert limit(sin(pi*n), n, oo) == 0
+    assert limit(cos(2*pi*n), n, oo) == 1
+    assert limit((S.NegativeOne/5)**n, n, oo) == 0
+    assert limit((Rational(-1, 5))**n, n, oo) == 0
+

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -904,4 +904,3 @@ def test_issue_19823():
     assert limit(cos(2*pi*n), n, oo) == 1
     assert limit((S.NegativeOne/5)**n, n, oo) == 0
     assert limit((Rational(-1, 5))**n, n, oo) == 0
-

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -76,7 +76,7 @@ def test_basic1():
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
     assert limit((1 + cos(x))**oo, x, 0) == Limit((cos(x) + 1)**oo, x, 0)
 
-    
+
 def test_basic2():
     assert limit(x**x, x, 0, dir="+") == 1
     assert limit((exp(x) - 1)/x, x, 0) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. --> Fixes #19823


#### Brief description of what is fixed or changed
The issue mentions that `limit((-1)**n/n,n,oo)` throws a NotImplementedError exception due to a limitation of the Gruntz algorithm, but that calling `limit_seq` on the same expression seems to work fine. This is because the expression maps to real numbers only if n is an integer, which `limit()` does not consider. For limits similar to this (i.e. alternating sign limits), the limit module now reroutes the limit to be computed via the `limit_seq()` function so that it may produce the correct output without throwing an uncaught exception.

#### Other comments
The added test cases in `test_limits.py` are modifed versions of the alternating sign tests from `test_limitseq.py`.

`hints` now takes in a boolean value `seq` which stops the reroute process from being applied to limits already being computed as a sequence. (Lacking this, the golden ratio test in `test_limitseq.py` seems to recurse infinitely.)

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * gruntz: Added a custom exception SignException thrown if a term has a sign other than 1 or -1
  * limits: Added code to catch a SignException, reroute the limit to limit_seq()
<!-- END RELEASE NOTES -->