### PR TITLE
Added `probability_simplify` function to simplify expressions of random variables.

### DIFF
--- a/sympy/stats/simplify_probability.py
+++ b/sympy/stats/simplify_probability.py
@@ -1,0 +1,79 @@
+from sympy import S, exp, log, symbols, Add, sqrt
+from sympy.stats import Normal, LogNormal
+
+# This import is not optional, it will register the main SymPy nodes with the MatchPy tree walker:
+from sympy.utilities.matchpy_connector import matchpy, WildDot, WildPlus, WildStar
+
+if matchpy:
+    from matchpy import ManyToOneReplacer, ReplacementRule, Pattern, Operation
+
+from sympy.stats.rv import RandomSymbol
+from sympy.stats.crv import SingleContinuousPSpace, SingleContinuousDistribution
+
+
+def _check_reparse(n):
+    import re
+    m = re.match(r"RandomSymbol<(.+)>", str(n))
+    if m is None:
+        return n
+    return S(m.group(1))
+
+
+def _name_combine(n1, n2, operator):
+    n1 = _check_reparse(n1)
+    n2 = _check_reparse(n2)
+    return f"RandomSymbol<{operator(n1, n2)}>"
+
+
+class _GetMatchpyReplacerForStats:
+
+    replacer = None
+
+    def __new__(cls):
+        obj = object.__new__(cls)
+        if cls.replacer is None:
+            cls.register_operations()
+            cls.initialize_replacer()
+        return obj
+
+    @classmethod
+    def register_operations(cls):
+        # MatchPy needs every node of the expression tree to be registered:
+        Operation.register(RandomSymbol)
+        Operation.register(SingleContinuousPSpace)
+        Operation.register(SingleContinuousDistribution)
+
+    @classmethod
+    def initialize_replacer(cls):
+
+        # I believe `WildDot` is limited to matching symbols only, this can be fixed:
+        name_ = WildDot("name")
+        mu_ = WildDot("mu")
+        sigma_ = WildDot("sigma")
+
+        wplus = WildPlus("wplus")
+        wstar = WildStar("wstar")
+
+        # Define the replacer:
+        cls.replacer = ManyToOneReplacer()
+
+        # Recognize `exp(Normal)` as the LogNormal distribution:
+        rule1 = Pattern(exp(Normal(name_, mu_, sigma_)))
+        repl1 = lambda name, mu, sigma: LogNormal(f"exp({name.name})", mu, sigma)
+        cls.replacer.add(ReplacementRule(rule1, repl1))
+
+        # Recognize `exp(Normal)` as the LogNormal distribution:
+        rule2 = Pattern(log(LogNormal(name_, mu_, sigma_)))
+        repl2 = lambda name, mu, sigma: Normal(f"log({name.name})", mu, sigma)
+        cls.replacer.add(ReplacementRule(rule2, repl2))
+
+        # Addition of two normal distributions:
+        n1, n2, mu1, mu2, sigma1, sigma2 = symbols("n1 n2 mu1 mu2 sigma1 sigma2", cls=WildDot)
+        rule3 = Pattern(wstar + Normal(n1, mu1, sigma1) + Normal(n2, mu2, sigma2))
+        repl3 = lambda wstar, n1, n2, mu1, mu2, sigma1, sigma2: Add.fromiter(wstar) + Normal(_name_combine(n1, n2, Add), mu1+mu2, sqrt(sigma1**2 + sigma2**2))
+        cls.replacer.add(ReplacementRule(rule3, repl3))
+
+
+def probability_simplify(expr):
+    replacer = _GetMatchpyReplacerForStats().replacer
+    return replacer.replace(expr)

--- a/sympy/stats/tests/test_simplify_probability.py
+++ b/sympy/stats/tests/test_simplify_probability.py
@@ -1,0 +1,49 @@
+from sympy.external.importtools import import_module
+
+from sympy import exp, symbols, log
+from sympy.stats import Normal, LogNormal
+from sympy.stats.crv_types import NormalDistribution, LogNormalDistribution
+from sympy.stats.rv import RandomSymbol
+from sympy.stats.simplify_probability import probability_simplify
+
+mu, sigma = symbols("mu sigma")
+mu1, mu2, mu3, mu4 = symbols("mu1:5")
+sigma1, sigma2, sigma3, sigma4 = symbols("sigma1:5")
+
+matchpy = import_module("matchpy")
+
+
+def test_simplify_random_var_expressions():
+    if matchpy is None:
+        return
+
+    N = Normal("N", mu, sigma)
+    result = probability_simplify(exp(N))
+    assert isinstance(result, RandomSymbol)
+    assert result.name == 'exp(N)'
+    assert isinstance(result.pspace.distribution, LogNormalDistribution)
+
+    LN = LogNormal("LN", mu, sigma)
+    result = probability_simplify(log(LN))
+    assert isinstance(result, RandomSymbol)
+    assert result.name == 'log(LN)'
+    assert isinstance(result.pspace.distribution, NormalDistribution)
+
+    N1 = Normal("N1", mu1, sigma1)
+    N2 = Normal("N2", mu2, sigma2)
+    N3 = Normal("N3", mu3, sigma3)
+    N4 = Normal("N4", mu4, sigma4)
+    result = probability_simplify(N1 + N2)
+    assert isinstance(result, RandomSymbol)
+    assert result.name == 'RandomSymbol<N1 + N2>'
+    assert isinstance(result.pspace.distribution, NormalDistribution)
+
+    result = probability_simplify(N1 + N2 + N3)
+    assert isinstance(result, RandomSymbol)
+    assert result.name == 'RandomSymbol<N1 + N2 + N3>'
+    assert isinstance(result.pspace.distribution, NormalDistribution)
+
+    result = probability_simplify(N1 + N2 + N3 + N4)
+    assert isinstance(result, RandomSymbol)
+    assert result.name == 'RandomSymbol<N1 + N2 + N3 + N4>'
+    assert isinstance(result.pspace.distribution, NormalDistribution)

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -3,7 +3,8 @@ from sympy.functions import (log, sin, cos, tan, cot, csc, sec, erf, gamma, uppe
 from sympy.functions.elementary.hyperbolic import acosh, asinh, atanh, acoth, acsch, asech, cosh, sinh, tanh, coth, sech, csch
 from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei
-from sympy import (Basic, Mul, Add, Pow, Integral, exp)
+from sympy import (Basic, Mul, Add, Pow, Integral, exp, Symbol)
+from sympy.utilities.decorator import doctest_depends_on
 
 matchpy = import_module("matchpy")
 
@@ -79,3 +80,61 @@ if matchpy:
     @create_operation_expression.register(Basic)
     def sympy_op_factory(old_operation, new_operands, variable_name=True):
          return type(old_operation)(*new_operands)
+
+
+if matchpy:
+    from matchpy import Wildcard
+else:
+    class Wildcard:
+        def __init__(self, min_length, fixed_size, variable_name, optional):
+            pass
+
+
+@doctest_depends_on(modules=('matchpy',))
+class _WildAbstract(Wildcard, Symbol):
+    min_length = None  # abstract field required in subclasses
+    fixed_size = None  # abstract field required in subclasses
+
+    def __init__(self, variable_name=None, optional=None, **assumptions):
+        min_length = self.min_length
+        fixed_size = self.fixed_size
+        Wildcard.__init__(self, min_length, fixed_size, str(variable_name), optional)
+
+    def __new__(cls, variable_name=None, optional=None, **assumptions):
+        cls._sanitize(assumptions, cls)
+        return _WildAbstract.__xnew__(cls, variable_name, optional, **assumptions)
+
+    def __getnewargs__(self):
+        return self.min_count, self.fixed_size, self.variable_name, self.optional
+
+    @staticmethod
+    def __xnew__(cls, variable_name=None, optional=None, **assumptions):
+        obj = Symbol.__xnew__(cls, variable_name, **assumptions)
+        return obj
+
+    def _hashable_content(self):
+        if self.optional:
+            return super()._hashable_content() + (self.min_count, self.fixed_size, self.variable_name, self.optional)
+        else:
+            return super()._hashable_content() + (self.min_count, self.fixed_size, self.variable_name)
+
+    def __copy__(self) -> '_WildAbstract':
+        return type(self)(variable_name=self.variable_name, optional=self.optional)
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildDot(_WildAbstract):
+    min_length = 1
+    fixed_size = True
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildPlus(_WildAbstract):
+    min_length = 1
+    fixed_size = False
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildStar(_WildAbstract):
+    min_length = 0
+    fixed_size = False


### PR DESCRIPTION
Added `probability_simplify` function to simplify expressions of random variables by using replacement rules and MatchPy.

**WARNING**: MatchPy and Python >= 3.6 required to run this code, use `pip install matchpy`.

#### Brief description of what is fixed or changed

In the stats module:

- new function `probability_simplify( )` to simplify expressions of random variables using pattern matching.
- tests for Normal <===> LogNormal transformation and addition of (univariate) normal distributions.
- registered expression tree for distributions and probability spaces with MatchPy.


In `sympy.utilities.matchpy_connector`:
- added `WildDot`, `WildPlus` and `WildStar` corresponding to `.` `.+` `.*` expressions commonly used in Perl-compatible regular expressions. These three classes use multiple inheritance to inherit both MatchPy`s `Wildcard` class and SymPy`s `Symbol`, allowing their instances to be used in both SymPy and MatchPy.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
  * Added `probability_simplify( )` function to simplify expressions of random variables.
<!-- END RELEASE NOTES -->