### PR TITLE
Fix incorrect header level in core.rst

### DIFF
--- a/doc/src/modules/core.rst
+++ b/doc/src/modules/core.rst
@@ -59,17 +59,17 @@ expr
 .. module:: sympy.core.expr
 
 Expr
-----
+^^^^
 .. autoclass:: Expr
    :members:
 
 UnevaluatedExpr
----------------
+^^^^^^^^^^^^^^^
 .. autoclass:: UnevaluatedExpr
    :members:
 
 AtomicExpr
-----------
+^^^^^^^^^^
 .. autoclass:: AtomicExpr
    :members:
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Separated from #20599

#### Brief description of what is fixed or changed
Classes in `expr` has now '^' header instead of '-', as other classes in `core.rst` do.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->