### PR TITLE
Changed build badge from travis to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SymPy
 
 [![pypi version](https://img.shields.io/pypi/v/sympy.svg)](https://pypi.python.org/pypi/sympy)
-[![Build status](https://secure.travis-ci.org/sympy/sympy.svg?branch=master)](https://travis-ci.org/sympy/sympy)
+[![Build status](https://github.com/sympy/sympy/workflows/test/badge.svg)](https://github.com/sympy/sympy/actions?query=workflow%3Atest)
 [![Join the chat at https://gitter.im/sympy/sympy](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sympy/sympy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Zenodo Badge](https://zenodo.org/badge/18918/sympy/sympy.svg)](https://zenodo.org/badge/latestdoi/18918/sympy/sympy)
 [![codecov Badge](https://codecov.io/gh/sympy/sympy/branch/master/graph/badge.svg)](https://codecov.io/gh/sympy/sympy)


### PR DESCRIPTION
Since we've switched to GH Actions, I changed the build badge in the README from Travis to GH Actions.


#### References to other Issues or PRs
Fixes #20647 

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->