### PR TITLE
fix(core): use __slots__ for DefaultPrinting and Basic

### DIFF
--- a/sympy/core/_print_helpers.py
+++ b/sympy/core/_print_helpers.py
@@ -17,6 +17,11 @@ class Printable:
     This also adds support for LaTeX printing in jupyter notebooks.
     """
 
+    # Since this class is used as a mixin we set empty slots. That means that
+    # instances of any subclasses that use slots will not need to have a
+    # __dict__.
+    __slots__ = ()
+
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting. See issue 5487.
     def __str__(self):

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -34,6 +34,12 @@ def test_structure():
     assert bool(b1)
 
 
+def test_immutable():
+    assert not hasattr(b1, '__dict__')
+    with raises(AttributeError):
+        b1.x = 1
+
+
 def test_equality():
     instances = [b1, b2, b3, b21, Basic(b1, b1, b1), Basic]
     for i, b_i in enumerate(instances):


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/20567

Any mixin class should define __slots__ = () to work correctly with
subclasses that use __slots__. Otherwise instances will still have a
__dict__ and it will be possible to set arbitrary attributes on them.

Since Basic now inherits DefaultPrinting this meant that all Basic
instances had __dict__ which they mostly should not.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20567 on the 1.7 branch for the 1.7.1 release.

#### Brief description of what is fixed or changed

Adds `__slots__ = ()` to `DefaultPrinting` to make sure that `Basic` instances do not have `__dict__`.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * There was a regression in 1.7 that meant that `__slots__` would not work correctly for Basic instances and they would end up having `__dict__`. This also made it possible to set arbitrary attributes on `Basic` instances such as symbols which breaks immutability. This was fixed in 1.7.1 to ensure that `Basic` instances do not have `__dict__` and it is not possible to set attributes on them.
<!-- END RELEASE NOTES -->