### PR TITLE
Fix SVG printing for symbolic geometry

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -171,6 +171,9 @@ class GeometryEntity(Basic):
             # will fall back to the next representation
             return None
 
+        if any([not x.is_number or not x.is_finite for x in bounds]):
+            return None
+
         svg_top = '''<svg xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
             width="{1}" height="{2}" viewBox="{0}"

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, Rational
+from sympy import Symbol, Rational, S
 from sympy.geometry import Circle, Ellipse, Line, Point, Polygon, Ray, RegularPolygon, Segment, Triangle
 from sympy.geometry.entity import scale, GeometryEntity
 from sympy.testing.pytest import raises
@@ -24,6 +24,17 @@ def test_entity():
     assert GeometryEntity.encloses(c, Polygon(Point(0, 0), Point(1, 0), Point(0, 1)))
     assert GeometryEntity.encloses(c, RegularPolygon(Point(8, 8), 1, 3)) is False
 
+
+def test_svg():
+    a = Symbol('a')
+    b = Symbol('b')
+    d = Symbol('d')
+
+    entity = Circle(Point(a, b), d)
+    assert entity._repr_svg_() is None
+
+    entity = Circle(Point(0, 0), S.Infinity)
+    assert entity._repr_svg_() is None
 
 
 def test_subs():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20577

#### Brief description of what is fixed or changed

This fixes the geometry issues with drawing in symbolic coordinates. I've also disallowed infinities.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- geometry
  - Geometric entities with symbolic coordinates will not be printed in SVG.
<!-- END RELEASE NOTES -->