### PR TITLE
Fixed Infinite Recursion in periodicity()

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, S, exp, log, sqrt, oo, E, zoo, pi, tan, sin, cos,
-                   cot, sec, csc, Abs, symbols, I, re, simplify,
+                   cot, sec, csc, asin, Abs, symbols, I, re, simplify,
                    expint, Rational)
 from sympy.calculus.util import (function_range, continuous_domain, not_empty_in,
                                  periodicity, lcim, AccumBounds, is_convex,
@@ -133,7 +133,8 @@ def test_periodicity():
     assert periodicity(tan((3*x-2)%4), x) == Rational(4, 3)
     assert periodicity((sqrt(2)*(x+1)+x) % 3, x) == 3 / (sqrt(2)+1)
     assert periodicity((x**2+1) % x, x) is None
-    assert periodicity(sin(re(x)), x) == 2*pi
+    assert periodicity(sin(re(z)), z) == 2*pi
+    assert periodicity(sin(re(x)), x) == None
     assert periodicity(sin(x)**2 + cos(x)**2, x) is S.Zero
     assert periodicity(tan(x), y) is S.Zero
     assert periodicity(sin(x) + I*cos(x), x) == 2*pi
@@ -152,6 +153,7 @@ def test_periodicity():
     assert periodicity(log(x), x) is None
     assert periodicity(exp(x)**sin(x), x) is None
     assert periodicity(sin(x)**y, y) is None
+    assert periodicity(exp(asin(x)), x) is None
 
     assert periodicity(Abs(sin(Abs(sin(x)))), x) == pi
     assert all(periodicity(Abs(f(x)), x) == pi for f in (
@@ -164,6 +166,7 @@ def test_periodicity():
     assert periodicity(x**3 - x**2 + 1, x) is None
     assert periodicity(Abs(x), x) is None
     assert periodicity(Abs(x**2 - 1), x) is None
+    assert periodicity(Abs(x**2 - 3*x), x) is None
 
     assert periodicity((x**2 + 4)%2, x) is None
     assert periodicity((E**x)%3, x) is None

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -403,7 +403,7 @@ def periodicity(f, symbol, check=False):
     from sympy.solvers.decompogen import decompogen
     from sympy.polys.polytools import degree
 
-    temp = Dummy('x', real=True)
+    temp = Dummy('x')
     f = f.subs(symbol, temp)
     symbol = temp
 
@@ -463,10 +463,13 @@ def periodicity(f, symbol, check=False):
             # checked below
 
     if isinstance(f, exp):
-        f = f.func(expand_mul(f.args[0]))
-        if im(f) != 0:
-            period_real = periodicity(re(f), symbol)
-            period_imag = periodicity(im(f), symbol)
+        # See issue #20566
+        # Use real substitution exclusively for instances of exp since their expansion depends heavily upon x being real
+        symbol_temp = Dummy('x',real = True)
+        f_temp = (f.func(expand_mul(f.args[0]))).subs(symbol, symbol_temp)
+        if im(f_temp) != 0:
+            period_real = periodicity(re(f_temp), symbol_temp)
+            period_imag = periodicity(im(f_temp), symbol_temp)
             if period_real is not None and period_imag is not None:
                 period = lcim([period_real, period_imag])
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #20566 


#### Brief description of what is fixed or changed

The issue was related to #12620 , here we added a check for a conditional for checking equality with both the original function and the simplified expression. 

https://github.com/sympy/sympy/blob/962cd98b4fb74d05101f721120f6616565cc56f7/sympy/calculus/util.py#L522

But in here it so happens that down the line `decompogen()` is called upon the expression `exp(re(asin(_x)))` while calculating periodicity of real part of the expression (#L468 in utils.py), which gives output as `[exp(_x), _ x, asin(x)]` (since `_x` is declared as a real dummy variable `decompogen()` simplifies `re(_x)` to just `_x` ) . So when `compogen()` is called upon this list it gives expression `exp(asinx(_x)` which fails the equality check with the original one. 

I don't think calling `compogen(decompogen())` upon the original function just before the equality check will have any ill effect since that was the intention of #12620 to begin with.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- calculus
  - Fixed infinite recursion in periodicity()
<!-- END RELEASE NOTES -->