### PR TITLE
added string printers for MatchPy wildcards

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -805,6 +805,15 @@ class StrPrinter(Printer):
     def _print_WildFunction(self, expr):
         return expr.name + '_'
 
+    def _print_WildDot(self, expr):
+        return expr.name + '_'
+
+    def _print_WildPlus(self, expr):
+        return expr.name + '__'
+
+    def _print_WildStar(self, expr):
+        return expr.name + '___'
+
     def _print_Zero(self, expr):
         if self._settings.get("sympy_integers", False):
             return "S(0)"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -6,6 +6,7 @@ from sympy import (Add, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
     AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice)
 from sympy.core import Expr, Mul
+from sympy.external import import_module
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
 from sympy.physics.units import second, joule
 from sympy.polys import (Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ,
@@ -714,6 +715,26 @@ def test_wild_str():
     assert str(1/w + 1) == '1 + 1/x_'
     assert str(w**2 + 1) == 'x_**2 + 1'
     assert str(1/(1 - w)) == '1/(1 - x_)'
+
+
+def test_wild_matchpy():
+    from sympy.utilities.matchpy_connector import WildDot, WildPlus, WildStar
+
+    matchpy = import_module("matchpy")
+
+    if matchpy is None:
+        return
+
+    wd = WildDot('w')
+    wp = WildPlus('w')
+    ws = WildStar('w')
+
+    assert str(wd) == 'w_'
+    assert str(wp) == 'w__'
+    assert str(ws) == 'w___'
+
+    assert str(wp/ws + 2**wd) == '2**w_ + w__/w___'
+    assert str(sin(wd)*cos(wp)*sqrt(ws)) == 'sqrt(w___)*sin(w_)*cos(w__)'
 
 
 def test_zeta():

--- a/sympy/utilities/matchpy_connector.py
+++ b/sympy/utilities/matchpy_connector.py
@@ -125,6 +125,9 @@ class _WildAbstract(Wildcard, Symbol):
     def __copy__(self) -> '_WildAbstract':
         return type(self)(variable_name=self.variable_name, optional=self.optional)
 
+    def __repr__(self):
+        return str(self)
+
 
 @doctest_depends_on(modules=('matchpy',))
 class WildDot(_WildAbstract):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added string printers for MatchPy-compatible wildcards in sympy.utilities.matchpy_connector
<!-- END RELEASE NOTES -->