### PR TITLE
pretty_symbology: Remove Python 2 fallbacks

### DIFF
--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -58,6 +58,13 @@ def pretty_use_unicode(flag=None):
 def pretty_try_use_unicode():
     """See if unicode output is available and leverage it if possible"""
 
+    encoding = getattr(sys.stdout, 'encoding', None)
+
+    # this happens when e.g. stdout is redirected through a pipe, or is
+    # e.g. a cStringIO.StringO
+    if encoding is None:
+        return  # sys.stdout has no encoding
+
     symbols = []
 
     # see if we can represent greek alphabet
@@ -70,19 +77,12 @@ def pretty_try_use_unicode():
         if s is None:
             return  # common symbols not present!
 
-        encoding = getattr(sys.stdout, 'encoding', None)
-
-        # this happens when e.g. stdout is redirected through a pipe, or is
-        # e.g. a cStringIO.StringO
-        if encoding is None:
-            return  # sys.stdout has no encoding
-
         try:
             s.encode(encoding)
         except UnicodeEncodeError:
             return
 
-    # all the characters were encodable
+    # all the characters were present and encodable
     pretty_use_unicode(True)
 
 


### PR DESCRIPTION
`unicodedata` was added in Python 2.5. Since Python 2.4 is very not supported, we can get rid of this

This also removes a section of code marked for 2.X removal, and cleans up some exception handling

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->