### PR TITLE
added boilerplate index method for FracField

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -155,7 +155,7 @@ class FracField(DefaultPrinting):
         if isinstance(gen, self.dtype):
             return self.ring.index(gen.to_poly())
         else:
-            raise ValueError("expected a %, got %s instead" % (self.dtype,gen,))
+            raise ValueError("expected a %s, got %s instead" % (self.dtype,gen))
 
     def __eq__(self, other):
         return isinstance(other, FracField) and \

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -151,6 +151,14 @@ class FracField(DefaultPrinting):
     def __hash__(self):
         return self._hash
 
+    def index(self, gen):
+        if isinstance(gen, self.dtype):
+            return self.ring.index(gen.to_poly())
+        elif isinstance(gen, self.ring.dtype) or isinstance(gen, int) or isinstance(gen, str):
+            return self.ring.index(gen)
+        else:
+            raise ValueError("expected a polynomial generator, an integer, a string or None, got %s" % gen)
+
     def __eq__(self, other):
         return isinstance(other, FracField) and \
             (self.symbols, self.ngens, self.domain, self.order) == \

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -154,10 +154,8 @@ class FracField(DefaultPrinting):
     def index(self, gen):
         if isinstance(gen, self.dtype):
             return self.ring.index(gen.to_poly())
-        elif isinstance(gen, self.ring.dtype) or isinstance(gen, int) or isinstance(gen, str):
-            return self.ring.index(gen)
         else:
-            raise ValueError("expected a polynomial generator, an integer, a string or None, got %s" % gen)
+            raise ValueError("expected a %, got %s instead" % (self.dtype,gen,))
 
     def __eq__(self, other):
         return isinstance(other, FracField) and \

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -354,7 +354,7 @@ def test_FracField_index():
     F, x, y, z = field('x y z', QQ)
     assert F.index(x) == 0
     assert F.index(y) == 1
-    assert F.index(x.to_poly()) == 0
 
+    raises(ValueError, lambda: F.index(1))
     raises(ValueError, lambda: F.index(a))
     pass

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -348,3 +348,13 @@ def test_FracElement_subs():
 
 def test_FracElement_compose():
     pass
+
+def test_FracField_index():
+    a = symbols("a")
+    F, x, y, z = field('x y z', QQ)
+    assert F.index(x) == 0
+    assert F.index(y) == 1
+    assert F.index(x.to_poly()) == 0
+
+    raises(ValueError, lambda: F.index(a))
+    pass


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #20501 

#### Brief description of what is fixed or changed

PolyRing has an index method but FracField does not. This PR adds an index method to the FracField class.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * added boilerplate index method for FracField
<!-- END RELEASE NOTES -->