### PR TITLE
Consistent matrix output versus tuple output

### DIFF
--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -141,7 +141,7 @@ class CoordSys3D(Basic):
             l = l._projections
             lambda_lame = CoordSys3D._get_lame_coeff('cartesian')
             lambda_inverse = lambda x, y, z: r.inv()*Matrix(
-                [x-l[0], y-l[1], z-l[2]]) ###############################################################
+                [x-l[0], y-l[1], z-l[2]])
         elif isinstance(transformation, Str):
             trname = transformation.name
             lambda_transformation = CoordSys3D._get_transformation_lambdas(trname)

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1005,9 +1005,15 @@ class CoordSys3D(Basic):
         >>> a = CoordSys3D('a')
         >>> b = a.create_new('b', transformation='spherical')
         >>> b.transformation_to_parent()
-        (b.r*sin(b.theta)*cos(b.phi), b.r*sin(b.phi)*sin(b.theta), b.r*cos(b.theta))
+        Matrix([
+                [b.r*sin(b.theta)*cos(b.phi)],
+                [b.r*sin(b.phi)*sin(b.theta)],
+                [           b.r*cos(b.theta)]])
         >>> b.transformation_from_parent()
-        (sqrt(a.x**2 + a.y**2 + a.z**2), acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2)), atan2(a.y, a.x))
+        Matrix([
+                [          sqrt(a.x**2 + a.y**2 + a.z**2)],
+                [acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2))],
+                [                         atan2(a.y, a.x)]])
 
         """
         return CoordSys3D(name, parent=self, transformation=transformation,

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -141,7 +141,7 @@ class CoordSys3D(Basic):
             l = l._projections
             lambda_lame = CoordSys3D._get_lame_coeff('cartesian')
             lambda_inverse = lambda x, y, z: r.inv()*Matrix(
-                [x-l[0], y-l[1], z-l[2]])
+                [x-l[0], y-l[1], z-l[2]]) ###############################################################
         elif isinstance(transformation, Str):
             trname = transformation.name
             lambda_transformation = CoordSys3D._get_transformation_lambdas(trname)
@@ -471,14 +471,14 @@ class CoordSys3D(Basic):
         return self._lame_coefficients
 
     def transformation_to_parent(self):
-        return self._transformation_lambda(*self.base_scalars())
+        return tuple_to_matrix(self._transformation_lambda(*self.base_scalars()))
 
     def transformation_from_parent(self):
         if self._parent is None:
             raise ValueError("no parent coordinate system, use "
                              "`transformation_from_parent_function()`")
-        return self._transformation_from_parent_lambda(
-                            *self._parent.base_scalars())
+        return tuple_to_matrix(self._transformation_from_parent_lambda(
+                            *self._parent.base_scalars()))
 
     def transformation_from_parent_function(self):
         return self._transformation_from_parent_lambda
@@ -1029,11 +1029,7 @@ class CoordSys3D(Basic):
             return r
 
         dx, dy, dz = [translation.dot(i) for i in parent.base_vectors()]
-        t = lambda x, y, z: (
-            x + dx,
-            y + dy,
-            z + dz,
-        )
+        t = lambda x, y, z: Matrix([[x + dx], [y + dy], [z + dz]])
         return lambda x, y, z: t(*r(x, y, z))
 
 
@@ -1045,6 +1041,16 @@ def _check_strings(arg_name, arg):
         if not isinstance(s, str):
             raise TypeError(errorstr)
 
+def tuple_to_matrix(tuple):
+    if (isinstance(tuple, Matrix)):
+        pass
+    index = 0
+    M = Matrix([ [ ] ])
+    for elt in tuple:
+        temp = Matrix([ [ elt ] ])
+        M = M.row_insert(index, temp)
+        index += 1
+    return M
 
 # Delayed import to avoid cyclic import problems:
 from sympy.vector.vector import BaseVector

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -296,9 +296,9 @@ def test_create_new():
     c = a.create_new('c', transformation='spherical')
     assert c._parent == a
     assert c.transformation_to_parent() == \
-           (c.r*sin(c.theta)*cos(c.phi), c.r*sin(c.theta)*sin(c.phi), c.r*cos(c.theta))
+           Matrix([[c.r*sin(c.theta)*cos(c.phi)], [c.r*sin(c.theta)*sin(c.phi)], [c.r*cos(c.theta)]])
     assert c.transformation_from_parent() == \
-           (sqrt(a.x**2 + a.y**2 + a.z**2), acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2)), atan2(a.y, a.x))
+           Matrix([[sqrt(a.x**2 + a.y**2 + a.z**2)], [acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2))], [atan2(a.y, a.x)]])
 
 
 def test_evalf():
@@ -335,11 +335,11 @@ def test_transformation_equations():
     raises(AttributeError, lambda: a.y)
     raises(AttributeError, lambda: a.z)
 
-    assert a.transformation_to_parent() == (
-        r*sin(theta)*cos(phi),
-        r*sin(theta)*sin(phi),
-        r*cos(theta)
-    )
+    assert a.transformation_to_parent() == Matrix([
+        [r*sin(theta)*cos(phi)],
+        [r*sin(theta)*sin(phi)],
+        [r*cos(theta)]
+    ])
     assert a.lame_coefficients() == (1, r, r*sin(theta))
     assert a.transformation_from_parent_function()(x, y, z) == (
         sqrt(x ** 2 + y ** 2 + z ** 2),
@@ -349,17 +349,17 @@ def test_transformation_equations():
     a = CoordSys3D('a', transformation='cylindrical',
                    variable_names=["r", "theta", "z"])
     r, theta, z = a.base_scalars()
-    assert a.transformation_to_parent() == (
-        r*cos(theta),
-        r*sin(theta),
-        z
-    )
+    assert a.transformation_to_parent() == Matrix([
+        [r*cos(theta)],
+        [r*sin(theta)],
+        [z]
+    ])
     assert a.lame_coefficients() == (1, a.r, 1)
     assert a.transformation_from_parent_function()(x, y, z) == (sqrt(x**2 + y**2),
                             atan2(y, x), z)
 
     a = CoordSys3D('a', 'cartesian')
-    assert a.transformation_to_parent() == (a.x, a.y, a.z)
+    assert a.transformation_to_parent() == Matrix([[a.x], [a.y], [a.z]])
     assert a.lame_coefficients() == (1, 1, 1)
     assert a.transformation_from_parent_function()(x, y, z) == (x, y, z)
 
@@ -369,7 +369,7 @@ def test_transformation_equations():
     x, y, z = symbols('x y z')
     a = CoordSys3D('a', ((x, y, z), (x, y, z)))
     a._calculate_inv_trans_equations()
-    assert a.transformation_to_parent() == (a.x1, a.x2, a.x3)
+    assert a.transformation_to_parent() == Matrix([[a.x1], [a.x2], [a.x3]])
     assert a.lame_coefficients() == (1, 1, 1)
     assert a.transformation_from_parent_function()(x, y, z) == (x, y, z)
     r, theta, z = symbols("r theta z")
@@ -378,9 +378,9 @@ def test_transformation_equations():
     a = CoordSys3D('a', [(r, theta, z), (r*cos(theta), r*sin(theta), z)],
                    variable_names=["r", "theta", "z"])
     r, theta, z = a.base_scalars()
-    assert a.transformation_to_parent() == (
-        r*cos(theta), r*sin(theta), z
-    )
+    assert a.transformation_to_parent() == Matrix([
+        [r*cos(theta)], [r*sin(theta)], [z]
+    ])
     assert a.lame_coefficients() == (
         sqrt(sin(theta)**2 + cos(theta)**2),
         sqrt(r**2*sin(theta)**2 + r**2*cos(theta)**2),
@@ -391,7 +391,7 @@ def test_transformation_equations():
 
     # Cartesian with `lambda`
     a = CoordSys3D('a', lambda x, y, z: (x, y, z))
-    assert a.transformation_to_parent() == (a.x1, a.x2, a.x3)
+    assert a.transformation_to_parent() == Matrix([[a.x1], [a.x2], [a.x3]])
     assert a.lame_coefficients() == (1, 1, 1)
     a._calculate_inv_trans_equations()
     assert a.transformation_from_parent_function()(x, y, z) == (x, y, z)
@@ -400,9 +400,9 @@ def test_transformation_equations():
     a = CoordSys3D('a', lambda r, theta, phi: (r*sin(theta)*cos(phi), r*sin(theta)*sin(phi), r*cos(theta)),
                    variable_names=["r", "theta", "phi"])
     r, theta, phi = a.base_scalars()
-    assert a.transformation_to_parent() == (
-        r*sin(theta)*cos(phi), r*sin(phi)*sin(theta), r*cos(theta)
-    )
+    assert a.transformation_to_parent() == Matrix([
+        [r*sin(theta)*cos(phi)], [r*sin(phi)*sin(theta)], [r*cos(theta)]
+    ])
     assert a.lame_coefficients() == (
         sqrt(sin(phi)**2*sin(theta)**2 + sin(theta)**2*cos(phi)**2 + cos(theta)**2),
         sqrt(r**2*sin(phi)**2*cos(theta)**2 + r**2*sin(theta)**2 + r**2*cos(phi)**2*cos(theta)**2),
@@ -415,7 +415,7 @@ def test_transformation_equations():
         variable_names=["r", "theta", "z"]
     )
     r, theta, z = a.base_scalars()
-    assert a.transformation_to_parent() == (r*cos(theta), r*sin(theta), z)
+    assert a.transformation_to_parent() == Matrix([[r*cos(theta)], [r*sin(theta)], [z]])
     assert a.lame_coefficients() == (
         sqrt(sin(theta)**2 + cos(theta)**2),
         sqrt(r**2*sin(theta)**2 + r**2*cos(theta)**2),
@@ -460,3 +460,13 @@ def test_rotation_trans_equations():
            (-sin(q0) * c.y + cos(q0) * c.x, sin(q0) * c.x + cos(q0) * c.y, c.z)
     assert c._rotation_trans_equations(c._inverse_rotation_matrix(), c.base_scalars()) == \
            (sin(q0) * c.y + cos(q0) * c.x, -sin(q0) * c.x + cos(q0) * c.y, c.z)
+
+def test_issue_19725():
+    N = CoordSys3D('N')
+    M = N.create_new("M", transformation="cylindrical")
+    a = symbols("a")
+    O = N.orient_new_axis("O", a, N.k)
+
+    assert M.transformation_to_parent() == Matrix([[M.r*cos(M.theta)], [M.r*sin(M.theta)], [M.z]])
+    assert M.transformation_from_parent() == Matrix([[sqrt(N.x**2 + N.y**2)], [atan2(N.y, N.x)], [N.z]])
+    assert isinstance(O.transformation_to_parent(), Matrix)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. --> Fixes #19725 


#### Brief description of what is fixed or changed
The issue in question talked about there being inconsistent outputs of matrices; some matrices were printed as tuples while others were printed as normal Sympy-style matrices. To the best of my ability, I have made the output of matrices consistent, and if there is inconsistency elsewhere in the vector module, I have written a function which can be called to turn the tuple into a proper matrix.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* vector
    * Added a function to allow for consistency across matrix printing in the vector module.
<!-- END RELEASE NOTES -->