### PR TITLE
Fix parse_latex sqrt evaluation

### DIFF
--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -482,9 +482,9 @@ def convert_func(func):
         expr = convert_expr(func.base)
         if func.root:
             r = convert_expr(func.root)
-            return sympy.root(expr, r)
+            return sympy.root(expr, r, evaluate=False)
         else:
-            return sympy.sqrt(expr)
+            return sympy.sqrt(expr, evaluate=False)
     elif func.FUNC_SUM():
         return handle_sum_or_prod(func, "summation")
     elif func.FUNC_PROD():

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -6,7 +6,7 @@ from sympy import (
     csc, sec, Limit, oo, Derivative, Integral, factorial,
     sqrt, root, StrictLessThan, LessThan, StrictGreaterThan,
     GreaterThan, Sum, Product, E, log, tan, Function, binomial, exp,
-    floor, ceiling, Unequality, Integer
+    floor, ceiling, Unequality
 )
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum.state import Bra, Ket

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -6,7 +6,7 @@ from sympy import (
     csc, sec, Limit, oo, Derivative, Integral, factorial,
     sqrt, root, StrictLessThan, LessThan, StrictGreaterThan,
     GreaterThan, Sum, Product, E, log, tan, Function, binomial, exp,
-    floor, ceiling, Unequality
+    floor, ceiling, Unequality, Integer
 )
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum.state import Bra, Ket
@@ -32,6 +32,10 @@ def _Mul(a, b):
 
 def _Pow(a, b):
     return Pow(a, b, evaluate=False)
+
+
+def _Sqrt(a):
+    return sqrt(a, evaluate=False)
 
 
 def _Abs(a):
@@ -87,10 +91,10 @@ GOOD_PAIRS = [
     ("\\left(  x + y\\right ) z", _Mul(_Add(x, y), z)),
     ("\\left[x + y\\right] z", _Mul(_Add(x, y), z)),
     ("\\left\\{x + y\\right\\} z", _Mul(_Add(x, y), z)),
-    ("1+1", Add(1, 1, evaluate=False)),
-    ("0+1", Add(0, 1, evaluate=False)),
-    ("1*2", Mul(1, 2, evaluate=False)),
-    ("0*1", Mul(0, 1, evaluate=False)),
+    ("1+1", _Add(1, 1)),
+    ("0+1", _Add(0, 1)),
+    ("1*2", _Mul(1, 2)),
+    ("0*1", _Mul(0, 1)),
     ("x = y", Eq(x, y)),
     ("x \\neq y", Ne(x, y)),
     ("x < y", Lt(x, y)),
@@ -178,6 +182,7 @@ GOOD_PAIRS = [
     ("\\sqrt[3]{\\sin x}", root(sin(x), 3)),
     ("\\sqrt[y]{\\sin x}", root(sin(x), y)),
     ("\\sqrt[\\theta]{\\sin x}", root(sin(x), theta)),
+    ("\\sqrt{\\frac{12}{6}}", _Sqrt(_Mul(12, _Pow(6, -1)))),
     ("x < y", StrictLessThan(x, y)),
     ("x \\leq y", LessThan(x, y)),
     ("x > y", StrictGreaterThan(x, y)),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #20319 

#### Brief description of what is fixed or changed
The latex parser does not evaluate `sqrt` expressions anymore - i.e. the expression `"\\sqrt{\\frac{12}{6}}"` is parsed into `sqrt(12/6)` and not into `sqrt(2)` as it used to.

#### Other comments

Added a test for coverage.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Latex parser does not evaluate `sqrt` expressions anymore.
<!-- END RELEASE NOTES -->