### PR TITLE
Core: Fixes Lazy Computation of series expansion having Mul

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3222,23 +3222,14 @@ class Expr(Basic, EvalfMixin):
         # terms.
         n = 0
         series = self._eval_nseries(x, n=n, logx=logx, cdir=cdir)
-        if not series.is_Order:
-            newseries = series.cancel()
-            if not newseries.is_Order:
-                if series.is_Add:
-                    yield series.removeO()
-                else:
-                    yield series
-                return
-            else:
-                series = newseries
 
         while series.is_Order:
             n += 1
             series = self._eval_nseries(x, n=n, logx=logx, cdir=cdir)
+
         e = series.removeO()
         yield e
-        if e.is_zero:
+        if e is S.Zero:
             return
 
         while 1:

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -317,3 +317,9 @@ def test_issue_11407():
 
 def test_issue_14037():
     assert (sin(x**50)/x**51).series(x, n=0) == 1/x + O(1, x)
+
+
+def test_issue_20551():
+    expr = (exp(x)/x).series(x, n=None)
+    terms = [ next(expr) for i in range(3) ]
+    assert terms == [1/x, 1, x/2]


### PR DESCRIPTION
Fixes: #20551 

#### Brief description of what is fixed or changed

Fixes lazy computation of `series expansion` involving `Mul` terms.

#### Other Comments
Regression Test has been added.


#### Release Notes


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->