### PR TITLE
fix finiteness relational comparisons by checking if arguments are possibly infinite

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -651,7 +651,7 @@ class Add(Expr, AssocOp):
                     v = _monotonic_sign(self)
                     if v is not None and v != self and v.is_extended_positive:
                         return True
-        pos = nonneg = nonpos = unknown_sign = False
+        pos = nonneg = nonpos = unknown_sign = possibly_infinite = False
         saw_INF = set()
         args = [a for a in self.args if not a.is_zero]
         if not args:
@@ -663,6 +663,8 @@ class Add(Expr, AssocOp):
                 saw_INF.add(fuzzy_or((ispos, a.is_extended_nonnegative)))
                 if True in saw_INF and False in saw_INF:
                     return
+            elif infinite is None:
+                possibly_infinite = True
             if ispos:
                 pos = True
                 continue
@@ -678,7 +680,7 @@ class Add(Expr, AssocOp):
             unknown_sign = True
 
         if saw_INF:
-            if len(saw_INF) > 1:
+            if len(saw_INF) > 1 or possibly_infinite:
                 return
             return saw_INF.pop()
         elif unknown_sign:
@@ -735,7 +737,7 @@ class Add(Expr, AssocOp):
                     v = _monotonic_sign(self)
                     if v is not None and v != self and v.is_extended_negative:
                         return True
-        neg = nonpos = nonneg = unknown_sign = False
+        neg = nonpos = nonneg = unknown_sign = possibly_infinite = False
         saw_INF = set()
         args = [a for a in self.args if not a.is_zero]
         if not args:
@@ -747,6 +749,8 @@ class Add(Expr, AssocOp):
                 saw_INF.add(fuzzy_or((isneg, a.is_extended_nonpositive)))
                 if True in saw_INF and False in saw_INF:
                     return
+            elif infinite is None:
+                possibly_infinite = True
             if isneg:
                 neg = True
                 continue
@@ -762,7 +766,7 @@ class Add(Expr, AssocOp):
             unknown_sign = True
 
         if saw_INF:
-            if len(saw_INF) > 1:
+            if len(saw_INF) > 1 or possibly_infinite:
                 return
             return saw_INF.pop()
         elif unknown_sign:


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #20584


#### Brief description of what is fixed or changed
Some relational expressions do not evaluate correctly with (in)finite symbols against infinity. To mitigate a check is added for possibly infinite arguments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug that resulted in incorrect relational evaluation against infinity for particular arguments
<!-- END RELEASE NOTES -->