### PR TITLE
Stats: Fixes simplification bug in Stochastic Processes

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1051,6 +1051,10 @@ def test_sympy__stats__crv__SingleContinuousPSpace():
     assert _test_args(SingleContinuousPSpace(x, nd))
 
 @SKIP("abstract class")
+def test_sympy__stats__rv__Distribution():
+    pass
+
+@SKIP("abstract class")
 def test_sympy__stats__crv__SingleContinuousDistribution():
     pass
 

--- a/sympy/stats/compound_rv.py
+++ b/sympy/stats/compound_rv.py
@@ -1,6 +1,6 @@
 from sympy import Basic, Sum, Dummy, Lambda, Integral
 from sympy.stats.rv import (NamedArgsMixin, random_symbols, _symbol_converter,
-                        PSpace, RandomSymbol, is_random)
+                        PSpace, RandomSymbol, is_random, Distribution)
 from sympy.stats.crv import ContinuousDistribution, SingleContinuousPSpace
 from sympy.stats.drv import DiscreteDistribution, SingleDiscretePSpace
 from sympy.stats.frv import SingleFiniteDistribution, SingleFinitePSpace
@@ -120,7 +120,7 @@ class CompoundPSpace(PSpace):
         return new_pspace.conditional_space(condition)
 
 
-class CompoundDistribution(Basic, NamedArgsMixin):
+class CompoundDistribution(Distribution, NamedArgsMixin):
     """
     Class for Compound Distributions.
 

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -21,7 +21,7 @@ from sympy.solvers.inequalities import reduce_rational_inequalities
 from sympy.core.sympify import _sympify
 from sympy.external import import_module
 from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain, is_random,
-        ProductDomain, PSpace, SinglePSpace, random_symbols, NamedArgsMixin)
+        ProductDomain, PSpace, SinglePSpace, random_symbols, NamedArgsMixin, Distribution)
 
 
 class ContinuousDomain(RandomDomain):
@@ -140,7 +140,7 @@ class ConditionalContinuousDomain(ContinuousDomain, ConditionalDomain):
                 "Set of Conditional Domain not Implemented")
 
 
-class ContinuousDistribution(Basic):
+class ContinuousDistribution(Distribution):
     def __call__(self, *args):
         return self.pdf(*args)
 

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -6,7 +6,7 @@ from sympy.polys.polyerrors import PolynomialError
 from sympy.stats.crv import reduce_rational_inequalities_wrap
 from sympy.stats.rv import (NamedArgsMixin, SinglePSpace, SingleDomain,
                             random_symbols, PSpace, ConditionalDomain, RandomDomain,
-                            ProductDomain)
+                            ProductDomain, Distribution)
 from sympy.stats.symbolic_probability import Probability
 from sympy.sets.fancysets import Range, FiniteSet
 from sympy.sets.sets import Union
@@ -16,7 +16,7 @@ from sympy.core.sympify import _sympify
 from sympy.external import import_module
 
 
-class DiscreteDistribution(Basic):
+class DiscreteDistribution(Distribution):
     def __call__(self, *args):
         return self.pdf(*args)
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -19,7 +19,7 @@ from sympy.core.sympify import _sympify
 from sympy.sets.sets import FiniteSet
 from sympy.stats.rv import (RandomDomain, ProductDomain, ConditionalDomain,
                             PSpace, IndependentProductPSpace, SinglePSpace, random_symbols,
-                            sumsets, rv_subs, NamedArgsMixin, Density)
+                            sumsets, rv_subs, NamedArgsMixin, Density, Distribution)
 from sympy.external import import_module
 
 
@@ -181,7 +181,7 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
     def as_boolean(self):
         return FiniteDomain.as_boolean(self)
 
-class SingleFiniteDistribution(Basic, NamedArgsMixin):
+class SingleFiniteDistribution(Distribution, NamedArgsMixin):
     def __new__(cls, *args):
         args = list(map(sympify, args))
         return Basic.__new__(cls, *args)

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -20,8 +20,9 @@ from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices import ImmutableMatrix, matrix2numpy, list2numpy
 from sympy.stats.crv import SingleContinuousDistribution, SingleContinuousPSpace
 from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
-from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
-                            ProductDomain, RandomSymbol, random_symbols, SingleDomain, _symbol_converter)
+from sympy.stats.rv import (ProductPSpace, NamedArgsMixin, Distribution,
+                            ProductDomain, RandomSymbol, random_symbols,
+                            SingleDomain, _symbol_converter)
 from sympy.utilities.misc import filldedent
 from sympy.external import import_module
 
@@ -232,7 +233,7 @@ _get_sample_class_jrv = {
     'numpy': SampleJointNumpy
 }
 
-class JointDistribution(Basic, NamedArgsMixin):
+class JointDistribution(Distribution, NamedArgsMixin):
     """
     Represented by the random variables part of the joint distribution.
     Contains methods for PDF, CDF, sampling, marginal densities, etc.
@@ -306,7 +307,7 @@ class JointRandomSymbol(RandomSymbol):
 
 
 
-class MarginalDistribution(Basic):
+class MarginalDistribution(Distribution):
     """
     Represents the marginal distribution of a joint probability space.
 

--- a/sympy/stats/matrix_distributions.py
+++ b/sympy/stats/matrix_distributions.py
@@ -4,7 +4,7 @@ from sympy.matrices import (ImmutableMatrix, Inverse, Trace, Determinant,
                             MatrixSymbol, MatrixBase, Transpose, MatrixSet,
                             matrix2numpy)
 from sympy.stats.rv import (_value_check, RandomMatrixSymbol, NamedArgsMixin, PSpace,
-                            _symbol_converter, MatrixDomain)
+                            _symbol_converter, MatrixDomain, Distribution)
 from sympy.external import import_module
 
 
@@ -153,7 +153,7 @@ _get_sample_class_matrixrv = {
 #-------------------------Matrix Distribution----------------------------------#
 ################################################################################
 
-class MatrixDistribution(Basic, NamedArgsMixin):
+class MatrixDistribution(Distribution, NamedArgsMixin):
     """
     Abstract class for Matrix Distribution
     """

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -330,12 +330,7 @@ class RandomIndexedSymbol(RandomSymbol):
 
     @property
     def pspace(self):
-        from sympy.stats.stochastic_process import StochasticPSpace
-        temp_pspace = self.args[1]
-        if len(temp_pspace.args) == 0:
-            # Allow single arg
-            return PSpace()
-        return StochasticPSpace(temp_pspace.args[0], temp_pspace.args[1], temp_pspace.args[2])
+        return self.args[1]
 
 class RandomMatrixSymbol(RandomSymbol, MatrixSymbol): # type: ignore
     def __new__(cls, symbol, n, m, pspace=None):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -328,6 +328,15 @@ class RandomIndexedSymbol(RandomSymbol):
             return free_syms
         return {self}
 
+    @property
+    def pspace(self):
+        from sympy.stats.stochastic_process import StochasticPSpace
+        temp_pspace = self.args[1]
+        if len(temp_pspace.args) == 0:
+            # Allow single arg
+            return PSpace()
+        return StochasticPSpace(temp_pspace.args[0], temp_pspace.args[1])
+
 class RandomMatrixSymbol(RandomSymbol, MatrixSymbol): # type: ignore
     def __new__(cls, symbol, n, m, pspace=None):
         n, m = _sympify(n), _sympify(m)
@@ -339,6 +348,9 @@ class RandomMatrixSymbol(RandomSymbol, MatrixSymbol): # type: ignore
 
     symbol = property(lambda self: self.args[0])
     pspace = property(lambda self: self.args[3])
+
+class Distribution(Basic):
+    pass
 
 class ProductPSpace(PSpace):
     """
@@ -1528,7 +1540,7 @@ def _symbol_converter(sym):
     True
     """
     if isinstance(sym, str):
-            sym = Symbol(sym)
+        sym = Symbol(sym)
     if not isinstance(sym, Symbol):
         raise TypeError("%s is neither a Symbol nor a string"%(sym))
     return sym

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -335,7 +335,7 @@ class RandomIndexedSymbol(RandomSymbol):
         if len(temp_pspace.args) == 0:
             # Allow single arg
             return PSpace()
-        return StochasticPSpace(temp_pspace.args[0], temp_pspace.args[1])
+        return StochasticPSpace(temp_pspace.args[0], temp_pspace.args[1], temp_pspace.args[2])
 
 class RandomMatrixSymbol(RandomSymbol, MatrixSymbol): # type: ignore
     def __new__(cls, symbol, n, m, pspace=None):
@@ -628,8 +628,9 @@ def pspace(expr):
     if all(rv.pspace == rvs[0].pspace for rv in rvs):
         return rvs[0].pspace
     from sympy.stats.compound_rv import CompoundPSpace
+    from sympy.stats.stochastic_process import StochasticPSpace
     for rv in rvs:
-        if isinstance(rv.pspace, CompoundPSpace):
+        if isinstance(rv.pspace, (CompoundPSpace, StochasticPSpace)):
             return rv.pspace
     # Otherwise make a product space
     return IndependentProductPSpace(*[rv.pspace for rv in rvs])

--- a/sympy/stats/stochastic_process.py
+++ b/sympy/stats/stochastic_process.py
@@ -1,6 +1,6 @@
 from sympy import Basic
 from sympy.stats.joint_rv import ProductPSpace
-from sympy.stats.rv import ProductDomain, _symbol_converter
+from sympy.stats.rv import ProductDomain, _symbol_converter, Distribution
 
 
 class StochasticPSpace(ProductPSpace):
@@ -17,7 +17,7 @@ class StochasticPSpace(ProductPSpace):
     parameter should not be passed.
     """
 
-    def __new__(cls, sym, process, distribution=None):
+    def __new__(cls, sym, process, distribution=Distribution()):
         sym = _symbol_converter(sym)
         from sympy.stats.stochastic_process_types import StochasticProcess
         if not isinstance(process, StochasticProcess):

--- a/sympy/stats/stochastic_process.py
+++ b/sympy/stats/stochastic_process.py
@@ -17,11 +17,13 @@ class StochasticPSpace(ProductPSpace):
     parameter should not be passed.
     """
 
-    def __new__(cls, sym, process, distribution=Distribution()):
+    def __new__(cls, sym, process, distribution=None):
         sym = _symbol_converter(sym)
         from sympy.stats.stochastic_process_types import StochasticProcess
         if not isinstance(process, StochasticProcess):
             raise TypeError("`process` must be an instance of StochasticProcess.")
+        if distribution is None:
+            distribution = Distribution()
         return Basic.__new__(cls, sym, process, distribution)
 
     @property

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -287,7 +287,7 @@ class ContinuousTimeStochasticProcess(StochasticProcess):
         if not time.is_symbol and time not in self.index_set:
             raise IndexError("%s is not in the index set of %s"%(time, self.symbol))
         func_obj = Function(self.symbol)(time)
-        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution(time))
+        pspace_obj = StochasticPSpace(self.symbol, self, distribution=self.distribution(key=time))
         return RandomIndexedSymbol(func_obj, pspace_obj)
 
 class TransitionMatrixOf(Boolean):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -20,7 +20,8 @@ from sympy.stats.joint_rv import JointDistribution
 from sympy.stats.joint_rv_types import JointDistributionHandmade
 from sympy.stats.rv import (RandomIndexedSymbol, random_symbols, RandomSymbol,
                             _symbol_converter, _value_check, pspace, given,
-                           dependent, is_random, sample_iter, Distribution)
+                           dependent, is_random, sample_iter, Distribution,
+                           Density)
 from sympy.stats.stochastic_process import StochasticPSpace
 from sympy.stats.symbolic_probability import Probability, Expectation
 from sympy.stats.frv_types import Bernoulli, BernoulliDistribution, FiniteRV
@@ -184,7 +185,7 @@ class StochasticProcess(Basic):
         return Distribution()
 
     def density(self, x):
-        return None
+        return Density()
 
     def __call__(self, time):
         """
@@ -237,11 +238,10 @@ class StochasticProcess(Basic):
                 raise ValueError("Expected a RandomIndexedSymbol or "
                                 "key not  %s"%(type(arg)))
 
-        density = self.density(args[0])
-        if density is None:
+        if args[0].pspace.distribution != Distribution():
             return JointDistribution(*args)
         density = Lambda(tuple(args),
-                expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
+                         expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
         return JointDistributionHandmade(density)
 
     def expectation(self, condition, given_condition):

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -234,17 +234,12 @@ class StochasticProcess(Basic):
                 raise ValueError("Expected a RandomIndexedSymbol or "
                                 "key not  %s"%(type(arg)))
 
-        t = Dummy('t')
-        dist = self.distribution(t)
-        if type(dist) is Distribution: # checks if there is any distribution available
-            return JointDistribution(*args)
-        if hasattr(dist, 'pdf'):
+        proc = args[0].pspace.process
+        if hasattr(proc, 'density'):
             density = Lambda(tuple(args),
-                    expr=Mul.fromiter(self.distribution(arg.key).pdf(arg) for arg in args))
-        elif hasattr(dist, 'pmf'):
-            density = Lambda(tuple(args),
-                    expr=Mul.fromiter(self.distribution(arg.key).pmf(arg) for arg in args))
-        return JointDistributionHandmade(density)
+                    expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
+            return JointDistributionHandmade(density)
+        return JointDistribution(*args)
 
     def expectation(self, condition, given_condition):
         raise NotImplementedError("Abstract method for expectation queries.")

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -174,7 +174,7 @@ class StochasticProcess(Basic):
     def _deprecation_warn_distribution(self):
         SymPyDeprecationWarning(
             feature="Calling distribution with RandomIndexedSymbol",
-            useinstead="distribution with just Symbol as argument",
+            useinstead="distribution with just timestamp as argument",
             issue=20078,
             deprecated_since_version="1.7.1"
         ).warn()

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -287,7 +287,7 @@ class ContinuousTimeStochasticProcess(StochasticProcess):
         if not time.is_symbol and time not in self.index_set:
             raise IndexError("%s is not in the index set of %s"%(time, self.symbol))
         func_obj = Function(self.symbol)(time)
-        pspace_obj = StochasticPSpace(self.symbol, self, distribution=self.distribution(key=time))
+        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution(time))
         return RandomIndexedSymbol(func_obj, pspace_obj)
 
 class TransitionMatrixOf(Boolean):
@@ -2196,7 +2196,7 @@ class PoissonProcess(CountingProcess):
     def state_space(self):
         return S.Naturals0
 
-    def distribution(self, key=None):
+    def distribution(self, key):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return PoissonDistribution(self.lamda*key.key)
@@ -2264,7 +2264,7 @@ class WienerProcess(CountingProcess):
     def state_space(self):
         return S.Reals
 
-    def distribution(self, key=None):
+    def distribution(self, key):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return NormalDistribution(0, sqrt(key.key))
@@ -2337,7 +2337,7 @@ class GammaProcess(CountingProcess):
     def state_space(self):
         return _set_converter(Interval(0, oo))
 
-    def distribution(self, key=None):
+    def distribution(self, key):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return GammaDistribution(self.gamma*key.key, 1/self.lamda)

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -238,7 +238,7 @@ class StochasticProcess(Basic):
                 raise ValueError("Expected a RandomIndexedSymbol or "
                                 "key not  %s"%(type(arg)))
 
-        if args[0].pspace.distribution != Distribution():
+        if args[0].pspace.distribution == Distribution():
             return JointDistribution(*args)
         density = Lambda(tuple(args),
                          expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
@@ -2196,7 +2196,7 @@ class PoissonProcess(CountingProcess):
     def state_space(self):
         return S.Naturals0
 
-    def distribution(self, key):
+    def distribution(self, key=None):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return PoissonDistribution(self.lamda*key.key)
@@ -2264,7 +2264,7 @@ class WienerProcess(CountingProcess):
     def state_space(self):
         return S.Reals
 
-    def distribution(self, key):
+    def distribution(self, key=None):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return NormalDistribution(0, sqrt(key.key))
@@ -2337,7 +2337,7 @@ class GammaProcess(CountingProcess):
     def state_space(self):
         return _set_converter(Interval(0, oo))
 
-    def distribution(self, key):
+    def distribution(self, key=None):
         if isinstance(key, RandomIndexedSymbol):
             self._deprecation_warn_distribution()
             return GammaDistribution(self.gamma*key.key, 1/self.lamda)

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -183,6 +183,9 @@ class StochasticProcess(Basic):
             self._deprecation_warn_distribution()
         return Distribution()
 
+    def density(self, x):
+        return None
+
     def __call__(self, time):
         """
         Overridden in ContinuousTimeStochasticProcess.
@@ -234,12 +237,12 @@ class StochasticProcess(Basic):
                 raise ValueError("Expected a RandomIndexedSymbol or "
                                 "key not  %s"%(type(arg)))
 
-        proc = args[0].pspace.process
-        if hasattr(proc, 'density'):
-            density = Lambda(tuple(args),
-                    expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
-            return JointDistributionHandmade(density)
-        return JointDistribution(*args)
+        density = self.density(args[0])
+        if density is None:
+            return JointDistribution(*args)
+        density = Lambda(tuple(args),
+                expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
+        return JointDistributionHandmade(density)
 
     def expectation(self, condition, given_condition):
         raise NotImplementedError("Abstract method for expectation queries.")

--- a/sympy/stats/stochastic_process_types.py
+++ b/sympy/stats/stochastic_process_types.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division
 import random
 
 import itertools
@@ -19,7 +20,7 @@ from sympy.stats.joint_rv import JointDistribution
 from sympy.stats.joint_rv_types import JointDistributionHandmade
 from sympy.stats.rv import (RandomIndexedSymbol, random_symbols, RandomSymbol,
                             _symbol_converter, _value_check, pspace, given,
-                           dependent, is_random, sample_iter)
+                           dependent, is_random, sample_iter, Distribution)
 from sympy.stats.stochastic_process import StochasticPSpace
 from sympy.stats.symbolic_probability import Probability, Expectation
 from sympy.stats.frv_types import Bernoulli, BernoulliDistribution, FiniteRV
@@ -169,9 +170,18 @@ class StochasticProcess(Basic):
             return FiniteSet(*self.args[1])
         return self.args[1]
 
-    @property
-    def distribution(self):
-        return None
+    def _deprecation_warn_distribution(self):
+        SymPyDeprecationWarning(
+            feature="Calling distribution with RandomIndexedSymbol",
+            useinstead="distribution with just Symbol as argument",
+            issue=20078,
+            deprecated_since_version="1.7.1"
+        ).warn()
+
+    def distribution(self, key=None):
+        if key is None:
+            self._deprecation_warn_distribution()
+        return Distribution()
 
     def __call__(self, time):
         """
@@ -224,12 +234,17 @@ class StochasticProcess(Basic):
                 raise ValueError("Expected a RandomIndexedSymbol or "
                                 "key not  %s"%(type(arg)))
 
-        if args[0].pspace.distribution == None: # checks if there is any distribution available
+        t = Dummy('t')
+        dist = self.distribution(t)
+        if type(dist) is Distribution: # checks if there is any distribution available
             return JointDistribution(*args)
-
-        pdf = Lambda(tuple(args),
-                expr=Mul.fromiter(arg.pspace.process.density(arg) for arg in args))
-        return JointDistributionHandmade(pdf)
+        if hasattr(dist, 'pdf'):
+            density = Lambda(tuple(args),
+                    expr=Mul.fromiter(self.distribution(arg.key).pdf(arg) for arg in args))
+        elif hasattr(dist, 'pmf'):
+            density = Lambda(tuple(args),
+                    expr=Mul.fromiter(self.distribution(arg.key).pmf(arg) for arg in args))
+        return JointDistributionHandmade(density)
 
     def expectation(self, condition, given_condition):
         raise NotImplementedError("Abstract method for expectation queries.")
@@ -254,7 +269,7 @@ class DiscreteTimeStochasticProcess(StochasticProcess):
         if not time.is_symbol and time not in self.index_set:
             raise IndexError("%s is not in the index set of %s"%(time, self.symbol))
         idx_obj = Indexed(self.symbol, time)
-        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution)
+        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution(time))
         return RandomIndexedSymbol(idx_obj, pspace_obj)
 
 class ContinuousTimeStochasticProcess(StochasticProcess):
@@ -274,7 +289,7 @@ class ContinuousTimeStochasticProcess(StochasticProcess):
         if not time.is_symbol and time not in self.index_set:
             raise IndexError("%s is not in the index set of %s"%(time, self.symbol))
         func_obj = Function(self.symbol)(time)
-        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution)
+        pspace_obj = StochasticPSpace(self.symbol, self, self.distribution(time))
         return RandomIndexedSymbol(func_obj, pspace_obj)
 
 class TransitionMatrixOf(Boolean):
@@ -1449,7 +1464,7 @@ class DiscreteMarkovChain(DiscreteTimeStochasticProcess, MarkovProcess):
             densities[state] = {states[i]: Tlist[state][i]
                         for i in range(len(states))}
         while time < S.Infinity:
-            samps.append(next(sample_iter(FiniteRV("_", densities[samps[time - 1]]))))
+            samps.append((next(sample_iter(FiniteRV("_", densities[samps[time - 1]])))))
             yield samps[time]
             time += 1
 
@@ -1665,9 +1680,11 @@ class BernoulliProcess(DiscreteTimeStochasticProcess):
     def state_space(self):
         return _set_converter([self.success, self.failure])
 
-    @property
-    def distribution(self):
-        return BernoulliDistribution(self.p)
+    def distribution(self, key=None):
+        if key is None:
+            self._deprecation_warn_distribution()
+            return BernoulliDistribution(self.p)
+        return BernoulliDistribution(self.p, self.success, self.failure)
 
     def simple_rv(self, rv):
         return Bernoulli(rv.name, p=self.p,
@@ -2181,8 +2198,11 @@ class PoissonProcess(CountingProcess):
     def state_space(self):
         return S.Naturals0
 
-    def distribution(self, rv):
-        return PoissonDistribution(self.lamda*rv.key)
+    def distribution(self, key):
+        if isinstance(key, RandomIndexedSymbol):
+            self._deprecation_warn_distribution()
+            return PoissonDistribution(self.lamda*key.key)
+        return PoissonDistribution(self.lamda*key)
 
     def density(self, x):
         return (self.lamda*x.key)**x / factorial(x) * exp(-(self.lamda*x.key))
@@ -2246,8 +2266,11 @@ class WienerProcess(CountingProcess):
     def state_space(self):
         return S.Reals
 
-    def distribution(self, rv):
-        return NormalDistribution(0, sqrt(rv.key))
+    def distribution(self, key):
+        if isinstance(key, RandomIndexedSymbol):
+            self._deprecation_warn_distribution()
+            return NormalDistribution(0, sqrt(key.key))
+        return NormalDistribution(0, sqrt(key))
 
     def density(self, x):
         return exp(-x**2/(2*x.key)) / (sqrt(2*pi)*sqrt(x.key))
@@ -2316,8 +2339,11 @@ class GammaProcess(CountingProcess):
     def state_space(self):
         return _set_converter(Interval(0, oo))
 
-    def distribution(self, rv):
-        return GammaDistribution(self.gamma*rv.key, 1/self.lamda)
+    def distribution(self, key):
+        if isinstance(key, RandomIndexedSymbol):
+            self._deprecation_warn_distribution()
+            return GammaDistribution(self.gamma*key.key, 1/self.lamda)
+        return GammaDistribution(self.gamma*key, 1/self.lamda)
 
     def density(self, x):
         k = self.gamma*x.key

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -73,7 +73,7 @@ class Probability(Expr):
 
         if condition.has(RandomIndexedSymbol):
             return pspace(condition).probability(condition, given_condition,
-                                evaluate=for_rewrite)
+                                             evaluate=for_rewrite)
 
         if isinstance(given_condition, RandomSymbol):
             condrv = random_symbols(condition)

--- a/sympy/stats/tests/test_stochastic_process.py
+++ b/sympy/stats/tests/test_stochastic_process.py
@@ -338,6 +338,13 @@ def test_DiscreteMarkovChain():
     query_lt = P(Lt(Y[a], b), Eq(Y[c], d))
     assert query_ge.subs({a:4, b:1, c:0, d:2}).evalf() + query_lt.subs({a:4, b:1, c:0, d:2}).evalf() == 1
 
+    #test issue 20078
+    assert (2*Y[1] + 3*Y[1]).simplify() == 5*Y[1]
+    assert (2*Y[1] - 3*Y[1]).simplify() == -Y[1]
+    assert (2*(0.25*Y[1])).simplify() == 0.5*Y[1]
+    assert ((2*Y[1]) * (0.25*Y[1])).simplify() == 0.5*Y[1]**2
+    assert (Y[1]**2 + Y[1]**3).simplify() == (Y[1] + 1)*Y[1]**2
+
 def test_sample_stochastic_process():
     if not import_module('scipy'):
         skip('SciPy Not installed. Skip sampling tests')
@@ -424,6 +431,13 @@ def test_ContinuousMarkovChain():
     query_lt = P(Lt(C(a), b), Eq(C(c), d))
     assert query_ge.subs({a:7.43, b:1, c:1.45, d:0}).evalf() + query_lt.subs({a:7.43, b:1, c:1.45, d:0}).evalf() == 1
 
+    #test issue 20078
+    assert (2*C(1) + 3*C(1)).simplify() == 5*C(1)
+    assert (2*C(1) - 3*C(1)).simplify() == -C(1)
+    assert (2*(0.25*C(1))).simplify() == 0.5*C(1)
+    assert (2*C(1) * 0.25*C(1)).simplify() == 0.5*C(1)**2
+    assert (C(1)**2 + C(1)**3).simplify() == (C(1) + 1)*C(1)**2
+
 def test_BernoulliProcess():
 
     B = BernoulliProcess("B", p=0.6, success=1, failure=0)
@@ -492,6 +506,12 @@ def test_BernoulliProcess():
     assert B[4].free_symbols == {B[4]}
     assert B[x*t].free_symbols == {B[x*t], x, t}
 
+    #test issue 20078
+    assert (2*B[t] + 3*B[t]).simplify() == 5*B[t]
+    assert (2*B[t] - 3*B[t]).simplify() == -B[t]
+    assert (2*(0.25*B[t])).simplify() == 0.5*B[t]
+    assert (2*B[t] * 0.25*B[t]).simplify() == 0.5*B[t]**2
+    assert (B[t]**2 + B[t]**3).simplify() == (B[t] + 1)*B[t]**2
 
 def test_PoissonProcess():
     X = PoissonProcess("X", 3)
@@ -501,7 +521,7 @@ def test_PoissonProcess():
 
     t, d, x, y = symbols('t d x y', positive=True)
     assert isinstance(X(t), RandomIndexedSymbol)
-    assert X.distribution(X(t)) == PoissonDistribution(3*t)
+    assert X.distribution(t) == PoissonDistribution(3*t)
     raises(ValueError, lambda: PoissonProcess("X", -1))
     raises(NotImplementedError, lambda: X[t])
     raises(IndexError, lambda: X(-5))
@@ -601,6 +621,13 @@ def test_PoissonProcess():
     assert P(Eq(X(2), 5) & Eq(X(1), 2)) == P(Eq(X(1), 3))*P(Eq(X(1), 2))
     assert P(Eq(X(3), 4), Eq(X(1), 3)) == P(Eq(X(2), 1))
 
+    #test issue 20078
+    assert (2*X(t) + 3*X(t)).simplify() == 5*X(t)
+    assert (2*X(t) - 3*X(t)).simplify() == -X(t)
+    assert (2*(0.25*X(t))).simplify() == 0.5*X(t)
+    assert (2*X(t) * 0.25*X(t)).simplify() == 0.5*X(t)**2
+    assert (X(t)**2 + X(t)**3).simplify() == (X(t) + 1)*X(t)**2
+
 def test_WienerProcess():
     X = WienerProcess("X")
     assert X.state_space == S.Reals
@@ -608,7 +635,7 @@ def test_WienerProcess():
 
     t, d, x, y = symbols('t d x y', positive=True)
     assert isinstance(X(t), RandomIndexedSymbol)
-    assert X.distribution(X(t)) == NormalDistribution(0, sqrt(t))
+    assert X.distribution(t) == NormalDistribution(0, sqrt(t))
     raises(ValueError, lambda: PoissonProcess("X", -1))
     raises(NotImplementedError, lambda: X[t])
     raises(IndexError, lambda: X(-2))
@@ -643,6 +670,13 @@ def test_WienerProcess():
     Contains(d, Interval.Ropen(1, 2)) & Contains(t, Interval.Lopen(0, 1)))
     assert E(X(t) + x*E(X(3))) == 0
 
+    #test issue 20078
+    assert (2*X(t) + 3*X(t)).simplify() == 5*X(t)
+    assert (2*X(t) - 3*X(t)).simplify() == -X(t)
+    assert (2*(0.25*X(t))).simplify() == 0.5*X(t)
+    assert (2*X(t) * 0.25*X(t)).simplify() == 0.5*X(t)**2
+    assert (X(t)**2 + X(t)**3).simplify() == (X(t) + 1)*X(t)**2
+
 
 def test_GammaProcess_symbolic():
     t, d, x, y, g, l = symbols('t d x y g l', positive=True)
@@ -652,7 +686,7 @@ def test_GammaProcess_symbolic():
     raises(IndexError, lambda: X(-1))
     assert isinstance(X(t), RandomIndexedSymbol)
     assert X.state_space == Interval(0, oo)
-    assert X.distribution(X(t)) == GammaDistribution(g*t, 1/l)
+    assert X.distribution(t) == GammaDistribution(g*t, 1/l)
     assert X.joint_distribution(5, X(3)) == JointDistributionHandmade(Lambda(
         (X(5), X(3)), l**(8*g)*exp(-l*X(3))*exp(-l*X(5))*X(3)**(3*g - 1)*X(5)**(5*g
         - 1)/(gamma(3*g)*gamma(5*g))))
@@ -668,6 +702,13 @@ def test_GammaProcess_symbolic():
     assert P(X(t) > 3, Contains(t, Interval.Lopen(3, 4))).simplify() == \
                                 1 - lowergamma(g, 3*l)/gamma(g) # equivalent to P(X(1)>3)
 
+
+    #test issue 20078
+    assert (2*X(t) + 3*X(t)).simplify() == 5*X(t)
+    assert (2*X(t) - 3*X(t)).simplify() == -X(t)
+    assert (2*(0.25*X(t))).simplify() == 0.5*X(t)
+    assert (2*X(t) * 0.25*X(t)).simplify() == 0.5*X(t)**2
+    assert (X(t)**2 + X(t)**3).simplify() == (X(t) + 1)*X(t)**2
 def test_GammaProcess_numeric():
     t, d, x, y = symbols('t d x y', positive=True)
     X = GammaProcess("X", 1, 2)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#20078 

#### Brief description of what is fixed or changed
Before fix:
```
>>> print((2*W(t)).simplify())
>>> AttributeError: 'function' object has no attribute 'is_Rational'
```

After fix:
```
>>> print((2*W(t)).simplify())
>>> 2*W(t)
```

#### Other comments
Changes originally [proposed](https://gist.github.com/czgdp1807/879223647496d9cef0b246272731c3db) by @czgdp1807
A minor change was made in pspace property of `RandomIndexedSymbol`, to allow for calling `RandomIndexedSymbol` with one argument.

Originally, this PR was #20588 , but due to some rebasing issues, I have moved to a new branch, keeping the intended changes. Please read the discussion over there too. Sorry for the inconvenience caused.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
    * Fixed simplification bug in Stochastic Processes by introducing abstract Distribution class
    * API changed for `StochasticProcess.distribution` which now expects a timestamp argument instead of `RandomIndexedSymbol` object.
<!-- END RELEASE NOTES -->