### PR TITLE
Let pyglet choose the image decoder

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -27,12 +27,12 @@ def _check_output_no_window(*args, **kwargs):
 def _run_pyglet(fname, fmt):
     from pyglet import window, image, gl
     from pyglet.window import key
+    from pyglet.image.codecs import ImageDecodeException
 
-    if fmt == "png":
-        from pyglet.image.codecs.png import PNGImageDecoder
-        img = image.load(fname, decoder=PNGImageDecoder())
-    else:
-        raise ValueError("pyglet preview works only for 'png' files.")
+    try:
+        img = image.load(fname)
+    except ImageDecodeException:
+        raise ValueError("pyglet preview does not work for '{}' files.".format(fmt))
 
     offset = 25
 


### PR DESCRIPTION
The Fedora Linux version of pyglet does not include `PNGImageDecoder`.  Fedora can guarantee that pillow is installed whenever pyglet is, and pyglet uses pillow's PNG decoder if it is available before falling back to `PNGImageDecoder`.  Therefore, `PNGImageDecoder` is never used by pyglet, so it was removed from the package.

This commit lets pyglet choose which decoder to use.  This has the added benefit of supporting more image types: whatever pyglet supports on a given platform can be supported in the previewer.

<!-- BEGIN RELEASE NOTES -->
* printing
  * `preview`'s use of `pyglet` now works on Fedora Linux
<!-- END RELEASE NOTES -->