### PR TITLE
stats: Made changes to return value in entropy()

### DIFF
--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -133,8 +133,8 @@ def entropy(expr, condition=None, **kwargs):
     """
     pdf = density(expr, condition, **kwargs)
     base = kwargs.get('b', exp(1))
-    if hasattr(pdf, 'dict'):
-            return sum([-prob*log(prob, base) for prob in pdf.dict.values()])
+    if isinstance(pdf, dict):
+            return sum([-prob*log(prob, base) for prob in pdf.values()])
     return expectation(-log(pdf(expr), base))
 
 def covariance(X, Y, condition=None, **kwargs):

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,4 +1,4 @@
-from sympy import (S, Symbol, Interval, exp, Or,
+from sympy import (S, Symbol, Interval, binomial, nan, exp, Or,
         symbols, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic, Indexed,
         DiracDelta, Lambda, log, pi, FallingFactorial, Rational, Matrix)
 from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
@@ -12,7 +12,8 @@ from sympy.testing.pytest import raises, skip, XFAIL, ignore_warnings
 from sympy.external import import_module
 from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
-from sympy.series.order import O
+from sympy.core.symbol import Dummy
+from sympy.functions.elementary.piecewise import Piecewise
 
 def test_where():
     X, Y = Die('X'), Die('Y')
@@ -390,5 +391,6 @@ def test_issue_6810():
 def test_issue_20286():
     n, p = symbols('n p')
     B = Binomial('B', n, p)
+    _k = Dummy('_k', integer = True)
     assert H(B) == Sum(Piecewise((-p**_k*(1 - p)**(-_k + n)*log(p**_k*(1 - p)**(-_k + n)*binomial(n, _k))*binomial(n, _k), (_k >= 0) & (_k <= n)), (nan, True)), (_k, 0, n))
     

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -394,4 +394,4 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
-    
+

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -391,6 +391,7 @@ def test_issue_6810():
 def test_issue_20286():
     n, p = symbols('n p')
     B = Binomial('B', n, p)
-    _k = Dummy('_k', integer = True)
-    assert H(B) == Sum(Piecewise((-p**_k*(1 - p)**(-_k + n)*log(p**_k*(1 - p)**(-_k + n)*binomial(n, _k))*binomial(n, _k), (_k >= 0) & (_k <= n)), (nan, True)), (_k, 0, n))
+    k = Dummy('k', integer = True)
+    eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
+    assert eq.dummy_eq(H(B))
     

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -12,6 +12,7 @@ from sympy.testing.pytest import raises, skip, XFAIL, ignore_warnings
 from sympy.external import import_module
 from sympy.core.numbers import comp
 from sympy.stats.frv_types import BernoulliDistribution
+from sympy.series.order import O
 
 def test_where():
     X, Y = Die('X'), Die('Y')
@@ -385,3 +386,9 @@ def test_issue_6810():
     assert P(Eq(Y, 0)) == 0
     assert P(Or(X > 2, X < 3)) == 1
     assert P(And(X > 3, X > 2)) == S(1)/2
+
+def test_issue_20286():
+    n, p = symbols('n p')
+    B = Binomial('B', n, p)
+    assert H(B) == log(2*pi*exp(1)*n*p*(1-p), 2)/2 + O(1/n)
+    

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -394,4 +394,3 @@ def test_issue_20286():
     k = Dummy('k', integer = True)
     eq = Sum(Piecewise((-p**k*(1 - p)**(-k + n)*log(p**k*(1 - p)**(-k + n)*binomial(n, k))*binomial(n, k), (k >= 0) & (k <= n)), (nan, True)), (k, 0, n))
     assert eq.dummy_eq(H(B))
-

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -390,5 +390,5 @@ def test_issue_6810():
 def test_issue_20286():
     n, p = symbols('n p')
     B = Binomial('B', n, p)
-    assert H(B) == log(2*pi*exp(1)*n*p*(1-p), 2)/2 + O(1/n)
+    assert H(B) == Sum(Piecewise((-p**_k*(1 - p)**(-_k + n)*log(p**_k*(1 - p)**(-_k + n)*binomial(n, _k))*binomial(n, _k), (_k >= 0) & (_k <= n)), (nan, True)), (_k, 0, n))
     


### PR DESCRIPTION
Attempt at fixing ```AttributeError: 'Density' object has no attribute 'values' ```, when the entropy() method is
used for an expression for binomial distribution.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20286 

#### Brief description of what is fixed or changed
Changes made to the method ```entropy()``` in the file ```rv_interface.py``` of the stats module.

#### Other comments


#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->