### PR TITLE
Added support for ellipsis in slicing matrices

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -110,12 +110,16 @@ class DenseMatrix(MatrixBase):
 
                 if isinstance(i, slice):
                     i = range(self.rows)[i]
+                elif (i is Ellipsis):
+                    i = range(self.rows)
                 elif is_sequence(i):
                     pass
                 else:
                     i = [i]
                 if isinstance(j, slice):
                     j = range(self.cols)[j]
+                elif (j is Ellipsis):
+                    j = range(self.cols)
                 elif is_sequence(j):
                     pass
                 else:
@@ -125,6 +129,8 @@ class DenseMatrix(MatrixBase):
             # row-wise decomposition of matrix
             if isinstance(key, slice):
                 return self._mat[key]
+            elif (key is Ellipsis):
+                return self.extract(range(self.rows), range(self.cols))
             return self._mat[a2idx(key)]
 
     def __setitem__(self, key, value):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -278,6 +278,10 @@ class MatrixExpr(Expr):
             return MatrixSlice(self, key, (0, None, 1))
         if isinstance(key, tuple) and len(key) == 2:
             i, j = key
+            if (i is Ellipsis):
+                i = slice(None, None, None)
+            if (j is Ellipsis):
+                j = slice(None, None, None)
             if isinstance(i, slice) or isinstance(j, slice):
                 from sympy.matrices.expressions.slice import MatrixSlice
                 return MatrixSlice(self, i, j)
@@ -286,6 +290,10 @@ class MatrixExpr(Expr):
                 return self._entry(i, j)
             else:
                 raise IndexError("Invalid indices (%s, %s)" % (i, j))
+        if (key is Ellipsis):
+            i = j = slice(None, None, None)
+            from sympy.matrices.expressions.slice import MatrixSlice
+            return MatrixSlice(self, i, j)
         elif isinstance(key, (SYMPY_INTS, Integer)):
             # row-wise decomposition of matrix
             rows, cols = self.shape

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -482,3 +482,14 @@ def test_MatrixSet():
     raises(ValueError, lambda: MatrixSet(2, -2, S.Reals))
     raises(ValueError, lambda: MatrixSet(2.4, -1, S.Reals))
     raises(TypeError, lambda: MatrixSet(2, 2, (1, 2, 3)))
+
+def test_ellipses():
+    from sympy.abc import a, b
+    X = MatrixSymbol('X', a, b)
+
+    assert X[:] == X[...]
+    assert X[2, :] == X[2, ...]
+    assert X[:, 2] == X[..., 2]
+    assert X[a, :] == X[a, ...]
+    assert X[:, b] == X[..., b]
+    assert X[:, :] == X[..., ...]

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2892,6 +2892,14 @@ def test_issue_8207():
     assert d == b[0, 0]
     assert e == 0
 
+def test_ellipses():
+    m = Matrix([[1,2,3], [4,5,6], [7,8,9]])
+
+    assert m == m[...]
+    assert m[1, :] == m[1, ...]
+    assert m[:, 1] == m[..., 1]
+    assert m[:, :] == m[..., ...]
+
 def test_func():
     from sympy.simplify.simplify import nthroot
 


### PR DESCRIPTION
Fixes #11345

Added the requested support for ellipsis in matrix slicing. The slice operator (with no preceding or succeeding integer) and ellipsis can now be used interchangeably. The only exception is when a tuple is not used (e.g. M[:] outputs the values of the matrix in a list, whereas M[...] outputs the matrix itself).

Tests were also added to ensure accuracy of the changes.


#### Release Notes



<!-- BEGIN RELEASE NOTES -->
* matrices
    * Added support for ellipsis when slicing matrices
    * Added tests for ellipsis when slicing matrices
<!-- END RELEASE NOTES -->