### PR TITLE
add checking if modules is an empty collection in lambdify

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -737,7 +737,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     from sympy.core.symbol import Symbol
 
     # If the user hasn't specified any modules, use what is available.
-    if modules is None:
+    if modules is None or hasattr(modules, '__len__') and len(modules) == 0:
         try:
             _import("scipy")
         except ImportError:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -737,7 +737,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     from sympy.core.symbol import Symbol
 
     # If the user hasn't specified any modules, use what is available.
-    if modules is None or hasattr(modules, '__len__') and len(modules) == 0:
+    if not modules:
         try:
             _import("scipy")
         except ImportError:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1342,5 +1342,4 @@ def test_empty_modules():
 
     no_modules = lambdify([x, y], expr)
     empty_modules = lambdify([x, y], expr, modules=[])
-    
     assert no_modules(3, 7) == empty_modules(3, 7)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -10,7 +10,7 @@ from sympy import (
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk, S, beta,
-    fresnelc, fresnels)
+    fresnelc, fresnels, Mod)
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, log10, hypot
 from sympy.codegen.numpy_nodes import logaddexp, logaddexp2
 from sympy.codegen.scipy_nodes import cosm1
@@ -1335,3 +1335,12 @@ def test_scipy_special_math():
 
     cm1 = lambdify((x,), cosm1(x), modules='scipy')
     assert abs(cm1(1e-20) + 5e-41) < 1e-200
+
+def test_empty_modules():
+    x, y = symbols('x y')
+    expr = -Mod(x, y)
+
+    no_modules = lambdify([x, y], expr)
+    empty_modules = lambdify([x, y], expr, modules=[])
+    
+    assert no_modules(3, 7) == empty_modules(3, 7)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #17737 


#### Brief description of what is fixed or changed
Added checking is `modules` is a collection with length 0.
Now `lambdify([x, y], expr, modules=[])` behaves same way as `lambdify([x, y], expr)`

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * fix issue with incorrect behaviour of `Mod` when `modules = []`
<!-- END RELEASE NOTES -->