### PR TITLE
Make NonElementaryIntegerals work with evalf()

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1275,6 +1275,7 @@ def _create_evalf_table():
     from sympy.functions.elementary.piecewise import Piecewise
     from sympy.functions.elementary.trigonometric import atan, cos, sin
     from sympy.integrals.integrals import Integral
+    from sympy.integrals.risch import NonElementaryIntegral
     evalf_table = {
         Symbol: evalf_symbol,
         Dummy: evalf_symbol,
@@ -1310,6 +1311,7 @@ def _create_evalf_table():
         ceiling: evalf_ceiling,
 
         Integral: evalf_integral,
+        NonElementaryIntegral: evalf_integral,
         Sum: evalf_sum,
         Product: evalf_prod,
         Piecewise: evalf_piecewise,

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -182,7 +182,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     >>> from sympy.abc import _clash1
     >>> _clash1
-    {'C': C, 'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
+    {'O': O, 'Q': Q, 'N': N, 'I': I, 'E': E, 'S': S}
     >>> sympify('I & Q', _clash1)
     I & Q
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -182,7 +182,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     >>> from sympy.abc import _clash1
     >>> _clash1
-    {'O': O, 'Q': Q, 'N': N, 'I': I, 'E': E, 'S': S}
+    {'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
     >>> sympify('I & Q', _clash1)
     I & Q
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,7 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from sympy import (Poly, I, S, Function, log, symbols, exp, tan, sqrt,
     Symbol, Lambda, sin, Ne, Piecewise, factor, expand_log, cancel,
-    diff, pi, atan, Rational)
+    diff, pi, atan, Rational, Float)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -731,3 +731,7 @@ def test_DifferentialExtension_printing():
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})")
+
+def test_NonElementaryIntegral_evalf():
+    I = NonElementaryIntegral(x**x, (x, 0, 1))
+    assert I.evalf(10) == Float('0.783430510712134', 10)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20133

#### Brief description of what is fixed or changed
Added NonElementaryIntegeral to `evalf_table`. 

#### Other comments
Earlier `evalf` didn't work with NonElementary Integerals. Didn't use `_eval_evalf` because it doesn't handle `options` which would make it asymmetric with Integerals. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Make NonElementaryIntegerals work with .evalf()
<!-- END RELEASE NOTES -->