### PR TITLE
Pretty printing bug fix

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1902,15 +1902,12 @@ class PrettyPrinter(Printer):
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
     # A helper function for _print_Pow to print x**(1/n)
-    def _print_nth_root(self, base, expt, den_p):
-        # den_p is the prettyForm of denominator of the exponent (n in this case)
-        # it is needed as using args will not work for 1/E and also to check
-        # whether a symbol is simple (single character) or not
+    def _print_nth_root(self, base, root):
         bpretty = self._print(base)
 
         # In very simple cases, use a single-char root sign
         if (self._settings['use_unicode_sqrt_char'] and self._use_unicode
-            and expt is S.Half and bpretty.height() == 1
+            and root == 2 and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
             return prettyForm(*bpretty.left('\N{SQUARE ROOT}'))
@@ -1918,16 +1915,13 @@ class PrettyPrinter(Printer):
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ
-        # Make exponent number to put above it
-        if isinstance(expt, Rational):
-            exp = str(expt.q)
-            if exp == '2':
-                exp = ''
-        else:
-            if den_p.height() > 1 or den_p.width() > 1:
-                return self._print(base)**self._print(expt)
-            exp = str(den_p)
-        exp = exp.ljust(2)
+        # Constructing the number to put on root
+        rpretty = self._print(root)
+        # If n is not an integer or simple symbol, print without root sign
+        if not root.is_Integer and (rpretty.height() > 1 or rpretty.width() > 1):
+            return self._print(base)**self._print(1/root)
+        # If power is half, no number should appear on top of root sign
+        exp = '' if root == 2 else str(rpretty).ljust(2)
         if len(exp) > 2:
             rootsign = ' '*(len(exp) - 2) + rootsign
         # Stack the exponent
@@ -1961,8 +1955,7 @@ class PrettyPrinter(Printer):
             n, d = fraction(e)
             if n is S.One and d.is_Atom and not e.is_Integer and (e.is_Rational or d.is_Symbol) \
                     and self._settings['root_notation']:
-                den_p = self._print(d)
-                return self._print_nth_root(b, e, den_p)
+                return self._print_nth_root(b, d)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1957,7 +1957,8 @@ class PrettyPrinter(Printer):
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
-            if n is S.One and d.is_Atom and not e.is_Integer and not e.is_irrational and self._settings['root_notation']:
+            if n is S.One and d.is_Atom and not e.is_Integer and (e.is_Rational or d.is_Symbol)\
+                    and self._settings['root_notation']:
                 den_p = self._print(d)
                 return self._print_nth_root(b, e, den_p)
             if e.is_Rational and e < 0:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1916,12 +1916,13 @@ class PrettyPrinter(Printer):
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ
         # Make exponent number to put above it
+        #print(dir(expt))
         if isinstance(expt, Rational):
             exp = str(expt.q)
             if exp == '2':
                 exp = ''
         else:
-            exp = str(expt.args[0])
+            exp = str(expt.args[0]) if hasattr(expt, 'arg') else str(expt)
         exp = exp.ljust(2)
         if len(exp) > 2:
             rootsign = ' '*(len(exp) - 2) + rootsign
@@ -1954,7 +1955,7 @@ class PrettyPrinter(Printer):
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
-            if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
+            if n is S.One and d.is_Atom and not e.is_Integer and e.is_Rational and self._settings['root_notation']:
                 return self._print_nth_root(b, e)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1902,7 +1902,7 @@ class PrettyPrinter(Printer):
             return prettyForm.__mul__(*a)/prettyForm.__mul__(*b)
 
     # A helper function for _print_Pow to print x**(1/n)
-    def _print_nth_root(self, base, expt):
+    def _print_nth_root(self, base, expt, den_p):
         bpretty = self._print(base)
 
         # In very simple cases, use a single-char root sign
@@ -1922,7 +1922,9 @@ class PrettyPrinter(Printer):
             if exp == '2':
                 exp = ''
         else:
-            exp = str(expt.args[0]) if hasattr(expt, 'arg') else str(expt)
+            if den_p.height() > 1 or den_p.width() > 1:
+                return self._print(base)**self._print(expt)
+            exp = str(den_p)
         exp = exp.ljust(2)
         if len(exp) > 2:
             rootsign = ' '*(len(exp) - 2) + rootsign
@@ -1955,8 +1957,9 @@ class PrettyPrinter(Printer):
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
-            if n is S.One and d.is_Atom and not e.is_Integer and e.is_Rational and self._settings['root_notation']:
-                return self._print_nth_root(b, e)
+            if n is S.One and d.is_Atom and not e.is_Integer and not e.is_irrational and self._settings['root_notation']:
+                den_p = self._print(d)
+                return self._print_nth_root(b, e, den_p)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1917,8 +1917,8 @@ class PrettyPrinter(Printer):
         rootsign = xobj('\\', 1) + _zZ
         # Constructing the number to put on root
         rpretty = self._print(root)
-        # If n is not an integer or simple symbol, print without root sign
-        if not root.is_Integer and (rpretty.height() > 1 or rpretty.width() > 1):
+        # roots look bad if they are not a single line
+        if rpretty.height() != 1:
             return self._print(base)**self._print(1/root)
         # If power is half, no number should appear on top of root sign
         exp = '' if root == 2 else str(rpretty).ljust(2)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1903,6 +1903,9 @@ class PrettyPrinter(Printer):
 
     # A helper function for _print_Pow to print x**(1/n)
     def _print_nth_root(self, base, expt, den_p):
+        # den_p is the prettyForm of denominator of the exponent (n in this case)
+        # it is needed as using args will not work for 1/E and also to check
+        # whether a symbol is simple (single character) or not
         bpretty = self._print(base)
 
         # In very simple cases, use a single-char root sign
@@ -1956,7 +1959,7 @@ class PrettyPrinter(Printer):
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
-            if n is S.One and d.is_Atom and not e.is_Integer and (e.is_Rational or d.is_Symbol)\
+            if n is S.One and d.is_Atom and not e.is_Integer and (e.is_Rational or d.is_Symbol) \
                     and self._settings['root_notation']:
                 den_p = self._print(d)
                 return self._print_nth_root(b, e, den_p)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1916,7 +1916,6 @@ class PrettyPrinter(Printer):
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ
         # Make exponent number to put above it
-        #print(dir(expt))
         if isinstance(expt, Rational):
             exp = str(expt.q)
             if exp == '2':

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7285,8 +7285,10 @@ def test_issue_17616():
     'pi          '
 
     assert upretty(pi**(1/EulerGamma)) == \
-    'γ ___\n'\
-    '╲╱ π '
+    ' 1\n'\
+    ' ─\n'\
+    ' γ\n'\
+    'π '
 
     z = Symbol("x_17")
     assert upretty(7**(1/z)) == \

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7246,16 +7246,12 @@ def test_issue_17616():
 
     z = Symbol("x_17")
     assert upretty(7**(1/z)) == \
-    '  1 \n'\
-    ' ───\n'\
-    ' x₁₇\n'\
-    '7   '
+    'x₁₇___\n'\
+    ' ╲╱ 7 '
 
     assert pretty(7**(1/z)) == \
-    '  1  \n'\
-    ' ----\n'\
-    ' x_17\n'\
-    '7    '
+    'x_17___\n'\
+    '  \\/ 7 '
 
 
 def test_issue_17857():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5943,10 +5943,10 @@ def test_PrettyPoly():
 def test_issue_6285():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
     assert pretty(Pow(x, (1/pi))) == \
-    ' 1\n'\
-    ' ─\n'\
-    ' π\n'\
-    'x'
+    ' 1 \n'\
+    ' --\n'\
+    ' pi\n'\
+    'x  '
 
 
 def test_issue_6359():
@@ -7256,7 +7256,47 @@ def test_diffgeom():
     assert pretty(b) == "x"
 
 def test_issue_17616():
-    assert pretty(pi**(1/E)) == \
-   '  ⎛ -1⎞\n'\
-   '  ⎝ℯ  ⎠\n'\
-   ' π'
+    assert pretty(pi**(1/exp(1))) == \
+   '  / -1\\\n'\
+   '  \e  /\n'\
+   'pi     '
+
+    assert upretty(pi**(1/exp(1))) == \
+   ' ⎛ -1⎞\n'\
+   ' ⎝ℯ  ⎠\n'\
+   'π     '
+
+    assert pretty(pi**(1/pi)) == \
+    '  1 \n'\
+    '  --\n'\
+    '  pi\n'\
+    'pi  '
+
+    assert upretty(pi**(1/pi)) == \
+    ' 1\n'\
+    ' ─\n'\
+    ' π\n'\
+    'π '
+
+    assert pretty(pi**(1/EulerGamma)) == \
+    '      1     \n'\
+    '  ----------\n'\
+    '  EulerGamma\n'\
+    'pi          '
+
+    assert upretty(pi**(1/EulerGamma)) == \
+    'γ ___\n'\
+    '╲╱ π '
+
+    z = Symbol("x_17")
+    assert upretty(7**(1/z)) == \
+    '  1 \n'\
+    ' ───\n'\
+    ' x₁₇\n'\
+    '7   '
+
+    assert pretty(7**(1/z)) == \
+    '  1  \n'\
+    ' ----\n'\
+    ' x_17\n'\
+    '7    '

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7209,52 +7209,6 @@ def test_is_combining():
         [False, True, False, False]
 
 
-def test_issue_17857():
-    assert pretty(Range(-oo, oo)) == '{..., -1, 0, 1, ...}'
-    assert pretty(Range(oo, -oo, -1)) == '{..., 1, 0, -1, ...}'
-
-def test_issue_18272():
-    x = Symbol('x')
-    n = Symbol('n')
-
-    assert upretty(ConditionSet(x, Eq(-x + exp(x), 0), S.Complexes)) == \
-    '⎧            ⎛      x    ⎞⎫\n'\
-    '⎨x | x ∊ ℂ ∧ ⎝-x + ℯ  = 0⎠⎬\n'\
-    '⎩                         ⎭'
-    assert upretty(ConditionSet(x, Contains(n/2, Interval(0, oo)), FiniteSet(-n/2, n/2))) == \
-    '⎧        ⎧-n   n⎫   ⎛n         ⎞⎫\n'\
-    '⎨x | x ∊ ⎨───, ─⎬ ∧ ⎜─ ∈ [0, ∞)⎟⎬\n'\
-    '⎩        ⎩ 2   2⎭   ⎝2         ⎠⎭'
-    assert upretty(ConditionSet(x, Eq(Piecewise((1, x >= 3), (x/2 - 1/2, x >= 2), (1/2, x >= 1),
-                (x/2, True)) - 1/2, 0), Interval(0, 3))) == \
-    '⎧                 ⎛⎛⎧   1     for x ≥ 3⎞          ⎞⎫\n'\
-    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪x                 ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪─ - 0.5  for x ≥ 2⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪2                 ⎟          ⎟⎪\n'\
-    '⎨x | x ∊ [0, 3] ∧ ⎜⎜⎨                  ⎟ - 0.5 = 0⎟⎬\n'\
-    '⎪                 ⎜⎜⎪  0.5    for x ≥ 1⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
-    '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
-    '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
-
-def test_Str():
-    from sympy.core.symbol import Str
-    assert pretty(Str('x')) == 'x'
-
-def test_diffgeom():
-    from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
-    x,y = symbols('x y', real=True)
-    m = Manifold('M', 2)
-    assert pretty(m) == 'M'
-    p = Patch('P', m)
-    assert pretty(p) == "P"
-    rect = CoordSystem('rect', p, [x, y])
-    assert pretty(rect) == "rect"
-    b = BaseScalarField(rect, 0)
-    assert pretty(b) == "x"
-
 def test_issue_17616():
     assert pretty(pi**(1/exp(1))) == \
    '  / -1\\\n'\
@@ -7302,3 +7256,50 @@ def test_issue_17616():
     ' ----\n'\
     ' x_17\n'\
     '7    '
+
+
+def test_issue_17857():
+    assert pretty(Range(-oo, oo)) == '{..., -1, 0, 1, ...}'
+    assert pretty(Range(oo, -oo, -1)) == '{..., 1, 0, -1, ...}'
+
+def test_issue_18272():
+    x = Symbol('x')
+    n = Symbol('n')
+
+    assert upretty(ConditionSet(x, Eq(-x + exp(x), 0), S.Complexes)) == \
+    '⎧            ⎛      x    ⎞⎫\n'\
+    '⎨x | x ∊ ℂ ∧ ⎝-x + ℯ  = 0⎠⎬\n'\
+    '⎩                         ⎭'
+    assert upretty(ConditionSet(x, Contains(n/2, Interval(0, oo)), FiniteSet(-n/2, n/2))) == \
+    '⎧        ⎧-n   n⎫   ⎛n         ⎞⎫\n'\
+    '⎨x | x ∊ ⎨───, ─⎬ ∧ ⎜─ ∈ [0, ∞)⎟⎬\n'\
+    '⎩        ⎩ 2   2⎭   ⎝2         ⎠⎭'
+    assert upretty(ConditionSet(x, Eq(Piecewise((1, x >= 3), (x/2 - 1/2, x >= 2), (1/2, x >= 1),
+                (x/2, True)) - 1/2, 0), Interval(0, 3))) == \
+    '⎧                 ⎛⎛⎧   1     for x ≥ 3⎞          ⎞⎫\n'\
+    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪x                 ⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪─ - 0.5  for x ≥ 2⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪2                 ⎟          ⎟⎪\n'\
+    '⎨x | x ∊ [0, 3] ∧ ⎜⎜⎨                  ⎟ - 0.5 = 0⎟⎬\n'\
+    '⎪                 ⎜⎜⎪  0.5    for x ≥ 1⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪                  ⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪   x              ⎟          ⎟⎪\n'\
+    '⎪                 ⎜⎜⎪   ─     otherwise⎟          ⎟⎪\n'\
+    '⎩                 ⎝⎝⎩   2              ⎠          ⎠⎭'
+
+def test_Str():
+    from sympy.core.symbol import Str
+    assert pretty(Str('x')) == 'x'
+
+def test_diffgeom():
+    from sympy.diffgeom import Manifold, Patch, CoordSystem, BaseScalarField
+    x,y = symbols('x y', real=True)
+    m = Manifold('M', 2)
+    assert pretty(m) == 'M'
+    p = Patch('P', m)
+    assert pretty(p) == "P"
+    rect = CoordSystem('rect', p, [x, y])
+    assert pretty(rect) == "rect"
+    b = BaseScalarField(rect, 0)
+    assert pretty(b) == "x"

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5942,7 +5942,11 @@ def test_PrettyPoly():
 
 def test_issue_6285():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
-    assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
+    assert pretty(Pow(x, (1/pi))) == \
+    ' 1\n'\
+    ' ─\n'\
+    ' π\n'\
+    'x'
 
 
 def test_issue_6359():
@@ -7250,3 +7254,9 @@ def test_diffgeom():
     assert pretty(rect) == "rect"
     b = BaseScalarField(rect, 0)
     assert pretty(b) == "x"
+
+def test_issue_17616():
+    assert pretty(pi**(1/E)) == \
+   '  ⎛ -1⎞\n'\
+   '  ⎝ℯ  ⎠\n'\
+   ' π'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #17616 
Closes https://github.com/sympy/sympy/pull/17620
Closes https://github.com/sympy/sympy/pull/17628

#### Brief description of what is fixed or changed
Earlier, 
```
>>> pprint(pi**(1/exp(1)))
-1___
╲╱ π 
```
Now,
```
>>> pprint(pi**(1/exp(1)))
 ⎛ -1⎞
 ⎝ℯ  ⎠
π     
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * irrational powers are no longer printed with square root sign, they are printed as fractional powers
<!-- END RELEASE NOTES -->