### PR TITLE
Added WildDot, WildPlus and WildStar classes to MatchPy connector

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1830,6 +1830,21 @@ def test_sympy__stats__matrix_distributions__MatrixNormalDistribution():
     assert _test_args(MatrixNormalDistribution(L, S1, S2))
 
 
+def test_sympy__utilities__matchpy_connector__WildDot():
+    from sympy.utilities.matchpy_connector import WildDot
+    assert _test_args(WildDot("w_"))
+
+
+def test_sympy__utilities__matchpy_connector__WildPlus():
+    from sympy.utilities.matchpy_connector import WildPlus
+    assert _test_args(WildPlus("w__"))
+
+
+def test_sympy__utilities__matchpy_connector__WildStar():
+    from sympy.utilities.matchpy_connector import WildStar
+    assert _test_args(WildStar("w___"))
+
+
 def test_sympy__core__symbol__Str():
     from sympy.core.symbol import Str
     assert _test_args(Str('t'))

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -1,9 +1,14 @@
+"""
+The objects in this module allow the usage of the MatchPy pattern matching
+library on SymPy expressions.
+"""
 from sympy.external import import_module
 from sympy.functions import (log, sin, cos, tan, cot, csc, sec, erf, gamma, uppergamma)
 from sympy.functions.elementary.hyperbolic import acosh, asinh, atanh, acoth, acsch, asech, cosh, sinh, tanh, coth, sech, csch
 from sympy.functions.elementary.trigonometric import atan, acsc, asin, acot, acos, asec
 from sympy.functions.special.error_functions import fresnelc, fresnels, erfc, erfi, Ei
-from sympy import (Basic, Mul, Add, Pow, Integral, exp)
+from sympy import (Basic, Mul, Add, Pow, Integral, exp, Symbol)
+from sympy.utilities.decorator import doctest_depends_on
 
 matchpy = import_module("matchpy")
 
@@ -79,3 +84,61 @@ if matchpy:
     @create_operation_expression.register(Basic)
     def sympy_op_factory(old_operation, new_operands, variable_name=True):
          return type(old_operation)(*new_operands)
+
+
+if matchpy:
+    from matchpy import Wildcard
+else:
+    class Wildcard:
+        def __init__(self, min_length, fixed_size, variable_name, optional):
+            pass
+
+
+@doctest_depends_on(modules=('matchpy',))
+class _WildAbstract(Wildcard, Symbol):
+    min_length = None  # abstract field required in subclasses
+    fixed_size = None  # abstract field required in subclasses
+
+    def __init__(self, variable_name=None, optional=None, **assumptions):
+        min_length = self.min_length
+        fixed_size = self.fixed_size
+        Wildcard.__init__(self, min_length, fixed_size, str(variable_name), optional)
+
+    def __new__(cls, variable_name=None, optional=None, **assumptions):
+        cls._sanitize(assumptions, cls)
+        return _WildAbstract.__xnew__(cls, variable_name, optional, **assumptions)
+
+    def __getnewargs__(self):
+        return self.min_count, self.fixed_size, self.variable_name, self.optional
+
+    @staticmethod
+    def __xnew__(cls, variable_name=None, optional=None, **assumptions):
+        obj = Symbol.__xnew__(cls, variable_name, **assumptions)
+        return obj
+
+    def _hashable_content(self):
+        if self.optional:
+            return super()._hashable_content() + (self.min_count, self.fixed_size, self.variable_name, self.optional)
+        else:
+            return super()._hashable_content() + (self.min_count, self.fixed_size, self.variable_name)
+
+    def __copy__(self) -> '_WildAbstract':
+        return type(self)(variable_name=self.variable_name, optional=self.optional)
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildDot(_WildAbstract):
+    min_length = 1
+    fixed_size = True
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildPlus(_WildAbstract):
+    min_length = 1
+    fixed_size = False
+
+
+@doctest_depends_on(modules=('matchpy',))
+class WildStar(_WildAbstract):
+    min_length = 0
+    fixed_size = False

--- a/sympy/utilities/tests/test_matchpy_connector.py
+++ b/sympy/utilities/tests/test_matchpy_connector.py
@@ -1,0 +1,45 @@
+from sympy import symbols
+from sympy.external import import_module
+from sympy.utilities.matchpy_connector import WildDot, WildPlus, WildStar
+
+matchpy = import_module("matchpy")
+
+x, y, z = symbols("x y z")
+
+
+def _get_first_match(expr, pattern):
+    from matchpy import ManyToOneMatcher, Pattern
+
+    matcher = ManyToOneMatcher()
+    matcher.add(Pattern(pattern))
+    return next(iter(matcher.match(expr)))
+
+
+def test_matchpy_connector():
+    if matchpy is None:
+        return
+
+    from multiset import Multiset
+    from matchpy import Pattern, Substitution
+
+    w_ = WildDot("w_")
+    w__ = WildPlus("w__")
+    w___ = WildStar("w___")
+
+    expr = x + y
+    pattern = x + w_
+    p, subst = _get_first_match(expr, pattern)
+    assert p == Pattern(pattern)
+    assert subst == Substitution({'w_': y})
+
+    expr = x + y + z
+    pattern = x + w__
+    p, subst = _get_first_match(expr, pattern)
+    assert p == Pattern(pattern)
+    assert subst == Substitution({'w__': Multiset([y, z])})
+
+    expr = x + y + z
+    pattern = x + y + z + w___
+    p, subst = _get_first_match(expr, pattern)
+    assert p == Pattern(pattern)
+    assert subst == Substitution({'w___': Multiset()})


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added WildDot, WildPlus and WildStar classes to MatchPy connector. These classes correspond to the dot, dot-plut and dot-star expressions in regular expression, but operate on SymPy expression trees and are aware of associative and commutative properties, features supported through the MatchPy library.
<!-- END RELEASE NOTES -->