### PR TITLE
added changes in domain_check for Piecewise Equations #20552

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -434,7 +434,27 @@ def _domain_check(f, symbol, p):
         return True
     elif f.subs(symbol, p).is_infinite:
         return False
+    elif isinstance(f, Piecewise):
+        # Check the cases of the Piecewise in turn. There might be invalid
+        # expressions in later cases that don't apply e.g.
+        #    solveset(Piecewise((0, Eq(x, 0)), (1/x, True)), x)
+        for expr, cond in f.args:
+            condsubs = cond.subs(symbol, p)
+            if condsubs is S.false:
+                continue
+            elif cond.subs is S.true:
+                return _domain_check(expr, symbol, p)
+            else:
+                # We don't know which case of the Piecewise holds. On this
+                # basis we cannot decide whether any solution is in or out of
+                # the domain. Ideally this function would allow returning a
+                # symbolic condition for the validity of the solution that
+                # could be handled in the calling code. In the mean time we'll
+                # give this particular solution the benefit of the doubt and
+                # let it pass.
+                return True
     else:
+        # We should not blindly recurse through all args of arbitrary expressions like this:
         return all([_domain_check(g, symbol, p)
                     for g in f.args])
 


### PR DESCRIPTION
**References to other Issues or PRs**
Fixes #20552 

**Brief description of what is fixed or changed**
Here we added one more condition to `domain_check` so that it goes through Piecewise instances to check its cases in turn.
This will prevent `domain_check` to discard possible solutions for Piecewise equations where expression is divided by zero. Changes were suggested by @oscarbenjamin [here](https://github.com/sympy/sympy/issues/20552).

**Release Notes**
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->