### PR TITLE
symbols: faster creation of functions sharing parameters

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -5,7 +5,7 @@ from .sympify import sympify
 from .singleton import S
 from .expr import Expr, AtomicExpr
 from .cache import cacheit
-from .function import FunctionClass
+from .function import FunctionClass, Function
 from sympy.core.logic import fuzzy_bool
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.iterables import cartes, sift
@@ -657,6 +657,15 @@ def symbols(names, *, cls=Symbol, **args):
         >>> type(_[0])
         <class 'sympy.core.function.UndefinedFunction'>
 
+    If several functions share the same arguments, it is convenient 
+    to construct them at once as in (note that cls=Function is not needed anymore)::
+
+        >>> x,y,t = symbols('x,y,t')
+        >>> symbols('f,g,h', function_of=t)
+        (f(t), g(t), h(t))
+        >>> symbols('f,g,h', function_of=(x,y))
+        (f(x,y), g(x,y), h(x,y))
+
     """
     result = []
 
@@ -694,6 +703,13 @@ def symbols(names, *, cls=Symbol, **args):
             names[i: i + 1] = names[i].split()
 
         seq = args.pop('seq', as_seq)
+        
+        # check & prepare function_of
+        function_of = args.pop('function_of',None)
+        if function_of is not None:
+            if not isinstance(function_of,tuple): 
+                function_of=(function_of,)
+            cls = Function  # force class to Function
 
         for name in names:
             if not name:
@@ -701,6 +717,7 @@ def symbols(names, *, cls=Symbol, **args):
 
             if ':' not in name:
                 symbol = cls(literal(name), **args)
+                if function_of is not None: symbol=symbol(*function_of)
                 result.append(symbol)
                 continue
 
@@ -736,10 +753,10 @@ def symbols(names, *, cls=Symbol, **args):
                     names = split[0]
                 else:
                     names = [''.join(s) for s in cartes(*split)]
-                if literals:
-                    result.extend([cls(literal(s), **args) for s in names])
-                else:
-                    result.extend([cls(s, **args) for s in names])
+                result_tmp=[cls(literal(s) if literals else s, **args) for s in names]
+                if function_of is not None:
+                    result_tmp[:]=[f(*function_of) for f in result_tmp]
+                result.extend(result_tmp)
 
         if not seq and len(result) <= 1:
             if not result:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -664,7 +664,7 @@ def symbols(names, *, cls=Symbol, **args):
         >>> symbols('f,g,h', function_of=t)
         (f(t), g(t), h(t))
         >>> symbols('f,g,h', function_of=(x,y))
-        (f(x,y), g(x,y), h(x,y))
+        (f(x, y), g(x, y), h(x, y))
 
     """
     result = []

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -657,7 +657,7 @@ def symbols(names, *, cls=Symbol, **args):
         >>> type(_[0])
         <class 'sympy.core.function.UndefinedFunction'>
 
-    If several functions share the same arguments, it is convenient 
+    If several functions share the same arguments, it is convenient
     to construct them at once as in (note that cls=Function is not needed anymore)::
 
         >>> x,y,t = symbols('x,y,t')
@@ -703,11 +703,11 @@ def symbols(names, *, cls=Symbol, **args):
             names[i: i + 1] = names[i].split()
 
         seq = args.pop('seq', as_seq)
-        
+
         # check & prepare function_of
         function_of = args.pop('function_of',None)
         if function_of is not None:
-            if not isinstance(function_of,tuple): 
+            if not isinstance(function_of,tuple):
                 function_of=(function_of,)
             cls = Function  # force class to Function
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -387,3 +387,10 @@ def test_disambiguate():
     assert disambiguate(*t7) == (y*y_1, y_1)
     assert disambiguate(Dummy('x_1'), Dummy('x_1')
         ) == (x_1, Symbol('x_1_1'))
+
+
+def test_function_of_20519():
+    from sympy.core.function import Function
+    x, y = symbols('x y')
+    assert symbols('f',function_of=x)     == symbols('f',cls=Function)(x)
+    assert symbols('f',function_of=(x,y)) == symbols('f',cls=Function)(x,y)


### PR DESCRIPTION
Add argument 'function_of' to sympy.symbols

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #20519 

#### Brief description of what is fixed or changed
If several functions share the same arguments, it is currently awkward (too long) to create them all.
Here is a proposal to construct them at once as in (note that cls=Function is not needed anymore):
It uses an additional option 'function_of'

> x,y,t = symbols('x,y,t')
> symbols('f,g,h', function_of=t)
(f(t), g(t), h(t))
> symbols('f,g,h', function_of=(x,y))
(f(x,y), g(x,y), h(x,y))

#### Other comments

* Argument symbols must be created prior to using `function_of`.
* It also works with numbers or function as argument. 
* There is not type checking on given arguments yet, it should be a symbol or a tuple of symbols.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * Faster creation of functions sharing parameters adding 'function_of' as argument of symbols.
<!-- END RELEASE NOTES -->