### PR TITLE
sets: made Rationals.contains(float) indeterminate

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -42,8 +42,6 @@ class Rationals(Set, metaclass=Singleton):
     def _contains(self, other):
         if not isinstance(other, Expr):
             return False
-        if other.is_Number:
-            return other.is_Rational
         return other.is_rational
 
     def __iter__(self):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1046,8 +1046,7 @@ def test_Rationals():
         Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
-    assert S.Rationals.contains(0.5) is not True
-    assert S.Rationals.contains(0.5) is not False
+    assert S.Rationals.contains(0.5) == Contains(0.5, S.Rationals, evaluate=False)
     assert 2 in S.Rationals
     r = symbols('r', rational=True)
     assert r in S.Rationals

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1046,7 +1046,8 @@ def test_Rationals():
         Rational(1, 3), 3, Rational(-1, 3), -3, Rational(2, 3)]
     assert Basic() not in S.Rationals
     assert S.Half in S.Rationals
-    assert 1.0 not in S.Rationals
+    assert S.Rationals.contains(0.5) is not True
+    assert S.Rationals.contains(0.5) is not False
     assert 2 in S.Rationals
     r = symbols('r', rational=True)
     assert r in S.Rationals


### PR DESCRIPTION
Currently, sympy.Rationals.contains(0.5) evaluates to False.
This patch instead evaluates the expression to indeterminate
based on the following logic: a float represents an approximation
of an underlying number that could be either rational or irrational.
In relation with this change, I have also adjusted a test case
that currently asserts sympy.Rationals.contains(1.0) evaluates
to False. This test was changed to assert that the expression
above evaluates to indeterminate instead of False or True.

Fixes #20364 

Current master behavior:
In [1]: sympy.Rationals.contains(0.5)
>>> False

Patched behavior:
In [1]: sympy.Rationals.contains(0.5)
>>> Contains(0.5, Rationals)

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
   * changed behavior of Rationals.contains(float) to indeterminate
   * tests modified to include new behavior
<!-- END RELEASE NOTES -->