### PR TITLE
Fix cxx printing for Min/Max

### DIFF
--- a/sympy/printing/cxx.py
+++ b/sympy/printing/cxx.py
@@ -90,13 +90,15 @@ class _CXXCodePrinterBase:
         from sympy import Max
         if len(expr.args) == 1:
             return self._print(expr.args[0])
-        return "%smax(%s, %s)" % (self._ns, expr.args[0], self._print(Max(*expr.args[1:])))
+        return "%smax(%s, %s)" % (self._ns, self._print(expr.args[0]), 
+                                  self._print(Max(*expr.args[1:])))
 
     def _print_Min(self, expr):
         from sympy import Min
         if len(expr.args) == 1:
             return self._print(expr.args[0])
-        return "%smin(%s, %s)" % (self._ns, expr.args[0], self._print(Min(*expr.args[1:])))
+        return "%smin(%s, %s)" % (self._ns, self._print(expr.args[0]),
+                                  self._print(Min(*expr.args[1:])))
 
     def _print_using(self, expr):
         if expr.alias == none:

--- a/sympy/printing/cxx.py
+++ b/sympy/printing/cxx.py
@@ -90,7 +90,7 @@ class _CXXCodePrinterBase:
         from sympy import Max
         if len(expr.args) == 1:
             return self._print(expr.args[0])
-        return "%smax(%s, %s)" % (self._ns, self._print(expr.args[0]), 
+        return "%smax(%s, %s)" % (self._ns, self._print(expr.args[0]),
                                   self._print(Max(*expr.args[1:])))
 
     def _print_Min(self, expr):

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -61,3 +61,11 @@ def test_cxxcode_submodule():
     # Test the compatibility sympy.printing.cxxcode module imports
     with warns_deprecated_sympy():
         import sympy.printing.cxxcode # noqa:F401
+
+def test_cxxcode_nested_minmax():
+    assert cxxcode(sp.Max(sp.Min(sp.Symbol('x'), sp.Symbol('y')), 
+                   sp.Min(sp.Symbol('u'), sp.Symbol('v')))) \
+        == 'std::max(std::min(u, v), std::min(x, y))'
+    assert cxxcode(sp.Min(sp.Max(sp.Symbol('x'), sp.Symbol('y')), 
+                   sp.Max(sp.Symbol('u'), sp.Symbol('v')))) \
+        == 'std::min(std::max(u, v), std::max(x, y))'

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -5,7 +5,7 @@ from sympy.codegen.cfunctions import log1p
 
 from sympy.testing.pytest import warns_deprecated_sympy
 
-x, y = symbols('x y')
+x, y, u, v = symbols('x y u v')
 
 
 def test_CXX98CodePrinter():
@@ -63,9 +63,7 @@ def test_cxxcode_submodule():
         import sympy.printing.cxxcode # noqa:F401
 
 def test_cxxcode_nested_minmax():
-    assert cxxcode(sp.Max(sp.Min(sp.Symbol('x'), sp.Symbol('y')),
-                   sp.Min(sp.Symbol('u'), sp.Symbol('v')))) \
+    assert cxxcode(Max(Min(x, y), Min(u, v))) \
         == 'std::max(std::min(u, v), std::min(x, y))'
-    assert cxxcode(sp.Min(sp.Max(sp.Symbol('x'), sp.Symbol('y')),
-                   sp.Max(sp.Symbol('u'), sp.Symbol('v')))) \
+    assert cxxcode(Min(Max(x, y), Max(u, v))) \
         == 'std::min(std::max(u, v), std::max(x, y))'

--- a/sympy/printing/tests/test_cxx.py
+++ b/sympy/printing/tests/test_cxx.py
@@ -63,9 +63,9 @@ def test_cxxcode_submodule():
         import sympy.printing.cxxcode # noqa:F401
 
 def test_cxxcode_nested_minmax():
-    assert cxxcode(sp.Max(sp.Min(sp.Symbol('x'), sp.Symbol('y')), 
+    assert cxxcode(sp.Max(sp.Min(sp.Symbol('x'), sp.Symbol('y')),
                    sp.Min(sp.Symbol('u'), sp.Symbol('v')))) \
         == 'std::max(std::min(u, v), std::min(x, y))'
-    assert cxxcode(sp.Min(sp.Max(sp.Symbol('x'), sp.Symbol('y')), 
+    assert cxxcode(sp.Min(sp.Max(sp.Symbol('x'), sp.Symbol('y')),
                    sp.Max(sp.Symbol('u'), sp.Symbol('v')))) \
         == 'std::min(std::max(u, v), std::max(x, y))'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #20557 

#### Brief description of what is fixed or changed
Previous implementation used string conversion for first argument. Fixed correctly using using codeprinting

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * make cxxcode correctly print the first argument of Min/Max functions
<!-- END RELEASE NOTES -->