### PR TITLE
Made ordered() calls faster for large expressions

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -472,6 +472,8 @@ def default_sort_key(item, order=None):
     return (cls_index, 0, item.__class__.__name__
             ), args, S.One.sort_key(), S.One
 
+def _node_count(e):
+    return 1 + sum(map(_node_count, e.args))
 
 def _nodes(e):
     """
@@ -486,7 +488,7 @@ def _nodes(e):
     if isinstance(e, Basic):
         if isinstance(e, Derivative):
             return _nodes(e.expr) + len(e.variables)
-        return e.count(Basic)
+        return _node_count(e)
     elif iterable(e):
         return 1 + sum(_nodes(ei) for ei in e)
     elif isinstance(e, dict):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -496,7 +496,7 @@ class LatticeOp(AssocOp):
         else:
             # XXX in almost every other case for __new__, *_args is
             # passed along, but the expectation here is for _args
-            obj = super(AssocOp, cls).__new__(cls, _args)
+            obj = super(AssocOp, cls).__new__(cls, *ordered(_args))
             obj._argset = _args
             return obj
 
@@ -523,13 +523,6 @@ class LatticeOp(AssocOp):
             return expr._argset
         else:
             return frozenset([sympify(expr)])
-
-    # XXX: This should be cached on the object rather than using cacheit
-    # Maybe _argset can just be sorted in the constructor?
-    @property  # type: ignore
-    @cacheit
-    def args(self):
-        return tuple(ordered(self._argset))
 
     @staticmethod
     def _compare_pretty(a, b):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,6 +1,7 @@
 from sympy.core import Function, S, sympify
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
+from sympy.core.compatibility import ordered
 from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
     ArgumentIndexError)
@@ -405,7 +406,7 @@ class MinMaxBase(Expr, LatticeOp):
 
         # base creation
         _args = frozenset(args)
-        obj = Expr.__new__(cls, _args, **assumptions)
+        obj = Expr.__new__(cls, *ordered(_args), **assumptions)
         obj._argset = _args
         return obj
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1280,8 +1280,8 @@ def test_SymmetricDifference():
             == FiniteSet(5)
     assert FiniteSet(1, 2, 3, 4, 5) ^ FiniteSet(1, 2, 5, 6) == \
             FiniteSet(3, 4, 6)
-    assert Set(1, 2 , 3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
-            Set(2, 3, 4) - Set(1, 2, 3))
+    assert Set(S(1), S(2) , S(3)) ^ Set(S(2), S(3), S(4)) == Union(Set(S(1), S(2), S(3)) - Set(S(2), S(3), S(4)), \
+            Set(S(2), S(3), S(4)) - Set(S(1), S(2), S(3)))
     assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
             Interval(2, 5), Interval(2, 5) - Interval(0, 4))
 

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -1,4 +1,4 @@
-from sympy import Add, Basic, symbols, Symbol, And
+from sympy import Add, Basic, symbols, Symbol, And, S
 from sympy.core.symbol import Str
 from sympy.unify.core import Compound, Variable
 from sympy.unify.usympy import (deconstruct, construct, unify, is_associative,
@@ -124,11 +124,11 @@ def test_FiniteSet_commutivity():
 def test_FiniteSet_complex():
     from sympy import FiniteSet
     a, b, c, x, y, z = symbols('a,b,c,x,y,z')
-    expr = FiniteSet(Basic(1, x), y, Basic(x, z))
+    expr = FiniteSet(Basic(S(1), x), y, Basic(x, z))
     pattern = FiniteSet(a, Basic(x, b))
     variables = a, b
     expected = tuple([{b: 1, a: FiniteSet(y, Basic(x, z))},
-                      {b: z, a: FiniteSet(y, Basic(1, x))}])
+                      {b: z, a: FiniteSet(y, Basic(S(1), x))}])
     assert iterdicteq(unify(expr, pattern, variables=variables), expected)
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to #20359 

#### Brief description of what is fixed or changed

Added changes suggested by @oscarbenjamin in the issue page. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- core
  - ordered() made faster for large expressions

<!-- END RELEASE NOTES -->