### PR TITLE
Remove dead code from core.compatibility

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -57,7 +57,6 @@ import string
 
 from .core import Symbol, symbols
 from .core.alphabets import greeks
-from .core.compatibility import exec_
 
 ##### Symbol definitions #####
 
@@ -93,7 +92,7 @@ _greek.remove("lambda")
 _greek.append("lamda")
 
 ns = {}  # type: Dict[str, Any]
-exec_('from sympy import *', ns)
+exec('from sympy import *', ns)
 _clash1 = {}
 _clash2 = {}
 while ns:

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
+from collections.abc import MutableMapping
 
 from sympy.assumptions.ask import Q
 from sympy.assumptions.assume import Predicate, AppliedPredicate
 from sympy.assumptions.cnf import AND, OR, to_NNF
 from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol,)
-from sympy.core.compatibility import MutableMapping
 from sympy.core.numbers import ImaginaryUnit
 from sympy.core.rules import Transform
 from sympy.core.sympify import _sympify

--- a/sympy/codegen/algorithms.py
+++ b/sympy/codegen/algorithms.py
@@ -108,13 +108,12 @@ def newtons_method_function(expr, wrt, params=None, func_name="newton", attrs=Tu
     >>> from sympy import symbols, cos
     >>> from sympy.codegen.algorithms import newtons_method_function
     >>> from sympy.codegen.pyutils import render_as_module
-    >>> from sympy.core.compatibility import exec_
     >>> x = symbols('x')
     >>> expr = cos(x) - x**3
     >>> func = newtons_method_function(expr, x)
     >>> py_mod = render_as_module(func)  # source code as string
     >>> namespace = {}
-    >>> exec_(py_mod, namespace, namespace)
+    >>> exec(py_mod, namespace, namespace)
     >>> res = eval('newton(0.5)', namespace)
     >>> abs(res - 0.865474033102) < 1e-12
     True

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1,13 +1,14 @@
 import bisect
 import itertools
 from functools import reduce
+from itertools import accumulate
 from collections import defaultdict
 
 from sympy import Indexed, IndexedBase, Tuple, Sum, Add, S, Integer, diagonalize_vector, DiagMatrix
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import _af_invert
 from sympy.core.basic import Basic
-from sympy.core.compatibility import accumulate, default_sort_key
+from sympy.core.compatibility import default_sort_key
 from sympy.core.mul import Mul
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta

--- a/sympy/codegen/tests/test_algorithms.py
+++ b/sympy/codegen/tests/test_algorithms.py
@@ -1,6 +1,5 @@
 import tempfile
 import sympy as sp
-from sympy.core.compatibility import exec_
 from sympy.codegen.ast import Assignment
 from sympy.codegen.algorithms import newtons_method, newtons_method_function
 from sympy.codegen.fnodes import bind_C
@@ -75,7 +74,7 @@ def test_newtons_method_function__pycode():
     func = newtons_method_function(expr, x)
     py_mod = py_module(func)
     namespace = {}
-    exec_(py_mod, namespace, namespace)
+    exec(py_mod, namespace, namespace)
     res = eval('newton(0.5)', namespace)
     assert abs(res - 0.865474033102) < 1e-12
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1,12 +1,13 @@
 import random
 from collections import defaultdict
+from collections.abc import Iterable
 from functools import reduce
 
 from sympy.core.parameters import global_parameters
 from sympy.core.basic import Atom
 from sympy.core.expr import Expr
 from sympy.core.compatibility import \
-    is_sequence, as_int, Iterable
+    is_sequence, as_int
 from sympy.core.numbers import Integer
 from sympy.core.sympify import _sympify
 from sympy.matrices import zeros

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1,11 +1,12 @@
 import random
 from collections import defaultdict
+from functools import reduce
 
 from sympy.core.parameters import global_parameters
 from sympy.core.basic import Atom
 from sympy.core.expr import Expr
 from sympy.core.compatibility import \
-    is_sequence, reduce, as_int, Iterable
+    is_sequence, as_int, Iterable
 from sympy.core.numbers import Integer
 from sympy.core.sympify import _sympify
 from sympy.matrices import zeros

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-from functools import cmp_to_key
+from functools import cmp_to_key, reduce
 from .basic import Basic
-from .compatibility import reduce, is_sequence
+from .compatibility import is_sequence
 from .parameters import global_parameters
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,11 +1,12 @@
 """Base class for all the objects in SymPy"""
 from collections import defaultdict
+from collections.abc import Mapping
 from itertools import chain, zip_longest
 
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
-from .compatibility import iterable, ordered, Mapping
+from .compatibility import iterable, ordered
 from .singleton import S
 from ._print_helpers import Printable
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -57,106 +57,34 @@ __all__ = [
 ]
 
 import sys
-PY3 = sys.version_info[0] > 2
+PY3 = True
 
-if PY3:
-    int_info = sys.int_info
+int_info = sys.int_info
 
-    # String / unicode compatibility
-    unicode = str
+# String / unicode compatibility
+unicode = str
 
-    def u_decode(x):
-        return x
+def u_decode(x):
+    return x
 
-    # Moved definitions
-    get_function_code = operator.attrgetter("__code__")
-    get_function_globals = operator.attrgetter("__globals__")
-    get_function_name = operator.attrgetter("__name__")
+# Moved definitions
+get_function_code = operator.attrgetter("__code__")
+get_function_globals = operator.attrgetter("__globals__")
+get_function_name = operator.attrgetter("__name__")
 
-    import builtins
-    from functools import reduce
-    from io import StringIO
-    cStringIO = StringIO
+import builtins
+from functools import reduce
+from io import StringIO
+cStringIO = StringIO
 
-    exec_ = getattr(builtins, "exec")
+exec_ = getattr(builtins, "exec")
 
-    from collections.abc import (Mapping, Callable, MutableMapping,
-        MutableSet, Iterable, Hashable)
+from collections.abc import (Mapping, Callable, MutableMapping,
+    MutableSet, Iterable, Hashable)
 
-    from inspect import unwrap
-    from itertools import accumulate
-else:
-    int_info = sys.long_info
+from inspect import unwrap
+from itertools import accumulate
 
-    # String / unicode compatibility
-    unicode = unicode
-
-    def u_decode(x):
-        return x.decode('utf-8')
-
-    # Moved definitions
-    get_function_code = operator.attrgetter("func_code")
-    get_function_globals = operator.attrgetter("func_globals")
-    get_function_name = operator.attrgetter("func_name")
-
-    import __builtin__ as builtins
-    reduce = reduce
-    from StringIO import StringIO
-    from cStringIO import StringIO as cStringIO
-
-    def exec_(_code_, _globs_=None, _locs_=None):
-        """Execute code in a namespace."""
-        if _globs_ is None:
-            frame = sys._getframe(1)
-            _globs_ = frame.f_globals
-            if _locs_ is None:
-                _locs_ = frame.f_locals
-            del frame
-        elif _locs_ is None:
-            _locs_ = _globs_
-        exec("exec _code_ in _globs_, _locs_")
-
-    from collections import (Mapping, Callable, MutableMapping,
-        MutableSet, Iterable, Hashable)
-
-    def unwrap(func, stop=None):
-        """Get the object wrapped by *func*.
-
-       Follows the chain of :attr:`__wrapped__` attributes returning the last
-       object in the chain.
-
-       *stop* is an optional callback accepting an object in the wrapper chain
-       as its sole argument that allows the unwrapping to be terminated early if
-       the callback returns a true value. If the callback never returns a true
-       value, the last object in the chain is returned as usual. For example,
-       :func:`signature` uses this to stop unwrapping if any object in the
-       chain has a ``__signature__`` attribute defined.
-
-       :exc:`ValueError` is raised if a cycle is encountered.
-
-        """
-        if stop is None:
-            def _is_wrapper(f):
-                return hasattr(f, '__wrapped__')
-        else:
-            def _is_wrapper(f):
-                return hasattr(f, '__wrapped__') and not stop(f)
-        f = func  # remember the original func for error reporting
-        memo = {id(f)} # Memoise by id to tolerate non-hashable objects
-        while _is_wrapper(func):
-            func = func.__wrapped__
-            id_func = id(func)
-            if id_func in memo:
-                raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
-            memo.add(id_func)
-        return func
-
-    def accumulate(iterable, func=operator.add):
-        state = iterable[0]
-        yield state
-        for i in iterable[1:]:
-            state = func(state, i)
-            yield state
 
 
 def with_metaclass(meta, *bases):

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -7,9 +7,10 @@
 """
 
 from collections import OrderedDict
+from collections.abc import MutableSet
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int, MutableSet
+from sympy.core.compatibility import as_int
 from sympy.core.sympify import _sympify, sympify, converter, SympifyError
 from sympy.utilities.iterables import iterable
 

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -7,7 +7,6 @@ dependencies, so that they can be easily imported anywhere in sympy/core.
 
 from functools import wraps
 from .sympify import SympifyError, sympify
-from sympy.core.compatibility import get_function_code
 
 
 def deprecated(**decorator_kwargs):
@@ -76,10 +75,10 @@ def __sympifyit(func, arg, retval=None):
     """
 
     # we support f(a,b) only
-    if not get_function_code(func).co_argcount:
+    if not func.__code__.co_argcount:
         raise LookupError("func not found")
     # only b is _sympified
-    assert get_function_code(func).co_varnames[1] == arg
+    assert func.__code__.co_varnames[1] == arg
     if retval is None:
         @wraps(func)
         def __sympifyit_wrapper(a, b):
@@ -243,12 +242,12 @@ class _SympifyWrapper:
 
         # Raise RuntimeError since this is a failure at import time and should
         # not be recoverable.
-        nargs = get_function_code(func).co_argcount
+        nargs = func.__code__.co_argcount
         # we support f(a, b) only
         if nargs != 2:
             raise RuntimeError('sympify_return can only be used with 2 argument functions')
         # only b is _sympified
-        if get_function_code(func).co_varnames[1] != parameter:
+        if func.__code__.co_varnames[1] != parameter:
             raise RuntimeError('parameter name mismatch "%s" in %s' %
                     (parameter, func.__name__))
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1,4 +1,5 @@
 from typing import Tuple as tTuple
+from functools import reduce
 
 from .sympify import sympify, _sympify, SympifyError
 from .basic import Basic, Atom
@@ -6,7 +7,7 @@ from .singleton import S
 from .evalf import EvalfMixin, pure_complex
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
 from .cache import cacheit
-from .compatibility import reduce, as_int, default_sort_key, Iterable
+from .compatibility import as_int, default_sort_key, Iterable
 from sympy.utilities.misc import func_name
 from mpmath.libmp import mpf_log, prec_to_dps
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1,4 +1,5 @@
 from typing import Tuple as tTuple
+from collections.abc import Iterable
 from functools import reduce
 
 from .sympify import sympify, _sympify, SympifyError
@@ -7,7 +8,7 @@ from .singleton import S
 from .evalf import EvalfMixin, pure_complex
 from .decorators import call_highest_priority, sympify_method_args, sympify_return
 from .cache import cacheit
-from .compatibility import as_int, default_sort_key, Iterable
+from .compatibility import as_int, default_sort_key
 from sympy.utilities.misc import func_name
 from mpmath.libmp import mpf_log, prec_to_dps
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from functools import cmp_to_key
+from functools import cmp_to_key, reduce
 import operator
 
 from .sympify import sympify
@@ -8,7 +8,6 @@ from .singleton import S
 from .operations import AssocOp, AssocOpDispatcher
 from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
-from .compatibility import reduce
 from .expr import Expr
 from .parameters import global_parameters
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3,6 +3,7 @@ import decimal
 import fractions
 import math
 import re as regex
+import sys
 
 from .containers import Tuple
 from .sympify import (SympifyError, converter, sympify, _convert_numpy_types, _sympify,
@@ -14,7 +15,7 @@ from .decorators import _sympifyit
 from .cache import cacheit, clear_cache
 from .logic import fuzzy_not
 from sympy.core.compatibility import (as_int, HAS_GMPY, SYMPY_INTS,
-    int_info, gmpy)
+    gmpy)
 from sympy.core.cache import lru_cache
 from sympy.multipledispatch import dispatch
 import mpmath
@@ -333,7 +334,7 @@ def igcd_lehmer(a, b):
     # pair (a, b) with a pair of shorter consecutive elements
     # of the Euclidean gcd sequence until a and b
     # fit into two Python (long) int digits.
-    nbits = 2*int_info.bits_per_digit
+    nbits = 2*sys.int_info.bits_per_digit
 
     while a.bit_length() > nbits and b != 0:
         # Quotients are mostly small integers that can

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -157,9 +157,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     In order to have ``bitcount`` be recognized it can be imported into a
     namespace dictionary and passed as locals:
 
-    >>> from sympy.core.compatibility import exec_
     >>> ns = {}
-    >>> exec_('from sympy.core.evalf import bitcount', ns)
+    >>> exec('from sympy.core.evalf import bitcount', ns)
     >>> sympify(s, locals=ns)
     6
 
@@ -169,7 +168,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     >>> from sympy import Symbol
     >>> ns["O"] = Symbol("O")  # method 1
-    >>> exec_('from sympy.abc import O', ns)  # method 2
+    >>> exec('from sympy.abc import O', ns)  # method 2
     >>> ns.update(dict(O=Symbol("O")))  # method 3
     >>> sympify("O + 1", locals=ns)
     O + 1

--- a/sympy/core/tests/test_singleton.py
+++ b/sympy/core/tests/test_singleton.py
@@ -2,8 +2,6 @@ from sympy.core.basic import Basic
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S, Singleton
 
-from sympy.core.compatibility import exec_
-
 def test_Singleton():
     global instantiated
     instantiated = 0
@@ -65,7 +63,7 @@ def test_names_in_namespace():
     # str printer should print a form that does not use S. This is because
     # sympify() disables attribute lookups by default for safety purposes.
     d = {}
-    exec_('from sympy import *', d)
+    exec('from sympy import *', d)
 
     for name in dir(S) + list(S._classes_to_install):
         if name.startswith('_'):

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -11,7 +11,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
-from sympy.core.compatibility import exec_, HAS_GMPY
+from sympy.core.compatibility import HAS_GMPY
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 
@@ -532,7 +532,7 @@ def test_issue_6046():
     assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
     assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
     locals = {}
-    exec_("from sympy.abc import Q, C", locals)
+    exec("from sympy.abc import Q, C", locals)
     assert str(S('C&Q', locals)) == 'C & Q'
 
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1,5 +1,6 @@
 from typing import Any, Set
 
+from functools import reduce
 from itertools import permutations
 
 from sympy.combinatorics import Permutation
@@ -8,7 +9,7 @@ from sympy.core import (
     Pow, Mul, Add, Atom, Lambda, S, Tuple, Dict
 )
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import reduce
+
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,8 +1,9 @@
 from typing import List
+from functools import reduce
 
 from sympy.core import S, sympify, Dummy, Mod
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import reduce, HAS_GMPY
+from sympy.core.compatibility import HAS_GMPY
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import Integer, pi

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -1,8 +1,9 @@
 """Hypergeometric and Meijer G-functions"""
+from functools import reduce
 
 from sympy.core import S, I, pi, oo, zoo, ilcm, Mod
 from sympy.core.function import Function, Derivative, ArgumentIndexError
-from sympy.core.compatibility import reduce
+
 from sympy.core.containers import Tuple
 from sympy.core.mul import Mul
 from sympy.core.symbol import Dummy

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from itertools import permutations
+from functools import reduce
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic
@@ -35,7 +36,7 @@ from sympy.polys.rings import PolyRing
 from sympy.polys.solvers import solve_lin_sys
 from sympy.polys.constructor import construct_domain
 
-from sympy.core.compatibility import reduce, ordered
+from sympy.core.compatibility import ordered
 from sympy.integrals.integrals import integrate
 
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -18,12 +18,12 @@ To enable simple substitutions, add the match to find_substitutions.
 """
 
 from typing import Dict as tDict, Optional
-
 from collections import namedtuple, defaultdict
+from functools import reduce
 
 import sympy
 
-from sympy.core.compatibility import reduce, Mapping, iterable
+from sympy.core.compatibility import Mapping, iterable
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
 from sympy.core.logic import fuzzy_not

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -19,11 +19,12 @@ To enable simple substitutions, add the match to find_substitutions.
 
 from typing import Dict as tDict, Optional
 from collections import namedtuple, defaultdict
+from collections.abc import Mapping
 from functools import reduce
 
 import sympy
 
-from sympy.core.compatibility import Mapping, iterable
+from sympy.core.compatibility import iterable
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
 from sympy.core.logic import fuzzy_not

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -15,8 +15,9 @@ the right hand side of the equation (i.e., qi in k[t]).  See the docstring of
 each function for more information.
 """
 
+from functools import reduce
+
 from sympy.core import Dummy, ilcm, Add, Mul, Pow, S
-from sympy.core.compatibility import reduce
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     bound_degree)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, derivation,

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -22,9 +22,9 @@ Manuel Bronstein.  See also the docstring of risch.py.
 """
 
 from operator import mul
+from functools import reduce
 
 from sympy.core import oo
-from sympy.core.compatibility import reduce
 from sympy.core.symbol import Dummy
 
 from sympy.polys import Poly, gcd, ZZ, cancel

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -33,7 +33,7 @@ from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
-from sympy.core.compatibility import reduce, ordered
+from sympy.core.compatibility import ordered
 from sympy.integrals.heurisch import _symbols
 
 from sympy.functions import (acos, acot, asin, atan, cos, cot, exp, log,
@@ -47,6 +47,7 @@ from sympy.polys import gcd, cancel, PolynomialError, Poly, reduced, RootSum, Do
 from sympy.utilities.iterables import numbered_symbols
 
 from types import GeneratorType
+from functools import reduce
 
 
 def integer_powers(exprs):

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1,7 +1,8 @@
 """ Integral Transforms """
+from functools import reduce
 
 from sympy.core import S
-from sympy.core.compatibility import reduce, iterable
+from sympy.core.compatibility import iterable
 from sympy.core.function import Function
 from sympy.core.relational import _canonical, Ge, Gt
 from sympy.core.numbers import oo

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -13,7 +13,7 @@ from sympy.printing.defaults import Printable
 def _init_python_printing(stringify_func, **settings):
     """Setup printing in Python interactive session. """
     import sys
-    from sympy.core.compatibility import builtins
+    import builtins
 
     def _displayhook(arg):
         """Python's pretty-printer display hook.

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -109,7 +109,7 @@ def int_to_Integer(s):
     1/2
     """
     from tokenize import generate_tokens, untokenize, NUMBER, NAME, OP
-    from sympy.core.compatibility import StringIO
+    from io import StringIO
 
     def _is_int(num):
         """

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -4,16 +4,16 @@ when creating more advanced matrices (e.g., matrices over rings,
 etc.).
 """
 
-from sympy.core.logic import FuzzyBool
-
 from collections import defaultdict
 from inspect import isfunction
+from functools import reduce
 
+from sympy.core.logic import FuzzyBool
 from sympy.assumptions.refine import refine
 from sympy.core import SympifyError, Add
 from sympy.core.basic import Atom
 from sympy.core.compatibility import (
-    Iterable, as_int, is_sequence, reduce)
+    Iterable, as_int, is_sequence)
 from sympy.core.decorators import call_highest_priority
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -5,6 +5,7 @@ etc.).
 """
 
 from collections import defaultdict
+from collections.abc import Iterable
 from inspect import isfunction
 from functools import reduce
 
@@ -12,8 +13,7 @@ from sympy.core.logic import FuzzyBool
 from sympy.assumptions.refine import refine
 from sympy.core import SympifyError, Add
 from sympy.core.basic import Atom
-from sympy.core.compatibility import (
-    Iterable, as_int, is_sequence)
+from sympy.core.compatibility import as_int, is_sequence
 from sympy.core.decorators import call_highest_priority
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,8 +1,9 @@
 import random
+from functools import reduce
 
 from sympy.core import SympifyError, Add
 from sympy.core.basic import Basic
-from sympy.core.compatibility import is_sequence, reduce
+from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import reduce
+from functools import reduce
 import operator
 
 from sympy.core import Add, Basic, sympify

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
+from functools import reduce
 
 from sympy.core import SympifyError, Add
-from sympy.core.compatibility import Callable, as_int, is_sequence, reduce
+from sympy.core.compatibility import Callable, as_int, is_sequence
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
 from sympy.core.singleton import S

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
+from collections.abc import Callable
 from functools import reduce
 
 from sympy.core import SympifyError, Add
-from sympy.core.compatibility import Callable, as_int, is_sequence
+from sympy.core.compatibility import as_int, is_sequence
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
 from sympy.core.singleton import S

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,5 +1,6 @@
 import random
 import concurrent.futures
+from collections.abc import Hashable
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, Poly, Pow, PurePoly, Rational,
@@ -15,7 +16,7 @@ from sympy.matrices import (
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix,
     MatrixSymbol, dotprodsimp)
 from sympy.matrices.utilities import _dotprodsimp_state
-from sympy.core.compatibility import iterable, Hashable
+from sympy.core.compatibility import iterable
 from sympy.core import Tuple, Wild
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.utilities.iterables import flatten, capture

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,4 +1,6 @@
-from sympy.core.compatibility import as_int, reduce
+from functools import reduce
+
+from sympy.core.compatibility import as_int
 from sympy.core.mul import prod
 from sympy.core.numbers import igcdex, igcd
 from sympy.ntheory.primetest import isprime

--- a/sympy/parsing/ast_parser.py
+++ b/sympy/parsing/ast_parser.py
@@ -20,7 +20,6 @@ before returning the node.
 """
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import exec_
 from sympy.core.sympify import SympifyError
 
 from ast import parse, NodeTransformer, Call, Name, Load, \
@@ -70,7 +69,7 @@ def parse_expr(s, local_dict):
     automatically creates Symbols.
     """
     global_dict = {}
-    exec_('from sympy import *', global_dict)
+    exec('from sympy import *', global_dict)
     try:
         a = parse(s.strip(), mode="eval")
     except SyntaxError:

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -9,7 +9,7 @@ import ast
 import unicodedata
 from io import StringIO
 
-from sympy.core.compatibility import exec_, iterable
+from sympy.core.compatibility import iterable
 from sympy.core.basic import Basic
 from sympy.core import Symbol
 from sympy.core.function import arity
@@ -981,7 +981,7 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     if global_dict is None:
         global_dict = {}
-        exec_('from sympy import *', global_dict)
+        exec('from sympy import *', global_dict)
     elif not isinstance(global_dict, dict):
         raise TypeError('expecting global_dict to be a dict')
 

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -7,8 +7,9 @@ from keyword import iskeyword
 
 import ast
 import unicodedata
+from io import StringIO
 
-from sympy.core.compatibility import exec_, StringIO, iterable
+from sympy.core.compatibility import exec_, iterable
 from sympy.core.basic import Basic
 from sympy.core import Symbol
 from sympy.core.function import arity

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -1,13 +1,13 @@
 __all__ = ['Linearizer']
 
 from sympy.core.backend import Matrix, eye, zeros
-from sympy.core.compatibility import Iterable
 from sympy import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import msubs
 
 from collections import namedtuple
+from collections.abc import Iterable
 
 class Linearizer:
     """This object holds the general model form for a dynamic system.

--- a/sympy/physics/quantum/circuitutils.py
+++ b/sympy/physics/quantum/circuitutils.py
@@ -1,8 +1,9 @@
 """Primitive circuit operations on quantum circuits."""
 
+from functools import reduce
+
 from sympy import Symbol, Tuple, Mul, sympify, default_sort_key
 from sympy.utilities import numbered_symbols
-from sympy.core.compatibility import reduce
 from sympy.physics.quantum.gate import Gate
 
 __all__ = [

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -5,12 +5,12 @@ Authors:
 * Matt Curry
 """
 
+from functools import reduce
+
 from sympy import Basic, Interval, oo, sympify
 from sympy.printing.pretty.stringpict import prettyForm
-
 from sympy.physics.quantum.qexpr import QuantumError
 
-from sympy.core.compatibility import reduce
 
 __all__ = [
     'HilbertSpaceError',

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -22,7 +22,6 @@ from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.sho1d import RaisingOp
 
 from sympy import Derivative, Function, Interval, Matrix, Pow, S, symbols, Symbol, oo
-from sympy.core.compatibility import exec_
 from sympy.testing.pytest import XFAIL
 
 # Imports used in srepr strings
@@ -36,15 +35,15 @@ MutableDenseMatrix = Matrix
 
 
 ENV = {}  # type: Dict[str, Any]
-exec_('from sympy import *', ENV)
-exec_('from sympy.physics.quantum import *', ENV)
-exec_('from sympy.physics.quantum.cg import *', ENV)
-exec_('from sympy.physics.quantum.spin import *', ENV)
-exec_('from sympy.physics.quantum.hilbert import *', ENV)
-exec_('from sympy.physics.quantum.qubit import *', ENV)
-exec_('from sympy.physics.quantum.qexpr import *', ENV)
-exec_('from sympy.physics.quantum.gate import *', ENV)
-exec_('from sympy.physics.quantum.constants import *', ENV)
+exec('from sympy import *', ENV)
+exec('from sympy.physics.quantum import *', ENV)
+exec('from sympy.physics.quantum.cg import *', ENV)
+exec('from sympy.physics.quantum.spin import *', ENV)
+exec('from sympy.physics.quantum.hilbert import *', ENV)
+exec('from sympy.physics.quantum.qubit import *', ENV)
+exec('from sympy.physics.quantum.qexpr import *', ENV)
+exec('from sympy.physics.quantum.gate import *', ENV)
+exec('from sympy.physics.quantum.constants import *', ENV)
 
 
 def sT(expr, string):

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -13,10 +13,10 @@ question of adding time to length has no meaning.
 from typing import Dict as tDict
 
 import collections
+from functools import reduce
 
 from sympy import (Integer, Matrix, S, Symbol, sympify, Basic, Tuple, Dict,
     default_sort_key)
-from sympy.core.compatibility import reduce
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
 from sympy.utilities.exceptions import SymPyDeprecationWarning

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -2,9 +2,10 @@
 Several methods to simplify expressions involving unit objects.
 """
 from functools import reduce
+from collections.abc import Iterable
 
 from sympy import Add, Mul, Pow, Tuple, sympify
-from sympy.core.compatibility import Iterable, ordered
+from sympy.core.compatibility import ordered
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension
 from sympy.physics.units.prefixes import Prefix

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -1,9 +1,10 @@
 """
 Several methods to simplify expressions involving unit objects.
 """
+from functools import reduce
 
 from sympy import Add, Mul, Pow, Tuple, sympify
-from sympy.core.compatibility import reduce, Iterable, ordered
+from sympy.core.compatibility import Iterable, ordered
 from sympy.matrices.common import NonInvertibleMatrixError
 from sympy.physics.units.dimensions import Dimension
 from sympy.physics.units.prefixes import Prefix

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -1,7 +1,8 @@
+from functools import reduce
+
 from sympy.core.backend import (sympify, diff, sin, cos, Matrix, symbols,
                                 Function, S, Symbol)
 from sympy import integrate, trigsimp
-from sympy.core.compatibility import reduce
 from .vector import Vector, _check_vector
 from .frame import CoordinateSym, _check_frame
 from .dyadic import Dyadic

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -198,7 +198,7 @@ def vprint(expr, **settings):
 
     outstr = vsprint(expr, **settings)
 
-    from sympy.core.compatibility import builtins
+    import builtins
     if (outstr != 'None'):
         builtins._ = outstr
         print(outstr)

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -13,7 +13,6 @@ and so on).
 
 import re
 from sympy import Symbol, NumberSymbol, I, zoo, oo
-from sympy.core.compatibility import exec_
 from sympy.utilities.iterables import numbered_symbols
 
 #  We parse the expression string into a tree that identifies functions. Then
@@ -266,7 +265,7 @@ class Lambdifier:
             print(newexpr)
         eval_str = 'lambda %s : ( %s )' % (argstr, newexpr)
         self.eval_str = eval_str
-        exec_("from __future__ import division; MYNEWLAMBDA = %s" % eval_str, namespace)
+        exec("from __future__ import division; MYNEWLAMBDA = %s" % eval_str, namespace)
         self.lambda_func = namespace['MYNEWLAMBDA']
 
     def __call__(self, *args, **kwargs):

--- a/sympy/plotting/intervalmath/lib_interval.py
+++ b/sympy/plotting/intervalmath/lib_interval.py
@@ -1,8 +1,8 @@
+""" The module contains implemented functions for interval arithmetic."""
+from functools import reduce
+
 from sympy.plotting.intervalmath import interval
 from sympy.external import import_module
-from sympy.core.compatibility import reduce
-""" The module contains implemented functions for interval arithmetic."""
-
 
 
 def Abs(x):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -24,11 +24,11 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 
 
 import warnings
+from collections.abc import Callable
 
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
 from sympy.external import import_module
 from sympy.core.function import arity
-from sympy.core.compatibility import Callable
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)
 

--- a/sympy/polys/agca/ideals.py
+++ b/sympy/polys/agca/ideals.py
@@ -1,7 +1,7 @@
 """Computations with ideals of polynomial rings."""
 
+from functools import reduce
 
-from sympy.core.compatibility import reduce
 from sympy.polys.polyerrors import CoercionFailed
 
 

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -19,8 +19,9 @@ convenience methods, for example if there are faster algorithms available.
 
 
 from copy import copy
+from functools import reduce
 
-from sympy.core.compatibility import iterable, reduce
+from sympy.core.compatibility import iterable
 from sympy.polys.agca.ideals import Ideal
 from sympy.polys.domains.field import Field
 from sympy.polys.orderings import ProductOrder, monomial_key

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -1,7 +1,7 @@
 """Ground types for various mathematical domains in SymPy. """
 
-
-from sympy.core.compatibility import builtins, HAS_GMPY
+import builtins
+from sympy.core.compatibility import HAS_GMPY
 
 PythonInteger = builtins.int
 PythonReal = builtins.float

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -2,10 +2,11 @@
 
 
 from typing import Any, Dict
+from functools import reduce
 
 from operator import add, mul, lt, le, gt, ge
 
-from sympy.core.compatibility import is_sequence, reduce
+from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.mod import Mod
 from sympy.core.numbers import Exp1

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -5,7 +5,7 @@ from itertools import combinations_with_replacement, product
 from textwrap import dedent
 
 from sympy.core import Mul, S, Tuple, sympify
-from sympy.core.compatibility import exec_, iterable
+from sympy.core.compatibility import iterable
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.utilities import public
@@ -405,7 +405,7 @@ class MonomialOps:
 
     def _build(self, code, name):
         ns = {}
-        exec_(code, ns)
+        exec(code, ns)
         return ns[name]
 
     def _vars(self, name):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -1,12 +1,13 @@
 """Computational algebraic field theory. """
 
+from functools import reduce
 
 from sympy import (
     S, Rational, AlgebraicNumber, GoldenRatio, TribonacciConstant,
     Add, Mul, sympify, Dummy, expand_mul, I, pi
 )
 from sympy.functions import sqrt, cbrt
-from sympy.core.compatibility import reduce
+
 from sympy.core.exprtools import Factors
 from sympy.core.function import _mexpand
 from sympy.functions.elementary.exponential import exp

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -2,9 +2,10 @@
 
 
 import math
+from functools import reduce
 
 from sympy.core import S, I, pi
-from sympy.core.compatibility import ordered, reduce
+from sympy.core.compatibility import ordered
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import _mexpand
 from sympy.core.logic import fuzzy_not

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -439,7 +439,7 @@ class PicklableWithSlots:
 
     To make :mod:`pickle` happy in doctest we have to use these hacks::
 
-        >>> from sympy.core.compatibility import builtins
+        >>> import builtins
         >>> builtins.Some = Some
         >>> from sympy.polys import polyutils
         >>> polyutils.Some = Some

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -4,9 +4,10 @@
 from typing import Any, Dict
 
 from operator import add, mul, lt, le, gt, ge
+from functools import reduce
 from types import GeneratorType
 
-from sympy.core.compatibility import is_sequence, reduce
+from sympy.core.compatibility import is_sequence
 from sympy.core.expr import Expr
 from sympy.core.numbers import igcd, oo
 from sympy.core.symbol import Symbol, symbols as _symbols

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1,5 +1,6 @@
 """Test sparse polynomials. """
 
+from functools import reduce
 from operator import add, mul
 
 from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement
@@ -11,7 +12,7 @@ from sympy.polys.polyerrors import GeneratorsError, \
 
 from sympy.testing.pytest import raises
 from sympy.core import Symbol, symbols
-from sympy.core.compatibility import reduce
+
 from sympy import sqrt, pi, oo
 
 def test_PolyRing___init__():

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -4,7 +4,7 @@ A few practical conventions common to all printers.
 
 import re
 
-from sympy.core.compatibility import Iterable
+from collections.abc import Iterable
 from sympy import Derivative
 
 _name_with_digits_p = re.compile(r'^([a-zA-Z]+)([0-9]+)$')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4708,7 +4708,7 @@ def test_pretty_prec():
 
 def test_pprint():
     import sys
-    from sympy.core.compatibility import StringIO
+    from io import StringIO
     fd = StringIO()
     sso = sys.stdout
     sys.stdout = fd

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -1,8 +1,8 @@
 from distutils.version import LooseVersion as V
+from collections.abc import Iterable
 
 from sympy import Mul, S
 from sympy.codegen.cfunctions import Sqrt
-from sympy.core.compatibility import Iterable
 from sympy.external import import_module
 from sympy.printing.precedence import PRECEDENCE
 from sympy.printing.pycode import AbstractPythonCodePrinter

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -5,7 +5,6 @@ from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
     sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol)
 from sympy.combinatorics import Cycle, Permutation
-from sympy.core.compatibility import exec_
 from sympy.core.symbol import Str
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -18,7 +17,7 @@ x, y = symbols('x,y')
 # eval(srepr(expr)) == expr has to succeed in the right environment. The right
 # environment is the scope of "from sympy import *" for most cases.
 ENV = {"Str": Str}  # type: Dict[str, Any]
-exec_("from sympy import *", ENV)
+exec("from sympy import *", ENV)
 
 
 def sT(expr, string, import_stmt=None):
@@ -32,7 +31,7 @@ def sT(expr, string, import_stmt=None):
         ENV2 = ENV
     else:
         ENV2 = ENV.copy()
-        exec_(import_stmt, ENV2)
+        exec(import_stmt, ENV2)
 
     assert srepr(expr) == string
     assert eval(string, ENV2) == expr

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -116,9 +116,11 @@ And check manually which line is wrong. Then go to the source code and
 debug this function to figure out the exact problem.
 
 """
+from functools import reduce
+
 from sympy import cacheit
 from sympy.core import Basic, S, oo, I, Dummy, Wild, Mul
-from sympy.core.compatibility import reduce
+
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp, powdenest

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
+from functools import reduce
 
 from sympy.core import (sympify, Basic, S, Expr, expand_mul, factor_terms,
     Mul, Dummy, igcd, FunctionClass, Add, symbols, Wild, expand)
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import reduce, iterable, SYMPY_INTS
+from sympy.core.compatibility import iterable, SYMPY_INTS
 from sympy.core.function import count_ops, _mexpand
 from sympy.core.numbers import I, Integer
 from sympy.functions import sin, cos, exp, cosh, tanh, sinh, tan, cot, coth

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -32,10 +32,12 @@ more information on each (run help(pde)):
     variable coefficients.
 
 """
+from functools import reduce
+
 from itertools import combinations_with_replacement
 from sympy.simplify import simplify  # type: ignore
 from sympy.core import Add, S
-from sympy.core.compatibility import reduce, is_sequence
+from sympy.core.compatibility import is_sequence
 from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, symbols

--- a/sympy/strategies/branch/core.py
+++ b/sympy/strategies/branch/core.py
@@ -1,5 +1,4 @@
 """ Generic SymPy-Independent Strategies """
-from sympy.core.compatibility import get_function_name
 
 def identity(x):
     yield x
@@ -31,7 +30,7 @@ def debug(brule, file=None):
         file = stdout
 
     def write(brl, expr, result):
-        file.write("Rule: %s\n" % get_function_name(brl))
+        file.write("Rule: %s\n" % brl.__name__)
         file.write("In: %s\nOut: %s\n\n" % (expr, result))
 
     return onaction(brule, write)

--- a/sympy/strategies/branch/tests/test_core.py
+++ b/sympy/strategies/branch/tests/test_core.py
@@ -34,7 +34,7 @@ def test_exhaust():
     assert set(brl(5)) == {0, 10}
 
 def test_debug():
-    from sympy.core.compatibility import StringIO
+    from io import StringIO
     file = StringIO()
     rl = debug(posdec, file)
     list(rl(5))

--- a/sympy/strategies/branch/tests/test_core.py
+++ b/sympy/strategies/branch/tests/test_core.py
@@ -1,7 +1,6 @@
 from sympy.strategies.branch.core import (exhaust, debug, multiplex,
         condition, notempty, chain, onaction, sfilter, yieldify, do_one,
         identity)
-from sympy.core.compatibility import get_function_name
 
 def posdec(x):
     if x > 0:
@@ -42,7 +41,7 @@ def test_debug():
     log = file.getvalue()
     file.close()
 
-    assert get_function_name(posdec) in log
+    assert posdec.__name__ in log
     assert '5' in log
     assert '4' in log
 

--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -1,5 +1,4 @@
 """ Generic SymPy-Independent Strategies """
-from sympy.core.compatibility import get_function_name
 
 identity = lambda x: x
 
@@ -52,7 +51,7 @@ def debug(rule, file=None):
         expr = args[0]
         result = rule(*args, **kwargs)
         if result != expr:
-            file.write("Rule: %s\n" % get_function_name(rule))
+            file.write("Rule: %s\n" % rule.__name__)
             file.write("In:   %s\nOut:  %s\n\n"%(expr, result))
         return result
     return debug_rl

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -56,7 +56,7 @@ def test_do_one():
     assert rule(rule(1)) == 3
 
 def test_debug():
-    from sympy.core.compatibility import StringIO
+    from io import StringIO
     file = StringIO()
     rl = debug(posdec, file)
     rl(5)

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -1,7 +1,6 @@
 from sympy import S
 from sympy.strategies.core import (null_safe, exhaust, memoize, condition,
         chain, tryit, do_one, debug, switch, minimize)
-from sympy.core.compatibility import get_function_name
 
 def test_null_safe():
     def rl(expr):
@@ -64,7 +63,7 @@ def test_debug():
     log = file.getvalue()
     file.close()
 
-    assert get_function_name(posdec) in log
+    assert posdec.__name__ in log
     assert '5' in log
     assert '4' in log
 

--- a/sympy/strategies/tests/test_tree.py
+++ b/sympy/strategies/tests/test_tree.py
@@ -1,6 +1,5 @@
 from sympy.strategies.tree import treeapply, greedy, allresults, brute
-from sympy.core.compatibility import reduce
-from functools import partial
+from functools import partial, reduce
 
 def test_treeapply():
     tree = ([3, 3], [4, 1], 2)

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,8 +1,8 @@
 import itertools
+from collections.abc import Iterable
 
 from sympy import S, Tuple, diff, Basic
 
-from sympy.core.compatibility import Iterable
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.array.dense_ndim_array import DenseNDimArray, ImmutableDenseNDimArray
 from sympy.tensor.array.sparse_ndim_array import SparseNDimArray

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -3,10 +3,11 @@ from sympy import S
 from sympy.core.expr import Expr
 from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import SYMPY_INTS, Iterable
+from sympy.core.compatibility import SYMPY_INTS
 from sympy.printing.defaults import Printable
 
 import itertools
+from collections.abc import Iterable
 
 
 class NDimArray(Printable):

--- a/sympy/tensor/functions.py
+++ b/sympy/tensor/functions.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
+
 from sympy import Expr, S, Mul, sympify
-from sympy.core.compatibility import Iterable
 from sympy.core.parameters import global_parameters
 
 

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -10,7 +10,8 @@
     refactoring.
 """
 
-from sympy.core.compatibility import reduce
+from functools import reduce
+
 from sympy.core.function import Function
 from sympy.functions import exp, Piecewise
 from sympy.tensor.indexed import Idx, Indexed

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -103,13 +103,13 @@ See the appropriate docstrings for a detailed explanation of the output.
 #      - Idx with range smaller than dimension of Indexed
 #      - Idx with stepsize != 1
 #      - Idx with step determined by function call
+from collections.abc import Iterable
 
 from sympy import Number
 from sympy.core.assumptions import StdFactKB
 from sympy.core import Expr, Tuple, sympify, S
 from sympy.core.symbol import _filter_assumptions, Symbol
-from sympy.core.compatibility import (is_sequence, NotIterable,
-                                      Iterable)
+from sympy.core.compatibility import (is_sequence, NotIterable)
 from sympy.core.logic import fuzzy_bool, fuzzy_not
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -30,6 +30,7 @@ lowered when the tensor is put in canonical form.
 """
 
 from typing import Any, Dict as tDict, List, Set
+from functools import reduce
 
 from abc import abstractmethod, ABCMeta
 from collections import defaultdict
@@ -41,7 +42,7 @@ from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, Expr, sympify, Add, Mul, S
 from sympy.core.assumptions import ManagedProperties
-from sympy.core.compatibility import reduce, SYMPY_INTS
+from sympy.core.compatibility import SYMPY_INTS
 from sympy.core.containers import Tuple, Dict
 from sympy.core.decorators import deprecated
 from sympy.core.symbol import Symbol, symbols

--- a/sympy/testing/benchmarking.py
+++ b/sympy/testing/benchmarking.py
@@ -9,8 +9,6 @@ import timeit
 
 from inspect import getsource
 
-from sympy.core.compatibility import exec_
-
 
 # from IPython.Magic.magic_timeit
 units = ["s", "ms", "us", "ns"]
@@ -50,8 +48,8 @@ class Timer(timeit.Timer):
         self.src = src  # Save for traceback display
         code = compile(src, timeit.dummy_src_name, "exec")
         ns = {}
-        #exec code in globals(), ns      -- original timeit code
-        exec_(code, globals, ns)  # -- we use caller-provided globals instead
+        #exec(code, globals(), ns)      -- original timeit code
+        exec(code, globals, ns)  # -- we use caller-provided globals instead
         self.inner = ns["inner"]
 
 

--- a/sympy/testing/pytest.py
+++ b/sympy/testing/pytest.py
@@ -6,7 +6,6 @@ import os
 import contextlib
 import warnings
 
-from sympy.core.compatibility import get_function_name
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
@@ -145,10 +144,10 @@ else:
             except Exception as e:
                 message = str(e)
                 if message != "Timeout":
-                    raise XFail(get_function_name(func))
+                    raise XFail(func.__name__)
                 else:
                     raise Skipped("Timeout")
-            raise XPass(get_function_name(func))
+            raise XPass(func.__name__)
 
         wrapper = functools.update_wrapper(wrapper, func)
         return wrapper

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -37,7 +37,7 @@ import warnings
 from contextlib import contextmanager
 
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import (exec_, PY3, unwrap)
+from sympy.core.compatibility import (PY3, unwrap)
 from sympy.external import import_module
 
 IS_WINDOWS = (os.name == 'nt')
@@ -1223,7 +1223,7 @@ class SymPyTests:
                         pass
 
                 code = compile(source, filename, "exec", flags=0, dont_inherit=True)
-                exec_(code, gl)
+                exec(code, gl)
             except (SystemExit, KeyboardInterrupt):
                 raise
             except ImportError:

--- a/sympy/testing/runtests.py
+++ b/sympy/testing/runtests.py
@@ -1398,7 +1398,7 @@ class SymPyDocTests:
     def test_file(self, filename):
         clear_cache()
 
-        from sympy.core.compatibility import StringIO
+        from io import StringIO
         import sympy.interactive.printing as interactive_printing
         from sympy import pprint_use_unicode
 

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
 
     import sys
     import inspect
-    from sympy.core.compatibility import builtins
+    import builtins
 
     import optparse
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -81,10 +81,11 @@ unsurmountable issues that can only be tackled with dedicated code generator:
 
 import os
 import textwrap
+from io import StringIO
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Tuple, Equality, Function, Basic
-from sympy.core.compatibility import is_sequence, StringIO
+from sympy.core.compatibility import is_sequence
 from sympy.printing.c import c_code_printers
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.fortran import FCodePrinter

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -5,7 +5,7 @@ import types
 import inspect
 
 from sympy.core.decorators import wraps
-from sympy.core.compatibility import get_function_globals, get_function_name, iterable
+from sympy.core.compatibility import iterable
 from sympy.testing.runtests import DependencyError, SymPyDocTests, PyTestReporter
 
 def threaded_factory(func, use_add):
@@ -206,8 +206,8 @@ def public(obj):
 
     """
     if isinstance(obj, types.FunctionType):
-        ns = get_function_globals(obj)
-        name = get_function_name(obj)
+        ns = obj.__globals__
+        name = obj.__name__
     elif isinstance(obj, (type(type), type)):
         ns = sys.modules[obj.__module__].__dict__
         name = obj.__name__

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -720,7 +720,7 @@ def capture(func):
     '2\\n-\\nx\\n'
 
     """
-    from sympy.core.compatibility import StringIO
+    from io import StringIO
     import sys
 
     stdout = sys.stdout

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -12,7 +12,7 @@ import textwrap
 import linecache
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from sympy.core.compatibility import (exec_, is_sequence, iterable,
+from sympy.core.compatibility import (is_sequence, iterable,
     NotIterable)
 from sympy.utilities.misc import filldedent
 from sympy.utilities.decorator import doctest_depends_on
@@ -139,7 +139,7 @@ def _import(module, reload=False):
                 continue
         else:
             try:
-                exec_(import_command, {}, namespace)
+                exec(import_command, {}, namespace)
                 continue
             except ImportError:
                 pass
@@ -847,13 +847,13 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
             if k not in namespace:
                 ln = "from %s import %s" % (mod, k)
                 try:
-                    exec_(ln, {}, namespace)
+                    exec(ln, {}, namespace)
                 except ImportError:
                     # Tensorflow 2.0 has issues with importing a specific
                     # function from its submodule.
                     # https://github.com/tensorflow/tensorflow/issues/33022
                     ln = "%s = %s.%s" % (k, mod, k)
-                    exec_(ln, {}, namespace)
+                    exec(ln, {}, namespace)
                 imp_mod_lines.append(ln)
 
     # Provide lambda expression with builtins, and compatible implementation of range
@@ -864,7 +864,7 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
     filename = '<lambdifygenerated-%s>' % _lambdify_generated_counter
     _lambdify_generated_counter += 1
     c = compile(funcstr, filename, 'exec')
-    exec_(c, namespace, funclocals)
+    exec(c, namespace, funclocals)
     # mtime has to be None or else linecache.checkcache will remove it
     linecache.cache[filename] = (len(funcstr), None, funcstr.splitlines(True), filename) # type: ignore
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -5,6 +5,7 @@ lambda functions which can be used to calculate numerical values very fast.
 
 from typing import Any, Dict, Iterable
 
+import builtins
 import inspect
 import keyword
 import textwrap
@@ -12,7 +13,7 @@ import linecache
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.compatibility import (exec_, is_sequence, iterable,
-    NotIterable, builtins)
+    NotIterable)
 from sympy.utilities.misc import filldedent
 from sympy.utilities.decorator import doctest_depends_on
 

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -7,7 +7,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from sympy.core.compatibility import get_function_name, as_int
+from sympy.core.compatibility import as_int
 from sympy.core.decorators import deprecated
 
 
@@ -217,12 +217,12 @@ def debug_decorator(func):
         # that are called, *before* they are called
         #from sympy.core.compatibility import reduce
         #print("%s%s %s%s" % (_debug_iter, reduce(lambda x, y: x + y, \
-        #    map(lambda x: '-', range(1, 2 + _debug_iter))), get_function_name(f), args))
+        #    map(lambda x: '-', range(1, 2 + _debug_iter))), f.__name__, args))
 
         r = f(*args, **kw)
 
         _debug_iter -= 1
-        s = "%s%s = %s\n" % (get_function_name(f), args, r)
+        s = "%s%s = %s\n" % (f.__name__, args, r)
         if _debug_tmp != []:
             s += tree(_debug_tmp)
         _debug_tmp = oldtmp
@@ -302,10 +302,6 @@ def func_name(x, short=False):
     'StrictLessThan'
     >>> func_name(x < 1, short=True)
     'Lt'
-
-    See Also
-    ========
-    sympy.core.compatibility get_function_name
     """
     alias = {
     'GreaterThan': 'Ge',

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -215,7 +215,7 @@ def debug_decorator(func):
         # If there is a bug and the algorithm enters an infinite loop, enable the
         # following lines. It will print the names and parameters of all major functions
         # that are called, *before* they are called
-        #from sympy.core.compatibility import reduce
+        #from functools import reduce
         #print("%s%s %s%s" % (_debug_iter, reduce(lambda x, y: x + y, \
         #    map(lambda x: '-', range(1, 2 + _debug_iter))), f.__name__, args))
 

--- a/sympy/utilities/pkgdata.py
+++ b/sympy/utilities/pkgdata.py
@@ -19,7 +19,7 @@ object (such as StringIO).
 
 import sys
 import os
-from sympy.core.compatibility import cStringIO as StringIO
+from io import StringIO
 
 
 def get_resource(identifier, pkgname=__name__):

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -4,9 +4,9 @@
 import os
 import tempfile
 import shutil
+from io import StringIO
 
 from sympy.core import symbols, Eq
-from sympy.core.compatibility import StringIO
 from sympy.utilities.autowrap import (autowrap, binary_function,
             CythonCodeWrapper, UfuncifyCodeWrapper, CodeWrapper)
 from sympy.utilities.codegen import (

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1,5 +1,6 @@
+from io import StringIO
+
 from sympy.core import symbols, Eq, pi, Catalan, Lambda, Dummy
-from sympy.core.compatibility import StringIO
 from sympy import erf, Integral, Symbol
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -1,5 +1,6 @@
+from io import StringIO
+
 from sympy.core import S, symbols, Eq, pi, Catalan, EulerGamma, Function
-from sympy.core.compatibility import StringIO
 from sympy import Piecewise
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -1,5 +1,6 @@
+from io import StringIO
+
 from sympy.core import S, symbols, Eq, pi, Catalan, EulerGamma, Function
-from sympy.core.compatibility import StringIO
 from sympy import Piecewise
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -1,5 +1,6 @@
+from io import StringIO
+
 from sympy.core import S, symbols, pi, Catalan, EulerGamma, Function
-from sympy.core.compatibility import StringIO
 from sympy import Piecewise
 from sympy import Equality
 from sympy.utilities.codegen import RustCodeGen, codegen, make_routine

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
+
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.basic import Basic
-from sympy.core.compatibility import Callable
 from sympy.core.cache import cacheit
 from sympy.core import S, Dummy, Lambda
 from sympy.core.symbol import Str


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
This removes all the dead code in `sympy.core.compatibility`, and adjust all callers that use the compatibility aliases to directly use the builtins.

It leaves the aliases behind, in case downstream projects are using them still.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->