### PR TITLE
Ad-hoc fix for sampling failures with lambdify

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1298,7 +1298,7 @@ def sample_iter(expr, condition=None, size=(), library='scipy',
         count = 0
         while count < numsamples:
             args = [d[rv][count] for rv in rvs]
-            # TODO: Replace the try-except block with only given_fn(*args)
+            # TODO: Replace the try-except block with only fn(*args)
             # once lambdify works with unevaluated SymPy objects.
             try:
                 yield fn(*args)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1255,6 +1255,8 @@ def sample_iter(expr, condition=None, size=(), library='scipy',
             args = [d[rv] for rv in rvs]
 
             if condition is not None:  # Check that these values satisfy the condition
+                # TODO: Replace the try-except block with only given_fn(*args)
+                # once lambdify works with unevaluated SymPy objects.
                 try:
                     gd = given_fn(*args)
                 except (NameError, TypeError):
@@ -1279,6 +1281,8 @@ def sample_iter(expr, condition=None, size=(), library='scipy',
                 args = [d[rv][count] for rv in rvs]
 
                 if condition is not None:  # Check that these values satisfy the condition
+                    # TODO: Replace the try-except block with only given_fn(*args)
+                    # once lambdify works with unevaluated SymPy objects.
                     try:
                         gd = given_fn(*args)
                     except (NameError, TypeError):
@@ -1294,6 +1298,8 @@ def sample_iter(expr, condition=None, size=(), library='scipy',
         count = 0
         while count < numsamples:
             args = [d[rv][count] for rv in rvs]
+            # TODO: Replace the try-except block with only given_fn(*args)
+            # once lambdify works with unevaluated SymPy objects.
             try:
                 yield fn(*args)
             except (NameError, TypeError):

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,11 +1,13 @@
 from sympy import (S, Symbol, Interval, exp, Or,
         symbols, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic, Indexed,
-        DiracDelta, Lambda, log, pi, FallingFactorial, Rational, Matrix)
+        DiracDelta, Lambda, log, pi, FallingFactorial, Rational, Matrix,
+        ConditionSet, Gt)
 from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, H, variance,
         density, given, independent, dependent, where, pspace, GaussianUnitaryEnsemble,
         random_symbols, sample, Geometric, factorial_moment, Binomial, Hypergeometric,
         DiscreteUniform, Poisson, characteristic_function, moment_generating_function,
-        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance)
+        BernoulliProcess, Variance, Expectation, Probability, Covariance, covariance,
+        Uniform)
 from sympy.stats.rv import (IndependentProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, sample_iter, PSpace, is_random, RandomIndexedSymbol, RandomMatrixSymbol)
 from sympy.testing.pytest import raises, skip, XFAIL, ignore_warnings
@@ -115,6 +117,12 @@ def test_sample_iter():
     itr_inf_2 = sample_iter(U, seed=0)
     for _ in range(10):
         assert next(itr_inf_1) == next(itr_inf_2)
+
+    x = Symbol('x')
+    interval = ConditionSet(x, Gt(x, 0), Interval(-1, 1))
+    U = Uniform('U', -1, 1)
+    s1 = sample(U, interval.contains(U), seed=0)
+    assert interval.contains(next(s1))
 
 def test_pspace():
     X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
https://github.com/sympy/sympy/issues/20563

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
    * `sympy.stats.sample` and `sample.stats.sample_iter` will now use `subs` if `lambdify` fails with `NameError`/`TypeError`.
<!-- END RELEASE NOTES -->