### PR TITLE
Removed redundant methods from DiscreteMarkovChain

### DIFF
--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -918,48 +918,6 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         """
         return self.args[2]
 
-    def _transient2transient(self):
-        """
-        Computes the one step probabilities of transient
-        states to transient states. Used in finding
-        fundamental matrix, absorbing probabilities.
-        """
-        trans_probs = self.transition_probabilities
-        if not isinstance(trans_probs, ImmutableMatrix):
-            return None
-
-        m = trans_probs.shape[0]
-        trans_states = [i for i in range(m) if trans_probs[i, i] != 1]
-        t2t = [[trans_probs[si, sj] for sj in trans_states] for si in trans_states]
-
-        return ImmutableMatrix(t2t)
-
-    def _transient2absorbing(self):
-        """
-        Computes the one step probabilities of transient
-        states to absorbing states. Used in finding
-        fundamental matrix, absorbing probabilities.
-        """
-        trans_probs = self.transition_probabilities
-        if not isinstance(trans_probs, ImmutableMatrix):
-            return None
-
-        m, trans_states, absorb_states = \
-            trans_probs.shape[0], [], []
-        for i in range(m):
-            if trans_probs[i, i] == 1:
-                absorb_states.append(i)
-            else:
-                trans_states.append(i)
-
-        if not absorb_states or not trans_states:
-            return None
-
-        t2a = [[trans_probs[si, sj] for sj in absorb_states]
-                for si in trans_states]
-
-        return ImmutableMatrix(t2a)
-
     def communication_classes(self) -> tList[tTuple[tList[Basic], Boolean, Integer]]:
         """
         Returns the list of communication classes that partition

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1055,11 +1055,11 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         return sympify(list(zip(classes, recurrence, periods)))
 
     def fundamental_matrix(self):
-        Q = self._transient2transient()
+        _, _, _, Q = self.decompose()
         if Q == None:
             return None
         I = eye(Q.shape[0])
-        if (I - Q).det() == 0:
+        if Q.shape[0]*Q.shape[1] == 0 or (I - Q).det() == 0:
             raise ValueError("Fundamental matrix doesn't exists.")
         return ImmutableMatrix((I - Q).inv().tolist())
 
@@ -1070,9 +1070,9 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
         probability of Markov chain being absorbed
         in state j starting from state i.
         """
-        R = self._transient2absorbing()
+        _, _, R, _ = self.decompose()
         N = self.fundamental_matrix()
-        if R == None or N == None:
+        if R is None or N is None:
             return None
         return N*R
 

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -79,8 +79,6 @@ def test_DiscreteMarkovChain():
     TS = MatrixSymbol('T', 3, 3)
     Y = DiscreteMarkovChain("Y", [0, 1, 2], T)
     YS = DiscreteMarkovChain("Y", ['One', 'Two', 3], TS)
-    assert YS._transient2transient() == None
-    assert YS._transient2absorbing() == None
     assert Y.joint_distribution(1, Y[2], 3) == JointDistribution(Y[1], Y[2], Y[3])
     raises(ValueError, lambda: Y.joint_distribution(Y[1].symbol, Y[2].symbol))
     assert P(Eq(Y[3], 2), Eq(Y[1], 1)).round(2) == Float(0.36, 2)
@@ -119,10 +117,9 @@ def test_DiscreteMarkovChain():
 
     # testing properties of Markov chain
     TO2 = Matrix([[S.One, 0, 0],[Rational(1, 3), Rational(1, 3), Rational(1, 3)],[0, Rational(1, 4), Rational(3, 4)]])
-    TO3 = Matrix([[Rational(1, 4), Rational(3, 4), 0],[Rational(1, 3), Rational(1, 3), Rational(1, 3)],[0, Rational(1, 4), Rational(3, 4)]])
+    TO3 = Matrix([[Rational(1, 4), Rational(3, 4), 0],[Rational(1, 3), Rational(1, 3), Rational(1, 3)], [0, Rational(1, 4), Rational(3, 4)]])
     Y2 = DiscreteMarkovChain('Y', trans_probs=TO2)
     Y3 = DiscreteMarkovChain('Y', trans_probs=TO3)
-    assert Y3._transient2absorbing() == None
     raises (ValueError, lambda: Y3.fundamental_matrix())
     assert Y2.is_absorbing_chain() == True
     assert Y3.is_absorbing_chain() == False
@@ -142,8 +139,6 @@ def test_DiscreteMarkovChain():
     assert Y5.stationary_distribution(condition_set=True).subs(TS1, TO4).contains(w).doit() == S.true
     TO6 = Matrix([[S.One, 0, 0, 0, 0],[S.Half, 0, S.Half, 0, 0],[0, S.Half, 0, S.Half, 0], [0, 0, S.Half, 0, S.Half], [0, 0, 0, 0, 1]])
     Y6 = DiscreteMarkovChain('Y', trans_probs=TO6)
-    assert Y6._transient2absorbing() == ImmutableMatrix([[S.Half, 0], [0, 0], [0, S.Half]])
-    assert Y6._transient2transient() == ImmutableMatrix([[0, S.Half, 0], [S.Half, 0, S.Half], [0, S.Half, 0]])
     assert Y6.fundamental_matrix() == ImmutableMatrix([[Rational(3, 2), S.One, S.Half], [S.One, S(2), S.One], [S.Half, S.One, Rational(3, 2)]])
     assert Y6.absorbing_probabilities() == ImmutableMatrix([[Rational(3, 4), Rational(1, 4)], [S.Half, S.Half], [Rational(1, 4), Rational(3, 4)]])
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
`DiscreteMarkovChain._transient2absorbing` and `DiscreteMarkovChain._transient2transient` have been replaced with `DiscreteMarkovChain.decompose`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->