### PR TITLE
Make complex exponential algebraic

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -445,15 +445,15 @@ class exp(ExpBase):
         return fuzzy_or(complex_extended_negative(self.args[0]))
 
     def _eval_is_algebraic(self):
-        s = self.func(*self.args)
-        if s.func == self.func:
-            if fuzzy_not(self.exp.is_zero):
-                if self.exp.is_algebraic:
-                    return False
-                elif (self.exp/S.Pi).is_rational:
-                    return False
-        else:
-            return s.is_algebraic
+        if fuzzy_not(self.exp.is_zero):
+            if (self.exp / S.Pi / S.ImaginaryUnit).is_rational:
+                return True
+            if self.exp.is_algebraic:
+                return False
+            elif (self.exp / S.Pi).is_rational:
+                return False
+        elif self.exp.is_zero:
+            return True
 
     def _eval_is_extended_positive(self):
         if self.args[0].is_extended_real:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -445,15 +445,13 @@ class exp(ExpBase):
         return fuzzy_or(complex_extended_negative(self.args[0]))
 
     def _eval_is_algebraic(self):
+        if (self.exp / S.Pi / S.ImaginaryUnit).is_rational:
+            return True
         if fuzzy_not(self.exp.is_zero):
-            if (self.exp / S.Pi / S.ImaginaryUnit).is_rational:
-                return True
             if self.exp.is_algebraic:
                 return False
             elif (self.exp / S.Pi).is_rational:
                 return False
-        elif self.exp.is_zero:
-            return True
 
     def _eval_is_extended_positive(self):
         if self.args[0].is_extended_real:

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -382,6 +382,10 @@ def test_exp_assumptions():
     assert exp(pi*r).is_algebraic is None
     assert exp(pi*rn).is_algebraic is False
 
+    assert exp(0, evaluate=False).is_algebraic is True
+    assert exp(I*pi/3, evaluate=False).is_algebraic is True
+    assert exp(I*pi*r, evaluate=False).is_algebraic is True
+
 
 def test_exp_AccumBounds():
     assert exp(AccumBounds(1, 2)) == AccumBounds(E, E**2)

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -5,7 +5,8 @@ from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, CC, EX
 from sympy.polys.domains.realfield import RealField
 from sympy.polys.domains.complexfield import ComplexField
 
-from sympy import S, sqrt, sin, Float, E, I, GoldenRatio, pi, Catalan, Rational
+from sympy import (
+    S, sqrt, sin, exp, Float, E, I, GoldenRatio, pi, Catalan, Rational)
 from sympy.abc import x, y
 
 
@@ -147,6 +148,17 @@ def test_construct_domain():
     assert construct_domain(Rational(2, 3)) == (QQ, QQ(2, 3))
 
     assert construct_domain({}) == (ZZ, {})
+
+
+def test_complex_exponential():
+    w = exp(-I*2*pi/3, evaluate=False)
+    alg = QQ.algebraic_field(w)
+    assert construct_domain([w**2, w, 1], extension=True) == (
+        alg,
+        [alg.convert(w**2),
+         alg.convert(w),
+         alg.convert(1)]
+    )
 
 
 def test_composite_option():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #20617 

#### Brief description of what is fixed or changed

I've modified the _eval_is_algebraic to accept rational multiples of `I*pi` as algebraic numbers, but I'd first see if this passes the tests.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- functions
  - Fixed assumption `is_algebraic` for exponentials with rational multiples of `I*pi` to be `True`.
<!-- END RELEASE NOTES -->