### PR TITLE
Introduce kind

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -549,3 +549,22 @@ ordered
 ^^^^^^^
 
 .. autofunction:: sympy.core.compatibility.ordered
+
+kind
+----
+.. module:: sympy.core.kind
+
+Kind
+^^^^
+.. autoclass:: Kind
+   :members:
+
+NumberKind
+^^^^^^^^^^
+.. autoclass:: NumberKind
+   :members:
+
+BooleanKind
+^^^^^^^^^^^
+.. autoclass:: BooleanKind
+   :members:

--- a/doc/src/special_topics/classification.rst
+++ b/doc/src/special_topics/classification.rst
@@ -1,0 +1,100 @@
+===============================
+Classification of SymPy objects
+===============================
+
+There are several ways of how SymPy object is classified.
+
+class
+=====
+
+Like any other object in Python, SymPy expression is an instance of class. You can
+get the class of the object with built-in `type()` function, and check it with
+`isinstance()` function.
+
+    >>> from sympy import Add
+    >>> from sympy.abc import x,y
+    >>> type(x + y)
+    <class 'sympy.core.add.Add'>
+    >>> isinstance(x + y, Add)
+    True
+
+Classes represent only the programmatic structures of the objects, and does not
+distinguish the mathematical difference between them. For example, the integral
+of number and the integral of matrix both have the class `Integral`, although the
+former is number and the latter is matrix.
+
+    >>> from sympy import MatrixSymbol, Integral
+    >>> A = MatrixSymbol('A', 2, 2)
+    >>> type(Integral(1, x))
+    <class 'sympy.integrals.integrals.Integral'>
+    >>> type(Integral(A, x))
+    <class 'sympy.integrals.integrals.Integral'>
+
+kind
+====
+
+Kind indicates what mathematical object does the expression represent.
+You can retrieve the kind of expression with `.kind` property.
+
+    >>> Integral(1, x).kind
+    NumberKind
+    >>> Integral(A, x).kind
+    MatrixKind(NumberKind)
+
+This result shows that `Integral(1, x)` is number, and `Integral(A, x)` is matrix with number element.
+
+Since the class cannot guarantee to catch this difference, kind of the object is very important.
+For example, if you are building a function or class that is designed to work only for
+numbers, you should consider filtering the arguments with `NumberKind` so that the user
+does not naively pass unsupported objects such as `Integral(A, x)`.
+
+For the performance, set theory is not implemented in kind system. For example,
+
+    `NumberKind` does not distinguish the real number and complex number.
+
+    >>> from sympy import pi, I
+    >>> pi.kind
+    NumberKind
+    >>> I.kind
+    NumberKind
+
+    SymPy's `Set` and kind are not compatible.
+
+    >>> from sympy import S
+    >>> from sympy.core.kind import NumberKind
+    >>> S.Reals.is_subset(S.Complexes)
+    True
+    >>> S.Reals.is_subset(NumberKind)
+    Traceback (most recent call last):
+    ...
+    ValueError: Unknown argument 'NumberKind'
+
+sets and assumptions
+====================
+
+If you want to classify the object in strictly mathematical way, you may need
+SymPy's sets and assumptions.
+
+    >>> from sympy import ask, Q
+    >>> S.One in S.Reals
+    True
+    >>> ask(Q.even(2*x), Q.odd(x))
+    True
+
+See `assumptions` module and `sets` module for more information.
+
+func
+====
+
+`func` is the head of the object, and it is used to recurse over the expression tree.
+
+    >>> Add(x + y).func
+    <class 'sympy.core.add.Add'>
+    >>> Add(x + x).func
+    <class 'sympy.core.mul.Mul'>
+    >>> Q.even(x).func
+    Q.even
+
+As you can see, resulting head may be a class or another SymPy object.
+Keep this in mind when you classify the object with this attribute.
+See :ref:`tutorial-manipulation` for detailed information.

--- a/doc/src/special_topics/index.rst
+++ b/doc/src/special_topics/index.rst
@@ -9,3 +9,4 @@
 
    intro.rst
    finite_diff_derivatives.rst
+   classification.rst

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -201,6 +201,10 @@ class ExprWithLimits(Expr):
         return self._args[0]
 
     @property
+    def kind(self):
+        return self.function.kind
+
+    @property
     def limits(self):
         """Return the limits of expression.
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from functools import cmp_to_key, reduce
+from operator import attrgetter
 from .basic import Basic
 from .compatibility import is_sequence
 from .parameters import global_parameters
@@ -9,6 +10,7 @@ from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
+from .kind import UndefinedKind
 
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)
@@ -65,6 +67,7 @@ def _unevaluated_Add(*args):
     if co:
         newargs.insert(0, co)
     return Add._from_args(newargs)
+
 
 class Add(Expr, AssocOp):
 
@@ -291,6 +294,19 @@ class Add(Expr, AssocOp):
     def class_key(cls):
         """Nice order of classes"""
         return 3, 1, cls.__name__
+
+    @property
+    def kind(self):
+        k = attrgetter('kind')
+        kinds = map(k, self.args)
+        kinds = frozenset(kinds)
+        if len(kinds) != 1:
+            # Since addition is group operator, kind must be same.
+            # We know that this is unexpected signature, so return this.
+            result = UndefinedKind
+        else:
+            result, = kinds
+        return result
 
     def as_coefficients_dict(a):
         """Return a dictionary mapping terms to their Rational coefficient.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,6 +8,7 @@ from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import iterable, ordered
 from .singleton import S
+from .kind import UndefinedKind
 from ._print_helpers import Printable
 
 from inspect import getmro
@@ -106,6 +107,8 @@ class Basic(Printable, metaclass=ManagedProperties):
     is_Point = False
     is_MatAdd = False
     is_MatMul = False
+
+    kind = UndefinedKind
 
     def __new__(cls, *args):
         obj = object.__new__(cls)

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -19,6 +19,10 @@ the type of itself.
 
 This module defines basic kinds for core objects. Other kinds such as
 ``ArrayKind`` or ``MatrixKind`` can be found in corresponding modules.
+
+.. notes::
+       This approach is experimental, and can be replaced or deleted in the future.
+       See https://github.com/sympy/sympy/pull/20549.
 """
 
 
@@ -59,6 +63,7 @@ class Kind(object, metaclass=KindMeta):
 
     ``Kind`` behaves in singleton-like fashion. Same signature will
     return the same object.
+
     """
     def __new__(cls, *args):
         if args in cls._inst:

--- a/sympy/core/kind.py
+++ b/sympy/core/kind.py
@@ -1,0 +1,175 @@
+"""
+Module to efficiently partition SymPy objects.
+
+This system is introduced because class of SymPy object does not always
+represent the mathematical classification of the entity. For example,
+``Integral(1, x)`` and ``Integral(Matrix([1,2]), x)`` are both instance
+of ``Integral`` class. However the former is number and the latter is
+matrix.
+
+One way to resolve this is defining subclass for each mathematical type,
+such as ``MatAdd`` for the addition between matrices. Basic algebraic
+operation such as addition or multiplication take this approach, but
+defining every class for every mathematical object is not scalable.
+
+Therefore, we define the "kind" of the object and let the expression
+infer the kind of itself from its arguments. Function and class can
+filter the arguments by their kind, and behave differently according to
+the type of itself.
+
+This module defines basic kinds for core objects. Other kinds such as
+``ArrayKind`` or ``MatrixKind`` can be found in corresponding modules.
+"""
+
+
+class KindMeta(type):
+    """
+    Metaclass for ``Kind``.
+
+    Assigns empty ``dict`` as class attribute ``_inst`` for every class,
+    in order to endow singleton-like behavior.
+    """
+    def __new__(cls, clsname, bases, dct):
+        dct['_inst'] = {}
+        return super().__new__(cls, clsname, bases, dct)
+
+
+class Kind(object, metaclass=KindMeta):
+    """
+    Base class for kinds.
+
+    Kind of the object represents the mathematical classification that
+    the entity falls into. It is expected that functions and classes
+    recognize and filter the argument by its kind.
+
+    Kind of every object must be carefully selected so that it shows the
+    intention of design. Expressions may have different kind according
+    to the kind of its arguements. For example, arguements of ``Add``
+    must have common kind since addition is group operator, and the
+    resulting ``Add()`` has the same kind.
+
+    For the performance, each kind is as broad as possible and is not
+    based on set theory. For example, ``NumberKind`` includes not only
+    complex number but expression containing ``S.Infinity`` or ``S.NaN``
+    which are not strictly number.
+
+    Kind may have arguments as parameter. For example, ``MatrixKind()``
+    may be constructed with one element which represents the kind of its
+    elements.
+
+    ``Kind`` behaves in singleton-like fashion. Same signature will
+    return the same object.
+    """
+    def __new__(cls, *args):
+        if args in cls._inst:
+            inst = cls._inst[args]
+        else:
+            inst = super().__new__(cls)
+            cls._inst[args] = inst
+        return inst
+
+
+class UndefinedKind(Kind):
+    """
+    Default kind for all SymPy object. If the kind is not defined for
+    the object, or if the object cannot infer the kind from its
+    arguments, this will be returned.
+
+    Examples
+    ========
+
+    >>> from sympy import Expr
+    >>> Expr().kind
+    UndefinedKind
+    """
+    def __new__(cls):
+        return super().__new__(cls)
+
+    def __repr__(self):
+        return "UndefinedKind"
+
+UndefinedKind = UndefinedKind()
+
+
+class NumberKind(Kind):
+    """
+    Kind for all numeric object.
+
+    This kind represents every number, including complex numbers,
+    infinity and ``S.NaN``. Other objects such as quaternions do not
+    have this kind.
+
+    Most ``Expr`` are initially designed to represent the number, so
+    this will be the most common kind in SymPy core. For example
+    ``Symbol()``, which represents a scalar, has this kind as long as it
+    is commutative.
+
+    Numbers form a field. Any operation between number-kind objects will
+    result this kind as well.
+
+    Examples
+    ========
+
+    >>> from sympy import S, oo, Symbol
+    >>> S.One.kind
+    NumberKind
+    >>> (-oo).kind
+    NumberKind
+    >>> S.NaN.kind
+    NumberKind
+
+    Commutative symbol are treated as number.
+
+    >>> x = Symbol('x')
+    >>> x.kind
+    NumberKind
+    >>> Symbol('y', commutative=False).kind
+    UndefinedKind
+
+    Operation between numbers results number.
+
+    >>> (x+1).kind
+    NumberKind
+
+    See Also
+    ========
+
+    sympy.core.expr.Expr.is_Number : check if the object is strictly
+    subclass of ``Number`` class.
+
+    sympy.core.expr.Expr.is_number : check if the object is number
+    without any free symbol.
+
+    """
+    def __new__(cls):
+        return super().__new__(cls)
+
+    def __repr__(self):
+        return "NumberKind"
+
+NumberKind = NumberKind()
+
+
+class BooleanKind(Kind):
+    """
+    Kind for boolean objects.
+
+    SymPy's ``S.true``, ``S.false``, and built-in ``True`` and ``False``
+    have this kind. Boolean number ``1`` and ``0`` are not relevent.
+
+    Examples
+    ========
+
+    >>> from sympy import S, Q
+    >>> S.true.kind
+    BooleanKind
+    >>> Q.even(3).kind
+    BooleanKind
+    """
+    def __new__(cls):
+        return super().__new__(cls)
+
+    def __repr__(self):
+        return "BooleanKind"
+
+BooleanKind = BooleanKind()

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,5 +1,6 @@
 from sympy.core.numbers import nan
 from .function import Function
+from .kind import NumberKind
 
 
 class Mod(Function):
@@ -30,6 +31,8 @@ class Mod(Function):
     1
 
     """
+
+    kind = NumberKind
 
     @classmethod
     def eval(cls, p, q):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -17,6 +17,7 @@ from .logic import fuzzy_not
 from sympy.core.compatibility import (as_int, HAS_GMPY, SYMPY_INTS,
     gmpy)
 from sympy.core.cache import lru_cache
+from .kind import NumberKind
 from sympy.multipledispatch import dispatch
 import mpmath
 import mpmath.libmp as mlib
@@ -586,6 +587,8 @@ class Number(AtomicExpr):
 
     # Used to make max(x._prec, y._prec) return x._prec when only x is a float
     _prec = -1
+
+    kind = NumberKind
 
     def __new__(cls, *obj):
         if len(obj) == 1:
@@ -2433,6 +2436,9 @@ class AlgebraicNumber(Expr):
     is_algebraic = True
     is_number = True
 
+
+    kind = NumberKind
+
     # Optional alias symbol is not free.
     # Actually, alias should be a Str, but some methods
     # expect that it be an instance of Expr.
@@ -3310,6 +3316,8 @@ class ComplexInfinity(AtomicExpr, metaclass=Singleton):
     is_complex = False
     is_extended_real = False
 
+    kind = NumberKind
+
     __slots__ = ()
 
     def __new__(cls):
@@ -3362,6 +3370,8 @@ class NumberSymbol(AtomicExpr):
     __slots__ = ()
 
     is_NumberSymbol = True
+
+    kind = NumberKind
 
     def __new__(cls):
         return AtomicExpr.__new__(cls)
@@ -3847,6 +3857,8 @@ class ImaginaryUnit(AtomicExpr, metaclass=Singleton):
     is_number = True
     is_algebraic = True
     is_transcendental = False
+
+    kind = NumberKind
 
     __slots__ = ()
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -6,6 +6,7 @@ from .singleton import S
 from .expr import Expr, AtomicExpr
 from .cache import cacheit
 from .function import FunctionClass
+from .kind import NumberKind, UndefinedKind
 from sympy.core.logic import fuzzy_bool
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.iterables import cartes, sift
@@ -204,6 +205,12 @@ class Symbol(AtomicExpr, Boolean):
 
     is_Symbol = True
     is_symbol = True
+
+    @property
+    def kind(self):
+        if self.is_commutative:
+            return NumberKind
+        return UndefinedKind
 
     @property
     def _diff_wrt(self):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -52,6 +52,9 @@ def test_all_classes_are_tested():
                 cls = getattr(mod, name)
                 if hasattr(cls, '_sympy_deprecated_func'):
                     cls = cls._sympy_deprecated_func
+                if not isinstance(cls, type):
+                    # check instance of singleton class with same name
+                    cls = type(cls)
                 return issubclass(cls, Basic)
 
             names = list(filter(is_Basic, names))

--- a/sympy/core/tests/test_kind.py
+++ b/sympy/core/tests/test_kind.py
@@ -1,0 +1,39 @@
+from sympy.core.add import Add
+from sympy.core.kind import NumberKind, UndefinedKind
+from sympy.core.numbers import pi, zoo, I, AlgebraicNumber
+from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.integrals.integrals import Integral
+from sympy.matrices import (Matrix, SparseMatrix, ImmutableMatrix,
+    ImmutableSparseMatrix, MatrixSymbol, MatrixKind)
+
+comm_x = Symbol('x')
+noncomm_x = Symbol('x', commutative=False)
+
+def test_NumberKind():
+    assert S.One.kind is NumberKind
+    assert pi.kind is NumberKind
+    assert S.NaN.kind is NumberKind
+    assert zoo.kind is NumberKind
+    assert I.kind is NumberKind
+    assert AlgebraicNumber(1).kind is NumberKind
+
+def test_Add_kind():
+    assert Add(2, 3, evaluate=False).kind is NumberKind
+    assert Add(2,comm_x).kind is NumberKind
+    assert Add(2,noncomm_x).kind is UndefinedKind
+
+def test_Symbol_kind():
+    assert comm_x.kind is NumberKind
+    assert noncomm_x.kind is UndefinedKind
+
+def test_Integral_kind():
+    A = MatrixSymbol('A', 2,2)
+    assert Integral(comm_x, comm_x).kind is NumberKind
+    assert Integral(A, comm_x).kind is MatrixKind(NumberKind)
+
+def test_Matrix_kind():
+    classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)
+    for cls in classes:
+        m = cls.zeros(3, 2)
+        assert m.kind is MatrixKind(NumberKind)

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -154,6 +154,12 @@ class Tr(Expr):
 
             return Expr.__new__(cls, expr, indices)
 
+    @property
+    def kind(self):
+        expr = self.args[0]
+        expr_kind = expr.kind
+        return expr_kind.element_kind
+
     def doit(self, **kwargs):
         """ Perform the trace operation.
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -14,6 +14,7 @@ from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
 from sympy.core.singleton import Singleton, S
 from sympy.core.sympify import converter, _sympify, sympify
+from sympy.core.kind import BooleanKind
 from sympy.utilities.iterables import sift, ibin
 from sympy.utilities.misc import filldedent
 
@@ -64,6 +65,8 @@ class Boolean(Basic):
     """A boolean object is an object for which logic operations make sense."""
 
     __slots__ = ()
+
+    kind = BooleanKind
 
     @sympify_return([('other', 'Boolean')], NotImplemented)
     def __and__(self, other):

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -10,7 +10,7 @@ from .dense import (
     randMatrix, rot_axis1, rot_axis2, rot_axis3, symarray, wronskian,
     zeros)
 from .dense import MutableDenseMatrix
-from .matrices import DeferredVector, MatrixBase
+from .matrices import DeferredVector, MatrixBase, MatrixKind
 
 Matrix = MutableMatrix = MutableDenseMatrix
 
@@ -42,7 +42,7 @@ __all__ = [
 
     'MutableDenseMatrix',
 
-    'DeferredVector', 'MatrixBase',
+    'DeferredVector', 'MatrixBase', 'MatrixKind',
 
     'Matrix', 'MutableMatrix',
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -14,6 +14,7 @@ from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.matrices.common import NonSquareMatrixError
 from sympy.simplify import simplify
+from sympy.matrices.matrices import MatrixKind
 from sympy.utilities.misc import filldedent
 from sympy.multipledispatch import dispatch
 
@@ -74,6 +75,8 @@ class MatrixExpr(Expr):
     is_number = False
     is_symbol = False
     is_scalar = False
+
+    kind = MatrixKind()
 
     def __new__(cls, *args, **kwargs):
         args = map(_sympify, args)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -18,6 +18,7 @@ from sympy.polys import cancel
 from sympy.printing import sstr
 from sympy.printing.defaults import Printable
 from sympy.simplify import simplify as _simplify
+from sympy.core.kind import Kind, NumberKind
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import filldedent
@@ -742,6 +743,46 @@ class MatrixDeprecated(MatrixCommon):
         return self.permute_rows(perm, direction='forward')
 
 
+class MatrixKind(Kind):
+    """
+    Kind for all matrices in SymPy.
+
+    Basic class for this kind is ``MatrixBase`` and ``MatrixExpr``,
+    but any expression representing the matrix can have this.
+
+    Parameters
+    ==========
+
+    element_kind : Kind
+        Kind of the element. Default is ``NumberKind``, which means that
+        the matrix contains only numbers.
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol, Integral
+    >>> from sympy.abc import x
+    >>> A = MatrixSymbol('A', 2,2)
+    >>> A.kind
+    MatrixKind(NumberKind)
+    >>> Integral(A,x).kind
+    MatrixKind(NumberKind)
+
+    See Also
+    ========
+
+    sympy.tensor.ArrayKind : Kind for N-dimensional arrays.
+
+    """
+    def __new__(cls, element_kind=NumberKind):
+        obj = super().__new__(cls, element_kind)
+        obj.element_kind = element_kind
+        return obj
+
+    def __repr__(self):
+        return "MatrixKind(%s)" % self.element_kind
+
+
 class MatrixBase(MatrixDeprecated,
                  MatrixCalculus,
                  MatrixEigen,
@@ -756,6 +797,8 @@ class MatrixBase(MatrixDeprecated,
     _sympify = staticmethod(sympify)
     zero = S.Zero
     one = S.One
+
+    kind = MatrixKind()
 
     def __array__(self, dtype=object):
         from .dense import matrix2numpy

--- a/sympy/tensor/array/__init__.py
+++ b/sympy/tensor/array/__init__.py
@@ -227,7 +227,7 @@ z*cos(y*z) + exp(x)
 
 from .dense_ndim_array import MutableDenseNDimArray, ImmutableDenseNDimArray, DenseNDimArray
 from .sparse_ndim_array import MutableSparseNDimArray, ImmutableSparseNDimArray, SparseNDimArray
-from .ndim_array import NDimArray
+from .ndim_array import NDimArray, ArrayKind
 from .arrayop import tensorproduct, tensorcontraction, tensordiagonal, derive_by_array, permutedims
 from .array_comprehension import ArrayComprehension, ArrayComprehensionMap
 
@@ -238,7 +238,7 @@ __all__ = [
 
     'MutableSparseNDimArray', 'ImmutableSparseNDimArray', 'SparseNDimArray',
 
-    'NDimArray',
+    'NDimArray', 'ArrayKind',
 
     'tensorproduct', 'tensorcontraction', 'tensordiagonal', 'derive_by_array',
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -3,11 +3,49 @@ from sympy import S
 from sympy.core.expr import Expr
 from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify
+from sympy.core.kind import Kind, NumberKind
 from sympy.core.compatibility import SYMPY_INTS
 from sympy.printing.defaults import Printable
 
 import itertools
 from collections.abc import Iterable
+
+
+class ArrayKind(Kind):
+    """
+    Kind for N-dimensional array in SymPy.
+
+    This kind represents the multidimensional array that algebraic
+    operations are defined. Basic class for this kind is ``NDimArray``,
+    but any expression representing the array can have this.
+
+    Parameters
+    ==========
+
+    element_kind : Kind
+        Kind of the element. Default is ``NumberKind``, which means that
+        the array contains only numbers.
+
+    Examples
+    ========
+
+    >>> from sympy import NDimArray
+    >>> NDimArray([1,2,3]).kind
+    ArrayKind(NumberKind)
+
+    See Also
+    ========
+
+    sympy.matrices.MatrixKind : Kind for matrices.
+
+    """
+    def __new__(cls, element_kind=NumberKind):
+        obj = super().__new__(cls, element_kind)
+        obj.element_kind = element_kind
+        return obj
+
+    def __repr__(self):
+        return "ArrayKind(%s)" % self.element_kind
 
 
 class NDimArray(Printable):
@@ -69,6 +107,10 @@ class NDimArray(Printable):
     def __new__(cls, iterable, shape=None, **kwargs):
         from sympy.tensor.array import ImmutableDenseNDimArray
         return ImmutableDenseNDimArray(iterable, shape, **kwargs)
+
+    @property
+    def kind(self):
+        return ArrayKind()
 
     def _parse_index(self, index):
         if isinstance(index, (SYMPY_INTS, Integer)):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #20158 

#### Brief description of what is fixed or changed

1. `core/kind` module is introduced.
2. `Basic` has `UndefinedKind` as default kind.
3. Every classes in `core/numbers` module, `int`, `float` have `NumberKind.
4.  NDimArrays have parametrisable `ArrayKind`. Matrices have parametrisable `MatrixKind`.
5. Boolean expressions have `BooleanKind`.
6. Following classes support kind inference:
    - `Add`
    - `Symbol`
    - `Integral`
    - `Tr`
7. Documentation is made in `docs/src/special_topics`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- core
    - Kind classification of objects is introduced. This feature is experimental, and can be replaced or deleted in the future.
<!-- END RELEASE NOTES -->