### PR TITLE
Fix for limit bug

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -319,8 +319,10 @@ class Limit(Expr):
 
         try:
             if str(dir) == '+-':
-                r = gruntz(e, z, z0, '+')
-                l = gruntz(e, z, z0, '-')
+                r = limit(e, z, z0, '+')
+                l = limit(e, z, z0, '-')
+                if isinstance(r, Limit) or isinstance(l, Limit):
+                    return Limit(e, z, z0, '+-')
                 if l != r:
                     raise ValueError("The limit does not exist since "
                             "left hand limit = %s and right hand limit = %s"

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -184,6 +184,7 @@ def test_abs():
     assert limit(abs(sin(x)), x, 0) == 0
     assert limit(abs(cos(x)), x, 0) == 1
     assert limit(abs(sin(x + 1)), x, 0) == sin(1)
+    assert limit(abs(x)*sin(1/x),x,0,"+-") == 0
 
 
 def test_heuristic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20578 

#### Brief description of what is fixed or changed
In [this line](https://github.com/sympy/sympy/blob/962cd98b4fb74d05101f721120f6616565cc56f7/sympy/series/limits.py#L322) `gruntz()` is unable to compute `gruntz(abs(x)*sin(1/x),x,0)` and we get `PoleError`. Hence, `limit()` is added as an alternative in case `gruntz()` fails.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->