### PR TITLE
solved "summation introduces spurious symbols "

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1161,14 +1161,11 @@ def eval_sum_symbolic(f, limits):
             if e_exp is not None:
                 e.update(e_exp)
 
-        if e is not None:
-            p = (c1**c3).subs(e)
-            q = (c1**c2).subs(e)
-
-            r = p*(q**a - q**(b + 1))/(1 - q)
-            l = p*(b - a + 1)
-
-            return Piecewise((l, Eq(q, S.One)), (r, True))
+                p = (c1**c3).subs(e)
+                q = (c1**c2).subs(e)
+                r = p*(q**a - q**(b + 1))/(1 - q)
+                l = p*(b - a + 1)
+                return Piecewise((l, Eq(q, S.One)), (r, True))
 
         r = gosper_sum(f, (i, a, b))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1354,6 +1354,10 @@ def test_issue_19379():
     assert Sum(factorial(n)/factorial(n + 2), (n, 1, oo)).is_convergent() is S.true
 
 
+def test_issue_20777():
+    assert Sum(exp(x*sin(n/m)), (n, 1, m)).doit() == Sum(exp(x*sin(n/m)), (n, 1, m))
+
+
 def test__dummy_with_inherited_properties_concrete():
     x = Symbol('x')
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes https://github.com/sympy/sympy/issues/20523
Closes #20777 
Closes #20778

#### Brief description of what is fixed or changed
Here we first attempt powsimp on f for easier matching with the exponential pattern, and attempt expansion on the exponent for easier matching with the linear pattern. The change was made alongside the update .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
    * A bug leading to incorrect evaluation of a summation of an exponential function was fixed.
<!-- END RELEASE NOTES -->