### PR TITLE
Introduce polyadic predicate based on multipledispatch

### DIFF
--- a/doc/src/modules/assumptions/handlers/index.rst
+++ b/doc/src/modules/assumptions/handlers/index.rst
@@ -10,8 +10,8 @@ Contents
 .. toctree::
     :maxdepth: 3
 
-    calculus.rst
     common.rst
+    calculus.rst
     matrices.rst
     ntheory.rst
     order.rst

--- a/doc/src/modules/assumptions/index.rst
+++ b/doc/src/modules/assumptions/index.rst
@@ -17,30 +17,42 @@ Contents
     refine.rst
     handlers/index.rst
 
-Queries are used to ask information about expressions. Main method for this
-is ask():
 
-.. autofunction:: sympy.assumptions.ask::ask
+Predicates
+==========
+
+
+.. autoclass:: sympy.assumptions.assume::Predicate
    :noindex:
+
+.. autoclass:: sympy.assumptions.assume::AppliedPredicate
+   :noindex:
+
 
 Querying
 ========
 
-ask's optional second argument should be a boolean expression involving
-assumptions about objects in expr. Valid values include:
+Queries are used to ask information about expressions. Main method for this
+is ``ask()``:
 
-    * Q.integer(x)
-    * Q.positive(x)
-    * Q.integer(x) & Q.positive(x)
+.. autofunction:: sympy.assumptions.ask::ask
+   :noindex:
+
+``ask``'s optional second argument should be a boolean expression involving
+assumptions about objects in *expr*. Valid values include:
+
+    * ``Q.integer(x)``
+    * ``Q.positive(x)``
+    * ``Q.integer(x) & Q.positive(x)``
     * etc.
 
-Q is an object holding known predicates.
+``Q`` is an object holding known predicates.
 
 See documentation for the logic module for a complete list of valid boolean
 expressions.
 
 You can also define a context so you don't have to pass that argument
-each time to function ask(). This is done by using the assuming context manager
+each time to function ``ask()``. This is done by using the assuming context manager
 from module sympy.assumptions. ::
 
      >>> from sympy import *
@@ -50,68 +62,6 @@ from module sympy.assumptions. ::
      >>> with assuming(*facts):
      ...     print(ask(Q.positive(2*x + y)))
      True
-
-
-Design
-======
-
-Each time ask is called, the appropriate Handler for the current key is called. This is
-always a subclass of sympy.assumptions.AskHandler. Its classmethods have the names of the classes
-it supports. For example, a (simplified) AskHandler for the ask 'positive' would
-look like this::
-
-    class AskPositiveHandler(CommonHandler):
-
-        def Mul(self):
-            # return True if all argument's in self.expr.args are positive
-            ...
-
-        def Add(self):
-            for arg in self.expr.args:
-                if not ask(arg, positive, self.assumptions):
-                    break
-            else:
-                # if all argument's are positive
-                return True
-        ...
-
-The .Mul() method is called when self.expr is an instance of Mul, the Add method
-would be called when self.expr is an instance of Add and so on.
-
-
-Extensibility
-=============
-
-You can define new queries or support new types by subclassing sympy.assumptions.AskHandler
- and registering that handler for a particular key by calling register_handler:
-
-.. autofunction:: sympy.assumptions.ask::register_handler
-                  :noindex:
-
-You can undo this operation by calling remove_handler.
-
-.. autofunction:: sympy.assumptions.ask::remove_handler
-                  :noindex:
-
-You can support new types [1]_ by adding a handler to an existing key. In the
-following example, we will create a new type MyType and extend the key 'prime'
-to accept this type (and return True)
-
-.. parsed-literal::
-
-    >>> from sympy.core import Basic
-    >>> from sympy.assumptions import register_handler
-    >>> from sympy.assumptions.handlers import AskHandler
-    >>> class MyType(Basic):
-    ...     pass
-    >>> class MyAskHandler(AskHandler):
-    ...     @staticmethod
-    ...     def MyType(expr, assumptions):
-    ...         return True
-    >>> a = MyType()
-    >>> register_handler('prime', MyAskHandler)
-    >>> ask(Q.prime(a))
-    True
 
 
 Performance improvements
@@ -130,6 +80,3 @@ Misc
 
 You can find more examples in the in the form of test under directory
 sympy/assumptions/tests/
-
-.. [1] New type must inherit from Basic, otherwise an exception will be raised.
-   This is a bug and should be fixed.

--- a/sympy/assumptions/__init__.py
+++ b/sympy/assumptions/__init__.py
@@ -1,9 +1,16 @@
-from .assume import AppliedPredicate, Predicate, AssumptionsContext, assuming
+"""
+A module to implement logical predicates and assumption system.
+"""
+
+from .assume import (
+    AppliedPredicate, Predicate, AssumptionsContext, assuming,
+    global_assumptions
+)
 from .ask import Q, ask, register_handler, remove_handler
 from .refine import refine
 
 __all__ = [
     'AppliedPredicate', 'Predicate', 'AssumptionsContext', 'assuming',
-    'Q', 'ask', 'register_handler', 'remove_handler',
+    'global_assumptions', 'Q', 'ask', 'register_handler', 'remove_handler',
     'refine',
 ]

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1353,7 +1353,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     context : AssumptionsContext, optional
         Default assumptions to evaluate the *proposition*. By default,
-        this is ``global_assumptions``.
+        this is ``sympy.assumptions.global_assumptions`` variable.
 
 
     Examples

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -5,8 +5,8 @@ from sympy.assumptions.assume import (global_assumptions, Predicate,
 from sympy.core import sympify
 from sympy.core.cache import cacheit
 from sympy.core.relational import Relational
-from sympy.logic.boolalg import (to_cnf, And, Not, Or, Implies, Equivalent,
-                                 BooleanFunction, BooleanAtom)
+from sympy.core.kind import BooleanKind
+from sympy.logic.boolalg import (to_cnf, And, Not, Or, Implies, Equivalent)
 from sympy.logic.inference import satisfiable
 from sympy.utilities.decorator import memoize_property
 from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
@@ -19,9 +19,14 @@ from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 
 class AssumptionKeys:
     """
-    This class contains all the supported keys by ``ask``. It should be accessed via the instance ``sympy.Q``.
+    This class contains all the supported keys by ``ask``.
+    It should be accessed via the instance ``sympy.Q``.
 
     """
+
+    # DO NOT add methods or properties other than predicate keys.
+    # SAT solver checks the properties of Q and use them to compute the
+    # fact system. Non-predicate attributes will break this.
 
     @memoize_property
     def hermitian(self):
@@ -1301,12 +1306,12 @@ def _extract_facts(expr, symbol, check_reversed_rel=True):
         return expr.func(*args)
 
 
-def _extract_all_facts(expr, symbol):
+def _extract_all_facts(expr, symbols):
     facts = set()
-    if isinstance(symbol, Relational):
-        symbols = (symbol, symbol.reversed)
-    else:
-        symbols = (symbol,)
+    if len(symbols) == 1 and isinstance(symbols[0], Relational):
+        rel = symbols[0]
+        symbols = (rel, rel.reversed)
+
     for clause in expr.clauses:
         args = []
         for literal in clause:
@@ -1325,18 +1330,31 @@ def _extract_all_facts(expr, symbol):
 
 def ask(proposition, assumptions=True, context=global_assumptions):
     """
-    Method for inferring properties about objects.
-
-    Explanation
-    ===========
+    Function to evaluate the proposition with assumptions.
 
     **Syntax**
 
         * ask(proposition)
+            Evaluate the *proposition* in global assumption context.
 
         * ask(proposition, assumptions)
+            Evaluate the *proposition* with respect to *assumptions* in
+            global assumption context.
 
-            where ``proposition`` is any boolean expression
+    Parameters
+    ==========
+
+    proposition : any boolean expression
+        Proposition which will be evaluated to boolean value. If this is
+        not ``AppliedPredicate``, it will be wrapped by ``Q.is_true``.
+
+    assumptions : any boolean expression, optional
+        Local assumptions to evaluate the *proposition*.
+
+    context : AssumptionsContext, optional
+        Default assumptions to evaluate the *proposition*. By default,
+        this is ``global_assumptions``.
+
 
     Examples
     ========
@@ -1350,7 +1368,13 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     >>> ask(Q.prime(4*x), Q.integer(x))
     False
 
+    If the truth value cannot be determined, ``None`` will be returned.
+
+    >>> print(ask(Q.odd(3*x))) # cannot determine unless we know x
+    None
+
     **Remarks**
+
         Relations in assumptions are not implemented (yet), so the following
         will not give a meaningful result.
 
@@ -1361,21 +1385,24 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     """
     from sympy.assumptions.satask import satask
 
-    if not isinstance(proposition, (BooleanFunction, AppliedPredicate, bool, BooleanAtom)):
+    proposition = sympify(proposition)
+    assumptions = sympify(assumptions)
+
+    if isinstance(proposition, Predicate) or proposition.kind is not BooleanKind:
         raise TypeError("proposition must be a valid logical expression")
 
-    if not isinstance(assumptions, (BooleanFunction, AppliedPredicate, bool, BooleanAtom)):
+    if isinstance(assumptions, Predicate) or assumptions.kind is not BooleanKind:
         raise TypeError("assumptions must be a valid logical expression")
 
     if isinstance(proposition, AppliedPredicate):
-        key, expr = proposition.func, sympify(proposition.arg)
+        key, args = proposition.function, proposition.arguments
     else:
-        key, expr = Q.is_true, sympify(proposition)
+        key, args = Q.is_true, (proposition,)
 
     assump = CNF.from_prop(assumptions)
     assump.extend(context)
 
-    local_facts = _extract_all_facts(assump, expr)
+    local_facts = _extract_all_facts(assump, args)
 
     known_facts_cnf = get_all_known_facts()
     known_facts_dict = get_known_facts_dict()
@@ -1405,7 +1432,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
                     return False
 
     # direct resolution method, no logic
-    res = key(expr)._eval_ask(assumptions)
+    res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
     # using satask (still costly)
@@ -1443,8 +1470,9 @@ def register_handler(key, handler):
         True
 
     """
-    if type(key) is Predicate:
-        key = key.name
+    # Will be deprecated
+    if isinstance(key, Predicate):
+        key = key.name.name
     Qkey = getattr(Q, key, None)
     if Qkey is not None:
         Qkey.add_handler(handler)
@@ -1454,8 +1482,9 @@ def register_handler(key, handler):
 
 def remove_handler(key, handler):
     """Removes a handler from the ask system. Same syntax as register_handler"""
-    if type(key) is Predicate:
-        key = key.name
+    # Will be deprecated
+    if isinstance(key, Predicate):
+        key = key.name.name
     getattr(Q, key).remove_handler(handler)
 
 
@@ -1543,7 +1572,7 @@ def compute_known_facts(known_facts, known_facts_keys):
 _val_template = 'sympy.assumptions.handlers.%s'
 _handlers = [
     ("antihermitian",     "sets.AskAntiHermitianHandler"),
-    ("finite",           "calculus.AskFiniteHandler"),
+    ("finite",            "calculus.AskFiniteHandler"),
     ("commutative",       "AskCommutativeHandler"),
     ("complex",           "sets.AskComplexHandler"),
     ("composite",         "ntheory.AskCompositeHandler"),

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -14,7 +14,8 @@ from sympy.utilities.source import get_class
 
 class AssumptionsContext(set):
     """
-    Set representing assumptions. Defaultly applies to ``ask()``.
+    Set containing default assumptions which are applied to the ``ask()``
+    function.
 
     Explanation
     ===========
@@ -81,7 +82,7 @@ class AppliedPredicate(Boolean):
     """
     The class of expressions resulting from applying ``Predicate`` to
     the arguments. ``AppliedPredicate`` merely wraps its argument and
-    remain unevaluated. To evaluate it, use the ``ask`` function.
+    remain unevaluated. To evaluate it, use the ``ask()`` function.
 
     Examples
     ========
@@ -150,11 +151,17 @@ class AppliedPredicate(Boolean):
 
     @property
     def function(self):
+        """
+        Return the predicate.
+        """
         # Will be changed to self.args[0] after args overridding is removed
         return self._args[0]
 
     @property
     def arguments(self):
+        """
+        Return the arguments which are applied to the predicate.
+        """
         # Will be changed to self.args[1:] after args overridding is removed
         return self._args[1:]
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -1,15 +1,20 @@
+"""A module which implements predicates and assumption context."""
+
+from contextlib import contextmanager
 import inspect
-from sympy.core.cache import cacheit
-from sympy.core.singleton import S
+from sympy.core.assumptions import ManagedProperties
+from sympy.core.symbol import Str
 from sympy.core.sympify import _sympify
 from sympy.logic.boolalg import Boolean
+from sympy.multipledispatch.dispatcher import (
+    Dispatcher, MDNotImplementedError
+)
 from sympy.utilities.source import get_class
-from contextlib import contextmanager
 
 
 class AssumptionsContext(set):
     """
-    Set representing assumptions.
+    Set representing assumptions. Defaultly applies to ``ask()``.
 
     Explanation
     ===========
@@ -21,18 +26,42 @@ class AssumptionsContext(set):
     Examples
     ========
 
-    >>> from sympy import Q
-    >>> from sympy.assumptions.assume import global_assumptions
+    Default assumption context is ``global_assumptions``, which is empty
+    by default.
+
+    >>> from sympy import ask, Q
+    >>> from sympy.assumptions import global_assumptions
     >>> global_assumptions
     AssumptionsContext()
+
+    You can add default assumption.
+
     >>> from sympy.abc import x
     >>> global_assumptions.add(Q.real(x))
     >>> global_assumptions
     AssumptionsContext({Q.real(x)})
+    >>> ask(Q.real(x))
+    True
+
+    And you can remove it.
+
     >>> global_assumptions.remove(Q.real(x))
+    >>> print(ask(Q.real(x)))
+    None
+
+    ``clear()`` method removes every assumptions.
+
+    >>> global_assumptions.add(Q.positive(x))
+    >>> global_assumptions
+    AssumptionsContext({Q.positive(x)})
+    >>> global_assumptions.clear()
     >>> global_assumptions
     AssumptionsContext()
-    >>> global_assumptions.clear()
+
+    See Also
+    ========
+
+    assuming
 
     """
 
@@ -50,26 +79,43 @@ global_assumptions = AssumptionsContext()
 
 
 class AppliedPredicate(Boolean):
-    """The class of expressions resulting from applying a Predicate.
+    """
+    The class of expressions resulting from applying ``Predicate`` to
+    the arguments. ``AppliedPredicate`` merely wraps its argument and
+    remain unevaluated. To evaluate it, use ``ask`` function.
 
     Examples
     ========
 
-    >>> from sympy import Q, Symbol
-    >>> x = Symbol('x')
-    >>> Q.integer(x)
-    Q.integer(x)
-    >>> type(Q.integer(x))
+    >>> from sympy import Q, ask
+    >>> Q.integer(1)
+    Q.integer(1)
+
+    ``function`` attribute returns the predicate, and ``arguments``
+    attribute returns the tuple of arguments.
+
+    >>> type(Q.integer(1))
     <class 'sympy.assumptions.assume.AppliedPredicate'>
+    >>> Q.integer(1).function
+    Q.integer
+    >>> Q.integer(1).arguments
+    (1,)
+
+    Applied predicate can be evaluated to boolean value.
+
+    >>> ask(Q.integer(1))
+    True
 
     """
     __slots__ = ()
 
-    def __new__(cls, predicate, arg):
-        arg = _sympify(arg)
-        return Boolean.__new__(cls, predicate, arg)
-
     is_Atom = True  # do not attempt to decompose this
+
+    def __new__(cls, predicate, *args):
+        if not isinstance(predicate, Predicate):
+            raise TypeError("%s is not Predicate." % predicate)
+        args = map(_sympify, args)
+        return super().__new__(cls, predicate, *args)
 
     @property
     def arg(self):
@@ -86,79 +132,225 @@ class AppliedPredicate(Boolean):
         x + 1
 
         """
-        return self._args[1]
+        # Will be deprecated
+        args = self._args
+        if len(args) == 2:
+            # backwards compatibility
+            return args[1]
+        raise TypeError("'arg' property is allowed only for unary predicate.")
 
     @property
     def args(self):
+        # Will be deprecated and return normal Basic.func
         return self._args[1:]
 
     @property
     def func(self):
+        # Will be deprecated and return normal Basic.func
         return self._args[0]
 
-    @cacheit
-    def sort_key(self, order=None):
-        return (self.class_key(), (2, (self.func.name, self.arg.sort_key())),
-                S.One.sort_key(), S.One)
+    @property
+    def function(self):
+        # Will be changed to self.args[0] after args overridding is removed
+        return self._args[0]
 
-    def __eq__(self, other):
-        if type(other) is AppliedPredicate:
-            return self._args == other._args
-        return False
-
-    def __hash__(self):
-        return super().__hash__()
+    @property
+    def arguments(self):
+        # Will be changed to self.args[1:] after args overridding is removed
+        return self._args[1:]
 
     def _eval_ask(self, assumptions):
-        return self.func.eval(self.arg, assumptions)
+        return self.function.eval(self.arguments, assumptions)
 
     @property
     def binary_symbols(self):
         from sympy.core.relational import Eq, Ne
-        if self.func.name in ['is_true', 'is_false']:
-            i = self.arg
+        from .ask import Q
+        if self.function == Q.is_true:
+            i = self.arguments[0]
             if i.is_Boolean or i.is_Symbol or isinstance(i, (Eq, Ne)):
                 return i.binary_symbols
         return set()
 
 
-class Predicate(Boolean):
+class PredicateMeta(ManagedProperties):
     """
-    A predicate is a function that returns a boolean value.
+    Metaclass for ``Predicate``
 
-    Predicates merely wrap their argument and remain unevaluated:
+    If class attribute ``handler`` is not defined, assigns empty Dispatcher
+    to it.
+    """
+    def __new__(cls, clsname, bases, dct):
+        if "handler" not in dct:
+            name = ''.join(["Ask", clsname.capitalize(), "Handler"])
+            handler = Dispatcher(name, doc="Handler for key %s" % name)
+            dct["handler"] = handler
+        return super().__new__(cls, clsname, bases, dct)
 
-        >>> from sympy import Q, ask
-        >>> type(Q.prime)
-        <class 'sympy.assumptions.assume.Predicate'>
-        >>> Q.prime.name
-        'prime'
-        >>> Q.prime(7)
-        Q.prime(7)
-        >>> _.func.name
-        'prime'
 
-    To obtain the truth value of an expression containing predicates, use
-    the function ``ask``:
+class Predicate(Boolean, metaclass=PredicateMeta):
+    """
+    Base class for mathematical predicates. It also serves as a
+    constructor for undefined predicate objects.
 
-        >>> ask(Q.prime(7))
-        True
+    Explanation
+    ===========
+
+    Predicate is a function that returns a boolean value [1].
+
+    Predicate function is object, and it is instance of predicate class.
+    When a predicate is applied to arguments, ``AppliedPredicate``
+    instance is returned. This merely wraps the argument and remain
+    unevaluated. To obtain the truth value of applied predicate, use the
+    function ``ask``.
+
+    Evaluation of predicate is done by multiple dispatching. You can
+    register new handler to the predicate to support new types.
+
+    Every predicate in SymPy can be accessed via the property of ``Q``.
+    For example, ``Q.even`` returns the predicate which checks if the
+    argument is even number.
+
+    To define a predicate which can be evaluated, you must subclass this
+    class, make an instance of it, and register it to ``Q``. After then,
+    dispatch the handler by argument types.
+
+    If you directly construct predicate using this class, you will get
+    ``UndefinedPredicate`` which cannot be dispatched. This is useful
+    when you are building boolean expressions which do not need to be
+    evaluated.
+
+    Examples
+    ========
+
+    Applying and evaluating to boolean value:
+
+    >>> from sympy import Q, ask
+    >>> from sympy.abc import x
+    >>> ask(Q.prime(7))
+    True
+
+    You can define a new predicate by subclassing and dispatching. Here,
+    we define a predicate for sexy primes [2] as an example.
+
+    >>> from sympy import Predicate, Integer
+    >>> class SexyPrimePredicate(Predicate):
+    ...     name = "sexyprime"
+    >>> Q.sexyprime = SexyPrimePredicate()
+    >>> @Q.sexyprime.register(Integer, Integer)
+    ... def _(int1, int2, assumptions):
+    ...     args = sorted([int1, int2])
+    ...     if not all(ask(Q.prime(a), assumptions) for a in args):
+    ...         return False
+    ...     return args[1] - args[0] == 6
+    >>> ask(Q.sexyprime(5, 11))
+    True
+
+    Direct constructing returns ``UndefinedPredicate``, which can be
+    applied but cannot be dispatched.
+
+    >>> from sympy import Predicate, Integer
+    >>> Q.P = Predicate("P")
+    >>> type(Q.P)
+    <class 'sympy.assumptions.assume.UndefinedPredicate'>
+    >>> Q.P(1)
+    Q.P(1)
+    >>> Q.P.register(Integer)(lambda expr, assump: True)
+    Traceback (most recent call last):
+      ...
+    TypeError: <class 'sympy.assumptions.assume.UndefinedPredicate'> cannot be dispatched.
 
     The tautological predicate ``Q.is_true`` can be used to wrap other objects:
+    >>> Q.is_true(x > 1)
+    Q.is_true(x > 1)
 
-        >>> from sympy.abc import x
-        >>> Q.is_true(x > 1)
-        Q.is_true(x > 1)
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Predicate_(mathematical_logic)
+    .. [2] https://en.wikipedia.org/wiki/Sexy_prime
 
     """
 
     is_Atom = True
 
+    def __new__(cls, *args, **kwargs):
+        if cls is Predicate:
+            return UndefinedPredicate(*args, **kwargs)
+        obj = super().__new__(cls, *args)
+        return obj
+
+    @property
+    def name(self):
+        # May be overridden
+        return type(self).__name__
+
+    def register(self, *types, **kwargs):
+        if self.handler is None:
+            # condition for UndefinedPredicate
+            raise TypeError("%s cannot be dispatched." % type(self))
+        return lambda func: self.handler.register(*types, **kwargs)(func)
+
+    def __call__(self, *args):
+        return AppliedPredicate(self, *args)
+
+    def eval(self, args, assumptions=True):
+        """
+        Evaluate ``self(*args)`` under the given assumptions.
+
+        This uses only direct resolution methods, not logical inference.
+        """
+        types = tuple(type(a) for a in args)
+        result = None
+        for func in self.handler.dispatch_iter(*types):
+            try:
+                result = func(*args, assumptions)
+            except MDNotImplementedError:
+                continue
+            else:
+                if result is not None:
+                    return result
+        return result
+
+
+class UndefinedPredicate(Predicate):
+    """
+    Predicate without handler.
+
+    Explanation
+    ===========
+
+    This predicate is generated by using ``Predicate`` directly for
+    construction. It does not have a handler, and evaluating this with
+    arguments is done by SAT solver.
+
+    Examples
+    ========
+
+    >>> from sympy import Predicate, Q
+    >>> Q.P = Predicate('P')
+    >>> Q.P.func
+    <class 'sympy.assumptions.assume.UndefinedPredicate'>
+    >>> Q.P.name
+    Str('P')
+
+    """
+
     def __new__(cls, name, handlers=None):
-        obj = Boolean.__new__(cls)
-        obj.name = name
+        # "handlers" parameter supports old design
+        if not isinstance(name, Str):
+            name = Str(name)
+        obj = super(Boolean, cls).__new__(cls, name)
         obj.handlers = handlers or []
         return obj
+
+    @property
+    def name(self):
+        return self.args[0]
+
+    @property
+    def handler(self):
+        return None
 
     def _hashable_content(self):
         return (self.name,)
@@ -170,21 +362,17 @@ class Predicate(Boolean):
         return AppliedPredicate(self, expr)
 
     def add_handler(self, handler):
+        # Will be deprecated
         self.handlers.append(handler)
 
     def remove_handler(self, handler):
+        # Will be deprecated
         self.handlers.remove(handler)
 
-    @cacheit
-    def sort_key(self, order=None):
-        return self.class_key(), (1, (self.name,)), S.One.sort_key(), S.One
-
-    def eval(self, expr, assumptions=True):
-        """
-        Evaluate self(expr) under the given assumptions.
-
-        This uses only direct resolution methods, not logical inference.
-        """
+    def eval(self, args, assumptions=True):
+        # Support for deprecated design
+        # When old design is removed, this will always return None
+        expr, = args
         res, _res = None, None
         mro = inspect.getmro(type(expr))
         for handler in self.handlers:
@@ -221,10 +409,8 @@ def assuming(*assumptions):
 
     >>> from sympy.assumptions import assuming, Q, ask
     >>> from sympy.abc import x, y
-
     >>> print(ask(Q.integer(x + y)))
     None
-
     >>> with assuming(Q.integer(x), Q.integer(y)):
     ...     print(ask(Q.integer(x + y)))
     True

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -26,15 +26,14 @@ class AssumptionsContext(set):
     Examples
     ========
 
-    Default assumption context is ``global_assumptions``, which is empty
-    by default.
+    The default assumption context is ``global_assumptions``, which is initially empty:
 
     >>> from sympy import ask, Q
     >>> from sympy.assumptions import global_assumptions
     >>> global_assumptions
     AssumptionsContext()
 
-    You can add default assumption.
+    You can add default assumptions:
 
     >>> from sympy.abc import x
     >>> global_assumptions.add(Q.real(x))
@@ -43,13 +42,13 @@ class AssumptionsContext(set):
     >>> ask(Q.real(x))
     True
 
-    And you can remove it.
+    And remove them:
 
     >>> global_assumptions.remove(Q.real(x))
     >>> print(ask(Q.real(x)))
     None
 
-    ``clear()`` method removes every assumptions.
+    The ``clear()`` method removes every assumption:
 
     >>> global_assumptions.add(Q.positive(x))
     >>> global_assumptions
@@ -82,7 +81,7 @@ class AppliedPredicate(Boolean):
     """
     The class of expressions resulting from applying ``Predicate`` to
     the arguments. ``AppliedPredicate`` merely wraps its argument and
-    remain unevaluated. To evaluate it, use ``ask`` function.
+    remain unevaluated. To evaluate it, use the ``ask`` function.
 
     Examples
     ========
@@ -91,7 +90,7 @@ class AppliedPredicate(Boolean):
     >>> Q.integer(1)
     Q.integer(1)
 
-    ``function`` attribute returns the predicate, and ``arguments``
+    The ``function`` attribute returns the predicate, and the ``arguments``
     attribute returns the tuple of arguments.
 
     >>> type(Q.integer(1))
@@ -101,7 +100,7 @@ class AppliedPredicate(Boolean):
     >>> Q.integer(1).arguments
     (1,)
 
-    Applied predicate can be evaluated to boolean value.
+    Applied predicates can be evaluated to a boolean value with ``ask``:
 
     >>> ask(Q.integer(1))
     True
@@ -113,7 +112,7 @@ class AppliedPredicate(Boolean):
 
     def __new__(cls, predicate, *args):
         if not isinstance(predicate, Predicate):
-            raise TypeError("%s is not Predicate." % predicate)
+            raise TypeError("%s is not a Predicate." % predicate)
         args = map(_sympify, args)
         return super().__new__(cls, predicate, *args)
 
@@ -137,7 +136,7 @@ class AppliedPredicate(Boolean):
         if len(args) == 2:
             # backwards compatibility
             return args[1]
-        raise TypeError("'arg' property is allowed only for unary predicate.")
+        raise TypeError("'arg' property is allowed only for unary predicates.")
 
     @property
     def args(self):
@@ -182,7 +181,7 @@ class PredicateMeta(ManagedProperties):
     """
     def __new__(cls, clsname, bases, dct):
         if "handler" not in dct:
-            name = ''.join(["Ask", clsname.capitalize(), "Handler"])
+            name = f"Ask{clsname.capitalize()}Handler"
             handler = Dispatcher(name, doc="Handler for key %s" % name)
             dct["handler"] = handler
         return super().__new__(cls, clsname, bases, dct)
@@ -289,7 +288,7 @@ class Predicate(Boolean, metaclass=PredicateMeta):
         if self.handler is None:
             # condition for UndefinedPredicate
             raise TypeError("%s cannot be dispatched." % type(self))
-        return lambda func: self.handler.register(*types, **kwargs)(func)
+        return self.handler.register(*types, **kwargs)
 
     def __call__(self, *args):
         return AppliedPredicate(self, *args)

--- a/sympy/assumptions/handlers/__init__.py
+++ b/sympy/assumptions/handlers/__init__.py
@@ -1,5 +1,11 @@
-from .common import (AskHandler, CommonHandler, AskCommutativeHandler,
-    TautologicalHandler, test_closed_group)
+"""
+Multipledispatch handlers for ``Predicate`` are implemented here.
+Handlers in this module are not directly imported to other modules in
+order to avoid circular import problem.
+"""
+
+from .common import (AskHandler, CommonHandler,
+    AskCommutativeHandler, TautologicalHandler, test_closed_group)
 
 __all__ = [
     'AskHandler', 'CommonHandler', 'AskCommutativeHandler',

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -1,6 +1,11 @@
+"""
+This module defines base class for handlers and some core handlers:
+``Q.commutative`` and ``Q.is_true``.
+"""
+
+from sympy.assumptions import Q, ask
 from sympy.core.logic import _fuzzy_group
 from sympy.logic.boolalg import conjuncts
-from sympy.assumptions import Q, ask
 
 
 class AskHandler:

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -19,12 +19,12 @@ def refine(expr, assumptions=True):
     Examples
     ========
 
-        >>> from sympy import refine, sqrt, Q
-        >>> from sympy.abc import x
-        >>> refine(sqrt(x**2), Q.real(x))
-        Abs(x)
-        >>> refine(sqrt(x**2), Q.positive(x))
-        x
+    >>> from sympy import refine, sqrt, Q
+    >>> from sympy.abc import x
+    >>> refine(sqrt(x**2), Q.real(x))
+    Abs(x)
+    >>> refine(sqrt(x**2), Q.positive(x))
+    x
 
     """
     if not isinstance(expr, Basic):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,14 +1,14 @@
 from sympy.abc import t, w, x, y, z, n, k, m, p, i
 from sympy.assumptions import (ask, AssumptionsContext, Q, register_handler,
         remove_handler)
-from sympy.assumptions.assume import global_assumptions
+from sympy.assumptions.assume import global_assumptions, Predicate
 from sympy.assumptions.ask import compute_known_facts, single_fact_lookup
 from sympy.assumptions.handlers import AskHandler
 from sympy.core.add import Add
 from sympy.core.numbers import (I, Integer, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
-from sympy.core.symbol import symbols
+from sympy.core.symbol import symbols, Symbol
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.complexes import (Abs, im, re, sign)
 from sympy.functions.elementary.exponential import (exp, log)
@@ -2040,38 +2040,53 @@ def test_key_extensibility():
     # make sure the key is not defined
     raises(AttributeError, lambda: ask(Q.my_key(x)))
 
+    # Old handler system
     class MyAskHandler(AskHandler):
         @staticmethod
         def Symbol(expr, assumptions):
             return True
-    register_handler('my_key', MyAskHandler)
-    assert ask(Q.my_key(x)) is True
-    assert ask(Q.my_key(x + 1)) is None
-    remove_handler('my_key', MyAskHandler)
-    del Q.my_key
+    try:
+        register_handler('my_key', MyAskHandler)
+        assert ask(Q.my_key(x)) is True
+        assert ask(Q.my_key(x + 1)) is None
+    finally:
+        remove_handler('my_key', MyAskHandler)
+        del Q.my_key
+    raises(AttributeError, lambda: ask(Q.my_key(x)))
+
+    # New handler system
+    class MyPredicate(Predicate):
+        pass
+    try:
+        Q.my_key = MyPredicate()
+        @Q.my_key.register(Symbol)
+        def _(expr, assumptions):
+            return True
+        assert ask(Q.my_key(x)) is True
+        assert ask(Q.my_key(x+1)) is None
+    finally:
+        del Q.my_key
     raises(AttributeError, lambda: ask(Q.my_key(x)))
 
 
 def test_type_extensibility():
     """test that new types can be added to the ask system at runtime
-    We create a custom type MyType, and override ask Q.prime=True with handler
-    MyAskHandler for this type
-
-    TODO: test incompatible resolutors
     """
     from sympy.core import Basic
 
     class MyType(Basic):
         pass
 
+    # Old handler system
     class MyAskHandler(AskHandler):
         @staticmethod
         def MyType(expr, assumptions):
             return True
-
     a = MyType()
     register_handler(Q.prime, MyAskHandler)
     assert ask(Q.prime(a)) is True
+
+    #TODO: add test for new handler system after predicates are migrated
 
 
 def test_single_fact_lookup():
@@ -2253,11 +2268,9 @@ def test_autosimp_used_to_fail():
 
 
 def test_custom_AskHandler():
-    from sympy.assumptions import register_handler, ask, Q
-    from sympy.assumptions.handlers import AskHandler
     from sympy.logic.boolalg import conjuncts
-    from sympy import Symbol
 
+    # Old handler system
     class MersenneHandler(AskHandler):
         @staticmethod
         def Integer(expr, assumptions):
@@ -2268,7 +2281,69 @@ def test_custom_AskHandler():
         def Symbol(expr, assumptions):
             if expr in conjuncts(assumptions):
                 return True
-    register_handler('mersenne', MersenneHandler)
+    try:
+        register_handler('mersenne', MersenneHandler)
+        n = Symbol('n', integer=True)
+        assert ask(Q.mersenne(7))
+        assert ask(Q.mersenne(n), Q.mersenne(n))
+    finally:
+        del Q.mersenne
 
-    n = Symbol('n', integer=True)
-    assert ask(Q.mersenne(n), Q.mersenne(n))
+    # New handler system
+    class MersennePredicate(Predicate):
+        pass
+    try:
+        Q.mersenne = MersennePredicate()
+        @Q.mersenne.register(Integer)
+        def _(expr, assumptions):
+            from sympy import log
+            if ask(Q.integer(log(expr + 1, 2))):
+                return True
+        @Q.mersenne.register(Symbol)
+        def _(expr, assumptions):
+            if expr in conjuncts(assumptions):
+                return True
+        assert ask(Q.mersenne(7))
+        assert ask(Q.mersenne(n), Q.mersenne(n))
+    finally:
+        del Q.mersenne
+
+
+def test_polyadic_predicate():
+
+    class SexyPredicate(Predicate):
+        pass
+    try:
+        Q.sexyprime = SexyPredicate()
+
+        @Q.sexyprime.register(Integer, Integer)
+        def _(int1, int2, assumptions):
+            args = sorted([int1, int2])
+            if not all(ask(Q.prime(a), assumptions) for a in args):
+                return False
+            return args[1] - args[0] == 6
+
+        @Q.sexyprime.register(Integer, Integer, Integer)
+        def _(int1, int2, int3, assumptions):
+            args = sorted([int1, int2, int3])
+            if not all(ask(Q.prime(a), assumptions) for a in args):
+                return False
+            return args[2] - args[1] == 6 and args[1] - args[0] == 6
+
+        assert ask(Q.sexyprime(5, 11))
+        assert ask(Q.sexyprime(7, 13, 19))
+    finally:
+        del Q.sexyprime
+
+
+def test_Predicate_handler_is_unique():
+
+    # Undefined predicate does not have a handler
+    assert Predicate('mypredicate').handler is None
+
+    # Handler of defined predicate is unique to the class
+    class MyPredicate(Predicate):
+        pass
+    mp1 = MyPredicate('mp1')
+    mp2 = MyPredicate('mp2')
+    assert mp1.handler is mp2.handler

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -91,7 +91,11 @@ def test_sympy__assumptions__assume__AppliedPredicate():
     assert _test_args(AppliedPredicate(Predicate("test"), 2))
     assert _test_args(Q.is_true(True))
 
+@SKIP("abstract class")
 def test_sympy__assumptions__assume__Predicate():
+    pass
+
+def test_sympy__assumptions__assume__UndefinedPredicate():
     from sympy.assumptions.assume import Predicate
     assert _test_args(Predicate("test"))
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -241,10 +241,12 @@ class ReprPrinter(Printer):
             )
 
     def _print_Predicate(self, expr):
-        return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        return "Q.%s" % expr.name
 
     def _print_AppliedPredicate(self, expr):
-        return "%s(%s, %s)" % (expr.__class__.__name__, expr.func, expr.arg)
+        # will be changed to just expr.args when args overriding is removed
+        args = expr._args
+        return "%s(%s)" % (expr.__class__.__name__, self.reprify(args, ", "))
 
     def _print_str(self, expr):
         return repr(expr)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -85,7 +85,8 @@ class StrPrinter(Printer):
         return self.stringify(expr.args, " ^ ", PRECEDENCE["BitwiseXor"])
 
     def _print_AppliedPredicate(self, expr):
-        return '%s(%s)' % (self._print(expr.func), self._print(expr.arg))
+        return '%s(%s)' % (
+            self._print(expr.function), self.stringify(expr.arguments, ", "))
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from sympy.testing.pytest import raises
 from sympy import (symbols, sympify, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
-    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol)
+    sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild, MatrixSymbol, Q)
 from sympy.combinatorics import Cycle, Permutation
 from sympy.core.symbol import Str
 from sympy.geometry import Point, Ellipse
@@ -334,3 +334,9 @@ def test_set():
     assert srepr(s) == "set()"
     s = {x, y}
     assert srepr(s) in ("{Symbol('x'), Symbol('y')}", "{Symbol('y'), Symbol('x')}")
+
+def test_Predicate():
+    sT(Q.even, "Q.even")
+
+def test_AppliedPredicate():
+    sT(Q.even(Symbol('z')), "AppliedPredicate(Q.even, Symbol('z'))")

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,8 @@ from sympy import (Add, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice)
+    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs, MatrixSymbol, MatrixSlice,
+    Q)
 from sympy.core import Expr, Mul
 from sympy.external import import_module
 from sympy.physics.control.lti import TransferFunction, Series, Parallel, Feedback
@@ -1021,3 +1022,9 @@ def test_NDimArray():
     assert sstr(NDimArray(1.0), full_prec=False) == '1.0'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=True) == '[1.00000000000000, 2.00000000000000]'
     assert sstr(NDimArray([1.0, 2.0]), full_prec=False) == '[1.0, 2.0]'
+
+def test_Predicate():
+    assert sstr(Q.even) == 'Q.even'
+
+def test_AppliedPredicate():
+    assert sstr(Q.even(x)) == 'Q.even(x)'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Closes #20209

#### Brief description of what is fixed or changed

This PR improves the predicate and handler design in `assumptions` module.

1. Assumption handlers are now multipledispatch instance. Predicate now uses a single handler instead of a list of handlers.
2. `Predicate("...")` now returns `UndefinedPredicate`, which cannot be evaluated. To make predicate that can be evaluated, subclass of `Predicate` must be defined.
3. `Predicate` can now take multiple arguments.

This PR does not break back compatibility. Existing handlers are not yet migrated to this new design. It will be done in succeeding PRs.

Also, printing of predicates is improved and tests are added.

#### Other comments

Previous handler design was very unstable. It made `Predicate` mutable, it filters the argument by its class "name", and could not take multiple arguments. This new multipledispatch design fixes these.

Just as `Function('f')` returns undefined function which cannot be evaluated, `Predicate('...')` returns `UndefinedPredicate` in this PR. This instance does not have handler and cannot be evaluated by its own, but it can be used to construct expressions like `Not` and evaluated by SAT solver.

To define a new predicate with handler, new predicate class must be defined and functions must be dispatched to its handler. For example,

```python
    class SexyPredicate(Predicate):
        """https://en.wikipedia.org/wiki/Sexy_prime"""
        name = "sexyprime"
    Q.sexyprime = SexyPredicate()

    @Q.sexyprime.register(Integer, Integer)
    def _(int1, int2, assumptions):
        args = sorted([int1, int2])
        if not all(ask(Q.prime(a), assumptions) for a in args):
            return False
        return args[1] - args[0] == 6

    @Q.sexyprime.register(Integer, Integer, Integer)
    def _(int1, int2, int3, assumptions):
        args = sorted([int1, int2, int3])
        if not all(ask(Q.prime(a), assumptions) for a in args):
            return False
        return args[2] - args[1] == 6 and args[1] - args[0] == 6
```
Evaluating this to boolean is done by `ask` as usual.
```python
>>> ask(Q.sexyprime(5, 11))
True
>>> ask(Q.sexyprime(7, 13, 19))
True
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- assumptions
    - `Predicate` now uses a single handler which is multipledispatch instance.
    - `Predicate` can now take multiple arguments.
    - `Predicate("...")` now returns `UndefinedPredicate` instance. To define a predicate, you must make a subclass of `Predicate`.
<!-- END RELEASE NOTES -->