### PR TITLE
Lambert and _is_lambert modifications

### DIFF
--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -4,6 +4,7 @@ from sympy.core.function import expand_log
 from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
+from sympy.core.numbers import I
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.miscellaneous import root
 from sympy.polys.polyroots import roots
@@ -118,7 +119,7 @@ def _linab(arg, symbol):
     return a, b, x
 
 
-def _lambert(eq, x):
+def _lambert(eq, x, domain=S.Complexes):
     """
     Given an expression assumed to be in the form
         ``F(X, a..f) = a*log(b*X + c) + d*X + f = 0``
@@ -176,8 +177,26 @@ def _lambert(eq, x):
     p, den = den.as_coeff_Mul()
     e = exp(num/den)
     t = Dummy('t')
-    args = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
 
+    if p == 1:
+        t = e
+        args = [d/(a*b)*t]
+    elif domain.is_subset(S.Reals):
+        # print(l090)
+        ind_ls = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
+        args = []
+        j = -1
+        for i in ind_ls:
+            j += 1
+            if not isinstance(i,int):
+                if not i.has(I):
+                    args.append(ind_ls[j])
+            elif isinstance(i,int):
+                args.append(ind_ls[j])
+    else:
+        args = [d/(a*b)*t for t in roots(t**p - e, t).keys()]
+    if len(args) == 0:
+        return S.EmptySet
     # calculating solutions from args
     for arg in args:
         for k in lambert_real_branches:
@@ -191,7 +210,11 @@ def _lambert(eq, x):
     return sol
 
 
-def _solve_lambert(f, symbol, gens):
+def _lambert_real(eq, x):
+    return _lambert(eq, x, domain=S.Reals)
+
+
+def _solve_lambert(f, symbol, gens, domain=S.Complexes):
     """Return solution to ``f`` if it is a Lambert-type expression
     else raise NotImplementedError.
 
@@ -225,7 +248,7 @@ def _solve_lambert(f, symbol, gens):
       X = B, a = -1, d = a*log(p), f = -log(d) - g*log(p)
     """
 
-    def _solve_even_degree_expr(expr, t, symbol):
+    def _solve_even_degree_expr(expr, t, symbol, domain=S.Complexes):
         """Return the unique solutions of equations derived from
         ``expr`` by replacing ``t`` with ``+/- symbol``.
 
@@ -269,9 +292,11 @@ def _solve_lambert(f, symbol, gens):
         """
         nlhs, plhs = [
             expr.xreplace({t: sgn*symbol}) for sgn in (-1, 1)]
-        sols = _solve_lambert(nlhs, symbol, gens)
+        sols = _solve_lambert(nlhs, symbol, gens, domain)
+        if sols == S.EmptySet:
+            return S.EmptySet
         if plhs != nlhs:
-            sols.extend(_solve_lambert(plhs, symbol, gens))
+            sols.extend(_solve_lambert(plhs, symbol, gens, domain))
         # uniq is needed for a case like
         # 2*log(t) - log(-z**2) + log(z + log(x) + log(z))
         # where subtituting t with +/-x gives all the same solution;
@@ -306,7 +331,7 @@ def _solve_lambert(f, symbol, gens):
             if not t_term.is_Add and _rhs and not (
                     t_term.has(S.ComplexInfinity, S.NaN)):
                 eq = expand_log(log(t_term) - log(_rhs))
-                return _solve_even_degree_expr(eq, t, symbol)
+                return _solve_even_degree_expr(eq, t, symbol, domain)
         elif lhs.is_Mul and rhs:
             # this needs to happen whether t is present or not
             lhs = expand_log(log(lhs), force=True)
@@ -314,7 +339,7 @@ def _solve_lambert(f, symbol, gens):
             if lhs.has(t) and lhs.is_Add:
                 # it expanded from Mul to Add
                 eq = lhs - rhs
-                return _solve_even_degree_expr(eq, t, symbol)
+                return _solve_even_degree_expr(eq, t, symbol, domain)
 
         # restore symbol in lhs
         lhs = lhs.xreplace({t: symbol})
@@ -343,7 +368,10 @@ def _solve_lambert(f, symbol, gens):
         mainlog = _mostfunc(lhs, log, symbol)
         if mainlog:
             if lhs.is_Mul and rhs != 0:
-                soln = _lambert(log(lhs) - log(rhs), symbol)
+                if domain.is_subset(S.Reals):
+                    soln = _lambert_real(log(lhs) - log(rhs), symbol)
+                else:
+                    soln = _lambert(log(lhs) - log(rhs), symbol)
             elif lhs.is_Add:
                 other = lhs.subs(mainlog, 0)
                 if other and not other.is_Add and [
@@ -353,11 +381,18 @@ def _solve_lambert(f, symbol, gens):
                         diff = log(other) - log(other - lhs)
                     else:
                         diff = log(lhs - other) - log(rhs - other)
-                    soln = _lambert(expand_log(diff), symbol)
+                    if domain.is_subset(S.Reals):
+                        soln = _lambert_real(expand_log(diff), symbol)
+                    else:
+                        soln = _lambert(expand_log(diff), symbol)
                 else:
                     #it's ready to go
-                    soln = _lambert(lhs - rhs, symbol)
-
+                    if domain.is_subset(S.Reals):
+                        soln = _lambert_real(lhs - rhs, symbol)
+                    else:
+                        soln = _lambert(lhs - rhs, symbol)
+                    if soln == S.EmptySet :
+                            return S.EmptySet
     # For the next forms,
     #
     #     collect on main exp
@@ -374,7 +409,10 @@ def _solve_lambert(f, symbol, gens):
         if mainexp:
             lhs = collect(lhs, mainexp)
             if lhs.is_Mul and rhs != 0:
-                soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
+                if domain.is_subset(S.Reals):
+                    soln = _lambert_real(expand_log(log(lhs) - log(rhs)), symbol)
+                else:
+                    soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
             elif lhs.is_Add:
                 # move all but mainexp-containing term to rhs
                 other = lhs.subs(mainexp, 0)
@@ -385,7 +423,11 @@ def _solve_lambert(f, symbol, gens):
                     mainterm *= -1
                     rhs *= -1
                 diff = log(mainterm) - log(rhs)
-                soln = _lambert(expand_log(diff), symbol)
+                if domain.is_subset(S.Reals):
+                    soln = _lambert_real(expand_log(diff), symbol)
+                else:
+                    soln = _lambert(expand_log(diff), symbol)
+
 
     # For the last form:
     #
@@ -399,14 +441,20 @@ def _solve_lambert(f, symbol, gens):
             lhs = collect(lhs, mainpow)
             if lhs.is_Mul and rhs != 0:
                 # b*B = 0
-                soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
+                if domain.is_subset(S.Reals):
+                    soln = _lambert_real(expand_log(log(lhs) - log(rhs)), symbol)
+                else:
+                    soln = _lambert(expand_log(log(lhs) - log(rhs)), symbol)
             elif lhs.is_Add:
                 # move all but mainpow-containing term to rhs
                 other = lhs.subs(mainpow, 0)
                 mainterm = lhs - other
                 rhs = rhs - other
                 diff = log(mainterm) - log(rhs)
-                soln = _lambert(expand_log(diff), symbol)
+                if domain.is_subset(S.Reals):
+                    soln = _lambert_real(expand_log(diff), symbol)
+                else:
+                    soln = _lambert(expand_log(diff), symbol)
 
     if not soln:
         raise NotImplementedError('%s does not appear to have a solution in '

--- a/sympy/solvers/ode/systems.py
+++ b/sympy/solvers/ode/systems.py
@@ -314,6 +314,10 @@ def linodesolve_type(A, t, b=None):
 
 
 def _first_order_type5_6_subs(A, t, b=None):
+    from sympy.solvers.solveset import _is_lambert
+    from sympy.sets.conditionset import ConditionSet
+    from sympy import symbols
+    x = symbols('x')
     match = {}
 
     factor_terms = _factor_matrix(A, t)
@@ -322,8 +326,11 @@ def _first_order_type5_6_subs(A, t, b=None):
     if factor_terms is not None:
         t_ = Symbol("{}_".format(t))
         F_t = integrate(factor_terms[0], t)
-        inverse = solveset(Eq(t_, F_t), t)
 
+        if _is_lambert(F_t,x):
+            inverse = ConditionSet(t_, Eq(F_t,0),S.Complexes)
+        else:
+            inverse = solveset(Eq(t_, F_t), t)
         # Note: A simple way to check if a function is invertible
         # or not.
         if isinstance(inverse, FiniteSet) and not inverse.has(Piecewise)\

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -55,7 +55,7 @@ from sympy.core.compatibility import ordered, default_sort_key, is_sequence
 
 from types import GeneratorType
 from collections import defaultdict
-from sympy import sqrt, abc
+from sympy import sqrt
 
 
 class NonlinearError(ValueError):
@@ -1823,10 +1823,10 @@ def _is_lambert(f, symbol):
     Equations containing `Pow`, `log` or `exp` terms are currently
     treated as Lambert types.
     """
-    for arg in list(_term_factors(f.expand())):
-        if isinstance(arg,(Pow,exp)):
-            base, exponent = arg.as_base_exp()
-            if isinstance(arg,(Pow,Mul)) and len(list(Add.make_args(f))) == 1:
+    for arg1 in list(_term_factors(f.expand())):
+        if isinstance(arg1,(Pow,exp)):
+            base, exponent = arg1.as_base_exp()
+            if isinstance(arg1,(Pow,Mul)) and len(list(Add.make_args(f))) == 1:
                 for a in list(Mul.make_args(f)):
                     if isinstance(a,exp):
                         base, exponent = a.as_base_exp()
@@ -1859,14 +1859,14 @@ def _is_lambert(f, symbol):
 
             else:
                 return False
-        elif isinstance(arg,log):
+        elif isinstance(arg1,log):
             i, j,k = 0,0,0
-            for arg in list(_term_factors(f)):
-                if arg.atoms(log) :
+            for arg2 in list(_term_factors(f)):
+                if arg2.atoms(log) :
                     j += 1
-                    if arg.has((symbol)):
+                    if arg2.has((symbol)):
                         i += 1
-                elif arg.has(symbol):
+                elif arg2.has(symbol):
                     k += 1
 
             return (j>1 or k>0) and (i >0)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -14,11 +14,10 @@ from sympy.core.sympify import sympify
 from sympy.core import (S, Pow, Dummy, pi, Expr, Wild, Mul, Equality,
                         Add)
 from sympy.core.containers import Tuple
-from sympy.core.numbers import I, Number, Rational, oo
+from sympy.core.numbers import I, Number, Rational, oo, igcd
 from sympy.core.function import (Lambda, expand_complex, AppliedUndef,
                                 expand_log)
 from sympy.core.mod import Mod
-from sympy.core.numbers import igcd
 from sympy.core.relational import Eq, Ne, Relational
 from sympy.core.symbol import Symbol, _uniquely_named_symbol
 from sympy.core.sympify import _sympify
@@ -26,7 +25,7 @@ from sympy.simplify.simplify import simplify, fraction, trigsimp
 from sympy.simplify import powdenest, logcombine
 from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
                              acos, asin, acsc, asec, arg,
-                             piecewise_fold, Piecewise)
+                             piecewise_fold, Piecewise, LambertW)
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.functions.elementary.miscellaneous import real_root
@@ -42,10 +41,11 @@ from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf, factor, lcm, gcd)
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.polys.polytools import invert
+from sympy.solvers.bivariate import _solve_lambert, _filtered_gens, bivariate_type
 from sympy.polys.solvers import (sympy_eqs_to_ring, solve_lin_sys,
     PolyNonlinearError)
 from sympy.solvers.solvers import (checksol, denoms, unrad,
-    _simple_dens, recast_to_symbols)
+    _simple_dens, recast_to_symbols, solve, _tsolve)
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
@@ -55,6 +55,7 @@ from sympy.core.compatibility import ordered, default_sort_key, is_sequence
 
 from types import GeneratorType
 from collections import defaultdict
+from sympy import sqrt, abc
 
 
 class NonlinearError(ValueError):
@@ -277,6 +278,8 @@ def _invert_real(f, g_ys, symbol):
                 elif one == S.false:
                     return _invert_real(expo, S.EmptySet, symbol)
 
+        else:
+            return _invert_real(expo*log(base), imageset(Lambda(n, log(n)), g_ys), symbol)
 
     if isinstance(f, TrigonometricFunction):
         if isinstance(g_ys, FiniteSet):
@@ -298,6 +301,8 @@ def _invert_real(f, g_ys, symbol):
                 invs += Union(*[imageset(Lambda(n, L(g)), S.Integers) for g in g_ys])
             return _invert_real(f.args[0], invs, symbol)
 
+    if isinstance(f, LambertW):
+        return _invert_real(f.args[0], imageset(Lambda(n, n*exp(n)), g_ys), symbol)
     return (f, g_ys)
 
 
@@ -968,6 +973,8 @@ def _solveset(f, symbol, domain, _check=False):
     # _check controls whether the answer is checked or not
     from sympy.simplify.simplify import signsimp
     from sympy.logic.boolalg import BooleanTrue
+    from sympy.functions.elementary.complexes import re
+
 
     if isinstance(f, BooleanTrue):
         return domain
@@ -1064,7 +1071,17 @@ def _solveset(f, symbol, domain, _check=False):
                         result_rational = _solve_as_rational(equation, symbol, domain)
                         if isinstance(result_rational, ConditionSet):
                             # may be a transcendental type equation
-                            result += _transolve(equation, symbol, domain)
+                            if isinstance(f, Pow):
+                                base_sym = list(f.base.free_symbols)[0]
+                                pow_sym = list(f.exp.free_symbols)[0]
+                                if base_sym == pow_sym:
+                                    result = Intersection(solveset(f.base, base_sym), \
+                                        ConditionSet(pow_sym, re(pow_sym)>0, domain))
+                                else:
+                                    result = ProductSet(solveset(f.base, base_sym), \
+                                        ConditionSet(pow_sym, re(pow_sym)>0, domain))
+                            else:
+                                result = _transolve(equation, symbol, domain)
                         else:
                             result += result_rational
                 else:
@@ -1085,7 +1102,46 @@ def _solveset(f, symbol, domain, _check=False):
                 result = _result - singularities
 
     if _check:
-        if isinstance(result, ConditionSet):
+        if (isinstance(result,ConditionSet)) and \
+                (domain.is_subset(S.Reals) and \
+                    (not isinstance(result,list))):
+            x = Symbol('x')
+            f = f.subs({symbol: x})
+            if _is_lambert(f,x):
+                if result.has(cos,sin):
+                    if (result.has(exp)) or (f.has(sqrt(x))) or\
+                        f.has(Abs):
+                        return result
+                    elif not domain.is_subset(S.Integers) and \
+                        ((result.has(cos) and not result.has(sin)) or \
+                            (result.has(sin) and not result.has(cos))) :
+                        f = solve(f,x)
+                        f = FiniteSet(*f)
+                        return f
+                elif domain.is_subset(S.Reals):
+                    if not any(i for i in f.atoms(Pow) if i.exp is S.Half) and f.count_ops() < 120:
+                        indls = _tsolve(f,x)
+                        if indls is None or indls == []:
+                            return result
+                        elif indls is not None:
+                            if len(indls) == 1:
+                                if indls[0] == 0:
+                                    return result
+                        if indls is not None:
+                            args = []
+                            j = -1
+                            for i in indls:
+                                j += 1
+                                if not isinstance(i,int):
+                                    if not i.has(I):
+                                        args.append(indls[j])
+                                elif isinstance(i,int):
+                                    args.append(indls[j])
+                            f = FiniteSet(*args)
+                            return f
+            else:
+                return result
+        elif isinstance(result,ConditionSet):
             # it wasn't solved or has enumerated all conditions
             # -- leave it alone
             return result
@@ -1103,6 +1159,11 @@ def _solveset(f, symbol, domain, _check=False):
             result = FiniteSet(*[s for s in result
                       if isinstance(s, RootOf)
                       or domain_check(fx, symbol, s)])
+        elif isinstance(result,list):
+            for _ in range(len(result) - 1):
+                result = result[_] + result[_+1]
+            if len(result) == 1:
+                return result[0]
 
     return result
 
@@ -1728,6 +1789,122 @@ def _is_logarithmic(f, symbol):
     return rv
 
 
+def _is_bivariate(f, symbol):
+    r"""
+    Return True if the equation has two generators, else False.
+    """
+    poly = f.as_poly()
+    gens = _filtered_gens(poly, symbol)
+
+    return len(gens) == 2
+
+
+def _solve_as_bivariate(lhs, rhs, symbol, domain):
+    r"""
+    Helper solver to solve equations of bivariate form.
+    """
+    result = ConditionSet(symbol, Eq(lhs - rhs, 0), domain)
+
+    poly = lhs.as_poly()
+    gens = _filtered_gens(poly, symbol)
+    gpu = bivariate_type(lhs - rhs, *gens)
+    if gpu is not None:
+        g, p, u = gpu
+        if g != lhs:
+            usol = _solveset(p, u, domain)
+            if not isinstance(usol, ConditionSet):
+                result = [_solveset(g - us, symbol, domain) for us in usol]
+    return result
+
+
+def _is_lambert(f, symbol):
+    r"""
+    Return True if the equation is of Lambert type, else False.
+    Equations containing `Pow`, `log` or `exp` terms are currently
+    treated as Lambert types.
+    """
+    for arg in list(_term_factors(f.expand())):
+        if isinstance(arg,(Pow,exp)):
+            base, exponent = arg.as_base_exp()
+            if isinstance(arg,(Pow,Mul)) and len(list(Add.make_args(f))) == 1:
+                for a in list(Mul.make_args(f)):
+                    if isinstance(a,exp):
+                        base, exponent = a.as_base_exp()
+            if not exponent.has(symbol,Dummy) and len(list(Add.make_args(f))) > 1:
+                continue
+            if exponent.has(symbol,Dummy, TrigonometricFunction, HyperbolicFunction): # exponent is variable
+                if len(list(Add.make_args(f))) <= 2:
+                    j=0
+                    for args in list(Add.make_args(f)):
+                        from sympy import symbols
+                        x= symbols('x')
+                        if isinstance(args,Mul) and args.atoms(exp(x)) and (args.atoms(symbol) or args.atoms(Dummy)):
+                            for ar in list(Mul.make_args(args)):
+                                return ar.is_real
+                        elif len(list(args.atoms(symbol,Dummy))) == 1 :
+                            if list(args.atoms(symbol))[0].has(symbol,Dummy):
+                                j+=1
+                        else:
+                            return True
+                    return j>1
+                elif len(list(Add.make_args(f))) > 2:
+                    j=0
+                    for args in list(Add.make_args(f)):
+                        if len(list(args.atoms(symbol))) == 1 :
+                            if list(args.atoms(symbol))[0].has(symbol): # to check it has more than 2 variables
+                                j+=1
+                        else:
+                            return True
+                    return j>1
+
+            else:
+                return False
+        elif isinstance(arg,log):
+            i, j,k = 0,0,0
+            for arg in list(_term_factors(f)):
+                if arg.atoms(log) :
+                    j += 1
+                    if arg.has((symbol)):
+                        i += 1
+                elif arg.has(symbol):
+                    k += 1
+
+            return (j>1 or k>0) and (i >0)
+
+def _compute_lambert_solutions(lhs, rhs, symbol,domain=S.Complexes):
+    """
+    Computes the Lambert solutions. Returns `None` if it
+    fails doing so.
+    """
+    try:
+        poly = lhs.as_poly()
+        gens = _filtered_gens(poly, symbol)
+        return _solve_lambert(lhs - rhs, symbol, gens,domain)
+    except NotImplementedError:
+        pass
+
+
+def _solve_as_lambert(lhs, rhs, symbol, domain):
+    r"""
+    Helper solver to handle equations having Lambert solutions.
+    First tries to solve equation directly. If unsuccessful
+    attempts to find the solutions by making the `symbol` positive.
+    """
+    result = ConditionSet(symbol, Eq(lhs - rhs, 0), domain)
+    soln = _compute_lambert_solutions(lhs, rhs, symbol,domain)
+    if soln is None:
+        # try with positive `symbol`
+        u = Dummy('u', positive=True)
+        pos_lhs = lhs.subs({symbol: u})
+        soln = _compute_lambert_solutions(pos_lhs, rhs, u)
+        if soln:
+            result = FiniteSet(*soln)
+    else:
+        result = FiniteSet(*soln)
+
+    return result
+
+
 def _transolve(f, symbol, domain):
     r"""
     Function to solve transcendental equations. It is a helper to
@@ -1736,6 +1913,7 @@ def _transolve(f, symbol, domain):
 
         - Exponential equations
         - Logarithmic equations
+        - Lambert type equations
 
     Parameters
     ==========
@@ -1922,6 +2100,12 @@ def _transolve(f, symbol, domain):
         # check if it is logarithmic type equation
         elif _is_logarithmic(lhs, symbol):
             result = _solve_logarithm(lhs, rhs, symbol, domain)
+        elif _is_lambert(lhs, symbol):
+            # try to get solutions in form of Lambert
+            result = _solve_as_lambert(lhs, rhs, symbol, domain)
+            if isinstance(result, ConditionSet):
+                if _is_bivariate(lhs, symbol):
+                    result = _solve_as_bivariate(lhs, rhs, symbol, domain)
 
         return result
 
@@ -1937,6 +2121,13 @@ def _transolve(f, symbol, domain):
 
         if lhs.is_Add:
             result = add_type(lhs, rhs, symbol, domain)
+        elif _is_lambert(lhs, symbol):
+            # try to get solutions in form of Lambert
+            result = _solve_as_lambert(lhs, rhs, symbol, domain)
+            if isinstance(result, ConditionSet):
+                if _is_bivariate(lhs, symbol):
+                    result = _solve_as_bivariate(lhs, rhs, symbol, domain)
+
     else:
         result = rhs_s
 
@@ -2089,15 +2280,16 @@ def solveset(f, symbol=None, domain=S.Complexes):
     # solveset should ignore assumptions on symbols
     if symbol not in _rc:
         x = _rc[0] if domain.is_subset(S.Reals) else _rc[1]
-        rv = solveset(f.xreplace({symbol: x}), x, domain)
-        # try to use the original symbol if possible
-        try:
-            _rv = rv.xreplace({x: symbol})
-        except TypeError:
-            _rv = rv
-        if rv.dummy_eq(_rv):
-            rv = _rv
-        return rv
+        if not isinstance(f,list):
+            rv = solveset(f.xreplace({symbol: x}), x, domain)
+            # try to use the original symbol if possible
+            try:
+                _rv = rv.xreplace({x: symbol})
+            except TypeError:
+                _rv = rv
+            if rv.dummy_eq(_rv):
+                rv = _rv
+            return rv
 
     # Abs has its own handling method which avoids the
     # rewriting property that the first piece of abs(x)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1041,100 +1041,6 @@ def test_solve_trig_simplified():
         imageset(Lambda(n, n*pi - pi/4), S.Integers))
 
 
-@XFAIL
-def test_solve_lambert():
-    assert solveset_real(x*exp(x) - 1, x) == FiniteSet(LambertW(1))
-    assert solveset_real(exp(x) + x, x) == FiniteSet(-LambertW(1))
-    assert solveset_real(x + 2**x, x) == \
-        FiniteSet(-LambertW(log(2))/log(2))
-
-    # issue 4739
-    ans = solveset_real(3*x + 5 + 2**(-5*x + 3), x)
-    assert ans == FiniteSet(Rational(-5, 3) +
-                            LambertW(-10240*2**Rational(1, 3)*log(2)/3)/(5*log(2)))
-
-    eq = 2*(3*x + 4)**5 - 6*7**(3*x + 9)
-    result = solveset_real(eq, x)
-    ans = FiniteSet((log(2401) +
-                     5*LambertW(-log(7**(7*3**Rational(1, 5)/5))))/(3*log(7))/-1)
-    assert result == ans
-    assert solveset_real(eq.expand(), x) == result
-
-    assert solveset_real(5*x - 1 + 3*exp(2 - 7*x), x) == \
-        FiniteSet(Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7)
-
-    assert solveset_real(2*x + 5 + log(3*x - 2), x) == \
-        FiniteSet(Rational(2, 3) + LambertW(2*exp(Rational(-19, 3))/3)/2)
-
-    assert solveset_real(3*x + log(4*x), x) == \
-        FiniteSet(LambertW(Rational(3, 4))/3)
-
-    assert solveset_real(x**x - 2) == FiniteSet(exp(LambertW(log(2))))
-
-    a = Symbol('a')
-    assert solveset_real(-a*x + 2*x*log(x), x) == FiniteSet(exp(a/2))
-    a = Symbol('a', real=True)
-    assert solveset_real(a/x + exp(x/2), x) == \
-        FiniteSet(2*LambertW(-a/2))
-    assert solveset_real((a/x + exp(x/2)).diff(x), x) == \
-        FiniteSet(4*LambertW(sqrt(2)*sqrt(a)/4))
-
-    # coverage test
-    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
-
-    assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
-        FiniteSet(LambertW(3*S.Exp1)/3)
-    assert solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x) == \
-        FiniteSet(LambertW(3*exp(-sqrt(2)))/3, LambertW(3*exp(sqrt(2)))/3)
-    assert solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) == \
-        FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(-sqrt(3) + 1))/3)
-    assert solveset_real(x*log(x) + 3*x + 1, x) == \
-        FiniteSet(exp(-3 + LambertW(-exp(3))))
-    eq = (x*exp(x) - 3).subs(x, x*exp(x))
-    assert solveset_real(eq, x) == \
-        FiniteSet(LambertW(3*exp(-LambertW(3))))
-
-    assert solveset_real(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == \
-        FiniteSet(-((log(a**5) + LambertW(Rational(1, 3)))/(3*log(a))))
-    p = symbols('p', positive=True)
-    assert solveset_real(3*log(p**(3*x + 5)) + p**(3*x + 5), x) == \
-        FiniteSet(
-        log((-3**Rational(1, 3) - 3**Rational(5, 6)*I)*LambertW(Rational(1, 3))**Rational(1, 3)/(2*p**Rational(5, 3)))/log(p),
-        log((-3**Rational(1, 3) + 3**Rational(5, 6)*I)*LambertW(Rational(1, 3))**Rational(1, 3)/(2*p**Rational(5, 3)))/log(p),
-        log((3*LambertW(Rational(1, 3))/p**5)**(1/(3*log(p)))),)  # checked numerically
-    # check collection
-    b = Symbol('b')
-    eq = 3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5)
-    assert solveset_real(eq, x) == FiniteSet(
-        -((log(a**5) + LambertW(1/(b + 3)))/(3*log(a))))
-
-    # issue 4271
-    assert solveset_real((a/x + exp(x/2)).diff(x, 2), x) == FiniteSet(
-        6*LambertW((-1)**Rational(1, 3)*a**Rational(1, 3)/3))
-
-    assert solveset_real(x**3 - 3**x, x) == \
-        FiniteSet(-3/log(3)*LambertW(-log(3)/3))
-    assert solveset_real(3**cos(x) - cos(x)**3) == FiniteSet(
-        acos(-3*LambertW(-log(3)/3)/log(3)))
-
-    assert solveset_real(x**2 - 2**x, x) == \
-        solveset_real(-x**2 + 2**x, x)
-
-    assert solveset_real(3*log(x) - x*log(3)) == FiniteSet(
-        -3*LambertW(-log(3)/3)/log(3),
-        -3*LambertW(-log(3)/3, -1)/log(3))
-
-    assert solveset_real(LambertW(2*x) - y) == FiniteSet(
-        y*exp(y)/2)
-
-
-@XFAIL
-def test_other_lambert():
-    a = Rational(6, 5)
-    assert solveset_real(x**a - a**x, x) == FiniteSet(
-        a, -a*LambertW(-log(a)/a)/log(a))
-
-
 def test_solveset():
     f = Function('f')
     raises(ValueError, lambda: solveset(x + y))
@@ -1238,7 +1144,7 @@ def test_conditionset():
         ).dummy_eq(ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals))
 
     assert solveset(y**x-z, x, S.Reals
-        ).dummy_eq(ConditionSet(x, Eq(y**x - z, 0), S.Reals))
+        ).dummy_eq(FiniteSet(log(z)/log(y)))
 
 
 @XFAIL
@@ -1608,14 +1514,8 @@ def test_nonlinsolve_using_substitution():
     assert nonlinsolve(system, [x, y]) == FiniteSet(soln)
 
     system = [z**2*x**2 - z**2*y**2/exp(x)]
-    soln_real_1 = (y, x, 0)
-    soln_real_2 = (-exp(x/2)*Abs(x), x, z)
-    soln_real_3 = (exp(x/2)*Abs(x), x, z)
-    soln_complex_1 = (-x*exp(x/2), x, z)
-    soln_complex_2 = (x*exp(x/2), x, z)
     syms = [y, x, z]
-    soln = FiniteSet(soln_real_1, soln_complex_1, soln_complex_2,\
-        soln_real_2, soln_real_3)
+    soln = FiniteSet((y, x, 0), (y, 2*LambertW(-y/2), z), (y, 2*LambertW(y/2), z), (x*exp(x/2), x, z), (-x*exp(x/2), x, z))
     assert nonlinsolve(system,syms) == soln
 
 
@@ -2125,8 +2025,7 @@ def test_exponential_real():
     assert solveset_real(x**2 - y**2/exp(x), y) == Intersection(
         S.Reals, FiniteSet(-sqrt(x**2*exp(x)), sqrt(x**2*exp(x))))
     p = Symbol('p', positive=True)
-    assert solveset_real((1/p + 1)**(p + 1), p).dummy_eq(
-        ConditionSet(x, Eq((1 + 1/x)**(x + 1), 0), S.Reals))
+    assert solveset_real((1/p + 1)**(p + 1), p) == EmptySet()
 
 
 @XFAIL
@@ -2169,7 +2068,7 @@ def test_expo_conditionset():
     f5 = 2**x + 3**x - 5**x
 
     assert solveset(f1, x, S.Reals).dummy_eq(ConditionSet(
-        x, Eq((exp(x) + 1)**x - 2, 0), S.Reals))
+        x,Eq(x*log(exp(x) + 1) - log(2), 0), S.Reals))
     assert solveset(f2, x, S.Reals).dummy_eq(ConditionSet(
         x, Eq(x*(x + 2)**y - 3, 0), S.Reals))
     assert solveset(f3, x, S.Reals).dummy_eq(ConditionSet(
@@ -2193,14 +2092,13 @@ def test_exponential_symbols():
     assert solveset(f1, w, S.Reals) == sol1, solveset(f1, w, S.Reals)
     assert solveset(f2, w, S.Reals) == sol2, solveset(f2, w, S.Reals)
 
-    assert solveset(x**x, x, Interval.Lopen(0,oo)).dummy_eq(
-        ConditionSet(w, Eq(w**w, 0), Interval.open(0, oo)))
     assert solveset(x**y - 1, y, S.Reals) == FiniteSet(0)
     assert solveset(exp(x/y)*exp(-z/y) - 2, y, S.Reals) == FiniteSet(
         (x - z)/log(2)) - FiniteSet(0)
 
     assert solveset(a**x - b**x, x).dummy_eq(ConditionSet(
         w, Ne(a, 0) & Ne(b, 0), FiniteSet(0)))
+    assert solveset(x**x, x, Interval.Lopen(0,oo)) == EmptySet()
 
 
 def test_ignore_assumptions():
@@ -2216,10 +2114,9 @@ def test_issue_10864():
     assert solveset(x**(y*z) - x, x, S.Reals) == FiniteSet(1)
 
 
-@XFAIL
 def test_solve_only_exp_2():
     assert solveset_real(sqrt(exp(x)) + sqrt(exp(-x)) - 4, x) == \
-        FiniteSet(2*log(-sqrt(3) + 2), 2*log(sqrt(3) + 2))
+        FiniteSet(log(7 - 4*sqrt(3)), log(4*sqrt(3) + 7))
 
 
 def test_is_exponential():
@@ -2299,6 +2196,111 @@ def test_solve_logarithm():
     assert _solve_logarithm(log(x)*log(y), 0, x, S.Reals) == FiniteSet(1)
 
 # end of logarithmic tests
+
+
+# lambert tests
+
+def test_solve_lambert():
+    a = Symbol('a', real=True)
+    x = Symbol('x')
+    y = Symbol('y')
+    assert solveset_real(3*log(x) - x*log(3), x) == FiniteSet(
+        -3*LambertW(-log(3)/3)/log(3),
+        -3*LambertW(-log(3)/3, -1)/log(3))
+
+    assert solveset_real(3*log(a**(3*x + 5)) + a**(3*x + 5), x) ==FiniteSet(
+        (-log(a**5) - LambertW(S(1)/3))/(3*log(a)))
+    assert solveset_real(exp(x) + x, x) == FiniteSet(-LambertW(1))
+    assert solveset_real(x + 2**x, x) == \
+        FiniteSet(-LambertW(log(2))/log(2))
+
+    ans = solveset_real(3*x + 5 + 2**(-5*x + 3), x)
+    assert ans == FiniteSet(-Rational(5,3) +
+        LambertW(-10240*2**(S(1)/3)*log(2)/3)/(5*log(2)))
+
+    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
+    assert solveset_real(3**cos(x) - cos(x)**3,x) == FiniteSet(acos(3), acos(-3*LambertW(-log(3)/3)/log(3)))
+
+    assert solveset_real(LambertW(2*x) - y, x) == Intersection(FiniteSet(y*exp(y)/2), S.Reals)
+    # check collection
+    b = Symbol('b')
+    eq = 3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5)
+    assert solveset_real(eq, x) == FiniteSet(
+        (-log(a**5) - LambertW(S(1)/(b + 3)))/(3*log(a)))
+
+    p = symbols('p', positive=True)
+    eq = 3*log(p**(3*x + 5)) + p**(3*x + 5)
+    assert solveset(eq, x) == FiniteSet(-S(5)/3 - LambertW(S(1)/3)/(3*log(p)))
+    assert solveset_real(eq, x) == FiniteSet(-S(5)/3 - LambertW(S(1)/3)/(3*log(p)))
+
+    assert solveset_real(2*x + 5 + log(3*x - 2), x) == \
+        FiniteSet(Rational(2, 3) + LambertW(2*exp(-Rational(19, 3))/3)/2)
+
+    assert solveset_real(3*x + log(4*x), x) == \
+        FiniteSet(LambertW(Rational(3, 4))/3)
+
+    assert solveset_real(a/x + exp(x/2), x) == \
+        FiniteSet(2*LambertW(-a/2)) - FiniteSet(0)
+
+    assert solveset_real(x*exp(x) - 1, x) == FiniteSet(LambertW(1))
+    eq = (x*exp(x) - 3).subs(x, x*exp(x))
+    assert solveset_real(eq, x) == \
+        FiniteSet(LambertW(3*exp(-LambertW(3))))
+
+    assert solveset_real(x*log(x) + 3*x + 1, x) == \
+        FiniteSet(exp(-3 + LambertW(-exp(3))))
+    # issue 4271
+    assert solveset_real((a/x + exp(x/2)).diff(x, 2), x) == \
+        Complement(FiniteSet(6*LambertW((-a)**(S(1)/3)/3)), FiniteSet(0))
+    assert solveset_real(x**3 - 3**x, x) == FiniteSet(
+        -3*LambertW(-log(3)/3)/log(3), -3*LambertW(-log(3)/3, -1)/log(3))
+    assert solveset_real(x**2 - 2**x, x) == solveset_real(-x**2 + 2**x, x)
+
+    assert solveset_real((a/x + exp(x/2)).diff(x), x) == \
+        Complement(FiniteSet(4*LambertW(-sqrt(2)*sqrt(a)/4),
+         4*LambertW(sqrt(2)*sqrt(a)/4)), FiniteSet(0))
+    a = -1
+    assert solveset_real((a/x + exp(x/2)).diff(x), x) == S.EmptySet
+    a = 1
+    assert solveset_real((a/x + exp(x/2)).diff(x), x) == FiniteSet(
+        4*LambertW(sqrt(2)/4),4*LambertW(-sqrt(2)/4, -1),4*LambertW(-sqrt(2)/4))
+
+    assert solveset_real(x**x - 2, x) == FiniteSet(exp(LambertW(log(2))))
+
+    assert solveset_real(log(log(x - 3)) + log(x-3), x) == FiniteSet(
+        exp(LambertW(1)) + 3)
+
+    assert solveset_real(5*x - 1 + 3*exp(2 - 7*x), x) == \
+        FiniteSet(Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7)
+
+
+def test_solve_bivariate():
+
+    assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*S.Exp1)/3)
+
+    assert solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x) == \
+        FiniteSet(LambertW(3*exp(sqrt(2)))/3, LambertW(3*exp(-sqrt(2)))/3)
+
+    assert solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(1 - sqrt(3)))/3)
+
+    eq = 2*(3*x + 4)**5 - 6*7**(3*x + 9)
+    result = solveset_real(eq, x)
+    ans = FiniteSet((log(2401) +
+                     5*LambertW(-log(7**(7*3**Rational(1, 5)/5))))/(3*log(7))/-1)
+    assert result == ans
+    assert solveset_real(eq.expand(), x) == result
+    assert solveset_real(-a*x + 2*x*log(x), x) == FiniteSet(S.Zero, exp(a/2))
+
+
+@XFAIL
+def test_other_solve_lambert():
+    assert solveset_real(x**a - a**x, x) == \
+        FiniteSet(a, -a*LambertW(-log(a)/a)/log(a))
+
+
+# end of transolve's tests
 
 
 def test_linear_coeffs():


### PR DESCRIPTION
Tried to make a better version according to the latest updates as well as removing some errors accordingly

#14972,#18759,#20537,#20545
* solvers
  * improve solving of Lambert
  * improved _is_lambert 

From #14792 here's the finishing touch up. 
Herewith cases we are going to discuss more below accordingly.

### Case(1):
**Here we see an error message specifically in `.subs` case so, here I modified accordingly and finally arrived to required solution.**
### Input :
```
solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x)
solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x)
solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) 
```
### Output:
> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "/Users/owais/Desktop/symp_doc/sympy/sympy/solvers/solveset.py", line 2127, in solveset_real
>     return solveset(f, symbol, S.Reals)
>   File "/Users/owais/Desktop/symp_doc/sympy/sympy/solvers/solveset.py", line 2105, in solveset
>     return solveset(f.xreplace({symbol: r}), r, domain
>   File "/Users/owais/Desktop/symp_doc/sympy/sympy/solvers/solveset.py", line 2123, in solveset
>     return _solveset(f, symbol, domain, _check=True)
>   File "/Users/owais/Desktop/symp_doc/sympy/sympy/solvers/solveset.py", line 994, in _solveset
>     result += _transolve(equation, symbol, domain)
> TypeError: unsupported operand type(s) for +=: 'EmptySet' and 'list'`

### After Modification :
```
FiniteSet(LambertW(3*E)/3)

FiniteSet(LambertW(3*exp(sqrt(2)))/3, LambertW(3*exp(-sqrt(2)))/3)

FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(1 - sqrt(3)))/3)
```

### Case(2):
**Here, It was returning the complex solutions, but the requirement is only to get real solution hence accordingly modified.**
### PART(A):
### Input:
```
solveset_real((a/x + exp(x/2)).diff(x, 2), x)

solveset_real(3*x + 5 + 2**(-5*x + 3), x)     
```
### Output:

> Complement(FiniteSet(6*LambertW((-a)**(1/3)/3), 6*LambertW(-(-a)**(1/3)/6 - sqrt(3)*I*(-a)**(1/3)/6), 6*LambertW(-(-a)**(1/3)/6 + sqrt(3)*I*(-a)**(1/3)/6)), FiniteSet(0))
> FiniteSet(-5/3 + LambertW(-10240*2**(1/3)*log(2)/3)/(5*log(2)), -5/3 + 
> LambertW(-5*(-1024*2**(1/3) - 1024*2**(1/3)*sqrt(3)*I)*log(2)/3)/(5*log(2)), -5/3 + 
> LambertW(-5*(-1024*2**(1/3) + 1024*2**(1/3)*sqrt(3)*I)*log(2)/3)/(5*log(2)))

### After Modification:
```
Complement(FiniteSet(6*LambertW((-a)**(1/3)/3)), FiniteSet(0))
FiniteSet(-5/3 + LambertW(-10240*2**(1/3)*log(2)/3)/(5*log(2)))
```
### PART(B):
### Input:
```
`p = symbols('p', positive=True)`
`eq = 3*log(p**(3*x + 5)) + p**(3*x + 5)`
`solveset(eq, x)`
`solveset_real(eq, x)`
```
### Output:
> FiniteSet(-5/3 - LambertW(1/3)/(3*log(p)))
> FiniteSet(-5/3 - LambertW(1/3)/(3*log(p)), -5/3 - LambertW(-1/6 - sqrt(3)*I/6)/(3*log(p)), -5/3 - LambertW(-1/6 + sqrt(3)*I/6)/(3*log(p)))`
### After Modification: 
```
FiniteSet(-5/3 - LambertW(1/3)/(3*log(p)))
FiniteSet(-5/3 - LambertW(1/3)/(3*log(p)))
```
### PART(C):
### Input :
```
solveset_real(2*x + 5 + log(3*x - 2), x)
```
### Output:
> FiniteSet(LambertW(2*exp(-19/3)/3)/2 + 2/3, 2/3 + LambertW(-exp(-19/3)/3 - sqrt(3)*I*exp(-19/3)/3)/2, 2/3 + LambertW(-exp(-19/3)/3 + sqrt(3)*I*exp(-19/3)/3)/2)

### After Modification:
```
FiniteSet(LambertW(2*exp(-19/3)/3)/2 + 2/3)
```

**I'm really fascinated by the work on Lambert equations(obviously huge credit specifically goes to  @smichr 
 @Yathartha22 @jmig5776 and others) as it solves more such varieties of problems, hence increasing the domain of solving the equations in a more specific manner.**

_But some more such equations are to be solved in `solveset_real,` where the solutions are obtained by `solve` method but instead we are not getting it with `solveset_real` so more work has to be done considering all cases ._

I'm really glad to have further discussions and also to work on it.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
