### PR TITLE
Enable numerical evaluation of complex valued implemented functions

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -39,7 +39,7 @@ from .cache import cacheit
 from .compatibility import iterable, is_sequence, as_int, ordered, Iterable
 from .decorators import _sympifyit
 from .expr import Expr, AtomicExpr
-from .numbers import Rational, Float
+from .numbers import Rational, Float, I
 from .operations import LatticeOp
 from .rules import Transform
 from .singleton import S
@@ -559,14 +559,14 @@ class Function(Application, Expr):
                 cast_to_complex = not self.is_real
             else:
                 cast_to_complex = False
-            from mpmath import mpf, mpc, workdps
+            from mpmath import re, im, workdps
             try:
                 num = imp(*[i.evalf(prec) for i in self.args])
                 with workdps(prec):
                     if cast_to_complex:
-                        return sympify(mpc(num))
+                        return Float(re(num), prec) + Float(im(num), prec) * I
                     else:
-                        return sympify(mpf(num))
+                        return Float(num, prec)
             except (TypeError, ValueError):
                 return None
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -555,8 +555,18 @@ class Function(Application, Expr):
             imp = getattr(self, '_imp_', None)
             if imp is None:
                 return None
+            if isinstance(self.is_real, bool):
+                cast_to_complex = not self.is_real
+            else:
+                cast_to_complex = False
+            from mpmath import mpf, mpc, workdps
             try:
-                return Float(imp(*[i.evalf(prec) for i in self.args]), prec)
+                num = imp(*[i.evalf(prec) for i in self.args])
+                with workdps(prec):
+                    if cast_to_complex:
+                        return sympify(mpc(num))
+                    else:
+                        return sympify(mpf(num))
             except (TypeError, ValueError):
                 return None
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -346,6 +346,14 @@ def test_implemented_function_evalf():
     assert fc(x).evalf() == fc(x)
     del fc._imp_    # XXX: due to caching _imp_ would influence all other tests
 
+    # this one is more involved then it looks like
+    # since mpf(np.int64(1)) raises "TypeError: cannot create mpf from 1"
+    fi = Function('fi', real=False)
+    fi = implemented_function(fi, lambda x: 1)
+    assert conjugate(fi(1)).evalf() == 1
+    assert fi(x).evalf() == 1
+    del fi._imp_    # XXX: due to caching _imp_ would influence all other tests
+
 
 def test_evaluate_false():
     for no in [0, False]:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factor,
     factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
-    integrate, log, Mul, N, oo, pi, Pow, product, Product,
+    integrate, log, Mul, N, oo, pi, Pow, product, Product, conjugate,
     Rational, S, Sum, simplify, sin, sqrt, sstr, sympify, Symbol, Max, nfloat, cosh, acosh, acos)
 from sympy.core.numbers import comp
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
@@ -339,6 +339,12 @@ def test_implemented_function_evalf():
     f = implemented_function(Function('sin'), lambda x: x + 1)
     assert f(2).evalf() != sin(2)
     del f._imp_     # XXX: due to caching _imp_ would influence all other tests
+
+    fc = Function('fc', real=False)
+    fc = implemented_function(fc, lambda x: x + 1j)
+    assert conjugate(fc(2)).evalf() == 2-1j
+    assert fc(x).evalf() == fc(x)
+    del fc._imp_    # XXX: due to caching _imp_ would influence all other tests
 
 
 def test_evaluate_false():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Consider the the following implemented function `f_imp`
```
def f_num(x): return x + 1
f_sym = sp.Function("f", real=False)
f_imp = implemented_function(f_sym, f_num)
```

At the moment it is only possible to get a numerical value if the return value of `f_num` is real valued, for example
```
print(f_imp(1).evalf())
```

With this pr also
```
print(f_imp(1j).evalf())
```
provides the correct complex value.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Enable numerical evaluation of complex valued implemented functions
<!-- END RELEASE NOTES -->