### PR TITLE
Cupy support to lambdify

### DIFF
--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -73,6 +73,18 @@ If you have array-based data this can confer a considerable speedup, on the
 order of 10 nano-seconds per element. Unfortunately numpy incurs some start-up
 time and introduces an overhead of a few microseconds.
 
+CuPy is a NumPy-compatible array library that mainly runs on CUDA, but has 
+increasing support for other GPUs manufacturer. It can in many cases be used as 
+a drop-in replacement for numpy. It is particu
+
+    >>> f = lambdify(x, expr, "cupy")
+    >>> import cupy as cp
+    >>> data = cp.linspace(1, 10, 10000)
+    >>> y = f(data) # perform the computation
+    >>> cp.asnumpy(y) # explicitly copy from GPU to CPU / numpy array
+    [ 0.84147098  0.84119981  0.84092844 ... -0.05426074 -0.05433146
+     -0.05440211]
+
 uFuncify
 --------
 
@@ -120,8 +132,10 @@ So Which Should I Use?
 
 The options here were listed in order from slowest and least dependencies to
 fastest and most dependencies.  For example, if you have Theano installed then
-that will often be the best choice.  If you don't have Theano but do have
-``f2py`` then you should use ``ufuncify``.
+that will often be the best choice. If you don't have Theano but do have
+``f2py`` then you should use ``ufuncify``. If you have been comfortable using 
+lambdify with the numpy module, but have a GPU, cupy can provide substantial 
+speedups with little effort.
 
 +-----------------+-------+-----------------------------+---------------+
 | Tool            | Speed | Qualities                   | Dependencies  |
@@ -133,6 +147,8 @@ that will often be the best choice.  If you don't have Theano but do have
 | lambdify-numpy  | 10ns  | Vector functions            | numpy         |
 +-----------------+-------+-----------------------------+---------------+
 | ufuncify        | 10ns  | Complex vector expressions  | f2py, Cython  |
++-----------------+-------+-----------------------------+---------------+
+| lambdify-cupy   | 10ns  | Vector functions on GPUs    | cupy          |
 +-----------------+-------+-----------------------------+---------------+
 | Theano          | 10ns  | Many outputs, CSE, GPUs     | Theano        |
 +-----------------+-------+-----------------------------+---------------+

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -23,6 +23,7 @@ __doctest_requires__ = {('lambdify',): ['numpy', 'tensorflow']}
 # by simple variable maps, like I => 1j
 MATH_DEFAULT = {}  # type: Dict[str, Any]
 MPMATH_DEFAULT = {}  # type: Dict[str, Any]
+CUPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 NUMPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 SCIPY_DEFAULT = {"I": 1j}  # type: Dict[str, Any]
 TENSORFLOW_DEFAULT = {}  # type: Dict[str, Any]
@@ -35,6 +36,7 @@ NUMEXPR_DEFAULT = {}  # type: Dict[str, Any]
 
 MATH = MATH_DEFAULT.copy()
 MPMATH = MPMATH_DEFAULT.copy()
+CUPY = CUPY_DEFAULT.copy()
 NUMPY = NUMPY_DEFAULT.copy()
 SCIPY = SCIPY_DEFAULT.copy()
 TENSORFLOW = TENSORFLOW_DEFAULT.copy()
@@ -80,6 +82,7 @@ MPMATH_TRANSLATIONS = {
     "FallingFactorial": "ff",
 }
 
+CUPY_TRANSLATIONS = {}  # type: Dict[str, str]
 NUMPY_TRANSLATIONS = {}  # type: Dict[str, str]
 SCIPY_TRANSLATIONS = {}  # type: Dict[str, str]
 
@@ -93,6 +96,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
+    "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy; import scipy; from scipy import *; from scipy.special import *",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",
@@ -787,6 +791,8 @@ def lambdify(args: Iterable, expr, modules=None, printer=None, use_imps=True,
             from sympy.printing.pycode import SciPyPrinter as Printer # type: ignore
         elif _module_present('numpy', namespaces):
             from sympy.printing.pycode import NumPyPrinter as Printer # type: ignore
+        elif _module_present('cupy', namespaces):
+            from sympy.printing.pycode import CuPyPrinter as Printer # type: ignore
         elif _module_present('numexpr', namespaces):
             from sympy.printing.lambdarepr import NumExprPrinter as Printer # type: ignore
         elif _module_present('tensorflow', namespaces):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -96,7 +96,7 @@ MODULES = {
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
     "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
-    "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy; import scipy; from scipy import *; from scipy.special import *",)),
+    "cupy": (CUPY, CUPY_DEFAULT, CUPY_TRANSLATIONS, ("import cupy",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import tensorflow",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (
         "from sympy.functions import *",


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Resubmission of #20271 by different author (forked that PR)

#### Brief description of what is fixed or changed
Adds a small codechange + simple docs to the CuPy contribution made by @emcastillo. 
Primarily works on CUDA GPUs, but there is increasing support for ROCm (AMD).

To test:
`conda install cupy` or `pip install cupy` 

The following takes 1ms on my GTX1080TI and 203ms on my i7-9700K 8 core computer.

```python 
import sympy as sp
import cupy as cp

x = sp.symbols('x')
expr = sp.sin(x) + sp.cos(x)
f = sp.lambdify(x, expr, 'cupy') # swap to 'numpy' to compare
x = cp.arange(10000000) # swap to 'np' to compare
y = f(x)
```
#### Other comments
This is hard to test. I'm unaware of any way to test GPU libraries on CI using Github Actions or equivalent. Much of this PR is a copy-paste from the numpy lambdify support (find+replace "numpy" -> "cupy"), so I suggest that since that is tested, this is acceptable as-is.

I find cupy a valuable addition, as it is very easy to install and provides a significant speed boost over numpy.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added support for using CuPy to GPU accelerate lambdify functions.
<!-- END RELEASE NOTES -->