### PR TITLE
Fixes Lazy Computation of series having Mul

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3222,23 +3222,14 @@ class Expr(Basic, EvalfMixin):
         # terms.
         n = 0
         series = self._eval_nseries(x, n=n, logx=logx, cdir=cdir)
-        if not series.is_Order:
-            newseries = series.cancel()
-            if not newseries.is_Order:
-                if series.is_Add:
-                    yield series.removeO()
-                else:
-                    yield series
-                return
-            else:
-                series = newseries
 
         while series.is_Order:
             n += 1
             series = self._eval_nseries(x, n=n, logx=logx, cdir=cdir)
+
         e = series.removeO()
         yield e
-        if e.is_zero:
+        if e is S.Zero:
             return
 
         while 1:

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -317,3 +317,9 @@ def test_issue_11407():
 
 def test_issue_14037():
     assert (sin(x**50)/x**51).series(x, n=0) == 1/x + O(1, x)
+
+
+def test_issue_20551():
+    expr = (exp(x)/x).series(x, n=None)
+    terms = [ next(expr) for i in range(3) ]
+    assert terms == [1/x, 1, x/2]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

#20587 backported to 1.7 for the 1.7.1 release.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed lazy iteration of series with `expr.series(x, n=None)` which was broken in the 1.7 release.
<!-- END RELEASE NOTES -->