### PR TITLE
WIP: feat(polys): add inverse methods to DomainMatrix

### DIFF
--- a/sympy/polys/domainmatrix.py
+++ b/sympy/polys/domainmatrix.py
@@ -190,7 +190,7 @@ class DDM(list):
         for ai in ais[:-1]:
             bi = a @ (e*ai + bi)
         bi = bi + e*ais[-1]
-        ainv = bi * (-1/a0)
+        ainv = bi * (-a.domain.one/a0)
         return ainv
 
     def lu(a):
@@ -569,6 +569,8 @@ class DomainMatrix:
 
     def convert_to(self, K):
         Kold = self.domain
+        if K == Kold:
+            return self.from_ddm(self.rep.copy())
         new_rows = [[K.convert_from(e, Kold) for e in row] for row in self.rep]
         return DomainMatrix(new_rows, self.shape, K)
 

--- a/sympy/polys/domainmatrix.py
+++ b/sympy/polys/domainmatrix.py
@@ -314,9 +314,10 @@ def ddm_irref_score(a, score):
             if k == i or not ak[j]:
                 continue
             akj = ak[j]
-            ak[j] -= akj # ak[j] = zero
-            for l in range(j+1, n):
-                ak[l] -= akj * ai[l]
+            if akj:
+                ak[j] -= akj # ak[j] = zero
+                for l in range(j+1, n):
+                    ak[l] -= akj * ai[l]
 
         # next row
         pivots.append(j)
@@ -594,6 +595,10 @@ class DomainMatrix:
         from sympy.matrices.dense import MutableDenseMatrix
         rows_sympy = [[self.domain.to_sympy(e) for e in row] for row in self.rep]
         return MutableDenseMatrix(rows_sympy)
+
+    @classmethod
+    def eye(cls, n, domain):
+        return cls.from_ddm(DDM.eye(n, domain))
 
     def __repr__(self):
         rows_str = ['[%s]' % (', '.join(map(str, row))) for row in self.rep]

--- a/sympy/polys/tests/test_domainmatrix.py
+++ b/sympy/polys/tests/test_domainmatrix.py
@@ -389,49 +389,49 @@ def test_ddm_irref():
     A = []
     Ar = []
     pivots = []
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # Standard square case
     A = [[QQ(0), QQ(1)], [QQ(1), QQ(1)]]
     Ar = [[QQ(1), QQ(0)], [QQ(0), QQ(1)]]
     pivots = [0, 1]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # m < n  case
     A = [[QQ(1), QQ(2), QQ(1)], [QQ(3), QQ(4), QQ(1)]]
     Ar = [[QQ(1), QQ(0), QQ(-1)], [QQ(0), QQ(1), QQ(1)]]
     pivots = [0, 1]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # same m < n  but reversed
     A = [[QQ(3), QQ(4), QQ(1)], [QQ(1), QQ(2), QQ(1)]]
     Ar = [[QQ(1), QQ(0), QQ(-1)], [QQ(0), QQ(1), QQ(1)]]
     pivots = [0, 1]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # m > n case
     A = [[QQ(1), QQ(0)], [QQ(1), QQ(3)], [QQ(0), QQ(1)]]
     Ar = [[QQ(1), QQ(0)], [QQ(0), QQ(1)], [QQ(0), QQ(0)]]
     pivots = [0, 1]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # Example with missing pivot
     A = [[QQ(1), QQ(0), QQ(1)], [QQ(3), QQ(0), QQ(1)]]
     Ar = [[QQ(1), QQ(0), QQ(0)], [QQ(0), QQ(0), QQ(1)]]
     pivots = [0, 2]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
     # Example with missing pivot and no replacement
     A = [[QQ(0), QQ(1)], [QQ(0), QQ(2)], [QQ(1), QQ(0)]]
     Ar = [[QQ(1), QQ(0)], [QQ(0), QQ(1)], [QQ(0), QQ(0)]]
     pivots = [0, 1]
-    assert ddm_irref(A) == pivots
+    assert ddm_irref(A, QQ) == pivots
     assert A == Ar
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

See https://github.com/sympy/sympy/issues/19920#issuecomment-731878333

#### Brief description of what is fixed or changed

Adds some methods to DomainMatrix for interacting with scalars and also for computing the inverse of a matrix using the characteristic polynomial or LU decomposition. There are 3 methods for computing the inverse in this PR:
1. GE. Gaussian elimination (current method on master)
2. LU. Uses LU decomposition (seems more or less equivalent to GE)
3. charpoly. Uses the characteristic polynomial. Seems to be faster in most cases.

Usage:
```python
In [1]: from sympy.polys.domainmatrix import DomainMatrix                                                                         

In [2]: R1, R2, R3, R4, R5, R6, R7, R8, R9, R10 = symbols('R1, R2, R3, R4, R5, R6, R7, R8, R9, R10', positive=True) 
   ...:  
   ...: X = Matrix([[1/R9 + 1/R8 + 1/R5 + 1/R4 + 1/R1, 0, -1/R8, 0, 0, -1/R5, 1], 
   ...:                   [0, 1/R6 + 1/R3, -1/R3, 0, 0, 0, 0], 
   ...:                   [-1/R8, -1/R3, 1/R8 + 1/R3 + 1/R10, -1/R10, 0, 0, -1], 
   ...:                   [0, 0, -1/R10, 1/R2 + 1/R10, -1/R2, 0, 0], 
   ...:                   [0, 0, 0, -1/R2, 1/R7 + 1/R2, -1/R7, 0], 
   ...:                   [-1/R5, 0, 0, 0, -1/R7, 1/R7 + 1/R5, 0],  
   ...:                   [1, 0, -1, 0, 0, 0, 0]])                                                                                

In [3]: M = DomainMatrix.from_Matrix(X)                                                                                           

In [4]: %time Minv = M.inv(method='charpoly')                                                                                     
CPU times: user 424 ms, sys: 3.3 ms, total: 428 ms
Wall time: 426 ms

In [5]: %time Minv = M.inv()  # current DomainMatrix.inv method                                                                                                    
CPU times: user 3min 17s, sys: 1.64 s, total: 3min 19s
Wall time: 3min 25s

In [6]: %time Xinv = X.inv() # Matrix.inv method (takes longer)                                                                                       
^C---------------------------------------------------------------------------
KeyboardInterrupt
```

#### Other comments

I'm not sure about the API here. I'm just putting this up for now but further work is needed.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->